### PR TITLE
Fix and optmize NBS-like multiactor load, #39757

### DIFF
--- a/ydb/core/load_test/nbs_dbg_like_load.cpp
+++ b/ydb/core/load_test/nbs_dbg_like_load.cpp
@@ -503,10 +503,22 @@ private:
         if (!entry) {
             return;
         }
-        // Guard against cross-type replies (e.g. from a reused cookie).
+        // Guard against cross-type replies. Should be unreachable with
+        // monotonic cookies; if it ever fires, erase the entry and release
+        // its inflight budget so the queue front can't be pinned forever.
         if (entry->IsRead) {
             LOG_E("HandleWriteResult cookie type mismatch Tag# " << Tag
                 << " Cookie# " << cookie << " expected write but IsRead=true");
+            Y_DEBUG_ABORT_UNLESS(false, "cookie type mismatch in HandleWriteResult");
+            const ui32 sizeBytes = entry->SizeBytes;
+            Inflight.Erase(cookie);
+            if (ReadInFlight > 0) {
+                --ReadInFlight;
+            }
+            if (Reads.BytesInFlight) {
+                *Reads.BytesInFlight -= sizeBytes;
+            }
+            CheckDrainComplete();
             return;
         }
         const TInflightEntry e = *entry;
@@ -580,10 +592,22 @@ private:
         if (!entry) {
             return;
         }
-        // Guard against cross-type replies (e.g. from a reused cookie).
+        // Guard against cross-type replies. Should be unreachable with
+        // monotonic cookies; if it ever fires, erase the entry and release
+        // its inflight budget so the queue front can't be pinned forever.
         if (!entry->IsRead) {
             LOG_E("HandleReadResult cookie type mismatch Tag# " << Tag
                 << " Cookie# " << cookie << " expected read but IsRead=false");
+            Y_DEBUG_ABORT_UNLESS(false, "cookie type mismatch in HandleReadResult");
+            const ui32 sizeBytes = entry->SizeBytes;
+            Inflight.Erase(cookie);
+            if (WriteInFlight > 0) {
+                --WriteInFlight;
+            }
+            if (Writes.BytesInFlight) {
+                *Writes.BytesInFlight -= sizeBytes;
+            }
+            CheckDrainComplete();
             return;
         }
         const TInflightEntry e = *entry;
@@ -978,6 +1002,15 @@ private:
                 << ") exceeds VChunkSizeBytes (" << vChunkSizeBytes << ")");
             return;
         }
+        // The tablet's ComputeRoutingParams marks IoValid=false unless
+        // IoSizeBytes evenly divides VChunkSizeBytes; fail fast here instead
+        // of letting every worker get NBSIO_NOT_CONFIGURED.
+        if (vChunkSizeBytes % ioBytes != 0) {
+            EmitError(TStringBuilder()
+                << "IoSizeBytes (" << ioBytes
+                << ") must evenly divide VChunkSizeBytes (" << vChunkSizeBytes << ")");
+            return;
+        }
         if (ioBytes > Max<ui32>()) {
             EmitError("ReadWriteSizeKiB * 1024 overflows ui32");
             return;
@@ -1007,6 +1040,13 @@ private:
         if (totalStopCount > 0) {
             numWorkers = Min(numWorkers, totalStopCount);
         }
+        // Each worker needs a non-empty slice of the flat io-unit space;
+        // otherwise it fails the run with "Degenerate address space slice".
+        // Cap by the total number of io-units (>= 1: all factors validated
+        // non-zero above, and ioBytes divides vChunkSizeBytes).
+        const ui64 addressSpaceIoUnits = static_cast<ui64>(effectiveDbgCount)
+            * static_cast<ui64>(targetNumVChunks) * (vChunkSizeBytes / ioBytes);
+        numWorkers = static_cast<ui32>(Min<ui64>(numWorkers, addressSpaceIoUnits));
 
         LOG_N("Proxy GetSummary OK Tag# " << Tag
             << " TotalDbgCount# " << totalDbgs
@@ -1132,6 +1172,15 @@ private:
         // No-op.
     }
 
+    void HandleWorkWakeup(TEvents::TEvWakeup::TPtr& ev) {
+        // The init-timeout wakeup scheduled in Bootstrap() is not cancelled
+        // on the success path and fires here; ignore it.
+        if (ev->Get()->Tag != kWakeupInitTimeoutTag) {
+            LOG_D("Proxy unexpected wakeup Tag# " << Tag
+                << " WakeupTag# " << ev->Get()->Tag);
+        }
+    }
+
     void HandlePoison(TEvents::TEvPoisonPill::TPtr&) {
         LOG_I("Proxy poison Tag# " << Tag
             << " forwarding to " << Workers.size() << " worker(s)");
@@ -1211,6 +1260,7 @@ private:
         hFunc(TEvTabletPipe::TEvClientConnected, HandleWorkPipeConnected)
         hFunc(TEvTabletPipe::TEvClientDestroyed, HandleWorkPipeDestroyed)
         hFunc(TEvents::TEvPoisonPill, HandlePoison)
+        hFunc(TEvents::TEvWakeup, HandleWorkWakeup)
     )
 
 private:

--- a/ydb/core/load_test/nbs_dbg_like_load.cpp
+++ b/ydb/core/load_test/nbs_dbg_like_load.cpp
@@ -4,6 +4,7 @@
 
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet_pipe.h>
+#include <ydb/core/util/circular_sparse_queue.h>
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
@@ -67,11 +68,40 @@ TRope BuildWritePayload(ui32 size, TFastRng64& rng) {
     return TRope(std::move(data));
 }
 
+// Distributes `total` io-units across `count` workers as evenly as possible.
+// Workers with index < (total % count) get one extra unit, so shares sum to `total`.
+static ui64 SplitShare(ui64 total, ui32 count, ui32 index) {
+    if (count == 0) {
+        return total;
+    }
+    return total / count + (index < (total % count) ? 1 : 0);
+}
+
+// Returns the start offset for worker `index` — i.e. the sum of all shares
+// before it: index * (total/count) + min(index, total%count).
+static ui64 SplitStart(ui64 total, ui32 count, ui32 index) {
+    if (count == 0) {
+        return 0;
+    }
+    const ui64 base  = total / count;
+    const ui64 extra = total % count;
+    return base * index + Min<ui64>(index, extra);
+}
+
 struct TInflightEntry {
     ui64 Address = 0;
     ui32 SizeBytes = 0;
     NHPTimer::STime SentAt = 0;
     bool IsRead = false;
+};
+
+// Summary info resolved by the proxy (from GetSummary + validation).
+// Passed to each worker so they skip GetSummary and ConfigureTablet.
+struct TResolvedTabletInfo {
+    ui32 EffectiveDbgCount = 0;
+    ui64 VChunkSizeBytes = 0;
+    ui32 TargetNumVChunks = 0;
+    ui32 IoSizeBytes = 0;
 };
 
 // Builds the combined TEvLoadTestFinished from an already-aggregated
@@ -174,17 +204,29 @@ public:
         return NKikimrServices::TActivity::BS_LOAD_NBS_DBG_LIKE;
     }
 
