### PR TITLE
ci: retry automerge on push race instead of blocking the PR

### DIFF
--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -110,9 +110,8 @@ class PrAutomerger:
             self.add_failed_comment(pr, "Unable to push merged revision (failed to schedule retry).")
             self.add_pr_failed_label(pr)
 
-    def git_merge_pr(self, pr: PullRequest):
-        shutil.rmtree("merge-repo", ignore_errors=True)
-        original_dir = os.getcwd()
+    def clone_merge_repo(self, pr: PullRequest):
+        repo_url = f"https://{self.token}@github.com/{self.repo_name}.git"
         try:
             self.git_run(
                 "clone",
@@ -120,9 +119,29 @@ class PrAutomerger:
                 "--single-branch",
                 "--branch",
                 pr.base.ref,
-                f"https://{self.token}@github.com/{self.repo_name}.git",
+                repo_url,
                 "merge-repo",
             )
+        except subprocess.CalledProcessError:
+            self.logger.warning(
+                "blobless clone failed, falling back to single-branch clone",
+                exc_info=True,
+            )
+            shutil.rmtree("merge-repo", ignore_errors=True)
+            self.git_run(
+                "clone",
+                "--single-branch",
+                "--branch",
+                pr.base.ref,
+                repo_url,
+                "merge-repo",
+            )
+
+    def git_merge_pr(self, pr: PullRequest):
+        shutil.rmtree("merge-repo", ignore_errors=True)
+        original_dir = os.getcwd()
+        try:
+            self.clone_merge_repo(pr)
             os.chdir("merge-repo")
             self.git_run("fetch", "origin", f"pull/{pr.number}/head:PR")
             self.git_run("checkout", pr.base.ref)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -7,6 +7,7 @@ import subprocess
 import argparse
 from typing import Optional
 from github import Github
+from github.GithubException import GithubException
 from github.PullRequest import PullRequest
 
 automerge_pr_label = "automerge"
@@ -162,14 +163,28 @@ class PrAutomerger:
             os.chdir(original_dir)
             shutil.rmtree("merge-repo", ignore_errors=True)
 
+    def delete_head_ref(self, pr: PullRequest):
+        if pr.head.repo.full_name != self.repo_name:
+            self.logger.info("skip deleting head ref %r (fork PR)", pr.head.ref)
+            return
+        self.logger.info("deleting ref %r", pr.head.ref)
+        try:
+            self.repo.get_git_ref(f"heads/{pr.head.ref}").delete()
+        except GithubException as e:
+            if e.status == 404:
+                # GitHub may delete the branch when it detects the merge
+                # (auto-merge, "delete head branch" setting, etc.).
+                self.logger.info("head ref %r already gone", pr.head.ref)
+                return
+            raise
+
     def merge_pr(self, pr: PullRequest):
         self.logger.info("start merge %s into %s", pr, pr.base.ref)
         if not self.git_merge_pr(pr):
             self.logger.info("unable to merge PR")
             return
         self.clear_retry_label(pr)
-        self.logger.info("deleting ref %r", pr.head.ref)
-        self.repo.get_git_ref(f"heads/{pr.head.ref}").delete()
+        self.delete_head_ref(pr)
         body = f"The PR was successfully merged into {pr.base.ref} using workflow"
         pr.create_issue_comment(body=body)
 

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -89,7 +89,7 @@ class PrAutomerger:
         try:
             pr.remove_from_labels(pr_label_error)
         except Exception:
-            self.logger.warning("failed to remove %s label", pr_label_error)
+            self.logger.warning("failed to remove %s label", pr_label_error, exc_info=True)
 
     def git_merge_pr(self, pr: PullRequest):
         shutil.rmtree("merge-repo", ignore_errors=True)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -114,8 +114,9 @@ class PrAutomerger:
             self.add_failed_comment(pr, "Unable to push merged revision (failed to schedule retry).")
             self.add_pr_failed_label(pr)
 
-    def clone_merge_repo(self, pr: PullRequest):
-        repo_url = f"https://{self.token}@github.com/{self.repo_name}.git"
+    def git_merge_pr(self, pr: PullRequest):
+        shutil.rmtree("merge-repo", ignore_errors=True)
+        original_dir = os.getcwd()
         try:
             self.git_run(
                 "clone",
@@ -123,29 +124,9 @@ class PrAutomerger:
                 "--single-branch",
                 "--branch",
                 pr.base.ref,
-                repo_url,
+                f"https://{self.token}@github.com/{self.repo_name}.git",
                 "merge-repo",
             )
