### PR TITLE
Add a freshness marker to SnapshotRegistry

### DIFF
--- a/ydb/core/protos/long_tx_service_config.proto
+++ b/ydb/core/protos/long_tx_service_config.proto
@@ -17,4 +17,6 @@ message TLongTxServiceConfig {
     optional TRetrySettings PublisherSettings = 7;
     optional TRetrySettings SubscriberSettings = 8;
     optional uint64 PrefillTimeoutSeconds = 9 [default = 5];
+    // Wall-clock skew margin subtracted from OldestCollectionTime when used as a cleanup floor.
+    optional uint64 MaxClockSkewMs = 10 [default = 5000];
 }

--- a/ydb/core/tx/columnshard/engines/ut/ut_scan_snapshot_guard.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_scan_snapshot_guard.cpp
@@ -43,9 +43,9 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         return config;
     }
 
-    // Freshness margin subtracted from OldestCollectionTime by the registry guard:
-    // LocalSnapshotPromotionTimeSeconds (120s) + MaxClockSkewMs (5000ms) = 125000ms.
-    static constexpr ui64 FreshnessMarginMs = 125000;
+    ui64 FreshnessMarginMs(const NKikimrConfig::TLongTxServiceConfig& config) {
+        return TDuration::Seconds(config.GetLocalSnapshotPromotionTimeSeconds()).MilliSeconds() + config.GetMaxClockSkewMs();
+    }
 
     Y_UNIT_TEST(LocalGuardSmoke) {
         auto csControllerGuard = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
@@ -84,7 +84,8 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         translator.Add(internalPathId, { ssPathId });
 
         // Collection time well newer than the border, so the border caps the floor.
-        auto registry = CreateSnapshotRegistry(TRowVersion(900, 0), {}, TInstant::MilliSeconds(30000 + FreshnessMarginMs));
+        const ui64 marginMs = FreshnessMarginMs(longTxConfig);
+        auto registry = CreateSnapshotRegistry(TRowVersion(900, 0), {}, TInstant::MilliSeconds(30000 + marginMs));
 
         const NOlap::TSnapshot lastCleanupSnapshot = NOlap::TSnapshot::Zero();
         auto guard = CreateRegistryScanSnapshotGuard(
@@ -116,7 +117,8 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
             /*passedStep*/ 200000, schemeShardId, lastCleanupSnapshot, translator, registry, longTxConfig);
 
         // No border: floor = OldestCollectionTime(155000) - margin(125000) = 30000.
-        UNIT_ASSERT_VALUES_EQUAL(guard->GetMinSnapshotForNewReads().GetPlanStep(), 155000 - FreshnessMarginMs);
+        const ui64 marginMs = FreshnessMarginMs(longTxConfig);
+        UNIT_ASSERT_VALUES_EQUAL(guard->GetMinSnapshotForNewReads().GetPlanStep(), 155000 - marginMs);
         UNIT_ASSERT(guard->MayStartScanAt(Step(30000), ssPathId));
         UNIT_ASSERT(guard->MayStartScanAt(Step(10), ssPathId));
         UNIT_ASSERT(!guard->MayStartScanAt(Step(9), ssPathId));

--- a/ydb/core/tx/columnshard/engines/ut/ut_scan_snapshot_guard.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_scan_snapshot_guard.cpp
@@ -21,12 +21,13 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         return TInFlightReadsTracker(nullptr, nullptr);
     }
 
