### PR TITLE
ci: make release-asan test failures blocking in PR-check

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -214,7 +214,6 @@ runs:
             params+=(
               --build "release" --sanitize="address"
             )
-            IS_TEST_RESULT_IGNORED=1
             ;;
           release-tsan)
             params+=(


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Part 2 of enabling ASAN test blocking (split from #43185). Companion to #43232.

Removes `IS_TEST_RESULT_IGNORED=1` for the `release-asan` preset, reverting the "Do not paint red for asan" behavior (#9704). After this change, ASAN test failures on the last retry will:

- mark the `test_release-asan` commit status as `failure` (instead of always `success`),
- show a red PR comment (instead of yellow "This fail is not in blocking policy yet"),
- fail the `Build and test release-asan` job via `check test results` / `fail-checker.py`.

Together with #43232, `checks_integrated` then requires a green `test_release-asan`, making ASAN test failures block PR merge.

Retries are unchanged: ASAN keeps the default 3 tries (#41686). TSAN/MSAN remain ignored.

Effective for PRs targeting `main` only: the action runs from the PR checkout, so stable branches keep the old behavior until this is backported.

Made with [Cursor](https://cursor.com)