### PR TITLE
CODEOWNERS: assign .github to CI team with carve-outs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,9 @@
 /.github/workflows/ydbdoc-*
 # Mute lists have no owner: no code owner review required
 /.github/config/muted_ya*
+# Ownership files have no owner: no code owner review required
+/.github/CODEOWNERS
+/.github/TESTOWNERS
 /.github/docker @ydb-platform/appteam
 
 /build @ydb-platform/ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,11 @@
 /CLAUDE.md @ydb-platform/ai-reviewers
 
 /.cursorindexingignore-personal @ydb-platform/ai-reviewers
+
+/.github/ @ydb-platform/ci
+# Docs-related workflows are owned by the docs team and don't require CI review
+/.github/workflows/docs_* @ydb-platform/docs
+/.github/workflows/ydbdoc-* @ydb-platform/docs
 /.github/docker @ydb-platform/appteam
 
 /build @ydb-platform/ci

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,9 @@
 /.cursorindexingignore-personal @ydb-platform/ai-reviewers
 
 /.github/ @ydb-platform/ci
-# Docs-related workflows are owned by the docs team and don't require CI review
-/.github/workflows/docs_* @ydb-platform/docs
-/.github/workflows/ydbdoc-* @ydb-platform/docs
+# Docs-related workflows have no owner: no code owner review required
+/.github/workflows/docs_*
+/.github/workflows/ydbdoc-*
 # Mute lists have no owner: no code owner review required
 /.github/config/muted_ya*
 /.github/docker @ydb-platform/appteam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,12 +11,9 @@
 /.cursorindexingignore-personal @ydb-platform/ai-reviewers
 
 /.github/ @ydb-platform/ci
-# Docs-related workflows have no owner: no code owner review required
 /.github/workflows/docs_*
 /.github/workflows/ydbdoc-*
-# Mute lists have no owner: no code owner review required
 /.github/config/muted_ya*
-# Ownership files have no owner: no code owner review required
 /.github/CODEOWNERS
 /.github/TESTOWNERS
 /.github/docker @ydb-platform/appteam

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,8 @@
 # Docs-related workflows are owned by the docs team and don't require CI review
 /.github/workflows/docs_* @ydb-platform/docs
 /.github/workflows/ydbdoc-* @ydb-platform/docs
+# Mute lists have no owner: no code owner review required
+/.github/config/muted_ya*
 /.github/docker @ydb-platform/appteam
 
 /build @ydb-platform/ci


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Раньше правки в `.github/` (workflows, actions, скрипты CI) не требовали ревью CI-команды — owner был только у `.github/docker`. Так, например, #43128 влился без ок от CI (откачен в #43243).

Теперь `/.github/` принадлежит `@ydb-platform/ci`, с исключениями:

* `docs_*` и `ydbdoc-*` workflows — без владельца;
* `.github/config/muted_ya*` — без владельца (автообновления мьют-листа);
* `.github/CODEOWNERS` и `.github/TESTOWNERS` — без владельца;
* `.github/docker` — `@ydb-platform/appteam` (без изменений).

Чтобы это блокировало merge, в branch protection для `main` должно быть включено "Require review from Code Owners".