### PR TITLE
ci: include test_release-asan in checks_integrated aggregation

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -307,15 +307,20 @@ jobs:
       - name: Gather required checks results
         shell: bash
         run: |
-          successbuilds=$(curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X GET -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
+          integrated_status=$(curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X GET -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/commits/${{github.event.pull_request.head.sha}}/status | \
-            jq -cr '.statuses | .[] | select(.state=="success") | select(.context | (startswith("build_relwithdebinfo") or startswith("build_release-asan") or startswith("test_relwithdebinfo")) ) | .context' | \
-            wc -l )
-          if [[ $successbuilds == "3" ]];then
-            integrated_status="success"
-          else
-            integrated_status="failure"
-          fi
+            jq -cr '
+              .statuses
+              | group_by(.context)
+              | map(.[0])
+              | map(select(.context | (
+                  startswith("build_relwithdebinfo")
+                  or startswith("build_release-asan")
+                  or startswith("test_relwithdebinfo")
+                  or startswith("test_release-asan")
+                )))
+              | if length == 4 and all(.state == "success") then "success" else "failure" end
+            ')
           curl --retry 5 --retry-all-errors --retry-delay 10 --fail --show-error -L -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{github.token}}" -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/${{github.repository}}/statuses/${{github.event.pull_request.head.sha}} \
             -d '{"state":"'$integrated_status'","description":"All checks completed","context":"checks_integrated","target_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Part 1 of enabling ASAN test blocking (split from #43185).

- `checks_integrated` now derives the **latest state per context** (`group_by(.context) | map(.[0])`) instead of counting all historical `success` entries with `wc -l`. The old counting could produce a false `success` from stale/duplicate statuses after reruns.
- `test_release-asan` is added to the required contexts (3 → 4, all must be `success`).

**No behavior change yet**: while `release-asan` test failures are ignored in `test_ya` (`IS_TEST_RESULT_IGNORED=1`), the `test_release-asan` status is always `success`. Actual blocking is enabled by the follow-up PR that removes the ignore flag.

Note: since `pull_request_target` workflows now always run from the default branch, this aggregation applies to PRs targeting all branches; it is harmless for stable branches where the ignore flag is still in place.

Made with [Cursor](https://cursor.com)