### PR TITLE
Extract separate "filter" and "container" targets to break circular deps

### DIFF
--- a/ydb/core/formats/arrow/accessor/abstract/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/abstract/accessor.cpp
@@ -1,7 +1,7 @@
 #include "accessor.h"
 
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 
 #include <ydb/library/actors/core/log.h>

--- a/ydb/core/formats/arrow/accessor/abstract/common.cpp
+++ b/ydb/core/formats/arrow/accessor/abstract/common.cpp
@@ -1,6 +1,6 @@
 #include "common.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 namespace NKikimr::NArrow::NAccessor {
 

--- a/ydb/core/formats/arrow/accessor/abstract/ya.make
+++ b/ydb/core/formats/arrow/accessor/abstract/ya.make
@@ -7,6 +7,7 @@ PEERDIR(
     ydb/services/metadata/abstract
     ydb/library/actors/core
     ydb/core/formats/arrow/accessor/common
+    ydb/core/formats/arrow/filter
     ydb/library/formats/arrow/protos
     ydb/library/arrow_kernels
 )

--- a/ydb/core/formats/arrow/accessor/composite/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/composite/accessor.cpp
@@ -1,6 +1,6 @@
 #include "accessor.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 #include <ydb/library/formats/arrow/arrow_helpers.h>
 namespace NKikimr::NArrow::NAccessor {

--- a/ydb/core/formats/arrow/accessor/composite/ut/ut_composite.cpp
+++ b/ydb/core/formats/arrow/accessor/composite/ut/ut_composite.cpp
@@ -1,6 +1,6 @@
 #include <ydb/core/formats/arrow/accessor/composite/accessor.h>
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/ydb/core/formats/arrow/accessor/composite/ut/ya.make
+++ b/ydb/core/formats/arrow/accessor/composite/ut/ya.make
@@ -6,9 +6,9 @@ PEERDIR(
     ydb/core/formats/arrow/accessor/sparsed
     ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
-    ydb/core/formats/arrow
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/formats/arrow/accessor/composite/ya.make
+++ b/ydb/core/formats/arrow/accessor/composite/ya.make
@@ -2,6 +2,7 @@ LIBRARY(library-formats-arrow-accessor-composite)
 
 PEERDIR(
     contrib/libs/apache/arrow
+    ydb/core/formats/arrow/filter
     ydb/library/formats/arrow/common
 )
 

--- a/ydb/core/formats/arrow/accessor/dictionary/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/dictionary/accessor.cpp
@@ -3,7 +3,7 @@
 
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <library/cpp/json/writer/json_value.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/concatenate.h>

--- a/ydb/core/formats/arrow/accessor/dictionary/ut/ut_dictionary.cpp
+++ b/ydb/core/formats/arrow/accessor/dictionary/ut/ut_dictionary.cpp
@@ -3,7 +3,7 @@
 #include <ydb/core/formats/arrow/accessor/dictionary/additional_data.h>
 #include <ydb/core/formats/arrow/accessor/dictionary/constructor.h>
 #include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 
 #include <ydb/library/actors/core/log.h>

--- a/ydb/core/formats/arrow/accessor/dictionary/ut/ya.make
+++ b/ydb/core/formats/arrow/accessor/dictionary/ut/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     ydb/core/formats/arrow/accessor/dictionary
     ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
 )

--- a/ydb/core/formats/arrow/accessor/dictionary/ya.make
+++ b/ydb/core/formats/arrow/accessor/dictionary/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 PEERDIR(
     ydb/core/formats/arrow/accessor/abstract
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/engines/protos
     ydb/library/formats/arrow
     ydb/library/formats/arrow/protos

--- a/ydb/core/formats/arrow/accessor/sparsed/accessor.cpp
+++ b/ydb/core/formats/arrow/accessor/sparsed/accessor.cpp
@@ -1,6 +1,6 @@
 #include "accessor.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/save_load/loader.h>
 #include <ydb/core/formats/arrow/size_calcer.h>
 #include <ydb/core/formats/arrow/splitter/simple.h>

--- a/ydb/core/formats/arrow/accessor/sparsed/ut/ut_sparsed.cpp
+++ b/ydb/core/formats/arrow/accessor/sparsed/ut/ut_sparsed.cpp
@@ -1,5 +1,5 @@
 #include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 

--- a/ydb/core/formats/arrow/accessor/sparsed/ut/ya.make
+++ b/ydb/core/formats/arrow/accessor/sparsed/ut/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     ydb/core/formats/arrow/accessor/sparsed
     ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     yql/essentials/public/udf/service/stub
     yql/essentials/sql/pg_dummy
 )

--- a/ydb/core/formats/arrow/accessor/sparsed/ya.make
+++ b/ydb/core/formats/arrow/accessor/sparsed/ya.make
@@ -4,6 +4,7 @@ PEERDIR(
     ydb/core/formats/arrow/accessor/abstract
     ydb/library/formats/arrow
     ydb/library/formats/arrow/protos
+    ydb/core/formats/arrow/filter
     ydb/core/formats/arrow/save_load
     ydb/core/formats/arrow/serializer
     ydb/core/formats/arrow/splitter

--- a/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/accessor.h
@@ -8,9 +8,9 @@
 #include <ydb/core/formats/arrow/accessor/abstract/accessor.h>
 #include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 
 #include <ydb/library/accessor/accessor.h>
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.cpp
@@ -1,6 +1,7 @@
 #include "columns_storage.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/container/filterable/filterable.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 #include <yql/essentials/types/binary_json/read.h>
 
@@ -31,8 +32,7 @@ TColumnsData TColumnsData::ApplyFilter(const TColumnFilter& filter) const {
     if (!Stats.GetColumnsCount()) {
         return *this;
     }
-    auto records = Records;
-    filter.Apply(records);
+    auto records = NArrow::ApplyFilter(filter, Records);
     if (records->GetRecordsCount()) {
         TDictStats::TBuilder builder;
         ui32 idx = 0;

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -2,7 +2,7 @@
 
 #include "stats.h"
 
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 
 #include <ydb/library/accessor/accessor.h>
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/others_storage.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/others_storage.cpp
@@ -2,7 +2,8 @@
 
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/container/filterable/filterable.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 
 #include <ydb/library/formats/arrow/arrow_helpers.h>
@@ -270,8 +271,7 @@ TConclusion<std::shared_ptr<TJsonPathAccessor>> TOthersData::GetPathAccessor(con
     for (TIterator it(Records); it.IsValid(); it.Next()) {
         filter.Add(it.GetKeyIndex() == *idx);
     }
-    auto recordsFiltered = Records;
-    filter.Apply(recordsFiltered);
+    auto recordsFiltered = NArrow::ApplyFilter(filter, Records);
     auto table = recordsFiltered->BuildTableVerified(std::set<std::string>({ "record_idx", "value" }));
 
     TSparsedArray::TBuilder builder(nullptr, arrow::binary());

--- a/ydb/core/formats/arrow/accessor/sub_columns/others_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/others_storage.h
@@ -5,7 +5,7 @@
 #include <ydb/core/formats/arrow/accessor/common/binary_json_value_view.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 
 #include <ydb/library/accessor/accessor.h>
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/partial.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/partial.h
@@ -3,7 +3,7 @@
 #include "others_storage.h"
 
 #include <ydb/core/formats/arrow/accessor/sub_columns/json_value_path.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 namespace NKikimr::NArrow::NAccessor {
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/ya.make
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ya.make
@@ -5,8 +5,9 @@ PEERDIR(
     ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow/accessor/sparsed
     ydb/core/formats/arrow/accessor/composite_serial
+    ydb/core/formats/arrow/filter
     ydb/core/formats/arrow/save_load
-    ydb/core/formats/arrow/common
+    ydb/core/formats/arrow/container/filterable
     ydb/library/signals
     ydb/library/formats/arrow
     ydb/library/formats/arrow/protos

--- a/ydb/core/formats/arrow/arrow_helpers.h
+++ b/ydb/core/formats/arrow/arrow_helpers.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "process_columns.h"
+#include <ydb/core/formats/arrow/process_columns.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <library/cpp/json/writer/json_value.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/api.h>

--- a/ydb/core/formats/arrow/common/adapter.h
+++ b/ydb/core/formats/arrow/common/adapter.h
@@ -1,17 +1,14 @@
 #pragma once
-#include "container.h"
+#include <ydb/core/formats/arrow/container/container.h>
 
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
 
-#include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/library/formats/arrow/validation/validation.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_base.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_primitive.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/chunked_array.h>
-#include <contrib/libs/apache/arrow/cpp/src/arrow/compute/api_vector.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/datum.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/record_batch.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/table.h>
@@ -41,28 +38,6 @@ public:
     [[nodiscard]] static std::shared_ptr<arrow::RecordBatch> Build(const std::shared_ptr<arrow::Schema>& schema, std::vector<std::shared_ptr<TColumn>>&& columns, const ui32 count) {
         return arrow::RecordBatch::Make(schema, count, std::move(columns));
     }
-    [[nodiscard]] static std::shared_ptr<arrow::RecordBatch> ApplyArrowFilter(
-        const std::shared_ptr<arrow::RecordBatch>& batch, const TColumnFilter& filter) {
-        auto res = arrow::compute::Filter(batch, filter.BuildArrowFilter(batch->num_rows()));
-        Y_VERIFY_S(res.ok(), res.status().message());
-        Y_ABORT_UNLESS(res->kind() == arrow::Datum::RECORD_BATCH);
-        return res->record_batch();
-    }
-    [[nodiscard]] static std::shared_ptr<arrow::RecordBatch> ApplySlicesFilter(
-        const std::shared_ptr<arrow::RecordBatch>& batch, TColumnFilter::TSlicesIterator filter) {
-        AFL_VERIFY(filter.GetRecordsCount() == batch->num_rows());
-        std::vector<std::shared_ptr<arrow::RecordBatch>> slices;
-        for (filter.Start(); filter.IsValid(); filter.Next()) {
-            if (!filter.IsFiltered()) {
-                continue;
-            }
-            slices.emplace_back(batch->Slice(filter.GetStartIndex(), filter.GetSliceSize()));
-        }
-        return NArrow::ToBatch(TStatusValidator::GetValid(arrow::Table::FromRecordBatches(slices)));
-    }
-    [[nodiscard]] static std::shared_ptr<arrow::RecordBatch> GetEmptySame(const std::shared_ptr<arrow::RecordBatch>& batch) {
-        return batch->Slice(0, 0);
-    }
 };
 
 template <>
@@ -79,28 +54,6 @@ public:
     [[nodiscard]] static std::shared_ptr<arrow::Table> AddColumn(
         const std::shared_ptr<arrow::Table>& batch, const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& extCol) {
         return TStatusValidator::GetValid(batch->AddColumn(batch->num_columns(), field, std::make_shared<arrow::ChunkedArray>(extCol)));
-    }
-
-    [[nodiscard]] static std::shared_ptr<arrow::Table> ApplyArrowFilter(
-        const std::shared_ptr<arrow::Table>& batch, const TColumnFilter& filter) {
-        auto res = arrow::compute::Filter(batch, filter.BuildArrowFilter(batch->num_rows()));
-        Y_VERIFY_S(res.ok(), res.status().message());
-        Y_ABORT_UNLESS(res->kind() == arrow::Datum::TABLE);
-        return res->table();
-    }
-    [[nodiscard]] static std::shared_ptr<arrow::Table> ApplySlicesFilter(
-        const std::shared_ptr<arrow::Table>& batch, TColumnFilter::TSlicesIterator filter) {
-        std::vector<std::shared_ptr<arrow::Table>> slices;
-        for (filter.Start(); filter.IsValid(); filter.Next()) {
-            if (!filter.IsFiltered()) {
-                continue;
-            }
-            slices.emplace_back(batch->Slice(filter.GetStartIndex(), filter.GetSliceSize()));
-        }
-        return TStatusValidator::GetValid(arrow::ConcatenateTables(slices));
-    }
-    [[nodiscard]] static std::shared_ptr<arrow::Table> GetEmptySame(const std::shared_ptr<arrow::Table>& batch) {
-        return batch->Slice(0, 0);
     }
 };
 
@@ -119,18 +72,6 @@ public:
         const std::shared_ptr<arrow::Field>& field, const std::shared_ptr<arrow::Array>& extCol) {
         batch->AddField(field, std::make_shared<NAccessor::TTrivialArray>(extCol)).Validate();
         return batch;
-    }
-    [[nodiscard]] static std::shared_ptr<TGeneralContainer> ApplyArrowFilter(
-        const std::shared_ptr<TGeneralContainer>& batch, const TColumnFilter& filter) {
-        return std::make_shared<TGeneralContainer>(batch->ApplyFilter(filter));
-    }
-    [[nodiscard]] static std::shared_ptr<TGeneralContainer> ApplySlicesFilter(
-        const std::shared_ptr<TGeneralContainer>& batch, TColumnFilter::TSlicesIterator filter) {
-        auto table = batch->BuildTableVerified();
-        return std::make_shared<TGeneralContainer>(TDataBuilderPolicy<arrow::Table>::ApplySlicesFilter(table, filter));
-    }
-    [[nodiscard]] static std::shared_ptr<TGeneralContainer> GetEmptySame(const std::shared_ptr<TGeneralContainer>& batch) {
-        return batch->BuildEmptySame();
     }
 };
 

--- a/ydb/core/formats/arrow/container/container.cpp
+++ b/ydb/core/formats/arrow/container/container.cpp
@@ -1,8 +1,6 @@
 #include "container.h"
 
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/arrow_helpers.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/formats/arrow/common/vector_operations.h>
@@ -240,18 +238,6 @@ NJson::TJsonValue TGeneralContainer::DebugJson(const bool withData) const {
         }
     }
     return result;
-}
-
-TGeneralContainer TGeneralContainer::ApplyFilter(const TColumnFilter& filter) const {
-    if (!Columns.size()) {
-        return *BuildEmptySame();
-    } else {
-        std::vector<std::shared_ptr<NAccessor::IChunkedArray>> columns;
-        for (auto&& i : Columns) {
-            columns.emplace_back(filter.Apply(i));
-        }
-        return TGeneralContainer(Schema->GetFields(), std::move(columns));
-    }
 }
 
 TConclusion<std::shared_ptr<arrow::Scalar>> IFieldsConstructor::GetDefaultColumnElementValue(

--- a/ydb/core/formats/arrow/container/container.h
+++ b/ydb/core/formats/arrow/container/container.h
@@ -32,8 +32,6 @@ private:
 public:
     TGeneralContainer(const ui32 recordsCount);
 
-    TGeneralContainer ApplyFilter(const TColumnFilter& filter) const;
-
     TGeneralContainer Slice(const ui32 offset, const ui32 count) const {
         std::vector<std::shared_ptr<NAccessor::IChunkedArray>> columns;
         for (auto&& i : Columns) {

--- a/ydb/core/formats/arrow/container/filterable/filterable.cpp
+++ b/ydb/core/formats/arrow/container/filterable/filterable.cpp
@@ -1,0 +1,29 @@
+#include "filterable.h"
+
+namespace NKikimr::NArrow {
+
+ui32 TGeneralContainerFilterable::GetRecordsCount() const {
+    return Container ? Container->GetRecordsCount() : 0;
+}
+
+void TGeneralContainerFilterable::ApplyEmpty() {
+    Container = Container->BuildEmptySame();
+}
+
+void TGeneralContainerFilterable::ApplyArrowFilter(const TColumnFilter& filter) {
+    Container = std::make_shared<TGeneralContainer>(ApplyArrowFilterToTable(Container->BuildTableVerified(), filter));
+}
+
+void TGeneralContainerFilterable::ApplySlicesFilter(TColumnFilter::TSlicesIterator slices) {
+    Container = std::make_shared<TGeneralContainer>(ApplySlicesToTable(Container->BuildTableVerified(), slices));
+}
+
+std::shared_ptr<TGeneralContainer> ApplyFilter(
+    const TColumnFilter& filter, const std::shared_ptr<TGeneralContainer>& container, const TColumnFilter::TApplyContext& context) {
+    auto wrapper = std::make_shared<TGeneralContainerFilterable>(container);
+    std::shared_ptr<TColumnFilter::IFilterable> filterable = wrapper;
+    filter.Apply(filterable, context);
+    return wrapper->GetData();
+}
+
+}   // namespace NKikimr::NArrow

--- a/ydb/core/formats/arrow/container/filterable/filterable.cpp
+++ b/ydb/core/formats/arrow/container/filterable/filterable.cpp
@@ -11,7 +11,15 @@ void TGeneralContainerFilterable::ApplyEmpty() {
 }
 
 void TGeneralContainerFilterable::ApplyArrowFilter(const TColumnFilter& filter) {
-    Container = std::make_shared<TGeneralContainer>(ApplyArrowFilterToTable(Container->BuildTableVerified(), filter));
+    if (!Container->GetColumns().size()) {
+        Container = Container->BuildEmptySame();
+    } else {
+        std::vector<std::shared_ptr<NAccessor::IChunkedArray>> columns;
+        for (auto&& i : Container->GetColumns()) {
+            columns.emplace_back(filter.Apply(i));
+        }
+        Container = std::make_shared<TGeneralContainer>(Container->GetSchema()->GetFields(), std::move(columns));
+    }
 }
 
 void TGeneralContainerFilterable::ApplySlicesFilter(TColumnFilter::TSlicesIterator slices) {

--- a/ydb/core/formats/arrow/container/filterable/filterable.h
+++ b/ydb/core/formats/arrow/container/filterable/filterable.h
@@ -1,0 +1,35 @@
+#pragma once
+#include <ydb/core/formats/arrow/container/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
+
+#include <memory>
+
+namespace NKikimr::NArrow {
+
+// IFilterable implementation for TGeneralContainer. Lives separately from the `filter`
+// library so that `filter` does not depend on `container`.
+class TGeneralContainerFilterable: public TColumnFilter::IFilterable {
+private:
+    std::shared_ptr<TGeneralContainer> Container;
+
+public:
+    explicit TGeneralContainerFilterable(const std::shared_ptr<TGeneralContainer>& container)
+        : Container(container) {
+    }
+
+    const std::shared_ptr<TGeneralContainer>& GetData() const {
+        return Container;
+    }
+
+    ui32 GetRecordsCount() const override;
+    void ApplyArrowFilter(const TColumnFilter& filter) override;
+    void ApplySlicesFilter(TColumnFilter::TSlicesIterator slices) override;
+    void ApplyEmpty() override;
+};
+
+// Applies `filter` to `container` (wrapping it into TGeneralContainerFilterable) and returns the filtered container.
+[[nodiscard]] std::shared_ptr<TGeneralContainer> ApplyFilter(const TColumnFilter& filter,
+    const std::shared_ptr<TGeneralContainer>& container,
+    const TColumnFilter::TApplyContext& context = Default<TColumnFilter::TApplyContext>());
+
+}   // namespace NKikimr::NArrow

--- a/ydb/core/formats/arrow/container/filterable/ya.make
+++ b/ydb/core/formats/arrow/container/filterable/ya.make
@@ -1,0 +1,13 @@
+LIBRARY()
+
+PEERDIR(
+    contrib/libs/apache/arrow
+    ydb/core/formats/arrow/container
+    ydb/core/formats/arrow/filter
+)
+
+SRCS(
+    filterable.cpp
+)
+
+END()

--- a/ydb/core/formats/arrow/container/ya.make
+++ b/ydb/core/formats/arrow/container/ya.make
@@ -1,17 +1,19 @@
+RECURSE(
+    filterable
+)
+
 LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
-    ydb/core/formats/arrow/container
-    ydb/core/formats/arrow/switch
+    ydb/library/accessor
     ydb/library/actors/core
     ydb/library/conclusion
     ydb/library/formats/arrow
-    ydb/core/formats/arrow/splitter
 )
 
 SRCS(
-    adapter.cpp
+    container.cpp
 )
 
 END()

--- a/ydb/core/formats/arrow/dictionary/conversion.cpp
+++ b/ydb/core/formats/arrow/dictionary/conversion.cpp
@@ -1,6 +1,5 @@
 #include "conversion.h"
 #include <ydb/core/formats/arrow/switch/switch_type.h>
-#include <ydb/core/formats/arrow/size_calcer.h>
 #include <ydb/library/formats/arrow/simple_builder/filler.h>
 #include <ydb/library/formats/arrow/simple_builder/array.h>
 

--- a/ydb/core/formats/arrow/filter/filter.cpp
+++ b/ydb/core/formats/arrow/filter/filter.cpp
@@ -1,16 +1,17 @@
-#include "arrow_filter.h"
+#include "filter.h"
 
-#include "common/adapter.h"
-#include "common/container.h"
-#include "switch/switch_type.h"
+#include <ydb/core/formats/arrow/accessor/abstract/accessor.h>
+#include <ydb/core/formats/arrow/switch/switch_type.h>
 
 #include <ydb/library/actors/core/log.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/library/yverify_stream/yverify_stream.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_primitive.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/chunked_array.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/compute/api_vector.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/record_batch.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/table.h>
 
 namespace NKikimr::NArrow {
 
@@ -186,50 +187,157 @@ ui32 TColumnFilter::CrossSize(const ui32 s1, const ui32 f1, const ui32 s2, const
     return f - s;
 }
 
-template <class TData>
-void ApplyImpl(const TColumnFilter& filter, std::shared_ptr<TData>& batch, const TColumnFilter::TApplyContext& context) {
-    if (!batch || !batch->num_rows()) {
-        return;
+std::shared_ptr<arrow::Table> ApplyArrowFilterToTable(const std::shared_ptr<arrow::Table>& table, const TColumnFilter& filter) {
+    auto res = arrow::compute::Filter(table, filter.BuildArrowFilter(table->num_rows()));
+    Y_VERIFY_S(res.ok(), res.status().message());
+    Y_ABORT_UNLESS(res->kind() == arrow::Datum::TABLE);
+    return res->table();
+}
+
+std::shared_ptr<arrow::Table> ApplySlicesToTable(const std::shared_ptr<arrow::Table>& table, TColumnFilter::TSlicesIterator slices) {
+    std::vector<std::shared_ptr<arrow::Table>> slicesData;
+    for (slices.Start(); slices.IsValid(); slices.Next()) {
+        if (!slices.IsFiltered()) {
+            continue;
+        }
+        slicesData.emplace_back(table->Slice(slices.GetStartIndex(), slices.GetSliceSize()));
     }
+    return TStatusValidator::GetValid(arrow::ConcatenateTables(slicesData));
+}
+
+namespace {
+
+void VerifyFilterSize(const TColumnFilter& filter, const ui32 recordsCount, const TColumnFilter::TApplyContext& context) {
     if (!filter.IsEmpty()) {
         if (context.HasSlice()) {
             AFL_VERIFY(filter.GetRecordsCountVerified() >= *context.GetStartPos() + *context.GetCount())(
                                                                                     "filter_size", filter.GetRecordsCountVerified())(
                                                                                     "start", context.GetStartPos())("count", context.GetCount());
-            AFL_VERIFY(*context.GetCount() == (size_t)batch->num_rows())("count", context.GetCount())("batch_size", batch->num_rows());
+            AFL_VERIFY(*context.GetCount() == (size_t)recordsCount)("count", context.GetCount())("batch_size", recordsCount);
         } else {
-            AFL_VERIFY(filter.GetRecordsCountVerified() == (size_t)batch->num_rows())("filter_size", filter.GetRecordsCountVerified())(
-                                                             "batch_size", batch->num_rows());
+            AFL_VERIFY(filter.GetRecordsCountVerified() == (size_t)recordsCount)("filter_size", filter.GetRecordsCountVerified())(
+                                                             "batch_size", recordsCount);
         }
     }
-    if (filter.IsTotalDenyFilter()) {
-        batch = NAdapter::TDataBuilderPolicy<TData>::GetEmptySame(batch);
+}
+
+bool ShouldTrySlices(const TColumnFilter& filter, const TColumnFilter::TApplyContext& context) {
+    return context.GetTrySlices() && filter.GetFilter().size() * 10 < filter.GetRecordsCountVerified() &&
+        filter.GetRecordsCountVerified() < filter.GetFilteredCountVerified() * 50;
+}
+
+class TArrowTableFilterable: public TColumnFilter::IFilterable {
+private:
+    std::shared_ptr<arrow::Table> Table;
+
+public:
+    explicit TArrowTableFilterable(const std::shared_ptr<arrow::Table>& table)
+        : Table(table) {
+    }
+
+    const std::shared_ptr<arrow::Table>& GetData() const {
+        return Table;
+    }
+
+    ui32 GetRecordsCount() const override {
+        return Table ? Table->num_rows() : 0;
+    }
+
+    void ApplyEmpty() override {
+        Table = Table->Slice(0, 0);
+    }
+
+    void ApplyArrowFilter(const TColumnFilter& filter) override {
+        Table = ApplyArrowFilterToTable(Table, filter);
+    }
+
+    void ApplySlicesFilter(TColumnFilter::TSlicesIterator slices) override {
+        Table = ApplySlicesToTable(Table, slices);
+    }
+};
+
+class TArrowRecordBatchFilterable: public TColumnFilter::IFilterable {
+private:
+    std::shared_ptr<arrow::RecordBatch> Batch;
+
+public:
+    explicit TArrowRecordBatchFilterable(const std::shared_ptr<arrow::RecordBatch>& batch)
+        : Batch(batch) {
+    }
+
+    const std::shared_ptr<arrow::RecordBatch>& GetData() const {
+        return Batch;
+    }
+
+    ui32 GetRecordsCount() const override {
+        return Batch ? Batch->num_rows() : 0;
+    }
+
+    void ApplyEmpty() override {
+        Batch = Batch->Slice(0, 0);
+    }
+
+    void ApplyArrowFilter(const TColumnFilter& filter) override {
+        auto res = arrow::compute::Filter(Batch, filter.BuildArrowFilter(Batch->num_rows()));
+        Y_VERIFY_S(res.ok(), res.status().message());
+        Y_ABORT_UNLESS(res->kind() == arrow::Datum::RECORD_BATCH);
+        Batch = res->record_batch();
+    }
+
+    void ApplySlicesFilter(TColumnFilter::TSlicesIterator slices) override {
+        AFL_VERIFY(slices.GetRecordsCount() == Batch->num_rows());
+        std::vector<std::shared_ptr<arrow::RecordBatch>> slicesData;
+        for (slices.Start(); slices.IsValid(); slices.Next()) {
+            if (!slices.IsFiltered()) {
+                continue;
+            }
+            slicesData.emplace_back(Batch->Slice(slices.GetStartIndex(), slices.GetSliceSize()));
+        }
+        Batch = NArrow::ToBatch(TStatusValidator::GetValid(arrow::Table::FromRecordBatches(slicesData)));
+    }
+};
+
+}   // namespace
+
+void TColumnFilter::Apply(std::shared_ptr<IFilterable>& batch, const TApplyContext& context) const {
+    if (!batch || !batch->GetRecordsCount()) {
         return;
     }
-    if (filter.IsTotalAllowFilter()) {
+    VerifyFilterSize(*this, batch->GetRecordsCount(), context);
+    if (IsTotalDenyFilter()) {
+        batch->ApplyEmpty();
         return;
     }
-    if (context.GetTrySlices() && filter.GetFilter().size() * 10 < filter.GetRecordsCountVerified() &&
-        filter.GetRecordsCountVerified() < filter.GetFilteredCountVerified() * 50) {
-        batch =
-            NAdapter::TDataBuilderPolicy<TData>::ApplySlicesFilter(batch, filter.BuildSlicesIterator(context.GetStartPos(), context.GetCount()));
+    if (IsTotalAllowFilter()) {
+        return;
+    }
+    if (ShouldTrySlices(*this, context)) {
+        batch->ApplySlicesFilter(BuildSlicesIterator(context.GetStartPos(), context.GetCount()));
     } else if (context.HasSlice()) {
-        batch = NAdapter::TDataBuilderPolicy<TData>::ApplyArrowFilter(batch, filter.Slice(*context.GetStartPos(), *context.GetCount()));
+        batch->ApplyArrowFilter(Slice(*context.GetStartPos(), *context.GetCount()));
     } else {
-        batch = NAdapter::TDataBuilderPolicy<TData>::ApplyArrowFilter(batch, filter);
+        batch->ApplyArrowFilter(*this);
     }
-}
-
-void TColumnFilter::Apply(std::shared_ptr<TGeneralContainer>& batch, const TApplyContext& context) const {
-    return ApplyImpl(*this, batch, context);
-}
-
-void TColumnFilter::Apply(std::shared_ptr<arrow::Table>& batch, const TApplyContext& context) const {
-    return ApplyImpl(*this, batch, context);
 }
 
 void TColumnFilter::Apply(std::shared_ptr<arrow::RecordBatch>& batch, const TApplyContext& context) const {
-    return ApplyImpl(*this, batch, context);
+    if (!batch || !batch->num_rows()) {
+        return;
+    }
+    auto filterable = std::make_shared<TArrowRecordBatchFilterable>(batch);
+    std::shared_ptr<IFilterable> impl = filterable;
+    Apply(impl, context);
+    batch = filterable->GetData();
+}
+
+void TColumnFilter::Apply(std::shared_ptr<arrow::Table>& batch, const TApplyContext& context) const {
+    if (!batch || !batch->num_rows()) {
+        return;
+    }
+    auto filterable = std::make_shared<TArrowTableFilterable>(batch);
+    std::shared_ptr<IFilterable> impl = filterable;
+    Apply(impl, context);
+    batch = filterable->GetData();
 }
 
 void TColumnFilter::Apply(const ui32 expectedRecordsCount, std::vector<arrow::Datum*>& datums) const {

--- a/ydb/core/formats/arrow/filter/filter.h
+++ b/ydb/core/formats/arrow/filter/filter.h
@@ -13,8 +13,6 @@ class IChunkedArray;
 
 namespace NKikimr::NArrow {
 
-class TGeneralContainer;
-
 enum class ECompareType {
     LESS = 1,
     LESS_OR_EQUAL,
@@ -296,7 +294,19 @@ public:
         TApplyContext& Slice(const ui32 start, const ui32 count);
     };
 
-    void Apply(std::shared_ptr<TGeneralContainer>& batch, const TApplyContext& context = Default<TApplyContext>()) const;
+    // Abstraction over a filterable batch-like container. TColumnFilter operates on this
+    // interface, so the filter library has no dependency on concrete container types.
+    class IFilterable {
+    public:
+        virtual ~IFilterable() = default;
+
+        virtual ui32 GetRecordsCount() const = 0;
+        virtual void ApplyArrowFilter(const TColumnFilter& filter) = 0;
+        virtual void ApplySlicesFilter(TSlicesIterator slices) = 0;
+        virtual void ApplyEmpty() = 0;
+    };
+
+    void Apply(std::shared_ptr<IFilterable>& batch, const TApplyContext& context = Default<TApplyContext>()) const;
     void Apply(std::shared_ptr<arrow::Table>& batch, const TApplyContext& context = Default<TApplyContext>()) const;
     void Apply(std::shared_ptr<arrow::RecordBatch>& batch, const TApplyContext& context = Default<TApplyContext>()) const;
     void Apply(const ui32 expectedRecordsCount, std::vector<arrow::Datum*>& datums) const;
@@ -306,5 +316,10 @@ public:
     // Combines filters by 'and' operator (extFilter count is true positions count in self, thought extFitler patch exactly that positions)
     TColumnFilter CombineSequentialAnd(const TColumnFilter& extFilter) const Y_WARN_UNUSED_RESULT;
 };
+
+// Table-level filtering primitives shared between TColumnFilter::IFilterable implementations.
+[[nodiscard]] std::shared_ptr<arrow::Table> ApplyArrowFilterToTable(const std::shared_ptr<arrow::Table>& table, const TColumnFilter& filter);
+[[nodiscard]] std::shared_ptr<arrow::Table> ApplySlicesToTable(
+    const std::shared_ptr<arrow::Table>& table, TColumnFilter::TSlicesIterator slices);
 
 }   // namespace NKikimr::NArrow

--- a/ydb/core/formats/arrow/filter/ya.make
+++ b/ydb/core/formats/arrow/filter/ya.make
@@ -2,16 +2,16 @@ LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
-    ydb/core/formats/arrow/container
     ydb/core/formats/arrow/switch
+    ydb/library/accessor
     ydb/library/actors/core
     ydb/library/conclusion
     ydb/library/formats/arrow
-    ydb/core/formats/arrow/splitter
+    ydb/library/yverify_stream
 )
 
 SRCS(
-    adapter.cpp
+    filter.cpp
 )
 
 END()

--- a/ydb/core/formats/arrow/permutations.cpp
+++ b/ydb/core/formats/arrow/permutations.cpp
@@ -1,6 +1,5 @@
 #include "arrow_helpers.h"
 #include "permutations.h"
-#include "size_calcer.h"
 
 #include "hash/calcer.h"
 

--- a/ydb/core/formats/arrow/process_columns.cpp
+++ b/ydb/core/formats/arrow/process_columns.cpp
@@ -1,6 +1,6 @@
 #include "process_columns.h"
 
-#include "common/adapter.h"
+#include <ydb/core/formats/arrow/common/adapter.h>
 
 #include <ydb/library/formats/arrow/modifier/schema.h>
 #include <ydb/library/formats/arrow/modifier/subset.h>

--- a/ydb/core/formats/arrow/process_columns.h
+++ b/ydb/core/formats/arrow/process_columns.h
@@ -2,16 +2,14 @@
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/accessor/validator_simple.h>
 #include <ydb/library/conclusion/result.h>
+#include <ydb/library/formats/arrow/modifier/schema.h>
+#include <ydb/library/formats/arrow/modifier/subset.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/type.h>
 
 #include <functional>
 
 namespace NKikimr::NArrow {
-
-class TSchemaSubset;
-class TSchemaLite;
-class TSchemaLiteView;
 
 class TOrderedColumnIndexesImpl {
 private:

--- a/ydb/core/formats/arrow/program/collection.h
+++ b/ydb/core/formats/arrow/program/collection.h
@@ -3,8 +3,8 @@
 #include "abstract.h"
 
 #include <ydb/core/formats/arrow/accessor/abstract/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
+#include <ydb/core/formats/arrow/container/container.h>
 
 #include <ydb/library/formats/arrow/validation/validation.h>
 

--- a/ydb/core/formats/arrow/program/filter.cpp
+++ b/ydb/core/formats/arrow/program/filter.cpp
@@ -2,7 +2,7 @@
 #include "execution.h"
 #include "filter.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 #include <ydb/library/formats/arrow/arrow_helpers.h>
 #include <ydb/library/formats/arrow/validation/validation.h>

--- a/ydb/core/formats/arrow/program/ya.make
+++ b/ydb/core/formats/arrow/program/ya.make
@@ -5,6 +5,7 @@ PEERDIR(
     ydb/library/actors/core
     ydb/library/services
     ydb/core/formats/arrow/accessor/sub_columns
+    ydb/core/formats/arrow/filter
 
     yql/essentials/core/arrow_kernels/registry
     yql/essentials/core/arrow_kernels/request

--- a/ydb/core/formats/arrow/reader/batch_iterator.h
+++ b/ydb/core/formats/arrow/reader/batch_iterator.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "position.h"
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 namespace NKikimr::NArrow::NMerger {
 

--- a/ydb/core/formats/arrow/reader/merger.h
+++ b/ydb/core/formats/arrow/reader/merger.h
@@ -3,7 +3,7 @@
 #include "heap.h"
 #include "position.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 namespace NKikimr::NArrow::NMerger {
 

--- a/ydb/core/formats/arrow/reader/position.h
+++ b/ydb/core/formats/arrow/reader/position.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <ydb/core/formats/arrow/accessor/abstract/accessor.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 #include <ydb/core/formats/arrow/permutations.h>
 #include <ydb/core/formats/arrow/switch/switch_type.h>
 #include <ydb/core/scheme_types/scheme_type_info.h>

--- a/ydb/core/formats/arrow/reader/ya.make
+++ b/ydb/core/formats/arrow/reader/ya.make
@@ -2,8 +2,9 @@ LIBRARY()
 
 PEERDIR(
     contrib/libs/apache/arrow
+    ydb/core/formats/arrow/filter
     ydb/core/formats/arrow/switch
-    ydb/core/formats/arrow/common
+    ydb/core/formats/arrow/container
     ydb/library/actors/core
     ydb/library/services
     ydb/library/formats/arrow

--- a/ydb/core/formats/arrow/serializer/native.cpp
+++ b/ydb/core/formats/arrow/serializer/native.cpp
@@ -2,13 +2,12 @@
 #include "parsing.h"
 #include "stream.h"
 
-#include <ydb/core/formats/arrow/dictionary/conversion.h>
-
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/formats/arrow/validation/validation.h>
 #include <ydb/library/services/services.pb.h>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/buffer.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/type.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/io/memory.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/ipc/dictionary.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/ipc/reader.h>

--- a/ydb/core/formats/arrow/special_keys.cpp
+++ b/ydb/core/formats/arrow/special_keys.cpp
@@ -4,7 +4,6 @@
 
 #include "reader/position.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 

--- a/ydb/core/formats/arrow/ut/ut_arrow.cpp
+++ b/ydb/core/formats/arrow/ut/ut_arrow.cpp
@@ -1,7 +1,7 @@
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
 #include <ydb/core/formats/arrow/arrow_helpers.h>
 #include <ydb/core/formats/arrow/converter.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/permutations.h>
 #include <ydb/core/formats/arrow/reader/merger.h>
 #include <ydb/core/formats/arrow/reader/result_builder.h>

--- a/ydb/core/formats/arrow/ut/ut_column_filter.cpp
+++ b/ydb/core/formats/arrow/ut/ut_column_filter.cpp
@@ -1,4 +1,4 @@
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/formats/arrow/ut/ya.make
+++ b/ydb/core/formats/arrow/ut/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     contrib/libs/apache/arrow
     ydb/library/arrow_kernels
     ydb/library/formats/arrow/simple_builder
+    ydb/core/formats/arrow/filter
     ydb/core/formats/arrow/program
     ydb/core/base
     ydb/library/formats/arrow

--- a/ydb/core/formats/arrow/ya.make
+++ b/ydb/core/formats/arrow/ya.make
@@ -1,3 +1,8 @@
+RECURSE(
+    container
+    filter
+)
+
 RECURSE_FOR_TESTS(
     ut
 )
@@ -34,13 +39,12 @@ SRCS(
     arrow_batch_builder.cpp
     arrow_helpers.cpp
     arrow_helpers_minikql.cpp
-    arrow_filter.cpp
     converter.cpp
     converter.h
     permutations.cpp
+    process_columns.cpp
     size_calcer.cpp
     special_keys.cpp
-    process_columns.cpp
 )
 
 END()

--- a/ydb/core/tx/columnshard/engines/changes/compaction/dictionary/logic.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/dictionary/logic.cpp
@@ -3,7 +3,7 @@
 #include <ydb/core/formats/arrow/accessor/composite/accessor.h>
 #include <ydb/core/formats/arrow/accessor/dictionary/constructor.h>
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/switch/switch_type.h>
 #include <ydb/core/tx/columnshard/engines/storage/chunks/column.h>
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/dictionary/ya.make
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/dictionary/ya.make
@@ -5,6 +5,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/engines/changes/compaction/common
 )
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/merger.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/merger.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/reader/position.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/engines/changes/abstract/abstract.h>

--- a/ydb/core/tx/columnshard/engines/changes/compaction/ya.make
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/ya.make
@@ -5,6 +5,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/formats/arrow/filter
     ydb/core/tx/tiering
     ydb/core/tx/columnshard/engines/changes/compaction/abstract
     ydb/core/tx/columnshard/engines/changes/compaction/common

--- a/ydb/core/tx/columnshard/engines/changes/merge_subset.h
+++ b/ydb/core/tx/columnshard/engines/changes/merge_subset.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "abstract/abstract.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/tx/columnshard/engines/portions/read_with_blobs.h>
 #include <ydb/core/tx/columnshard/engines/portions/write_with_blobs.h>
 #include <ydb/core/tx/columnshard/engines/scheme/versions/filtered_scheme.h>

--- a/ydb/core/tx/columnshard/engines/changes/ya.make
+++ b/ydb/core/tx/columnshard/engines/changes/ya.make
@@ -11,7 +11,8 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/core/formats/arrow
+    ydb/core/formats/arrow/container
+    ydb/core/formats/arrow/filter
     ydb/core/protos
     ydb/core/tablet_flat
     ydb/core/tx/columnshard/common

--- a/ydb/core/tx/columnshard/engines/filter.h
+++ b/ydb/core/tx/columnshard/engines/filter.h
@@ -2,7 +2,7 @@
 
 #include "defs.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>
 
 #include <ydb/library/formats/arrow/replace_key.h>

--- a/ydb/core/tx/columnshard/engines/portions/data_accessor.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/data_accessor.cpp
@@ -6,7 +6,7 @@
 #include <ydb/core/formats/arrow/accessor/composite/accessor.h>
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
 #include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 #include <ydb/core/tx/columnshard/blobs_reader/task.h>
 #include <ydb/core/tx/columnshard/data_sharing/protos/data.pb.h>
 #include <ydb/core/tx/columnshard/engines/db_wrapper.h>

--- a/ydb/core/tx/columnshard/engines/portions/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/meta.cpp
@@ -1,7 +1,7 @@
 #include "meta.h"
 
 #include <ydb/core/base/appdata.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/tx/columnshard/blobs_action/common/const.h>
 #include <ydb/core/tx/columnshard/engines/scheme/index_info.h>

--- a/ydb/core/tx/columnshard/engines/portions/ya.make
+++ b/ydb/core/tx/columnshard/engines/portions/ya.make
@@ -19,6 +19,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/engines/scheme
     ydb/core/tx/columnshard/splitter
     ydb/core/tx/columnshard/common

--- a/ydb/core/tx/columnshard/engines/predicate/container.h
+++ b/ydb/core/tx/columnshard/engines/predicate/container.h
@@ -2,8 +2,8 @@
 #include "predicate.h"
 
 #include <ydb/core/formats/arrow/accessor/abstract/accessor.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/reader/position.h>
 #include <ydb/core/formats/arrow/rows/view.h>
 

--- a/ydb/core/tx/columnshard/engines/predicate/predicate.h
+++ b/ydb/core/tx/columnshard/engines/predicate/predicate.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/reader/position.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
 

--- a/ydb/core/tx/columnshard/engines/predicate/ya.make
+++ b/ydb/core/tx/columnshard/engines/predicate/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     contrib/libs/apache/arrow
     ydb/core/protos
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.h
@@ -2,7 +2,7 @@
 #include "fetching.h"
 #include "source.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/program/collection.h>
 #include <ydb/core/tx/columnshard/blob.h>
 #include <ydb/core/tx/columnshard/blobs_reader/task.h>

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetch_steps.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetch_steps.cpp
@@ -1,7 +1,7 @@
 #include "fetch_steps.h"
 #include "source.h"
 
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 #include <ydb/core/tx/columnshard/engines/reader/tracing/data_source_probes.h>
 #include <ydb/core/tx/columnshard/engines/scheme/abstract/index_info.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetched_data.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetched_data.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <ydb/core/base/appdata.h>
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/program/collection.h>
 #include <ydb/core/formats/arrow/size_calcer.h>
 #include <ydb/core/tx/columnshard/blob.h>

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/ya.make
@@ -17,6 +17,7 @@ PEERDIR(
     ydb/core/formats/arrow/accessor/dictionary
     ydb/core/formats/arrow/accessor/plain
     ydb/core/formats/arrow/accessor/sub_columns
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/engines/reader/tracing
     ydb/core/tx/columnshard/engines/scheme
     ydb/core/tx/columnshard/engines/storage/indexes/skip_index

--- a/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/plain_reader/iterator/ya.make
@@ -15,6 +15,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/blobs_action
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
     ydb/core/tx/conveyor/usage

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/common.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/common.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 #include <ydb/core/formats/arrow/reader/position.h>
 #include <ydb/core/formats/arrow/rows/view.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/events.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/events.h
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/tx/columnshard/columnshard_private_events.h>
 
 #include <ydb/library/actors/core/event_local.h>

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/ya.make
@@ -12,6 +12,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
 )
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/distinct_limit.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/distinct_limit.cpp
@@ -1,6 +1,6 @@
 #include "distinct_limit.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/tx/columnshard/counters/scan.h>
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections/abstract.h>
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/sync_points/ya.make
@@ -9,7 +9,7 @@ SRCS(
 )
 
 PEERDIR(
-    ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/counters
 )
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/ya.make
@@ -12,6 +12,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/blobs_action
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
     ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/collections

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/common.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/common.cpp
@@ -1,7 +1,7 @@
 #include "common.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/rows/view.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/abstract.h>

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/events.h
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/events.h
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/tx/columnshard/columnshard_private_events.h>
 
 #include <ydb/library/actors/core/event_local.h>

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/ya.make
@@ -13,6 +13,7 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
 )
 

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/ya.make
@@ -12,6 +12,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     ydb/core/tx/columnshard/blobs_action
     ydb/core/tx/columnshard/engines/reader/common_reader/iterator
     ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/collections

--- a/ydb/core/tx/columnshard/engines/scheme/abstract/index_info.h
+++ b/ydb/core/tx/columnshard/engines/scheme/abstract/index_info.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 #include <ydb/core/formats/arrow/save_load/loader.h>
 #include <ydb/core/formats/arrow/save_load/saver.h>
 #include <ydb/core/tx/columnshard/common/portion.h>

--- a/ydb/core/tx/columnshard/engines/scheme/defaults/common/ya.make
+++ b/ydb/core/tx/columnshard/engines/scheme/defaults/common/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/library/conclusion
     ydb/core/scheme_types
     ydb/library/actors/core
+    ydb/library/formats/arrow
 )
 
 END()

--- a/ydb/core/tx/columnshard/engines/scheme/versions/abstract_scheme.h
+++ b/ydb/core/tx/columnshard/engines/scheme/versions/abstract_scheme.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ydb/core/formats/arrow/common/container.h>
+#include <ydb/core/formats/arrow/container/container.h>
 #include <ydb/core/formats/arrow/process_columns.h>
 #include <ydb/core/formats/arrow/save_load/loader.h>
 #include <ydb/core/formats/arrow/save_load/saver.h>

--- a/ydb/core/tx/columnshard/engines/ya.make
+++ b/ydb/core/tx/columnshard/engines/ya.make
@@ -22,6 +22,7 @@ PEERDIR(
     contrib/libs/apache/arrow
     ydb/core/base
     ydb/core/formats
+    ydb/core/formats/arrow/filter
     ydb/core/protos
     ydb/core/scheme
     ydb/core/tablet

--- a/ydb/core/tx/columnshard/operations/batch_builder/merger.h
+++ b/ydb/core/tx/columnshard/operations/batch_builder/merger.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ydb/core/formats/arrow/arrow_filter.h>
+#include <ydb/core/formats/arrow/filter/filter.h>
 #include <ydb/core/formats/arrow/reader/position.h>
 #include <ydb/core/formats/arrow/reader/result_builder.h>
 #include <ydb/core/scheme/scheme_type_info.h>

--- a/ydb/core/tx/columnshard/operations/batch_builder/ya.make
+++ b/ydb/core/tx/columnshard/operations/batch_builder/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
     ydb/core/tx/conveyor/usage
     ydb/core/tx/columnshard/common
     ydb/core/tx/data_events
+    ydb/core/formats/arrow/filter
     ydb/core/formats/arrow/reader
     ydb/library/conclusion
     ydb/core/tx/columnshard/engines/scheme/versions

--- a/ydb/core/tx/program/ya.make
+++ b/ydb/core/tx/program/ya.make
@@ -9,6 +9,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
+    ydb/core/formats/arrow/filter
     ydb/core/protos
     ydb/library/formats/arrow/protos
     ydb/core/tablet_flat


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Break circular dependency between TGeneralContainer, TColumnFilter and accessors (TGeneral container requires IChunkedArray, TColumnFilter::Apply has an overload for TGeneralContainer, IChunkedArray requires TColumnFilter for its own apply).

Now TColumnFilter::Apply depends on IFilterable abstraction, while implementation of IFilterable for TGeneralContainer is in a separate target.
