### PR TITLE
Support RowId for JsonIndex, fix consistent copy for fulltext/json indexes

### DIFF
--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -202,6 +202,8 @@ public:
                 // is enabled, so that UseRowIdAsDocId survives downstream into the query compiler.
                 if (index.GetSpecializedIndexDescriptionCase() == NKikimrSchemeOp::TIndexDescription::kFulltextIndexDescription) {
                     SpecializedIndexDescription = index.GetFulltextIndexDescription();
+                } else {
+                    YQL_ENSURE(index.GetSpecializedIndexDescriptionCase() == NKikimrSchemeOp::TIndexDescription::SPECIALIZEDINDEXDESCRIPTION_NOT_SET);
                 }
                 break;
             case EType::LocalBloomFilter:
@@ -246,6 +248,8 @@ public:
                 // JSON indexes carry a fulltext description only in rowid mode (__ydb_row_id as doc_id).
                 if (message->GetSpecializedIndexDescriptionCase() == NKikimrKqp::TIndexDescriptionProto::kFulltextIndexDescription) {
                     SpecializedIndexDescription = message->GetFulltextIndexDescription();
+                } else {
+                    YQL_ENSURE(message->GetSpecializedIndexDescriptionCase() == NKikimrKqp::TIndexDescriptionProto::SPECIALIZEDINDEXDESCRIPTION_NOT_SET);
                 }
                 break;
             case EType::GlobalSyncVectorKMeansTree:

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -177,9 +177,7 @@ public:
             case EType::GlobalSync:
             case EType::GlobalAsync:
             case EType::GlobalSyncUnique:
-            case EType::GlobalJson:
             case EType::LocalMinMax:
-            case EType::GlobalJsonCompact:
                 // no specialized index description
                 YQL_ENSURE(index.GetSpecializedIndexDescriptionCase() == NKikimrSchemeOp::TIndexDescription::SPECIALIZEDINDEXDESCRIPTION_NOT_SET);
                 break;
@@ -198,6 +196,14 @@ public:
                 SpecializedIndexDescription = index.GetFulltextIndexDescription();
                 break;
             }
+            case EType::GlobalJson:
+            case EType::GlobalJsonCompact:
+                // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)
+                // is enabled, so that UseRowIdAsDocId survives downstream into the query compiler.
+                if (index.GetSpecializedIndexDescriptionCase() == NKikimrSchemeOp::TIndexDescription::kFulltextIndexDescription) {
+                    SpecializedIndexDescription = index.GetFulltextIndexDescription();
+                }
+                break;
             case EType::LocalBloomFilter:
                 if (index.HasBloomFilterDescription()) {
                     SpecializedIndexDescription = ExtractBloomFilterDescription(index.GetBloomFilterDescription());
@@ -231,11 +237,16 @@ public:
             case EType::GlobalSync:
             case EType::GlobalAsync:
             case EType::GlobalSyncUnique:
-            case EType::GlobalJson:
             case EType::LocalMinMax:
-            case EType::GlobalJsonCompact:
                 // no specialized index description
                 YQL_ENSURE(message->GetSpecializedIndexDescriptionCase() == NKikimrKqp::TIndexDescriptionProto::SPECIALIZEDINDEXDESCRIPTION_NOT_SET);
+                break;
+            case EType::GlobalJson:
+            case EType::GlobalJsonCompact:
+                // JSON indexes carry a fulltext description only in rowid mode (__ydb_row_id as doc_id).
+                if (message->GetSpecializedIndexDescriptionCase() == NKikimrKqp::TIndexDescriptionProto::kFulltextIndexDescription) {
+                    SpecializedIndexDescription = message->GetFulltextIndexDescription();
+                }
                 break;
             case EType::GlobalSyncVectorKMeansTree:
                 SpecializedIndexDescription = message->GetVectorIndexKmeansTreeDescription();
@@ -355,11 +366,18 @@ public:
             case EType::GlobalSync:
             case EType::GlobalAsync:
             case EType::GlobalSyncUnique:
-            case EType::GlobalJson:
             case EType::LocalMinMax:
-            case EType::GlobalJsonCompact:
                 // no specialized index description
                 Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
+                break;
+            case EType::GlobalJson:
+            case EType::GlobalJsonCompact:
+                // JSON indexes carry a fulltext description only in rowid mode (__ydb_row_id as doc_id).
+                if (const auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&SpecializedIndexDescription)) {
+                    *message->MutableFulltextIndexDescription() = *ft;
+                } else {
+                    Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
+                }
                 break;
             case EType::GlobalSyncVectorKMeansTree:
                 *message->MutableVectorIndexKmeansTreeDescription() = std::get<NKikimrKqp::TVectorIndexKmeansTreeDescription>(SpecializedIndexDescription);

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1414,40 +1414,42 @@ private:
             auto [indexMeta, index] = tableMeta->GetIndex(indexName);
 
             NKqpProto::EKqpFullTextIndexType kqpType;
-            bool hasDesc = false;
+            bool isDescriptionRequired = true;
+
             switch (index->Type) {
             case TIndexDescription::EType::GlobalFulltextRelevance:
                 kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextRelevance;
-                hasDesc = true;
                 break;
             case TIndexDescription::EType::GlobalFulltextPlain:
                 kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextPlain;
-                hasDesc = true;
                 break;
             case TIndexDescription::EType::GlobalJson:
                 kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextJson;
+                isDescriptionRequired = false;
                 break;
             case TIndexDescription::EType::GlobalFulltextCompactRelevance:
                 kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompactRelevance;
-                hasDesc = true;
                 break;
             case TIndexDescription::EType::GlobalFulltextCompact:
                 kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextCompact;
-                hasDesc = true;
                 break;
             case TIndexDescription::EType::GlobalJsonCompact:
                 kqpType = NKqpProto::EKqpFullTextIndexType::EKqpFullTextJsonCompact;
+                isDescriptionRequired = false;
                 break;
             default:
                 YQL_ENSURE(false, "Index type " << index->Type << " is not supported");
             }
+
             fullTextProto.SetIndexType(kqpType);
-            if (hasDesc) {
-                auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
-                YQL_ENSURE(desc, "unexpected index description type");
+
+            // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id) is enabled.
+            if (auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription)) {
                 // Copy the whole description (incl. UseRowIdAsDocId), not just Settings; the
                 // index type was already set from the switch above (handles Compact variants too).
                 fullTextProto.MutableIndexDescription()->CopyFrom(*desc);
+            } else if (isDescriptionRequired) {
+                YQL_ENSURE(false, "Fulltext index description is required for index type " << index->Type);
             }
 
             auto fillCol = [&](const NYql::TKikimrColumnMetadata* columnMeta, NKikimrKqp::TKqpColumnMetadataProto* columnProto) {
@@ -1485,52 +1487,53 @@ private:
                 }
             }
 
