### PR TITLE
Fix viewer/browse_db field used

### DIFF
--- a/ydb/core/viewer/browse_db.h
+++ b/ydb/core/viewer/browse_db.h
@@ -137,9 +137,6 @@ public:
                     if (pbTable.HasUniformPartitionsCount()) {
                         pbCommon.SetPartitions(pbTable.GetUniformPartitionsCount());
                     }
-                    if (pbTable.SplitBoundarySize() > 0) {
-                        pbCommon.SetPartitions(pbTable.SplitBoundarySize() + 1);
-                    }
                     if (pbTable.ColumnsSize() > 0) {
                         NKikimrViewer::TMetaTableInfo& pbMetaTable = *metaInfo.MutableTable();
                         for (const auto& column : pbTable.GetColumns()) {
@@ -157,6 +154,7 @@ public:
                 }
                 if (pbPathDescription.HasTableStats()) {
                     const auto& pbTableStats(pbPathDescription.GetTableStats());
+                    pbCommon.SetPartitions(pbTableStats.GetPartCount());
                     pbCommon.SetRowCount(pbTableStats.GetRowCount());
                     pbCommon.SetAccessTime(pbTableStats.GetLastAccessTime());
                     pbCommon.SetUpdateTime(pbTableStats.GetLastUpdateTime());


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`viewer/browse_db` no longer relies on `Table.SplitBoundary` to compute table partition count.
Previously, `browse_db` did not explicitly request `SetReturnBoundaries`, but still derived partition count from `SplitBoundarySize() + 1`. ReturnBoundaries is false by dafault, but is still present in responce because of a bug fixed in #43001

Now partition count is taken from `PathDescription.TableStats.PartCount` which avoids requiring boundary payloads at all.

- The problem revealed spontaneously in scope of https://github.com/ydb-platform/ydb-embedded-ui/issues/3988