### PR TITLE
Added index load tests workflow

### DIFF
--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -33,6 +33,22 @@ on:
         description: 'Warmup duration in seconds before each measured run'
         required: false
         default: '30'
+      main_feature_flags:
+        description: 'Comma-separated feature flags for main branch (e.g. enable_foo,enable_bar)'
+        required: false
+        default: ''
+      current_feature_flags:
+        description: 'Comma-separated feature flags for current branch (e.g. enable_foo,enable_bar)'
+        required: false
+        default: ''
+      main_table_service_config:
+        description: 'Comma-separated table_service_config options for main branch (e.g. enable_vector_index_read=true)'
+        required: false
+        default: ''
+      current_table_service_config:
+        description: 'Comma-separated table_service_config options for current branch (e.g. enable_vector_index_read=true)'
+        required: false
+        default: ''
 
 jobs:
   compare:
@@ -45,13 +61,45 @@ jobs:
 
       - name: Run performance comparison
         run: |
+          MAIN_FLAG_ARGS=""
+          IFS=',' read -ra FLAGS <<< "${{ inputs.main_feature_flags || '' }}"
+          for flag in "${FLAGS[@]}"; do
+            if [[ -n "$flag" ]]; then
+              MAIN_FLAG_ARGS="$MAIN_FLAG_ARGS --main-feature-flag $flag"
+            fi
+          done
+          CURRENT_FLAG_ARGS=""
+          IFS=',' read -ra FLAGS <<< "${{ inputs.current_feature_flags || '' }}"
+          for flag in "${FLAGS[@]}"; do
+            if [[ -n "$flag" ]]; then
+              CURRENT_FLAG_ARGS="$CURRENT_FLAG_ARGS --current-feature-flag $flag"
+            fi
+          done
+          MAIN_TSC_ARGS=""
+          IFS=',' read -ra OPTS <<< "${{ inputs.main_table_service_config || '' }}"
+          for opt in "${OPTS[@]}"; do
+            if [[ -n "$opt" ]]; then
+              MAIN_TSC_ARGS="$MAIN_TSC_ARGS --main-table-service-config $opt"
+            fi
+          done
+          CURRENT_TSC_ARGS=""
+          IFS=',' read -ra OPTS <<< "${{ inputs.current_table_service_config || '' }}"
+          for opt in "${OPTS[@]}"; do
+            if [[ -n "$opt" ]]; then
+              CURRENT_TSC_ARGS="$CURRENT_TSC_ARGS --current-table-service-config $opt"
+            fi
+          done
           ./ydb/tests/stress/compare_index_performance.sh \
             --duration ${{ inputs.duration || '600' }} \
             --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
             --ref ${{ inputs.ref || 'main' }} \
             --targets ${{ inputs.targets || '100' }} \
             --iterations ${{ inputs.iterations || '3' }} \
-            --warmup ${{ inputs.warmup || '30' }}
+            --warmup ${{ inputs.warmup || '30' }} \
+            $MAIN_FLAG_ARGS \
+            $CURRENT_FLAG_ARGS \
+            $MAIN_TSC_ARGS \
+            $CURRENT_TSC_ARGS
 
       - name: Post results to job summary
         if: always()

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -21,6 +21,15 @@ on:
         description: 'S3 ref to compare against (e.g. main, stable-26-1-1)'
         required: false
         default: 'main'
+      workload:
+        description: 'Workload to run'
+        required: false
+        type: choice
+        options:
+          - all
+          - vector
+          - fulltext
+        default: all
       targets:
         description: 'Number of query vectors for vector select'
         required: false
@@ -94,6 +103,7 @@ jobs:
             --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
             --ref ${{ inputs.ref || 'main' }} \
             --targets ${{ inputs.targets || '100' }} \
+            --workload ${{ inputs.workload || 'all' }} \
             --iterations ${{ inputs.iterations || '3' }} \
             --warmup ${{ inputs.warmup || '30' }} \
             $MAIN_FLAG_ARGS \

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -33,7 +33,7 @@ on:
       rows:
         description: 'Number of rows in generated database'
         required: false
-        default: '100000'
+        default: '10000'
       targets:
         description: 'Number of query vectors for vector select'
         required: false
@@ -77,45 +77,59 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run performance comparison
+        env:
+          INPUT_DURATION: ${{ inputs.duration || '600' }}
+          INPUT_BUILD_PRESET: ${{ inputs.build_preset || 'relwithdebinfo' }}
+          INPUT_REF: ${{ inputs.ref || 'main' }}
+          INPUT_WORKLOAD: ${{ inputs.workload || 'all' }}
+          INPUT_ROWS: ${{ inputs.rows || '10000' }}
+          INPUT_TARGETS: ${{ inputs.targets || '1000' }}
+          INPUT_ITERATIONS: ${{ inputs.iterations || '20' }}
+          INPUT_WARMUP: ${{ inputs.warmup || '30' }}
+          INPUT_THREADS: ${{ inputs.threads || '10' }}
+          INPUT_MAIN_FEATURE_FLAGS: ${{ inputs.main_feature_flags || '' }}
+          INPUT_CURRENT_FEATURE_FLAGS: ${{ inputs.current_feature_flags || '' }}
+          INPUT_MAIN_TABLE_SERVICE_CONFIG: ${{ inputs.main_table_service_config || '' }}
+          INPUT_CURRENT_TABLE_SERVICE_CONFIG: ${{ inputs.current_table_service_config || '' }}
         run: |
           MAIN_FLAG_ARGS=""
-          IFS=',' read -ra FLAGS <<< "${{ inputs.main_feature_flags || '' }}"
+          IFS=',' read -ra FLAGS <<< "$INPUT_MAIN_FEATURE_FLAGS"
           for flag in "${FLAGS[@]}"; do
             if [[ -n "$flag" ]]; then
               MAIN_FLAG_ARGS="$MAIN_FLAG_ARGS --main-feature-flag $flag"
             fi
           done
           CURRENT_FLAG_ARGS=""
-          IFS=',' read -ra FLAGS <<< "${{ inputs.current_feature_flags || '' }}"
+          IFS=',' read -ra FLAGS <<< "$INPUT_CURRENT_FEATURE_FLAGS"
           for flag in "${FLAGS[@]}"; do
             if [[ -n "$flag" ]]; then
               CURRENT_FLAG_ARGS="$CURRENT_FLAG_ARGS --current-feature-flag $flag"
             fi
           done
           MAIN_TSC_ARGS=""
-          IFS=',' read -ra OPTS <<< "${{ inputs.main_table_service_config || '' }}"
+          IFS=',' read -ra OPTS <<< "$INPUT_MAIN_TABLE_SERVICE_CONFIG"
           for opt in "${OPTS[@]}"; do
             if [[ -n "$opt" ]]; then
               MAIN_TSC_ARGS="$MAIN_TSC_ARGS --main-table-service-config $opt"
             fi
           done
           CURRENT_TSC_ARGS=""
-          IFS=',' read -ra OPTS <<< "${{ inputs.current_table_service_config || '' }}"
+          IFS=',' read -ra OPTS <<< "$INPUT_CURRENT_TABLE_SERVICE_CONFIG"
           for opt in "${OPTS[@]}"; do
             if [[ -n "$opt" ]]; then
               CURRENT_TSC_ARGS="$CURRENT_TSC_ARGS --current-table-service-config $opt"
             fi
           done
           ./ydb/tests/stress/compare_index_performance.sh \
-            --duration ${{ inputs.duration || '600' }} \
-            --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
-            --ref ${{ inputs.ref || 'main' }} \
-            --targets ${{ inputs.targets || '1000' }} \
-            --workload ${{ inputs.workload || 'all' }} \
-            --rows ${{ inputs.rows || '100000' }} \
-            --iterations ${{ inputs.iterations || '3' }} \
-            --warmup ${{ inputs.warmup || '30' }} \
-            --threads ${{ inputs.threads || '10' }} \
+            --duration "$INPUT_DURATION" \
+            --build-preset "$INPUT_BUILD_PRESET" \
+            --ref "$INPUT_REF" \
+            --targets "$INPUT_TARGETS" \
+            --workload "$INPUT_WORKLOAD" \
+            --rows "$INPUT_ROWS" \
+            --iterations "$INPUT_ITERATIONS" \
+            --warmup "$INPUT_WARMUP" \
+            --threads "$INPUT_THREADS" \
             $MAIN_FLAG_ARGS \
             $CURRENT_FLAG_ARGS \
             $MAIN_TSC_ARGS \

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -21,6 +21,18 @@ on:
         description: 'S3 ref to compare against (e.g. main, stable-26-1-1)'
         required: false
         default: 'main'
+      targets:
+        description: 'Number of query vectors for vector select'
+        required: false
+        default: '100'
+      iterations:
+        description: 'Number of iterations per workload (median reported)'
+        required: false
+        default: '3'
+      warmup:
+        description: 'Warmup duration in seconds before each measured run'
+        required: false
+        default: '30'
 
 jobs:
   compare:
@@ -36,7 +48,10 @@ jobs:
           ./ydb/tests/stress/compare_index_performance.sh \
             --duration ${{ inputs.duration || '600' }} \
             --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
-            --ref ${{ inputs.ref || 'main' }}
+            --ref ${{ inputs.ref || 'main' }} \
+            --targets ${{ inputs.targets || '100' }} \
+            --iterations ${{ inputs.iterations || '3' }} \
+            --warmup ${{ inputs.warmup || '30' }}
 
       - name: Post results to job summary
         if: always()

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -30,10 +30,14 @@ on:
           - vector
           - fulltext
         default: all
+      rows:
+        description: 'Number of rows in generated database'
+        required: false
+        default: '100000'
       targets:
         description: 'Number of query vectors for vector select'
         required: false
-        default: '100'
+        default: '10000'
       iterations:
         description: 'Number of iterations per workload (median reported)'
         required: false
@@ -102,8 +106,9 @@ jobs:
             --duration ${{ inputs.duration || '600' }} \
             --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
             --ref ${{ inputs.ref || 'main' }} \
-            --targets ${{ inputs.targets || '100' }} \
+            --targets ${{ inputs.targets || '10000' }} \
             --workload ${{ inputs.workload || 'all' }} \
+            --rows ${{ inputs.rows || '100000' }} \
             --iterations ${{ inputs.iterations || '3' }} \
             --warmup ${{ inputs.warmup || '30' }} \
             $MAIN_FLAG_ARGS \

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -37,7 +37,7 @@ on:
       targets:
         description: 'Number of query vectors for vector select'
         required: false
-        default: '10000'
+        default: '1000'
       iterations:
         description: 'Number of iterations per workload (median reported)'
         required: false
@@ -46,6 +46,10 @@ on:
         description: 'Warmup duration in seconds before each measured run'
         required: false
         default: '30'
+      threads:
+        description: 'Number of threads for load testing'
+        required: false
+        default: '10'
       main_feature_flags:
         description: 'Comma-separated feature flags for main branch (e.g. enable_foo,enable_bar)'
         required: false
@@ -106,11 +110,12 @@ jobs:
             --duration ${{ inputs.duration || '600' }} \
             --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
             --ref ${{ inputs.ref || 'main' }} \
-            --targets ${{ inputs.targets || '10000' }} \
+            --targets ${{ inputs.targets || '1000' }} \
             --workload ${{ inputs.workload || 'all' }} \
             --rows ${{ inputs.rows || '100000' }} \
             --iterations ${{ inputs.iterations || '3' }} \
             --warmup ${{ inputs.warmup || '30' }} \
+            --threads ${{ inputs.threads || '10' }} \
             $MAIN_FLAG_ARGS \
             $CURRENT_FLAG_ARGS \
             $MAIN_TSC_ARGS \

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -1,4 +1,4 @@
-name: Regression-compare_performance
+name: compare_index_performance
 
 on:
   schedule:
@@ -28,7 +28,7 @@ on:
       iterations:
         description: 'Number of iterations per workload (median reported)'
         required: false
-        default: '3'
+        default: '20'
       warmup:
         description: 'Warmup duration in seconds before each measured run'
         required: false

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -1,0 +1,56 @@
+name: Regression-compare_performance
+
+on:
+  schedule:
+    - cron: "0 23 * * *"  # At 23:00 every day
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Duration of each workload run in seconds'
+        required: false
+        default: '600'
+      build_preset:
+        description: 'Build preset (must match S3 prebuilt binary)'
+        required: false
+        type: choice
+        options:
+          - relwithdebinfo
+          - release
+        default: relwithdebinfo
+      ref:
+        description: 'S3 ref to compare against (e.g. main, stable-26-1-1)'
+        required: false
+        default: 'main'
+
+jobs:
+  compare:
+    name: Compare performance (${{ inputs.ref || 'main' }} vs current)
+    runs-on: [ self-hosted, auto-provisioned, "build-preset-relwithdebinfo" ]
+    timeout-minutes: 1200
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run performance comparison
+        run: |
+          ./ydb/tests/stress/compare_index_performance.sh \
+            --duration ${{ inputs.duration || '600' }} \
+            --build-preset ${{ inputs.build_preset || 'relwithdebinfo' }} \
+            --ref ${{ inputs.ref || 'main' }}
+
+      - name: Post results to job summary
+        if: always()
+        run: |
+          if [[ -f benchmark_results/report.md ]]; then
+            cat benchmark_results/report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report generated." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload benchmark logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark_results/
+          retention-days: 30

--- a/.github/workflows/compare_index_performance.yml
+++ b/.github/workflows/compare_index_performance.yml
@@ -70,7 +70,7 @@ on:
 jobs:
   compare:
     name: Compare performance (${{ inputs.ref || 'main' }} vs current)
-    runs-on: [ self-hosted, auto-provisioned, "build-preset-relwithdebinfo" ]
+    runs-on: [ self-hosted, auto-provisioned, "build-preset-${{ inputs.build_preset || 'relwithdebinfo' }}" ]
     timeout-minutes: 1200
     steps:
       - name: Checkout

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -100,12 +100,16 @@ run_test() {
     local ydbd_path="$2"
     local test_path="$3"
     local log_file="$4"
+    shift 4
+    # Remaining arguments are extra --test-param flags
+    local extra_params=("$@")
 
     echo "--- Running $test_path with $label ydbd ---"
     cd "$REPO_ROOT"
     ./ya make --build "$BUILD_PRESET" -tA "$test_path" \
         -DYDB_DRIVER_BINARY_PREBUILT="$ydbd_path" \
         --test-param stress_default_duration="$DURATION" \
+        "${extra_params[@]}" \
         2>&1 | tee "$log_file" | tail -5
     echo ""
 }
@@ -147,12 +151,19 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
     echo "=========================================="
 
     VECTOR_TEST="ydb/tests/stress/vector_workload/tests"
+    VECTOR_DATA_DIR="$RESULTS_DIR/vector_data"
 
-    run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main.log"
+    # Main: generate data + dump to files
+    run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main.log" \
+        --test-param vector_mode=generate \
+        --test-param vector_data_dir="$VECTOR_DATA_DIR"
     VECTOR_MAIN_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
     VECTOR_MAIN_TXS=$(extract_total_txs_sec "$VECTOR_MAIN_LOG_DIR")
 
-    run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current.log"
+    # Current: load data from dump
+    run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current.log" \
+        --test-param vector_mode=load \
+        --test-param vector_data_dir="$VECTOR_DATA_DIR"
     VECTOR_CURRENT_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
     VECTOR_CURRENT_TXS=$(extract_total_txs_sec "$VECTOR_CURRENT_LOG_DIR")
 fi

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -9,7 +9,7 @@
 # The S3 bucket has builds for: release, relwithdebinfo.
 #
 # Usage:
