### PR TITLE
Remove costly methods from universal spans

### DIFF
--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -221,9 +221,12 @@ void TBlobStorageQueue::SendToVDisk(const TActorContext& ctx, const TActorId& re
         ++*QueueItemsSent;
 
         // send item
-        item.Span && item.Span.Event("SendToVDisk", {
-            {"VDiskOrderNumber", vdiskOrderNumber}
-        });
+
+        if (NWilson::TSpan* wilsonSpan = item.Span.GetWilsonSpanPtr()) {
+            wilsonSpan->Event("SendToVDisk", {
+                {"VDiskOrderNumber", vdiskOrderNumber}
+            });
+        }
         item.Event.SendToVDisk(ctx, remoteVDisk, item.QueueCookie, item.MsgId, item.SequenceId, sendMeCostSettings,
             item.Span.GetTraceId(), ClientId, item.ProcessingTimer);
 
@@ -241,10 +244,12 @@ void TBlobStorageQueue::ReplyWithError(TItem& item, NKikimrProto::EReplyStatus s
         << " cookie# " << item.Event.GetCookie()
         << " processingTime# " << processingTime);
 
-    if (item.Span) {
-        item.Span.EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(status) << ": " << errorReason);
-        item.Span.Reset();
+    if (NWilson::TSpan* wilsonSpan = item.Span.GetWilsonSpanPtr()) {
+        wilsonSpan->EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(status) << ": " << errorReason);
+    } else if (TNamedSpan* retroSpan = item.Span.GetRetroSpanPtr()) {
+        retroSpan->EndError();
     }
+    item.Span.Reset();
 
     ctx.Send(item.Event.GetSender(), item.Event.MakeErrorReply(status, errorReason, QueueDeserializedItems,
             QueueDeserializedBytes), 0, item.Event.GetCookie());
