### PR TITLE
query replay: write_types_mismatch при расхождении типа write-операции (Upsert vs Replace)

### DIFF
--- a/ydb/tools/query_replay/query_compiler.cpp
+++ b/ydb/tools/query_replay/query_compiler.cpp
@@ -88,17 +88,6 @@ TString ToString(EWriteType writeType) {
     }
 }
 
-EWriteType NormalizeWriteType(EWriteType writeType) {
-    if (writeType == Replace) {
-        return Upsert;
-    }
-    return writeType;
-}
-
-bool WriteTypesEquivalent(EWriteType lhs, EWriteType rhs) {
-    return NormalizeWriteType(lhs) == NormalizeWriteType(rhs);
-}
-
 struct TTableWriteInfo {
     EWriteType WriteType;
     std::vector<std::string> WriteColumns;
@@ -125,23 +114,6 @@ struct TTableStats {
         return std::tie(Name, Reads, Writes) < std::tie(other.Name, other.Reads, other.Writes);
     }
 };
-
-bool TableStatsEquivalent(const TTableStats& lhs, const TTableStats& rhs) {
-    if (lhs.Name != rhs.Name || lhs.Reads != rhs.Reads || lhs.Writes.size() != rhs.Writes.size()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < lhs.Writes.size(); ++i) {
-        if (lhs.Writes[i].WriteColumns != rhs.Writes[i].WriteColumns) {
-            return false;
-        }
-        if (!WriteTypesEquivalent(lhs.Writes[i].WriteType, rhs.Writes[i].WriteType)) {
-            return false;
-        }
-    }
-
-    return true;
-}
 
 struct TMetadataInfoHolder {
     const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
@@ -539,7 +511,7 @@ private:
                 return {TQueryReplayEvents::WriteColumnsMismatch, TStringBuilder() << "Write columns mismatch"};
             }
 
-            if (!WriteTypesEquivalent(oldEngineStats.Writes[i].WriteType, newEngineStats.Writes[i].WriteType)) {
+            if (oldEngineStats.Writes[i].WriteType != newEngineStats.Writes[i].WriteType) {
                 return {TQueryReplayEvents::WriteTypesMismatch, TStringBuilder() << "Write types mismatch, old engine: "
                     << ToString(oldEngineStats.Writes[i].WriteType) << ", new engine: "
                     << ToString(newEngineStats.Writes[i].WriteType)};
@@ -562,7 +534,7 @@ private:
                     TStringBuilder() << "Table " << table << " not found in new engine plan"};
             }
 
