### PR TITLE
Introduce cluster-opaque TAppConfig::PrivateDatabaseConfig

### DIFF
--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -24,6 +24,7 @@
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/json_writer.h>
 #include <library/cpp/protobuf/json/proto2json.h>
+#include <library/cpp/protobuf/json/util.h>
 
 #include <util/generic/bitmap.h>
 #include <util/generic/ptr.h>
@@ -77,6 +78,7 @@ const THashSet<ui32> DYNAMIC_KINDS({
     (ui32)NKikimrConsole::TConfigItem::BlockstoreConfigItem,
     (ui32)NKikimrConsole::TConfigItem::StatisticsConfigItem,
     (ui32)NKikimrConsole::TConfigItem::TliConfigItem,
+    (ui32)NKikimrConsole::TConfigItem::PrivateDatabaseConfigItem,
 });
 
 const THashSet<ui32> NON_YAML_KINDS({
@@ -180,6 +182,19 @@ public:
     TDynBitMap FilterKinds(const TDynBitMap& in);
 
     void UpdateCandidateStartupConfig(TEvConsole::TEvConfigSubscriptionNotification::TPtr &ev);
+
+    struct TParsedOpaqueConfig {
+        // Raw JSON section text used for cheap equality between updates.
+        // !empty() (empty strings aka "section present but empty" treated as absent config and not stored)
+        TString RawJson;
+        // May be null in the cache (parser produced nothing), but null
+        // never placed into an outgoing event — see PopulateWithOpaqueConfigs.
+        std::shared_ptr<::google::protobuf::Message> Parsed;
+    };
+
+    THashMap<ui32, TParsedOpaqueConfig> ParseOpaqueConfigs() const;
+
+    void PopulateWithOpaqueConfigs(TEvConsole::TEvConfigNotificationRequest& ev, const TDynBitMap& kinds) const;
 
     void Handle(NMon::TEvHttpInfo::TPtr &ev);
     void Handle(TEvInterconnect::TEvNodesInfo::TPtr &ev);
@@ -340,6 +355,15 @@ private:
     NKikimrConsole::TYamlConfigUnknownFields ResolvedConfigUnknownFields;
     std::optional<TString> ConfigurationVersion;
 
+    // Per-kind parsers for opaque config sections, injected by a client that
+    // reuses the dispatcher. The dispatcher has no schema for these sections; it
+    // just calls the parser and attaches the result to the node-local notification.
+    THashMap<ui32, TOpaqueConfigParser> OpaqueConfigParsers;
+
+    // Parsed opaque-config view, refreshed on every console notification.
+    // Used to detect opaque-only changes and to populate outgoing subscriber
+    // notifications without re-parsing per subscriber.
+    THashMap<ui32, TParsedOpaqueConfig> CurrentOpaqueConfigs;
 };
 
 TConfigsDispatcher::TConfigsDispatcher(const TConfigsDispatcherInitInfo& initInfo)
@@ -354,6 +378,7 @@ TConfigsDispatcher::TConfigsDispatcher(const TConfigsDispatcherInitInfo& initInf
         , RecordedInitialConfiguratorDeps(std::move(initInfo.RecordedInitialConfiguratorDeps))
         , Args(initInfo.Args)
         , NextRequestCookie(Now().GetValue())
+        , OpaqueConfigParsers(initInfo.OpaqueConfigParsers)
 {}
 
 void TConfigsDispatcher::Bootstrap()
@@ -416,6 +441,8 @@ void TConfigsDispatcher::SendUpdateToSubscriber(TSubscription::TPtr subscription
 
     auto notification = MakeHolder<TEvConsole::TEvConfigNotificationRequest>();
     notification->Record.CopyFrom(subscription->UpdateInProcess->Record);
+    // Parsed once when UpdateInProcess was built; share the (read-only) result.
+    notification->OpaqueConfigs = subscription->UpdateInProcess->OpaqueConfigs;
 
     BLOG_TRACE("Send TEvConsole::TEvConfigNotificationRequest to " << subscriber
                 << ": " << notification->Record.ShortDebugString());
@@ -1141,6 +1168,67 @@ catch (...) {
     *StartupConfigChanged = 1;
 }
 
+THashMap<ui32, TConfigsDispatcher::TParsedOpaqueConfig> TConfigsDispatcher::ParseOpaqueConfigs() const
+{
+    THashMap<ui32, TParsedOpaqueConfig> result;
+    if (OpaqueConfigParsers.empty() || ResolvedJsonConfig.empty()) {
+        return result;
+    }
+    // The opaque carrier proto is empty by design — its content lives in the
+    // resolved YAML. Pull each kind's section out and pass it to the end-node
+    // parser that owns the real schema.
+    NJson::TJsonValue resolved;
+    if (!NJson::ReadJsonTree(ResolvedJsonConfig, &resolved)) {
+        return result;
+    }
+    const NJson::TJsonValue* configSection = &resolved;
+    if (const NJson::TJsonValue* c = nullptr; resolved.GetValuePointer("config", &c)) {
+        configSection = c;
+    }
+    const auto* desc = NKikimrConfig::TAppConfig::descriptor();
+    for (const auto& [kind, parser] : OpaqueConfigParsers) {
+        const auto* field = desc->FindFieldByNumber(kind);
+        if (!field) {
+            continue;
+        }
+        TString name = field->name();
+        NProtobufJson::ToSnakeCaseDense(&name);
+        const NJson::TJsonValue* section = nullptr;
+        if (!configSection->GetValuePointer(name, &section)) {
+            continue;   // section absent — no config
+        }
+        TParsedOpaqueConfig entry;
+        entry.RawJson = NJson::WriteJson(section, /*formatOutput=*/ false);
+        if (entry.RawJson.empty()) {
+            continue;   // empty section — treated as "no config"
+        }
+        try {
+            entry.Parsed = parser(entry.RawJson);
+        }
+        catch (const std::exception& e) {
+            BLOG_ERROR("Error parsing opaque config [#" << kind << ":" << name << "]: " << e.what());
+        }
+        catch (...) {
+            BLOG_ERROR("Error parsing opaque config [#" << kind << ":" << name << "]: unknown exception");
+        }
+        result.emplace(kind, std::move(entry));
+    }
+    return result;
+}
+
+void TConfigsDispatcher::PopulateWithOpaqueConfigs(
+    TEvConsole::TEvConfigNotificationRequest& ev,
+    const TDynBitMap& kinds) const
+{
+    Y_FOR_EACH_BIT(kind, kinds) {
+        auto it = CurrentOpaqueConfigs.find(kind);
+        if (it == CurrentOpaqueConfigs.end() || !it->second.Parsed) {
+            continue;   // absent OR empty/reset — never emit a null payload
+        }
+        ev.OpaqueConfigs[kind] = it->second.Parsed;
+    }
+}
+
 void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::TPtr &ev)
 {
     auto &rec = ev->Get()->Record;
@@ -1205,10 +1293,35 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
         affectedKinds.insert(kind);
     }
 
+    // Re-parse opaque configs from the resolved JSON and fold any add /
+    // remove / mutation / empty<->non-empty transition into affectedKinds.
+    // Opaque sections are invisible to AffectedKinds and to the proto diff,
+    // so without this an opaque-only update never reaches subscribers.
+    auto newOpaqueConfigs = ParseOpaqueConfigs();
+    for (const auto& [kind, parsed] : newOpaqueConfigs) {
+        auto it = CurrentOpaqueConfigs.find(kind);
+        if (it == CurrentOpaqueConfigs.end() || it->second.RawJson != parsed.RawJson) {
+            // config was added or changed
+            affectedKinds.insert(kind);
+        }
+    }
+    for (const auto& [kind, _] : CurrentOpaqueConfigs) {
+        if (!newOpaqueConfigs.contains(kind)) {
+            // config was removed
+            affectedKinds.insert(kind);
+        }
+    }
+    CurrentOpaqueConfigs = std::move(newOpaqueConfigs);
+
     for (auto &[kinds, subscription] : SubscriptionsByKinds) {
         NKikimrConfig::TAppConfig trunc;
 
         bool hasAffectedKinds = false;
+        Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
+            if (affectedKinds.contains(kind)) {
+                hasAffectedKinds = true;
+            }
+        }
 
         if (subscription->Yaml && YamlConfigEnabled) {
             if (!isYamlChanged && !yamlConfigTurnedOff && CurrentStateFunc() != &TThis::StateInit) {
@@ -1220,12 +1333,6 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
             }
             ReplaceConfigItems(YamlProtoConfig, trunc, FilterKinds(subscription->Kinds), BaseConfig);
         } else {
-            Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
-                if (affectedKinds.contains(kind)) {
-                    hasAffectedKinds = true;
-                }
-            }
-
             // we try resend all configs if yaml config was turned off
             if (!hasAffectedKinds && !yamlConfigTurnedOff && CurrentStateFunc() != &TThis::StateInit) {
                 continue;
@@ -1245,6 +1352,7 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
             Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
                 subscription->UpdateInProcess->Record.AddItemKinds(kind);
             }
+            PopulateWithOpaqueConfigs(*subscription->UpdateInProcess, FilterKinds(kinds));
             subscription->UpdateInProcessCookie = ++NextRequestCookie;
             subscription->UpdateInProcessConfigVersion = FilterVersion(ev->Get()->Record.GetConfig().GetVersion(), FilterKinds(kinds));
 
@@ -1389,6 +1497,7 @@ void TConfigsDispatcher::Handle(TEvConfigsDispatcher::TEvSetConfigSubscriptionRe
             Y_FOR_EACH_BIT(kind, kinds) {
                 subscription->UpdateInProcess->Record.AddItemKinds(kind);
             }
+            PopulateWithOpaqueConfigs(*subscription->UpdateInProcess, FilterKinds(kinds));
             subscription->UpdateInProcessCookie = ++NextRequestCookie;
             subscription->UpdateInProcessConfigVersion = FilterVersion(CurrentConfig.GetVersion(), kinds);
         }

--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -189,7 +189,7 @@ public:
         TString RawJson;
         // May be null in the cache (parser produced nothing), but null
         // never placed into an outgoing event — see PopulateWithOpaqueConfigs.
-        std::shared_ptr<::google::protobuf::Message> Parsed;
+        std::shared_ptr<const ::google::protobuf::Message> Parsed;
     };
 
     THashMap<ui32, TParsedOpaqueConfig> ParseOpaqueConfigs() const;
@@ -1171,7 +1171,7 @@ catch (...) {
 THashMap<ui32, TConfigsDispatcher::TParsedOpaqueConfig> TConfigsDispatcher::ParseOpaqueConfigs() const
 {
     THashMap<ui32, TParsedOpaqueConfig> result;
-    if (OpaqueConfigParsers.empty() || ResolvedJsonConfig.empty()) {
+    if (!YamlConfigEnabled || OpaqueConfigParsers.empty() || ResolvedJsonConfig.empty()) {
         return result;
     }
     // The opaque carrier proto is empty by design — its content lives in the
@@ -1297,33 +1297,36 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
     // remove / mutation / empty<->non-empty transition into affectedKinds.
     // Opaque sections are invisible to AffectedKinds and to the proto diff,
     // so without this an opaque-only update never reaches subscribers.
-    auto newOpaqueConfigs = ParseOpaqueConfigs();
-    for (const auto& [kind, parsed] : newOpaqueConfigs) {
-        auto it = CurrentOpaqueConfigs.find(kind);
-        if (it == CurrentOpaqueConfigs.end() || it->second.RawJson != parsed.RawJson) {
-            // config was added or changed
-            affectedKinds.insert(kind);
+    THashSet<ui32> affectedOpaqueKinds;
+    if (isYamlChanged) {
+        auto newOpaqueConfigs = ParseOpaqueConfigs();
+        for (const auto& [kind, parsed] : newOpaqueConfigs) {
+            auto it = CurrentOpaqueConfigs.find(kind);
+            if (it == CurrentOpaqueConfigs.end() || it->second.RawJson != parsed.RawJson) {
+                // config was added or changed
+                affectedOpaqueKinds.insert(kind);
+            }
         }
-    }
-    for (const auto& [kind, _] : CurrentOpaqueConfigs) {
-        if (!newOpaqueConfigs.contains(kind)) {
-            // config was removed
-            affectedKinds.insert(kind);
+        for (const auto& [kind, _] : CurrentOpaqueConfigs) {
+            if (!newOpaqueConfigs.contains(kind)) {
+                // config was removed
+                affectedOpaqueKinds.insert(kind);
+            }
         }
+        CurrentOpaqueConfigs = std::move(newOpaqueConfigs);
     }
-    CurrentOpaqueConfigs = std::move(newOpaqueConfigs);
 
     for (auto &[kinds, subscription] : SubscriptionsByKinds) {
         NKikimrConfig::TAppConfig trunc;
 
         bool hasAffectedKinds = false;
-        Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
-            if (affectedKinds.contains(kind)) {
-                hasAffectedKinds = true;
-            }
-        }
 
         if (subscription->Yaml && YamlConfigEnabled) {
+            Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
+                if (affectedOpaqueKinds.contains(kind)) {
+                    hasAffectedKinds = true;
+                }
+            }
             if (!isYamlChanged && !yamlConfigTurnedOff && CurrentStateFunc() != &TThis::StateInit) {
                 continue;
             }
@@ -1333,6 +1336,11 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
             }
             ReplaceConfigItems(YamlProtoConfig, trunc, FilterKinds(subscription->Kinds), BaseConfig);
         } else {
+            Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
+                if (affectedKinds.contains(kind)) {
+                    hasAffectedKinds = true;
+                }
+            }
             // we try resend all configs if yaml config was turned off
             if (!hasAffectedKinds && !yamlConfigTurnedOff && CurrentStateFunc() != &TThis::StateInit) {
                 continue;

--- a/ydb/core/cms/console/configs_dispatcher_ut.cpp
+++ b/ydb/core/cms/console/configs_dispatcher_ut.cpp
@@ -6,6 +6,11 @@
 #include <ydb/core/tablet/bootstrapper.h>
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
 #include <ydb/core/testlib/tablet_helpers.h>
+#include <ydb/core/cms/console/ut_configs_dispatcher/ut_private_database_config.pb.h>
+#include <ydb/library/fyamlcpp/fyamlcpp.h>
+#include <ydb/library/yaml_config/yaml_config_parser.h>
+#include <ydb/library/yaml_config/yaml_config_helpers.h>
+#include <library/cpp/protobuf/json/json2proto.h>
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/monlib/service/mon_service_http_request.h>
@@ -166,6 +171,8 @@ struct TEvPrivate {
         EvSetSubscription,
         EvGotNotification,
         EvComplete,
+        EvParsedPrivateDatabaseConfig,
+        EvResetPrivateDatabaseConfig,
         EvEnd
     };
 
@@ -206,6 +213,19 @@ struct TEvPrivate {
     };
 
     struct TEvComplete : public TEventLocal<TEvComplete, EvComplete> {};
+
+
+    // Carries the secret_port the end-node subscriber read from the dispatcher-
+    // parsed TUtPrivateDatabaseConfig (OpaqueConfigs), proving the dispatcher did the parse.
+    struct TEvParsedPrivateDatabaseConfig : public TEventLocal<TEvParsedPrivateDatabaseConfig, EvParsedPrivateDatabaseConfig> {
+        ui32 SecretPort = 0;
+    };
+
+    // Emitted when the subscriber received a notification for its subscribed
+    // opaque kind but OpaqueConfigs carried no parsed payload — i.e. the
+    // dispatcher signaled "section absent / cleared".
+    struct TEvResetPrivateDatabaseConfig : public TEventLocal<TEvResetPrivateDatabaseConfig, EvResetPrivateDatabaseConfig> {
+    };
 };
 
 class TTestSubscriber : public TActorBootstrapped<TTestSubscriber> {
@@ -1692,6 +1712,371 @@ selector_config: []
             "labels": []
         })json");
         UNIT_ASSERT_C(expected == actual, jsonBody);
+    }
+}
+
+Y_UNIT_TEST_SUITE(TConfigsDispatcherOpaqueConfigTests) {
+
+    // End-node subscriber: subscribes to the opaque kind PrivateDatabaseConfigItem
+    // and reads the already-parsed TUtPrivateDatabaseConfig from the notification's OpaqueConfigs
+    class TPrivateDatabaseConfigSubscriber : public TActorBootstrapped<TPrivateDatabaseConfigSubscriber> {
+        TActorId Sink;
+    public:
+        // No trust to the runtime.SetObserverFunc() - fires multiple times per delivery
+        // for ES_PRIVATE events that share a numeric id with other unrelated private events;
+        // ev->Sender + ev->Recipient filter not help.
+        std::atomic<int> parsedCnt{0};
+        std::atomic<int> resetCnt{0};
+
+        TPrivateDatabaseConfigSubscriber(TActorId sink)
+            : Sink(sink)
+        {}
+
+        void Bootstrap(const TActorContext &ctx) {
+            Become(&TThis::StateWork);
+            ctx.Send(MakeConfigsDispatcherID(ctx.SelfID.NodeId()),
+                new TEvConfigsDispatcher::TEvSetConfigSubscriptionRequest(
+                    (ui32)NKikimrConsole::TConfigItem::PrivateDatabaseConfigItem, ctx.SelfID));
+        }
+
+        void Handle(TEvConsole::TEvConfigNotificationRequest::TPtr &ev, const TActorContext &ctx) {
+            auto &rec = ev->Get()->Record;
+            const auto &opaqueConfigs = ev->Get()->OpaqueConfigs;
+
+            if (auto it = opaqueConfigs.find((ui32)NKikimrConsole::TConfigItem::PrivateDatabaseConfigItem);
+                it != opaqueConfigs.end() && it->second)
+            {
+                NKikimrOpaqueConfigUt::TUtPrivateDatabaseConfig impl;
+                impl.CopyFrom(*it->second);                 // descriptor-checked, no RTTI
+                auto *event = new TEvPrivate::TEvParsedPrivateDatabaseConfig;
+                event->SecretPort = impl.GetSecretPort();
+                parsedCnt++;
+                ctx.Send(Sink, event);
+            } else {
+                // Notification arrived for subscribed kind but no parsed
+                // opaque payload — section became absent / was cleared
+                resetCnt++;
+                ctx.Send(Sink, new TEvPrivate::TEvResetPrivateDatabaseConfig);
+            }
+            ctx.Send(ev->Sender, new TEvConsole::TEvConfigNotificationResponse(rec), 0, ev->Cookie);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                HFunc(TEvConsole::TEvConfigNotificationRequest, Handle);
+                IgnoreFunc(TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse);
+            }
+        }
+    };
+
+    void DoTestDispatcherParseAndSendOpaquePrivateDatabaseConfig(bool withParser) {
+        const TString mainYaml0 = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 0
+config:
+  yaml_config_enabled: true
+  feature_flags:
+    database_yaml_config_allowed: true
+)";
+        const TString mainYaml1 = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 1
+config:
+  yaml_config_enabled: true
+  feature_flags:
+    database_yaml_config_allowed: true
+  private_database_config:
+    secret_port: 666
+)";
+        const TString databaseYamlTemplate = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc-1/users/tenant-1"
+  version: VERSION
+config:
+  private_database_config:
+    secret_port: VALUE
+)";
+
+        // Set the end-node parser for the opaque kind into the dispatcher.
+        NKikimrConfig::TAppConfig appcfg;
+        auto *label = appcfg.AddLabels();
+        label->SetName("tenant");
+        label->SetValue(TENANT1_1_NAME);
+        appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
+
+        TTenantTestConfig testConfig = DefaultConsoleTestConfig();
+        if (withParser) {
+            auto parser = std::bind(NKikimr::NYaml::DefaultOpaqueConfigParser<NKikimrOpaqueConfigUt::TUtPrivateDatabaseConfig>, std::placeholders::_1, true);
+            testConfig.OpaqueConfigParsers[(ui32)NKikimrConsole::TConfigItem::PrivateDatabaseConfigItem] = parser;
+        }
+
+        TTenantTestRuntime runtime(testConfig, appcfg);
+
+        // The end-node consumer subscribes to the private kind.
+        auto subscriber = new TPrivateDatabaseConfigSubscriber(runtime.Sender);
+        TActorId subscriberId = runtime.Register(subscriber);
+        runtime.EnableScheduleForActor(subscriberId, true);
+
+        // Init cluster with main config without private_database_config
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, mainYaml0);
+
+        // No private_database_config yet.
+        // The subscriber must report nothing.
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 0);
+
+        // The OpaqueConfig marker makes the cluster accept config.private_database_config
+        // WITHOUT allow_unknown_fields.
+        // The dispatcher resolves it and pulls config.private_database_config from the resolved
+        // YAML for the injected parser.
+
+        // Set the opaque section in the main config.
+        //  withParser: The subscriber reports secret_port read from the dispatcher-parsed config.
+        // !withParser: The subscriber must report nothing.
+        {
+            subscriber->parsedCnt = 0;
+            CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, mainYaml1);
+            TAutoPtr<IEventHandle> handle;
+            if (withParser) {
+                auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvParsedPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+                UNIT_ASSERT_C(ev, "No PrivateDatabaseConfig received and processed by subscriber");
+                UNIT_ASSERT_VALUES_EQUAL(ev->SecretPort, 666);
+                UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 1);
+            }
+            else {
+                runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+                UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 0);
+            }
+        }
+
+        // Set the opaque section in the database config.
+        //  withParser: The subscriber reports secret_port read from the dispatcher-parsed config.
+        // !withParser: The subscriber must report nothing.
+        // Run several times to ensure opaque-only change is passed to subscriber.
+        subscriber->parsedCnt = 0;
+        for (int i = 0; i < 5; i++ ) {
+            auto databaseYaml = databaseYamlTemplate;
+
+            SubstGlobal(databaseYaml, "VERSION", ToString(i));
+            SubstGlobal(databaseYaml, "VALUE", ToString(i+1));
+
+            CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, databaseYaml);
+            {
+                TAutoPtr<IEventHandle> handle;
+                if (withParser) {
+                    auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvParsedPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+                    UNIT_ASSERT_C(ev, "No PrivateDatabaseConfig received and processed by subscriber");
+                    UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), i+1);
+                    UNIT_ASSERT_VALUES_EQUAL(ev->SecretPort, i+1);
+                }
+                else {
+                    runtime.DispatchEvents(TDispatchOptions(), TDuration::Seconds(1));
+                    UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 0);
+                }
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), withParser ? 5 : 0);
+    }
+
+    Y_UNIT_TEST(TestDispatcherOmitsOpaquePrivateDatabaseConfigWithoutParser) {
+        DoTestDispatcherParseAndSendOpaquePrivateDatabaseConfig(/*withParser=*/false);
+    }
+
+    Y_UNIT_TEST(TestDispatcherParseAndSendOpaquePrivateDatabaseConfigWithParser) {
+        DoTestDispatcherParseAndSendOpaquePrivateDatabaseConfig(/*withParser=*/true);
+    }
+
+    // Test every transition of the opaque configs changes Edge cases:
+    //   absent -> absent             (init, no dispatch)
+    //   absent -> non-empty          (added - dispatch, parsed payload)
+    //   non-empty -> non-empty       (same value - no dispatch)
+    //   non-empty(A) -> non-empty(B) (mutated - dispatch, parsed payload)
+    //   non-empty -> absent          (removed - dispatch, reset / no payload)
+    //   absent -> non-empty          (re-added via database yaml - dispatch, parsed)
+    //   non-empty -> non-empty       (mutated via database yaml - dispatch, parsed)
+    Y_UNIT_TEST(TestOpaquePrivateDatabaseConfigEdgeCases) {
+        // No private_database_config - opaque section absent.
+        const TString mainYamlAbsent = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: VERSION
+config:
+  yaml_config_enabled: true
+  feature_flags:
+    database_yaml_config_allowed: true
+)";
+        // With private_database_config.secret_port = VALUE.
+        const TString mainYamlWithOpaque = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: VERSION
+config:
+  yaml_config_enabled: true
+  feature_flags:
+    database_yaml_config_allowed: true
+  private_database_config:
+    secret_port: VALUE
+)";
+        const TString databaseYamlTemplate = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc-1/users/tenant-1"
+  version: VERSION
+config:
+  private_database_config:
+    secret_port: VALUE
+)";
+        auto subst = [](TString tmpl, ui64 version, ui64 value) {
+            SubstGlobal(tmpl, "VERSION", ToString(version));
+            SubstGlobal(tmpl, "VALUE", ToString(value));
+            return tmpl;
+        };
+
+        NKikimrConfig::TAppConfig appcfg;
+        auto *label = appcfg.AddLabels();
+        label->SetName("tenant");
+        label->SetValue(TENANT1_1_NAME);
+        appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
+
+        TTenantTestConfig testConfig = DefaultConsoleTestConfig();
+        auto parser = std::bind(NKikimr::NYaml::DefaultOpaqueConfigParser<NKikimrOpaqueConfigUt::TUtPrivateDatabaseConfig>, std::placeholders::_1, true);
+        testConfig.OpaqueConfigParsers[(ui32)NKikimrConsole::TConfigItem::PrivateDatabaseConfigItem] = parser;
+
+        TTenantTestRuntime runtime(testConfig, appcfg);
+
+        auto subscriber = new TPrivateDatabaseConfigSubscriber(runtime.Sender);
+        TActorId subscriberId = runtime.Register(subscriber);
+        runtime.EnableScheduleForActor(subscriberId, true);
+
+        // No trust to the runtime.SetObserverFunc() - fires multiple times per delivery
+        // for ES_PRIVATE events that share a numeric id with other unrelated private events;
+        // ev->Sender + ev->Recipient filter not help.
+        auto pollOneOfEither = [&](TDuration timeout) -> ui32 {
+            TAutoPtr<IEventHandle> handle;
+            auto [parsed, reset] = runtime.GrabEdgeEventsRethrow<
+                TEvPrivate::TEvParsedPrivateDatabaseConfig,
+                TEvPrivate::TEvResetPrivateDatabaseConfig>(handle, timeout);
+            if (parsed) {
+                return TEvPrivate::EvParsedPrivateDatabaseConfig;
+            }
+            if (reset) {
+                return TEvPrivate::EvResetPrivateDatabaseConfig;
+            }
+            return 0;
+        };
+
+        int mainVersion = 0;
+
+        // Case 1: absent -> absent (initial state). No opaque dispatch
+        // expected. There may be an initial subscription notification that
+        // arrives empty — observed via subscriber->resetQuan.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, subst(mainYamlAbsent, mainVersion++, 0));
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvResetPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "absent -> absent must produce the initial reset notification");
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 0);
+        // No subscriber->resetQuan.load() check - the subscriber-init notification always
+        // dispatches once on the dispatcher side, so subscriber->resetQuan may have grown.
+
+        // Case 2: absent -> non-empty (added). Expect one parsed event.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, subst(mainYamlWithOpaque, mainVersion++, 666));
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvParsedPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "absent -> non-empty must dispatch a parsed opaque config");
+            UNIT_ASSERT_VALUES_EQUAL(ev->SecretPort, 666);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->resetCnt.load(), 0);
+
+        // Case 3: non-empty -> non-empty (same value, version bumped).
+        // The opaque RawJson is byte-identical so no opaque-driven dispatch;
+        // and the proto truncation for this kind is unchanged so the regular
+        // path also does not fire. Expect zero new events.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, subst(mainYamlWithOpaque, mainVersion++, 666));
+        {
+            UNIT_ASSERT_VALUES_EQUAL_C(pollOneOfEither(TDuration::Seconds(1)), 0u,
+                                      "identical opaque must not redispatch");
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(subscriber->parsedCnt.load(), 0, "identical opaque must not redispatch");
+        UNIT_ASSERT_VALUES_EQUAL_C(subscriber->resetCnt.load(), 0, "identical opaque must not redispatch");
+
+        // Case 4: non-empty(666) -> non-empty(777). RawJson differs:
+        // expect exactly one parsed event carrying the new value.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, subst(mainYamlWithOpaque, mainVersion++, 777));
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvParsedPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "non-empty A -> non-empty B must dispatch a parsed opaque config");
+            UNIT_ASSERT_VALUES_EQUAL(ev->SecretPort, 777);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->resetCnt.load(), 0);
+
+        // Case 5: non-empty -> absent (removed). Expect one reset event
+        // and no parsed event.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, subst(mainYamlAbsent, mainVersion++, 0));
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvResetPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "non-empty -> absent must dispatch a reset notification");
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->resetCnt.load(), 1);
+
+        int databaseVersion = 0;
+
+        // Case 6: absent -> non-empty via database yaml. The opaque
+        // section reappears with a different value.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, subst(databaseYamlTemplate, databaseVersion++, 888));
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvParsedPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "absent -> non-empty (via db yaml) must dispatch parsed opaque config");
+            UNIT_ASSERT_VALUES_EQUAL(ev->SecretPort, 888);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->resetCnt.load(), 0);
+
+        // Case 7: non-empty(888) -> non-empty(999) via database yaml.
+        subscriber->parsedCnt = 0;
+        subscriber->resetCnt = 0;
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, subst(databaseYamlTemplate, databaseVersion++, 999));
+        {
+            TAutoPtr<IEventHandle> handle;
+            auto ev = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvParsedPrivateDatabaseConfig>(handle, TDuration::Seconds(1));
+            UNIT_ASSERT_C(ev, "non-empty A -> non-empty B (via db yaml) must dispatch parsed opaque config");
+            UNIT_ASSERT_VALUES_EQUAL(ev->SecretPort, 999);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->parsedCnt.load(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(subscriber->resetCnt.load(), 0);
     }
 }
 