@@ -357,7 +362,11 @@ void TBlobStorageQueue::OnConnect() {
 
 TBlobStorageQueue::TItemList::iterator TBlobStorageQueue::EraseItem(TItemList& queue, TItemList::iterator it) {
     SetItemQueue(*it, EItemQueue::NotSet);
-    it->Span.EndError("EraseItem called");
+    if (NWilson::TSpan* wilsonSpan = it->Span.GetWilsonSpanPtr()) {
+        wilsonSpan->EndError("Erase item called");
+    } else if (TNamedSpan* retroSpan = it->Span.GetRetroSpanPtr()) {
+        retroSpan->EndError();
+    }
     TItemList::iterator nextIter = std::next(it);
     if (Queues.Unused.size() < MaxUnusedItems) {
         Queues.Unused.splice(Queues.Unused.end(), queue, it);

--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -66,10 +66,9 @@ class TBlobStorageQueue {
             , DirtyCost(true)
             , ProcessingTimer(useActorSystemTime)
         {
-            if (Span) {
-                Span
-                    .Attribute("event", TypeName<TEvent>())
-                    .Attribute("local", local);
+            if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                wilsonSpan->Attribute("event", TypeName<TEvent>());
+                wilsonSpan->Attribute("local", local);
             }
         }
 

--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -56,7 +56,8 @@ class TBlobStorageQueue {
                 bool local, bool useActorSystemTime)
             : Queue(EItemQueue::NotSet)
             , CostEssence(*event->Get())
-            , Span(TWilson::VDiskTopLevel, std::move(event->TraceId), "Backpressure.InFlight")
+            , Span(TWilson::VDiskTopLevel, std::move(event->TraceId), "Backpressure.InFlight",
+                    NWilson::EFlags::AUTO_END)
             , Event(event, serItems, serBytes, bspctx, interconnectChannel, local)
             , MsgId(Max<ui64>())
             , SequenceId(0)

--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -56,8 +56,7 @@ class TBlobStorageQueue {
                 bool local, bool useActorSystemTime)
             : Queue(EItemQueue::NotSet)
             , CostEssence(*event->Get())
-            , Span(TWilson::VDiskTopLevel, std::move(event->TraceId), "Backpressure.InFlight",
-                    NWilson::EFlags::AUTO_END)
+            , Span(TWilson::VDiskTopLevel, std::move(event->TraceId), "Backpressure.InFlight")
             , Event(event, serItems, serBytes, bspctx, interconnectChannel, local)
             , MsgId(Max<ui64>())
             , SequenceId(0)

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -233,7 +233,7 @@ public:
         if (ParentSpan) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = NWilson::TSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(parentTraceId.GetVerbosity(),
-                parentTraceId.GetTimeToLive()), ParentSpan.GetName());
+                    parentTraceId.GetTimeToLive()), params.TypeSpecific.Name);
             ParentSpan.GetWilsonSpanPtr()->Link(Span.GetTraceId());
             Span.GetWilsonSpanPtr()->Attribute("GroupId", Info->GroupID.GetRawId());
             Span.GetWilsonSpanPtr()->Attribute("RestartCounter", RestartCounter);

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -230,16 +230,20 @@ public:
         , ForceGroupGeneration(params.Common.ForceGroupGeneration)
         , DoSendDeathNote(params.Common.DoSendDeathNote)
     {
-        if (ParentSpan) {
+        if (NWilson::TSpan* parentWilsonSpan = ParentSpan.GetWilsonSpanPtr()) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = NWilson::TSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(parentTraceId.GetVerbosity(),
                     parentTraceId.GetTimeToLive()), params.TypeSpecific.Name);
-            ParentSpan.GetWilsonSpanPtr()->Link(Span.GetTraceId());
-            Span.GetWilsonSpanPtr()->Attribute("GroupId", Info->GroupID.GetRawId());
-            Span.GetWilsonSpanPtr()->Attribute("RestartCounter", RestartCounter);
-            Span.GetWilsonSpanPtr()->Attribute("database", AppData()->TenantName);
-            Span.GetWilsonSpanPtr()->Attribute("storagePool", Info->GetStoragePoolName());
-            params.Common.Event->ToSpan(*Span.GetWilsonSpanPtr());
+            parentWilsonSpan->Link(Span.GetTraceId());
+
+            // if for extra safety
+            if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                wilsonSpan->Attribute("GroupId", Info->GroupID.GetRawId());
+                wilsonSpan->Attribute("RestartCounter", RestartCounter);
+                wilsonSpan->Attribute("database", AppData()->TenantName);
+                wilsonSpan->Attribute("storagePool", Info->GetStoragePoolName());
+                params.Common.Event->ToSpan(*wilsonSpan);
+            }
         } else if (ParentSpan.GetRetroSpanPtr()) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage,

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -243,10 +243,10 @@ public:
         } else if (ParentSpan.GetRetroSpanPtr()) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage,
-                    parentTraceId.GetTimeToLive(), true), "DSProxy.RTX", NWilson::EFlags::AUTO_END);
+                    parentTraceId.GetTimeToLive(), true), "DSProxy.Retro", NWilson::EFlags::AUTO_END);
         } else {
-            Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
-                    "DSProxy.RTX");
+            // Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
+            //         "DSProxy.Retro");
         }
 
         Y_ABORT_UNLESS(CostModel);

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -243,10 +243,10 @@ public:
         } else if (ParentSpan.GetRetroSpanPtr()) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage,
-                    parentTraceId.GetTimeToLive(), true), "DSProxy.RTX");
+                    parentTraceId.GetTimeToLive(), true), "DSProxy.RTX", NWilson::EFlags::AUTO_END);
         } else {
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
-                                  "DSProxy.RTX");
+                                  "DSProxy.RTX", NWilson::EFlags::AUTO_END);
         }
 
         Y_ABORT_UNLESS(CostModel);

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -245,8 +245,8 @@ public:
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage,
                     parentTraceId.GetTimeToLive(), true), "DSProxy.RTX");
         } else {
-            // Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
-            //         "DSProxy.RTX");
+            Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
+                                  "DSProxy.RTX");
         }
 
         Y_ABORT_UNLESS(CostModel);

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -243,7 +243,7 @@ public:
         } else if (ParentSpan.GetRetroSpanPtr()) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage,
