### PR TITLE
[EXT-2281] Add link parameter mappings for support links

### DIFF
--- a/ydb/mvp/meta/meta.cpp
+++ b/ydb/mvp/meta/meta.cpp
@@ -228,7 +228,8 @@ void TMVP::InitMeta() {
     RegisterMetaHandler(
         httpIncomingProxyId,
         "/meta/support_links",
-        ActorSystem.Register(new NMVP::TMetaSupportLinksHandlerActor(HttpProxyId, MetaLocation, MetaSettings))
+        ActorSystem.Register(new NMVP::TMetaSupportLinksHandlerActor(HttpProxyId, MetaLocation, MetaSettings)),
+        2
     );
 
     RegisterMetaHandler(

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -15,12 +15,14 @@ message TMetaConfig {
             message TLinkParameterMapping {
                 // Target parameter name in the generated link.
                 optional string Parameter = 1;
-                // Request parameter name used as the mapping source.
-                optional string FromRequest = 2;
-                // Cluster info column name used as the mapping source.
-                optional string FromClusterInfo = 3;
-                // Constant value used as the mapping source.
-                optional string StaticValue = 4;
+                oneof SourceValue {
+                    // Request parameter name used as the mapping source.
+                    string FromRequest = 10;
+                    // Cluster info column name used as the mapping source.
+                    string FromClusterInfo = 11;
+                    // Constant value used as the mapping source.
+                    string StaticValue = 12;
+                }
             }
 
             // Link source identifier (for example: grafana/dashboard/search).

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -12,6 +12,17 @@ message TMetaConfig {
 
     message TSupportLinksConfig {
         message TSupportLinkEntry {
+            message TLinkParameterMapping {
+                // Target parameter name in the generated link.
+                optional string Parameter = 1;
+                // Request parameter name used as the mapping source.
+                optional string FromRequest = 2;
+                // Cluster info column name used as the mapping source.
+                optional string FromClusterInfo = 3;
+                // Constant value used as the mapping source.
+                optional string StaticValue = 4;
+            }
+
             // Link source identifier (for example: grafana/dashboard/search).
             optional string Source = 1;
             // Optional display name shown in UI.
@@ -22,7 +33,11 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
+            // Optional override for source-specific generated link parameters.
+            // When omitted, source defaults are used.
+            repeated TLinkParameterMapping LinkParameterMappings = 6;
         }
+
         // Support links resolved for cluster entity.
         repeated TSupportLinkEntry Cluster = 1;
         // Support links resolved for database entity.

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -22,8 +22,6 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
-            // Bucket override for source=grafana/logging.
-            optional string Bucket = 6 [default = "ydb"];
         }
         // Support links resolved for cluster entity.
         repeated TSupportLinkEntry Cluster = 1;

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -22,7 +22,7 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
-            // Loki bucket override for source=grafana/logging.
+            // Bucket override for source=grafana/logging.
             optional string Bucket = 6 [default = "ydb"];
         }
         // Support links resolved for cluster entity.

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -22,6 +22,8 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
+            // Loki bucket override for source=grafana/logging.
+            optional string Bucket = 6 [default = "ydb"];
         }
         // Support links resolved for cluster entity.
         repeated TSupportLinkEntry Cluster = 1;

--- a/ydb/mvp/meta/support_links/grafana_dashboard_common.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_common.h
@@ -3,6 +3,7 @@
 #include "source_common.h"
 #include "source.h"
 #include "types.h"
+#include "param_bindings.h"
 
 #include <library/cpp/cgiparam/cgiparam.h>
 
@@ -10,18 +11,6 @@ namespace NMVP::NSupportLinks {
 
 inline constexpr TStringBuf GRAFANA_WORKSPACE_KEY = "k8s_namespace";
 inline constexpr TStringBuf GRAFANA_DATASOURCE_KEY = "datasource";
-
-inline void ApplyGrafanaDashboardClusterBindings(TCgiParameters& queryParameters, const THashMap<TString, TString>& clusterInfo) {
-    const auto workspaceIt = clusterInfo.find(GRAFANA_WORKSPACE_KEY);
-    if (workspaceIt != clusterInfo.end() && !workspaceIt->second.empty()) {
-        queryParameters.InsertUnescaped("var-workspace", workspaceIt->second);
-    }
-
-    const auto datasourceIt = clusterInfo.find(GRAFANA_DATASOURCE_KEY);
-    if (datasourceIt != clusterInfo.end() && !datasourceIt->second.empty()) {
-        queryParameters.InsertUnescaped("var-ds", datasourceIt->second);
-    }
-}
 
 inline std::pair<TString, TCgiParameters> BuildGrafanaDashboardUrlParts(TStringBuf grafanaEndpoint, TStringBuf url) {
     TString resolvedUrl = IsAbsoluteUrl(url)
@@ -38,19 +27,47 @@ inline std::pair<TString, TCgiParameters> BuildGrafanaDashboardUrlParts(TStringB
     return {std::move(path), std::move(queryParameters)};
 }
 
-inline TCgiParameters BuildForwardedDashboardParameters(const TEntityIdentity& entityIdentity, const TCgiParameters& additionalRequestParams) {
-    return BuildForwardedParameters(entityIdentity, additionalRequestParams);
+inline void InsertOrReplaceDashboardVar(TCgiParameters& queryParameters, TStringBuf label, TStringBuf value) {
+    const TString varName = TStringBuilder() << "var-" << label;
+    queryParameters.EraseAll(varName);
+    queryParameters.InsertUnescaped(varName, value);
+}
+
+inline TResolvedParamBindings BuildDefaultGrafanaDashboardParamBindings() {
+    return TResolvedParamBindings{
+        .RequestMappings = {
+            {"cluster", "cluster"},
+            {"database", "database"},
+            {"node", "node"},
+            {"host", "host"},
+        },
+        .ClusterInfoMappings = {
+            {TString(GRAFANA_DATASOURCE_KEY), "ds"},
+            {TString(GRAFANA_WORKSPACE_KEY), "workspace"},
+        },
+        .StaticMappings = {},
+    };
 }
 
 inline void ApplyGrafanaDashboardBindingPolicy(
     TCgiParameters& queryParameters,
     const THashMap<TString, TString>& clusterInfo,
-    const TCgiParameters& requestQueryParameters)
-{
-    ApplyGrafanaDashboardClusterBindings(queryParameters, clusterInfo);
+    const TCgiParameters& requestQueryParameters,
+    const TResolvedParamBindings& paramBindings) {
+    for (const auto& [name, value] : BuildNonIdentityRequestParamValues(requestQueryParameters)) {
+        InsertOrReplaceDashboardVar(queryParameters, name, value);
+    }
 
-    for (const auto& [name, value] : requestQueryParameters) {
-        queryParameters.InsertUnescaped(TStringBuilder() << "var-" << name, value);
+    for (const auto& [label, value] : BuildClusterInfoParamValues(clusterInfo, paramBindings.ClusterInfoMappings)) {
+        InsertOrReplaceDashboardVar(queryParameters, label, value);
+    }
+
+    for (const auto& [label, value] : BuildStaticParamValues(paramBindings.StaticMappings)) {
+        InsertOrReplaceDashboardVar(queryParameters, label, value);
+    }
+
+    for (const auto& [label, value] : BuildRequestParamValues(requestQueryParameters, paramBindings.RequestMappings)) {
+        InsertOrReplaceDashboardVar(queryParameters, label, value);
     }
 }
 
@@ -58,10 +75,10 @@ inline TString BuildGrafanaDashboardUrl(
     TStringBuf grafanaEndpoint,
     TStringBuf url,
     const THashMap<TString, TString>& clusterInfo,
-    const TCgiParameters& requestQueryParameters)
-{
+    const TCgiParameters& requestQueryParameters,
+    const TResolvedParamBindings& paramBindings) {
     auto [path, queryParameters] = BuildGrafanaDashboardUrlParts(grafanaEndpoint, url);
-    ApplyGrafanaDashboardBindingPolicy(queryParameters, clusterInfo, requestQueryParameters);
+    ApplyGrafanaDashboardBindingPolicy(queryParameters, clusterInfo, requestQueryParameters, paramBindings);
 
     return queryParameters.empty()
         ? path
@@ -71,10 +88,10 @@ inline TString BuildGrafanaDashboardUrl(
 inline TString BuildGrafanaDashboardUrl(
     TStringBuf grafanaEndpoint,
     TStringBuf url,
-    const ILinkSource::TLinkResolveInput& input)
-{
-    const TCgiParameters forwardedParameters = BuildForwardedDashboardParameters(input.Identity, input.AdditionalRequestParams);
-    return BuildGrafanaDashboardUrl(grafanaEndpoint, url, input.ClusterInfo, forwardedParameters);
+    const ILinkSource::TLinkResolveInput& input,
+    const TResolvedParamBindings& paramBindings) {
+    const TCgiParameters forwardedParameters = BuildForwardedParameters(input.Identity, input.AdditionalRequestParams);
+    return BuildGrafanaDashboardUrl(grafanaEndpoint, url, input.ClusterInfo, forwardedParameters, paramBindings);
 }
 
 } // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -24,15 +24,12 @@ namespace NMVP::NSupportLinks {
 
 class TGrafanaDashboardSearchActor : public NActors::TActorBootstrapped<TGrafanaDashboardSearchActor> {
 public:
-    TGrafanaDashboardSearchActor(
-        TSupportLinkEntryConfig config,
-        TString grafanaEndpoint,
-        const ILinkSource::TLinkResolveInput& input,
-        const ILinkSource::TResolveContext& context)
+    TGrafanaDashboardSearchActor(TSupportLinkEntryConfig config, TString grafanaEndpoint, TResolvedParamBindings paramBindings, const ILinkSource::TLinkResolveInput& input, const ILinkSource::TResolveContext& context)
         : Config(std::move(config))
         , GrafanaEndpoint(std::move(grafanaEndpoint))
+        , ParamBindings(std::move(paramBindings))
         , ClusterInfo(input.ClusterInfo)
-        , RequestQueryParameters(BuildForwardedDashboardParameters(input.Identity, input.AdditionalRequestParams))
+        , RequestQueryParameters(BuildForwardedParameters(input.Identity, input.AdditionalRequestParams))
         , Context(context)
     {}
 
@@ -56,6 +53,7 @@ public:
 private:
     TSupportLinkEntryConfig Config;
     TString GrafanaEndpoint;
+    TResolvedParamBindings ParamBindings;
     THashMap<TString, TString> ClusterInfo;
     TCgiParameters RequestQueryParameters;
     ILinkSource::TResolveContext Context;
@@ -145,11 +143,7 @@ private:
                 continue;
             }
 
-            const TString resolvedUrl = BuildGrafanaDashboardUrl(
-                GrafanaEndpoint,
-                dashboardUrl,
-                ClusterInfo,
-                RequestQueryParameters);
+            const TString resolvedUrl = BuildGrafanaDashboardUrl(GrafanaEndpoint, dashboardUrl, ClusterInfo, RequestQueryParameters, ParamBindings);
             if (!resolvedUrl.empty()) {
                 Links.emplace_back(TResolvedLink{
                     .Title = std::move(title),
@@ -180,9 +174,10 @@ namespace NMVP::NSupportLinks {
 
 class TGrafanaDashboardSearchSource : public ILinkSource {
 public:
-    TGrafanaDashboardSearchSource(TSupportLinkEntryConfig config, TString grafanaEndpoint)
+    TGrafanaDashboardSearchSource(TSupportLinkEntryConfig config, TString grafanaEndpoint, TResolvedParamBindings paramBindings)
         : Config(std::move(config))
         , GrafanaEndpoint(std::move(grafanaEndpoint))
+        , ParamBindings(std::move(paramBindings))
     {}
 
     TResolveOutput Resolve(const ILinkSource::TLinkResolveInput& input, const ILinkSource::TResolveContext& context) const override {
@@ -193,6 +188,7 @@ public:
             new TGrafanaDashboardSearchActor(
                 Config,
                 GrafanaEndpoint,
+                ParamBindings,
                 input,
                 context),
             context.Owner);
@@ -202,6 +198,7 @@ public:
 private:
     TSupportLinkEntryConfig Config;
     TString GrafanaEndpoint;
+    TResolvedParamBindings ParamBindings;
 };
 
 inline void ValidateGrafanaDashboardSearchSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
@@ -211,14 +208,13 @@ inline void ValidateGrafanaDashboardSearchSourceConfig(const TSupportLinkEntryCo
     if (TMVP::MetaDatabaseTokenName.empty()) {
         ythrow yexception() << "meta.meta_database_token_name is required for source=" << config.GetSource();
     }
+    ValidateResolvedParamBindings(ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings()), config);
 }
 
 inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSearchSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
     ValidateGrafanaDashboardSearchSourceConfig(config, metaSettings);
-    return std::make_shared<TGrafanaDashboardSearchSource>(
-        std::move(config),
-        metaSettings.SupportLinks.GrafanaEndpoint
-    );
+    auto paramBindings = ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings());
+    return std::make_shared<TGrafanaDashboardSearchSource>(std::move(config), metaSettings.SupportLinks.GrafanaEndpoint, std::move(paramBindings));
 }
 
 } // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.h
@@ -208,7 +208,7 @@ inline void ValidateGrafanaDashboardSearchSourceConfig(const TSupportLinkEntryCo
     if (TMVP::MetaDatabaseTokenName.empty()) {
         ythrow yexception() << "meta.meta_database_token_name is required for source=" << config.GetSource();
     }
-    ValidateResolvedParamBindings(ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings()), config);
+    ValidateParamsAreUnique(ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings()), config);
 }
 
 inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSearchSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source.h
@@ -48,7 +48,7 @@ inline void ValidateGrafanaDashboardSourceConfig(const TSupportLinkEntryConfig& 
     if (!IsAbsoluteUrl(config.GetUrl()) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
         ythrow yexception() << "grafana.endpoint is required for relative url";
     }
-    ValidateResolvedParamBindings(ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings()), config);
+    ValidateParamsAreUnique(ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings()), config);
 }
 
 inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source.h
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source.h
@@ -11,15 +11,16 @@ namespace NMVP::NSupportLinks {
 
 class TGrafanaDashboardSource : public ILinkSource {
 public:
-    TGrafanaDashboardSource(TString sourceName, TString title, TString url, TString grafanaEndpoint)
+    TGrafanaDashboardSource(TString sourceName, TString title, TString url, TString grafanaEndpoint, TResolvedParamBindings paramBindings)
         : SourceName(std::move(sourceName))
         , Title(std::move(title))
         , Url(std::move(url))
         , GrafanaEndpoint(std::move(grafanaEndpoint))
+        , ParamBindings(std::move(paramBindings))
     {}
 
     TResolveOutput Resolve(const ILinkSource::TLinkResolveInput& input, const ILinkSource::TResolveContext&) const override {
-        TString resolvedUrl = BuildGrafanaDashboardUrl(GrafanaEndpoint, Url, input);
+        TString resolvedUrl = BuildGrafanaDashboardUrl(GrafanaEndpoint, Url, input, ParamBindings);
         TResolveOutput result{
             .Name = SourceName,
         };
@@ -37,6 +38,7 @@ private:
     TString Title;
     TString Url;
     TString GrafanaEndpoint;
+    TResolvedParamBindings ParamBindings;
 };
 
 inline void ValidateGrafanaDashboardSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
@@ -46,16 +48,14 @@ inline void ValidateGrafanaDashboardSourceConfig(const TSupportLinkEntryConfig& 
     if (!IsAbsoluteUrl(config.GetUrl()) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
         ythrow yexception() << "grafana.endpoint is required for relative url";
     }
+    ValidateResolvedParamBindings(ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings()), config);
 }
 
 inline std::shared_ptr<ILinkSource> MakeGrafanaDashboardSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
     ValidateGrafanaDashboardSourceConfig(config, metaSettings);
+    auto paramBindings = ResolveParamBindings(config, BuildDefaultGrafanaDashboardParamBindings());
     return std::make_shared<TGrafanaDashboardSource>(
-        config.GetSource(),
-        config.GetTitle(),
-        config.GetUrl(),
-        metaSettings.SupportLinks.GrafanaEndpoint
-    );
+        config.GetSource(), config.GetTitle(), config.GetUrl(), metaSettings.SupportLinks.GrafanaEndpoint, std::move(paramBindings));
 }
 
 } // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source_ut.cpp
@@ -261,4 +261,40 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaDashboardSource) {
             "https://grafana.example.net/d/cpu?var-workspace=ydb-workspace&var-ds=3f8a1e2c-6b7d-4c91-9a52-1d7f0e8b4a63&var-cluster=ydb-global&var-host=storage-1.example.net&var-custom_label=kept"
         );
     }
