### PR TITLE
Add query_replay_yt plan-check library and CI unit tests

### DIFF
--- a/ydb/tools/query_replay_yt/common_deps.inc
+++ b/ydb/tools/query_replay_yt/common_deps.inc
@@ -1,8 +1,9 @@
-SET(YDB_REPLAY_SRCS
-    query_compiler.cpp
-    query_replay.cpp
-    query_replay.h
-    main.cpp
+SET(YDB_REPLAY_LIB_SRCS
+    ../query_compiler.cpp
+    ../query_replay.cpp
+    ../plan_check.cpp
+    ../metadata.cpp
+    ../replay_runner.cpp
 )
 
 SET(YDB_REPLAY_PEERDIRS

--- a/ydb/tools/query_replay_yt/lib/ya.make
+++ b/ydb/tools/query_replay_yt/lib/ya.make
@@ -1,0 +1,20 @@
+LIBRARY(query_replay_yt_lib)
+
+YQL_LAST_ABI_VERSION()
+INCLUDE(${ARCADIA_ROOT}/ydb/tools/query_replay_yt/common_deps.inc)
+
+SRCS(
+    ${YDB_REPLAY_LIB_SRCS}
+    ../plan_check.h
+    ../metadata.h
+    ../replay_runner.h
+    ../query_replay.h
+)
+
+PEERDIR(${YDB_REPLAY_PEERDIRS})
+
+END()
+
+RECURSE_FOR_TESTS(
+    ../ut
+)

--- a/ydb/tools/query_replay_yt/main.cpp
+++ b/ydb/tools/query_replay_yt/main.cpp
@@ -1,12 +1,8 @@
 #include "query_replay.h"
 
-#include <ydb/library/actors/core/actorsystem.h>
-#include <ydb/core/client/minikql_compile/mkql_compile_service.h>
-#include <ydb/core/kqp/rm_service/kqp_rm_service.h>
-#include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
-#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
-
-#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include "metadata.h"
+#include "plan_check.h"
+#include "replay_runner.h"
 
 #include <yt/cpp/mapreduce/interface/operation.h>
 #include <yt/cpp/mapreduce/interface/client.h>
@@ -17,7 +13,6 @@
 #include <library/cpp/logger/backend.h>
 #include <ydb/library/yql/utils/actor_log/log.h>
 
-#include <util/string/split.h>
 #include <util/system/fs.h>
 #include <util/datetime/base.h>
 #include <exception>
@@ -51,76 +46,14 @@ TString TruncateOutputField(TString value, TStringBuf fieldName, TStringBuf quer
 
 } // anonymous namespace
 
-TVector<std::pair<TString, TString>> GetJobFiles(TVector<TString> udfs) {
-    TVector<std::pair<TString, TString>> result;
-
-    for(const TString& udf: udfs) {
-        TVector<TString> splitResult;
-        Split(udf.data(), "/", splitResult);
-        while(!splitResult.empty() && splitResult.back().empty()) {
-            splitResult.pop_back();
-        }
-
-        Y_ENSURE(!splitResult.empty());
-
-        result.push_back(std::make_pair(udf, splitResult.back()));
-    }
-
-    return result;
-}
-
 class TQueryReplayMapper
     : public NYT::IMapper<NYT::TTableReader<NYT::TNode>, NYT::TTableWriter<NYT::TNode>>
 {
-
-    THolder<NActors::TActorSystem> ActorSystem;
-    TAutoPtr<TLogBackend> LogBackend;
-    std::unique_ptr<NYql::NLog::YqlLoggerScope> YqlLogger;
-    TIntrusivePtr<NActors::NLog::TSettings> LogSettings;
-    THolder<NKikimr::TAppData> AppData;
-    TIntrusivePtr<NKikimr::NScheme::TKikimrTypeRegistry> TypeRegistry;
-    TIntrusivePtr<NKikimr::NMiniKQL::IMutableFunctionRegistry> FunctionRegistry;
-    TIntrusivePtr<NKikimr::NKqp::TModuleResolverState> ModuleResolverState;
-
-    NYql::IHTTPGateway::TPtr HttpGateway;
     TVector<TString> UdfFiles;
     ui32 ActorSystemThreadsCount = 5;
     NActors::NLog::EPriority YqlLogPriority = NActors::NLog::EPriority::PRI_ERROR;
     bool Antlr4ParserIsAmbiguityError = false;
-
-public:
-    static TString GetFailReason(const TQueryReplayEvents::TCheckQueryPlanStatus& status) {
-        switch (status) {
-            case TQueryReplayEvents::CompileError:
-                return "compile_error";
-            case TQueryReplayEvents::CompileTimeout:
-                return "compile_timeout";
-            case TQueryReplayEvents::TableMissing:
-                return "table_missing";
-            case TQueryReplayEvents::ExtraReadingOldEngine:
-                return "extra_reading_old_engine";
-            case TQueryReplayEvents::ExtraReadingNewEngine:
-                return "extra_reading_new_engine";
-            case TQueryReplayEvents::ReadTypesMismatch:
-                return "read_types_mismatch";
-            case TQueryReplayEvents::ReadLimitsMismatch:
-                return "read_limits_mismatch";
-            case TQueryReplayEvents::ReadColumnsMismatch:
-                return "read_columns_mismatch";
-            case TQueryReplayEvents::ExtraWriting:
-                return "extra_writing";
-            case TQueryReplayEvents::WriteColumnsMismatch:
-                return "write_columns_mismatch";
-            case TQueryReplayEvents::UncategorizedPlanMismatch:
-                return "uncategorized_plan_mismatch";
-            case TQueryReplayEvents::MissingTableMetadata:
-                return "missing_table_metadata";
-            case TQueryReplayEvents::UncategorizedFailure:
-                return "uncategorized_failure";
-            default:
-                return "unspecified";
-        }
-    }
+    TQueryReplayRunner Runner;
 
 public:
     TQueryReplayMapper() = default;
@@ -129,73 +62,14 @@ public:
 
     TQueryReplayMapper(TVector<TString> udfFiles, ui32 actorSystemThreadsCount, bool antlr4ParserIsAmbiguityError,
         NActors::NLog::EPriority yqlLogPriority = NActors::NLog::EPriority::PRI_ERROR)
-        : UdfFiles(udfFiles)
+        : UdfFiles(std::move(udfFiles))
         , ActorSystemThreadsCount(actorSystemThreadsCount)
         , YqlLogPriority(yqlLogPriority)
         , Antlr4ParserIsAmbiguityError(antlr4ParserIsAmbiguityError)
     {}
 
     void Start(NYT::TTableWriter<NYT::TNode>*) override {
-        YqlLogger = std::make_unique<NYql::NLog::YqlLoggerScope>(&Cerr);
-        NYql::NDq::SetYqlLogLevels(YqlLogPriority);
-
-        TypeRegistry.Reset(new NKikimr::NScheme::TKikimrTypeRegistry());
-        FunctionRegistry.Reset(NKikimr::NMiniKQL::CreateFunctionRegistry(NKikimr::NMiniKQL::CreateBuiltinRegistry())->Clone());
-        NKikimr::NMiniKQL::FillStaticModules(*FunctionRegistry);
-        NKikimr::NMiniKQL::TUdfModuleRemappings remappings;
-        THashSet<TString> usedUdfPaths;
-
-        for(const auto& [realPath, udfPath]: GetJobFiles(UdfFiles)) {
-            if (usedUdfPaths.insert(udfPath).second) {
-                if (NFs::Exists(udfPath)) {
-                    FunctionRegistry->LoadUdfs(udfPath, remappings, 0);
-                    continue;
-                }
-
-                if (NFs::Exists(realPath)) {
-                    FunctionRegistry->LoadUdfs(realPath, remappings, 0);
-                    continue;
-                }
-            }
-        }
-
-        AppData.Reset(new NKikimr::TAppData(0, 0, 0, 0, {}, TypeRegistry.Get(), FunctionRegistry.Get(), nullptr, nullptr));
-        AppData->Counters = MakeIntrusive<NMonitoring::TDynamicCounters>(new NMonitoring::TDynamicCounters());
-        auto setup = BuildActorSystemSetup(ActorSystemThreadsCount);
-        ActorSystem.Reset(new TActorSystem(setup, AppData.Get()));
-        ActorSystem->Start();
-        ActorSystem->Register(NKikimr::NKqp::CreateKqpResourceManagerActor({}, nullptr));
-        ModuleResolverState = MakeIntrusive<NKikimr::NKqp::TModuleResolverState>();
-        HttpGateway = NYql::IHTTPGateway::Make();
-        Y_ABORT_UNLESS(GetYqlDefaultModuleResolver(ModuleResolverState->ExprCtx, ModuleResolverState->ModuleResolver));
-    }
-
-    THolder<TQueryReplayEvents::TEvCompileResponse> RunReplay(NJson::TJsonValue&& json) {
-        TString queryType = json["query_type"].GetStringSafe();
-        if (queryType == "QUERY_TYPE_AST_SCAN" || queryType == "QUERY_TYPE_AST_DML") {
-            return nullptr;
-        }
-
-        if (queryType == "QUERY_TYPE_SQL_GENERIC_SCRIPT") {
-            return nullptr;
-        }
-
-        NJson::TJsonValue replayJson = std::move(json);
-
-        THolder<TQueryReplayEvents::TEvCompileResponse> replayResult;
-        {
-            NJson::TJsonValue firstCompileReplayJson = replayJson;
-            auto compileActorId = ActorSystem->Register(CreateQueryCompiler(ModuleResolverState, FunctionRegistry.Get(), HttpGateway, Antlr4ParserIsAmbiguityError));
-
-            auto future = ActorSystem->Ask<TQueryReplayEvents::TEvCompileResponse>(
-                compileActorId,
-                THolder(new TQueryReplayEvents::TEvCompileRequest(std::move(firstCompileReplayJson))),
-                TDuration::Seconds(600));
-
-            replayResult.Reset(future.ExtractValueSync().Release());
-        }
-
-        return replayResult;
+        Runner.Init(UdfFiles, ActorSystemThreadsCount, Antlr4ParserIsAmbiguityError, YqlLogPriority);
     }
 
     void Do(NYT::TTableReader<NYT::TNode>* in, NYT::TTableWriter<NYT::TNode>* out) override {
@@ -209,13 +83,13 @@ public:
                 json.InsertValue(key, NJson::TJsonValue(child.AsString()));
             }
 
-            auto response = RunReplay(std::move(json));
+            auto response = Runner.RunReplay(std::move(json));
             if (response == nullptr)
                 continue;
 
             auto status = response.Get()->Status;
 
-            TString failReason = GetFailReason(status);
+            TString failReason = NKikimr::NQueryReplay::StatusToFailReason(status);
 
             if (failReason == "unspecified" || status == TQueryReplayEvents::MissingTableMetadata) {
                 continue;
@@ -251,7 +125,7 @@ public:
     }
 
     void Finish(NYT::TTableWriter<NYT::TNode>*) override {
-        ActorSystem->Stop();
+        Runner.Stop();
     }
 };
 
@@ -296,10 +170,10 @@ int main(int argc, const char** argv) {
 
     if (config.QueryFile) {
         Cerr << "Running in local mode for single query file: " << config.QueryFile << Endl;
-        auto fakeMapper = TQueryReplayMapper(config.UdfFiles, config.ActorSystemThreadsCount, config.Antlr4ParserIsAmbiguityError, config.YqlLogLevel);
-        fakeMapper.Start(nullptr);
+        TQueryReplayRunner runner;
+        runner.Init(config.UdfFiles, config.ActorSystemThreadsCount, config.Antlr4ParserIsAmbiguityError, config.YqlLogLevel);
         Y_DEFER {
-            fakeMapper.Finish(nullptr);
+            runner.Stop();
         };
 
         NJson::TJsonValue queryJson;
@@ -313,23 +187,26 @@ int main(int argc, const char** argv) {
             << "Database: " << queryJson["query_database"].GetStringSafe() << Endl
             << UnescapeC(queryJson["query_text"].GetStringSafe()) << Endl;
 
-        auto TableMetadata = ExtractStaticMetadata(queryJson);
+        auto tableMetadata = ExtractStaticMetadata(queryJson);
         Cerr << "Tables: " << Endl;
 
-	    for(auto& [name, meta]: TableMetadata) {
+        for (auto& [name, meta] : tableMetadata) {
             Cerr << "TableName: " << name << Endl;
             NKikimrKqp::TKqpTableMetadataProto protoDescription;
             meta->ToMessage(&protoDescription);
             Cerr << protoDescription.Utf8DebugString() << Endl;
         }
 
-        auto result = fakeMapper.RunReplay(std::move(queryJson));
-
-        auto status = result.Get()->Status;
-        TString failReason = TQueryReplayMapper::GetFailReason(status);
+        auto result = runner.RunReplay(std::move(queryJson));
+        if (!result) {
+            Cerr << "Query type is not supported for replay" << Endl;
+            return EXIT_FAILURE;
+        }
+        const auto status = result->Status;
+        const TString failReason = NKikimr::NQueryReplay::StatusToFailReason(status);
         Cerr << failReason << Endl;
-        Cerr << result.Get()->Message << Endl;
-        return 0;
+        Cerr << result->Message << Endl;
+        return status == TQueryReplayEvents::Success ? EXIT_SUCCESS : EXIT_FAILURE;
     }
 
     if (config.Cluster.empty() || config.SrcPath.empty() || config.DstPath.empty()) {

--- a/ydb/tools/query_replay_yt/metadata.cpp
+++ b/ydb/tools/query_replay_yt/metadata.cpp
@@ -1,0 +1,62 @@
+#include "metadata.h"
+
+#include <library/cpp/protobuf/json/json2proto.h>
+#include <library/cpp/string_utils/base64/base64.h>
+#include <library/cpp/json/json_reader.h>
+#include <ydb/core/protos/kqp.pb.h>
+
+TMetadataInfoHolder::TMetadataInfoHolder(THashMap<TString, NYql::TKikimrTableMetadataPtr>&& tableMetadata)
+    : TableMetadata(std::move(tableMetadata))
+{
+    for (auto& [name, ptr] : TableMetadata) {
+        Y_UNUSED(name);
+        for (auto implTable : ptr->ImplTables) {
+            YQL_ENSURE(implTable);
+            do {
+                auto nextImplTable = implTable->Next;
+                Indexes.emplace(implTable->Name, std::move(implTable));
+                implTable = std::move(nextImplTable);
+            } while (implTable);
+        }
+    }
+}
+
+const NYql::TKikimrTableMetadataPtr* TMetadataInfoHolder::FindPtr(const TString& key) const {
+    const auto* result = TableMetadata.FindPtr(key);
+    if (result != nullptr) {
+        return result;
+    }
+    return Indexes.FindPtr(key);
+}
+
+THashMap<TString, NYql::TKikimrTableMetadataPtr> ExtractStaticMetadata(const NJson::TJsonValue& data) {
+    EMetaSerializationType metaType = EMetaSerializationType::EncodedProto;
+    if (data.Has("table_meta_serialization_type")) {
+        metaType = static_cast<EMetaSerializationType>(data["table_meta_serialization_type"].GetUIntegerSafe());
+    }
+    THashMap<TString, NYql::TKikimrTableMetadataPtr> meta;
+
+    if (metaType == EMetaSerializationType::EncodedProto) {
+        static NJson::TJsonReaderConfig readerConfig;
+        NJson::TJsonValue tablemetajson;
+        TStringInput in(data["table_metadata"].GetStringSafe());
+        NJson::ReadJsonTree(&in, &readerConfig, &tablemetajson, false);
+        Y_ENSURE(tablemetajson.IsArray());
+        for (auto& node : tablemetajson.GetArray()) {
+            NKikimrKqp::TKqpTableMetadataProto proto;
+            TString decoded = Base64Decode(node.GetStringRobust());
+            Y_ENSURE(proto.ParseFromString(decoded));
+            NYql::TKikimrTableMetadataPtr ptr = MakeIntrusive<NYql::TKikimrTableMetadata>(&proto);
+            meta.emplace(proto.GetName(), ptr);
+        }
+    } else {
+        Y_ENSURE(data["table_metadata"].IsArray());
+        for (auto& node : data["table_metadata"].GetArray()) {
+            NKikimrKqp::TKqpTableMetadataProto proto;
+            NProtobufJson::Json2Proto(node.GetStringRobust(), proto);
+            NYql::TKikimrTableMetadataPtr ptr = MakeIntrusive<NYql::TKikimrTableMetadata>(&proto);
+            meta.emplace(proto.GetName(), ptr);
+        }
+    }
+    return meta;
+}

--- a/ydb/tools/query_replay_yt/metadata.h
+++ b/ydb/tools/query_replay_yt/metadata.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <ydb/core/kqp/gateway/kqp_gateway.h>
+
+#include <library/cpp/json/json_value.h>
+
+#include <memory>
+
+struct TMetadataInfoHolder {
+    const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
+    THashMap<TString, NYql::TKikimrTableMetadataPtr> Indexes;
+
+    explicit TMetadataInfoHolder(THashMap<TString, NYql::TKikimrTableMetadataPtr>&& tableMetadata);
+
+    THashMap<TString, NYql::TKikimrTableMetadataPtr>::const_iterator find(const TString& key) const {
+        return TableMetadata.find(key);
+    }
+
+    THashMap<TString, NYql::TKikimrTableMetadataPtr>::const_iterator end() const {
+        return TableMetadata.end();
+    }
+
+    const NYql::TKikimrTableMetadataPtr* FindPtr(const TString& key) const;
+};
+
+THashMap<TString, NYql::TKikimrTableMetadataPtr> ExtractStaticMetadata(const NJson::TJsonValue& data);

--- a/ydb/tools/query_replay_yt/plan_check.cpp
+++ b/ydb/tools/query_replay_yt/plan_check.cpp
@@ -1,0 +1,221 @@
+#include "plan_check.h"
+
+#include <library/cpp/json/json_reader.h>
+#include <util/string/builder.h>
+
+namespace NKikimr::NQueryReplay {
+
+NJson::TJsonValue ParseQueryPlan(const TString& plan) {
+    static NJson::TJsonReaderConfig readConfig;
+    TStringInput in(plan);
+    NJson::TJsonValue reply;
+    NJson::ReadJsonTree(&in, &readConfig, &reply, false);
+    return reply;
+}
+
+std::map<std::string, TTableStats> ExtractTableStats(
+    const NJson::TJsonValue& plan,
+    const TTableMetadataLookup& metadataLookup)
+{
+    std::map<std::string, TTableStats> result;
+
+    if (!plan.Has("tables")) {
+        return result;
+    }
+
+    for (const auto& table : plan["tables"].GetArraySafe()) {
+        TString name = table["name"].GetStringSafe();
+        std::vector<TTableReadAccessInfo> reads;
+        std::vector<TTableWriteInfo> writes;
+
+        if (table.Has("reads")) {
+            for (const auto& read : table["reads"].GetArraySafe()) {
+                std::vector<std::string> columns;
+                if (read.Has("columns")) {
+                    const NYql::TKikimrTableMetadataPtr* tableMetadata = metadataLookup(name);
+                    Y_ENSURE(tableMetadata);
+                    const auto& keyColumnNames = tableMetadata->Get()->KeyColumnNames;
+                    std::unordered_set<std::string_view> keyColumns(keyColumnNames.begin(), keyColumnNames.end());
+                    for (const auto& column : read["columns"].GetArraySafe()) {
+                        if (!keyColumns.contains(column.GetStringSafe())) {
+                            columns.push_back(column.GetStringSafe());
+                        }
+                    }
+                    std::sort(columns.begin(), columns.end());
+                }
+
+                const auto& type = read["type"].GetStringSafe();
+                i32 limit = -1;
+                if (read.Has("limit") && read["limit"].IsInteger()) {
+                    limit = read["limit"].GetIntegerSafe();
+                }
+
+                bool probablyLookupScan = false;
+                if (read.Has("lookup_by") && read.Has("scan_by")) {
+                    probablyLookupScan = true;
+                }
+
+                if (type == "Lookup") {
+                    if (probablyLookupScan) {
+                        reads.push_back(TTableReadAccessInfo{"Scan", limit, columns});
+                    } else {
+                        reads.push_back(TTableReadAccessInfo{"Lookup", limit, columns});
+                    }
+                } else if (type == "MultiLookup") {
+                    reads.push_back(TTableReadAccessInfo{"Lookup", limit, columns});
+                } else {
+                    reads.push_back(TTableReadAccessInfo({type, limit, columns}));
+                }
+            }
+
+            std::sort(reads.begin(), reads.end());
+        }
+
+        if (table.Has("writes")) {
+            for (const auto& write : table["writes"].GetArraySafe()) {
+                std::vector<std::string> columns;
+                if (write.Has("columns")) {
+                    const NYql::TKikimrTableMetadataPtr* tableMetadata = metadataLookup(name);
+                    Y_ENSURE(tableMetadata);
+                    const auto& keyColumnNames = tableMetadata->Get()->KeyColumnNames;
+                    std::unordered_set<std::string_view> keyColumns(keyColumnNames.begin(), keyColumnNames.end());
+                    for (const auto& column : write["columns"].GetArraySafe()) {
+                        if (!keyColumns.contains(column.GetStringSafe())) {
+                            columns.push_back(column.GetStringSafe());
+                        }
+                    }
+                    std::sort(columns.begin(), columns.end());
+                }
+
+                const auto& type = write["type"].GetStringSafe();
+                writes.push_back(TTableWriteInfo{type, columns});
+            }
+
+            std::sort(writes.begin(), writes.end());
+        }
+
+        result.emplace(name, TTableStats{name, std::move(reads), std::move(writes)});
+    }
+
+    return result;
+}
+
+std::pair<TQueryReplayEvents::TCheckQueryPlanStatus, TString> CompareTableStats(
+    const TTableStats& oldEngineStats,
+    const TTableStats& newEngineStats)
+{
+    Y_ENSURE(oldEngineStats.Name == newEngineStats.Name);
+    if (oldEngineStats.Reads.size() > newEngineStats.Reads.size()) {
+        return {TQueryReplayEvents::ExtraReadingOldEngine, TStringBuilder()
+            << "Extra reading in old engine plan for table " << oldEngineStats.Name};
+    }
+
+    if (oldEngineStats.Reads.size() < newEngineStats.Reads.size()) {
+        return {TQueryReplayEvents::ExtraReadingNewEngine, TStringBuilder()
+            << "Extra reading in new engine plan for table " << newEngineStats.Name};
+    }
+
+    for (size_t i = 0; i < oldEngineStats.Reads.size(); ++i) {
+        if (oldEngineStats.Reads[i].ReadType != newEngineStats.Reads[i].ReadType) {
+            return {TQueryReplayEvents::ReadTypesMismatch, TStringBuilder() << "Read types mismatch, old engine: "
+                << oldEngineStats.Reads[i].ReadType << ", new engine: " << newEngineStats.Reads[i].ReadType};
+        }
+
+        if (oldEngineStats.Reads[i].PushedLimit != newEngineStats.Reads[i].PushedLimit) {
+            return {TQueryReplayEvents::ReadLimitsMismatch, TStringBuilder() << "Read limits mismatch, old engine: "
+                << oldEngineStats.Reads[i].PushedLimit << ", new engine: " << newEngineStats.Reads[i].PushedLimit};
+        }
+
+        if (oldEngineStats.Reads[i].ReadColumns != newEngineStats.Reads[i].ReadColumns) {
+            return {TQueryReplayEvents::ReadColumnsMismatch, TStringBuilder() << "Read columns mismatch"};
+        }
+    }
+
+    if (oldEngineStats.Writes.size() > newEngineStats.Writes.size()) {
+        return {TQueryReplayEvents::ExtraWriting, TStringBuilder()
+            << "Extra write operation in old engine plan for table " << oldEngineStats.Name};
+    }
+
+    if (oldEngineStats.Writes.size() < newEngineStats.Writes.size()) {
+        return {TQueryReplayEvents::ExtraWriting, TStringBuilder()
+            << "Extra write operation in new engine plan for table " << newEngineStats.Name};
+    }
+
+    for (size_t i = 0; i < oldEngineStats.Writes.size(); ++i) {
+        if (oldEngineStats.Writes[i].WriteType != newEngineStats.Writes[i].WriteType) {
+            return {TQueryReplayEvents::WriteTypesMismatch, TStringBuilder() << "Write types mismatch, old engine: "
+                << oldEngineStats.Writes[i].WriteType << ", new engine: " << newEngineStats.Writes[i].WriteType};
+        }
+
+        if (oldEngineStats.Writes[i].WriteColumns != newEngineStats.Writes[i].WriteColumns) {
+            return {TQueryReplayEvents::WriteColumnsMismatch, TStringBuilder() << "Write columns mismatch"};
+        }
+    }
+
+    return {TQueryReplayEvents::UncategorizedPlanMismatch, ""};
+}
+
+std::pair<TQueryReplayEvents::TCheckQueryPlanStatus, TString> CheckQueryPlans(
+    const TString& oldPlanJson,
+    const NJson::TJsonValue& newPlan,
+    const TTableMetadataLookup& metadataLookup,
+    std::map<std::string, TTableStats>* newEngineStats)
+{
+    const NJson::TJsonValue oldEnginePlan = ParseQueryPlan(oldPlanJson);
+    const auto oldStats = ExtractTableStats(oldEnginePlan, metadataLookup);
+    auto newStats = ExtractTableStats(newPlan, metadataLookup);
+    if (newEngineStats) {
+        *newEngineStats = newStats;
+    }
+
+    for (const auto& [table, stats] : oldStats) {
+        auto it = newStats.find(table);
+        if (it == newStats.end()) {
+            return {TQueryReplayEvents::TableMissing,
+                TStringBuilder() << "Table " << table << " not found in new engine plan"};
+        }
+
+        if (stats != it->second) {
+            return CompareTableStats(stats, it->second);
+        }
+    }
+
+    return {TQueryReplayEvents::Success, ""};
+}
+
+TString StatusToFailReason(TQueryReplayEvents::TCheckQueryPlanStatus status) {
+    switch (status) {
+        case TQueryReplayEvents::CompileError:
+            return "compile_error";
+        case TQueryReplayEvents::CompileTimeout:
+            return "compile_timeout";
+        case TQueryReplayEvents::TableMissing:
+            return "table_missing";
+        case TQueryReplayEvents::ExtraReadingOldEngine:
+            return "extra_reading_old_engine";
+        case TQueryReplayEvents::ExtraReadingNewEngine:
+            return "extra_reading_new_engine";
+        case TQueryReplayEvents::ReadTypesMismatch:
+            return "read_types_mismatch";
+        case TQueryReplayEvents::ReadLimitsMismatch:
+            return "read_limits_mismatch";
+        case TQueryReplayEvents::ReadColumnsMismatch:
+            return "read_columns_mismatch";
+        case TQueryReplayEvents::ExtraWriting:
+            return "extra_writing";
+        case TQueryReplayEvents::WriteColumnsMismatch:
+            return "write_columns_mismatch";
+        case TQueryReplayEvents::WriteTypesMismatch:
+            return "write_types_mismatch";
+        case TQueryReplayEvents::UncategorizedPlanMismatch:
+            return "uncategorized_plan_mismatch";
+        case TQueryReplayEvents::MissingTableMetadata:
+            return "missing_table_metadata";
+        case TQueryReplayEvents::UncategorizedFailure:
+            return "uncategorized_failure";
+        default:
+            return "unspecified";
+    }
+}
+
+} // namespace NKikimr::NQueryReplay

--- a/ydb/tools/query_replay_yt/plan_check.h
+++ b/ydb/tools/query_replay_yt/plan_check.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "query_replay.h"
+
+#include <library/cpp/json/json_value.h>
+
+#include <functional>
+#include <map>
+
+namespace NKikimr::NQueryReplay {
+
+using TTableMetadataLookup = std::function<const NYql::TKikimrTableMetadataPtr*(const TString&)>;
+
+NJson::TJsonValue ParseQueryPlan(const TString& plan);
+
+std::map<std::string, TTableStats> ExtractTableStats(
+    const NJson::TJsonValue& plan,
+    const TTableMetadataLookup& metadataLookup);
+
+std::pair<TQueryReplayEvents::TCheckQueryPlanStatus, TString> CompareTableStats(
+    const TTableStats& oldEngineStats,
+    const TTableStats& newEngineStats);
+
+std::pair<TQueryReplayEvents::TCheckQueryPlanStatus, TString> CheckQueryPlans(
+    const TString& oldPlanJson,
+    const NJson::TJsonValue& newPlan,
+    const TTableMetadataLookup& metadataLookup,
+    std::map<std::string, TTableStats>* newEngineStats = nullptr);
+
+TString StatusToFailReason(TQueryReplayEvents::TCheckQueryPlanStatus status);
+
+} // namespace NKikimr::NQueryReplay

--- a/ydb/tools/query_replay_yt/query_compiler.cpp
+++ b/ydb/tools/query_replay_yt/query_compiler.cpp
@@ -1,5 +1,8 @@
 #include "query_replay.h"
 
+#include "metadata.h"
+#include "plan_check.h"
+
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
@@ -30,83 +33,7 @@ using namespace NYql;
 using namespace NYql::NDq;
 using namespace NKikimr;
 using namespace NKikimr::NKqp;
-
-
-struct TMetadataInfoHolder {
-    const THashMap<TString, NYql::TKikimrTableMetadataPtr> TableMetadata;
-    THashMap<TString, NYql::TKikimrTableMetadataPtr> Indexes;
-
-    explicit TMetadataInfoHolder(THashMap<TString,  NYql::TKikimrTableMetadataPtr>&& tableMetadata)
-        : TableMetadata(tableMetadata)
-    {
-        for (auto& [name, ptr] : TableMetadata) {
-            for (auto implTable : ptr->ImplTables) {
-                YQL_ENSURE(implTable);
-                do {
-                    auto nextImplTable = implTable->Next;
-                    Indexes.emplace(implTable->Name, std::move(implTable));
-                    implTable = std::move(nextImplTable);
-                } while (implTable);
-            }
-        }
-    }
-
-    THashMap<TString, NYql::TKikimrTableMetadataPtr>::const_iterator find(const TString& key) {
-        return TableMetadata.find(key);
-    }
-
-    const NYql::TKikimrTableMetadataPtr* FindPtr(const TString& key) const {
-        const auto* result = TableMetadata.FindPtr(key);
-        if (result != nullptr) {
-            return result;
-        }
-
-        return Indexes.FindPtr(key);
-    }
-
-    THashMap<TString, NYql::TKikimrTableMetadataPtr>::const_iterator begin() const {
-        return TableMetadata.begin();
-    }
-
-    THashMap<TString, NYql::TKikimrTableMetadataPtr>::const_iterator end() const {
-        return TableMetadata.end();
-    }
-};
-
-
-THashMap<TString, NYql::TKikimrTableMetadataPtr> ExtractStaticMetadata(const NJson::TJsonValue& data) {
-    EMetaSerializationType metaType = EMetaSerializationType::EncodedProto;
-    if (data.Has("table_meta_serialization_type")) {
-        metaType = static_cast<EMetaSerializationType>(data["table_meta_serialization_type"].GetUIntegerSafe());
-    }
-    THashMap<TString, NYql::TKikimrTableMetadataPtr> meta;
-
-    if (metaType == EMetaSerializationType::EncodedProto) {
-        static NJson::TJsonReaderConfig readerConfig;
-        NJson::TJsonValue tablemetajson;
-        TStringInput in(data["table_metadata"].GetStringSafe());
-        NJson::ReadJsonTree(&in, &readerConfig, &tablemetajson, false);
-        Y_ENSURE(tablemetajson.IsArray());
-        for (auto& node : tablemetajson.GetArray()) {
-            NKikimrKqp::TKqpTableMetadataProto proto;
-
-            TString decoded = Base64Decode(node.GetStringRobust());
-            Y_ENSURE(proto.ParseFromString(decoded));
-
-            NYql::TKikimrTableMetadataPtr ptr = MakeIntrusive<NYql::TKikimrTableMetadata>(&proto);
-            meta.emplace(proto.GetName(), ptr);
-        }
-    } else {
-        Y_ENSURE(data["table_metadata"].IsArray());
-        for (auto& node : data["table_metadata"].GetArray()) {
-            NKikimrKqp::TKqpTableMetadataProto proto;
-            NProtobufJson::Json2Proto(node.GetStringRobust(), proto);
-            NYql::TKikimrTableMetadataPtr ptr = MakeIntrusive<NYql::TKikimrTableMetadata>(&proto);
-            meta.emplace(proto.GetName(), ptr);
-        }
-    }
-    return meta;
-}
+using namespace NKikimr::NQueryReplay;
 
 
 class TStaticTableMetadataLoader: public NYql::IKikimrGateway::IKqpTableMetadataLoader, public NYql::IDbSchemeResolver {
@@ -296,95 +223,10 @@ private:
         AsyncCompileResult->Continue().Apply(callback);
     }
 
-    NJson::TJsonValue ExtractQueryPlan(const TString& plan) {
-        static NJson::TJsonReaderConfig readConfig;
-        TStringInput in(plan);
-        NJson::TJsonValue reply;
-        NJson::ReadJsonTree(&in, &readConfig, &reply, false);
-        return reply;
-    }
-
-    std::map<std::string, TTableStats> ExtractTableStats(const NJson::TJsonValue& rhs) {
-        std::map<std::string, TTableStats> result;
-
-        if (rhs.Has("tables")) {
-            for(const auto& table : rhs["tables"].GetArraySafe()) {
-                TString name = table["name"].GetStringSafe();
-                std::vector<TTableReadAccessInfo> reads;
-                std::vector<TTableWriteInfo> writes;
-
-                if (table.Has("reads")) {
-                    for(const auto& read: table["reads"].GetArraySafe()) {
-                        std::vector <std::string> columns;
-                        if (read.Has("columns")) {
-                            const auto tableMetadata = TableMetadata->FindPtr(name);
-                            Y_ENSURE(tableMetadata);
-                            const auto &keyColumnNames = tableMetadata->Get()->KeyColumnNames;
-                            std::unordered_set <std::string_view> keyColumns(keyColumnNames.begin(),
-                                                                             keyColumnNames.end());
-                            for (const auto &column : read["columns"].GetArraySafe()) {
-                                if (!keyColumns.contains(column.GetStringSafe())) {
-                                    columns.push_back(column.GetStringSafe());
-                                }
-                            }
-                            std::sort(columns.begin(), columns.end());
-                        }
-
-                        const auto &type = read["type"].GetStringSafe();
-                        i32 limit = -1;
-                        if (read.Has("limit") && read["limit"].IsInteger()) {
-                            limit = read["limit"].GetIntegerSafe();
-                        }
-
-                        bool probablyLookupScan = false;
-                        if (read.Has("lookup_by") && read.Has("scan_by")) {
-                            probablyLookupScan = true;
-                        }
-
-                        if (type == "Lookup") {
-                            if (probablyLookupScan) {
-                                reads.push_back(TTableReadAccessInfo{"Scan", limit, columns});
-                            } else {
-                                reads.push_back(TTableReadAccessInfo{"Lookup", limit, columns});
-                            }
-                        } else if (type == "MultiLookup") {
-                            reads.push_back(TTableReadAccessInfo{"Lookup", limit, columns});
-                        } else {
-                            reads.push_back(TTableReadAccessInfo({type, limit, columns}));
-                        }
-                    }
-
-                    std::sort(reads.begin(), reads.end());
-                }
-
-                if (table.Has("writes")) {
-                    for (const auto& write : table["writes"].GetArraySafe()) {
-                        std::vector<std::string> columns;
-                        if (write.Has("columns")) {
-                            const auto tableMetadata = TableMetadata->FindPtr(name);
-                            Y_ENSURE(tableMetadata);
-                            const auto& keyColumnNames = tableMetadata->Get()->KeyColumnNames;
-                            std::unordered_set<std::string_view> keyColumns(keyColumnNames.begin(), keyColumnNames.end());
-                            for (const auto& column : write["columns"].GetArraySafe()) {
-                                if (!keyColumns.contains(column.GetStringSafe())) {
-                                    columns.push_back(column.GetStringSafe());
-                                }
-                            }
-                            std::sort(columns.begin(), columns.end());
-                        }
-
-                        const auto& type = write["type"].GetStringSafe();
-                        writes.push_back(TTableWriteInfo{type, columns});
-                    }
-
-                    std::sort(writes.begin(), writes.end());
-                }
-
-                result.emplace(name, TTableStats{name, std::move(reads), std::move(writes)});
-            }
-        }
-
-        return result;
+    TTableMetadataLookup MetadataLookup() const {
+        return [this](const TString& name) {
+            return TableMetadata->FindPtr(name);
+        };
     }
 
     void WriteJsonData(const TString& fname, const NJson::TJsonValue& data) {
@@ -397,77 +239,6 @@ private:
         WriteJsonData("-repro.txt", ReplayDetails);
         WriteJsonData("-plan-lhs.txt", lhs);
         WriteJsonData("-plan-rhs.txt", rhs);
-    }
-
-    std::pair<TQueryReplayEvents::TCheckQueryPlanStatus, TString> OnTableOperationsMismatch(const TTableStats& oldEngineStats, const TTableStats& newEngineStats) {
-        Y_ENSURE(oldEngineStats.Name == newEngineStats.Name);
-        if (oldEngineStats.Reads.size() > newEngineStats.Reads.size()) {
-            return {TQueryReplayEvents::ExtraReadingOldEngine, TStringBuilder()
-                << "Extra reading in old engine plan for table " << oldEngineStats.Name};
-        }
-
-        if (oldEngineStats.Reads.size() < newEngineStats.Reads.size()) {
-            return {TQueryReplayEvents::ExtraReadingNewEngine, TStringBuilder()
-                << "Extra reading in new engine plan for table " << newEngineStats.Name};
-        }
-
-        for (size_t i = 0; i < oldEngineStats.Reads.size(); ++i) {
-            if (oldEngineStats.Reads[i].ReadType != newEngineStats.Reads[i].ReadType) {
-                return {TQueryReplayEvents::ReadTypesMismatch, TStringBuilder() << "Read types mismatch, old engine: "
-                    << ToString(oldEngineStats.Reads[i].ReadType) << ", new engine: " << ToString(newEngineStats.Reads[i].ReadType)};
-            }
-
-            if (oldEngineStats.Reads[i].PushedLimit != newEngineStats.Reads[i].PushedLimit) {
-                return {TQueryReplayEvents::ReadLimitsMismatch, TStringBuilder() << "Read limits mismatch, old engine: "
-                    << oldEngineStats.Reads[i].PushedLimit << ", new engine: " << newEngineStats.Reads[i].PushedLimit};
-            }
-
-            if (oldEngineStats.Reads[i].ReadColumns != newEngineStats.Reads[i].ReadColumns) {
-                return {TQueryReplayEvents::ReadColumnsMismatch, TStringBuilder() << "Read columns mismatch"};
-            }
-        }
-
-        if (oldEngineStats.Writes.size() > newEngineStats.Writes.size()) {
-            return {TQueryReplayEvents::ExtraWriting, TStringBuilder()
-                << "Extra write operation in old engine plan for table " << oldEngineStats.Name};
-        }
-
-        if (oldEngineStats.Writes.size() < newEngineStats.Writes.size()) {
-            return {TQueryReplayEvents::ExtraWriting, TStringBuilder()
-                << "Extra write operation in new engine plan for table " << newEngineStats.Name};
-        }
-
-        for (size_t i = 0; i < oldEngineStats.Writes.size(); ++i) {
-            if (oldEngineStats.Writes[i].WriteColumns != newEngineStats.Writes[i].WriteColumns) {
-                return {TQueryReplayEvents::WriteColumnsMismatch, TStringBuilder() << "Write columns mismatch"};
-            }
-        }
-
-        return {TQueryReplayEvents::UncategorizedPlanMismatch, ""};
-    }
-
-    std::pair<TQueryReplayEvents::TCheckQueryPlanStatus, TString> CheckQueryPlan(std::unique_ptr<TQueryReplayEvents::TEvCompileResponse>& ev,
-        const NJson::TJsonValue& newEnginePlan)
-    {
-        NJson::TJsonValue oldEnginePlan = ExtractQueryPlan(ReplayDetails["query_plan"].GetStringSafe());
-        const auto oldEngineStats = ExtractTableStats(oldEnginePlan);
-        ev->EngineTableStats = ExtractTableStats(newEnginePlan);
-
-        for (const auto& [table, stats] : oldEngineStats) {
-            auto it = ev->EngineTableStats.find(table);
-            if (it == ev->EngineTableStats.end()) {
-                WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
-                return {TQueryReplayEvents::TableMissing,
-                    TStringBuilder() << "Table " << table << " not found in new engine plan"};
-            }
-
-            if (stats != it->second) {
-                WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
-                return OnTableOperationsMismatch(stats, it->second);
-            }
-        }
-
-        return {TQueryReplayEvents::Success, ""};
     }
 
     void Reply(const Ydb::StatusIds::StatusCode& status, const TString& message) {
@@ -495,7 +266,16 @@ private:
         } else {
             Y_ENSURE(queryPlan);
             ev->Plan = *queryPlan;
-            std::tie(ev->Status, ev->Message) = CheckQueryPlan(ev, ExtractQueryPlan(*queryPlan));
+            const NJson::TJsonValue newEnginePlan = ParseQueryPlan(*queryPlan);
+            const NJson::TJsonValue oldEnginePlan = ParseQueryPlan(ReplayDetails["query_plan"].GetStringSafe());
+            std::tie(ev->Status, ev->Message) = CheckQueryPlans(
+                ReplayDetails["query_plan"].GetStringSafe(),
+                newEnginePlan,
+                MetadataLookup(),
+                &ev->EngineTableStats);
+            if (ev->Status != TQueryReplayEvents::Success) {
+                WriteQueryMismatchInfo(oldEnginePlan, newEnginePlan);
+            }
         }
 
         Send(Owner, ev.release());

--- a/ydb/tools/query_replay_yt/query_replay.h
+++ b/ydb/tools/query_replay_yt/query_replay.h
@@ -97,6 +97,7 @@ struct TQueryReplayEvents {
         ReadColumnsMismatch,
         ExtraWriting,
         WriteColumnsMismatch,
+        WriteTypesMismatch,
         UncategorizedPlanMismatch,
         MissingTableMetadata,
         UncategorizedFailure,

--- a/ydb/tools/query_replay_yt/replay_runner.cpp
+++ b/ydb/tools/query_replay_yt/replay_runner.cpp
@@ -1,0 +1,93 @@
+#include "replay_runner.h"
+
+#include <ydb/core/kqp/rm_service/kqp_rm_service.h>
+#include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
+
+#include <util/folder/path.h>
+#include <util/string/split.h>
+
+TVector<std::pair<TString, TString>> GetJobFiles(TVector<TString> udfs) {
+    TVector<std::pair<TString, TString>> result;
+
+    for (const TString& udf : udfs) {
+        TVector<TString> splitResult;
+        Split(udf.data(), "/", splitResult);
+        while (!splitResult.empty() && splitResult.back().empty()) {
+            splitResult.pop_back();
+        }
+
+        Y_ENSURE(!splitResult.empty());
+
+        result.push_back(std::make_pair(udf, splitResult.back()));
+    }
+
+    return result;
+}
+
+void TQueryReplayRunner::Init(
+    const TVector<TString>& udfFiles,
+    ui32 actorSystemThreadsCount,
+    bool antlr4ParserIsAmbiguityError,
+    NActors::NLog::EPriority yqlLogPriority)
+{
+    Antlr4ParserIsAmbiguityError = antlr4ParserIsAmbiguityError;
+    YqlLogger = std::make_unique<NYql::NLog::YqlLoggerScope>(&Cerr);
+    NYql::NDq::SetYqlLogLevels(yqlLogPriority);
+
+    TypeRegistry.Reset(new NKikimr::NScheme::TKikimrTypeRegistry());
+    FunctionRegistry.Reset(NKikimr::NMiniKQL::CreateFunctionRegistry(NKikimr::NMiniKQL::CreateBuiltinRegistry())->Clone());
+    NKikimr::NMiniKQL::FillStaticModules(*FunctionRegistry);
+    NKikimr::NMiniKQL::TUdfModuleRemappings remappings;
+    THashSet<TString> usedUdfPaths;
+
+    for (const auto& [realPath, udfPath] : GetJobFiles(udfFiles)) {
+        if (usedUdfPaths.insert(udfPath).second) {
+            if (NFs::Exists(udfPath)) {
+                FunctionRegistry->LoadUdfs(udfPath, remappings, 0);
+                continue;
+            }
+
+            if (NFs::Exists(realPath)) {
+                FunctionRegistry->LoadUdfs(realPath, remappings, 0);
+                continue;
+            }
+        }
+    }
+
+    AppData.Reset(new NKikimr::TAppData(0, 0, 0, 0, {}, TypeRegistry.Get(), FunctionRegistry.Get(), nullptr, nullptr));
+    AppData->Counters = MakeIntrusive<NMonitoring::TDynamicCounters>(new NMonitoring::TDynamicCounters());
+    auto setup = BuildActorSystemSetup(actorSystemThreadsCount);
+    ActorSystem.Reset(new NActors::TActorSystem(setup, AppData.Get()));
+    ActorSystem->Start();
+    ActorSystem->Register(NKikimr::NKqp::CreateKqpResourceManagerActor({}, nullptr));
+    ModuleResolverState = MakeIntrusive<NKikimr::NKqp::TModuleResolverState>();
+    HttpGateway = NYql::IHTTPGateway::Make();
+    Y_ABORT_UNLESS(GetYqlDefaultModuleResolver(ModuleResolverState->ExprCtx, ModuleResolverState->ModuleResolver));
+}
+
+THolder<TQueryReplayEvents::TEvCompileResponse> TQueryReplayRunner::RunReplay(NJson::TJsonValue replayDetails) {
+    const TString queryType = replayDetails["query_type"].GetStringSafe();
+    if (queryType == "QUERY_TYPE_AST_SCAN" || queryType == "QUERY_TYPE_AST_DML") {
+        return nullptr;
+    }
+
+    if (queryType == "QUERY_TYPE_SQL_GENERIC_SCRIPT") {
+        return nullptr;
+    }
+
+    auto compileActorId = ActorSystem->Register(
+        CreateQueryCompiler(ModuleResolverState, FunctionRegistry.Get(), HttpGateway, Antlr4ParserIsAmbiguityError));
+
+    auto future = ActorSystem->Ask<TQueryReplayEvents::TEvCompileResponse>(
+        compileActorId,
+        THolder(new TQueryReplayEvents::TEvCompileRequest(std::move(replayDetails))),
+        TDuration::Seconds(600));
+
+    return THolder(future.ExtractValueSync().Release());
+}
+
+void TQueryReplayRunner::Stop() {
+    if (ActorSystem) {
+        ActorSystem->Stop();
+    }
+}

--- a/ydb/tools/query_replay_yt/replay_runner.h
+++ b/ydb/tools/query_replay_yt/replay_runner.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "query_replay.h"
+
+#include <util/generic/vector.h>
+#include <util/generic/string.h>
+
+TVector<std::pair<TString, TString>> GetJobFiles(TVector<TString> udfs);
+
+#include <ydb/core/kqp/gateway/kqp_gateway.h>
+#include <ydb/library/yql/utils/actor_log/log.h>
+
+#include <library/cpp/json/json_value.h>
+
+#include <memory>
+
+class TQueryReplayRunner {
+public:
+    void Init(
+        const TVector<TString>& udfFiles,
+        ui32 actorSystemThreadsCount,
+        bool antlr4ParserIsAmbiguityError,
+        NActors::NLog::EPriority yqlLogPriority = NActors::NLog::EPriority::PRI_ERROR);
+
+    THolder<TQueryReplayEvents::TEvCompileResponse> RunReplay(NJson::TJsonValue replayDetails);
+
+    void Stop();
+
+private:
+    THolder<NActors::TActorSystem> ActorSystem;
+    THolder<NKikimr::TAppData> AppData;
+    TIntrusivePtr<NKikimr::NScheme::TKikimrTypeRegistry> TypeRegistry;
+    TIntrusivePtr<NKikimr::NMiniKQL::IFunctionRegistry> FunctionRegistry;
+    TIntrusivePtr<NKikimr::NKqp::TModuleResolverState> ModuleResolverState;
+    NYql::IHTTPGateway::TPtr HttpGateway;
+    std::unique_ptr<NYql::NLog::YqlLoggerScope> YqlLogger;
+    bool Antlr4ParserIsAmbiguityError = false;
+};

--- a/ydb/tools/query_replay_yt/ut/plan_check_ut.cpp
+++ b/ydb/tools/query_replay_yt/ut/plan_check_ut.cpp
@@ -1,0 +1,105 @@
+#include "plan_check.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr::NQueryReplay;
+
+namespace {
+
+NJson::TJsonValue PlanWithReadType(const TString& readType) {
+    NJson::TJsonValue plan(NJson::JSON_MAP);
+    NJson::TJsonValue tables(NJson::JSON_ARRAY);
+    NJson::TJsonValue table(NJson::JSON_MAP);
+    table["name"] = "t";
+    NJson::TJsonValue reads(NJson::JSON_ARRAY);
+    NJson::TJsonValue read(NJson::JSON_MAP);
+    read["type"] = readType;
+    reads.AppendValue(read);
+    table["reads"] = reads;
+    tables.AppendValue(table);
+    plan["tables"] = tables;
+    return plan;
+}
+
+NJson::TJsonValue PlanWithWrite(const TString& writeType, const TVector<TString>& columns) {
+    NJson::TJsonValue plan(NJson::JSON_MAP);
+    NJson::TJsonValue tables(NJson::JSON_ARRAY);
+    NJson::TJsonValue table(NJson::JSON_MAP);
+    table["name"] = "t";
+    NJson::TJsonValue writes(NJson::JSON_ARRAY);
+    NJson::TJsonValue write(NJson::JSON_MAP);
+    write["type"] = writeType;
+    if (!columns.empty()) {
+        NJson::TJsonValue cols(NJson::JSON_ARRAY);
+        for (const auto& column : columns) {
+            cols.AppendValue(column);
+        }
+        write["columns"] = cols;
+    }
+    writes.AppendValue(write);
+    table["writes"] = writes;
+    tables.AppendValue(table);
+    plan["tables"] = tables;
+    return plan;
+}
+
+TString WritePlanJson(const NJson::TJsonValue& plan) {
+    return NJson::WriteJson(plan, false);
+}
+
+const TTableMetadataLookup NoMetadataLookup = [](const TString&) {
+    return nullptr;
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TQueryReplayPlanCheck) {
+    Y_UNIT_TEST(ReadTypesMismatch) {
+        const auto oldPlan = PlanWithReadType("Scan");
+        const auto newPlan = PlanWithReadType("Lookup");
+        const auto [status, message] = CheckQueryPlans(
+            WritePlanJson(oldPlan),
+            newPlan,
+            NoMetadataLookup);
+        UNIT_ASSERT_EQUAL(status, TQueryReplayEvents::ReadTypesMismatch);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            message,
+            "Read types mismatch, old engine: Scan, new engine: Lookup");
+        UNIT_ASSERT_STRINGS_EQUAL(StatusToFailReason(status), "read_types_mismatch");
+    }
+
+    Y_UNIT_TEST(WriteTypesMismatch) {
+        const auto oldPlan = PlanWithWrite("MultiUpsert", {});
+        const auto newPlan = PlanWithWrite("MultiReplace", {});
+        const auto [status, message] = CheckQueryPlans(
+            WritePlanJson(oldPlan),
+            newPlan,
+            NoMetadataLookup);
+        UNIT_ASSERT_EQUAL(status, TQueryReplayEvents::WriteTypesMismatch);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            message,
+            "Write types mismatch, old engine: MultiUpsert, new engine: MultiReplace");
+        UNIT_ASSERT_STRINGS_EQUAL(StatusToFailReason(status), "write_types_mismatch");
+    }
+
+    Y_UNIT_TEST(WriteColumnsMismatch) {
+        const auto oldPlan = PlanWithWrite("Upsert", {"new"});
+        const auto newPlan = PlanWithWrite("Upsert", {"old"});
+        const auto [status, message] = CheckQueryPlans(
+            WritePlanJson(oldPlan),
+            newPlan,
+            NoMetadataLookup);
+        UNIT_ASSERT_EQUAL(status, TQueryReplayEvents::WriteColumnsMismatch);
+        UNIT_ASSERT_STRINGS_EQUAL(message, "Write columns mismatch");
+    }
+
+    Y_UNIT_TEST(MatchingPlansSuccess) {
+        const auto plan = PlanWithReadType("Lookup");
+        const auto [status, message] = CheckQueryPlans(
+            WritePlanJson(plan),
+            plan,
+            NoMetadataLookup);
+        UNIT_ASSERT_EQUAL(status, TQueryReplayEvents::Success);
+        UNIT_ASSERT_VALUES_EQUAL(message, "");
+    }
+}

--- a/ydb/tools/query_replay_yt/ut/replay_runner_ut.cpp
+++ b/ydb/tools/query_replay_yt/ut/replay_runner_ut.cpp
@@ -1,0 +1,36 @@
+#include "plan_check.h"
+#include "replay_runner.h"
+
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr::NQueryReplay;
+
+namespace {
+
+NJson::TJsonValue MakeInvalidSqlReplayDetails() {
+    NJson::TJsonValue details(NJson::JSON_MAP);
+    details["query_id"] = "invalid-sql-test";
+    details["query_text"] = "SELECT * FROM";
+    details["query_type"] = "QUERY_TYPE_SQL_SCAN";
+    details["query_database"] = "/local";
+    details["query_syntax"] = "1";
+    details["query_cluster"] = "local";
+    details["query_plan"] = "{}";
+    details["table_metadata"] = NJson::TJsonValue(NJson::JSON_ARRAY);
+    return details;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TQueryReplayRunner) {
+    Y_UNIT_TEST(CompileErrorOnInvalidSql) {
+        TQueryReplayRunner runner;
+        runner.Init({}, 2, false);
+        auto response = runner.RunReplay(MakeInvalidSqlReplayDetails());
+        UNIT_ASSERT(response);
+        UNIT_ASSERT_EQUAL(response->Status, TQueryReplayEvents::CompileError);
+        UNIT_ASSERT_STRINGS_EQUAL(StatusToFailReason(response->Status), "compile_error");
+        runner.Stop();
+    }
+}

--- a/ydb/tools/query_replay_yt/ut/ya.make
+++ b/ydb/tools/query_replay_yt/ut/ya.make
@@ -1,0 +1,35 @@
+IF (SANITIZER_TYPE AND AUTOCHECK)
+
+ELSE()
+
+UNITTEST_FOR(ydb/tools/query_replay_yt/lib)
+
+PEERDIR(
+    ydb/tools/query_replay_yt/lib
+)
+
+SRCS(
+    plan_check_ut.cpp
+)
+
+SIZE(SMALL)
+
+END()
+
+UNITTEST_FOR(ydb/tools/query_replay_yt/lib)
+
+PEERDIR(
+    ydb/tools/query_replay_yt/lib
+)
+
+SRCS(
+    replay_runner_ut.cpp
+)
+
+SIZE(LARGE)
+TIMEOUT(300)
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/large.inc)
+
+END()
+
+ENDIF()

--- a/ydb/tools/query_replay_yt/ya.make
+++ b/ydb/tools/query_replay_yt/ya.make
@@ -5,8 +5,12 @@ ALLOCATOR(LF)
 YQL_LAST_ABI_VERSION()
 INCLUDE(${ARCADIA_ROOT}/ydb/tools/query_replay_yt/common_deps.inc)
 
-SRCS(${YDB_REPLAY_SRCS})
+SRCS(
+    main.cpp
+)
 
-PEERDIR(${YDB_REPLAY_PEERDIRS})
+PEERDIR(
+    ydb/tools/query_replay_yt/lib
+)
 
 END()


### PR DESCRIPTION
## Summary

- Split `query_replay_yt` into a library (`query_replay_yt_lib`) and a thin program (`main.cpp`) so replay/plan-check logic can be tested without YT.
- Extracted `plan_check`, `metadata`, and `replay_runner` modules; `query_compiler` now uses shared `CheckQueryPlans`.
- Added unit tests: `plan_check_ut` (SMALL, PR-check) and `replay_runner_ut` (LARGE, regression large job).
- Added `WriteTypesMismatch` to plan comparison (write type in addition to columns).

## Test plan

- [ ] PR-check picks up `plan_check_ut` via `ydb/` small/medium test run
- [ ] `regression_run_large` runs `replay_runner_ut` after merge
- [ ] `query_replay_yt` program still builds and links against the new lib


Made with [Cursor](https://cursor.com)