--- a/ydb/core/cms/console/console.h
+++ b/ydb/core/cms/console/console.h
@@ -10,6 +10,10 @@
 #include <ydb/public/api/protos/ydb_cms.pb.h>
 #include <ydb/public/api/protos/draft/ydb_dynamic_config.pb.h>
 
+#include <util/generic/hash.h>
+
+#include <memory>
+
 namespace NKikimr::NConsole {
 
 namespace TEvConsole {
@@ -300,6 +304,11 @@ namespace TEvConsole {
 
     struct TEvConfigNotificationRequest : public TEventShortDebugPB<TEvConfigNotificationRequest, NKikimrConsole::TConfigNotificationRequest, EvConfigNotificationRequest> {
         const NKikimrConfig::TAppConfig& GetConfig() const { return Record.GetConfig(); }
+
+        // Node-local only: parsed forms of opaque config sections (kind -> message),
+        // produced by the configs dispatcher via an injected OpaqueConfigParser.
+        // .second != nullptr - config either not empty and present or not added into map
+        THashMap<ui32, std::shared_ptr<::google::protobuf::Message>> OpaqueConfigs;
     };
 
     struct TEvConfigNotificationResponse : public TEventShortDebugPB<TEvConfigNotificationResponse, NKikimrConsole::TConfigNotificationResponse, EvConfigNotificationResponse> {

--- a/ydb/core/cms/console/console.h
+++ b/ydb/core/cms/console/console.h
@@ -308,7 +308,7 @@ namespace TEvConsole {
         // Node-local only: parsed forms of opaque config sections (kind -> message),
         // produced by the configs dispatcher via an injected OpaqueConfigParser.
         // .second != nullptr - config either not empty and present or not added into map
-        THashMap<ui32, std::shared_ptr<::google::protobuf::Message>> OpaqueConfigs;
+        THashMap<ui32, std::shared_ptr<const ::google::protobuf::Message>> OpaqueConfigs;
     };
 
     struct TEvConfigNotificationResponse : public TEventShortDebugPB<TEvConfigNotificationResponse, NKikimrConsole::TConfigNotificationResponse, EvConfigNotificationResponse> {

--- a/ydb/core/cms/console/console_ut_configs.cpp
+++ b/ydb/core/cms/console/console_ut_configs.cpp
@@ -1214,106 +1214,6 @@ TVector<ui64> CheckConfigureLogAffected(TTenantTestRuntime &runtime,
     return {reply->Record.GetAddedItemIds().begin(), reply->Record.GetAddedItemIds().end()};
 }
 
-void DoFetchMainConfigFromConsole(TTenantTestRuntime &runtime, TString &yamlConfig)
-{
-    auto *event = new TEvConsole::TEvGetAllConfigsRequest;
-    runtime.SendToConsole(event);
-
-    TAutoPtr<IEventHandle> handle;
-    auto response = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
-
-    UNIT_ASSERT_C(response->Record.GetResponse().config_size() == 1,
-        "expected exactly one config in response");
-    UNIT_ASSERT_C(response->Record.GetResponse().identity_size() == 1,
-        "expected exactly one identity in response");
-    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).type_case() == Ydb::DynamicConfig::ConfigIdentity::kCluster,
-        "expected kCluster identity in response");
-
-    yamlConfig = response->Record.GetResponse().config(0);
-}
-
-void DoFetchDatabaseConfigFromConsole(TTenantTestRuntime &runtime, const TString &databasePath, TString &yamlConfig)
-{
-    auto *event = new TEvConsole::TEvGetAllConfigsRequest;
-    event->Record.SetIngressDatabase(databasePath);
-    runtime.SendToConsole(event);
-
-    TAutoPtr<IEventHandle> handle;
-    auto response = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
-
-    UNIT_ASSERT_C(response->Record.GetResponse().config_size() == 1,
-        "expected at least one config in response for database: " << databasePath);
-    UNIT_ASSERT_C(response->Record.GetResponse().identity_size() == 1,
-        "expected exactly one identity in response");
-    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).type_case() == Ydb::DynamicConfig::ConfigIdentity::kDatabase,
-        "expected kDatabase identity in response");
-    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).has_database(),
-        "kDatabase identity in response with no database set");
-    UNIT_ASSERT_EQUAL_C(response->Record.GetResponse().identity(0).database(), databasePath,
-        "database in response not match requested database");
-
-    yamlConfig = response->Record.GetResponse().config(0);
-}
-
-void DoReplaceYamlConfig(TTenantTestRuntime &runtime,
-                         const TString &yaml,
-                         Ydb::StatusIds::StatusCode expectedCode,
-                         const TString &errorSubstring = {},
-                         bool allowAbsentDatabase = false,
-                         bool allowUnknownFields = false)
-{
-    auto *event = new TEvConsole::TEvReplaceYamlConfigRequest;
-    event->Record.MutableRequest()->set_config(yaml);
-    if (allowAbsentDatabase) {
-        event->Record.MutableRequest()->set_allow_absent_database(true);
-    }
-    if (allowUnknownFields) {
-        event->Record.MutableRequest()->set_allow_unknown_fields(true);
-    }
-    runtime.SendToConsole(event);
-
-    TAutoPtr<IEventHandle> handle;
-    auto [success, error] = runtime.GrabEdgeEvents<
-        TEvConsole::TEvReplaceYamlConfigResponse,
-        TEvConsole::TEvGenericError>(handle);
-
-    if (expectedCode == Ydb::StatusIds::SUCCESS) {
-        UNIT_ASSERT_C(success != nullptr,
-            "expected success but got error: " <<
-            (error ? error->Record.ShortDebugString() : TString("no event")));
-    } else {
-        UNIT_ASSERT_C(error != nullptr,
-            "expected error " << static_cast<int>(expectedCode) << " but got success");
-        UNIT_ASSERT_VALUES_EQUAL(error->Record.GetYdbStatus(), expectedCode);
-        if (!errorSubstring.empty()) {
-            TString allMessages;
-            for (const auto& issue : error->Record.GetIssues()) {
-                allMessages += issue.message();
-                allMessages += ";";
-            }
-            UNIT_ASSERT_STRING_CONTAINS(allMessages, errorSubstring);
-        }
-    }
-}
-
-void DoEnsureMainConfigReplacedWith(TTenantTestRuntime &runtime, TString replaceConfig)
-{
-    TString consoleConfig;
-    TString expectedConfig = NYamlConfig::UpgradeMainConfigVersion(replaceConfig);
-
-    DoFetchMainConfigFromConsole(runtime, consoleConfig);
-    UNIT_ASSERT_VALUES_EQUAL_C(consoleConfig, expectedConfig, "CONSOLE config version not match replace config version");
-}
-
-void DoEnsureDatabaseConfigReplacedWith(TTenantTestRuntime &runtime, const TString& database, TString replaceConfig)
-{
-    TString consoleConfig;
-    TString expectedConfig = NYamlConfig::UpgradeDatabaseConfigVersion(replaceConfig);
-
-    DoFetchDatabaseConfigFromConsole(runtime, database, consoleConfig);
-    UNIT_ASSERT_VALUES_EQUAL_C(consoleConfig, expectedConfig, "CONSOLE config version not match replace config version");
-}
-
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(TConsoleConfigTests) {
@@ -1347,8 +1247,8 @@ Y_UNIT_TEST_SUITE(TConsoleConfigTests) {
     Y_UNIT_TEST(YamlConfigUnknownFieldsRoundTrip) {
         TTenantTestRuntime runtime(MultipleNodesConsoleTestConfig());
 
-        DoReplaceYamlConfig(runtime, YAML_CONFIG_WITH_UNKNOWN, Ydb::StatusIds::SUCCESS,
-            /* errorSubstring = */ {}, /* allowAbsentDatabase = */ false, /* allowUnknownFields = */ true);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, YAML_CONFIG_WITH_UNKNOWN,
+            /* errorSubstring = */ {}, /* allowUnknownFields = */ true);
 
         auto *event = new TEvConsole::TEvGetAllConfigsRequest;
         runtime.SendToConsole(event);
@@ -1366,8 +1266,8 @@ Y_UNIT_TEST_SUITE(TConsoleConfigTests) {
     Y_UNIT_TEST(YamlConfigUnknownFieldsSurviveReboot) {
         TTenantTestRuntime runtime(MultipleNodesConsoleTestConfig());
 
-        DoReplaceYamlConfig(runtime, YAML_CONFIG_WITH_UNKNOWN, Ydb::StatusIds::SUCCESS,
-            /* errorSubstring = */ {}, /* allowAbsentDatabase = */ false, /* allowUnknownFields = */ true);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, YAML_CONFIG_WITH_UNKNOWN,
+            /* errorSubstring = */ {}, /* allowUnknownFields = */ true);
 
         GracefulRestartTablet(runtime, MakeConsoleID(), runtime.AllocateEdgeActor(0));
 
@@ -1385,7 +1285,7 @@ Y_UNIT_TEST_SUITE(TConsoleConfigTests) {
     Y_UNIT_TEST(YamlConfigNoUnknownFieldsWhenClean) {
         TTenantTestRuntime runtime(MultipleNodesConsoleTestConfig());
 
-        DoReplaceYamlConfig(runtime, YAML_CONFIG_1, Ydb::StatusIds::SUCCESS);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, YAML_CONFIG_1);
 
         auto *event = new TEvConsole::TEvGetAllConfigsRequest;
         runtime.SendToConsole(event);
@@ -1400,8 +1300,8 @@ Y_UNIT_TEST_SUITE(TConsoleConfigTests) {
     Y_UNIT_TEST(YamlConfigUnknownFieldsInSelectorHaveSelectorPath) {
         TTenantTestRuntime runtime(MultipleNodesConsoleTestConfig());
 
-        DoReplaceYamlConfig(runtime, YAML_CONFIG_WITH_UNKNOWN_IN_SELECTOR, Ydb::StatusIds::SUCCESS,
-            /* errorSubstring = */ {}, /* allowAbsentDatabase = */ false, /* allowUnknownFields = */ true);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, YAML_CONFIG_WITH_UNKNOWN_IN_SELECTOR,
+            /* errorSubstring = */ {}, /* allowUnknownFields = */ true);
 
         auto *event = new TEvConsole::TEvGetAllConfigsRequest;
         runtime.SendToConsole(event);
@@ -4635,9 +4535,9 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
 
         CheckAddVolatileConfig(runtime, Ydb::StatusIds::SUCCESS, "", 1, 1, VOLATILE_YAML_CONFIG_1_2);
 
-        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, DATABASE_1_YAML_CONFIG_1, true);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, DATABASE_1_YAML_CONFIG_1);
 
-        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, DATABASE_2_YAML_CONFIG_1, true);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, DATABASE_2_YAML_CONFIG_1);
 
         ITEM_DOMAIN_LOG_1.MutableConfig()->MutableLogConfig()->SetClusterName("cluster-1");
 
@@ -4820,86 +4720,133 @@ Y_UNIT_TEST_SUITE(TConsoleInMemoryConfigSubscriptionTests) {
 
         // Fresh runtime: YamlVersion = 0. Per documentation, the client must send
         // the *current* stored version. A version ahead of stored is rejected.
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V1,
-            Ydb::StatusIds::BAD_REQUEST, "Version mismatch");
+        CheckReplaceConfig(runtime, Ydb::StatusIds::BAD_REQUEST, VERSIONED_MAIN_CONFIG_V1,
+            "Version mismatch");
 
         // version: 0 matches stored YamlVersion = 0 — accepted; YamlVersion becomes 1.
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
-            Ydb::StatusIds::SUCCESS);
-        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V0_STALE);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_MAIN_CONFIG_V0_STALE);
+        CheckMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V0_STALE);
 
         // version: 2 with stored = 1 — rejected.
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V2,
-            Ydb::StatusIds::BAD_REQUEST, "Version mismatch");
+        CheckReplaceConfig(runtime, Ydb::StatusIds::BAD_REQUEST, VERSIONED_MAIN_CONFIG_V2,
+            "Version mismatch");
 
         // Re-applying the same body with the stale version: 0 is silently
         // accepted (documented idempotent behaviour: wire == stored - 1 with
         // identical content). YamlVersion stays at 1.
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
-            Ydb::StatusIds::SUCCESS);
-        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V0_STALE);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_MAIN_CONFIG_V0_STALE);
+        CheckMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V0_STALE);
 
         // version: 1 matches stored YamlVersion = 1 — accepted; YamlVersion becomes 2.
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V1,
-            Ydb::StatusIds::SUCCESS);
-        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V1);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_MAIN_CONFIG_V1);
+        CheckMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V1);
 
         // version: 2 with a differing body now matches stored — accepted; YamlVersion = 3.
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V2,
-            Ydb::StatusIds::SUCCESS);
-        DoEnsureMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V2);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_MAIN_CONFIG_V2);
+        CheckMainConfigReplacedWith(runtime, VERSIONED_MAIN_CONFIG_V2);
     }
 
     Y_UNIT_TEST(TestReplaceDatabaseYamlConfigVersionCheck) {
         NKikimrConfig::TAppConfig appcfg;
         appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
-        TTenantTestRuntime runtime(MultipleTenantsConsoleTestConfig(), appcfg);
+        TTenantTestRuntime runtime(TenantConsoleTestConfig(), appcfg);
 
-        const TString DATABASE = "/dc-1/users/tenant-1";
+        const TString DATABASE = TENANT1_1_NAME;
 
         // ValidateDatabaseConfig appends the database config into the main config
         // and re-validates the result, which requires a non-empty MainYamlConfig.
         // Seed a minimal main config first (fresh YamlVersion = 0, so wire = 0).
-        DoReplaceYamlConfig(runtime, VERSIONED_MAIN_CONFIG_V0_STALE,
-            Ydb::StatusIds::SUCCESS);
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_MAIN_CONFIG_V0_STALE);
 
         // Fresh runtime: no per-database config stored, so currentVersion = 0.
         // Per documentation, the wire version must equal the stored version.
         // Sending version: 1 must be rejected.
