### PR TITLE
[NEW RBO] Fix IU conflicts during IN/EXISTS inlining

### DIFF
--- a/ydb/core/kqp/opt/rbo/rules/inline_generic_in_exists_subplan.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_generic_in_exists_subplan.cpp
@@ -142,21 +142,34 @@ TIntrusivePtr<IOperator> TInlineGenericInExistsSubplanRule::SimpleMatchAndApply(
     auto zero = MakeConstant("Uint64", "0", filter->Pos, &ctx.ExprCtx);
 
     if (subplanEntry.Type == ESubplanType::IN_SUBPLAN || !extraJoinKeys.empty()) {
+        auto leftInput = filter->GetInput();
+        auto rightInput = uncorrSubplan;
+
+        const auto commonIUs = IUSetIntersect(leftInput->GetOutputIUs(), rightInput->GetOutputIUs());
+        const auto rightRenamings = MakeRenameMap(commonIUs, props.InternalVarIdx);
+        if (!rightRenamings.empty()) {
+            rightInput = MakeMapFromRenames(rightInput, rightRenamings, filter->Pos, &ctx.ExprCtx, &props);
+            extraJoinKeys = RemapJoinKeysRightSide(extraJoinKeys, rightRenamings);
+            for (auto& joinFilter : joinFilters) {
+                joinFilter = joinFilter.ApplyRenames(rightRenamings);
+            }
+        }
+
         TVector<std::pair<TInfoUnit, TInfoUnit>> joinKeys;
-        auto planIUs = uncorrSubplan->GetOutputIUs();
+        auto planIUs = rightInput->GetOutputIUs();
 
         for (size_t i = 0; i < subplanEntry.Tuple.size(); i++) {
             joinKeys.push_back(std::make_pair(subplanEntry.Tuple[i], planIUs[i]));
         }
 
         // Fetch keys
-        auto keyColumns = filter->GetInput()->Props.Metadata->KeyColumns;
+        auto keyColumns = leftInput->Props.Metadata->KeyColumns;
         Y_ENSURE(!keyColumns.empty(), "Cannot inline a join filter because key columns are missing");
-        Y_ENSURE(CheckNonNullKeys(filter->GetInput(), keyColumns), "Key columns cannot be optional when decorrelating generic IN/EXISTS");
+        Y_ENSURE(CheckNonNullKeys(leftInput, keyColumns), "Key columns cannot be optional when decorrelating generic IN/EXISTS");
 
         // Build the join
         joinKeys.insert(joinKeys.begin(), extraJoinKeys.begin(), extraJoinKeys.end());
-        join = MakeIntrusive<TOpJoin>(filter->GetInput(), uncorrSubplan, input->Pos, "Inner", joinKeys, joinFilters);
+        join = MakeIntrusive<TOpJoin>(leftInput, rightInput, input->Pos, "Inner", joinKeys, joinFilters);
 
         // Build the counting aggregate and use a map operator to compute count > 0
         auto countResult = TInfoUnit("_rbo_arg_" + std::to_string(props.InternalVarIdx++), true);

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -4132,7 +4132,7 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
 
     Y_UNIT_TEST(TPCDS_YQL) {
         // RunTPC_YqlBenchmark(EBenchType::TPCDS, /*columnstore*/ true, {}, {}, /*new rbo*/ false);
-        RunTPC_YqlBenchmark(EBenchType::TPCDS, /*columnstore=*/true, {1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 13, 15, 18, 19, 21, 22, 24, 25, 26, 29, 30, 31, 32, 33, 34, 35, 37, 38, 40, 42, 43, 46, 48,
+        RunTPC_YqlBenchmark(EBenchType::TPCDS, /*columnstore=*/true, {1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 13, 15, 18, 19, 21, 22, 24, 25, 26, 29, 30, 31, 32, 33, 34, 35, 37, 38, 40, 42, 43, 45, 46, 48,
                                                                       50, 52, 54, 55, 56, 58, 59, 60, 61, 62, 64, 65, 66, 68, 69, 71, 72, 73, 74, 75, 76, 77, 78, 79, 81, 82, 83,
                                                                       84, 85, 87, 88, 90, 91, 92, 93, 96, 99},
                            /*rbo never finish*/{}, /*new rbo=*/true, /*printStatus=*/true, /*compareResults=*/true, /*checkNewRBOCbo=*/true,


### PR DESCRIPTION
Fixes TPCDS Q45. The query contains a subquery whose output columns have the same IU names as columns from the outer query, but they belong to a different scope. After generic IN/EXISTS inlining, the subquery is placed on the right side of a join with the outer plan, so those formerly separate columns become visible in one join output and produce duplicates.

This PR detects such left/right output conflicts before constructing the join, inserts a rename map on the right side, and remaps right-side join keys and filters to the new IUs.
