### PR TITLE
Fix empty protobuf tail in coroutine serialization. NBYDB-2299

### DIFF
--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -116,7 +116,7 @@ namespace NActors {
 
         NProtoBuf::io::CodedOutputStream *GetCodedOutputStream() override {
             if (!CodedOutputStream) {
-                CodedOutputStream.reset(new NProtoBuf::io::CodedOutputStream(this));
+                CodedOutputStream.reset(new NProtoBuf::io::CodedOutputStream(this, false));
             }
             return CodedOutputStream.get();
         }

--- a/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
+++ b/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
@@ -82,6 +82,32 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
         }
     }
 
+    Y_UNIT_TEST(CoroutineSerializerChunkSizesAroundSlopBoundary) {
+        TEvMessageWithPayload msg;
+        msg.Record.SetMeta("hello, world!");
+        msg.Record.AddPayloadId(msg.AddPayload(MakeStringRope(MakeString(256))));
+        msg.Record.AddSomeData(MakeString(128));
+
+        auto serializer = MakeHolder<TAllocChunkSerializer>();
+        UNIT_ASSERT(msg.SerializeToArcadiaStream(serializer.Get()));
+        const TString expected = serializer->Release(msg.CreateSerializationInfo(false))->GetString();
+        UNIT_ASSERT_VALUES_EQUAL(expected.size(), msg.CalculateSerializedSize());
+
+        for (size_t chunkSize = 1; chunkSize <= 32; ++chunkSize) {
+            TString actual;
+            TCoroutineChunkSerializer chunker;
+            chunker.SetSerializingEvent(&msg);
+            while (!chunker.IsComplete()) {
+                TString buffer(chunkSize, '\0');
+                for (const auto& [data, size] : chunker.FeedBuf(buffer.begin(), buffer.size())) {
+                    actual.append(data, size);
+                }
+            }
+            UNIT_ASSERT(chunker.IsSuccessfull());
+            UNIT_ASSERT_VALUES_EQUAL_C(actual, expected, "chunkSize# " << chunkSize);
+        }
+    }
+
 #if (!defined(_tsan_enabled_))
     Y_UNIT_TEST(SerializeDeserialize) {
         TestAllSizes<TEvMessageWithPayload>();

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -666,6 +666,59 @@ private:
     std::atomic<size_t> Received;
 };
 
+struct TEvTcpEmptyRecordWithPayload
+    : TEventPB<TEvTcpEmptyRecordWithPayload, NInterconnectTest::TEvTestSerialization, 0x10002>
+{};
+
+class TSingleEventSenderActor : public TActorBootstrapped<TSingleEventSenderActor> {
+public:
+    TSingleEventSenderActor(TActorId recipient, IEventBase* event)
+        : Recipient(recipient)
+        , Event(event)
+    {}
+
+    void Bootstrap() {
+        Send(Recipient, Event);
+        PassAway();
+    }
+
+private:
+    const TActorId Recipient;
+    IEventBase* const Event;
+};
+
+class TEmptyRecordWithPayloadReceiverActor : public TActorBootstrapped<TEmptyRecordWithPayloadReceiverActor> {
+public:
+    TEmptyRecordWithPayloadReceiverActor(TString expectedPayload)
+        : ExpectedPayload(std::move(expectedPayload))
+    {}
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+    }
+
+    void Handle(TEvTcpEmptyRecordWithPayload::TPtr& ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.ByteSize(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].GetSize(), ExpectedPayload.size());
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), ExpectedPayload);
+        Received.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    size_t GetReceived() const noexcept {
+        return Received.load(std::memory_order_relaxed);
+    }
+
+private:
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvTcpEmptyRecordWithPayload, Handle);
+    )
+
+private:
+    const TString ExpectedPayload;
+    std::atomic<size_t> Received = 0;
+};
+
 namespace {
 
 TTestICCluster::Flags GetKernelLivenessFlags(bool withRdma) {
@@ -689,6 +742,39 @@ void WaitForRdmaQpRts(TTestICCluster& cluster, ui32 nodeId, ui32 peerNodeId, TSt
             return false;
         }
     }, description);
