### PR TITLE
fix compaction metrics for enabled compaction token

### DIFF
--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_defs.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_defs.h
@@ -29,6 +29,17 @@ namespace NKikimr {
             }
         }
 
+        enum class ESelectStrategy {
+            None,
+            DelSst,
+            PromoteSsts,
+            Explicit,
+            BalanceLevel,
+            BalanceFull,
+            FreeSpace,
+            Squeeze,
+        };
+
         ////////////////////////////////////////////////////////////////////////////
         // NHullComp::TFullCompactionAttrs
         // Contains full compaction attributes, which are used to understand
@@ -302,6 +313,7 @@ namespace NKikimr {
             TMoveSsts MoveSsts;
             TCompactSsts CompactSsts;
             bool IsFullCompaction = false;
+            ESelectStrategy SelectStrategy = ESelectStrategy::None;
             // this field contains
             // * original std::optional<TFullCompactionAttrs>
             // * if 'first' was set, than result of full compaction: second=true -- full compaction has been finished
@@ -318,6 +330,7 @@ namespace NKikimr {
                 MoveSsts.Clear();
                 CompactSsts.Clear();
                 IsFullCompaction = false;
+                SelectStrategy = ESelectStrategy::None;
                 FullCompactionInfo.first.reset();
                 FullCompactionInfo.second = false;
             }

--- a/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
+++ b/ydb/core/blobstorage/vdisk/hulldb/compstrat/hulldb_compstrat_selector.cpp
@@ -35,40 +35,37 @@ namespace NKikimr {
             // delete free ssts
             action = TStrategyDelSst(HullCtx, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlobsDelSst();
+                Task->SelectStrategy = ESelectStrategy::DelSst;
                 return action;
             }
 
             // try to promote ssts on higher levels w/o merging
             action = TStrategyPromoteSsts(HullCtx, Params.Boundaries, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlobsPromoteSsts();
+                Task->SelectStrategy = ESelectStrategy::PromoteSsts;
                 return action;
             }
 
             // compact explicitly defined SST's, if set
             action = TStrategyExplicit(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlobsExplicit();
+                Task->SelectStrategy = ESelectStrategy::Explicit;
                 return action;
             }
 
             // try to find what to compact based on levels balance
             action = TStrategyBalance(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlobsBalance();
-                if (Task->IsFullCompaction) {
-                    ++HullCtx->CompactionStrategyGroup.BlobsBalanceFull();
-                } else {
-                    ++HullCtx->CompactionStrategyGroup.BlobsBalanceLevel();
-                }
+                Task->SelectStrategy = Task->IsFullCompaction
+                    ? ESelectStrategy::BalanceFull
+                    : ESelectStrategy::BalanceLevel;
                 return action;
             }
 
             // try to find what to compact based on storage consumption
             action = TStrategyFreeSpace(HullCtx, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlobsFreeSpace();
+                Task->SelectStrategy = ESelectStrategy::FreeSpace;
                 return action;
             }
 
@@ -76,7 +73,7 @@ namespace NKikimr {
             if (Params.SqueezeBefore) {
                 action = TStrategySqueeze(HullCtx, LevelSnap, Task, Params.SqueezeBefore).Select();
                 if (action != ActNothing) {
-                    ++HullCtx->CompactionStrategyGroup.BlobsSqueeze();
+                    Task->SelectStrategy = ESelectStrategy::Squeeze;
                     return action;
                 }
             }
@@ -99,21 +96,23 @@ namespace NKikimr {
             // try to promote ssts on higher levels w/o merging
             action = TStrategyPromoteSsts(HullCtx, Params.Boundaries, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlocksPromoteSsts();
+                Task->SelectStrategy = ESelectStrategy::PromoteSsts;
                 return action;
             }
 
             // compact explicitly defined SST's, if set
             action = TStrategyExplicit(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlocksExplicit();
+                Task->SelectStrategy = ESelectStrategy::Explicit;
                 return action;
             }
 
             // try to find what to compact based on levels balance
             action = TStrategyBalance(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BlocksBalance();
+                Task->SelectStrategy = Task->IsFullCompaction
+                    ? ESelectStrategy::BalanceFull
+                    : ESelectStrategy::BalanceLevel;
                 return action;
             }
 
@@ -136,21 +135,23 @@ namespace NKikimr {
             // try to promote ssts on higher levels w/o merging
             action = TStrategyPromoteSsts(HullCtx, Params.Boundaries, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BarriersPromoteSsts();
+                Task->SelectStrategy = ESelectStrategy::PromoteSsts;
                 return action;
             }
 
             // compact explicitly defined SST's, if set
             action = TStrategyExplicit(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BarriersExplicit();
+                Task->SelectStrategy = ESelectStrategy::Explicit;
                 return action;
             }
 
             // try to find what to compact based on levels balance
             action = TStrategyBalance(HullCtx, Params, LevelSnap, Task).Select();
             if (action != ActNothing) {
-                ++HullCtx->CompactionStrategyGroup.BarriersBalance();
+                Task->SelectStrategy = Task->IsFullCompaction
+                    ? ESelectStrategy::BalanceFull
+                    : ESelectStrategy::BalanceLevel;
                 return action;
             }
 

--- a/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
+++ b/ydb/core/blobstorage/vdisk/hullop/blobstorage_hullactor.cpp
@@ -9,6 +9,8 @@
 #include <ydb/core/blobstorage/vdisk/hulldb/bulksst_add/hulldb_bulksst_add.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/bulksst_add/hulldb_fullsyncsst_add.h>
 
+#include <type_traits>
+
 namespace NKikimr {
 
     ////////////////////////////////////////////////////////////////////////////
@@ -324,6 +326,70 @@ namespace NKikimr {
             ActiveActors.Insert(actorId, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
         }
 
+        void AccountSelectedStrategy() {
+            auto& group = HullDs->HullCtx->CompactionStrategyGroup;
+
+            if constexpr (std::is_same_v<TKey, TKeyLogoBlob>) {
+                switch (CompactionTask->SelectStrategy) {
+                    case NHullComp::ESelectStrategy::DelSst:
+                        ++group.BlobsDelSst();
+                        break;
+                    case NHullComp::ESelectStrategy::PromoteSsts:
+                        ++group.BlobsPromoteSsts();
+                        break;
+                    case NHullComp::ESelectStrategy::Explicit:
+                        ++group.BlobsExplicit();
+                        break;
+                    case NHullComp::ESelectStrategy::BalanceLevel:
+                        ++group.BlobsBalance();
+                        ++group.BlobsBalanceLevel();
+                        break;
+                    case NHullComp::ESelectStrategy::BalanceFull:
+                        ++group.BlobsBalance();
+                        ++group.BlobsBalanceFull();
+                        break;
+                    case NHullComp::ESelectStrategy::FreeSpace:
+                        ++group.BlobsFreeSpace();
+                        break;
+                    case NHullComp::ESelectStrategy::Squeeze:
+                        ++group.BlobsSqueeze();
+                        break;
+                    case NHullComp::ESelectStrategy::None:
+                        break;
+                }
+            } else if constexpr (std::is_same_v<TKey, TKeyBlock>) {
+                switch (CompactionTask->SelectStrategy) {
+                    case NHullComp::ESelectStrategy::PromoteSsts:
+                        ++group.BlocksPromoteSsts();
+                        break;
+                    case NHullComp::ESelectStrategy::Explicit:
+                        ++group.BlocksExplicit();
+                        break;
+                    case NHullComp::ESelectStrategy::BalanceLevel:
+                    case NHullComp::ESelectStrategy::BalanceFull:
+                        ++group.BlocksBalance();
+                        break;
+                    default:
+                        break;
+                }
+            } else if constexpr (std::is_same_v<TKey, TKeyBarrier>) {
+                switch (CompactionTask->SelectStrategy) {
+                    case NHullComp::ESelectStrategy::PromoteSsts:
+                        ++group.BarriersPromoteSsts();
+                        break;
+                    case NHullComp::ESelectStrategy::Explicit:
+                        ++group.BarriersExplicit();
+                        break;
+                    case NHullComp::ESelectStrategy::BalanceLevel:
+                    case NHullComp::ESelectStrategy::BalanceFull:
+                        ++group.BarriersBalance();
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
         void Handle(typename TSelected::TPtr &ev, const TActorContext &ctx) {
             ActiveActors.Erase(ev->Sender);
             Y_VERIFY_S(RTCtx->LevelIndex->GetCompState() == TLevelIndexBase::StateCompPolicyAtWork,
@@ -351,6 +417,7 @@ namespace NKikimr {
                     Y_VERIFY_S(CompactionTask->GetSstsToAdd().Empty() && !CompactionTask->GetSstsToDelete().Empty(),
                         HullDs->HullCtx->VCtx->VDiskLogPrefix);
                     if (CompactionTask->GetHugeBlobsToDelete().Empty() && CompactionTask->GetHugeBlobsAllocated().Empty()) {
+                        AccountSelectedStrategy();
                         ApplyCompactionResult(ctx, {}, {}, 0);
                     } else {
                         // switch compaction state to pre-compaction to block any attempts of concurrent compaction
@@ -368,6 +435,7 @@ namespace NKikimr {
                             Y_VERIFY_S(wId, HullDs->HullCtx->VCtx->VDiskLogPrefix);
                             LOG_DEBUG_S(ctx, NKikimrServices::BS_HULLCOMP, HullDs->HullCtx->VCtx->VDiskLogPrefix
                                 << "got PreCompactResult for ActDeleteSsts, wId# " << wId);
+                            AccountSelectedStrategy();
                             ApplyCompactionResult(ctx, {}, {}, wId);
                             RTCtx->LevelIndex->UpdateLevelStat(LevelStat);
                         });
@@ -378,6 +446,7 @@ namespace NKikimr {
                 case NHullComp::ActMoveSsts: {
                     Y_VERIFY_S(!CompactionTask->GetSstsToAdd().Empty() && !CompactionTask->GetSstsToDelete().Empty(),
                         HullDs->HullCtx->VCtx->VDiskLogPrefix);
+                    AccountSelectedStrategy();
                     ApplyCompactionResult(ctx, {}, {}, 0);
                     break;
                 }
@@ -392,6 +461,7 @@ namespace NKikimr {
                         LOG_DEBUG(ctx, NKikimrServices::BS_HULLCOMP,
                              VDISKP(HullDs->HullCtx->VCtx, "%s: compaction token not needed, starting compaction",
                                 PDiskSignatureForHullDbKey<TKey>().ToString().data()));
+                        AccountSelectedStrategy();
                         RunLevelCompaction(ctx, CompactionTask->CompactSsts.CompactionChains, CompactionTask->IsFullCompaction);
                         break;
                     }
@@ -401,6 +471,7 @@ namespace NKikimr {
                         LOG_INFO(ctx, NKikimrServices::BS_HULLCOMP,
                              VDISKP(HullDs->HullCtx->VCtx, "%s: token already acquired (token# %" PRIu64 "), starting compaction",
                                 PDiskSignatureForHullDbKey<TKey>().ToString().data(), CompactionToken));
+                        AccountSelectedStrategy();
                         RunLevelCompaction(ctx, CompactionTask->CompactSsts.CompactionChains, CompactionTask->IsFullCompaction);
                     } else {
                         LOG_DEBUG(ctx, NKikimrServices::BS_HULLCOMP,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Because the compaction token delays the launch of the compaction, it is more correct to calculate metrics not at the moment when the strategy is chosen, but at the moment when the compaction is actually launched.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