-        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V1,
-            Ydb::StatusIds::BAD_REQUEST, "Version mismatch",
-            /* allowAbsentDatabase = */ true);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::BAD_REQUEST, VERSIONED_DATABASE_CONFIG_V1,
+            "Version mismatch");
 
         // version: 0 matches stored currentVersion = 0 — accepted; stored version becomes 1.
-        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V0_STALE,
-            Ydb::StatusIds::SUCCESS, {},
-            /* allowAbsentDatabase = */ true);
-        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V0_STALE);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_DATABASE_CONFIG_V0_STALE);
+        CheckDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V0_STALE);
 
         // version: 2 with stored = 1 — rejected.
-        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V2,
-            Ydb::StatusIds::BAD_REQUEST, "Version mismatch",
-            /* allowAbsentDatabase = */ true);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::BAD_REQUEST, VERSIONED_DATABASE_CONFIG_V2,
+            "Version mismatch");
 
         // Re-applying the same body with the stale version: 0 is silently
         // accepted (documented idempotent behaviour: wire == stored - 1 with
         // identical content). Stored version stays at 1.
-        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V0_STALE,
-            Ydb::StatusIds::SUCCESS, {},
-            /* allowAbsentDatabase = */ true);
-        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V0_STALE);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_DATABASE_CONFIG_V0_STALE);
+        CheckDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V0_STALE);
 
         // version: 1 matches stored = 1 — accepted; stored version becomes 2.
