### PR TITLE
Fix docs build workflow failing on add-label errors

### DIFF
--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -12,7 +12,6 @@ on:
         type: string
 
 jobs:
-  # Privileged job: needs a write token, so it must never check out or run PR code.
   add-label:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
@@ -23,9 +22,8 @@ jobs:
       - name: Add documentation label
         uses: actions/github-script@v8
         with:
-          # Retry transient API failures, including the 401 seen on #42934
-          # (401/403 are retry-exempt by default, hence the trimmed list).
           retries: 3
+          # 401/403 are retry-exempt by default, but the original failure was a transient 401
           retry-exempt-status-codes: 400,404,422
           script: |
             const labels = context.payload.pull_request.labels.map((label) => label.name);
@@ -42,8 +40,6 @@ jobs:
                 labels: ['documentation']
               });
             } catch (error) {
-              // Labeling is best-effort (fallback for the doc-review queue);
-              // it must not turn the docs workflow red.
               core.warning(`Failed to add "documentation" label: ${error.message}`);
             }
 

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -23,6 +23,10 @@ jobs:
       - name: Add documentation label
         uses: actions/github-script@v8
         with:
+          # Retry transient API failures, including the 401 seen on #42934
+          # (401/403 are retry-exempt by default, hence the trimmed list).
+          retries: 3
+          retry-exempt-status-codes: 400,404,422
           script: |
             const labels = context.payload.pull_request.labels.map((label) => label.name);
             if (labels.includes('documentation')) {

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -43,7 +43,6 @@ jobs:
               core.warning(`Failed to add "documentation" label: ${error.message}`);
             }
 
-  # Unprivileged job: builds untrusted PR code, so it must run with a read-only token.
   build-docs:
     if: |
       github.event_name == 'workflow_dispatch' || 
@@ -53,14 +52,11 @@ jobs:
       group: docs-build-${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', inputs.pull_number) || github.event.pull_request.head.sha }}
-          persist-credentials: false
           
       - name: Get commit SHA
         id: sha

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -12,24 +12,6 @@ on:
         type: string
 
 jobs:
-  add-label:
-    if: github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Add documentation label
-        uses: actions/github-script@v8
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['documentation']
-            })
-            
   build-docs:
     if: |
       github.event_name == 'workflow_dispatch' || 
@@ -39,6 +21,10 @@ jobs:
       group: docs-build-${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -78,3 +64,22 @@ jobs:
           name: inputs
           path: ./inputs/
           overwrite: true
+
+      - name: Add documentation label
+        if: github.event_name == 'pull_request_target'
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name);
+            if (labels.includes('documentation')) {
+              core.info('Label "documentation" is already present, skipping');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['documentation']
+            });

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       pull-requests: write
     steps:
       - name: Checkout

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -12,6 +12,38 @@ on:
         type: string
 
 jobs:
+  # Privileged job: needs a write token, so it must never check out or run PR code.
+  add-label:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Add documentation label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name);
+            if (labels.includes('documentation')) {
+              core.info('Label "documentation" is already present, skipping');
+              return;
+            }
+
+            try {
+              await github.rest.issues.addLabels({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['documentation']
+              });
+            } catch (error) {
+              // Labeling is best-effort (fallback for the doc-review queue);
+              // it must not turn the docs workflow red.
+              core.warning(`Failed to add "documentation" label: ${error.message}`);
+            }
+
+  # Unprivileged job: builds untrusted PR code, so it must run with a read-only token.
   build-docs:
     if: |
       github.event_name == 'workflow_dispatch' || 
@@ -23,31 +55,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
-      - name: Add documentation label
-        if: github.event_name == 'pull_request_target'
-        continue-on-error: true
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const labels = context.payload.pull_request.labels.map((label) => label.name);
-            if (labels.includes('documentation')) {
-              core.info('Label "documentation" is already present, skipping');
-              return;
-            }
-
-            await github.rest.issues.addLabels({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['documentation']
-            });
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', inputs.pull_number) || github.event.pull_request.head.sha }}
+          persist-credentials: false
           
       - name: Get commit SHA
         id: sha

--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -25,6 +25,25 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Add documentation label
+        if: github.event_name == 'pull_request_target'
+        continue-on-error: true
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((label) => label.name);
+            if (labels.includes('documentation')) {
+              core.info('Label "documentation" is already present, skipping');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['documentation']
+            });
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -63,22 +82,3 @@ jobs:
           name: inputs
           path: ./inputs/
           overwrite: true
-
-      - name: Add documentation label
-        if: github.event_name == 'pull_request_target'
-        continue-on-error: true
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const labels = context.payload.pull_request.labels.map((label) => label.name);
-            if (labels.includes('documentation')) {
-              core.info('Label "documentation" is already present, skipping');
-              return;
-            }
-
-            await github.rest.issues.addLabels({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['documentation']
-            });


### PR DESCRIPTION
## Зачем

На PR #42934 job `add-label` упал с `401 Requires authentication`, хотя сборка документации (`build-docs`) прошла успешно. Из-за этого:

- весь workflow **Build documentation** получил статус `failure`;
- бот оставил ложный комментарий «Revision build failed», хотя preview был собран;
- на PR завис красный check `add-label`, который manual rebuild через `workflow_dispatch` не лечит (job `add-label` там skipped).

Простановка лейбла `documentation` — некритичная операция (fallback для doc-review-очереди). Она не должна валить workflow сборки доков.

## Что меняем

Job `add-label` остаётся отдельным (write-токен не попадает в `build-docs`, который чекаутит код PR под `pull_request_target`), но становится best-effort:

- step пропускается, если лейбл `documentation` уже стоит на PR;
- транзиентные ошибки API ретраятся встроенным механизмом `github-script` (`retries: 3`); `401`/`403` убраны из retry-exempt списка, т.к. исходный сбой был именно `401`;
- если все попытки исчерпаны, `try/catch` логирует `core.warning` — job и workflow остаются зелёными.

`build-docs` не меняется.

## Test plan

- [ ] Обновить docs PR и убедиться, что оба check'а (`add-label`, `build-docs`) зелёные при успешной сборке.
- [ ] Убедиться, что лейбл `documentation` ставится, если его ещё нет, и step скипается, если уже стоит.
- [ ] Убедиться, что при ошибке API лейбла job остаётся зелёным с warning, а preview-комментарий отражает результат сборки.
