### PR TITLE
Export release:* labels to info.releaseblocker_state for BI

### DIFF
--- a/.github/scripts/analytics/data_mart_executor.py
+++ b/.github/scripts/analytics/data_mart_executor.py
@@ -6,6 +6,7 @@ import ydb
 import os
 import re
 import time
+from typing import List
 from ydb_wrapper import YDBWrapper
 
 # Get repository path
@@ -38,6 +39,28 @@ def ydb_type_to_str(ydb_type, store_type = 'ROW'):
             result_type = ydb.PrimitiveType.Uint8
         name = 'Uint8'
     return result_type, name
+
+
+def string_column_names(column_types, store_type: str) -> List[str]:
+    """Columns typed as YDB String in query metadata (need bytes for bulk upsert)."""
+    names = []
+    for column_name, column_ydb_type in column_types:
+        _, column_type_str = ydb_type_to_str(column_ydb_type, store_type.upper())
+        if column_type_str.replace('?', '') == 'String':
+            names.append(column_name)
+    return names
+
+
+def normalize_rows_for_bulk_upsert(rows: List[dict], string_columns: List[str]) -> None:
+    """In-place: YDB String columns expect bytes, scan rows often have str."""
+    if not string_columns:
+        return
+    for row in rows:
+        for col in string_columns:
+            val = row.get(col)
+            if isinstance(val, str):
+                row[col] = val.encode('utf-8')
+
 
 def create_table(ydb_wrapper, table_path, column_types, store_type, partition_keys, primary_keys, ttl_min, ttl_key):
     """Create table using ydb_wrapper based on the structure of the provided column types."""
@@ -291,6 +314,11 @@ def main():
         for column_name, column_ydb_type in column_types:
             column_type_obj, column_type_str = ydb_type_to_str(column_ydb_type, args.store_type.upper())
             column_types_map.add_column(column_name, column_type_obj)
+
+        string_columns = string_column_names(column_types, args.store_type)
+        if string_columns:
+            print(f'Normalizing YDB String columns for bulk upsert: {string_columns}')
+            normalize_rows_for_bulk_upsert(results, string_columns)
 
         cleanup_args_set = any([args.cleanup_window_key, args.cleanup_window_interval])
         if cleanup_args_set:

--- a/.github/scripts/analytics/data_mart_executor.py
+++ b/.github/scripts/analytics/data_mart_executor.py
@@ -6,7 +6,6 @@ import ydb
 import os
 import re
 import time
-from typing import List
 from ydb_wrapper import YDBWrapper
 
 # Get repository path
@@ -39,28 +38,6 @@ def ydb_type_to_str(ydb_type, store_type = 'ROW'):
             result_type = ydb.PrimitiveType.Uint8
         name = 'Uint8'
     return result_type, name
-
-
-def string_column_names(column_types, store_type: str) -> List[str]:
-    """Columns typed as YDB String in query metadata (need bytes for bulk upsert)."""
-    names = []
-    for column_name, column_ydb_type in column_types:
-        _, column_type_str = ydb_type_to_str(column_ydb_type, store_type.upper())
-        if column_type_str.replace('?', '') == 'String':
-            names.append(column_name)
-    return names
-
-
-def normalize_rows_for_bulk_upsert(rows: List[dict], string_columns: List[str]) -> None:
-    """In-place: YDB String columns expect bytes, scan rows often have str."""
-    if not string_columns:
-        return
-    for row in rows:
-        for col in string_columns:
-            val = row.get(col)
-            if isinstance(val, str):
-                row[col] = val.encode('utf-8')
-
 
 def create_table(ydb_wrapper, table_path, column_types, store_type, partition_keys, primary_keys, ttl_min, ttl_key):
     """Create table using ydb_wrapper based on the structure of the provided column types."""
@@ -314,11 +291,6 @@ def main():
         for column_name, column_ydb_type in column_types:
             column_type_obj, column_type_str = ydb_type_to_str(column_ydb_type, args.store_type.upper())
             column_types_map.add_column(column_name, column_type_obj)
-
-        string_columns = string_column_names(column_types, args.store_type)
-        if string_columns:
-            print(f'Normalizing YDB String columns for bulk upsert: {string_columns}')
-            normalize_rows_for_bulk_upsert(results, string_columns)
 
         cleanup_args_set = any([args.cleanup_window_key, args.cleanup_window_interval])
         if cleanup_args_set:

--- a/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_full.sql
+++ b/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_full.sql
@@ -50,6 +50,7 @@ SELECT
     i.max_branch AS max_branch,
     i.env AS env,
     i.priority AS priority,
