### PR TITLE
Improve ydb free args completion in ydb config completion json

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/ut/completion_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ut/completion_ut.cpp
@@ -161,6 +161,8 @@ Y_UNIT_TEST_SUITE(CompletionGraphJson) {
         opts.AddLongOption("verbose").NoArgument();
         opts.AddLongOption("endpoint").RequiredArgument("ENDPOINT");
         opts.AddLongOption("input").RequiredArgument("FILE").Completer(NLastGetopt::NComp::File());
+        opts.AddLongOption("dir").RequiredArgument("DIR").Completer(NLastGetopt::NComp::Directory());
+        opts.AddLongOption("default").RequiredArgument("X").Completer(NLastGetopt::NComp::Default());
         opts.AddLongOption("host").RequiredArgument("HOST").Completer(NLastGetopt::NComp::Host());
         opts.AddLongOption("format").RequiredArgument("FORMAT").Choices(TVector<TString>{"json", "csv"});
 
@@ -174,6 +176,11 @@ Y_UNIT_TEST_SUITE(CompletionGraphJson) {
         UNIT_ASSERT_VALUES_EQUAL(options["--endpoint"].GetStringSafe(), "file");
         // An explicit File() completer is also local files.
         UNIT_ASSERT_VALUES_EQUAL(options["--input"].GetStringSafe(), "file");
+        // Directory() and Default() also list local filesystem entries (their zsh
+        // actions start with _files/_default); guards CompletesLocalFiles() against
+        // those action strings changing.
+        UNIT_ASSERT_VALUES_EQUAL(options["--dir"].GetStringSafe(), "file");
+        UNIT_ASSERT_VALUES_EQUAL(options["--default"].GetStringSafe(), "file");
         // A non-file completer (host) is reported as an opaque value.
         UNIT_ASSERT_VALUES_EQUAL(options["--host"].GetStringSafe(), "value");
         // Choices are listed and sorted.
@@ -193,12 +200,21 @@ Y_UNIT_TEST_SUITE(CompletionGraphJson) {
             o.SetFreeArgsNum(1);
             o.GetFreeArgSpec(0).Completer(NLastGetopt::NComp::Host());
         });
+        // Unbounded args (the TOpts default max) with only a trailing completer set
+        // and no title/help: exercises the trailing-arg branch in
+        // WriteFreeArgsValue and the IsDefault()/Completer_ guard -- without that
+        // guard this would be misreported as null.
+        TConfigurableLeaf trailingCustom([](NLastGetopt::TOpts& o) {
+            o.SetFreeArgsMax(NLastGetopt::TOpts::UNLIMITED_ARGS);
+            o.GetTrailingArgSpec().Completer(NLastGetopt::NComp::Host());
+        });
 
         TModChooser chooser;
         chooser.AddMode("undeclared", &undeclared, "");
         chooser.AddMode("no-args", &noArgs, "");
         chooser.AddMode("file-arg", &fileArg, "");
         chooser.AddMode("custom-arg", &customArg, "");
+        chooser.AddMode("trailing-custom", &trailingCustom, "");
 
         NLastGetopt::TOpts rootOpts;
         auto root = GenerateAndParse(chooser, rootOpts);
@@ -210,6 +226,7 @@ Y_UNIT_TEST_SUITE(CompletionGraphJson) {
         UNIT_ASSERT(handlers["no-args"]["free_args"].IsNull());
         UNIT_ASSERT_VALUES_EQUAL(handlers["file-arg"]["free_args"].GetStringSafe(), "file");
         UNIT_ASSERT_VALUES_EQUAL(handlers["custom-arg"]["free_args"].GetStringSafe(), "value");
+        UNIT_ASSERT_VALUES_EQUAL(handlers["trailing-custom"]["free_args"].GetStringSafe(), "value");
         // Leaves expose no subcommands.
         UNIT_ASSERT(handlers["file-arg"]["handlers"].GetMapSafe().empty());
     }

--- a/ydb/public/lib/ydb_cli/commands/ut/completion_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ut/completion_ut.cpp
@@ -1,11 +1,18 @@
 #include <ydb/public/lib/ydb_cli/commands/ydb_root_common.h>
 #include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
 #include <ydb/public/lib/ydb_cli/common/completion.h>
+#include <ydb/public/lib/ydb_cli/common/completion_graph_json.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/getopt/small/completer.h>
+#include <library/cpp/getopt/small/last_getopt.h>
 #include <library/cpp/getopt/small/modchooser.h>
+#include <library/cpp/json/json_reader.h>
 
 #include <util/generic/hash.h>
+#include <util/stream/str.h>
+
+#include <functional>
 
 using namespace NYdb::NConsoleClient;
 
@@ -107,5 +114,103 @@ Y_UNIT_TEST_SUITE(CompletionData) {
         CollectCompletionErrors(chooser, "ydb", errors);
 
         UNIT_ASSERT_C(errors.empty(), FormatErrors(errors));
+    }
+}
+
+namespace {
+
+// Minimal leaf command (TMainClassArgs) whose options/free-args are configured by
+// a callback, so tests can run GenerateJsonCompletion against a real graph node.
+class TConfigurableLeaf : public TMainClassArgs {
+public:
+    using TSetup = std::function<void(NLastGetopt::TOpts&)>;
+
+    explicit TConfigurableLeaf(TSetup setup)
+        : Setup_(std::move(setup))
+    {
+    }
+
+protected:
+    void RegisterOptions(NLastGetopt::TOpts& opts) override {
+        if (Setup_) {
+            Setup_(opts);
+        }
+    }
+
+    int DoRun(NLastGetopt::TOptsParseResult&&) override {
+        return 0;
+    }
+
+private:
+    TSetup Setup_;
+};
+
+NJson::TJsonValue GenerateAndParse(const TModChooser& chooser, const NLastGetopt::TOpts& rootOpts) {
+    TStringStream out;
+    GenerateJsonCompletion(chooser, rootOpts, out);
+    NJson::TJsonValue root;
+    UNIT_ASSERT_C(NJson::ReadJsonTree(out.Str(), &root), "produced invalid JSON: " << out.Str());
+    return root;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(CompletionGraphJson) {
+    Y_UNIT_TEST(OptionValueKinds) {
+        NLastGetopt::TOpts opts;
+        opts.AddLongOption("verbose").NoArgument();
+        opts.AddLongOption("endpoint").RequiredArgument("ENDPOINT");
+        opts.AddLongOption("input").RequiredArgument("FILE").Completer(NLastGetopt::NComp::File());
+        opts.AddLongOption("host").RequiredArgument("HOST").Completer(NLastGetopt::NComp::Host());
+        opts.AddLongOption("format").RequiredArgument("FORMAT").Choices(TVector<TString>{"json", "csv"});
+
+        TModChooser chooser;
+        auto root = GenerateAndParse(chooser, opts);
+        const auto& options = root["options"];
+
+        // A flag stays null.
+        UNIT_ASSERT(options["--verbose"].IsNull());
+        // A value option without a completer defaults to local file completion.
+        UNIT_ASSERT_VALUES_EQUAL(options["--endpoint"].GetStringSafe(), "file");
+        // An explicit File() completer is also local files.
+        UNIT_ASSERT_VALUES_EQUAL(options["--input"].GetStringSafe(), "file");
+        // A non-file completer (host) is reported as an opaque value.
+        UNIT_ASSERT_VALUES_EQUAL(options["--host"].GetStringSafe(), "value");
+        // Choices are listed and sorted.
+        UNIT_ASSERT(options["--format"].IsArray());
+        UNIT_ASSERT_VALUES_EQUAL(options["--format"].GetArray().size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(options["--format"][0].GetStringSafe(), "csv");
+        UNIT_ASSERT_VALUES_EQUAL(options["--format"][1].GetStringSafe(), "json");
+        // The root behaves as a command group.
+        UNIT_ASSERT(root["free_args"].IsNull());
+    }
+
+    Y_UNIT_TEST(LeafFreeArgs) {
+        TConfigurableLeaf undeclared([](NLastGetopt::TOpts&) {});
+        TConfigurableLeaf noArgs([](NLastGetopt::TOpts& o) { o.SetFreeArgsNum(0); });
+        TConfigurableLeaf fileArg([](NLastGetopt::TOpts& o) { o.SetFreeArgsNum(1); });
+        TConfigurableLeaf customArg([](NLastGetopt::TOpts& o) {
+            o.SetFreeArgsNum(1);
+            o.GetFreeArgSpec(0).Completer(NLastGetopt::NComp::Host());
+        });
+
+        TModChooser chooser;
+        chooser.AddMode("undeclared", &undeclared, "");
+        chooser.AddMode("no-args", &noArgs, "");
+        chooser.AddMode("file-arg", &fileArg, "");
+        chooser.AddMode("custom-arg", &customArg, "");
+
+        NLastGetopt::TOpts rootOpts;
+        auto root = GenerateAndParse(chooser, rootOpts);
+        const auto& handlers = root["handlers"];
+
+        // A command that never restricted/declared its positionals must not make
+        // the consumer dump the cwd (regression guard for the "386 files" bug).
+        UNIT_ASSERT(handlers["undeclared"]["free_args"].IsNull());
+        UNIT_ASSERT(handlers["no-args"]["free_args"].IsNull());
+        UNIT_ASSERT_VALUES_EQUAL(handlers["file-arg"]["free_args"].GetStringSafe(), "file");
+        UNIT_ASSERT_VALUES_EQUAL(handlers["custom-arg"]["free_args"].GetStringSafe(), "value");
+        // Leaves expose no subcommands.
+        UNIT_ASSERT(handlers["file-arg"]["handlers"].GetMapSafe().empty());
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/ut/ya.make
+++ b/ydb/public/lib/ydb_cli/commands/ut/ya.make
@@ -1,5 +1,9 @@
 UNITTEST_FOR(ydb/public/lib/ydb_cli/commands)
 
+PEERDIR(
+    library/cpp/json
+)
+
 SRCS(
     completion_ut.cpp
 )

--- a/ydb/public/lib/ydb_cli/common/completion_graph_json.cpp
+++ b/ydb/public/lib/ydb_cli/common/completion_graph_json.cpp
@@ -109,11 +109,15 @@ void WriteOpts(NJsonWriter::TBuf& json, const TOpts& opts) {
 //               scheme path).
 void WriteFreeArgsValue(NJsonWriter::TBuf& json, const TOpts& opts) {
     const ui32 maxArgs = opts.GetFreeArgsMax();
+    // TFreeArgSpec::IsDefault() inspects only Title_/Help_, not the completer, so
+    // check Completer_ explicitly: a trailing completer set without a title/help
+    // is a declared positional and must not be mistaken for the untouched default.
     const bool untouchedDefault =
         maxArgs == TOpts::UNLIMITED_ARGS &&
         opts.GetFreeArgsMin() == 0 &&
         opts.GetFreeArgSpecs().empty() &&
-        opts.GetTrailingArgSpec().IsDefault();
+        opts.GetTrailingArgSpec().IsDefault() &&
+        !opts.GetTrailingArgSpec().Completer_;
     if (maxArgs == 0 || untouchedDefault) {
         json.WriteNull();
         return;

--- a/ydb/public/lib/ydb_cli/common/completion_graph_json.cpp
+++ b/ydb/public/lib/ydb_cli/common/completion_graph_json.cpp
@@ -1,5 +1,6 @@
 #include "completion_graph_json.h"
 
+#include <library/cpp/getopt/small/completer.h>
 #include <library/cpp/json/writer/json.h>
 
 #include <util/generic/algorithm.h>
@@ -12,25 +13,35 @@ namespace {
 
 using namespace NLastGetopt;
 
-// Write the JSON value describing what the option accepts:
-//   null         -- flag without a value (e.g. --help, --verbose),
-//                   or option that takes an arbitrary value (URL, path, ...)
-//   [v1, v2]     -- option with a fixed set of allowed values (TOpt::Choices),
-//                   sorted lexicographically for stable output
-void WriteOptValue(NJsonWriter::TBuf& json, const TOpt& opt) {
-    if (opt.GetHasArg() == NO_ARGUMENT) {
-        json.WriteNull();
-        return;
+// Markers for a free-form value (no fixed set of choices):
+//   "file"  -- the value is completed as a local filesystem path,
+//   "value" -- the value has custom/server-side completion (e.g. a YDB scheme
+//              path) that a third party cannot reproduce as local files.
+constexpr TStringBuf FileArgMarker = "file";
+constexpr TStringBuf ValueArgMarker = "value";
+
+// Decide whether a value with the given completer (or no completer at all) is
+// completed as a local file/path. This mirrors what the native zsh generator
+// does: an option/argument without a completer falls back to `_default`, and the
+// File()/Directory()/Default() completers emit `_files`/`_default` -- all of
+// which list local filesystem entries. Every other completer (host, pid,
+// choices, scheme path, ...) completes something a third party cannot turn into
+// local files. We probe the completer through the zsh action it generates,
+// which is the only public way to introspect the otherwise opaque ICompleter.
+bool CompletesLocalFiles(const NComp::ICompleterPtr& completer) {
+    if (!completer) {
+        return true;
     }
-    // TOpt::Choices_ is a THashSet<TString>; GetChoicesHelp() is the only public
-    // accessor and exposes its contents as ", "-joined string. Choices in YDB CLI
-    // are plain identifiers (e.g. "csv", "json"), so splitting by ", " is safe in
-    // practice. Output is sorted to keep the JSON deterministic across runs.
-    const TString choicesHelp = opt.GetChoicesHelp();
-    if (choicesHelp.empty()) {
-        json.WriteNull();
-        return;
-    }
+    NComp::TCompleterManager manager{"ydb"};
+    const TStringBuf action = completer->GenerateZshAction(manager);
+    return action.StartsWith("_files") || action.StartsWith("_default");
+}
+
+// Write the option's allowed values as a sorted JSON list. TOpt::Choices_ is a
+// THashSet<TString> exposed only via GetChoicesHelp() as a ", "-joined string.
+// Choices in YDB CLI are plain identifiers (e.g. "csv", "json"), so splitting by
+// ", " is safe in practice. Output is sorted to keep the JSON deterministic.
+void WriteChoices(NJsonWriter::TBuf& json, const TString& choicesHelp) {
     TVector<TString> values;
     StringSplitter(choicesHelp).SplitByString(", ").SkipEmpty().Collect(&values);
     for (TString& value : values) {
@@ -42,6 +53,24 @@ void WriteOptValue(NJsonWriter::TBuf& json, const TOpt& opt) {
         json.WriteString(value);
     }
     json.EndList();
+}
+
+// Write the JSON value describing what the option accepts:
+//   null         -- a flag without a value (e.g. --help, --verbose),
+//   [v1, v2]     -- a fixed set of allowed values (TOpt::Choices), sorted,
+//   "file"       -- a free-form value completed as a local file/path,
+//   "value"      -- a free-form value with custom/server-side completion.
+void WriteOptValue(NJsonWriter::TBuf& json, const TOpt& opt) {
+    if (opt.GetHasArg() == NO_ARGUMENT) {
+        json.WriteNull();
+        return;
+    }
+    const TString choicesHelp = opt.GetChoicesHelp();
+    if (!choicesHelp.empty()) {
+        WriteChoices(json, choicesHelp);
+        return;
+    }
+    json.WriteString(CompletesLocalFiles(opt.Completer_) ? FileArgMarker : ValueArgMarker);
 }
 
 void WriteOpts(NJsonWriter::TBuf& json, const TOpts& opts) {
@@ -68,6 +97,43 @@ void WriteOpts(NJsonWriter::TBuf& json, const TOpts& opts) {
     json.EndObject();
 }
 
+// Write the JSON value describing the positional (free) arguments a leaf command
+// accepts:
+//   null     -- no positional arguments. Also used when the command left the
+//               default "unlimited but undescribed" policy untouched: we must
+//               not claim file completion there, otherwise commands that simply
+//               never declared positionals (e.g. `table query execute`) would
+//               make a third party dump the current directory.
+//   "file"   -- positional(s) completed as local files/paths,
+//   "value"  -- positional(s) with custom/server-side completion (e.g. a YDB
+//               scheme path).
+void WriteFreeArgsValue(NJsonWriter::TBuf& json, const TOpts& opts) {
+    const ui32 maxArgs = opts.GetFreeArgsMax();
+    const bool untouchedDefault =
+        maxArgs == TOpts::UNLIMITED_ARGS &&
+        opts.GetFreeArgsMin() == 0 &&
+        opts.GetFreeArgSpecs().empty() &&
+        opts.GetTrailingArgSpec().IsDefault();
+    if (maxArgs == 0 || untouchedDefault) {
+        json.WriteNull();
+        return;
+    }
+    // Report "file" only if every declared positional (and the trailing one,
+    // when the count is unbounded) completes as a local file/path; otherwise
+    // some slot uses custom completion and we fall back to the opaque "value".
+    bool files = true;
+    for (const auto& spec : opts.GetFreeArgSpecs()) {
+        if (!CompletesLocalFiles(spec.second.Completer_)) {
+            files = false;
+            break;
+        }
+    }
+    if (files && maxArgs == TOpts::UNLIMITED_ARGS && !CompletesLocalFiles(opts.GetTrailingArgSpec().Completer_)) {
+        files = false;
+    }
+    json.WriteString(files ? FileArgMarker : ValueArgMarker);
+}
+
 void WriteModes(NJsonWriter::TBuf& json, const TModChooser& chooser);
 
 void WriteNodeBody(NJsonWriter::TBuf& json, TMainClass* main) {
@@ -79,9 +145,20 @@ void WriteNodeBody(NJsonWriter::TBuf& json, TMainClass* main) {
         json.WriteKey("handlers").BeginObject().EndObject();
     }
     if (mainArgs) {
-        WriteOpts(json, mainArgs->GetOptions());
+        const TOpts& opts = mainArgs->GetOptions();
+        WriteOpts(json, opts);
+        // Positional arguments are meaningful only on leaves. On a command group
+        // (mainModes) the first positional selects a subcommand, which is already
+        // described by "handlers", so report no free args there.
+        json.WriteKey("free_args");
+        if (mainModes) {
+            json.WriteNull();
+        } else {
+            WriteFreeArgsValue(json, opts);
+        }
     } else {
         json.WriteKey("options").BeginObject().EndObject();
+        json.WriteKey("free_args").WriteNull();
     }
 }
 
@@ -112,6 +189,8 @@ void GenerateJsonCompletion(const TModChooser& chooser, const TOpts& rootOpts, I
     json.BeginObject();
     WriteModes(json, chooser);
     WriteOpts(json, rootOpts);
+    // The root acts as a command group: its positional selects a subcommand.
+    json.WriteKey("free_args").WriteNull();
     json.EndObject();
     out << "\n";
 }

--- a/ydb/public/lib/ydb_cli/common/completion_graph_json.h
+++ b/ydb/public/lib/ydb_cli/common/completion_graph_json.h
@@ -35,6 +35,12 @@ namespace NYdb::NConsoleClient {
 //   * "file"          -- positional(s) completed as local files/paths
 //   * "value"         -- positional(s) with custom/server-side completion
 //
+// The schema is additive: new <opt_value>/<free_args_value> markers may appear
+// over time, and the "free_args" key is absent in output from older binaries.
+// Consumers should tolerate unknown string markers and treat a missing
+// "free_args" as null; the in-tree consumer (internal `ya ydb`) is updated in
+// tandem with such changes.
+//
 // Hidden subcommands and options are omitted. Handlers and options are emitted in
 // stable (sorted) order so the output can be cached and compared between runs.
 void GenerateJsonCompletion(const TModChooser& chooser, const NLastGetopt::TOpts& rootOpts, IOutputStream& out);

--- a/ydb/public/lib/ydb_cli/common/completion_graph_json.h
+++ b/ydb/public/lib/ydb_cli/common/completion_graph_json.h
@@ -8,8 +8,8 @@
 namespace NYdb::NConsoleClient {
 
 // Generate machine-readable JSON description of the CLI command tree.
-// Used by external tools (e.g. internal `ya ydb`) to build their own shell completion
-// without re-implementing the YDB CLI command structure.
+// Used by external tools to build their own shell completion without
+// re-implementing the YDB CLI command structure.
 //
 // Schema for each node (root has the same shape):
 //   {
@@ -38,8 +38,7 @@ namespace NYdb::NConsoleClient {
 // The schema is additive: new <opt_value>/<free_args_value> markers may appear
 // over time, and the "free_args" key is absent in output from older binaries.
 // Consumers should tolerate unknown string markers and treat a missing
-// "free_args" as null; the in-tree consumer (internal `ya ydb`) is updated in
-// tandem with such changes.
+// "free_args" as null; producers and consumers are expected to evolve in tandem.
 //
 // Hidden subcommands and options are omitted. Handlers and options are emitted in
 // stable (sorted) order so the output can be cached and compared between runs.

--- a/ydb/public/lib/ydb_cli/common/completion_graph_json.h
+++ b/ydb/public/lib/ydb_cli/common/completion_graph_json.h
@@ -13,16 +13,27 @@ namespace NYdb::NConsoleClient {
 //
 // Schema for each node (root has the same shape):
 //   {
-//     "handlers": { <subcommand_name>: <node>, ... },   // sorted by key
-//     "options":  { "--flag" | "-x": <opt_value>, ... } // sorted by key
+//     "handlers":  { <subcommand_name>: <node>, ... }, // sorted by key
+//     "options":   { "--flag" | "-x": <opt_value>, ... }, // sorted by key
+//     "free_args": <free_args_value>
 //   }
 //
-// <opt_value> is one of:
+// <opt_value> describes what the option accepts and is one of:
 //   * null            -- the option is a flag without an argument (e.g. --help)
-//                        or it accepts an arbitrary value (URL, path, number, ...);
-//                        in both cases no completion choices are available
 //   * [v1, v2, ...]   -- the option accepts only one of the listed values
 //                        (TOpt::Choices); the list is sorted lexicographically
+//   * "file"          -- the option takes a free-form value that is completed as
+//                        a local file/path (the CLI's default for value options)
+//   * "value"         -- the option takes a free-form value with custom or
+//                        server-side completion (e.g. a YDB scheme path) that a
+//                        third party cannot reproduce as local files
+//
+// <free_args_value> describes the positional (free) arguments and is one of:
+//   * null            -- no positional arguments. Also reported on command groups
+//                        (where the positional selects a subcommand listed in
+//                        "handlers") and on commands that never declared any
+//   * "file"          -- positional(s) completed as local files/paths
+//   * "value"         -- positional(s) with custom/server-side completion
 //
 // Hidden subcommands and options are omitted. Handlers and options are emitted in
 // stable (sorted) order so the output can be cached and compared between runs.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

## Improve `ydb config completion json`: describe value/file/free-arg kinds

### Summary
The machine-readable command tree emitted by `ydb config completion json`
now describes **what each option and positional argument
actually accepts**, instead of collapsing everything into "flag or unknown".

For every node it now reports:
- **Options** — distinguish a pure flag from a value-taking option, and for
  value options say whether the value is a local file/path, a fixed set of
  choices, or an opaque/custom value.
- **`free_args`** — a new per-node field describing the positional (free)
  arguments of a leaf command.

### Motivation
The JSON command graph is consumed by external tools that generate their own
shell completion from it (without re-implementing the CLI command structure).

Previously an option value was just `null` both for a flag (`--help`) **and**
for a value-taking option without a fixed choice list. A consumer therefore
could not tell:
- whether an option expects a value at all (needed to correctly skip that value
  when interpreting a partially typed command line), or
- whether offering local files for that value makes sense.

There was also no information about positional arguments at all, so a generated
completion had to either offer local files everywhere (noisy — e.g. dumping the
whole working directory for a command that takes no positional) or nowhere.

With the enriched schema a consumer can offer files only where a file is
expected, choices where there is a fixed set, and nothing (or a custom
completer) otherwise.

### Schema change
Before:
```text
"options": { "--flag" | "-x": <opt_value> }   // node had no "free_args"
<opt_value> = null | [choices]                 // null = flag OR arbitrary value
```
After:
```text
"options":   { "--flag" | "-x": <opt_value> },
"free_args": <free_args_value>

<opt_value>       = null | [choices] | "file" | "value"
<free_args_value> = null | "file" | "value"
```
- `null` (option) — flag, takes no argument.
- `[v1, v2, ...]` — fixed set of allowed values (sorted).
- `"file"` — free-form value completed as a local file/path.
- `"value"` — free-form value with custom/server-side completion (e.g. a scheme
  path, a host) that a third party cannot reproduce as local files.
- `free_args`: `null` (no positionals, or a command group whose positional just
  selects a subcommand), `"file"`, or `"value"`.

### Examples
Illustrative (not literal) output for a few nodes:

```jsonc
// a leaf command's options
"options": {
  "--help":       null,              // flag — no value
  "--format":     ["csv", "json"],   // fixed choices
  "--input-file": "file",            // value = local path  (was: null)
  "<custom-opt>": "value"            // value with custom completion (was: null)
}
```

```jsonc
// positional arguments, per command:
// `... import file csv <FILE>...`      -> local file(s)
"free_args": "file"

// `... scheme describe <SCHEME_PATH>`  -> server-side scheme path
"free_args": "value"

// `... table query execute`           -> takes no positional at all
"free_args": null
```

The last case is the important one: such a command previously could not be
distinguished from "accepts anything", which led consumers to offer the entire
current directory as completion candidates.

### Backward compatibility
This is an additive but not strictly backward-compatible change: value options
that used to be `null` are now `"file"`/`"value"`, and the new `free_args` key
appears on every node. The schema is documented as additive — consumers should
treat unknown string markers conservatively and a missing `free_args` as `null`.
Output remains deterministic (sorted) so it can be cached and diffed.

### Tests
- `CompletionGraphJson::OptionValueKinds` — flag/choices/file/value option kinds,
  including `File()`, `Directory()`, `Default()` (-> `"file"`) and a non-file
  completer (-> `"value"`).
- `CompletionGraphJson::LeafFreeArgs` — undeclared / zero / file / custom-completer
  positionals, plus an unbounded-args command with only a trailing completer.