+
+    Y_UNIT_TEST(ResolveUsesExplicitMappingsForIdentityParametersButKeepsNonIdentityParameters) {
+        TGrafanaDashboardTestContext context;
+        auto* databaseMapping = context.Config.AddLinkParameterMappings();
+        databaseMapping->SetParameter("db_path");
+        databaseMapping->SetFromRequest("database");
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&database=%2Froot%2Ftest&custom_label=kept");
+        context.EntityType = EEntityType::Database;
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-custom_label=kept&var-db_path=/root/test"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesClusterInfoAndStaticMappingsAndSkipsMissingValues) {
+        TGrafanaDashboardTestContext context;
+        auto* workspaceMapping = context.Config.AddLinkParameterMappings();
+        workspaceMapping->SetParameter("workspace");
+        workspaceMapping->SetFromClusterInfo("custom_namespace");
+        auto* bucketMapping = context.Config.AddLinkParameterMappings();
+        bucketMapping->SetParameter("bucket");
+        bucketMapping->SetStaticValue("ydb");
+        auto* missingMapping = context.Config.AddLinkParameterMappings();
+        missingMapping->SetParameter("missing");
+        missingMapping->SetFromClusterInfo("missing_namespace");
+        context.ClusterInfo["custom_namespace"] = "custom-workspace";
+        context.UrlParameters = MakeUrlParameters("custom_label=kept");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://grafana.example.net/d/cpu?var-custom_label=kept&var-workspace=custom-workspace&var-bucket=ydb"
+        );
+    }
 }