-            if (!TableStatsEquivalent(stats, it->second)) {
+            if (stats != it->second) {
                 WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
                 return OnTableOperationsMismatch(stats, it->second);
             }

--- a/ydb/tools/query_replay/query_compiler.cpp
+++ b/ydb/tools/query_replay/query_compiler.cpp
@@ -77,11 +77,11 @@ enum EWriteType : ui32 {
 
 TString ToString(EWriteType writeType) {
     switch (writeType) {
-        case Upsert:
+        case EWriteType::Upsert:
             return "upsert";
-        case Erase:
+        case EWriteType::Erase:
             return "erase";
-        case Replace:
+        case EWriteType::Replace:
             return "replace";
         default:
             return "unknown";

--- a/ydb/tools/query_replay/query_compiler.cpp
+++ b/ydb/tools/query_replay/query_compiler.cpp
@@ -71,8 +71,33 @@ struct TTableReadAccessInfo {
 
 enum EWriteType : ui32 {
     Upsert = 1,
-    Erase = 2
+    Erase = 2,
+    Replace = 3,
 };
+
+TString ToString(EWriteType writeType) {
+    switch (writeType) {
+        case Upsert:
+            return "upsert";
+        case Erase:
+            return "erase";
+        case Replace:
+            return "replace";
+        default:
+            return "unknown";
+    }
+}
+
+EWriteType NormalizeWriteType(EWriteType writeType) {
+    if (writeType == Replace) {
+        return Upsert;
+    }
+    return writeType;
+}
+
+bool WriteTypesEquivalent(EWriteType lhs, EWriteType rhs) {
+    return NormalizeWriteType(lhs) == NormalizeWriteType(rhs);
+}
 
 struct TTableWriteInfo {
     EWriteType WriteType;
@@ -100,6 +125,23 @@ struct TTableStats {
         return std::tie(Name, Reads, Writes) < std::tie(other.Name, other.Reads, other.Writes);
     }
 };
+
+bool TableStatsEquivalent(const TTableStats& lhs, const TTableStats& rhs) {
+    if (lhs.Name != rhs.Name || lhs.Reads != rhs.Reads || lhs.Writes.size() != rhs.Writes.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < lhs.Writes.size(); ++i) {
+        if (lhs.Writes[i].WriteColumns != rhs.Writes[i].WriteColumns) {
+            return false;
+        }
+        if (!WriteTypesEquivalent(lhs.Writes[i].WriteType, rhs.Writes[i].WriteType)) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 struct TMetadataInfoHolder {
     const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
@@ -425,6 +467,8 @@ private:
                         const auto& type = write["type"].GetStringSafe();
                         if (type == "Upsert" || type == "MultiUpsert") {
                             writes.push_back(TTableWriteInfo{EWriteType::Upsert, columns});
+                        } else if (type == "Replace" || type == "MultiReplace") {
+                            writes.push_back(TTableWriteInfo{EWriteType::Replace, columns});
                         } else if (type == "Erase" || type == "MultiErase") {
                             writes.push_back(TTableWriteInfo{EWriteType::Erase, columns});
                         }
@@ -494,6 +538,12 @@ private:
             if (oldEngineStats.Writes[i].WriteColumns != newEngineStats.Writes[i].WriteColumns) {
                 return {TQueryReplayEvents::WriteColumnsMismatch, TStringBuilder() << "Write columns mismatch"};
             }
+
+            if (!WriteTypesEquivalent(oldEngineStats.Writes[i].WriteType, newEngineStats.Writes[i].WriteType)) {
+                return {TQueryReplayEvents::WriteTypesMismatch, TStringBuilder() << "Write types mismatch, old engine: "
+                    << ToString(oldEngineStats.Writes[i].WriteType) << ", new engine: "
+                    << ToString(newEngineStats.Writes[i].WriteType)};
+            }
         }
 
         return {TQueryReplayEvents::UncategorizedPlanMismatch, ""};
@@ -512,7 +562,7 @@ private:
                     TStringBuilder() << "Table " << table << " not found in new engine plan"};
             }
 
-            if (stats != it->second) {
+            if (!TableStatsEquivalent(stats, it->second)) {
                 WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
                 return OnTableOperationsMismatch(stats, it->second);
             }

--- a/ydb/tools/query_replay/query_proccessor.cpp
+++ b/ydb/tools/query_replay/query_proccessor.cpp
@@ -139,6 +139,9 @@ public:
             case TQueryReplayEvents::WriteColumnsMismatch:
                 failReason = "write_columns_mismatch";
                 break;
+            case TQueryReplayEvents::WriteTypesMismatch:
+                failReason = "write_types_mismatch";
+                break;
             case TQueryReplayEvents::UncategorizedPlanMismatch:
                 failReason = "uncategorized_plan_mismatch";
                 break;

--- a/ydb/tools/query_replay/query_replay.h
+++ b/ydb/tools/query_replay/query_replay.h
@@ -168,6 +168,7 @@ struct TQueryReplayEvents {
         ReadColumnsMismatch,
         ExtraWriting,
         WriteColumnsMismatch,
+        WriteTypesMismatch,
         UncategorizedPlanMismatch,
         Unspecified,
     };

--- a/ydb/tools/query_replay_yt/main.cpp
+++ b/ydb/tools/query_replay_yt/main.cpp
@@ -111,6 +111,8 @@ public:
                 return "extra_writing";
             case TQueryReplayEvents::WriteColumnsMismatch:
                 return "write_columns_mismatch";
+            case TQueryReplayEvents::WriteTypesMismatch:
+                return "write_types_mismatch";
             case TQueryReplayEvents::UncategorizedPlanMismatch:
                 return "uncategorized_plan_mismatch";
             case TQueryReplayEvents::MissingTableMetadata:

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -31,6 +31,37 @@ using namespace NYql::NDq;
 using namespace NKikimr;
 using namespace NKikimr::NKqp;
 
+std::string NormalizeWriteType(const std::string& writeType) {
+    std::string base = writeType;
+    if (base.size() > 5 && base.substr(0, 5) == "Multi") {
+        base = base.substr(5);
+    }
+    if (base == "Replace") {
+        return "Upsert";
+    }
+    return base;
+}
+
+bool WriteTypesEquivalent(const std::string& lhs, const std::string& rhs) {
+    return NormalizeWriteType(lhs) == NormalizeWriteType(rhs);
+}
+
+bool TableStatsEquivalent(const TTableStats& lhs, const TTableStats& rhs) {
+    if (lhs.Name != rhs.Name || lhs.Reads != rhs.Reads || lhs.Writes.size() != rhs.Writes.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < lhs.Writes.size(); ++i) {
+        if (lhs.Writes[i].WriteColumns != rhs.Writes[i].WriteColumns) {
+            return false;
+        }
+        if (!WriteTypesEquivalent(lhs.Writes[i].WriteType, rhs.Writes[i].WriteType)) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 struct TMetadataInfoHolder {
     const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
@@ -441,6 +472,11 @@ private:
             if (oldEngineStats.Writes[i].WriteColumns != newEngineStats.Writes[i].WriteColumns) {
                 return {TQueryReplayEvents::WriteColumnsMismatch, TStringBuilder() << "Write columns mismatch"};
             }
+
+            if (!WriteTypesEquivalent(oldEngineStats.Writes[i].WriteType, newEngineStats.Writes[i].WriteType)) {
+                return {TQueryReplayEvents::WriteTypesMismatch, TStringBuilder() << "Write types mismatch, old engine: "
+                    << oldEngineStats.Writes[i].WriteType << ", new engine: " << newEngineStats.Writes[i].WriteType};
+            }
         }
 
         return {TQueryReplayEvents::UncategorizedPlanMismatch, ""};
@@ -461,7 +497,7 @@ private:
                     TStringBuilder() << "Table " << table << " not found in new engine plan"};
             }
 
-            if (stats != it->second) {
+            if (!TableStatsEquivalent(stats, it->second)) {
                 WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
                 return OnTableOperationsMismatch(stats, it->second);
             }

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -31,6 +31,14 @@ using namespace NYql::NDq;
 using namespace NKikimr;
 using namespace NKikimr::NKqp;
 
+std::string NormalizePlanWriteType(TStringBuf type) {
+    std::string normalized(type);
+    if (normalized.size() > 5 && normalized.substr(0, 5) == "Multi") {
+        normalized = normalized.substr(5);
+    }
+    return normalized;
+}
+
 struct TMetadataInfoHolder {
     const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
     THashMap<TString, NYql::TKikimrTableMetadataPtr> Indexes;
@@ -373,7 +381,7 @@ private:
                         }
 
                         const auto& type = write["type"].GetStringSafe();
-                        writes.push_back(TTableWriteInfo{type, columns});
+                        writes.push_back(TTableWriteInfo{NormalizePlanWriteType(type), columns});
                     }
 
                     std::sort(writes.begin(), writes.end());

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -31,38 +31,6 @@ using namespace NYql::NDq;
 using namespace NKikimr;
 using namespace NKikimr::NKqp;
 
-std::string NormalizeWriteType(const std::string& writeType) {
-    std::string base = writeType;
-    if (base.size() > 5 && base.substr(0, 5) == "Multi") {
-        base = base.substr(5);
-    }
-    if (base == "Replace") {
-        return "Upsert";
-    }
-    return base;
-}
-
-bool WriteTypesEquivalent(const std::string& lhs, const std::string& rhs) {
-    return NormalizeWriteType(lhs) == NormalizeWriteType(rhs);
-}
-
-bool TableStatsEquivalent(const TTableStats& lhs, const TTableStats& rhs) {
-    if (lhs.Name != rhs.Name || lhs.Reads != rhs.Reads || lhs.Writes.size() != rhs.Writes.size()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < lhs.Writes.size(); ++i) {
-        if (lhs.Writes[i].WriteColumns != rhs.Writes[i].WriteColumns) {
-            return false;
-        }
-        if (!WriteTypesEquivalent(lhs.Writes[i].WriteType, rhs.Writes[i].WriteType)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 struct TMetadataInfoHolder {
     const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
     THashMap<TString, NYql::TKikimrTableMetadataPtr> Indexes;
@@ -473,7 +441,7 @@ private:
                 return {TQueryReplayEvents::WriteColumnsMismatch, TStringBuilder() << "Write columns mismatch"};
             }
 
-            if (!WriteTypesEquivalent(oldEngineStats.Writes[i].WriteType, newEngineStats.Writes[i].WriteType)) {
+            if (oldEngineStats.Writes[i].WriteType != newEngineStats.Writes[i].WriteType) {
                 return {TQueryReplayEvents::WriteTypesMismatch, TStringBuilder() << "Write types mismatch, old engine: "
                     << oldEngineStats.Writes[i].WriteType << ", new engine: " << newEngineStats.Writes[i].WriteType};
             }
@@ -497,7 +465,7 @@ private:
                     TStringBuilder() << "Table " << table << " not found in new engine plan"};
             }
 
-            if (!TableStatsEquivalent(stats, it->second)) {
+            if (stats != it->second) {
                 WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
                 return OnTableOperationsMismatch(stats, it->second);
             }

--- a/ydb/tools/query_replay_yt/query_replay.h
+++ b/ydb/tools/query_replay_yt/query_replay.h
@@ -97,6 +97,7 @@ struct TQueryReplayEvents {
         ReadColumnsMismatch,
         ExtraWriting,
         WriteColumnsMismatch,
+        WriteTypesMismatch,
         UncategorizedPlanMismatch,
         MissingTableMetadata,
         UncategorizedFailure,


### PR DESCRIPTION
## Summary

Раньше при совпадении write-колонок, но разном типе write-операции в `tables[]` плана (например `MultiUpsert` в проде vs `MultiReplace` при replay) query replay не сравнивал типы и падал в **`uncategorized_plan_mismatch`** с пустым `extra_message`.

Этот PR **для таких случаев** вводит **`write_types_mismatch`** (аналог уже существующего `read_types_mismatch`):

- количество write-операций на таблицу совпадает;
- списки write-колонок (после отсечения key-колонок) совпадают;
- **тип write-операции различается** — типично `Upsert`/`MultiUpsert` ↔ `Replace`/`MultiReplace` для `REPLACE INTO`.

Дополнительно в `query_replay` (не-YT) начинаем парсить `Replace`/`MultiReplace` в stats плана — раньше новый план мог не попадать в write stats.

**`uncategorized_plan_mismatch` не заменяем глобально** — он остаётся для plan diff, который не объясняется известными категориями (reads, limits, columns, extra write и т.д.) и требует ручного triage.

## Triage

- Мьютить **`write_types_mismatch`** в `known_issues.yaml` (например Upsert/Replace для `REPLACE INTO`).
- **`uncategorized_plan_mismatch`** не мьютить blanket — оставлять new на gate.

## Test plan

- [ ] `REPLACE INTO ... AS_TABLE`: `MultiUpsert` vs `MultiReplace` → `write_types_mismatch`, `extra_message` с типами old/new
- [ ] `Erase` vs `Upsert` при совпадающих колонках → `write_types_mismatch`
- [ ] Непонятный plan diff без совпадения по известным категориям → `uncategorized_plan_mismatch`