+    i.releaseblocker_state AS releaseblocker_state,
     i.branch AS branch,
     i.area AS area,
     CAST(
@@ -100,6 +101,7 @@ CROSS JOIN (
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,
+        COALESCE(JSON_VALUE(t.info, "$.releaseblocker_state"), 'release:-') AS releaseblocker_state,
         COALESCE(JSON_VALUE(t.info, "$.branch"), '-') AS branch,
         COALESCE(JSON_VALUE(t.info, "$.area"), 'area/-') AS area
     FROM `github_data/issues` AS t

--- a/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_full.sql
+++ b/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_full.sql
@@ -97,7 +97,7 @@ CROSS JOIN (
         t.issue_type AS issue_type,
         t.exported_at AS exported_at,
         COALESCE(m.owner_team, 'unknown') AS owner_team,
-        CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS String) AS labels_list,
+        COALESCE(CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS Utf8), '') AS labels_list,
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,

--- a/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_full.sql
+++ b/.github/scripts/analytics/data_mart_queries/datalens_ds_queries/github_issues_timeline_full.sql
@@ -50,7 +50,6 @@ SELECT
     i.max_branch AS max_branch,
     i.env AS env,
     i.priority AS priority,
-    i.releaseblocker_state AS releaseblocker_state,
     i.branch AS branch,
     i.area AS area,
     CAST(
@@ -97,11 +96,10 @@ CROSS JOIN (
         t.issue_type AS issue_type,
         t.exported_at AS exported_at,
         COALESCE(m.owner_team, 'unknown') AS owner_team,
-        COALESCE(CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS Utf8), '') AS labels_list,
+        CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS String) AS labels_list,
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,
-        COALESCE(JSON_VALUE(t.info, "$.releaseblocker_state"), 'release:-') AS releaseblocker_state,
         COALESCE(JSON_VALUE(t.info, "$.branch"), '-') AS branch,
         COALESCE(JSON_VALUE(t.info, "$.area"), 'area/-') AS area
     FROM `github_data/issues` AS t

--- a/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
@@ -107,7 +107,7 @@ CROSS JOIN (
         t.issue_type AS issue_type,
         t.exported_at AS exported_at,
         COALESCE(m.owner_team, 'unknown') AS owner_team,
-        CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS String) AS labels_list,
+        COALESCE(CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS Utf8), '') AS labels_list,
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,