--- a/ydb/mvp/meta/support_links/grafana_logging_source.h
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.h
@@ -188,7 +188,7 @@ inline void ValidateGrafanaLoggingSourceConfig(const TSupportLinkEntryConfig& co
     if (!IsAbsoluteUrl(url) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
         ythrow yexception() << "grafana.endpoint is required for relative url";
     }
-    ValidateResolvedParamBindings(ResolveParamBindings(config, BuildDefaultGrafanaLoggingParamBindings()), config);
+    ValidateParamsAreUnique(ResolveParamBindings(config, BuildDefaultGrafanaLoggingParamBindings()), config);
 }
 
 inline std::shared_ptr<ILinkSource> MakeGrafanaLoggingSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {

--- a/ydb/mvp/meta/support_links/grafana_logging_source.h
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "param_bindings.h"
 #include "source_common.h"
 
 #include <ydb/mvp/meta/support_links/source.h>
@@ -16,23 +17,20 @@ namespace NMVP::NSupportLinks {
 
 inline constexpr TStringBuf GRAFANA_LOGGING_DEFAULT_URL = "/explore";
 
-inline TVector<std::pair<TString, TString>> BuildGrafanaLoggingBindings(const TEntityIdentity& entityIdentity) {
-    TVector<std::pair<TString, TString>> bindings;
-
-    if (!entityIdentity.Cluster.empty()) {
-        bindings.emplace_back("cluster", entityIdentity.Cluster);
-    }
-    if (entityIdentity.Database && !entityIdentity.Database->empty()) {
-        bindings.emplace_back("database", *entityIdentity.Database);
-    }
-    if (entityIdentity.Node && !entityIdentity.Node->empty()) {
-        bindings.emplace_back("node", *entityIdentity.Node);
-    }
-    if (entityIdentity.Host && !entityIdentity.Host->empty()) {
-        bindings.emplace_back("host", *entityIdentity.Host);
-    }
-
-    return bindings;
+inline TResolvedParamBindings BuildDefaultGrafanaLoggingParamBindings() {
+    return TResolvedParamBindings{
+        .RequestMappings = {
+            {"database", "database"},
+            {"node", "node_id"},
+            {"host", "k8s_node_name"},
+        },
+        .ClusterInfoMappings = {
+            {"k8s_namespace", "__workspace__"},
+        },
+        .StaticMappings = {
+            {"ydb", "__bucket__"},
+        },
+    };
 }
 
 inline TString BuildGrafanaLoggingExpr(const TVector<std::pair<TString, TString>>& bindings) {
@@ -74,9 +72,9 @@ inline bool TryBuildGrafanaLoggingUrl(
     TStringBuf grafanaEndpoint,
     TStringBuf url,
     const ILinkSource::TLinkResolveInput& input,
+    const TResolvedParamBindings& paramBindings,
     TString& resolvedUrl,
-    TString& errorMessage)
-{
+    TString& errorMessage) {
     const TStringBuf path = url.empty() ? GRAFANA_LOGGING_DEFAULT_URL : url;
     resolvedUrl = IsAbsoluteUrl(path) ? TString(path) : JoinUrl(grafanaEndpoint, path);
 
@@ -85,18 +83,43 @@ inline bool TryBuildGrafanaLoggingUrl(
         return false;
     }
 
-    const auto datasourceIt = input.ClusterInfo.find("datasource_logging");
-    if (datasourceIt == input.ClusterInfo.end() || datasourceIt->second.empty()) {
+    TString datasource;
+    if (const auto datasourceIt = input.ClusterInfo.find("datasource_logging");
+        datasourceIt != input.ClusterInfo.end() && !datasourceIt->second.empty()) {
+        datasource = datasourceIt->second;
+    }
+
+    const TCgiParameters forwardedParameters = BuildForwardedParameters(input.Identity, input.AdditionalRequestParams);
+    TVector<std::pair<TString, TString>> bindings = BuildNonIdentityRequestParamValues(forwardedParameters);
+    for (auto& binding : BuildRequestParamValues(forwardedParameters, paramBindings.RequestMappings)) {
+        bindings.push_back(std::move(binding));
+    }
+    for (auto& binding : BuildClusterInfoParamValues(input.ClusterInfo, paramBindings.ClusterInfoMappings)) {
+        bindings.push_back(std::move(binding));
+    }
+    for (auto& binding : BuildStaticParamValues(paramBindings.StaticMappings)) {
+        bindings.push_back(std::move(binding));
+    }
+
+    TVector<std::pair<TString, TString>> resolvedBindings;
+    resolvedBindings.reserve(bindings.size());
+    for (auto& binding : bindings) {
+        if (binding.first == "datasource") {
+            datasource = std::move(binding.second);
+            continue;
+        }
+        resolvedBindings.push_back(std::move(binding));
+    }
+
+    if (datasource.empty()) {
         errorMessage = "datasource_logging is required in cluster info for source=grafana/logging";
         return false;
     }
 
-    TVector<std::pair<TString, TString>> bindings = BuildGrafanaLoggingBindings(input.Identity);
-
     TCgiParameters queryParameters;
     queryParameters.InsertUnescaped("schemaVersion", "1");
     queryParameters.InsertUnescaped("panes", NJson::WriteJson(
-        BuildGrafanaLoggingPanesJson(datasourceIt->second, bindings),
+        BuildGrafanaLoggingPanesJson(datasource, resolvedBindings),
         false));
     queryParameters.InsertUnescaped("orgId", "1");
 
@@ -110,11 +133,12 @@ namespace NMVP::NSupportLinks {
 
 class TGrafanaLoggingSource : public ILinkSource {
 public:
-    TGrafanaLoggingSource(TString sourceName, TString title, TString url, TString grafanaEndpoint)
+    TGrafanaLoggingSource(TString sourceName, TString title, TString url, TString grafanaEndpoint, TResolvedParamBindings paramBindings)
         : SourceName(std::move(sourceName))
         , Title(std::move(title))
         , Url(std::move(url))
         , GrafanaEndpoint(std::move(grafanaEndpoint))
+        , ParamBindings(std::move(paramBindings))
     {}
 
     TResolveOutput Resolve(const ILinkSource::TLinkResolveInput& input, const ILinkSource::TResolveContext&) const override {
@@ -128,6 +152,7 @@ public:
                 GrafanaEndpoint,
                 Url,
                 input,
+                ParamBindings,
                 resolvedUrl,
                 errorMessage))
         {
@@ -150,6 +175,7 @@ private:
     TString Title;
     TString Url;
     TString GrafanaEndpoint;
+    TResolvedParamBindings ParamBindings;
 };
 
 inline void ValidateGrafanaLoggingSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
@@ -162,16 +188,14 @@ inline void ValidateGrafanaLoggingSourceConfig(const TSupportLinkEntryConfig& co
     if (!IsAbsoluteUrl(url) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
         ythrow yexception() << "grafana.endpoint is required for relative url";
     }
+    ValidateResolvedParamBindings(ResolveParamBindings(config, BuildDefaultGrafanaLoggingParamBindings()), config);
 }
 
 inline std::shared_ptr<ILinkSource> MakeGrafanaLoggingSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
     ValidateGrafanaLoggingSourceConfig(config, metaSettings);
+    auto paramBindings = ResolveParamBindings(config, BuildDefaultGrafanaLoggingParamBindings());
     return std::make_shared<TGrafanaLoggingSource>(
-        config.GetSource(),
-        config.GetTitle(),
-        config.GetUrl(),
-        metaSettings.SupportLinks.GrafanaEndpoint
-    );
+        config.GetSource(), config.GetTitle(), config.GetUrl(), metaSettings.SupportLinks.GrafanaEndpoint, std::move(paramBindings));
 }
 
 } // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
@@ -87,8 +87,7 @@ void AssertPanesQuery(
     const TString& url,
     TStringBuf expectedBaseUrl,
     TStringBuf expectedExpr,
-    TStringBuf expectedDatasource)
-{
+    TStringBuf expectedDatasource) {
     const TStringBuf actualUrl = url;
     UNIT_ASSERT_VALUES_EQUAL(actualUrl.Before('?'), expectedBaseUrl);
 
@@ -138,7 +137,7 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{database=\"/root/tenant\"}",
+            "{database=\"/root/tenant\", __bucket__=\"ydb\"}",
             "cd868168-09d4-4ece-82db-e646130697e5"
         );
     }
@@ -155,7 +154,7 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://external.example.net/explore",
-            "{database=\"/new/db\"}",
+            "{database=\"/new/db\", __bucket__=\"ydb\"}",
             "ds-42"
         );
     }
@@ -172,7 +171,7 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{database=\"/new/db\"}",
+            "{custom_label=\"new-value\", database=\"/new/db\", __bucket__=\"ydb\"}",
             "ds-42"
         );
     }
@@ -189,7 +188,7 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{cluster=\"test-cluster\", host=\"storage-1.example.net\"}",
+            "{custom_label=\"kept\", k8s_node_name=\"storage-1.example.net\", __bucket__=\"ydb\"}",
             "ds-42"
         );
     }