-        except subprocess.CalledProcessError:
-            self.logger.warning(
-                "blobless clone failed, falling back to single-branch clone",
-                exc_info=True,
-            )
-            shutil.rmtree("merge-repo", ignore_errors=True)
-            self.git_run(
-                "clone",
-                "--single-branch",
-                "--branch",
-                pr.base.ref,
-                repo_url,
-                "merge-repo",
-            )
-
-    def git_merge_pr(self, pr: PullRequest):
-        shutil.rmtree("merge-repo", ignore_errors=True)
-        original_dir = os.getcwd()
-        try:
-            self.clone_merge_repo(pr)
             os.chdir("merge-repo")
             self.git_run("fetch", "origin", f"pull/{pr.number}/head:PR")
             self.git_run("checkout", pr.base.ref)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -83,7 +83,15 @@ class PrAutomerger:
         shutil.rmtree("merge-repo", ignore_errors=True)
         original_dir = os.getcwd()
         try:
-            self.git_run("clone", f"https://{self.token}@github.com/{self.repo_name}.git", "merge-repo")
+            self.git_run(
+                "clone",
+                "--filter=blob:none",
+                "--single-branch",
+                "--branch",
+                pr.base.ref,
+                f"https://{self.token}@github.com/{self.repo_name}.git",
+                "merge-repo",
+            )
             os.chdir("merge-repo")
             self.git_run("fetch", "origin", f"pull/{pr.number}/head:PR")
             self.git_run("checkout", pr.base.ref)
@@ -100,8 +108,13 @@ class PrAutomerger:
                 self.git_run("push")
                 return True
             except subprocess.CalledProcessError:
-                self.add_failed_comment(pr, "Unable to push merged revision.")
-                self.add_pr_failed_label(pr)
+                # Most likely a race: someone pushed to the base branch between
+                # our clone and push. Not a PR problem, retry on next iteration.
+                self.logger.warning("push to %s rejected, will retry on next iteration", pr.base.ref)
+                text = f"Unable to push merged revision to `{pr.base.ref}` (probably a race with another push), will retry automatically."
+                if self.workflow_url:
+                    text += f" Sync workflow logs can be found [here]({self.workflow_url})."
+                pr.create_issue_comment(text)
                 return False
         finally:
             os.chdir(original_dir)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -72,6 +72,8 @@ class PrAutomerger:
             return
 
         elif check.state == "success":
+            if pr_label_error in pr_labels:
+                self.logger.info("retrying merge after previous push failure (%s)", pr_label_error)
             self.logger.info("check success, going to merge")
             self.merge_pr(pr)
         else:
@@ -111,8 +113,8 @@ class PrAutomerger:
             except subprocess.CalledProcessError:
                 pr_labels = [l.name for l in pr.labels]
                 if pr_label_error in pr_labels:
-                    # Second failure in a row: this is not a transient race
-                    # (token/permissions/branch protection?), needs a human.
+                    # Second push failure while the label is present (same run or
+                    # next run): likely persistent, not a one-off race.
                     self.logger.warning("push to %s rejected again, blocking automerge", pr.base.ref)
                     self.add_failed_comment(pr, "Unable to push merged revision (failed twice in a row).")
                     self.add_pr_failed_label(pr)
@@ -136,6 +138,9 @@ class PrAutomerger:
         if not self.git_merge_pr(pr):
             self.logger.info("unable to merge PR")
             return
+        pr_labels = [l.name for l in pr.labels]
+        if pr_label_error in pr_labels:
+            pr.remove_from_labels(pr_label_error)
         self.logger.info("deleting ref %r", pr.head.ref)
         self.repo.get_git_ref(f"heads/{pr.head.ref}").delete()
         body = f"The PR was successfully merged into {pr.base.ref} using workflow"

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -14,6 +14,7 @@ pr_label_fail = "automerge-blocked"
 pr_label_error = "automerge-error"
 check_name = "checks_integrated"
 failed_comment_mark = "<!--SyncFailed-->"
+retry_comment_mark = "<!--SyncRetry-->"
 
 
 class PrAutomerger:
@@ -91,6 +92,24 @@ class PrAutomerger:
         except Exception:
             self.logger.warning("failed to remove %s label", pr_label_error, exc_info=True)
 