+}
+
+void RunTcpEmptyProtoRecordWithPayloadRoundTrip(bool enableExternalDataChannel) {
+    const TString payload(5000, 'x');
+    auto settingsCustomizer = [enableExternalDataChannel](ui32, TInterconnectSettings& settings) {
+        settings.EnableExternalDataChannel = enableExternalDataChannel;
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, TTestICCluster::DISABLE_RDMA,
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* receiverPtr = new TEmptyRecordWithPayloadReceiverActor(payload);
+    const TActorId recipient = cluster.RegisterActor(receiverPtr, 1);
+
+    auto* event = new TEvTcpEmptyRecordWithPayload;
+    event->AddPayload(TRope(payload));
+    UNIT_ASSERT_VALUES_EQUAL(event->Record.ByteSize(), 0);
+    UNIT_ASSERT(event->AllowExternalDataChannel());
+
+    cluster.RegisterActor(new TSingleEventSenderActor(recipient, event), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return receiverPtr->GetReceived() == 1;
+    }, "TCP empty protobuf record with payload delivery");
+
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseExternalDataChannel"),
+        enableExternalDataChannel ? 1ULL : 0ULL);
+    if (enableExternalDataChannel) {
+        UNIT_ASSERT_C(WaitForSessionCounter(cluster, 1, 2, "XdcSections") > 0,
+            "payload was not received through XDC sections");
+    } else {
+        UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "XdcSections"), 0ULL);
+    }
 }
 
 ui64 MeasureIdleGeneratedPackets(bool enableKernelLiveness, bool withRdma) {
@@ -1236,6 +1322,14 @@ Y_UNIT_TEST_SUITE(Interconnect) {
             return recipientOnNode1Ptr->GetReceived() > receivedOnNode1Before
                 && recipientOnNode2Ptr->GetReceived() > receivedOnNode2Before;
         }, "bidirectional delivery after simultaneous RDMA reconnect");
