### PR TITLE
Remove support GetShortDebugString() and add YDB_LOG_CREATE_CONTEXT macro

### DIFF
--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -243,6 +243,18 @@ Y_UNIT_TEST_SUITE(StructLog) {
         TString ToString() const {
             return "some value";
         }
+
+        TString ToString() {
+            return "wrong value from non-const ToString()";
+        }
+
+        static TString ToString(int) {
+            return "wrong value from static ToString(int)";
+        }
+
+        TString ToString(bool) {
+            return "wrong value from ToString(bool)";
+        }
     };
 
     struct TTestTypeToStructuredMessage {

--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -261,39 +261,10 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
-    struct TTestTypeShortDebugString {
-        TString ShortDebugString() const {
-            return "short_debug_string";
-        }
-    };
-
-    struct TTestTypeShortDebugStringToString {
-        TString ShortDebugString() const {
-            return "short_debug_string";
-        }
-
-        TString ToString() const {
-            return "some value";
-        }
-    };
-
-    struct TTestTypeShortDebugStringToStructuredMessage {
-        TString ShortDebugString() const {
-            return "short_debug_string";
-        }
-
-        TStructuredMessage ToStructuredMessage() const {
-            return YDB_LOG_CREATE_MESSAGE({"value1", 1}, {"value2", 2});
-        }
-    };
-
     Y_UNIT_TEST(CreateMessageToMethods) {
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToString{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStructuredMessage{}}), "value.value1=1, value.value2=2");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringToStructuredMessage{}}), "value.value1=1, value.value2=2");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeShortDebugString{}}), "value=short_debug_string");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeShortDebugStringToString{}}), "value=some value");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeShortDebugStringToStructuredMessage{}}), "value.value1=1, value.value2=2");
     }
 
     Y_UNIT_TEST(CreateMessageIterable) {
@@ -415,6 +386,15 @@ Y_UNIT_TEST_SUITE(StructLog) {
                 TEST_MESSAGE(TLogStack::GetTop(), "v1=1, v2=2");
             }
 
+            TEST_MESSAGE(TLogStack::GetTop(), "v1=1");
+        }
+        TEST_MESSAGE(TLogStack::GetTop(), "");
+    }
+
+    Y_UNIT_TEST(LogStackCreateContext) {
+        TEST_MESSAGE(TLogStack::GetTop(), "");
+        {
+            YDB_LOG_CREATE_CONTEXT({"v1", 1});
             TEST_MESSAGE(TLogStack::GetTop(), "v1=1");
         }
         TEST_MESSAGE(TLogStack::GetTop(), "");

--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -251,7 +251,7 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
-    struct TTestTypeToStringBoth {
+    struct TTestTypeToBoth {
         TString ToString() const {
             return "some value";
         }
@@ -264,7 +264,7 @@ Y_UNIT_TEST_SUITE(StructLog) {
     Y_UNIT_TEST(CreateMessageToMethods) {
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToString{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStructuredMessage{}}), "value.value1=1, value.value2=2");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringBoth{}}), "value.value1=1, value.value2=2");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToBoth{}}), "value.value1=1, value.value2=2");
     }
 
     Y_UNIT_TEST(CreateMessageIterable) {

--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -251,7 +251,7 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
-    struct TTestTypeToStringToStructuredMessage {
+    struct TTestTypeToStringBoth {
         TString ToString() const {
             return "some value";
         }
@@ -264,7 +264,7 @@ Y_UNIT_TEST_SUITE(StructLog) {
     Y_UNIT_TEST(CreateMessageToMethods) {
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToString{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStructuredMessage{}}), "value.value1=1, value.value2=2");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringToStructuredMessage{}}), "value.value1=1, value.value2=2");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringBoth{}}), "value.value1=1, value.value2=2");
     }
 
     Y_UNIT_TEST(CreateMessageIterable) {

--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -251,7 +251,7 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
-    struct TTestTypeToBoth {
+    struct TTestTypeToStringToStructuredMessage {
         TString ToString() const {
             return "some value";
         }
@@ -261,17 +261,39 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
-    struct TTestTypeGetDebugShortString {
-        TString GetDebugShortString() const {
+    struct TTestTypeShortDebugString {
+        TString ShortDebugString() const {
             return "short_debug_string";
+        }
+    };
+
+    struct TTestTypeShortDebugStringToString {
+        TString ShortDebugString() const {
+            return "short_debug_string";
+        }
+
+        TString ToString() const {
+            return "some value";
+        }
+    };
+
+    struct TTestTypeShortDebugStringToStructuredMessage {
+        TString ShortDebugString() const {
+            return "short_debug_string";
+        }
+
+        TStructuredMessage ToStructuredMessage() const {
+            return YDB_LOG_CREATE_MESSAGE({"value1", 1}, {"value2", 2});
         }
     };
 
     Y_UNIT_TEST(CreateMessageToMethods) {
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToString{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStructuredMessage{}}), "value.value1=1, value.value2=2");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToBoth{}}), "value.value1=1, value.value2=2");
-        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeGetDebugShortString{}}), "value=short_debug_string");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringToStructuredMessage{}}), "value.value1=1, value.value2=2");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeShortDebugString{}}), "value=short_debug_string");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeShortDebugStringToString{}}), "value=some value");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeShortDebugStringToStructuredMessage{}}), "value.value1=1, value.value2=2");
     }
 
     Y_UNIT_TEST(CreateMessageIterable) {

--- a/ydb/library/actors/struct_log/create_message_impl.h
+++ b/ydb/library/actors/struct_log/create_message_impl.h
@@ -45,7 +45,7 @@ public:
     template <typename T>
     class THasToStringMethod {
         // check the signature if it exists
-        template <typename X> static constexpr typename std::is_same<decltype(&X::ToString), TString(X::*)()const>::type check(int);
+        template <typename X> static constexpr decltype(static_cast<TString (X::*)() const>(&X::ToString), std::true_type{}) check(int);
         // in case when there is no such signature
         template <typename>   static constexpr std::false_type check(...);
     public:

--- a/ydb/library/actors/struct_log/create_message_impl.h
+++ b/ydb/library/actors/struct_log/create_message_impl.h
@@ -6,6 +6,7 @@
 #include <ydb/core/base/id_wrapper.h>
 #include <ydb/library/services/services.pb.h>
 
+#include <util/generic/overloaded.h>
 #include <util/generic/maybe.h>
 
 #include <google/protobuf/descriptor.h>
@@ -53,9 +54,9 @@ public:
     };
 
     template <typename T>
-    class THasGetDebugShortStringMethod {
+    class THasShortDebugStringMethod {
         // check the signature if it exists
-        template <typename X> static constexpr typename std::is_same<decltype(&X::GetDebugShortString), TString(X::*)()const>::type check(int);
+        template <typename X> static constexpr typename std::is_same<decltype(&X::ShortDebugString), TString(X::*)()const>::type check(int);
         // in case when there is no such signature
         template <typename>   static constexpr std::false_type check(...);
     public:
@@ -127,10 +128,10 @@ public:
             // By default, Out<T> can't write classes with ToString() method. (see TStateStorageInfo as example)
             // Because of this, OutputParam must be able to process various standard containers, variants, tuples, etc...
             s << value.ToString();
-        } else if constexpr (THasGetDebugShortStringMethod<Tx>::value) {
-            // By default, Out<T> can't write classes with GetDebugShortString() method.
+        } else if constexpr (THasShortDebugStringMethod<Tx>::value) {
+            // By default, Out<T> can't write classes with ShortDebugString() method.
             // Because of this, OutputParam must be able to process various standard containers, variants, tuples, etc...
-            s << value.GetDebugShortString();
+            s << value.ShortDebugString();
         } else if constexpr (TOptionalTraits<Tx>::HasOptionalValue) {
             // YDB uses several ways to store/pass optional values (see TOptionalTraits<T> below).
             // So, it is required to process optional data using this OutputParam<TValue> (instead of Out<T>).

--- a/ydb/library/actors/struct_log/create_message_impl.h
+++ b/ydb/library/actors/struct_log/create_message_impl.h
@@ -54,16 +54,6 @@ public:
     };
 
     template <typename T>
-    class THasShortDebugStringMethod {
-        // check the signature if it exists
-        template <typename X> static constexpr typename std::is_same<decltype(&X::ShortDebugString), TString(X::*)()const>::type check(int);
-        // in case when there is no such signature
-        template <typename>   static constexpr std::false_type check(...);
-    public:
-        static constexpr bool value = decltype(check<T>(0))::value;
-    };
-
-    template <typename T>
     class THasToStructuredMessageMethod {
         // check the signature if it exists
         template <typename X> static constexpr typename std::is_same<decltype(&X::ToStructuredMessage), TStructuredMessage(X::*)()const>::type check(int);
@@ -128,10 +118,6 @@ public:
             // By default, Out<T> can't write classes with ToString() method. (see TStateStorageInfo as example)
             // Because of this, OutputParam must be able to process various standard containers, variants, tuples, etc...
             s << value.ToString();
-        } else if constexpr (THasShortDebugStringMethod<Tx>::value) {
-            // By default, Out<T> can't write classes with ShortDebugString() method.
-            // Because of this, OutputParam must be able to process various standard containers, variants, tuples, etc...
-            s << value.ShortDebugString();
         } else if constexpr (TOptionalTraits<Tx>::HasOptionalValue) {
             // YDB uses several ways to store/pass optional values (see TOptionalTraits<T> below).
             // So, it is required to process optional data using this OutputParam<TValue> (instead of Out<T>).

--- a/ydb/library/actors/struct_log/create_message_impl.h
+++ b/ydb/library/actors/struct_log/create_message_impl.h
@@ -6,7 +6,6 @@
 #include <ydb/core/base/id_wrapper.h>
 #include <ydb/library/services/services.pb.h>
 
-#include <util/generic/overloaded.h>
 #include <util/generic/maybe.h>
 
 #include <google/protobuf/descriptor.h>

--- a/ydb/library/actors/struct_log/log_stack.h
+++ b/ydb/library/actors/struct_log/log_stack.h
@@ -26,7 +26,11 @@ public:
     };
 };
 
-#define YDB_LOG_UPDATE_CONTEXT(...) YDB_LOG_UPDATE_MESSAGE(TLogStack::GetTop(), __VA_ARGS__)
-#define YDB_LOG_REMOVE_CONTEXT(...) TLogStack::GetTop().RemoveValues({__VA_ARGS__})
+#define YDB_LOG_CREATE_CONTEXT(...) \
+    ::NActors::NStructuredLog::TLogStack::TLogGuard ydblogContextGuard; \
+    YDB_LOG_UPDATE_MESSAGE(TLogStack::GetTop(), __VA_ARGS__)
+
+#define YDB_LOG_UPDATE_CONTEXT(...) YDB_LOG_UPDATE_MESSAGE(::NActors::NStructuredLog::TLogStack::GetTop(), __VA_ARGS__)
+#define YDB_LOG_REMOVE_CONTEXT(...) ::NActors::NStructuredLog::TLogStack::GetTop().RemoveValues({__VA_ARGS__})
 
 }  // namespace NActors::NStructuredLog


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

1. Don't support `GetDebugShortString`
2. Add macro `YDB_LOG_CREATE_CONTEXT`
3. Improve support of `ToString() const` method