+    // Workers are constructed by the proxy after it has resolved tablet info.
+    // All fields from TResolvedTabletInfo are already validated by the proxy.
     TNbsDbgLikeLoadActor(
         const TEvLoadTestRequest::TNbsDbgLikeLoad& cmd,
         const TActorId& parent,
         TIntrusivePtr<::NMonitoring::TDynamicCounters> counters,
-        ui64 tag)
+        ui64 tag,
+        ui32 workerIndex,
+        ui32 numWorkers,
+        TResolvedTabletInfo resolved)
         : Parent(parent)
         , Tag(tag)
         , TabletId(cmd.GetNbsDbgLikeTabletId())
         , Config(cmd.GetWorkloadConfig())
+        , WorkerIndex(workerIndex)
+        , NumWorkers(numWorkers)
+        , EffectiveDbgCount(resolved.EffectiveDbgCount)
+        , VChunkSizeBytes(resolved.VChunkSizeBytes)
+        , TargetNumVChunks(resolved.TargetNumVChunks)
+        , IoSizeBytes(resolved.IoSizeBytes)
         , Rng(TInstant::Now().GetValue() ^ tag)
         , Counters(std::move(counters))
+        , Inflight(Max<size_t>(1, Config.GetMaxInFlight()))
         , MeasuredWriteLatencyUs(kLatencyHistMaxUs, kLatencyHistPrecision)
         , MeasuredReadLatencyUs(kLatencyHistMaxUs, kLatencyHistPrecision)
     {
@@ -198,82 +240,53 @@ public:
             << " DurationSeconds# " << Config.GetDurationSeconds()
             << " MaxInFlight# " << Config.GetMaxInFlight()
             << " ReadRatio# " << Config.GetReadRatio()
-            << " Sequential# " << Config.GetSequential());
+            << " Sequential# " << Config.GetSequential()
+            << " Worker# " << WorkerIndex << "/" << NumWorkers);
 
-        if (TabletId == 0) {
-            ErrorReason = "NbsDbgLikeTabletId is not set";
+        // Compute this worker's slice of the flat io-unit address space.
+        // The summary fields (EffectiveDbgCount, VChunkSizeBytes, etc.) were
+        // already validated by the proxy.
+        ComputeWorkerSlice();
+        if (!ErrorReason.empty()) {
+            LOG_N("ComputeWorkerSlice error Tag# " << Tag << " " << ErrorReason);
             FinishRun();
             return;
         }
 
+        // Open a pipe for I/O only (no GetSummary, no ConfigureTablet — that
+        // was already done by the proxy before spawning us).
         NTabletPipe::TClientConfig pipeConfig{
             .RetryPolicy = {.RetryLimitCount = kPipeRetryLimit}
         };
         PipeClient = Register(NTabletPipe::CreateClient(SelfId(), TabletId, pipeConfig));
-
-        auto req = std::make_unique<TEvLoad::TEvNbsLoadTabletGetSummary>();
-        NTabletPipe::SendData(SelfId(), PipeClient, req.release());
 
         Schedule(kInitTimeout, new TEvents::TEvWakeup(kWakeupInitTimeoutTag));
         Become(&TNbsDbgLikeLoadActor::StateInit);
     }
 
 private:
-    // ---- StateInit: wait for GetSummary reply before starting the load ----
+    // ---- StateInit: wait for pipe connection ----
 