--- a/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
@@ -110,6 +110,7 @@ CROSS JOIN (
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,
+        COALESCE(JSON_VALUE(t.info, "$.releaseblocker_state"), 'release:-') AS releaseblocker_state,
         COALESCE(JSON_VALUE(t.info, "$.branch"), '-') AS branch,
         Coalesce(m.matched_area,
             CASE

--- a/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
@@ -60,7 +60,6 @@ SELECT
     i.max_branch AS max_branch,
     i.env AS env,
     i.priority AS priority,
-    i.releaseblocker_state AS releaseblocker_state,
     i.branch AS branch,
     i.area AS area,
     CAST(
@@ -107,11 +106,10 @@ CROSS JOIN (
         t.issue_type AS issue_type,
         t.exported_at AS exported_at,
         COALESCE(m.owner_team, 'unknown') AS owner_team,
-        COALESCE(CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS Utf8), '') AS labels_list,
+        CAST(JSON_QUERY(t.labels, "$.name" WITH UNCONDITIONAL ARRAY WRAPPER) AS String) AS labels_list,
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,
-        COALESCE(JSON_VALUE(t.info, "$.releaseblocker_state"), 'release:-') AS releaseblocker_state,
         COALESCE(JSON_VALUE(t.info, "$.branch"), '-') AS branch,
         Coalesce(m.matched_area,
             CASE

--- a/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
@@ -60,6 +60,7 @@ SELECT
     i.max_branch AS max_branch,
     i.env AS env,
     i.priority AS priority,
+    i.releaseblocker_state AS releaseblocker_state,
     i.branch AS branch,
     i.area AS area,
     CAST(
@@ -110,6 +111,7 @@ CROSS JOIN (
         COALESCE(JSON_VALUE(t.info, "$.max_branch"), '-') AS max_branch,
         COALESCE(JSON_VALUE(t.info, "$.env"), 'env:-') AS env,
         COALESCE(JSON_VALUE(t.info, "$.priority"), 'priority:-') AS priority,
+        COALESCE(JSON_VALUE(t.info, "$.releaseblocker_state"), 'release:-') AS releaseblocker_state,
         COALESCE(JSON_VALUE(t.info, "$.branch"), '-') AS branch,
         Coalesce(m.matched_area,
             CASE

--- a/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
+++ b/.github/scripts/analytics/data_mart_queries/github_issues_timeline.sql
@@ -60,6 +60,7 @@ SELECT
     i.max_branch AS max_branch,
     i.env AS env,
     i.priority AS priority,
+    i.releaseblocker_state AS releaseblocker_state,
     i.branch AS branch,
     i.area AS area,
     CAST(

--- a/.github/scripts/analytics/export_issues_to_ydb.py
+++ b/.github/scripts/analytics/export_issues_to_ydb.py
@@ -38,7 +38,6 @@ def run_query(query: str, variables: Optional[Dict] = None) -> Dict[str, Any]:
     payload = {'query': query, 'variables': variables}
 
     backoff = _GITHUB_QUERY_INITIAL_BACKOFF_SEC
-    last_exc = None
     for attempt in range(_GITHUB_QUERY_MAX_RETRIES + 1):
         try:
             request = requests.post(
@@ -48,7 +47,6 @@ def run_query(query: str, variables: Optional[Dict] = None) -> Dict[str, Any]:
                 timeout=_GITHUB_QUERY_TIMEOUT_SEC,
             )
         except requests.RequestException as exc:
-            last_exc = exc
             if attempt >= _GITHUB_QUERY_MAX_RETRIES:
                 raise
             backoff = _github_query_retry_wait(
@@ -59,8 +57,7 @@ def run_query(query: str, variables: Optional[Dict] = None) -> Dict[str, Any]:
         if request.status_code == 200:
             try:
                 response = request.json()
-            except json.JSONDecodeError as exc:
-                last_exc = exc
+            except ValueError as exc:
                 if attempt >= _GITHUB_QUERY_MAX_RETRIES:
                     raise
                 backoff = _github_query_retry_wait(
@@ -82,10 +79,6 @@ def run_query(query: str, variables: Optional[Dict] = None) -> Dict[str, Any]:
             continue
 
         raise Exception(f"Query failed with status {request.status_code}: {request.text}")
-
-    if last_exc is not None:
-        raise last_exc
-    raise RuntimeError("GitHub API query failed after retries")
 
 def get_last_update_time(ydb_wrapper: YDBWrapper, table_path: str) -> Optional[datetime]:
     """Get the latest updated_at timestamp from existing records"""

--- a/.github/scripts/analytics/export_issues_to_ydb.py
+++ b/.github/scripts/analytics/export_issues_to_ydb.py
@@ -11,34 +11,81 @@ import requests
 from typing import List, Dict, Any, Optional
 from ydb_wrapper import YDBWrapper
 
-# Configuration
 ORG_NAME = 'ydb-platform'
 REPO_NAME = 'ydb'
 PROJECT_ID = None #'45'  # Optional: set to None to skip project data
+ISSUES_PAGE_SIZE = 50  # smaller pages → smaller GraphQL payloads (avoids truncated JSON)
 
 
 # YDB configuration is now handled by ydb_wrapper
 
+_RETRYABLE_GITHUB_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+_GITHUB_QUERY_MAX_RETRIES = 8
+_GITHUB_QUERY_INITIAL_BACKOFF_SEC = 2.0
+_GITHUB_QUERY_TIMEOUT_SEC = 120
+
+
+def _github_query_retry_wait(attempt: int, backoff: float, reason: str) -> float:
+    print(f"{reason}, retry {attempt + 1}/{_GITHUB_QUERY_MAX_RETRIES} in {backoff:.0f}s...")
+    time.sleep(backoff)
+    return min(backoff * 2, 60)
+
+
 def run_query(query: str, variables: Optional[Dict] = None) -> Dict[str, Any]:
-    """Execute GraphQL query against GitHub API"""
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-    HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}", "Content-Type": "application/json"}
-    
-    request = requests.post(
-        'https://api.github.com/graphql', 
-        json={'query': query, 'variables': variables}, 
-        headers=HEADERS
-    )
-    
-    if request.status_code == 200:
-        response = request.json()
-        if 'errors' in response:
-            for error in response['errors']:
-                print(f"GraphQL Error: {error.get('message', 'Unknown error')}")
-                raise Exception(f"GraphQL Error: {error.get('message', 'Unknown error')}")
-        return response
-    else:
+    """Execute GraphQL query against GitHub API (retries transient 5xx/429 and truncated JSON)."""
+    github_token = os.environ["GITHUB_TOKEN"]
+    headers = {"Authorization": f"Bearer {github_token}", "Content-Type": "application/json"}
+    payload = {'query': query, 'variables': variables}
+
+    backoff = _GITHUB_QUERY_INITIAL_BACKOFF_SEC
+    last_exc = None
+    for attempt in range(_GITHUB_QUERY_MAX_RETRIES + 1):
+        try:
+            request = requests.post(
+                'https://api.github.com/graphql',
+                json=payload,
+                headers=headers,
+                timeout=_GITHUB_QUERY_TIMEOUT_SEC,
+            )
+        except requests.RequestException as exc:
+            last_exc = exc
+            if attempt >= _GITHUB_QUERY_MAX_RETRIES:
+                raise
+            backoff = _github_query_retry_wait(
+                attempt, backoff, f"GitHub API request error ({exc})"
+            )
+            continue
+
+        if request.status_code == 200:
+            try:
+                response = request.json()
+            except json.JSONDecodeError as exc:
+                last_exc = exc
+                if attempt >= _GITHUB_QUERY_MAX_RETRIES:
+                    raise
+                backoff = _github_query_retry_wait(
+                    attempt,
+                    backoff,
+                    f"GitHub API truncated/invalid JSON ({exc})",
+                )
+                continue
+            if 'errors' in response:
+                for error in response['errors']:
+                    print(f"GraphQL Error: {error.get('message', 'Unknown error')}")
+                raise Exception(f"GraphQL Error: {response['errors'][0].get('message', 'Unknown error')}")
+            return response
+
+        if request.status_code in _RETRYABLE_GITHUB_STATUS_CODES and attempt < _GITHUB_QUERY_MAX_RETRIES:
+            backoff = _github_query_retry_wait(
+                attempt, backoff, f"GitHub API {request.status_code}"
+            )
+            continue
+
         raise Exception(f"Query failed with status {request.status_code}: {request.text}")
+
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("GitHub API query failed after retries")
 
 def get_last_update_time(ydb_wrapper: YDBWrapper, table_path: str) -> Optional[datetime]:
     """Get the latest updated_at timestamp from existing records"""
@@ -192,7 +239,7 @@ def fetch_repository_issues(org_name: str = ORG_NAME, repo_name: str = REPO_NAME
     {
       organization(login: "%s") {
         repository(name: "%s") {
-          issues(first: 100, after: %s, orderBy: {field: UPDATED_AT, direction: DESC}%s) {
+          issues(first: %d, after: %s, orderBy: {field: UPDATED_AT, direction: DESC}%s) {
             nodes {
               id
               number
@@ -282,7 +329,7 @@ def fetch_repository_issues(org_name: str = ORG_NAME, repo_name: str = REPO_NAME
     
     total_fetched = 0
     while has_next_page:
-        query = repository_issues_query % (org_name, repo_name, end_cursor, since_filter)
+        query = repository_issues_query % (org_name, repo_name, ISSUES_PAGE_SIZE, end_cursor, since_filter)
         result = run_query(query)
         
         if result and 'data' in result:

--- a/.github/scripts/analytics/export_issues_to_ydb.py
+++ b/.github/scripts/analytics/export_issues_to_ydb.py
@@ -557,6 +557,7 @@ def transform_issues_for_ydb(issues: List[Dict[str, Any]], project_fields: Optio
         branch_labels = []
         env = None
         priority = None
+        releaseblocker_state = None
         area = None
         for label in issue.get('labels', {}).get('nodes', []):
             name = label.get('name', '')
@@ -574,12 +575,22 @@ def transform_issues_for_ydb(issues: List[Dict[str, Any]], project_fields: Optio
             # priority detection
             if name.startswith('prio:'):
                 priority = name
+            # release blocker detection
+            if name.startswith('release:'):
+                releaseblocker_state = name
             # area detection
             if name.startswith('area/'):
                 area = name
         branch = ';'.join(branch_labels) if branch_labels else None
         max_branch = get_max_branch(branch_labels) if branch_labels else None
-        info = {'branch': branch, 'max_branch': max_branch, 'env': env, 'priority': priority, 'area': area}
+        info = {
+            'branch': branch,
+            'max_branch': max_branch,
+            'env': env,
+            'priority': priority,
+            'releaseblocker_state': releaseblocker_state,
+            'area': area,
+        }
         proj_list = projects_for_info_json(issue)
         if proj_list:
             info['projects'] = proj_list


### PR DESCRIPTION
## Summary
- Export the last `release:*` GitHub label into `info.releaseblocker_state` in `github_data/issues` (same pattern as `prio:*` → `info.priority`).
- Expose the field in `github_issues_timeline` marts via `JSON_VALUE` for DataLens and downstream SQL.

## Test plan
- [x] Run full issues export: `python3 .github/scripts/analytics/export_issues_to_ydb.py --full`
- [x] Verify sample issue with `release:known-issue` has `JSON_VALUE(info, "$.releaseblocker_state") = "release:known-issue"`
- [x] Rebuild timeline mart (full reload via `github_issues_timeline_full.sql` or incremental via `github_issues_timeline.sql`)


Made with [Cursor](https://cursor.com)