@@ -206,7 +205,27 @@ Y_UNIT_TEST_SUITE(SupportLinksGrafanaLoggingSource) {
         AssertPanesQuery(
             result.Links[0].Url,
             "https://grafana.example.net/explore",
-            "{database=\"/new/db\"}",
+            "{database=\"/new/db\", __bucket__=\"ydb\"}",
+            "ds-42"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesExplicitMappingsForIdentityParametersButKeepsNonIdentityParameters) {
+        TGrafanaLoggingTestContext context;
+        context.ClusterInfo["datasource_logging"] = "ds-42";
+        auto* databaseMapping = context.Config.AddLinkParameterMappings();
+        databaseMapping->SetParameter("db_path");
+        databaseMapping->SetFromRequest("database");
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&database=%2Fnew%2Fdb&custom_label=kept");
+        context.EntityType = EEntityType::Database;
+        auto result = context.Resolve();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+        AssertPanesQuery(
+            result.Links[0].Url,
+            "https://grafana.example.net/explore",
+            "{custom_label=\"kept\", db_path=\"/new/db\"}",
             "ds-42"
         );
     }

--- a/ydb/mvp/meta/support_links/param_bindings.h
+++ b/ydb/mvp/meta/support_links/param_bindings.h
@@ -28,22 +28,24 @@ inline TResolvedParamBindings ResolveConfiguredParamMappings(const TSupportLinkE
             ythrow yexception() << "link_parameter_mappings.parameter is required for source=" << config.GetSource();
         }
 
-        if (!mapping.HasFromRequest() && !mapping.HasFromClusterInfo() && !mapping.HasStaticValue()) {
-            ythrow yexception()
-                << "link_parameter_mappings.parameter=" << mapping.GetParameter()
-                << " must set one of from_request, from_cluster_info or static_value for source="
-                << config.GetSource();
-        }
+        switch (mapping.GetSourceValueCase()) {
+            case TSupportLinkEntryConfig::TLinkParameterMapping::kFromRequest:
+                paramBindings.RequestMappings.emplace_back(mapping.GetFromRequest(), mapping.GetParameter());
+                break;
 
-        if (mapping.HasFromRequest()) {
-            paramBindings.RequestMappings.emplace_back(mapping.GetFromRequest(), mapping.GetParameter());
-            continue;
-        }
+            case TSupportLinkEntryConfig::TLinkParameterMapping::kFromClusterInfo:
+                paramBindings.ClusterInfoMappings.emplace_back(mapping.GetFromClusterInfo(), mapping.GetParameter());
+                break;
 
-        if (mapping.HasFromClusterInfo()) {
-            paramBindings.ClusterInfoMappings.emplace_back(mapping.GetFromClusterInfo(), mapping.GetParameter());
-        } else {
-            paramBindings.StaticMappings.emplace_back(mapping.GetStaticValue(), mapping.GetParameter());
+            case TSupportLinkEntryConfig::TLinkParameterMapping::kStaticValue:
+                paramBindings.StaticMappings.emplace_back(mapping.GetStaticValue(), mapping.GetParameter());
+                break;
+
+            case TSupportLinkEntryConfig::TLinkParameterMapping::SOURCEVALUE_NOT_SET:
+                ythrow yexception()
+                    << "link_parameter_mappings.parameter=" << mapping.GetParameter()
+                    << " must set one of from_request, from_cluster_info or static_value for source="
+                    << config.GetSource();
         }
     }
 

--- a/ydb/mvp/meta/support_links/param_bindings.h
+++ b/ydb/mvp/meta/support_links/param_bindings.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include "source.h"
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
+#include <util/generic/yexception.h>
+
+namespace NMVP::NSupportLinks {
+
+struct TResolvedParamBindings {
+    TVector<std::pair<TString, TString>> RequestMappings;
+    TVector<std::pair<TString, TString>> ClusterInfoMappings;
+    TVector<std::pair<TString, TString>> StaticMappings;
+};
+
+inline TResolvedParamBindings ResolveConfiguredParamMappings(const TSupportLinkEntryConfig& config) {
+    TResolvedParamBindings paramBindings;
+    paramBindings.RequestMappings.reserve(config.LinkParameterMappingsSize());
+    paramBindings.ClusterInfoMappings.reserve(config.LinkParameterMappingsSize());
+    paramBindings.StaticMappings.reserve(config.LinkParameterMappingsSize());
+
+    const int linkParameterMappingsSize = config.LinkParameterMappingsSize();
+    for (int i = 0; i < linkParameterMappingsSize; ++i) {
+        const auto& mapping = config.GetLinkParameterMappings(i);
+        if (!mapping.HasParameter() || mapping.GetParameter().empty()) {
+            ythrow yexception() << "link_parameter_mappings.parameter is required for source=" << config.GetSource();
+        }
+
+        const bool hasFromRequest = mapping.HasFromRequest();
+        const bool hasFromClusterInfo = mapping.HasFromClusterInfo();
+        const bool hasStaticValue = mapping.HasStaticValue();
+        const size_t sourceCount = hasFromRequest + hasFromClusterInfo + hasStaticValue;
+        if (sourceCount != 1) {
+            ythrow yexception()
+                << "link_parameter_mappings.parameter=" << mapping.GetParameter()
+                << " must set exactly one of from_request, from_cluster_info or static_value for source="
+                << config.GetSource();
+        }
+
+        if (hasFromRequest) {
+            paramBindings.RequestMappings.emplace_back(mapping.GetFromRequest(), mapping.GetParameter());
+            continue;
+        }
+
+        if (hasFromClusterInfo) {
+            paramBindings.ClusterInfoMappings.emplace_back(mapping.GetFromClusterInfo(), mapping.GetParameter());
+        } else {
+            paramBindings.StaticMappings.emplace_back(mapping.GetStaticValue(), mapping.GetParameter());
+        }
+    }
+
+    return paramBindings;
+}
+
+inline TResolvedParamBindings ResolveParamBindings(const TSupportLinkEntryConfig& config, const TResolvedParamBindings& defaultParamBindings) {
+    if (config.LinkParameterMappingsSize() != 0) {
+        return ResolveConfiguredParamMappings(config);
+    }
+
+    return defaultParamBindings;
+}
+
+inline void ValidateResolvedParamBindings(const TResolvedParamBindings& paramBindings, const TSupportLinkEntryConfig& config) {
+    THashSet<TString> labels;
+
+    for (const auto& [requestParamName, targetLabel] : paramBindings.RequestMappings) {
+        Y_UNUSED(requestParamName);
+        if (!labels.insert(targetLabel).second) {
+            ythrow yexception()
+                << "duplicate target label '" << targetLabel
+                << "' in link_parameter_mappings for source=" << config.GetSource();
+        }
+    }
+
+    for (const auto& [clusterInfoField, targetLabel] : paramBindings.ClusterInfoMappings) {
+        Y_UNUSED(clusterInfoField);
+        if (!labels.insert(targetLabel).second) {
+            ythrow yexception()
+                << "duplicate target label '" << targetLabel
+                << "' in link_parameter_mappings for source=" << config.GetSource();
+        }
+    }
+
+    for (const auto& [staticValue, targetLabel] : paramBindings.StaticMappings) {
+        Y_UNUSED(staticValue);
+        if (!labels.insert(targetLabel).second) {
+            ythrow yexception()
+                << "duplicate target label '" << targetLabel
+                << "' in link_parameter_mappings for source=" << config.GetSource();
+        }
+    }
+}
+
+inline TVector<std::pair<TString, TString>> BuildRequestParamValues(const TCgiParameters& requestParameters, const TVector<std::pair<TString, TString>>& requestMappings) {
+    TVector<std::pair<TString, TString>> paramValues;
+
+    for (const auto& [requestParamName, targetLabel] : requestMappings) {
+        const TString value = requestParameters.Get(requestParamName);
+        if (!value.empty()) {
+            paramValues.emplace_back(targetLabel, value);
+        }
+    }
+
+    return paramValues;
+}
+
+inline TVector<std::pair<TString, TString>> BuildNonIdentityRequestParamValues(const TCgiParameters& requestParameters) {
+    TVector<std::pair<TString, TString>> paramValues;
+
+    for (const auto& [name, value] : requestParameters) {
+        if (!IsIdentityRequestParameter(name) && !value.empty()) {
+            paramValues.emplace_back(name, value);
+        }
+    }
+
+    return paramValues;
+}
+
+inline TVector<std::pair<TString, TString>> BuildClusterInfoParamValues(const THashMap<TString, TString>& clusterInfo, const TVector<std::pair<TString, TString>>& clusterInfoMappings) {
+    TVector<std::pair<TString, TString>> paramValues;
+
+    for (const auto& [clusterInfoField, targetLabel] : clusterInfoMappings) {
+        const auto it = clusterInfo.find(clusterInfoField);
+        if (it != clusterInfo.end() && !it->second.empty()) {
+            paramValues.emplace_back(targetLabel, it->second);
+        }
+    }
+
+    return paramValues;
+}
+
+inline TVector<std::pair<TString, TString>> BuildStaticParamValues(const TVector<std::pair<TString, TString>>& staticMappings) {
+    TVector<std::pair<TString, TString>> paramValues;
+    paramValues.reserve(staticMappings.size());
+
+    for (const auto& [staticValue, targetLabel] : staticMappings) {
+        paramValues.emplace_back(targetLabel, staticValue);
+    }
+
+    return paramValues;
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/param_bindings.h
+++ b/ydb/mvp/meta/support_links/param_bindings.h
@@ -28,23 +28,19 @@ inline TResolvedParamBindings ResolveConfiguredParamMappings(const TSupportLinkE
             ythrow yexception() << "link_parameter_mappings.parameter is required for source=" << config.GetSource();
         }
 
-        const bool hasFromRequest = mapping.HasFromRequest();
-        const bool hasFromClusterInfo = mapping.HasFromClusterInfo();
-        const bool hasStaticValue = mapping.HasStaticValue();
-        const size_t sourceCount = hasFromRequest + hasFromClusterInfo + hasStaticValue;
-        if (sourceCount != 1) {
+        if (!mapping.HasFromRequest() && !mapping.HasFromClusterInfo() && !mapping.HasStaticValue()) {
             ythrow yexception()
                 << "link_parameter_mappings.parameter=" << mapping.GetParameter()
-                << " must set exactly one of from_request, from_cluster_info or static_value for source="
+                << " must set one of from_request, from_cluster_info or static_value for source="
                 << config.GetSource();
         }
 
-        if (hasFromRequest) {
+        if (mapping.HasFromRequest()) {
             paramBindings.RequestMappings.emplace_back(mapping.GetFromRequest(), mapping.GetParameter());
             continue;
         }
 
-        if (hasFromClusterInfo) {
+        if (mapping.HasFromClusterInfo()) {
             paramBindings.ClusterInfoMappings.emplace_back(mapping.GetFromClusterInfo(), mapping.GetParameter());
         } else {
             paramBindings.StaticMappings.emplace_back(mapping.GetStaticValue(), mapping.GetParameter());
@@ -62,7 +58,7 @@ inline TResolvedParamBindings ResolveParamBindings(const TSupportLinkEntryConfig
     return defaultParamBindings;
 }
 
-inline void ValidateResolvedParamBindings(const TResolvedParamBindings& paramBindings, const TSupportLinkEntryConfig& config) {
+inline void ValidateParamsAreUnique(const TResolvedParamBindings& paramBindings, const TSupportLinkEntryConfig& config) {
     THashSet<TString> labels;
 
     for (const auto& [requestParamName, targetLabel] : paramBindings.RequestMappings) {

--- a/ydb/tests/functional/mvp/meta/test_support_links.py
+++ b/ydb/tests/functional/mvp/meta/test_support_links.py
@@ -180,7 +180,7 @@ def test_meta_support_links_returns_logging_link_for_node_id(meta_support_links_
     assert_logging_support_links_response(
         meta_support_links_env.get_ok_support_links_payload(CLUSTER_NAME, node=NODE_ID),
         "Node Logs",
-        f'{{cluster="{CLUSTER_NAME}", node="{NODE_ID}"}}',
+        f'{{node_id="{NODE_ID}", __workspace__="{WORKSPACE_NAME}", __bucket__="ydb"}}',
     )
 
 
@@ -188,7 +188,7 @@ def test_meta_support_links_returns_logging_link_for_host(meta_support_links_env
     assert_logging_support_links_response(
         meta_support_links_env.get_ok_support_links_payload(CLUSTER_NAME, host=HOST_NAME),
         "Host Logs",
-        f'{{cluster="{CLUSTER_NAME}", host="{HOST_NAME}"}}',
+        f'{{k8s_node_name="{HOST_NAME}", __workspace__="{WORKSPACE_NAME}", __bucket__="ydb"}}',
     )
 
 
@@ -200,8 +200,8 @@ def test_meta_support_links_combines_node_and_host_groups(meta_support_links_env
             host=HOST_NAME,
         ),
         [
-            ("Node Logs", f'{{cluster="{CLUSTER_NAME}", node="{NODE_ID}"}}'),
-            ("Host Logs", f'{{cluster="{CLUSTER_NAME}", host="{HOST_NAME}"}}'),
+            ("Node Logs", f'{{node_id="{NODE_ID}", __workspace__="{WORKSPACE_NAME}", __bucket__="ydb"}}'),
+            ("Host Logs", f'{{k8s_node_name="{HOST_NAME}", __workspace__="{WORKSPACE_NAME}", __bucket__="ydb"}}'),
         ],
     )
 
@@ -215,8 +215,8 @@ def test_meta_support_links_skips_additional_and_foreign_identity_params_for_log
             extra_params={"custom_label": "kept"},
         ),
         [
-            ("Node Logs", f'{{cluster="{CLUSTER_NAME}", node="{NODE_ID}"}}'),
-            ("Host Logs", f'{{cluster="{CLUSTER_NAME}", host="{HOST_NAME}"}}'),
+            ("Node Logs", f'{{custom_label="kept", node_id="{NODE_ID}", __workspace__="{WORKSPACE_NAME}", __bucket__="ydb"}}'),
+            ("Host Logs", f'{{custom_label="kept", k8s_node_name="{HOST_NAME}", __workspace__="{WORKSPACE_NAME}", __bucket__="ydb"}}'),
         ],
     )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR adds configurable `link_parameter_mappings` for Meta support links.
It allows a support link entry to map a generated link parameter from a request parameter, from cluster info, or from a static value.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Added configurable `link_parameter_mappings` for Meta support links.
- A generated link parameter can now come from `from_request`, `from_cluster_info`, or `static_value`.

- Without `link_parameter_mappings`, source-specific default bindings are used.

- Without `link_parameter_mappings`, `grafana/dashboard`:
  - forwards request parameters as `var-*`
  - includes default mappings for `cluster`, `database`, `node`, and `host`
  - adds `var-workspace` and `var-ds` from cluster info when available

- Without `link_parameter_mappings`, `grafana/logging`:
  - forwards only non-key request parameters automatically
  - includes default mappings for `database`, `node`, and `host`
  - does not forward `cluster` automatically
  - adds `__workspace__` from cluster info
  - adds `__bucket__ = ydb`

- When `link_parameter_mappings` are set:
  - only non-key request parameters are forwarded automatically
  - key parameters must be mapped explicitly if needed
  - source-specific default cluster-info/static mappings are no longer added automatically

- For `grafana/dashboard`, mapped parameters are written to the final URL with the `var-` prefix.

- For `grafana/logging`, `cluster` is included only if it is mapped explicitly.

- If a mapped value is missing in request or cluster info, that generated parameter is skipped without error.