### PR TITLE
Return ydb/docs RECURSE

### DIFF
--- a/ydb/ya.make
+++ b/ydb/ya.make
@@ -1,5 +1,6 @@
 RECURSE(
     apps
+    docs
     core
     library
     mvp
@@ -11,13 +12,5 @@ RECURSE(
 IF(NOT EXPORT_CMAKE)
   RECURSE(
     tests
-  )
-ENDIF()
-
-IF(NOT OPENSOURCE)
-  # YFM tool is not supported 
-  # for OSS ya make yet
-  RECURSE(
-    docs
   )
 ENDIF()


### PR DESCRIPTION
Коллеги из диплодока говорят что теперь так можно, так как yfm официально поддерживается в ya tool (ранее они не поддерживали сборку доков через oss ya tool)

Прошлая попытка
https://github.com/ydb-platform/ydb/pull/8092 