### PR TITLE
Improve cherry-pick v2 error handling and backport comments

### DIFF
--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -555,6 +555,110 @@ def find_existing_backport_comment(pull: Any, logger):
     return None
 
 
+def collect_unique_pulls(sources: List[Source]) -> List[Any]:
+    pulls = []
+    seen = set()
+    for source in sources:
+        for pull in source.pull_requests:
+            if pull.number not in seen:
+                pulls.append(pull)
+                seen.add(pull.number)
+    return pulls
+
+
+def build_shared_skip_comment(
+    pull_number: Optional[int],
+    sources: List[Source],
+    preflights: Dict[str, BranchPreflight],
+    invalid_branches: Set[str],
+    target_branches: List[str],
+    workflow_url: Optional[str],
+    cancelled_entire_run: bool,
+) -> str:
+    source = get_source_for_pull(pull_number, sources) if pull_number else None
+    branch_lines = []
+    for branch in target_branches:
+        if branch in invalid_branches:
+            branch_lines.append(f"`{branch}`: skipped (branch does not exist)")
+            continue
+
+        preflight = preflights.get(branch)
+        if not preflight:
+            continue
+        if preflight.all_present:
+            branch_lines.append(f"`{branch}`: skipped (all commits already present)")
+        elif source and all(sha in preflight.already_present_shas for sha in source.commit_shas):
+            branch_lines.append(f"`{branch}`: skipped (already present)")
+        else:
+            branch_lines.append(f"`{branch}`: skipped (already present)")
+
+    if cancelled_entire_run:
+        if len(branch_lines) == 1:
+            text = f"Backport cancelled: {branch_lines[0]}"
+        else:
+            text = "Backport cancelled:\n" + "\n".join(f"- {line}" for line in branch_lines)
+    elif len(branch_lines) == 1:
+        text = f"Backport skipped: {branch_lines[0]}"
+    else:
+        text = "Backport skipped:\n" + "\n".join(f"- {line}" for line in branch_lines)
+
+    if workflow_url:
+        text += f"\n\n[workflow run]({workflow_url})"
+    return text
+
+
+def notify_already_present_pulls(
+    pulls: List[Any],
+    sources: List[Source],
+    ordered_commit_shas: List[str],
+    preflights: Dict[str, BranchPreflight],
+    invalid_branches: Set[str],
+    target_branches: List[str],
+    workflow_url: Optional[str],
+    cancelled_entire_run: bool,
+    logger,
+    personalized: bool,
+):
+    for pull in pulls:
+        if personalized:
+            message = build_pull_result_comment(
+                pull.number,
+                sources,
+                ordered_commit_shas,
+                preflights,
+                [],
+                [],
+                invalid_branches,
+                target_branches,
+                workflow_url,
+            )
+            if cancelled_entire_run:
+                message = message.replace(
+                    "Backport result for this PR:",
+                    "Backport skipped:",
+                    1,
+                ).replace(
+                    "Backport results for this PR:",
+                    "Backport skipped:",
+                    1,
+                )
+        else:
+            message = build_shared_skip_comment(
+                pull.number,
+                sources,
+                preflights,
+                invalid_branches,
+                target_branches,
+                workflow_url,
+                cancelled_entire_run,
+            )
+        try:
+            pull.create_issue_comment(message)
+            logger.info("Posted skip backport comment on PR #%s", pull.number)
+        except GithubException as e:
+            logger.warning("Failed to post skip backport comment on PR #%s: %s", pull.number, e)
+
+
 def create_initial_backport_comments(
     pulls: List[Any],
     target_branches: List[str],
@@ -982,6 +1086,7 @@ def main():
     all_commit_shas = []
     for source in sources:
         all_commit_shas.extend(source.commit_shas)
+    unique_pull_requests = collect_unique_pulls(sources)
 
     if not all_commit_shas:
         logger.error("VALIDATION_ERROR: No commits to cherry-pick")
@@ -1029,10 +1134,22 @@ def main():
         has_work = bool(pulls_to_notify)
 
         if not has_work:
+            notify_already_present_pulls(
+                unique_pull_requests,
+                sources,
+                all_commit_shas,
+                preflights,
+                set(invalid_branches),
+                target_branches,
+                workflow_url,
+                True,
+                logger,
+                True,
+            )
             logger.info("WORKFLOW_SUCCESS: Nothing to backport — all commits are already present in target branch(es).")
             if summary_path:
                 with open(summary_path, 'a') as f:
-                    f.write("Nothing to backport — no comments posted to source PRs.\n\n")
+                    f.write("Nothing to backport — posted skip reason to source PRs.\n\n")
             return
 
         backport_comments = create_initial_backport_comments(
@@ -1081,6 +1198,23 @@ def main():
             backport_comments, sources, all_commit_shas, preflights, results,
             branch_failures, set(invalid_branches), target_branches, workflow_url, logger,
         )
+
+        already_present_pulls = [
+            pull for pull in unique_pull_requests if pull.number not in pulls_to_notify
+        ]
+        if already_present_pulls:
+            notify_already_present_pulls(
+                already_present_pulls,
+                sources,
+                all_commit_shas,
+                preflights,
+                set(invalid_branches),
+                target_branches,
+                workflow_url,
+                False,
+                logger,
+                True,
+            )
 
         if has_errors:
             error_msg = "Cherry-pick workflow completed with errors. See details above."

--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -696,7 +696,6 @@ def format_source_branch_status(
     failure: Optional[BranchBackportFailure],
     sources: List[Source],
 ) -> str:
-    source_shas = set(source.commit_shas)
     already_present = set(preflight.already_present_shas if preflight else [])
 
     if preflight and all(sha in already_present for sha in source.commit_shas):
@@ -704,7 +703,7 @@ def format_source_branch_status(
 
     if failure and failure.target_branch == target_branch:
         progress = failure.progress
-        if progress.failed_commit_sha in source_shas:
+        if progress.failed_commit_sha in source.commit_shas:
             return f"`{target_branch}`: failed ({failure.error})"
 
         failed_idx = (

--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 import shutil
 import json
-from typing import List, Optional, Tuple, Any
+from typing import List, Optional, Tuple, Any, Set
 from dataclasses import dataclass, field
 from github import Github, GithubException, Auth
 import requests
@@ -50,10 +50,63 @@ class BackportResult:
     pr: Optional[Any] = None
     conflict_files: List[ConflictInfo] = field(default_factory=list)
     cherry_pick_logs: List[str] = field(default_factory=list)
+    skipped_commit_shas: List[str] = field(default_factory=list)
+    applied_commit_shas: List[str] = field(default_factory=list)
     
     @property
     def has_conflicts(self) -> bool:
         return len(self.conflict_files) > 0
+
+
+@dataclass
+class CherryPickProgress:
+    skipped_commit_shas: List[str] = field(default_factory=list)
+    applied_commit_shas: List[str] = field(default_factory=list)
+    failed_commit_sha: Optional[str] = None
+
+
+class BranchBackportSkipped(Exception):
+    def __init__(self, target_branch: str, progress: CherryPickProgress):
+        self.target_branch = target_branch
+        self.progress = progress
+        super().__init__(f"all commits already present in `{target_branch}`")
+
+
+class CherryPickFailed(Exception):
+    def __init__(self, target_branch: str, message: str, progress: CherryPickProgress):
+        self.target_branch = target_branch
+        self.progress = progress
+        super().__init__(message)
+
+
+@dataclass
+class BranchBackportFailure:
+    target_branch: str
+    error: str
+    progress: CherryPickProgress
+
+
+def describe_commit(commit_sha: str, sources: List[Source]) -> str:
+    for source in sources:
+        if commit_sha in source.commit_shas:
+            return source.title
+    return f"commit {commit_sha[:7]}"
+
+
+def get_source_for_pull(pull_number: int, sources: List[Source]) -> Optional[Source]:
+    for source in sources:
+        for pull in source.pull_requests:
+            if pull.number == pull_number:
+                return source
+    return None
+
+
+def is_empty_cherry_pick_output(output: str) -> bool:
+    lowered = output.lower()
+    return (
+        "cherry-pick is now empty" in lowered
+        or "nothing to commit" in lowered
+    )
 
 
 def run_git(repo_path: str, cmd: List[str], logger, check=True) -> subprocess.CompletedProcess:
@@ -397,76 +450,151 @@ def find_existing_backport_comment(pull: Any, logger):
     return None
 
 
-def update_comments(backport_comments: List[Tuple[Any, object]], results: List, skipped_branches: List[Tuple[str, str]], target_branches: List[str], workflow_url: Optional[str], logger):
-    """Updates comments with backport results"""
+def format_source_branch_status(
+    source: Source,
+    target_branch: str,
+    ordered_commit_shas: List[str],
+    result: Optional[BackportResult],
+    failure: Optional[BranchBackportFailure],
+    skip: Optional[BranchBackportSkipped],
+    sources: List[Source],
+) -> str:
+    source_shas = set(source.commit_shas)
+    source_indices = [ordered_commit_shas.index(sha) for sha in source.commit_shas]
+
+    if skip and skip.target_branch == target_branch:
+        if all(sha in skip.progress.skipped_commit_shas for sha in source.commit_shas):
+            return f"`{target_branch}`: already present"
+
+    if failure and failure.target_branch == target_branch:
+        progress = failure.progress
+        failed_idx = (
+            ordered_commit_shas.index(progress.failed_commit_sha)
+            if progress.failed_commit_sha in ordered_commit_shas
+            else len(ordered_commit_shas)
+        )
+        max_source_idx = max(source_indices)
+        min_source_idx = min(source_indices)
+
+        if progress.failed_commit_sha in source_shas:
+            return f"`{target_branch}`: failed ({failure.error})"
+        if max_source_idx < failed_idx:
+            if all(sha in progress.skipped_commit_shas for sha in source.commit_shas):
+                return f"`{target_branch}`: already present"
+            if all(sha in progress.applied_commit_shas for sha in source.commit_shas):
+                return (
+                    f"`{target_branch}`: not backported "
+                    f"(workflow failed before backport PR was created)"
+                )
+        if min_source_idx > failed_idx and progress.failed_commit_sha:
+            failed_label = describe_commit(progress.failed_commit_sha, sources)
+            return f"`{target_branch}`: not backported (workflow failed on {failed_label})"
+
+    if result and result.target_branch == target_branch:
+        if all(sha in result.skipped_commit_shas for sha in source.commit_shas):
+            return f"`{target_branch}`: already present"
+        if any(sha in result.applied_commit_shas for sha in source.commit_shas) and result.pr:
+            status = "draft PR" if result.has_conflicts else "backport PR"
+            conflict_note = " (contains conflicts requiring manual resolution)" if result.has_conflicts else ""
+            return f"`{target_branch}`: included in {status} {result.pr.html_url}{conflict_note}"
+
+    return f"`{target_branch}`: status unknown"
+
+
+def build_pull_result_comment(
+    pull_number: int,
+    sources: List[Source],
+    ordered_commit_shas: List[str],
+    results: List[BackportResult],
+    branch_failures: List[BranchBackportFailure],
+    branch_skips: List[BranchBackportSkipped],
+    invalid_branches: Set[str],
+    target_branches: List[str],
+    workflow_url: Optional[str],
+) -> str:
+    source = get_source_for_pull(pull_number, sources)
+    if not source:
+        return "Backport completed (no source metadata for this PR)"
+
+    branch_lines = []
+    for branch in target_branches:
+        if branch in invalid_branches:
+            branch_lines.append(f"`{branch}`: skipped (branch does not exist)")
+            continue
+
+        result = next((r for r in results if r.target_branch == branch), None)
+        failure = next((f for f in branch_failures if f.target_branch == branch), None)
+        skip = next((s for s in branch_skips if s.target_branch == branch), None)
+        branch_lines.append(format_source_branch_status(
+            source, branch, ordered_commit_shas, result, failure, skip, sources,
+        ))
+
+    if len(branch_lines) == 1:
+        text = f"Backport result for this PR: {branch_lines[0]}"
+    else:
+        text = "Backport results for this PR:\n" + "\n".join(f"- {line}" for line in branch_lines)
+
+    if workflow_url:
+        text += f"\n\n[workflow run]({workflow_url})"
+    return text
+
+
+def update_comments(
+    backport_comments: List[Tuple[Any, object]],
+    sources: List[Source],
+    ordered_commit_shas: List[str],
+    results: List[BackportResult],
+    branch_failures: List[BranchBackportFailure],
+    branch_skips: List[BranchBackportSkipped],
+    invalid_branches: Set[str],
+    target_branches: List[str],
+    workflow_url: Optional[str],
+    logger,
+):
+    """Updates comments with per-PR backport results"""
     if not backport_comments:
         return
-    
+
     for pull, comment in backport_comments:
         try:
             existing_body = comment.body
-            total_branches = len(results) + len(skipped_branches)
-            
-            if total_branches == 0:
-                new_results = f"Backport to {', '.join([f'`{b}`' for b in target_branches])} completed with no results"
-                if workflow_url:
-                    new_results += f" - [workflow run]({workflow_url})"
-            elif total_branches == 1 and len(results) == 1:
-                result = results[0]
-                if result.pr:
-                    status = "draft PR" if result.has_conflicts else "PR"
-                    new_results = f"Backported to `{result.target_branch}`: {status} {result.pr.html_url}"
-                    if result.has_conflicts:
-                        new_results += " (contains conflicts requiring manual resolution)"
-                    if workflow_url:
-                        new_results += f" - [workflow run]({workflow_url})"
-                else:
-                    new_results = f"Backported to `{result.target_branch}`: failed"
-                    if workflow_url:
-                        new_results += f" - [workflow run]({workflow_url})"
-            else:
-                new_results = "Backport results:\n"
-                for result in results:
-                    if result.pr:
-                        status = "draft PR" if result.has_conflicts else "PR"
-                        conflict_note = " (contains conflicts requiring manual resolution)" if result.has_conflicts else ""
-                        new_results += f"- `{result.target_branch}`: {status} {result.pr.html_url}{conflict_note}\n"
-                    else:
-                        new_results += f"- `{result.target_branch}`: failed\n"
-                for target_branch, reason in skipped_branches:
-                    new_results += f"- `{target_branch}`: skipped ({reason})\n"
-                if workflow_url:
-                    new_results += f"\n[workflow run]({workflow_url})"
-            
-            # Replace "in progress" line with results
+            new_results = build_pull_result_comment(
+                pull.number,
+                sources,
+                ordered_commit_shas,
+                results,
+                branch_failures,
+                branch_skips,
+                invalid_branches,
+                target_branches,
+                workflow_url,
+            )
+
             lines = existing_body.split('\n')
             updated_lines = []
             found = False
-            
+
             for line in lines:
-                # Check if this is the "in progress" line for our target branches
                 is_progress_line = (
-                    "in progress" in line and 
-                    any(f"`{b}`" in line for b in target_branches) and
-                    (not workflow_url or workflow_url in line)
+                    "in progress" in line
+                    and any(f"`{b}`" in line for b in target_branches)
+                    and (not workflow_url or workflow_url in line)
                 )
-                
+
                 if is_progress_line and not found:
                     updated_lines.append(new_results)
                     found = True
                 else:
                     updated_lines.append(line)
-            
+
             if not found:
                 updated_lines.append("")
                 updated_lines.append(new_results)
-            
-            updated_comment = '\n'.join(updated_lines)
-            
-            comment.edit(updated_comment)
-            logger.info(f"Updated backport comment in original PR #{pull.number}")
+
+            comment.edit('\n'.join(updated_lines))
+            logger.info("Updated backport comment in original PR #%s", pull.number)
         except GithubException as e:
-            logger.warning(f"Failed to update comment in original PR #{pull.number}: {e}")
+            logger.warning("Failed to update comment in original PR #%s: %s", pull.number, e)
 
 
 def process_branch(
@@ -484,33 +612,71 @@ def process_branch(
     run_git(repo_path, ['checkout', '-B', target_branch, f'origin/{target_branch}'], logger)
     run_git(repo_path, ['checkout', '-b', dev_branch_name, target_branch], logger)
     
+    progress = CherryPickProgress()
+
     # Cherry-pick each commit
     for commit_sha in commit_shas:
-        logger.info("Cherry-picking commit: %s", commit_sha[:7])
-        # Fetch commit to ensure it's available locally (needed for unmerged PRs)
+        commit_label = describe_commit(commit_sha, sources)
+        logger.info("Cherry-picking %s (%s)", commit_sha[:7], commit_label)
         run_git(repo_path, ['fetch', 'origin', commit_sha], logger, check=False)
         try:
             result = run_git(repo_path, ['cherry-pick', '--allow-empty', commit_sha], logger, check=False)
             output = (result.stdout or '') + (('\n' + result.stderr) if result.stderr else '')
-            
+
             if result.returncode != 0:
+                if is_empty_cherry_pick_output(output):
+                    run_git(repo_path, ['cherry-pick', '--skip'], logger, check=False)
+                    skip_msg = (
+                        f"{commit_label} ({commit_sha[:7]}) is already present in `{target_branch}`, skipped"
+                    )
+                    logger.warning("ALREADY_PRESENT: %s", skip_msg)
+                    cherry_pick_logs.append(f"=== Skipped {commit_sha[:7]} ===\n{skip_msg}\n")
+                    progress.skipped_commit_shas.append(commit_sha)
+                    continue
+
+                progress.failed_commit_sha = commit_sha
                 if "conflict" in output.lower():
                     conflicts = detect_conflicts(repo_path, logger)
                     if conflicts:
                         run_git(repo_path, ['add', '-A'], logger)
                         run_git(repo_path, ['commit', '-m', f"BACKPORT-CONFLICT: manual resolution required for commit {commit_sha[:7]}"], logger)
                         all_conflict_files.extend(conflicts)
+                        progress.applied_commit_shas.append(commit_sha)
                     else:
                         run_git(repo_path, ['cherry-pick', '--abort'], logger, check=False)
-                        raise RuntimeError(f"Cherry-pick failed for commit {commit_sha[:7]}")
+                        raise CherryPickFailed(
+                            target_branch,
+                            f"Cherry-pick failed for {commit_label} ({commit_sha[:7]}): "
+                            f"git reported a conflict but no conflicted files were detected.\n{output.strip()}",
+                            progress,
+                        )
                 else:
-                    raise RuntimeError(f"Cherry-pick failed for commit {commit_sha[:7]}: {output}")
-            
-            if output:
+                    raise CherryPickFailed(
+                        target_branch,
+                        f"Cherry-pick failed for {commit_label} ({commit_sha[:7]}): {output.strip()}",
+                        progress,
+                    )
+            else:
+                progress.applied_commit_shas.append(commit_sha)
+
+            if output and commit_sha not in progress.skipped_commit_shas:
                 cherry_pick_logs.append(f"=== Cherry-picking {commit_sha[:7]} ===\n{output}")
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(f"Cherry-pick failed for commit {commit_sha[:7]}: {e}")
-    
+            progress.failed_commit_sha = commit_sha
+            raise CherryPickFailed(
+                target_branch,
+                f"Cherry-pick failed for {commit_label} ({commit_sha[:7]}): {e}",
+                progress,
+            )
+
+    if not progress.applied_commit_shas:
+        raise BranchBackportSkipped(target_branch, progress)
+
+    applied_sources = [
+        source for source in sources
+        if any(sha in progress.applied_commit_shas for sha in source.commit_shas)
+    ]
+
     # Push branch
     run_git(repo_path, ['push', '--set-upstream', 'origin', dev_branch_name], logger)
     
@@ -518,7 +684,7 @@ def process_branch(
     has_conflicts = len(all_conflict_files) > 0
     title, body = build_pr_content(
         repo_name, repo, token, target_branch, dev_branch_name,
-        sources, all_conflict_files, cherry_pick_logs,
+        applied_sources, all_conflict_files, cherry_pick_logs,
         workflow_triggerer, workflow_url, None, logger
     )
     
@@ -535,7 +701,7 @@ def process_branch(
     if has_conflicts:
         _, updated_body = build_pr_content(
             repo_name, repo, token, target_branch, dev_branch_name,
-            sources, all_conflict_files, cherry_pick_logs,
+            applied_sources, all_conflict_files, cherry_pick_logs,
             workflow_triggerer, workflow_url, pr.number, logger
         )
         pr.edit(body=updated_body)
@@ -574,7 +740,9 @@ def process_branch(
         target_branch=target_branch,
         pr=pr,
         conflict_files=all_conflict_files,
-        cherry_pick_logs=cherry_pick_logs
+        cherry_pick_logs=cherry_pick_logs,
+        skipped_commit_shas=progress.skipped_commit_shas,
+        applied_commit_shas=progress.applied_commit_shas,
     )
 
 
@@ -764,15 +932,14 @@ def main():
         )
         
         # Process each target branch
-        results: list[BackportResult] = []
-        skipped_branches = []
-        # Add invalid branches from validation
-        for invalid_branch in invalid_branches:
-            skipped_branches.append((invalid_branch, "branch does not exist"))
-        
+        results: List[BackportResult] = []
+        branch_failures: List[BranchBackportFailure] = []
+        branch_skips: List[BranchBackportSkipped] = []
+        invalid_branch_set = set(invalid_branches)
+
         has_errors = False
         dtm = datetime.datetime.now().strftime("%y%m%d-%H%M%S")
-        
+
         for target_branch in valid_target_branches:
             try:
                 dev_branch_name = f"cherry-pick-{target_branch}-{dtm}"
@@ -781,34 +948,65 @@ def main():
                     repo_name, repo, token, sources, workflow_triggerer, workflow_url, summary_path, logger
                 )
                 results.append(result)
-            except Exception as e:
+            except BranchBackportSkipped as e:
+                logger.info("Branch %s skipped: %s", target_branch, e)
+                branch_skips.append(e)
+                if summary_path:
+                    skipped_labels = ", ".join(
+                        describe_commit(sha, sources) for sha in e.progress.skipped_commit_shas
+                    )
+                    with open(summary_path, 'a') as f:
+                        f.write(f"### Branch `{target_branch}`: skipped\n\nAll commits already present: {skipped_labels}\n\n")
+            except CherryPickFailed as e:
                 has_errors = True
-                error_msg = f"UNEXPECTED_ERROR: Branch {target_branch} - {type(e).__name__}: {e}"
-                logger.error(error_msg)
+                logger.error("BACKPORT_ERROR: Branch `%s`: %s", target_branch, e)
+                branch_failures.append(BranchBackportFailure(target_branch, str(e), e.progress))
                 if summary_path:
                     with open(summary_path, 'a') as f:
-                        f.write(f"Branch {target_branch} error: {type(e).__name__}\n```\n{e}\n```\n\n")
-                skipped_branches.append((target_branch, f"unexpected error: {type(e).__name__}"))
-        
-        # Update comments
-        update_comments(backport_comments, results, skipped_branches, target_branches, workflow_url, logger)
-        
-        # Check errors
+                        f.write(f"### Branch `{target_branch}`: failed\n\n```\n{e}\n```\n\n")
+            except Exception as e:
+                has_errors = True
+                logger.error("BACKPORT_ERROR: Branch `%s`: %s", target_branch, e)
+                branch_failures.append(BranchBackportFailure(
+                    target_branch, str(e), CherryPickProgress(failed_commit_sha=all_commit_shas[0] if all_commit_shas else None),
+                ))
+                if summary_path:
+                    with open(summary_path, 'a') as f:
+                        f.write(f"### Branch `{target_branch}`: failed\n\n```\n{e}\n```\n\n")
+
+        update_comments(
+            backport_comments, sources, all_commit_shas, results,
+            branch_failures, branch_skips, invalid_branch_set,
+            target_branches, workflow_url, logger,
+        )
+
         if has_errors:
-            error_msg = "WORKFLOW_FAILED: Cherry-pick workflow completed with errors. Check logs above for details."
-            logger.error(error_msg)
+            error_msg = "Cherry-pick workflow completed with errors. See details above."
+            logger.error("WORKFLOW_FAILED: %s", error_msg)
             if summary_path:
                 with open(summary_path, 'a') as f:
-                    f.write(f'{error_msg}\n\n')
+                    f.write(f"**{error_msg}**\n\n")
             sys.exit(1)
-        
-        logger.info("WORKFLOW_SUCCESS: All cherry-pick operations completed successfully")
-        if summary_path:
-            with open(summary_path, 'a') as f:
-                f.write("All cherry-pick operations completed successfully\n\n")
+
+        if branch_skips and not results:
+            logger.info(
+                "WORKFLOW_SUCCESS: Nothing to backport — all commits are already present in target branch(es)."
+            )
+            if summary_path:
+                with open(summary_path, 'a') as f:
+                    f.write("Nothing to backport — all commits are already present in target branch(es).\n\n")
+        else:
+            logger.info("WORKFLOW_SUCCESS: Cherry-pick workflow completed successfully")
+            if summary_path:
+                with open(summary_path, 'a') as f:
+                    f.write("Cherry-pick workflow completed successfully\n\n")
         if results_path:
             with open(results_path, 'w') as f:
-                json.dump([{'pr_id': r.pr.id, 'pr_number': r.pr.number, 'branch': r.target_branch} for r in results if r.pr], f, indent=2)
+                json.dump(
+                    [{'pr_id': r.pr.id, 'pr_number': r.pr.number, 'branch': r.target_branch} for r in results if r.pr],
+                    f,
+                    indent=2,
+                )
     finally:
         if os.path.exists(repo_dir):
             shutil.rmtree(repo_dir)

--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -59,7 +59,7 @@ class BackportResult:
 
 
 @dataclass
-class CherryPickProgress:
+class BackportProgress:
     skipped_commit_shas: List[str] = field(default_factory=list)
     applied_commit_shas: List[str] = field(default_factory=list)
     failed_commit_sha: Optional[str] = None
@@ -78,14 +78,14 @@ class BranchPreflight:
 
 
 class BranchBackportSkipped(Exception):
-    def __init__(self, target_branch: str, progress: CherryPickProgress):
+    def __init__(self, target_branch: str, progress: BackportProgress):
         self.target_branch = target_branch
         self.progress = progress
         super().__init__(f"all commits already present in `{target_branch}`")
 
 
 class CherryPickFailed(Exception):
-    def __init__(self, target_branch: str, message: str, progress: CherryPickProgress):
+    def __init__(self, target_branch: str, message: str, progress: BackportProgress):
         self.target_branch = target_branch
         self.progress = progress
         super().__init__(message)
@@ -95,7 +95,7 @@ class CherryPickFailed(Exception):
 class BranchBackportFailure:
     target_branch: str
     error: str
-    progress: CherryPickProgress
+    progress: BackportProgress
 
 
 def describe_commit(commit_sha: str, sources: List[Source]) -> str:
@@ -133,6 +133,57 @@ def is_empty_cherry_pick_output(output: str) -> bool:
         "cherry-pick is now empty" in lowered
         or "nothing to commit" in lowered
     )
+
+
+def git_output(result: subprocess.CompletedProcess) -> str:
+    output = result.stdout or ''
+    if result.stderr:
+        output = f"{output}\n{result.stderr}" if output else result.stderr
+    return output
+
+
+@dataclass
+class CherryPickOutcome:
+    status: str  # already_present, needs_backport, applied, conflict, failed
+    output: str = ''
+    conflicts: List[ConflictInfo] = field(default_factory=list)
+
+
+def cherry_pick_commit(
+    repo_path: str,
+    commit_sha: str,
+    logger,
+    *,
+    preflight: bool = False,
+) -> CherryPickOutcome:
+    run_git(repo_path, ['fetch', 'origin', commit_sha], logger, check=False)
+    cmd = (
+        ['cherry-pick', '--no-commit', commit_sha]
+        if preflight
+        else ['cherry-pick', '--allow-empty', commit_sha]
+    )
+    result = run_git(repo_path, cmd, logger, check=False)
+    output = git_output(result)
+
+    if result.returncode == 0:
+        if preflight:
+            status = run_git(repo_path, ['status', '--porcelain'], logger, check=False)
+            if not status.stdout.strip():
+                return CherryPickOutcome('already_present', output)
+            return CherryPickOutcome('needs_backport', output)
+        return CherryPickOutcome('applied', output)
+
+    if is_empty_cherry_pick_output(output):
+        if not preflight:
+            run_git(repo_path, ['cherry-pick', '--skip'], logger, check=False)
+        return CherryPickOutcome('already_present', output)
+
+    if not preflight and 'conflict' in output.lower():
+        conflicts = detect_conflicts(repo_path, logger)
+        if conflicts:
+            return CherryPickOutcome('conflict', output, conflicts)
+
+    return CherryPickOutcome('failed', output)
 
 
 def run_git(repo_path: str, cmd: List[str], logger, check=True) -> subprocess.CompletedProcess:
@@ -187,24 +238,9 @@ def classify_commits_for_branch(
 
     for commit_sha in commit_shas:
         commit_label = describe_commit(commit_sha, sources)
-        run_git(repo_path, ['fetch', 'origin', commit_sha], logger, check=False)
-        result = run_git(repo_path, ['cherry-pick', '--no-commit', commit_sha], logger, check=False)
-        output = (result.stdout or '') + (('\n' + result.stderr) if result.stderr else '')
+        outcome = cherry_pick_commit(repo_path, commit_sha, logger, preflight=True)
 
-        if result.returncode == 0:
-            status = run_git(repo_path, ['status', '--porcelain'], logger, check=False)
-            if not status.stdout.strip():
-                already_present.append(commit_sha)
-                msg = f"{commit_label} ({commit_sha[:7]}) already present in `{target_branch}`"
-                logger.info("PREFLIGHT: %s", msg)
-                logs.append(msg)
-            else:
-                needs_backport.append(commit_sha)
-                logger.info("PREFLIGHT: %s needs backport to `%s`", commit_label, target_branch)
-            reset_branch_to_target(repo_path, target_branch, logger)
-            continue
-
-        if is_empty_cherry_pick_output(output):
+        if outcome.status == 'already_present':
             already_present.append(commit_sha)
             msg = f"{commit_label} ({commit_sha[:7]}) already present in `{target_branch}`"
             logger.info("PREFLIGHT: %s", msg)
@@ -212,6 +248,7 @@ def classify_commits_for_branch(
         else:
             needs_backport.append(commit_sha)
             logger.info("PREFLIGHT: %s needs backport to `%s`", commit_label, target_branch)
+
         reset_branch_to_target(repo_path, target_branch, logger)
 
     return BranchPreflight(
@@ -566,47 +603,6 @@ def collect_unique_pulls(sources: List[Source]) -> List[Any]:
     return pulls
 
 
-def build_shared_skip_comment(
-    pull_number: Optional[int],
-    sources: List[Source],
-    preflights: Dict[str, BranchPreflight],
-    invalid_branches: Set[str],
-    target_branches: List[str],
-    workflow_url: Optional[str],
-    cancelled_entire_run: bool,
-) -> str:
-    source = get_source_for_pull(pull_number, sources) if pull_number else None
-    branch_lines = []
-    for branch in target_branches:
-        if branch in invalid_branches:
-            branch_lines.append(f"`{branch}`: skipped (branch does not exist)")
-            continue
-
-        preflight = preflights.get(branch)
-        if not preflight:
-            continue
-        if preflight.all_present:
-            branch_lines.append(f"`{branch}`: skipped (all commits already present)")
-        elif source and all(sha in preflight.already_present_shas for sha in source.commit_shas):
-            branch_lines.append(f"`{branch}`: skipped (already present)")
-        else:
-            branch_lines.append(f"`{branch}`: skipped (already present)")
-
-    if cancelled_entire_run:
-        if len(branch_lines) == 1:
-            text = f"Backport cancelled: {branch_lines[0]}"
-        else:
-            text = "Backport cancelled:\n" + "\n".join(f"- {line}" for line in branch_lines)
-    elif len(branch_lines) == 1:
-        text = f"Backport skipped: {branch_lines[0]}"
-    else:
-        text = "Backport skipped:\n" + "\n".join(f"- {line}" for line in branch_lines)
-
-    if workflow_url:
-        text += f"\n\n[workflow run]({workflow_url})"
-    return text
-
-
 def notify_already_present_pulls(
     pulls: List[Any],
     sources: List[Source],
@@ -617,40 +613,28 @@ def notify_already_present_pulls(
     workflow_url: Optional[str],
     cancelled_entire_run: bool,
     logger,
-    personalized: bool,
 ):
     for pull in pulls:
-        if personalized:
-            message = build_pull_result_comment(
-                pull.number,
-                sources,
-                ordered_commit_shas,
-                preflights,
-                [],
-                [],
-                invalid_branches,
-                target_branches,
-                workflow_url,
-            )
-            if cancelled_entire_run:
-                message = message.replace(
-                    "Backport result for this PR:",
-                    "Backport skipped:",
-                    1,
-                ).replace(
-                    "Backport results for this PR:",
-                    "Backport skipped:",
-                    1,
-                )
-        else:
-            message = build_shared_skip_comment(
-                pull.number,
-                sources,
-                preflights,
-                invalid_branches,
-                target_branches,
-                workflow_url,
-                cancelled_entire_run,
+        message = build_pull_result_comment(
+            pull.number,
+            sources,
+            ordered_commit_shas,
+            preflights,
+            [],
+            [],
+            invalid_branches,
+            target_branches,
+            workflow_url,
+        )
+        if cancelled_entire_run:
+            message = message.replace(
+                "Backport result for this PR:",
+                "Backport skipped:",
+                1,
+            ).replace(
+                "Backport results for this PR:",
+                "Backport skipped:",
+                1,
             )
         try:
             pull.create_issue_comment(message)
@@ -713,48 +697,38 @@ def format_source_branch_status(
     sources: List[Source],
 ) -> str:
     source_shas = set(source.commit_shas)
-    source_indices = [ordered_commit_shas.index(sha) for sha in source.commit_shas]
-    already_present_shas = set(preflight.already_present_shas if preflight else [])
+    already_present = set(preflight.already_present_shas if preflight else [])
 
-    if preflight and preflight.all_present:
-        if all(sha in already_present_shas for sha in source.commit_shas):
-            return f"`{target_branch}`: already present"
+    if preflight and all(sha in already_present for sha in source.commit_shas):
+        return f"`{target_branch}`: already present"
 
     if failure and failure.target_branch == target_branch:
         progress = failure.progress
+        if progress.failed_commit_sha in source_shas:
+            return f"`{target_branch}`: failed ({failure.error})"
+
         failed_idx = (
             ordered_commit_shas.index(progress.failed_commit_sha)
             if progress.failed_commit_sha in ordered_commit_shas
             else len(ordered_commit_shas)
         )
-        max_source_idx = max(source_indices)
-        min_source_idx = min(source_indices)
-
-        if progress.failed_commit_sha in source_shas:
-            return f"`{target_branch}`: failed ({failure.error})"
-        if max_source_idx < failed_idx:
-            if all(sha in already_present_shas or sha in progress.skipped_commit_shas for sha in source.commit_shas):
+        source_indices = [ordered_commit_shas.index(sha) for sha in source.commit_shas]
+        if max(source_indices) < failed_idx:
+            if all(
+                sha in already_present or sha in progress.skipped_commit_shas
+                for sha in source.commit_shas
+            ):
                 return f"`{target_branch}`: already present"
-            if all(sha in progress.applied_commit_shas for sha in source.commit_shas):
-                return (
-                    f"`{target_branch}`: not backported "
-                    f"(workflow failed before backport PR was created)"
-                )
-        if min_source_idx > failed_idx and progress.failed_commit_sha:
-            failed_label = describe_commit(progress.failed_commit_sha, sources)
-            return f"`{target_branch}`: not backported (workflow failed on {failed_label})"
+            return f"`{target_branch}`: not backported (workflow failed before backport PR was created)"
 
-    if preflight and all(sha in already_present_shas for sha in source.commit_shas):
-        return f"`{target_branch}`: already present"
+        failed_label = describe_commit(progress.failed_commit_sha, sources)
+        return f"`{target_branch}`: not backported (workflow failed on {failed_label})"
 
     if result and result.target_branch == target_branch:
         if any(sha in result.applied_commit_shas for sha in source.commit_shas) and result.pr:
             status = "draft PR" if result.has_conflicts else "backport PR"
             conflict_note = " (contains conflicts requiring manual resolution)" if result.has_conflicts else ""
             return f"`{target_branch}`: included in {status} {result.pr.html_url}{conflict_note}"
-
-    if preflight and preflight.all_present:
-        return f"`{target_branch}`: already present"
 
     return f"`{target_branch}`: status unknown"
 
@@ -797,6 +771,35 @@ def build_pull_result_comment(
     return text
 
 
+def replace_progress_line(
+    existing_body: str,
+    new_results: str,
+    target_branches: List[str],
+    workflow_url: Optional[str],
+) -> str:
+    lines = existing_body.split('\n')
+    updated_lines = []
+    found = False
+
+    for line in lines:
+        is_progress_line = (
+            "in progress" in line
+            and any(f"`{b}`" in line for b in target_branches)
+            and (not workflow_url or workflow_url in line)
+        )
+
+        if is_progress_line and not found:
+            updated_lines.append(new_results)
+            found = True
+        else:
+            updated_lines.append(line)
+
+    if not found:
+        updated_lines.extend(["", new_results])
+
+    return '\n'.join(updated_lines)
+
+
 def update_comments(
     backport_comments: List[Tuple[Any, object]],
     sources: List[Source],
@@ -815,7 +818,6 @@ def update_comments(
 
     for pull, comment in backport_comments:
         try:
-            existing_body = comment.body
             new_results = build_pull_result_comment(
                 pull.number,
                 sources,
@@ -827,29 +829,9 @@ def update_comments(
                 target_branches,
                 workflow_url,
             )
-
-            lines = existing_body.split('\n')
-            updated_lines = []
-            found = False
-
-            for line in lines:
-                is_progress_line = (
-                    "in progress" in line
-                    and any(f"`{b}`" in line for b in target_branches)
-                    and (not workflow_url or workflow_url in line)
-                )
-
-                if is_progress_line and not found:
-                    updated_lines.append(new_results)
-                    found = True
-                else:
-                    updated_lines.append(line)
-
-            if not found:
-                updated_lines.append("")
-                updated_lines.append(new_results)
-
-            comment.edit('\n'.join(updated_lines))
+            comment.edit(replace_progress_line(
+                comment.body, new_results, target_branches, workflow_url,
+            ))
             logger.info("Updated backport comment in original PR #%s", pull.number)
         except GithubException as e:
             logger.warning("Failed to update comment in original PR #%s: %s", pull.number, e)
@@ -881,53 +863,52 @@ def process_branch(
     run_git(repo_path, ['checkout', '-B', target_branch, f'origin/{target_branch}'], logger)
     run_git(repo_path, ['checkout', '-b', dev_branch_name, target_branch], logger)
 
-    progress = CherryPickProgress(skipped_commit_shas=list(preflight.already_present_shas))
+    progress = BackportProgress(skipped_commit_shas=list(preflight.already_present_shas))
 
     for commit_sha in commit_shas:
         commit_label = describe_commit(commit_sha, sources)
         logger.info("Cherry-picking %s (%s)", commit_sha[:7], commit_label)
-        run_git(repo_path, ['fetch', 'origin', commit_sha], logger, check=False)
         try:
-            result = run_git(repo_path, ['cherry-pick', '--allow-empty', commit_sha], logger, check=False)
-            output = (result.stdout or '') + (('\n' + result.stderr) if result.stderr else '')
+            outcome = cherry_pick_commit(repo_path, commit_sha, logger)
+            output = outcome.output
 
-            if result.returncode != 0:
-                if is_empty_cherry_pick_output(output):
-                    run_git(repo_path, ['cherry-pick', '--skip'], logger, check=False)
-                    skip_msg = (
-                        f"{commit_label} ({commit_sha[:7]}) is already present in `{target_branch}`, skipped"
-                    )
-                    logger.warning("ALREADY_PRESENT: %s", skip_msg)
-                    cherry_pick_logs.append(f"=== Skipped {commit_sha[:7]} ===\n{skip_msg}\n")
-                    progress.skipped_commit_shas.append(commit_sha)
-                    continue
+            if outcome.status == 'already_present':
+                skip_msg = (
+                    f"{commit_label} ({commit_sha[:7]}) is already present in `{target_branch}`, skipped"
+                )
+                logger.warning("ALREADY_PRESENT: %s", skip_msg)
+                cherry_pick_logs.append(f"=== Skipped {commit_sha[:7]} ===\n{skip_msg}\n")
+                progress.skipped_commit_shas.append(commit_sha)
+                continue
 
+            if outcome.status == 'failed':
                 progress.failed_commit_sha = commit_sha
-                if "conflict" in output.lower():
-                    conflicts = detect_conflicts(repo_path, logger)
-                    if conflicts:
-                        run_git(repo_path, ['add', '-A'], logger)
-                        run_git(repo_path, ['commit', '-m', f"BACKPORT-CONFLICT: manual resolution required for commit {commit_sha[:7]}"], logger)
-                        all_conflict_files.extend(conflicts)
-                        progress.applied_commit_shas.append(commit_sha)
-                    else:
-                        run_git(repo_path, ['cherry-pick', '--abort'], logger, check=False)
-                        raise CherryPickFailed(
-                            target_branch,
-                            f"Cherry-pick failed for {commit_label} ({commit_sha[:7]}): "
-                            f"git reported a conflict but no conflicted files were detected.\n{output.strip()}",
-                            progress,
-                        )
-                else:
-                    raise CherryPickFailed(
-                        target_branch,
-                        f"Cherry-pick failed for {commit_label} ({commit_sha[:7]}): {output.strip()}",
-                        progress,
+                run_git(repo_path, ['cherry-pick', '--abort'], logger, check=False)
+                if 'conflict' in output.lower():
+                    detail = (
+                        f"git reported a conflict but no conflicted files were detected.\n{output.strip()}"
                     )
+                else:
+                    detail = output.strip()
+                raise CherryPickFailed(
+                    target_branch,
+                    f"Cherry-pick failed for {commit_label} ({commit_sha[:7]}): {detail}",
+                    progress,
+                )
+
+            if outcome.status == 'conflict':
+                run_git(repo_path, ['add', '-A'], logger)
+                run_git(
+                    repo_path,
+                    ['commit', '-m', f"BACKPORT-CONFLICT: manual resolution required for commit {commit_sha[:7]}"],
+                    logger,
+                )
+                all_conflict_files.extend(outcome.conflicts)
+                progress.applied_commit_shas.append(commit_sha)
             else:
                 progress.applied_commit_shas.append(commit_sha)
 
-            if output and commit_sha not in progress.skipped_commit_shas:
+            if output:
                 cherry_pick_logs.append(f"=== Cherry-picking {commit_sha[:7]} ===\n{output}")
         except subprocess.CalledProcessError as e:
             progress.failed_commit_sha = commit_sha
@@ -1144,7 +1125,6 @@ def main():
                 workflow_url,
                 True,
                 logger,
-                True,
             )
             logger.info("WORKFLOW_SUCCESS: Nothing to backport — all commits are already present in target branch(es).")
             if summary_path:
@@ -1188,7 +1168,11 @@ def main():
                 has_errors = True
                 logger.error("BACKPORT_ERROR: Branch `%s`: %s", target_branch, e)
                 branch_failures.append(BranchBackportFailure(
-                    target_branch, str(e), CherryPickProgress(failed_commit_sha=all_commit_shas[0] if all_commit_shas else None),
+                    target_branch,
+                    str(e),
+                    BackportProgress(
+                        failed_commit_sha=all_commit_shas[0] if all_commit_shas else None,
+                    ),
                 ))
                 if summary_path:
                     with open(summary_path, 'a') as f:
@@ -1213,7 +1197,6 @@ def main():
                 workflow_url,
                 False,
                 logger,
-                True,
             )
 
         if has_errors:

--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 import shutil
 import json
-from typing import List, Optional, Tuple, Any, Set
+from typing import List, Optional, Tuple, Any, Set, Dict
 from dataclasses import dataclass, field
 from github import Github, GithubException, Auth
 import requests
@@ -52,7 +52,7 @@ class BackportResult:
     cherry_pick_logs: List[str] = field(default_factory=list)
     skipped_commit_shas: List[str] = field(default_factory=list)
     applied_commit_shas: List[str] = field(default_factory=list)
-    
+
     @property
     def has_conflicts(self) -> bool:
         return len(self.conflict_files) > 0
@@ -63,6 +63,18 @@ class CherryPickProgress:
     skipped_commit_shas: List[str] = field(default_factory=list)
     applied_commit_shas: List[str] = field(default_factory=list)
     failed_commit_sha: Optional[str] = None
+
+
+@dataclass
+class BranchPreflight:
+    target_branch: str
+    already_present_shas: List[str] = field(default_factory=list)
+    needs_backport_shas: List[str] = field(default_factory=list)
+    logs: List[str] = field(default_factory=list)
+
+    @property
+    def all_present(self) -> bool:
+        return not self.needs_backport_shas
 
 
 class BranchBackportSkipped(Exception):
@@ -101,6 +113,20 @@ def get_source_for_pull(pull_number: int, sources: List[Source]) -> Optional[Sou
     return None
 
 
+def get_pulls_for_commits(sources: List[Source], commit_shas: List[str]) -> List[Any]:
+    pulls = []
+    seen = set()
+    commit_set = set(commit_shas)
+    for source in sources:
+        if not any(sha in commit_set for sha in source.commit_shas):
+            continue
+        for pull in source.pull_requests:
+            if pull.number not in seen:
+                pulls.append(pull)
+                seen.add(pull.number)
+    return pulls
+
+
 def is_empty_cherry_pick_output(output: str) -> bool:
     lowered = output.lower()
     return (
@@ -119,6 +145,106 @@ def run_git(repo_path: str, cmd: List[str], logger, check=True) -> subprocess.Co
         check=check
     )
     return result
+
+
+def reset_branch_to_target(repo_path: str, target_branch: str, logger) -> None:
+    run_git(repo_path, ['cherry-pick', '--abort'], logger, check=False)
+    run_git(repo_path, ['reset', '--hard', f'origin/{target_branch}'], logger)
+    run_git(repo_path, ['clean', '-fd'], logger, check=False)
+
+
+def setup_branch_repo(token: str, repo_name: str, target_branch: str, logger) -> str:
+    repo_dir = tempfile.mkdtemp(prefix="ydb-cherry-pick-")
+    repo_url = f"https://{token}@github.com/{repo_name}.git"
+    logger.info("Cloning branch `%s` to %s", target_branch, repo_dir)
+    subprocess.run(
+        ['git', 'clone', '--depth=1', '--branch', target_branch, repo_url, repo_dir],
+        env={**os.environ, 'GIT_PROTOCOL': '2'},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return repo_dir
+
+
+def classify_commits_for_branch(
+    repo_path: str,
+    target_branch: str,
+    commit_shas: List[str],
+    sources: List[Source],
+    logger,
+) -> BranchPreflight:
+    run_git(repo_path, ['fetch', 'origin', target_branch], logger, check=False)
+    run_git(
+        repo_path,
+        ['checkout', '-B', f'preflight-{target_branch}', f'origin/{target_branch}'],
+        logger,
+    )
+
+    already_present: List[str] = []
+    needs_backport: List[str] = []
+    logs: List[str] = []
+
+    for commit_sha in commit_shas:
+        commit_label = describe_commit(commit_sha, sources)
+        run_git(repo_path, ['fetch', 'origin', commit_sha], logger, check=False)
+        result = run_git(repo_path, ['cherry-pick', '--no-commit', commit_sha], logger, check=False)
+        output = (result.stdout or '') + (('\n' + result.stderr) if result.stderr else '')
+
+        if result.returncode == 0:
+            status = run_git(repo_path, ['status', '--porcelain'], logger, check=False)
+            if not status.stdout.strip():
+                already_present.append(commit_sha)
+                msg = f"{commit_label} ({commit_sha[:7]}) already present in `{target_branch}`"
+                logger.info("PREFLIGHT: %s", msg)
+                logs.append(msg)
+            else:
+                needs_backport.append(commit_sha)
+                logger.info("PREFLIGHT: %s needs backport to `%s`", commit_label, target_branch)
+            reset_branch_to_target(repo_path, target_branch, logger)
+            continue
+
+        if is_empty_cherry_pick_output(output):
+            already_present.append(commit_sha)
+            msg = f"{commit_label} ({commit_sha[:7]}) already present in `{target_branch}`"
+            logger.info("PREFLIGHT: %s", msg)
+            logs.append(msg)
+        else:
+            needs_backport.append(commit_sha)
+            logger.info("PREFLIGHT: %s needs backport to `%s`", commit_label, target_branch)
+        reset_branch_to_target(repo_path, target_branch, logger)
+
+    return BranchPreflight(
+        target_branch=target_branch,
+        already_present_shas=already_present,
+        needs_backport_shas=needs_backport,
+        logs=logs,
+    )
+
+
+def write_preflight_summary(
+    preflights: List[BranchPreflight],
+    sources: List[Source],
+    summary_path: Optional[str],
+    logger,
+) -> None:
+    if not summary_path:
+        return
+    with open(summary_path, 'a') as f:
+        f.write("### Pre-flight check\n\n")
+        for preflight in preflights:
+            if preflight.all_present:
+                f.write(f"- `{preflight.target_branch}`: all commits already present\n")
+            elif preflight.already_present_shas:
+                f.write(
+                    f"- `{preflight.target_branch}`: will backport {len(preflight.needs_backport_shas)} commit(s); "
+                    f"{len(preflight.already_present_shas)} already present\n"
+                )
+                for line in preflight.logs:
+                    f.write(f"  - {line}\n")
+            else:
+                f.write(f"- `{preflight.target_branch}`: will backport {len(preflight.needs_backport_shas)} commit(s)\n")
+        f.write("\n")
 
 
 def expand_sha(repo, ref: str, logger) -> str:
@@ -145,13 +271,12 @@ def create_commit_source(commit, repo, logger) -> Source:
             linked_pr = pulls.get_page(0)[0]
     except Exception:
         pass
-    
+
     author = linked_pr.user.login if linked_pr else (commit.author.login if commit.author else None)
     body_item = f"* commit {commit.html_url}: {linked_pr.title}" if linked_pr else f"* commit {commit.html_url}"
-    
-    # Get commit message title (first line)
+
     commit_title = commit.commit.message.split('\n')[0].strip() if commit.commit.message else f"commit {commit.sha[:7]}"
-    
+
     return Source(
         type='commit',
         commit_shas=[commit.sha],
@@ -174,7 +299,7 @@ def create_pr_source(pull: Any, allow_unmerged: bool, logger) -> Source:
         commit_shas = [c.sha for c in pull.get_commits()]
         if not commit_shas:
             raise ValueError(f"PR #{pull.number} contains no commits to cherry-pick")
-    
+
     return Source(
         type='pr',
         commit_shas=commit_shas,
@@ -189,12 +314,12 @@ def detect_conflicts(repo_path: str, logger) -> List[ConflictInfo]:
     """Detects conflicts from git status"""
     conflict_files = []
     CONFLICT_STATUS_CODES = ['UU', 'AA', 'DD', 'DU', 'UD', 'AU', 'UA']
-    
+
     try:
         result = run_git(repo_path, ['status', '--porcelain'], logger)
         if not result.stdout.strip():
             return []
-        
+
         for line in result.stdout.strip().split('\n'):
             status_code = line[:2]
             if status_code in CONFLICT_STATUS_CODES:
@@ -205,7 +330,7 @@ def detect_conflicts(repo_path: str, logger) -> List[ConflictInfo]:
                         conflict_files.append(ConflictInfo(file_path=file_path))
     except Exception as e:
         logger.error(f"Error detecting conflicts: {e}")
-    
+
     return conflict_files
 
 
@@ -213,10 +338,9 @@ def get_linked_issues(repo, token: str, pull_requests: List[Any], logger) -> str
     """Gets linked issues for all PRs"""
     all_issues = []
     owner, repo_name = repo.full_name.split('/')
-    
+
     for pull in pull_requests:
         issues = []
-        # Try GraphQL
         try:
             query = """
             query($owner: String!, $repo: String!, $prNumber: Int!) {
@@ -254,13 +378,12 @@ def get_linked_issues(repo, token: str, pull_requests: List[Any], logger) -> str
                         issues.append(f"{owner_name}/{repo_name_issue}#{number}")
         except Exception:
             pass
-        
-        # Fallback to parsing PR body
+
         if not issues and pull.body:
             issues = [f"#{num}" for num in re.findall(r'#(\d+)', pull.body)]
-        
+
         all_issues.extend(issues)
-    
+
     unique_issues = list(dict.fromkeys(all_issues))
     return ' '.join(unique_issues) if unique_issues else 'None'
 
@@ -269,26 +392,23 @@ def extract_changelog(pr_body: str) -> Tuple[Optional[str], Optional[str], Optio
     """Extracts changelog category, entry, and entry content"""
     if not pr_body:
         return None, None, None
-    
-    # Category
+
     category_match = re.search(r"### Changelog category.*?\n(.*?)(\n###|$)", pr_body, re.DOTALL)
     category = None
     if category_match:
         categories = [line.lstrip('* ').strip() for line in category_match.group(1).splitlines() if line.strip() and line.strip().startswith('*')]
         category = categories[0] if categories else None
-    
-    # Entry
+
     entry_match = re.search(r"### Changelog entry.*?\n(.*?)(\n###|$)", pr_body, re.DOTALL)
     entry = entry_match.group(1).strip() if entry_match else None
     if entry in ['...', '']:
         entry = None
-    
-    # Entry content (stops at category)
+
     entry_content_match = re.search(r"### Changelog entry.*?\n(.*?)(\n### Changelog category|$)", pr_body, re.DOTALL)
     entry_content = entry_content_match.group(1).strip() if entry_content_match else None
     if entry_content in ['...', '']:
         entry_content = None
-    
+
     return category, entry, entry_content
 
 
@@ -300,100 +420,85 @@ def build_pr_content(
 ) -> Tuple[str, str]:
     """Generates PR title and body"""
     has_conflicts = len(conflict_files) > 0
-    # Collect data
-    all_commit_shas = []
-    all_pull_requests = []
     all_titles = []
     all_body_items = []
     all_authors = []
-    
+    all_pull_requests = []
+
     for source in sources:
-        all_commit_shas.extend(source.commit_shas)
         all_pull_requests.extend(source.pull_requests)
         all_titles.append(source.title)
         all_body_items.append(source.body_item)
         if source.author and source.author not in all_authors:
             all_authors.append(source.author)
-    
-    # Title
+
     if len(all_titles) == 1:
         title = f"[Backport {target_branch}] {all_titles[0]}"
     else:
         title = f"[Backport {target_branch}] {', '.join(all_titles)}"
     if has_conflicts:
         title = f"[CONFLICT] {title}"
-    if len(title) > 256: # GitHub limit for PR title
+    if len(title) > 256:
         title = title[:253] + "..."
-    
-    # Issues
+
     issue_refs = get_linked_issues(repo, token, all_pull_requests, logger)
     authors_str = ', '.join([f"@{a}" for a in set(all_authors)]) if all_authors else "Unknown"
-    
-    # Changelog: build entry for each source, then merge
+
     categories = []
     changelog_entries = []
-    
+
     for source in sources:
         source_entry = None
         source_category = None
-        
-        # For PR or merge commit with linked PR
+
         if source.pull_requests:
             pull = source.pull_requests[0]
             if pull.body:
                 cat, ent, ent_content = extract_changelog(pull.body)
                 source_category = cat
-                # Use entry_content if available, otherwise entry
                 source_entry = ent_content if ent_content else ent
-            
-            # Format: "PR Title: changelog_entry" or just "PR Title"
+
             if source_entry:
                 changelog_entries.append(f"{pull.title}: {source_entry}")
             else:
                 changelog_entries.append(pull.title)
-        
-        # For commit SHA (no linked PR)
         elif source.type == 'commit' and source.commit_shas:
             try:
                 commit = repo.get_commit(source.commit_shas[0])
-                commit_message = commit.commit.message
-                commit_title = commit_message.split('\n')[0].strip()
+                commit_title = commit.commit.message.split('\n')[0].strip()
                 changelog_entries.append(commit_title)
             except Exception as e:
                 logger.debug(f"Failed to get commit message for {source.commit_shas[0]}: {e}")
                 changelog_entries.append(f"commit {source.commit_shas[0][:7]}")
-        
+
         if source_category:
             categories.append(source_category)
-    
+
     changelog_category = categories[0] if len(set(categories)) == 1 else None
-    
-    # Merge all entries
+
     if len(changelog_entries) > 1:
         changelog_entry = "\n\n---\n\n".join(changelog_entries)
     elif len(changelog_entries) == 1:
         changelog_entry = changelog_entries[0]
     else:
-        # Fallback
         changelog_entry = f"Backport to `{target_branch}`"
-    
+
     if changelog_category == "Bugfix" and issue_refs != "None":
         if not any(re.search(p, changelog_entry) for p in ISSUE_PATTERNS):
             changelog_entry = f"{changelog_entry} ({issue_refs})"
-    
+
     category_section = f"* {changelog_category}" if changelog_category else get_category_section_template()
     commits = '\n'.join(all_body_items)
-    
-    # Build body sections
+
     description = f"#### Original PR(s)\n{commits}\n\n#### Metadata\n"
     description += f"- **Original PR author(s):** {authors_str}\n"
     description += f"- **Cherry-picked by:** @{workflow_triggerer}\n"
     description += f"- **Related issues:** {issue_refs}"
-    
+
     cherry_pick_log_section = ""
     if cherry_pick_logs:
         cherry_pick_log_section = "\n\n### Git Cherry-Pick Log\n\n```\n" + '\n'.join(log if log.endswith('\n') else log + '\n' for log in cherry_pick_logs) + "```\n"
-    
+
     conflicts_section = ""
     if has_conflicts:
         branch_for_instructions = dev_branch_name or target_branch
@@ -420,9 +525,9 @@ After resolving conflicts:
 1. Fix the PR title (remove `[CONFLICT]` if conflicts are resolved)
 2. Mark PR as ready for review
 """
-    
+
     workflow_section = f"\n\n---\n\nPR was created by cherry-pick workflow [run]({workflow_url})" if workflow_url else "\n\n---\n\nPR was created by cherry-pick script"
-    
+
     body = f"""### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
 
 {changelog_entry}
@@ -435,7 +540,7 @@ After resolving conflicts:
 
 {description}{conflicts_section}{cherry_pick_log_section}{workflow_section}
 """
-    
+
     return title, body
 
 
@@ -450,20 +555,65 @@ def find_existing_backport_comment(pull: Any, logger):
     return None
 
 
+def create_initial_backport_comments(
+    pulls: List[Any],
+    target_branches: List[str],
+    workflow_url: Optional[str],
+    logger,
+) -> List[Tuple[Any, object]]:
+    backport_comments = []
+    if not pulls:
+        return backport_comments
+
+    target_branches_str = ', '.join([f"`{b}`" for b in target_branches])
+    if workflow_url:
+        new_line = f"Backport to {target_branches_str} in progress: [workflow run]({workflow_url})"
+    else:
+        new_line = f"Backport to {target_branches_str} in progress"
+
+    for pull in pulls:
+        try:
+            existing_comment = find_existing_backport_comment(pull, logger)
+            if existing_comment:
+                existing_body = existing_comment.body
+                branches_already_mentioned = all(f"`{b}`" in existing_body for b in target_branches)
+                should_skip = (
+                    branches_already_mentioned
+                    and ("in progress" in existing_body)
+                    and (not workflow_url or workflow_url in existing_body)
+                )
+
+                if should_skip:
+                    backport_comments.append((pull, existing_comment))
+                else:
+                    existing_comment.edit(f"{existing_body}\n\n{new_line}")
+                    backport_comments.append((pull, existing_comment))
+                    logger.info("Updated existing backport comment in original PR #%s", pull.number)
+            else:
+                comment = pull.create_issue_comment(new_line)
+                backport_comments.append((pull, comment))
+                logger.info("Created initial backport comment in original PR #%s", pull.number)
+        except GithubException as e:
+            logger.warning("Failed to create/update initial comment in original PR #%s: %s", pull.number, e)
+
+    return backport_comments
+
+
 def format_source_branch_status(
     source: Source,
     target_branch: str,
     ordered_commit_shas: List[str],
+    preflight: Optional[BranchPreflight],
     result: Optional[BackportResult],
     failure: Optional[BranchBackportFailure],
-    skip: Optional[BranchBackportSkipped],
     sources: List[Source],
 ) -> str:
     source_shas = set(source.commit_shas)
     source_indices = [ordered_commit_shas.index(sha) for sha in source.commit_shas]
+    already_present_shas = set(preflight.already_present_shas if preflight else [])
 
-    if skip and skip.target_branch == target_branch:
-        if all(sha in skip.progress.skipped_commit_shas for sha in source.commit_shas):
+    if preflight and preflight.all_present:
+        if all(sha in already_present_shas for sha in source.commit_shas):
             return f"`{target_branch}`: already present"
 
     if failure and failure.target_branch == target_branch:
@@ -479,7 +629,7 @@ def format_source_branch_status(
         if progress.failed_commit_sha in source_shas:
             return f"`{target_branch}`: failed ({failure.error})"
         if max_source_idx < failed_idx:
-            if all(sha in progress.skipped_commit_shas for sha in source.commit_shas):
+            if all(sha in already_present_shas or sha in progress.skipped_commit_shas for sha in source.commit_shas):
                 return f"`{target_branch}`: already present"
             if all(sha in progress.applied_commit_shas for sha in source.commit_shas):
                 return (
@@ -490,13 +640,17 @@ def format_source_branch_status(
             failed_label = describe_commit(progress.failed_commit_sha, sources)
             return f"`{target_branch}`: not backported (workflow failed on {failed_label})"
 
+    if preflight and all(sha in already_present_shas for sha in source.commit_shas):
+        return f"`{target_branch}`: already present"
+
     if result and result.target_branch == target_branch:
-        if all(sha in result.skipped_commit_shas for sha in source.commit_shas):
-            return f"`{target_branch}`: already present"
         if any(sha in result.applied_commit_shas for sha in source.commit_shas) and result.pr:
             status = "draft PR" if result.has_conflicts else "backport PR"
             conflict_note = " (contains conflicts requiring manual resolution)" if result.has_conflicts else ""
             return f"`{target_branch}`: included in {status} {result.pr.html_url}{conflict_note}"
+
+    if preflight and preflight.all_present:
+        return f"`{target_branch}`: already present"
 
     return f"`{target_branch}`: status unknown"
 
@@ -505,9 +659,9 @@ def build_pull_result_comment(
     pull_number: int,
     sources: List[Source],
     ordered_commit_shas: List[str],
+    preflights: Dict[str, BranchPreflight],
     results: List[BackportResult],
     branch_failures: List[BranchBackportFailure],
-    branch_skips: List[BranchBackportSkipped],
     invalid_branches: Set[str],
     target_branches: List[str],
     workflow_url: Optional[str],
@@ -522,11 +676,11 @@ def build_pull_result_comment(
             branch_lines.append(f"`{branch}`: skipped (branch does not exist)")
             continue
 
+        preflight = preflights.get(branch)
         result = next((r for r in results if r.target_branch == branch), None)
         failure = next((f for f in branch_failures if f.target_branch == branch), None)
-        skip = next((s for s in branch_skips if s.target_branch == branch), None)
         branch_lines.append(format_source_branch_status(
-            source, branch, ordered_commit_shas, result, failure, skip, sources,
+            source, branch, ordered_commit_shas, preflight, result, failure, sources,
         ))
 
     if len(branch_lines) == 1:
@@ -543,9 +697,9 @@ def update_comments(
     backport_comments: List[Tuple[Any, object]],
     sources: List[Source],
     ordered_commit_shas: List[str],
+    preflights: Dict[str, BranchPreflight],
     results: List[BackportResult],
     branch_failures: List[BranchBackportFailure],
-    branch_skips: List[BranchBackportSkipped],
     invalid_branches: Set[str],
     target_branches: List[str],
     workflow_url: Optional[str],
@@ -562,9 +716,9 @@ def update_comments(
                 pull.number,
                 sources,
                 ordered_commit_shas,
+                preflights,
                 results,
                 branch_failures,
-                branch_skips,
                 invalid_branches,
                 target_branches,
                 workflow_url,
@@ -598,23 +752,33 @@ def update_comments(
 
 
 def process_branch(
-    repo_path: str, target_branch: str, dev_branch_name: str, commit_shas: List[str],
-    repo_name: str, repo, token: str, sources: List[Source], workflow_triggerer: str,
-    workflow_url: Optional[str], summary_path: Optional[str], logger
+    repo_path: str,
+    target_branch: str,
+    dev_branch_name: str,
+    commit_shas: List[str],
+    preflight: BranchPreflight,
+    repo_name: str,
+    repo,
+    token: str,
+    sources: List[Source],
+    workflow_triggerer: str,
+    workflow_url: Optional[str],
+    summary_path: Optional[str],
+    logger,
 ):
     """Processes single branch"""
     all_conflict_files = []
     cherry_pick_logs = []
-    
-    # Prepare branch
+    if preflight.logs:
+        cherry_pick_logs.append("=== Pre-flight ===\n" + '\n'.join(preflight.logs) + "\n")
+
     run_git(repo_path, ['fetch', 'origin', target_branch], logger)
     run_git(repo_path, ['reset', '--hard', 'HEAD'], logger)
     run_git(repo_path, ['checkout', '-B', target_branch, f'origin/{target_branch}'], logger)
     run_git(repo_path, ['checkout', '-b', dev_branch_name, target_branch], logger)
-    
-    progress = CherryPickProgress()
 
-    # Cherry-pick each commit
+    progress = CherryPickProgress(skipped_commit_shas=list(preflight.already_present_shas))
+
     for commit_sha in commit_shas:
         commit_label = describe_commit(commit_sha, sources)
         logger.info("Cherry-picking %s (%s)", commit_sha[:7], commit_label)
@@ -677,17 +841,15 @@ def process_branch(
         if any(sha in progress.applied_commit_shas for sha in source.commit_shas)
     ]
 
-    # Push branch
     run_git(repo_path, ['push', '--set-upstream', 'origin', dev_branch_name], logger)
-    
-    # Create PR
+
     has_conflicts = len(all_conflict_files) > 0
     title, body = build_pr_content(
         repo_name, repo, token, target_branch, dev_branch_name,
         applied_sources, all_conflict_files, cherry_pick_logs,
         workflow_triggerer, workflow_url, None, logger
     )
-    
+
     pr = repo.create_pull(
         base=target_branch,
         head=dev_branch_name,
@@ -696,8 +858,7 @@ def process_branch(
         maintainer_can_modify=True,
         draft=has_conflicts
     )
-    
-    # Update body with PR number for correct links
+
     if has_conflicts:
         _, updated_body = build_pr_content(
             repo_name, repo, token, target_branch, dev_branch_name,
@@ -705,15 +866,13 @@ def process_branch(
             workflow_triggerer, workflow_url, pr.number, logger
         )
         pr.edit(body=updated_body)
-    
-    # Assign assignee
+
     if workflow_triggerer != 'unknown':
         try:
             pr.add_to_assignees(workflow_triggerer)
         except GithubException:
             pass
-    
-    # Enable automerge if no conflicts
+
     if not has_conflicts:
         try:
             pr.enable_automerge(merge_method='MERGE')
@@ -722,8 +881,7 @@ def process_branch(
                 pr.enable_automerge(merge_method='SQUASH')
             except Exception:
                 pass
-    
-    # Write to summary
+
     if summary_path:
         summary = f"### Branch `{target_branch}`: "
         summary += f"**CONFLICT** Draft PR {pr.html_url}\n\n" if has_conflicts else f"PR {pr.html_url}\n\n"
@@ -735,7 +893,7 @@ def process_branch(
                 summary += f"- `{conflict.file_path}`\n"
         with open(summary_path, 'a') as f:
             f.write(f'{summary}\n\n')
-    
+
     return BackportResult(
         target_branch=target_branch,
         pr=pr,
@@ -755,18 +913,16 @@ def main():
 
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(name)s - %(message)s", level=logging.DEBUG)
     logger = logging.getLogger("cherry-pick")
-    
+
     repo_name = os.environ["REPO"]
     token = os.environ["TOKEN"]
     workflow_triggerer = os.environ.get('GITHUB_ACTOR', 'unknown')
     summary_path = os.getenv('GITHUB_STEP_SUMMARY')
     results_path = os.getenv('RESULTS_PATH')
-    
-    # Initialize GitHub
+
     gh = Github(auth=Auth.Token(token))
     repo = gh.get_repo(repo_name)
-    
-    # Get workflow URL
+
     workflow_url = None
     run_id = os.getenv('GITHUB_RUN_ID')
     if run_id:
@@ -774,19 +930,17 @@ def main():
             workflow_url = repo.get_workflow_run(int(run_id)).html_url
         except (GithubException, ValueError):
             pass
-    
-    # Parse input
+
     def split_input(s: str) -> List[str]:
         if not s:
             return []
         pattern = r"[, \n]+"
         return [part.strip() for part in re.split(pattern, s) if part.strip()]
-    
+
     commits = split_input(args.commits)
     target_branches = split_input(args.target_branches)
     allow_unmerged = getattr(args, 'allow_unmerged', False)
-    
-    # Collect sources
+
     sources = []
     for c in commits:
         ref = c.split('/')[-1].strip()
@@ -797,74 +951,45 @@ def main():
             except GithubException as e:
                 logger.error(f"VALIDATION_ERROR: PR #{pr_num} does not exist: {e}")
                 sys.exit(1)
-            
+
             if not pull.merged and not allow_unmerged:
                 raise ValueError(f"PR #{pr_num} is not merged. Use --allow-unmerged to backport unmerged PRs")
             if not pull.merged:
                 logger.info(f"PR #{pr_num} is not merged, but --allow-unmerged is set, proceeding with commits from PR")
             source = create_pr_source(pull, allow_unmerged, logger)
             sources.append(source)
-            if not pull.merged:
-                logger.info(f"PR #{pr_num} is unmerged, using {len(source.commit_shas)} commits from PR")
-            elif pull.merge_commit_sha:
-                merge_commit = repo.get_commit(pull.merge_commit_sha)
-                if merge_commit.parents and len(merge_commit.parents) > 1:
-                    logger.info(f"PR #{pr_num} was merged as merge commit, using {len(source.commit_shas)} individual commits")
-                else:
-                    logger.info(f"PR #{pr_num} was merged as squash/rebase, using merge_commit_sha")
         except ValueError:
-            # Not a PR number, treat as commit SHA
             try:
                 expanded_sha = expand_sha(repo, ref, logger)
             except ValueError as e:
                 logger.error(f"VALIDATION_ERROR: Failed to expand SHA {ref}: {e}")
                 sys.exit(1)
-            
+
             try:
                 commit = repo.get_commit(expanded_sha)
             except GithubException as e:
                 logger.error(f"VALIDATION_ERROR: Commit {ref} (expanded to {expanded_sha}) does not exist: {e}")
                 sys.exit(1)
-            
-            # Check if commit is linked to PR
+
             pulls = commit.get_pulls()
             if pulls.totalCount > 0:
                 pr = pulls.get_page(0)[0]
                 if not pr.merged and not allow_unmerged:
                     raise ValueError(f"PR #{pr.number} (associated with commit {expanded_sha[:7]}) is not merged. Cannot backport unmerged PR. Use --allow-unmerged to allow")
-                if not pr.merged:
-                    logger.info(f"PR #{pr.number} (associated with commit {expanded_sha[:7]}) is not merged, but --allow-unmerged is set, proceeding")
-            
             source = create_commit_source(commit, repo, logger)
             sources.append(source)
-    
-    # Validate
+
     all_commit_shas = []
-    all_pull_requests = []
     for source in sources:
         all_commit_shas.extend(source.commit_shas)
-        all_pull_requests.extend(source.pull_requests)
-    
+
     if not all_commit_shas:
         logger.error("VALIDATION_ERROR: No commits to cherry-pick")
         sys.exit(1)
     if not target_branches:
         logger.error("VALIDATION_ERROR: No target branches specified")
         sys.exit(1)
-    
-    for pull in all_pull_requests:
-        if not pull.merged and not allow_unmerged:
-            logger.error(f"VALIDATION_ERROR: PR #{pull.number} is not merged. Use --allow-unmerged to allow backporting unmerged PRs")
-            sys.exit(1)
-    
-    for commit_sha in all_commit_shas:
-        try:
-            repo.get_commit(commit_sha)
-        except GithubException as e:
-            logger.error(f"VALIDATION_ERROR: Commit {commit_sha} does not exist: {e}")
-            sys.exit(1)
-    
-    # Validate branches and collect invalid ones
+
     invalid_branches = []
     for branch in target_branches:
         try:
@@ -872,91 +997,69 @@ def main():
         except GithubException as e:
             logger.error(f"VALIDATION_ERROR: Branch {branch} does not exist: {e}")
             invalid_branches.append(branch)
-    
-    # Remove invalid branches from target_branches
+
     valid_target_branches = [b for b in target_branches if b not in invalid_branches]
-    
     if not valid_target_branches:
         logger.error("VALIDATION_ERROR: No valid target branches after validation")
         sys.exit(1)
-    
+
     if invalid_branches:
         logger.warning(f"VALIDATION_WARNING: Skipping invalid branches: {', '.join(invalid_branches)}")
-    
+
     logger.info("Input validation successful")
-    
-    # Create initial comment
-    backport_comments = []
-    if all_pull_requests:
-        target_branches_str = ', '.join([f"`{b}`" for b in target_branches])
-        if workflow_url:
-            new_line = f"Backport to {target_branches_str} in progress: [workflow run]({workflow_url})"
-        else:
-            new_line = f"Backport to {target_branches_str} in progress"
-        
-        for pull in all_pull_requests:
-            try:
-                existing_comment = find_existing_backport_comment(pull, logger)
-                if existing_comment:
-                    existing_body = existing_comment.body
-                    branches_already_mentioned = all(f"`{b}`" in existing_body for b in target_branches)
-                    should_skip = (
-                        branches_already_mentioned and 
-                        ("in progress" in existing_body) and
-                        (not workflow_url or workflow_url in existing_body)
-                    )
-                    
-                    if should_skip:
-                        backport_comments.append((pull, existing_comment))
-                    else:
-                        existing_comment.edit(f"{existing_body}\n\n{new_line}")
-                        backport_comments.append((pull, existing_comment))
-                        logger.info(f"Updated existing backport comment in original PR #{pull.number}")
-                else:
-                    comment = pull.create_issue_comment(new_line)
-                    backport_comments.append((pull, comment))
-                    logger.info(f"Created initial backport comment in original PR #{pull.number}")
-            except GithubException as e:
-                logger.warning(f"Failed to create/update initial comment in original PR #{pull.number}: {e}")
-    
-    # Clone repository
-    repo_dir = tempfile.mkdtemp(prefix="ydb-cherry-pick-")
+
+    preflights: Dict[str, BranchPreflight] = {}
+    repo_dirs: Dict[str, str] = {}
+    pulls_to_notify: Dict[int, Any] = {}
+
     try:
-        repo_url = f"https://{token}@github.com/{repo_name}.git"
-        logger.info("Cloning repository: %s to %s", repo_url, repo_dir)
-        subprocess.run(
-            ['git', 'clone', repo_url, repo_dir],
-            env={**os.environ, 'GIT_PROTOCOL': '2'},
-            check=True,
-            capture_output=True
+        for target_branch in valid_target_branches:
+            repo_dir = setup_branch_repo(token, repo_name, target_branch, logger)
+            repo_dirs[target_branch] = repo_dir
+            preflight = classify_commits_for_branch(
+                repo_dir, target_branch, all_commit_shas, sources, logger,
+            )
+            preflights[target_branch] = preflight
+            if not preflight.all_present:
+                for pull in get_pulls_for_commits(sources, preflight.needs_backport_shas):
+                    pulls_to_notify[pull.number] = pull
+
+        write_preflight_summary(list(preflights.values()), sources, summary_path, logger)
+
+        has_work = bool(pulls_to_notify)
+
+        if not has_work:
+            logger.info("WORKFLOW_SUCCESS: Nothing to backport — all commits are already present in target branch(es).")
+            if summary_path:
+                with open(summary_path, 'a') as f:
+                    f.write("Nothing to backport — no comments posted to source PRs.\n\n")
+            return
+
+        backport_comments = create_initial_backport_comments(
+            list(pulls_to_notify.values()), target_branches, workflow_url, logger,
         )
-        
-        # Process each target branch
+
         results: List[BackportResult] = []
         branch_failures: List[BranchBackportFailure] = []
-        branch_skips: List[BranchBackportSkipped] = []
-        invalid_branch_set = set(invalid_branches)
-
         has_errors = False
         dtm = datetime.datetime.now().strftime("%y%m%d-%H%M%S")
 
         for target_branch in valid_target_branches:
+            preflight = preflights[target_branch]
+            if preflight.all_present:
+                continue
+
             try:
                 dev_branch_name = f"cherry-pick-{target_branch}-{dtm}"
                 result = process_branch(
-                    repo_dir, target_branch, dev_branch_name, all_commit_shas,
-                    repo_name, repo, token, sources, workflow_triggerer, workflow_url, summary_path, logger
+                    repo_dirs[target_branch], target_branch, dev_branch_name,
+                    preflight.needs_backport_shas, preflight,
+                    repo_name, repo, token, sources, workflow_triggerer,
+                    workflow_url, summary_path, logger,
                 )
                 results.append(result)
             except BranchBackportSkipped as e:
                 logger.info("Branch %s skipped: %s", target_branch, e)
-                branch_skips.append(e)
-                if summary_path:
-                    skipped_labels = ", ".join(
-                        describe_commit(sha, sources) for sha in e.progress.skipped_commit_shas
-                    )
-                    with open(summary_path, 'a') as f:
-                        f.write(f"### Branch `{target_branch}`: skipped\n\nAll commits already present: {skipped_labels}\n\n")
             except CherryPickFailed as e:
                 has_errors = True
                 logger.error("BACKPORT_ERROR: Branch `%s`: %s", target_branch, e)
@@ -975,9 +1078,8 @@ def main():
                         f.write(f"### Branch `{target_branch}`: failed\n\n```\n{e}\n```\n\n")
 
         update_comments(
-            backport_comments, sources, all_commit_shas, results,
-            branch_failures, branch_skips, invalid_branch_set,
-            target_branches, workflow_url, logger,
+            backport_comments, sources, all_commit_shas, preflights, results,
+            branch_failures, set(invalid_branches), target_branches, workflow_url, logger,
         )
 
         if has_errors:
@@ -988,18 +1090,10 @@ def main():
                     f.write(f"**{error_msg}**\n\n")
             sys.exit(1)
 
-        if branch_skips and not results:
-            logger.info(
-                "WORKFLOW_SUCCESS: Nothing to backport — all commits are already present in target branch(es)."
-            )
-            if summary_path:
-                with open(summary_path, 'a') as f:
-                    f.write("Nothing to backport — all commits are already present in target branch(es).\n\n")
-        else:
-            logger.info("WORKFLOW_SUCCESS: Cherry-pick workflow completed successfully")
-            if summary_path:
-                with open(summary_path, 'a') as f:
-                    f.write("Cherry-pick workflow completed successfully\n\n")
+        logger.info("WORKFLOW_SUCCESS: Cherry-pick workflow completed successfully")
+        if summary_path:
+            with open(summary_path, 'a') as f:
+                f.write("Cherry-pick workflow completed successfully\n\n")
         if results_path:
             with open(results_path, 'w') as f:
                 json.dump(
@@ -1008,8 +1102,9 @@ def main():
                     indent=2,
                 )
     finally:
-        if os.path.exists(repo_dir):
-            shutil.rmtree(repo_dir)
+        for repo_dir in repo_dirs.values():
+            if os.path.exists(repo_dir):
+                shutil.rmtree(repo_dir)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/cherry_pick_v2.yml
+++ b/.github/workflows/cherry_pick_v2.yml
@@ -67,6 +67,7 @@ jobs:
             ${{ inputs.allow_unmerged == true && '--allow-unmerged' || '' }}
 
       - name: Upload Artifact
+        if: success() && hashFiles('created_pulls.json') != ''
         uses: actions/upload-artifact@v7
         with:
           name: created-pulls


### PR DESCRIPTION
## Summary
- Handle empty cherry-picks when commits are already present in the target branch instead of failing with an opaque `RuntimeError`
- Post per-PR backport status comments (`already present`, `included in backport PR`, `failed`, etc.) instead of one identical comment on all source PRs
- Improve workflow summary/error messages and skip artifact upload when no backport PR was created

## Test plan
- [ ] Run `Cherry-pick_v2` with a PR already present in the target branch and verify workflow succeeds with `already present` comment
- [ ] Run with a mixed list (some PRs already in stable, some not) and verify skipped PRs get `already present`, others get `included in backport PR`
- [ ] Run with a PR that causes a real cherry-pick failure and verify the failing PR gets a detailed `failed (...)` comment


Made with [Cursor](https://cursor.com)