-    TTrueAtomicSharedPtr<IImmutableSnapshotRegistry> CreateSnapshotRegistry(
-        const std::optional<TRowVersion>& border = std::nullopt, const std::vector<std::pair<NKikimr::TTableId, TRowVersion>>& snapshots = {}) {
+    TTrueAtomicSharedPtr<IImmutableSnapshotRegistry> CreateSnapshotRegistry(const std::optional<TRowVersion>& border = std::nullopt,
+        const std::vector<std::pair<NKikimr::TTableId, TRowVersion>>& snapshots = {}, const TInstant oldestCollectionTime = TInstant::Zero()) {
         auto registryBuilder = CreateImmutableSnapshotRegistryBuilder();
         if (border) {
             registryBuilder->SetSnapshotBorder(*border);
         }
+        registryBuilder->SetOldestCollectionTime(oldestCollectionTime);
         for (const auto& [tableId, snapshot] : snapshots) {
             registryBuilder->AddSnapshot({ tableId }, snapshot);
         }
@@ -38,8 +39,13 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         config.SetLocalSnapshotPromotionTimeSeconds(120);
         config.SetSnapshotsExchangeIntervalSeconds(10);
         config.SetSnapshotsRegistryUpdateIntervalSeconds(30);
+        config.SetMaxClockSkewMs(5000);
         return config;
     }
+
+    // Freshness margin subtracted from OldestCollectionTime by the registry guard:
+    // LocalSnapshotPromotionTimeSeconds (120s) + MaxClockSkewMs (5000ms) = 125000ms.
+    static constexpr ui64 FreshnessMarginMs = 125000;
 
     Y_UNIT_TEST(LocalGuardSmoke) {
         auto csControllerGuard = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
@@ -77,14 +83,14 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         const auto ssPathId = TSchemeShardLocalPathId::FromRawValue(70);
         translator.Add(internalPathId, { ssPathId });
 
-        auto registry = CreateSnapshotRegistry(TRowVersion(900, 0));
+        // Collection time well newer than the border, so the border caps the floor.
+        auto registry = CreateSnapshotRegistry(TRowVersion(900, 0), {}, TInstant::MilliSeconds(30000 + FreshnessMarginMs));
 
         const NOlap::TSnapshot lastCleanupSnapshot = NOlap::TSnapshot::Zero();
         auto guard = CreateRegistryScanSnapshotGuard(
             /*passedStep*/ 200000, schemeShardId, lastCleanupSnapshot, translator, registry, longTxConfig);
 
-        // default delay = 120 + 10 + 30 + 10 = 170 seconds -> service min step = 30000
-        // border = 900 -> effective min step = min(30000, 900) = 900
+        // border = 900 is older than the freshness floor -> effective min step = 900
         UNIT_ASSERT_VALUES_EQUAL(guard->GetMinSnapshotForNewReads().GetPlanStep(), 900);
         UNIT_ASSERT(guard->MayStartScanAt(Step(900), ssPathId));
         UNIT_ASSERT(!guard->MayStartScanAt(Step(850), ssPathId));
@@ -102,14 +108,15 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         const auto ssPathId = TSchemeShardLocalPathId::FromRawValue(70);
         translator.Add(internalPathId, { ssPathId });
 
-        auto registry = CreateSnapshotRegistry(std::nullopt, { { TTableId(schemeShardId, ssPathId.GetRawValue(), 0), TRowVersion(10, 1) } });
+        auto registry = CreateSnapshotRegistry(
+            std::nullopt, { { TTableId(schemeShardId, ssPathId.GetRawValue(), 0), TRowVersion(10, 1) } }, TInstant::MilliSeconds(155000));
 
         const NOlap::TSnapshot lastCleanupSnapshot = NOlap::TSnapshot::Zero();
         auto guard = CreateRegistryScanSnapshotGuard(
             /*passedStep*/ 200000, schemeShardId, lastCleanupSnapshot, translator, registry, longTxConfig);
 
-        // default delay = 120 + 10 + 30 + 10 = 170 seconds, no border -> effective min step = 30000
-        UNIT_ASSERT_VALUES_EQUAL(guard->GetMinSnapshotForNewReads().GetPlanStep(), 30000);
+        // No border: floor = OldestCollectionTime(155000) - margin(125000) = 30000.
+        UNIT_ASSERT_VALUES_EQUAL(guard->GetMinSnapshotForNewReads().GetPlanStep(), 155000 - FreshnessMarginMs);
         UNIT_ASSERT(guard->MayStartScanAt(Step(30000), ssPathId));
         UNIT_ASSERT(guard->MayStartScanAt(Step(10), ssPathId));
         UNIT_ASSERT(!guard->MayStartScanAt(Step(9), ssPathId));
@@ -158,7 +165,8 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardTests) {
         auto guard = CreateRegistryScanSnapshotGuard(
             /*passedStep*/ 200000, schemeShardId, lastCleanupSnapshot, translator, registry, longTxConfig);
 
-        // No border: min snapshot should be max(serviceMinReadStep=30000, lastCleanupSnapshot=45000) = 45000.
+        // OldestCollectionTime unset -> serviceMinReadStep=0; no border:
+        // min snapshot should be max(0, lastCleanupSnapshot=45000) = 45000.
         UNIT_ASSERT_VALUES_EQUAL(guard->GetMinSnapshotForNewReads(), lastCleanupSnapshot);
         UNIT_ASSERT(guard->MayStartScanAt(Step(45000), ssPathId));
         UNIT_ASSERT(!guard->MayStartScanAt(Step(44999), ssPathId));

--- a/ydb/core/tx/columnshard/scan_snapshot_guard.cpp
+++ b/ydb/core/tx/columnshard/scan_snapshot_guard.cpp
@@ -66,27 +66,22 @@ public:
 
 NOlap::TSnapshot BuildRegistryMinSnapshotForNewReads(const ui64 passedStep, const NOlap::TSnapshot& lastCleanupSnapshot,
     const TTrueAtomicSharedPtr<IImmutableSnapshotRegistry>& registry, const NKikimrConfig::TLongTxServiceConfig& longTxConfig) {
-    // How long it may take for a snapshot from the most remote node to reach this columnshard
-    // in the worst case by default:
-    //   promotion delay (120s) + exchange period (10s) + registry rebuild period (30s) + network/propagation delta (10s) = 170s.
-    // 10 seconds delta is the agreed conservative estimate:
-    //   4 messages * log_10(100k nodes) * 0.5s (ping time between the nodes) = 10s.
-
-    // But, in fact, the registry is not ready right after the node start, it takes it a while to materialize.
-    // During this period of materialization the shard keeps all portions (do not delete anything), see `TRegistryNotReadySnapshotGuard`.
-    // A practical upper estimate of this additional startup "no-delete" window with default config:
-    // exchange period (10s) + registry rebuild period (30s) + network/propagation delta (10s) = 50s
-    // Therefore the total default conservative duration of keeping removed portions is roughly:
-    //   170s (steady-state delay window) + 50s (startup materialization period) = ~220 seconds.
-    // That is at most for how long we will keep removed portions by default.
-    const ui64 delaySeconds = longTxConfig.GetLocalSnapshotPromotionTimeSeconds() + longTxConfig.GetSnapshotsExchangeIntervalSeconds() +
-                              longTxConfig.GetSnapshotsRegistryUpdateIntervalSeconds() + 10;
-    const ui64 delayMillisec = TDuration::Seconds(delaySeconds).MilliSeconds();
-    const ui64 serviceMinReadStep = (passedStep > delayMillisec ? passedStep - delayMillisec : 0);
+    // OldestCollectionTime tells us how fresh the registry actually is (oldest collection time
+    // across all contributing nodes). Anchoring on it means the floor backs off on its own when
+    // the registry is stale (e.g. under CPU saturation), instead of trusting a fixed worst-case
+    // estimate. A read on a remote node may still be missing from the registry for up to:
+    //   - LocalSnapshotPromotionTimeSeconds: a snapshot isn't propagated until it is promoted;
+    //   - MaxClockSkewMs: that collection time was stamped against the remote node's wall clock.
+    // So we may only clean strictly below OldestCollectionTime minus that margin.
+    const ui64 marginMs =
+        TDuration::Seconds(longTxConfig.GetLocalSnapshotPromotionTimeSeconds()).MilliSeconds() + longTxConfig.GetMaxClockSkewMs();
+    const ui64 oldestCollectionMs = registry->GetOldestCollectionTime().MilliSeconds();
+    ui64 serviceMinReadStep = (oldestCollectionMs > marginMs ? oldestCollectionMs - marginMs : 0);
+    // The freshness floor must never exceed the current step.
+    serviceMinReadStep = std::min(serviceMinReadStep, passedStep);
 
     NOlap::TSnapshot minSnapshot = std::max(NOlap::TSnapshot(serviceMinReadStep, 0), lastCleanupSnapshot);
-    // Registry border may be older than the calculated delay window.
-    // In that case we use the older border to preserve correctness.
+    // Registry border may be older than the computed floor; use the older to preserve correctness.
     const TRowVersion border = registry->GetBorder();
     return std::min(minSnapshot, NOlap::TSnapshot(border.Step, border.TxId));
 }

--- a/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
+++ b/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
@@ -36,8 +36,8 @@ namespace {
 // collapse the cleanup floor to 0 and nothing would ever be collected.
 class TLiveEmptySnapshotRegistry: public IImmutableSnapshotRegistry {
 public:
-    bool HasSnapshot(const NKikimr::TTableId&, const TRowVersion& version) const override {
-        return version >= TRowVersion::Max();
+    bool HasSnapshot(const NKikimr::TTableId&, const TRowVersion&) const override {
+        return false;
     }
 
     TSet<TRowVersion> GetActiveSnapshots(const NKikimr::TTableId&) const override {

--- a/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
+++ b/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.cpp
@@ -1,6 +1,7 @@
 #include "columnshard_ut_common.h"
 #include "shard_reader.h"
 
+#include <ydb/core/base/appdata.h>
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/base/tablet_resolver.h>
 #include <ydb/core/protos/data_events.pb.h>
@@ -24,6 +25,35 @@ namespace NKikimr::NTxUT {
 
 using namespace NColumnShard;
 using namespace Tests;
+
+namespace {
+
+// The basic tablet test runtime has no LongTxService to keep a registry fresh, but cleanup that goes
+// through TRegistryScanSnapshotGuard needs a freshness marker (OldestCollectionTime) that advances
+// with the clock. This stand-in is an always-empty registry (border = Max, no snapshots) whose
+// OldestCollectionTime is the live "now", mirroring a single-node cluster where the local node's
+// collection time is always current. A frozen value (e.g. the default TInstant::Zero()) would
+// collapse the cleanup floor to 0 and nothing would ever be collected.
+class TLiveEmptySnapshotRegistry: public IImmutableSnapshotRegistry {
+public:
+    bool HasSnapshot(const NKikimr::TTableId&, const TRowVersion& version) const override {
+        return version >= TRowVersion::Max();
+    }
+
+    TSet<TRowVersion> GetActiveSnapshots(const NKikimr::TTableId&) const override {
+        return {};
+    }
+
+    TRowVersion GetBorder() const override {
+        return TRowVersion::Max();
+    }
+
+    TInstant GetOldestCollectionTime() const override {
+        return AppData()->TimeProvider->Now();
+    }
+};
+
+}   // namespace
 
 void TTester::Setup(TTestActorRuntime& runtime) {
     runtime.SetLogPriority(NKikimrServices::TX_COLUMNSHARD, NActors::NLog::PRI_DEBUG);
@@ -51,27 +81,31 @@ void TTester::Setup(TTestActorRuntime& runtime) {
     app.AddDomain(domain.Release());
     SetupTabletServices(runtime, &app);
 
-    // No LongTxService actor is created in this basic test runtime, so we initialize the
-    // SnapshotRegistryHolder with an empty registry (border = TRowVersion::Max, no active scans).
-    // This makes TRegistryScanSnapshotGuard use purely timing-based MinSnapshotForNewReads.
-    // Short LongTxServiceConfig delays (1+1+1+10 = 13s) ensure cleanup can run within test timeouts.
-    // Tests that specifically test the registry path (ut_scan_snapshot_guard_integration.cpp)
-    // override these settings after calling Setup().
-    {
-        auto builder = CreateImmutableSnapshotRegistryBuilder();
-        // Leave border at the default TRowVersion::Max and add no snapshots → empty registry.
-        auto holder = CreateImmutableSnapshotRegistryHolder();
-        holder->Set(std::move(*builder).Build());
-        for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
-            auto& appData = runtime.GetAppData(nodeIndex);
-            appData.SnapshotRegistryHolder = holder;
-            appData.LongTxServiceConfig.SetLocalSnapshotPromotionTimeSeconds(1);
-            appData.LongTxServiceConfig.SetSnapshotsExchangeIntervalSeconds(1);
-            appData.LongTxServiceConfig.SetSnapshotsRegistryUpdateIntervalSeconds(1);
-        }
-    }
+    // No LongTxService actor is created in this basic test runtime, so install a stand-in registry with a
+    // live OldestCollectionTime; otherwise TRegistryScanSnapshotGuard sees a frozen Zero freshness and
+    // never advances the cleanup floor. Tests that specifically test the registry path
+    // (ut_scan_snapshot_guard_integration.cpp) override these settings after calling Setup().
+    InstallTimingBasedSnapshotRegistry(runtime);
 
     runtime.UpdateCurrentTime(TInstant::Now());
+}
+
+void InstallTimingBasedSnapshotRegistry(TTestActorRuntime& runtime) {
+    // margin = LocalSnapshotPromotionTimeSeconds + MaxClockSkewMs = 1s + 12s = the old ~13s cleanup window,
+    // so TRegistryScanSnapshotGuard yields MinSnapshotForNewReads = now - 13s (see TLiveEmptySnapshotRegistry).
+    for (ui32 nodeIndex = 0; nodeIndex < runtime.GetNodeCount(); ++nodeIndex) {
+        auto& appData = runtime.GetAppData(nodeIndex);
+        auto holder = CreateImmutableSnapshotRegistryHolder();
+        holder->Set(std::make_unique<TLiveEmptySnapshotRegistry>());
+        appData.SnapshotRegistryHolder = holder;
+        appData.LongTxServiceConfig.SetLocalSnapshotPromotionTimeSeconds(1);
+        appData.LongTxServiceConfig.SetMaxClockSkewMs(12000);
+        // If a real LongTxService is present (e.g. TTestEnv), it may take over this holder once its remote
+        // storage is ready. Keep its exchange/rebuild cadence short so the registry it publishes keeps a
+        // fresh OldestCollectionTime; harmless in runtimes that have no LongTxService.
+        appData.LongTxServiceConfig.SetSnapshotsExchangeIntervalSeconds(1);
+        appData.LongTxServiceConfig.SetSnapshotsRegistryUpdateIntervalSeconds(1);
+    }
 }
 
 void RefreshTiering(TTestBasicRuntime& runtime, const TActorId& sender) {

--- a/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.h
+++ b/ydb/core/tx/columnshard/test_helper/columnshard_ut_common.h
@@ -45,6 +45,13 @@ public:
     static void Setup(TTestActorRuntime& runtime);
 };
 
+// Installs, on every node of the runtime, a stand-in snapshot registry whose OldestCollectionTime tracks
+// the live test clock together with LongTxService margins that reproduce the legacy ~13s cleanup window.
+// Use in test runtimes that exercise TRegistryScanSnapshotGuard-based cleanup but have no LongTxService to
+// keep the registry fresh; otherwise registry freshness collapses to TInstant::Zero() and the cleanup
+// floor never advances (nothing is ever collected).
+void InstallTimingBasedSnapshotRegistry(TTestActorRuntime& runtime);
+
 namespace NTypeIds = NScheme::NTypeIds;
 using TTypeId = NScheme::TTypeId;
 using TTypeInfo = NScheme::TTypeInfo;

--- a/ydb/core/tx/columnshard/ut_rw/ut_scan_snapshot_guard_integration.cpp
+++ b/ydb/core/tx/columnshard/ut_rw/ut_scan_snapshot_guard_integration.cpp
@@ -230,6 +230,8 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardIntegration) {
         const ui64 marginMs =
             TDuration::Seconds(longTxConfig.GetLocalSnapshotPromotionTimeSeconds()).MilliSeconds() + longTxConfig.GetMaxClockSkewMs();
 
+        ConfigureRegistry(context);
+
         const ui64 write1Step = WriteValueOnShard(context, /*key*/ 1, /*message*/ 1);
         const NOlap::TSnapshot activeSnapshot(write1Step, 2000);
         AssertScanHasSingleMessageValue(context, activeSnapshot, "1");
@@ -238,7 +240,7 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardIntegration) {
         context.Runtime.SimulateSleep(TDuration::Seconds(20));
         const ui64 passedStep = UpdateSnapshotOnShard(context);
 
-        // Freshly-updated registry: OldestCollectionTime = now, the old snapshot is still tracked as active.
+        // Publish the registry under test: OldestCollectionTime = now, old snapshot still tracked as active.
         const TInstant oldestCollectionTime = context.Runtime.GetCurrentTime();
         ConfigureRegistry(context, std::nullopt, { TRowVersion(activeSnapshot.GetPlanStep(), activeSnapshot.GetTxId()) }, oldestCollectionTime);
 

--- a/ydb/core/tx/columnshard/ut_rw/ut_scan_snapshot_guard_integration.cpp
+++ b/ydb/core/tx/columnshard/ut_rw/ut_scan_snapshot_guard_integration.cpp
@@ -102,11 +102,14 @@ void AssertScanHasSingleMessageValue(TScanContext& context, const NOlap::TSnapsh
     UNIT_ASSERT_VALUES_EQUAL(TString(messageColumn->GetString(0)), expectedMessage);
 }
 
-void ConfigureRegistry(
-    TScanContext& context, const std::optional<TRowVersion>& border = std::nullopt, const TVector<TRowVersion>& snapshots = {}) {
+void ConfigureRegistry(TScanContext& context, const std::optional<TRowVersion>& border = std::nullopt,
+    const TVector<TRowVersion>& snapshots = {}, const std::optional<TInstant>& oldestCollectionTime = std::nullopt) {
     auto registryBuilder = CreateImmutableSnapshotRegistryBuilder();
     if (border) {
         registryBuilder->SetSnapshotBorder(*border);
+    }
+    if (oldestCollectionTime) {
+        registryBuilder->SetOldestCollectionTime(*oldestCollectionTime);
     }
     for (const auto& snapshot : snapshots) {
         registryBuilder->AddSnapshot({}, snapshot);
@@ -184,21 +187,23 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardIntegration) {
 
         auto& longTxConfig = context.Runtime.GetAppData(0).LongTxServiceConfig;
         longTxConfig.SetLocalSnapshotPromotionTimeSeconds(1);
-        longTxConfig.SetSnapshotsExchangeIntervalSeconds(2);
-        longTxConfig.SetSnapshotsRegistryUpdateIntervalSeconds(3);
+        longTxConfig.SetMaxClockSkewMs(5000);
 
         const ui64 write1Step = WriteValueOnShard(context, /*key*/ 1, /*message*/ 1);
         const TRowVersion border(write1Step, 2000);
-        ConfigureRegistry(context, border);
+        ConfigureRegistry(context, border, {}, context.Runtime.GetCurrentTime());
 
         const NOlap::TSnapshot snapshotAtBorder(border.Step, border.TxId);
         AssertScanHasSingleMessageValue(context, snapshotAtBorder, "1");
 
-        // Delay > (1 + 2 + 3 + 10)s so service cutoff becomes newer than border.
-        // This makes border the effective min snapshot for new reads.
+        // Advance well past the freshness margin (promotion 1s + skew 5s) and write a newer version.
         context.Runtime.SimulateSleep(TDuration::Seconds(17));
         const ui64 write2Step = WriteValueOnShard(context, /*key*/ 1, /*message*/ 3);
         UNIT_ASSERT(write2Step > write1Step);
+        // Refresh the registry so its freshness (OldestCollectionTime) reflects "now"; the border is unchanged.
+        // The resulting freshness floor (now - margin) is newer than the border, so the border becomes the
+        // effective min snapshot for new reads.
+        ConfigureRegistry(context, border, {}, context.Runtime.GetCurrentTime());
         RunCleanupAndWait(context);
 
         const NOlap::TSnapshot snapshotYoungerThanBorder(write2Step, 3000);
@@ -221,23 +226,24 @@ Y_UNIT_TEST_SUITE(TScanSnapshotGuardIntegration) {
 
         auto& longTxConfig = context.Runtime.GetAppData(0).LongTxServiceConfig;
         longTxConfig.SetLocalSnapshotPromotionTimeSeconds(1);
-        longTxConfig.SetSnapshotsExchangeIntervalSeconds(2);
-        longTxConfig.SetSnapshotsRegistryUpdateIntervalSeconds(3);
-        const ui64 delayMs =
-            TDuration::Seconds(longTxConfig.GetLocalSnapshotPromotionTimeSeconds() + longTxConfig.GetSnapshotsExchangeIntervalSeconds() +
-                               longTxConfig.GetSnapshotsRegistryUpdateIntervalSeconds() + 10)
-                .MilliSeconds();
+        longTxConfig.SetMaxClockSkewMs(5000);
+        const ui64 marginMs =
+            TDuration::Seconds(longTxConfig.GetLocalSnapshotPromotionTimeSeconds()).MilliSeconds() + longTxConfig.GetMaxClockSkewMs();
 
         const ui64 write1Step = WriteValueOnShard(context, /*key*/ 1, /*message*/ 1);
         const NOlap::TSnapshot activeSnapshot(write1Step, 2000);
         AssertScanHasSingleMessageValue(context, activeSnapshot, "1");
-        ConfigureRegistry(context, std::nullopt, { TRowVersion(activeSnapshot.GetPlanStep(), activeSnapshot.GetTxId()) });
 
         Y_UNUSED(WriteValueOnShard(context, /*key*/ 1, /*message*/ 3));
         context.Runtime.SimulateSleep(TDuration::Seconds(20));
         const ui64 passedStep = UpdateSnapshotOnShard(context);
-        UNIT_ASSERT(passedStep > delayMs + 10);
-        const ui64 minStep = passedStep - delayMs;
+
+        // Freshly-updated registry: OldestCollectionTime = now, the old snapshot is still tracked as active.
+        const TInstant oldestCollectionTime = context.Runtime.GetCurrentTime();
+        ConfigureRegistry(context, std::nullopt, { TRowVersion(activeSnapshot.GetPlanStep(), activeSnapshot.GetTxId()) }, oldestCollectionTime);
+
+        // Freshness floor = OldestCollectionTime - margin, capped at passedStep.
+        const ui64 minStep = std::min(oldestCollectionTime.MilliSeconds() - marginMs, passedStep);
         UNIT_ASSERT(minStep > activeSnapshot.GetPlanStep() + 1);
         RunCleanupAndWait(context);
 

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -1775,6 +1775,7 @@ void TLongTxServiceActor::UpdateImmutableSnapshotsRegistry() {
 
     auto registryBuilder = CreateImmutableSnapshotRegistryBuilder();
     registryBuilder->SetSnapshotBorder(RemoteSnapshotsStorage->GetBorder());
+    registryBuilder->SetOldestCollectionTime(RemoteSnapshotsStorage->GetOldestCollectionTime());
 
     size_t localSnapshotsCount = 0;
     for (const auto& snapshotInfo : LocalSnapshotsStorage->View()) {

--- a/ydb/core/tx/long_tx_service/long_tx_service_ut.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_ut.cpp
@@ -906,6 +906,112 @@ Y_UNIT_TEST_SUITE(LongTxService) {
         }
     }
 
+    // Prefill must not let a node re-adopt its OWN snapshots that a peer still remembers. Both nodes take
+    // a snapshot and exchange, so node 0 ends up holding node 1's snapshot. Node 1 is then "restarted" (its
+    // local snapshot is gone) and prefills from node 0, whose response still echoes node 1's old snapshot
+    // back. Node 1 must drop it (RemoteSnapshotsStorage tracks other nodes only) and keep a real freshness.
+    // A broken filter would store node 1's own snapshot under its own node id with a Zero collection time,
+    // which both resurrects the snapshot and collapses OldestCollectionTime to Zero.
+    Y_UNIT_TEST(PrefillSkipsSelfSnapshots) {
+        const ui32 nodesCount = 2;
+        // Per-node tables: HasSnapshot keys off (table, version), so giving each node its own table lets us
+        // tell node 1's own snapshot apart from node 0's even when both land on the same coordinator step.
+        const ::NKikimr::TTableId table0(0, 1);
+        const ::NKikimr::TTableId table1(0, 2);
+
+        NKikimrConfig::TAppConfig appConfig;
+        appConfig.MutableFeatureFlags()->SetEnableSnapshotsLocking(true);
+        appConfig.MutableLongTxServiceConfig()->SetSnapshotsExchangeIntervalSeconds(1);
+        appConfig.MutableLongTxServiceConfig()->SetSnapshotsRegistryUpdateIntervalSeconds(1);
+        appConfig.MutableLongTxServiceConfig()->SetLocalSnapshotPromotionTimeSeconds(1);
+        appConfig.MutableLongTxServiceConfig()->SetMaxRemoteSnapshots(10);
+        // Keep node 0's copy of node 1's snapshot alive across node 1's brief restart.
+        appConfig.MutableLongTxServiceConfig()->SetUnavailableNodeSnapshotsExpirationTimeSeconds(1000);
+
+        TTenantTestRuntime runtime(MakeTenantTestConfig(false, nodesCount), appConfig);
+        runtime.SetLogPriority(NKikimrServices::LONG_TX_SERVICE, NLog::PRI_DEBUG);
+        StartSchemeCache(runtime);
+
+        bool blockPropagation = false;
+        bool prefillNotEmpty = false;
+        auto observer = [&](TAutoPtr<IEventHandle>& ev) -> auto {
+            switch (ev->GetTypeRewrite()) {
+                case TEvLongTxService::TEvCollectSnapshots::EventType:
+                case TEvLongTxService::TEvPropagateSnapshots::EventType:
+                    if (blockPropagation && ev->Sender.NodeId() != ev->Recipient.NodeId()) {
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+                case TEvLongTxService::TEvRemoteSnapshotsPrefillResult::EventType:
+                    if (ev->Get<TEvLongTxService::TEvRemoteSnapshotsPrefillResult>()->Record.GetSnapshots().SnapshotsSize() > 0) {
+                        prefillNotEmpty = true;
+                    }
+                    break;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        auto saveObserver = runtime.SetObserverFunc(observer);
+        Y_DEFER {
+            runtime.SetObserverFunc(saveObserver);
+        };
+
+        SimulateSleep(runtime, TDuration::Seconds(1));
+
+        // Acquire a snapshot on each node, each against its own table.
+        const auto acquire = [&](ui32 nodeIdx, const ::NKikimr::TTableId& tableId) {
+            const auto sender = runtime.AllocateEdgeActor(nodeIdx);
+            const auto service = MakeLongTxServiceID(runtime.GetNodeId(nodeIdx));
+            runtime.Send(
+                new IEventHandle(service, sender,
+                    new TEvLongTxService::TEvAcquireReadSnapshot("/dc-1", {tableId})),
+                nodeIdx, true);
+            auto ev = runtime.GrabEdgeEventRethrow<TEvLongTxService::TEvAcquireReadSnapshotResult>(sender);
+            auto* msg = ev->Get();
+            UNIT_ASSERT_VALUES_EQUAL(msg->Status, Ydb::StatusIds::SUCCESS);
+            return std::make_pair(std::move(msg->SnapshotHandle), msg->Snapshot);
+        };
+        auto [handle0, snapshot0] = acquire(0, table0);
+        auto [handle1, snapshot1] = acquire(1, table1);
+
+        // Let both nodes promote and exchange, so node 0's RemoteSnapshotsStorage learns node 1's snapshot.
+        SimulateSleep(runtime, TDuration::Seconds(5));
+        for (ui32 node = 0; node < nodesCount; ++node) {
+            const auto& registry = runtime.GetAppData(node).SnapshotRegistryHolder->Get();
+            UNIT_ASSERT(registry.get());
+            UNIT_ASSERT(registry->HasSnapshot(table0, snapshot0));
+            UNIT_ASSERT(registry->HasSnapshot(table1, snapshot1));
+        }
+
+        // From now on prefill is the only channel for node 1, so the self-filter we test is prefill's own.
+        blockPropagation = true;
+        prefillNotEmpty = false;
+
+        // Restart node 1's snapshot subsystem via the feature flag: disabling clears its storages and
+        // poisons its exchanger, re-enabling spawns a fresh one that (with propagation blocked) can only
+        // repopulate via prefill from node 0.
+        runtime.GetAppData(1).FeatureFlags.SetEnableSnapshotsLocking(false);
+        SimulateSleep(runtime, TDuration::Seconds(2));
+        UNIT_ASSERT(!runtime.GetAppData(1).SnapshotRegistryHolder->Get().get());
+        // Sanity: node 0 still remembers node 1's snapshot, so it will echo it back during prefill.
+        UNIT_ASSERT(runtime.GetAppData(0).SnapshotRegistryHolder->Get()->HasSnapshot(table1, snapshot1));
+
+        runtime.GetAppData(1).FeatureFlags.SetEnableSnapshotsLocking(true);
+        SimulateSleep(runtime, TDuration::Seconds(2));
+
+        {
+            const auto& registry = runtime.GetAppData(1).SnapshotRegistryHolder->Get();
+            UNIT_ASSERT(registry.get());
+            UNIT_ASSERT(prefillNotEmpty);
+            // node 0's snapshot is genuinely remote to node 1 => kept.
+            UNIT_ASSERT(registry->HasSnapshot(table0, snapshot0));
+            // node 1's own snapshot, echoed back by node 0's stale copy, must be filtered out: its local
+            // copy is gone after the restart and RemoteSnapshotsStorage only tracks other nodes.
+            UNIT_ASSERT(!registry->HasSnapshot(table1, snapshot1));
+            // And freshness stays a real instant; a broken self-filter would collapse it to Zero.
+            UNIT_ASSERT(registry->GetOldestCollectionTime() > TInstant::Zero());
+        }
+    }
+
 } // Y_UNIT_TEST_SUITE(LongTxService)
 
 Y_UNIT_TEST_SUITE(LockWaitGraph) {

--- a/ydb/core/tx/long_tx_service/long_tx_service_ut.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_ut.cpp
@@ -375,6 +375,15 @@ Y_UNIT_TEST_SUITE(LongTxService) {
 
         auto service1 = MakeLongTxServiceID(runtime.GetNodeId(0));
 
+        // Once the registry is materialized, OldestCollectionTime must be a real, recent instant:
+        // the local node counts as now, remote nodes contribute their propagated collection times.
+        const auto assertFreshOldestCollectionTime = [&](const auto& registry) {
+            const TInstant oldest = registry->GetOldestCollectionTime();
+            UNIT_ASSERT(oldest > TInstant::Zero());
+            UNIT_ASSERT(oldest <= runtime.GetCurrentTime());
+            return oldest;
+        };
+
         // Sleep a little, so there's at least one plan step generated
         SimulateSleep(runtime, TDuration::Seconds(1));
 
@@ -424,9 +433,11 @@ Y_UNIT_TEST_SUITE(LongTxService) {
         SimulateSleep(runtime, TDuration::Seconds(10));
 
         // snapshots have been promoted
+        TVector<TInstant> oldestAfterPromotion(nodesCount);
         for (size_t node = 0; node < nodesCount; ++node) {
             const auto& registry = runtime.GetAppData(node).SnapshotRegistryHolder->Get();
             UNIT_ASSERT(registry);
+            oldestAfterPromotion[node] = assertFreshOldestCollectionTime(registry);
             if (manySnapshots) {
                 const TRowVersion expectedBorder = *std::min_element(snapshots.begin(), snapshots.end());
                 UNIT_ASSERT_VALUES_EQUAL(registry->GetBorder(), expectedBorder);
@@ -462,6 +473,8 @@ Y_UNIT_TEST_SUITE(LongTxService) {
         for (size_t node = 0; node < nodesCount; ++node) {
             const auto& registry = runtime.GetAppData(node).SnapshotRegistryHolder->Get();
             UNIT_ASSERT(registry);
+            // Freshness keeps advancing as exchange rounds continue, even after snapshots are gone.
+            UNIT_ASSERT(assertFreshOldestCollectionTime(registry) > oldestAfterPromotion[node]);
             UNIT_ASSERT_VALUES_EQUAL(registry->GetBorder(), TRowVersion::Max());
             UNIT_ASSERT(registry->GetActiveSnapshots(table).empty());
             UNIT_ASSERT(registry->GetActiveSnapshots(tableWithSchema).empty());

--- a/ydb/core/tx/long_tx_service/public/snapshot_registry.cpp
+++ b/ydb/core/tx/long_tx_service/public/snapshot_registry.cpp
@@ -20,9 +20,10 @@ namespace {
 
         TImmutableSnapshotRegistry() = default;
         
-        explicit TImmutableSnapshotRegistry(TSnapshotMap&& snapshots, TRowVersion snapshotBorder)
+        explicit TImmutableSnapshotRegistry(TSnapshotMap&& snapshots, TRowVersion snapshotBorder, TInstant oldestCollectionTime)
             : Snapshots(std::move(snapshots))
             , SnapshotBorder(snapshotBorder)
+            , OldestCollectionTime(oldestCollectionTime)
         {}
 
         ~TImmutableSnapshotRegistry() override = default;
@@ -45,6 +46,10 @@ namespace {
 
         TRowVersion GetBorder() const override {
             return SnapshotBorder;
+        }
+
+        TInstant GetOldestCollectionTime() const override {
+            return OldestCollectionTime;
         }
         
     private:        
@@ -71,6 +76,7 @@ namespace {
 
         const TSnapshotMap Snapshots;
         const TRowVersion SnapshotBorder;
+        const TInstant OldestCollectionTime;
     };
 
     class TImmutableSnapshotRegistryHolder : public IImmutableSnapshotRegistryHolder {
@@ -100,6 +106,10 @@ namespace {
         void SetSnapshotBorder(const TRowVersion& version) override {
             SnapshotBorder = version;
         }
+
+        void SetOldestCollectionTime(TInstant oldestCollectionTime) override {
+            OldestCollectionTime = oldestCollectionTime;
+        }
         
         void AddSnapshot(const TVector<NKikimr::TTableId>& tableIds, const TRowVersion& version) override {
             if (version >= SnapshotBorder) {
@@ -119,11 +129,12 @@ namespace {
             for (auto& [tableId, versions] : Snapshots) {
                 std::sort(versions.begin(), versions.end());
             }
-            return std::make_unique<TImmutableSnapshotRegistry>(std::move(Snapshots), SnapshotBorder);
+            return std::make_unique<TImmutableSnapshotRegistry>(std::move(Snapshots), SnapshotBorder, OldestCollectionTime);
         }
 
     private:
         TRowVersion SnapshotBorder = TRowVersion::Max();
+        TInstant OldestCollectionTime;
         THashMap<NKikimr::TTableId, TVector<TRowVersion>> Snapshots;
     };
 }

--- a/ydb/core/tx/long_tx_service/public/snapshot_registry.h
+++ b/ydb/core/tx/long_tx_service/public/snapshot_registry.h
@@ -3,6 +3,7 @@
 #include <ydb/core/base/row_version.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 #include <util/system/types.h>
+#include <util/datetime/base.h>
 #include <util/generic/hash.h>
 #include <util/generic/set.h>
 #include <util/generic/vector.h>
@@ -18,6 +19,9 @@ public:
     virtual bool HasSnapshot(const NKikimr::TTableId& tableId, const TRowVersion& version) const = 0;
     virtual TSet<TRowVersion> GetActiveSnapshots(const NKikimr::TTableId& tableId) const = 0;
     virtual TRowVersion GetBorder() const = 0;
+
+    // Freshness bound for cleanup: oldest collection time across all nodes (local node = now).
+    virtual TInstant GetOldestCollectionTime() const = 0;
 };
 
 class IImmutableSnapshotRegistryHolder : public TThrRefBase {
@@ -38,6 +42,8 @@ public:
     virtual ~IImmutableSnapshotRegistryBuilder() = default;
 
     virtual void SetSnapshotBorder(const TRowVersion& version) = 0;
+
+    virtual void SetOldestCollectionTime(TInstant oldestCollectionTime) = 0;
 
     virtual void AddSnapshot(const TVector<NKikimr::TTableId>& tableIds, const TRowVersion& version) = 0;
 

--- a/ydb/core/tx/long_tx_service/snapshots_exchange.cpp
+++ b/ydb/core/tx/long_tx_service/snapshots_exchange.cpp
@@ -747,6 +747,18 @@ private:
         resultEvent->Record.MutableSnapshots()->SetBorderStep(snapshotBorder.Step);
         resultEvent->Record.MutableSnapshots()->SetBorderTxId(snapshotBorder.TxId);
 
+        // Convey per-node collection times so the receiver's registry freshness (OldestCollectionTime)
+        // is meaningful right after prefill, instead of treating all prefilled nodes as unknown (Zero).
+        for (const auto& [nodeId, collectionTime] : RemoteSnapshotsStorage->GetNodeIdToCollectionTime()) {
+            auto* nodeInfoProto = resultEvent->Record.MutableSnapshots()->AddNodesCollectionInfo();
+            nodeInfoProto->SetNodeId(nodeId);
+            nodeInfoProto->SetUpdateTime(collectionTime.Seconds());
+        }
+        // This node's own snapshots are known as of now.
+        auto* localNodeInfoProto = resultEvent->Record.MutableSnapshots()->AddNodesCollectionInfo();
+        localNodeInfoProto->SetNodeId(SelfId().NodeId());
+        localNodeInfoProto->SetUpdateTime(AppData()->TimeProvider->Now().Seconds());
+
         TXLOG_DEBUG("Sending TEvRemoteSnapshotsPrefillResult to " << ev->Sender
             << " with " << resultEvent->Record.GetSnapshots().GetSnapshots().size() << " snapshots");
         Send(ev->Sender, resultEvent.release());
@@ -814,6 +826,11 @@ private:
         for (const auto& snapshot : snapshots.GetSnapshots()) {
             NActors::TActorId sessionActorId = ActorIdFromProto(snapshot.GetSessionActorId());
             AFL_ENSURE(sessionActorId);
+            // RemoteSnapshotsStorage tracks other nodes only (own snapshots live in LocalSnapshotsStorage),
+            // so skip our own node here, consistently with collection times below and the propagation path.
+            if (sessionActorId.NodeId() == SelfId().NodeId()) {
+                continue;
+            }
             TVector<::NKikimr::TTableId> tableIds;
             tableIds.reserve(snapshot.GetTableIds().size());
             for (const auto& tableIdProto : snapshot.GetTableIds()) {
@@ -825,6 +842,13 @@ private:
                 std::move(tableIds)});
         }
 
+        THashMap<ui32, TInstant> nodeIdToCollectionTime;
+        for (const auto& nodeCollectionInfo : snapshots.GetNodesCollectionInfo()) {
+            if (nodeCollectionInfo.GetNodeId() != SelfId().NodeId()) {
+                nodeIdToCollectionTime[nodeCollectionInfo.GetNodeId()] = TInstant::Seconds(nodeCollectionInfo.GetUpdateTime());
+            }
+        }
+
         TRowVersion border(snapshots.GetBorderStep(), snapshots.GetBorderTxId());
         TXLOG_DEBUG("Applying prefill remote snapshots: " << remoteSnapshots.size()
             << ", border " << border.Step << ":" << border.TxId);
@@ -832,7 +856,7 @@ private:
         RemoteSnapshotsStorage->UpdateBorder(border);
         std::sort(std::begin(remoteSnapshots), std::end(remoteSnapshots),
             TRemoteSnapshotInfo::TComparatorBySnapshotAndSessionId{});
-        RemoteSnapshotsStorage->Init(remoteSnapshots);
+        RemoteSnapshotsStorage->Init(remoteSnapshots, nodeIdToCollectionTime);
         LastRemoteSnapshotsUpdate = AppData()->TimeProvider->Now();
 
         ProceedToPublish();

--- a/ydb/core/tx/long_tx_service/snapshots_storage.cpp
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.cpp
@@ -44,8 +44,13 @@ TLocalSnapshotsStorage::TView TLocalSnapshotsStorage::View() const {
         now - TDuration::Seconds(AppData()->LongTxServiceConfig.GetLocalSnapshotPromotionTimeSeconds())};
 }
 
-void TRemoteSnapshotsStorage::Init(const TVector<TRemoteSnapshotInfo>& snapshots) {
+void TRemoteSnapshotsStorage::Init(const TVector<TRemoteSnapshotInfo>& snapshots, const THashMap<ui32, TInstant>& nodeIdToCollectionTime) {
     AFL_ENSURE(NodeIdToState.empty());
+    // Seed collection times from the peer first, so freshness (GetOldestCollectionTime) is meaningful
+    // right after prefill instead of collapsing to Zero (which disables age-based cleanup).
+    for (const auto& [nodeId, collectionTime] : nodeIdToCollectionTime) {
+        NodeIdToState[nodeId].CollectionTime = collectionTime;
+    }
     for (const auto& snapshot : snapshots) {
         const auto nodeId = snapshot.SessionActorId.NodeId();
         NodeIdToState[nodeId].RemoteSnapshots.push_back(snapshot);
@@ -146,6 +151,15 @@ TInstant TRemoteSnapshotsStorage::GetOldestCollectionTime() const {
         oldest = std::min(oldest, state.CollectionTime);
     }
     return oldest;
+}
+
+THashMap<ui32, TInstant> TRemoteSnapshotsStorage::GetNodeIdToCollectionTime() const {
+    THashMap<ui32, TInstant> result;
+    result.reserve(NodeIdToState.size());
+    for (const auto& [nodeId, state] : NodeIdToState) {
+        result[nodeId] = state.CollectionTime;
+    }
+    return result;
 }
 
 bool TRemoteSnapshotsStorage::IsReady() const {

--- a/ydb/core/tx/long_tx_service/snapshots_storage.cpp
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.cpp
@@ -140,6 +140,14 @@ TRowVersion TRemoteSnapshotsStorage::GetBorder() const {
     return SnapshotBorder;
 }
 
+TInstant TRemoteSnapshotsStorage::GetOldestCollectionTime() const {
+    TInstant oldest = AppData()->TimeProvider->Now();
+    for (const auto& [nodeId, state] : NodeIdToState) {
+        oldest = std::min(oldest, state.CollectionTime);
+    }
+    return oldest;
+}
+
 bool TRemoteSnapshotsStorage::IsReady() const {
     return Ready;
 }

--- a/ydb/core/tx/long_tx_service/snapshots_storage.h
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.h
@@ -104,7 +104,7 @@ class TRemoteSnapshotsStorage : public TThrRefBase {
     };
 
 public:
-    void Init(const TVector<TRemoteSnapshotInfo>& snapshots);
+    void Init(const TVector<TRemoteSnapshotInfo>& snapshots, const THashMap<ui32, TInstant>& nodeIdToCollectionTime);
     void UpdateAndCleanExpired(const TVector<TRemoteSnapshotInfo>& snapshots, const THashMap<ui32, TInstant>& updatedNodeIdToCollectionTime);
     void UpdateBorder(const TRowVersion& border);
     void Clear();
@@ -134,6 +134,9 @@ public:
     // Oldest collection time across all contributing nodes, including the local node (counted
     // as now since its snapshots are collected right now). With no remote nodes this is now.
     TInstant GetOldestCollectionTime() const;
+
+    // Per-node collection times, used to seed a peer's registry freshness during prefill.
+    THashMap<ui32, TInstant> GetNodeIdToCollectionTime() const;
 
     bool IsReady() const;
 

--- a/ydb/core/tx/long_tx_service/snapshots_storage.h
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.h
@@ -131,6 +131,10 @@ public:
     TView View() const;
     TRowVersion GetBorder() const;
 
+    // Oldest collection time across all contributing nodes, including the local node (counted
+    // as now since its snapshots are collected right now). With no remote nodes this is now.
+    TInstant GetOldestCollectionTime() const;
+
     bool IsReady() const;
 
 private:

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -7,7 +7,6 @@
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
 #include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/protos/long_tx_service_config.pb.h>
-#include <ydb/core/tx/long_tx_service/public/snapshot_registry.h>
 
 using namespace NKikimr::NSchemeShard;
 using namespace NKikimr;
@@ -1043,15 +1042,9 @@ Y_UNIT_TEST_SUITE(TOlap) {
         appData.SchemeShardConfig.SetStatsMaxBatchSize(0);
         runtime.GetAppData().ColumnShardConfig.SetDefaultCompactionPreset("tiling");
 
-        {
-            auto builder = CreateImmutableSnapshotRegistryBuilder();
-            auto holder = CreateImmutableSnapshotRegistryHolder();
-            holder->Set(std::move(*builder).Build());
-            appData.SnapshotRegistryHolder = holder;
-            appData.LongTxServiceConfig.SetLocalSnapshotPromotionTimeSeconds(1);
-            appData.LongTxServiceConfig.SetSnapshotsExchangeIntervalSeconds(1);
-            appData.LongTxServiceConfig.SetSnapshotsRegistryUpdateIntervalSeconds(1);
-        }
+        // No LongTxService keeps a live registry here, so install a stand-in whose OldestCollectionTime
+        // tracks the clock; otherwise the cleanup floor stays at 0 and deleted data is never collected.
+        NKikimr::NTxUT::InstallTimingBasedSnapshotRegistry(runtime);
 
         // apply config via reboot
         TActorId sender = runtime.AllocateEdgeActor();


### PR DESCRIPTION
# What is done

- Added a freshness marker to ImmutableSnapshotRegistry.
- Changed the way columnshards calculate MinSnapshotForNewScans accordingly 

After this change, columnshards will adapt if SnapshotRegistry gets updated more rare than it supposed to be. So, MinSnapshotForNewScans will become larger. So, columnshards will not delete the data that must be visible to snapshots anymore.

We just use OldestCollectionTime (wall-clock) + max_clock_skew here.

I have got max_clock_skew as a value that is well above the real max_clock_skew on the biggest prod clusters.

# Why not to use the mediator time as the time instead of wall-clock

1. The current implementation of SnapshotRegistry does not explicitly support the serverless environment. It works in such an environment but databases there will see each others snapshots, and will have to keep the data that is visible to them. Ideally, databases should not see each other's snapshots of course.
2. To get the mediator time, we need to know what environment the current node is. For dedicated case, we just get the mediator at the start, for serverless, we ignore mediator time, or support more complex logic for accessing necessary mediators for each database on the given node. I have not found a "reasonable" way to find out what environment the current node is in at the moment.

Supporting the mediator time even only for the dedicated case would complicate the current pr and SnapshotRegistry too much. So I left it alone for now.

If we want to support the mediator time for the dedicated environment we need:
1. Add/find a first order way to understand if the node is in the serverless environment or not. Currently we can understand that by the second order observations (like checking schemeshard ids from the holding snapshots and comparing them to the node's tenant schemeshard id), but it does not feel right.
2. Support the mediator time is SnapshotRegistry for the dedicated case. If the mediator time is absent, client should use the current OldestCollectionTime

Ideally, we need to properly support the serverless case:
1. At least keep all the snapshots in different buckets by their schemeshard ids.
2. Optional: support the mediator time for the serveless case too.