-    void HandleSummaryResult(TEvLoad::TEvNbsLoadTabletGetSummaryResult::TPtr& ev) {
-        const auto& rec = ev->Get()->Record;
-        if (rec.GetStatus() != NBSLT_OK) {
+    void HandlePipeConnectedInit(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
+        if (ev->Get()->ClientId != PipeClient) {
+            return;
+        }
+        if (ev->Get()->Status != NKikimrProto::OK) {
             ErrorReason = TStringBuilder()
-                << "GetSummary failed: status=" << rec.GetStatus()
-                << " reason=" << rec.GetErrorReason();
-            LOG_N("GetSummary error Tag# " << Tag << " " << ErrorReason);
+                << "pipe connect failed: status=" << static_cast<int>(ev->Get()->Status);
+            LOG_N("Pipe connect error Tag# " << Tag << " " << ErrorReason);
             FinishRun();
             return;
         }
 
-        const ui32 totalDbgs = rec.GetNumDirectBlockGroups();
-        const ui32 readyDbgs = rec.GetNumReadyDirectBlockGroups();
-        VChunkSizeBytes = rec.GetVChunkSizeBytes();
-        TargetNumVChunks = rec.GetTargetNumVChunks();
-
-        // Use the ready count (longest contiguous prefix of DBGs with peers
-        // connected) as the base. Only target DBGs that can actually accept
-        // writes; targeting unconnected DBGs would silently drop writes and
-        // consume the entire inflight budget. Fall back to the total count for
-        // backward compatibility with tablets that don't set the field yet.
-        EffectiveDbgCount = (readyDbgs > 0) ? readyDbgs : totalDbgs;
-
-        // Apply NumDirectBlockGroupsToUse slice.
-        const ui32 mDbg = Config.GetNumDirectBlockGroupsToUse();
-        if (mDbg > 0 && mDbg < EffectiveDbgCount) {
-            EffectiveDbgCount = mDbg;
-        }
-
-        Validate();
-        if (!ErrorReason.empty()) {
-            LOG_N("Validate error Tag# " << Tag << " " << ErrorReason);
-            FinishRun();
-            return;
-        }
-
-        LOG_N("GetSummary OK Tag# " << Tag
-            << " TotalDbgCount# " << totalDbgs
-            << " ReadyDbgCount# " << readyDbgs
+        LOG_N("Worker ready Tag# " << Tag
             << " EffectiveDbgCount# " << EffectiveDbgCount
             << " VChunkSizeBytes# " << VChunkSizeBytes
             << " TargetNumVChunks# " << TargetNumVChunks
             << " IoSizeBytes# " << IoSizeBytes
+            << " Worker# " << WorkerIndex << "/" << NumWorkers
+            << " UnitRange# [" << UnitRangeStart << "," << UnitRangeStart + UnitRangeCount << ")"
             << " — starting load");
-
-        // Tell the tablet the per-run I/O size and DBG slice.
-        {
-            auto cfg = std::make_unique<TEvLoad::TEvConfigureTablet>();
-            cfg->Record = Config.GetTabletConfig();
-            cfg->Record.SetNumDirectBlockGroupsToUse(EffectiveDbgCount);
-            cfg->Record.SetIoSizeBytes(IoSizeBytes);
-            NTabletPipe::SendData(SelfId(), PipeClient, cfg.release());
-        }
 
         InitCounters();
         WritePayload = BuildWritePayload(IoSizeBytes, Rng);
@@ -295,7 +308,7 @@ private:
             return;
         }
         PipeClient = TActorId();
-        ErrorReason = "pipe lost before GetSummary reply";
+        ErrorReason = "pipe lost before connecting";
         FinishRun();
     }
 
@@ -306,11 +319,11 @@ private:
 
     void HandleInitWakeup(TEvents::TEvWakeup::TPtr& ev) {
         if (ev->Get()->Tag == kWakeupInitTimeoutTag) {
-            LOG_N("GetSummary timeout after " << kInitTimeout
+            LOG_N("Pipe connect timeout after " << kInitTimeout
                 << " Tag# " << Tag
                 << " TabletId# " << TabletId);
             ErrorReason = TStringBuilder()
-                << "GetSummary timed out after " << kInitTimeout
+                << "pipe connect timed out after " << kInitTimeout
                 << " (TabletId " << TabletId << ")";
             FinishRun();
         }
@@ -318,61 +331,31 @@ private:
 
     // ---- Helpers shared by both states ----
 
-    void Validate() {
-        if (EffectiveDbgCount == 0) {
-            ErrorReason = "EffectiveDbgCount=0 (NumDirectBlockGroups from tablet)";
-            return;
-        }
-        if (TargetNumVChunks == 0) {
-            ErrorReason = "TargetNumVChunks=0 (from tablet GetSummary)";
-            return;
-        }
-        if (VChunkSizeBytes == 0 || VChunkSizeBytes % kSectorSize != 0) {
-            ErrorReason = TStringBuilder()
-                << "VChunkSizeBytes (" << VChunkSizeBytes
-                << ") must be a positive multiple of " << kSectorSize;
-            return;
-        }
-        const ui32 kib = Config.GetReadWriteSizeKiB();
-        if (kib < 4 || (kib % 4) != 0) {
-            ErrorReason = TStringBuilder()
-                << "ReadWriteSizeKiB (" << kib << " KiB) must be >= 4 and a multiple of 4";
-            return;
-        }
-        const ui64 ioBytes = static_cast<ui64>(kib) * 1024;
-        if (ioBytes > VChunkSizeBytes) {
-            ErrorReason = TStringBuilder()
-                << "ReadWriteSizeKiB * 1024 (" << ioBytes
-                << ") exceeds VChunkSizeBytes (" << VChunkSizeBytes << ")";
-            return;
-        }
-        if (ioBytes > Max<ui32>()) {
-            ErrorReason = "ReadWriteSizeKiB * 1024 overflows ui32";
-            return;
-        }
-        if (Config.GetDurationSeconds() == 0 && Config.GetStopOnWritesDoneCount() == 0) {
-            ErrorReason = "at least one of DurationSeconds or StopOnWritesDoneCount must be non-zero";
-            return;
-        }
-        if (Config.GetDurationSeconds() > 0
-            && Config.GetDelayBeforeMeasurementsSeconds() >= Config.GetDurationSeconds())
-        {
-            ErrorReason = TStringBuilder()
-                << "DelayBeforeMeasurementsSeconds (" << Config.GetDelayBeforeMeasurementsSeconds()
-                << ") must be < DurationSeconds (" << Config.GetDurationSeconds() << ")";
-            return;
-        }
-        if (Config.GetTabletConfig().GetDisableReplication() && Config.GetReadRatio() > 0) {
-            ErrorReason = "DisableReplication is incompatible with ReadRatio > 0 (reads require flush)";
-            return;
-        }
-
-        IoSizeBytes = static_cast<ui32>(ioBytes);
+    // Compute the derived address-space fields and this worker's io-unit slice.
+    // Called during Bootstrap; all summary fields are already set from TResolvedTabletInfo.
+    void ComputeWorkerSlice() {
         BytesPerDbg = static_cast<ui64>(TargetNumVChunks) * VChunkSizeBytes;
         AddressSpaceBytes = static_cast<ui64>(EffectiveDbgCount) * BytesPerDbg;
         IoUnitsPerVChunk = VChunkSizeBytes / IoSizeBytes;
         AddressSpaceIoUnits = static_cast<ui64>(EffectiveDbgCount)
             * static_cast<ui64>(TargetNumVChunks) * IoUnitsPerVChunk;
+
+        const ui64 unitsPerDbg = static_cast<ui64>(TargetNumVChunks) * IoUnitsPerVChunk;
+        if (EffectiveDbgCount >= NumWorkers) {
+            // Preferred: align to whole DBG boundaries.
+            UnitRangeStart = SplitStart(EffectiveDbgCount, NumWorkers, WorkerIndex) * unitsPerDbg;
+            UnitRangeCount = SplitShare(EffectiveDbgCount, NumWorkers, WorkerIndex) * unitsPerDbg;
+        } else {
+            // Fewer DBGs than workers: fall back to io-unit granularity.
+            UnitRangeStart = SplitStart(AddressSpaceIoUnits, NumWorkers, WorkerIndex);
+            UnitRangeCount = SplitShare(AddressSpaceIoUnits, NumWorkers, WorkerIndex);
+        }
+        if (UnitRangeCount == 0) {
+            ErrorReason = TStringBuilder()
+                << "Degenerate address space slice for worker #" << WorkerIndex
+                << " (AddressSpaceIoUnits=" << AddressSpaceIoUnits
+                << " NumWorkers=" << NumWorkers << ")";
+        }
     }
 
     void InitCounters() {
@@ -403,15 +386,20 @@ private:
     }
 
     ui64 PickAddress(ui32 sizeBytes) {
-        Y_ABORT_UNLESS(AddressSpaceIoUnits != 0);
+        Y_ABORT_UNLESS(UnitRangeCount != 0);
         ui64 unit;
         if (Config.GetSequential()) {
+            if (NextSequentialIoUnit < UnitRangeStart ||
+                NextSequentialIoUnit >= UnitRangeStart + UnitRangeCount) {
+                // First call or out-of-range: start from the beginning of our slice.
+                NextSequentialIoUnit = UnitRangeStart;
+            }
             unit = NextSequentialIoUnit;
-            if (++NextSequentialIoUnit >= AddressSpaceIoUnits) {
-                NextSequentialIoUnit = 0;
+            if (++NextSequentialIoUnit >= UnitRangeStart + UnitRangeCount) {
+                NextSequentialIoUnit = UnitRangeStart;
             }
         } else {
-            unit = Rng.GenRand() % AddressSpaceIoUnits;
+            unit = UnitRangeStart + Rng.GenRand() % UnitRangeCount;
         }
         // Sampling in I/O units guarantees the resulting flat address is
         // aligned to sizeBytes and fits entirely inside its vChunk.
@@ -443,22 +431,31 @@ private:
                         / static_cast<double>(WritesIssued))
                     < static_cast<double>(readRatio) / 100.0;
             if (wantRead) {
-                IssueRead();
+                if (!IssueRead()) {
+                    break;
+                }
             } else if (stopCount == 0 || WritesIssued < stopCount) {
-                IssueWrite();
+                if (!IssueWrite()) {
+                    break;
+                }
             } else {
                 break; // write cap reached; no more ops to issue
             }
         }
     }
 
-    void IssueWrite() {
+    // Returns false if the inflight queue was full (slot occupied by stuck entry).
+    bool IssueWrite() {
         const ui32 size = IoSizeBytes;
         const ui64 addr = PickAddress(size);
-        const ui64 cookie = ++NextCookie;
         NHPTimer::STime sentAt = 0;
         NHPTimer::GetTime(&sentAt);
-        Inflight[cookie] = TInflightEntry{addr, size, sentAt, /*IsRead=*/false};
+        auto res = Inflight.Emplace(addr, size, sentAt, /*IsRead=*/false);
+        if (!res) {
+            LOG_D("IssueWrite queue full Tag# " << Tag << " " << res.error());
+            return false;
+        }
+        const ui64 cookie = res.value();
         auto ev = std::make_unique<TEvLoad::TEvNbsWrite>(addr, size);
         ev->Payload = TRope(WritePayload);
         NTabletPipe::SendData(SelfId(), PipeClient, ev.release(), cookie);
@@ -471,15 +468,21 @@ private:
         if (Writes.BytesInFlight) {
             *Writes.BytesInFlight += size;
         }
+        return true;
     }
 
-    void IssueRead() {
+    // Returns false if the inflight queue was full (slot occupied by stuck entry).
+    bool IssueRead() {
         const ui32 size = IoSizeBytes;
         const ui64 addr = PickAddress(size);
-        const ui64 cookie = ++NextCookie;
         NHPTimer::STime sentAt = 0;
         NHPTimer::GetTime(&sentAt);
-        Inflight[cookie] = TInflightEntry{addr, size, sentAt, /*IsRead=*/true};
+        auto res = Inflight.Emplace(addr, size, sentAt, /*IsRead=*/true);
+        if (!res) {
+            LOG_D("IssueRead queue full Tag# " << Tag << " " << res.error());
+            return false;
+        }
+        const ui64 cookie = res.value();
         auto ev = std::make_unique<TEvLoad::TEvNbsRead>(addr, size);
         NTabletPipe::SendData(SelfId(), PipeClient, ev.release(), cookie);
         ++ReadInFlight;
@@ -491,16 +494,23 @@ private:
         if (Reads.BytesInFlight) {
             *Reads.BytesInFlight += size;
         }
+        return true;
     }
 
     void HandleWriteResult(TEvLoad::TEvNbsWriteResult::TPtr& ev) {
         const ui64 cookie = ev->Cookie;
-        auto it = Inflight.find(cookie);
-        if (it == Inflight.end()) {
+        auto* entry = Inflight.Find(cookie);
+        if (!entry) {
             return;
         }
-        const TInflightEntry e = it->second;
-        Inflight.erase(it);
+        // Guard against cross-type replies (e.g. from a reused cookie).
+        if (entry->IsRead) {
+            LOG_E("HandleWriteResult cookie type mismatch Tag# " << Tag
+                << " Cookie# " << cookie << " expected write but IsRead=true");
+            return;
+        }
+        const TInflightEntry e = *entry;
+        Inflight.Erase(cookie);
 
         NHPTimer::STime now = 0;
         NHPTimer::GetTime(&now);
@@ -566,12 +576,18 @@ private:
 
     void HandleReadResult(TEvLoad::TEvNbsReadResult::TPtr& ev) {
         const ui64 cookie = ev->Cookie;
-        auto it = Inflight.find(cookie);
-        if (it == Inflight.end()) {
+        auto* entry = Inflight.Find(cookie);
+        if (!entry) {
             return;
         }
-        const TInflightEntry e = it->second;
-        Inflight.erase(it);
+        // Guard against cross-type replies (e.g. from a reused cookie).
+        if (!entry->IsRead) {
+            LOG_E("HandleReadResult cookie type mismatch Tag# " << Tag
+                << " Cookie# " << cookie << " expected read but IsRead=false");
+            return;
+        }
+        const TInflightEntry e = *entry;
+        Inflight.Erase(cookie);
 
         NHPTimer::STime now = 0;
         NHPTimer::GetTime(&now);
@@ -736,14 +752,13 @@ private:
         PassAway();
     }
 
-    void HandlePipeConnected(TEvTabletPipe::TEvClientConnected::TPtr&) {
-        // Nothing to do — we already sent GetSummary; wait for the reply.
+    void HandlePipeConnectedRunning(TEvTabletPipe::TEvClientConnected::TPtr&) {
+        // Reconnect during run — no action needed; the pipe client retried for us.
     }
 
     STRICT_STFUNC(StateInit,
-        hFunc(TEvLoad::TEvNbsLoadTabletGetSummaryResult, HandleSummaryResult)
+        hFunc(TEvTabletPipe::TEvClientConnected, HandlePipeConnectedInit)
         hFunc(TEvTabletPipe::TEvClientDestroyed, HandleInitPipeDestroyed)
-        hFunc(TEvTabletPipe::TEvClientConnected, HandlePipeConnected)
         hFunc(TEvents::TEvPoisonPill, HandleInitPoison)
         hFunc(TEvents::TEvWakeup, HandleInitWakeup)
     )
@@ -754,7 +769,7 @@ private:
         hFunc(TEvents::TEvPoisonPill, HandlePoison)
         hFunc(TEvents::TEvWakeup, HandleWakeup)
         hFunc(TEvTabletPipe::TEvClientDestroyed, HandleRunPipeDestroyed)
-        hFunc(TEvTabletPipe::TEvClientConnected, HandlePipeConnected)
+        hFunc(TEvTabletPipe::TEvClientConnected, HandlePipeConnectedRunning)
     )
 
 private:
@@ -783,12 +798,19 @@ private:
     const ui64 TabletId;
     TEvLoadTestRequest::TNbsDbgLikeLoad::TWorkloadConfig Config;
 
-    // Filled in from GetSummary reply.
+    const ui32 WorkerIndex;
+    const ui32 NumWorkers;
+
+    // Set from TResolvedTabletInfo; validated by the proxy before worker creation.
     ui32 EffectiveDbgCount = 0;
     ui64 VChunkSizeBytes = 0;
     ui32 TargetNumVChunks = 0;
-
     ui32 IoSizeBytes = 0;
+
+    // Assigned slice of the flat io-unit space; computed in ComputeWorkerSlice().
+    ui64 UnitRangeStart = 0;
+    ui64 UnitRangeCount = 0;
+
     ui64 BytesPerDbg = 0;
     ui64 AddressSpaceBytes = 0;
     ui64 IoUnitsPerVChunk = 0;
@@ -805,8 +827,7 @@ private:
 
     TActorId PipeClient;
 
-    THashMap<ui64, TInflightEntry> Inflight;
-    ui64 NextCookie = 0;
+    TCircularSparseQueue<TInflightEntry> Inflight;
 
     ui32 WriteInFlight = 0;
     ui32 ReadInFlight  = 0;
@@ -843,6 +864,11 @@ private:
 // StopOnWritesDoneCount budget), then merges their per-worker results
 // into a single TEvLoadTestFinished — exactly the event the service actor
 // (which registers one actor per Tag) expects.
+//
+// The proxy is responsible for the init sequence:
+//   1. Open pipe → send GetSummary → validate → send single ConfigureTablet
+//   2. Spawn workers (passing resolved info); switch to StateWork
+//   3. Merge worker results; close pipe; emit combined TEvLoadTestFinished
 class TNbsDbgLikeLoadActorProxy : public TActorBootstrapped<TNbsDbgLikeLoadActorProxy> {
 public:
     static constexpr auto ActorActivityType() {
@@ -862,35 +888,157 @@ public:
     {}
 
     void Bootstrap() {
+        if (TabletId == 0) {
+            EmitError("NbsDbgLikeTabletId is not set");
+            return;
+        }
+
         const auto& config = Cmd.GetWorkloadConfig();
         TotalMaxInFlight = config.GetMaxInFlight();
+
+        LOG_I("Proxy bootstrap Tag# " << Tag
+            << " TabletId# " << TabletId
+            << " TotalMaxInFlight# " << TotalMaxInFlight);
+
+        NTabletPipe::TClientConfig pipeConfig{
+            .RetryPolicy = {.RetryLimitCount = kPipeRetryLimit}
+        };
+        ProxyPipeClient = Register(NTabletPipe::CreateClient(SelfId(), TabletId, pipeConfig));
+
+        auto req = std::make_unique<TEvLoad::TEvNbsLoadTabletGetSummary>();
+        NTabletPipe::SendData(SelfId(), ProxyPipeClient, req.release());
+
+        Schedule(kInitTimeout, new TEvents::TEvWakeup(kWakeupInitTimeoutTag));
+        Become(&TNbsDbgLikeLoadActorProxy::StateInit);
+    }
+
+private:
+    static ui32 CalcNumWorkers(ui32 totalMaxInFlight, bool sequential) {
+        if (sequential) {
+            return 1;
+        }
+        // At least one worker even when MaxInFlight is 0.
+        return Max<ui32>(
+            1,
+            (totalMaxInFlight + kMaxInflightPerActor - 1) / kMaxInflightPerActor);
+    }
+
+    // ---- StateInit ----
+
+    void HandleProxySummaryResult(TEvLoad::TEvNbsLoadTabletGetSummaryResult::TPtr& ev) {
+        const auto& rec = ev->Get()->Record;
+        if (rec.GetStatus() != NBSLT_OK) {
+            EmitError(TStringBuilder()
+                << "GetSummary failed: status=" << rec.GetStatus()
+                << " reason=" << rec.GetErrorReason());
+            return;
+        }
+
+        const ui32 totalDbgs = rec.GetNumDirectBlockGroups();
+        const ui32 readyDbgs = rec.GetNumReadyDirectBlockGroups();
+        const ui64 vChunkSizeBytes = rec.GetVChunkSizeBytes();
+        const ui32 targetNumVChunks = rec.GetTargetNumVChunks();
+
+        // Use the ready count (longest contiguous prefix of DBGs with peers
+        // connected) as the base. Fall back to total count for backward
+        // compatibility with tablets that don't set the field yet.
+        ui32 effectiveDbgCount = (readyDbgs > 0) ? readyDbgs : totalDbgs;
+
+        const auto& config = Cmd.GetWorkloadConfig();
+        const ui32 mDbg = config.GetNumDirectBlockGroupsToUse();
+        if (mDbg > 0 && mDbg < effectiveDbgCount) {
+            effectiveDbgCount = mDbg;
+        }
+
+        // Validate everything the workers would have validated.
+        if (effectiveDbgCount == 0) {
+            EmitError("EffectiveDbgCount=0 (NumDirectBlockGroups from tablet)");
+            return;
+        }
+        if (targetNumVChunks == 0) {
+            EmitError("TargetNumVChunks=0 (from tablet GetSummary)");
+            return;
+        }
+        if (vChunkSizeBytes == 0 || vChunkSizeBytes % kSectorSize != 0) {
+            EmitError(TStringBuilder()
+                << "VChunkSizeBytes (" << vChunkSizeBytes
+                << ") must be a positive multiple of " << kSectorSize);
+            return;
+        }
+        const ui32 kib = config.GetReadWriteSizeKiB();
+        if (kib < 4 || (kib % 4) != 0) {
+            EmitError(TStringBuilder()
+                << "ReadWriteSizeKiB (" << kib << " KiB) must be >= 4 and a multiple of 4");
+            return;
+        }
+        const ui64 ioBytes = static_cast<ui64>(kib) * 1024;
+        if (ioBytes > vChunkSizeBytes) {
+            EmitError(TStringBuilder()
+                << "ReadWriteSizeKiB * 1024 (" << ioBytes
+                << ") exceeds VChunkSizeBytes (" << vChunkSizeBytes << ")");
+            return;
+        }
+        if (ioBytes > Max<ui32>()) {
+            EmitError("ReadWriteSizeKiB * 1024 overflows ui32");
+            return;
+        }
+        if (config.GetDurationSeconds() == 0 && config.GetStopOnWritesDoneCount() == 0) {
+            EmitError("at least one of DurationSeconds or StopOnWritesDoneCount must be non-zero");
+            return;
+        }
+        if (config.GetDurationSeconds() > 0
+            && config.GetDelayBeforeMeasurementsSeconds() >= config.GetDurationSeconds())
+        {
+            EmitError(TStringBuilder()
+                << "DelayBeforeMeasurementsSeconds (" << config.GetDelayBeforeMeasurementsSeconds()
+                << ") must be < DurationSeconds (" << config.GetDurationSeconds() << ")");
+            return;
+        }
+        if (config.GetTabletConfig().GetDisableReplication() && config.GetReadRatio() > 0) {
+            EmitError("DisableReplication is incompatible with ReadRatio > 0 (reads require flush)");
+            return;
+        }
+
+        const ui32 ioSizeBytes = static_cast<ui32>(ioBytes);
         const ui32 totalStopCount = config.GetStopOnWritesDoneCount();
 
-        // Sequential runs must keep a single address cursor, so we don't
-        // split them across workers. Otherwise fan out so each worker gets
-        // at most kMaxInflightPerActor; SplitShare distributes any remainder.
+        // Determine worker count.
         ui32 numWorkers = CalcNumWorkers(TotalMaxInFlight, config.GetSequential());
-
-        // When a write cap is set, every worker must get a non-zero share:
-        // SplitShare would hand 0 to workers past index (totalStopCount - 1),
-        // and a worker with StopOnWritesDoneCount=0 treats it as "no cap" and
-        // writes for the entire DurationSeconds, exceeding the requested total.
         if (totalStopCount > 0) {
             numWorkers = Min(numWorkers, totalStopCount);
         }
 
-        LOG_I("Proxy bootstrap Tag# " << Tag
-            << " TabletId# " << TabletId
+        LOG_N("Proxy GetSummary OK Tag# " << Tag
+            << " TotalDbgCount# " << totalDbgs
+            << " ReadyDbgCount# " << readyDbgs
+            << " EffectiveDbgCount# " << effectiveDbgCount
+            << " VChunkSizeBytes# " << vChunkSizeBytes
+            << " TargetNumVChunks# " << targetNumVChunks
+            << " IoSizeBytes# " << ioSizeBytes
             << " NumWorkers# " << numWorkers
             << " TotalMaxInFlight# " << TotalMaxInFlight
             << " TotalStopOnWritesDoneCount# " << totalStopCount);
 
+        // Send a single ConfigureTablet. The proxy's pipe stays open until
+        // PassAway() to ensure delivery.
+        {
+            auto cfg = std::make_unique<TEvLoad::TEvConfigureTablet>();
+            cfg->Record = config.GetTabletConfig();
+            cfg->Record.SetNumDirectBlockGroupsToUse(effectiveDbgCount);
+            cfg->Record.SetIoSizeBytes(ioSizeBytes);
+            NTabletPipe::SendData(SelfId(), ProxyPipeClient, cfg.release());
+        }
+
+        // Spawn workers and switch to StateWork.
+        const TResolvedTabletInfo resolved{effectiveDbgCount, vChunkSizeBytes,
+                                           targetNumVChunks, ioSizeBytes};
         for (ui32 i = 0; i < numWorkers; ++i) {
             auto workerCmd = Cmd;
             auto& wc = *workerCmd.MutableWorkloadConfig();
-            wc.SetMaxInFlight(SplitShare(TotalMaxInFlight, numWorkers, i));
+            wc.SetMaxInFlight(static_cast<ui32>(SplitShare(TotalMaxInFlight, numWorkers, i)));
             if (totalStopCount > 0) {
-                wc.SetStopOnWritesDoneCount(SplitShare(totalStopCount, numWorkers, i));
+                wc.SetStopOnWritesDoneCount(
+                    static_cast<ui32>(SplitShare(totalStopCount, numWorkers, i)));
             }
 
             TIntrusivePtr<::NMonitoring::TDynamicCounters> workerCounters = Counters
@@ -905,37 +1053,43 @@ public:
             // service actor only ever sees the real tag.
             const ui64 workerTag = Tag * 1000 + i;
             const TActorId workerId = Register(
-                new TNbsDbgLikeLoadActor(workerCmd, SelfId(), workerCounters, workerTag));
+                new TNbsDbgLikeLoadActor(
+                    workerCmd, SelfId(), workerCounters,
+                    workerTag, i, numWorkers, resolved));
             Workers.insert(workerId);
         }
 
         Become(&TNbsDbgLikeLoadActorProxy::StateWork);
     }
 
-private:
-    static ui32 CalcNumWorkers(ui32 totalMaxInFlight, bool sequential) {
-        if (sequential) {
-            return 1;
-        }
-        // At least one worker even when MaxInFlight is 0.
-        return Max<ui32>(
-            1,
-            (totalMaxInFlight + kMaxInflightPerActor - 1) / kMaxInflightPerActor);
+    void HandleInitPipeConnected(TEvTabletPipe::TEvClientConnected::TPtr&) {
+        // No-op: we wait for the GetSummary reply, not for the connection event.
     }
 
-    // Distributes `total` across `count` workers as evenly as possible:
-    // the first (total % count) workers get one extra unit so the shares
-    // sum back to `total`.
-    static ui32 SplitShare(ui32 total, ui32 count, ui32 index) {
-        if (count == 0) {
-            return total;
+    void HandleInitPipeDestroyed(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+        if (ev->Get()->ClientId != ProxyPipeClient) {
+            return;
         }
-        ui32 share = total / count;
-        if (index < (total % count)) {
-            ++share;
-        }
-        return share;
+        ProxyPipeClient = TActorId();
+        EmitError("proxy pipe lost before GetSummary reply");
     }
+
+    void HandleInitPoison(TEvents::TEvPoisonPill::TPtr&) {
+        EmitError("stopped before start");
+    }
+
+    void HandleInitWakeup(TEvents::TEvWakeup::TPtr& ev) {
+        if (ev->Get()->Tag == kWakeupInitTimeoutTag) {
+            LOG_N("Proxy GetSummary timeout after " << kInitTimeout
+                << " Tag# " << Tag
+                << " TabletId# " << TabletId);
+            EmitError(TStringBuilder()
+                << "GetSummary timed out after " << kInitTimeout
+                << " (TabletId " << TabletId << ")");
+        }
+    }
+
+    // ---- StateWork ----
 
     void HandleWorkerFinished(TEvLoad::TEvLoadTestFinished::TPtr& ev) {
         const TActorId worker = ev->Sender;
@@ -962,6 +1116,30 @@ private:
         if (Workers.empty()) {
             EmitCombined();
         }
+    }
+
+    void HandleWorkPipeDestroyed(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
+        if (ev->Get()->ClientId != ProxyPipeClient) {
+            return;
+        }
+        ProxyPipeClient = TActorId();
+        // The proxy pipe dying during the run is benign: ConfigureTablet was
+        // already delivered. Workers have their own pipes and self-manage.
+        LOG_D("Proxy pipe to tablet " << TabletId << " destroyed during run Tag# " << Tag);
+    }
+
+    void HandleWorkPipeConnected(TEvTabletPipe::TEvClientConnected::TPtr&) {
+        // No-op.
+    }
+
+    void HandlePoison(TEvents::TEvPoisonPill::TPtr&) {
+        LOG_I("Proxy poison Tag# " << Tag
+            << " forwarding to " << Workers.size() << " worker(s)");
+        for (const TActorId& worker : Workers) {
+            Send(worker, new TEvents::TEvPoisonPill);
+        }
+        // Keep the proxy alive; workers will send TEvLoadTestFinished back,
+        // and HandleWorkerFinished will call EmitCombined when all are done.
     }
 
     void MergeStats(TNbsDbgLikeFinishStats& s) {
@@ -996,6 +1174,10 @@ private:
     }
 
     void EmitCombined() {
+        if (ProxyPipeClient) {
+            NTabletPipe::CloseClient(SelfId(), ProxyPipeClient);
+            ProxyPipeClient = TActorId();
+        }
         Merged.MaxInFlight = TotalMaxInFlight;
         auto* finishEv = BuildNbsDbgLikeFinishEvent(
             Tag, TabletId, CombinedError, std::move(Merged));
@@ -1003,16 +1185,31 @@ private:
         PassAway();
     }
 
-    void HandlePoison(TEvents::TEvPoisonPill::TPtr&) {
-        LOG_I("Proxy poison Tag# " << Tag
-            << " forwarding to " << Workers.size() << " worker(s)");
-        for (const TActorId& worker : Workers) {
-            Send(worker, new TEvents::TEvPoisonPill);
+    void EmitError(TString reason) {
+        LOG_N("Proxy error Tag# " << Tag << " " << reason);
+        if (ProxyPipeClient) {
+            NTabletPipe::CloseClient(SelfId(), ProxyPipeClient);
+            ProxyPipeClient = TActorId();
         }
+        TNbsDbgLikeFinishStats stats;
+        stats.MaxInFlight = TotalMaxInFlight;
+        auto* finishEv = BuildNbsDbgLikeFinishEvent(Tag, TabletId, reason, std::move(stats));
+        Send(Parent, finishEv);
+        PassAway();
     }
+
+    STRICT_STFUNC(StateInit,
+        hFunc(TEvLoad::TEvNbsLoadTabletGetSummaryResult, HandleProxySummaryResult)
+        hFunc(TEvTabletPipe::TEvClientConnected, HandleInitPipeConnected)
+        hFunc(TEvTabletPipe::TEvClientDestroyed, HandleInitPipeDestroyed)
+        hFunc(TEvents::TEvPoisonPill, HandleInitPoison)
+        hFunc(TEvents::TEvWakeup, HandleInitWakeup)
+    )
 
     STRICT_STFUNC(StateWork,
         hFunc(TEvLoad::TEvLoadTestFinished, HandleWorkerFinished)
+        hFunc(TEvTabletPipe::TEvClientConnected, HandleWorkPipeConnected)
+        hFunc(TEvTabletPipe::TEvClientDestroyed, HandleWorkPipeDestroyed)
         hFunc(TEvents::TEvPoisonPill, HandlePoison)
     )
 
@@ -1023,6 +1220,7 @@ private:
     const ui64 TabletId;
     TIntrusivePtr<::NMonitoring::TDynamicCounters> Counters;
 
+    TActorId ProxyPipeClient;
     ui32 TotalMaxInFlight = 0;
     THashSet<TActorId> Workers;
 

--- a/ydb/core/load_test/nbs_dbg_like_load_tablet.cpp
+++ b/ydb/core/load_test/nbs_dbg_like_load_tablet.cpp
@@ -2172,12 +2172,10 @@ void TNbsDbgLikeActor::HandleNbsWrite(TEvLoad::TEvNbsWrite::TPtr& ev, const TAct
             << " Cookie# " << cookie
             << " PBConnected# " << pbConnectedCount
             << " need# " << kPrimaryHostsPerDbg
-            << "; dropping silently");
-        // Mirror v1 worker StateConnect semantics: silently drop the request
-        // while the DBG's peers are still mid-handshake. The load actor's
-        // drain-timeout safety net reaps any never-replied cookies on Run
-        // shutdown; replying ERROR here would force the load actor into a
-        // tight retry loop that pins simulated time.
+            << "; replying TABLET_NOT_READY");
+        ReplyWriteErr(origin, cookie, NBSIO_TABLET_NOT_READY,
+            TStringBuilder() << "PB peers not ready: " << pbConnectedCount
+                << "/" << kPrimaryHostsPerDbg);
         return;
     }
 
@@ -2372,11 +2370,16 @@ void TNbsDbgLikeActor::HandleNbsRead(TEvLoad::TEvNbsRead::TPtr& ev,
     const ui32 vChunkIndex = decoded->VChunkIndex;
     const ui32 offset = decoded->OffsetInVChunk;
 
-    if (Dbg.DDConnected.count() < kPrimaryHostsPerDbg) {
-        // See HandleNbsWrite: drop silently while peers are still mid-handshake
-        // so the load actor doesn't tight-loop and pin simulated time.
+    const ui32 ddConnectedCount = static_cast<ui32>(Dbg.DDConnected.count());
+    if (ddConnectedCount < kPrimaryHostsPerDbg) {
         LOG_D("HandleNbsRead peers not ready DBG# " << dbgIndex
-            << " Cookie# " << cookie << "; dropping silently");
+            << " Cookie# " << cookie
+            << " DDConnected# " << ddConnectedCount
+            << " need# " << kPrimaryHostsPerDbg
+            << "; replying TABLET_NOT_READY");
+        ReplyReadErr(origin, cookie, NBSIO_TABLET_NOT_READY,
+            TStringBuilder() << "DDisk peers not ready: " << ddConnectedCount
+                << "/" << kPrimaryHostsPerDbg);
         return;
     }
 
@@ -3099,6 +3102,14 @@ void TNbsDbgLikeActor::BestEffortEraseAll(TPerDbgState& dbg) {
     std::array<std::vector<ui64>, kHostsPerDbgMax> pending;
     const ui32 hostsPerDbg = HostsPerDbg();
     for (auto& [lsn, info] : dbg.Lsns) {
+        // Never erase an LSN whose write reply has not been sent yet: erasing
+        // it here would drop it from dbg.Lsns, causing HandleWritePbsResult
+        // to find no LSN and silently skip the reply — permanently leaking the
+        // load actor's in-flight counter. Un-replied LSNs will reach
+        // quorum/failure via the normal path and be erased by DoErase.
+        if (!info.ReplySent) {
+            continue;
+        }
         if (!info.EraseTarget.any()) {
             info.EraseTarget |= info.WriteConfirmed;
         }

--- a/ydb/core/load_test/ya.make
+++ b/ydb/core/load_test/ya.make
@@ -21,6 +21,7 @@ PEERDIR(
     ydb/core/tablet_flat
     ydb/core/tx/columnshard
     ydb/core/tx/datashard
+    ydb/core/util
     ydb/library/workload/abstract
     ydb/library/workload/kv
     ydb/library/workload/stock


### PR DESCRIPTION
* use circular sparse queue for inflight infos
* split address space between load actors
* fix multiactor nbs-like load logic: don't race in configure tablet

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
