### PR TITLE
Reduce core/formats/arrow deps

### DIFF
--- a/ydb/core/formats/arrow/accessor/abstract/ya.make
+++ b/ydb/core/formats/arrow/accessor/abstract/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     ydb/library/conclusion
     ydb/services/metadata/abstract
     ydb/library/actors/core
+    ydb/core/formats/arrow
     ydb/core/formats/arrow/accessor/common
     ydb/core/formats/arrow/filter
     ydb/library/formats/arrow/protos

--- a/ydb/core/formats/arrow/accessor/plain/ya.make
+++ b/ydb/core/formats/arrow/accessor/plain/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 PEERDIR(
+    ydb/core/formats/arrow
     ydb/core/formats/arrow/accessor/abstract
     ydb/library/formats/arrow
     ydb/library/formats/arrow/protos

--- a/ydb/core/formats/arrow/common/ya.make
+++ b/ydb/core/formats/arrow/common/ya.make
@@ -2,12 +2,13 @@ LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
+    ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow/container
+    ydb/core/formats/arrow/splitter
     ydb/core/formats/arrow/switch
     ydb/library/actors/core
     ydb/library/conclusion
     ydb/library/formats/arrow
-    ydb/core/formats/arrow/splitter
 )
 
 SRCS(

--- a/ydb/core/formats/arrow/hash/calcer.cpp
+++ b/ydb/core/formats/arrow/hash/calcer.cpp
@@ -1,6 +1,5 @@
 #include "calcer.h"
 
-#include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/switch/switch_type.h>
 
 #include <ydb/library/actors/core/log.h>
@@ -143,6 +142,47 @@ ui64 TXX64::CalcHash(const std::shared_ptr<arrow::Scalar>& scalar) {
     calcer.Start();
     AppendField(scalar, calcer);
     return calcer.Finish();
+}
+
+namespace {
+
+template <class TDataContainer>
+bool BuildHashUI64Impl(std::shared_ptr<TDataContainer>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName) {
+    if (fieldNames.size() == 0) {
+        return false;
+    }
+    Y_ABORT_UNLESS(!batch->GetColumnByName(hashFieldName));
+    if (fieldNames.size() == 1) {
+        auto column = batch->GetColumnByName(fieldNames.front());
+        if (!column) {
+            AFL_WARN(NKikimrServices::ARROW_HELPER)("event", "cannot_build_hash")("reason", "field_not_found")("field_name", fieldNames.front());
+            return false;
+        }
+        Y_ABORT_UNLESS(column);
+        if (column->type()->id() == arrow::Type::UINT64 || column->type()->id() == arrow::Type::UINT32 ||
+            column->type()->id() == arrow::Type::INT64 || column->type()->id() == arrow::Type::INT32) {
+            batch = TStatusValidator::GetValid(
+                batch->AddColumn(batch->num_columns(), std::make_shared<arrow::Field>(hashFieldName, column->type()), column));
+            return true;
+        }
+    }
+    std::shared_ptr<arrow::Array> hashColumn =
+        NArrow::NHash::TXX64(fieldNames, NArrow::NHash::TXX64::ENoColumnPolicy::Verify, 34323543).ExecuteToArray(batch);
+    batch = NAdapter::TDataBuilderPolicy<TDataContainer>::AddColumn(
+        batch, std::make_shared<arrow::Field>(hashFieldName, hashColumn->type()), hashColumn);
+    return true;
+}
+
+}   // namespace
+
+bool THashConstructor::BuildHashUI64(
+    std::shared_ptr<arrow::Table>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName) {
+    return BuildHashUI64Impl(batch, fieldNames, hashFieldName);
+}
+
+bool THashConstructor::BuildHashUI64(
+    std::shared_ptr<arrow::RecordBatch>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName) {
+    return BuildHashUI64Impl(batch, fieldNames, hashFieldName);
 }
 
 }   // namespace NKikimr::NArrow::NHash

--- a/ydb/core/formats/arrow/hash/calcer.h
+++ b/ydb/core/formats/arrow/hash/calcer.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <ydb/core/formats/arrow/common/adapter.h>
-#include <ydb/core/formats/arrow/reader/position.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/formats/arrow/hash/xx_hash.h>
@@ -159,6 +158,13 @@ public:
         AFL_VERIFY(ExecuteToArrayImpl(batch, acceptor));
         return result;
     }
+};
+
+class THashConstructor {
+public:
+    static bool BuildHashUI64(std::shared_ptr<arrow::Table>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName);
+    static bool BuildHashUI64(std::shared_ptr<arrow::RecordBatch>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName);
+
 };
 
 }   // namespace NKikimr::NArrow::NHash

--- a/ydb/core/formats/arrow/hash/ya.make
+++ b/ydb/core/formats/arrow/hash/ya.make
@@ -2,8 +2,8 @@ LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
+    ydb/core/formats/arrow/common
     ydb/core/formats/arrow/switch