+    }
+
+    Y_UNIT_TEST(TcpXdcEmptyProtoRecordWithPayloadRoundTrip) {
+        RunTcpEmptyProtoRecordWithPayloadRoundTrip(true);
+    }
+
+    Y_UNIT_TEST(TcpInlineEmptyProtoRecordWithPayloadRoundTrip) {
+        RunTcpEmptyProtoRecordWithPayloadRoundTrip(false);
     }
 
     Y_UNIT_TEST(KernelLivenessMixedConfigFallback) {

--- a/ydb/library/actors/interconnect/ut/xdc_shuffle_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/xdc_shuffle_ut.cpp
@@ -1,0 +1,136 @@
+#include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/interconnect/events_local.h>
+#include <ydb/library/actors/interconnect/interconnect_channel.h>
+#include <ydb/library/actors/interconnect/ut/protos/interconnect_test.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NActors;
+
+namespace {
+
+struct TEvEmptyRecordWithPayload
+    : TEventPB<TEvEmptyRecordWithPayload, NInterconnectTest::TEvTestSerialization, 0x10001>
+{};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(InterconnectXdcShuffle) {
+
+    Y_UNIT_TEST(EmptyProtoRecordCompletesAfterPayload) {
+        TEvEmptyRecordWithPayload event;
+        const TString payload(5000, 'x');
+        event.AddPayload(TRope(payload));
+
+        UNIT_ASSERT_VALUES_EQUAL(event.Record.ByteSize(), 0);
+
+        const TEventSerializationInfo info = event.CreateSerializationInfo(true);
+        UNIT_ASSERT_VALUES_EQUAL(info.Sections.size(), 3u);
+        UNIT_ASSERT(info.Sections[0].IsInline);
+        UNIT_ASSERT_VALUES_UNEQUAL(info.Sections[0].Size, 0u);
+        UNIT_ASSERT(!info.Sections[1].IsInline);
+        UNIT_ASSERT_VALUES_EQUAL(info.Sections[1].Size, payload.size());
+        UNIT_ASSERT(info.Sections[2].IsInline);
+        UNIT_ASSERT_VALUES_EQUAL(info.Sections[2].Size, 0u);
+
+        auto getSerializedSize = [](std::span<TCoroutineChunkSerializer::TChunk> chunks) {
+            size_t result = 0;
+            for (const auto& [_, size] : chunks) {
+                result += size;
+            }
+            return result;
+        };
+
+        TCoroutineChunkSerializer chunker;
+        chunker.SetSerializingEvent(&event);
+
+        TString headerBuffer(info.Sections[0].Size, '\0');
+        auto chunks = chunker.FeedBuf(headerBuffer.begin(), headerBuffer.size());
+        UNIT_ASSERT_VALUES_EQUAL(getSerializedSize(chunks), info.Sections[0].Size);
+        UNIT_ASSERT(!chunker.IsComplete());
+
+        TString payloadBuffer(payload.size(), '\0');
+        chunks = chunker.FeedBuf(payloadBuffer.begin(), payloadBuffer.size());
+        UNIT_ASSERT_VALUES_EQUAL(getSerializedSize(chunks), payload.size());
+        UNIT_ASSERT(chunker.IsComplete());
+        UNIT_ASSERT(chunker.IsSuccessfull());
+    }
+
+    Y_UNIT_TEST(EmptyProtoRecordAfterXdcPayloadDoesNotAbort) {
+        auto common = MakeIntrusive<TInterconnectProxyCommon>();
+        common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        std::shared_ptr<IInterconnectMetrics> metrics = CreateInterconnectCounters(common);
+        metrics->SetPeerInfo("peer", "1", "peer");
+
+        auto destroyCallback = [](THolder<IEventBase>) {};
+        TEventHolderPool pool(common, destroyCallback);
+
+        TSessionParams params;
+        params.UseExternalDataChannel = true;
+        params.UseXdcShuffle = true;
+
+        TEventOutputChannel channel(1, 1, 64 << 20, metrics, params, nullptr);
+
+        auto* event = new TEvEmptyRecordWithPayload;
+        const TString payload(5000, 'x');
+        event->AddPayload(TRope(payload));
+
+        const TEventSerializationInfo info = event->CreateSerializationInfo(true);
+        UNIT_ASSERT_VALUES_EQUAL(info.Sections.size(), 3u);
+        UNIT_ASSERT(info.Sections[0].IsInline);
+        UNIT_ASSERT_VALUES_UNEQUAL(info.Sections[0].Size, 0u);
+        UNIT_ASSERT(!info.Sections[1].IsInline);
+        UNIT_ASSERT_VALUES_EQUAL(info.Sections[1].Size, payload.size());
+        UNIT_ASSERT(info.Sections[2].IsInline);
+        UNIT_ASSERT_VALUES_EQUAL(info.Sections[2].Size, 0u);
+
+        auto handle = MakeHolder<IEventHandle>(TActorId(), TActorId(), event);
+        channel.Push(*handle, pool, TInstant::Zero());
+
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(params, main, xdc);
+
+        UNIT_ASSERT(channel.FeedBuf(task, 1));
+    }
+
+    Y_UNIT_TEST(EmptyProtoRecordAfterXdcPayloadAllowsNextEvent) {
+        auto common = MakeIntrusive<TInterconnectProxyCommon>();
+        common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        std::shared_ptr<IInterconnectMetrics> metrics = CreateInterconnectCounters(common);
+        metrics->SetPeerInfo("peer", "1", "peer");
+
+        auto destroyCallback = [](THolder<IEventBase>) {};
+        TEventHolderPool pool(common, destroyCallback);
+
+        TSessionParams params;
+        params.UseExternalDataChannel = true;
+        params.UseXdcShuffle = true;
+
+        TEventOutputChannel channel(1, 1, 64 << 20, metrics, params, nullptr);
+
+        auto* first = new TEvEmptyRecordWithPayload;
+        const TString payload(5000, 'x');
+        first->AddPayload(TRope(payload));
+        UNIT_ASSERT_VALUES_EQUAL(first->Record.ByteSize(), 0);
+
+        auto* second = new TEvEmptyRecordWithPayload;
+        second->Record.SetBlobID(42);
+        UNIT_ASSERT_VALUES_UNEQUAL(second->Record.ByteSize(), 0);
+
+        auto firstHandle = MakeHolder<IEventHandle>(TActorId(), TActorId(), first);
+        auto secondHandle = MakeHolder<IEventHandle>(TActorId(), TActorId(), second);
+        channel.Push(*firstHandle, pool, TInstant::Zero());
+        channel.Push(*secondHandle, pool, TInstant::Zero());
+
+        NInterconnect::TOutgoingStream main;
+        NInterconnect::TOutgoingStream xdc;
+        TTcpPacketOutTask task(params, main, xdc);
+
+        UNIT_ASSERT(channel.FeedBuf(task, 1));
+        UNIT_ASSERT(channel.FeedBuf(task, 2));
+    }
+
+}

--- a/ydb/library/actors/interconnect/ut/ya.make
+++ b/ydb/library/actors/interconnect/ut/ya.make
@@ -20,6 +20,7 @@ SRCS(
     dynamic_proxy_ut.cpp
     sticking_ut.cpp
     #uring_ut.cpp
+    xdc_shuffle_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -1056,6 +1056,37 @@ TEST_F(XdcRdmaTest, SendRdma) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
+TEST_F(XdcRdmaTest, SendRdmaEmptyProtoRecordWithPayload) {
+    TTestICCluster cluster(2);
+    auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+
+    auto buf = memPool->AllocRcBuf(5000, 0).value();
+    std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000, 'X');
+
+    auto* ev = new TEvTestSerialization();
+    ev->AddPayload(TRope(std::move(buf)));
+    UNIT_ASSERT_VALUES_EQUAL(ev->Record.ByteSize(), 0);
+    UNIT_ASSERT(ev->AllowExternalDataChannel());
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.ByteSize(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].GetSize(), 5000u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), TString(5000, 'X'));
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    Sleep(TDuration::MilliSeconds(1000));
+
+    auto senderPtr = new TSendActor(receiver, ev);
+    cluster.RegisterActor(senderPtr, 2);
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+}
+
 TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
     TTestICCluster cluster(2);
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

auto* event = new TEvEmptyRecordWithPayload;
const TString payload(5000, 'x');
event->AddPayload(TRope(payload));

У него protobuf record пустой:

event->Record.ByteSize() == 0

Но payload есть. Поэтому CreateSerializationInfo(true) строит XDC layout из трёх секций:
[0] inline header      size > 0
[1] external payload  size = 5000
[2] inline protobuf   size = 0
Суммарный размер секций корректный: header + payload + 0.
Дальше sender в TEventOutputChannel::FeedPayload идет по секциям:
Берёт inline section [0], вызывает FeedInlinePayload.
Chunker.FeedBuf() сериализует extended-payload header, отдаёт реальные байты.

Берёт external section [1], вызывает FeedExternalPayload.
Chunker.FeedBuf() сериализует payload, отдаёт 5000 байт.

Доходит до inline section [2] с Size == 0.

Для этой секции:
PartLenRemain += sections[SectionIndex].Size; // += 0
++SectionIndex;
PartLenRemain остаётся 0, а SectionIndex уже становится равен sections.size().

падаем по верифайке

Фикс: для пустого protobuf record CodedOutputStream больше не просит буфер. После сериализации payload protobuf tail завершается без дополнительного FeedBuf()

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
