### PR TITLE
get rid of sql/v1 dependency for minikql_compile

### DIFF
--- a/ydb/core/client/minikql_compile/ya.make
+++ b/ydb/core/client/minikql_compile/ya.make
@@ -17,7 +17,6 @@ PEERDIR(
     library/cpp/threading/future
     ydb/core/base
     ydb/core/engine
-    ydb/core/kqp/provider
     ydb/core/scheme
     yql/essentials/ast
     yql/essentials/core

--- a/ydb/core/client/minikql_compile/yql_expr_minikql.cpp
+++ b/ydb/core/client/minikql_compile/yql_expr_minikql.cpp
@@ -7,7 +7,7 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/domain.h>
-#include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
+#include <ydb/core/scheme/scheme_tabledefs.h>
 #include <ydb/library/ydb_issue/proto/issue_id.pb.h>
 #include <ydb/public/lib/scheme_types/scheme_type_id.h>
 
@@ -389,9 +389,10 @@ private:
             const TTypeAnnotationNode *columnDataType;
             auto typeConstraint = EColumnTypeConstraint::Nullable;
 
-            auto systemColumnType = KikimrSystemColumns().find(columnName);
-            if (systemColumnType != KikimrSystemColumns().end()) {
-                columnDataType = ctx.MakeType<TDataExprType>(systemColumnType->second);
+            auto systemColumn = GetSystemColumns().find(columnName);
+            if (systemColumn != GetSystemColumns().end()) {
+                columnDataType = GetMkqlDataTypeAnnotation(
+                    TDataType::Create(systemColumn->second.TypeId, *MkqlCtx->TypeEnv), ctx);
             } else {
                 auto column = lookup->Columns.FindPtr(columnName);
                 YQL_ENSURE(column);
@@ -873,7 +874,7 @@ void ValidateCompiledTable(const TExprNode& node, const TTableId& tableId) {
             << " current: " << currentVersion
             << " for table: " << TString(node.Child(0)->Child(0)->Content());
     }
-    auto currentPathId = TKikimrPathId(tableId.PathId.OwnerId, tableId.PathId.LocalPathId).ToString();
+    const TString currentPathId = TStringBuilder() << tableId.PathId.OwnerId << ':' << tableId.PathId.LocalPathId;
     const auto& programPathId = node.Child(0)->Child(2)->Content();
     // TODO: Remove this checks.
     // Check for programPathId just to be able to disable this check

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -157,7 +157,7 @@ struct TKikimrData {
             TYdbOperation::TruncateTable;
 
         SystemColumns = {
-            {"_yql_partition_id", NKikimr::NUdf::EDataSlot::Uint64}
+            {NKikimr::YqlPartitionColumnName, NKikimr::NUdf::EDataSlot::Uint64}
         };
     }
 };

--- a/ydb/core/kqp/provider/yql_kikimr_provider_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_ut.cpp
@@ -1,5 +1,7 @@
 #include <ydb/core/kqp/provider/yql_kikimr_provider_impl.h>
 
+#include <ydb/core/scheme/scheme_tabledefs.h>
+
 #include <yql/essentials/ast/yql_expr.h>
 #include <yql/essentials/providers/common/provider/yql_provider.h>
 #include <yql/essentials/sql/v1/context.h>
@@ -61,6 +63,22 @@ void Find(const TAstNode* node, const std::function<bool(const TAstNode*)>& pred
 } // anonymous namespace
 
 Y_UNIT_TEST_SUITE(KikimrProvider) {
+    Y_UNIT_TEST(SystemColumnsMatchCoreScheme) {
+        const auto& schemeColumns = NKikimr::GetSystemColumns();
+        const auto& kikimrColumns = KikimrSystemColumns();
+
+        UNIT_ASSERT_VALUES_EQUAL(kikimrColumns.size(), schemeColumns.size());
+        for (const auto& [name, schemeColumn] : schemeColumns) {
+            const auto* kikimrType = kikimrColumns.FindPtr(name);
+            UNIT_ASSERT_C(kikimrType, "Missing KQP system column: " << name);
+            UNIT_ASSERT_VALUES_EQUAL(*kikimrType, NKikimr::NUdf::GetDataSlot(schemeColumn.TypeId));
+        }
+
+        const auto* partitionColumn = schemeColumns.FindPtr(NKikimr::YqlPartitionColumnName);
+        UNIT_ASSERT(partitionColumn);
+        UNIT_ASSERT_VALUES_EQUAL(partitionColumn->ColumnId, NKikimr::TKeyDesc::EColumnIdDataShard);
+    }
+
     Y_UNIT_TEST(TestFillAuthPropertiesNone) {
         THashMap<TString, TString> properties;
         TExternalSource source;

--- a/ydb/core/kqp/provider/yql_kikimr_provider_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_ut.cpp
@@ -76,7 +76,9 @@ Y_UNIT_TEST_SUITE(KikimrProvider) {
 
         const auto* partitionColumn = schemeColumns.FindPtr(NKikimr::YqlPartitionColumnName);
         UNIT_ASSERT(partitionColumn);
-        UNIT_ASSERT_VALUES_EQUAL(partitionColumn->ColumnId, NKikimr::TKeyDesc::EColumnIdDataShard);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui32>(partitionColumn->ColumnId),
+            static_cast<ui32>(NKikimr::TKeyDesc::EColumnIdDataShard));
     }
 
     Y_UNIT_TEST(TestFillAuthPropertiesNone) {

--- a/ydb/core/persqueue/events/internal.h
+++ b/ydb/core/persqueue/events/internal.h
@@ -22,9 +22,10 @@
 #include <ydb/library/actors/core/event.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/actorid.h>
-#include <ydb/core/grpc_services/rpc_calls.h>
+#include <ydb/library/actors/wilson/wilson_span.h>
 #include <ydb/public/api/protos/draft/persqueue_error_codes.pb.h>
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
+#include <ydb/public/api/protos/ydb_status_codes.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h>
 
 #include <ydb/core/persqueue/events/internal/protos/events.pb.h>

--- a/ydb/core/persqueue/events/ya.make
+++ b/ydb/core/persqueue/events/ya.make
@@ -12,6 +12,7 @@ PEERDIR(
     ydb/core/protos
     ydb/core/persqueue/public/counters
     ydb/core/tablet
+    ydb/public/api/grpc/draft
     ydb/public/api/protos
     ydb/library/persqueue/topic_parser
     ydb/core/persqueue/events/internal/protos

--- a/ydb/core/persqueue/pqtablet/cache/ya.make
+++ b/ydb/core/persqueue/pqtablet/cache/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/core/keyvalue
     ydb/core/persqueue/pqtablet/blob
     ydb/core/persqueue/events
+    ydb/public/api/grpc/draft
 )
 
 END()
@@ -17,4 +18,3 @@ END()
 RECURSE_FOR_TESTS(
     ut
 )
-

--- a/ydb/core/scheme/scheme_tabledefs.cpp
+++ b/ydb/core/scheme/scheme_tabledefs.cpp
@@ -360,10 +360,8 @@ void TKeyDesc::Out(IOutputStream& o, TKeyDesc::EStatus x) {
 }
 
 struct TSystemColumnsData {
-    const TString PartitionColumnName = "_yql_partition_id";
-
     const TMap<TString, TSystemColumnInfo> SystemColumns = {
-        {PartitionColumnName, {TKeyDesc::EColumnIdDataShard, NScheme::NTypeIds::Uint64}}
+        {YqlPartitionColumnName, {TKeyDesc::EColumnIdDataShard, NScheme::NTypeIds::Uint64}}
     };
 };
 

--- a/ydb/core/scheme/scheme_tabledefs.h
+++ b/ydb/core/scheme/scheme_tabledefs.h
@@ -799,6 +799,8 @@ struct TSystemColumnInfo {
     NKikimr::NScheme::TTypeId TypeId;
 };
 
+inline constexpr char YqlPartitionColumnName[] = "_yql_partition_id";
+
 const TMap<TString, TSystemColumnInfo>& GetSystemColumns();
 
 bool IsSystemColumn(ui32 columnId);

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/tx/schemeshard/schemeshard_effective_acl.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/public/api/protos/ydb_coordination.pb.h>
 
 #include <util/generic/size_literals.h>
 #include <util/string/cast.h>

--- a/ydb/core/tx/schemeshard/ut_base/ya.make
+++ b/ydb/core/tx/schemeshard/ut_base/ya.make
@@ -12,6 +12,7 @@ PEERDIR(
     ydb/core/testlib/pg
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers
+    ydb/public/api/protos
     yql/essentials/public/udf/service/exception_policy
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

ydb/core/tx/datashard$ ../../../../ya dump relation yql/essentials/sql/v1
Sorry, path not found


### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
