### PR TITLE
gitignore local.ymake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ path.bash.inc
 
 # Pyright config (local IDE settings)
 **/pyrightconfig.json
+
+# Local configuration for `ya`
+/local.ymake


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Developers documentation recommends tuning build cache size via ya.conf at the repository root. It requires special care to not commit it and to save modifications on pulls. `ya` supports another file - `local.ymake` specifically for local configuration modifications. local.ymake overrides ya.conf.