-        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V1,
-            Ydb::StatusIds::SUCCESS, {},
-            /* allowAbsentDatabase = */ true);
-        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V1);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_DATABASE_CONFIG_V1);
+        CheckDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V1);
 
         // version: 2 with a differing body now matches stored = 2 — accepted; version = 3.
-        DoReplaceYamlConfig(runtime, VERSIONED_DATABASE_CONFIG_V2,
-            Ydb::StatusIds::SUCCESS, {},
-            /* allowAbsentDatabase = */ true);
-        DoEnsureDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V2);
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_DATABASE_CONFIG_V2);
+        CheckDatabaseConfigReplacedWith(runtime, DATABASE, VERSIONED_DATABASE_CONFIG_V2);
+    }
+
+    // PrivateDatabaseConfig is marked '(NMarkers.OpaqueConfig) = true'
+    // - unknown fields nested anywhere inside it must NOT cause Console's YAML
+    // validator to reject the config, in both the main cluster YAML and the
+    // per-database YAML.
+
+    Y_UNIT_TEST(TestReplaceMainYamlConfigWithUnknownsUnderPrivateDatabaseConfig) {
+        NKikimrConfig::TAppConfig appcfg;
+        appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
+        TTenantTestRuntime runtime(TenantConsoleTestConfig(), appcfg);
+
+        const TString mainConfig = R"(
+---
+metadata:
+  kind: MainConfig
+  cluster: ""
+  version: 0
+config:
+  log_config:
+    cluster_name: clusterA
+  private_database_config:
+    some_unknown_field: 42
+    some_unknown_struct:
+      field_1: 1
+      field_2: abc
+      struct_3:
+        field_1: 2
+        field_2: def
+)";
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, mainConfig);
+        CheckMainConfigReplacedWith(runtime, mainConfig);
+    }
+
+    Y_UNIT_TEST(TestReplaceDatabaseYamlConfigWithUnknownsUnderPrivateDatabaseConfig) {
+        NKikimrConfig::TAppConfig appcfg;
+        appcfg.MutableFeatureFlags()->SetDatabaseYamlConfigAllowed(true);
+        TTenantTestRuntime runtime(TenantConsoleTestConfig(), appcfg);
+
+        // ValidateDatabaseConfig appends the database config into the main config
+        // and re-validates the result, which requires a non-empty MainYamlConfig.
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, VERSIONED_MAIN_CONFIG_V0_STALE);
+
+        const TString DATABASE = TENANT1_1_NAME;
+        const TString databaseConfig = R"(
+---
+metadata:
+  kind: DatabaseConfig
+  database: "/dc-1/users/tenant-1"
+  version: 0
+config:
+  private_database_config:
+    some_unknown_field: 42
+    some_unknown_struct:
+      field_1: 1
+      field_2: abc
+      struct_3:
+        field_1: 2
+        field_2: def
+)";
+        CheckReplaceDatabaseConfig(runtime, Ydb::StatusIds::SUCCESS, databaseConfig);
+        CheckDatabaseConfigReplacedWith(runtime, DATABASE, databaseConfig);
     }
 }
 