+    def add_retry_comment(self, pr: PullRequest, text: str):
+        if self.workflow_url:
+            text += f" Sync workflow logs can be found [here]({self.workflow_url})."
+        pr.create_issue_comment(f"{retry_comment_mark}\n{text}")
+
+    def mark_push_retry(self, pr: PullRequest, base_ref: str):
+        text = (
+            f"Unable to push merged revision to `{base_ref}` "
+            "(probably a race with another push), will retry automatically."
+        )
+        try:
+            pr.add_to_labels(pr_label_error)
+            self.add_retry_comment(pr, text)
+        except Exception:
+            self.logger.warning("failed to mark push retry on %r", pr, exc_info=True)
+            self.add_failed_comment(pr, "Unable to push merged revision (failed to schedule retry).")
+            self.add_pr_failed_label(pr)
+
     def git_merge_pr(self, pr: PullRequest):
         shutil.rmtree("merge-repo", ignore_errors=True)
         original_dir = os.getcwd()
@@ -133,11 +152,7 @@ class PrAutomerger:
                     # Most likely a race: someone pushed to the base branch between
                     # our clone and push. Not a PR problem, retry on next iteration.
                     self.logger.warning("push to %s rejected, will retry on next iteration", pr.base.ref)
-                    pr.add_to_labels(pr_label_error)
-                    text = f"Unable to push merged revision to `{pr.base.ref}` (probably a race with another push), will retry automatically."
-                    if self.workflow_url:
-                        text += f" Sync workflow logs can be found [here]({self.workflow_url})."
-                    pr.create_issue_comment(text)
+                    self.mark_push_retry(pr, pr.base.ref)
                 return False
         finally:
             os.chdir(original_dir)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -69,6 +69,7 @@ class PrAutomerger:
             self.logger.info("check failed")
             self.add_failed_comment(pr, f"Check `{check_name}` failed.")
             self.add_pr_failed_label(pr)
+            self.clear_error_label(pr)
             return
 
         elif check.state == "success":
@@ -81,6 +82,14 @@ class PrAutomerger:
 
     def add_pr_failed_label(self, pr: PullRequest):
         pr.add_to_labels(pr_label_fail)
+
+    def clear_error_label(self, pr: PullRequest):
+        if pr_label_error not in [l.name for l in pr.labels]:
+            return
+        try:
+            pr.remove_from_labels(pr_label_error)
+        except Exception:
+            self.logger.warning("failed to remove %s label", pr_label_error)
 
     def git_merge_pr(self, pr: PullRequest):
         shutil.rmtree("merge-repo", ignore_errors=True)
@@ -105,6 +114,7 @@ class PrAutomerger:
             except subprocess.CalledProcessError:
                 self.add_failed_comment(pr, "Unable to merge PR.")
                 self.add_pr_failed_label(pr)
+                self.clear_error_label(pr)
                 return False
 
             try:
@@ -118,7 +128,7 @@ class PrAutomerger:
                     self.logger.warning("push to %s rejected again, blocking automerge", pr.base.ref)
                     self.add_failed_comment(pr, "Unable to push merged revision (failed twice in a row).")
                     self.add_pr_failed_label(pr)
-                    pr.remove_from_labels(pr_label_error)
+                    self.clear_error_label(pr)
                 else:
                     # Most likely a race: someone pushed to the base branch between
                     # our clone and push. Not a PR problem, retry on next iteration.
@@ -138,9 +148,7 @@ class PrAutomerger:
         if not self.git_merge_pr(pr):
             self.logger.info("unable to merge PR")
             return
-        pr_labels = [l.name for l in pr.labels]
-        if pr_label_error in pr_labels:
-            pr.remove_from_labels(pr_label_error)
+        self.clear_error_label(pr)
         self.logger.info("deleting ref %r", pr.head.ref)
         self.repo.get_git_ref(f"heads/{pr.head.ref}").delete()
         body = f"The PR was successfully merged into {pr.base.ref} using workflow"

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -11,6 +11,7 @@ from github.PullRequest import PullRequest
 
 automerge_pr_label = "automerge"
 pr_label_fail = "automerge-blocked"
+pr_label_error = "automerge-error"
 check_name = "checks_integrated"
 failed_comment_mark = "<!--SyncFailed-->"
 
@@ -108,13 +109,23 @@ class PrAutomerger:
                 self.git_run("push")
                 return True
             except subprocess.CalledProcessError:
-                # Most likely a race: someone pushed to the base branch between
-                # our clone and push. Not a PR problem, retry on next iteration.
-                self.logger.warning("push to %s rejected, will retry on next iteration", pr.base.ref)
-                text = f"Unable to push merged revision to `{pr.base.ref}` (probably a race with another push), will retry automatically."
-                if self.workflow_url:
-                    text += f" Sync workflow logs can be found [here]({self.workflow_url})."
-                pr.create_issue_comment(text)
+                pr_labels = [l.name for l in pr.labels]
+                if pr_label_error in pr_labels:
+                    # Second failure in a row: this is not a transient race
+                    # (token/permissions/branch protection?), needs a human.
+                    self.logger.warning("push to %s rejected again, blocking automerge", pr.base.ref)
+                    self.add_failed_comment(pr, "Unable to push merged revision (failed twice in a row).")
+                    self.add_pr_failed_label(pr)
+                    pr.remove_from_labels(pr_label_error)
+                else:
+                    # Most likely a race: someone pushed to the base branch between
+                    # our clone and push. Not a PR problem, retry on next iteration.
+                    self.logger.warning("push to %s rejected, will retry on next iteration", pr.base.ref)
+                    pr.add_to_labels(pr_label_error)
+                    text = f"Unable to push merged revision to `{pr.base.ref}` (probably a race with another push), will retry automatically."
+                    if self.workflow_url:
+                        text += f" Sync workflow logs can be found [here]({self.workflow_url})."
+                    pr.create_issue_comment(text)
                 return False
         finally:
             os.chdir(original_dir)

--- a/ydb/ci/rightlib/automerge.py
+++ b/ydb/ci/rightlib/automerge.py
@@ -11,7 +11,7 @@ from github.PullRequest import PullRequest
 
 automerge_pr_label = "automerge"
 pr_label_fail = "automerge-blocked"
-pr_label_error = "automerge-error"
+pr_label_retry = "automerge-retry"
 check_name = "checks_integrated"
 failed_comment_mark = "<!--SyncFailed-->"
 retry_comment_mark = "<!--SyncRetry-->"
@@ -70,12 +70,12 @@ class PrAutomerger:
             self.logger.info("check failed")
             self.add_failed_comment(pr, f"Check `{check_name}` failed.")
             self.add_pr_failed_label(pr)
-            self.clear_error_label(pr)
+            self.clear_retry_label(pr)
             return
 
         elif check.state == "success":
-            if pr_label_error in pr_labels:
-                self.logger.info("retrying merge after previous push failure (%s)", pr_label_error)
+            if pr_label_retry in pr_labels:
+                self.logger.info("retrying merge after previous push failure (%s)", pr_label_retry)
             self.logger.info("check success, going to merge")
             self.merge_pr(pr)
         else:
@@ -84,13 +84,13 @@ class PrAutomerger:
     def add_pr_failed_label(self, pr: PullRequest):
         pr.add_to_labels(pr_label_fail)
 
-    def clear_error_label(self, pr: PullRequest):
-        if pr_label_error not in [l.name for l in pr.labels]:
+    def clear_retry_label(self, pr: PullRequest):
+        if pr_label_retry not in [l.name for l in pr.labels]:
             return
         try:
-            pr.remove_from_labels(pr_label_error)
+            pr.remove_from_labels(pr_label_retry)
         except Exception:
-            self.logger.warning("failed to remove %s label", pr_label_error, exc_info=True)
+            self.logger.warning("failed to remove %s label", pr_label_retry, exc_info=True)
 
     def add_retry_comment(self, pr: PullRequest, text: str):
         if self.workflow_url:
@@ -103,10 +103,14 @@ class PrAutomerger:
             "(probably a race with another push), will retry automatically."
         )
         try:
-            pr.add_to_labels(pr_label_error)
+            pr.add_to_labels(pr_label_retry)
             self.add_retry_comment(pr, text)
         except Exception:
             self.logger.warning("failed to mark push retry on %r", pr, exc_info=True)
+            try:
+                pr.remove_from_labels(pr_label_retry)
+            except Exception:
+                pass
             self.add_failed_comment(pr, "Unable to push merged revision (failed to schedule retry).")
             self.add_pr_failed_label(pr)
 
@@ -152,7 +156,7 @@ class PrAutomerger:
             except subprocess.CalledProcessError:
                 self.add_failed_comment(pr, "Unable to merge PR.")
                 self.add_pr_failed_label(pr)
-                self.clear_error_label(pr)
+                self.clear_retry_label(pr)
                 return False
 
             try:
@@ -160,13 +164,13 @@ class PrAutomerger:
                 return True
             except subprocess.CalledProcessError:
                 pr_labels = [l.name for l in pr.labels]
-                if pr_label_error in pr_labels:
+                if pr_label_retry in pr_labels:
                     # Second push failure while the label is present (same run or
                     # next run): likely persistent, not a one-off race.
                     self.logger.warning("push to %s rejected again, blocking automerge", pr.base.ref)
                     self.add_failed_comment(pr, "Unable to push merged revision (failed twice in a row).")
                     self.add_pr_failed_label(pr)
