### PR TITLE
[DO NOT MERGE] test: CI trigger check — minimal test change, expected to fail

### DIFF
--- a/ydb/library/naming_conventions/ut/naming_conventions_ut.cpp
+++ b/ydb/library/naming_conventions/ut/naming_conventions_ut.cpp
@@ -21,4 +21,9 @@ Y_UNIT_TEST_SUITE(NamingConventionsSuite) {
         UNIT_ASSERT_EQUAL("Bfg", SnakeToCamelCase("bfg_"));
     }
 
+    Y_UNIT_TEST(TestIntentionalFailure) {
+        // Intentionally failing: CI blocking-policy experiment, do not merge.
+        UNIT_ASSERT_VALUES_EQUAL("kebab-case", CamelToSnakeCase("KebabCase"));
+    }
+
 }


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

**CI experiment, DO NOT MERGE.**

Adds an intentionally failing test to `ydb/library/naming_conventions/ut` — the smallest leaf suite (single source file, depends only on `util`). The assertion expects `kebab-case` from `CamelToSnakeCase("KebabCase")`, which returns `kebab_case`, so the test fails deterministically in every build preset on all 3 retries.

Purpose: verify the red path of PR-check with a minimal trigger surface:

- current main: `test_relwithdebinfo` = failure, `test_release-asan` = success (ignored), `checks_integrated` stuck pending
- with #43232 + #43233: `test_release-asan` = failure as well

Companion passing-test PR: #43234.

Made with [Cursor](https://cursor.com)