### PR TITLE
Reduce PQ head memory after DataHead reload

### DIFF
--- a/ydb/core/persqueue/pqtablet/blob/blob.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob.cpp
@@ -20,24 +20,29 @@ bool CanWriteOffsetDeltaInKeys() {
 struct TSharedPackedDataStats {
     ui32 LiveBatchCount = 0;
     ui64 LivePayloadSize = 0;
-    bool ShouldMaterialize = false;
 };
 
 bool ShouldMaterializeSharedData(const TPackedBatchDataOwner& owner, const TSharedPackedDataStats& stats)
 {
-    if (!owner.InitialBatchCount || !stats.LiveBatchCount) {
+    if (!stats.LiveBatchCount) {
         return false;
     }
 
-    // A materialized batch gets its own small heap allocation. The estimate is
-    // deliberately conservative: it accounts for allocator rounding plus local
-    // buffer metadata without depending on a particular allocator size class.
-    static constexpr ui64 PerOwnedBatchOverheadEstimate = 256;
-    static constexpr ui32 MinDroppedBatchRatio = 2;
-    const ui64 materializedBytesEstimate = stats.LivePayloadSize + stats.LiveBatchCount * PerOwnedBatchOverheadEstimate;
+    AFL_ENSURE(stats.LiveBatchCount <= owner.InitialBatchCount)
+        ("liveBatchCount", stats.LiveBatchCount)
+        ("initialBatchCount", owner.InitialBatchCount);
+    AFL_ENSURE(stats.LivePayloadSize <= owner.InitialPayloadSize)
+        ("livePayloadSize", stats.LivePayloadSize)
+        ("initialPayloadSize", owner.InitialPayloadSize);
 
-    return stats.LiveBatchCount * MinDroppedBatchRatio <= owner.InitialBatchCount
-        && owner.Data.size() > materializedBytesEstimate;
+    // Keep the DataHead value shared while most of its parsed batches are still
+    // live. Materialize only after at least as much data was dropped as remains
+    // live, so small head movement does not destroy the allocation-saving
+    // effect of sharing.
+    const ui32 droppedBatchCount = owner.InitialBatchCount - stats.LiveBatchCount;
+    const ui64 droppedPayloadSize = owner.InitialPayloadSize - stats.LivePayloadSize;
+    return droppedBatchCount >= stats.LiveBatchCount
+        || droppedPayloadSize >= stats.LivePayloadSize;
 }
 
 }
@@ -70,14 +75,14 @@ TPackedBatchData::TPackedBatchData(TBuffer&& data)
 TPackedBatchData::TPackedBatchData(TIntrusivePtr<TPackedBatchDataOwner> owner, ui32 offset, ui32 size)
     : Owner(std::move(owner))
     , Offset(offset)
-    , Size_(size)
+    , PayloadSize(size)
 {
     AFL_ENSURE(Owner);
-    AFL_ENSURE(static_cast<size_t>(Offset) + Size_ <= Owner->Data.size())
+    AFL_ENSURE(static_cast<size_t>(Offset) + PayloadSize <= Owner->Data.size())
         ("offset", Offset)
-        ("size", Size_)
+        ("size", PayloadSize)
         ("ownerSize", Owner->Data.size());
-    Owner->RegisterBatch(Size_);
+    Owner->RegisterBatch(PayloadSize);
 }
 
 const char* TPackedBatchData::data() const noexcept
@@ -92,12 +97,12 @@ size_t TPackedBatchData::size() const noexcept
 
 size_t TPackedBatchData::Size() const noexcept
 {
-    return Owner ? Size_ : Buffer.Size();
+    return Owner ? PayloadSize : Buffer.Size();
 }
 
 size_t TPackedBatchData::Capacity() const noexcept
 {
-    return Owner ? Size_ : Buffer.Capacity();
+    return Owner ? PayloadSize : Buffer.Capacity();
 }
 
 bool TPackedBatchData::Empty() const noexcept
@@ -121,10 +126,10 @@ void TPackedBatchData::Materialize()
         return;
     }
 
-    TBuffer buffer(Owner->Data.data() + Offset, Size_);
+    TBuffer buffer(Owner->Data.data() + Offset, PayloadSize);
     Owner.Reset();
     Offset = 0;
-    Size_ = 0;
+    PayloadSize = 0;
     Buffer = std::move(buffer);
 }
 
@@ -132,7 +137,7 @@ void TPackedBatchData::Reset()
 {
     Owner.Reset();
     Offset = 0;
-    Size_ = 0;
+    PayloadSize = 0;
     TBuffer().Swap(Buffer);
 }
 
@@ -500,10 +505,6 @@ void THead::MaterializeRetainedSharedData() {
         }
     }
 
