### PR TITLE
Fix region index overflow load tests

### DIFF
--- a/ydb/core/load_test/nbs2_load_actor.cpp
+++ b/ydb/core/load_test/nbs2_load_actor.cpp
@@ -35,6 +35,8 @@
 
 namespace {
 
+constexpr ui64 MaxSupportedBlockCount = 1048576;
+
 void FillLatency(
     const NYdb::NBS::TLatencyHistogram& hist,
     NYdb::NBS::NProto::TLatency& latency)
@@ -104,8 +106,8 @@ public:
         DirectPartitionId.Parse(cmd.GetDirectPartitionId().data(), cmd.GetDirectPartitionId().size());
         google::protobuf::TextFormat::PrintToString(cmd, &ConfigString);
 
-        if (RangeTest.GetStart() >= RangeTest.GetEnd() || RangeTest.GetEnd() > 1048576) {
-            ythrow NKikimr::TLoadActorException() << "Range must be in [0, 1048576]";
+        if (RangeTest.GetStart() >= RangeTest.GetEnd() || RangeTest.GetEnd() >= MaxSupportedBlockCount) {
+            ythrow NKikimr::TLoadActorException() << "Range must be in [0, " << (MaxSupportedBlockCount - 1) << "]";
         }
         if (RangeTest.GetZeroRate() > 0) {
             ythrow NKikimr::TLoadActorException() << "ZeroRate is unsupported";

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -223,7 +223,7 @@ NThreading::TFuture<TReadBlocksLocalResponse> TFastPathService::ReadBlocksLocal(
         ythrow yexception()
             << "Region index out of bound: Regions.size() = " << Regions.size()
             << ", regionIndex = " << regionIndex
-            << ", range = " << request->Headers.Range;
+            << ", range = " << request -> Headers.Range;
     }
 
     auto result = Regions[regionIndex]->ReadBlocksLocal(
@@ -273,7 +273,7 @@ TFastPathService::WriteBlocksLocal(
         ythrow yexception()
             << "Region index out of bound: Regions.size() = " << Regions.size()
             << ", regionIndex = " << regionIndex
-            << ", range = " << request->Headers.Range;
+            << ", range = " << request -> Headers.Range;
     }
 
     auto result = Regions[regionIndex]->WriteBlocksLocal(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -219,12 +219,11 @@ NThreading::TFuture<TReadBlocksLocalResponse> TFastPathService::ReadBlocksLocal(
     const size_t regionIndex =
         GetRegionIndex(*request->Headers.VolumeConfig, request->Headers.Range);
 
-    if (regionIndex >= Regions.size()) {
-        ythrow yexception()
-            << "Region index out of bound: Regions.size() = " << Regions.size()
-            << ", regionIndex = " << regionIndex
-            << ", range = " << request -> Headers.Range;
-    }
+    Y_ABORT_UNLESS(
+        regionIndex < Regions.size(),
+        "Region index out of bound: %" PRISZT " >= %" PRISZT,
+        regionIndex,
+        Regions.size());
 
     auto result = Regions[regionIndex]->ReadBlocksLocal(
         std::move(callContext),
@@ -269,12 +268,11 @@ TFastPathService::WriteBlocksLocal(
     const size_t regionIndex =
         GetRegionIndex(*request->Headers.VolumeConfig, request->Headers.Range);
 
-    if (regionIndex >= Regions.size()) {
-        ythrow yexception()
-            << "Region index out of bound: Regions.size() = " << Regions.size()
-            << ", regionIndex = " << regionIndex
-            << ", range = " << request -> Headers.Range;
-    }
+    Y_ABORT_UNLESS(
+        regionIndex < Regions.size(),
+        "Region index out of bound: %" PRISZT " >= %" PRISZT,
+        regionIndex,
+        Regions.size());
 
     auto result = Regions[regionIndex]->WriteBlocksLocal(
         std::move(callContext),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -218,6 +218,13 @@ NThreading::TFuture<TReadBlocksLocalResponse> TFastPathService::ReadBlocksLocal(
 
     const size_t regionIndex =
         GetRegionIndex(*request->Headers.VolumeConfig, request->Headers.Range);
+
+    if (regionIndex >= Regions.size()) {
+        ythrow yexception() << "Region index out of bound: Regions.size() = "
+                            << Regions.size() << ", regionIndex = " << regionIndex
+                            << ", range = " << request->Headers.Range;
+    }
+
     auto result = Regions[regionIndex]->ReadBlocksLocal(
         std::move(callContext),
         std::move(request),
@@ -260,6 +267,12 @@ TFastPathService::WriteBlocksLocal(
 
     const size_t regionIndex =
         GetRegionIndex(*request->Headers.VolumeConfig, request->Headers.Range);
+
+    if (regionIndex >= Regions.size()) {
+        ythrow yexception() << "Region index out of bound: Regions.size() = "
+                            << Regions.size() << ", regionIndex = " << regionIndex
+                            << ", range = " << request->Headers.Range;
+    }
 
     auto result = Regions[regionIndex]->WriteBlocksLocal(
         std::move(callContext),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -220,9 +220,10 @@ NThreading::TFuture<TReadBlocksLocalResponse> TFastPathService::ReadBlocksLocal(
         GetRegionIndex(*request->Headers.VolumeConfig, request->Headers.Range);
 
     if (regionIndex >= Regions.size()) {
-        ythrow yexception() << "Region index out of bound: Regions.size() = "
-                            << Regions.size() << ", regionIndex = " << regionIndex
-                            << ", range = " << request->Headers.Range;
+        ythrow yexception()
+            << "Region index out of bound: Regions.size() = " << Regions.size()
+            << ", regionIndex = " << regionIndex
+            << ", range = " << request -> Headers.Range;
     }
 
     auto result = Regions[regionIndex]->ReadBlocksLocal(
@@ -269,9 +270,10 @@ TFastPathService::WriteBlocksLocal(
         GetRegionIndex(*request->Headers.VolumeConfig, request->Headers.Range);
 
     if (regionIndex >= Regions.size()) {
-        ythrow yexception() << "Region index out of bound: Regions.size() = "
-                            << Regions.size() << ", regionIndex = " << regionIndex
-                            << ", range = " << request->Headers.Range;
+        ythrow yexception()
+            << "Region index out of bound: Regions.size() = " << Regions.size()
+            << ", regionIndex = " << regionIndex
+            << ", range = " << request -> Headers.Range;
     }
 
     auto result = Regions[regionIndex]->WriteBlocksLocal(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -223,7 +223,7 @@ NThreading::TFuture<TReadBlocksLocalResponse> TFastPathService::ReadBlocksLocal(
         ythrow yexception()
             << "Region index out of bound: Regions.size() = " << Regions.size()
             << ", regionIndex = " << regionIndex
-            << ", range = " << request -> Headers.Range;
+            << ", range = " << request->Headers.Range;
     }
 
     auto result = Regions[regionIndex]->ReadBlocksLocal(
@@ -273,7 +273,7 @@ TFastPathService::WriteBlocksLocal(
         ythrow yexception()
             << "Region index out of bound: Regions.size() = " << Regions.size()
             << ", regionIndex = " << regionIndex
-            << ", range = " << request -> Headers.Range;
+            << ", range = " << request->Headers.Range;
     }
 
     auto result = Regions[regionIndex]->WriteBlocksLocal(

--- a/ydb/tests/functional/nbs/common.py
+++ b/ydb/tests/functional/nbs/common.py
@@ -194,7 +194,7 @@ class NbsTestBase:
         io_depth=32,
         load_type="LOAD_TYPE_RANDOM",
         range_start=0,
-        range_end=DEFAULT_DISK_BLOCKS_COUNT,
+        range_end=DEFAULT_DISK_BLOCKS_COUNT-1,
     ):
         """
         Helper function to run NBS load test with specified parameters

--- a/ydb/tests/functional/nbs/common.py
+++ b/ydb/tests/functional/nbs/common.py
@@ -194,7 +194,7 @@ class NbsTestBase:
         io_depth=32,
         load_type="LOAD_TYPE_RANDOM",
         range_start=0,
-        range_end=DEFAULT_DISK_BLOCKS_COUNT-1,
+        range_end=DEFAULT_DISK_BLOCKS_COUNT - 1,
     ):
         """
         Helper function to run NBS load test with specified parameters


### PR DESCRIPTION
TestRange is inclusive so [0,1048576] is actually 1048576 blocks, which is 1 block larger than the disk

This caused load tests to randomly fail whenever the block 1048576 is selected due to rangeIndex out of bounds in FastPashService

1. Changed TestRange for load tests to [0,1048575]
2. Adjusted range validation boundaries in load actor
3. Added exceptions in FastPathService for such overflow case