### PR TITLE
[DO NOT MERGE] test: CI trigger check — fails only under release-asan

### DIFF
--- a/ydb/library/naming_conventions/ut/naming_conventions_ut.cpp
+++ b/ydb/library/naming_conventions/ut/naming_conventions_ut.cpp
@@ -4,6 +4,7 @@
 
 #include <util/stream/format.h>
 #include <util/stream/str.h>
+#include <util/system/sanitizers.h>
 
 using namespace NKikimr::NNaming;
 
@@ -19,6 +20,12 @@ Y_UNIT_TEST_SUITE(NamingConventionsSuite) {
         UNIT_ASSERT_EQUAL("CamelCase", SnakeToCamelCase("camel_case"));
         UNIT_ASSERT_EQUAL("Snakesnake", SnakeToCamelCase("snakesnake"));
         UNIT_ASSERT_EQUAL("Bfg", SnakeToCamelCase("bfg_"));
+    }
+
+    Y_UNIT_TEST(TestIntentionalAsanOnlyFailure) {
+        // Intentionally failing only under AddressSanitizer:
+        // CI blocking-policy experiment, do not merge.
+        UNIT_ASSERT_C(!NSan::ASanIsOn(), "intentional failure under ASAN build");
     }
 
 }


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

**CI experiment, DO NOT MERGE.**

Adds a test to `ydb/library/naming_conventions/ut` (smallest leaf suite) that fails **only in the `release-asan` preset**: the assertion checks `!NSan::ASanIsOn()`, which is a compile-time constant from `util/system/sanitizers.h` (`_asan_enabled_`). No real memory error — deterministic, no flakiness, passes everywhere except ASAN, fails on all 3 ASAN retries.

This reproduces exactly scenario "ASAN fail, rwdi ok":

- current main: `test_relwithdebinfo` = success, `test_release-asan` = **success** (ignored, yellow "not in blocking policy yet"), `checks_integrated` = success → merge allowed
- with #43232 + #43233: `test_release-asan` = **failure**, ASAN job red, merge blocked

Companion PRs: #43234 (all green), #43235 (fails everywhere).

Made with [Cursor](https://cursor.com)