-#   ./ydb/tests/stress/compare_performance.sh [OPTIONS]
+#   ./ydb/tests/stress/compare_index_performance.sh [OPTIONS]
 #
 # Options:
 #   --duration SECONDS     Duration of each workload run (default: 60)
@@ -17,6 +17,7 @@
 #   --main-ydbd PATH       Path to pre-built main branch ydbd (skips downloading)
 #   --current-ydbd PATH    Path to pre-built current branch ydbd (skips building)
 #   --ref REF              S3 ref to download ydbd from (default: main)
+#   --workload WORKLOAD    Run only specified workload: vector, fulltext, or all (default: all)
 
 set -euo pipefail
 
@@ -27,6 +28,7 @@ MAIN_YDBD=""
 CURRENT_YDBD=""
 S3_REF="main"
 BUILD_PRESET="relwithdebinfo"
+WORKLOAD="all"
 RESULTS_DIR="$REPO_ROOT/benchmark_results"
 S3_BASE_URL="https://storage.yandexcloud.net/ydb-builds"
 
@@ -37,9 +39,15 @@ while [[ $# -gt 0 ]]; do
         --main-ydbd) MAIN_YDBD="$2"; shift 2 ;;
         --current-ydbd) CURRENT_YDBD="$2"; shift 2 ;;
         --ref) S3_REF="$2"; shift 2 ;;
+        --workload) WORKLOAD="$2"; shift 2 ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
+
+if [[ "$WORKLOAD" != "all" && "$WORKLOAD" != "vector" && "$WORKLOAD" != "fulltext" ]]; then
+    echo "ERROR: --workload must be one of: all, vector, fulltext"
+    exit 1
+fi
 
 mkdir -p "$RESULTS_DIR"
 
@@ -47,6 +55,7 @@ CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
 echo "=== Performance comparison: $S3_REF vs $CURRENT_BRANCH ==="
 echo "Build preset: $BUILD_PRESET"
 echo "Duration per run: ${DURATION}s"
+echo "Workload: $WORKLOAD"
 echo ""
 
 # --- Download ydbd from S3 if not provided ---
@@ -115,39 +124,6 @@ extract_total_txs_sec() {
     grep -A1 "^Total" "$test_log" | tail -1 | awk '{print $3}'
 }
 