-            if (index->Type != TIndexDescription::EType::GlobalJson) {
-                auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
-                if (desc && desc->GetUseRowIdAsDocId()) {
-                    const TIndexDescription* uniqueIdx = nullptr;
-                    TIntrusivePtr<TKikimrTableMetadata> uniqueImplMeta;
-                    TString uniqueIdxName;
-                    YQL_ENSURE(tableMeta->Indexes.size() == tableMeta->ImplTables.size());
-                    for (size_t i = 0; i < tableMeta->Indexes.size(); ++i) {
-                        const auto& candidate = tableMeta->Indexes[i];
-                        if (candidate.Type == TIndexDescription::EType::GlobalSyncUnique
-                            && candidate.State == TIndexDescription::EIndexState::Ready
-                            && candidate.KeyColumns.size() == 1
-                            && candidate.KeyColumns[0] == NKikimr::NTableIndex::NFulltext::RowIdColumn)
-                        {
-                            uniqueIdx = &candidate;
-                            uniqueImplMeta = tableMeta->ImplTables[i];
-                            uniqueIdxName = candidate.Name;
-                            break;
-                        }
+            // Resolve the unique secondary index over __ydb_row_id used to map doc_id back to the
+            // main-table PK. Applies to both fulltext and JSON indexes in rowid mode (the
+            // GetUseRowIdAsDocId() check below is false for legacy indexes, so this is a no-op there).
+            auto* desc = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&index->SpecializedIndexDescription);
+            if (desc && desc->GetUseRowIdAsDocId()) {
+                const TIndexDescription* uniqueIdx = nullptr;
+                TIntrusivePtr<TKikimrTableMetadata> uniqueImplMeta;
+                TString uniqueIdxName;
+                YQL_ENSURE(tableMeta->Indexes.size() == tableMeta->ImplTables.size());
+                for (size_t i = 0; i < tableMeta->Indexes.size(); ++i) {
+                    const auto& candidate = tableMeta->Indexes[i];
+                    if (candidate.Type == TIndexDescription::EType::GlobalSyncUnique
+                        && candidate.State == TIndexDescription::EIndexState::Ready
+                        && candidate.KeyColumns.size() == 1
+                        && candidate.KeyColumns[0] == NKikimr::NTableIndex::NFulltext::RowIdColumn)
+                    {
+                        uniqueIdx = &candidate;
+                        uniqueImplMeta = tableMeta->ImplTables[i];
+                        uniqueIdxName = candidate.Name;
+                        break;
                     }
-                    YQL_ENSURE(uniqueIdx, "fulltext index has UseRowIdAsDocId=true but no Ready unique index on " << NKikimr::NTableIndex::NFulltext::RowIdColumn << " was found");
-                    YQL_ENSURE(uniqueImplMeta);
+                }
+                YQL_ENSURE(uniqueIdx, "fulltext index has UseRowIdAsDocId=true but no Ready unique index on " << NKikimr::NTableIndex::NFulltext::RowIdColumn << " was found");
+                YQL_ENSURE(uniqueImplMeta);
 
-                    TVector<TString> uniquePathParts = {
-                        TString(settings.Table().Cast().Path()),
-                        uniqueIdxName,
-                        TString(NKikimr::NTableIndex::ImplTable),
-                    };
-                    TString uniqueImplPath = NKikimr::JoinPath(uniquePathParts);
-                    FillTablesMap(uniqueImplPath, tablesMap);
+                TVector<TString> uniquePathParts = {
+                    TString(settings.Table().Cast().Path()),
+                    uniqueIdxName,
+                    TString(NKikimr::NTableIndex::ImplTable),
+                };
+                TString uniqueImplPath = NKikimr::JoinPath(uniquePathParts);
+                FillTablesMap(uniqueImplPath, tablesMap);
 
-                    auto* uniqueProto = fullTextProto.MutableUniqueIndexImplTable();
-                    uniqueProto->MutableTable()->SetOwnerId(uniqueImplMeta->PathId.OwnerId());
-                    uniqueProto->MutableTable()->SetTableId(uniqueImplMeta->PathId.TableId());
-                    uniqueProto->MutableTable()->SetPath(uniqueImplPath);
-                    uniqueProto->MutableTable()->SetSysView(uniqueImplMeta->SysView);
-                    uniqueProto->MutableTable()->SetVersion(uniqueImplMeta->SchemaVersion);
+                auto* uniqueProto = fullTextProto.MutableUniqueIndexImplTable();
+                uniqueProto->MutableTable()->SetOwnerId(uniqueImplMeta->PathId.OwnerId());
+                uniqueProto->MutableTable()->SetTableId(uniqueImplMeta->PathId.TableId());
+                uniqueProto->MutableTable()->SetPath(uniqueImplPath);
+                uniqueProto->MutableTable()->SetSysView(uniqueImplMeta->SysView);
+                uniqueProto->MutableTable()->SetVersion(uniqueImplMeta->SchemaVersion);
 
-                    // Only KeyColumns are consumed by the runtime reader (see TUniqueIndexReader in
-                    // kqp_full_text_source.cpp); it never reads UniqueIndexImplTable.Columns. Filling
-                    // the full column list here would just bloat the protobuf with unused data.
-                    for (auto& keyColumn : uniqueImplMeta->KeyColumnNames) {
-                        auto* columnPtr = uniqueImplMeta->Columns.FindPtr(keyColumn);
-                        YQL_ENSURE(columnPtr);
-                        fillCol(columnPtr, uniqueProto->AddKeyColumns());
-                    }
+                // Only KeyColumns are consumed by the runtime reader (see TUniqueIndexReader in
+                // kqp_full_text_source.cpp); it never reads UniqueIndexImplTable.Columns. Filling
+                // the full column list here would just bloat the protobuf with unused data.
+                for (auto& keyColumn : uniqueImplMeta->KeyColumnNames) {
+                    auto* columnPtr = uniqueImplMeta->Columns.FindPtr(keyColumn);
+                    YQL_ENSURE(columnPtr);
+                    fillCol(columnPtr, uniqueProto->AddKeyColumns());
                 }
             }
 
@@ -2617,7 +2620,8 @@ private:
             bool hasFulltextRowIdMode = false;
             for (const auto& idx : tableMeta->Indexes) {
                 if (idx.Type != TIndexDescription::EType::GlobalFulltextPlain
-                    && idx.Type != TIndexDescription::EType::GlobalFulltextRelevance)
+                    && idx.Type != TIndexDescription::EType::GlobalFulltextRelevance
+                    && idx.Type != TIndexDescription::EType::GlobalJson)
                 {
                     continue;
                 }

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1509,7 +1509,8 @@ private:
                         break;
                     }
                 }
-                YQL_ENSURE(uniqueIdx, "fulltext index has UseRowIdAsDocId=true but no Ready unique index on " << NKikimr::NTableIndex::NFulltext::RowIdColumn << " was found");
+                YQL_ENSURE(uniqueIdx, "Index '" << indexName << "' has UseRowIdAsDocId=true but no Ready unique index on '"
+                    << NKikimr::NTableIndex::NFulltext::RowIdColumn << "' was found");
                 YQL_ENSURE(uniqueImplMeta);
 
                 TVector<TString> uniquePathParts = {

--- a/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
+++ b/ydb/core/kqp/query_compiler/kqp_query_compiler.cpp
@@ -1449,7 +1449,7 @@ private:
                 // index type was already set from the switch above (handles Compact variants too).
                 fullTextProto.MutableIndexDescription()->CopyFrom(*desc);
             } else if (isDescriptionRequired) {
-                YQL_ENSURE(false, "Fulltext index description is required for index type " << index->Type);
+                YQL_ENSURE(false, "Index description is required for index type " << index->Type);
             }
 
             auto fillCol = [&](const NYql::TKikimrColumnMetadata* columnMeta, NKikimrKqp::TKqpColumnMetadataProto* columnProto) {

--- a/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
+++ b/ydb/core/kqp/ut/indexes/json/kqp_indexes_json_ut.cpp
@@ -7,6 +7,22 @@ namespace NKikimr::NKqp {
 using namespace NYdb::NQuery;
 using namespace NYdb;
 
+namespace {
+
+// A runner for the __ydb_row_id opt-in: JSON indexes plus the unique-index feature, so a JSON index
+// over a non-single-integer primary key can use __ydb_row_id as its doc_id and resolve it back to the
+// primary key through a unique secondary index (the mechanism shared with fulltext indexes).
+TKikimrRunner KikimrJsonRowId() {
+    NKikimrConfig::TFeatureFlags featureFlags;
+    featureFlags.SetEnableJsonIndex(true);
+    featureFlags.SetEnableAddUniqueIndex(true);
+    auto settings = TKikimrSettings().SetFeatureFlags(featureFlags);
+    settings.AppConfig.MutableTableServiceConfig()->SetBackportMode(NKikimrConfig::TTableServiceConfig_EBackportMode_All);
+    return TKikimrRunner(settings);
+}
+
+} // namespace
+
 Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     Y_UNIT_TEST(AddJsonIndexJson) {
         TestAddJsonIndex("Json", true);
@@ -142,6 +158,8 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST(NonIntegerPk) {
+        // With the unique-index feature OFF (the default), a JSON index over a non-integer PK can neither
+        // use the PK as doc_id nor auto-provision the __ydb_row_id infrastructure, so it is rejected.
         auto kikimr = Kikimr();
         auto db = kikimr.GetQueryClient();
 
@@ -166,8 +184,86 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             )";
             auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
-                "Error: JSON index requires primary key column 'Key' to be of type 'Uint64', 'Int64', 'Uint32' or 'Int32' but got Utf8");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "requires the unique-index feature");
+        }
+    }
+
+    Y_UNIT_TEST(NonIntegerPkRowId) {
+        // End-to-end: a table keyed by a non-integer (Utf8) PK plus a __ydb_row_id Uint64 NOT NULL column
+        // and a unique secondary index on __ydb_row_id supports a JSON index. The JSON index uses
+        // __ydb_row_id as doc_id; the runtime resolves __ydb_row_id -> PK before reading the main table.
+        // Mirrors SelectWithFulltextMatch_RowIdOptIn_Plain in kqp_fulltext_search_ut.cpp.
+        auto kikimr = KikimrJsonRowId();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key Utf8 NOT NULL,
+                    Text Json,
+                    Data Utf8,
+                    __ydb_row_id Uint64 NOT NULL,
+                    PRIMARY KEY (Key)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX uniq_rowid GLOBAL UNIQUE ON (__ydb_row_id);
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                UPSERT INTO `/Root/TestTable` (Key, Text, Data, __ydb_row_id) VALUES
+                    ("a"u, Json('{"k1": 1}'),  "d1"u, 100),
+                    ("b"u, Json('{"k1": 2}'),  "d2"u, 200),
+                    ("c"u, Json('{"k2": 3}'),  "d3"u, 300),
+                    ("d"u, Json('{"k1": 10}'), "d4"u, 400);
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            // The __ydb_row_id column + Ready unique index already exist, so the JSON index build enables
+            // rowid mode through the "Reuse" classification.
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            // Row "d" has k1 == 10; doc_id -> PK resolution must return its Utf8 key.
+            std::string query = R"(
+                SELECT Key FROM `/Root/TestTable` VIEW json_idx
+                WHERE JSON_VALUE(Text, '$.k1' RETURNING Int64) == 10
+                ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 1);
+        }
+
+        {
+            std::string query = R"(
+                SELECT Key FROM `/Root/TestTable` VIEW json_idx
+                WHERE JSON_EXISTS(Text, '$.k2')
+                ORDER BY Key;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 1);
         }
     }
 