-    ydb/core/formats/arrow/reader
     ydb/library/actors/core
     ydb/library/services
     ydb/library/actors/protos

--- a/ydb/core/formats/arrow/permutations.cpp
+++ b/ydb/core/formats/arrow/permutations.cpp
@@ -90,45 +90,4 @@ std::shared_ptr<arrow::UInt64Array> MakeSortPermutation(
     return MakeSortPermutation(keyBatch->columns(), andUnique);
 }
 
-namespace {
-
-template <class TDataContainer>
-bool BuildHashUI64Impl(std::shared_ptr<TDataContainer>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName) {
-    if (fieldNames.size() == 0) {
-        return false;
-    }
-    Y_ABORT_UNLESS(!batch->GetColumnByName(hashFieldName));
-    if (fieldNames.size() == 1) {
-        auto column = batch->GetColumnByName(fieldNames.front());
-        if (!column) {
-            AFL_WARN(NKikimrServices::ARROW_HELPER)("event", "cannot_build_hash")("reason", "field_not_found")("field_name", fieldNames.front());
-            return false;
-        }
-        Y_ABORT_UNLESS(column);
-        if (column->type()->id() == arrow::Type::UINT64 || column->type()->id() == arrow::Type::UINT32 ||
-            column->type()->id() == arrow::Type::INT64 || column->type()->id() == arrow::Type::INT32) {
-            batch = TStatusValidator::GetValid(
-                batch->AddColumn(batch->num_columns(), std::make_shared<arrow::Field>(hashFieldName, column->type()), column));
-            return true;
-        }
-    }
-    std::shared_ptr<arrow::Array> hashColumn =
-        NArrow::NHash::TXX64(fieldNames, NArrow::NHash::TXX64::ENoColumnPolicy::Verify, 34323543).ExecuteToArray(batch);
-    batch = NAdapter::TDataBuilderPolicy<TDataContainer>::AddColumn(
-        batch, std::make_shared<arrow::Field>(hashFieldName, hashColumn->type()), hashColumn);
-    return true;
-}
-
-}   // namespace
-
-bool THashConstructor::BuildHashUI64(
-    std::shared_ptr<arrow::Table>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName) {
-    return BuildHashUI64Impl(batch, fieldNames, hashFieldName);
-}
-
-bool THashConstructor::BuildHashUI64(
-    std::shared_ptr<arrow::RecordBatch>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName) {
-    return BuildHashUI64Impl(batch, fieldNames, hashFieldName);
-}
-
 }   // namespace NKikimr::NArrow