-                    parentTraceId.GetTimeToLive(), true), "DSProxy.Retro", NWilson::EFlags::AUTO_END);
+                    parentTraceId.GetTimeToLive(), true), "DSProxy.Retro");
         } else {
             // Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
             //         "DSProxy.Retro");

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -246,7 +246,7 @@ public:
                     parentTraceId.GetTimeToLive(), true), "DSProxy.RTX", NWilson::EFlags::AUTO_END);
         } else {
             Span = TLazyRetroSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(TWilson::BlobStorage, Max<ui32>(), true),
-                                  "DSProxy.RTX", NWilson::EFlags::AUTO_END);
+                    "DSProxy.RTX");
         }
 
         Y_ABORT_UNLESS(CostModel);

--- a/ydb/core/blobstorage/dsproxy/dsproxy.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy.h
@@ -234,11 +234,11 @@ public:
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();
             Span = NWilson::TSpan(TWilson::BlobStorage, NWilson::TTraceId::NewTraceId(parentTraceId.GetVerbosity(),
                 parentTraceId.GetTimeToLive()), ParentSpan.GetName());
-            ParentSpan.Link(Span.GetTraceId());
-            Span.Attribute("GroupId", Info->GroupID.GetRawId());
-            Span.Attribute("RestartCounter", RestartCounter);
-            Span.Attribute("database", AppData()->TenantName);
-            Span.Attribute("storagePool", Info->GetStoragePoolName());
+            ParentSpan.GetWilsonSpanPtr()->Link(Span.GetTraceId());
+            Span.GetWilsonSpanPtr()->Attribute("GroupId", Info->GroupID.GetRawId());
+            Span.GetWilsonSpanPtr()->Attribute("RestartCounter", RestartCounter);
+            Span.GetWilsonSpanPtr()->Attribute("database", AppData()->TenantName);
+            Span.GetWilsonSpanPtr()->Attribute("storagePool", Info->GetStoragePoolName());
             params.Common.Event->ToSpan(*Span.GetWilsonSpanPtr());
         } else if (ParentSpan.GetRetroSpanPtr()) {
             const NWilson::TTraceId& parentTraceId = ParentSpan.GetTraceId();

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -9,6 +9,8 @@
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/util/stlog.h>
 
+#include <ydb/library/actors/retro_tracing/retro_collector.h>
+
 #include <util/generic/ymath.h>
 #include <util/system/datetime.h>
 #include <util/system/hp_timer.h>
@@ -493,6 +495,9 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
             PassAway();
             Done = true;
             return true;
+        }
+        if (RandomNumber<ui32>(1000) == 1) {
+            NRetroTracing::DemandTrace(Span.GetTraceId());
         }
         return false;
     }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -473,6 +473,7 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         }
 
         if ((TActivationContext::Monotonic() - RequestStartTime >= LongRequestThreshold) && PopAllowToken(HandleClass)) {
+            // NRetroTracing::DemandTrace(Span.GetTraceId());
             STLOG(PRI_WARN, BS_PROXY_PUT, BPP71, "Long TEvPut request detected",
                     (LongRequestThreshold, LongRequestThreshold),
                     (GroupId, Info->GroupID),
@@ -492,9 +493,6 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         }
 
         if (ResponsesSent == PutImpl.Blobs.size()) {
-            if (RandomNumber<ui32>(1000) == 0) {
-                NRetroTracing::DemandTrace(Span.GetTraceId());
-            }
             PassAway();
             Done = true;
             return true;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -497,9 +497,6 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
             Done = true;
             return true;
         }
-        if (RandomNumber<ui32>(1000) == 1) {
-            NRetroTracing::DemandTrace(Span.GetTraceId());
-        }
         return false;
     }
 

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -9,7 +9,7 @@
 #include <ydb/core/blobstorage/lwtrace_probes/blobstorage_probes.h>
 #include <ydb/core/util/stlog.h>
 
