### PR TITLE
NBYDB-2274 allow to optionally disable checksums in IC

### DIFF
--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -133,6 +133,7 @@ namespace NActors {
             return x;
         }
 
+        // Note that ChannelBits bits in Flags are reserved for channel
         enum EFlags: ui32 {
             FlagTrackDelivery = 1 << 0,
             FlagForwardOnNondelivery = 1 << 1,
@@ -142,6 +143,7 @@ namespace NActors {
             FlagExtendedFormat = 1 << 5,
             FlagDebugTrackReceive = 1 << 6,
             FlagFailFastWhenDisconnected = 1 << 7,
+            FlagDisablePayloadChecksums = 1 << 8, // When set, IC will not calculate or check XDC/RDMA checksums
         };
         using TEventFlags = ui32;
 

--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -475,14 +475,15 @@ namespace NActors {
                 for (const TRope& rope : payload) {
                     headerLen += SerializeNumber(rope.size(), temp);
                 }
-                info.Sections.push_back(TEventSectionInfo{0, headerLen, 0, 0, true, false});
+                info.Sections.push_back(TEventSectionInfo{0, headerLen, 0, 0, true /*IsInline*/, false /*IsRdma*/});
+
                 for (const TRope& rope : payload) {
-                    info.Sections.push_back(TEventSectionInfo{payloadHeaderSize, rope.size(), 0, payloadAlignment, false, IsRdma(rope)});
+                    info.Sections.push_back(TEventSectionInfo{payloadHeaderSize, rope.size(), 0, payloadAlignment, false /*IsInline*/, IsRdma(rope)});
                 }
             }
 
             const size_t byteSize = Max<ssize_t>(0, recordSize) + preserializedSize;
-            info.Sections.push_back(TEventSectionInfo{0, byteSize, 0, 0, true, false}); // protobuf itself
+            info.Sections.push_back(TEventSectionInfo{0, byteSize, 0, 0, true /*IsInline*/, false /*IsRdma*/}); // protobuf itself
 
 #ifndef NDEBUG
             size_t total = 0;

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -103,8 +103,9 @@ namespace NActors {
         event.Span.EndOk();
 
         Y_ABORT_UNLESS(SerializationInfo);
-        const ui32 flags = (event.Descr.Flags & ~(IEventHandle::FlagForwardOnNondelivery | IEventHandle::FlagSubscribeOnSession)) |
-            (SerializationInfo->IsExtendedFormat ? IEventHandle::FlagExtendedFormat : 0);
+        const ui32 flags = (event.Descr.Flags & ~(IEventHandle::FlagForwardOnNondelivery | IEventHandle::FlagSubscribeOnSession))
+            | (SerializationInfo->IsExtendedFormat ? IEventHandle::FlagExtendedFormat : 0)
+            | event.Descr.Flags & IEventHandle::FlagDisablePayloadChecksums;
 
         // prepare descriptor record
         TEventDescr2 descr{
@@ -288,13 +289,13 @@ namespace NActors {
     }
 
     template<bool External>
-    bool TEventOutputChannel::SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized) {
+    bool TEventOutputChannel::SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, bool disableChecksums, size_t *bytesSerialized) {
         auto addChunk = [&](const void *data, size_t len, bool allowCopy) {
             event.UpdateChecksum(data, len);
             if (allowCopy && (reinterpret_cast<uintptr_t>(data) & 63) + len <= 64) {
                 task.Write<External>(data, len);
             } else {
-                task.Append<External>(data, len, &event.ZcTransferId);
+                task.Append<External>(data, len, &event.ZcTransferId, disableChecksums);
             }
             *bytesSerialized += len;
             Y_DEBUG_ABORT_UNLESS(len <= PartLenRemain);
@@ -395,7 +396,7 @@ namespace NActors {
         auto partBookmark = task.Bookmark(sizeof(TChannelPart));
 
         size_t bytesSerialized = 0;
-        const bool complete = SerializeEvent<false>(task, event, &bytesSerialized);
+        const bool complete = SerializeEvent<false>(task, event, false /*disableChecksums*/, &bytesSerialized);
 
         Y_DEBUG_ABORT_UNLESS(bytesSerialized);
         Y_ABORT_UNLESS(bytesSerialized <= Max<ui16>());
@@ -428,8 +429,12 @@ namespace NActors {
 
     std::optional<bool> TEventOutputChannel::FeedRdmaPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex, bool checksumming) {
         Y_ABORT_UNLESS(rdmaDeviceIndex >= 0);
-
         Y_ABORT_UNLESS(event.Buffer);
+
+        const bool checksumsDisabledForEvent = Params.AllowDisablingPayloadChecksums &&
+            (event.Descr.Flags & IEventHandle::FlagDisablePayloadChecksums);
+        const bool checksumsDisabled = !checksumming || checksumsDisabledForEvent;
+
         if (RdmaCredsBuffer.CredsSize() == 0) {
             for (; Iter.Valid() && PartLenRemain; ) {
                 TRcBuf buf = Iter.GetChunk();
@@ -444,7 +449,7 @@ namespace NActors {
                 const size_t leftInChunk = buf.GetSize() - offset;
                 const size_t chunkSize = Min(leftInChunk, PartLenRemain);
 
-                if (checksumming) {
+                if (!checksumsDisabled) {
                     XXH3_64bits_update(&RdmaCumulativeChecksumState, data, chunkSize);
                 }
                 auto cred = RdmaCredsBuffer.AddCreds();
@@ -537,7 +542,10 @@ namespace NActors {
             .Size = static_cast<ui16>(partSize - sizeof(TChannelPart))
         };
         char *ptr = reinterpret_cast<char*>(part + 1);
-        *ptr++ = static_cast<ui8>(EXdcCommand::RDMA_READ);
+
+        // For backwards compatibility use of _NO_CHECKSUMS cmd is gated by Params.AllowDisablingPayloadChecksums
+        //  \todo replace with checksumsDisabled
+        *ptr++ = static_cast<ui8>(checksumsDisabledForEvent ? EXdcCommand::RDMA_READ_NO_CHECKSUMS : EXdcCommand::RDMA_READ); 
         WriteUnaligned<ui16>(ptr, credsSerializedSize);
         ptr += sizeof(ui16);
 
@@ -548,7 +556,14 @@ namespace NActors {
 
         Y_ABORT_UNLESS(rdmaCreds->SerializePartialToArray(ptr, credsSerializedSize));
         ptr += credsSerializedSize;
-        WriteUnaligned<ui32>(ptr, checksumming ? XXH3_64bits_digest(&RdmaCumulativeChecksumState) : 0);
+
+        if (checksumsDisabled) {
+            WriteUnaligned<ui32>(ptr, 0);
+        }
+        else {
+            WriteUnaligned<ui32>(ptr, XXH3_64bits_digest(&RdmaCumulativeChecksumState));
+        }
+
         OutputQueueSize -= payloadSz;
 
         task.Write<false>(buffer, partSize);
@@ -565,18 +580,22 @@ namespace NActors {
     }
 
     std::optional<bool> TEventOutputChannel::FeedExternalPayload(TTcpPacketOutTask& task, TEventHolder& event) {
-        const size_t partSize = sizeof(TChannelPart) + sizeof(ui8) + sizeof(ui16) + (Params.Encryption ? 0 : sizeof(ui32));
+        const bool disableChecksumsForEvent = Params.AllowDisablingPayloadChecksums 
+            && (event.Descr.Flags & IEventHandle::FlagDisablePayloadChecksums);
+        const bool disableChecksums = Params.Encryption || disableChecksumsForEvent;
+
+        const size_t partSize = sizeof(TChannelPart) + sizeof(ui8) + sizeof(ui16) + (disableChecksums ? 0 : sizeof(ui32));
         if (task.GetInternalFreeAmount() < partSize || task.GetExternalFreeAmount() == 0) {
             return std::nullopt;
         }
 
-        // clear external checksum for this chunk
+        // clear external crc checksum for this chunk, it will be written to in SerializeEvent() below
         task.ExternalChecksum = 0;
 
         auto partBookmark = task.Bookmark(partSize);
 
         size_t bytesSerialized = 0;
-        const bool complete = SerializeEvent<true>(task, event, &bytesSerialized);
+        const bool complete = SerializeEvent<true>(task, event, disableChecksums, &bytesSerialized);
 
         Y_ABORT_UNLESS(0 < bytesSerialized && bytesSerialized <= Max<ui16>());
 
@@ -587,20 +606,27 @@ namespace NActors {
             .Size = static_cast<ui16>(partSize - sizeof(TChannelPart))
         };
         char *ptr = reinterpret_cast<char*>(part + 1);
-        *ptr++ = static_cast<ui8>(EXdcCommand::PUSH_DATA);
+
+        // For backwards compatibility use of _NO_CHECKSUMS cmd is gated by Params.AllowDisablingPayloadChecksums
+        //  \todo replace with checksumsDisabled
+        *ptr++ = static_cast<ui8>(disableChecksumsForEvent ? EXdcCommand::PUSH_DATA_NO_CHECKSUMS : EXdcCommand::PUSH_DATA);
 
         WriteUnaligned<ui16>(ptr, bytesSerialized);
         ptr += sizeof(ui16);
-        if (task.ChecksummingXxhash()) {
-            XXH3_state_t state;
-            XXH3_64bits_reset(&state);
-            task.XdcStream.ScanLastBytes(bytesSerialized, [&state](TContiguousSpan span) {
-                XXH3_64bits_update(&state, span.data(), span.size());
-            });
-            const ui32 cs = XXH3_64bits_digest(&state);
-            WriteUnaligned<ui32>(ptr, cs);
-        } else if (task.ChecksummingCrc32c()) {
-            WriteUnaligned<ui32>(ptr, task.ExternalChecksum);
+
+        if (!disableChecksums)
+        {
+            if (task.ChecksummingXxhash()) {
+                XXH3_state_t state;
+                XXH3_64bits_reset(&state);
+                task.XdcStream.ScanLastBytes(bytesSerialized, [&state](TContiguousSpan span) {
+                    XXH3_64bits_update(&state, span.data(), span.size());
+                });
+                const ui32 cs = XXH3_64bits_digest(&state);
+                WriteUnaligned<ui32>(ptr, cs);
+            } else if (task.ChecksummingCrc32c()) {
+                WriteUnaligned<ui32>(ptr, task.ExternalChecksum);
+            }
         }
 
         task.WriteBookmark(std::move(partBookmark), buffer, partSize);

--- a/ydb/library/actors/interconnect/interconnect_channel.h
+++ b/ydb/library/actors/interconnect/interconnect_channel.h
@@ -58,6 +58,8 @@ namespace NActors {
         DECLARE_SECTION_INLINE,
         DECLARE_SECTION_RDMA,
         RDMA_READ,
+        PUSH_DATA_NO_CHECKSUMS,
+        RDMA_READ_NO_CHECKSUMS,
     };
 
     struct TExSerializedEventTooLarge : std::exception {
@@ -159,7 +161,7 @@ namespace NActors {
         const static ui32 RdmaCredsMinSizeSerialized;
 
         template<bool External>
-        bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, size_t *bytesSerialized);
+        bool SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, bool disableChecksums, size_t *bytesSerialized);
         bool SerializeEventRdma(TEventHolder& event);
 
         bool FeedPayload(TTcpPacketOutTask& task, TEventHolder& event, ssize_t rdmaDeviceIndex);

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -955,6 +955,7 @@ namespace NActors {
                 request.SetRequestExternalDataChannel(Common->Settings.EnableExternalDataChannel);
                 request.SetRequestXxhash(true);
                 request.SetRequestXdcShuffle(true);
+                request.SetRequestAllowDisablingPayloadChecksums(true);
                 request.SetHandshakeId(*HandshakeId);
 
                 ui32 pending = 0;
@@ -1048,6 +1049,7 @@ namespace NActors {
                 Params.UseExternalDataChannel = success.GetUseExternalDataChannel();
                 Params.UseXxhash = success.GetUseXxhash();
                 Params.UseXdcShuffle = success.GetUseXdcShuffle();
+                Params.AllowDisablingPayloadChecksums = success.GetAllowDisablingPayloadChecksums();
                 // Kernel liveness mode is a local transport decision: it depends on whether this side
                 // configured keepalive/user-timeout on its own socket.
                 Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
@@ -1348,7 +1350,8 @@ namespace NActors {
                 Params.UseExternalDataChannel = request.GetRequestExternalDataChannel() && Common->Settings.EnableExternalDataChannel;
                 Params.UseXxhash = request.GetRequestXxhash();
                 Params.UseXdcShuffle = request.GetRequestXdcShuffle();
-                Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
+                Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady(); 
+                Params.AllowDisablingPayloadChecksums = request.GetRequestAllowDisablingPayloadChecksums();
 
                 if (Params.UseExternalDataChannel) {
                     if (request.HasHandshakeId()) {
@@ -1421,6 +1424,7 @@ namespace NActors {
                     success.SetUseExternalDataChannel(Params.UseExternalDataChannel);
                     success.SetUseXxhash(Params.UseXxhash);
                     success.SetUseXdcShuffle(Params.UseXdcShuffle);
+                    success.SetAllowDisablingPayloadChecksums(Params.AllowDisablingPayloadChecksums);
 
                     ui32 pending = 0;
                     auto& actors = Common->ConnectionCheckerActorIds;

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -747,8 +747,9 @@ namespace NActors {
                     continue;
                 }
 
-                case EXdcCommand::PUSH_DATA: {
-                    const size_t cmdLen = sizeof(ui16) + (Params.Encryption ? 0 : sizeof(ui32));
+                case EXdcCommand::PUSH_DATA:
+                case EXdcCommand::PUSH_DATA_NO_CHECKSUMS: {
+                    const size_t cmdLen = sizeof(ui16) + ((Params.Encryption || (cmd == EXdcCommand::PUSH_DATA_NO_CHECKSUMS)) ? 0 : sizeof(ui32));
                     if (static_cast<size_t>(end - ptr) < cmdLen) {
                         LOG_CRIT_IC_SESSION("ICIS18", "XDC command format error");
                         throw TExDestroySession{TDisconnectReason::FormatError()};
@@ -760,9 +761,15 @@ namespace NActors {
                         throw TExDestroySession{TDisconnectReason::FormatError()};
                     }
 
+                    // HandleXdcChecksum is noop if Params.Encryption is set
                     if (!Params.Encryption) {
-                        const ui32 checksumExpected = ReadUnaligned<ui32>(ptr + sizeof(ui16));
-                        XdcChecksumQ.emplace_back(size, checksumExpected);
+                        if (cmd == EXdcCommand::PUSH_DATA) {
+                            const ui32 checksumExpected = ReadUnaligned<ui32>(ptr + sizeof(ui16));
+                            XdcChecksumQ.emplace_back(size, checksumExpected);
+                        }
+                        else {
+                            XdcChecksumQ.emplace_back(size, std::nullopt);
+                        }
                     }
 
                     // account channel and number of bytes in XDC for this packet
@@ -789,7 +796,8 @@ namespace NActors {
                     continue;
                 }
 
-                case NActors::EXdcCommand::RDMA_READ: {
+                case NActors::EXdcCommand::RDMA_READ:
+                case NActors::EXdcCommand::RDMA_READ_NO_CHECKSUMS: {
                     using namespace NInterconnect::NRdma;
                     if (!RdmaQp || !RdmaCq) {
                         LOG_CRIT_IC_SESSION("ICIS22", "unexpected XDC RDMA_READ command without RDMA QP");
@@ -833,10 +841,11 @@ namespace NActors {
                     NActorsInterconnect::TRdmaCreds creds;
                     Y_ABORT_UNLESS(creds.ParseFromArray(ptr, credsSerializedSize));
                     ptr += credsSerializedSize;
-                    if (Params.ChecksumRdmaEvent) {
+
+                    if (cmd == EXdcCommand::RDMA_READ && Params.ChecksumRdmaEvent) {
                         context.PendingEvents.back().RdmaCumulativeCheckSum = ReadUnaligned<ui32>(ptr);
                     } else {
-                        context.PendingEvents.back().RdmaCumulativeCheckSum = 0;
+                        context.PendingEvents.back().RdmaCumulativeCheckSum = std::nullopt;
                     }
 
                     ptr += sizeof(ui32);
@@ -966,7 +975,7 @@ namespace NActors {
                     }
                 }
                 checksum = XXH3_64bits_digest(&state);
-                if (checksum != pendingEvent.RdmaCumulativeCheckSum) {
+                if (checksum != *pendingEvent.RdmaCumulativeCheckSum) {
                     LOG_CRIT_IC_SESSION("ICIS05", "event rdma checksum error Type# 0x%08" PRIx32, descr.Type);
                     throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
                 }
@@ -1290,21 +1299,25 @@ namespace NActors {
             Y_DEBUG_ABORT_UNLESS(!XdcChecksumQ.empty());
             auto& [size, expected] = XdcChecksumQ.front();
             const size_t n = Min<size_t>(size, span.size());
-            if (Params.UseXxhash) {
-                XXH3_64bits_update(&XxhashXdcState, span.data(), n);
-            } else {
-                XdcCurrentChecksum = Crc32cExtendMSanCompatible(XdcCurrentChecksum, span.data(), n);
+            if (expected) {
+                if (Params.UseXxhash) {
+                    XXH3_64bits_update(&XxhashXdcState, span.data(), n);
+                } else {
+                    XdcCurrentChecksum = Crc32cExtendMSanCompatible(XdcCurrentChecksum, span.data(), n);
+                }
             }
             span = span.SubSpan(n, Max<size_t>());
             size -= n;
             if (!size) {
-                if (Params.UseXxhash) {
-                    XdcCurrentChecksum = XXH3_64bits_digest(&XxhashXdcState);
-                    XXH3_64bits_reset(&XxhashXdcState);
-                }
-                if (XdcCurrentChecksum != expected) {
-                    LOG_ERROR_IC_SESSION("ICIS16", "payload checksum error");
-                    throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
+                if (expected) {
+                    if (Params.UseXxhash) {
+                        XdcCurrentChecksum = XXH3_64bits_digest(&XxhashXdcState);
+                        XXH3_64bits_reset(&XxhashXdcState);
+                    }
+                    if (XdcCurrentChecksum != *expected) {
+                        LOG_ERROR_IC_SESSION("ICIS16", "payload checksum error");
+                        throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
+                    }
                 }
                 XdcChecksumQ.pop_front();
                 XdcCurrentChecksum = 0;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -158,7 +158,7 @@ namespace NActors {
                 std::deque<NInterconnect::NRdma::TMemRegionSlice> RdmaBuffers;
                 TRdmaReadContext::TPtr RdmaReadContext = nullptr;
                 size_t RdmaSize = 0;
-                ui32 RdmaCumulativeCheckSum = 0;
+                std::optional<ui32> RdmaCumulativeCheckSum;
             };
 
             std::deque<TPendingEvent> PendingEvents;
@@ -306,7 +306,7 @@ namespace NActors {
         };
         std::deque<TInboundPacket> InboundPacketQ;
         std::deque<std::tuple<ui16, TMutableContiguousSpan>> XdcInputQ; // target buffers for the XDC stream with channel reference
-        std::deque<std::tuple<ui16, ui32>> XdcChecksumQ; // (size, expectedChecksum)
+        std::deque<std::tuple<ui16, std::optional<ui32>>> XdcChecksumQ; // (size, optional(expectedChecksum)). nullopt if checksums are disabled. 
         ui32 XdcCurrentChecksum = 0;
 
         // catch stream -- used after TCP reconnect to match XDC stream with main packet stream

--- a/ydb/library/actors/interconnect/packet.h
+++ b/ydb/library/actors/interconnect/packet.h
@@ -201,11 +201,13 @@ struct TTcpPacketOutTask : TNonCopyable {
 
     // Append reference to some data (acquired previously or external pointer).
     template<bool External>
-    void Append(const void *buffer, size_t len, ui32* const zcHandle) {
+    void Append(const void *buffer, size_t len, ui32* const zcHandle, bool disableChecksum) {
         Y_DEBUG_ABORT_UNLESS(len <= (External ? GetExternalFreeAmount() : GetInternalFreeAmount()));
         (External ? ExternalSize : InternalSize) += len;
         (External ? XdcStream : OutgoingStream).Append({static_cast<const char*>(buffer), len}, zcHandle);
-        ProcessChecksum<External>(buffer, len);
+        if (! disableChecksum) {
+            ProcessChecksum<External>(buffer, len);
+        }
     }
 
     // Write some data with copying.

--- a/ydb/library/actors/interconnect/types.h
+++ b/ydb/library/actors/interconnect/types.h
@@ -62,6 +62,7 @@ namespace NActors {
         bool UseKernelLiveness = {};
         bool UseRdma = {};
         bool ChecksumRdmaEvent = {};
+        bool AllowDisablingPayloadChecksums = {};
         TString AuthCN;
         NActors::TScopeId PeerScopeId;
     };

--- a/ydb/library/actors/interconnect/ut/event_output_channel_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/event_output_channel_ut.cpp
@@ -1,0 +1,285 @@
+#include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/interconnect/interconnect_channel.h>
+#include <ydb/library/actors/interconnect/interconnect_counters.h>
+#include <ydb/library/actors/interconnect/outgoing_stream.h>
+#include <ydb/library/actors/interconnect/ut/protos/interconnect_test.pb.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <optional>
+
+using namespace NActors;
+
+namespace {
+
+struct TEvTestSerialization : public TEventPB<TEvTestSerialization, NInterconnectTest::TEvTestSerialization, 123> {};
+
+struct TXdcPushData {
+    EXdcCommand Command = EXdcCommand::PUSH_DATA;
+    ui16 Size = 0;
+    std::optional<ui32> Checksum;
+};
+
+struct TSerializedEvent {
+    TVector<TXdcPushData> PushData;
+    TString MainStreamData;
+    TString XdcPayloadData;
+    ui32 DescriptorFlags = 0;
+    bool HasDescriptor = false;
+};
+
+TString ProduceString(NInterconnect::TOutgoingStream& stream) {
+    TVector<TConstIoVec> data;
+    stream.ProduceIoVec(data, 1024, Max<size_t>());
+
+    TString result;
+    for (const auto& [ptr, len] : data) {
+        result.append(static_cast<const char*>(ptr), len);
+    }
+    return result;
+}
+
+void SkipDeclareSection(const char** ptr, const char* end) {
+    const ui64 headroom = NInterconnect::NDetail::DeserializeNumber(ptr, end);
+    const ui64 size = NInterconnect::NDetail::DeserializeNumber(ptr, end);
+    const ui64 tailroom = NInterconnect::NDetail::DeserializeNumber(ptr, end);
+    const ui64 alignment = NInterconnect::NDetail::DeserializeNumber(ptr, end);
+
+    UNIT_ASSERT_VALUES_UNEQUAL(headroom, Max<ui64>());
+    UNIT_ASSERT_VALUES_UNEQUAL(size, Max<ui64>());
+    UNIT_ASSERT_VALUES_UNEQUAL(tailroom, Max<ui64>());
+    UNIT_ASSERT_VALUES_UNEQUAL(alignment, Max<ui64>());
+}
+
+TVector<TXdcPushData> ExtractPushDataCommands(const TString& packet, ui32* descriptorFlags, bool* hasDescriptor) {
+    UNIT_ASSERT_C(packet.size() >= sizeof(TTcpPacketHeader_v2), "packet is too short");
+
+    TVector<TXdcPushData> result;
+    const char* ptr = packet.data() + sizeof(TTcpPacketHeader_v2);
+    const char* end = packet.data() + packet.size();
+
+    while (ptr < end) {
+        UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= sizeof(TChannelPart), "missing channel part header");
+
+        TChannelPart part;
+        memcpy(&part, ptr, sizeof(part));
+        ptr += sizeof(part);
+
+        UNIT_ASSERT_C(static_cast<size_t>(end - ptr) >= part.Size, "invalid channel part payload size");
+        const char* partEnd = ptr + part.Size;
+
+        if (!part.IsXdc()) {
+            if (part.IsLastPart()) {
+                UNIT_ASSERT_VALUES_EQUAL(part.Size, sizeof(TEventDescr2));
+                TEventDescr2 descr;
+                memcpy(&descr, ptr, sizeof(descr));
+                *descriptorFlags = descr.Flags;
+                *hasDescriptor = true;
+            }
+            ptr = partEnd;
+            continue;
+        }
+
+        while (ptr < partEnd) {
+            const auto cmd = static_cast<EXdcCommand>(*ptr++);
+            switch (cmd) {
+                case EXdcCommand::DECLARE_SECTION:
+                case EXdcCommand::DECLARE_SECTION_INLINE:
+                case EXdcCommand::DECLARE_SECTION_RDMA:
+                    SkipDeclareSection(&ptr, partEnd);
+                    break;
+
+                case EXdcCommand::PUSH_DATA: {
+                    constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
+                    UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA command");
+
+                    const ui16 size = ReadUnaligned<ui16>(ptr);
+                    ptr += sizeof(ui16);
+                    const ui32 checksum = ReadUnaligned<ui32>(ptr);
+                    ptr += sizeof(ui32);
+
+                    result.push_back(TXdcPushData{
+                        .Command = cmd,
+                        .Size = size,
+                        .Checksum = checksum,
+                    });
+                    break;
+                }
+
+                case EXdcCommand::PUSH_DATA_NO_CHECKSUMS: {
+                    UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16),
+                        "invalid PUSH_DATA_NO_CHECKSUMS command");
+
+                    const ui16 size = ReadUnaligned<ui16>(ptr);
+                    ptr += sizeof(ui16);
+
+                    result.push_back(TXdcPushData{
+                        .Command = cmd,
+                        .Size = size,
+                        .Checksum = std::nullopt,
+                    });
+                    break;
+                }
+
+                case EXdcCommand::RDMA_READ:
+                case EXdcCommand::RDMA_READ_NO_CHECKSUMS: {
+                    UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ command");
+                    const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
+                    ptr += sizeof(ui16);
+                    UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= credsSerializedSize + sizeof(ui32),
+                        "invalid RDMA_READ payload");
+                    ptr += credsSerializedSize + sizeof(ui32);
+                    break;
+                }
+
+                default:
+                    UNIT_FAIL("unknown XDC command");
+            }
+        }
+    }
+
+    return result;
+}
+
+TSerializedEvent SerializeEvent(bool useXxhash, bool allowDisablingPayloadChecksums, ui32 eventFlags) {
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+    std::shared_ptr<IInterconnectMetrics> metrics = CreateInterconnectCounters(common);
+    metrics->SetPeerInfo("peer", "1", "peer");
+
+    auto releaseCallback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, releaseCallback);
+
+    TSessionParams params;
+    params.UseExternalDataChannel = true;
+    params.UseXxhash = useXxhash;
+    params.AllowDisablingPayloadChecksums = allowDisablingPayloadChecksums;
+
+    TEventOutputChannel channel(1, 1, 64 << 20, metrics, params, nullptr);
+
+    auto* ev = new TEvTestSerialization;
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer("metadata");
+    ev->AddPayload(TRope(TString(5000, 'x')));
+    UNIT_ASSERT(ev->AllowExternalDataChannel());
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TActorId(),
+        TActorId(),
+        ev,
+        eventFlags);
+
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    NInterconnect::TOutgoingStream mainStream;
+    NInterconnect::TOutgoingStream xdcStream;
+    TTcpPacketOutTask task(params, mainStream, xdcStream);
+
+    UNIT_ASSERT(channel.FeedBuf(task, 1));
+    task.Finish(1, 0);
+
+    TSerializedEvent result;
+    result.MainStreamData = ProduceString(mainStream);
+    result.XdcPayloadData = ProduceString(xdcStream);
+    result.PushData = ExtractPushDataCommands(result.MainStreamData, &result.DescriptorFlags, &result.HasDescriptor);
+    return result;
+}
+
+ui32 CalculateExpectedChecksum(const TString& payload, bool useXxhash) {
+    if (useXxhash) {
+        return XXH3_64bits(payload.data(), payload.size());
+    }
+    return Crc32cExtendMSanCompatible(0, payload.data(), payload.size());
+}
+
+ui32 CalculateExpectedMainChannelChecksum(TString packet, bool useXxhash) {
+    UNIT_ASSERT_C(packet.size() >= sizeof(TTcpPacketHeader_v2), "packet is too short");
+
+    TTcpPacketHeader_v2 header;
+    memcpy(&header, packet.data(), sizeof(header));
+    header.Checksum = 0;
+    memcpy(&packet[0], &header, sizeof(header));
+
+    return CalculateExpectedChecksum(packet, useXxhash);
+}
+
+void AssertMainChannelChecksum(const TSerializedEvent& event, bool useXxhash) {
+    UNIT_ASSERT_C(event.MainStreamData.size() >= sizeof(TTcpPacketHeader_v2), "packet is too short");
+
+    TTcpPacketHeader_v2 header;
+    memcpy(&header, event.MainStreamData.data(), sizeof(header));
+
+    UNIT_ASSERT_VALUES_EQUAL(header.PayloadLength, event.MainStreamData.size() - sizeof(TTcpPacketHeader_v2));
+    UNIT_ASSERT_VALUES_UNEQUAL(header.Checksum, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(header.Checksum, CalculateExpectedMainChannelChecksum(event.MainStreamData, useXxhash));
+}
+
+void AssertSinglePushData(const TSerializedEvent& event, ui32 expectedFlags, bool useXxhash) {
+    AssertMainChannelChecksum(event, useXxhash);
+    UNIT_ASSERT(event.HasDescriptor);
+    UNIT_ASSERT_VALUES_EQUAL(event.PushData.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(event.PushData.front().Size, event.XdcPayloadData.size());
+    UNIT_ASSERT_VALUES_EQUAL(event.DescriptorFlags & IEventHandle::FlagDisablePayloadChecksums, expectedFlags);
+}
+
+void AssertDisabledPayloadChecksums(bool useXxhash) {
+    const TSerializedEvent event = SerializeEvent(
+        useXxhash,
+        true /*allow disabling checksums*/,
+        IEventHandle::FlagDisablePayloadChecksums);
+
+    AssertSinglePushData(event, IEventHandle::FlagDisablePayloadChecksums, useXxhash);
+
+    const TXdcPushData& pushData = event.PushData.front();
+    UNIT_ASSERT(pushData.Command == EXdcCommand::PUSH_DATA_NO_CHECKSUMS);
+    UNIT_ASSERT(!pushData.Checksum);
+}
+
+void AssertChecksumsWhenEventFlagIsNotSet(bool useXxhash) {
+    const TSerializedEvent event = SerializeEvent(
+        useXxhash,
+        true /*allow disabling checksums*/,
+        0);
+
+    AssertSinglePushData(event, 0, useXxhash);
+
+    const TXdcPushData& pushData = event.PushData.front();
+    UNIT_ASSERT(pushData.Command == EXdcCommand::PUSH_DATA);
+    UNIT_ASSERT(pushData.Checksum);
+    UNIT_ASSERT_VALUES_EQUAL(*pushData.Checksum, CalculateExpectedChecksum(event.XdcPayloadData, useXxhash));
+}
+
+void AssertChecksumsWhenDisablingIsNotNegotiated(bool useXxhash) {
+    const TSerializedEvent event = SerializeEvent(
+        useXxhash,
+        false /*allow disabling checksums*/,
+        IEventHandle::FlagDisablePayloadChecksums);
+
+    AssertSinglePushData(event, IEventHandle::FlagDisablePayloadChecksums, useXxhash);
+
+    const TXdcPushData& pushData = event.PushData.front();
+    UNIT_ASSERT(pushData.Command == EXdcCommand::PUSH_DATA);
+    UNIT_ASSERT(pushData.Checksum);
+    UNIT_ASSERT_VALUES_EQUAL(*pushData.Checksum, CalculateExpectedChecksum(event.XdcPayloadData, useXxhash));
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(EventOutputChannel) {
+    Y_UNIT_TEST(DisabledPayloadChecksums) {
+        AssertDisabledPayloadChecksums(false);
+        AssertDisabledPayloadChecksums(true);
+    }
+
+    Y_UNIT_TEST(EnabledPayloadChecksums) {
+        AssertChecksumsWhenEventFlagIsNotSet(false);
+        AssertChecksumsWhenEventFlagIsNotSet(true);
+    }
+
+    Y_UNIT_TEST(DisablingChecksumsNotNegotiated) {
+        AssertChecksumsWhenDisablingIsNotNegotiated(false);
+        AssertChecksumsWhenDisablingIsNotNegotiated(true);
+    }
+}

--- a/ydb/library/actors/interconnect/ut/ya.make
+++ b/ydb/library/actors/interconnect/ut/ya.make
@@ -12,6 +12,7 @@ SRCS(
     channel_scheduler_ut.cpp
     connection_checker_ut.cpp
     event_holder_pool_ut.cpp
+    event_output_channel_ut.cpp
     interconnect_ut.cpp
     large.cpp
     outgoing_stream_ut.cpp

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -490,7 +490,9 @@ namespace {
         ui32 DeclareSectionInline = 0;
         ui32 DeclareSectionRdma = 0;
         ui32 PushData = 0;
-        ui32 RdmaRead = 0;
+        ui32 RdmaReadWithChecksums = 0;
+        ui32 RdmaReadWithoutChecksums = 0;
+        ui32 RdmaRead() const { return RdmaReadWithChecksums + RdmaReadWithoutChecksums; }
     };
 
     static TString CollectStreamData(NInterconnect::TOutgoingStream& stream) {
@@ -540,22 +542,31 @@ namespace {
                         }
                         break;
                     }
-                    case EXdcCommand::PUSH_DATA: {
-                        constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
+                    case EXdcCommand::PUSH_DATA: 
+                    case EXdcCommand::PUSH_DATA_NO_CHECKSUMS: {
+                        const size_t cmdLen = sizeof(ui16) + (cmd == EXdcCommand::PUSH_DATA ? sizeof(ui32) : 0);
                         UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA");
                         ptr += cmdLen;
                         ++counters.PushData;
                         break;
                     }
-                    case EXdcCommand::RDMA_READ: {
+                    case EXdcCommand::RDMA_READ: 
+                    case EXdcCommand::RDMA_READ_NO_CHECKSUMS: {
                         UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ");
                         const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
                         ptr += sizeof(ui16);
                         UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= credsSerializedSize + sizeof(ui32),
                             "invalid RDMA_READ payload");
                         ptr += credsSerializedSize;
+                        const ui32 checksum = ReadUnaligned<ui32>(ptr);
                         ptr += sizeof(ui32);
-                        ++counters.RdmaRead;
+                        if (cmd == EXdcCommand::RDMA_READ) {
+                            ++counters.RdmaReadWithChecksums;
+                            UNIT_ASSERT_C(checksum, "expected checksum");
+                        } else {
+                            ++counters.RdmaReadWithoutChecksums;
+                            UNIT_ASSERT_C(!checksum, "unexpected checksum");
+                        }
                         break;
                     }
                 }
@@ -651,13 +662,15 @@ TEST_F(XdcRdmaTest, ShuffleRdmaUsesIteratorOffsetInsideChunk) {
                         }
                         break;
                     }
-                    case EXdcCommand::PUSH_DATA: {
+                    case EXdcCommand::PUSH_DATA:
+                    case EXdcCommand::PUSH_DATA_NO_CHECKSUMS: {
                         constexpr size_t cmdLen = sizeof(ui16) + sizeof(ui32);
                         UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= cmdLen, "invalid PUSH_DATA");
                         ptr += cmdLen;
                         break;
                     }
-                    case EXdcCommand::RDMA_READ: {
+                    case EXdcCommand::RDMA_READ: 
+                    case EXdcCommand::RDMA_READ_NO_CHECKSUMS: {
                         UNIT_ASSERT_C(static_cast<size_t>(partEnd - ptr) >= sizeof(ui16), "invalid RDMA_READ");
                         const ui16 credsSerializedSize = ReadUnaligned<ui16>(ptr);
                         ptr += sizeof(ui16);
@@ -684,6 +697,91 @@ TEST_F(XdcRdmaTest, ShuffleRdmaUsesIteratorOffsetInsideChunk) {
     UNIT_ASSERT_VALUES_EQUAL(rdmaReadSize, rdmaSize);
     UNIT_ASSERT_VALUES_EQUAL(rdmaReadAddr, expectedAddr);
 }
+
+struct TRdmaPayloadChecksumTestParams {
+    bool AllowDisablingPayloadChecksums = false;
+    bool DisablePayloadChecksumsFlag = false;
+};
+
+class XdcRdmaPayloadChecksumTest
+    : public XdcRdmaTest
+    , public ::testing::WithParamInterface<TRdmaPayloadChecksumTestParams>
+{};
+
+TEST_P(XdcRdmaPayloadChecksumTest, RdmaPayloadChecksums) {
+    const TRdmaPayloadChecksumTestParams params = GetParam();
+    const bool disablePayloadChecksums = params.AllowDisablingPayloadChecksums && params.DisablePayloadChecksumsFlag;
+
+    auto common = MakeIntrusive<TInterconnectProxyCommon>();
+    common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+    std::shared_ptr<IInterconnectMetrics> ctr = CreateInterconnectCounters(common);
+    ctr->SetPeerInfo("peer", "1", "peer");
+
+    auto callback = [](THolder<IEventBase>) {};
+    TEventHolderPool pool(common, callback);
+
+    const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+
+    TSessionParams p;
+    p.UseExternalDataChannel = true;
+    p.UseXdcShuffle = true;
+    p.UseRdma = true;
+    p.ChecksumRdmaEvent = true;
+    p.AllowDisablingPayloadChecksums = params.AllowDisablingPayloadChecksums;
+    TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
+
+    constexpr size_t payloadSize = 257;
+    auto rcBuf = memPool->AllocRcBuf(payloadSize, 0).value();
+    for (size_t i = 0; i < payloadSize; ++i) {
+        rcBuf.GetDataMut()[i] = static_cast<char>(i);
+    }
+    const ui32 checksumIfCalculated = XXH3_64bits(rcBuf.GetData(), payloadSize);
+    UNIT_ASSERT_VALUES_UNEQUAL(checksumIfCalculated, 0u);
+
+    TEventSerializationInfo info;
+    info.Sections.push_back(TEventSectionInfo{0, payloadSize, 0, 0, false, true /*IsRdmaCapable*/});
+    auto serialized = MakeIntrusive<TEventSerializedData>(TRope(std::move(rcBuf)), std::move(info));
+
+    auto evHandle = MakeHolder<IEventHandle>(
+        TEvTestSerialization::EventType,
+        params.DisablePayloadChecksumsFlag ? IEventHandle::FlagDisablePayloadChecksums : 0,
+        TActorId(),
+        TActorId(),
+        serialized,
+        0
+    );
+    channel.Push(*evHandle, pool, TInstant::Zero());
+
+    NInterconnect::TOutgoingStream main;
+    NInterconnect::TOutgoingStream xdc;
+    TTcpPacketOutTask task(p, main, xdc);
+    UNIT_ASSERT(channel.FeedBuf(task, 1, 0));
+    task.Finish(1, 0);
+
+    TXdcCommandCounters counters;
+    AccumulateXdcCommandCounters(CollectStreamData(main), counters);
+
+    UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaReadWithChecksums, disablePayloadChecksums ? 0u : 1u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaReadWithoutChecksums, disablePayloadChecksums ? 1u : 0u);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DisablePayloadChecksums,
+    XdcRdmaPayloadChecksumTest,
+    ::testing::Values(
+        TRdmaPayloadChecksumTestParams{false, false},
+        TRdmaPayloadChecksumTestParams{false, true},
+        TRdmaPayloadChecksumTestParams{true, false},
+        TRdmaPayloadChecksumTestParams{true, true}
+    ),
+    [](const testing::TestParamInfo<TRdmaPayloadChecksumTestParams>& info) {
+        return std::string(info.param.AllowDisablingPayloadChecksums ? "AllowDisabling" : "DisablingNotAllowed")
+            + "_" + (info.param.DisablePayloadChecksumsFlag ? "FlagSet" : "FlagNotSet");
+    }
+);
 
 TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
     auto common = MakeIntrusive<TInterconnectProxyCommon>();
@@ -730,7 +828,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
     UNIT_ASSERT(counters.DeclareSection > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
-    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead(), 0u);
 }
 
 TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenSerializeToRopeFails) {
@@ -768,7 +866,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenSerializeToRopeFails) {
     UNIT_ASSERT(counters.DeclareSection > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
-    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead(), 0u);
 }
 
 #ifndef NDEBUG
@@ -820,7 +918,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered) 
     UNIT_ASSERT(counters.DeclareSection > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
-    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead(), 0u);
 }
 
 TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunks) {
@@ -879,7 +977,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunk
     UNIT_ASSERT(counters.DeclareSection > 0u);
     UNIT_ASSERT_VALUES_EQUAL(counters.DeclareSectionRdma, 0u);
     UNIT_ASSERT(counters.PushData > 0u);
-    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(counters.RdmaRead(), 0u);
 }
 #endif
 

--- a/ydb/library/actors/protos/interconnect.proto
+++ b/ydb/library/actors/protos/interconnect.proto
@@ -107,6 +107,7 @@ message THandshakeRequest {
     optional bool RequestExternalDataChannel = 21;
     optional bool RequestXxhash = 24;
     optional bool RequestXdcShuffle = 25;
+    optional bool RequestAllowDisablingPayloadChecksums = 28; // Can be requested per event. Affects XDC and RDMA payloads.
 
     optional bytes CompatibilityInfo = 22;
 
@@ -144,6 +145,7 @@ message THandshakeSuccess {
     optional bool UseExternalDataChannel = 14;
     optional bool UseXxhash = 16;
     optional bool UseXdcShuffle = 17;
+    optional bool AllowDisablingPayloadChecksums = 21;
 
     optional bytes CompatibilityInfo = 15;
 


### PR DESCRIPTION
This PR allows to request IC not to calculate and/or validate checksums.

The goal is to avoid scanning data in IC as it may cause lots of cache misses, and instead rely on calculating checksums in dsproxy, which is already partially implemented.

Changes handling of RDMA checksums - 0 is no longer indicates a disabled checksum.