@@ -188,6 +284,7 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
     }
 
     Y_UNIT_TEST(NoCompositePk) {
+        // With the unique-index feature OFF (the default), a composite-PK table cannot host a JSON index.
         auto kikimr = Kikimr();
         auto db = kikimr.GetQueryClient();
 
@@ -213,8 +310,71 @@ Y_UNIT_TEST_SUITE(KqpJsonIndexes) {
             )";
             auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
             UNIT_ASSERT_C(!result.IsSuccess(), result.GetIssues().ToString());
-            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(),
-                "Error: JSON index requires exactly one primary key column of type 'Uint64', 'Int64', 'Uint32' or 'Int32', but table has 2 primary key columns");
+            UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "requires the unique-index feature");
+        }
+    }
+
+    Y_UNIT_TEST(CompositePkRowId) {
+        // A composite-PK table with an explicit __ydb_row_id Uint64 NOT NULL column and a unique index on
+        // it supports a JSON index that resolves the synthetic doc_id back to the (Key1, Key2) primary key.
+        auto kikimr = KikimrJsonRowId();
+        auto db = kikimr.GetQueryClient();
+
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::BUILD_INDEX, NActors::NLog::PRI_TRACE);
+        kikimr.GetTestServer().GetRuntime()->SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        {
+            std::string query = R"(
+                CREATE TABLE `/Root/TestTable` (
+                    Key1 Uint64 NOT NULL,
+                    Key2 Uint64 NOT NULL,
+                    Text Json,
+                    __ydb_row_id Uint64 NOT NULL,
+                    PRIMARY KEY (Key1, Key2)
+                );
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX uniq_rowid GLOBAL UNIQUE ON (__ydb_row_id);
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                UPSERT INTO `/Root/TestTable` (Key1, Key2, Text, __ydb_row_id) VALUES
+                    (1, 1, Json('{"k1": 1}'),  100),
+                    (1, 2, Json('{"k1": 2}'),  200),
+                    (2, 1, Json('{"k2": 3}'),  300),
+                    (2, 2, Json('{"k1": 10}'), 400);
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            std::string query = R"(
+                ALTER TABLE `/Root/TestTable` ADD INDEX json_idx GLOBAL USING json ON (Text)
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        {
+            // Three rows have k1; doc_id -> (Key1, Key2) resolution must return all of them.
+            std::string query = R"(
+                SELECT Key1, Key2 FROM `/Root/TestTable` VIEW json_idx
+                WHERE JSON_EXISTS(Text, '$.k1')
+                ORDER BY Key1, Key2;
+            )";
+            auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+            UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 3);
         }
     }
 