--- a/ydb/core/formats/arrow/permutations.h
+++ b/ydb/core/formats/arrow/permutations.h
@@ -9,13 +9,6 @@
 
 namespace NKikimr::NArrow {
 
-class THashConstructor {
-public:
-    static bool BuildHashUI64(std::shared_ptr<arrow::Table>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName);
-    static bool BuildHashUI64(std::shared_ptr<arrow::RecordBatch>& batch, const std::vector<std::string>& fieldNames, const std::string& hashFieldName);
-
-};
-
 std::shared_ptr<arrow::UInt64Array> MakeSortPermutation(
     const std::shared_ptr<arrow::RecordBatch>& batch, const std::shared_ptr<arrow::Schema>& sortingKey, const bool andUnique);
 

--- a/ydb/core/formats/arrow/program/ya.make
+++ b/ydb/core/formats/arrow/program/ya.make
@@ -4,6 +4,8 @@ PEERDIR(
     ydb/library/conclusion
     ydb/library/actors/core
     ydb/library/services
+    ydb/core/formats/arrow/accessor/composite
+    ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow/accessor/sub_columns
     ydb/core/formats/arrow/filter
 

--- a/ydb/core/formats/arrow/reader/ya.make
+++ b/ydb/core/formats/arrow/reader/ya.make
@@ -2,9 +2,13 @@ LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
+    ydb/core/formats/arrow/accessor/abstract
+    ydb/core/formats/arrow/common
+    ydb/core/formats/arrow/container
     ydb/core/formats/arrow/filter
     ydb/core/formats/arrow/switch
-    ydb/core/formats/arrow/container
+    ydb/core/scheme
+
     ydb/library/actors/core
     ydb/library/services
     ydb/library/formats/arrow

--- a/ydb/core/formats/arrow/ut/ya.make
+++ b/ydb/core/formats/arrow/ut/ya.make
@@ -7,7 +7,10 @@ PEERDIR(
     ydb/library/arrow_kernels
     ydb/library/formats/arrow/simple_builder
     ydb/core/formats/arrow/filter
+    ydb/core/formats/arrow/hash
+    ydb/core/formats/arrow/printer
     ydb/core/formats/arrow/program
+    ydb/core/formats/arrow/reader
     ydb/core/base
     ydb/library/formats/arrow
 

--- a/ydb/core/formats/arrow/ya.make
+++ b/ydb/core/formats/arrow/ya.make
@@ -1,36 +1,16 @@
-RECURSE(
-    container
-    filter
-)
-
-RECURSE_FOR_TESTS(
-    ut
-)
-
 LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
-    ydb/core/scheme
-    ydb/core/formats/arrow/accessor
-    ydb/core/formats/arrow/dictionary
-    ydb/core/formats/arrow/hash
-    ydb/core/formats/arrow/printer
-    ydb/core/formats/arrow/reader
-    ydb/core/formats/arrow/rows
-    ydb/core/formats/arrow/save_load
     ydb/core/formats/arrow/serializer
-    ydb/core/formats/arrow/splitter
-    ydb/core/formats/arrow/transformer
+    ydb/core/kqp/common/result_set_format
+    ydb/core/scheme
     ydb/library/actors/core
-    ydb/library/arrow_kernels
-    yql/essentials/types/binary_json
-    yql/essentials/types/dynumber
     ydb/library/formats/arrow
     ydb/library/services
-    yql/essentials/core/arrow_kernels/request
     yql/essentials/minikql
-    ydb/core/kqp/common/result_set_format
+    yql/essentials/types/binary_json
+    yql/essentials/types/dynumber
 )
 
 YQL_LAST_ABI_VERSION()
@@ -48,3 +28,21 @@ SRCS(
 )
 
 END()
+
+RECURSE(
+    accessor
+    container
+    dictionary
+    filter
+    hash
+    printer
+    reader
+    rows
+    save_load
+    splitter
+    transformer
+)
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/tx/columnshard/common/ya.make
+++ b/ydb/core/tx/columnshard/common/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     ydb/library/formats/arrow/protos
     contrib/libs/apache/arrow
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/rows
     ydb/core/tx/columnshard/common/protos
     ydb/core/tx/columnshard/data_sharing/protos
     ydb/core/tx/columnshard/transactions/protos

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/merge.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/merge.cpp
@@ -2,6 +2,7 @@
 #include "plain_read_data.h"
 #include "source.h"
 
+#include <ydb/core/formats/arrow/hash/calcer.h>
 #include <ydb/core/formats/arrow/program/collection.h>
 #include <ydb/core/formats/arrow/reader/result_builder.h>
 #include <ydb/core/formats/arrow/serializer/native.h>
@@ -55,7 +56,7 @@ TConclusionStatus TBaseMergeTask::PrepareResultBatch() {
     }
     if (ResultBatch && ResultBatch->num_rows()) {
         const auto& shardingPolicy = Context->GetCommonContext()->GetComputeShardingPolicy();
-        if (NArrow::THashConstructor::BuildHashUI64(ResultBatch, shardingPolicy.GetColumnNames(), "__compute_sharding_hash")) {
+        if (NArrow::NHash::THashConstructor::BuildHashUI64(ResultBatch, shardingPolicy.GetColumnNames(), "__compute_sharding_hash")) {
             ShardedBatch = NArrow::TShardingSplitIndex::Apply(shardingPolicy.GetShardsCount(), ResultBatch, "__compute_sharding_hash");
         } else {
             ShardedBatch = NArrow::TShardedRecordBatch(ResultBatch);

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/ya.make
@@ -15,7 +15,11 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
-    ydb/core/formats/arrow/filter
+    ydb/core/formats/arrow/accessor/plain
+    ydb/core/formats/arrow/hash
+    ydb/core/formats/arrow/program
+    ydb/core/formats/arrow/reader
+    ydb/core/formats/arrow/serializer
     ydb/core/tx/columnshard/blobs_action
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
     ydb/core/tx/conveyor/usage

--- a/ydb/core/tx/columnshard/tools/memory_tests/bin/ya.make
+++ b/ydb/core/tx/columnshard/tools/memory_tests/bin/ya.make
@@ -4,7 +4,8 @@ PEERDIR(
     yql/essentials/public/udf/service/exception_policy
     yql/essentials/parser/pg_wrapper
     yql/essentials/sql/pg
-    ydb/core/formats/arrow
+    ydb/core/formats/arrow/reader
+    ydb/core/formats/arrow/rows
 )
 
 SRCDIR(

--- a/ydb/core/tx/program/ya.make
+++ b/ydb/core/tx/program/ya.make
@@ -10,12 +10,13 @@ SRCS(
 PEERDIR(
     ydb/core/formats/arrow
     ydb/core/formats/arrow/filter
+    ydb/core/formats/arrow/printer
+    ydb/core/formats/arrow/program
     ydb/core/protos
     ydb/library/formats/arrow/protos
     ydb/core/tablet_flat
     yql/essentials/minikql/comp_nodes
     yql/essentials/core/arrow_kernels/registry
-    ydb/core/formats/arrow/program
 )
 
 YQL_LAST_ABI_VERSION()


### PR DESCRIPTION
Proper ydb/core/formats/arrow dependencies, reduce rebuilds.   
Move THashConstructor from permutations.h to hash library.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

