### PR TITLE
Fix selectivity computation logic for pushed-down filters.

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_operator.h
+++ b/ydb/core/kqp/opt/rbo/kqp_operator.h
@@ -77,6 +77,10 @@ struct TPhysicalOpProps {
     std::optional<NKikimr::NKqp::EJoinAlgoType> JoinAlgo;
     std::optional<double> Cost;
 
+    // Selectivity of a single-table predicate that was pushed down into a TOpRead.
+    // It is computed at pushdown time while the predicate expression is still live and type-annotated.
+    std::optional<double> PushedDownFilterSelectivity;
+
     // CBO decision for this join's input edges.
     // std::nullopt means there was no explicit decision.
     // Empty vector means shuffle is eliminated.

--- a/ydb/core/kqp/opt/rbo/kqp_operator.h
+++ b/ydb/core/kqp/opt/rbo/kqp_operator.h
@@ -77,10 +77,6 @@ struct TPhysicalOpProps {
     std::optional<NKikimr::NKqp::EJoinAlgoType> JoinAlgo;
     std::optional<double> Cost;
 
-    // Selectivity of a single-table predicate that was pushed down into a TOpRead.
-    // It is computed at pushdown time while the predicate expression is still live and type-annotated.
-    std::optional<double> PushedDownFilterSelectivity;
-
     // CBO decision for this join's input edges.
     // std::nullopt means there was no explicit decision.
     // Empty vector means shuffle is eliminated.

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -232,6 +232,7 @@ void TOpRead::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
     if (Props.PushedDownFilterSelectivity.has_value()) {
         double filterSelectivity = Props.PushedDownFilterSelectivity.value() * Props.Statistics->Selectivity;
         Props.Statistics->EBytes = filterSelectivity * Props.Statistics->EBytes;
+        Props.Statistics->ERows = filterSelectivity * Props.Statistics->ERows;
         Props.Statistics->Selectivity = filterSelectivity;
     }
 }
@@ -279,6 +280,7 @@ void TOpFilter::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
 
     double filterSelectivity = selectivity * Props.Statistics->Selectivity;
     Props.Statistics->EBytes = filterSelectivity * Props.Statistics->EBytes;
+    Props.Statistics->ERows = filterSelectivity * Props.Statistics->ERows;
     Props.Statistics->Selectivity = filterSelectivity;
 }
 

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -228,9 +228,13 @@ void TOpRead::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
         }
     }
 
-    // Overwrite with pre-computed selectivity for successfully pushed-down filters within the read operator.
-    if (Props.PushedDownFilterSelectivity.has_value()) {
-        double filterSelectivity = Props.PushedDownFilterSelectivity.value() * Props.Statistics->Selectivity;
+    // Overwrite with selectivity for successfully pushed-down filters within the read operator.
+    if (OriginalPredicate.has_value()) {
+        auto inputStats = std::make_shared<TOptimizerStatistics>(BuildOptimizerStatistics(Props, true));
+        auto lambda = TCoLambda(OriginalPredicate->Node);
+        double selectivity = TPredicateSelectivityComputer(inputStats).Compute(lambda.Body());
+
+        double filterSelectivity = selectivity * Props.Statistics->Selectivity;
         Props.Statistics->EBytes = filterSelectivity * Props.Statistics->EBytes;
         Props.Statistics->ERows = filterSelectivity * Props.Statistics->ERows;
         Props.Statistics->Selectivity = filterSelectivity;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -227,6 +227,13 @@ void TOpRead::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
             }
         }
     }