--- a/ydb/core/tx/schemeshard/index/build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index.cpp
@@ -113,6 +113,9 @@ void TSchemeShard::PersistCreateBuildIndex(NIceDb::TNiceDb& db, const TIndexBuil
             case NKikimrSchemeOp::EIndexTypeGlobal:
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
+                // no specialized index description
+                Y_ASSERT(std::holds_alternative<std::monostate>(info.SpecializedIndexDescription));
+                break;
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
             case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
                 // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)

--- a/ydb/core/tx/schemeshard/index/build_index.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index.cpp
@@ -115,8 +115,13 @@ void TSchemeShard::PersistCreateBuildIndex(NIceDb::TNiceDb& db, const TIndexBuil
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
             case NKikimrSchemeOp::EIndexTypeGlobalJson:
             case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
-                // no specialized index description
-                Y_ASSERT(std::holds_alternative<std::monostate>(info.SpecializedIndexDescription));
+                // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)
+                // has been enabled; otherwise there is no specialized index description.
+                if (const auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&info.SpecializedIndexDescription)) {
+                    *serializableRepresentation.MutableFulltextIndexDescription() = *ft;
+                } else {
+                    Y_ASSERT(std::holds_alternative<std::monostate>(info.SpecializedIndexDescription));
+                }
                 break;
             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
                 *serializableRepresentation.MutableVectorIndexKmeansTreeDescription() =

--- a/ydb/core/tx/schemeshard/index/build_index__create.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__create.cpp
@@ -178,8 +178,16 @@ public:
                 tableInfo, tablePath.Base()->GetChildren(), Self->Indexes, indexDesc, explain);
             auto enableRowIdMode = [&]() {
                 indexDesc.MutableFulltextIndexDescription()->SetUseRowIdAsDocId(true);
-                std::get<NKikimrSchemeOp::TFulltextIndexDescription>(buildInfo->SpecializedIndexDescription)
-                    .SetUseRowIdAsDocId(true);
+                // Fulltext index builds always carry a TFulltextIndexDescription. JSON index builds
+                // historically carry std::monostate (no settings); attach a fulltext description here
+                // so the UseRowIdAsDocId flag is persisted and propagated like for fulltext.
+                if (auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&buildInfo->SpecializedIndexDescription)) {
+                    ft->SetUseRowIdAsDocId(true);
+                } else {
+                    NKikimrSchemeOp::TFulltextIndexDescription ftd;
+                    ftd.SetUseRowIdAsDocId(true);
+                    buildInfo->SpecializedIndexDescription = std::move(ftd);
+                }
             };
             switch (classification.Plan) {
                 case NTableIndex::EFulltextRowIdPlan::Error:
@@ -194,7 +202,7 @@ public:
                     if (!Self->EnableAddUniqueIndex) {
                         return Reply(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder()
                             << "Auto-provisioning '" << NTableIndex::NFulltext::RowIdColumn
-                            << "' for a fulltext index on a non-integer-PK table requires the unique-index feature");
+                            << "' for a fulltext/JSON index on a non-integer-PK table requires the unique-index feature");
                     }
                     buildInfo->FulltextNeedsRowIdColumn = classification.NeedColumn;
                     buildInfo->FulltextNeedsUniqueIndex = classification.NeedUniqueIndex;

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -487,8 +487,6 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTablePropose(
 
     auto modifyScheme = AlterMainTableTemplate(ss, buildInfo);
 
-    auto path = TPath::Init(buildInfo.TablePathId, ss);
-
     for (const auto& colInfo : buildInfo.BuildColumns) {
         auto col = modifyScheme.MutableAlterTable()->AddColumns();
         NScheme::TTypeInfo typeInfo;
@@ -503,8 +501,10 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTablePropose(
         col->SetType(NScheme::TypeName(typeInfo, typeMod));
         col->SetName(colInfo.ColumnName);
         if (colInfo.IsFromSequence()) {
-            // DefaultFromSequence stores the sequence leaf; full path is <tablePath>/<leaf>.
-            *col->MutableDefaultFromSequence() = JoinPath({path.PathString(), colInfo.DefaultFromSequence});
+            // Store the sequence as a table-local leaf name (not an absolute path), matching
+            // the create-table convention and how the path describer / KQP key local
+            // sequences by leaf.
+            *col->MutableDefaultFromSequence() = colInfo.DefaultFromSequence;
         } else {
             col->MutableDefaultFromLiteral()->CopyFrom(colInfo.DefaultFromLiteral);
         }

--- a/ydb/core/tx/schemeshard/index/index_build_info.cpp
+++ b/ydb/core/tx/schemeshard/index/index_build_info.cpp
@@ -38,10 +38,18 @@ void TIndexBuildInfo::SerializeToProto(TSchemeShard* ss, NKikimrSchemeOp::TIndex
         case NKikimrSchemeOp::EIndexTypeGlobal:
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-        case NKikimrSchemeOp::EIndexTypeGlobalJson:
-        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
+            break;
+        case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+            // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)
+            // has been enabled; otherwise there is no specialized index description.
+            if (const auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&SpecializedIndexDescription)) {
+                *index.MutableFulltextIndexDescription() = *ft;
+            } else {
+                Y_ASSERT(std::holds_alternative<std::monostate>(SpecializedIndexDescription));
+            }
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
             *index.MutableVectorIndexKmeansTreeDescription() = std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(SpecializedIndexDescription);

--- a/ydb/core/tx/schemeshard/index/index_utils.cpp
+++ b/ydb/core/tx/schemeshard/index/index_utils.cpp
@@ -973,10 +973,13 @@ TFulltextRowIdClassification ClassifyFulltextRowId(
 
     const auto indexType = GetIndexType(indexDesc);
     if (indexType != NKikimrSchemeOp::EIndexTypeGlobalFulltextPlain &&
-        indexType != NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance) {
+        indexType != NKikimrSchemeOp::EIndexTypeGlobalFulltextRelevance &&
+        indexType != NKikimrSchemeOp::EIndexTypeGlobalJson) {
         result.Plan = EFulltextRowIdPlan::NotApplicable;
         return result;
     }
+    // Used in user-facing error messages so a JSON index build does not talk about "Fulltext".
+    const TStringBuf indexKind = (indexType == NKikimrSchemeOp::EIndexTypeGlobalJson) ? "JSON" : "Fulltext";
 
     // Look for a live __ydb_row_id column on the main table.
     const NSchemeShard::TTableInfo::TColumn* rowIdColumn = nullptr;
@@ -1019,14 +1022,14 @@ TFulltextRowIdClassification ClassifyFulltextRowId(
         // A user-managed or previously auto-provisioned __ydb_row_id column exists: it must be well-formed.
         if (rowIdColumn->PType.GetTypeId() != NScheme::NTypeIds::Uint64) {
             error = TStringBuilder()
-                << "Fulltext index opt-in requires column '" << NFulltext::RowIdColumn
+                << indexKind << " index opt-in requires column '" << NFulltext::RowIdColumn
                 << "' to be of type 'Uint64' but got " << NScheme::TypeName(rowIdColumn->PType);
             result.Plan = EFulltextRowIdPlan::Error;
             return result;
         }
         if (!rowIdColumn->NotNull) {
             error = TStringBuilder()
-                << "Fulltext index opt-in requires column '" << NFulltext::RowIdColumn << "' to be NOT NULL";
+                << indexKind << " index opt-in requires column '" << NFulltext::RowIdColumn << "' to be NOT NULL";
             result.Plan = EFulltextRowIdPlan::Error;
             return result;
         }
@@ -1039,7 +1042,7 @@ TFulltextRowIdClassification ClassifyFulltextRowId(
             // A unique index on __ydb_row_id exists but is not Ready - either a concurrent build or an
             // interrupted prior auto-provisioning. Refuse rather than create a duplicate.
             error = TStringBuilder()
-                << "Fulltext index over '" << NFulltext::RowIdColumn << "' found a not-yet-Ready unique"
+                << indexKind << " index over '" << NFulltext::RowIdColumn << "' found a not-yet-Ready unique"
                 << " secondary index on '" << NFulltext::RowIdColumn << "'; wait for it to complete or drop"
                 << " index '" << NFulltext::RowIdUniqueIndexName << "' and retry";
             result.Plan = EFulltextRowIdPlan::Error;
@@ -1061,7 +1064,7 @@ TFulltextRowIdClassification ClassifyFulltextRowId(
     }
 
     TString ignore;
-    if (CheckSingleIntegerPrimaryKey(baseTableColumns, baseColumnTypes, "Fulltext", ignore)) {
+    if (CheckSingleIntegerPrimaryKey(baseTableColumns, baseColumnTypes, indexKind, ignore)) {
         result.Plan = EFulltextRowIdPlan::LegacyIntegerPk;
         return result;
     }
@@ -1093,7 +1096,7 @@ bool MaybeEnableFulltextRowIdMode(
             // driven by ClassifyFulltextRowId in the build-service entry point (TTxCreate) instead.
             if (error.empty()) {
                 error = TStringBuilder()
-                    << "Fulltext index over '" << NFulltext::RowIdColumn
+                    << "Index over '" << NFulltext::RowIdColumn
                     << "' requires a Ready unique secondary index on '" << NFulltext::RowIdColumn << "'";
             }
             return false;

--- a/ydb/core/tx/schemeshard/index/index_utils.h
+++ b/ydb/core/tx/schemeshard/index/index_utils.h
@@ -316,9 +316,14 @@ bool CommonCheck(const TTableDesc& tableDesc, const NKikimrSchemeOp::TIndexCreat
         case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact: {
             Y_ABORT_UNLESS(indexKeys.KeyColumns.size() >= 1);
 
-            if (!CheckSingleIntegerPrimaryKey(baseTableColumns, baseColumnTypes, "JSON", error)) {
-                status = NKikimrScheme::EStatus::StatusInvalidParameter;
-                return false;
+            // __ydb_row_id opt-in: when the rowid mode has been enabled (ClassifyFulltextRowId /
+            // MaybeEnableFulltextRowIdMode), skip the single-integer-PK requirement - the doc_id is
+            // __ydb_row_id, not the PK. Mirrors the fulltext case above.
+            if (!indexDesc.GetFulltextIndexDescription().GetUseRowIdAsDocId()) {
+                if (!CheckSingleIntegerPrimaryKey(baseTableColumns, baseColumnTypes, "JSON", error)) {
+                    status = NKikimrScheme::EStatus::StatusInvalidParameter;
+                    return false;
+                }
             }
 
             if (indexKeys.KeyColumns.size() != 1) {

--- a/ydb/core/tx/schemeshard/olap/operations/prepare_index_validation.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/prepare_index_validation.cpp
@@ -142,7 +142,7 @@ public:
 
         const TTableInfo::TPtr tableInfo = context.SS->Tables.at(txState->TargetPathId);
         tableInfo->AlterVersion += 1;
-        tableInfo->MutablePartitionConfig().SetShadowData(false);
+        tableInfo->MutablePartitionConfig().ClearShadowData();
         tableInfo->MutablePartitionConfig().MutableCompactionPolicy()->SetKeepEraseMarkers(false);
         context.SS->PersistTableAlterVersion(db, txState->TargetPathId, tableInfo);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_table.cpp
@@ -623,7 +623,10 @@ public:
             if (column.HasDefaultFromSequence()) {
                 TString defaultFromSequence = column.GetDefaultFromSequence();
 
-                const auto sequencePath = TPath::Resolve(defaultFromSequence, context.SS);
+                // A table-local sequence is referenced by its leaf name (the create-table convention)
+                const auto sequencePath = defaultFromSequence.StartsWith('/')
+                    ? TPath::Resolve(defaultFromSequence, context.SS)
+                    : path.Child(defaultFromSequence);
                 {
                     const auto checks = sequencePath.Check();
                     checks
@@ -642,7 +645,9 @@ public:
                     }
                 }
 
-                localSequences.insert(sequencePath.PathString());
+                // CreateAlterData compares the column's raw DefaultFromSequence against this set
+                // and stores it verbatim, so insert the same (possibly relative) form.
+                localSequences.insert(defaultFromSequence);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -77,11 +77,18 @@ static std::optional<NKikimrSchemeOp::TModifyScheme> CreateIndexTask(NKikimr::NS
         case NKikimrSchemeOp::EIndexTypeGlobal:
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-        case NKikimrSchemeOp::EIndexTypeGlobalJson:
-        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
         case NKikimrSchemeOp::EIndexTypeLocalMinMax:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
+            break;
+        case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+            // JSON indexes carry a fulltext description only in rowid mode (__ydb_row_id as doc_id).
+            if (const auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexInfo->SpecializedIndexDescription)) {
+                *operation->MutableFulltextIndexDescription() = *ft;
+            } else {
+                Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
+            }
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
             *operation->MutableVectorIndexKmeansTreeDescription() =

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -1066,11 +1066,18 @@ TVector<ISubOperation::TPtr> CreateCopyTable(TOperationId nextId, const TTxTrans
                 case NKikimrSchemeOp::EIndexTypeGlobal:
                 case NKikimrSchemeOp::EIndexTypeGlobalAsync:
                 case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-                case NKikimrSchemeOp::EIndexTypeGlobalJson:
-                case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
                 case NKikimrSchemeOp::EIndexTypeLocalMinMax:
                     // no specialized index description
                     Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
+                    break;
+                case NKikimrSchemeOp::EIndexTypeGlobalJson:
+                case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+                    // JSON indexes carry a fulltext description only in rowid mode (__ydb_row_id as doc_id).
+                    if (const auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexInfo->SpecializedIndexDescription)) {
+                        *operation->MutableFulltextIndexDescription() = *ft;
+                    } else {
+                        Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
+                    }
                     break;
                 case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
                     *operation->MutableVectorIndexKmeansTreeDescription() =

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1391,7 +1391,7 @@ bool TPartitionConfigMerger::VerifyCreateParams(
     const NKikimrSchemeOp::TPartitionConfig &config,
     const TAppData *appData, const bool shadowDataAllowed, TString &errDescr)
 {
-    if (config.HasShadowData() && config.GetShadowData()) {
+    if (config.HasShadowData()) {
         if (!shadowDataAllowed) {
             errDescr = TStringBuilder() << "Setting ShadowData is prohibited";
             return false;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -1391,7 +1391,7 @@ bool TPartitionConfigMerger::VerifyCreateParams(
     const NKikimrSchemeOp::TPartitionConfig &config,
     const TAppData *appData, const bool shadowDataAllowed, TString &errDescr)
 {
-    if (config.HasShadowData()) {
+    if (config.HasShadowData() && config.GetShadowData()) {
         if (!shadowDataAllowed) {
             errDescr = TStringBuilder() << "Setting ShadowData is prohibited";
             return false;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -3030,11 +3030,20 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
             case NKikimrSchemeOp::EIndexTypeGlobal:
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-            case NKikimrSchemeOp::EIndexTypeGlobalJson:
-            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             case NKikimrSchemeOp::EIndexTypeLocalMinMax:
                 // no specialized index description
                 Y_ASSERT(description.empty());
+                break;
+            case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+                // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)
+                // is enabled (the serialized description is then non-empty); legacy JSON indexes have none.
+                if (!description.empty()) {
+                    auto success = SpecializedIndexDescription
+                        .emplace<NKikimrSchemeOp::TFulltextIndexDescription>()
+                        .ParseFromString(description);
+                    Y_ENSURE(success, description);
+                }
                 break;
             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree: {
                 auto success = SpecializedIndexDescription
@@ -3129,10 +3138,16 @@ struct TTableIndexInfo : public TSimpleRefCount<TTableIndexInfo> {
             case NKikimrSchemeOp::EIndexTypeGlobal:
             case NKikimrSchemeOp::EIndexTypeGlobalAsync:
             case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-            case NKikimrSchemeOp::EIndexTypeGlobalJson:
-            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
             case NKikimrSchemeOp::EIndexTypeLocalMinMax:
                 // no specialized index description
+                break;
+            case NKikimrSchemeOp::EIndexTypeGlobalJson:
+            case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+                // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)
+                // is enabled; otherwise there is no specialized index description.
+                if (config.HasFulltextIndexDescription()) {
+                    alterData->SpecializedIndexDescription = config.GetFulltextIndexDescription();
+                }
                 break;
             case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
                 alterData->SpecializedIndexDescription = config.GetVectorIndexKmeansTreeDescription();

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1544,11 +1544,19 @@ void TSchemeShard::DescribeTableIndex(const TPathId& pathId, const TString& name
         case NKikimrSchemeOp::EIndexTypeGlobal:
         case NKikimrSchemeOp::EIndexTypeGlobalAsync:
         case NKikimrSchemeOp::EIndexTypeGlobalUnique:
-        case NKikimrSchemeOp::EIndexTypeGlobalJson:
-        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
         case NKikimrSchemeOp::EIndexTypeLocalMinMax:
             // no specialized index description
             Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
+            break;
+        case NKikimrSchemeOp::EIndexTypeGlobalJson:
+        case NKikimrSchemeOp::EIndexTypeGlobalJsonCompact:
+            // JSON indexes carry a fulltext description only when rowid mode (__ydb_row_id as doc_id)
+            // is enabled; otherwise there is no specialized index description.
+            if (const auto* ft = std::get_if<NKikimrSchemeOp::TFulltextIndexDescription>(&indexInfo->SpecializedIndexDescription)) {
+                *entry.MutableFulltextIndexDescription() = *ft;
+            } else {
+                Y_ASSERT(std::holds_alternative<std::monostate>(indexInfo->SpecializedIndexDescription));
+            }
             break;
         case NKikimrSchemeOp::EIndexTypeGlobalVectorKmeansTree:
             *entry.MutableVectorIndexKmeansTreeDescription() = std::get<NKikimrSchemeOp::TVectorIndexKmeansTreeDescription>(indexInfo->SpecializedIndexDescription);

--- a/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
@@ -179,6 +179,173 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
         {"json"});
     }
 
+    Y_UNIT_TEST(ConsistentCopyTableWithGlobalJsonRowIdAutoProvisionIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        SetupLogging(runtime);
+        auto& ff = runtime.GetAppData().FeatureFlags;
+        ff.SetEnableJsonIndex(true);
+        ff.SetEnableFulltextIndex(true);
+        ff.SetEnableAddUniqueIndex(true);
+        ff.SetEnableUniqConstraint(true);
+
+        // Table with Utf8 PK - no __ydb_row_id yet; build will auto-provision it.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "texts"
+            Columns { Name: "pk"   Type: "Utf8" NotNull: true }
+            Columns { Name: "data" Type: "Json" }
+            KeyColumnNames: ["pk"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            Ydb::Table::TableIndex index;
+            index.set_name("json_idx");
+            index.add_index_columns("data");
+            index.mutable_global_json_index();
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index);
+        }
+        env.TestWaitNotification(runtime, txId);
+
+        TestConsistentCopyTables(runtime, ++txId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/texts"
+                DstPath: "/MyRoot/texts_copy"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // The copy must have 2 indexes: json_idx and the auto-provisioned unique index.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts_copy"), {
+            NLs::PathExist, NLs::IsTable, NLs::IndexesCount(2),
+        });
+
+        // json_idx must preserve UseRowIdAsDocId=true through the copy.
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts_copy/json_idx"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalJson),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+        {
+            const auto d = DescribePrivatePath(runtime, "/MyRoot/texts_copy/json_idx");
+            const auto& ti = d.GetPathDescription().GetTableIndex();
+            UNIT_ASSERT_C(ti.HasFulltextIndexDescription(),
+                "json_idx copy: FulltextIndexDescription must be set");
+            UNIT_ASSERT_C(ti.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+                "json_idx copy: UseRowIdAsDocId must be preserved through ConsistentCopyTables");
+        }
+
+        // Impl-table must be keyed by [__ydb_token, __ydb_row_id].
+        TestDescribeResult(DescribePrivatePath(runtime,
+                "/MyRoot/texts_copy/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+
+        // Auto-provisioned unique index must have been copied.
+        TestDescribeResult(DescribePrivatePath(runtime,
+                TStringBuilder() << "/MyRoot/texts_copy/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+    }
+
+    Y_UNIT_TEST(ConsistentCopyTableWithGlobalJsonRowIdManualInfraIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        SetupLogging(runtime);
+        auto& ff = runtime.GetAppData().FeatureFlags;
+        ff.SetEnableJsonIndex(true);
+        ff.SetEnableFulltextIndex(true);
+        ff.SetEnableAddUniqueIndex(true);
+        ff.SetEnableUniqConstraint(true);
+
+        // Table with Utf8 PK + explicit __ydb_row_id + user-created unique index.
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            TableDescription {
+                Name: "texts"
+                Columns { Name: "pk"   Type: "Utf8"   NotNull: true }
+                Columns { Name: "data" Type: "Json" }
+                Columns { Name: "%s"   Type: "Uint64" NotNull: true }
+                KeyColumnNames: ["pk"]
+            }
+            IndexDescription {
+                Name: "uniq_rowid"
+                KeyColumnNames: ["%s"]
+                Type: EIndexTypeGlobalUnique
+            }
+        )", NTableIndex::NFulltext::RowIdColumn, NTableIndex::NFulltext::RowIdColumn));
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            Ydb::Table::TableIndex index;
+            index.set_name("json_idx");
+            index.add_index_columns("data");
+            index.mutable_global_json_index();
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index);
+        }
+        env.TestWaitNotification(runtime, txId);
+
+        TestConsistentCopyTables(runtime, ++txId, "/MyRoot", R"(
+            CopyTableDescriptions {
+                SrcPath: "/MyRoot/texts"
+                DstPath: "/MyRoot/texts_copy"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // The copy must have 2 indexes: json_idx and the user-created unique index.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts_copy"), {
+            NLs::PathExist, NLs::IsTable, NLs::IndexesCount(2),
+        });
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts_copy/json_idx"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalJson),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+        {
+            const auto d = DescribePrivatePath(runtime, "/MyRoot/texts_copy/json_idx");
+            const auto& ti = d.GetPathDescription().GetTableIndex();
+            UNIT_ASSERT_C(ti.HasFulltextIndexDescription(),
+                "json_idx copy: FulltextIndexDescription must be set");
+            UNIT_ASSERT_C(ti.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+                "json_idx copy: UseRowIdAsDocId must be preserved through ConsistentCopyTables");
+        }
+
+        TestDescribeResult(DescribePrivatePath(runtime,
+                "/MyRoot/texts_copy/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+
+        // User-created unique index must have been copied.
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts_copy/uniq_rowid"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        // Auto-provision index must NOT exist (user infra was reused).
+        TestDescribeResult(DescribePrivatePath(runtime,
+                TStringBuilder() << "/MyRoot/texts_copy/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathNotExist,
+        });
+    }
+
     Y_UNIT_TEST(ConsistentCopyTableWithGlobalFulltextRelevanceIndex) {
         ConsistentCopyTableWithIndex(R"(
             IndexDescription {

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_json_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_json_index_build.cpp
@@ -34,12 +34,83 @@ void DoWriteJsonRows(TTestBasicRuntime& runtime, const TVector<std::pair<ui64, T
     }
 }
 
-Ydb::Table::TableIndex JsonIndexConfig() {
+Ydb::Table::TableIndex JsonIndexConfig(const TString& name = "json_idx") {
     Ydb::Table::TableIndex index;
-    index.set_name("json_idx");
+    index.set_name(name);
     index.add_index_columns("data");
     index.mutable_global_json_index();
     return index;
+}
+
+void DoCreateJsonTableWithRowId(TTestBasicRuntime& runtime, TTestEnv& env, ui64& txId,
+    const TString& rowIdType = "Uint64", bool rowIdNotNull = true, bool createUniqueIndex = true,
+    const TString& uniqueIndexKey = NTableIndex::NFulltext::RowIdColumn)
+{
+    const TString tableColumns = Sprintf(R"(
+            Columns { Name: "pk" Type: "Utf8" NotNull: true }
+            Columns { Name: "data" Type: "Json" }
+            Columns { Name: "%s" Type: "%s" %s }
+            KeyColumnNames: ["pk"]
+    )", NTableIndex::NFulltext::RowIdColumn, rowIdType.c_str(),
+        rowIdNotNull ? "NotNull: true" : "");
+
+    if (!createUniqueIndex) {
+        TestCreateTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            Name: "texts"
+            %s
+        )", tableColumns.c_str()));
+    } else {
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            TableDescription {
+                Name: "texts"
+                %s
+            }
+            IndexDescription {
+                Name: "uniq_rowid"
+                KeyColumnNames: ["%s"]
+                Type: EIndexTypeGlobalUnique
+            }
+        )", tableColumns.c_str(), uniqueIndexKey.c_str()));
+    }
+    env.TestWaitNotification(runtime, txId);
+}
+
+void DoCreateCustomPkJsonTable(TTestBasicRuntime& runtime, TTestEnv& env, ui64& txId) {
+    TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+        Name: "texts"
+        Columns { Name: "pk" Type: "Utf8" NotNull: true }
+        Columns { Name: "data" Type: "Json" }
+        KeyColumnNames: ["pk"]
+    )");
+    env.TestWaitNotification(runtime, txId);
+}
+
+void DoWriteJsonTextRows(TTestBasicRuntime& runtime, bool withRowId) {
+    struct TRow { TString Pk; TString Json; ui64 RowId; };
+    const TVector<TRow> rows = {
+        {"pone",   R"({"a": 1})",          1},
+        {"ptwo",   R"({"a": 1, "b": 2})",  2},
+        {"pthree", R"({"b": 2})",          3},
+        {"pfour",  R"({"c": 3})",          4},
+    };
+    for (const auto& row : rows) {
+        TVector<TCell> keys = {TCell(row.Pk.data(), row.Pk.size())};
+        TVector<TCell> values = {TCell(row.Json.data(), row.Json.size())};
+        TVector<ui32> valueTags = {2};
+        if (withRowId) {
+            values.push_back(TCell::Make(row.RowId));
+            valueTags.push_back(3);
+        }
+        UploadRow(runtime, "/MyRoot/texts", 0, {1}, valueTags, keys, values);
+    }
+}
+
+void EnableJsonRowIdFlags(TTestActorRuntime& runtime) {
+    auto& appData = runtime.GetAppData();
+    appData.FeatureFlags.SetEnableJsonIndex(true);
+    appData.FeatureFlags.SetEnableFulltextIndex(true);
+    appData.FeatureFlags.SetEnableAddUniqueIndex(true);
+    appData.FeatureFlags.SetEnableUniqConstraint(true);
 }
 
 } // namespace
@@ -279,5 +350,230 @@ Y_UNIT_TEST_SUITE(JsonIndexBuildTest) {
         checkIndex("/MyRoot/table_imported");
 
         NKikimr::ShutdownAwsAPI();
+    }
+
+    Y_UNIT_TEST(RowIdOptIn_BuildsAndKeysByRowId) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        DoCreateJsonTableWithRowId(runtime, env, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/uniq_rowid"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        // No data is written here: the assertion below is purely on the impl-table schema (its key columns),
+        // which holds regardless of contents. Bulk upload cannot target a table that already has the unique
+        // secondary index, and the custom-PK auto-provision tests cover the data-backfill path instead.
+
+        const ui64 buildIndexTx = ++txId;
+        TestBuildIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig());
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        {
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                op.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+                op.DebugString());
+        }
+
+        // The JSON posting impl-table must be keyed by [__ydb_token, __ydb_row_id], not by [__ydb_token, pk].
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+    }
+
+    Y_UNIT_TEST(RowIdOptIn_RejectsIfRowIdWrongType) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        DoCreateJsonTableWithRowId(runtime, env, txId,
+            /*rowIdType=*/ "Uint32",
+            /*rowIdNotNull=*/ true,
+            /*createUniqueIndex=*/ false);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig(),
+            Ydb::StatusIds::BAD_REQUEST);
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(RowIdOptIn_RejectsIfRowIdNullable) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        DoCreateJsonTableWithRowId(runtime, env, txId,
+            /*rowIdType=*/ "Uint64",
+            /*rowIdNotNull=*/ false,
+            /*createUniqueIndex=*/ false);
+
+        TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig(),
+            Ydb::StatusIds::BAD_REQUEST);
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(RowIdOptIn_AutoProvisionsMissingUniqueIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        // __ydb_row_id is well-formed (Uint64 NOT NULL) but has no unique index yet - auto-provision it.
+        DoCreateJsonTableWithRowId(runtime, env, txId,
+            /*rowIdType=*/ "Uint64",
+            /*rowIdNotNull=*/ true,
+            /*createUniqueIndex=*/ false);
+
+        const ui64 buildIndexTx = ++txId;
+        TestBuildIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig());
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+        UNIT_ASSERT_VALUES_EQUAL_C(op.GetIndexBuild().GetState(),
+            Ydb::Table::IndexBuildState::STATE_DONE, op.DebugString());
+
+        TestDescribeResult(DescribePrivatePath(runtime,
+            TStringBuilder() << "/MyRoot/texts/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+    }
+
+    Y_UNIT_TEST(RowIdOptIn_AutoProvisionsRowIdAndUniqueIndexForCustomPk) {
+        // A custom (non single integer) PK without __ydb_row_id is auto-provisioned: the build adds the
+        // __ydb_row_id column and a unique index over it.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
+
+        DoCreateCustomPkJsonTable(runtime, env, txId);
+        DoWriteJsonTextRows(runtime, /*withRowId=*/ false);
+
+        const ui64 buildIndexTx = ++txId;
+        TestBuildIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig());
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        {
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+            UNIT_ASSERT_VALUES_EQUAL_C(op.GetIndexBuild().GetState(),
+                Ydb::Table::IndexBuildState::STATE_DONE, op.DebugString());
+        }
+
+        // Both the __ydb_row_id column and its unique index were auto-provisioned; the unique index is Ready.
+        TestDescribeResult(DescribePrivatePath(runtime,
+            TStringBuilder() << "/MyRoot/texts/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        // The JSON posting impl-table is keyed by [__ydb_token, __ydb_row_id].
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+    }
+
+    Y_UNIT_TEST(AutoProvision_SecondJsonBuildReusesInfra) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        DoCreateCustomPkJsonTable(runtime, env, txId);
+        DoWriteJsonTextRows(runtime, /*withRowId=*/ false);
+
+        // First JSON index provisions __ydb_row_id + the unique index.
+        {
+            const ui64 buildTx = ++txId;
+            TestBuildIndex(runtime, buildTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig("json_one"));
+            env.TestWaitNotification(runtime, buildTx);
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildTx);
+            UNIT_ASSERT_VALUES_EQUAL_C(op.GetIndexBuild().GetState(),
+                Ydb::Table::IndexBuildState::STATE_DONE, op.DebugString());
+        }
+
+        // Second JSON index reuses the existing __ydb_row_id + unique index (no duplicates).
+        {
+            const ui64 buildTx = ++txId;
+            TestBuildIndex(runtime, buildTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", JsonIndexConfig("json_two"));
+            env.TestWaitNotification(runtime, buildTx);
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildTx);
+            UNIT_ASSERT_VALUES_EQUAL_C(op.GetIndexBuild().GetState(),
+                Ydb::Table::IndexBuildState::STATE_DONE, op.DebugString());
+        }
+
+        TestDescribeResult(DescribePrivatePath(runtime,
+            TStringBuilder() << "/MyRoot/texts/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathExist,
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/json_two/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+    }
+
+    Y_UNIT_TEST(AutoProvision_SingleIntegerPkUnaffected) {
+        // A single integer PK keeps the legacy doc_id=PK behaviour: no __ydb_row_id / unique index added.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        EnableJsonRowIdFlags(runtime);
+        ui64 txId = 100;
+
+        DoCreateJsonTable(runtime, env, txId);
+
+        const ui64 buildIndexTx = ++txId;
+        TestBuildIndex(runtime, buildIndexTx, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/table", JsonIndexConfig());
+        env.TestWaitNotification(runtime, buildIndexTx);
+
+        {
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexTx);
+            UNIT_ASSERT_VALUES_EQUAL_C(op.GetIndexBuild().GetState(),
+                Ydb::Table::IndexBuildState::STATE_DONE, op.DebugString());
+        }
+
+        // No auto unique index was created.
+        TestDescribeResult(DescribePrivatePath(runtime,
+            TStringBuilder() << "/MyRoot/table/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathNotExist,
+        });
+
+        // The JSON impl-table is keyed by [__ydb_token, id] (the integer PK), not __ydb_row_id.
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/table/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, "id" },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, "id" },
+                /*strictCount=*/ true),
+        });
     }
 }

--- a/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_json_index_build_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build_reboots/ut_json_index_build_reboots.cpp
@@ -8,6 +8,53 @@ using namespace NKikimr;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
 
+namespace {
+
+void EnableJsonRowIdFlags(TTestActorRuntime& runtime) {
+    auto& appData = runtime.GetAppData();
+    appData.FeatureFlags.SetEnableJsonIndex(true);
+    appData.FeatureFlags.SetEnableFulltextIndex(true);
+    appData.FeatureFlags.SetEnableAddUniqueIndex(true);
+    appData.FeatureFlags.SetEnableUniqConstraint(true);
+}
+
+// Check that the index at `indexPath` has UseRowIdAsDocId=true in its persisted description
+// and that its impl-table is keyed by [__ydb_token, __ydb_row_id].
+void CheckRowIdJsonIndex(TTestActorRuntime& runtime, const TString& indexPath) {
+    {
+        const auto d = DescribePrivatePath(runtime, indexPath);
+        const auto& tableIndex = d.GetPathDescription().GetTableIndex();
+        UNIT_ASSERT_C(tableIndex.HasFulltextIndexDescription(),
+            indexPath << ": FulltextIndexDescription must be set for rowid-mode JSON index");
+        UNIT_ASSERT_C(tableIndex.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+            indexPath << ": UseRowIdAsDocId must be true after persistence through schemeshard reboots");
+    }
+
+    TestDescribeResult(DescribePrivatePath(runtime, indexPath + "/" + TString(NTableIndex::ImplTable)), {
+        NLs::PathExist,
+        NLs::CheckColumns(TString(NTableIndex::ImplTable),
+            { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+            {},
+            { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+            /*strictCount=*/ true),
+    });
+}
+
+// Common reboot event filter for JSON index build tests.
+void SetupRebootFilter(TTestWithReboots& t) {
+    t.TabletIds.clear();
+    t.TabletIds.push_back(t.SchemeShardTabletId);
+    t.NoRebootEventTypes.insert(TEvSchemeShard::EvModifySchemeTransaction);
+    t.NoRebootEventTypes.insert(TSchemeBoardEvents::EvUpdateAck);
+    t.NoRebootEventTypes.insert(TEvSchemeShard::EvNotifyTxCompletionRegistered);
+    t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerDisconnected);
+    t.NoRebootEventTypes.insert(TEvTabletPipe::EvServerConnected);
+    t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientConnected);
+    t.NoRebootEventTypes.insert(TEvTabletPipe::EvClientDestroyed);
+    t.NoRebootEventTypes.insert(TEvDataShard::EvBuildIndexProgressResponse);
+}
+
+} // namespace
 
 Y_UNIT_TEST_SUITE(JsonIndexBuildTestReboots) {
     Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(BaseCase, /* rebootBuckets */ 4, /* pipeResetBuckets */ 4, /* killOnCommit */ true) {
@@ -103,6 +150,163 @@ Y_UNIT_TEST_SUITE(JsonIndexBuildTestReboots) {
                     auto rows = CountRows(runtime, TTestTxConfig::SchemeShard, indexPath + "/" + TString(NTableIndex::ImplTable));
                     Cerr << "... impl table contains " << rows << " rows" << Endl;
                     UNIT_ASSERT_C(rows > 0, "indexImplTable must be non-empty after building");
+                }
+            }
+        });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(RowIdAutoProvision, /* rebootBuckets */ 4, /* pipeResetBuckets */ 4, /* killOnCommit */ true) {
+        SetupRebootFilter(t);
+
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            EnableJsonRowIdFlags(runtime);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "texts"
+                    Columns { Name: "pk"   Type: "Utf8" NotNull: true }
+                    Columns { Name: "data" Type: "Json" }
+                    KeyColumnNames: ["pk"]
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                const struct { const char* Pk; const char* Json; } rows[] = {
+                    {"aaa", R"({"k": 1})"},
+                    {"bbb", R"({"k": 2})"},
+                    {"ccc", R"({"k": 1, "m": 3})"},
+                };
+                for (const auto& row : rows) {
+                    TString pk(row.Pk), json(row.Json);
+                    UploadRow(runtime, "/MyRoot/texts", 0,
+                        /*keyTags=*/ {1}, /*valueTags=*/ {2},
+                        /*keys=*/ {TCell(pk.data(), pk.size())},
+                        /*values=*/ {TCell(json.data(), json.size())});
+                }
+            }
+
+            const ui64 buildIndexId = ++t.TxId;
+            {
+                auto sender = runtime.AllocateEdgeActor();
+                Ydb::Table::TableIndex index;
+                index.set_name("json_idx");
+                index.add_index_columns("data");
+                index.mutable_global_json_index();
+                auto request = CreateBuildIndexRequest(buildIndexId, "/MyRoot", "/MyRoot/texts", index);
+                // Disable scan batching to keep the test fast under reboots.
+                request->Record.MutableSettings()->MutableScanSettings()->Clear();
+                ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, request);
+            }
+
+            t.TestEnv->TestWaitNotification(runtime, buildIndexId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    op.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+                    op.DebugString());
+
+                TestDescribeResult(DescribePrivatePath(runtime,
+                    TStringBuilder() << "/MyRoot/texts/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+                    NLs::PathExist,
+                    NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+                    NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+                });
+
+                CheckRowIdJsonIndex(runtime, "/MyRoot/texts/json_idx");
+
+                {
+                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard,
+                        "/MyRoot/texts/json_idx/" + TString(NTableIndex::ImplTable));
+                    Cerr << "... json_idx impl-table contains " << rows << " rows" << Endl;
+                    UNIT_ASSERT_C(rows > 0, "json_idx impl-table must be non-empty after building");
+                }
+            }
+        });
+    }
+
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(RowIdManualInfra, /* rebootBuckets */ 4, /* pipeResetBuckets */ 4, /* killOnCommit */ true) {
+        SetupRebootFilter(t);
+
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            EnableJsonRowIdFlags(runtime);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateIndexedTable(runtime, ++t.TxId, "/MyRoot", Sprintf(R"(
+                    TableDescription {
+                        Name: "texts"
+                        Columns { Name: "pk"   Type: "Utf8"   NotNull: true }
+                        Columns { Name: "data" Type: "Json" }
+                        Columns { Name: "%s"   Type: "Uint64" NotNull: true }
+                        KeyColumnNames: ["pk"]
+                    }
+                    IndexDescription {
+                        Name: "uniq_rowid"
+                        KeyColumnNames: ["%s"]
+                        Type: EIndexTypeGlobalUnique
+                    }
+                )", NTableIndex::NFulltext::RowIdColumn, NTableIndex::NFulltext::RowIdColumn));
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                const struct { const char* Pk; const char* Json; ui64 RowId; } rows[] = {
+                    {"aaa", R"({"k": 1})",       100},
+                    {"bbb", R"({"k": 2})",       200},
+                    {"ccc", R"({"k": 1, "m": 3})", 300},
+                };
+                for (const auto& row : rows) {
+                    TString pk(row.Pk), json(row.Json);
+                    UploadRow(runtime, "/MyRoot/texts", 0,
+                        /*keyTags=*/ {1}, /*valueTags=*/ {2, 3},
+                        /*keys=*/ {TCell(pk.data(), pk.size())},
+                        /*values=*/ {TCell(json.data(), json.size()), TCell::Make(row.RowId)});
+                }
+            }
+
+            const ui64 buildIndexId = ++t.TxId;
+            {
+                auto sender = runtime.AllocateEdgeActor();
+                Ydb::Table::TableIndex index;
+                index.set_name("json_idx");
+                index.add_index_columns("data");
+                index.mutable_global_json_index();
+                auto request = CreateBuildIndexRequest(buildIndexId, "/MyRoot", "/MyRoot/texts", index);
+                request->Record.MutableSettings()->MutableScanSettings()->Clear();
+                ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, request);
+            }
+
+            t.TestEnv->TestWaitNotification(runtime, buildIndexId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", buildIndexId);
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    op.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+                    op.DebugString());
+
+                TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts/uniq_rowid"), {
+                    NLs::PathExist,
+                    NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+                    NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+                });
+
+                TestDescribeResult(DescribePrivatePath(runtime,
+                    TStringBuilder() << "/MyRoot/texts/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+                    NLs::PathNotExist,
+                });
+
+                CheckRowIdJsonIndex(runtime, "/MyRoot/texts/json_idx");
+
+                {
+                    auto rows = CountRows(runtime, TTestTxConfig::SchemeShard,
+                        "/MyRoot/texts/json_idx/" + TString(NTableIndex::ImplTable));
+                    Cerr << "... json_idx impl-table contains " << rows << " rows" << Endl;
+                    UNIT_ASSERT_C(rows > 0, "json_idx impl-table must be non-empty after building");
                 }
             }
         });

