### PR TITLE
EXT-2287 Add synclog wait for cut on restart

### DIFF
--- a/ydb/core/base/blobstorage.h
+++ b/ydb/core/base/blobstorage.h
@@ -793,6 +793,7 @@ struct TEvBlobStorage {
         EvStartupDataSyncDone,
         EvPhantomFlagExtractedFromChunk,
         EvSyncLogDiskOutOfSpace,
+        EvRecoveryLogCutDone,
 
         EvYardInitResult = EvPut + 9 * 512,                     /// 268 636 672
         EvLogResult,

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_huge.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_huge.cpp
@@ -228,7 +228,8 @@ class THugeModuleRecoveryActor : public TActorBootstrapped<THugeModuleRecoveryAc
                         HmCtx->PDiskCtx->Dsk->OwnerRound,
                         HmCtx->LsnMngr->GetLsn(),
                         HmCtx->Counters));
-        TLogCutterCtx logCutterCtx = {HmCtx->VCtx, HmCtx->PDiskCtx, HmCtx->LsnMngr, HmCtx->Config, HmCtx->LoggerID, false};
+        TLogCutterCtx logCutterCtx = {HmCtx->VCtx, HmCtx->PDiskCtx, HmCtx->LsnMngr, HmCtx->Config,
+            HmCtx->LoggerID, false, {}};
         HmCtx->LogCutterID = ctx.Register(CreateRecoveryLogCutter(std::move(logCutterCtx)));
         RepairedHuge->FinishRecovery(ctx);
         auto hugeKeeperCtx = std::make_shared<THugeKeeperCtx>(HmCtx->VCtx, HmCtx->PDiskCtx, HmCtx->LsnMngr,

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
@@ -199,7 +199,8 @@ class TSyncLogTestWriteActor : public TActorBootstrapped<TSyncLogTestWriteActor>
                     Db->VCtx->VDiskCounters));
 
         // RecoveryLogCutter
-        TLogCutterCtx logCutterCtx = {VCtx, TestCtx->PDiskCtx, TestCtx->LsnMngr, VDiskConfig, TestCtx->LoggerId, false};
+        TLogCutterCtx logCutterCtx = {VCtx, TestCtx->PDiskCtx, TestCtx->LsnMngr, VDiskConfig,
+            TestCtx->LoggerId, false, {}};
         LogCutterId = ctx.Register(CreateRecoveryLogCutter(std::move(logCutterCtx)));
 
         // Repaired SyncLog State

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.cpp
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.cpp
@@ -58,6 +58,9 @@ namespace NKikimr {
             CHECK_PDISK_RESPONSE(LogCutterCtx.VCtx, ev, ctx);
 
             WriteInProgress = false;
+            if (LogCutterCtx.NotifyId) {
+                ctx.Send(LogCutterCtx.NotifyId, new TEvRecoveryLogCutDone(FirstLsnToKeepLastWritten));
+            }
             Process(ctx);
         }
 

--- a/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.h
+++ b/ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.h
@@ -39,6 +39,14 @@ namespace NKikimr {
         }
     };
 
+    struct TEvRecoveryLogCutDone : public TEventLocal<TEvRecoveryLogCutDone, TEvBlobStorage::EvRecoveryLogCutDone> {
+        const ui64 FirstLsnToKeep;
+
+        explicit TEvRecoveryLogCutDone(ui64 firstLsnToKeep)
+            : FirstLsnToKeep(firstLsnToKeep)
+        {}
+    };
+
     class TVDiskContext;
     class TPDiskCtx;
     class TLsnMngr;
@@ -50,6 +58,7 @@ namespace NKikimr {
         TIntrusivePtr<TVDiskConfig> Config;
         TActorId LoggerId;
         bool WriteMetadata = false;
+        TActorId NotifyId;
     };
 
     IActor* CreateRecoveryLogCutter(TLogCutterCtx &&logCutterCtx);

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_defs.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_defs.cpp
@@ -240,6 +240,14 @@ namespace NKikimr {
         RecoveredLogStartLsn = lsn;
     }
 