-#include <ydb/library/actors/retro_tracing/retro_collector.h>
+#include <ydb/library/actors/retro_tracing/collector/retro_collector.h>
 
 #include <util/generic/ymath.h>
 #include <util/system/datetime.h>
@@ -492,6 +492,9 @@ class TBlobStorageGroupPutRequest : public TBlobStorageGroupRequestActor {
         }
 
         if (ResponsesSent == PutImpl.Blobs.size()) {
+            if (RandomNumber<ui32>(1000) == 0) {
+                NRetroTracing::DemandTrace(Span.GetTraceId());
+            }
             PassAway();
             Done = true;
             return true;

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -1014,7 +1014,7 @@ namespace NKikimr {
                 }
 
                 if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
-                    wilsonSpan->EndError(errorReason);
+                    wilsonSpan->EndError(std::move(errorReason));
                 } else if (TNamedSpan* retroSpan = Span.GetRetroSpanPtr()) {
                     retroSpan->EndError();
                 }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -1007,8 +1007,17 @@ namespace NKikimr {
                 ParentSpan.EndOk();
                 Span.EndOk();
             } else {
-                ParentSpan.EndError(errorReason);
-                Span.EndError(std::move(errorReason));
+                if (NWilson::TSpan* wilsonSpan = ParentSpan.GetWilsonSpanPtr()) {
+                    wilsonSpan->EndError(errorReason);
+                } else if (TNamedSpan* retroSpan = ParentSpan.GetRetroSpanPtr()) {
+                    retroSpan->EndError();
+                }
+
+                if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                    wilsonSpan->EndError(errorReason);
+                } else if (TNamedSpan* retroSpan = Span.GetRetroSpanPtr()) {
+                    retroSpan->EndError();
+                }
             }
         }
 

--- a/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
+++ b/ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.cpp
@@ -211,7 +211,9 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             LOG_DEBUG(ctx, BS_HULLHUGE, VDISKP(HugeKeeperCtx->VCtx->VDiskLogPrefix,
                 "Writer: bootstrap: id# %s storedBlobSize# %u writtenSize# %u blobId# %s wId# %" PRIu64,
                 HugeSlot.ToString().data(), storedBlobSize, writtenSize, Item->LogoBlobId.ToString().data(), WriteId));
-            Span && Span.Event("Send_TEvChunkWrite", {{"ChunkId", chunkId}, {"Offset", offset}, {"WrittenSize", writtenSize}});
+            if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                wilsonSpan->Event("Send_TEvChunkWrite", {{"ChunkId", chunkId}, {"Offset", offset}, {"WrittenSize", writtenSize}});
+            }
             auto ev = std::make_unique<NPDisk::TEvChunkWrite>(HugeKeeperCtx->PDiskCtx->Dsk->Owner,
                         HugeKeeperCtx->PDiskCtx->Dsk->OwnerRound, chunkId, offset,
                         partsPtr, Cookie, true, GetWritePriority(), false);
@@ -231,7 +233,11 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             if (ev->Get()->Status == NKikimrProto::OK) {
                 Span.EndOk();
             } else {
-                Span.EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(ev->Get()->Status));
+                if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                    wilsonSpan->EndError(TStringBuilder() << NKikimrProto::EReplyStatus_Name(ev->Get()->Status));
+                } else if (TNamedSpan* retroSpan = Span.GetRetroSpanPtr()) {
+                    retroSpan->EndError();
+                }
             }
             CHECK_PDISK_RESPONSE(HugeKeeperCtx->VCtx, ev, ctx);
             ctx.Send(NotifyID, new TEvHullHugeWritten(HugeSlot));
