### PR TITLE
ci: make release-asan test failures block PR merge

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -211,7 +211,6 @@ runs:
             params+=(
               --build "release" --sanitize="address"
             )
-            IS_TEST_RESULT_IGNORED=1
             ;;
           release-tsan)
             params+=(

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -275,9 +275,9 @@ jobs:
         run: |
           successbuilds=$(curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X GET -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/commits/${{github.event.pull_request.head.sha}}/status | \
-            jq -cr '.statuses | .[] | select(.state=="success") | select(.context | (startswith("build_relwithdebinfo") or startswith("build_release-asan") or startswith("test_relwithdebinfo")) ) | .context' | \
+            jq -cr '.statuses | .[] | select(.state=="success") | select(.context | (startswith("build_relwithdebinfo") or startswith("build_release-asan") or startswith("test_relwithdebinfo") or startswith("test_release-asan")) ) | .context' | \
             wc -l )
-          if [[ $successbuilds == "3" ]];then
+          if [[ $successbuilds == "4" ]];then
             integrated_status="success"
           else
             integrated_status="failure"

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -268,7 +268,7 @@ jobs:
   update_integrated_status:
     runs-on: [self-hosted, tiny-worker]
     needs: build_and_test
-    if: ${{ always() && github.event.pull_request.state == 'open' }}
+    if: ${{github.event.pull_request.state == 'open'}}
     steps:
       - name: Gather required checks results
         shell: bash

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -268,20 +268,25 @@ jobs:
   update_integrated_status:
     runs-on: [self-hosted, tiny-worker]
     needs: build_and_test
-    if: ${{github.event.pull_request.state == 'open'}}
+    if: ${{ always() && github.event.pull_request.state == 'open' }}
     steps:
       - name: Gather required checks results
         shell: bash
         run: |
-          successbuilds=$(curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X GET -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
+          integrated_status=$(curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X GET -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/commits/${{github.event.pull_request.head.sha}}/status | \
-            jq -cr '.statuses | .[] | select(.state=="success") | select(.context | (startswith("build_relwithdebinfo") or startswith("build_release-asan") or startswith("test_relwithdebinfo") or startswith("test_release-asan")) ) | .context' | \
-            wc -l )
-          if [[ $successbuilds == "4" ]];then
-            integrated_status="success"
-          else
-            integrated_status="failure"
-          fi
+            jq -cr '
+              .statuses
+              | group_by(.context)
+              | map(.[0])
+              | map(select(.context | (
+                  startswith("build_relwithdebinfo")
+                  or startswith("build_release-asan")
+                  or startswith("test_relwithdebinfo")
+                  or startswith("test_release-asan")
+                )))
+              | if length == 4 and all(.state == "success") then "success" else "failure" end
+            ')
           curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
             -d '{"state":"'$integrated_status'","description":"All checks completed","context":"checks_integrated","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'


### PR DESCRIPTION
## Summary
- Re-enable blocking policy for `release-asan` test failures in PR-check by removing `IS_TEST_RESULT_IGNORED=1` from `test_ya` action.
- Include `test_release-asan` in `checks_integrated` aggregation (required success count: 3 → 4).

After this change, failed ASAN tests on the last retry will:
- mark `test_release-asan` commit status as failure,
- fail the PR-check job on `check test results`,
- block `checks_integrated` until ASAN tests pass.

ASAN retries (try_1/try_2/try_3) remain unchanged.

## Test plan
- [ ] Open a PR and verify `test_release-asan` turns red when ASAN tests fail on try 3
- [ ] Verify PR comment shows red failure (not yellow "not in blocking policy yet")
- [ ] Verify `checks_integrated` stays red until all 4 required statuses succeed
- [ ] Verify passing PR still gets green `test_release-asan` and `checks_integrated`

Example of  "not in blocking policy yet"
<img width="632" height="154" alt="image" src="https://github.com/user-attachments/assets/2e0e32e6-8a37-4d04-9497-f7f00e00d2fb" />
