### PR TITLE
Allow to read all partitions without consumer

### DIFF
--- a/ydb/core/persqueue/public/utils.cpp
+++ b/ydb/core/persqueue/public/utils.cpp
@@ -265,6 +265,17 @@ TString TPartitionGraph::DebugString() const {
     return sb;
 }
 
+std::vector<ui32> TPartitionGraph::GetRootPartitions() const {
+    std::vector<ui32> rootPartitions;
+
+    for (auto& [id, n] : Partitions) {
+        if (n.IsRoot()) {
+            rootPartitions.push_back(id);
+        }
+    }
+    return rootPartitions;
+}
+
 template<typename TPartition>
 inline int GetPartitionId(TPartition p) {
     return p.GetPartitionId();

--- a/ydb/core/persqueue/public/utils.h
+++ b/ydb/core/persqueue/public/utils.h
@@ -87,6 +87,7 @@ public:
 
     TString DebugString() const;
 
+    std::vector<ui32> GetRootPartitions() const;
 private:
     std::unordered_map<ui32, Node> Partitions;
 };

--- a/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
+++ b/ydb/core/persqueue/ut/common/autoscaling_ut_common.cpp
@@ -301,6 +301,9 @@ std::shared_ptr<TTestReadSession<SdkVersion::Topic>::TSdkReadSession> TTestReadS
     for (auto partitionId : settings.Partitions) {
         readSettings.Topics_[0].AppendPartitionIds(partitionId);
     }