@@ -277,8 +283,8 @@ LWTRACE_USING(BLOBSTORAGE_PROVIDER);
             , DiskAddr()
             , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.HugeBlobKeeper.Write")
         {
-            if (Span) {
-                Span.Attribute("blob_id", Item->LogoBlobId.ToString());
+            if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                wilsonSpan->Attribute("blob_id", Item->LogoBlobId.ToString());
             }
         }
     };

--- a/ydb/core/blobstorage/vdisk/query/query_base.h
+++ b/ydb/core/blobstorage/vdisk/query/query_base.h
@@ -48,8 +48,8 @@ namespace NKikimr {
             , ReplSchedulerId(replSchedulerId)
             , Span(TWilson::VDiskTopLevel, std::move(BatcherCtx->OrigEv->TraceId), name, NWilson::EFlags::AUTO_END)
         {
-            if (Span) {
-                Span.Attribute("event", TEvBlobStorage::TEvVGet::ToString(BatcherCtx->OrigEv->Get()->Record));
+            if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                wilsonSpan->Attribute("event", TEvBlobStorage::TEvVGet::ToString(BatcherCtx->OrigEv->Get()->Record));
             }
             Y_VERIFY_DEBUG_S(Result, QueryCtx->HullCtx->VCtx->VDiskLogPrefix);
         }
@@ -102,7 +102,11 @@ namespace NKikimr {
                             ResultSize.GetSize(), BatcherCtx->OrigEv->Get()->ToString().data());
                 LOG_CRIT(ctx, NKikimrServices::BS_VDISK_GET, msg);
 
-                Span.EndError(std::move(msg));
+                if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                    wilsonSpan->EndError(std::move(msg));
+                } else if (TNamedSpan* retroSpan = Span.GetRetroSpanPtr()) {
+                    retroSpan->EndError();
+                }
             } else {
                 ui64 total = 0;
                 for (const auto& result : Result->Record.GetResult()) {

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -767,6 +767,7 @@ namespace NKikimr {
         }
 
         void PrivateHandle(TEvBlobStorage::TEvVPut::TPtr &ev, const TActorContext &ctx) {
+            Cerr << "DEBUG PrivateHandle# " << ev->TraceId.GetHexTraceId() << Endl;
             IFaceMonGroup->PutMsgs()++;
             IFaceMonGroup->PutTotalBytes() += ev->GetSize();
             TInstant now = TAppData::TimeProvider->Now();

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -767,7 +767,6 @@ namespace NKikimr {
         }
 
         void PrivateHandle(TEvBlobStorage::TEvVPut::TPtr &ev, const TActorContext &ctx) {
-            Cerr << "DEBUG PrivateHandle# " << ev->TraceId.GetHexTraceId() << Endl;
             IFaceMonGroup->PutMsgs()++;
             IFaceMonGroup->PutTotalBytes() += ev->GetSize();
             TInstant now = TAppData::TimeProvider->Now();

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -128,7 +128,9 @@ namespace NKikimr {
                 , Trace(std::move(trace))
                 , InternalMessageId(internalMessageId)
             {
-                Span.Attribute("QueueName", std::move(name));
+                if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+                    wilsonSpan->Attribute("QueueName", std::move(name));
+                }
                 Ev->TraceId = Span.GetTraceId();
             }
         };

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeletonfront.cpp
@@ -19,6 +19,7 @@
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/backpressure/queue_backpressure_server.h>
 
+#include <ydb/core/retro_tracing_impl/spans/lazy_retro_span.h>
 #include <ydb/core/util/light.h>
 #include <ydb/core/util/max_tracker.h>
 #include <ydb/core/util/queue_inplace.h>
@@ -106,7 +107,7 @@ namespace NKikimr {
             NKikimrBlobStorage::EVDiskQueueId ExtQueueId;
             NBackpressure::TQueueClientId ClientId;
             TActorId ActorId;
-            NWilson::TSpan Span;
+            TLazyRetroSpan Span;
             std::shared_ptr<TVDiskSkeletonTrace> Trace;
             ui64 InternalMessageId;
 

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_loggedrec.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_loggedrec.cpp
@@ -44,12 +44,12 @@ namespace NKikimr {
         , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.Put")
         , HandleClass(handleClass)
     {
-        if (Span) {
-            Span.Attribute("blob_id", id.ToString());
-            Span.Attribute("group_id", vctx->GroupId.GetRawId());
-            Span.Attribute("vdisk_id", vdiskId.ToString());
-            Span.Attribute("storage_pool", config->BaseInfo.StoragePoolName);
-            Span.Attribute("handle_class", NKikimrBlobStorage::EPutHandleClass_Name(handleClass));
+        if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+            wilsonSpan->Attribute("blob_id", id.ToString());
+            wilsonSpan->Attribute("group_id", vctx->GroupId.GetRawId());
+            wilsonSpan->Attribute("vdisk_id", vdiskId.ToString());
+            wilsonSpan->Attribute("storage_pool", config->BaseInfo.StoragePoolName);
+            wilsonSpan->Attribute("handle_class", NKikimrBlobStorage::EPutHandleClass_Name(handleClass));
         }
     }
 
@@ -99,12 +99,12 @@ namespace NKikimr {
         , RecipientCookie(recipientCookie)
         , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.MultiPutItem")
     {
-        if (Span) {
-            Span.Attribute("blob_id", Id.ToString());
-            Span.Attribute("group_id", vctx->GroupId.GetRawId());
-            Span.Attribute("vdisk_id", vdiskId.ToString());
-            Span.Attribute("storage_pool", config->BaseInfo.StoragePoolName);
-            Span.Attribute("handle_class", NKikimrBlobStorage::EPutHandleClass_Name(handleClass));
+        if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+            wilsonSpan->Attribute("blob_id", Id.ToString());
+            wilsonSpan->Attribute("group_id", vctx->GroupId.GetRawId());
+            wilsonSpan->Attribute("vdisk_id", vdiskId.ToString());
+            wilsonSpan->Attribute("storage_pool", config->BaseInfo.StoragePoolName);
+            wilsonSpan->Attribute("handle_class", NKikimrBlobStorage::EPutHandleClass_Name(handleClass));
         }
     }
 
@@ -142,12 +142,12 @@ namespace NKikimr {
         , Ev(ev)
         , Span(TWilson::VDiskInternals, std::move(Ev->TraceId), "VDisk.Log.PutHuge")
     {
-        if (Span) {
-            Span.Attribute("blob_id", Ev->Get()->LogoBlobID.ToString());
-            Span.Attribute("group_id", vctx->GroupId.GetRawId());
-            Span.Attribute("vdisk_id", vdiskId.ToString());
-            Span.Attribute("storage_pool", config->BaseInfo.StoragePoolName);
-            Span.Attribute("handle_class", NKikimrBlobStorage::EPutHandleClass_Name(
+        if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
+            wilsonSpan->Attribute("blob_id", Ev->Get()->LogoBlobID.ToString());
+            wilsonSpan->Attribute("group_id", vctx->GroupId.GetRawId());
+            wilsonSpan->Attribute("vdisk_id", vdiskId.ToString());
+            wilsonSpan->Attribute("storage_pool", config->BaseInfo.StoragePoolName);
+            wilsonSpan->Attribute("handle_class", NKikimrBlobStorage::EPutHandleClass_Name(
                     Ev->Get()->HandleClass));
         }
     }

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_loggedrec.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_loggedrec.cpp
@@ -41,7 +41,7 @@ namespace NKikimr {
         , Result(std::move(result))
         , Recipient(recipient)
         , RecipientCookie(recipientCookie)
-        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.Put", NWilson::EFlags::AUTO_END)
+        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.Put")
         , HandleClass(handleClass)
     {
         if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
@@ -97,7 +97,7 @@ namespace NKikimr {
         , Result(std::move(result))
         , Recipient(recipient)
         , RecipientCookie(recipientCookie)
-        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.MultiPutItem", NWilson::EFlags::AUTO_END)
+        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.MultiPutItem")
     {
         if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
             wilsonSpan->Attribute("blob_id", Id.ToString());

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_loggedrec.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_loggedrec.cpp
@@ -41,7 +41,7 @@ namespace NKikimr {
         , Result(std::move(result))
         , Recipient(recipient)
         , RecipientCookie(recipientCookie)
-        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.Put")
+        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.Put", NWilson::EFlags::AUTO_END)
         , HandleClass(handleClass)
     {
         if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
@@ -97,7 +97,7 @@ namespace NKikimr {
         , Result(std::move(result))
         , Recipient(recipient)
         , RecipientCookie(recipientCookie)
-        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.MultiPutItem")
+        , Span(TWilson::VDiskInternals, std::move(traceId), "VDisk.Log.MultiPutItem", NWilson::EFlags::AUTO_END)
     {
         if (NWilson::TSpan* wilsonSpan = Span.GetWilsonSpanPtr()) {
             wilsonSpan->Attribute("blob_id", Id.ToString());

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_overload_handler.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_overload_handler.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/blobstorage/vdisk/hulldb/base/blobstorage_hullsatisfactionrank.h>
 #include <ydb/core/blobstorage/vdisk/hullop/blobstorage_hull.h>
 #include <ydb/core/control/lib/immediate_control_board_impl.h>
+#include <ydb/core/retro_tracing_impl/spans/lazy_retro_span.h>
 #include <ydb/core/util/queue_inplace.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
@@ -16,7 +17,7 @@ namespace NKikimr {
         struct TItem {
             std::unique_ptr<IEventHandle> Ev;
             ui64 Size = 0;
-            NWilson::TSpan Span;
+            TLazyRetroSpan Span;
 
             TItem() = default;
 

--- a/ydb/core/retro_tracing_impl/spans/universal_span_wilson_api.h
+++ b/ydb/core/retro_tracing_impl/spans/universal_span_wilson_api.h
@@ -82,71 +82,26 @@ public:
         return res;
     }
 
-    template <typename T>
-    TUniversalSpanWilsonApi& Name(T&& name) {
+    TUniversalSpanWilsonApi& Name(const char* name) {
         if constexpr (std::is_same_v<TRetroSpanType, TNamedSpan>) {
             std::visit(TOverloaded{
                 [&](NWilson::TSpan& span) -> void {
-                    span.Name(std::forward<T>(name));
+                    span.Name(name);
                 },
                 [&](TRetroSpanType& span) -> void {
-                    span.SetName(std::forward<T>(name));
+                    span.SetName(name);
                 },
                 [&](const std::monostate&) -> void {},
             }, this->Span);
         } else {
             std::visit(TOverloaded{
                 [&](NWilson::TSpan& span) -> void {
-                    span.Name(std::forward<T>(name));
+                    span.Name(name);
                 },
                 [&](const TRetroSpanType&) -> void {},
                 [&](const std::monostate&) -> void {},
             }, this->Span);
         }
-        return *this;
-    }
-
-    template<typename T, typename T1>
-    TUniversalSpanWilsonApi& Attribute(T&& name, T1&& value) {
-        std::visit(TOverloaded{
-            [&](NWilson::TSpan& span) -> void {
-                span.Attribute(std::forward<T>(name), std::forward<T1>(value));
-            },
-            [&](const TRetroSpanType&) -> void {},
-            [&](const std::monostate&) -> void {},
-        }, this->Span);
-        return *this;
-    }
-
-    template<typename T, typename T1 =
-            std::initializer_list<std::pair<const char*, NWilson::TAttributeValue>>>
-    TUniversalSpanWilsonApi& Event(T&& name, T1&& attributes) {
-        std::visit(TOverloaded{
-            [&](NWilson::TSpan& span) -> void {
-                span.Event(std::forward<T>(name), std::forward<T1>(attributes));
-            },
-            [&](const TRetroSpanType&) -> void {},
-            [&](const std::monostate&) -> void {},
-        }, this->Span);
-        return *this;
-    }
-
-    TUniversalSpanWilsonApi& Link(const NWilson::TTraceId& traceId) {
-        std::visit(TOverloaded{
-            [&](NWilson::TSpan& span) -> void { span.Link(traceId); },
-            [&](const TRetroSpanType&) -> void {},
-            [&](const std::monostate&) -> void {},
-        }, this->Span);
-        return *this;
-    }
-
-    template<typename T = std::initializer_list<std::pair<TString, NWilson::TAttributeValue>>>
-    TUniversalSpanWilsonApi& Link(const NWilson::TTraceId& traceId, T&& attributes) {
-        std::visit(TOverloaded{
-            [&](NWilson::TSpan& span) -> void { span.Link(traceId, std::forward<T>(attributes)); },
-            [&](const TRetroSpanType&) -> void {},
-            [&](const std::monostate&) -> void {},
-        }, this->Span);
         return *this;
     }
 };

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -89,7 +89,7 @@ namespace NActors {
             TEventHolder& event = pool.Allocate(Queue);
             const ui32 bytes = event.Fill(ev, now) + sizeof(TEventDescr2);
             OutputQueueSize += bytes;
-            event.Span = NWilson::TSpan(15 /*max verbosity*/, NWilson::TTraceId(ev.TraceId), "Interconnect.Queue");
+            event.Span = NActors::TPacketSpan::TUniversal(15 /*max verbosity*/, NWilson::TTraceId(ev.TraceId), "Interconnect.Queue");
             if (NWilson::TSpan* wilsonSpan = event.Span.GetWilsonSpanPtr()) {
                 wilsonSpan->Attribute("OutputQueueItems", static_cast<i64>(Queue.size()));
                 wilsonSpan->Attribute("OutputQueueSize", static_cast<i64>(OutputQueueSize));

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -266,7 +266,7 @@ namespace NActors {
             auto& d = DelayedEvents.emplace_back();
             d.Event = std::move(ev);
             if (Y_UNLIKELY(d.Event->TraceId)) {
-                d.Span = NWilson::TSpan(15 /*max verbosity*/, std::move(d.Event->TraceId), "Interconnect.Delay");
+                d.Span = NActors::TDelayedEventSpan::TUniversal(15 /*max verbosity*/, std::move(d.Event->TraceId), "Interconnect.Delay");
                 // Reparent event to the delay span
                 d.Event->TraceId = d.Span.GetTraceId();
             }

--- a/ydb/library/actors/retro_tracing/collector/retro_collector.cpp
+++ b/ydb/library/actors/retro_tracing/collector/retro_collector.cpp
@@ -50,6 +50,10 @@ NActors::IActor* CreateRetroCollector() {
 }
 
 void DemandTrace(const NWilson::TTraceId& traceId) {
+    if (!traceId.IsRetroTrace()) {
+        return;
+    }
+
     NActors::TActivationContext::Send(std::make_unique<NActors::IEventHandle>(
             MakeRetroCollectorId(), NActors::TActorId{},
             new TEvCollectRetroTrace(traceId)));

--- a/ydb/library/actors/retro_tracing/span/universal_span.h
+++ b/ydb/library/actors/retro_tracing/span/universal_span.h
@@ -137,10 +137,9 @@ public:
         }, Span);
     }
 
-    template<typename T>
-    void EndError(T&& error) {
+    void EndError(const char* error) {
         std::visit(TOverloaded{
-            [&](NWilson::TSpan& span) -> void { span.EndError(std::move(error)); },
+            [&](NWilson::TSpan& span) -> void { span.EndError(error); },
             [&](TRetroSpanType& span) -> void { span.EndError(); },
             [&](const std::monostate&) -> void {},
         }, Span);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Remove costly methods from UniversalSpan class (e.g. string allocations).

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)