### PR TITLE
demo: query replay regression test (DO NOT MERGE)

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2327,7 +2327,13 @@ void WriteCommonTablesInfo(NJsonWriter::TBuf& writer, TMap<TString, TTableInfo>&
 
             for (auto& read : table.Reads) {
                 writer.BeginObject();
-                writer.WriteKey("type").WriteString(ToString(read.Type));
+                // DEMO ONLY (DO NOT MERGE): intentional query-replay regression test.
+                // Report Lookup reads as Scan to trigger read_types_mismatch on replay.
+                EPlanTableReadType planReadType = read.Type;
+                if (planReadType == EPlanTableReadType::Lookup) {
+                    planReadType = EPlanTableReadType::Scan;
+                }
+                writer.WriteKey("type").WriteString(ToString(planReadType));
 
                 if (!read.LookupBy.empty()) {
                     writer.WriteKey("lookup_by");


### PR DESCRIPTION
## Summary

**DO NOT MERGE** — demo PR для проверки query replay / triage.

В `kqp_query_plan.cpp` Lookup-чтения в JSON плана записываются как Scan. При replay prod-план (Lookup) не совпадёт с replay-планом (Scan) → `read_types_mismatch` с сообщением вида `old engine: Lookup, new engine: Scan`.

Это **не** покрыто `known_issues.yaml` (там замьючен только обратный случай Scan→Lookup, issue #43148).

## Как прогнать query replay

В Arcadia CI (`query_replay.yaml` → action **Run replay**):

- `version`: `pull/<номер_этого_pr>`
- опционально `fail_on_unknown: true` — gate упадёт на `check_new_unknown_errors`

После прогона смотреть DataLens badge / `summary_results_fast_unknown`.

## Test plan

- [ ] `run_replay` с `version=pull/<id>` — incremental triage, строки в `summary_results_fast_unknown`
- [ ] с `fail_on_unknown=true` — job `check_new_unknown_errors` красный
- [ ] после revert коммита — unknown ошибки исчезают


Made with [Cursor](https://cursor.com)