-    for (auto& [owner, stats] : owners) {
-        stats.ShouldMaterialize = ShouldMaterializeSharedData(*owner, stats);
-    }
-
     for (auto& batch : Batches) {
         if (!batch.Packed) {
             continue;
@@ -511,7 +512,7 @@ void THead::MaterializeRetainedSharedData() {
 
         if (const auto* owner = batch.PackedData.SharedOwner()) {
             const auto it = owners.find(owner);
-            if (it != owners.end() && it->second.ShouldMaterialize) {
+            if (it != owners.end() && ShouldMaterializeSharedData(*owner, it->second)) {
                 batch.PackedData.Materialize();
             }
         }

--- a/ydb/core/persqueue/pqtablet/blob/blob.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob.cpp
@@ -1,6 +1,7 @@
 #include "blob.h"
 #include "header.h"
 
+#include <util/generic/hash.h>
 #include <util/string/builder.h>
 #include <util/string/escape.h>
 #include <util/system/unaligned_mem.h>
@@ -16,6 +17,123 @@ bool CanWriteOffsetDeltaInKeys() {
     return HasAppData() && AppData()->FeatureFlags.GetEnableTopicWriteOffsetDeltaInKeys();
 }
 
+struct TSharedPackedDataStats {
+    ui32 LiveBatchCount = 0;
+    ui64 LivePayloadSize = 0;
+    bool ShouldMaterialize = false;
+};
+
+bool ShouldMaterializeSharedData(const TPackedBatchDataOwner& owner, const TSharedPackedDataStats& stats)
+{
+    if (!owner.InitialBatchCount || !stats.LiveBatchCount) {
+        return false;
+    }
+
+    // A materialized batch gets its own small heap allocation. The estimate is
+    // deliberately conservative: it accounts for allocator rounding plus local
+    // buffer metadata without depending on a particular allocator size class.
+    static constexpr ui64 PerOwnedBatchOverheadEstimate = 256;
+    static constexpr ui32 MinDroppedBatchRatio = 2;
+    const ui64 materializedBytesEstimate = stats.LivePayloadSize + stats.LiveBatchCount * PerOwnedBatchOverheadEstimate;
+
+    return stats.LiveBatchCount * MinDroppedBatchRatio <= owner.InitialBatchCount
+        && owner.Data.size() > materializedBytesEstimate;
+}
+
+}
+
+//
+// TPackedBatchData
+//
+
+TPackedBatchDataOwner::TPackedBatchDataOwner(TString&& data)
+    : Data(std::move(data))
+{
+}
+
+void TPackedBatchDataOwner::RegisterBatch(ui32 payloadSize)
+{
+    ++InitialBatchCount;
+    InitialPayloadSize += payloadSize;
+}
+
+TPackedBatchData::TPackedBatchData(const char* data, size_t size)
+    : Buffer(data, size)
+{
+}
+
+TPackedBatchData::TPackedBatchData(TBuffer&& data)
+    : Buffer(std::move(data))
+{
+}
+
+TPackedBatchData::TPackedBatchData(TIntrusivePtr<TPackedBatchDataOwner> owner, ui32 offset, ui32 size)
+    : Owner(std::move(owner))
+    , Offset(offset)
+    , Size_(size)
+{
+    AFL_ENSURE(Owner);
+    AFL_ENSURE(static_cast<size_t>(Offset) + Size_ <= Owner->Data.size())
+        ("offset", Offset)
+        ("size", Size_)
+        ("ownerSize", Owner->Data.size());
+    Owner->RegisterBatch(Size_);
+}
+
+const char* TPackedBatchData::data() const noexcept
+{
+    return Owner ? Owner->Data.data() + Offset : Buffer.data();
+}
+
+size_t TPackedBatchData::size() const noexcept
+{
+    return Size();
+}
+
+size_t TPackedBatchData::Size() const noexcept
+{
+    return Owner ? Size_ : Buffer.Size();
+}
+
+size_t TPackedBatchData::Capacity() const noexcept
+{
+    return Owner ? Size_ : Buffer.Capacity();
+}
+
+bool TPackedBatchData::Empty() const noexcept
+{
+    return Size() == 0;
+}
+
+bool TPackedBatchData::IsShared() const noexcept
+{
+    return static_cast<bool>(Owner);
+}
+
+const TPackedBatchDataOwner* TPackedBatchData::SharedOwner() const noexcept
+{
+    return Owner.Get();
+}
+
+void TPackedBatchData::Materialize()
+{
+    if (!Owner) {
+        return;
+    }
+
+    TBuffer buffer(Owner->Data.data() + Offset, Size_);
+    Owner.Reset();
+    Offset = 0;
+    Size_ = 0;
+    Buffer = std::move(buffer);
+}
+
+void TPackedBatchData::Reset()
+{
+    Owner.Reset();
+    Offset = 0;
+    Size_ = 0;
+    TBuffer().Swap(Buffer);
 }
 
 //
@@ -114,7 +232,6 @@ TString TClientBlob::DebugString() const {
 TBatch::TBatch()
     : Packed(false)
 {
-    PackedData.Reserve(8_MB);
 }
 
 TBatch::TBatch(const ui64 offset, const ui16 partNo)
@@ -131,6 +248,13 @@ TBatch::TBatch(const NKikimrPQ::TBatchHeader &header, const char* data)
     : Packed(true)
     , Header(header)
     , PackedData(data, header.GetPayloadSize())
+{
+}
+
+TBatch::TBatch(const NKikimrPQ::TBatchHeader& header, TIntrusivePtr<TPackedBatchDataOwner> owner, ui32 payloadOffset)
+    : Packed(true)
+    , Header(header)
+    , PackedData(std::move(owner), payloadOffset, header.GetPayloadSize())
 {
 }
 
@@ -327,6 +451,11 @@ void THead::AddBatch(const TBatch& batch) {
     InternalPartsCount += b.GetInternalPartsCount();
 }
 
+void THead::AddBatch(TBatch&& batch) {
+    auto& b = Batches.emplace_back(std::move(batch));
+    InternalPartsCount += b.GetInternalPartsCount();
+}
+
 void THead::ClearBatches() {
     Batches.clear();
     InternalPartsCount = 0;
@@ -345,12 +474,48 @@ const TBatch& THead::GetLastBatch() const {
     return Batches.back();
 }
 
-TBatch THead::ExtractFirstBatch() {
+TBatch THead::ExtractFirstBatch(bool materializeSharedData) {
     AFL_ENSURE(!Batches.empty());
     auto batch = std::move(Batches.front());
     InternalPartsCount -= batch.GetInternalPartsCount();
     Batches.pop_front();
+    if (materializeSharedData) {
+        MaterializeRetainedSharedData();
+    }
     return batch;
+}
+
+void THead::MaterializeRetainedSharedData() {
+    THashMap<const TPackedBatchDataOwner*, TSharedPackedDataStats> owners;
+
+    for (const auto& batch : Batches) {
+        if (!batch.Packed) {
+            continue;
+        }
+
+        if (const auto* owner = batch.PackedData.SharedOwner()) {
+            auto& stats = owners[owner];
+            ++stats.LiveBatchCount;
+            stats.LivePayloadSize += batch.PackedData.Size();
+        }
+    }
+
+    for (auto& [owner, stats] : owners) {
+        stats.ShouldMaterialize = ShouldMaterializeSharedData(*owner, stats);
+    }
+
+    for (auto& batch : Batches) {
+        if (!batch.Packed) {
+            continue;
+        }
+
+        if (const auto* owner = batch.PackedData.SharedOwner()) {
+            const auto it = owners.find(owner);
+            if (it != owners.end() && it->second.ShouldMaterialize) {
+                batch.PackedData.Materialize();
+            }
+        }
+    }
 }
 
 void THead::AddBlob(const TClientBlob& blob) {
@@ -798,13 +963,25 @@ bool TPartitionedBlob::IsNextPart(const TString& sourceId, const ui64 seqNo, con
 
 
 TBlobIterator::TBlobIterator(const TKey& key, const TString& blob)
+    : TBlobIterator(key, blob, EDataOwnership::Borrowed)
+{
+}
+
+TBlobIterator::TBlobIterator(const TKey& key, const TString& blob, EDataOwnership ownership)
     : Key(key)
-    , Data(blob.c_str())
-    , End(Data + blob.size())
     , Offset(key.GetOffset())
     , Count(0)
     , InternalPartsCount(0)
 {
+    if (ownership == EDataOwnership::Shared) {
+        Owner = MakeIntrusive<TPackedBatchDataOwner>(TString(blob));
+        Data = Owner->Data.data();
+        End = Data + Owner->Data.size();
+    } else {
+        Data = blob.data();
+        End = Data + blob.size();
+    }
+
     AFL_ENSURE(Data != End)("Key", Key.ToString())("blob.size", blob.size());
     ParseBatch();
     AFL_ENSURE(Header.GetPartNo() == Key.GetPartNo());
@@ -843,7 +1020,15 @@ TBatch TBlobIterator::GetBatch()
 {
     AFL_ENSURE(IsValid());
 
-    return TBatch(Header, Data + sizeof(ui16) + Header.ByteSize());
+    const char* payload = Data + sizeof(ui16) + Header.ByteSize();
+    if (Owner) {
+        const auto offset = payload - Owner->Data.data();
+        AFL_ENSURE(offset >= 0);
+        AFL_ENSURE(static_cast<ui64>(offset) <= Max<ui32>());
+        return TBatch(Header, Owner, static_cast<ui32>(offset));
+    }
+
+    return TBatch(Header, payload);
 }
 
 TVector<TBatch> GetUnpackedBatches(const TKey& key, const TString& blob)

--- a/ydb/core/persqueue/pqtablet/blob/blob.h
+++ b/ydb/core/persqueue/pqtablet/blob/blob.h
@@ -2,8 +2,10 @@
 #include <ydb/core/persqueue/common/key.h>
 
 #include <util/datetime/base.h>
+#include <util/generic/buffer.h>
 #include <util/generic/size_literals.h>
 #include <util/generic/maybe.h>
+#include <util/generic/ptr.h>
 #include <util/generic/vector.h>
 
 #include <deque>
@@ -79,6 +81,42 @@ struct TPosition {
     ui16 PartNo;
 };
 
+struct TPackedBatchDataOwner final: public TAtomicRefCount<TPackedBatchDataOwner> {
+    explicit TPackedBatchDataOwner(TString&& data);
+
+    void RegisterBatch(ui32 payloadSize);
+
+    TString Data;
+    ui32 InitialBatchCount = 0;
+    ui64 InitialPayloadSize = 0;
+};
+
+class TPackedBatchData {
+public:
+    TPackedBatchData() = default;
+    TPackedBatchData(const char* data, size_t size);
+    explicit TPackedBatchData(TBuffer&& data);
+    TPackedBatchData(TIntrusivePtr<TPackedBatchDataOwner> owner, ui32 offset, ui32 size);
+
+    const char* data() const noexcept;
+
+    size_t size() const noexcept;
+    size_t Size() const noexcept;
+    size_t Capacity() const noexcept;
+    bool Empty() const noexcept;
+    bool IsShared() const noexcept;
+    const TPackedBatchDataOwner* SharedOwner() const noexcept;
+
+    void Materialize();
+    void Reset();
+
+private:
+    TBuffer Buffer;
+    TIntrusivePtr<TPackedBatchDataOwner> Owner;
+    ui32 Offset = 0;
+    ui32 Size_ = 0;
+};
+
 //TBatch represents several clientBlobs. Can be in unpacked state(TVector<TClientBlob> blobs)
 //or packed(PackedData)
 //on disk representation:
@@ -93,12 +131,13 @@ struct TBatch {
     TVector<TClientBlob> Blobs;
     TVector<ui32> InternalPartsPos;
     NKikimrPQ::TBatchHeader Header;
-    TBuffer PackedData;
+    TPackedBatchData PackedData;
     TInstant EndWriteTimestamp;
 
     TBatch();
     TBatch(const ui64 offset, const ui16 partNo);
     TBatch(const NKikimrPQ::TBatchHeader &header, const char* data);
+    TBatch(const NKikimrPQ::TBatchHeader& header, TIntrusivePtr<TPackedBatchDataOwner> owner, ui32 payloadOffset);
 
     static TBatch FromBlobs(const ui64 offset, std::deque<TClientBlob>&& blobs);
 
@@ -134,7 +173,13 @@ TClientBlob DeserializeClientBlob(const char *data, ui32 size);
 
 class TBlobIterator {
 public:
+    enum class EDataOwnership {
+        Borrowed,
+        Shared,
+    };
+
     TBlobIterator(const TKey& key, const TString& blob);
+    TBlobIterator(const TKey& key, const TString& blob, EDataOwnership ownership);
 
     //return true is there is batch
     bool IsValid();
@@ -148,6 +193,7 @@ private:
     NKikimrPQ::TBatchHeader Header;
 
     const TKey& Key;
+    TIntrusivePtr<TPackedBatchDataOwner> Owner;
     const char *Data;
     const char *End;
 
@@ -207,14 +253,17 @@ public:
     ui32 FindPos(const ui64 offset, const ui16 partNo) const;
 
     void AddBatch(const TBatch& batch);
+    void AddBatch(TBatch&& batch);
     void ClearBatches();
     const std::deque<TBatch>& GetBatches() const;
     const TBatch& GetBatch(ui32 idx) const;
     const TBatch& GetLastBatch() const;
     TBatchAccessor MutableBatch(ui32 idx);
     TBatchAccessor MutableLastBatch();
-    TBatch ExtractFirstBatch();
+    TBatch ExtractFirstBatch(bool materializeSharedData = true);
     void AddBlob(const TClientBlob& blob);
+
+    void MaterializeRetainedSharedData();
 
     friend IOutputStream& operator <<(IOutputStream& out, const THead& value);
 };

--- a/ydb/core/persqueue/pqtablet/blob/blob.h
+++ b/ydb/core/persqueue/pqtablet/blob/blob.h
@@ -114,7 +114,7 @@ private:
     TBuffer Buffer;
     TIntrusivePtr<TPackedBatchDataOwner> Owner;
     ui32 Offset = 0;
-    ui32 Size_ = 0;
+    ui32 PayloadSize = 0;
 };
 
 //TBatch represents several clientBlobs. Can be in unpacked state(TVector<TClientBlob> blobs)
@@ -203,6 +203,7 @@ private:
 };
 
 class TPartitionedBlob;
+struct TPartitionBlobEncoder;
 
 //THead represents bathes, stored in head(at most 8 Mb)
 struct THead {
@@ -216,6 +217,9 @@ private:
     ui16 InternalPartsCount = 0;
 
     friend class TPartitionedBlob;
+    friend struct TPartitionBlobEncoder;
+
+    void MaterializeRetainedSharedData();
 
     class TBatchAccessor {
         TBatch& Batch;
@@ -262,8 +266,6 @@ public:
     TBatchAccessor MutableLastBatch();
     TBatch ExtractFirstBatch(bool materializeSharedData = true);
     void AddBlob(const TClientBlob& blob);
-
-    void MaterializeRetainedSharedData();
 
     friend IOutputStream& operator <<(IOutputStream& out, const THead& value);
 };

--- a/ydb/core/persqueue/pqtablet/blob/blob_serialization.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob_serialization.cpp
@@ -116,13 +116,15 @@ ui32 BlobSize(const TClientBlob& blob) {
 
 template<NKikimrPQ::TBatchHeader::EPayloadFormat Type>
 struct TBatchSerializer {
-    TBatchSerializer(TBatch& batch)
-        : Batch(batch) {
+    TBatchSerializer(TBatch& batch, TBuffer& output)
+        : Batch(batch)
+        , Output(output) {
     }
 
     void Pack();
 
     TBatch& Batch;
+    TBuffer& Output;
 };
 
 
@@ -139,7 +141,6 @@ struct TBatchDeserializer {
 
 template<>
 void TBatchSerializer<NKikimrPQ::TBatchHeader::ECompressed>::Pack() {
-    Batch.PackedData.Clear();
     bool hasUncompressed = false;
     bool hasKinesis = false;
     bool hasBatchInfo = false;
@@ -192,8 +193,8 @@ void TBatchSerializer<NKikimrPQ::TBatchHeader::ECompressed>::Pack() {
 
     //output order
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Output);
         for (const auto& p : pos) {
             chunk->AddData((const char*)&p, sizeof(p));
         }
@@ -203,46 +204,46 @@ void TBatchSerializer<NKikimrPQ::TBatchHeader::ECompressed>::Pack() {
             chunk->AddData((const char*)&p, sizeof(p));
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     //output SourceId
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Output);
         for (auto it = reorderMap.begin(); it != reorderMap.end(); ++it) {
             chunk->AddData(it->first.data(), it->first.size());
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     //output SeqNo
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TDeltaVarIntCodec<ui64, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TDeltaVarIntCodec<ui64, false>>(Output);
         for (const auto& p : pos) {
             chunk->AddData((const char*)&Batch.Blobs[p].SeqNo, sizeof(ui64));
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     //output Data
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Output);
         for (const auto& p : pos) {
             chunk->AddData(Batch.Blobs[p].Data.data(), Batch.Blobs[p].Data.size());
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     //output PartData::Pos + payload
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Output);
         ui32 cnt = 0;
         for (ui32 i = 0; i < Batch.Blobs.size(); ++i) {
             if (Batch.Blobs[i].PartData) {
@@ -261,78 +262,78 @@ void TBatchSerializer<NKikimrPQ::TBatchHeader::ECompressed>::Pack() {
             }
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     //output Wtime
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TDeltaVarIntCodec<ui64, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TDeltaVarIntCodec<ui64, false>>(Output);
         for (ui32 i = 0; i < Batch.Blobs.size(); ++i) {
             ui64 writeTimestampMs = Batch.Blobs[i].WriteTimestamp.MilliSeconds();
             chunk->AddData((const char*)&writeTimestampMs, sizeof(ui64));
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     if (hasKinesis) {
         {
-            ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-            auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Batch.PackedData);
+            ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+            auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Output);
             for (const auto &p : pos) {
                 chunk->AddData(Batch.Blobs[p].PartitionKey.data(), Batch.Blobs[p].PartitionKey.size());
             }
             chunk->Seal();
-            WriteActualChunkSize(Batch.PackedData, sizeOffset);
+            WriteActualChunkSize(Output, sizeOffset);
         }
 
         {
-            ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-            auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Batch.PackedData);
+            ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+            auto chunk = MakeChunk<NScheme::TVarLenCodec<false>>(Output);
             for (const auto &p : pos) {
                 chunk->AddData(Batch.Blobs[p].ExplicitHashKey.data(), Batch.Blobs[p].ExplicitHashKey.size());
             }
             chunk->Seal();
-            WriteActualChunkSize(Batch.PackedData, sizeOffset);
+            WriteActualChunkSize(Output, sizeOffset);
         }
     }
 
     //output Ctime
     {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TDeltaVarIntCodec<ui64, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TDeltaVarIntCodec<ui64, false>>(Output);
         for (ui32 i = 0; i < Batch.Blobs.size(); ++i) {
             ui64 createTimestampMs = Batch.Blobs[i].CreateTimestamp.MilliSeconds();
             chunk->AddData((const char*)&createTimestampMs, sizeof(ui64));
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     //output Uncompressed
     if (hasUncompressed || hasBatchInfo) {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Output);
         for (ui32 i = 0; i < Batch.Blobs.size(); ++i) {
             chunk->AddData((const char*)&Batch.Blobs[i].UncompressedSize, sizeof(ui32));
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
     if (hasBatchInfo) {
-        ui32 sizeOffset = WriteTemporaryChunkSize(Batch.PackedData);
-        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Batch.PackedData);
+        ui32 sizeOffset = WriteTemporaryChunkSize(Output);
+        auto chunk = MakeChunk<NScheme::TVarIntCodec<ui32, false>>(Output);
         for (ui32 i = 0; i < Batch.Blobs.size(); ++i) {
             ui32 messageMetadata = PackMessageMetadata(Batch.Blobs[i]);
             chunk->AddData((const char*)&messageMetadata, sizeof(ui32));
         }
         chunk->Seal();
-        WriteActualChunkSize(Batch.PackedData, sizeOffset);
+        WriteActualChunkSize(Output, sizeOffset);
     }
 
-    Batch.Header.SetPayloadSize(Batch.PackedData.size());
+    Batch.Header.SetPayloadSize(Output.size());
 }
 
 template<>
@@ -538,11 +539,10 @@ void TBatchDeserializer<NKikimrPQ::TBatchHeader::ECompressed>::Unpack(TVector<TC
 template<>
 void TBatchSerializer<NKikimrPQ::TBatchHeader::EUncompressed>::Pack() {
     Batch.Header.SetFormat(NKikimrPQ::TBatchHeader::EUncompressed);
-    Batch.PackedData.Clear();
     for (ui32 i = 0; i < Batch.Blobs.size(); ++i) {
-        Serialize(Batch.Blobs[i], Batch.PackedData);
+        Serialize(Batch.Blobs[i], Output);
     }
-    Batch.Header.SetPayloadSize(Batch.PackedData.size());
+    Batch.Header.SetPayloadSize(Output.size());
 }
 
 template<>
@@ -593,10 +593,16 @@ void TBatch::Pack() {
     }
     Packed = true;
 
-    TBatchSerializer<NKikimrPQ::TBatchHeader::ECompressed>(*this).Pack();
+    TBuffer packedData;
+    packedData.Reserve(GetUnpackedSize() + GetMaxHeaderSize());
+    TBatchSerializer<NKikimrPQ::TBatchHeader::ECompressed>(*this, packedData).Pack();
+    PackedData = TPackedBatchData(std::move(packedData));
 
     if (GetPackedSize() > GetUnpackedSize() + GetMaxHeaderSize()) { //packing is not effective, write as-is
-        TBatchSerializer<NKikimrPQ::TBatchHeader::EUncompressed>(*this).Pack();
+        TBuffer unpackedData;
+        unpackedData.Reserve(GetUnpackedSize() + GetMaxHeaderSize());
+        TBatchSerializer<NKikimrPQ::TBatchHeader::EUncompressed>(*this, unpackedData).Pack();
+        PackedData = TPackedBatchData(std::move(unpackedData));
     }
 
     for (auto& b : Blobs) {
@@ -625,7 +631,7 @@ void TBatch::Unpack() {
     }
     AFL_ENSURE(InternalPartsPos.size() == GetInternalPartsCount());
 
-    TBuffer().Swap(PackedData);
+    PackedData.Reset();
 }
 
 void TBatch::UnpackTo(TVector<TClientBlob> *blobs) const

--- a/ydb/core/persqueue/pqtablet/blob/blob_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob_ut.cpp
@@ -4,7 +4,104 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <type_traits>
+
 namespace NKikimr::NPQ {
+namespace {
+
+template <class T, class = void>
+struct THasDataOwnership : std::false_type {
+};
+
+template <class T>
+struct THasDataOwnership<T, std::void_t<typename T::EDataOwnership>> : std::true_type {
+};
+
+template <class T = TBlobIterator>
+std::enable_if_t<THasDataOwnership<T>::value, T> MakeInitPathIterator(const TKey& key, const TString& blob)
+{
+    return T(key, blob, T::EDataOwnership::Shared);
+}
+
+template <class T = TBlobIterator>
+std::enable_if_t<!THasDataOwnership<T>::value, T> MakeInitPathIterator(const TKey& key, const TString& blob)
+{
+    return T(key, blob);
+}
+
+template <class T, class = void>
+struct THasIsShared : std::false_type {
+};
+
+template <class T>
+struct THasIsShared<T, std::void_t<decltype(std::declval<const T&>().IsShared())>> : std::true_type {
+};
+
+template <class T>
+bool IsPackedDataShared(const T& packedData, std::true_type)
+{
+    return packedData.IsShared();
+}
+
+template <class T>
+bool IsPackedDataShared(const T&, std::false_type)
+{
+    return false;
+}
+
+bool IsBatchPayloadShared(const TBatch& batch)
+{
+    return IsPackedDataShared(batch.PackedData, THasIsShared<decltype(batch.PackedData)>());
+}
+
+TString MakePayload(ui32 blobNo, ui32 batchNo, size_t size)
+{
+    TString payload;
+    payload.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        payload.push_back(static_cast<char>(1 + (i * 131 + blobNo * 17 + batchNo * 29) % 251));
+    }
+    return payload;
+}
+
+TString MakeDataHeadValue(ui64 firstOffset, ui32 blobNo, ui32 batchCount, size_t payloadSize)
+{
+    TString value;
+    value.reserve(batchCount * (payloadSize + 128));
+    const auto ts = TInstant::Seconds(1000 + blobNo);
+
+    for (ui32 batchNo = 0; batchNo < batchCount; ++batchNo) {
+        TBatch batch(firstOffset + batchNo, 0);
+        batch.AddBlob(TClientBlob(
+            TString("sourceId"),
+            batchNo + 1,
+            MakePayload(blobNo, batchNo, payloadSize),
+            TMaybe<TPartData>(),
+            ts,
+            ts,
+            0,
+            "",
+            ""
+        ));
+        batch.Pack();
+        batch.SerializeTo(value);
+    }
+
+    return value;
+}
+
+void LoadHeadFromDataHeadBlob(THead& head, const TKey& key, const TString& value)
+{
+    head.Offset = key.GetOffset();
+    head.PartNo = key.GetPartNo();
+
+    for (auto it = MakeInitPathIterator(key, value); it.IsValid(); it.Next()) {
+        head.AddBatch(it.GetBatch());
+    }
+    head.PackedSize += value.size();
+}
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(BlobTest) {
     Y_UNIT_TEST(Flags_HasPartData) {
@@ -265,6 +362,50 @@ Y_UNIT_TEST_SUITE(BatchMemory) {
         UNIT_ASSERT_VALUES_EQUAL(batch.Blobs[0].MessageCount, 5u);
         UNIT_ASSERT_VALUES_EQUAL(batch.FindPos(0, 0).BlobIdx, 0u);
         UNIT_ASSERT_VALUES_EQUAL(batch.FindPos(1, 0).BlobIdx, 0u);
+    }
+
+    Y_UNIT_TEST(DroppedHeadBatchesDoNotKeepOriginalDataHeadBlobs) {
+        constexpr ui32 DataHeadBlobCount = 64;
+        constexpr ui32 BatchesPerDataHeadBlob = 64;
+        constexpr size_t PayloadSize = 1_KB;
+
+        TVector<THead> heads;
+        heads.reserve(DataHeadBlobCount);
+
+        ui64 nextOffset = 1000;
+        for (ui32 blobNo = 0; blobNo < DataHeadBlobCount; ++blobNo) {
+            const auto key = TKey::ForHead(
+                TKeyPrefix::TypeData,
+                TPartitionId(0),
+                nextOffset,
+                0,
+                BatchesPerDataHeadBlob,
+                0
+            );
+            const TString value = MakeDataHeadValue(nextOffset, blobNo, BatchesPerDataHeadBlob, PayloadSize);
+
+            heads.emplace_back();
+            auto& head = heads.back();
+            LoadHeadFromDataHeadBlob(head, key, value);
+
+            while (head.GetBatches().size() > 1) {
+                head.ExtractFirstBatch();
+            }
+
+            nextOffset += BatchesPerDataHeadBlob;
+        }
+
+        ui32 sharedBatches = 0;
+        for (const auto& head : heads) {
+            UNIT_ASSERT_VALUES_EQUAL(head.GetBatches().size(), 1);
+            sharedBatches += IsBatchPayloadShared(head.GetLastBatch()) ? 1 : 0;
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            sharedBatches,
+            0,
+            "A small live suffix of each DataHead blob must not keep the whole original DataHead value in memory"
+        );
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -488,10 +488,20 @@ void TPartitionBlobEncoder::SyncNewHeadKey()
         return false;
     };
 
+    bool replacedHeadKeys = false;
     while (!HeadKeys.empty() && !isLess(HeadKeys.back().Key, NewHeadKey.Key)) {
         // HeadKeys.back >= NewHeadKey
         ScheduleDelete(HeadKeys.back());
         HeadKeys.pop_back();
+        replacedHeadKeys = true;
+    }
+
+    if (replacedHeadKeys && CompactedKeys.empty()) {
+        // The new head key replaces a suffix of the old head key layout, but
+        // the old in-memory batches remain live and are now covered by the new
+        // key. This is the production path where init-loaded shared owners can
+        // become sparse without Head being cleared wholesale.
+        Head.MaterializeRetainedSharedData();
     }
 
     HeadKeys.push_back(std::move(NewHeadKey));
@@ -558,7 +568,7 @@ void TPartitionBlobEncoder::SyncHead(ui64& startOffset, ui64& endOffset)
     AFL_ENSURE(!ForFastWrite);
     //append Head with newHead
     while (!NewHead.GetBatches().empty()) {
-        Head.AddBatch(NewHead.ExtractFirstBatch());
+        Head.AddBatch(NewHead.ExtractFirstBatch(false));
     }
     Head.PackedSize += NewHead.PackedSize;
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -497,10 +497,10 @@ void TPartitionBlobEncoder::SyncNewHeadKey()
     }
 
     if (replacedHeadKeys && CompactedKeys.empty()) {
-        // The new head key replaces a suffix of the old head key layout, but
-        // the old in-memory batches remain live and are now covered by the new
-        // key. This is the production path where init-loaded shared owners can
-        // become sparse without Head being cleared wholesale.
+        // This is the only sync path where old HeadKeys are replaced while the
+        // old in-memory Head is retained. If some init-loaded shared owners
+        // became sparse, materialize them here. Paths with CompactedKeys clear
+        // Head wholesale via SyncHeadFromNewHead().
         Head.MaterializeRetainedSharedData();
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1001,7 +1001,7 @@ void TInitDataStep::Handle(TEvKeyValue::TEvResponse::TPtr &ev, const TActorConte
                     ("offset", offset)("CompactionBlobEncoder.EndOffset", Partition()->CompactionBlobEncoder.EndOffset);
                 PQ_INIT_ENSURE(size == read.GetValue().size())("size", size)("read.GetValue().size()", read.GetValue().size());
 
-                for (TBlobIterator it(key, read.GetValue()); it.IsValid(); it.Next()) {
+                for (TBlobIterator it(key, read.GetValue(), TBlobIterator::EDataOwnership::Shared); it.IsValid(); it.Next()) {
                     PQ_LOG_D("add batch");
                     head.AddBatch(it.GetBatch());
                 }

--- a/ydb/core/persqueue/pqtablet/partition/partition_monitoring.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_monitoring.cpp
@@ -20,6 +20,7 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/time_provider/time_provider.h>
 #include <util/folder/path.h>
+#include <util/generic/hash_set.h>
 #include <util/string/escape.h>
 #include <util/system/byteorder.h>
 
@@ -38,6 +39,44 @@ void TPartition::HandleMonitoring(TEvPQ::TEvMonRequest::TPtr& ev, const TActorCo
     static constexpr std::pair<TStringBuf, const TPartitionBlobEncoder TPartition::*> encoders[2]{
         {"Compacted"sv, &TPartition::CompactionBlobEncoder},
         {"FastWrite"sv, &TPartition::BlobEncoder},
+    };
+    struct THeadMonitoringStats {
+        ui64 PackedPayloadSize = 0;
+        ui64 PackedPayloadCapacity = 0;
+        ui64 SharedPackedRetainedSize = 0;
+        ui64 SharedPackedLivePayloadSize = 0;
+        ui64 UnpackedClientBlobs = 0;
+        ui32 PackedBatches = 0;
+        ui32 UnpackedBatches = 0;
+        ui32 SharedPackedOwners = 0;
+        ui32 SharedPackedBatches = 0;
+        ui32 OwnedPackedBatches = 0;
+    };
+    auto getHeadStats = [](const THead& head) {
+        THeadMonitoringStats stats;
+        THashSet<const TPackedBatchDataOwner*> sharedOwners;
+        for (const auto& batch : head.GetBatches()) {
+            if (batch.Packed) {
+                ++stats.PackedBatches;
+                stats.PackedPayloadSize += batch.PackedData.Size();
+                stats.PackedPayloadCapacity += batch.PackedData.Capacity();
+                if (const auto* owner = batch.PackedData.SharedOwner()) {
+                    ++stats.SharedPackedBatches;
+                    stats.SharedPackedLivePayloadSize += batch.PackedData.Size();
+                    if (!sharedOwners.contains(owner)) {
+                        sharedOwners.insert(owner);
+                        ++stats.SharedPackedOwners;
+                        stats.SharedPackedRetainedSize += owner->Data.size();
+                    }
+                } else {
+                    ++stats.OwnedPackedBatches;
+                }
+            } else {
+                ++stats.UnpackedBatches;
+                stats.UnpackedClientBlobs += batch.Blobs.size();
+            }
+        }
+        return stats;
     };
 
     TStringStream out;
@@ -133,7 +172,39 @@ void TPartition::HandleMonitoring(TEvPQ::TEvMonRequest::TPtr& ev, const TActorCo
                         PROPERTY("MaxCurrently writing", BlobEncoder.MaxWriteResponsesSize);
                         for (const auto& [encoderName, encoderPtr] : encoders) {
                             const TPartitionBlobEncoder& encoder = this->*encoderPtr;
+                            const auto headStats = getHeadStats(encoder.Head);
+                            const auto newHeadStats = getHeadStats(encoder.NewHead);
+                            ui32 dataKeysHeadKeys = 0;
+                            for (const auto& level : encoder.DataKeysHead) {
+                                dataKeysHeadKeys += level.KeysCount();
+                            }
                             PROPERTY(TString::Join(encoderName, " DataKeysBody size"), encoder.DataKeysBody.size());
+                            PROPERTY(TString::Join(encoderName, " DataKeysHead keys"), dataKeysHeadKeys);
+                            PROPERTY(TString::Join(encoderName, " HeadKeys size"), encoder.HeadKeys.size());
+                            PROPERTY(TString::Join(encoderName, " Head batches"), encoder.Head.GetBatches().size()
+                                << " packed: " << headStats.PackedBatches
+                                << " unpacked: " << headStats.UnpackedBatches
+                                << " sharedPacked: " << headStats.SharedPackedBatches
+                                << " ownedPacked: " << headStats.OwnedPackedBatches);
+                            PROPERTY(TString::Join(encoderName, " Head payload bytes"), headStats.PackedPayloadSize
+                                << " capacity: " << headStats.PackedPayloadCapacity
+                                << " sharedOwners: " << headStats.SharedPackedOwners
+                                << " sharedRetained: " << headStats.SharedPackedRetainedSize
+                                << " sharedLivePayload: " << headStats.SharedPackedLivePayloadSize
+                                << " unpackedClientBlobs: " << headStats.UnpackedClientBlobs);
+                            PROPERTY(TString::Join(encoderName, " NewHead batches"), encoder.NewHead.GetBatches().size()
+                                << " packed: " << newHeadStats.PackedBatches
+                                << " unpacked: " << newHeadStats.UnpackedBatches
+                                << " sharedPacked: " << newHeadStats.SharedPackedBatches
+                                << " ownedPacked: " << newHeadStats.OwnedPackedBatches);
+                            PROPERTY(TString::Join(encoderName, " NewHead payload bytes"), newHeadStats.PackedPayloadSize
+                                << " capacity: " << newHeadStats.PackedPayloadCapacity
+                                << " sharedOwners: " << newHeadStats.SharedPackedOwners
+                                << " sharedRetained: " << newHeadStats.SharedPackedRetainedSize
+                                << " sharedLivePayload: " << newHeadStats.SharedPackedLivePayloadSize
+                                << " unpackedClientBlobs: " << newHeadStats.UnpackedClientBlobs);
+                            PROPERTY(TString::Join(encoderName, " PartitionedBlob"), "clientBlobs: " << encoder.PartitionedBlob.GetClientBlobs().size()
+                                << " formedBlobs: " << encoder.PartitionedBlob.GetFormedBlobs().size());
                         }
                     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_read.cpp
@@ -383,13 +383,6 @@ static void AddResultDebugInfo(const TEvPQ::TEvBlobResponse* response, T* readRe
         readResult->SetBlobsFromDisk(diskBlobs);
 }
 
-ui64 GetFirstHeaderOffset(const TKey& key, const TString& blob)
-{
-    TBlobIterator it(key, blob);
-    AFL_ENSURE(it.IsValid());
-    return it.GetBatch().GetOffset();
-}
-
 bool TReadInfo::UpdateUsage(const TClientBlob& blob,
                             ui32& cnt, ui32& size, ui32& lastBlobSize) const
 {

--- a/ydb/core/persqueue/pqtablet/partition/ut/partition_blob_encoder_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/ut/partition_blob_encoder_ut.cpp
@@ -1,0 +1,106 @@
+#include <ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h>
+#include <ydb/core/persqueue/pqtablet/partition/partition_util.h>
+
+#include <library/cpp/testing/gtest/gtest.h>
+
+using namespace NKikimr::NPQ;
+
+namespace {
+
+TBlobKeyTokenPtr MakeBlobKeyToken(const TString& key)
+{
+    auto token = std::make_shared<TBlobKeyToken>();
+    token->Key = key;
+    return token;
+}
+
+TString MakePayload(ui32 batchNo, size_t size)
+{
+    TString payload;
+    payload.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        payload.push_back(static_cast<char>(1 + (i * 131 + batchNo * 29) % 251));
+    }
+    return payload;
+}
+
+TString MakeDataHeadValue(ui64 firstOffset, ui32 batchCount, size_t payloadSize)
+{
+    TString value;
+    value.reserve(batchCount * (payloadSize + 128));
+    const auto ts = TInstant::Seconds(1000);
+
+    for (ui32 batchNo = 0; batchNo < batchCount; ++batchNo) {
+        TBatch batch(firstOffset + batchNo, 0);
+        batch.AddBlob(TClientBlob(
+            TString("sourceId"),
+            batchNo + 1,
+            MakePayload(batchNo, payloadSize),
+            TMaybe<TPartData>(),
+            ts,
+            ts,
+            0,
+            "",
+            ""
+        ));
+        batch.Pack();
+        batch.SerializeTo(value);
+    }
+
+    return value;
+}
+
+void LoadSharedHead(THead& head, const TKey& key, const TString& value)
+{
+    head.Offset = key.GetOffset();
+    head.PartNo = key.GetPartNo();
+
+    for (TBlobIterator it(key, value, TBlobIterator::EDataOwnership::Shared); it.IsValid(); it.Next()) {
+        head.AddBatch(it.GetBatch());
+    }
+    head.PackedSize += value.size();
+}
+
+TDataKey MakeDataKey(const TKey& key, ui32 size)
+{
+    return {
+        .Key = key,
+        .Size = size,
+        .Timestamp = TInstant::Seconds(1000),
+        .CumulativeSize = 0,
+        .BlobKeyToken = MakeBlobKeyToken(key.ToString()),
+    };
+}
+
+} // namespace
+
+TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyMaterializesSparseSharedHeadAfterKeyReplacement)
+{
+    constexpr ui32 BatchesPerDataHeadBlob = 64;
+    constexpr size_t PayloadSize = 1_KB;
+
+    TPartitionBlobEncoder encoder(TPartitionId(0), false);
+    const auto key = TKey::ForHead(
+        TKeyPrefix::TypeData,
+        TPartitionId(0),
+        1000,
+        0,
+        BatchesPerDataHeadBlob,
+        0
+    );
+    const TString value = MakeDataHeadValue(key.GetOffset(), BatchesPerDataHeadBlob, PayloadSize);
+
+    LoadSharedHead(encoder.Head, key, value);
+    encoder.HeadKeys.push_back(MakeDataKey(key, value.size()));
+
+    while (encoder.Head.GetBatches().size() > 1) {
+        encoder.Head.ExtractFirstBatch(false);
+    }
+
+    ASSERT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+
+    encoder.NewHeadKey = MakeDataKey(key, encoder.Head.GetLastBatch().GetPackedSize());
+    encoder.SyncNewHeadKey();
+
+    EXPECT_FALSE(encoder.Head.GetLastBatch().PackedData.IsShared());
+}

--- a/ydb/core/persqueue/pqtablet/partition/ut/partition_blob_encoder_ut.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/ut/partition_blob_encoder_ut.cpp
@@ -72,6 +72,18 @@ TDataKey MakeDataKey(const TKey& key, ui32 size)
     };
 }
 
+TKey MakeHeadKey(ui64 offset, ui32 count)
+{
+    return TKey::ForHead(
+        TKeyPrefix::TypeData,
+        TPartitionId(0),
+        offset,
+        0,
+        count,
+        0
+    );
+}
+
 } // namespace
 
 TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyMaterializesSparseSharedHeadAfterKeyReplacement)
@@ -80,14 +92,7 @@ TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyMaterializesSparseSharedHeadAfterK
     constexpr size_t PayloadSize = 1_KB;
 
     TPartitionBlobEncoder encoder(TPartitionId(0), false);
-    const auto key = TKey::ForHead(
-        TKeyPrefix::TypeData,
-        TPartitionId(0),
-        1000,
-        0,
-        BatchesPerDataHeadBlob,
-        0
-    );
+    const auto key = MakeHeadKey(1000, BatchesPerDataHeadBlob);
     const TString value = MakeDataHeadValue(key.GetOffset(), BatchesPerDataHeadBlob, PayloadSize);
 
     LoadSharedHead(encoder.Head, key, value);
@@ -103,4 +108,82 @@ TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyMaterializesSparseSharedHeadAfterK
     encoder.SyncNewHeadKey();
 
     EXPECT_FALSE(encoder.Head.GetLastBatch().PackedData.IsShared());
+}
+
+TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyKeepsDenseSharedHeadAfterKeyReplacement)
+{
+    constexpr ui32 BatchesPerDataHeadBlob = 64;
+    constexpr size_t PayloadSize = 1_KB;
+
+    TPartitionBlobEncoder encoder(TPartitionId(0), false);
+    const auto key = MakeHeadKey(1000, BatchesPerDataHeadBlob);
+    const TString value = MakeDataHeadValue(key.GetOffset(), BatchesPerDataHeadBlob, PayloadSize);
+
+    LoadSharedHead(encoder.Head, key, value);
+    encoder.HeadKeys.push_back(MakeDataKey(key, value.size()));
+
+    ASSERT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+
+    encoder.NewHeadKey = MakeDataKey(key, value.size());
+    encoder.SyncNewHeadKey();
+
+    EXPECT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+}
+
+TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyKeepsMostlyLiveSharedHeadAfterKeyReplacement)
+{
+    constexpr ui32 BatchesPerDataHeadBlob = 64;
+    constexpr size_t PayloadSize = 1_KB;
+
+    TPartitionBlobEncoder encoder(TPartitionId(0), false);
+    const auto key = MakeHeadKey(1000, BatchesPerDataHeadBlob);
+    const TString value = MakeDataHeadValue(key.GetOffset(), BatchesPerDataHeadBlob, PayloadSize);
+
+    LoadSharedHead(encoder.Head, key, value);
+    encoder.HeadKeys.push_back(MakeDataKey(key, value.size()));
+
+    encoder.Head.ExtractFirstBatch(false);
+
+    ASSERT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+
+    encoder.NewHeadKey = MakeDataKey(key, value.size() - PayloadSize);
+    encoder.SyncNewHeadKey();
+
+    EXPECT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+}
+
+TEST(TPartitionBlobEncoderTest, SyncNewHeadKeyDefersSparseSharedHeadWhenCompactedKeysWillClearHead)
+{
+    constexpr ui32 BatchesPerDataHeadBlob = 64;
+    constexpr size_t PayloadSize = 1_KB;
+
+    TPartitionBlobEncoder encoder(TPartitionId(0), false);
+    const auto key = MakeHeadKey(1000, BatchesPerDataHeadBlob);
+    const TString value = MakeDataHeadValue(key.GetOffset(), BatchesPerDataHeadBlob, PayloadSize);
+
+    LoadSharedHead(encoder.Head, key, value);
+    encoder.HeadKeys.push_back(MakeDataKey(key, value.size()));
+
+    while (encoder.Head.GetBatches().size() > 1) {
+        encoder.Head.ExtractFirstBatch(false);
+    }
+
+    ASSERT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+
+    encoder.CompactedKeys.emplace_back(TKey::ForBody(
+        TKeyPrefix::TypeData,
+        TPartitionId(0),
+        key.GetOffset(),
+        key.GetPartNo(),
+        key.GetCount(),
+        key.GetInternalPartsCount()
+    ), value.size());
+    encoder.NewHeadKey = MakeDataKey(key, encoder.Head.GetLastBatch().GetPackedSize());
+    encoder.SyncNewHeadKey();
+
+    ASSERT_TRUE(encoder.Head.GetLastBatch().PackedData.IsShared());
+
+    encoder.SyncHeadFromNewHead();
+
+    EXPECT_TRUE(encoder.Head.GetBatches().empty());
 }

--- a/ydb/core/persqueue/pqtablet/partition/ut/ya.make
+++ b/ydb/core/persqueue/pqtablet/partition/ut/ya.make
@@ -4,6 +4,7 @@ GTEST()
 SRCS(
     consumer_offset_tracker_ut.cpp
     message_id_deduplicator_ut.cpp
+    partition_blob_encoder_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/core/persqueue/ut/internals_ut.cpp
+++ b/ydb/core/persqueue/ut/internals_ut.cpp
@@ -7,6 +7,7 @@
 #include <util/generic/size_literals.h>
 #include <util/stream/format.h>
 
+#include <cstring>
 
 namespace NKikimr::NPQ {
 namespace {
@@ -185,11 +186,12 @@ Y_UNIT_TEST(TestBatchPacking) {
         ));
     }
     batch.Pack();
-    TBuffer b = batch.PackedData;
+    TBuffer b(batch.PackedData.data(), batch.PackedData.size());
     UNIT_ASSERT(batch.Header.GetFormat() == NKikimrPQ::TBatchHeader::ECompressed);
     batch.Unpack();
     batch.Pack();
-    UNIT_ASSERT(batch.PackedData == b);
+    UNIT_ASSERT_VALUES_EQUAL(batch.PackedData.size(), b.size());
+    UNIT_ASSERT(!batch.PackedData.size() || std::memcmp(batch.PackedData.data(), b.Data(), batch.PackedData.size()) == 0);
     TString str;
     batch.SerializeTo(str);
     auto header = ExtractHeader(str.c_str(), str.size());

--- a/ydb/tests/stress/topic_head_memory/test_pq_head_rss.py
+++ b/ydb/tests/stress/topic_head_memory/test_pq_head_rss.py
@@ -1,0 +1,278 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import sys
+import time
+import uuid
+
+import yatest.common
+
+from ydb.tests.library.common.types import Erasure
+from ydb.tests.library.common.msgbus_types import MessageBusStatus, SchemeStatus
+from ydb.tests.library.common.protobuf_ss import CreateTopicRequest
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.library.harness.kikimr_runner import KiKiMR
+from ydb.tests.oss.ydb_sdk_import import ydb
+
+
+DATABASE = "/Root"
+
+
+def _test_param(name, default=None):
+    value = yatest.common.get_param(name, None)
+    if value is None:
+        value = os.environ.get("YDB_" + name.upper(), default)
+    return value
+
+
+def _int_param(name, default):
+    return int(_test_param(name, default))
+
+
+def _bool_param(name, default):
+    value = _test_param(name, "true" if default else "false")
+    if isinstance(value, bool):
+        return value
+
+    value = str(value).lower()
+    if value in ("1", "true", "yes", "y", "on"):
+        return True
+    if value in ("0", "false", "no", "n", "off"):
+        return False
+
+    raise ValueError("Expected boolean value for {}, got {!r}".format(name, value))
+
+
+def _optional_int_param(name):
+    value = _test_param(name)
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def _read_proc_status_kb(pid):
+    result = {}
+    wanted = {"VmRSS", "VmHWM", "RssAnon", "RssFile", "RssShmem"}
+    with open("/proc/{}/status".format(pid), "r") as status:
+        for line in status:
+            key, sep, value = line.partition(":")
+            if sep and key in wanted:
+                parts = value.split()
+                if parts:
+                    result[key + "_kb"] = int(parts[0])
+
+    if "VmRSS_kb" not in result:
+        raise RuntimeError("VmRSS is missing in /proc/{}/status".format(pid))
+    return result
+
+
+def _rss_sample(pid, label, settle_seconds):
+    if settle_seconds:
+        time.sleep(settle_seconds)
+
+    sample = _read_proc_status_kb(pid)
+    sample["pid"] = pid
+    sample["label"] = label
+    sample["timestamp"] = time.time()
+    print("PQ_HEAD_RSS_SAMPLE {}".format(json.dumps(sample, sort_keys=True)), file=sys.stderr)
+    return sample
+
+
+class TestPersQueueHeadRss(object):
+    @classmethod
+    def setup_class(cls):
+        cls.cluster = KiKiMR(KikimrConfigGenerator(
+            erasure=Erasure.NONE,
+            nodes=1,
+            use_in_memory_pdisks=False,
+        ))
+        cls.cluster.start()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.cluster.stop()
+
+    def _endpoint(self):
+        return "grpc://localhost:{}".format(self.cluster.nodes[1].grpc_port)
+
+    def _make_driver(self):
+        driver = ydb.Driver(ydb.DriverConfig(
+            endpoint=self._endpoint(),
+            database=DATABASE,
+        ))
+        driver.wait(timeout=60, fail_fast=True)
+        return driver
+
+    def _restart_node(self, driver):
+        driver.stop()
+        old_pid = self.cluster.nodes[1].pid
+        self.cluster.nodes[1].stop()
+        self.cluster.nodes[1].start()
+        return old_pid, self.cluster.nodes[1].pid, self._make_driver()
+
+    def _create_topic(self, topic_name, partitions, partition_per_tablet):
+        options = (
+            CreateTopicRequest.Options()
+            .with_partitions_count(partitions)
+            .with_partition_per_table(partition_per_tablet)
+        )
+        response = self.cluster.client.send_and_poll_request(
+            CreateTopicRequest(os.path.join(DATABASE, topic_name), options=options).protobuf
+        )
+        assert response.Status == MessageBusStatus.MSTATUS_OK, response
+        assert response.SchemeStatus == SchemeStatus.StatusSuccess, response
+
+    def _topic_end_offset(self, driver, topic_name):
+        description = driver.topic_client.describe_topic(topic_name, include_stats=True)
+        return sum(partition.partition_stats.partition_end for partition in description.partitions)
+
+    def _wait_topic_end_offset(self, driver, topic_name, expected, timeout_seconds):
+        deadline = time.time() + timeout_seconds
+        last_offset = None
+        last_error = None
+
+        while time.time() < deadline:
+            try:
+                last_offset = self._topic_end_offset(driver, topic_name)
+                if last_offset >= expected:
+                    return last_offset
+            except Exception as error:
+                last_error = error
+            time.sleep(1)
+
+        raise AssertionError(
+            "Topic {} end offset did not reach {} in {}s, last offset {}, last error {}".format(
+                topic_name,
+                expected,
+                timeout_seconds,
+                last_offset,
+                last_error,
+            )
+        )
+
+    def _write_messages(self, driver, topic_name, messages_per_partition, partitions, payload_bytes, flush_every, progress):
+        payload = "x" * payload_bytes
+        total_messages = messages_per_partition * partitions
+        total_sent = 0
+        started_at = time.time()
+        next_progress_percent = 1
+
+        for partition_id in range(partitions):
+            with driver.topic_client.writer(
+                topic_name,
+                partition_id=partition_id,
+                producer_id="rss-producer-{}".format(partition_id),
+            ) as writer:
+                for index in range(messages_per_partition):
+                    writer.write(ydb.TopicWriterMessage(payload))
+                    if (index + 1) % flush_every == 0:
+                        writer.flush()
+
+                    total_sent += 1
+                    if progress:
+                        sent_percent = min(total_sent * 100 // total_messages, 100)
+                        if sent_percent >= next_progress_percent or total_sent == total_messages:
+                            elapsed = time.time() - started_at
+                            print(
+                                "PQ_HEAD_RSS_WRITE_PROGRESS sent_percent={} written={} total={} partition={} elapsed_sec={:.1f}".format(
+                                    sent_percent,
+                                    total_sent,
+                                    total_messages,
+                                    partition_id,
+                                    elapsed,
+                                ),
+                                file=sys.stderr,
+                            )
+                            next_progress_percent = sent_percent + 1
+
+                writer.flush()
+
+    def test_pq_partition_head_reload_rss(self):
+        messages_per_partition = _int_param("pq_head_rss_messages", 100000)
+        payload_bytes = _int_param("pq_head_rss_payload_bytes", 16)
+        flush_every = _int_param("pq_head_rss_flush_every", 1)
+        partitions = _int_param("pq_head_rss_partitions", 1)
+        partition_per_tablet = _int_param("pq_head_rss_partition_per_tablet", 1)
+        settle_seconds = _int_param("pq_head_rss_settle_seconds", 3)
+        wait_timeout_seconds = _int_param("pq_head_rss_wait_timeout_seconds", 300)
+        progress = _bool_param("progress", True)
+        max_delta_mb = _optional_int_param("pq_head_rss_max_delta_mb")
+        total_messages = messages_per_partition * partitions
+
+        assert messages_per_partition > 0
+        assert partitions > 0
+        assert partition_per_tablet > 0
+        assert payload_bytes >= 0
+        assert flush_every > 0
+
+        topic_name = "pq_head_rss_{}".format(uuid.uuid4().hex)
+        driver = self._make_driver()
+
+        try:
+            self._create_topic(topic_name, partitions, partition_per_tablet)
+            self._wait_topic_end_offset(driver, topic_name, 0, wait_timeout_seconds)
+            empty_live = _rss_sample(self.cluster.nodes[1].pid, "empty_live", settle_seconds)
+
+            _, empty_restart_pid, driver = self._restart_node(driver)
+            self._wait_topic_end_offset(driver, topic_name, 0, wait_timeout_seconds)
+            empty_restart = _rss_sample(empty_restart_pid, "empty_restart", settle_seconds)
+
+            self._write_messages(
+                driver,
+                topic_name,
+                messages_per_partition,
+                partitions,
+                payload_bytes,
+                flush_every,
+                progress,
+            )
+            written = self._wait_topic_end_offset(driver, topic_name, total_messages, wait_timeout_seconds)
+            after_write = _rss_sample(self.cluster.nodes[1].pid, "after_write", settle_seconds)
+
+            _, head_restart_pid, driver = self._restart_node(driver)
+            written_after_restart = self._wait_topic_end_offset(
+                driver,
+                topic_name,
+                total_messages,
+                wait_timeout_seconds,
+            )
+            head_restart = _rss_sample(head_restart_pid, "head_restart", settle_seconds)
+
+            delta_kb = head_restart["VmRSS_kb"] - empty_restart["VmRSS_kb"]
+            delta_per_message = delta_kb * 1024.0 / max(total_messages, 1)
+            report = {
+                "topic": topic_name,
+                "database": DATABASE,
+                "messages_per_partition": messages_per_partition,
+                "partitions": partitions,
+                "partition_per_tablet": partition_per_tablet,
+                "total_messages": total_messages,
+                "payload_bytes": payload_bytes,
+                "flush_every": flush_every,
+                "progress": progress,
+                "written_before_restart": written,
+                "written_after_restart": written_after_restart,
+                "rss_delta_after_restart_kb": delta_kb,
+                "rss_delta_per_message_bytes": delta_per_message,
+                "samples": {
+                    "empty_live": empty_live,
+                    "empty_restart": empty_restart,
+                    "after_write": after_write,
+                    "head_restart": head_restart,
+                },
+            }
+
+            report_path = yatest.common.output_path("pq_head_rss_report.json")
+            with open(report_path, "w") as report_file:
+                json.dump(report, report_file, sort_keys=True, indent=2)
+
+            print("PQ_HEAD_RSS_REPORT {}".format(json.dumps(report, sort_keys=True)), file=sys.stderr)
+            print("PQ_HEAD_RSS_REPORT_PATH {}".format(report_path), file=sys.stderr)
+
+            assert written_after_restart >= total_messages
+            if max_delta_mb is not None:
+                assert delta_kb <= max_delta_mb * 1024, (
+                    "PQ head reload RSS delta is {} KB, expected <= {} MB".format(delta_kb, max_delta_mb)
+                )
+        finally:
+            driver.stop()

--- a/ydb/tests/stress/topic_head_memory/ya.make
+++ b/ydb/tests/stress/topic_head_memory/ya.make
@@ -1,0 +1,24 @@
+PY3TEST()
+
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
+ENV(YDB_USE_IN_MEMORY_PDISKS=false)
+
+TEST_SRCS(
+    test_pq_head_rss.py
+)
+
+TAG(ya:not_autocheck)
+SIZE(LARGE)
+REQUIREMENTS(ram:16 cpu:2)
+FORK_SUBTESTS()
+
+DEPENDS(
+    ydb/apps/ydb
+)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/oss/ydb_sdk_import
+)
+
+END()

--- a/ydb/tests/stress/ya.make
+++ b/ydb/tests/stress/ya.make
@@ -26,6 +26,7 @@ RECURSE(
     system_tablet_backup
     testshard_workload
     topic
+    topic_head_memory
     topic_kafka
     topic_sqs
     transfer


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Reduce PQ head memory after DataHead reload
    
    During PQ partition init, DataHead KV values are parsed into THead batches. Previously every parsed packed batch copied its payload into an independent TBuffer, creating one small heap allocation per batch even though all payload bytes were already contiguous in the DataHead value. With many partition actors this produced millions of small allocations attributed to PERSQUEUE_PARTITION_ACTOR after restart or move.
    
    Add TPackedBatchData as an immutable packed payload holder. Newly packed batches still own their generated TBuffer payloads, while the init path can ask TBlobIterator for shared ownership. In that mode one TPackedBatchDataOwner keeps the source DataHead value alive and each packed batch stores owner, payload offset and payload size. Serialization and deserialization continue to use data()/size(), so the on-disk format stays unchanged.
    
    To avoid retaining a whole DataHead value after most of its batches are dropped, THead can materialize sparse shared owners back into private TBuffer payloads. This safeguard is used after extracting head batches and when SyncNewHeadKey replaces an old head-key layout without clearing the in-memory head. Partition monitoring also exposes owned/shared head payload counters.
    
    Add regression coverage for freeing packed data on unpack, sparse shared DataHead materialization, and the SyncNewHeadKey production path.
    
    With the PQ head RSS stress test configured as 32 partitions, 20000 messages per partition, partition_per_tablet=1, flush_every=1 and payload_bytes=16, the measured head-restart RSS delta decreased from 279316 KB before this optimization to 248584 KB with it. Per-message delta changed from 446.9056 to 397.7344 bytes, saving 30732 KB (about 30.0 MiB), or 11.0%.

### Changelog category <!-- remove all except one -->

* Improvement


### Description for reviewers <!-- (optional) description for those who read this PR -->

...
