### PR TITLE
Phase 1: TPageLocation types, IDataPageCollection, TLoadedPage migration

### DIFF
--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -205,13 +205,14 @@ void TBlockIO::Terminate(EStatus code)
 
     auto *ev = new TEvData(code, PageCollection, RequestCookie);
 
-    ev->Pages.resize(Pages.size());
+    ev->Pages.reserve(Pages.size());
     for (auto index : xrange(Pages.size())) {
-        auto& page = ev->Pages[index];
-        page.PageId = Pages[index];
-        if (code == NKikimrProto::OK) {
-            page.Data = std::move(BlockStates.at(index++).Data);
-        }
+        auto data = (code == NKikimrProto::OK)
+            ? std::move(BlockStates.at(index).Data)
+            : TSharedData{};
+        auto loc = PageCollection->GetLocation(Pages[index]);
+        ev->Pages.emplace_back(loc, std::move(data));
+        ev->Pages.back().PageId = Pages[index];
     }
 
     if (StatActorId)

--- a/ydb/core/tablet_flat/flat_boot_warm.h
+++ b/ydb/core/tablet_flat/flat_boot_warm.h
@@ -61,8 +61,9 @@ namespace NBoot {
             Y_ENSURE(page < state.Pages.size());
             Y_ENSURE(!state.Pages[page].Data);
 
-            state.Pages[page].PageId = page;
-            state.Pages[page].Data = load->PlainData();
+            auto data = load->PlainData();
+            state.Pages[page].Location = NTable::NPage::TPageLocation::FromPageIndex(page, data.size());
+            state.Pages[page].Data = std::move(data);
 
             if (!--state.Pending) {
                 state.Blobs->Assign(state.Pages);

--- a/ydb/core/tablet_flat/flat_fwd_env.h
+++ b/ydb/core/tablet_flat/flat_fwd_env.h
@@ -178,7 +178,9 @@ namespace NFwd {
             for (auto& page : pages) {
                 auto type = EPage(pageCollection->Page(page.PageId).Type);
                 auto data = NSharedCache::TPinnedPageRef(page.Page).GetData();
-                NPageCollection::TLoadedPage loadedPage{page.PageId, std::move(data)};
+                auto loc = pageCollection->GetLocation(page.PageId);
+                NPageCollection::TLoadedPage loadedPage{loc, std::move(data)};
+                loadedPage.PageId = page.PageId;
                 if (IsIndexPage(type)) {
                     Y_ENSURE(queue.IndexPageCollection->Label() == pageCollection->Label(), "TPart head storage doesn't match with fetch result");
                     queue->Fill(loadedPage, std::move(page.Page), type);

--- a/ydb/core/tablet_flat/flat_mem_blobs.h
+++ b/ydb/core/tablet_flat/flat_mem_blobs.h
@@ -72,9 +72,10 @@ namespace NMem {
         void Assign(TArrayRef<NPageCollection::TLoadedPage> pages)
         {
             for (auto &one : pages) {
-                Y_ENSURE(one.PageId < Store.size());
+                size_t index = one.Location.GetPageIndex();
+                Y_ENSURE(index < Store.size());
 
-                Store[one.PageId].Data = std::move(one.Data);
+                Store[index].Data = std::move(one.Data);
             }
         }
 

--- a/ydb/core/tablet_flat/flat_ops_compact.h
+++ b/ydb/core/tablet_flat/flat_ops_compact.h
@@ -362,9 +362,9 @@ namespace NTabletFlatExecutor {
                     auto resultingPageCollection = MakeIntrusive<NTable::TLoader::TPageCollection>(pageCollection.PageCollection);
                     auto saveCompactedPages = MakeHolder<NSharedCache::TEvSaveCompactedPages>(pageCollection.PageCollection);
                     auto gcList = SharedCachePages->GCList;
-                    auto addPage = [&saveCompactedPages, &pageCollection, &resultingPageCollection, &gcList](NPageCollection::TLoadedPage& loadedPage, bool sticky) {
+                    auto addPage = [&saveCompactedPages, &resultingPageCollection, &gcList](NPageCollection::TLoadedPage& loadedPage, bool sticky) {
                         auto pageId = loadedPage.PageId;
-                        auto pageSize = pageCollection.PageCollection->Page(pageId).Size;
+                        auto pageSize = loadedPage.Location.Size;
                         auto sharedPage = MakeIntrusive<TPage>(pageId, pageSize, nullptr);
                         sharedPage->ProvideBody(std::move(loadedPage.Data));
                         saveCompactedPages->Pages.push_back(sharedPage);

--- a/ydb/core/tablet_flat/flat_page_blobs.h
+++ b/ydb/core/tablet_flat/flat_page_blobs.h
@@ -100,6 +100,11 @@ namespace NPage {
             return data && data.size() == Array.at(page).Bytes();
         }
 
+        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override
+        {
+            return NTable::NPage::TPageLocation::FromPageIndex(pageId, Glob(pageId).Bytes());
+        }
+
         size_t BackingSize() const noexcept override
         {
             return Raw.size();

--- a/ydb/core/tablet_flat/flat_page_iface.h
+++ b/ydb/core/tablet_flat/flat_page_iface.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <util/system/types.h>
+#include <util/generic/utility.h>
 #include <util/stream/output.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 
 namespace NKikimr {
 namespace NTable {
@@ -9,6 +11,132 @@ namespace NPage {
 
     using TSize = ui32;
     using TPageId = ui32;
+
+    class TPageOffset {
+        ui64 Raw;
+
+        static constexpr ui64 MaxRaw = ::Max<ui64>();
+        static constexpr ui64 IndexTag = ui64(1) << 63;
+
+        explicit constexpr TPageOffset(ui64 raw) noexcept
+            : Raw(raw)
+        {}
+
+    public:
+        /** Default constructor — Max sentinel (all bits set) */
+        TPageOffset() noexcept
+            : Raw(MaxRaw)
+        {}
+
+        /** Factory: create from a real byte offset (pages in a blob sequence).
+            Clears the MSB to prevent accidental PageIndex tag. */
+        static TPageOffset FromByteOffset(ui64 value) noexcept {
+            Y_VERIFY_DEBUG(value < IndexTag,
+                "Byte offset is too large to be represented as TPageOffset");
+            return TPageOffset(value);
+        }
+
+        /** Factory: create from a page index (independently addressed pages).
+            Sets the MSB to tag this as a page index. */
+        static TPageOffset FromPageIndex(ui32 value) noexcept {
+            return TPageOffset(static_cast<ui64>(value) | IndexTag);
+        }
+
+        /** Max sentinel — all bits set */
+        static TPageOffset Max() noexcept { return TPageOffset(); }
+
+        /** True when this is not the Max sentinel */
+        explicit operator bool() const noexcept { return Raw != MaxRaw; }
+
+        bool IsMax() const noexcept { return Raw == MaxRaw; }
+        bool IsByteOffset() const noexcept { return !IsMax() && !(Raw & IndexTag); }
+        bool IsPageIndex() const noexcept { return !IsMax() && (Raw & IndexTag); }
+
+        /** Access as a real byte offset — asserts ByteOffset kind */
+        ui64 AsByteOffset() const noexcept {
+            Y_VERIFY_DEBUG(IsByteOffset(),
+                "TPageOffset is not a byte offset (raw=%" PRIu64 ")", Raw);
+            return Raw;
+        }
+
+        /** Access as a page index — asserts PageIndex kind */
+        ui32 AsPageIndex() const noexcept {
+            Y_VERIFY_DEBUG(IsPageIndex(),
+                "TPageOffset is not a page index (raw=%" PRIu64 ")", Raw);
+            return static_cast<ui32>(Raw);
+        }
+
+        bool operator==(const TPageOffset& rhs) const noexcept { return Raw == rhs.Raw; }
+        bool operator!=(const TPageOffset& rhs) const noexcept { return Raw != rhs.Raw; }
+
+        explicit operator size_t() const noexcept {
+            return static_cast<size_t>(Raw);
+        }
+
+        void Describe(IOutputStream& out) const noexcept {
+            if (IsMax()) {
+                out << "Max";
+            } else if (IsByteOffset()) {
+                out << "bo:" << Raw;
+            } else {
+                out << "pi:" << static_cast<ui32>(Raw);
+            }
+        }
+
+        friend IOutputStream& operator<<(IOutputStream& out, const TPageOffset& offset) {
+            offset.Describe(out);
+            return out;
+        }
+    };
+
+    struct TPageLocation {
+        TPageOffset Offset;
+        ui64 Size = 0;
+        ui32 Crc32 = 0;
+        ui32 Pad0_ = 0;
+
+        TPageLocation() = default;
+
+        /// Construct from a real byte offset (pages in a blob sequence)
+        static TPageLocation FromByteOffset(ui64 offset, ui64 size,
+                                            ui32 crc32 = 0) noexcept {
+            return {TPageOffset::FromByteOffset(offset), size, crc32};
+        }
+
+        /// Construct from a page index (independently addressed pages)
+        static TPageLocation FromPageIndex(ui32 pageId, ui64 size) noexcept {
+            return {TPageOffset::FromPageIndex(pageId), size, 0};
+        }
+
+    private:
+        TPageLocation(TPageOffset offset, ui64 size, ui32 crc32) noexcept
+            : Offset(offset), Size(size), Crc32(crc32)
+        {}
+
+    public:
+
+        explicit operator bool() const noexcept { return bool(Offset); }
+
+        /** Access the offset as a byte offset — asserts the location was built from FromByteOffset */
+        ui64 GetByteOffset() const noexcept { return Offset.AsByteOffset(); }
+
+        /** Access the offset as a page index — asserts the location was built from FromPageIndex */
+        ui32 GetPageIndex() const noexcept { return Offset.AsPageIndex(); }
+
+        bool operator==(const TPageLocation& rhs) const noexcept {
+            // Skip Crc32 as it can be zero
+            // 2 pages at the same offset is impossible
+            Y_VERIFY_DEBUG(Offset != rhs.Offset || Size == rhs.Size);
+            return Offset == rhs.Offset;
+        }
+        bool operator!=(const TPageLocation& rhs) const noexcept { return !(*this == rhs); }
+
+        static TPageLocation Max() noexcept { return TPageLocation{}; }
+
+        void Describe(IOutputStream& out) const {
+            out << "{" << Offset << "," << Size << "," << Crc32 << "}";
+        }
+    };
 
     /**
      * A type-safe column group identifier

--- a/ydb/core/tablet_flat/flat_sausage_datacollection.h
+++ b/ydb/core/tablet_flat/flat_sausage_datacollection.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "flat_sausage_misc.h"
+#include "flat_page_iface.h"
+
+namespace NKikimr {
+namespace NPageCollection {
+
+    class IDataPageCollection: public TAtomicRefCount<IDataPageCollection> {
+    public:
+        virtual ~IDataPageCollection() = default;
+
+        /// Maps a page location to the blob storage range containing it
+        virtual TBorder Bounds(NTable::NPage::TPageLocation location) const = 0;
+
+        /// Verifies that data matches the expected size and checksum
+        virtual bool Verify(NTable::NPage::TPageLocation location, TArrayRef<const char> data) const = 0;
+    };
+
+}   // namespace NPageCollection
+}   // namespace NKikimr

--- a/ydb/core/tablet_flat/flat_sausage_fetch.h
+++ b/ydb/core/tablet_flat/flat_sausage_fetch.h
@@ -15,19 +15,22 @@ namespace NPageCollection {
     struct TLoadedPage {
         TLoadedPage() = default;
 
-        TLoadedPage(TPageId page, TSharedData data)
-            : PageId(page)
+        TLoadedPage(NTable::NPage::TPageLocation location, TSharedData data)
+            : Location(location)
             , Data(std::move(data))
         {
 
         }
 
+        TLoadedPage(TPageId page, TSharedData data) = delete;
+
         explicit operator bool() const noexcept
         {
-            return Data && PageId != Max<TPageId>();
+            return Data && bool(Location);
         }
 
-        TPageId PageId = Max<TPageId>();
+        NTable::NPage::TPageLocation Location;
+        TPageId PageId = ::Max<TPageId>();
         TSharedData Data;
     };
 

--- a/ydb/core/tablet_flat/flat_sausage_gut.h
+++ b/ydb/core/tablet_flat/flat_sausage_gut.h
@@ -17,6 +17,7 @@ namespace NPageCollection {
         virtual TGlobId Glob(ui32 blob) const = 0;
         virtual bool Verify(ui32 page, TArrayRef<const char>) const = 0;
         virtual size_t BackingSize() const noexcept = 0;
+        virtual NTable::NPage::TPageLocation GetLocation(ui32 pageId) const = 0;
     };
 
 }

--- a/ydb/core/tablet_flat/flat_sausage_meta.cpp
+++ b/ydb/core/tablet_flat/flat_sausage_meta.cpp
@@ -78,6 +78,26 @@ ui64 TMeta::GetPageSize(ui32 pageId) const
     return Index[pageId].Page - begin;
 }
 
+NTable::NPage::TPageLocation TMeta::GetLocation(ui32 pageId) const
+{
+    Y_DEBUG_ABORT_UNLESS(pageId < Header->Pages);
+
+    const ui64 offset = (pageId == 0) ? 0 : Index[pageId - 1].Page;
+    const ui64 size = Index[pageId].Page - offset;
+
+    return NTable::NPage::TPageLocation::FromByteOffset(offset, size, Extra[pageId].Crc32);
+}
+
+TBorder TMeta::Bounds(NTable::NPage::TPageLocation location) const
+{
+    return TAlign(Steps).Lookup(location.GetByteOffset(), location.Size);
+}
+
+bool TMeta::Verify(NTable::NPage::TPageLocation location, TArrayRef<const char> data) const
+{
+    return data.size() == location.Size && Checksum(data) == location.Crc32;
+}
+
 TStringBuf TMeta::GetPageInplaceData(ui32 pageId) const
 {
     Y_DEBUG_ABORT_UNLESS(pageId < Header->Pages);

--- a/ydb/core/tablet_flat/flat_sausage_meta.h
+++ b/ydb/core/tablet_flat/flat_sausage_meta.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "flat_sausage_datacollection.h"
 #include "flat_sausage_misc.h"
 #include "flat_sausage_layout.h"
 #include "flat_sausage_solid.h"
@@ -9,7 +10,7 @@
 namespace NKikimr {
 namespace NPageCollection {
 
-    class TMeta {
+    class TMeta : public IDataPageCollection {
     public:
         TMeta(TSharedData blob, ui32 group);
         ~TMeta();
@@ -40,6 +41,13 @@ namespace NPageCollection {
         ui32 GetPageChecksum(ui32 pageId) const;
         ui64 GetPageSize(ui32 pageId) const;
         TStringBuf GetPageInplaceData(ui32 pageId) const;
+
+        // IDataPageCollection
+        TBorder Bounds(NTable::NPage::TPageLocation location) const override;
+        bool Verify(NTable::NPage::TPageLocation location, TArrayRef<const char> data) const override;
+
+        /// Returns the location of a page identified by its index
+        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const;
 
     public:
         const TSharedData Raw;  /* Page collection serialized meta blob */

--- a/ydb/core/tablet_flat/flat_sausage_packet.h
+++ b/ydb/core/tablet_flat/flat_sausage_packet.h
@@ -53,6 +53,11 @@ namespace NPageCollection {
                 && Meta.GetPageChecksum(page) == Checksum(body);
         }
 
+        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override
+        {
+            return Meta.GetLocation(pageId);
+        }
+
         size_t BackingSize() const noexcept override
         {
             return Meta.BackingSize();

--- a/ydb/core/tablet_flat/flat_writer_blocks.h
+++ b/ydb/core/tablet_flat/flat_writer_blocks.h
@@ -53,6 +53,7 @@ namespace NWriter {
 
             Y_ENSURE(!Writer, "Block writer is not empty after Finish");
 
+            Offset = 0;
             return std::exchange(Result, {});
         }
 
@@ -64,12 +65,17 @@ namespace NWriter {
                 Cone->Put(std::move(glob));
             }
 
+            auto location = NTable::NPage::TPageLocation::FromByteOffset(Offset, raw.size());
+            Offset += raw.size();
+
             if (NTable::TLoader::NeedIn(type) || Cache == ECache::Ever || StickyFlatIndex && type == EPage::FlatIndex) {
-                Result.StickyPages.emplace_back(pageId, std::move(raw));
+                Result.StickyPages.emplace_back(location, std::move(raw));
+                Result.StickyPages.back().PageId = pageId;
             } else if (bool(Cache) && type == EPage::DataPage || type == EPage::BTreeIndex || CacheMode == ECacheMode::TryKeepInMemory) {
                 // TODO: take into account memory limits for TryKeepInMemory mode
                 // Note: save b-tree index pages to shared cache regardless of a cache mode
-                Result.RegularPages.emplace_back(pageId, std::move(raw));
+                Result.RegularPages.emplace_back(location, std::move(raw));
+                Result.RegularPages.back().PageId = pageId;
             }
 
             return pageId;
@@ -95,6 +101,7 @@ namespace NWriter {
 
         NPageCollection::TWriter Writer;
         TResult Result;
+        ui64 Offset = 0;
     };
 }
 }

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -180,13 +180,25 @@ namespace NTest {
                     PageLoadingLogic->Forward(this, upper);
                 }
 
-                for (auto &seq: IndexFetch) {
-                    NPageCollection::TLoadedPage page(seq, *Store->GetPage(IndexRoom, seq));
-                    PageLoadingLogic->Fill(page, {}, Store->GetPageType(IndexRoom, seq)); /* will move data */
+                {
+                    for (auto &seq: IndexFetch) {
+                        auto pageData = Store->GetPage(IndexRoom, seq);
+                        NPageCollection::TLoadedPage page(
+                            NTable::NPage::TPageLocation::FromPageIndex(seq, pageData->size()),
+                            *pageData);
+                        page.PageId = seq;
+                        PageLoadingLogic->Fill(page, {}, Store->GetPageType(IndexRoom, seq)); /* will move data */
+                    }
                 }
-                for (auto &seq: GroupFetch) {
-                    NPageCollection::TLoadedPage page(seq, *Store->GetPage(GroupRoom, seq));
-                    PageLoadingLogic->Fill(page, {}, Store->GetPageType(GroupRoom, seq)); /* will move data */
+                {
+                    for (auto &seq: GroupFetch) {
+                        auto pageData = Store->GetPage(GroupRoom, seq);
+                        NPageCollection::TLoadedPage page(
+                            NTable::NPage::TPageLocation::FromPageIndex(seq, pageData->size()),
+                            *pageData);
+                        page.PageId = seq;
+                        PageLoadingLogic->Fill(page, {}, Store->GetPageType(GroupRoom, seq)); /* will move data */
+                    }
                 }
 
                 IndexFetch.clear();

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -99,7 +99,10 @@ namespace {
                     UNIT_ASSERT(false);
                 }
 
-                load.emplace_back(page, TSharedData::Copy(TString(rel.Size, 'x')));
+                load.emplace_back(
+                    NTable::NPage::TPageLocation::FromPageIndex(page, rel.Size),
+                    TSharedData::Copy(TString(rel.Size, 'x')));
+                load.back().PageId = page;
             }
 
             if (load.size() < least || load.size() >= most) {
@@ -190,7 +193,9 @@ namespace {
             TVector<NPageCollection::TLoadedPage> load;
             NTest::TTestEnv testEnv;
             for (auto pageId : std::exchange(Queue, TDeque<ui32>{ })) {
-                load.emplace_back(pageId, *testEnv.TryGetPage(Part.Get(), pageId, { }));
+                auto* data = testEnv.TryGetPage(Part.Get(), pageId, { });
+                load.emplace_back(NTable::NPage::TPageLocation::FromPageIndex(pageId, data->size()), *data);
+                load.back().PageId = pageId;
             }
 
             Shuffle(load.begin(), load.end(), Rnd);
@@ -211,7 +216,7 @@ namespace {
             }
 
             UNIT_ASSERT_VALUES_EQUAL_C(TVector<TPageId>(Queue.begin(), Queue.end()), pageIds, CurrentStepStr());
-        
+
             UNIT_ASSERT_VALUES_EQUAL_C(Cache->Stat, stat, CurrentStepStr());
 
             return *this;
@@ -231,7 +236,9 @@ namespace {
                     }
                 }
                 UNIT_ASSERT_C(found, CurrentStepStr());
-                load.emplace_back(pageId, *testEnv.TryGetPage(Part.Get(), pageId, { }));
+                auto* data = testEnv.TryGetPage(Part.Get(), pageId, { });
+                load.emplace_back(NTable::NPage::TPageLocation::FromPageIndex(pageId, data->size()), *data);
+                load.back().PageId = pageId;
             }
 
             Shuffle(load.begin(), load.end(), Rnd);

--- a/ydb/core/tablet_flat/ut/ut_sausage.cpp
+++ b/ydb/core/tablet_flat/ut/ut_sausage.cpp
@@ -1,10 +1,13 @@
 #include <ydb/core/tablet_flat/flat_sausage_align.h>
 #include <ydb/core/tablet_flat/flat_sausage_meta.h>
 #include <ydb/core/tablet_flat/flat_sausage_writer.h>
+#include <ydb/core/tablet_flat/flat_sausage_packet.h>
 #include <ydb/core/tablet_flat/flat_sausage_flow.h>
 #include <ydb/core/tablet_flat/flat_sausage_solid.h>
 #include <ydb/core/tablet_flat/flat_sausage_chop.h>
 #include <ydb/core/tablet_flat/flat_sausage_grind.h>
+#include <ydb/core/tablet_flat/flat_page_blobs.h>
+#include <ydb/core/tablet_flat/flat_page_other.h>
 #include <ydb/core/tablet_flat/util_fmt_desc.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -408,6 +411,203 @@ Y_UNIT_TEST_SUITE(NPageCollection) {
             auto glob = cookieAllocator.Do(3, 77);
 
             UNIT_ASSERT(glob == TGlobId(TLogoBlobID(1, 2, 6, 3, 77, 11), 999));
+        }
+    }
+
+    Y_UNIT_TEST(TPageLocation_Basics)
+    {
+        using NTable::NPage::TPageLocation;
+        using NTable::NPage::TPageOffset;
+
+        // Default construction yields Max
+        TPageLocation def;
+        UNIT_ASSERT(!def);
+        UNIT_ASSERT(def.Offset == TPageOffset::Max());
+
+        // Parameterized construction
+        auto loc = TPageLocation::FromByteOffset(42, 1024, 0x12345678);
+        UNIT_ASSERT(bool(loc));
+        UNIT_ASSERT(loc.Offset == TPageOffset::FromByteOffset(42));
+        UNIT_ASSERT(loc.Size == 1024);
+        UNIT_ASSERT(loc.Crc32 == 0x12345678);
+
+        // Equality (compares offset, verifies size)
+        auto same = TPageLocation::FromByteOffset(42, 1024, 0);
+        auto diff = TPageLocation::FromByteOffset(99, 1024, 0);
+        UNIT_ASSERT(loc == same);
+        UNIT_ASSERT(loc != diff);
+
+        // Max factory
+        auto maxed = TPageLocation::Max();
+        UNIT_ASSERT(!maxed);
+        UNIT_ASSERT(maxed.Offset.IsMax());
+    }
+
+    Y_UNIT_TEST(GetLocation)
+    {
+        const TMeta meta(MakeMeta(), 0);
+        // Pages: { 50, 30, 80, 60, 40, 60, 70, 380, 10 }
+        //
+        // Expected offsets:
+        //   0:   0,  1:  50,  2:  80,  3: 160,  4: 220,
+        //   5: 260,  6: 320,  7: 390,  8: 770
+
+        const std::pair<ui64, ui32> expected[9] = {
+            {   0, 50 },
+            {  50, 30 },
+            {  80, 80 },
+            { 160, 60 },
+            { 220, 40 },
+            { 260, 60 },
+            { 320, 70 },
+            { 390, 380 },
+            { 770, 10 },
+        };
+
+        for (ui32 i = 0; i < 9; i++) {
+            auto loc = meta.GetLocation(i);
+            UNIT_ASSERT(loc);
+            UNIT_ASSERT_VALUES_EQUAL(loc.GetByteOffset(), expected[i].first);
+            UNIT_ASSERT_VALUES_EQUAL(loc.Size,   expected[i].second);
+            UNIT_ASSERT_VALUES_EQUAL(loc.Crc32,  meta.GetPageChecksum(i));
+        }
+    }
+
+    Y_UNIT_TEST(Bounds_via_Location)
+    {
+        const TMeta meta(MakeMeta(), 0);
+
+        for (ui32 i = 0; i < 9; i++) {
+            auto loc = meta.GetLocation(i);
+
+            // Bounds(TPageLocation) must match Bounds(ui32)
+            auto boundsViaId   = meta.Bounds(i);
+            auto boundsViaLoc  = meta.Bounds(loc);
+
+            UNIT_ASSERT(boundsViaLoc.Lo.Blob == boundsViaId.Lo.Blob);
+            UNIT_ASSERT(boundsViaLoc.Lo.Skip == boundsViaId.Lo.Skip);
+            UNIT_ASSERT(boundsViaLoc.Up.Blob == boundsViaId.Up.Blob);
+            UNIT_ASSERT(boundsViaLoc.Up.Skip == boundsViaId.Up.Skip);
+            UNIT_ASSERT(boundsViaLoc.Bytes == boundsViaId.Bytes);
+        }
+    }
+
+    Y_UNIT_TEST(Verify_via_Location)
+    {
+        auto metaBlob = MakeMeta();
+        const TMeta meta(metaBlob, 0);
+
+        for (ui32 i = 0; i < 9; i++) {
+            auto loc = meta.GetLocation(i);
+
+            // Correct data: verify through IDataPageCollection
+            TString data(loc.Size, '9');
+            UNIT_ASSERT(meta.Verify(loc, TArrayRef<const char>(data.data(), data.size())));
+
+            // Wrong size → false
+            TString wrongSize(loc.Size + 1, '9');
+            UNIT_ASSERT(!meta.Verify(loc, TArrayRef<const char>(wrongSize.data(), wrongSize.size())));
+
+            // Wrong data → false
+            if (loc.Size > 0) {
+                TString wrongData(loc.Size, 'X');
+                UNIT_ASSERT(!meta.Verify(loc, TArrayRef<const char>(wrongData.data(), wrongData.size())));
+            }
+        }
+    }
+
+    Y_UNIT_TEST(TPageCollection_GetLocation)
+    {
+        auto metaBlob = MakeMeta();
+        // Build a TLargeGlobId with Bytes matching the blob size
+        TLargeGlobId largeGlobId(0, TLogoBlobID(10, 20, 30, 1, metaBlob.size(), 0), metaBlob.size());
+        TPageCollection pageCollection(largeGlobId, metaBlob);
+
+        UNIT_ASSERT_VALUES_EQUAL(pageCollection.Total(), 9);
+
+        // TPageCollection::GetLocation must delegate to TMeta::GetLocation
+        TMeta rawMeta(MakeMeta(), 0);
+        for (ui32 i = 0; i < 9; i++) {
+            auto viaPC = pageCollection.GetLocation(i);
+            auto viaRaw = rawMeta.GetLocation(i);
+            UNIT_ASSERT(viaPC == viaRaw);
+            UNIT_ASSERT_VALUES_EQUAL(viaPC.Offset, viaRaw.Offset);
+            UNIT_ASSERT_VALUES_EQUAL(viaPC.Size,   viaRaw.Size);
+            UNIT_ASSERT_VALUES_EQUAL(viaPC.Crc32,  viaRaw.Crc32);
+        }
+    }
+
+    Y_UNIT_TEST(TExtBlobs_GetLocation)
+    {
+        // Build 5 globs with varying sizes
+        const std::array<NPageCollection::TGlobId, 5> globs = {{
+            { TLogoBlobID(1, 2, 3,  1, 100, 0), 7 },
+            { TLogoBlobID(1, 2, 3,  7,  50, 1), 7 },
+            { TLogoBlobID(1, 2, 3, 13, 200, 2), 7 },
+            { TLogoBlobID(1, 2, 3, 33,  80, 3), 4 },
+            { TLogoBlobID(1, 2, 3, 57, 120, 4), 7 },
+        }};
+
+        NTable::NPage::TExtBlobsWriter writer;
+        for (auto &g : globs) {
+            writer.Put(g);
+        }
+
+        auto blob = writer.Make();
+        NTable::NPage::TExtBlobs extBlobs(blob, TLogoBlobID(1, 2, 3, 1, blob.size(), 0));
+
+        // For independently addressed blobs, Offset equals pageId (index in Array)
+        //   0:   0,  1:   1,  2:   2,  3:   3,  4:   4
+        const ui64 expectedOffset[5] = { 0, 1, 2, 3, 4 };
+        const ui32 expectedSize[5]   = { 100, 50, 200, 80, 120 };
+
+        UNIT_ASSERT_VALUES_EQUAL(extBlobs.Total(), 5);
+
+        for (ui32 i = 0; i < 5; i++) {
+            auto loc = extBlobs.GetLocation(i);
+            UNIT_ASSERT(bool(loc));
+            UNIT_ASSERT_VALUES_EQUAL(loc.GetPageIndex(), expectedOffset[i]);
+            UNIT_ASSERT_VALUES_EQUAL(loc.Size,   expectedSize[i]);
+            UNIT_ASSERT_VALUES_EQUAL(loc.Crc32,  0);  // TExtBlobs always sets Crc32=0
+        }
+    }
+
+    Y_UNIT_TEST(IPageCollection_GetLocation_Polymorphic)
+    {
+        // Verify pure virtual dispatch works for both TPageCollection and TExtBlobs
+
+        // --- TPageCollection via IPageCollection& ---
+        auto metaBlob = MakeMeta();
+        TLargeGlobId largeGlobId(0, TLogoBlobID(10, 20, 30, 1, metaBlob.size(), 0), metaBlob.size());
+        TPageCollection pageCollection(largeGlobId, metaBlob);
+
+        const IPageCollection& pcRef = pageCollection;
+        TMeta rawMeta(MakeMeta(), 0);
+        for (ui32 i = 0; i < 9; i++) {
+            auto loc = pcRef.GetLocation(i);
+            auto expected = rawMeta.GetLocation(i);
+            UNIT_ASSERT(loc == expected);
+        }
+
+        // --- TExtBlobs via IPageCollection& ---
+        const std::array<NPageCollection::TGlobId, 3> globs = {{
+            { TLogoBlobID(1, 2, 3,  1, 60, 0), 7 },
+            { TLogoBlobID(1, 2, 3,  7, 40, 1), 7 },
+            { TLogoBlobID(1, 2, 3, 13, 90, 2), 7 },
+        }};
+
+        NTable::NPage::TExtBlobsWriter writer;
+        for (auto &g : globs) writer.Put(g);
+        auto blob = writer.Make();
+        NTable::NPage::TExtBlobs extBlobs(blob, TLogoBlobID(1, 2, 3, 1, blob.size(), 0));
+
+        const IPageCollection& ebRef = extBlobs;
+        for (ui32 i = 0; i < 3; i++) {
+            auto loc = ebRef.GetLocation(i);
+            UNIT_ASSERT(bool(loc));
+            // For independently addressed blobs, Offset equals pageId (index in Array)
+            UNIT_ASSERT_VALUES_EQUAL(loc.GetPageIndex(), i);
+            UNIT_ASSERT_VALUES_EQUAL(loc.Size, globs[i].Bytes());
         }
     }
 }

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
@@ -76,6 +76,10 @@ struct TPageCollectionMock : public IPageCollection {
         return 10 * TotalPages;
     }
 
+    NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override {
+        return NTable::NPage::TPageLocation::FromPageIndex(pageId, 10);
+    }
+
 private:
     TLogoBlobID Id;
     ui32 TotalPages;
@@ -182,7 +186,9 @@ struct TSharedPageCacheMock {
     TSharedPageCacheMock& Provide(TIntrusiveConstPtr<TPageCollectionMock> collection, TVector<TPageId> pages, ui64 eventCookie = NO_QUEUE_COOKIE) { // event cookie -> queue type
         auto data = new NBlockIO::TEvData(NKikimrProto::OK, collection, pages.size() * 10); // fetch cookie -> requested size
         for (auto pageId : pages) {
-            data->Pages.push_back(TLoadedPage(pageId, TSharedData::Copy(TString(10, 'x'))));
+            auto loc = NTable::NPage::TPageLocation::FromPageIndex(pageId, 10);
+            data->Pages.emplace_back(loc, TSharedData::Copy(TString(10, 'x')));
+            data->Pages.back().PageId = pageId;
         }
         Send(BlockIoSender, data, eventCookie);
 
@@ -258,7 +264,7 @@ struct TSharedPageCacheMock {
             UNIT_ASSERT_VALUES_EQUAL(r->Get()->Status, status);
             auto& result = *r->Get();
             actual.push_back(TFetch{result.Cookie, result.PageCollection, {}});
-            for (auto p : r->Get()->Pages) {
+            for (auto& p : r->Get()->Pages) {
                 actual.back().Pages.push_back(p.PageId);
                 pages.emplace(p.PageId, p.Page);
             }
@@ -367,7 +373,11 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->PageCollectionOwners->Val(), 4);
 
         auto data = new NBlockIO::TEvData(NKikimrProto::ERROR, sharedCache.Collection1, 30);
-        data->Pages = {NPageCollection::TLoadedPage{1, {}}, NPageCollection::TLoadedPage{2, {}}, NPageCollection::TLoadedPage{3, {}}};
+        data->Pages.clear();
+        for (ui32 pageId = 1; pageId <= 3; pageId++) {
+            data->Pages.emplace_back(NTable::NPage::TPageLocation::FromPageIndex(pageId, 0), TSharedData{});
+            data->Pages.back().PageId = pageId;
+        }
         sharedCache.Send(sharedCache.BlockIoSender, data, NO_QUEUE_COOKIE);
         sharedCache.CheckResults({
             TFetch{1, sharedCache.Collection1, {}},
@@ -477,7 +487,9 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->PageCollectionOwners->Val(), 4);
 
         auto data = new NBlockIO::TEvData(NKikimrProto::ERROR, sharedCache.Collection1, 10);
-        data->Pages = {NPageCollection::TLoadedPage{1, {}}};
+        data->Pages.clear();
+        data->Pages.emplace_back(NTable::NPage::TPageLocation::FromPageIndex(1, 0), TSharedData{});
+        data->Pages.back().PageId = 1;
         sharedCache.Send(sharedCache.BlockIoSender, data, ASYNC_QUEUE_COOKIE);
         sharedCache.CheckResults({
             TFetch{1, sharedCache.Collection1, {}},

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -106,6 +106,11 @@ namespace {
             return Part->Store->PageCollectionBytes(Room);
         }
 
+        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override
+        {
+            return NTable::NPage::TPageLocation::FromPageIndex(pageId, Page(pageId).Size);
+        }
+
     private:
         TIntrusiveConstPtr<NTest::TPartStore> Part;
         ui32 Room;


### PR DESCRIPTION
- Add TPageOffset and TPageLocation types with FromByteOffset/FromPageIndex factories
- Create IDataPageCollection interface with Bounds(TPageLocation) and Verify(TPageLocation, data)
- TMeta implements IDataPageCollection; add TMeta::GetLocation(TPageId) -> TPageLocation
- TLoadedPage(TPageId, TSharedData) ctor deleted; primary ctor takes TPageLocation
- TWriter support for TPageLocation; fix TBlocks::Write offset calc (single offset)
- IPageCollection gets GetLocation(ui32) pure virtual
- Migrate all callers: bio actor, fwd env, boot warm, writer, test envs, tests

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