--- a/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
+++ b/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
@@ -1633,6 +1633,185 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         {"json"});
     }
 
+    Y_UNIT_TEST(MoveTableWithGlobalJsonRowIdAutoProvisionIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        auto& ff = runtime.GetAppData().FeatureFlags;
+        ff.SetEnableJsonIndex(true);
+        ff.SetEnableFulltextIndex(true);
+        ff.SetEnableAddUniqueIndex(true);
+        ff.SetEnableUniqConstraint(true);
+
+        // Table with Utf8 PK - no __ydb_row_id yet; build will auto-provision it.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "texts"
+            Columns { Name: "pk"   Type: "Utf8" NotNull: true }
+            Columns { Name: "data" Type: "Json" }
+            KeyColumnNames: ["pk"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            Ydb::Table::TableIndex index;
+            index.set_name("json_idx");
+            index.add_index_columns("data");
+            index.mutable_global_json_index();
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index);
+        }
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts"),
+                           {NLs::IsTable, NLs::IndexesCount(2)});
+
+        auto preMoveDomainDesc = DescribePath(runtime, "/MyRoot");
+        const ui64 expectedDomainPaths =
+            preMoveDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+        const ui64 expectedDomainShards =
+            preMoveDomainDesc.GetPathDescription().GetDomainDescription().GetShardsInside();
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/texts", "/MyRoot/texts_moved");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts_moved"),
+                           {NLs::IsTable, NLs::IndexesCount(2)});
+
+        // json_idx must preserve UseRowIdAsDocId=true through the move.
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts_moved/json_idx"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalJson),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+        {
+            const auto d = DescribePrivatePath(runtime, "/MyRoot/texts_moved/json_idx");
+            const auto& ti = d.GetPathDescription().GetTableIndex();
+            UNIT_ASSERT_C(ti.HasFulltextIndexDescription(),
+                "json_idx after move: FulltextIndexDescription must be set");
+            UNIT_ASSERT_C(ti.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+                "json_idx after move: UseRowIdAsDocId must be preserved through MoveTable");
+        }
+
+        // Impl-table must be keyed by [__ydb_token, __ydb_row_id].
+        TestDescribeResult(DescribePrivatePath(runtime,
+                "/MyRoot/texts_moved/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+
+        // Auto-provisioned unique index must have been moved.
+        TestDescribeResult(DescribePrivatePath(runtime,
+                TStringBuilder() << "/MyRoot/texts_moved/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(expectedDomainShards)});
+    }
+
+    Y_UNIT_TEST(MoveTableWithGlobalJsonRowIdManualInfraIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        auto& ff = runtime.GetAppData().FeatureFlags;
+        ff.SetEnableJsonIndex(true);
+        ff.SetEnableFulltextIndex(true);
+        ff.SetEnableAddUniqueIndex(true);
+        ff.SetEnableUniqConstraint(true);
+
+        // Table with Utf8 PK + explicit __ydb_row_id + user-created unique index.
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", Sprintf(R"(
+            TableDescription {
+                Name: "texts"
+                Columns { Name: "pk"   Type: "Utf8"   NotNull: true }
+                Columns { Name: "data" Type: "Json" }
+                Columns { Name: "%s"   Type: "Uint64" NotNull: true }
+                KeyColumnNames: ["pk"]
+            }
+            IndexDescription {
+                Name: "uniq_rowid"
+                KeyColumnNames: ["%s"]
+                Type: EIndexTypeGlobalUnique
+            }
+        )", NTableIndex::NFulltext::RowIdColumn, NTableIndex::NFulltext::RowIdColumn));
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            Ydb::Table::TableIndex index;
+            index.set_name("json_idx");
+            index.add_index_columns("data");
+            index.mutable_global_json_index();
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/texts", index);
+        }
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts"),
+                           {NLs::IsTable, NLs::IndexesCount(2)});
+
+        auto preMoveDomainDesc = DescribePath(runtime, "/MyRoot");
+        const ui64 expectedDomainPaths =
+            preMoveDomainDesc.GetPathDescription().GetDomainDescription().GetPathsInside();
+        const ui64 expectedDomainShards =
+            preMoveDomainDesc.GetPathDescription().GetDomainDescription().GetShardsInside();
+
+        TestMoveTable(runtime, ++txId, "/MyRoot/texts", "/MyRoot/texts_moved");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/texts_moved"),
+                           {NLs::IsTable, NLs::IndexesCount(2)});
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts_moved/json_idx"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalJson),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+        {
+            const auto d = DescribePrivatePath(runtime, "/MyRoot/texts_moved/json_idx");
+            const auto& ti = d.GetPathDescription().GetTableIndex();
+            UNIT_ASSERT_C(ti.HasFulltextIndexDescription(),
+                "json_idx after move: FulltextIndexDescription must be set");
+            UNIT_ASSERT_C(ti.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+                "json_idx after move: UseRowIdAsDocId must be preserved through MoveTable");
+        }
+
+        TestDescribeResult(DescribePrivatePath(runtime,
+                "/MyRoot/texts_moved/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+
+        // User-created unique index must have been moved.
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/texts_moved/uniq_rowid"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        // Auto-provision index must NOT exist on the moved table (user infra was reused).
+        TestDescribeResult(DescribePrivatePath(runtime,
+                TStringBuilder() << "/MyRoot/texts_moved/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathNotExist,
+        });
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"),
+                           {NLs::PathsInsideDomain(expectedDomainPaths),
+                            NLs::ShardsInsideDomain(expectedDomainShards)});
+    }
+
     Y_UNIT_TEST(AsyncIndexWithSyncInFly) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -7220,6 +7220,202 @@ Y_UNIT_TEST_SUITE(TImportTests) {
         {"json"});
     }
 