+    void TLocalRecoveryInfo::SetRecoveredLocalSyncDataLsn(ui64 lsn) {
+        RecoveredLocalSyncDataLsn = Max(RecoveredLocalSyncDataLsn, lsn);
+    }
+
+    ui64 TLocalRecoveryInfo::GetRecoveredLocalSyncDataLsn() const {
+        return RecoveredLocalSyncDataLsn;
+    }
+
     void TLocalRecoveryInfo::CheckConsistency() {
         if (SuccessfulRecovery) {
             bool emptyLog = (RecoveryLogFirstLsn == Max<ui64>()) && RecoveryLogLastLsn == 0;

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_defs.h
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_defs.h
@@ -104,6 +104,8 @@ namespace NKikimr {
         TVector<NLocRecovery::TReadLogReply> ReadLogReplies;
         // lsn we starting with after local recovery and lsn shift
         ui64 RecoveredLogStartLsn = 0;
+        // last replayed SignatureLocalSyncData recovery-log record lsn, if any
+        ui64 RecoveredLocalSyncDataLsn = 0;
         // found starting points
         using TSignatureToLsn = TMap<TLogSignature, ui64>;
         TSignatureToLsn StartingPoints;
@@ -275,6 +277,8 @@ namespace NKikimr {
         void SetStartingPoint(TLogSignature signature, ui64 lsn);
         void HandleReadLogResult(const NPDisk::TEvReadLogResult::TResults &results);
         void SetRecoveredLogStartLsn(ui64 lsn);
+        void SetRecoveredLocalSyncDataLsn(ui64 lsn);
+        ui64 GetRecoveredLocalSyncDataLsn() const;
         void CheckConsistency();
         // finish dispatching
         void FinishDispatching();

--- a/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_logreplay.cpp
+++ b/ydb/core/blobstorage/vdisk/localrecovery/localrecovery_logreplay.cpp
@@ -556,6 +556,7 @@ namespace NKikimr {
                 LocRecCtx->SyncerData->PutFromRecoveryLog(LocalSyncDataMsg.VDiskID, LocalSyncDataMsg.SyncState);
             }
 
+            LocRecCtx->RecovInfo->SetRecoveredLocalSyncDataLsn(record.Lsn);
             return EDispatchStatus::Success;
         }
 

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -1970,6 +1970,19 @@ namespace NKikimr {
             LOG_INFO_S(ctx, BS_SKELETON, VCtx->VDiskLogPrefix << "SKELETON LOCAL RECOVERY SUCCEEDED"
                     << " Marker# BSVS29");
 
+            const bool waitForLocalSyncDataCut =
+                AppData(ctx)->FeatureFlags.GetEnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay();
+            const ui64 recoveredLocalSyncDataLsn = LocalRecovInfo->GetRecoveredLocalSyncDataLsn();
+            StartupDataSyncBlockedUntilCutLsn =
+                waitForLocalSyncDataCut && recoveredLocalSyncDataLsn ? recoveredLocalSyncDataLsn + 1 : 0;
+            if (StartupDataSyncBlockedUntilCutLsn) {
+                LOG_DEBUG_S(ctx, BS_SKELETON, VCtx->VDiskLogPrefix
+                    << "Startup data sync will wait until replayed LocalSyncData is cut"
+                    << " recoveredLocalSyncDataLsn# " << recoveredLocalSyncDataLsn
+                    << " blockedUntilCutLsn# " << StartupDataSyncBlockedUntilCutLsn
+                    << " Marker# BSVS38");
+            }
+
             bool writeMetadata = (ev->Get()->HasMetadata || AppData(ctx)->FeatureFlags.GetEnableTinyDisks());
 
             // run logger forwarder
@@ -1986,7 +1999,7 @@ namespace NKikimr {
 
             // run LogCutter in the same mailbox
             TLogCutterCtx logCutterCtx = {VCtx, PDiskCtx, Db->LsnMngr, Config,
-                    (TActorId)(Db->LoggerID), writeMetadata};
+                    (TActorId)(Db->LoggerID), writeMetadata, ctx.SelfID};
             Db->LogCutterID.Set(ctx.RegisterWithSameMailbox(CreateRecoveryLogCutter(std::move(logCutterCtx))));
             ActiveActors.Insert(Db->LogCutterID, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE); // keep forever
 
@@ -2130,7 +2143,8 @@ namespace NKikimr {
                     Hull->GetHullDs()->LogoBlobs,
                     Hull->GetHullDs()->Blocks,
                     Hull->GetHullDs()->Barriers,
-                    Config);
+                    Config,
+                    StartupDataSyncBlockedUntilCutLsn);
                 // syncer performes sync recovery
                 Db->SyncerID.Set(ctx.Register(CreateSyncerActor(sc, GInfo, ev->Get()->SyncerData)));
                 ActiveActors.Insert(Db->SyncerID, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE); // keep forever
@@ -2410,6 +2424,12 @@ namespace NKikimr {
                         << " DELAYED actorid# " << ctx.SelfID.ToString()
                         << " Marker# BSVS34");
                 CutLogDelayedMsg = std::move(msg);
+            }
+        }
+
+        void Handle(TEvRecoveryLogCutDone::TPtr &ev, const TActorContext &ctx) {
+            if (Db->SyncerID) {
+                ctx.Send(ev->Forward(Db->SyncerID));
             }
         }
 
@@ -2953,6 +2973,7 @@ namespace NKikimr {
             CFunc(TEvBlobStorage::EvTimeToUpdateStats, UpdateWhiteboard)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NPDisk::TEvConfigureSchedulerResult, Handle)
             HFunc(TEvVGenerationChange, Handle)
             HFunc(NPDisk::TEvYardResizeResult, Handle)
@@ -3026,6 +3047,7 @@ namespace NKikimr {
             CFunc(TEvBlobStorage::EvTimeToUpdateStats, UpdateWhiteboard)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NPDisk::TEvConfigureSchedulerResult, Handle)
             HFunc(TEvVGenerationChange, Handle)
             HFunc(NPDisk::TEvYardResizeResult, Handle)
@@ -3157,6 +3179,7 @@ namespace NKikimr {
         TActiveActors ActiveActors;
         // fields for handling NPDisk::TEvCutLog
         std::unique_ptr<NPDisk::TEvCutLog> CutLogDelayedMsg;
+        ui64 StartupDataSyncBlockedUntilCutLsn = 0;
         bool LocalDbInitialized = false;
         std::shared_ptr<TRopeArena> Arena;
         NMonGroup::TVDiskStateGroup VDiskMonGroup;

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -2919,6 +2919,7 @@ namespace NKikimr {
             HFunc(TEvVDiskStatRequest, Handle)
             CFunc(TEvBlobStorage::EvTimeToUpdateStats, UpdateWhiteboard)
             HFunc(NPDisk::TEvCutLog, Handle)
+            IgnoreFunc(TEvRecoveryLogCutDone)
             HFunc(TEvVGenerationChange, Handle)
             HFunc(NPDisk::TEvYardResizeResult, Handle)
             HFunc(TEvents::TEvPoisonPill, HandlePoison)

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
@@ -462,6 +462,13 @@ namespace NKikimr {
 
             const ui64 firstLsnToKeep = ev->Get()->FirstLsnToKeep;
             if (firstLsnToKeep < StartupDataSyncBlockedUntilCutLsn) {
+                StartupDataSyncCutRequested = false;
+                LOG_DEBUG(ctx, BS_SYNCER,
+                    VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
+                        "Startup data sync recovery log cut dependency is not satisfied yet"
+                        " firstLsnToKeep# %" PRIu64 " blockedUntilCutLsn# %" PRIu64 " Marker# BSS48",
+                        firstLsnToKeep, StartupDataSyncBlockedUntilCutLsn));
+                AskForRecoveryLogCut(ctx);
                 return;
             }
 

--- a/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
+++ b/ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer.cpp
@@ -181,6 +181,8 @@ namespace NKikimr {
         std::unique_ptr<NSyncer::TOutcome> GuidRecovOutcome;
         TDelayedQueue DelayedQueue;
         TSublog<> Sublog;
+        ui64 StartupDataSyncBlockedUntilCutLsn = 0;
+        bool StartupDataSyncCutRequested = false;
 
         friend class TActorBootstrapped<TSyncer>;
 
@@ -224,6 +226,37 @@ namespace NKikimr {
                     "%s: Creating syncer scheduler on node %d", __PRETTY_FUNCTION__, SelfId().NodeId()));
             SchedulerId = ctx.Register(CreateSyncerSchedulerActor(SyncerCtx, GInfo, SyncerData, CommitterId, SelfId()));
             ActiveActors.Insert(SchedulerId, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
+        }
+
+        void AskForRecoveryLogCut(const TActorContext& ctx) {
+            if (!StartupDataSyncBlockedUntilCutLsn || StartupDataSyncCutRequested) {
+                return;
+            }
+
+            ctx.Send(SyncerCtx->PDiskCtx->PDiskId, new NPDisk::TEvAskForCutLog(
+                SyncerCtx->PDiskCtx->Dsk->Owner,
+                SyncerCtx->PDiskCtx->Dsk->OwnerRound));
+            StartupDataSyncCutRequested = true;
+
+            LOG_DEBUG(ctx, BS_SYNCER,
+                VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
+                    "Startup data sync is waiting for recovery log cut"
+                    " blockedUntilCutLsn# %" PRIu64 " Marker# BSS46",
+                    StartupDataSyncBlockedUntilCutLsn));
+        }
+
+        void TryStartStartupDataSync(const TActorContext& ctx) {
+            if (SchedulerId || StartupDataSyncTokenRequested || SyncerCtx->Config->BaseInfo.ReadOnly) {
+                return;
+            }
+
+            if (StartupDataSyncBlockedUntilCutLsn) {
+                AskForRecoveryLogCut(ctx);
+                return;
+            }
+
+            Become(&TThis::AwaitStartupDataSyncTokenStateFunc);
+            QueryStartupDataSyncToken(ctx);
         }
 
         ////////////////////////////////////////////////////////////////////////
@@ -273,7 +306,7 @@ namespace NKikimr {
                     break;
                 case EDecision::LostData:
                     LOG_DEBUG(ctx, NKikimrServices::BS_VDISK_CHUNKS, VDISKP(SyncerCtx->VCtx->VDiskLogPrefix, "GUID: PDiskId# %s LostData", SyncerCtx->PDiskCtx->PDiskIdString.data()));
-                    RecoverLostData(ctx);
+                    StartRecoverLostData(ctx);
                     break;
                 case EDecision::Inconsistency:
                     LOG_DEBUG(ctx, NKikimrServices::BS_VDISK_CHUNKS, VDISKP(SyncerCtx->VCtx->VDiskLogPrefix, "GUID: PDiskId# %s Inconsistency", SyncerCtx->PDiskCtx->PDiskIdString.data()));
@@ -288,6 +321,7 @@ namespace NKikimr {
             HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
             HFunc(TEvSyncerCommitDone, Handle)
             HFunc(TEvVDiskGuidRecovered, Handle)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NMon::TEvHttpInfo, Handle)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
@@ -310,6 +344,7 @@ namespace NKikimr {
         STRICT_STFUNC(InconsistentancyStateFunc,
             HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
             HFunc(TEvSyncerCommitDone, Handle)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NMon::TEvHttpInfo, Handle)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
@@ -322,7 +357,7 @@ namespace NKikimr {
         ////////////////////////////////////////////////////////////////////////
         // Recover Lost Data
         ////////////////////////////////////////////////////////////////////////
-        void RecoverLostData(const TActorContext &ctx) {
+        void StartRecoverLostData(const TActorContext &ctx) {
             if (SyncerCtx->Config->BaseInfo.ReadOnly) {
                 LOG_WARN(ctx, BS_SYNCER,
                     VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
@@ -333,6 +368,11 @@ namespace NKikimr {
 
             Become(&TThis::RecoverLostDataStateFunc);
             Phase = TPhaseVal::PhaseRecoverLostData;
+
+            if (StartupDataSyncBlockedUntilCutLsn) {
+                AskForRecoveryLogCut(ctx);
+                return;
+            }
 
             if (SyncerCtx->Config->EnableVDiskCooldownTimeout) {
                 Schedule(SyncerCtx->Config->BaseInfo.YardInitDelay, new TEvents::TEvWakeup);
@@ -358,6 +398,7 @@ namespace NKikimr {
             HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
             HFunc(TEvSyncerCommitDone, Handle)
             HFunc(TEvSyncerLostDataRecovered, Handle)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NMon::TEvHttpInfo, Handle)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
@@ -383,8 +424,8 @@ namespace NKikimr {
             SyncerData->Neighbors->DbBirthLsn = LocalSyncerState.DbBirthLsn;
             Phase = TPhaseVal::PhaseStandardMode;
             if (!SyncerCtx->Config->BaseInfo.ReadOnly) {
-                Become(&TThis::AwaitStartupDataSyncTokenStateFunc);
-                QueryStartupDataSyncToken(ctx);
+                Become(&TThis::StandardModeStateFunc);
+                TryStartStartupDataSync(ctx);
             } else {
                 Become(&TThis::StandardModeStateFunc);
                 LOG_WARN(ctx, BS_SYNCER,
@@ -414,11 +455,41 @@ namespace NKikimr {
             ReleaseStartupDataSyncToken(ctx);
         }
 
+        void Handle(TEvRecoveryLogCutDone::TPtr &ev, const TActorContext &ctx) {
+            if (!StartupDataSyncBlockedUntilCutLsn) {
+                return;
+            }
+
+            const ui64 firstLsnToKeep = ev->Get()->FirstLsnToKeep;
+            if (firstLsnToKeep < StartupDataSyncBlockedUntilCutLsn) {
+                return;
+            }
+
+            LOG_DEBUG(ctx, BS_SYNCER,
+                VDISKP(SyncerCtx->VCtx->VDiskLogPrefix,
+                    "Startup data sync recovery log cut dependency satisfied"
+                    " firstLsnToKeep# %" PRIu64 " blockedUntilCutLsn# %" PRIu64 " Marker# BSS47",
+                    firstLsnToKeep, StartupDataSyncBlockedUntilCutLsn));
+
+            StartupDataSyncBlockedUntilCutLsn = 0;
+            StartupDataSyncCutRequested = false;
+
+            if (Phase == TPhaseVal::PhaseRecoverLostData && !RecoverLostDataId) {
+                StartRecoverLostData(ctx);
+                return;
+            }
+
+            if (Phase == TPhaseVal::PhaseStandardMode) {
+                TryStartStartupDataSync(ctx);
+            }
+        }
+
         STRICT_STFUNC(AwaitStartupDataSyncTokenStateFunc,
             HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
             HFunc(TEvSyncerCommitDone, Handle)
             HFunc(TEvVDiskOperationToken, Handle)
             HFunc(TEvents::TEvUndelivered, HandleStartupDataSyncBrokerUndelivered)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NMon::TEvHttpInfo, Handle)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
@@ -432,6 +503,7 @@ namespace NKikimr {
             HFunc(TEvBlobStorage::TEvVSyncGuid, Handle)
             HFunc(TEvSyncerCommitDone, Handle)
             HFunc(TEvStartupDataSyncDone, Handle)
+            HFunc(TEvRecoveryLogCutDone, Handle)
             HFunc(NMon::TEvHttpInfo, Handle)
             HFunc(TEvLocalStatus, Handle)
             HFunc(NPDisk::TEvCutLog, Handle)
@@ -653,7 +725,9 @@ namespace NKikimr {
             GInfo = msg->NewInfo;
 
             // reconfigure guid recovery actor
-            ctx.Send(RecoverLostDataId, msg->Clone());
+            if (RecoverLostDataId) {
+                ctx.Send(RecoverLostDataId, msg->Clone());
+            }
         }
 
     public:
@@ -669,6 +743,7 @@ namespace NKikimr {
             , GInfo(info)
             , SyncerData(syncerData)
             , LocalSyncerState(SyncerData->LocalSyncerState)
+            , StartupDataSyncBlockedUntilCutLsn(SyncerCtx->StartupDataSyncBlockedUntilCutLsn)
         {
             Y_VERIFY_S(SyncerCtx->VCtx->Top->EqualityCheck(info->GetTopology()),
                 SyncerCtx->VCtx->VDiskLogPrefix);

--- a/ydb/core/blobstorage/vdisk/syncer/syncer_context.h
+++ b/ydb/core/blobstorage/vdisk/syncer/syncer_context.h
@@ -26,6 +26,7 @@ namespace NKikimr {
         const TIntrusivePtr<TLevelIndex<TKeyBlock, TMemRecBlock>> LevelIndexBlock;
         const TIntrusivePtr<TLevelIndex<TKeyBarrier, TMemRecBarrier>> LevelIndexBarrier;
         const TIntrusivePtr<TVDiskConfig> Config;
+        const ui64 StartupDataSyncBlockedUntilCutLsn;
         NMonGroup::TSyncerGroup MonGroup;
 
         TSyncerContext(TIntrusivePtr<TVDiskContext> vctx,
@@ -39,7 +40,8 @@ namespace NKikimr {
                 TIntrusivePtr<TLevelIndex<TKeyLogoBlob, TMemRecLogoBlob>> levelIndexLogoBlob,
                 TIntrusivePtr<TLevelIndex<TKeyBlock, TMemRecBlock>> levelIndexBlock,
                 TIntrusivePtr<TLevelIndex<TKeyBarrier, TMemRecBarrier>> levelIndexBarrier,
-                TIntrusivePtr<TVDiskConfig> config)
+                TIntrusivePtr<TVDiskConfig> config,
+                ui64 startupDataSyncBlockedUntilCutLsn = 0)
             : VCtx(std::move(vctx))
             , LsnMngr(std::move(lsnMngr))
             , PDiskCtx(std::move(pdiskCtx))
@@ -52,6 +54,7 @@ namespace NKikimr {
             , LevelIndexBlock(levelIndexBlock)
             , LevelIndexBarrier(levelIndexBarrier)
             , Config(std::move(config))
+            , StartupDataSyncBlockedUntilCutLsn(startupDataSyncBlockedUntilCutLsn)
             , MonGroup(VCtx->VDiskCounters, "subsystem", "syncer")
         {
             Y_ABORT_UNLESS(VCtx && LsnMngr && PDiskCtx);

--- a/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
@@ -1,5 +1,6 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/blobstorage/base/utility.h>
+#include <ydb/core/blobstorage/base/vdisk_priorities.h>
 #include <ydb/core/blobstorage/backpressure/queue_backpressure_client.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo.h>
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
@@ -9,7 +10,9 @@
 #include <ydb/core/blobstorage/vdisk/common/vdisk_config.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_events.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
+#include <ydb/core/blobstorage/vdisk/syncer/blobstorage_syncer_localwriter.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogdata.h>
+#include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogmsgwriter.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_private_events.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_public_events.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_committer.h>
@@ -45,6 +48,10 @@ struct TRealPDiskTestConfig {
     ui32 MaxLogoBlobDataSize = 0;
     ui32 MinHugeBlobInBytes = 0;
     ui32 MilestoneHugeBlobInBytes = 0;
+    ui64 MaxCommonLogChunks = 0;
+    ui32 GroupId = 0;
+    bool EnableSmallDiskOptimization = true;
+    bool RunSyncer = false;
     TDuration AdvanceEntryPointTimeout = TDuration::Seconds(5);
     TDuration RecoveryLogCutterFirstDuration = TDuration::Seconds(3);
     TDuration RecoveryLogCutterRegularDuration = TDuration::Seconds(5);
@@ -102,6 +109,23 @@ TString MakeData(ui32 size) {
     return data;
 }
 
+TString MakeLocalSyncDataBlockPayload(ui32 minPayloadBytes) {
+    NSyncLog::TNaiveFragmentWriter writer;
+    ui64 lsn = 1;
+    while (writer.GetSize() < minPayloadBytes) {
+        char buf[NSyncLog::MaxRecFullSize];
+        const ui32 generation = 1 + static_cast<ui32>(lsn % 10'000);
+        const ui32 size = NSyncLog::TSerializeRoutines::SetBlock(buf, lsn,
+            1'000'000 + lsn, generation, 0);
+        writer.Push(reinterpret_cast<const NSyncLog::TRecordHdr*>(buf), size);
+        ++lsn;
+    }
+
+    TString result;
+    writer.Finish(&result);
+    return result;
+}
+
 TIntrusivePtr<TBlobStorageGroupInfo> MakeGroupInfo(ui32 nodeId, ui32 groupId, TBlobStorageGroupType::EErasureSpecies erasure) {
     const TBlobStorageGroupType groupType(erasure);
     const ui32 numVDisks = groupType.BlobSubgroupSize();
@@ -131,7 +155,7 @@ TIntrusivePtr<TVDiskConfig> MakeTestVDiskConfig(const TIntrusivePtr<TAllVDiskKin
     vdiskConfig->RecoveryLogCutterFirstDuration = testConfig.RecoveryLogCutterFirstDuration;
     vdiskConfig->RecoveryLogCutterRegularDuration = testConfig.RecoveryLogCutterRegularDuration;
     vdiskConfig->RunRepl = false;
-    vdiskConfig->RunSyncer = false;
+    vdiskConfig->RunSyncer = testConfig.RunSyncer;
     vdiskConfig->UseCostTracker = false;
     return vdiskConfig;
 }
@@ -150,10 +174,13 @@ class TTestRuntimeCallbackGuard {
 public:
     TTestRuntimeCallbackGuard(TTestActorRuntimeBase& runtime,
             TTestActorRuntimeBase::TEventObserver previousObserver,
-            TTestActorRuntimeBase::TEventFilter previousEventFilter)
+            TTestActorRuntimeBase::TEventFilter previousEventFilter,
+            TTestActorRuntimeBase::TRegistrationObserver previousRegistrationObserver =
+                &TTestActorRuntimeBase::DefaultRegistrationObserver)
         : Runtime(runtime)
         , PreviousObserver(std::move(previousObserver))
         , PreviousEventFilter(std::move(previousEventFilter))
+        , PreviousRegistrationObserver(std::move(previousRegistrationObserver))
     {}
 
     TTestRuntimeCallbackGuard(const TTestRuntimeCallbackGuard&) = delete;
@@ -162,12 +189,14 @@ public:
     ~TTestRuntimeCallbackGuard() {
         Runtime.SetEventFilter(std::move(PreviousEventFilter));
         Runtime.SetObserverFunc(std::move(PreviousObserver));
+        Runtime.SetRegistrationObserverFunc(std::move(PreviousRegistrationObserver));
     }
 
 private:
     TTestActorRuntimeBase& Runtime;
     TTestActorRuntimeBase::TEventObserver PreviousObserver;
     TTestActorRuntimeBase::TEventFilter PreviousEventFilter;
+    TTestActorRuntimeBase::TRegistrationObserver PreviousRegistrationObserver;
 };
 
 TRealStorage SetupRealPDiskAndRealVDisk(TTestActorRuntime& runtime,
@@ -176,7 +205,7 @@ TRealStorage SetupRealPDiskAndRealVDisk(TTestActorRuntime& runtime,
     runtime.Initialize(MakeRuntimeEgg());
 
     const ui32 nodeId = runtime.GetNodeId(NodeIndex);
-    const ui32 groupId = 0;
+    const ui32 groupId = testConfig.GroupId;
     const TBlobStorageGroupType groupType(erasure);
     const ui32 numVDisks = groupType.BlobSubgroupSize();
     const TString pdiskPath = TStringBuilder() << runtime.GetTempDir() << testConfig.PDiskPathSuffix;
@@ -186,7 +215,7 @@ TRealStorage SetupRealPDiskAndRealVDisk(TTestActorRuntime& runtime,
     const auto sectorMap = MakeIntrusive<NPDisk::TSectorMap>(testConfig.DiskSize);
     TFormatOptions formatOptions;
     formatOptions.SectorMap = sectorMap;
-    formatOptions.EnableSmallDiskOptimization = false;
+    formatOptions.EnableSmallDiskOptimization = testConfig.EnableSmallDiskOptimization;
     formatOptions.EnableSectorEncryption = false;
     FormatPDisk(pdiskPath, testConfig.DiskSize, testConfig.SectorSize, testConfig.ChunkSize, PDiskGuid, MainKeyValue, MainKeyValue, MainKeyValue,
         MainKeyValue,
@@ -197,8 +226,12 @@ TRealStorage SetupRealPDiskAndRealVDisk(TTestActorRuntime& runtime,
     pdiskConfig->SectorSize = testConfig.SectorSize;
     pdiskConfig->SectorMap = sectorMap;
     pdiskConfig->FeatureFlags.SetEnablePDiskDataEncryption(false);
+    pdiskConfig->FeatureFlags.SetEnableSmallDiskOptimization(testConfig.EnableSmallDiskOptimization);
     pdiskConfig->GetDriveDataSwitch = NKikimrBlobStorage::TPDiskConfig::DoNotTouch;
     pdiskConfig->WriteCacheSwitch = NKikimrBlobStorage::TPDiskConfig::DoNotTouch;
+    if (testConfig.MaxCommonLogChunks) {
+        pdiskConfig->MaxCommonLogChunks = testConfig.MaxCommonLogChunks;
+    }
 
     const NPDisk::TMainKey mainKey{ .Keys = { MainKeyValue }, .IsInitialized = true };
     const TActorId pdiskActorId = runtime.Register(CreatePDisk(pdiskConfig, mainKey, counters), NodeIndex, 0,
@@ -685,6 +718,290 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             << " deletes# " << FormatList(syncLogDeleteDetails)
             << " lastPDiskError# " << lastPDiskErrorReason);
 
+    }
+
+    Y_UNIT_TEST(LocalSyncDataUnsuccessfulFullRecoveryDoesNotExhaustLogChunks) {
+        /*
+         * Reproduces the VSyncFull retry window:
+         *
+         * 1. VDisk writes data received from full sync as SignatureLocalSyncData.
+         * 2. The node dies after PDisk has committed this record, but before VDisk observes the
+         *    log result and before the final SyncerState/cut becomes durable.
+         * 3. On restart the sync state is still old, but local recovery has already replayed the
+         *    durable local sync data; startup data sync must not start fetching more remote data
+         *    until recovery log cut durably passes the replayed record.
+         *
+         * The first TEvLocalSyncData is injected directly into Skeleton; this exercises the same
+         * recovery-log writer, PDisk common log, and local-recovery replay path without building
+         * a multi-vdisk sync topology. If the feature flag below is disabled by hand, the same
+         * loop keeps repeating this interrupted write and must fail on common-log OUT_OF_SPACE.
+         */
+        const ui32 targetPayloadBytes = 3_MB;
+        const TString localSyncData = MakeLocalSyncDataBlockPayload(targetPayloadBytes);
+        UNIT_ASSERT_C(localSyncData.size() >= targetPayloadBytes,
+            "LocalSyncData payload is too small; expected at least# " << targetPayloadBytes
+            << " actual# " << localSyncData.size());
+
+        TTestActorRuntime runtime(1, false);
+        TRealPDiskTestConfig testConfig;
+        testConfig.ChunkSize = 64_KB;
+        testConfig.DiskSize = 128_MB;
+        testConfig.MaxCommonLogChunks = 5;
+        testConfig.EnableSmallDiskOptimization = false;
+        testConfig.RunSyncer = true;
+        testConfig.GroupId = TGroupID(EGroupConfigurationType::Dynamic, DomainId, 2).GetRaw();
+        testConfig.AdvanceEntryPointTimeout = TDuration::Hours(1);
+        testConfig.RecoveryLogCutterFirstDuration = TDuration::Hours(1);
+        testConfig.RecoveryLogCutterRegularDuration = TDuration::Hours(1);
+        testConfig.PDiskPathSuffix = "local_sync_data_cut_wait.dat";
+
+        TActorId currentVDiskFront;
+        TActorId skeletonId;
+        TVector<std::pair<TActorId, TActorId>> registrations;
+        auto previousRegistrationObserver = runtime.SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase&, const TActorId& parentId, const TActorId& actorId) {
+                registrations.emplace_back(parentId, actorId);
+                if (parentId == currentVDiskFront && !skeletonId) {
+                    skeletonId = actorId;
+                }
+            });
+
+        auto storage = SetupRealPDiskAndRealVDisk(runtime, TBlobStorageGroupType::ErasureNone, testConfig);
+        runtime.GetAppData(NodeIndex).FeatureFlags
+            .SetEnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay(true);
+        const TVDiskID vdiskId = storage.Info->GetVDiskId(0);
+        const TActorId vdiskActorId = storage.Info->GetActorId(0);
+        const TActorId edge = storage.Edge;
+        currentVDiskFront = storage.VDiskActors[0];
+        for (const auto& [parentId, actorId] : registrations) {
+            if (parentId == currentVDiskFront) {
+                skeletonId = actorId;
+                break;
+            }
+        }
+
+        bool restartRequested = false;
+        bool dropNextLocalSyncDataLogResult = false;
+        bool observeAfterRestart = false;
+        bool localSyncDataOutOfSpace = false;
+        bool otherOutOfSpace = false;
+        bool cutRequested = false;
+        bool cutReachedInterruptedLsn = false;
+        bool startupTokenBeforeCut = false;
+        ui32 interruptedWrites = 0;
+        ui32 restartNo = 0;
+        ui64 interruptedLsn = 0;
+        ui64 lastCutFirstLsnToKeep = 0;
+        i64 maxLogChunkCount = 0;
+        TString details;
+        auto observedOutOfSpace = [&] {
+            return localSyncDataOutOfSpace || otherOutOfSpace;
+        };
+
+        auto setDetails = [&](TString value) {
+            if (details.empty()) {
+                details = std::move(value);
+            }
+        };
+
+        auto previousEventFilter = runtime.SetEventFilter([&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+            if (!ev) {
+                return false;
+            }
+
+            switch (ev->GetTypeRewrite()) {
+                case TEvBlobStorage::EvAcquireVDiskOperationToken:
+                    if (observeAfterRestart && !cutReachedInterruptedLsn) {
+                        startupTokenBeforeCut = true;
+                    }
+                    break;
+
+                case TEvBlobStorage::EvAskForCutLog:
+                    if (observeAfterRestart) {
+                        cutRequested = true;
+                    }
+                    break;
+
+                case TEvBlobStorage::EvRecoveryLogCutDone: {
+                    if (observeAfterRestart) {
+                        const auto *msg = ev->Get<TEvRecoveryLogCutDone>();
+                        lastCutFirstLsnToKeep = msg->FirstLsnToKeep;
+                        if (interruptedLsn && msg->FirstLsnToKeep >= interruptedLsn + 1) {
+                            cutReachedInterruptedLsn = true;
+                        }
+                    }
+                    break;
+                }
+
+                case TEvBlobStorage::EvLogResult: {
+                    const auto *msg = ev->Get<NPDisk::TEvLogResult>();
+                    maxLogChunkCount = Max(maxLogChunkCount, msg->LogChunkCount);
+
+                    if (msg->Status == NKikimrProto::OUT_OF_SPACE) {
+                        TString outOfSpaceDetails = TStringBuilder()
+                            << "TEvLogResult recipient# " << ev->Recipient
+                            << " status# " << NKikimrProto::EReplyStatus_Name(msg->Status)
+                            << " error# " << msg->ErrorReason
+                            << " logChunkCount# " << msg->LogChunkCount
+                            << " interruptedWrites# " << interruptedWrites;
+                        if (dropNextLocalSyncDataLogResult) {
+                            localSyncDataOutOfSpace = true;
+                        } else {
+                            otherOutOfSpace = true;
+                        }
+                        setDetails(std::move(outOfSpaceDetails));
+                        return true;
+                    }
+
+                    if (dropNextLocalSyncDataLogResult && msg->Status == NKikimrProto::OK) {
+                        dropNextLocalSyncDataLogResult = false;
+                        restartRequested = true;
+                        ++interruptedWrites;
+                        Y_ABORT_UNLESS(!msg->Results.empty());
+                        interruptedLsn = msg->Results.front().Lsn;
+                        cutRequested = false;
+                        cutReachedInterruptedLsn = false;
+                        return true;
+                    }
+                    break;
+                }
+
+                case TEvBlobStorage::EvChunkReserveResult:
+                    if (ev->Get<NPDisk::TEvChunkReserveResult>()->Status == NKikimrProto::OUT_OF_SPACE) {
+                        otherOutOfSpace = true;
+                        setDetails("TEvChunkReserveResult OUT_OF_SPACE");
+                        return true;
+                    }
+                    break;
+
+                case TEvBlobStorage::EvChunkWriteResult:
+                    if (ev->Get<NPDisk::TEvChunkWriteResult>()->Status == NKikimrProto::OUT_OF_SPACE) {
+                        otherOutOfSpace = true;
+                        setDetails("TEvChunkWriteResult OUT_OF_SPACE");
+                        return true;
+                    }
+                    break;
+            }
+
+            return false;
+        });
+        TTestRuntimeCallbackGuard runtimeCallbackGuard(runtime,
+            &TTestActorRuntimeBase::DefaultObserverFunc, std::move(previousEventFilter),
+            std::move(previousRegistrationObserver));
+
+        auto dispatchFor = [&](TDuration timeout) {
+            TDispatchOptions options;
+            const TDuration oldDispatchTimeout = runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
+            try {
+                runtime.DispatchEvents(options, timeout);
+            } catch (const TEmptyEventQueueException&) {
+            }
+            runtime.SetDispatchTimeout(oldDispatchTimeout);
+        };
+
+        auto pumpUntil = [&](auto predicate, ui32 iterations, TDuration step) {
+            for (ui32 i = 0; i < iterations && !predicate(); ++i) {
+                dispatchFor(step);
+            }
+            return predicate();
+        };
+
+        auto waitReady = [&] {
+            return pumpUntil([&] {
+                runtime.Send(new IEventHandle(vdiskActorId, edge,
+                    new TEvBlobStorage::TEvVStatus(vdiskId), IEventHandle::FlagTrackDelivery), NodeIndex);
+                auto res = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(edge, TDuration::Seconds(1));
+                return res && res->Get()->Record.GetStatus() == NKikimrProto::OK;
+            }, 60, TDuration::MilliSeconds(100));
+        };
+
+        auto restartVDisk = [&] {
+            runtime.Send(new IEventHandle(storage.VDiskActors[0], edge, new TEvents::TEvPoisonPill), NodeIndex);
+            dispatchFor(TDuration::MilliSeconds(100));
+
+            const NPDisk::TOwnerRound nextOwnerRound = 200 + restartNo++;
+            auto vdiskConfig = MakeTestVDiskConfig(storage.AllVDiskKinds, storage.Info, storage.PDiskServiceId,
+                0, nextOwnerRound, testConfig);
+            const TActorId vdiskActor = runtime.Register(CreateVDisk(vdiskConfig, storage.Info,
+                storage.Counters->GetSubgroup("subsystem", "vdisk")->GetSubgroup("slot", "0")),
+                NodeIndex, 0, TMailboxType::Revolving);
+            currentVDiskFront = vdiskActor;
+            skeletonId = {};
+            observeAfterRestart = true;
+            runtime.RegisterService(vdiskActorId, vdiskActor, NodeIndex);
+            storage.VDiskActors[0] = vdiskActor;
+            UNIT_ASSERT_C(pumpUntil([&] { return bool(skeletonId); }, 300, TDuration::MilliSeconds(10)),
+                "failed to discover Skeleton actor after restart"
+                << " interruptedWrites# " << interruptedWrites);
+        };
+
+        auto sendInterruptedLocalSyncData = [&] {
+            restartRequested = false;
+            dropNextLocalSyncDataLogResult = true;
+            runtime.Send(new IEventHandle(skeletonId, edge,
+                new TEvLocalSyncData(vdiskId, TSyncState(), localSyncData)), NodeIndex);
+
+            UNIT_ASSERT_C(pumpUntil([&] { return restartRequested || observedOutOfSpace(); },
+                    600, TDuration::MilliSeconds(10)),
+                "LocalSyncData write was not committed to PDisk"
+                << " interruptedWrites# " << interruptedWrites
+                << " payloadSize# " << localSyncData.size());
+            dropNextLocalSyncDataLogResult = false;
+        };
+
+        UNIT_ASSERT_C(skeletonId, "failed to discover initial Skeleton actor");
+        UNIT_ASSERT_C(waitReady(), "target VDisk did not become ready before LocalSyncData injection");
+        sendInterruptedLocalSyncData();
+        UNIT_ASSERT_C(!observedOutOfSpace(),
+            "initial LocalSyncData write exhausted space"
+            << " details# " << details);
+        UNIT_ASSERT_C(interruptedLsn,
+            "test did not capture interrupted LocalSyncData LSN");
+
+        restartVDisk();
+        UNIT_ASSERT_C(waitReady(),
+            "target VDisk did not become ready after interrupted LocalSyncData"
+            << " interruptedLsn# " << interruptedLsn);
+
+        auto waitForCut = [&] {
+            pumpUntil([&] { return cutRequested || observedOutOfSpace(); },
+                100, TDuration::MilliSeconds(10));
+            if (cutRequested) {
+                pumpUntil([&] { return cutReachedInterruptedLsn || observedOutOfSpace(); },
+                    600, TDuration::MilliSeconds(10));
+            }
+        };
+        waitForCut();
+
+        for (ui32 i = 0; i < 8 && !observedOutOfSpace(); ++i) {
+            sendInterruptedLocalSyncData();
+            if (!observedOutOfSpace()) {
+                restartVDisk();
+                UNIT_ASSERT_C(waitReady(),
+                    "target VDisk did not become ready after duplicate LocalSyncData"
+                    << " iteration# " << i
+                    << " interruptedWrites# " << interruptedWrites);
+                waitForCut();
+            }
+        }
+        UNIT_ASSERT_C(!localSyncDataOutOfSpace && !otherOutOfSpace,
+            "replayed LocalSyncData exhausted space"
+            << " localSyncDataOutOfSpace# " << localSyncDataOutOfSpace
+            << " otherOutOfSpace# " << otherOutOfSpace
+            << " interruptedWrites# " << interruptedWrites
+            << " maxLogChunkCount# " << maxLogChunkCount
+            << " details# " << details);
+        UNIT_ASSERT_C(cutRequested,
+            "startup data sync did not request recovery log cut"
+            << " interruptedLsn# " << interruptedLsn);
+        UNIT_ASSERT_C(cutReachedInterruptedLsn,
+            "recovery log cut did not pass replayed LocalSyncData"
+            << " interruptedLsn# " << interruptedLsn
+            << " lastCutFirstLsnToKeep# " << lastCutFirstLsnToKeep);
+        UNIT_ASSERT_C(!startupTokenBeforeCut,
+            "startup data sync token was requested before durable recovery log cut"
+            << " interruptedLsn# " << interruptedLsn
+            << " lastCutFirstLsnToKeep# " << lastCutFirstLsnToKeep);
     }
 
 } // Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk)

--- a/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
@@ -991,18 +991,24 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             << " actual# " << env.LocalSyncData.size());
         UNIT_ASSERT_C(env.SkeletonId, "failed to discover initial Skeleton actor");
         UNIT_ASSERT_C(env.WaitReady(), "target VDisk did not become ready before LocalSyncData injection");
+        // Persist LocalSyncData in PDisk, then drop the successful log result to emulate a crash
+        // after durable commit but before VDisk advances sync state or recovery-log cut.
         env.SendInterruptedLocalSyncData();
         UNIT_ASSERT_C(!env.ObservedOutOfSpace(),
             "initial LocalSyncData write exhausted space"
             << " details# " << env.Details);
         UNIT_ASSERT_C(env.InterruptedLsn, "test did not capture interrupted LocalSyncData LSN");
 
+        // After restart, local recovery replays the durable LocalSyncData. Startup sync must wait
+        // until the recovery log is durably cut past that replayed record.
         env.RestartVDisk();
         UNIT_ASSERT_C(env.WaitReady(),
             "target VDisk did not become ready after interrupted LocalSyncData"
             << " interruptedLsn# " << env.InterruptedLsn);
         env.WaitForCut();
 
+        // Repeat the same interrupted recovery window. Without the cut wait, these duplicate
+        // LocalSyncData writes eventually exhaust common log chunks.
         for (ui32 i = 0; i < 8 && !env.ObservedOutOfSpace(); ++i) {
             env.SendInterruptedLocalSyncData();
             if (!env.ObservedOutOfSpace()) {
@@ -1060,6 +1066,9 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         bool observedInsufficientCut = false;
         bool insufficientCutInjected = false;
         env.PreFilter = [&](TAutoPtr<IEventHandle>& ev) {
+            // Force the first cut notification to stop just before the replayed LocalSyncData.
+            // This makes the test deterministic even when the real PDisk layout would produce a
+            // sufficient first cut.
             if (ev->GetTypeRewrite() == TEvBlobStorage::EvRecoveryLogCutDone &&
                     env.ObserveAfterRestart && env.InterruptedLsn && !insufficientCutInjected) {
                 const ui64 insufficientFirstLsnToKeep = env.InterruptedLsn;
@@ -1076,6 +1085,8 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
 
         UNIT_ASSERT_C(env.SkeletonId, "failed to discover initial Skeleton actor");
         UNIT_ASSERT_C(env.WaitReady(), "target VDisk did not become ready before LocalSyncData injection");
+        // Write LocalSyncData durably but hide the OK result from VDisk, matching the OOM/restart
+        // window covered by the main regression test.
         env.SendInterruptedLocalSyncData();
         UNIT_ASSERT_C(!env.ObservedOutOfSpace(), "initial LocalSyncData write exhausted space");
         UNIT_ASSERT_C(env.InterruptedLsn, "test did not capture interrupted LocalSyncData LSN");

--- a/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
@@ -23,6 +23,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <deque>
+#include <functional>
 
 namespace NKikimr {
 
@@ -288,6 +289,241 @@ TRealStorage SetupRealPDiskAndRealVDisk(TTestActorRuntime& runtime,
         .PutQueue = putQueue,
     };
 }
+
+class TLocalSyncDataReplayEnv {
+public:
+    TTestActorRuntime Runtime;
+    TRealPDiskTestConfig TestConfig;
+    TString LocalSyncData;
+    TRealStorage Storage;
+    TVDiskID VDiskId;
+    TActorId VDiskActorId;
+    TActorId Edge;
+    TActorId SkeletonId;
+    TActorId CurrentVDiskFront;
+
+    bool RestartRequested = false;
+    bool DropNextLocalSyncDataLogResult = false;
+    bool ObserveAfterRestart = false;
+    bool LocalSyncDataOutOfSpace = false;
+    bool OtherOutOfSpace = false;
+    bool CutRequested = false;
+    bool CutReachedInterruptedLsn = false;
+    bool StartupTokenBeforeCut = false;
+    ui32 InterruptedWrites = 0;
+    ui32 RestartNo = 0;
+    ui32 CutRequestsAfterRestart = 0;
+    ui64 InterruptedLsn = 0;
+    ui64 LastCutFirstLsnToKeep = 0;
+    i64 MaxLogChunkCount = 0;
+    TString Details;
+    std::function<bool(TAutoPtr<IEventHandle>&)> PreFilter;
+
+    TLocalSyncDataReplayEnv(ui32 targetPayloadBytes, TRealPDiskTestConfig testConfig)
+        : Runtime(1, false)
+        , TestConfig(std::move(testConfig))
+        , LocalSyncData(MakeLocalSyncDataBlockPayload(targetPayloadBytes))
+    {
+        auto previousRegistrationObserver = Runtime.SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase&, const TActorId& parentId, const TActorId& actorId) {
+                Registrations.emplace_back(parentId, actorId);
+                if (parentId == CurrentVDiskFront && !SkeletonId) {
+                    SkeletonId = actorId;
+                }
+            });
+
+        Storage = SetupRealPDiskAndRealVDisk(Runtime, TBlobStorageGroupType::ErasureNone, TestConfig);
+        Runtime.GetAppData(NodeIndex).FeatureFlags
+            .SetEnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay(true);
+        VDiskId = Storage.Info->GetVDiskId(0);
+        VDiskActorId = Storage.Info->GetActorId(0);
+        Edge = Storage.Edge;
+        CurrentVDiskFront = Storage.VDiskActors[0];
+        for (const auto& [parentId, actorId] : Registrations) {
+            if (parentId == CurrentVDiskFront) {
+                SkeletonId = actorId;
+                break;
+            }
+        }
+
+        auto previousEventFilter = Runtime.SetEventFilter(
+            [&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+                return EventFilter(ev);
+            });
+        CallbackGuard = MakeHolder<TTestRuntimeCallbackGuard>(Runtime,
+            &TTestActorRuntimeBase::DefaultObserverFunc, std::move(previousEventFilter),
+            std::move(previousRegistrationObserver));
+    }
+
+    bool ObservedOutOfSpace() const {
+        return LocalSyncDataOutOfSpace || OtherOutOfSpace;
+    }
+
+    void DispatchFor(TDuration timeout) {
+        TDispatchOptions options;
+        const TDuration oldDispatchTimeout = Runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
+        try {
+            Runtime.DispatchEvents(options, timeout);
+        } catch (const TEmptyEventQueueException&) {
+        }
+        Runtime.SetDispatchTimeout(oldDispatchTimeout);
+    }
+
+    template <typename TPredicate>
+    bool PumpUntil(TPredicate predicate, ui32 iterations, TDuration step) {
+        for (ui32 i = 0; i < iterations && !predicate(); ++i) {
+            DispatchFor(step);
+        }
+        return predicate();
+    }
+
+    bool WaitReady() {
+        return PumpUntil([&] {
+            Runtime.Send(new IEventHandle(VDiskActorId, Edge,
+                new TEvBlobStorage::TEvVStatus(VDiskId), IEventHandle::FlagTrackDelivery), NodeIndex);
+            auto res = Runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(Edge, TDuration::Seconds(1));
+            return res && res->Get()->Record.GetStatus() == NKikimrProto::OK;
+        }, 60, TDuration::MilliSeconds(100));
+    }
+
+    void SendInterruptedLocalSyncData() {
+        RestartRequested = false;
+        DropNextLocalSyncDataLogResult = true;
+        Runtime.Send(new IEventHandle(SkeletonId, Edge,
+            new TEvLocalSyncData(VDiskId, TSyncState(), LocalSyncData)), NodeIndex);
+
+        UNIT_ASSERT_C(PumpUntil([&] { return RestartRequested || ObservedOutOfSpace(); },
+                600, TDuration::MilliSeconds(10)),
+            "LocalSyncData write was not committed to PDisk"
+            << " interruptedWrites# " << InterruptedWrites
+            << " payloadSize# " << LocalSyncData.size());
+        DropNextLocalSyncDataLogResult = false;
+    }
+
+    void RestartVDisk() {
+        Runtime.Send(new IEventHandle(Storage.VDiskActors[0], Edge, new TEvents::TEvPoisonPill), NodeIndex);
+        DispatchFor(TDuration::MilliSeconds(100));
+
+        const NPDisk::TOwnerRound nextOwnerRound = 200 + RestartNo++;
+        auto vdiskConfig = MakeTestVDiskConfig(Storage.AllVDiskKinds, Storage.Info, Storage.PDiskServiceId,
+            0, nextOwnerRound, TestConfig);
+        const TActorId vdiskActor = Runtime.Register(CreateVDisk(vdiskConfig, Storage.Info,
+            Storage.Counters->GetSubgroup("subsystem", "vdisk")->GetSubgroup("slot", "0")),
+            NodeIndex, 0, TMailboxType::Revolving);
+        CurrentVDiskFront = vdiskActor;
+        SkeletonId = {};
+        ObserveAfterRestart = true;
+        Runtime.RegisterService(VDiskActorId, vdiskActor, NodeIndex);
+        Storage.VDiskActors[0] = vdiskActor;
+        UNIT_ASSERT_C(PumpUntil([&] { return bool(SkeletonId); }, 300, TDuration::MilliSeconds(10)),
+            "failed to discover Skeleton actor after restart"
+            << " interruptedWrites# " << InterruptedWrites);
+    }
+
+    void WaitForCut() {
+        PumpUntil([&] { return CutRequested || ObservedOutOfSpace(); },
+            100, TDuration::MilliSeconds(10));
+        if (CutRequested) {
+            PumpUntil([&] { return CutReachedInterruptedLsn || ObservedOutOfSpace(); },
+                600, TDuration::MilliSeconds(10));
+        }
+    }
+
+private:
+    TVector<std::pair<TActorId, TActorId>> Registrations;
+    THolder<TTestRuntimeCallbackGuard> CallbackGuard;
+
+    void SetDetails(TString value) {
+        if (Details.empty()) {
+            Details = std::move(value);
+        }
+    }
+
+    bool EventFilter(TAutoPtr<IEventHandle>& ev) {
+        if (!ev) {
+            return false;
+        }
+        if (PreFilter && PreFilter(ev)) {
+            return true;
+        }
+
+        switch (ev->GetTypeRewrite()) {
+            case TEvBlobStorage::EvAcquireVDiskOperationToken:
+                if (ObserveAfterRestart && !CutReachedInterruptedLsn) {
+                    StartupTokenBeforeCut = true;
+                }
+                break;
+
+            case TEvBlobStorage::EvAskForCutLog:
+                if (ObserveAfterRestart) {
+                    CutRequested = true;
+                    ++CutRequestsAfterRestart;
+                }
+                break;
+
+            case TEvBlobStorage::EvRecoveryLogCutDone:
+                if (ObserveAfterRestart) {
+                    const auto *msg = ev->Get<TEvRecoveryLogCutDone>();
+                    LastCutFirstLsnToKeep = msg->FirstLsnToKeep;
+                    if (InterruptedLsn && msg->FirstLsnToKeep >= InterruptedLsn + 1) {
+                        CutReachedInterruptedLsn = true;
+                    }
+                }
+                break;
+
+            case TEvBlobStorage::EvLogResult: {
+                const auto *msg = ev->Get<NPDisk::TEvLogResult>();
+                MaxLogChunkCount = Max(MaxLogChunkCount, msg->LogChunkCount);
+
+                if (msg->Status == NKikimrProto::OUT_OF_SPACE) {
+                    TString outOfSpaceDetails = TStringBuilder()
+                        << "TEvLogResult recipient# " << ev->Recipient
+                        << " status# " << NKikimrProto::EReplyStatus_Name(msg->Status)
+                        << " error# " << msg->ErrorReason
+                        << " logChunkCount# " << msg->LogChunkCount
+                        << " interruptedWrites# " << InterruptedWrites;
+                    if (DropNextLocalSyncDataLogResult) {
+                        LocalSyncDataOutOfSpace = true;
+                    } else {
+                        OtherOutOfSpace = true;
+                    }
+                    SetDetails(std::move(outOfSpaceDetails));
+                    return true;
+                }
+
+                if (DropNextLocalSyncDataLogResult && msg->Status == NKikimrProto::OK) {
+                    DropNextLocalSyncDataLogResult = false;
+                    RestartRequested = true;
+                    ++InterruptedWrites;
+                    Y_ABORT_UNLESS(!msg->Results.empty());
+                    InterruptedLsn = msg->Results.front().Lsn;
+                    CutRequested = false;
+                    CutReachedInterruptedLsn = false;
+                    return true;
+                }
+                break;
+            }
+
+            case TEvBlobStorage::EvChunkReserveResult:
+                if (ev->Get<NPDisk::TEvChunkReserveResult>()->Status == NKikimrProto::OUT_OF_SPACE) {
+                    OtherOutOfSpace = true;
+                    SetDetails("TEvChunkReserveResult OUT_OF_SPACE");
+                    return true;
+                }
+                break;
+
+            case TEvBlobStorage::EvChunkWriteResult:
+                if (ev->Get<NPDisk::TEvChunkWriteResult>()->Status == NKikimrProto::OUT_OF_SPACE) {
+                    OtherOutOfSpace = true;
+                    SetDetails("TEvChunkWriteResult OUT_OF_SPACE");
+                    return true;
+                }
+                break;
+        }
+
+        return false;
+    }
+};
 
 } // namespace
 
@@ -737,12 +973,6 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
          * loop keeps repeating this interrupted write and must fail on common-log OUT_OF_SPACE.
          */
         const ui32 targetPayloadBytes = 3_MB;
-        const TString localSyncData = MakeLocalSyncDataBlockPayload(targetPayloadBytes);
-        UNIT_ASSERT_C(localSyncData.size() >= targetPayloadBytes,
-            "LocalSyncData payload is too small; expected at least# " << targetPayloadBytes
-            << " actual# " << localSyncData.size());
-
-        TTestActorRuntime runtime(1, false);
         TRealPDiskTestConfig testConfig;
         testConfig.ChunkSize = 64_KB;
         testConfig.DiskSize = 128_MB;
@@ -755,253 +985,122 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         testConfig.RecoveryLogCutterRegularDuration = TDuration::Hours(1);
         testConfig.PDiskPathSuffix = "local_sync_data_cut_wait.dat";
 
-        TActorId currentVDiskFront;
-        TActorId skeletonId;
-        TVector<std::pair<TActorId, TActorId>> registrations;
-        auto previousRegistrationObserver = runtime.SetRegistrationObserverFunc(
-            [&](TTestActorRuntimeBase&, const TActorId& parentId, const TActorId& actorId) {
-                registrations.emplace_back(parentId, actorId);
-                if (parentId == currentVDiskFront && !skeletonId) {
-                    skeletonId = actorId;
-                }
-            });
-
-        auto storage = SetupRealPDiskAndRealVDisk(runtime, TBlobStorageGroupType::ErasureNone, testConfig);
-        runtime.GetAppData(NodeIndex).FeatureFlags
-            .SetEnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay(true);
-        const TVDiskID vdiskId = storage.Info->GetVDiskId(0);
-        const TActorId vdiskActorId = storage.Info->GetActorId(0);
-        const TActorId edge = storage.Edge;
-        currentVDiskFront = storage.VDiskActors[0];
-        for (const auto& [parentId, actorId] : registrations) {
-            if (parentId == currentVDiskFront) {
-                skeletonId = actorId;
-                break;
-            }
-        }
-
-        bool restartRequested = false;
-        bool dropNextLocalSyncDataLogResult = false;
-        bool observeAfterRestart = false;
-        bool localSyncDataOutOfSpace = false;
-        bool otherOutOfSpace = false;
-        bool cutRequested = false;
-        bool cutReachedInterruptedLsn = false;
-        bool startupTokenBeforeCut = false;
-        ui32 interruptedWrites = 0;
-        ui32 restartNo = 0;
-        ui64 interruptedLsn = 0;
-        ui64 lastCutFirstLsnToKeep = 0;
-        i64 maxLogChunkCount = 0;
-        TString details;
-        auto observedOutOfSpace = [&] {
-            return localSyncDataOutOfSpace || otherOutOfSpace;
-        };
-
-        auto setDetails = [&](TString value) {
-            if (details.empty()) {
-                details = std::move(value);
-            }
-        };
-
-        auto previousEventFilter = runtime.SetEventFilter([&](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
-            if (!ev) {
-                return false;
-            }
-
-            switch (ev->GetTypeRewrite()) {
-                case TEvBlobStorage::EvAcquireVDiskOperationToken:
-                    if (observeAfterRestart && !cutReachedInterruptedLsn) {
-                        startupTokenBeforeCut = true;
-                    }
-                    break;
-
-                case TEvBlobStorage::EvAskForCutLog:
-                    if (observeAfterRestart) {
-                        cutRequested = true;
-                    }
-                    break;
-
-                case TEvBlobStorage::EvRecoveryLogCutDone: {
-                    if (observeAfterRestart) {
-                        const auto *msg = ev->Get<TEvRecoveryLogCutDone>();
-                        lastCutFirstLsnToKeep = msg->FirstLsnToKeep;
-                        if (interruptedLsn && msg->FirstLsnToKeep >= interruptedLsn + 1) {
-                            cutReachedInterruptedLsn = true;
-                        }
-                    }
-                    break;
-                }
-
-                case TEvBlobStorage::EvLogResult: {
-                    const auto *msg = ev->Get<NPDisk::TEvLogResult>();
-                    maxLogChunkCount = Max(maxLogChunkCount, msg->LogChunkCount);
-
-                    if (msg->Status == NKikimrProto::OUT_OF_SPACE) {
-                        TString outOfSpaceDetails = TStringBuilder()
-                            << "TEvLogResult recipient# " << ev->Recipient
-                            << " status# " << NKikimrProto::EReplyStatus_Name(msg->Status)
-                            << " error# " << msg->ErrorReason
-                            << " logChunkCount# " << msg->LogChunkCount
-                            << " interruptedWrites# " << interruptedWrites;
-                        if (dropNextLocalSyncDataLogResult) {
-                            localSyncDataOutOfSpace = true;
-                        } else {
-                            otherOutOfSpace = true;
-                        }
-                        setDetails(std::move(outOfSpaceDetails));
-                        return true;
-                    }
-
-                    if (dropNextLocalSyncDataLogResult && msg->Status == NKikimrProto::OK) {
-                        dropNextLocalSyncDataLogResult = false;
-                        restartRequested = true;
-                        ++interruptedWrites;
-                        Y_ABORT_UNLESS(!msg->Results.empty());
-                        interruptedLsn = msg->Results.front().Lsn;
-                        cutRequested = false;
-                        cutReachedInterruptedLsn = false;
-                        return true;
-                    }
-                    break;
-                }
-
-                case TEvBlobStorage::EvChunkReserveResult:
-                    if (ev->Get<NPDisk::TEvChunkReserveResult>()->Status == NKikimrProto::OUT_OF_SPACE) {
-                        otherOutOfSpace = true;
-                        setDetails("TEvChunkReserveResult OUT_OF_SPACE");
-                        return true;
-                    }
-                    break;
-
-                case TEvBlobStorage::EvChunkWriteResult:
-                    if (ev->Get<NPDisk::TEvChunkWriteResult>()->Status == NKikimrProto::OUT_OF_SPACE) {
-                        otherOutOfSpace = true;
-                        setDetails("TEvChunkWriteResult OUT_OF_SPACE");
-                        return true;
-                    }
-                    break;
-            }
-
-            return false;
-        });
-        TTestRuntimeCallbackGuard runtimeCallbackGuard(runtime,
-            &TTestActorRuntimeBase::DefaultObserverFunc, std::move(previousEventFilter),
-            std::move(previousRegistrationObserver));
-
-        auto dispatchFor = [&](TDuration timeout) {
-            TDispatchOptions options;
-            const TDuration oldDispatchTimeout = runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
-            try {
-                runtime.DispatchEvents(options, timeout);
-            } catch (const TEmptyEventQueueException&) {
-            }
-            runtime.SetDispatchTimeout(oldDispatchTimeout);
-        };
-
-        auto pumpUntil = [&](auto predicate, ui32 iterations, TDuration step) {
-            for (ui32 i = 0; i < iterations && !predicate(); ++i) {
-                dispatchFor(step);
-            }
-            return predicate();
-        };
-
-        auto waitReady = [&] {
-            return pumpUntil([&] {
-                runtime.Send(new IEventHandle(vdiskActorId, edge,
-                    new TEvBlobStorage::TEvVStatus(vdiskId), IEventHandle::FlagTrackDelivery), NodeIndex);
-                auto res = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(edge, TDuration::Seconds(1));
-                return res && res->Get()->Record.GetStatus() == NKikimrProto::OK;
-            }, 60, TDuration::MilliSeconds(100));
-        };
-
-        auto restartVDisk = [&] {
-            runtime.Send(new IEventHandle(storage.VDiskActors[0], edge, new TEvents::TEvPoisonPill), NodeIndex);
-            dispatchFor(TDuration::MilliSeconds(100));
-
-            const NPDisk::TOwnerRound nextOwnerRound = 200 + restartNo++;
-            auto vdiskConfig = MakeTestVDiskConfig(storage.AllVDiskKinds, storage.Info, storage.PDiskServiceId,
-                0, nextOwnerRound, testConfig);
-            const TActorId vdiskActor = runtime.Register(CreateVDisk(vdiskConfig, storage.Info,
-                storage.Counters->GetSubgroup("subsystem", "vdisk")->GetSubgroup("slot", "0")),
-                NodeIndex, 0, TMailboxType::Revolving);
-            currentVDiskFront = vdiskActor;
-            skeletonId = {};
-            observeAfterRestart = true;
-            runtime.RegisterService(vdiskActorId, vdiskActor, NodeIndex);
-            storage.VDiskActors[0] = vdiskActor;
-            UNIT_ASSERT_C(pumpUntil([&] { return bool(skeletonId); }, 300, TDuration::MilliSeconds(10)),
-                "failed to discover Skeleton actor after restart"
-                << " interruptedWrites# " << interruptedWrites);
-        };
-
-        auto sendInterruptedLocalSyncData = [&] {
-            restartRequested = false;
-            dropNextLocalSyncDataLogResult = true;
-            runtime.Send(new IEventHandle(skeletonId, edge,
-                new TEvLocalSyncData(vdiskId, TSyncState(), localSyncData)), NodeIndex);
-
-            UNIT_ASSERT_C(pumpUntil([&] { return restartRequested || observedOutOfSpace(); },
-                    600, TDuration::MilliSeconds(10)),
-                "LocalSyncData write was not committed to PDisk"
-                << " interruptedWrites# " << interruptedWrites
-                << " payloadSize# " << localSyncData.size());
-            dropNextLocalSyncDataLogResult = false;
-        };
-
-        UNIT_ASSERT_C(skeletonId, "failed to discover initial Skeleton actor");
-        UNIT_ASSERT_C(waitReady(), "target VDisk did not become ready before LocalSyncData injection");
-        sendInterruptedLocalSyncData();
-        UNIT_ASSERT_C(!observedOutOfSpace(),
+        TLocalSyncDataReplayEnv env(targetPayloadBytes, testConfig);
+        UNIT_ASSERT_C(env.LocalSyncData.size() >= targetPayloadBytes,
+            "LocalSyncData payload is too small; expected at least# " << targetPayloadBytes
+            << " actual# " << env.LocalSyncData.size());
+        UNIT_ASSERT_C(env.SkeletonId, "failed to discover initial Skeleton actor");
+        UNIT_ASSERT_C(env.WaitReady(), "target VDisk did not become ready before LocalSyncData injection");
+        env.SendInterruptedLocalSyncData();
+        UNIT_ASSERT_C(!env.ObservedOutOfSpace(),
             "initial LocalSyncData write exhausted space"
-            << " details# " << details);
-        UNIT_ASSERT_C(interruptedLsn,
-            "test did not capture interrupted LocalSyncData LSN");
+            << " details# " << env.Details);
+        UNIT_ASSERT_C(env.InterruptedLsn, "test did not capture interrupted LocalSyncData LSN");
 
-        restartVDisk();
-        UNIT_ASSERT_C(waitReady(),
+        env.RestartVDisk();
+        UNIT_ASSERT_C(env.WaitReady(),
             "target VDisk did not become ready after interrupted LocalSyncData"
-            << " interruptedLsn# " << interruptedLsn);
+            << " interruptedLsn# " << env.InterruptedLsn);
+        env.WaitForCut();
 
-        auto waitForCut = [&] {
-            pumpUntil([&] { return cutRequested || observedOutOfSpace(); },
-                100, TDuration::MilliSeconds(10));
-            if (cutRequested) {
-                pumpUntil([&] { return cutReachedInterruptedLsn || observedOutOfSpace(); },
-                    600, TDuration::MilliSeconds(10));
-            }
-        };
-        waitForCut();
-
-        for (ui32 i = 0; i < 8 && !observedOutOfSpace(); ++i) {
-            sendInterruptedLocalSyncData();
-            if (!observedOutOfSpace()) {
-                restartVDisk();
-                UNIT_ASSERT_C(waitReady(),
+        for (ui32 i = 0; i < 8 && !env.ObservedOutOfSpace(); ++i) {
+            env.SendInterruptedLocalSyncData();
+            if (!env.ObservedOutOfSpace()) {
+                env.RestartVDisk();
+                UNIT_ASSERT_C(env.WaitReady(),
                     "target VDisk did not become ready after duplicate LocalSyncData"
                     << " iteration# " << i
-                    << " interruptedWrites# " << interruptedWrites);
-                waitForCut();
+                    << " interruptedWrites# " << env.InterruptedWrites);
+                env.WaitForCut();
             }
         }
-        UNIT_ASSERT_C(!localSyncDataOutOfSpace && !otherOutOfSpace,
+        UNIT_ASSERT_C(!env.LocalSyncDataOutOfSpace && !env.OtherOutOfSpace,
             "replayed LocalSyncData exhausted space"
-            << " localSyncDataOutOfSpace# " << localSyncDataOutOfSpace
-            << " otherOutOfSpace# " << otherOutOfSpace
-            << " interruptedWrites# " << interruptedWrites
-            << " maxLogChunkCount# " << maxLogChunkCount
-            << " details# " << details);
-        UNIT_ASSERT_C(cutRequested,
+            << " localSyncDataOutOfSpace# " << env.LocalSyncDataOutOfSpace
+            << " otherOutOfSpace# " << env.OtherOutOfSpace
+            << " interruptedWrites# " << env.InterruptedWrites
+            << " maxLogChunkCount# " << env.MaxLogChunkCount
+            << " details# " << env.Details);
+        UNIT_ASSERT_C(env.CutRequested,
             "startup data sync did not request recovery log cut"
-            << " interruptedLsn# " << interruptedLsn);
-        UNIT_ASSERT_C(cutReachedInterruptedLsn,
+            << " interruptedLsn# " << env.InterruptedLsn);
+        UNIT_ASSERT_C(env.CutReachedInterruptedLsn,
             "recovery log cut did not pass replayed LocalSyncData"
-            << " interruptedLsn# " << interruptedLsn
-            << " lastCutFirstLsnToKeep# " << lastCutFirstLsnToKeep);
-        UNIT_ASSERT_C(!startupTokenBeforeCut,
+            << " interruptedLsn# " << env.InterruptedLsn
+            << " lastCutFirstLsnToKeep# " << env.LastCutFirstLsnToKeep);
+        UNIT_ASSERT_C(!env.StartupTokenBeforeCut,
             "startup data sync token was requested before durable recovery log cut"
-            << " interruptedLsn# " << interruptedLsn
-            << " lastCutFirstLsnToKeep# " << lastCutFirstLsnToKeep);
+            << " interruptedLsn# " << env.InterruptedLsn
+            << " lastCutFirstLsnToKeep# " << env.LastCutFirstLsnToKeep);
+    }
+
+    Y_UNIT_TEST(LocalSyncDataCutWaitRetriesAfterInsufficientCut) {
+        /*
+         * TEvAskForCutLog asks PDisk for an owner cut, not for a specific target LSN. If the
+         * first durable cut is still below the replayed LocalSyncData record, startup data sync
+         * must ask again instead of getting stuck. The exact PDisk chunk layout may produce an
+         * already sufficient first cut, so this test replaces the first cut notification with an
+         * insufficient one and checks the syncer retry behavior.
+         */
+        const ui32 targetPayloadBytes = 128_KB;
+        TRealPDiskTestConfig testConfig;
+        testConfig.ChunkSize = 64_KB;
+        testConfig.DiskSize = 128_MB;
+        testConfig.MaxCommonLogChunks = 10;
+        testConfig.EnableSmallDiskOptimization = false;
+        testConfig.RunSyncer = true;
+        testConfig.GroupId = TGroupID(EGroupConfigurationType::Dynamic, DomainId, 3).GetRaw();
+        testConfig.AdvanceEntryPointTimeout = TDuration::Hours(1);
+        testConfig.RecoveryLogCutterFirstDuration = TDuration::Hours(1);
+        testConfig.RecoveryLogCutterRegularDuration = TDuration::Hours(1);
+        testConfig.PDiskPathSuffix = "local_sync_data_cut_retry.dat";
+
+        TLocalSyncDataReplayEnv env(targetPayloadBytes, testConfig);
+        ui64 firstCutFirstLsnToKeep = 0;
+        bool observedInsufficientCut = false;
+        bool insufficientCutInjected = false;
+        env.PreFilter = [&](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::EvRecoveryLogCutDone &&
+                    env.ObserveAfterRestart && env.InterruptedLsn && !insufficientCutInjected) {
+                const ui64 insufficientFirstLsnToKeep = env.InterruptedLsn;
+                insufficientCutInjected = true;
+                observedInsufficientCut = true;
+                firstCutFirstLsnToKeep = insufficientFirstLsnToKeep;
+                env.LastCutFirstLsnToKeep = insufficientFirstLsnToKeep;
+                ev.Reset(new IEventHandle(ev->Recipient, ev->Sender,
+                    new TEvRecoveryLogCutDone(insufficientFirstLsnToKeep),
+                    ev->Flags, ev->Cookie));
+            }
+            return false;
+        };
+
+        UNIT_ASSERT_C(env.SkeletonId, "failed to discover initial Skeleton actor");
+        UNIT_ASSERT_C(env.WaitReady(), "target VDisk did not become ready before LocalSyncData injection");
+        env.SendInterruptedLocalSyncData();
+        UNIT_ASSERT_C(!env.ObservedOutOfSpace(), "initial LocalSyncData write exhausted space");
+        UNIT_ASSERT_C(env.InterruptedLsn, "test did not capture interrupted LocalSyncData LSN");
+
+        env.RestartVDisk();
+        UNIT_ASSERT_C(env.WaitReady(),
+            "target VDisk did not become ready after interrupted LocalSyncData"
+            << " interruptedLsn# " << env.InterruptedLsn);
+
+        UNIT_ASSERT_C(env.PumpUntil([&] { return observedInsufficientCut || env.ObservedOutOfSpace(); },
+                600, TDuration::MilliSeconds(10)),
+            "test did not observe an insufficient recovery log cut"
+            << " interruptedLsn# " << env.InterruptedLsn
+            << " firstCutFirstLsnToKeep# " << firstCutFirstLsnToKeep
+            << " lastCutFirstLsnToKeep# " << env.LastCutFirstLsnToKeep
+            << " cutRequestsAfterRestart# " << env.CutRequestsAfterRestart);
+
+        UNIT_ASSERT_C(!env.ObservedOutOfSpace(), "test exhausted space before checking cut retry");
+        UNIT_ASSERT_C(env.PumpUntil([&] { return env.CutRequestsAfterRestart > 1 || env.ObservedOutOfSpace(); },
+                100, TDuration::MilliSeconds(10)),
+            "startup data sync did not retry recovery log cut after an insufficient cut"
+            << " interruptedLsn# " << env.InterruptedLsn
+            << " firstCutFirstLsnToKeep# " << firstCutFirstLsnToKeep
+            << " lastCutFirstLsnToKeep# " << env.LastCutFirstLsnToKeep
+            << " cutRequestsAfterRestart# " << env.CutRequestsAfterRestart);
     }
 
 } // Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk)

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -320,4 +320,5 @@ message TFeatureFlags {
     optional bool EnableLocalIndexAsSchemeObject = 278 [default = true];
     optional bool EnableDataShardDetailedMetrics = 279 [default = false];
     optional bool EnableCompactFulltextIndex = 280 [default = false];
+    optional bool EnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay = 281 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added an experimental VDisk startup guard that waits for replayed LocalSyncData recovery-log records to be cut before starting startup data sync.

### Changelog category <!-- remove all except one -->

* Experimental feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change adds a feature-flagged guard for VDisk restart after local recovery.
If local recovery replays `SignatureLocalSyncData` records from the common log, the VDisk now records the highest replayed LocalSyncData LSN and, when `EnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay` is enabled, delays startup data sync until recovery log cutting confirms that those replayed records are no longer needed.
This prevents a restart loop from repeatedly accepting and writing the same full-sync LocalSyncData into common log chunks before the previous durable progress is cut, which can exhaust PDisk log chunks.
The change is disabled by default and covered by a real-PDisk regression test for repeated interrupted LocalSyncData replay.