--- a/ydb/core/cms/console/ut_configs_dispatcher/ut_private_database_config.proto
+++ b/ydb/core/cms/console/ut_configs_dispatcher/ut_private_database_config.proto
@@ -1,0 +1,14 @@
+// End-node-only configuration schema.
+//
+// This proto is compiled ONLY into the configs_dispatcher unit test, which
+// plays the role of a custom end node. It is deliberately NOT a dependency of
+// ydb/core/cms/console, so the console / configs_dispatcher code cannot parse
+// payloads of this type. The cluster only ever sees the opaque
+// TAppConfig.PrivateDatabaseConfig string captured from config.private_database_config;
+// this schema interprets it on the node side.
+
+package NKikimrOpaqueConfigUt;
+
+message TUtPrivateDatabaseConfig {
+    optional uint32 SecretPort = 1;
+}

--- a/ydb/core/cms/console/ut_configs_dispatcher/ya.make
+++ b/ydb/core/cms/console/ut_configs_dispatcher/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
 YQL_LAST_ABI_VERSION()
 
 SRCS(
+    ut_configs_dispatcher/ut_private_database_config.proto
     configs_cache_ut.cpp
     configs_dispatcher_ut.cpp
 )

--- a/ydb/core/cms/console/ut_helpers.h
+++ b/ydb/core/cms/console/ut_helpers.h
@@ -293,17 +293,109 @@ inline void CheckEqualsIgnoringVersion(NKikimrConfig::TAppConfig config1, NKikim
     UNIT_ASSERT_VALUES_EQUAL(config1.ShortDebugString(), config2.ShortDebugString());
 }
 
-inline void CheckReplaceConfig(TTenantTestRuntime &runtime,
-                               Ydb::StatusIds::StatusCode code,
-                               TString yamlConfig)
+inline void FetchMainConfigFromConsole(TTenantTestRuntime &runtime, TString &yamlConfig)
 {
-        TAutoPtr<IEventHandle> handle;
-        auto *event = new TEvConsole::TEvReplaceYamlConfigRequest;
-        event->Record.MutableRequest()->set_config(yamlConfig);
-        runtime.SendToConsole(event);
+    auto *event = new TEvConsole::TEvGetAllConfigsRequest;
+    runtime.SendToConsole(event);
 
-        runtime.GrabEdgeEventRethrow<TEvConsole::TEvReplaceYamlConfigResponse>(handle);
-        Y_UNUSED(code);
+    TAutoPtr<IEventHandle> handle;
+    //auto response = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
+    auto [response, error] = runtime.GrabEdgeEventsRethrow<
+        TEvConsole::TEvGetAllConfigsResponse,
+        TEvConsole::TEvGenericError>(handle, TDuration::Seconds(1));
+    UNIT_ASSERT_C(response != nullptr,
+        "error: " << (error ? error->Record.ShortDebugString() : TString("<no event>")));
+
+    UNIT_ASSERT_C(response->Record.GetResponse().config_size() == 1,
+        "expected exactly one config in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity_size() == 1,
+        "expected exactly one identity in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).type_case() == Ydb::DynamicConfig::ConfigIdentity::kCluster,
+        "expected kCluster identity in response");
+
+    yamlConfig = response->Record.GetResponse().config(0);
+}
+
+inline void FetchDatabaseConfigFromConsole(TTenantTestRuntime &runtime, const TString &databasePath, TString &yamlConfig)
+{
+    auto *event = new TEvConsole::TEvGetAllConfigsRequest;
+    event->Record.SetIngressDatabase(databasePath);
+    runtime.SendToConsole(event);
+
+    TAutoPtr<IEventHandle> handle;
+    //auto response = runtime.GrabEdgeEventRethrow<TEvConsole::TEvGetAllConfigsResponse>(handle);
+    auto [response, error] = runtime.GrabEdgeEventsRethrow<
+        TEvConsole::TEvGetAllConfigsResponse,
+        TEvConsole::TEvGenericError>(handle, TDuration::Seconds(1));
+    UNIT_ASSERT_C(response != nullptr,
+        "error: " << (error ? error->Record.ShortDebugString() : TString("<no event>")));
+
+    UNIT_ASSERT_C(response->Record.GetResponse().config_size() == 1,
+        "expected at least one config in response for database: " << databasePath);
+    UNIT_ASSERT_C(response->Record.GetResponse().identity_size() == 1,
+        "expected exactly one identity in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).type_case() == Ydb::DynamicConfig::ConfigIdentity::kDatabase,
+        "expected kDatabase identity in response");
+    UNIT_ASSERT_C(response->Record.GetResponse().identity(0).has_database(),
+        "kDatabase identity in response with no database set");
+    UNIT_ASSERT_EQUAL_C(response->Record.GetResponse().identity(0).database(), databasePath,
+        "database in response not match requested database");
+
+    yamlConfig = response->Record.GetResponse().config(0);
+}
+
+inline void CheckReplaceConfig(TTenantTestRuntime &runtime,
+                               Ydb::StatusIds::StatusCode expectedCode,
+                               const TString &yaml,
+                               const TString &expectedErrorSubstring = {},
+                               bool allowUnknownFields = false,
+                               bool allowAbsentDatabase = false)
+{
+    auto *event = new TEvConsole::TEvReplaceYamlConfigRequest;
+    event->Record.MutableRequest()->set_config(yaml);
+    if (allowUnknownFields) {
+        event->Record.MutableRequest()->set_allow_unknown_fields(true);
+    }
+    if (allowAbsentDatabase) {
+        event->Record.MutableRequest()->set_allow_absent_database(true);
+    }
+    runtime.SendToConsole(event);
+
+    TAutoPtr<IEventHandle> handle;
+    auto [success, error] = runtime.GrabEdgeEventsRethrow<
+        TEvConsole::TEvReplaceYamlConfigResponse,
+        TEvConsole::TEvGenericError>(handle, TDuration::Seconds(1));
+
+    if (expectedCode == Ydb::StatusIds::SUCCESS) {
+        UNIT_ASSERT_C(success != nullptr,
+            "expected success but got error: " <<
+            (error ? error->Record.ShortDebugString() : TString("<no event>")));
+    } else {
+        UNIT_ASSERT_C(error != nullptr,
+            "expected error " << static_cast<int>(expectedCode) << " but got success");
+        UNIT_ASSERT_VALUES_EQUAL_C(error->Record.GetYdbStatus(), expectedCode, error->Record.ShortDebugString());
+        if (!expectedErrorSubstring.empty()) {
+            UNIT_ASSERT_STRING_CONTAINS(error->Record.ShortDebugString(), expectedErrorSubstring);
+        }
+    }
+}
+
+inline void CheckMainConfigReplacedWith(TTenantTestRuntime &runtime, TString replaceConfig)
+{
+    TString consoleConfig;
+    TString expectedConfig = NYamlConfig::UpgradeMainConfigVersion(replaceConfig);
+
+    FetchMainConfigFromConsole(runtime, consoleConfig);
+    UNIT_ASSERT_VALUES_EQUAL_C(consoleConfig, expectedConfig, "CONSOLE config version not match replace config version");
+}
+
+inline void CheckDatabaseConfigReplacedWith(TTenantTestRuntime &runtime, const TString& database, TString replaceConfig)
+{
+    TString consoleConfig;
+    TString expectedConfig = NYamlConfig::UpgradeDatabaseConfigVersion(replaceConfig);
+
+    FetchDatabaseConfigFromConsole(runtime, database, consoleConfig);
+    UNIT_ASSERT_VALUES_EQUAL_C(consoleConfig, expectedConfig, "CONSOLE config version not match replace config version");
 }
 
 inline void CheckDropConfig(TTenantTestRuntime &runtime,
@@ -357,21 +449,12 @@ inline void CheckRemoveVolatileConfig(TTenantTestRuntime &runtime,
 }
 
 inline void CheckReplaceDatabaseConfig(TTenantTestRuntime &runtime,
-                                       Ydb::StatusIds::StatusCode code,
-                                       TString yamlConfig,
-                                       bool allowNoDb = false)
+                                       Ydb::StatusIds::StatusCode expectedCode,
+                                       const TString &yaml,
+                                       const TString &expectedErrorSubstring = {},
+                                       bool allowUnknownFields = false)
 {
-        TAutoPtr<IEventHandle> handle;
-        auto *event = new TEvConsole::TEvReplaceYamlConfigRequest;
-        event->Record.MutableRequest()->set_config(yamlConfig);
-        if (allowNoDb) {
-            event->Record.MutableRequest()->set_allow_absent_database(true);
-        }
-        runtime.SendToConsole(event);
-
-        runtime.GrabEdgeEventRethrow<TEvConsole::TEvReplaceYamlConfigResponse>(handle);
-        Y_UNUSED(code);
+    CheckReplaceConfig(runtime, expectedCode, yaml, expectedErrorSubstring, allowUnknownFields, true);
 }