+    Y_UNIT_TEST(ShouldSucceedOnGlobalJsonRowIdAutoProvisionAfterRestore) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions());
+        ui64 txId = 200;
+
+        auto& ff = runtime.GetAppData().FeatureFlags;
+        ff.SetEnableJsonIndex(true);
+        ff.SetEnableFulltextIndex(true);
+        ff.SetEnableAddUniqueIndex(true);
+        ff.SetEnableUniqConstraint(true);
+
+        // Import a table with Utf8 PK and a Json column - no JSON index in the import.
+        auto data = GenerateTestData(R"(
+            columns {
+              name: "pk"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "data"
+              type { optional_type { item { type_id: JSON } } }
+            }
+            primary_key: "pk"
+        )", {{"a", 1}});
+        // The generated CSV puts a bare word in the Json column, which fails JSON
+        // validation on import. Override it with a row containing valid JSON.
+        data.Data.assign(1, TTestData(TString(R"("a1","{"k":"v"}")") + "\n", EmptyYsonStr));
+
+        Run(runtime, env, ConvertTestData(data), R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist, NLs::IsTable, NLs::IndexesCount(0),
+        });
+
+        // Build a JSON index on the imported table.
+        {
+            Ydb::Table::TableIndex index;
+            index.set_name("json_idx");
+            index.add_index_columns("data");
+            index.mutable_global_json_index();
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", index);
+        }
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", txId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                op.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+                op.DebugString());
+        }
+
+        // Auto-provisioned unique index must be Ready on the restored table.
+        TestDescribeResult(DescribePrivatePath(runtime,
+                TStringBuilder() << "/MyRoot/Table/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        // UseRowIdAsDocId must be set on the JSON index built after restore.
+        {
+            const auto d = DescribePrivatePath(runtime, "/MyRoot/Table/json_idx");
+            const auto& ti = d.GetPathDescription().GetTableIndex();
+            UNIT_ASSERT_C(ti.HasFulltextIndexDescription(),
+                "json_idx after restore+build: FulltextIndexDescription must be set");
+            UNIT_ASSERT_C(ti.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+                "json_idx after restore+build: UseRowIdAsDocId must be true");
+        }
+
+        // Impl-table must be keyed by [__ydb_token, __ydb_row_id].
+        TestDescribeResult(DescribePrivatePath(runtime,
+                "/MyRoot/Table/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+    }
+
+    Y_UNIT_TEST(ShouldSucceedOnGlobalJsonRowIdManualInfraAfterRestore) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions());
+        ui64 txId = 200;
+
+        auto& ff = runtime.GetAppData().FeatureFlags;
+        ff.SetEnableJsonIndex(true);
+        ff.SetEnableFulltextIndex(true);
+        ff.SetEnableAddUniqueIndex(true);
+        ff.SetEnableUniqConstraint(true);
+
+        // Import a table with Utf8 PK + __ydb_row_id column + unique index on __ydb_row_id.
+        // The JSON index is NOT included in the import; it will be built afterward.
+        auto data = GenerateTestData(Sprintf(R"(
+            columns {
+              name: "pk"
+              type { optional_type { item { type_id: UTF8 } } }
+            }
+            columns {
+              name: "data"
+              type { optional_type { item { type_id: JSON } } }
+            }
+            columns {
+              name: "%s"
+              type { type_id: UINT64 }
+              not_null: true
+            }
+            primary_key: "pk"
+            indexes {
+              name: "uniq_rowid"
+              index_columns: "%s"
+              global_unique_index {}
+            }
+        )", NTableIndex::NFulltext::RowIdColumn, NTableIndex::NFulltext::RowIdColumn), {{"a", 1}});
+        // CSV columns follow scheme order (pk, data, __ydb_row_id). The Json column needs
+        // valid JSON, and the NOT NULL __ydb_row_id column needs an explicit value.
+        data.Data.assign(1, TTestData(TString(R"("a1","{"k":"v"}",1)") + "\n", EmptyYsonStr));
+
+        Run(runtime, env, ConvertTestData(data), R"(
+            ImportFromS3Settings {
+              endpoint: "localhost:%d"
+              scheme: HTTP
+              items {
+                source_prefix: ""
+                destination_path: "/MyRoot/Table"
+              }
+            }
+        )");
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist, NLs::IsTable, NLs::IndexesCount(1),
+        });
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/uniq_rowid"), {
+            NLs::PathExist,
+            NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+            NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+        });
+
+        // Build a JSON index; it must detect the existing uniq_rowid infrastructure (Reuse plan).
+        {
+            Ydb::Table::TableIndex index;
+            index.set_name("json_idx");
+            index.add_index_columns("data");
+            index.mutable_global_json_index();
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", index);
+        }
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            auto op = TestGetBuildIndex(runtime, TTestTxConfig::SchemeShard, "/MyRoot", txId);
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                op.GetIndexBuild().GetState(), Ydb::Table::IndexBuildState::STATE_DONE,
+                op.DebugString());
+        }
+
+        // uniq_rowid must still be the only unique index (no auto-provision duplicate).
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist, NLs::IsTable, NLs::IndexesCount(2),
+        });
+        TestDescribeResult(DescribePrivatePath(runtime,
+                TStringBuilder() << "/MyRoot/Table/" << NTableIndex::NFulltext::RowIdUniqueIndexName), {
+            NLs::PathNotExist,
+        });
+
+        // UseRowIdAsDocId must be set.
+        {
+            const auto d = DescribePrivatePath(runtime, "/MyRoot/Table/json_idx");
+            const auto& ti = d.GetPathDescription().GetTableIndex();
+            UNIT_ASSERT_C(ti.HasFulltextIndexDescription(),
+                "json_idx after restore+build: FulltextIndexDescription must be set");
+            UNIT_ASSERT_C(ti.GetFulltextIndexDescription().GetUseRowIdAsDocId(),
+                "json_idx after restore+build: UseRowIdAsDocId must be true");
+        }
+
+        // Impl-table must be keyed by [__ydb_token, __ydb_row_id].
+        TestDescribeResult(DescribePrivatePath(runtime,
+                "/MyRoot/Table/json_idx/" + TString(NTableIndex::ImplTable)), {
+            NLs::PathExist,
+            NLs::CheckColumns(TString(NTableIndex::ImplTable),
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                {},
+                { NTableIndex::NFulltext::TokenColumn, NTableIndex::NFulltext::RowIdColumn },
+                /*strictCount=*/ true),
+        });
+    }
+
     Y_UNIT_TEST(ReplicationImport) {
         TTestBasicRuntime runtime;
         auto options = TTestEnvOptions()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Extend #41499 for JSON indexes

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Add RowId support for JSON indexes
- Fix consistent copy of tables with fulltext/JSON indexes (clear ShadowData, sequence path fix)
- Add tests for copy/move/restore of JSON indexes and building with reboots
