### PR TITLE
TRequestHandlerBase: always set Promise

### DIFF
--- a/ydb/core/kqp/gateway/actors/kqp_ic_gateway_actors.h
+++ b/ydb/core/kqp/gateway/actors/kqp_ic_gateway_actors.h
@@ -33,6 +33,7 @@ public:
     }
 
     virtual void HandleResponse(typename TResponse::TPtr &ev, const TActorContext &ctx) {
+        PromiseHandedOff = true;
         Callback(Promise, std::move(*ev->Get()));
         this->Die(ctx);
     }
@@ -69,8 +70,8 @@ public:
     }
 
     ~TRequestHandlerBase() override {
-        if (!Promise.IsReady()) {
-            Promise.SetValue(NYql::NCommon::ResultFromIssues<TResult>(
+        if (!PromiseHandedOff && !Promise.IsReady()) {
+            Promise.TrySetValue(NYql::NCommon::ResultFromIssues<TResult>(
                 NYql::TIssuesIds::KIKIMR_OPERATION_ABORTED,
                 "Shutting down.", {}));
         }
@@ -80,6 +81,7 @@ protected:
     THolder<TRequest> Request;
     NThreading::TPromise<TResult> Promise;
     TCallbackFunc Callback;
+    bool PromiseHandedOff = false;
 };
 
 template<typename TRequest, typename TResponse, typename TResult>

--- a/ydb/core/kqp/gateway/actors/kqp_ic_gateway_actors.h
+++ b/ydb/core/kqp/gateway/actors/kqp_ic_gateway_actors.h
@@ -68,6 +68,14 @@ public:
         this->Die(ctx);
     }
 
+    ~TRequestHandlerBase() override {
+        if (!Promise.IsReady()) {
+            Promise.SetValue(NYql::NCommon::ResultFromIssues<TResult>(
+                NYql::TIssuesIds::KIKIMR_OPERATION_ABORTED,
+                "Shutting down.", {}));
+        }
+    }
+
 protected:
     THolder<TRequest> Request;
     NThreading::TPromise<TResult> Promise;

--- a/ydb/core/kqp/gateway/actors/kqp_ic_gateway_actors.h
+++ b/ydb/core/kqp/gateway/actors/kqp_ic_gateway_actors.h
@@ -33,8 +33,7 @@ public:
     }
 
     virtual void HandleResponse(typename TResponse::TPtr &ev, const TActorContext &ctx) {
-        PromiseHandedOff = true;
-        Callback(Promise, std::move(*ev->Get()));
+        Callback(std::move(Promise), std::move(*ev->Get()));
         this->Die(ctx);
     }
 
@@ -70,7 +69,7 @@ public:
     }
 
     ~TRequestHandlerBase() override {
-        if (!PromiseHandedOff && !Promise.IsReady()) {
+        if (Promise.Initialized() && !Promise.IsReady()) {
             Promise.TrySetValue(NYql::NCommon::ResultFromIssues<TResult>(
                 NYql::TIssuesIds::KIKIMR_OPERATION_ABORTED,
                 "Shutting down.", {}));
@@ -81,7 +80,6 @@ protected:
     THolder<TRequest> Request;
     NThreading::TPromise<TResult> Promise;
     TCallbackFunc Callback;
-    bool PromiseHandedOff = false;
 };
 
 template<typename TRequest, typename TResponse, typename TResult>


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This helps prevent TFutureState leaks caused by circular references when a future is captured in its own callback chain.