-# --- Run vector workload ---
-echo ""
-echo "=========================================="
-echo "  Vector workload"
-echo "=========================================="
-
-VECTOR_TEST="ydb/tests/stress/vector_workload/tests"
-
-run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main.log"
-VECTOR_MAIN_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
-VECTOR_MAIN_TXS=$(extract_total_txs_sec "$VECTOR_MAIN_LOG_DIR")
-
-run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current.log"
-VECTOR_CURRENT_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
-VECTOR_CURRENT_TXS=$(extract_total_txs_sec "$VECTOR_CURRENT_LOG_DIR")
-
-# --- Run fulltext workload ---
-echo ""
-echo "=========================================="
-echo "  Fulltext workload"
-echo "=========================================="
-
-FULLTEXT_TEST="ydb/tests/stress/fulltext_workload/tests"
-
-run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main.log"
-FULLTEXT_MAIN_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
-FULLTEXT_MAIN_TXS=$(extract_total_txs_sec "$FULLTEXT_MAIN_LOG_DIR")
-
-run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current.log"
-FULLTEXT_CURRENT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
-FULLTEXT_CURRENT_TXS=$(extract_total_txs_sec "$FULLTEXT_CURRENT_LOG_DIR")
-
-# --- Print comparison ---
 calc_diff() {
     local main_val="$1"
     local current_val="$2"
@@ -158,6 +134,48 @@ calc_diff() {
     awk "BEGIN { diff = ($current_val - $main_val) / $main_val * 100; printf \"%+.1f%%\", diff }"
 }
 
+VECTOR_MAIN_TXS="N/A"
+VECTOR_CURRENT_TXS="N/A"
+FULLTEXT_MAIN_TXS="N/A"
+FULLTEXT_CURRENT_TXS="N/A"
+
+# --- Run vector workload ---
+if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
+    echo ""
+    echo "=========================================="
+    echo "  Vector workload"
+    echo "=========================================="
+
+    VECTOR_TEST="ydb/tests/stress/vector_workload/tests"
+
+    run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main.log"
+    VECTOR_MAIN_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
+    VECTOR_MAIN_TXS=$(extract_total_txs_sec "$VECTOR_MAIN_LOG_DIR")
+
+    run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current.log"
+    VECTOR_CURRENT_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
+    VECTOR_CURRENT_TXS=$(extract_total_txs_sec "$VECTOR_CURRENT_LOG_DIR")
+fi
+
+# --- Run fulltext workload ---
+if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
+    echo ""
+    echo "=========================================="
+    echo "  Fulltext workload"
+    echo "=========================================="
+
+    FULLTEXT_TEST="ydb/tests/stress/fulltext_workload/tests"
+
+    run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main.log"
+    FULLTEXT_MAIN_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
+    FULLTEXT_MAIN_TXS=$(extract_total_txs_sec "$FULLTEXT_MAIN_LOG_DIR")
+
+    run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current.log"
+    FULLTEXT_CURRENT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
+    FULLTEXT_CURRENT_TXS=$(extract_total_txs_sec "$FULLTEXT_CURRENT_LOG_DIR")
+fi
+
+# --- Print comparison ---
 VECTOR_DIFF=$(calc_diff "$VECTOR_MAIN_TXS" "$VECTOR_CURRENT_TXS")
 FULLTEXT_DIFF=$(calc_diff "$FULLTEXT_MAIN_TXS" "$FULLTEXT_CURRENT_TXS")
 
@@ -169,22 +187,30 @@ echo "=========================================="
 echo ""
 printf "%-20s %15s %15s %10s\n" "Workload" "$S3_REF (Txs/Sec)" "$CURRENT_BRANCH (Txs/Sec)" "Diff"
 printf "%-20s %15s %15s %10s\n" "--------------------" "---------------" "---------------" "----------"
-printf "%-20s %15s %15s %10s\n" "vector select" "$VECTOR_MAIN_TXS" "$VECTOR_CURRENT_TXS" "$VECTOR_DIFF"
-printf "%-20s %15s %15s %10s\n" "fulltext select" "$FULLTEXT_MAIN_TXS" "$FULLTEXT_CURRENT_TXS" "$FULLTEXT_DIFF"
+if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
+    printf "%-20s %15s %15s %10s\n" "vector select" "$VECTOR_MAIN_TXS" "$VECTOR_CURRENT_TXS" "$VECTOR_DIFF"
+fi
+if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
+    printf "%-20s %15s %15s %10s\n" "fulltext select" "$FULLTEXT_MAIN_TXS" "$FULLTEXT_CURRENT_TXS" "$FULLTEXT_DIFF"
+fi
 echo ""
 echo "Detailed logs: $RESULTS_DIR/"
 
 # --- Write markdown report ---
 REPORT_FILE="$RESULTS_DIR/report.md"
-cat > "$REPORT_FILE" <<EOF
-## Performance Comparison: \`$S3_REF\` vs \`$CURRENT_BRANCH\`
-
-**Build preset:** \`$BUILD_PRESET\` | **Duration:** ${DURATION}s per workload
-
-| Workload | $S3_REF (Txs/Sec) | $CURRENT_BRANCH (Txs/Sec) | Diff |
-|---|---|---|---|
-| vector select | $VECTOR_MAIN_TXS | $VECTOR_CURRENT_TXS | $VECTOR_DIFF |
-| fulltext select | $FULLTEXT_MAIN_TXS | $FULLTEXT_CURRENT_TXS | $FULLTEXT_DIFF |
-EOF
+{
+    echo "## Performance Comparison: \`$S3_REF\` vs \`$CURRENT_BRANCH\`"
+    echo ""
+    echo "**Build preset:** \`$BUILD_PRESET\` | **Duration:** ${DURATION}s per workload"
+    echo ""
+    echo "| Workload | $S3_REF (Txs/Sec) | $CURRENT_BRANCH (Txs/Sec) | Diff |"
+    echo "|---|---|---|---|"
+    if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
+        echo "| vector select | $VECTOR_MAIN_TXS | $VECTOR_CURRENT_TXS | $VECTOR_DIFF |"
+    fi
+    if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
+        echo "| fulltext select | $FULLTEXT_MAIN_TXS | $FULLTEXT_CURRENT_TXS | $FULLTEXT_DIFF |"
+    fi
+} > "$REPORT_FILE"
 echo ""
 echo "Markdown report: $REPORT_FILE"

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+#
+# Compare vector/fulltext workload performance between main branch and current branch.
+#
+# The main branch ydbd is downloaded as a prebuilt binary from S3 (ydb-builds bucket).
+# The current branch ydbd is built from the local source tree.
+#
+# IMPORTANT: Both binaries must use the same build preset for a fair comparison.
+# The S3 bucket has builds for: release, relwithdebinfo.
+#
+# Usage:
+#   ./ydb/tests/stress/compare_performance.sh [OPTIONS]
+#
+# Options:
+#   --duration SECONDS     Duration of each workload run (default: 60)
+#   --build-preset PRESET  Build preset for both binaries (default: relwithdebinfo)
+#   --main-ydbd PATH       Path to pre-built main branch ydbd (skips downloading)
+#   --current-ydbd PATH    Path to pre-built current branch ydbd (skips building)
+#   --ref REF              S3 ref to download ydbd from (default: main)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DURATION=60
+MAIN_YDBD=""
+CURRENT_YDBD=""
+S3_REF="main"
+BUILD_PRESET="relwithdebinfo"
+RESULTS_DIR="$REPO_ROOT/benchmark_results"
+S3_BASE_URL="https://storage.yandexcloud.net/ydb-builds"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --duration) DURATION="$2"; shift 2 ;;
+        --build-preset) BUILD_PRESET="$2"; shift 2 ;;
+        --main-ydbd) MAIN_YDBD="$2"; shift 2 ;;
+        --current-ydbd) CURRENT_YDBD="$2"; shift 2 ;;
+        --ref) S3_REF="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+mkdir -p "$RESULTS_DIR"
+
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
+echo "=== Performance comparison: $S3_REF vs $CURRENT_BRANCH ==="
+echo "Build preset: $BUILD_PRESET"
+echo "Duration per run: ${DURATION}s"
+echo ""
+
+# --- Download ydbd from S3 if not provided ---
+if [[ -z "$MAIN_YDBD" ]]; then
+    MAIN_YDBD="$RESULTS_DIR/ydbd-${S3_REF}-${BUILD_PRESET}"
+    if [[ -x "$MAIN_YDBD" ]]; then
+        echo "Using cached $S3_REF ydbd: $MAIN_YDBD"
+    else
+        echo "=== Downloading ydbd from S3 ($S3_REF/$BUILD_PRESET) ==="
+        S3_URL="$S3_BASE_URL/$S3_REF/$BUILD_PRESET/ydbd"
+        echo "URL: $S3_URL"
+        wget -q --show-progress -O "$MAIN_YDBD" "$S3_URL"
+        chmod +x "$MAIN_YDBD"
+        echo "Downloaded: $MAIN_YDBD"
+    fi
+else
+    echo "Using pre-built $S3_REF ydbd: $MAIN_YDBD"
+fi
+
+# --- Build ydbd from current branch if not provided ---
+if [[ -z "$CURRENT_YDBD" ]]; then
+    echo "=== Building ydbd from current branch ($CURRENT_BRANCH, preset: $BUILD_PRESET) ==="
+    cd "$REPO_ROOT"
+    ./ya make --build "$BUILD_PRESET" ydb/apps/ydbd ydb/apps/ydb 2>&1 | tail -5
+    CURRENT_YDBD="$REPO_ROOT/ydb/apps/ydbd/ydbd"
+    echo "Current ydbd built: $CURRENT_YDBD"
+else
+    echo "Using pre-built current ydbd: $CURRENT_YDBD"
+fi
+
+# --- Verify binaries exist ---
+for binary in "$MAIN_YDBD" "$CURRENT_YDBD"; do
+    if [[ ! -x "$binary" ]]; then
+        echo "ERROR: Binary not found or not executable: $binary"
+        exit 1
+    fi
+done
+
+# --- Run tests and capture output ---
+run_test() {
+    local label="$1"
+    local ydbd_path="$2"
+    local test_path="$3"
+    local log_file="$4"
+
+    echo "--- Running $test_path with $label ydbd ---"
+    cd "$REPO_ROOT"
+    ./ya make --build "$BUILD_PRESET" -tA "$test_path" \
+        -DYDB_DRIVER_BINARY_PREBUILT="$ydbd_path" \
+        --test-param stress_default_duration="$DURATION" \
+        2>&1 | tee "$log_file" | tail -5
+    echo ""
+}
+
+extract_total_txs_sec() {
+    local log_dir="$1"
+    # Find the test log and extract the Total Txs/Sec line
+    local test_log
+    test_log=$(find "$log_dir" -name "*.log" -path "*/testing_out_stuff/*" 2>/dev/null | head -1)
+    if [[ -z "$test_log" ]]; then
+        echo "N/A"
+        return
+    fi
+    # The Total line format: "10          980 98.0    0       0       5       9       14      18"
+    # We want the Txs/Sec column (3rd field in the Total summary line)
+    grep -A1 "^Total" "$test_log" | tail -1 | awk '{print $3}'
+}
+
+# --- Run vector workload ---
+echo ""
+echo "=========================================="
+echo "  Vector workload"
+echo "=========================================="
+
+VECTOR_TEST="ydb/tests/stress/vector_workload/tests"
+
+run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main.log"
+VECTOR_MAIN_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
+VECTOR_MAIN_TXS=$(extract_total_txs_sec "$VECTOR_MAIN_LOG_DIR")
+
+run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current.log"
+VECTOR_CURRENT_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
+VECTOR_CURRENT_TXS=$(extract_total_txs_sec "$VECTOR_CURRENT_LOG_DIR")
+
+# --- Run fulltext workload ---
+echo ""
+echo "=========================================="
+echo "  Fulltext workload"
+echo "=========================================="
+
+FULLTEXT_TEST="ydb/tests/stress/fulltext_workload/tests"
+
+run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main.log"
+FULLTEXT_MAIN_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
+FULLTEXT_MAIN_TXS=$(extract_total_txs_sec "$FULLTEXT_MAIN_LOG_DIR")
+
+run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current.log"
+FULLTEXT_CURRENT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
+FULLTEXT_CURRENT_TXS=$(extract_total_txs_sec "$FULLTEXT_CURRENT_LOG_DIR")
+
+# --- Print comparison ---
+calc_diff() {
+    local main_val="$1"
+    local current_val="$2"
+    if [[ "$main_val" == "N/A" || "$current_val" == "N/A" || -z "$main_val" || -z "$current_val" ]]; then
+        echo "N/A"
+        return
+    fi
+    awk "BEGIN { diff = ($current_val - $main_val) / $main_val * 100; printf \"%+.1f%%\", diff }"
+}
+
+VECTOR_DIFF=$(calc_diff "$VECTOR_MAIN_TXS" "$VECTOR_CURRENT_TXS")
+FULLTEXT_DIFF=$(calc_diff "$FULLTEXT_MAIN_TXS" "$FULLTEXT_CURRENT_TXS")
+
+echo ""
+echo "=========================================="
+echo "  Performance Comparison Results"
+echo "  Build preset: $BUILD_PRESET"
+echo "=========================================="
+echo ""
+printf "%-20s %15s %15s %10s\n" "Workload" "$S3_REF (Txs/Sec)" "$CURRENT_BRANCH (Txs/Sec)" "Diff"
+printf "%-20s %15s %15s %10s\n" "--------------------" "---------------" "---------------" "----------"
+printf "%-20s %15s %15s %10s\n" "vector select" "$VECTOR_MAIN_TXS" "$VECTOR_CURRENT_TXS" "$VECTOR_DIFF"
+printf "%-20s %15s %15s %10s\n" "fulltext select" "$FULLTEXT_MAIN_TXS" "$FULLTEXT_CURRENT_TXS" "$FULLTEXT_DIFF"
+echo ""
+echo "Detailed logs: $RESULTS_DIR/"
+
+# --- Write markdown report ---
+REPORT_FILE="$RESULTS_DIR/report.md"
+cat > "$REPORT_FILE" <<EOF
+## Performance Comparison: \`$S3_REF\` vs \`$CURRENT_BRANCH\`
+
+**Build preset:** \`$BUILD_PRESET\` | **Duration:** ${DURATION}s per workload
+
+| Workload | $S3_REF (Txs/Sec) | $CURRENT_BRANCH (Txs/Sec) | Diff |
+|---|---|---|---|
+| vector select | $VECTOR_MAIN_TXS | $VECTOR_CURRENT_TXS | $VECTOR_DIFF |
+| fulltext select | $FULLTEXT_MAIN_TXS | $FULLTEXT_CURRENT_TXS | $FULLTEXT_DIFF |
+EOF
+echo ""
+echo "Markdown report: $REPORT_FILE"

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -21,6 +21,10 @@
 #   --targets N            Number of query vectors for vector select (default: 100)
 #   --iterations N         Number of iterations per workload (default: 3)
 #   --warmup SECONDS       Warmup duration before each measured run (default: 30)
+#   --main-feature-flag FLAG     Enable a feature flag for main branch (repeatable)
+#   --current-feature-flag FLAG  Enable a feature flag for current branch (repeatable)
+#   --main-table-service-config KEY=VALUE     Set table_service_config option for main branch (repeatable)
+#   --current-table-service-config KEY=VALUE  Set table_service_config option for current branch (repeatable)
 
 set -euo pipefail
 
@@ -35,6 +39,10 @@ WORKLOAD="all"
 TARGETS=100
 ITERATIONS=3
 WARMUP=30
+MAIN_FEATURE_FLAGS=()
+CURRENT_FEATURE_FLAGS=()
+MAIN_TABLE_SERVICE_CONFIG=()
+CURRENT_TABLE_SERVICE_CONFIG=()
 RESULTS_DIR="$REPO_ROOT/benchmark_results"
 S3_BASE_URL="https://storage.yandexcloud.net/ydb-builds"
 
@@ -49,6 +57,10 @@ while [[ $# -gt 0 ]]; do
         --targets) TARGETS="$2"; shift 2 ;;
         --iterations) ITERATIONS="$2"; shift 2 ;;
         --warmup) WARMUP="$2"; shift 2 ;;
+        --main-feature-flag) MAIN_FEATURE_FLAGS+=("$2"); shift 2 ;;
+        --current-feature-flag) CURRENT_FEATURE_FLAGS+=("$2"); shift 2 ;;
+        --main-table-service-config) MAIN_TABLE_SERVICE_CONFIG+=("$2"); shift 2 ;;
+        --current-table-service-config) CURRENT_TABLE_SERVICE_CONFIG+=("$2"); shift 2 ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -60,6 +72,25 @@ fi
 
 mkdir -p "$RESULTS_DIR"
 
+# Build feature flags test params (comma-separated)
+MAIN_FEATURE_FLAGS_PARAM=""
+if [[ ${#MAIN_FEATURE_FLAGS[@]} -gt 0 ]]; then
+    MAIN_FEATURE_FLAGS_PARAM=$(IFS=,; echo "${MAIN_FEATURE_FLAGS[*]}")
+fi
+CURRENT_FEATURE_FLAGS_PARAM=""
+if [[ ${#CURRENT_FEATURE_FLAGS[@]} -gt 0 ]]; then
+    CURRENT_FEATURE_FLAGS_PARAM=$(IFS=,; echo "${CURRENT_FEATURE_FLAGS[*]}")
+fi
+# Build table_service_config test params (comma-separated key=value pairs)
+MAIN_TABLE_SERVICE_CONFIG_PARAM=""
+if [[ ${#MAIN_TABLE_SERVICE_CONFIG[@]} -gt 0 ]]; then
+    MAIN_TABLE_SERVICE_CONFIG_PARAM=$(IFS=,; echo "${MAIN_TABLE_SERVICE_CONFIG[*]}")
+fi
+CURRENT_TABLE_SERVICE_CONFIG_PARAM=""
+if [[ ${#CURRENT_TABLE_SERVICE_CONFIG[@]} -gt 0 ]]; then
+    CURRENT_TABLE_SERVICE_CONFIG_PARAM=$(IFS=,; echo "${CURRENT_TABLE_SERVICE_CONFIG[*]}")
+fi
+
 CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)
 echo "=== Performance comparison: $S3_REF vs $CURRENT_BRANCH ==="
 echo "Build preset: $BUILD_PRESET"
@@ -68,6 +99,18 @@ echo "Workload: $WORKLOAD"
 echo "Vector targets: $TARGETS"
 echo "Iterations: $ITERATIONS"
 echo "Warmup: ${WARMUP}s"
+if [[ ${#MAIN_FEATURE_FLAGS[@]} -gt 0 ]]; then
+    echo "Main feature flags: ${MAIN_FEATURE_FLAGS[*]}"
+fi
+if [[ ${#CURRENT_FEATURE_FLAGS[@]} -gt 0 ]]; then
+    echo "Current feature flags: ${CURRENT_FEATURE_FLAGS[*]}"
+fi
+if [[ ${#MAIN_TABLE_SERVICE_CONFIG[@]} -gt 0 ]]; then
+    echo "Main table_service_config: ${MAIN_TABLE_SERVICE_CONFIG[*]}"
+fi
+if [[ ${#CURRENT_TABLE_SERVICE_CONFIG[@]} -gt 0 ]]; then
+    echo "Current table_service_config: ${CURRENT_TABLE_SERVICE_CONFIG[*]}"
+fi
 echo ""
 
 # --- Download ydbd from S3 if not provided ---
@@ -121,7 +164,7 @@ run_test() {
         -DYDB_DRIVER_BINARY_PREBUILT="$ydbd_path" \
         --test-param stress_default_duration="$DURATION" \
         "${extra_params[@]}" \
-        2>&1 | tee "$log_file" | tail -5
+        2>&1 | tee "$log_file" | tail -5 || true
     echo ""
 }
 
@@ -265,11 +308,20 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
         if [[ $i -eq 1 ]]; then
             local_mode="generate"
         fi
-        run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main_${i}.log" \
-            --test-param vector_mode="$local_mode" \
-            --test-param vector_data_dir="$VECTOR_DATA_DIR" \
-            --test-param vector_targets="$TARGETS" \
+        VECTOR_EXTRA_PARAMS=(
+            --test-param vector_mode="$local_mode"
+            --test-param vector_data_dir="$VECTOR_DATA_DIR"
+            --test-param vector_targets="$TARGETS"
             --test-param vector_warmup="$WARMUP"
+        )
+        if [[ -n "$MAIN_FEATURE_FLAGS_PARAM" ]]; then
+            VECTOR_EXTRA_PARAMS+=(--test-param feature_flags="$MAIN_FEATURE_FLAGS_PARAM")
+        fi
+        if [[ -n "$MAIN_TABLE_SERVICE_CONFIG_PARAM" ]]; then
+            VECTOR_EXTRA_PARAMS+=(--test-param table_service_config="$MAIN_TABLE_SERVICE_CONFIG_PARAM")
+        fi
+        run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main_${i}.log" \
+            "${VECTOR_EXTRA_PARAMS[@]}"
         VECTOR_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
         val=$(extract_total_txs_sec "$VECTOR_LOG_DIR")
         if [[ "$val" != "N/A" && -n "$val" ]]; then
@@ -278,11 +330,20 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
         echo "  $S3_REF iteration $i: $val Txs/Sec"
 
         # Run current
-        run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current_${i}.log" \
-            --test-param vector_mode=load \
-            --test-param vector_data_dir="$VECTOR_DATA_DIR" \
-            --test-param vector_targets="$TARGETS" \
+        VECTOR_EXTRA_PARAMS=(
+            --test-param vector_mode=load
+            --test-param vector_data_dir="$VECTOR_DATA_DIR"
+            --test-param vector_targets="$TARGETS"
             --test-param vector_warmup="$WARMUP"
+        )
+        if [[ -n "$CURRENT_FEATURE_FLAGS_PARAM" ]]; then
+            VECTOR_EXTRA_PARAMS+=(--test-param feature_flags="$CURRENT_FEATURE_FLAGS_PARAM")
+        fi
+        if [[ -n "$CURRENT_TABLE_SERVICE_CONFIG_PARAM" ]]; then
+            VECTOR_EXTRA_PARAMS+=(--test-param table_service_config="$CURRENT_TABLE_SERVICE_CONFIG_PARAM")
+        fi
+        run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current_${i}.log" \
+            "${VECTOR_EXTRA_PARAMS[@]}"
         VECTOR_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
         val=$(extract_total_txs_sec "$VECTOR_LOG_DIR")
         if [[ "$val" != "N/A" && -n "$val" ]]; then
@@ -326,7 +387,15 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
         echo "=== Fulltext iteration $i/$ITERATIONS ==="
 
         # Run main
-        run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main_${i}.log"
+        FULLTEXT_EXTRA_PARAMS=()
+        if [[ -n "$MAIN_FEATURE_FLAGS_PARAM" ]]; then
+            FULLTEXT_EXTRA_PARAMS+=(--test-param feature_flags="$MAIN_FEATURE_FLAGS_PARAM")
+        fi
+        if [[ -n "$MAIN_TABLE_SERVICE_CONFIG_PARAM" ]]; then
+            FULLTEXT_EXTRA_PARAMS+=(--test-param table_service_config="$MAIN_TABLE_SERVICE_CONFIG_PARAM")
+        fi
+        run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main_${i}.log" \
+            "${FULLTEXT_EXTRA_PARAMS[@]}"
         FULLTEXT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
         val=$(extract_total_txs_sec "$FULLTEXT_LOG_DIR")
         if [[ "$val" != "N/A" && -n "$val" ]]; then
@@ -335,7 +404,15 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
         echo "  $S3_REF iteration $i: $val Txs/Sec"
 
         # Run current
-        run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current_${i}.log"
+        FULLTEXT_EXTRA_PARAMS=()
+        if [[ -n "$CURRENT_FEATURE_FLAGS_PARAM" ]]; then
+            FULLTEXT_EXTRA_PARAMS+=(--test-param feature_flags="$CURRENT_FEATURE_FLAGS_PARAM")
+        fi
+        if [[ -n "$CURRENT_TABLE_SERVICE_CONFIG_PARAM" ]]; then
+            FULLTEXT_EXTRA_PARAMS+=(--test-param table_service_config="$CURRENT_TABLE_SERVICE_CONFIG_PARAM")
+        fi
+        run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current_${i}.log" \
+            "${FULLTEXT_EXTRA_PARAMS[@]}"
         FULLTEXT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
         val=$(extract_total_txs_sec "$FULLTEXT_LOG_DIR")
         if [[ "$val" != "N/A" && -n "$val" ]]; then

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -22,6 +22,7 @@
 #   --iterations N         Number of iterations per workload (default: 3)
 #   --warmup SECONDS       Warmup duration before each measured run (default: 30)
 #   --rows N               Number of rows in generated database (default: 100000)
+#   --threads N            Number of threads for load testing (default: 10)
 #   --main-feature-flag FLAG     Enable a feature flag for main branch (repeatable)
 #   --current-feature-flag FLAG  Enable a feature flag for current branch (repeatable)
 #   --main-table-service-config KEY=VALUE     Set table_service_config option for main branch (repeatable)
@@ -37,10 +38,11 @@ CURRENT_YDBD=""
 S3_REF="main"
 BUILD_PRESET="relwithdebinfo"
 WORKLOAD="all"
-TARGETS=10000
+TARGETS=1000
 ITERATIONS=3
 WARMUP=30
 ROWS=100000
+THREADS=10
 MAIN_FEATURE_FLAGS=()
 CURRENT_FEATURE_FLAGS=()
 MAIN_TABLE_SERVICE_CONFIG=()
@@ -60,6 +62,7 @@ while [[ $# -gt 0 ]]; do
         --iterations) ITERATIONS="$2"; shift 2 ;;
         --warmup) WARMUP="$2"; shift 2 ;;
         --rows) ROWS="$2"; shift 2 ;;
+        --threads) THREADS="$2"; shift 2 ;;
         --main-feature-flag) MAIN_FEATURE_FLAGS+=("$2"); shift 2 ;;
         --current-feature-flag) CURRENT_FEATURE_FLAGS+=("$2"); shift 2 ;;
         --main-table-service-config) MAIN_TABLE_SERVICE_CONFIG+=("$2"); shift 2 ;;
@@ -103,6 +106,7 @@ echo "Vector targets: $TARGETS"
 echo "Iterations: $ITERATIONS"
 echo "Warmup: ${WARMUP}s"
 echo "Rows: $ROWS"
+echo "Threads: $THREADS"
 if [[ ${#MAIN_FEATURE_FLAGS[@]} -gt 0 ]]; then
     echo "Main feature flags: ${MAIN_FEATURE_FLAGS[*]}"
 fi
@@ -318,6 +322,7 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
             --test-param vector_targets="$TARGETS"
             --test-param vector_warmup="$WARMUP"
             --test-param vector_rows="$ROWS"
+            --test-param vector_threads="$THREADS"
         )
         if [[ -n "$MAIN_FEATURE_FLAGS_PARAM" ]]; then
             VECTOR_EXTRA_PARAMS+=(--test-param feature_flags="$MAIN_FEATURE_FLAGS_PARAM")
@@ -341,6 +346,7 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
             --test-param vector_targets="$TARGETS"
             --test-param vector_warmup="$WARMUP"
             --test-param vector_rows="$ROWS"
+            --test-param vector_threads="$THREADS"
         )
         if [[ -n "$CURRENT_FEATURE_FLAGS_PARAM" ]]; then
             VECTOR_EXTRA_PARAMS+=(--test-param feature_flags="$CURRENT_FEATURE_FLAGS_PARAM")
@@ -393,7 +399,11 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
         echo "=== Fulltext iteration $i/$ITERATIONS ==="
 
         # Run main
-        FULLTEXT_EXTRA_PARAMS=()
+        FULLTEXT_EXTRA_PARAMS=(
+            --test-param fulltext_rows="$ROWS"
+            --test-param fulltext_threads="$THREADS"
+            --test-param fulltext_targets="$TARGETS"
+        )
         if [[ -n "$MAIN_FEATURE_FLAGS_PARAM" ]]; then
             FULLTEXT_EXTRA_PARAMS+=(--test-param feature_flags="$MAIN_FEATURE_FLAGS_PARAM")
         fi
@@ -410,7 +420,11 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
         echo "  $S3_REF iteration $i: $val Txs/Sec"
 
         # Run current
-        FULLTEXT_EXTRA_PARAMS=()
+        FULLTEXT_EXTRA_PARAMS=(
+            --test-param fulltext_rows="$ROWS"
+            --test-param fulltext_threads="$THREADS"
+            --test-param fulltext_targets="$TARGETS"
+        )
         if [[ -n "$CURRENT_FEATURE_FLAGS_PARAM" ]]; then
             FULLTEXT_EXTRA_PARAMS+=(--test-param feature_flags="$CURRENT_FEATURE_FLAGS_PARAM")
         fi

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -18,6 +18,9 @@
 #   --current-ydbd PATH    Path to pre-built current branch ydbd (skips building)
 #   --ref REF              S3 ref to download ydbd from (default: main)
 #   --workload WORKLOAD    Run only specified workload: vector, fulltext, or all (default: all)
+#   --targets N            Number of query vectors for vector select (default: 100)
+#   --iterations N         Number of iterations per workload (default: 3)
+#   --warmup SECONDS       Warmup duration before each measured run (default: 30)
 
 set -euo pipefail
 
@@ -29,6 +32,9 @@ CURRENT_YDBD=""
 S3_REF="main"
 BUILD_PRESET="relwithdebinfo"
 WORKLOAD="all"
+TARGETS=100
+ITERATIONS=3
+WARMUP=30
 RESULTS_DIR="$REPO_ROOT/benchmark_results"
 S3_BASE_URL="https://storage.yandexcloud.net/ydb-builds"
 
@@ -36,10 +42,13 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --duration) DURATION="$2"; shift 2 ;;
         --build-preset) BUILD_PRESET="$2"; shift 2 ;;
-        --main-ydbd) MAIN_YDBD="$2"; shift 2 ;;
-        --current-ydbd) CURRENT_YDBD="$2"; shift 2 ;;
+        --main-ydbd) MAIN_YDBD="$(realpath "$2")"; shift 2 ;;
+        --current-ydbd) CURRENT_YDBD="$(realpath "$2")"; shift 2 ;;
         --ref) S3_REF="$2"; shift 2 ;;
         --workload) WORKLOAD="$2"; shift 2 ;;
+        --targets) TARGETS="$2"; shift 2 ;;
+        --iterations) ITERATIONS="$2"; shift 2 ;;
+        --warmup) WARMUP="$2"; shift 2 ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -56,6 +65,9 @@ echo "=== Performance comparison: $S3_REF vs $CURRENT_BRANCH ==="
 echo "Build preset: $BUILD_PRESET"
 echo "Duration per run: ${DURATION}s"
 echo "Workload: $WORKLOAD"
+echo "Vector targets: $TARGETS"
+echo "Iterations: $ITERATIONS"
+echo "Warmup: ${WARMUP}s"
 echo ""
 
 # --- Download ydbd from S3 if not provided ---
@@ -94,14 +106,13 @@ for binary in "$MAIN_YDBD" "$CURRENT_YDBD"; do
     fi
 done
 
-# --- Run tests and capture output ---
+# --- Helper functions ---
 run_test() {
     local label="$1"
     local ydbd_path="$2"
     local test_path="$3"
     local log_file="$4"
     shift 4
-    # Remaining arguments are extra --test-param flags
     local extra_params=("$@")
 
     echo "--- Running $test_path with $label ydbd ---"
@@ -116,16 +127,52 @@ run_test() {
 
 extract_total_txs_sec() {
     local log_dir="$1"
-    # Find the test log and extract the Total Txs/Sec line
     local test_log
     test_log=$(find "$log_dir" -name "*.log" -path "*/testing_out_stuff/*" 2>/dev/null | head -1)
     if [[ -z "$test_log" ]]; then
         echo "N/A"
         return
     fi
-    # The Total line format: "10          980 98.0    0       0       5       9       14      18"
-    # We want the Txs/Sec column (3rd field in the Total summary line)
     grep -A1 "^Total" "$test_log" | tail -1 | awk '{print $3}'
+}
+
+median() {
+    # Read values from arguments, sort numerically, return median
+    local -a vals=("$@")
+    local n=${#vals[@]}
+    if [[ $n -eq 0 ]]; then
+        echo "N/A"
+        return
+    fi
+    local sorted
+    sorted=($(printf '%s\n' "${vals[@]}" | sort -n))
+    local mid=$((n / 2))
+    if (( n % 2 == 1 )); then
+        echo "${sorted[$mid]}"
+    else
+        awk "BEGIN { printf \"%.3f\", (${sorted[$mid-1]} + ${sorted[$mid]}) / 2 }"
+    fi
+}
+
+mean() {
+    local -a vals=("$@")
+    local n=${#vals[@]}
+    if [[ $n -eq 0 ]]; then
+        echo "N/A"
+        return
+    fi
+    awk "BEGIN { s=0 } { s+=\$1 } END { printf \"%.3f\", s/NR }" < <(printf '%s\n' "${vals[@]}")
+}
+
+stddev() {
+    # Sample standard deviation
+    local -a vals=("$@")
+    local n=${#vals[@]}
+    if [[ $n -lt 2 ]]; then
+        echo "0"
+        return
+    fi
+    awk "BEGIN { s=0; ss=0; n=0 } { s+=\$1; ss+=\$1*\$1; n++ } END { m=s/n; printf \"%.3f\", sqrt((ss - n*m*m)/(n-1)) }" < <(printf '%s\n' "${vals[@]}")
 }
 
 calc_diff() {
@@ -138,6 +185,57 @@ calc_diff() {
     awk "BEGIN { diff = ($current_val - $main_val) / $main_val * 100; printf \"%+.1f%%\", diff }"
 }
 
+calc_significance() {
+    # Check statistical significance using 3-sigma rule on the difference of means.
+    # Uses pooled standard error: SE = sqrt(s1^2/n1 + s2^2/n2)
+    # Returns "SIGNIFICANT (<diff> > 3σ=<threshold>)" or "not significant (<diff> <= 3σ=<threshold>)"
+    local main_mean="$1"
+    local current_mean="$2"
+    local main_stddev="$3"
+    local current_stddev="$4"
+    local main_n="$5"
+    local current_n="$6"
+
+    if [[ "$main_mean" == "N/A" || "$current_mean" == "N/A" ]]; then
+        echo "N/A"
+        return
+    fi
+    if [[ $main_n -lt 2 || $current_n -lt 2 ]]; then
+        echo "N/A (need >= 2 iterations)"
+        return
+    fi
+
+    awk "BEGIN {
+        se = sqrt(($main_stddev)^2/$main_n + ($current_stddev)^2/$current_n)
+        diff = $current_mean - $main_mean
+        absdiff = (diff < 0) ? -diff : diff
+        threshold = 3 * se
+        pct = diff / $main_mean * 100
+        if (threshold > 0 && absdiff > threshold) {
+            printf \"SIGNIFICANT (%+.1f%%, |diff|=%.1f > 3sigma=%.1f)\", pct, absdiff, threshold
+        } else if (threshold > 0) {
+            printf \"not significant (%+.1f%%, |diff|=%.1f <= 3sigma=%.1f)\", pct, absdiff, threshold
+        } else {
+            printf \"N/A (zero variance)\"
+        }
+    }"
+}
+
+format_values() {
+    # Format array of values as "median [v1, v2, ...]"
+    local median_val="$1"
+    shift
+    local -a vals=("$@")
+    if [[ ${#vals[@]} -le 1 ]]; then
+        echo "$median_val"
+        return
+    fi
+    local joined
+    joined=$(printf ", %s" "${vals[@]}")
+    joined="${joined:2}"  # remove leading ", "
+    echo "$median_val [$joined]"
+}
+
 VECTOR_MAIN_TXS="N/A"
 VECTOR_CURRENT_TXS="N/A"
 FULLTEXT_MAIN_TXS="N/A"
@@ -147,43 +245,121 @@ FULLTEXT_CURRENT_TXS="N/A"
 if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
     echo ""
     echo "=========================================="
-    echo "  Vector workload"
+    echo "  Vector workload ($ITERATIONS iterations, interleaved)"
     echo "=========================================="
 
     VECTOR_TEST="ydb/tests/stress/vector_workload/tests"
     VECTOR_DATA_DIR="$RESULTS_DIR/vector_data"
 
-    # Main: generate data + dump to files
-    run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main.log" \
-        --test-param vector_mode=generate \
-        --test-param vector_data_dir="$VECTOR_DATA_DIR"
-    VECTOR_MAIN_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
-    VECTOR_MAIN_TXS=$(extract_total_txs_sec "$VECTOR_MAIN_LOG_DIR")
+    VECTOR_MAIN_VALUES=()
+    VECTOR_CURRENT_VALUES=()
 
-    # Current: load data from dump
-    run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current.log" \
-        --test-param vector_mode=load \
-        --test-param vector_data_dir="$VECTOR_DATA_DIR"
-    VECTOR_CURRENT_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
-    VECTOR_CURRENT_TXS=$(extract_total_txs_sec "$VECTOR_CURRENT_LOG_DIR")
+    # First iteration: generate mode creates the query table
+    # Subsequent iterations: load mode reuses the query table
+    for i in $(seq 1 "$ITERATIONS"); do
+        echo ""
+        echo "=== Vector iteration $i/$ITERATIONS ==="
+
+        # Run main
+        local_mode="load"
+        if [[ $i -eq 1 ]]; then
+            local_mode="generate"
+        fi
+        run_test "$S3_REF" "$MAIN_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_main_${i}.log" \
+            --test-param vector_mode="$local_mode" \
+            --test-param vector_data_dir="$VECTOR_DATA_DIR" \
+            --test-param vector_targets="$TARGETS" \
+            --test-param vector_warmup="$WARMUP"
+        VECTOR_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
+        val=$(extract_total_txs_sec "$VECTOR_LOG_DIR")
+        if [[ "$val" != "N/A" && -n "$val" ]]; then
+            VECTOR_MAIN_VALUES+=("$val")
+        fi
+        echo "  $S3_REF iteration $i: $val Txs/Sec"
+
+        # Run current
+        run_test "current" "$CURRENT_YDBD" "$VECTOR_TEST" "$RESULTS_DIR/vector_current_${i}.log" \
+            --test-param vector_mode=load \
+            --test-param vector_data_dir="$VECTOR_DATA_DIR" \
+            --test-param vector_targets="$TARGETS" \
+            --test-param vector_warmup="$WARMUP"
+        VECTOR_LOG_DIR="$REPO_ROOT/$VECTOR_TEST/test-results/py3test/testing_out_stuff"
+        val=$(extract_total_txs_sec "$VECTOR_LOG_DIR")
+        if [[ "$val" != "N/A" && -n "$val" ]]; then
+            VECTOR_CURRENT_VALUES+=("$val")
+        fi
+        echo "  current iteration $i: $val Txs/Sec"
+    done
+
+    if [[ ${#VECTOR_MAIN_VALUES[@]} -gt 0 ]]; then
+        VECTOR_MAIN_TXS=$(median "${VECTOR_MAIN_VALUES[@]}")
+        VECTOR_MAIN_MEAN=$(mean "${VECTOR_MAIN_VALUES[@]}")
+        VECTOR_MAIN_STDDEV=$(stddev "${VECTOR_MAIN_VALUES[@]}")
+    fi
+    if [[ ${#VECTOR_CURRENT_VALUES[@]} -gt 0 ]]; then
+        VECTOR_CURRENT_TXS=$(median "${VECTOR_CURRENT_VALUES[@]}")
+        VECTOR_CURRENT_MEAN=$(mean "${VECTOR_CURRENT_VALUES[@]}")
+        VECTOR_CURRENT_STDDEV=$(stddev "${VECTOR_CURRENT_VALUES[@]}")
+    fi
+    VECTOR_MAIN_DETAIL=$(format_values "$VECTOR_MAIN_TXS" "${VECTOR_MAIN_VALUES[@]}")
+    VECTOR_CURRENT_DETAIL=$(format_values "$VECTOR_CURRENT_TXS" "${VECTOR_CURRENT_VALUES[@]}")
+    VECTOR_SIGNIFICANCE=$(calc_significance \
+        "${VECTOR_MAIN_MEAN:-N/A}" "${VECTOR_CURRENT_MEAN:-N/A}" \
+        "${VECTOR_MAIN_STDDEV:-0}" "${VECTOR_CURRENT_STDDEV:-0}" \
+        "${#VECTOR_MAIN_VALUES[@]}" "${#VECTOR_CURRENT_VALUES[@]}")
 fi
 
 # --- Run fulltext workload ---
 if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
     echo ""
     echo "=========================================="
-    echo "  Fulltext workload"
+    echo "  Fulltext workload ($ITERATIONS iterations, interleaved)"
     echo "=========================================="
 
     FULLTEXT_TEST="ydb/tests/stress/fulltext_workload/tests"
 
-    run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main.log"
-    FULLTEXT_MAIN_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
-    FULLTEXT_MAIN_TXS=$(extract_total_txs_sec "$FULLTEXT_MAIN_LOG_DIR")
+    FULLTEXT_MAIN_VALUES=()
+    FULLTEXT_CURRENT_VALUES=()
 
-    run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current.log"
-    FULLTEXT_CURRENT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
-    FULLTEXT_CURRENT_TXS=$(extract_total_txs_sec "$FULLTEXT_CURRENT_LOG_DIR")
+    for i in $(seq 1 "$ITERATIONS"); do
+        echo ""
+        echo "=== Fulltext iteration $i/$ITERATIONS ==="
+
+        # Run main
+        run_test "$S3_REF" "$MAIN_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_main_${i}.log"
+        FULLTEXT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
+        val=$(extract_total_txs_sec "$FULLTEXT_LOG_DIR")
+        if [[ "$val" != "N/A" && -n "$val" ]]; then
+            FULLTEXT_MAIN_VALUES+=("$val")
+        fi
+        echo "  $S3_REF iteration $i: $val Txs/Sec"
+
+        # Run current
+        run_test "current" "$CURRENT_YDBD" "$FULLTEXT_TEST" "$RESULTS_DIR/fulltext_current_${i}.log"
+        FULLTEXT_LOG_DIR="$REPO_ROOT/$FULLTEXT_TEST/test-results/py3test/testing_out_stuff"
+        val=$(extract_total_txs_sec "$FULLTEXT_LOG_DIR")
+        if [[ "$val" != "N/A" && -n "$val" ]]; then
+            FULLTEXT_CURRENT_VALUES+=("$val")
+        fi
+        echo "  current iteration $i: $val Txs/Sec"
+    done
+
+    if [[ ${#FULLTEXT_MAIN_VALUES[@]} -gt 0 ]]; then
+        FULLTEXT_MAIN_TXS=$(median "${FULLTEXT_MAIN_VALUES[@]}")
+        FULLTEXT_MAIN_MEAN=$(mean "${FULLTEXT_MAIN_VALUES[@]}")
+        FULLTEXT_MAIN_STDDEV=$(stddev "${FULLTEXT_MAIN_VALUES[@]}")
+    fi
+    if [[ ${#FULLTEXT_CURRENT_VALUES[@]} -gt 0 ]]; then
+        FULLTEXT_CURRENT_TXS=$(median "${FULLTEXT_CURRENT_VALUES[@]}")
+        FULLTEXT_CURRENT_MEAN=$(mean "${FULLTEXT_CURRENT_VALUES[@]}")
+        FULLTEXT_CURRENT_STDDEV=$(stddev "${FULLTEXT_CURRENT_VALUES[@]}")
+    fi
+    FULLTEXT_MAIN_DETAIL=$(format_values "$FULLTEXT_MAIN_TXS" "${FULLTEXT_MAIN_VALUES[@]}")
+    FULLTEXT_CURRENT_DETAIL=$(format_values "$FULLTEXT_CURRENT_TXS" "${FULLTEXT_CURRENT_VALUES[@]}")
+    FULLTEXT_SIGNIFICANCE=$(calc_significance \
+        "${FULLTEXT_MAIN_MEAN:-N/A}" "${FULLTEXT_CURRENT_MEAN:-N/A}" \
+        "${FULLTEXT_MAIN_STDDEV:-0}" "${FULLTEXT_CURRENT_STDDEV:-0}" \
+        "${#FULLTEXT_MAIN_VALUES[@]}" "${#FULLTEXT_CURRENT_VALUES[@]}")
 fi
 
 # --- Print comparison ---
@@ -194,6 +370,7 @@ echo ""
 echo "=========================================="
 echo "  Performance Comparison Results"
 echo "  Build preset: $BUILD_PRESET"
+echo "  Iterations: $ITERATIONS (median reported)"
 echo "=========================================="
 echo ""
 printf "%-20s %15s %15s %10s\n" "Workload" "$S3_REF (Txs/Sec)" "$CURRENT_BRANCH (Txs/Sec)" "Diff"
@@ -205,6 +382,19 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
     printf "%-20s %15s %15s %10s\n" "fulltext select" "$FULLTEXT_MAIN_TXS" "$FULLTEXT_CURRENT_TXS" "$FULLTEXT_DIFF"
 fi
 echo ""
+if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
+    echo "Vector details:"
+    echo "  $S3_REF:   ${VECTOR_MAIN_DETAIL:-N/A}  (mean=${VECTOR_MAIN_MEAN:-N/A}, σ=${VECTOR_MAIN_STDDEV:-N/A})"
+    echo "  current: ${VECTOR_CURRENT_DETAIL:-N/A}  (mean=${VECTOR_CURRENT_MEAN:-N/A}, σ=${VECTOR_CURRENT_STDDEV:-N/A})"
+    echo "  3σ test: ${VECTOR_SIGNIFICANCE:-N/A}"
+fi
+if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
+    echo "Fulltext details:"
+    echo "  $S3_REF:   ${FULLTEXT_MAIN_DETAIL:-N/A}  (mean=${FULLTEXT_MAIN_MEAN:-N/A}, σ=${FULLTEXT_MAIN_STDDEV:-N/A})"
+    echo "  current: ${FULLTEXT_CURRENT_DETAIL:-N/A}  (mean=${FULLTEXT_CURRENT_MEAN:-N/A}, σ=${FULLTEXT_CURRENT_STDDEV:-N/A})"
+    echo "  3σ test: ${FULLTEXT_SIGNIFICANCE:-N/A}"
+fi
+echo ""
 echo "Detailed logs: $RESULTS_DIR/"
 
 # --- Write markdown report ---
@@ -212,15 +402,15 @@ REPORT_FILE="$RESULTS_DIR/report.md"
 {
     echo "## Performance Comparison: \`$S3_REF\` vs \`$CURRENT_BRANCH\`"
     echo ""
-    echo "**Build preset:** \`$BUILD_PRESET\` | **Duration:** ${DURATION}s per workload"
+    echo "**Build preset:** \`$BUILD_PRESET\` | **Duration:** ${DURATION}s per workload | **Iterations:** $ITERATIONS (median reported)"
     echo ""
-    echo "| Workload | $S3_REF (Txs/Sec) | $CURRENT_BRANCH (Txs/Sec) | Diff |"
-    echo "|---|---|---|---|"
+    echo "| Workload | $S3_REF (Txs/Sec) | $CURRENT_BRANCH (Txs/Sec) | Diff | 3σ significance |"
+    echo "|---|---|---|---|---|"
     if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
-        echo "| vector select | $VECTOR_MAIN_TXS | $VECTOR_CURRENT_TXS | $VECTOR_DIFF |"
+        echo "| vector select | ${VECTOR_MAIN_DETAIL:-N/A} | ${VECTOR_CURRENT_DETAIL:-N/A} | $VECTOR_DIFF | ${VECTOR_SIGNIFICANCE:-N/A} |"
     fi
     if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "fulltext" ]]; then
-        echo "| fulltext select | $FULLTEXT_MAIN_TXS | $FULLTEXT_CURRENT_TXS | $FULLTEXT_DIFF |"
+        echo "| fulltext select | ${FULLTEXT_MAIN_DETAIL:-N/A} | ${FULLTEXT_CURRENT_DETAIL:-N/A} | $FULLTEXT_DIFF | ${FULLTEXT_SIGNIFICANCE:-N/A} |"
     fi
 } > "$REPORT_FILE"
 echo ""

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -11,6 +11,9 @@
 # Usage:
 #   ./ydb/tests/stress/compare_index_performance.sh [OPTIONS]
 #
+# Defaults are for quick local runs. The GitHub workflow uses larger values
+# (duration=600, iterations=20) for CI.
+#
 # Options:
 #   --duration SECONDS     Duration of each workload run (default: 60)
 #   --build-preset PRESET  Build preset for both binaries (default: relwithdebinfo)
@@ -18,10 +21,10 @@
 #   --current-ydbd PATH    Path to pre-built current branch ydbd (skips building)
 #   --ref REF              S3 ref to download ydbd from (default: main)
 #   --workload WORKLOAD    Run only specified workload: vector, fulltext, or all (default: all)
-#   --targets N            Number of query vectors for vector select (default: 10000)
+#   --targets N            Number of query vectors for vector select (default: 1000)
 #   --iterations N         Number of iterations per workload (default: 3)
 #   --warmup SECONDS       Warmup duration before each measured run (default: 30)
-#   --rows N               Number of rows in generated database (default: 100000)
+#   --rows N               Number of rows in generated database (default: 10000)
 #   --threads N            Number of threads for load testing (default: 10)
 #   --main-feature-flag FLAG     Enable a feature flag for main branch (repeatable)
 #   --current-feature-flag FLAG  Enable a feature flag for current branch (repeatable)
@@ -41,7 +44,7 @@ WORKLOAD="all"
 TARGETS=1000
 ITERATIONS=3
 WARMUP=30
-ROWS=100000
+ROWS=10000
 THREADS=10
 MAIN_FEATURE_FLAGS=()
 CURRENT_FEATURE_FLAGS=()
@@ -168,6 +171,7 @@ run_test() {
 
     echo "--- Running $test_path with $label ydbd ---"
     cd "$REPO_ROOT"
+    rm -rf "$REPO_ROOT/$test_path/test-results"
     ./ya make --build "$BUILD_PRESET" -tA "$test_path" \
         -DYDB_DRIVER_BINARY_PREBUILT="$ydbd_path" \
         --test-param stress_default_duration="$DURATION" \
@@ -233,7 +237,7 @@ calc_diff() {
         echo "N/A"
         return
     fi
-    awk "BEGIN { diff = ($current_val - $main_val) / $main_val * 100; printf \"%+.1f%%\", diff }"
+    awk "BEGIN { if ($main_val == 0) { print \"N/A (zero base)\" } else { diff = ($current_val - $main_val) / $main_val * 100; printf \"%+.1f%%\", diff } }"
 }
 
 calc_significance() {
@@ -261,7 +265,7 @@ calc_significance() {
         diff = $current_mean - $main_mean
         absdiff = (diff < 0) ? -diff : diff
         threshold = 3 * se
-        pct = diff / $main_mean * 100
+        pct = ($main_mean != 0) ? diff / $main_mean * 100 : 0
         if (threshold > 0 && absdiff > threshold) {
             printf \"SIGNIFICANT (%+.1f%%, |diff|=%.1f > 3sigma=%.1f)\", pct, absdiff, threshold
         } else if (threshold > 0) {

--- a/ydb/tests/stress/compare_index_performance.sh
+++ b/ydb/tests/stress/compare_index_performance.sh
@@ -18,9 +18,10 @@
 #   --current-ydbd PATH    Path to pre-built current branch ydbd (skips building)
 #   --ref REF              S3 ref to download ydbd from (default: main)
 #   --workload WORKLOAD    Run only specified workload: vector, fulltext, or all (default: all)
-#   --targets N            Number of query vectors for vector select (default: 100)
+#   --targets N            Number of query vectors for vector select (default: 10000)
 #   --iterations N         Number of iterations per workload (default: 3)
 #   --warmup SECONDS       Warmup duration before each measured run (default: 30)
+#   --rows N               Number of rows in generated database (default: 100000)
 #   --main-feature-flag FLAG     Enable a feature flag for main branch (repeatable)
 #   --current-feature-flag FLAG  Enable a feature flag for current branch (repeatable)
 #   --main-table-service-config KEY=VALUE     Set table_service_config option for main branch (repeatable)
@@ -36,9 +37,10 @@ CURRENT_YDBD=""
 S3_REF="main"
 BUILD_PRESET="relwithdebinfo"
 WORKLOAD="all"
-TARGETS=100
+TARGETS=10000
 ITERATIONS=3
 WARMUP=30
+ROWS=100000
 MAIN_FEATURE_FLAGS=()
 CURRENT_FEATURE_FLAGS=()
 MAIN_TABLE_SERVICE_CONFIG=()
@@ -57,6 +59,7 @@ while [[ $# -gt 0 ]]; do
         --targets) TARGETS="$2"; shift 2 ;;
         --iterations) ITERATIONS="$2"; shift 2 ;;
         --warmup) WARMUP="$2"; shift 2 ;;
+        --rows) ROWS="$2"; shift 2 ;;
         --main-feature-flag) MAIN_FEATURE_FLAGS+=("$2"); shift 2 ;;
         --current-feature-flag) CURRENT_FEATURE_FLAGS+=("$2"); shift 2 ;;
         --main-table-service-config) MAIN_TABLE_SERVICE_CONFIG+=("$2"); shift 2 ;;
@@ -99,6 +102,7 @@ echo "Workload: $WORKLOAD"
 echo "Vector targets: $TARGETS"
 echo "Iterations: $ITERATIONS"
 echo "Warmup: ${WARMUP}s"
+echo "Rows: $ROWS"
 if [[ ${#MAIN_FEATURE_FLAGS[@]} -gt 0 ]]; then
     echo "Main feature flags: ${MAIN_FEATURE_FLAGS[*]}"
 fi
@@ -313,6 +317,7 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
             --test-param vector_data_dir="$VECTOR_DATA_DIR"
             --test-param vector_targets="$TARGETS"
             --test-param vector_warmup="$WARMUP"
+            --test-param vector_rows="$ROWS"
         )
         if [[ -n "$MAIN_FEATURE_FLAGS_PARAM" ]]; then
             VECTOR_EXTRA_PARAMS+=(--test-param feature_flags="$MAIN_FEATURE_FLAGS_PARAM")
@@ -335,6 +340,7 @@ if [[ "$WORKLOAD" == "all" || "$WORKLOAD" == "vector" ]]; then
             --test-param vector_data_dir="$VECTOR_DATA_DIR"
             --test-param vector_targets="$TARGETS"
             --test-param vector_warmup="$WARMUP"
+            --test-param vector_rows="$ROWS"
         )
         if [[ -n "$CURRENT_FEATURE_FLAGS_PARAM" ]]; then
             VECTOR_EXTRA_PARAMS+=(--test-param feature_flags="$CURRENT_FEATURE_FLAGS_PARAM")

--- a/ydb/tests/stress/fulltext_workload/__main__.py
+++ b/ydb/tests/stress/fulltext_workload/__main__.py
@@ -9,8 +9,8 @@ if __name__ == '__main__':
     )
     parser.add_argument('--endpoint', default='grpc://localhost:2135', help="YDB endpoint")
     parser.add_argument('--database', default=None, required=True, help='A database to connect')
-    parser.add_argument('--duration', default=120, type=lambda x: int(x), help='A duration of workload in seconds')
-    parser.add_argument('--rows', default=100000, type=int, help='Number of rows in generated database (default: 100000)')
+    parser.add_argument('--duration', default=120, type=int, help='A duration of workload in seconds')
+    parser.add_argument('--rows', default=10000, type=int, help='Number of rows in generated database (default: 10000)')
     parser.add_argument('--targets', default=1000, type=int, help='Number of rows to sample for query word set (default: 1000)')
     parser.add_argument('--threads', default=10, type=int, help='Number of threads for load testing (default: 10)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
@@ -27,6 +27,6 @@ if __name__ == '__main__':
         )
 
     workload = YdbFulltextWorkload(args.endpoint, args.database, duration=args.duration,
-                                    rows=args.rows, targets=args.targets, threads=args.threads)
+                                   rows=args.rows, targets=args.targets, threads=args.threads)
     workload.start()
     workload.join()

--- a/ydb/tests/stress/fulltext_workload/__main__.py
+++ b/ydb/tests/stress/fulltext_workload/__main__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import argparse
+import logging
+from ydb.tests.stress.fulltext_workload.workload import YdbFulltextWorkload
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Workload fulltext wrapper", formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('--endpoint', default='grpc://localhost:2135', help="YDB endpoint")
+    parser.add_argument('--database', default=None, required=True, help='A database to connect')
+    parser.add_argument('--duration', default=120, type=lambda x: int(x), help='A duration of workload in seconds')
+    parser.add_argument('--log_file', default=None, help='Append log into specified file')
+
+    args = parser.parse_args()
+
+    if args.log_file:
+        logging.basicConfig(
+            filename=args.log_file,
+            filemode='a',
+            format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+            datefmt='%H:%M:%S',
+            level=logging.INFO
+        )
+
+    workload = YdbFulltextWorkload(args.endpoint, args.database, duration=args.duration)
+    workload.start()
+    workload.join()

--- a/ydb/tests/stress/fulltext_workload/__main__.py
+++ b/ydb/tests/stress/fulltext_workload/__main__.py
@@ -10,6 +10,9 @@ if __name__ == '__main__':
     parser.add_argument('--endpoint', default='grpc://localhost:2135', help="YDB endpoint")
     parser.add_argument('--database', default=None, required=True, help='A database to connect')
     parser.add_argument('--duration', default=120, type=lambda x: int(x), help='A duration of workload in seconds')
+    parser.add_argument('--rows', default=100000, type=int, help='Number of rows in generated database (default: 100000)')
+    parser.add_argument('--targets', default=1000, type=int, help='Number of rows to sample for query word set (default: 1000)')
+    parser.add_argument('--threads', default=10, type=int, help='Number of threads for load testing (default: 10)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
 
     args = parser.parse_args()
@@ -23,6 +26,7 @@ if __name__ == '__main__':
             level=logging.INFO
         )
 
-    workload = YdbFulltextWorkload(args.endpoint, args.database, duration=args.duration)
+    workload = YdbFulltextWorkload(args.endpoint, args.database, duration=args.duration,
+                                    rows=args.rows, targets=args.targets, threads=args.threads)
     workload.start()
     workload.join()

--- a/ydb/tests/stress/fulltext_workload/tests/test_workload.py
+++ b/ydb/tests/stress/fulltext_workload/tests/test_workload.py
@@ -26,9 +26,16 @@ class TestYdbFulltextWorkload(StressFixture):
         yield from self.setup_cluster(extra_feature_flags=extra_flags, table_service_config=tsc or None)
 
     def test(self):
+        rows = yatest.common.get_param('fulltext_rows', default='100000')
+        targets = yatest.common.get_param('fulltext_targets', default='1000')
+        threads = yatest.common.get_param('fulltext_threads', default='10')
+
         yatest.common.execute([
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
             "--endpoint", self.endpoint,
             "--database", self.database,
             "--duration", self.base_duration,
+            "--rows", rows,
+            "--targets", targets,
+            "--threads", threads,
         ])

--- a/ydb/tests/stress/fulltext_workload/tests/test_workload.py
+++ b/ydb/tests/stress/fulltext_workload/tests/test_workload.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import os
+import pytest
+import yatest
+
+from ydb.tests.library.stress.fixtures import StressFixture
+
+
+class TestYdbFulltextWorkload(StressFixture):
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        yield from self.setup_cluster(extra_feature_flags=["enable_fulltext_index"])
+
+    def test(self):
+        yatest.common.execute([
+            yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
+            "--endpoint", self.endpoint,
+            "--database", self.database,
+            "--duration", self.base_duration,
+        ])

--- a/ydb/tests/stress/fulltext_workload/tests/test_workload.py
+++ b/ydb/tests/stress/fulltext_workload/tests/test_workload.py
@@ -9,7 +9,21 @@ from ydb.tests.library.stress.fixtures import StressFixture
 class TestYdbFulltextWorkload(StressFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
-        yield from self.setup_cluster(extra_feature_flags=["enable_fulltext_index"])
+        feature_flags_str = yatest.common.get_param('feature_flags', default='')
+        extra_flags = [f for f in feature_flags_str.split(',') if f]
+        extra_flags.append("enable_fulltext_index")
+        tsc_str = yatest.common.get_param('table_service_config', default='')
+        tsc = {}
+        for item in tsc_str.split(','):
+            if '=' in item:
+                k, v = item.split('=', 1)
+                if v.lower() == 'true':
+                    tsc[k] = True
+                elif v.lower() == 'false':
+                    tsc[k] = False
+                else:
+                    tsc[k] = v
+        yield from self.setup_cluster(extra_feature_flags=extra_flags, table_service_config=tsc or None)
 
     def test(self):
         yatest.common.execute([

--- a/ydb/tests/stress/fulltext_workload/tests/test_workload.py
+++ b/ydb/tests/stress/fulltext_workload/tests/test_workload.py
@@ -26,7 +26,7 @@ class TestYdbFulltextWorkload(StressFixture):
         yield from self.setup_cluster(extra_feature_flags=extra_flags, table_service_config=tsc or None)
 
     def test(self):
-        rows = yatest.common.get_param('fulltext_rows', default='100000')
+        rows = yatest.common.get_param('fulltext_rows', default='10000')
         targets = yatest.common.get_param('fulltext_targets', default='1000')
         threads = yatest.common.get_param('fulltext_threads', default='10')
 

--- a/ydb/tests/stress/fulltext_workload/tests/ya.make
+++ b/ydb/tests/stress/fulltext_workload/tests/ya.make
@@ -1,0 +1,29 @@
+PY3TEST()
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
+ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
+ENV(YDB_ERASURE=mirror_3_dc)
+ENV(YDB_USE_IN_MEMORY_PDISKS=true)
+ENV(YDB_WORKLOAD_PATH="ydb/tests/stress/fulltext_workload/workload_fulltext")
+
+TEST_SRCS(
+    test_workload.py
+)
+
+REQUIREMENTS(ram:32 cpu:4)
+TAG(ya:external)
+
+SIZE(LARGE)
+TAG(ya:fat)
+TIMEOUT(1200)
+
+DEPENDS(
+    ydb/tests/stress/fulltext_workload
+    ydb/apps/ydb
+)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/library/stress
+)
+
+END()

--- a/ydb/tests/stress/fulltext_workload/workload/__init__.py
+++ b/ydb/tests/stress/fulltext_workload/workload/__init__.py
@@ -1,0 +1,97 @@
+import logging
+import os
+import stat
+import subprocess
+import tempfile
+import time
+
+from library.python import resource
+from ydb.tests.stress.common.common import WorkloadBase
+
+logger = logging.getLogger("YdbFulltextWorkload")
+
+MARKOV_MODEL_URL = "https://storage.yandexcloud.net/ydb-public/markov_dict.tsv.gz"
+MARKOV_MODEL_FILENAME = "markov_dict.tsv.gz"
+
+
+class YdbFulltextWorkload(WorkloadBase):
+    def __init__(self, endpoint, database, duration):
+        super().__init__(None, '', 'fulltext_workload', None)
+        self.endpoint = endpoint
+        self.database = database
+        self.duration = str(duration)
+        self.tempdir = None
+        self._unpack_resource('ydb_cli')
+        self._download_model()
+
+    def __del__(self):
+        self.tempdir.cleanup()
+
+    def _unpack_resource(self, name):
+        self.tempdir = tempfile.TemporaryDirectory(dir=os.getcwd())
+        self.working_dir = os.path.join(self.tempdir.name, "fulltext_ydb_cli")
+        os.makedirs(self.working_dir, exist_ok=True)
+        res = resource.find(name)
+        path_to_unpack = os.path.join(self.working_dir, name)
+        with open(path_to_unpack, "wb") as f:
+            f.write(res)
+
+        st = os.stat(path_to_unpack)
+        os.chmod(path_to_unpack, st.st_mode | stat.S_IEXEC)
+        self.cli_path = path_to_unpack
+
+    def _download_model(self):
+        self.model_path = os.path.join(self.working_dir, MARKOV_MODEL_FILENAME)
+        logger.info(f"Downloading markov model from {MARKOV_MODEL_URL}")
+        print(f"Downloading markov model from {MARKOV_MODEL_URL}")
+        subprocess.run(
+            ["wget", "-q", "-O", self.model_path, MARKOV_MODEL_URL],
+            check=True,
+            text=True,
+        )
+        print(f"Downloaded markov model to {self.model_path}")
+
+    def get_command_prefix(self, subcmds):
+        return [
+            self.cli_path,
+            '--verbose',
+            '--endpoint', self.endpoint,
+            '--database={}'.format(self.database),
+            'workload', 'fulltext'
+        ] + subcmds
+
+    def cmd_run(self, cmd):
+        logger.debug(f"Running cmd {cmd}")
+        print(f"Running cmd {cmd} at {time.time()}")
+        subprocess.run(cmd, check=True, text=True)
+        print(f"End at {time.time()}")
+
+    def __loop(self):
+        # init
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['init', '--clear'])
+        )
+        # import generator
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'import', 'generator',
+                '--model', self.model_path,
+                '--rows', '10000',
+            ])
+        )
+        # run select
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'run', 'select',
+                '--model', self.model_path,
+                '--seconds', self.duration,
+                '--threads', '10',
+            ])
+        )
+        # clean
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['clean'])
+        )
+
+    def get_workload_thread_funcs(self):
+        return [self.__loop]

--- a/ydb/tests/stress/fulltext_workload/workload/__init__.py
+++ b/ydb/tests/stress/fulltext_workload/workload/__init__.py
@@ -15,11 +15,14 @@ MARKOV_MODEL_FILENAME = "markov_dict.tsv.gz"
 
 
 class YdbFulltextWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration):
+    def __init__(self, endpoint, database, duration, rows=100000, targets=1000, threads=10):
         super().__init__(None, '', 'fulltext_workload', None)
         self.endpoint = endpoint
         self.database = database
         self.duration = str(duration)
+        self.rows = str(rows)
+        self.targets = str(targets)
+        self.threads = str(threads)
         self.tempdir = None
         self._unpack_resource('ydb_cli')
         self._download_model()
@@ -76,7 +79,7 @@ class YdbFulltextWorkload(WorkloadBase):
             self.get_command_prefix(subcmds=[
                 'import', 'generator',
                 '--model', self.model_path,
-                '--rows', '10000',
+                '--rows', self.rows,
             ])
         )
         # run select
@@ -85,7 +88,8 @@ class YdbFulltextWorkload(WorkloadBase):
                 'run', 'select',
                 '--model', self.model_path,
                 '--seconds', self.duration,
-                '--threads', '10',
+                '--threads', self.threads,
+                '--top-size', self.targets,
             ])
         )
         # clean

--- a/ydb/tests/stress/fulltext_workload/workload/__init__.py
+++ b/ydb/tests/stress/fulltext_workload/workload/__init__.py
@@ -15,7 +15,7 @@ MARKOV_MODEL_FILENAME = "markov_dict.tsv.gz"
 
 
 class YdbFulltextWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration, rows=100000, targets=1000, threads=10):
+    def __init__(self, endpoint, database, duration, rows=10000, targets=1000, threads=10):
         super().__init__(None, '', 'fulltext_workload', None)
         self.endpoint = endpoint
         self.database = database
@@ -28,7 +28,8 @@ class YdbFulltextWorkload(WorkloadBase):
         self._download_model()
 
     def __del__(self):
-        self.tempdir.cleanup()
+        if self.tempdir is not None:
+            self.tempdir.cleanup()
 
     def _unpack_resource(self, name):
         self.tempdir = tempfile.TemporaryDirectory(dir=os.getcwd())

--- a/ydb/tests/stress/fulltext_workload/workload/ya.make
+++ b/ydb/tests/stress/fulltext_workload/workload/ya.make
@@ -1,0 +1,18 @@
+PY3_LIBRARY()
+
+PY_SRCS(
+    __init__.py
+)
+
+BUNDLE(
+    ydb/apps/ydb NAME ydb_cli
+)
+RESOURCE(ydb_cli ydb_cli)
+PEERDIR(
+    ydb/tests/stress/common
+    ydb/public/sdk/python
+    library/python/resource
+    ydb/public/sdk/python/enable_v3_new_behavior
+)
+
+END()

--- a/ydb/tests/stress/fulltext_workload/ya.make
+++ b/ydb/tests/stress/fulltext_workload/ya.make
@@ -1,0 +1,16 @@
+PY3_PROGRAM(workload_fulltext)
+
+PY_SRCS(
+    __main__.py
+)
+
+PEERDIR(
+    ydb/tests/stress/common
+    ydb/tests/stress/fulltext_workload/workload
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    tests
+)

--- a/ydb/tests/stress/vector_workload/__main__.py
+++ b/ydb/tests/stress/vector_workload/__main__.py
@@ -13,6 +13,8 @@ if __name__ == '__main__':
     parser.add_argument('--mode', default='standalone', choices=['standalone', 'generate', 'load'],
                         help='Mode: standalone (default), generate (generate + dump), load (restore + run)')
     parser.add_argument('--data-dir', default=None, help='Directory for dump/restore data (required for generate/load modes)')
+    parser.add_argument('--targets', default=100, type=int, help='Number of query vectors for run select (default: 100)')
+    parser.add_argument('--warmup', default=0, type=int, help='Warmup duration in seconds before measured run (default: 0, disabled)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
 
     args = parser.parse_args()
@@ -30,6 +32,7 @@ if __name__ == '__main__':
         )
 
     workload = YdbVectorWorkload(args.endpoint, args.database, duration=args.duration,
-                                 mode=args.mode, data_dir=args.data_dir)
+                                 mode=args.mode, data_dir=args.data_dir, targets=args.targets,
+                                 warmup=args.warmup)
     workload.start()
     workload.join()

--- a/ydb/tests/stress/vector_workload/__main__.py
+++ b/ydb/tests/stress/vector_workload/__main__.py
@@ -10,9 +10,15 @@ if __name__ == '__main__':
     parser.add_argument('--endpoint', default='grpc://localhost:2135', help="YDB endpoint")
     parser.add_argument('--database', default=None, required=True, help='A database to connect')
     parser.add_argument('--duration', default=120, type=lambda x: int(x), help='A duration of workload in seconds')
+    parser.add_argument('--mode', default='standalone', choices=['standalone', 'generate', 'load'],
+                        help='Mode: standalone (default), generate (generate + dump), load (restore + run)')
+    parser.add_argument('--data-dir', default=None, help='Directory for dump/restore data (required for generate/load modes)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
 
     args = parser.parse_args()
+
+    if args.mode in ('generate', 'load') and not args.data_dir:
+        parser.error(f"--data-dir is required for --mode={args.mode}")
 
     if args.log_file:
         logging.basicConfig(
@@ -23,6 +29,7 @@ if __name__ == '__main__':
             level=logging.INFO
         )
 
-    workload = YdbVectorWorkload(args.endpoint, args.database, duration=args.duration)
+    workload = YdbVectorWorkload(args.endpoint, args.database, duration=args.duration,
+                                 mode=args.mode, data_dir=args.data_dir)
     workload.start()
     workload.join()

--- a/ydb/tests/stress/vector_workload/__main__.py
+++ b/ydb/tests/stress/vector_workload/__main__.py
@@ -13,8 +13,9 @@ if __name__ == '__main__':
     parser.add_argument('--mode', default='standalone', choices=['standalone', 'generate', 'load'],
                         help='Mode: standalone (default), generate (generate + dump), load (restore + run)')
     parser.add_argument('--data-dir', default=None, help='Directory for dump/restore data (required for generate/load modes)')
-    parser.add_argument('--targets', default=100, type=int, help='Number of query vectors for run select (default: 100)')
+    parser.add_argument('--targets', default=10000, type=int, help='Number of query vectors for run select (default: 10000)')
     parser.add_argument('--warmup', default=0, type=int, help='Warmup duration in seconds before measured run (default: 0, disabled)')
+    parser.add_argument('--rows', default=100000, type=int, help='Number of rows in generated database (default: 100000)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
 
     args = parser.parse_args()
@@ -33,6 +34,6 @@ if __name__ == '__main__':
 
     workload = YdbVectorWorkload(args.endpoint, args.database, duration=args.duration,
                                  mode=args.mode, data_dir=args.data_dir, targets=args.targets,
-                                 warmup=args.warmup)
+                                 warmup=args.warmup, rows=args.rows)
     workload.start()
     workload.join()

--- a/ydb/tests/stress/vector_workload/__main__.py
+++ b/ydb/tests/stress/vector_workload/__main__.py
@@ -9,13 +9,13 @@ if __name__ == '__main__':
     )
     parser.add_argument('--endpoint', default='grpc://localhost:2135', help="YDB endpoint")
     parser.add_argument('--database', default=None, required=True, help='A database to connect')
-    parser.add_argument('--duration', default=120, type=lambda x: int(x), help='A duration of workload in seconds')
+    parser.add_argument('--duration', default=120, type=int, help='A duration of workload in seconds')
     parser.add_argument('--mode', default='standalone', choices=['standalone', 'generate', 'load'],
                         help='Mode: standalone (default), generate (generate + dump), load (restore + run)')
     parser.add_argument('--data-dir', default=None, help='Directory for dump/restore data (required for generate/load modes)')
-    parser.add_argument('--targets', default=1000, type=int, help='Number of query vectors for run select (default: 10000)')
+    parser.add_argument('--targets', default=1000, type=int, help='Number of query vectors for run select (default: 1000)')
     parser.add_argument('--warmup', default=0, type=int, help='Warmup duration in seconds before measured run (default: 0, disabled)')
-    parser.add_argument('--rows', default=100000, type=int, help='Number of rows in generated database (default: 100000)')
+    parser.add_argument('--rows', default=10000, type=int, help='Number of rows in generated database (default: 10000)')
     parser.add_argument('--threads', default=10, type=int, help='Number of threads for load testing (default: 10)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
 

--- a/ydb/tests/stress/vector_workload/__main__.py
+++ b/ydb/tests/stress/vector_workload/__main__.py
@@ -13,9 +13,10 @@ if __name__ == '__main__':
     parser.add_argument('--mode', default='standalone', choices=['standalone', 'generate', 'load'],
                         help='Mode: standalone (default), generate (generate + dump), load (restore + run)')
     parser.add_argument('--data-dir', default=None, help='Directory for dump/restore data (required for generate/load modes)')
-    parser.add_argument('--targets', default=10000, type=int, help='Number of query vectors for run select (default: 10000)')
+    parser.add_argument('--targets', default=1000, type=int, help='Number of query vectors for run select (default: 10000)')
     parser.add_argument('--warmup', default=0, type=int, help='Warmup duration in seconds before measured run (default: 0, disabled)')
     parser.add_argument('--rows', default=100000, type=int, help='Number of rows in generated database (default: 100000)')
+    parser.add_argument('--threads', default=10, type=int, help='Number of threads for load testing (default: 10)')
     parser.add_argument('--log_file', default=None, help='Append log into specified file')
 
     args = parser.parse_args()
@@ -34,6 +35,6 @@ if __name__ == '__main__':
 
     workload = YdbVectorWorkload(args.endpoint, args.database, duration=args.duration,
                                  mode=args.mode, data_dir=args.data_dir, targets=args.targets,
-                                 warmup=args.warmup, rows=args.rows)
+                                 warmup=args.warmup, rows=args.rows, threads=args.threads)
     workload.start()
     workload.join()

--- a/ydb/tests/stress/vector_workload/__main__.py
+++ b/ydb/tests/stress/vector_workload/__main__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+import argparse
+import logging
+from ydb.tests.stress.vector_workload.workload import YdbVectorWorkload
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Workload vector wrapper", formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('--endpoint', default='grpc://localhost:2135', help="YDB endpoint")
+    parser.add_argument('--database', default=None, required=True, help='A database to connect')
+    parser.add_argument('--duration', default=120, type=lambda x: int(x), help='A duration of workload in seconds')
+    parser.add_argument('--log_file', default=None, help='Append log into specified file')
+
+    args = parser.parse_args()
+
+    if args.log_file:
+        logging.basicConfig(
+            filename=args.log_file,
+            filemode='a',
+            format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
+            datefmt='%H:%M:%S',
+            level=logging.INFO
+        )
+
+    workload = YdbVectorWorkload(args.endpoint, args.database, duration=args.duration)
+    workload.start()
+    workload.join()

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -27,8 +27,9 @@ class TestYdbVectorWorkload(StressFixture):
     def test(self):
         mode = yatest.common.get_param('vector_mode', default='standalone')
         data_dir = yatest.common.get_param('vector_data_dir', default=None)
-        targets = yatest.common.get_param('vector_targets', default='100')
+        targets = yatest.common.get_param('vector_targets', default='10000')
         warmup = yatest.common.get_param('vector_warmup', default='0')
+        rows = yatest.common.get_param('vector_rows', default='100000')
 
         cmd = [
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
@@ -38,6 +39,7 @@ class TestYdbVectorWorkload(StressFixture):
             "--mode", mode,
             "--targets", targets,
             "--warmup", warmup,
+            "--rows", rows,
         ]
         if data_dir:
             cmd.extend(["--data-dir", data_dir])

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -29,7 +29,7 @@ class TestYdbVectorWorkload(StressFixture):
         data_dir = yatest.common.get_param('vector_data_dir', default=None)
         targets = yatest.common.get_param('vector_targets', default='10000')
         warmup = yatest.common.get_param('vector_warmup', default='0')
-        rows = yatest.common.get_param('vector_rows', default='100000')
+        rows = yatest.common.get_param('vector_rows', default='10000')
         threads = yatest.common.get_param('vector_threads', default='10')
 
         cmd = [

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -14,6 +14,8 @@ class TestYdbVectorWorkload(StressFixture):
     def test(self):
         mode = yatest.common.get_param('vector_mode', default='standalone')
         data_dir = yatest.common.get_param('vector_data_dir', default=None)
+        targets = yatest.common.get_param('vector_targets', default='100')
+        warmup = yatest.common.get_param('vector_warmup', default='0')
 
         cmd = [
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
@@ -21,6 +23,8 @@ class TestYdbVectorWorkload(StressFixture):
             "--database", self.database,
             "--duration", self.base_duration,
             "--mode", mode,
+            "--targets", targets,
+            "--warmup", warmup,
         ]
         if data_dir:
             cmd.extend(["--data-dir", data_dir])

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+import os
+import pytest
+import yatest
+
+from ydb.tests.library.stress.fixtures import StressFixture
+
+
+class TestYdbVectorWorkload(StressFixture):
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        yield from self.setup_cluster()
+
+    def test(self):
+        yatest.common.execute([
+            yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
+            "--endpoint", self.endpoint,
+            "--database", self.database,
+            "--duration", self.base_duration,
+        ])

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -12,9 +12,17 @@ class TestYdbVectorWorkload(StressFixture):
         yield from self.setup_cluster()
 
     def test(self):
-        yatest.common.execute([
+        mode = yatest.common.get_param('vector_mode', default='standalone')
+        data_dir = yatest.common.get_param('vector_data_dir', default=None)
+
+        cmd = [
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
             "--endpoint", self.endpoint,
             "--database", self.database,
             "--duration", self.base_duration,
-        ])
+            "--mode", mode,
+        ]
+        if data_dir:
+            cmd.extend(["--data-dir", data_dir])
+
+        yatest.common.execute(cmd)

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -30,6 +30,7 @@ class TestYdbVectorWorkload(StressFixture):
         targets = yatest.common.get_param('vector_targets', default='10000')
         warmup = yatest.common.get_param('vector_warmup', default='0')
         rows = yatest.common.get_param('vector_rows', default='100000')
+        threads = yatest.common.get_param('vector_threads', default='10')
 
         cmd = [
             yatest.common.binary_path(os.environ["YDB_WORKLOAD_PATH"]),
@@ -40,6 +41,7 @@ class TestYdbVectorWorkload(StressFixture):
             "--targets", targets,
             "--warmup", warmup,
             "--rows", rows,
+            "--threads", threads,
         ]
         if data_dir:
             cmd.extend(["--data-dir", data_dir])

--- a/ydb/tests/stress/vector_workload/tests/test_workload.py
+++ b/ydb/tests/stress/vector_workload/tests/test_workload.py
@@ -9,7 +9,20 @@ from ydb.tests.library.stress.fixtures import StressFixture
 class TestYdbVectorWorkload(StressFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
-        yield from self.setup_cluster()
+        feature_flags_str = yatest.common.get_param('feature_flags', default='')
+        extra_flags = [f for f in feature_flags_str.split(',') if f]
+        tsc_str = yatest.common.get_param('table_service_config', default='')
+        tsc = {}
+        for item in tsc_str.split(','):
+            if '=' in item:
+                k, v = item.split('=', 1)
+                if v.lower() == 'true':
+                    tsc[k] = True
+                elif v.lower() == 'false':
+                    tsc[k] = False
+                else:
+                    tsc[k] = v
+        yield from self.setup_cluster(extra_feature_flags=extra_flags, table_service_config=tsc or None)
 
     def test(self):
         mode = yatest.common.get_param('vector_mode', default='standalone')

--- a/ydb/tests/stress/vector_workload/tests/ya.make
+++ b/ydb/tests/stress/vector_workload/tests/ya.make
@@ -10,6 +10,7 @@ TEST_SRCS(
 )
 
 REQUIREMENTS(ram:32 cpu:4)
+TAG(ya:external)
 
 SIZE(LARGE)
 TAG(ya:fat)

--- a/ydb/tests/stress/vector_workload/tests/ya.make
+++ b/ydb/tests/stress/vector_workload/tests/ya.make
@@ -1,0 +1,28 @@
+PY3TEST()
+INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
+ENV(YDB_CLI_BINARY="ydb/apps/ydb/ydb")
+ENV(YDB_ERASURE=mirror_3_dc)
+ENV(YDB_USE_IN_MEMORY_PDISKS=true)
+ENV(YDB_WORKLOAD_PATH="ydb/tests/stress/vector_workload/workload_vector")
+
+TEST_SRCS(
+    test_workload.py
+)
+
+REQUIREMENTS(ram:32 cpu:4)
+
+SIZE(LARGE)
+TAG(ya:fat)
+TIMEOUT(1200)
+
+DEPENDS(
+    ydb/tests/stress/vector_workload
+    ydb/apps/ydb
+)
+
+PEERDIR(
+    ydb/tests/library
+    ydb/tests/library/stress
+)
+
+END()

--- a/ydb/tests/stress/vector_workload/workload/__init__.py
+++ b/ydb/tests/stress/vector_workload/workload/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -10,15 +11,19 @@ from ydb.tests.stress.common.common import WorkloadBase
 
 logger = logging.getLogger("YdbVectorWorkload")
 
+QUERY_TABLE_NAME = "vector_query_table"
+
 
 class YdbVectorWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None):
+    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=100, warmup=0):
         super().__init__(None, '', 'vector_workload', None)
         self.endpoint = endpoint
         self.database = database
         self.duration = str(duration)
         self.mode = mode
         self.data_dir = data_dir
+        self.targets = str(targets)
+        self.warmup = str(warmup)
         self.tempdir = None
         self._unpack_resource('ydb_cli')
 
@@ -38,23 +43,19 @@ class YdbVectorWorkload(WorkloadBase):
         os.chmod(path_to_unpack, st.st_mode | stat.S_IEXEC)
         self.cli_path = path_to_unpack
 
-    def get_command_prefix(self, subcmds):
+    def get_cli_prefix(self):
         return [
             self.cli_path,
             '--verbose',
             '--endpoint', self.endpoint,
             '--database={}'.format(self.database),
-            'workload', 'vector'
-        ] + subcmds
+        ]
+
+    def get_command_prefix(self, subcmds):
+        return self.get_cli_prefix() + ['workload', 'vector'] + subcmds
 
     def get_tools_prefix(self, subcmds):
-        return [
-            self.cli_path,
-            '--verbose',
-            '--endpoint', self.endpoint,
-            '--database={}'.format(self.database),
-            'tools',
-        ] + subcmds
+        return self.get_cli_prefix() + ['tools'] + subcmds
 
     def cmd_run(self, cmd):
         logger.debug(f"Running cmd {cmd}")
@@ -62,37 +63,64 @@ class YdbVectorWorkload(WorkloadBase):
         subprocess.run(cmd, check=True, text=True)
         print(f"End at {time.time()}")
 
-    def __loop_standalone(self):
-        """Original mode: generate data, build index, run select, clean."""
-        self.cmd_run(
-            self.get_command_prefix(subcmds=['init', '--clear'])
+    def cmd_run_with_retry(self, cmd, retries=5, delay=30):
+        """Run command with retries and delay between attempts."""
+        for attempt in range(1, retries + 1):
+            try:
+                self.cmd_run(cmd)
+                return
+            except subprocess.CalledProcessError:
+                if attempt == retries:
+                    raise
+                print(f"Attempt {attempt}/{retries} failed, retrying in {delay}s...")
+                time.sleep(delay)
+
+    def _create_query_table(self):
+        """Create a query table with N rows from the main table."""
+        print(f"Creating query table {QUERY_TABLE_NAME} with {self.targets} rows...")
+        create_sql = (
+            f"CREATE TABLE `{QUERY_TABLE_NAME}` "
+            f"(id Uint64 NOT NULL, embedding String, PRIMARY KEY(id));"
         )
+        self.cmd_run(self.get_cli_prefix() + ['yql', '-s', create_sql])
+
+        populate_sql = (
+            f"UPSERT INTO `{QUERY_TABLE_NAME}` "
+            f"SELECT id, embedding FROM `vector_index_workload` "
+            f"ORDER BY id LIMIT {self.targets};"
+        )
+        self.cmd_run(self.get_cli_prefix() + ['yql', '-s', populate_sql])
+
+    def _dump_query_table(self):
+        """Dump query table to data_dir for reuse by load mode."""
+        print(f"Dumping query table to {self.data_dir}")
+        if os.path.exists(self.data_dir):
+            shutil.rmtree(self.data_dir)
         self.cmd_run(
-            self.get_command_prefix(subcmds=[
-                'import', 'generator',
-                '--rows', '10000',
-                '--distance', 'cosine',
+            self.get_tools_prefix(subcmds=[
+                'dump',
+                '-p', self.database + '/' + QUERY_TABLE_NAME,
+                '-o', self.data_dir,
             ])
-        )
-        print("Waiting for table statistics to be calculated...")
-        time.sleep(30)
-        self.cmd_run(
-            self.get_command_prefix(subcmds=[
-                'run', 'select',
-                '--seconds', self.duration,
-                '--threads', '10',
-                '--recall',
-            ])
-        )
-        self.cmd_run(
-            self.get_command_prefix(subcmds=['clean'])
         )
 
-    def __loop_generate(self):
-        """Generate mode: generate data, dump to files, build index, run select, clean."""
+    def _restore_query_table(self):
+        """Restore query table from data_dir."""
+        print(f"Restoring query table from {self.data_dir}")
+        self.cmd_run(
+            self.get_tools_prefix(subcmds=[
+                'restore',
+                '-p', self.database,
+                '-i', self.data_dir,
+            ])
+        )
+
+    def _import_data(self):
+        """Generate data using deterministic seed, build index, wait for stats."""
         self.cmd_run(
             self.get_command_prefix(subcmds=['init', '--clear'])
         )
+        # Import data without building index
         self.cmd_run(
             self.get_command_prefix(subcmds=[
                 'import', 'generator',
@@ -101,68 +129,62 @@ class YdbVectorWorkload(WorkloadBase):
                 '--index-type', 'None',
             ])
         )
-        # Dump table data to data_dir for later use by load mode
-        print(f"Dumping table data to {self.data_dir}")
-        if os.path.exists(self.data_dir):
-            import shutil
-            shutil.rmtree(self.data_dir)
-        self.cmd_run(
-            self.get_tools_prefix(subcmds=[
-                'dump',
-                '-p', self.database + '/vector_index_workload',
-                '-o', self.data_dir,
-            ])
-        )
-        # Build vector index
+        # Build index explicitly and wait for completion
         self.cmd_run(
             self.get_command_prefix(subcmds=[
                 'build-index',
                 '--distance', 'cosine',
             ])
         )
+        # Wait for table statistics to be calculated after index build
         print("Waiting for table statistics to be calculated...")
         time.sleep(30)
-        self.cmd_run(
-            self.get_command_prefix(subcmds=[
-                'run', 'select',
-                '--seconds', self.duration,
-                '--threads', '10',
-                '--recall',
-            ])
+
+    def _get_select_subcmds(self, seconds):
+        subcmds = [
+            'run', 'select',
+            '--seconds', str(seconds),
+            '--threads', '10',
+            '--targets', self.targets,
+        ]
+        if self.mode in ('generate', 'load'):
+            subcmds.extend(['--query-table', QUERY_TABLE_NAME])
+        return subcmds
+
+    def _run_select(self):
+        """Optionally warmup, then run select workload."""
+        if int(self.warmup) > 0:
+            print(f"Warmup run for {self.warmup}s...")
+            self.cmd_run_with_retry(
+                self.get_command_prefix(subcmds=self._get_select_subcmds(self.warmup))
+            )
+        self.cmd_run_with_retry(
+            self.get_command_prefix(subcmds=self._get_select_subcmds(self.duration))
         )
+
+    def __loop_standalone(self):
+        """Original mode: generate data, build index, run select, clean."""
+        self._import_data()
+        self._run_select()
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['clean'])
+        )
+
+    def __loop_generate(self):
+        """Generate mode: same import as load, but also create and dump query table."""
+        self._import_data()
+        self._create_query_table()
+        self._dump_query_table()
+        self._run_select()
         self.cmd_run(
             self.get_command_prefix(subcmds=['clean'])
         )
 
     def __loop_load(self):
-        """Load mode: restore data from dump, build index, run select, clean."""
-        # Restore table and data from dump
-        print(f"Restoring table data from {self.data_dir}")
-        self.cmd_run(
-            self.get_tools_prefix(subcmds=[
-                'restore',
-                '-p', self.database,
-                '-i', self.data_dir,
-                '--restore-indexes', '0',
-            ])
-        )
-        # Build vector index
-        self.cmd_run(
-            self.get_command_prefix(subcmds=[
-                'build-index',
-                '--distance', 'cosine',
-            ])
-        )
-        print("Waiting for table statistics to be calculated...")
-        time.sleep(30)
-        self.cmd_run(
-            self.get_command_prefix(subcmds=[
-                'run', 'select',
-                '--seconds', self.duration,
-                '--threads', '10',
-                '--recall',
-            ])
-        )
+        """Load mode: same import as generate, restore query table from dump."""
+        self._import_data()
+        self._restore_query_table()
+        self._run_select()
         self.cmd_run(
             self.get_command_prefix(subcmds=['clean'])
         )

--- a/ydb/tests/stress/vector_workload/workload/__init__.py
+++ b/ydb/tests/stress/vector_workload/workload/__init__.py
@@ -15,7 +15,7 @@ QUERY_TABLE_NAME = "vector_query_table"
 
 
 class YdbVectorWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=100, warmup=0):
+    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=10000, warmup=0, rows=100000):
         super().__init__(None, '', 'vector_workload', None)
         self.endpoint = endpoint
         self.database = database
@@ -24,6 +24,7 @@ class YdbVectorWorkload(WorkloadBase):
         self.data_dir = data_dir
         self.targets = str(targets)
         self.warmup = str(warmup)
+        self.rows = str(rows)
         self.tempdir = None
         self._unpack_resource('ydb_cli')
 
@@ -124,13 +125,13 @@ class YdbVectorWorkload(WorkloadBase):
         self.cmd_run(
             self.get_command_prefix(subcmds=[
                 'import', 'generator',
-                '--rows', '10000',
+                '--rows', self.rows,
                 '--distance', 'cosine',
                 '--index-type', 'None',
             ])
         )
         # Build index explicitly and wait for completion
-        self.cmd_run(
+        self.cmd_run_with_retry(
             self.get_command_prefix(subcmds=[
                 'build-index',
                 '--distance', 'cosine',

--- a/ydb/tests/stress/vector_workload/workload/__init__.py
+++ b/ydb/tests/stress/vector_workload/workload/__init__.py
@@ -12,11 +12,13 @@ logger = logging.getLogger("YdbVectorWorkload")
 
 
 class YdbVectorWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration):
+    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None):
         super().__init__(None, '', 'vector_workload', None)
         self.endpoint = endpoint
         self.database = database
         self.duration = str(duration)
+        self.mode = mode
+        self.data_dir = data_dir
         self.tempdir = None
         self._unpack_resource('ydb_cli')
 
@@ -45,18 +47,26 @@ class YdbVectorWorkload(WorkloadBase):
             'workload', 'vector'
         ] + subcmds
 
+    def get_tools_prefix(self, subcmds):
+        return [
+            self.cli_path,
+            '--verbose',
+            '--endpoint', self.endpoint,
+            '--database={}'.format(self.database),
+            'tools',
+        ] + subcmds
+
     def cmd_run(self, cmd):
         logger.debug(f"Running cmd {cmd}")
         print(f"Running cmd {cmd} at {time.time()}")
         subprocess.run(cmd, check=True, text=True)
         print(f"End at {time.time()}")
 
-    def __loop(self):
-        # init
+    def __loop_standalone(self):
+        """Original mode: generate data, build index, run select, clean."""
         self.cmd_run(
             self.get_command_prefix(subcmds=['init', '--clear'])
         )
-        # import generator
         self.cmd_run(
             self.get_command_prefix(subcmds=[
                 'import', 'generator',
@@ -64,10 +74,8 @@ class YdbVectorWorkload(WorkloadBase):
                 '--distance', 'cosine',
             ])
         )
-        # wait for table statistics to be calculated
         print("Waiting for table statistics to be calculated...")
         time.sleep(30)
-        # run select with recall measurement
         self.cmd_run(
             self.get_command_prefix(subcmds=[
                 'run', 'select',
@@ -76,10 +84,93 @@ class YdbVectorWorkload(WorkloadBase):
                 '--recall',
             ])
         )
-        # clean
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['clean'])
+        )
+
+    def __loop_generate(self):
+        """Generate mode: generate data, dump to files, build index, run select, clean."""
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['init', '--clear'])
+        )
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'import', 'generator',
+                '--rows', '10000',
+                '--distance', 'cosine',
+                '--index-type', 'None',
+            ])
+        )
+        # Dump table data to data_dir for later use by load mode
+        print(f"Dumping table data to {self.data_dir}")
+        if os.path.exists(self.data_dir):
+            import shutil
+            shutil.rmtree(self.data_dir)
+        self.cmd_run(
+            self.get_tools_prefix(subcmds=[
+                'dump',
+                '-p', self.database + '/vector_index_workload',
+                '-o', self.data_dir,
+            ])
+        )
+        # Build vector index
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'build-index',
+                '--distance', 'cosine',
+            ])
+        )
+        print("Waiting for table statistics to be calculated...")
+        time.sleep(30)
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'run', 'select',
+                '--seconds', self.duration,
+                '--threads', '10',
+                '--recall',
+            ])
+        )
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['clean'])
+        )
+
+    def __loop_load(self):
+        """Load mode: restore data from dump, build index, run select, clean."""
+        # Restore table and data from dump
+        print(f"Restoring table data from {self.data_dir}")
+        self.cmd_run(
+            self.get_tools_prefix(subcmds=[
+                'restore',
+                '-p', self.database,
+                '-i', self.data_dir,
+                '--restore-indexes', '0',
+            ])
+        )
+        # Build vector index
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'build-index',
+                '--distance', 'cosine',
+            ])
+        )
+        print("Waiting for table statistics to be calculated...")
+        time.sleep(30)
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'run', 'select',
+                '--seconds', self.duration,
+                '--threads', '10',
+                '--recall',
+            ])
+        )
         self.cmd_run(
             self.get_command_prefix(subcmds=['clean'])
         )
 
     def get_workload_thread_funcs(self):
-        return [self.__loop]
+        if self.mode == "generate":
+            return [self.__loop_generate]
+        elif self.mode == "load":
+            return [self.__loop_load]
+        else:
+            return [self.__loop_standalone]

--- a/ydb/tests/stress/vector_workload/workload/__init__.py
+++ b/ydb/tests/stress/vector_workload/workload/__init__.py
@@ -1,0 +1,85 @@
+import logging
+import os
+import stat
+import subprocess
+import tempfile
+import time
+
+from library.python import resource
+from ydb.tests.stress.common.common import WorkloadBase
+
+logger = logging.getLogger("YdbVectorWorkload")
+
+
+class YdbVectorWorkload(WorkloadBase):
+    def __init__(self, endpoint, database, duration):
+        super().__init__(None, '', 'vector_workload', None)
+        self.endpoint = endpoint
+        self.database = database
+        self.duration = str(duration)
+        self.tempdir = None
+        self._unpack_resource('ydb_cli')
+
+    def __del__(self):
+        self.tempdir.cleanup()
+
+    def _unpack_resource(self, name):
+        self.tempdir = tempfile.TemporaryDirectory(dir=os.getcwd())
+        self.working_dir = os.path.join(self.tempdir.name, "vector_ydb_cli")
+        os.makedirs(self.working_dir, exist_ok=True)
+        res = resource.find(name)
+        path_to_unpack = os.path.join(self.working_dir, name)
+        with open(path_to_unpack, "wb") as f:
+            f.write(res)
+
+        st = os.stat(path_to_unpack)
+        os.chmod(path_to_unpack, st.st_mode | stat.S_IEXEC)
+        self.cli_path = path_to_unpack
+
+    def get_command_prefix(self, subcmds):
+        return [
+            self.cli_path,
+            '--verbose',
+            '--endpoint', self.endpoint,
+            '--database={}'.format(self.database),
+            'workload', 'vector'
+        ] + subcmds
+
+    def cmd_run(self, cmd):
+        logger.debug(f"Running cmd {cmd}")
+        print(f"Running cmd {cmd} at {time.time()}")
+        subprocess.run(cmd, check=True, text=True)
+        print(f"End at {time.time()}")
+
+    def __loop(self):
+        # init
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['init', '--clear'])
+        )
+        # import generator
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'import', 'generator',
+                '--rows', '10000',
+                '--distance', 'cosine',
+            ])
+        )
+        # wait for table statistics to be calculated
+        print("Waiting for table statistics to be calculated...")
+        time.sleep(30)
+        # run select with recall measurement
+        self.cmd_run(
+            self.get_command_prefix(subcmds=[
+                'run', 'select',
+                '--seconds', self.duration,
+                '--threads', '10',
+                '--recall',
+            ])
+        )
+        # clean
+        self.cmd_run(
+            self.get_command_prefix(subcmds=['clean'])
+        )
+
+    def get_workload_thread_funcs(self):
+        return [self.__loop]

--- a/ydb/tests/stress/vector_workload/workload/__init__.py
+++ b/ydb/tests/stress/vector_workload/workload/__init__.py
@@ -15,7 +15,7 @@ QUERY_TABLE_NAME = "vector_query_table"
 
 
 class YdbVectorWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=10000, warmup=0, rows=100000):
+    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=1000, warmup=0, rows=100000, threads=10):
         super().__init__(None, '', 'vector_workload', None)
         self.endpoint = endpoint
         self.database = database
@@ -25,6 +25,7 @@ class YdbVectorWorkload(WorkloadBase):
         self.targets = str(targets)
         self.warmup = str(warmup)
         self.rows = str(rows)
+        self.threads = str(threads)
         self.tempdir = None
         self._unpack_resource('ydb_cli')
 
@@ -145,7 +146,7 @@ class YdbVectorWorkload(WorkloadBase):
         subcmds = [
             'run', 'select',
             '--seconds', str(seconds),
-            '--threads', '10',
+            '--threads', self.threads,
             '--targets', self.targets,
         ]
         if self.mode in ('generate', 'load'):

--- a/ydb/tests/stress/vector_workload/workload/__init__.py
+++ b/ydb/tests/stress/vector_workload/workload/__init__.py
@@ -15,7 +15,7 @@ QUERY_TABLE_NAME = "vector_query_table"
 
 
 class YdbVectorWorkload(WorkloadBase):
-    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=1000, warmup=0, rows=100000, threads=10):
+    def __init__(self, endpoint, database, duration, mode="standalone", data_dir=None, targets=1000, warmup=0, rows=10000, threads=10):
         super().__init__(None, '', 'vector_workload', None)
         self.endpoint = endpoint
         self.database = database
@@ -30,7 +30,8 @@ class YdbVectorWorkload(WorkloadBase):
         self._unpack_resource('ydb_cli')
 
     def __del__(self):
-        self.tempdir.cleanup()
+        if self.tempdir is not None:
+            self.tempdir.cleanup()
 
     def _unpack_resource(self, name):
         self.tempdir = tempfile.TemporaryDirectory(dir=os.getcwd())

--- a/ydb/tests/stress/vector_workload/workload/ya.make
+++ b/ydb/tests/stress/vector_workload/workload/ya.make
@@ -1,0 +1,18 @@
+PY3_LIBRARY()
+
+PY_SRCS(
+    __init__.py
+)
+
+BUNDLE(
+    ydb/apps/ydb NAME ydb_cli
+)
+RESOURCE(ydb_cli ydb_cli)
+PEERDIR(
+    ydb/tests/stress/common
+    ydb/public/sdk/python
+    library/python/resource
+    ydb/public/sdk/python/enable_v3_new_behavior
+)
+
+END()

--- a/ydb/tests/stress/vector_workload/ya.make
+++ b/ydb/tests/stress/vector_workload/ya.make
@@ -1,0 +1,16 @@
+PY3_PROGRAM(workload_vector)
+
+PY_SRCS(
+    __main__.py
+)
+
+PEERDIR(
+    ydb/tests/stress/common
+    ydb/tests/stress/vector_workload/workload
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    tests
+)

--- a/ydb/tests/stress/ya.make
+++ b/ydb/tests/stress/ya.make
@@ -4,6 +4,7 @@ RECURSE(
     common
     ctas
     federated_queries
+    fulltext_workload
     kafka
     kafka_serverless
     kv
@@ -30,6 +31,7 @@ RECURSE(
     topic_kafka
     topic_sqs
     transfer
+    vector_workload
     viewer
     streaming
 )


### PR DESCRIPTION
### Changelog entry 

### Changelog category 
* Not for changelog
### Description for reviewers
**Added vector and fulltext index performance benchmarking infrastructure**
- Added stress test workloads for vector index (vector_workload) and fulltext index (fulltext_workload) that use ydb workload vector and ydb workload fulltext CLI commands
- Added compare_index_performance.sh script that compares Txs/Sec between a baseline ydbd (downloaded from S3 or pre-built) and a current branch ydbd
- Added GitHub Actions workflow (compare_index_performance.yml) to run the comparison nightly and on demand

**Features**

  - Three modes for vector workload: standalone (self-contained), generate (creates + dumps query table), load (restores query table) — ensures both branches query identical vectors
  - Deterministic data: both branches use import generator --seed 42 for identical datasets
  - Interleaved iterations: runs alternate between baseline and current (ABABAB pattern) to cancel systematic drift, reports median
  - Statistical significance: computes mean, standard deviation, and 3-sigma test on the difference of means
  - Warmup support: optional warmup run before measured run to stabilize caches
  - Retry mechanism: build-index and run select retry on transient failures (e.g., tablet restarts, table statistics not ready)
  - Per-branch configuration: separate --main-feature-flag / --current-feature-flag and --main-table-service-config / --current-table-service-config options to test feature flags on one branch only
  - Configurable parameters: --duration, --rows, --targets, --threads, --iterations, --warmup, --workload (vector/fulltext/all)
  - Markdown report: generates a summary table posted to GitHub Actions job summary

**Usage**
Quick local comparison with pre-built binaries
./ydb/tests/stress/compare_index_performance.sh \
      --main-ydbd /path/to/baseline/ydbd \
      --current-ydbd /path/to/current/ydbd \
      --workload vector --iterations 3 --duration 60

Test a feature flag on current branch only
./ydb/tests/stress/compare_index_performance.sh \
      --main-ydbd /path/to/baseline/ydbd \
      --current-ydbd /path/to/current/ydbd \
      --current-table-service-config enable_vector_index_read=true