### PR TITLE
Try to fix test timeout

### DIFF
--- a/ydb/core/tx/tx_proxy/proxy_ut.cpp
+++ b/ydb/core/tx/tx_proxy/proxy_ut.cpp
@@ -3,6 +3,8 @@
 #include <ydb/core/base/path.h>
 #include <ydb/library/aclib/aclib.h>
 
+#include <library/cpp/retry/retry.h>
+
 using namespace NKikimr;
 using namespace NTxProxyUT;
 using namespace NHelpers;
@@ -1052,8 +1054,15 @@ Y_UNIT_TEST_SUITE(TModifyUserTest) {
 
             // user1 can change password for user2. user1 has ydb.granular.alter_schema permission
             // ACL publication to SchemeBoard is async; retry until the proxy cache sees the new effective ACL
-            Sleep(TDuration::MilliSeconds(500));
-            UNIT_ASSERT_VALUES_EQUAL(client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token), NMsgBusProxy::MSTATUS_OK);
+            NMsgBusProxy::EResponseStatus status = NMsgBusProxy::MSTATUS_ERROR;
+            const bool success = DoWithRetryOnRetCode(
+                [&] {
+                    status = client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token);
+                    return status == NMsgBusProxy::MSTATUS_OK;
+                },
+                TRetryOptions(10, TDuration::MilliSeconds(100))
+            );
+            UNIT_ASSERT_C(success, "Failed to modify user after retries, final status: " << status);
         }
 
         // user2 login with new password

--- a/ydb/core/tx/tx_proxy/proxy_ut.cpp
+++ b/ydb/core/tx/tx_proxy/proxy_ut.cpp
@@ -1051,7 +1051,15 @@ Y_UNIT_TEST_SUITE(TModifyUserTest) {
             client.Grant("/", "dc-1", "user1", NACLib::EAccessRights::AlterSchema);
 
             // user1 can change password for user2. user1 has ydb.granular.alter_schema permission
-            UNIT_ASSERT_VALUES_EQUAL(client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token), NMsgBusProxy::MSTATUS_OK);
+            // ACL publication to SchemeBoard is async; retry until the proxy cache sees the new effective ACL
+            auto status = NMsgBusProxy::MSTATUS_ERROR;
+            for (int i = 0; i < 10 && status != NMsgBusProxy::MSTATUS_OK; ++i) {
+                status = client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token);
+                if (status != NMsgBusProxy::MSTATUS_OK) {
+                    Sleep(TDuration::MilliSeconds(100));
+                }
+            }
+            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
         }
 
         // user2 login with new password

--- a/ydb/core/tx/tx_proxy/proxy_ut.cpp
+++ b/ydb/core/tx/tx_proxy/proxy_ut.cpp
@@ -1052,14 +1052,8 @@ Y_UNIT_TEST_SUITE(TModifyUserTest) {
 
             // user1 can change password for user2. user1 has ydb.granular.alter_schema permission
             // ACL publication to SchemeBoard is async; retry until the proxy cache sees the new effective ACL
-            auto status = NMsgBusProxy::MSTATUS_ERROR;
-            for (int i = 0; i < 10 && status != NMsgBusProxy::MSTATUS_OK; ++i) {
-                status = client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token);
-                if (status != NMsgBusProxy::MSTATUS_OK) {
-                    Sleep(TDuration::MilliSeconds(100));
-                }
-            }
-            UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+            Sleep(TDuration::MilliSeconds(500));
+            UNIT_ASSERT_VALUES_EQUAL(client.ModifyUser("/dc-1", { .User = "user2", .Password = "pas2user"}, user1Token), NMsgBusProxy::MSTATUS_OK);
         }
 
         // user2 login with new password

--- a/ydb/core/tx/tx_proxy/ut_base_tenant/ya.make
+++ b/ydb/core/tx/tx_proxy/ut_base_tenant/ya.make
@@ -12,6 +12,7 @@ ENDIF()
 
 PEERDIR(
     library/cpp/getopt
+    library/cpp/retry
     library/cpp/svnversion
     library/cpp/testing/unittest
     ydb/core/testlib/default


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Test: TModifyUserTest::ModifyUser fails at proxy_ut.cpp:1054

```
client.Grant("/", "dc-1", "user1", NACLib::EAccessRights::AlterSchema);
UNIT_ASSERT_VALUES_EQUAL(client.ModifyUser("/dc-1", {.User="user2", ...}, user1Token), MSTATUS_OK);  // line 1054
```

Root cause: race between ModifyACL success reply and SchemeBoard publication.

Log timeline (txid `...665` = Grant/ModifyACL, txid `...666` = ModifyUser):

1. `12:21:47.319610` - schemeshard executes `ESchemeOpModifyACL` (instant op, done in propose).
2. `12:21:47.319731` - Grant reply `Status# 48` (OK). Test immediately fires ModifyUser.
3. `12:21:47.320677` - schemereq for ModifyUser does `TEvNavigateKeySet` with SyncVersion; replicas still hold `/dc-1` Version 13 (pre-grant ACL). SyncVersion only guarantees subscriber↔replica consistency, not "publication finished" - replicas receive Version 15 (with `+(AS):user1`) only at `.321335+`.
4. `12:21:47.320899` - access check against stale cached effective ACL: `Access denied for user1 on path /dc-1, with access AlterSchema` → `MSTATUS_ERROR` → assertion fails.

The Grant on the domain root triggers republication of effective ACLs for 38 paths (root + 36 `.sys` sysview paths + `USER_0`, visible in the `ExamineTreeVFS` walk). Sysview path additions made the publication batch much larger/slower, widening the race window enough for the next request to slip in first. On fast runs publication wins and the test passes.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/issues/41606