-                    self.clear_error_label(pr)
+                    self.clear_retry_label(pr)
                 else:
                     # Most likely a race: someone pushed to the base branch between
                     # our clone and push. Not a PR problem, retry on next iteration.
@@ -182,7 +186,7 @@ class PrAutomerger:
         if not self.git_merge_pr(pr):
             self.logger.info("unable to merge PR")
             return
-        self.clear_error_label(pr)
+        self.clear_retry_label(pr)
         self.logger.info("deleting ref %r", pr.head.ref)
         self.repo.get_git_ref(f"heads/{pr.head.ref}").delete()
         body = f"The PR was successfully merged into {pr.base.ref} using workflow"


### PR DESCRIPTION
## Проблема

`automerge.py` вешал `automerge-blocked` на любой failed `git push`. Частый случай — race: полный clone репозитория занимал **~10 минут**, за это время кто-то успевал запушить в base branch, push отклонялся как non-fast-forward, и зелёный PR блокировался до ручного вмешательства.

Подтверждённый инцидент: [PR #43125](https://github.com/ydb-platform/ydb/pull/43125) (10 Jun 2026) — clone 13:45–13:55 UTC, push rejected `fetch first`, PR stuck с `automerge-blocked` до ручного merge.

Отдельно: после успешного push workflow падал на cleanup — `delete head ref` → **404**, если GitHub уже удалил ветку (`delete_branch_on_merge: true`). Merge проходил, но run был красным и success-коммент не писался (инцидент: [PR #43575](https://github.com/ydb-platform/ydb/pull/43575), 16 Jun 2026).

## Решение

1. **Blobless single-branch clone** — `git clone --filter=blob:none --single-branch --branch <base>` вместо полного clone: окно race с ~10 мин до секунд/минут.
2. **Two-strike при push fail** — первый fail → label `automerge-retry` + коммент с `<!--SyncRetry-->`, retry на следующей итерации automerge. Второй fail подряд (label уже есть) → `automerge-blocked`, как раньше.
3. **Cleanup transient state** — `automerge-retry` снимается при успешном merge, при block (failed checks / merge conflict / second push fail) и при ошибке постановки retry.
4. **Tolerate missing head ref** — после успешного push `delete_head_ref()` удаляет ветку PR; если GitHub уже удалил её (repo setting *Automatically delete head branches*), 404 считается успехом. Fork PR — skip delete.

Merge conflict и failed `checks_integrated` по-прежнему сразу блокируют PR.

## Labels (state machine)

| Labels на PR | Значение |
|---|---|
| `automerge` | PR в очереди automerge |
| `automerge-retry` | push race, retry на след. run |
| `automerge-blocked` | стоп, нужен человек (снять label вручную) |

Требуется label **`automerge-retry`** в репозитории (transient marker, не путать с `automerge-blocked`).

## Пример запуска с правками

Ручной прогон на коде из этого PR: [Automerge PR run #27640755625](https://github.com/ydb-platform/ydb/actions/runs/27640755625) (`workflow_dispatch`, commit `9e82a62`, ветка `automerge-retry-on-push-race`, **success**, 55m).

**Итерация 1** — два mute-PR подряд:

| PR | Результат |
|---|---|
| [#43621](https://github.com/ydb-platform/ydb/pull/43621) mute release-asan → `main` | checks ✅ → blobless clone ~2.2 min → merge + push ✅ |
| [#43620](https://github.com/ydb-platform/ydb/pull/43620) mute relwithdebinfo → `main` | checks ✅ → blobless clone ~1.9 min → merge + push ✅ |

После каждого push — delete head ref → **404** (GitHub уже удалил ветку) → лог `head ref '...' already gone`, **без crash** → success-коммент в PR.

**Итерации 2–10** — [#43304](https://github.com/ydb-platform/ydb/pull/43304) (sync rightlib): `checks_integrated` pending → `wait for success`, merge не начинался (ожидаемое поведение).

Ошибок, warnings и `automerge iteration N failed` в run не было.

## Test plan

- [ ] Push race: первый rejected push → `automerge-retry`, второй успешный → merge без `automerge-blocked`
- [ ] Два rejected push подряд → `automerge-blocked`
- [ ] Успешный merge при `delete_branch_on_merge: true` → workflow green, success-коммент в PR

### Changelog category

* Not for changelog (changelog entry is not required)