### PR TITLE
[DO NOT MERGE]  test: CI trigger check — minimal test change, expected to pass

### DIFF
--- a/ydb/library/naming_conventions/ut/naming_conventions_ut.cpp
+++ b/ydb/library/naming_conventions/ut/naming_conventions_ut.cpp
@@ -21,4 +21,9 @@ Y_UNIT_TEST_SUITE(NamingConventionsSuite) {
         UNIT_ASSERT_EQUAL("Bfg", SnakeToCamelCase("bfg_"));
     }
 
+    Y_UNIT_TEST(TestRoundTrip) {
+        UNIT_ASSERT_VALUES_EQUAL("ci_check", CamelToSnakeCase("CiCheck"));
+        UNIT_ASSERT_VALUES_EQUAL("CiCheck", SnakeToCamelCase("ci_check"));
+    }
+
 }


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

**CI experiment, not intended for merge as-is** (though the added test is harmless).

Adds a trivial passing round-trip test to `ydb/library/naming_conventions/ut` — the smallest leaf suite (single source file, depends only on `util`). Purpose: verify that a single test-file change triggers the minimal set of PR-check tests and everything goes green:

- `test_relwithdebinfo` / `test_release-asan` = success
- `checks_integrated` = success

Companion failing-test PR exercises the red path.

Made with [Cursor](https://cursor.com)