### PR TITLE
[ICRDMA] Add option to set RDMA payload copy threshold, and use regular memcpy instead of cache bypass NBYDB-1993

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -575,6 +575,9 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
     if (config.HasRdmaChecksum()) {
         result.RdmaChecksum = config.GetRdmaChecksum();
     }
+    if (config.HasRdmaPayloadCopySizeThreshold()) {
+        result.RdmaPayloadCopySizeThreshold = config.GetRdmaPayloadCopySizeThreshold();
+    }
 
     if (config.HasCollectSubscriptionStackTrace()) {
         result.CollectSubscriptionStackTrace = config.GetCollectSubscriptionStackTrace();

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -526,6 +526,7 @@ message TInterconnectConfig {
     optional uint32 RdmaMemPoolSizeLimitMb = 56 [default = 4096];
     optional bool UseKernelKeepAlive = 58 [default = false];
     optional bool CollectSubscriptionStackTrace = 59 [default = false];
+    optional uint32 RdmaPayloadCopySizeThreshold = 60 [default = 65536]; // 0 disables copying RDMA payload to regular memory
 
     // ballast is added to IC handshake frames to ensure correctness of jumbo frames transmission over network
     optional uint32 HandshakeBallastSize = 14;

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -77,6 +77,7 @@ namespace NActors {
         TDuration EventDelay = TDuration::Zero();
         ESocketSendOptimization SocketSendOptimization = ESocketSendOptimization::DISABLED;
         bool RdmaChecksum = true;
+        ui32 RdmaPayloadCopySizeThreshold = 64 << 10;
         bool CollectSubscriptionStackTrace = false;
     };
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -7,18 +7,6 @@
 
 #include <variant>
 
-#if defined(__x86_64__)
-#include <contrib/restricted/abseil-cpp-tstring/y_absl/crc/internal/non_temporal_memcpy.h>
-#endif
-
-Y_FORCE_INLINE void MemcpyNoCache(void* dst, const void* src, size_t len) {
-#if defined(__x86_64__)
-    y_absl::crc_internal::non_temporal_store_memcpy_avx(dst, src, len);
-#else
-    memcpy(dst, src, len);
-#endif
-}
-
 namespace NActors {
     LWTRACE_USING(ACTORLIB_PROVIDER);
 
@@ -79,20 +67,16 @@ namespace NActors {
         return 0;
     }
 
-    static bool NeedReallocateRdma(const NInterconnect::NRdma::TMemRegionSlice& region) {
-        // More complex logic here...
-
-        return !region.Empty();
+    static bool NeedReallocateRdma(const NInterconnect::NRdma::TMemRegionSlice& region, ui32 copySizeThreshold) {
+        return !region.Empty() && region.GetSize() < copySizeThreshold;
     }
 
-    static void ReallocPayload(TRope& rope) {
+    static void ReallocPayload(TRope& rope, ui32 copySizeThreshold) {
         for (TRope::TIterator it = rope.Begin(); it != rope.End(); ++it) {
             TRcBuf& chunk = it.GetChunk();
             const auto& region = NInterconnect::NRdma::TryExtractFromRcBuf(chunk);
-            if (NeedReallocateRdma(region)) {
-                auto newChunk = TRcBuf::Uninitialized(chunk.Size(), chunk.Headroom(), chunk.Tailroom());
-                MemcpyNoCache(newChunk.GetContiguousSpanMut().data(), chunk.GetContiguousSpan().data(), chunk.Size());
-                chunk = newChunk;
+            if (NeedReallocateRdma(region, copySizeThreshold)) {
+                chunk = TRcBuf::Copy(chunk.GetContiguousSpan(), chunk.Headroom(), chunk.Tailroom());
             }
         }
     }
@@ -989,7 +973,7 @@ namespace NActors {
             }
             pendingEvent.SerializationInfo.IsExtendedFormat = descr.Flags & IEventHandle::FlagExtendedFormat;
 
-            ReallocPayload(payload);
+            ReallocPayload(payload, Common->Settings.RdmaPayloadCopySizeThreshold);
 
             auto ev = std::make_unique<IEventHandle>(SessionId,
                 descr.Type,


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
[ICRDMA] Add option to set RDMA payload copy threshold
Also use regular memcpy instead of non-temporal copy. This effectively reverts b7093f2 because tests show non-temporal copy can cause performance problems in some cases.
### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
