### PR TITLE
Use YDBOT_TOKEN in ydbdoc workflows to trigger CI on translation PRs

### DIFF
--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -16,7 +16,8 @@ permissions:
 jobs:
   ydbdoc-review:
     if: |
-      github.event.label.name == 'doc_translate' 
+      github.event.label.name == 'doc_translate'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     concurrency:
       group: ydbdoc-review-${{ github.event.pull_request.number }}

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -46,14 +46,17 @@ jobs:
           YDBDOC_REVIEW_ENABLED: ${{ vars.YDBDOC_REVIEW_ENABLED }}
           YDBDOC_MODEL_CHECK: ${{ vars.YDBDOC_MODEL_CHECK }}
           YDBDOC_MODEL_TRANSLATE: ${{ vars.YDBDOC_MODEL_TRANSLATE }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # YDBOT_TOKEN (not GITHUB_TOKEN) so translation PR creation and labels
+          # trigger downstream workflows (PR-check, docs rebuild), same as backport.
+          GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
+          GITHUB_PUSH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
 
       - name: Trigger docs rebuild for translation PR
         if: ${{ !cancelled() }}
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -11,13 +11,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write 
+  issues: write
 
 jobs:
   ydbdoc-review:
-    if: |
-      github.event.label.name == 'doc_translate'
-      && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.label.name == 'doc_translate'
     runs-on: ubuntu-latest
     concurrency:
       group: ydbdoc-review-${{ github.event.pull_request.number }}
@@ -47,15 +45,19 @@ jobs:
           YDBDOC_REVIEW_ENABLED: ${{ vars.YDBDOC_REVIEW_ENABLED }}
           YDBDOC_MODEL_CHECK: ${{ vars.YDBDOC_MODEL_CHECK }}
           YDBDOC_MODEL_TRANSLATE: ${{ vars.YDBDOC_MODEL_TRANSLATE }}
-          # YDBOT_TOKEN (not GITHUB_TOKEN) so translation PR creation and labels
-          # trigger downstream workflows (PR-check, docs rebuild), same as backport.
-          GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
 
-      - name: Trigger docs rebuild for translation PR
-        if: ${{ !cancelled() }}
+  trigger-translation-ci:
+    needs: ydbdoc-review
+    if: ${{ !cancelled() && needs.ydbdoc-review.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger PR-check and docs rebuild on translation PR
         uses: actions/github-script@v8
         with:
+          # PAT only here (no checkout): cascades into PR-check/docs rebuild without
+          # exposing YDBOT_TOKEN next to untrusted fork PR code.
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
             const owner = context.repo.owner;
@@ -64,7 +66,6 @@ jobs:
             const head = `${owner}:ydbdoc-review/pr-${sourcePr}`;
             let translationPr = null;
 
-            // Translation PR creation can lag a bit right after doc_translate push.
             for (let attempt = 1; attempt <= 6; attempt++) {
               const { data: pulls } = await github.rest.pulls.list({
                 owner,
@@ -86,14 +87,19 @@ jobs:
             }
 
             if (!translationPr) {
-              core.warning(`Open translation PR not found for head ${head}. rebuild_docs was not added; rebuild can be triggered manually.`);
+              core.warning(
+                `Open translation PR not found for head ${head}. Labels were not added; CI can be triggered manually.`
+              );
               return;
             }
+
             await github.rest.issues.addLabels({
               owner,
               repo,
               issue_number: translationPr.number,
-              labels: ['rebuild_docs'],
+              labels: ['rebuild_docs', 'ok-to-test'],
             });
 
-            core.info(`Added rebuild_docs to PR #${translationPr.number}`);
+            core.info(
+              `Added rebuild_docs and ok-to-test to translation PR #${translationPr.number}`
+            );

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -49,7 +49,6 @@ jobs:
           # YDBOT_TOKEN (not GITHUB_TOKEN) so translation PR creation and labels
           # trigger downstream workflows (PR-check, docs rebuild), same as backport.
           GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
-          GITHUB_PUSH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
 
       - name: Trigger docs rebuild for translation PR

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -43,5 +43,7 @@ jobs:
           YANDEX_CLOUD_FOLDER_DOC_REVIEW: ${{ secrets.YANDEX_CLOUD_FOLDER_DOC_REVIEW }}
           YANDEX_CLOUD_API_KEY_DOC_REVIEW: ${{ secrets.YANDEX_CLOUD_API_KEY_DOC_REVIEW }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # YDBOT_TOKEN so verify repair commits trigger PR-check on synchronize.
+          GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
+          GITHUB_PUSH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
         

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -45,5 +45,4 @@ jobs:
           YDBDOC_REPO_PATH: ${{ github.workspace }}
           # YDBOT_TOKEN so verify repair commits trigger PR-check on synchronize.
           GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
-          GITHUB_PUSH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
-        
+

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -49,7 +49,7 @@ jobs:
     if: ${{ !cancelled() && needs.ydbdoc-verify.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger PR-check on translation PR
+      - name: Trigger PR-check and docs rebuild on translation PR
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
@@ -59,6 +59,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              labels: ['ok-to-test'],
+              labels: ['ok-to-test', 'rebuild_docs'],
             });
-            core.info(`Added ok-to-test to translation PR #${prNumber}`);
+            core.info(
+              `Added ok-to-test and rebuild_docs to translation PR #${prNumber}`
+            );

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -1,4 +1,5 @@
-# doc_verify на translation PR (same-repo only; fork PRs skip PAT-backed steps).
+# doc_verify на translation PR (ветка в upstream или в fork).
+# QA = тот же пайплайн, что после doc_translate (@v0.1.0).
 
 name: ydbdoc-review (doc_verify label)
 
@@ -14,9 +15,7 @@ permissions:
 
 jobs:
   ydbdoc-verify:
-    if: |
-      github.event.label.name == 'doc_verify'
-      && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.label.name == 'doc_verify'
     runs-on: ubuntu-latest
     concurrency:
       group: ydbdoc-verify-${{ github.event.pull_request.number }}
@@ -43,6 +42,23 @@ jobs:
           YANDEX_CLOUD_FOLDER_DOC_REVIEW: ${{ secrets.YANDEX_CLOUD_FOLDER_DOC_REVIEW }}
           YANDEX_CLOUD_API_KEY_DOC_REVIEW: ${{ secrets.YANDEX_CLOUD_API_KEY_DOC_REVIEW }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
-          # YDBOT_TOKEN so verify repair commits trigger PR-check on synchronize.
-          GITHUB_TOKEN: ${{ secrets.YDBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  trigger-verify-ci:
+    needs: ydbdoc-verify
+    if: ${{ !cancelled() && needs.ydbdoc-verify.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger PR-check on translation PR
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.YDBOT_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['ok-to-test'],
+            });
+            core.info(`Added ok-to-test to translation PR #${prNumber}`);

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -1,6 +1,4 @@
-# doc_verify на translation PR (ветка в upstream или в fork).
-# QA = тот же пайплайн, что после doc_translate (@v0.1.0).
-# Repair-коммит в head-ветку PR (после фикса push URL в action).
+# doc_verify на translation PR (same-repo only; fork PRs skip PAT-backed steps).
 
 name: ydbdoc-review (doc_verify label)
 
@@ -16,7 +14,9 @@ permissions:
 
 jobs:
   ydbdoc-verify:
-    if: github.event.label.name == 'doc_verify'
+    if: |
+      github.event.label.name == 'doc_verify'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     concurrency:
       group: ydbdoc-verify-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Проблема

После `doc_translate` появляется translation PR, но на нём **не стартуют PR-check и сборка доки** (#43034).

Причина: translation PR и лейблы создавались через **`GITHUB_TOKEN`**. GitHub **не запускает другие workflows** от действий такого токена. Плюс автор PR — `github-actions[bot]`, для него PR-check без лейбла `ok-to-test` всё равно не пошёл бы в тесты.

## Что сделали

Разбили каждый workflow на **два job'а**:

### `doc_translate` (`ydbdoc-review.yml`)

1. **`ydbdoc-review`** — перевод: checkout исходного PR, запуск `ydbdoc-review`, push ветки, создание translation PR. Токен: **`GITHUB_TOKEN`** (код PR здесь, PAT сюда не кладём).
2. **`trigger-translation-ci`** — после успешного перевода, **без checkout**: через **`YDBOT_TOKEN`** на translation PR вешаются лейблы **`rebuild_docs`** (сборка доки) и **`ok-to-test`** (PR-check).

### `doc_verify` (`ydbdoc-verify.yml`)

1. **`ydbdoc-verify`** — проверка и правки: checkout translation PR, repair-коммит при необходимости. Токен: **`GITHUB_TOKEN`**.
2. **`trigger-verify-ci`** — после успеха, **без checkout**: через **`YDBOT_TOKEN`** вешается **`ok-to-test`**, чтобы запустился PR-check.

Push repair-коммита через `GITHUB_TOKEN` **сам по себе PR-check не запускает** — поэтому `ok-to-test` добавляем отдельным job'ом с PAT.

## Почему два токена

- **`GITHUB_TOKEN`** в job с checkout — fork PR (~70% `doc_translate`) продолжают работать; PAT не лежит рядом с чужим кодом.
- **`YDBOT_TOKEN`** только в job без checkout — лейблы от PAT **доходят** до PR-check и docs rebuild (каскад GitHub).

## Test plan

- [ ] `doc_translate` на fork PR → у translation PR появляются PR-check и docs rebuild.
- [ ] `doc_verify` с repair-коммитом → PR-check стартует после `ok-to-test`.