### PR TITLE
sync CA: checkpoints: fix double-resume input channels

### DIFF
--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp
@@ -446,7 +446,7 @@ void TDqComputeActorCheckpoints::DoCheckpoint() {
 
     LOG_PCP_D("Performing task checkpoint");
     if (SaveState()) {
-        LOG_PCP_T("Injecting checkpoint barrier to outputs");
+        LOG_PCP_I("Injecting checkpoint barrier to outputs");
         ComputeActor->InjectBarrierToOutputs(*PendingCheckpoint.Checkpoint);
         ComputeActor->ResumeInputsByCheckpoint();
         TryToSavePendingCheckpoint();

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -843,7 +843,7 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
         ResumeExecution(EResumeSource::CAResumeByWatermark);
     }
 
-    void ResumeInputsByCheckpoint() override final {
+    void ResumeInputsByCheckpoint() override {
         for (auto& [id, channelInfo] : InputChannelsMap) {
             if (channelInfo.PendingCheckpoint) {
                 channelInfo.ResumeByCheckpoint();
@@ -1888,6 +1888,7 @@ protected:
 
     virtual void DrainAsyncOutput(ui64 outputIndex, TAsyncOutputInfoBase& outputInfo) = 0;
 
+    // sync CA only
     ui32 SendDataChunkToAsyncOutput(ui64 outputIndex, TAsyncOutputInfoBase& outputInfo, ui64 bytes) {
         auto sink = outputInfo.Buffer;
 
@@ -1913,8 +1914,7 @@ protected:
         TMaybe<NDqProto::TCheckpoint> maybeCheckpoint;
         if (hasCheckpoint) {
             maybeCheckpoint = checkpoint;
-            CA_LOG_I("Resume inputs");
-            ResumeInputsByCheckpoint();
+            static_cast<TDerived *>(this)->AdvanceResumeInputsByCheckpoint();
         }
 
         outputInfo.AsyncOutput->SendData(std::move(dataBatch), dataSize, maybeCheckpoint, outputInfo.Finished);
@@ -1922,6 +1922,9 @@ protected:
 
         return dataSize + checkpointSize;
     }
+
+public:
+    void AdvanceResumeInputsByCheckpoint(); // must be implemented if SendDataChunkToAsyncOutput() is used (sync CA only)
 
 protected:
     const TMaybe<NDqProto::TRlPath>& GetRlPath() const {

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor_impl.h
@@ -843,7 +843,7 @@ protected: //TDqComputeActorCheckpoints::ICallbacks
         ResumeExecution(EResumeSource::CAResumeByWatermark);
     }
 
-    void ResumeInputsByCheckpoint() override {
+    void ResumeInputsByCheckpoint() override final {
         for (auto& [id, channelInfo] : InputChannelsMap) {
             if (channelInfo.PendingCheckpoint) {
                 channelInfo.ResumeByCheckpoint();
@@ -1914,7 +1914,6 @@ protected:
         TMaybe<NDqProto::TCheckpoint> maybeCheckpoint;
         if (hasCheckpoint) {
             maybeCheckpoint = checkpoint;
-            static_cast<TDerived *>(this)->AdvanceResumeInputsByCheckpoint();
         }
 
         outputInfo.AsyncOutput->SendData(std::move(dataBatch), dataSize, maybeCheckpoint, outputInfo.Finished);
@@ -1922,9 +1921,6 @@ protected:
 
         return dataSize + checkpointSize;
     }
-
-public:
-    void AdvanceResumeInputsByCheckpoint(); // must be implemented if SendDataChunkToAsyncOutput() is used (sync CA only)
 
 protected:
     const TMaybe<NDqProto::TRlPath>& GetRlPath() const {

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -340,31 +340,6 @@ protected:
         return TaskRunner ? TaskRunner->GetInputTransformWatermarksTracker(inputId): nullptr;
     }
 
-private:
-    ui32 UnsentCheckpoints = 0;
-
-    void ResumeInputsByCheckpoint() override {
-        Y_ENSURE(UnsentCheckpoints == 0);
-        UnsentCheckpoints = this->SinksMap.size() + this->OutputChannelsMap.size();
-        MaybeResumeByCheckpoint();
-    }
-
-    void MaybeResumeByCheckpoint() {
-        if (UnsentCheckpoints > 0) {
-            CA_LOG_D("Pending " << UnsentCheckpoints << " checkpoints to be sent");
-            return;
-        }
-        CA_LOG_I("Resume inputs by checkpoint");
-        TBase::ResumeInputsByCheckpoint();
-    }
-
-public:
-    void AdvanceResumeInputsByCheckpoint() {
-        Y_ENSURE(UnsentCheckpoints > 0);
-        --UnsentCheckpoints;
-        MaybeResumeByCheckpoint();
-    }
-
 protected:
 
     // methods that are called via static_cast<TDerived*>(this) and may be overriden by a dervied class
@@ -402,10 +377,6 @@ protected:
             std::vector<typename TBase::TOutputChannelInfo::TDrainedChannelMessage> channelData = outputChannel.DrainChannel(drainPackSize);
             ui32 idx = 0;
             for (auto&& i : channelData) {
-                if (i.GetCheckpointOptional()) {
-                    AdvanceResumeInputsByCheckpoint();
-                }
-
                 this->Channels->SendChannelData(i.BuildChannelData(outputChannel.ChannelId), ++idx == channelData.size());
                 ++sentChunks;
             }

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -340,7 +340,33 @@ protected:
         return TaskRunner ? TaskRunner->GetInputTransformWatermarksTracker(inputId): nullptr;
     }
 
+private:
+    ui32 UnsentCheckpoints = 0;
+
+    void ResumeInputsByCheckpoint() override {
+        Y_ENSURE(UnsentCheckpoints == 0);
+        UnsentCheckpoints = this->SinksMap.size() + this->OutputChannelsMap.size();
+        MaybeResumeByCheckpoint();
+    }
+
+    void MaybeResumeByCheckpoint() {
+        if (UnsentCheckpoints > 0) {
+            CA_LOG_D("Pending " << UnsentCheckpoints << " checkpoints to be sent");
+            return;
+        }
+        CA_LOG_I("Resume inputs by checkpoint");
+        TBase::ResumeInputsByCheckpoint();
+    }
+
+public:
+    void AdvanceResumeInputsByCheckpoint() {
+        Y_ENSURE(UnsentCheckpoints > 0);
+        --UnsentCheckpoints;
+        MaybeResumeByCheckpoint();
+    }
+
 protected:
+
     // methods that are called via static_cast<TDerived*>(this) and may be overriden by a dervied class
     void* GetSourcesState() const {
         return nullptr;
@@ -377,8 +403,7 @@ protected:
             ui32 idx = 0;
             for (auto&& i : channelData) {
                 if (i.GetCheckpointOptional()) {
-                    CA_LOG_I("Resume inputs by checkpoint");
-                    TBase::ResumeInputsByCheckpoint();
+                    AdvanceResumeInputsByCheckpoint();
                 }
 
                 this->Channels->SendChannelData(i.BuildChannelData(outputChannel.ChannelId), ++idx == channelData.size());

--- a/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
+++ b/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h
@@ -341,7 +341,6 @@ protected:
     }
 
 protected:
-
     // methods that are called via static_cast<TDerived*>(this) and may be overriden by a dervied class
     void* GetSourcesState() const {
         return nullptr;


### PR DESCRIPTION
YQ-5391

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

SyncCA::ResumeInputsByCheckpoint was called twice (or more):
1) SyncCA::DoExecuteImpl -> Checkpoints::[DoCheckpoint](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_compute_actor_checkpoints.cpp#L451)
2) SyncCA::[DrainOutputChannel](https://github.com/ydb-platform/ydb/blob/main/ydb/library/yql/dq/actors/compute/dq_sync_compute_actor_base.h#L381) (for each output channel; upd: affects only channels 1.0)
3) SyncCA::DrainAsyncOutput -> SendDataChunkToAsyncOutput -> ResumeInputsByCheckpoint (for each sink; actually, there can be no more than one sink, so it just doubles resumes)