-
 
 } // namesapce NKikimr::NConsole::NUT

--- a/ydb/core/config/init/init.h
+++ b/ydb/core/config/init/init.h
@@ -272,7 +272,7 @@ struct TDebugInfo {
 //
 // @param opaqueYamlConfig - string content of opaque config section in YAML config
 // @return the parsed message, or nullptr to attach nothing.
-using TOpaqueConfigParser = std::function<std::shared_ptr<::google::protobuf::Message>(const TString& opaqueYamlConfig)>;
+using TOpaqueConfigParser = std::function<std::shared_ptr<const ::google::protobuf::Message>(const TString& opaqueYamlConfig)>;
 
 struct TConfigsDispatcherInitInfo {
     NKikimrConfig::TAppConfig InitialConfig;

--- a/ydb/core/config/init/init.h
+++ b/ydb/core/config/init/init.h
@@ -14,6 +14,9 @@
 #include <util/generic/string.h>
 #include <util/datetime/base.h>
 
+#include <functional>
+#include <memory>
+
 namespace NKikimr::NConfig {
 
 struct TConfigItemInfo {
@@ -258,6 +261,19 @@ struct TDebugInfo {
     THashMap<ui32, TConfigItemInfo> InitInfo;
 };
 
+// Opaque dynamic YAML config parser.
+// Parses YAML config section marked with NMarkers.OpaqueConfig in TAppConfig
+// into a message whose schema the configs dispatcher itself does not have.
+// Provided by the end node, so the configs dispatcher stays schema-agnostic.
+// The parsed message is attached to the node-local config notification
+// (see TEvConfigNotificationRequest).
+//
+// Thrown exceptions are catched and processed by configs dispatcher.
+//
+// @param opaqueYamlConfig - string content of opaque config section in YAML config
+// @return the parsed message, or nullptr to attach nothing.
+using TOpaqueConfigParser = std::function<std::shared_ptr<::google::protobuf::Message>(const TString& opaqueYamlConfig)>;
+
 struct TConfigsDispatcherInitInfo {
     NKikimrConfig::TAppConfig InitialConfig;
     TString StartupConfigYaml;
@@ -267,6 +283,10 @@ struct TConfigsDispatcherInitInfo {
     std::optional<TDebugInfo> DebugInfo;
     std::shared_ptr<NConfig::TRecordedInitialConfiguratorDeps> RecordedInitialConfiguratorDeps = nullptr;
     std::vector<TString> Args;
+    // Per-kind parsers for opaque config sections (kind == TAppConfig field
+    // number). Node-local; empty by default. When set, the dispatcher parses the
+    // section and attaches the result to the notification for that kind.
+    THashMap<ui32, TOpaqueConfigParser> OpaqueConfigParsers;
 };
 
 class IInitialConfigurator {

--- a/ydb/core/config/protos/marker.proto
+++ b/ydb/core/config/protos/marker.proto
@@ -53,5 +53,19 @@ extend google.protobuf.FieldOptions {
 
     // **Top-level** options marked with that label are allowed to be used in the database configuration.
     optional bool AllowInDatabaseConfig = 82004;
-}
 
+    // **Top-level** options marked with that label are opaque to the cluster
+    // in the dynamic YAML configuration (main and database).
+    //  - must be of (empty) message type (TOpaqueConfig type should be used)
+    //  - the cluster never understands the payload
+    //  - opaque configs are still subject:
+    //      - to the YAML syntax validation
+    //      - to the YAML resolving mechanism
+    //    These are the reasons message type is used instead of simple string
+    //  - makes the YAML->proto parser accept that sub-tree without validating it
+    //    (so the console needs no allow_unknown_fields)
+    //  - the actual content travels in the resolved YAML
+    //  - the configs dispatcher hands it to an end-node-provided parser,
+    //    which interprets it with its own schema
+    optional bool OpaqueConfig = 82005;
+}

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3140,6 +3140,13 @@ message TTliConfig {
     repeated string IgnoredTableRegexes = 1;
 }
 
+// Opaque (NMarkers.OpaqueConfig), end-node-owned configuration.
+// Authored as a nested YAML map under config.<opaque_config>.
+// See NMarkers.OpaqueConfig comments
+message TOpaqueConfig {
+    // Empty
+}
+
 message TAppConfig {
     option (NMarkers.Root) = true;
     optional TActorSystemConfig ActorSystemConfig = 1;
@@ -3229,6 +3236,7 @@ message TAppConfig {
     optional TBridgeConfig BridgeConfig = 91;
     optional TGroupedMemoryLimiterConfig CompGroupedMemoryLimiterConfig = 92;
     optional TBlockstoreConfig BlockstoreConfig = 93;
+    optional TOpaqueConfig PrivateDatabaseConfig = 94 [(NMarkers.AllowInDatabaseConfig) = true, (NMarkers.OpaqueConfig) = true];
 
     repeated TNamedConfig NamedConfigs = 100;
     optional string ClusterYamlConfig = 101;

--- a/ydb/core/protos/console_config.proto
+++ b/ydb/core/protos/console_config.proto
@@ -149,6 +149,7 @@ message TConfigItem {
         WorkloadManagerConfigItem = 90;
         CompGroupedMemoryLimiterConfig = 92;
         BlockstoreConfigItem = 93;
+        PrivateDatabaseConfigItem = 94;
 
         NamedConfigsItem = 100;
         ClusterYamlConfigItem = 101;

--- a/ydb/core/testlib/tenant_runtime.cpp
+++ b/ydb/core/testlib/tenant_runtime.cpp
@@ -1049,6 +1049,7 @@ void TTenantTestRuntime::Setup(bool createTenantPools)
                     NKikimr::NConfig::TConfigsDispatcherInitInfo {
                         .InitialConfig = Extension,
                         .Labels = labels,
+                        .OpaqueConfigParsers = Config.OpaqueConfigParsers,
                     }
                 ));
             EnableScheduleForActor(aid, true);

--- a/ydb/core/testlib/tenant_runtime.h
+++ b/ydb/core/testlib/tenant_runtime.h
@@ -3,6 +3,7 @@
 
 #include <ydb/core/base/events.h>
 #include <ydb/core/base/subdomain.h>
+#include <ydb/core/config/init/init.h>
 #include <ydb/core/mind/labels_maintainer.h>
 #include <ydb/core/mind/local.h>
 #include <ydb/core/mind/tenant_pool.h>
@@ -98,6 +99,9 @@ struct TTenantTestConfig {
     ui32 DataCenterCount;
     bool CreateConfigsDispatcher = false;
     bool RegisterFeatureFlagsConfigurator = false;
+    // Per-kind opaque config parsers injected into the framework-created
+    // ConfigsDispatcher (only used when CreateConfigsDispatcher is true).
+    THashMap<ui32, NConfig::TOpaqueConfigParser> OpaqueConfigParsers = {};
 };
 
 extern const ui64 SCHEME_SHARD1_ID;

--- a/ydb/library/yaml_config/ut/protos/test_config.proto
+++ b/ydb/library/yaml_config/ut/protos/test_config.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package NYamlConfigTest;
+
+message TTestServiceConfig {
+    optional string ServiceName = 1;
+    optional uint32 MaxConnections = 2;
+    optional bool TlsEnabled = 3;
+    repeated TEndpoint Endpoints = 4;
+
+    message TEndpoint {
+        optional string Host = 1;
+        optional uint32 Port = 2;
+    }
+}

--- a/ydb/library/yaml_config/ut/protos/ya.make
+++ b/ydb/library/yaml_config/ut/protos/ya.make
@@ -1,0 +1,9 @@
+PROTO_LIBRARY()
+
+SRCS(
+    test_config.proto
+)
+
+EXCLUDE_TAGS(GO_PROTO JAVA_PROTO)
+
+END()

--- a/ydb/library/yaml_config/ut/ya.make
+++ b/ydb/library/yaml_config/ut/ya.make
@@ -1,7 +1,12 @@
 UNITTEST_FOR(ydb/library/yaml_config)
 
+PEERDIR(
+    ydb/library/yaml_config/ut/protos
+)
+
 SRCS(
     console_dumper_ut.cpp
+    yaml_config_helpers_ut.cpp
     yaml_config_ut.cpp
     yaml_config_parser_ut.cpp
     yaml_config_proto2yaml_ut.cpp

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:887: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:890: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:891: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:894: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ya.make
+++ b/ydb/library/yaml_config/ya.make
@@ -18,6 +18,7 @@ PEERDIR(
     library/cpp/protobuf/json
     ydb/core/base
     ydb/core/cms/console/util
+    ydb/core/config/protos
     ydb/core/config/validation
     ydb/core/erasure
     ydb/core/protos

--- a/ydb/library/yaml_config/yaml_config.cpp
+++ b/ydb/library/yaml_config/yaml_config.cpp
@@ -5,7 +5,9 @@
 #include <ydb/core/base/appdata.h>
 
 #include <library/cpp/protobuf/json/json2proto.h>
+#include <library/cpp/protobuf/json/util.h>
 
+#include <ydb/core/config/protos/marker.pb.h>
 #include <ydb/core/protos/netclassifier.pb.h>
 #include <ydb/core/config/validation/validators.h>
 

--- a/ydb/library/yaml_config/yaml_config_helpers.h
+++ b/ydb/library/yaml_config/yaml_config_helpers.h
@@ -9,8 +9,12 @@
 #include <library/cpp/json/writer/json.h>
 
 #include <ydb/library/yaml_config/protos/config.pb.h>
+#include <ydb/library/fyamlcpp/fyamlcpp.h>
 #include <library/cpp/protobuf/json/util.h>
+#include <library/cpp/protobuf/json/json2proto.h>
 
+#include <functional>
+#include <memory>
 #include <span>
 
 namespace NKikimr::NYaml {
@@ -38,5 +42,51 @@ void IterateMut(
 void IterateMut(NJson::TJsonValue& json, const TStringBuf& path, std::function<void(const std::vector<ui32>&, NJson::TJsonValue&)> onElem);
 
 ui64 GetConfigHash(const TString& config);
+
+// Default Nkikimr::NConfig::TOpaqueConfigParser implementation template.
+// Parses YAML string into template-parameter specified proto message.
+// Silently ignores unknown fields if allowUnknownFields=true.
+//
+// @param opaqueYamlConfig - YAML document or YAML subfield (with no "---" YAML document prefix)
+// @param allowUnknownFields - silently ignore unknown fields (for specified Proto)
+//
+// @return
+//  nullptr - on empty imput YAML
+//  parsed Proto message - on successfull parsing
+//
+// @throw
+//  std::exception - on underlying parser errors / unknown fields present (without allowUnknownFields)
+//
+// Usage (within end-node service):
+//
+//  NKikimr::NConfig::TConfigsDispatcherInitInfo initInfo;
+//  auto parser = std::bind(NKikimr::NYaml::DefaultOpaqueConfigParser<UserNamespace::TPrivateDatabaseConfigProto>, std::placeholders::_1, true);
+//  initInfo.OpaqueConfigParsers[NKikimrConsole::TConfigItem::PrivateConfigItem] = std::move(parser);
+//  auto* dispatcher = NKikimr::NConsole::CreateConfigsDispatcher(initInfo);
+//
+template<typename Proto>
+std::shared_ptr<::google::protobuf::Message> DefaultOpaqueConfigParser(const TString& opaqueYamlConfig, bool allowUnknownFields)
+{
+    const auto& subYaml = ( opaqueYamlConfig.StartsWith("---") ? opaqueYamlConfig.substr(3) : opaqueYamlConfig);
+    if ( subYaml.find_first_not_of(" \t\n\r") == TString::npos )
+    {
+        return nullptr;
+    }
+
+    auto msg = std::make_shared<Proto>();
+    auto doc = NFyaml::TDocument::Parse(opaqueYamlConfig);
+
+    TStringStream jsonStream;
+    jsonStream << NFyaml::TJsonEmitter(doc.Root());
+
+    NJson::TJsonValue json;
+    Y_ENSURE(NJson::ReadJsonTree(jsonStream.Str(), &json));
+
+    auto config = GetJsonToProtoConfig(allowUnknownFields);
+    config.CastRobust = false;
+    NProtobufJson::Json2Proto(json, *msg, config);
+
+    return msg;
+}
 
 }

--- a/ydb/library/yaml_config/yaml_config_helpers.h
+++ b/ydb/library/yaml_config/yaml_config_helpers.h
@@ -65,7 +65,7 @@ ui64 GetConfigHash(const TString& config);
 //  auto* dispatcher = NKikimr::NConsole::CreateConfigsDispatcher(initInfo);
 //
 template<typename Proto>
-std::shared_ptr<::google::protobuf::Message> DefaultOpaqueConfigParser(const TString& opaqueYamlConfig, bool allowUnknownFields)
+std::shared_ptr<const ::google::protobuf::Message> DefaultOpaqueConfigParser(const TString& opaqueYamlConfig, bool allowUnknownFields)
 {
     const auto& subYaml = ( opaqueYamlConfig.StartsWith("---") ? opaqueYamlConfig.substr(3) : opaqueYamlConfig);
     if ( subYaml.find_first_not_of(" \t\n\r") == TString::npos )

--- a/ydb/library/yaml_config/yaml_config_helpers.h
+++ b/ydb/library/yaml_config/yaml_config_helpers.h
@@ -67,7 +67,7 @@ ui64 GetConfigHash(const TString& config);
 template<typename Proto>
 std::shared_ptr<const ::google::protobuf::Message> DefaultOpaqueConfigParser(const TString& opaqueYamlConfig, bool allowUnknownFields)
 {
-    const auto& subYaml = ( opaqueYamlConfig.StartsWith("---") ? opaqueYamlConfig.substr(3) : opaqueYamlConfig);
+    const auto& subYaml = (opaqueYamlConfig.StartsWith("---") ? opaqueYamlConfig.substr(3) : opaqueYamlConfig);
     if ( subYaml.find_first_not_of(" \t\n\r") == TString::npos )
     {
         return nullptr;
@@ -83,7 +83,6 @@ std::shared_ptr<const ::google::protobuf::Message> DefaultOpaqueConfigParser(con
     Y_ENSURE(NJson::ReadJsonTree(jsonStream.Str(), &json));
 
     auto config = GetJsonToProtoConfig(allowUnknownFields);
-    config.CastRobust = false;
     NProtobufJson::Json2Proto(json, *msg, config);
 
     return msg;

--- a/ydb/library/yaml_config/yaml_config_helpers_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_helpers_ut.cpp
@@ -30,7 +30,7 @@ endpoints:
             // (as long as fields happened to match), masking a real bug.
             // CopyFrom() is correct choise for production code where you already trust the source type
             // and just need to extract the data.
-            auto* cfg = dynamic_cast<NYamlConfigTest::TTestServiceConfig*>(msg.get());
+            auto* cfg = dynamic_cast<const NYamlConfigTest::TTestServiceConfig*>(msg.get());
             UNIT_ASSERT(cfg != nullptr);
 
             UNIT_ASSERT(cfg->HasServiceName());

--- a/ydb/library/yaml_config/yaml_config_helpers_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_helpers_ut.cpp
@@ -1,0 +1,162 @@
+#include "yaml_config_helpers.h"
+
+#include <ydb/library/yaml_config/ut/protos/test_config.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr::NYaml;
+
+Y_UNIT_TEST_SUITE(DefaultOpaqueConfigParser) {
+
+    Y_UNIT_TEST(ParsesFieldsCorrectly) {
+        const TString yamlTemplate = R"(
+service_name: my-service
+max_connections: 128
+tls_enabled: true
+endpoints:
+- host: node1.example.com
+  port: 8080
+- host: node2.example.com
+  port: 9090
+)";
+        TString yaml = "---\n" + yamlTemplate;
+        // Checks for YAML doc and YAML subfield
+        for ( int i = 0; i < 2; i++ ) {
+            auto msg = DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(yaml, true);
+            UNIT_ASSERT(msg);
+            // dynamic_cast is to verify that DefaultOpaqueConfigParser<TTestServiceConfig>
+            // actually returns a TTestServiceConfig inside the shared_ptr<Message>.
+            // CopyFrom() would silently succeed even if the function returned a wrong proto type
+            // (as long as fields happened to match), masking a real bug.
+            // CopyFrom() is correct choise for production code where you already trust the source type
+            // and just need to extract the data.
+            auto* cfg = dynamic_cast<NYamlConfigTest::TTestServiceConfig*>(msg.get());
+            UNIT_ASSERT(cfg != nullptr);
+
+            UNIT_ASSERT(cfg->HasServiceName());
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetServiceName(), "my-service");
+
+            UNIT_ASSERT(cfg->HasMaxConnections());
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetMaxConnections(), 128u);
+
+            UNIT_ASSERT(cfg->HasTlsEnabled());
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetTlsEnabled(), true);
+
+            UNIT_ASSERT_VALUES_EQUAL(cfg->EndpointsSize(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetEndpoints(0).GetHost(), "node1.example.com");
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetEndpoints(0).GetPort(), 8080u);
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetEndpoints(1).GetHost(), "node2.example.com");
+            UNIT_ASSERT_VALUES_EQUAL(cfg->GetEndpoints(1).GetPort(), 9090u);
+
+            yaml = yamlTemplate;
+        }
+    }
+
+    Y_UNIT_TEST(AbsentFieldsAreAbsent) {
+        const TString yaml = R"(---
+service_name: minimal
+)";
+        auto msg = DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(yaml, true);
+        UNIT_ASSERT(msg);
+        NYamlConfigTest::TTestServiceConfig cfg;
+        cfg.CopyFrom(*msg);
+
+        UNIT_ASSERT(cfg.HasServiceName());
+        UNIT_ASSERT_VALUES_EQUAL(cfg.GetServiceName(), "minimal");
+
+        UNIT_ASSERT(!cfg.HasMaxConnections());
+        UNIT_ASSERT(!cfg.HasTlsEnabled());
+        UNIT_ASSERT_VALUES_EQUAL(cfg.EndpointsSize(), 0);
+    }
+
+    Y_UNIT_TEST(AllowsUnknownFieldsWhenEnabled) {
+        const TString yaml = R"(
+service_name: my-service
+unknown_field_xyz: some_value
+)";
+        auto msg = DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(yaml, true);
+        UNIT_ASSERT(msg);
+        NYamlConfigTest::TTestServiceConfig cfg;
+        cfg.CopyFrom(*msg);
+
+        UNIT_ASSERT(cfg.HasServiceName());
+        UNIT_ASSERT_VALUES_EQUAL(cfg.GetServiceName(), "my-service");
+    }
+
+    Y_UNIT_TEST(ThrowsOnUnknownFieldsWhenDisabled) {
+        const TString yaml = R"(
+service_name: my-service
+unknown_field_xyz: some_value
+)";
+        UNIT_CHECK_GENERATED_EXCEPTION(
+            DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(yaml, false),
+            std::exception
+        );
+    }
+
+    Y_UNIT_TEST(EmptyInputProducesEmptyProto) {
+        const TString blanks[] = {"", " ", "\t", "\n", "\r\n", "  \t\n  \r\n  "};
+
+        TString prefix = "---";
+        // Checks for YAML doc and YAML subfield
+        for ( int i = 0; i < 2; i++ ) {
+            for (const auto& input : blanks) {
+                auto msg = DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(prefix + input, true);
+                UNIT_ASSERT(!msg);
+            }
+
+            prefix = "";
+        }
+    }
+
+    Y_UNIT_TEST(ThrowsOnMalformedYaml) {
+        TString prefix = "---\n";
+        // Checks for YAML doc and YAML subfield
+        for ( int i = 0; i < 2; i++ ) {
+            // Completely invalid YAML: bad indentation
+            UNIT_CHECK_GENERATED_EXCEPTION(
+                DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(
+                    prefix + "some random text", true),
+                std::exception
+            );
+
+            // Unclosed quote
+            UNIT_CHECK_GENERATED_EXCEPTION(
+                DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(
+                    prefix + "service_name: \"unclosed\n", true),
+                std::exception
+            );
+
+            // Duplicate key (strict YAML parsers reject this)
+            UNIT_CHECK_GENERATED_EXCEPTION(
+                DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(
+                    prefix + "service_name: first\nservice_name: second\n", true),
+                std::exception
+            );
+
+            // Tabs in indentation (forbidden by YAML spec)
+            UNIT_CHECK_GENERATED_EXCEPTION(
+                DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>(
+                    prefix + "endpoints:\n\t- host: bad\n", true),
+                std::exception
+            );
+
+            prefix = "";
+        }
+    }
+    Y_UNIT_TEST(CheckParserCreation) {
+        const TString yaml = R"(
+service_name: my-service
+unknown_field_xyz: some_value
+)";
+        auto parser = std::bind(NKikimr::NYaml::DefaultOpaqueConfigParser<NYamlConfigTest::TTestServiceConfig>, std::placeholders::_1, true);
+
+        auto msg = parser(yaml);
+        UNIT_ASSERT(msg);
+        NYamlConfigTest::TTestServiceConfig cfg;
+        cfg.CopyFrom(*msg);
+
+        UNIT_ASSERT(cfg.HasServiceName());
+        UNIT_ASSERT_VALUES_EQUAL(cfg.GetServiceName(), "my-service");
+    }
+}

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -18,8 +18,11 @@
 #include <ydb/core/protos/tablet.pb.h>
 #include <library/cpp/json/writer/json.h>
 #include <library/cpp/protobuf/json/util.h>
+#include <library/cpp/json/json_writer.h>
 #include <ydb/library/yaml_json/yaml_to_json.h>
+#include <ydb/core/config/protos/marker.pb.h>
 
+#include <util/generic/hash_set.h>
 #include <util/generic/string.h>
 
 template <>
@@ -1637,6 +1640,36 @@ endDiskTypeCheck:   ;
         return replaceRequest;
     }
 
+    const TVector<TOpaqueField>& OpaqueConfigFields() {
+        static const TVector<TOpaqueField> fields = [] {
+            TVector<TOpaqueField> result;
+            const auto* desc = NKikimrConfig::TAppConfig::descriptor();
+            for (int i = 0; i < desc->field_count(); ++i) {
+                const auto* field = desc->field(i);
+                if (field->options().GetExtension(NKikimrConfig::NMarkers::OpaqueConfig)) {
+                    Y_ENSURE(field->cpp_type() == ::google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE);
+                    TString name = field->name();
+                    NProtobufJson::ToSnakeCaseDense(&name);
+                    result.push_back({name});
+                }
+            }
+            return result;
+        }();
+        return fields;
+    }
+
+    void CaptureOpaqueConfigFields(NJson::TJsonValue& configJson) {
+        if (!configJson.IsMap()) {
+            return;
+        }
+        for (const auto& f : OpaqueConfigFields()) {
+            if (!configJson.Has(f.Name)) {
+                continue;
+            }
+            configJson[f.Name] = NJson::TJsonValue(NJson::JSON_MAP);
+        }
+    }
+
     void Parse(const NJson::TJsonValue& json, NProtobufJson::TJson2ProtoConfig convertConfig, NKikimrConfig::TAppConfig& config,
                bool transform, EParsePhase* phase, bool relaxed) {
         auto runPhase = [phase](EParsePhase value, auto&& func) {
@@ -1680,6 +1713,7 @@ endDiskTypeCheck:   ;
             ClearEphemeralFields(jsonNode);
         }
 
+        CaptureOpaqueConfigFields(jsonNode);
         runPhase(EParsePhase::JsonToProto, [&] {
             NProtobufJson::MergeJson2Proto(jsonNode, config, convertConfig);
         });

--- a/ydb/library/yaml_config/yaml_config_parser.h
+++ b/ydb/library/yaml_config/yaml_config_parser.h
@@ -51,6 +51,11 @@ namespace NKikimr::NYaml {
         std::map<ui32, TString> GroupErasureSpecies;
     };
 
+    // Top-level TAppConfig fields tagged with the OpaqueConfig marker
+    struct TOpaqueField {
+        TString Name;       // snake_case key
+    };
+
     NProtobufJson::TJson2ProtoConfig GetJsonToProtoConfig(
         bool allowUnknownFields = false,
         TSimpleSharedPtr<NProtobufJson::IUnknownFieldsCollector> unknownFieldsCollector = nullptr);
@@ -78,5 +83,17 @@ namespace NKikimr::NYaml {
     NKikimrConfig::TAppConfig Parse(const TString& data, bool transform = true);
 
     void ValidateMetadata(const NJson::TJsonValue& metadata);
+
+    // Get top-level TAppConfig fields tagged with the OpaqueConfig marker
+    // (computed once)
+    const TVector<TOpaqueField>& OpaqueConfigFields();
+
+    // Handle opaque-marked fields so the cluster accepts their content without
+    // knowing the schema and without allow_unknown_fields.
+    // Replaces the sub-tree with an empty object, so the proto merge stores
+    // an empty message and the unknown-field collector never sees the content
+    // (which is recovered later from the resolved YAML).
+    // Only message field types are supported.
+    void CaptureOpaqueConfigFields(NJson::TJsonValue& configJson);
 
 } // namespace NKikimr::NYaml

--- a/ydb/library/yaml_config/yaml_config_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_ut.cpp
@@ -1267,6 +1267,125 @@ TMap<TSet<TVector<NYamlConfig::TLabel>>, TVector<int>> ExpectedResolved =
     },
 };
 
+Y_UNIT_TEST_SUITE(YamlConfigOpaqueConfigMarker) {
+
+    Y_UNIT_TEST(OpaqueConfigFieldsIncludesExistingOpaqueFields) {
+        const auto& fields = NYaml::OpaqueConfigFields();
+
+        bool found = false;
+        for (const auto& f : fields) {
+            if (f.Name == "private_database_config") {
+                found = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(found,
+            "expected 'private_database_config' in OpaqueConfigFields()");
+    }
+
+    Y_UNIT_TEST(OpaqueConfigFieldsAreStable) {
+        // The list is computed once and cached; consecutive calls must return
+        // the same vector by reference.
+        const auto& a = NYaml::OpaqueConfigFields();
+        const auto& b = NYaml::OpaqueConfigFields();
+        UNIT_ASSERT_EQUAL(&a, &b);
+    }
+
+    Y_UNIT_TEST(CaptureOpaqueConfigFieldsReplacesMessageSubtreeWithEmptyMap) {
+        NJson::TJsonValue cfg(NJson::JSON_MAP);
+        auto& sub = cfg["private_database_config"];
+        sub.SetType(NJson::JSON_MAP);
+        sub["some_unknown_field"] = 42;
+        sub["some_unknown_struct"]["field_1"] = 1;
+        sub["some_unknown_struct"]["field_2"] = "abc";
+
+        NYaml::CaptureOpaqueConfigFields(cfg);
+
+        UNIT_ASSERT(cfg.Has("private_database_config"));
+        const auto& captured = cfg["private_database_config"];
+        UNIT_ASSERT_C(captured.IsMap(),
+            "private_database_config must remain a map after capture");
+        UNIT_ASSERT_C(captured.GetMap().empty(),
+            "private_database_config must be replaced with an empty map");
+    }
+
+    Y_UNIT_TEST(CaptureOpaqueConfigFieldsLeavesOtherFieldsUntouched) {
+        NJson::TJsonValue cfg(NJson::JSON_MAP);
+        cfg["private_database_config"]["dropped"] = "value";
+        cfg["feature_flags"]["enable_something"] = true;
+        cfg["actor_system_config"]["sys_executor"] = 0;
+
+        NYaml::CaptureOpaqueConfigFields(cfg);
+
+        UNIT_ASSERT(cfg["private_database_config"].IsMap());
+        UNIT_ASSERT(cfg["private_database_config"].GetMap().empty());
+
+        UNIT_ASSERT(cfg["feature_flags"].IsMap());
+        UNIT_ASSERT_EQUAL(cfg["feature_flags"]["enable_something"].GetBoolean(), true);
+
+        UNIT_ASSERT(cfg["actor_system_config"].IsMap());
+        UNIT_ASSERT_EQUAL(cfg["actor_system_config"]["sys_executor"].GetInteger(), 0);
+    }
+
+    Y_UNIT_TEST(CaptureOpaqueConfigFieldsIsNoopWhenFieldAbsent) {
+        NJson::TJsonValue cfg(NJson::JSON_MAP);
+        cfg["feature_flags"]["enable_something"] = true;
+
+        NYaml::CaptureOpaqueConfigFields(cfg);
+
+        UNIT_ASSERT(!cfg.Has("private_database_config"));
+        UNIT_ASSERT(cfg["feature_flags"].IsMap());
+        UNIT_ASSERT_EQUAL(cfg["feature_flags"]["enable_something"].GetBoolean(), true);
+    }
+
+    Y_UNIT_TEST(CaptureOpaqueConfigFieldsIsNoopOnNonMap) {
+        // Non-map inputs must not crash and must remain unchanged.
+        NJson::TJsonValue arr(NJson::JSON_ARRAY);
+        arr.AppendValue(1);
+        arr.AppendValue(2);
+        NYaml::CaptureOpaqueConfigFields(arr);
+        UNIT_ASSERT(arr.IsArray());
+        UNIT_ASSERT_VALUES_EQUAL(arr.GetArray().size(), 2u);
+
+        NJson::TJsonValue scalar(42);
+        NYaml::CaptureOpaqueConfigFields(scalar);
+        UNIT_ASSERT_EQUAL(scalar.GetInteger(), 42);
+    }
+
+    Y_UNIT_TEST(CaptureOpaqueConfigFieldsHandlesAlreadyEmptyMap) {
+        NJson::TJsonValue cfg(NJson::JSON_MAP);
+        cfg["private_database_config"].SetType(NJson::JSON_MAP);
+
+        NYaml::CaptureOpaqueConfigFields(cfg);
+
+        UNIT_ASSERT(cfg["private_database_config"].IsMap());
+        UNIT_ASSERT(cfg["private_database_config"].GetMap().empty());
+    }
+
+    Y_UNIT_TEST(ParseAcceptsUnknownOpaqueFieldSubtree) {
+        // End-to-end: the parser must accept unknown content under an
+        // opaque top-level field without allow_unknown_fields, because
+        // CaptureOpaqueConfigFields() strips the subtree before the
+        // proto merge.
+        const TString yaml = R"(---
+metadata:
+  cluster: ""
+  version: 0
+config:
+  private_database_config:
+    some_unknown_field: 42
+    some_unknown_struct:
+      field_1: 1
+      field_2: abc
+)";
+        NKikimrConfig::TAppConfig cfg;
+        UNIT_ASSERT_NO_EXCEPTION(cfg = NYaml::Parse(yaml, /*transform=*/ false));
+        // The merge stored an empty message for the opaque field; nothing
+        // from the YAML sub-tree leaked into the proto.
+        UNIT_ASSERT(cfg.HasPrivateDatabaseConfig());
+    }
+}
+
 Y_UNIT_TEST_SUITE(YamlConfig) {
     Y_UNIT_TEST(CollectLabels) {
         auto doc = NFyaml::TDocument::Parse(WholeConfig);


### PR DESCRIPTION
### Changelog entry

### Changelog category

* Not for changelog (changelog entry is not required)

### Motivation

Downstream consumers (e.g. NBS) need to ship per-database configuration whose proto schema is unknown to the YDB cluster. Today every config section must have its proto definition compiled into the cluster binary.

The goal is to allow tenants to ship private/closed-source dynamic database config
without forcing the upstream YDB cluster to know its schema.

This PR adds a generic mechanism for **opaque dynamic-config sections** — config sub-trees that travel through the existing Console/ConfigsDispatcher pipeline without requiring the cluster to understand their schema.

### What changed

**Proto layer**
- `marker.proto`: new field option `NMarkers.OpaqueConfig` (tag `82005`). Marking a top-level `TAppConfig` field with this option tells the YAML structure validator to suppress unknown-field rejection inside that sub-tree (YAML syntax is still validated).
- `config.proto`: new intentionally-empty message `PrivateDatabaseConfig` wired as `TAppConfig` field `94`, with corresponding `PrivateDatabaseConfigItem = 94` in `TConfigItem`.
- message type is used for `PrivateDatabaseConfig` instead of a simple string to keep config content under YAML syntax validation and selectors resolving mechanism.

**YAML config layer**
- `yaml_config_parser`: collects top-level `TAppConfig` fields bearing the `OpaqueConfig` marker and skips structure validation for their sub-trees (both main and database configs).
- `yaml_config_helpers.h`: provides `DefaultOpaqueConfigParser<Proto>()` — a convenience template that converts an opaque YAML/JSON sub-tree to a concrete proto message known only to the end node.

**ConfigsDispatcher**
- New injection point `OpaqueConfigParsers` on `TConfigsDispatcherInitInfo`: a `map<kind, TOpaqueConfigParser>` where each parser converts the opaque sub-tree to a real proto.
- `TEvConfigNotificationRequest` carries a new non-proto field `OpaqueConfigs` with parsed messages delivered to subscribers.

### End-to-end flow

1. Author writes `config.private_database_config` section in main/database YAML.
3. Console persists and resolves it as an opaque sub-tree (unknown fields accepted; YAML syntax validated; selectors resolved).
4. ConfigsDispatcher on the subscriber node invokes the end-service-registered `TOpaqueConfigParser` for the config kind.
5. Parsed proto message is attached to `TEvConfigNotificationRequest::OpaqueConfigs` and delivered to the node-local subscriber.

### Side fixes

- Refactored several `ut_helpers` to use the extended and more verbose console test helpers from `console_ut_configs`.

### Testing

- `yaml_config_ut.cpp`: unit tests for opaque-field detection and YAML structure validator suppression.
- `console_ut_configs.cpp`: tests for Console accepting unknown fields inside opaque sub-trees.
- `configs_dispatcher_ut.cpp`: end-to-end tests for opaque config delivery through the dispatcher pipeline.

Co-authored-by: Innokentii Mokin <innokentii@ydb.tech>