### PR TITLE
Get rid of premature updates of the SyncState in Skeleton

### DIFF
--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.cpp
@@ -67,7 +67,7 @@ namespace NKikimr {
         SyncLogAdvisedIndexedBlockSize = ui32(1) << ui32(20);       // 1 MB
         SyncLogMaxMemAmount = ui64(64) << ui64(20);                 // 64 MB
 
-        MaxSyncLogChunkSize = ui32(16) << ui32(10);                 // 32 Kb
+        MaxSyncDataCutterChunkSize = ui32(256) << ui32(10);         // 256 Kb
 
         ReplTimeInterval = TDuration::Seconds(60);                  // 60 seconds
         ReplRequestTimeout = TDuration::Seconds(10);                // 10 seconds

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -171,7 +171,7 @@ namespace NKikimr {
         TControlWrapper EnableLocalSyncLogDataCutting;
         TControlWrapper EnableSyncLogChunkCompression;
         TControlWrapper MaxSyncLogChunksInFlight;
-        ui32 MaxSyncLogChunkSize;
+        ui32 MaxSyncDataCutterChunkSize;
 
         ///////////// REPL SETTINGS /////////////////////////
         TDuration ReplTimeInterval;

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.cpp
@@ -198,6 +198,7 @@ namespace NKikimr {
         TActorId ParentId;
         std::unique_ptr<TEvLocalSyncData> Ev;
         std::vector<TString> Chunks;
+        TSyncState OldSyncState;
 
         ui32 ChunksInFlight = 0;
         bool CompressChunks;
@@ -263,7 +264,18 @@ namespace NKikimr {
 
         void SendChunks() {
             while (ChunksInFlight < MaxChunksInFlight && !Chunks.empty()) {
-                Send(SkeletonId, new TEvLocalSyncData(Ev->VDiskID, Ev->SyncState, std::move(Chunks.back())));
+                // The last chunk carries the new SyncState, which advances the peer's
+                // SyncedLsn cursor during recovery. It must only be sent (and thus logged)
+                // after all previous chunks have been confirmed durable; otherwise a crash
+                // that persists only the last chunk could advance the cursor past data that
+                // was never written, leading to a permanent local gap. All preceding chunks
+                // carry OldSyncState, which does not advance the cursor.
+                const bool isLastChunk = (Chunks.size() == 1);
+                if (isLastChunk && ChunksInFlight > 0) {
+                    break;
+                }
+                const TSyncState& syncState = isLastChunk ? Ev->SyncState : OldSyncState;
+                Send(SkeletonId, new TEvLocalSyncData(Ev->VDiskID, syncState, std::move(Chunks.back())));
                 Chunks.pop_back();
                 ++ChunksInFlight;
             }
@@ -279,11 +291,13 @@ namespace NKikimr {
                 const TIntrusivePtr<TVDiskContext>& vctx,
                 const TActorId& skeletonId,
                 const TActorId& parentId,
-                std::unique_ptr<TEvLocalSyncData> ev)
+                std::unique_ptr<TEvLocalSyncData> ev,
+                const TSyncState& oldSyncState)
             : VCtx(vctx)
             , SkeletonId(skeletonId)
             , ParentId(parentId)
             , Ev(std::move(ev))
+            , OldSyncState(oldSyncState)
             , CompressChunks(vconfig->MaxSyncLogChunksInFlight)
             , MaxChunksInFlight(vconfig->MaxSyncLogChunksInFlight)
             , MaxChunksSize(vconfig->MaxSyncLogChunkSize)
@@ -296,8 +310,9 @@ namespace NKikimr {
     };
 
     IActor* CreateLocalSyncDataCutter(const TIntrusivePtr<TVDiskConfig>& vconfig, const TIntrusivePtr<TVDiskContext>& vctx,
-        const TActorId& skeletonId, const TActorId& parentId, std::unique_ptr<TEvLocalSyncData> ev) {
-        return new TLocalSyncDataCutterActor(vconfig, vctx, skeletonId, parentId, std::move(ev));
+        const TActorId& skeletonId, const TActorId& parentId, std::unique_ptr<TEvLocalSyncData> ev,
+        const TSyncState& oldSyncState) {
+        return new TLocalSyncDataCutterActor(vconfig, vctx, skeletonId, parentId, std::move(ev), oldSyncState);
     }
 
 

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.cpp
@@ -298,9 +298,9 @@ namespace NKikimr {
             , ParentId(parentId)
             , Ev(std::move(ev))
             , OldSyncState(oldSyncState)
-            , CompressChunks(vconfig->MaxSyncLogChunksInFlight)
+            , CompressChunks(vconfig->EnableSyncLogChunkCompression)
             , MaxChunksInFlight(vconfig->MaxSyncLogChunksInFlight)
-            , MaxChunksSize(vconfig->MaxSyncLogChunkSize)
+            , MaxChunksSize(vconfig->MaxSyncDataCutterChunkSize)
         {}
 
     STRICT_STFUNC(StateFunc, {

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.h
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.h
@@ -85,6 +85,7 @@ namespace NKikimr {
     // CreateLocalSyncDataCutter
     ///////////////////////////////////////////////////////////////////////////////////////////////
     IActor* CreateLocalSyncDataCutter(const TIntrusivePtr<TVDiskConfig>& vconfig, const TIntrusivePtr<TVDiskContext>& vctx,
-        const TActorId& skeletonId, const TActorId& parentId, std::unique_ptr<TEvLocalSyncData> ev);
+        const TActorId& skeletonId, const TActorId& parentId, std::unique_ptr<TEvLocalSyncData> ev,
+        const TSyncState& oldSyncState);
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/syncer/syncer_job_task.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/syncer_job_task.cpp
@@ -206,6 +206,7 @@ namespace NKikimr {
                 return ReplyAndDie(TSyncStatusVal::ProtocolError);
             }
 
+            const TSyncState oldSyncState = GetCurrent().SyncState;
             SetSyncState(newSyncState);
             EndOfStream = record.GetFinished();
 
@@ -217,7 +218,8 @@ namespace NKikimr {
 
                 if (Ctx->SyncerCtx->Config->EnableLocalSyncLogDataCutting) {
                     std::unique_ptr<IActor> actor(CreateLocalSyncDataCutter(Ctx->SyncerCtx->Config,
-                            Ctx->SyncerCtx->VCtx, Ctx->SyncerCtx->SkeletonId, parentId, std::move(msg)));
+                            Ctx->SyncerCtx->VCtx, Ctx->SyncerCtx->SkeletonId, parentId, std::move(msg),
+                            oldSyncState));
                     return TSjOutcome::Actor(std::move(actor), true);
                 } else {
 
@@ -375,7 +377,8 @@ namespace NKikimr {
 
                 if (Ctx->SyncerCtx->Config->EnableLocalSyncLogDataCutting) {
                     std::unique_ptr<IActor> actor(CreateLocalSyncDataCutter(Ctx->SyncerCtx->Config,
-                            Ctx->SyncerCtx->VCtx, Ctx->SyncerCtx->SkeletonId, parentId, std::move(msg)));
+                            Ctx->SyncerCtx->VCtx, Ctx->SyncerCtx->SkeletonId, parentId, std::move(msg),
+                            OldSyncState));
                     return TSjOutcome::Actor(std::move(actor), true);
                 } else {
                     auto msg = std::make_unique<TEvLocalSyncData>(vdisk, OldSyncState, data);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix possible dataloss in sync protocol with SyncDataCutting enabled due to premature commit of SyncState
https://github.com/ydb-platform/ydb/issues/43217

### Changelog category <!-- remove all except one -->

* Bugfix 