### PR TITLE
Support multiple DML in one query for READ COMMITTED

### DIFF
--- a/ydb/core/kqp/host/kqp_host.cpp
+++ b/ydb/core/kqp/host/kqp_host.cpp
@@ -1658,6 +1658,7 @@ private:
             YQL_ENSURE(*settings.ConcurrentResults || queryType == EKikimrQueryType::Query);
             SessionCtx->Query().ConcurrentResults = *settings.ConcurrentResults;
         }
+        SessionCtx->Query().IsolateEffects = settings.UsePessimisticLocks;
         if (settings.RuntimeParameterSizeLimitSatisfied) {
             SessionCtx->Query().RuntimeParameterSizeLimitSatisfied = settings.RuntimeParameterSizeLimitSatisfied;
         }

--- a/ydb/core/kqp/provider/yql_kikimr_opt.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt.cpp
@@ -64,7 +64,7 @@ TAutoPtr<IGraphTransformer> CreateKiLogicalOptProposalTransformer(TIntrusivePtr<
             if (auto maybeDatasink = node.Maybe<TCoCommit>().DataSink().Maybe<TKiDataSink>()) {
                 auto cluster = TString(maybeDatasink.Cast().Cluster());
 
-                ret = KiBuildQuery(node, ctx, sessionCtx->GetDatabase(), sessionCtx->TablesPtr(), types, sessionCtx->Query().ConcurrentResults);
+                ret = KiBuildQuery(node, ctx, sessionCtx->GetDatabase(), sessionCtx->TablesPtr(), types, sessionCtx->Query().ConcurrentResults, sessionCtx->Query().IsolateEffects);
 
                 if (ret != inputNode) {
                     return ret;

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -183,6 +183,8 @@ struct TKiExploreTxResults {
 
         if (uncommittedChangesRead || IsolateEffects) {
             AddQueryBlock();
+        }
+        if (uncommittedChangesRead) {
             SetBlockHasUncommittedChangesRead();
         }
     }

--- a/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_opt_build.cpp
@@ -99,6 +99,7 @@ struct TKiExploreTxResults {
     };
 
     bool ConcurrentResults = true;
+    bool IsolateEffects = false;
 
     THashSet<const TExprNode*> Ops;
     TVector<TExprBase> Sync;
@@ -180,7 +181,7 @@ struct TKiExploreTxResults {
             uncommittedChangesRead = HasWriteOps(tableMeta->Name);
         }
 
-        if (uncommittedChangesRead) {
+        if (uncommittedChangesRead || IsolateEffects) {
             AddQueryBlock();
             SetBlockHasUncommittedChangesRead();
         }
@@ -269,7 +270,7 @@ struct TKiExploreTxResults {
             }
         }
 
-        if (QueryBlocks.empty() || uncommittedChangesRead) {
+        if (QueryBlocks.empty() || uncommittedChangesRead || IsolateEffects) {
             AddQueryBlock();
         }
 
@@ -931,7 +932,7 @@ TString GetShowCreateType(const TExprNode& settings) {
 } // anonymous namespace
 
 TExprNode::TPtr KiBuildQuery(TExprBase node, TExprContext& ctx, TStringBuf database, TIntrusivePtr<TKikimrTablesData> tablesData,
-    TTypeAnnotationContext& types, bool concurrentResults) {
+    TTypeAnnotationContext& types, bool concurrentResults, bool isolateEffects) {
     if (!node.Maybe<TCoCommit>().DataSink().Maybe<TKiDataSink>()) {
         return node.Ptr();
     }
@@ -1200,6 +1201,7 @@ TExprNode::TPtr KiBuildQuery(TExprBase node, TExprContext& ctx, TStringBuf datab
 
     TKiExploreTxResults txExplore;
     txExplore.ConcurrentResults = concurrentResults;
+    txExplore.IsolateEffects = isolateEffects;
     if (!ExploreTx(commit.World(), ctx, kiDataSink, txExplore, tablesData, types) || txExplore.HasErrors) {
         if (txExplore.HasErrors) {
             ctx.AddError(TIssue(ctx.GetPosition(node.Pos()), "ExploreTx failed"));

--- a/ydb/core/kqp/provider/yql_kikimr_provider.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.cpp
@@ -174,6 +174,7 @@ void TKikimrQueryContext::Reset() {
     SuppressDdlChecks = false;
     StatsMode = EKikimrStatsMode::None;
     Type = EKikimrQueryType::Unspecified;
+    IsolateEffects = false;
     Deadlines = {};
     Limits = {};
 

--- a/ydb/core/kqp/provider/yql_kikimr_provider.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider.h
@@ -157,6 +157,7 @@ struct TKikimrQueryContext : TThrRefBase {
     bool DocumentApiRestricted = true;
     bool IsInternalCall = false;
     bool ConcurrentResults = true;
+    bool IsolateEffects = false;
     i32 RuntimeParameterSizeLimit = 0;
     bool RuntimeParameterSizeLimitSatisfied = false;
 

--- a/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
+++ b/ydb/core/kqp/provider/yql_kikimr_provider_impl.h
@@ -355,7 +355,7 @@ void FillLiteralProto(const NNodes::TCoPgConst& literal, Ydb::TypedValue& proto)
 
 // Optimizer rules
 TExprNode::TPtr KiBuildQuery(NNodes::TExprBase node, TExprContext& ctx, TStringBuf database, TIntrusivePtr<TKikimrTablesData> tablesData,
-    TTypeAnnotationContext& types, bool sequentialResults);
+    TTypeAnnotationContext& types, bool concurrentResults, bool isolateEffects = false);
 TExprNode::TPtr KiBuildResult(NNodes::TExprBase node,  const TString& cluster, TExprContext& ctx);
 
 const THashSet<TStringBuf>& KikimrDataSourceFunctions();

--- a/ydb/core/kqp/ut/tx/kqp_read_committed_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_read_committed_ut.cpp
@@ -494,11 +494,41 @@ Y_UNIT_TEST_SUITE(KqpReadCommitted) {
         tester.Execute();
     }
 
-    Y_UNIT_TEST(TMultiStatements) {
+    Y_UNIT_TEST(TMultiStatementsDifferentTables) {
         TReadCommittedTakesLocks tester(R"(
             INSERT INTO `/Root/Test2` (Group, Name, Comment) VALUES (1u, "Unknown", "Inserted");
             INSERT INTO `/Root/Test` (Group, Name, Comment) VALUES (1u, "Unknown", "Inserted");
             )", 1 + 0, 4 + 2, 2 + 1);
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(TMultiStatementsUpdateInsert) {
+        TReadCommittedTakesLocks tester(R"(
+            UPDATE `/Root/Test` SET Comment = "Updated" WHERE Name == "Paul";
+            INSERT INTO `/Root/Test` (Group, Name, Comment) VALUES (2u, "New", "Inserted");
+            )", 1 + 0, 1 + 1 + 1, 2 + 1);
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(TMultiStatementsSameTable) {
+        TReadCommittedTakesLocks tester(R"(
+            INSERT INTO `/Root/Test` (Group, Name, Comment) VALUES (1u, "First", "Inserted");
+            INSERT INTO `/Root/Test` (Group, Name, Comment) VALUES (2u, "Second", "Inserted");
+            )", 0 + 0, 1 + 1 + 1, 1 + 1);
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
+    Y_UNIT_TEST(TMultiStatementsInsertAndSelect) {
+        TReadCommittedTakesLocks tester(R"(
+            INSERT INTO `/Root/Test` (Group, Name, Comment) VALUES (5u, "ToSelect", "BeforeSelect");
+            SELECT * FROM `/Root/Test` WHERE Group == 5u ORDER BY Name;
+            )", 0 + 1, 1 + 1, 1 + 0);
         tester.SetIsOlap(false);
         tester.SetUseRealThreads(false);
         tester.Execute();

--- a/ydb/core/kqp/ut/tx/kqp_read_committed_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_read_committed_ut.cpp
@@ -494,6 +494,16 @@ Y_UNIT_TEST_SUITE(KqpReadCommitted) {
         tester.Execute();
     }
 
+    Y_UNIT_TEST(TMultiStatements) {
+        TReadCommittedTakesLocks tester(R"(
+            INSERT INTO `/Root/Test2` (Group, Name, Comment) VALUES (1u, "Unknown", "Inserted");
+            INSERT INTO `/Root/Test` (Group, Name, Comment) VALUES (1u, "Unknown", "Inserted");
+            )", 1 + 0, 4 + 2, 2 + 1);
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
     class TpccPaymentReturningConflict : public TTableDataModificationTester {
     protected:
         void Setup(TKikimrSettings& settings) override {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix #40574  Support multiple DML in one query for READ COMMITTED