+    if (settings.WithoutConsumer) {
+        readSettings.WithoutConsumer();
+    }
 
     struct MsgWrapper : public IMessage {
 
@@ -419,6 +422,7 @@ std::shared_ptr<TTestReadSession<SdkVersion::PQv1>::TSdkReadSession> TTestReadSe
     for (auto partitionId : settings.Partitions) {
         readSettings.Topics_[0].PartitionGroupIds_.push_back(partitionId + 1);
     }
+    UNIT_ASSERT_VALUES_EQUAL_C(settings.WithoutConsumer, false, "Reading WithoutConsumer is not supported in PQv1");
 
     struct MsgWrapper : public IMessage {
 

--- a/ydb/core/persqueue/ut/common/autoscaling_ut_common.h
+++ b/ydb/core/persqueue/ut/common/autoscaling_ut_common.h
@@ -110,6 +110,7 @@ struct TestReadSessionSettings {
     bool AutoPartitioningSupport = true;
     std::vector<std::string> Topics = {TEST_TOPIC};
     std::optional<TDuration> ReadLag;
+    bool WithoutConsumer = false;
 };
 
 struct ITestReadSession {

--- a/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
@@ -67,7 +67,7 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
         SimpleTest(SdkVersion::PQv1, false);
     }
 
-    void ReadingAfterSplitTest(SdkVersion sdk, bool autoscaleAwareSDK, bool autoCommit) {
+    void ReadingAfterSplitTest(SdkVersion sdk, bool autoscaleAwareSDK, bool autoCommit, bool withoutConsumer) {
         TTopicSdkTestSetup setup = CreateSetup();
         setup.CreateTopicWithAutoscale();
 
@@ -86,11 +86,14 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
 
         UNIT_ASSERT(writeSession->Write(Msg("message_3.1", 5)));
 
-        auto readSession = CreateTestReadSession({ .Name="Session-0", .Setup=setup, .Sdk = sdk, .ExpectedMessagesCount = 3, .AutoCommit = autoCommit, .AutoPartitioningSupport = autoscaleAwareSDK });
+        auto readSession = CreateTestReadSession({ .Name="Session-0", .Setup=setup, .Sdk = sdk, .ExpectedMessagesCount = 3, .AutoCommit = autoCommit, .AutoPartitioningSupport = autoscaleAwareSDK, .WithoutConsumer = withoutConsumer });
         readSession->Run();
         readSession->WaitAllMessages();
 
+        std::vector<ui32> expectedPartionsOrder{0, 2, 4};
+        auto expectedNextPartionId = expectedPartionsOrder.begin();
         for(const auto& info : readSession->GetReceivedMessages()) {
+            UNIT_ASSERT_VALUES_EQUAL(*expectedNextPartionId++, info.PartitionId);
             if (info.Data == "message_1.1") {
                 UNIT_ASSERT_VALUES_EQUAL(0, info.PartitionId);
                 UNIT_ASSERT_VALUES_EQUAL(2, info.SeqNo);
@@ -110,22 +113,26 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_BeforeAutoscaleAwareSDK) {
-        ReadingAfterSplitTest(SdkVersion::Topic, false, true);
+        ReadingAfterSplitTest(SdkVersion::Topic, false, true, false);
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_AutoscaleAwareSDK) {
-        ReadingAfterSplitTest(SdkVersion::Topic, true, false);
+        ReadingAfterSplitTest(SdkVersion::Topic, true, false, false);
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_AutoscaleAwareSDK_AutoCommit) {
-        ReadingAfterSplitTest(SdkVersion::Topic, true, true);
+        ReadingAfterSplitTest(SdkVersion::Topic, true, true, false);
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_PQv1) {
-        ReadingAfterSplitTest(SdkVersion::PQv1, false, true);
+        ReadingAfterSplitTest(SdkVersion::PQv1, false, true, false);
     }
 
-    void ReadingAfterSplitTest_PreferedPartition(SdkVersion sdk, bool autoscaleAwareSDK) {
+    Y_UNIT_TEST(ReadingAfterSplitTest_AutoscaleAwareSDK_WithoutConsumer) {
+        ReadingAfterSplitTest(SdkVersion::Topic, true, false, true);
+    }
+
+    void ReadingAfterSplitTest_PreferedPartition(SdkVersion sdk, bool autoscaleAwareSDK, bool withoutConsumer) {
         TTopicSdkTestSetup setup = CreateSetup();
         setup.CreateTopicWithAutoscale();
 
@@ -144,7 +151,7 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
 
         UNIT_ASSERT(writeSession->Write(Msg("message_3.1", 5)));
 
-        auto readSession = CreateTestReadSession({ .Name="Session-0", .Setup=setup, .Sdk = sdk, .ExpectedMessagesCount = 1, .AutoCommit = !autoscaleAwareSDK, .Partitions= {2}, .AutoPartitioningSupport = autoscaleAwareSDK });
+        auto readSession = CreateTestReadSession({ .Name="Session-0", .Setup=setup, .Sdk = sdk, .ExpectedMessagesCount = 1, .AutoCommit = !autoscaleAwareSDK, .Partitions= {2}, .AutoPartitioningSupport = autoscaleAwareSDK, .WithoutConsumer = withoutConsumer });
         readSession->Run();
         readSession->WaitAllMessages();
 
@@ -164,15 +171,19 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_PreferedPartition_BeforeAutoscaleAwareSDK) {
-        ReadingAfterSplitTest_PreferedPartition(SdkVersion::Topic, false);
+        ReadingAfterSplitTest_PreferedPartition(SdkVersion::Topic, false, false);
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_PreferedPartition_AutoscaleAwareSDK) {
-        ReadingAfterSplitTest_PreferedPartition(SdkVersion::Topic, true);
+        ReadingAfterSplitTest_PreferedPartition(SdkVersion::Topic, true, false);
     }
 
     Y_UNIT_TEST(ReadingAfterSplitTest_PreferedPartition_PQv1) {
-        ReadingAfterSplitTest_PreferedPartition(SdkVersion::PQv1, false);
+        ReadingAfterSplitTest_PreferedPartition(SdkVersion::PQv1, false, false);
+    }
+
+    Y_UNIT_TEST(ReadingAfterSplitTest_PreferedPartition_AutoscaleAwareSDK_ReadWithoutConsumer) {
+        ReadingAfterSplitTest_PreferedPartition(SdkVersion::Topic, true, true);
     }
 
     void PartitionSplit_oldSDK(SdkVersion sdk) {

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -1170,13 +1170,21 @@ bool TReadSessionActor<UseMigrationProtocol>::InitSession(const TActorContext& c
 
     for (const auto& [topicName, topic] : Topics) {
         if (ReadWithoutConsumer) {
-            if (topic->Groups.size() == 0) {
-                CloseSession(PersQueue::ErrorCode::BAD_REQUEST, "explicitly specify the partitions when reading without a consumer", ctx);
-                return false;
-            }
-            for (auto group : topic->Groups) {
-                if (!SendLockPartitionToSelf(group-1, topicName, topic, ctx)) {
+            if (topic->Groups.empty()) {
+                if (!AutoPartitioningSupport) {
+                    CloseSession(PersQueue::ErrorCode::BAD_REQUEST, "explicitly specify the partitions when reading without a consumer by non-autoscale aware client", ctx);
                     return false;
+                }
+                for (auto partitionId : topic->GetPartitionGraph()->GetRootPartitions()) {
+                    if (!SendLockPartitionToSelf(partitionId, topicName, topic, ctx)) {
+                        return false;
+                    }
+                }
+            } else {
+                for (auto group : topic->Groups) {
+                    if (!SendLockPartitionToSelf(group-1, topicName, topic, ctx)) {
+                        return false;
+                    }
                 }
             }
         } else {
@@ -2470,6 +2478,11 @@ void TReadSessionActor<UseMigrationProtocol>::Handle(TEvPQProxy::TEvReadingFinis
             }
             for (auto p : msg->ChildPartitionIds) {
                 r->add_child_partition_ids(p);
+                if (ReadWithoutConsumer && topic->Groups.empty()) {
+                    if (!SendLockPartitionToSelf(p, it->first, topic, ctx)) {
+                        return;
+                    }
+                }
             }
 
             LOG_INFO_S(ctx, NKikimrServices::PQ_READ_PROXY, PQ_LOG_PREFIX << " sending to client end partition stream event");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Previously there were no possibility to read all partitions without consumer. Now it is allowed. 

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Potentially TPartitionGraph::GetRootPartitions could be a bottleneck in case if frequent use and large number of partitions. Possibly either cache result after first call or prebuild root partitions vector on graph init. 