+
+    // Overwrite with pre-computed selectivity for successfully pushed-down filters within the read operator.
+    if (Props.PushedDownFilterSelectivity.has_value()) {
+        double filterSelectivity = Props.PushedDownFilterSelectivity.value() * Props.Statistics->Selectivity;
+        Props.Statistics->EBytes = filterSelectivity * Props.Statistics->EBytes;
+        Props.Statistics->Selectivity = filterSelectivity;
+    }
 }
 
 /**

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_type_ann.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_type_ann.cpp
@@ -84,6 +84,21 @@ TStatus ComputeTypes(TIntrusivePtr<TOpRead> read, TRBOContext& ctx) {
     }
     auto newStructType = ctx.ExprCtx.MakeType<TStructExprType>(newItemTypes);
 
+    if (read->OriginalPredicate.has_value()) {
+        auto& lambda = read->OriginalPredicate.value().Node;
+        if (!UpdateLambdaAllArgumentsTypes(lambda, {newStructType}, ctx.ExprCtx)) {
+            YQL_CLOG(TRACE, CoreDq) << "Could not update original filter lambda arg types.";
+            return IGraphTransformer::TStatus::Error;
+        }
+
+        ctx.TypeAnnTransformer.Rewind();
+        IGraphTransformer::TStatus status(IGraphTransformer::TStatus::Ok, "Cannot type annotate original filter lambda.");
+        do {
+            status = ctx.TypeAnnTransformer.Transform(lambda, lambda, ctx.ExprCtx);
+        } while (status == IGraphTransformer::TStatus::Repeat);
+        Y_ENSURE(status == IGraphTransformer::TStatus::Ok && lambda->GetTypeAnn());
+    }
+
     if (IsNeededToUpdateOlapReadType(read->OlapFilterLambda)) {
         auto& lambda = read->OlapFilterLambda;
         if (!UpdateLambdaAllArgumentsTypes(lambda, {ctx.ExprCtx.MakeType<TFlowExprType>(structType)}, ctx.ExprCtx)) {

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
@@ -208,16 +208,12 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
         MakeIntrusive<TOpRead>(read->Alias, read->Columns, read->GetOutputIUs(), read->StorageType, read->TableCallable, newOlapFilterLambda.Ptr(), read->Limit,
                                read->GetRanges(), originalPredicate, read->SortDir, read->Props, read->Pos);
     if (IsValidPredicateToKeep(remainingFilter)) {
-        // Part of the predicate could not be pushed down. The remaining TOpFilter survives and its selectivity computed later.
+        // Part of the predicate could not be pushed down and the remaining TOpFilter survives.
         return MakeIntrusive<TOpFilter>(newRead, filter->Pos, filter->Props, TExpression(remainingFilter.Cast().Ptr(), &ctx.ExprCtx, &props));
     }
 
-    // Compute the predicate selectivity now, while the filter lambda is still live and type-annotated
-    auto readStats = std::make_shared<TOptimizerStatistics>(BuildOptimizerStatistics(read->Props, true));
-    const double pushedDownFilterSelectivity = TPredicateSelectivityComputer(readStats).Compute(lambda.Body());
 
-    // The whole predicate was pushed in: no TOpFilter remains, so carry its selectivity on the read.
-    newRead->Props.PushedDownFilterSelectivity = pushedDownFilterSelectivity;
+    // The whole predicate was pushed in and no TOpFilter remains.
     return newRead;
 }
 

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.h>
 #include <ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.h>
 #include <ydb/core/kqp/opt/physical/predicate_collector.h>
 #include <ydb/core/kqp/opt/rbo/kqp_rbo_rules.h>
@@ -103,6 +104,9 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
     auto predicate = lambda.Body();
     auto lambdaArg = lambda.Args().Arg(0).Ptr();
 
+    // Compute the predicate selectivity now, while the filter lambda is still live and type-annotated
+    const double pushedDownFilterSelectivity = TPredicateSelectivityComputer(std::make_shared<TOptimizerStatistics>()).Compute(lambda.Body());
+
     // Here we want to apply coalesce and propagate it to optional predicates.
     // clang-format off
     predicate = Build<TCoCoalesce>(ctx.ExprCtx, input->Pos)
@@ -207,8 +211,11 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
         MakeIntrusive<TOpRead>(read->Alias, read->Columns, read->GetOutputIUs(), read->StorageType, read->TableCallable, newOlapFilterLambda.Ptr(), read->Limit,
                                read->GetRanges(), originalPredicate, read->SortDir, read->Props, read->Pos);
     if (IsValidPredicateToKeep(remainingFilter)) {
+        // Part of the predicate could not be pushed down. The remaining TOpFilter survives and its selectivity computed later.
         return MakeIntrusive<TOpFilter>(newRead, filter->Pos, filter->Props, TExpression(remainingFilter.Cast().Ptr(), &ctx.ExprCtx, &props));
     }
+    // The whole predicate was pushed in: no TOpFilter remains, so carry its selectivity on the read.
+    newRead->Props.PushedDownFilterSelectivity = pushedDownFilterSelectivity;
     return newRead;
 }
 

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
@@ -1,4 +1,3 @@
-#include <ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.h>
 #include <ydb/core/kqp/opt/physical/kqp_opt_phy_olap_filter.h>
 #include <ydb/core/kqp/opt/physical/predicate_collector.h>
 #include <ydb/core/kqp/opt/rbo/kqp_rbo_rules.h>
@@ -211,7 +210,6 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
         // Part of the predicate could not be pushed down and the remaining TOpFilter survives.
         return MakeIntrusive<TOpFilter>(newRead, filter->Pos, filter->Props, TExpression(remainingFilter.Cast().Ptr(), &ctx.ExprCtx, &props));
     }
-
 
     // The whole predicate was pushed in and no TOpFilter remains.
     return newRead;

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
@@ -104,9 +104,6 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
     auto predicate = lambda.Body();
     auto lambdaArg = lambda.Args().Arg(0).Ptr();
 
-    // Compute the predicate selectivity now, while the filter lambda is still live and type-annotated
-    const double pushedDownFilterSelectivity = TPredicateSelectivityComputer(std::make_shared<TOptimizerStatistics>()).Compute(lambda.Body());
-
     // Here we want to apply coalesce and propagate it to optional predicates.
     // clang-format off
     predicate = Build<TCoCoalesce>(ctx.ExprCtx, input->Pos)
@@ -214,6 +211,11 @@ TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusi
         // Part of the predicate could not be pushed down. The remaining TOpFilter survives and its selectivity computed later.
         return MakeIntrusive<TOpFilter>(newRead, filter->Pos, filter->Props, TExpression(remainingFilter.Cast().Ptr(), &ctx.ExprCtx, &props));
     }
+
+    // Compute the predicate selectivity now, while the filter lambda is still live and type-annotated
+    auto readStats = std::make_shared<TOptimizerStatistics>(BuildOptimizerStatistics(read->Props, true));
+    const double pushedDownFilterSelectivity = TPredicateSelectivityComputer(readStats).Compute(lambda.Body());
+
     // The whole predicate was pushed in: no TOpFilter remains, so carry its selectivity on the read.
     newRead->Props.PushedDownFilterSelectivity = pushedDownFilterSelectivity;
     return newRead;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Inspecting selectivity computation for filters.
- Adding selectivity computation logic for pushed down filters within read operator.

### Changelog category <!-- remove all except one -->

* Improvement
* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
