### PR TITLE
Topic retention delete last blob

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -464,6 +464,130 @@ bool TPartition::ImportantConsumersNeedToKeepCurrentKey(const TDataKey& currentK
     return false;
 }
 
+bool TPartition::ImportantConsumersNeedToKeepLastKey(const TDataKey& currentKey, const TInstant now) const {
+    for (const auto& [name, userInfo] : UsersInfoStorage->ViewImportant()) {
+        const TDuration availabilityPeriod = GetAvailabilityPeriod(userInfo);
+        if (availabilityPeriod == TDuration::Zero()) {
+            continue;
+        }
+        const TInstant endOfLife = currentKey.Timestamp + availabilityPeriod;
+        if (endOfLife < now) {
+            continue;
+        }
+        ui64 curOffset = GetStartOffset();
+        if (userInfo.Offset >= 0) {
+            curOffset = userInfo.Offset;
+        }
+        if (curOffset < GetEndOffset()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void TPartition::FinalizeEmptyBlobEncoder(TPartitionBlobEncoder& encoder, ui64 startOffset, bool updateEndOffset) {
+    while (!encoder.HeadKeys.empty()) {
+        encoder.ScheduleDelete(encoder.HeadKeys.front());
+        encoder.HeadKeys.pop_front();
+    }
+    encoder.DataKeysBody.clear();
+    encoder.CompactedKeys.clear();
+    encoder.BodySize = 0;
+    encoder.Head.Clear();
+    encoder.Head.PartNo = 0;
+    encoder.StartOffset = startOffset;
+    if (updateEndOffset) {
+        encoder.EndOffset = startOffset;
+        encoder.Head.Offset = startOffset;
+    }
+    for (ui32 i = 0; i < TotalLevels; ++i) {
+        encoder.DataKeysHead[i].Clear();
+    }
+}
+
+bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCompactionZone, const TActorContext& ctx) {
+    if (encoder.DataKeysBody.empty()) {
+        return false;
+    }
+
+    const auto& partConfig = Config.GetPartitionConfig();
+    const TDuration lifetimeLimit{TDuration::Seconds(partConfig.GetLifetimeSeconds())};
+    const bool hasStorageLimit = partConfig.HasStorageLimitBytes();
+    const auto now = ctx.Now();
+    const ui64 partitionEndOffset = GetEndOffset();
+
+    auto canDrop = [&](const TDataKey& firstKey, bool isLastBlob) {
+        if (isLastBlob) {
+            if (ImportantConsumersNeedToKeepLastKey(firstKey, now)) {
+                return false;
+            }
+        } else {
+            const auto& nextKey = encoder.DataKeysBody[1];
+            if (ImportantConsumersNeedToKeepCurrentKey(firstKey, nextKey, now)) {
+                return false;
+            }
+        }
+
+        if (hasStorageLimit) {
+            if (isLastBlob) {
+                if (encoder.BodySize < partConfig.GetStorageLimitBytes()) {
+                    return false;
+                }
+            } else {
+                const auto bodySize = encoder.BodySize - firstKey.Size;
+                if (bodySize < partConfig.GetStorageLimitBytes()) {
+                    return false;
+                }
+            }
+        } else if (now < firstKey.Timestamp + lifetimeLimit) {
+            return false;
+        }
+        return true;
+    };
+
+    bool hasDrop = false;
+    while (!encoder.DataKeysBody.empty()) {
+        const auto& firstKey = encoder.DataKeysBody.front();
+        const bool isLastBlob = encoder.DataKeysBody.size() == 1;
+        if (!canDrop(firstKey, isLastBlob)) {
+            break;
+        }
+
+        if (!isLastBlob) {
+            const auto& nextKey = encoder.DataKeysBody[1];
+            encoder.pop_front();
+
+            if (isCompactionZone && !GapOffsets.empty() && nextKey.Key.GetOffset() == GapOffsets.front().second) {
+                GapSize -= GapOffsets.front().second - GapOffsets.front().first;
+                GapOffsets.pop_front();
+            }
+        } else {
+            encoder.pop_front();
+            if (isCompactionZone) {
+                GapOffsets.clear();
+                GapSize = 0;
+            }
+            FinalizeEmptyBlobEncoder(encoder, partitionEndOffset, !isCompactionZone);
+        }
+
+        hasDrop = true;
+
+        if (isLastBlob) {
+            break;
+        }
+    }
+
+    if (hasDrop && !encoder.DataKeysBody.empty()) {
+        const auto& lastKey = encoder.DataKeysBody.front().Key;
+        encoder.StartOffset = lastKey.GetOffset();
+        if (lastKey.GetPartNo() > 0) {
+            ++encoder.StartOffset;
+        }
+    }
+
+    return hasDrop;
+}
+
 
 TInstant TPartition::GetEndWriteTimestamp() const {
     return EndWriteTimestamp;
@@ -513,6 +637,8 @@ void TPartition::HandleWakeup(const TActorContext& ctx) {
     TryRunCompaction();
 
     AutopartitioningManager->CleanUp();
+
+    ProcessTxsAndUserActs(ctx);
 }
 
 void TPartition::AddMetaKey(TEvKeyValue::TEvRequest* request) {
@@ -521,8 +647,8 @@ void TPartition::AddMetaKey(TEvKeyValue::TEvRequest* request) {
     TKeyPrefix ikey(TKeyPrefix::TypeMeta, Partition);
 
     NKikimrPQ::TPartitionMeta meta;
-    //meta.SetStartOffset(GetStartOffset());
-    //meta.SetEndOffset(Max(BlobEncoder.NewHead.GetNextOffset(), GetEndOffset()));
+    meta.SetStartOffset(GetStartOffset());
+    meta.SetEndOffset(GetEndOffset());
     meta.SetSubDomainOutOfSpace(SubDomainOutOfSpace);
     meta.SetEndWriteTimestamp(PendingWriteTimestamp.MilliSeconds());
     meta.SetNextMessageIdDeduplicatorWAL(MessageIdDeduplicator.NextMessageIdDeduplicatorWAL);
@@ -569,64 +695,31 @@ bool TPartition::CleanUp(TEvKeyValue::TEvRequest* request, const TActorContext& 
 }
 
 bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorContext& ctx) {
-    if (GetStartOffset() == GetEndOffset() || CompactionBlobEncoder.DataKeysBody.size() <= 1) {
-        return false;
-    }
+    Y_UNUSED(request);
     if (Config.GetEnableCompactification()) {
         return false;
     }
-    const auto& partConfig = Config.GetPartitionConfig();
 
-    const TDuration lifetimeLimit{TDuration::Seconds(partConfig.GetLifetimeSeconds())};
+    bool hasDrop = CleanUpBlobsInEncoder(CompactionBlobEncoder, true, ctx);
 
-    const bool hasStorageLimit = partConfig.HasStorageLimitBytes();
-    const auto now = ctx.Now();
+    if (CompactionBlobEncoder.DataKeysBody.empty()) {
+        const ui64 compactionZoneEnd = BlobEncoder.DataKeysBody.empty() ? GetEndOffset() : BlobEncoder.StartOffset;
+        CompactionBlobEncoder.StartOffset = compactionZoneEnd;
+        CompactionBlobEncoder.EndOffset = compactionZoneEnd;
+        CompactionBlobEncoder.Head.Offset = compactionZoneEnd;
 
-    bool hasDrop = false;
-    while (CompactionBlobEncoder.DataKeysBody.size() > 1) {
-        const auto& nextKey = CompactionBlobEncoder.DataKeysBody[1];
-        const auto& firstKey = CompactionBlobEncoder.DataKeysBody.front();
-        if (ImportantConsumersNeedToKeepCurrentKey(firstKey, nextKey, now)) {
-            break;
-        }
-
-        if (hasStorageLimit) {
-            const auto bodySize = CompactionBlobEncoder.BodySize - firstKey.Size;
-            if (bodySize < partConfig.GetStorageLimitBytes()) {
-                break;
-            }
-        } else {
-            if (now < firstKey.Timestamp + lifetimeLimit) {
-                break;
-            }
-        }
-
-        CompactionBlobEncoder.pop_front();
-
-        if (!GapOffsets.empty() && nextKey.Key.GetOffset() == GapOffsets.front().second) {
-            GapSize -= GapOffsets.front().second - GapOffsets.front().first;
-            GapOffsets.pop_front();
-        }
-
-        hasDrop = true;
+        hasDrop |= CleanUpBlobsInEncoder(BlobEncoder, false, ctx);
     }
 
-    PQ_ENSURE(!CompactionBlobEncoder.DataKeysBody.empty());
-
-    if (!hasDrop) {
-        return false;
+    if (CompactionBlobEncoder.DataKeysBody.empty() && BlobEncoder.DataKeysBody.empty()) {
+        const ui64 endOffset = GetEndOffset();
+        CompactionBlobEncoder.StartOffset = endOffset;
+        CompactionBlobEncoder.EndOffset = endOffset;
+        CompactionBlobEncoder.Head.Offset = endOffset;
+        BlobEncoder.StartOffset = endOffset;
     }
 
-    const auto& lastKey = CompactionBlobEncoder.DataKeysBody.front().Key;
-
-    CompactionBlobEncoder.StartOffset = lastKey.GetOffset();
-    if (lastKey.GetPartNo() > 0) {
-        ++CompactionBlobEncoder.StartOffset;
-    }
-
-    Y_UNUSED(request);
-
-    return true;
+    return hasDrop;
 }
 
 void TPartition::Handle(TEvPQ::TEvMirrorerCounters::TPtr& ev, const TActorContext& /*ctx*/) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -509,7 +509,7 @@ void TPartition::FinalizeEmptyBlobEncoder(TPartitionBlobEncoder& encoder, ui64 s
 }
 
 bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCompactionZone, const TActorContext& ctx) {
-    if (encoder.DataKeysBody.empty()) {
+    if (encoder.DataKeysBody.empty() && encoder.HeadKeys.empty()) {
         return false;
     }
 
@@ -519,28 +519,73 @@ bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCo
     const auto now = ctx.Now();
     const ui64 partitionEndOffset = GetEndOffset();
 
-    auto canDrop = [&](const TDataKey& firstKey, bool isLastBlob) {
+    auto getEncoderDataSize = [&]() {
+        ui64 size = encoder.BodySize;
+        for (const auto& key : encoder.HeadKeys) {
+            size += key.Size;
+        }
+        return size;
+    };
+
+    auto getFwzFirstKey = [&]() -> const TDataKey* {
+        if (!BlobEncoder.DataKeysBody.empty()) {
+            return &BlobEncoder.DataKeysBody.front();
+        }
+        if (!BlobEncoder.HeadKeys.empty()) {
+            return &BlobEncoder.HeadKeys.front();
+        }
+        return nullptr;
+    };
+
+    auto isLastBlobInPartition = [&](bool hasMoreInEncoder) {
+        if (hasMoreInEncoder) {
+            return false;
+        }
+        if (isCompactionZone) {
+            return BlobEncoder.DataKeysBody.empty() && BlobEncoder.HeadKeys.empty();
+        }
+        return true;
+    };
+
+    auto updateStartOffsetFromKey = [&](const TKey& key) {
+        encoder.StartOffset = key.GetOffset();
+        if (key.GetPartNo() > 0) {
+            ++encoder.StartOffset;
+        }
+    };
+
+    auto updateStartOffsetFromFront = [&]() {
+        if (!encoder.DataKeysBody.empty()) {
+            updateStartOffsetFromKey(encoder.DataKeysBody.front().Key);
+        } else if (!encoder.HeadKeys.empty()) {
+            const auto& key = encoder.HeadKeys.front().Key;
+            updateStartOffsetFromKey(key);
+            encoder.Head.Offset = key.GetOffset();
+            encoder.Head.PartNo = key.GetPartNo();
+        }
+    };
+
+    auto popFrontHead = [&]() {
+        encoder.ScheduleDelete(encoder.HeadKeys.front());
+        encoder.HeadKeys.pop_front();
+    };
+
+    auto canDrop = [&](const TDataKey& firstKey, const TDataKey* nextKey, bool isLastBlob) {
         if (isLastBlob) {
             if (ImportantConsumersNeedToKeepLastKey(firstKey, now)) {
                 return false;
             }
         } else {
-            const auto& nextKey = encoder.DataKeysBody[1];
-            if (ImportantConsumersNeedToKeepCurrentKey(firstKey, nextKey, now)) {
+            Y_ABORT_UNLESS(nextKey);
+            if (ImportantConsumersNeedToKeepCurrentKey(firstKey, *nextKey, now)) {
                 return false;
             }
         }
 
         if (hasStorageLimit) {
-            if (isLastBlob) {
-                if (encoder.BodySize < partConfig.GetStorageLimitBytes()) {
-                    return false;
-                }
-            } else {
-                const auto bodySize = encoder.BodySize - firstKey.Size;
-                if (bodySize < partConfig.GetStorageLimitBytes()) {
-                    return false;
-                }
+            const auto dataSizeAfterDrop = getEncoderDataSize() - firstKey.Size;
+            if (dataSizeAfterDrop < partConfig.GetStorageLimitBytes()) {
+                return false;
             }
         } else if (now < firstKey.Timestamp + lifetimeLimit) {
             return false;
@@ -548,44 +593,81 @@ bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCo
         return true;
     };
 
+    auto finalizeIfEmpty = [&]() {
+        if (!encoder.DataKeysBody.empty() || !encoder.HeadKeys.empty()) {
+            return;
+        }
+        if (isCompactionZone) {
+            GapOffsets.clear();
+            GapSize = 0;
+        }
+        FinalizeEmptyBlobEncoder(encoder, partitionEndOffset, !isCompactionZone);
+    };
+
     bool hasDrop = false;
+
     while (!encoder.DataKeysBody.empty()) {
         const auto& firstKey = encoder.DataKeysBody.front();
-        const bool isLastBlob = encoder.DataKeysBody.size() == 1;
-        if (!canDrop(firstKey, isLastBlob)) {
+        const bool hasMoreInEncoder = encoder.DataKeysBody.size() > 1 || !encoder.HeadKeys.empty();
+        const bool isLastBlob = isLastBlobInPartition(hasMoreInEncoder);
+        const TDataKey* nextKey = nullptr;
+        if (encoder.DataKeysBody.size() > 1) {
+            nextKey = &encoder.DataKeysBody[1];
+        } else if (!encoder.HeadKeys.empty()) {
+            nextKey = &encoder.HeadKeys.front();
+        } else if (isCompactionZone) {
+            nextKey = getFwzFirstKey();
+        }
+
+        if (!canDrop(firstKey, nextKey, isLastBlob)) {
             break;
         }
 
-        if (!isLastBlob) {
-            const auto& nextKey = encoder.DataKeysBody[1];
+        if (nextKey) {
             encoder.pop_front();
 
-            if (isCompactionZone && !GapOffsets.empty() && nextKey.Key.GetOffset() == GapOffsets.front().second) {
+            if (isCompactionZone && !GapOffsets.empty() && nextKey->Key.GetOffset() == GapOffsets.front().second) {
                 GapSize -= GapOffsets.front().second - GapOffsets.front().first;
                 GapOffsets.pop_front();
             }
         } else {
             encoder.pop_front();
-            if (isCompactionZone) {
-                GapOffsets.clear();
-                GapSize = 0;
-            }
-            FinalizeEmptyBlobEncoder(encoder, partitionEndOffset, !isCompactionZone);
         }
 
         hasDrop = true;
+        finalizeIfEmpty();
 
         if (isLastBlob) {
             break;
         }
     }
 
-    if (hasDrop && !encoder.DataKeysBody.empty()) {
-        const auto& lastKey = encoder.DataKeysBody.front().Key;
-        encoder.StartOffset = lastKey.GetOffset();
-        if (lastKey.GetPartNo() > 0) {
-            ++encoder.StartOffset;
+    while (encoder.DataKeysBody.empty() && !encoder.HeadKeys.empty()) {
+        const auto& firstKey = encoder.HeadKeys.front();
+        const bool hasMoreInEncoder = encoder.HeadKeys.size() > 1;
+        const bool isLastBlob = isLastBlobInPartition(hasMoreInEncoder);
+        const TDataKey* nextKey = nullptr;
+        if (encoder.HeadKeys.size() > 1) {
+            nextKey = &encoder.HeadKeys[1];
+        } else if (isCompactionZone) {
+            nextKey = getFwzFirstKey();
         }
+
+        if (!canDrop(firstKey, nextKey, isLastBlob)) {
+            break;
+        }
+
+        popFrontHead();
+        hasDrop = true;
+        finalizeIfEmpty();
+
+        if (isLastBlob) {
+            break;
+        }
+    }
+
+    if (hasDrop) {
+        updateStartOffsetFromFront();
     }
 
     return hasDrop;
@@ -772,8 +854,10 @@ bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorCont
 
     bool hasDrop = CleanUpBlobsInEncoder(CompactionBlobEncoder, true, ctx);
 
-    if (CompactionBlobEncoder.DataKeysBody.empty()) {
-        const ui64 compactionZoneEnd = BlobEncoder.DataKeysBody.empty() ? GetEndOffset() : BlobEncoder.StartOffset;
+    if (CompactionBlobEncoder.DataKeysBody.empty() && CompactionBlobEncoder.HeadKeys.empty()) {
+        const ui64 compactionZoneEnd = BlobEncoder.DataKeysBody.empty() && BlobEncoder.HeadKeys.empty()
+            ? GetEndOffset()
+            : BlobEncoder.StartOffset;
         CompactionBlobEncoder.StartOffset = compactionZoneEnd;
         CompactionBlobEncoder.EndOffset = compactionZoneEnd;
         CompactionBlobEncoder.Head.Offset = compactionZoneEnd;
@@ -781,7 +865,8 @@ bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorCont
         hasDrop |= CleanUpBlobsInEncoder(BlobEncoder, false, ctx);
     }
 
-    if (CompactionBlobEncoder.DataKeysBody.empty() && BlobEncoder.DataKeysBody.empty()) {
+    if (CompactionBlobEncoder.DataKeysBody.empty() && CompactionBlobEncoder.HeadKeys.empty()
+        && BlobEncoder.DataKeysBody.empty() && BlobEncoder.HeadKeys.empty()) {
         const ui64 endOffset = GetEndOffset();
         CompactionBlobEncoder.StartOffset = endOffset;
         CompactionBlobEncoder.EndOffset = endOffset;

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -558,16 +558,12 @@ bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCo
         if (!encoder.DataKeysBody.empty()) {
             updateStartOffsetFromKey(encoder.DataKeysBody.front().Key);
         } else if (!encoder.HeadKeys.empty()) {
-            const auto& key = encoder.HeadKeys.front().Key;
-            updateStartOffsetFromKey(key);
-            encoder.Head.Offset = key.GetOffset();
-            encoder.Head.PartNo = key.GetPartNo();
+            updateStartOffsetFromKey(encoder.HeadKeys.front().Key);
         }
     };
 
     auto popFrontHead = [&]() {
-        encoder.ScheduleDelete(encoder.HeadKeys.front());
-        encoder.HeadKeys.pop_front();
+        encoder.PopFrontHeadKey();
     };
 
     auto canDrop = [&](const TDataKey& firstKey, const TDataKey* nextKey, bool isLastBlob) {

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -781,6 +781,21 @@ bool TPartition::CleanUp(TEvKeyValue::TEvRequest* request, const TActorContext& 
     return haveChanges;
 }
 
+ui64 TPartition::GetCompactionZoneEmptyStartOffset() const {
+    if (!CompactionBlobEncoder.HeadKeys.empty()) {
+        const auto& key = CompactionBlobEncoder.HeadKeys.front().Key;
+        return key.GetOffset() + (key.GetPartNo() > 0 ? 1 : 0);
+    }
+    if (!BlobEncoder.DataKeysBody.empty()) {
+        return BlobEncoder.StartOffset;
+    }
+    if (!BlobEncoder.HeadKeys.empty()) {
+        const auto& key = BlobEncoder.HeadKeys.front().Key;
+        return key.GetOffset() + (key.GetPartNo() > 0 ? 1 : 0);
+    }
+    return GetEndOffset();
+}
+
 bool TPartition::CleanUpBlobsLegacy(TEvKeyValue::TEvRequest *request, const TActorContext& ctx) {
     if (GetStartOffset() == GetEndOffset() || CompactionBlobEncoder.DataKeysBody.size() <= 1) {
         return false;
@@ -855,12 +870,11 @@ bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorCont
     bool hasDrop = CleanUpBlobsInEncoder(CompactionBlobEncoder, true, ctx);
 
     if (CompactionBlobEncoder.DataKeysBody.empty() && CompactionBlobEncoder.HeadKeys.empty()) {
-        const ui64 compactionZoneEnd = BlobEncoder.DataKeysBody.empty() && BlobEncoder.HeadKeys.empty()
-            ? GetEndOffset()
-            : BlobEncoder.StartOffset;
+        const ui64 compactionZoneEnd = GetCompactionZoneEmptyStartOffset();
         CompactionBlobEncoder.StartOffset = compactionZoneEnd;
         CompactionBlobEncoder.EndOffset = compactionZoneEnd;
         CompactionBlobEncoder.Head.Offset = compactionZoneEnd;
+        CompactionBlobEncoder.Head.PartNo = 0;
 
         hasDrop |= CleanUpBlobsInEncoder(BlobEncoder, false, ctx);
     }
@@ -871,6 +885,7 @@ bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorCont
         CompactionBlobEncoder.StartOffset = endOffset;
         CompactionBlobEncoder.EndOffset = endOffset;
         CompactionBlobEncoder.Head.Offset = endOffset;
+        CompactionBlobEncoder.Head.PartNo = 0;
         BlobEncoder.StartOffset = endOffset;
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -619,15 +619,12 @@ bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCo
             break;
         }
 
-        if (nextKey) {
-            encoder.pop_front();
+        encoder.pop_front();
 
-            if (isCompactionZone && !GapOffsets.empty() && nextKey->Key.GetOffset() == GapOffsets.front().second) {
-                GapSize -= GapOffsets.front().second - GapOffsets.front().first;
-                GapOffsets.pop_front();
-            }
-        } else {
-            encoder.pop_front();
+        if (isCompactionZone && nextKey && !GapOffsets.empty()
+            && nextKey->Key.GetOffset() == GapOffsets.front().second) {
+            GapSize -= GapOffsets.front().second - GapOffsets.front().first;
+            GapOffsets.pop_front();
         }
 
         hasDrop = true;

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -495,10 +495,13 @@ void TPartition::FinalizeEmptyBlobEncoder(TPartitionBlobEncoder& encoder, ui64 s
     encoder.BodySize = 0;
     encoder.Head.Clear();
     encoder.Head.PartNo = 0;
+    encoder.NewHead.Clear();
+    encoder.NewHeadKey = TDataKey{TKey{}, 0, TInstant::Zero(), 0};
     encoder.StartOffset = startOffset;
     if (updateEndOffset) {
         encoder.EndOffset = startOffset;
         encoder.Head.Offset = startOffset;
+        encoder.NewHead.Offset = startOffset;
     }
     for (ui32 i = 0; i < TotalLevels; ++i) {
         encoder.DataKeysHead[i].Clear();

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -638,7 +638,9 @@ void TPartition::HandleWakeup(const TActorContext& ctx) {
 
     AutopartitioningManager->CleanUp();
 
-    ProcessTxsAndUserActs(ctx);
+    if (AppData()->FeatureFlags.GetEnableTopicRetentionDeleteLastBlob()) {
+        ProcessTxsAndUserActs(ctx);
+    }
 }
 
 void TPartition::AddMetaKey(TEvKeyValue::TEvRequest* request) {
@@ -694,7 +696,72 @@ bool TPartition::CleanUp(TEvKeyValue::TEvRequest* request, const TActorContext& 
     return haveChanges;
 }
 
+bool TPartition::CleanUpBlobsLegacy(TEvKeyValue::TEvRequest *request, const TActorContext& ctx) {
+    if (GetStartOffset() == GetEndOffset() || CompactionBlobEncoder.DataKeysBody.size() <= 1) {
+        return false;
+    }
+    if (Config.GetEnableCompactification()) {
+        return false;
+    }
+    const auto& partConfig = Config.GetPartitionConfig();
+
+    const TDuration lifetimeLimit{TDuration::Seconds(partConfig.GetLifetimeSeconds())};
+
+    const bool hasStorageLimit = partConfig.HasStorageLimitBytes();
+    const auto now = ctx.Now();
+
+    bool hasDrop = false;
+    while (CompactionBlobEncoder.DataKeysBody.size() > 1) {
+        const auto& nextKey = CompactionBlobEncoder.DataKeysBody[1];
+        const auto& firstKey = CompactionBlobEncoder.DataKeysBody.front();
+        if (ImportantConsumersNeedToKeepCurrentKey(firstKey, nextKey, now)) {
+            break;
+        }
+
+        if (hasStorageLimit) {
+            const auto bodySize = CompactionBlobEncoder.BodySize - firstKey.Size;
+            if (bodySize < partConfig.GetStorageLimitBytes()) {
+                break;
+            }
+        } else {
+            if (now < firstKey.Timestamp + lifetimeLimit) {
+                break;
+            }
+        }
+
+        CompactionBlobEncoder.pop_front();
+
+        if (!GapOffsets.empty() && nextKey.Key.GetOffset() == GapOffsets.front().second) {
+            GapSize -= GapOffsets.front().second - GapOffsets.front().first;
+            GapOffsets.pop_front();
+        }
+
+        hasDrop = true;
+    }
+
+    PQ_ENSURE(!CompactionBlobEncoder.DataKeysBody.empty());
+
+    if (!hasDrop) {
+        return false;
+    }
+
+    const auto& lastKey = CompactionBlobEncoder.DataKeysBody.front().Key;
+
+    CompactionBlobEncoder.StartOffset = lastKey.GetOffset();
+    if (lastKey.GetPartNo() > 0) {
+        ++CompactionBlobEncoder.StartOffset;
+    }
+
+    Y_UNUSED(request);
+
+    return true;
+}
+
 bool TPartition::CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorContext& ctx) {
+    if (!AppData()->FeatureFlags.GetEnableTopicRetentionDeleteLastBlob()) {
+        return CleanUpBlobsLegacy(request, ctx);
+    }
+
     Y_UNUSED(request);
     if (Config.GetEnableCompactification()) {
         return false;

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -341,6 +341,9 @@ private:
     bool CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorContext& ctx);
     // Checks if any consumer has uncommited messages in their availability window
     bool ImportantConsumersNeedToKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const;
+    bool ImportantConsumersNeedToKeepLastKey(const TDataKey& currentKey, const TInstant now) const;
+    bool CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCompactionZone, const TActorContext& ctx);
+    void FinalizeEmptyBlobEncoder(TPartitionBlobEncoder& encoder, ui64 startOffset, bool updateEndOffset);
     bool IsQuotingEnabled() const;
     bool WaitingForPreviousBlobQuota() const;
     bool WaitingForSubDomainQuota(const ui64 withSize = 0) const;

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -339,6 +339,7 @@ private:
     // Removes blobs that are no longer required. Blobs are no longer required if the storage time of all messages
     // stored in this blob has expired and they have been read by all important consumers.
     bool CleanUpBlobs(TEvKeyValue::TEvRequest *request, const TActorContext& ctx);
+    bool CleanUpBlobsLegacy(TEvKeyValue::TEvRequest *request, const TActorContext& ctx);
     // Checks if any consumer has uncommited messages in their availability window
     bool ImportantConsumersNeedToKeepCurrentKey(const TDataKey& currentKey, const TDataKey& nextKey, const TInstant now) const;
     bool ImportantConsumersNeedToKeepLastKey(const TDataKey& currentKey, const TInstant now) const;
@@ -582,6 +583,9 @@ public:
     ui64 UsedReserveSize(const TActorContext& ctx) const;
 
     TInstant GetEndWriteTimestamp() const; // For tests only
+    bool IsTopicRetentionDeleteLastBlobEnabled() const {
+        return AppData()->FeatureFlags.GetEnableTopicRetentionDeleteLastBlob();
+    }
 
     //Bootstrap sends kvRead
     //Become StateInit

--- a/ydb/core/persqueue/pqtablet/partition/partition.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition.h
@@ -345,6 +345,7 @@ private:
     bool ImportantConsumersNeedToKeepLastKey(const TDataKey& currentKey, const TInstant now) const;
     bool CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCompactionZone, const TActorContext& ctx);
     void FinalizeEmptyBlobEncoder(TPartitionBlobEncoder& encoder, ui64 startOffset, bool updateEndOffset);
+    ui64 GetCompactionZoneEmptyStartOffset() const;
     bool IsQuotingEnabled() const;
     bool WaitingForPreviousBlobQuota() const;
     bool WaitingForSubDomainQuota(const ui64 withSize = 0) const;

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -660,6 +660,43 @@ void TPartitionBlobEncoder::pop_front() {
     DataKeysBody.pop_front();
 }
 
+void TPartitionBlobEncoder::PopFrontHeadKey() {
+    AFL_ENSURE(!HeadKeys.empty());
+
+    const TDataKey deletedKey = HeadKeys.front();
+    ScheduleDelete(HeadKeys.front());
+    HeadKeys.pop_front();
+
+    for (auto& level : DataKeysHead) {
+        if (level.KeysCount() > 0) {
+            AFL_ENSURE(level.GetKey(0) == deletedKey.Key);
+            level.PopFront();
+            break;
+        }
+    }
+
+    AFL_ENSURE(Head.PackedSize >= deletedKey.Size);
+    Head.PackedSize -= deletedKey.Size;
+
+    if (HeadKeys.empty()) {
+        Head.Clear();
+        return;
+    }
+
+    const auto& frontKey = HeadKeys.front().Key;
+    Head.Offset = frontKey.GetOffset();
+    Head.PartNo = frontKey.GetPartNo();
+
+    while (!Head.GetBatches().empty()) {
+        const auto& batch = Head.GetBatch(0);
+        if (batch.GetOffset() > frontKey.GetOffset() ||
+            (batch.GetOffset() == frontKey.GetOffset() && batch.GetPartNo() >= frontKey.GetPartNo())) {
+            break;
+        }
+        Head.ExtractFirstBatch();
+    }
+}
+
 void TPartitionBlobEncoder::ScheduleDelete(TDataKey& key) {
     if (key.BlobKeyToken->NeedDelete) {
         DeletedKeys.emplace_back(key.BlobKeyToken);

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h
@@ -104,6 +104,7 @@ struct TPartitionBlobEncoder {
     ui64 FirstUncompactedOffset = 0;
 
     void pop_front();
+    void PopFrontHeadKey();
     void ScheduleDelete(TDataKey& key);
 
     struct TDeletedKey {

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -746,10 +746,17 @@ void TPartitionCompaction::TCompactState::UpdateDataKeysBody() {
     Y_ENSURE(PartitionActor->CompactionBlobEncoder.DataKeysBody.size() == oldDataKeys.size() - zeroedKeys);
     Y_ENSURE(currCumulSize == PartitionActor->CompactionBlobEncoder.BodySize - sizeDiff);
     PartitionActor->CompactionBlobEncoder.BodySize = currCumulSize;
-    PartitionActor->CompactionBlobEncoder.StartOffset = Max(
-                    PartitionActor->CompactionBlobEncoder.StartOffset,
-                    PartitionActor->CompactionBlobEncoder.DataKeysBody.front().Key.GetOffset()
-                        + (ui32)(PartitionActor->CompactionBlobEncoder.DataKeysBody.front().Key.GetPartNo() > 0));
+    if (PartitionActor->CompactionBlobEncoder.DataKeysBody.empty()) {
+        const ui64 endOffset = PartitionActor->GetEndOffset();
+        PartitionActor->CompactionBlobEncoder.StartOffset = endOffset;
+        PartitionActor->CompactionBlobEncoder.EndOffset = endOffset;
+        PartitionActor->CompactionBlobEncoder.Head.Offset = endOffset;
+    } else {
+        PartitionActor->CompactionBlobEncoder.StartOffset = Max(
+                        PartitionActor->CompactionBlobEncoder.StartOffset,
+                        PartitionActor->CompactionBlobEncoder.DataKeysBody.front().Key.GetOffset()
+                            + (ui32)(PartitionActor->CompactionBlobEncoder.DataKeysBody.front().Key.GetPartNo() > 0));
+    }
 
     UpdatedKeys.clear();
     DeletedKeys.clear();

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -748,10 +748,11 @@ void TPartitionCompaction::TCompactState::UpdateDataKeysBody() {
     PartitionActor->CompactionBlobEncoder.BodySize = currCumulSize;
     if (PartitionActor->IsTopicRetentionDeleteLastBlobEnabled()) {
         if (PartitionActor->CompactionBlobEncoder.DataKeysBody.empty()) {
-            const ui64 endOffset = PartitionActor->GetEndOffset();
-            PartitionActor->CompactionBlobEncoder.StartOffset = endOffset;
-            PartitionActor->CompactionBlobEncoder.EndOffset = endOffset;
-            PartitionActor->CompactionBlobEncoder.Head.Offset = endOffset;
+            const ui64 startOffset = FirstHeadOffset + (FirstHeadPartNo > 0 ? 1 : 0);
+            PartitionActor->CompactionBlobEncoder.StartOffset = startOffset;
+            PartitionActor->CompactionBlobEncoder.EndOffset = startOffset;
+            PartitionActor->CompactionBlobEncoder.Head.Offset = startOffset;
+            PartitionActor->CompactionBlobEncoder.Head.PartNo = 0;
         } else {
             PartitionActor->CompactionBlobEncoder.StartOffset = Max(
                             PartitionActor->CompactionBlobEncoder.StartOffset,

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -746,11 +746,18 @@ void TPartitionCompaction::TCompactState::UpdateDataKeysBody() {
     Y_ENSURE(PartitionActor->CompactionBlobEncoder.DataKeysBody.size() == oldDataKeys.size() - zeroedKeys);
     Y_ENSURE(currCumulSize == PartitionActor->CompactionBlobEncoder.BodySize - sizeDiff);
     PartitionActor->CompactionBlobEncoder.BodySize = currCumulSize;
-    if (PartitionActor->CompactionBlobEncoder.DataKeysBody.empty()) {
-        const ui64 endOffset = PartitionActor->GetEndOffset();
-        PartitionActor->CompactionBlobEncoder.StartOffset = endOffset;
-        PartitionActor->CompactionBlobEncoder.EndOffset = endOffset;
-        PartitionActor->CompactionBlobEncoder.Head.Offset = endOffset;
+    if (PartitionActor->IsTopicRetentionDeleteLastBlobEnabled()) {
+        if (PartitionActor->CompactionBlobEncoder.DataKeysBody.empty()) {
+            const ui64 endOffset = PartitionActor->GetEndOffset();
+            PartitionActor->CompactionBlobEncoder.StartOffset = endOffset;
+            PartitionActor->CompactionBlobEncoder.EndOffset = endOffset;
+            PartitionActor->CompactionBlobEncoder.Head.Offset = endOffset;
+        } else {
+            PartitionActor->CompactionBlobEncoder.StartOffset = Max(
+                            PartitionActor->CompactionBlobEncoder.StartOffset,
+                            PartitionActor->CompactionBlobEncoder.DataKeysBody.front().Key.GetOffset()
+                                + (ui32)(PartitionActor->CompactionBlobEncoder.DataKeysBody.front().Key.GetPartNo() > 0));
+        }
     } else {
         PartitionActor->CompactionBlobEncoder.StartOffset = Max(
                         PartitionActor->CompactionBlobEncoder.StartOffset,

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -321,6 +321,14 @@ void TInitMetaStep::LoadMeta(const NKikimrClient::TResponse& kvResponse) {
         Partition()->BlobEncoder.EndOffset = meta.GetEndOffset();
         Partition()->BlobEncoder.FirstUncompactedOffset = meta.GetFirstUncompactedOffset();
 
+        if (meta.HasStartOffset()) {
+            Partition()->CompactionBlobEncoder.StartOffset = meta.GetStartOffset();
+        }
+        if (meta.HasEndOffset()) {
+            Partition()->CompactionBlobEncoder.EndOffset = meta.GetEndOffset();
+            Partition()->CompactionBlobEncoder.Head.Offset = meta.GetEndOffset();
+        }
+
         if (Partition()->BlobEncoder.StartOffset == Partition()->BlobEncoder.EndOffset) {
            Partition()->BlobEncoder.NewHead.Offset = Partition()->BlobEncoder.Head.Offset = Partition()->BlobEncoder.EndOffset;
         }

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -146,6 +146,8 @@ protected:
         TMaybe<size_t> Count;
         TMaybe<ui64> PlanStep;
         TMaybe<ui64> TxId;
+        TMaybe<ui64> MetaStartOffset;
+        TMaybe<ui64> MetaEndOffset;
         THashMap<size_t, TUserInfoMatcher> UserInfos;
         THashMap<size_t, TDeleteRangeMatcher> DeleteRanges;
     };
@@ -573,12 +575,27 @@ void TPartitionFixture::WaitCmdWrite(const TCmdWriteMatcher& matcher)
     auto event = Ctx->Runtime->GrabEdgeEvent<TEvKeyValue::TEvRequest>();
     UNIT_ASSERT(event != nullptr);
     Cerr << "Got cmd write: \n" << event->Record.DebugString() << Endl;
+    bool metaFound = false;
     for (unsigned i = 0; i < event->Record.CmdWriteSize(); ++i) {
         auto& cmd = event->Record.GetCmdWrite(i);
         TString key = cmd.GetKey();
 
         UNIT_ASSERT(key.size() >= 1);
         switch (key[0]) {
+        case TKeyPrefix::TypeMeta: {
+            NKikimrPQ::TPartitionMeta meta;
+            UNIT_ASSERT(meta.ParseFromString(cmd.GetValue()));
+            if (matcher.MetaStartOffset.Defined()) {
+                UNIT_ASSERT(meta.HasStartOffset());
+                UNIT_ASSERT_VALUES_EQUAL(*matcher.MetaStartOffset, meta.GetStartOffset());
+            }
+            if (matcher.MetaEndOffset.Defined()) {
+                UNIT_ASSERT(meta.HasEndOffset());
+                UNIT_ASSERT_VALUES_EQUAL(*matcher.MetaEndOffset, meta.GetEndOffset());
+            }
+            metaFound = true;
+            break;
+        }
         case TKeyPrefix::TypeTxMeta: {
             NKikimrPQ::TPartitionTxMeta meta;
             UNIT_ASSERT(meta.ParseFromString(event->Record.GetCmdWrite(i).GetValue()));
@@ -657,6 +674,10 @@ void TPartitionFixture::WaitCmdWrite(const TCmdWriteMatcher& matcher)
             TString consumer = key.substr(12);
             UNIT_ASSERT_VALUES_EQUAL(*deleteRange.Consumer, consumer);
         }
+    }
+
+    if (matcher.MetaStartOffset.Defined() || matcher.MetaEndOffset.Defined()) {
+        UNIT_ASSERT(metaFound);
     }
 }
 

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -4785,7 +4785,8 @@ void AddHeadKeyWithBatch(
     const TPartitionId& partitionId,
     ui64 offset,
     char fill,
-    ui64 seqNo)
+    ui64 seqNo,
+    ui32 levelIndex = 0)
 {
     std::deque<TClientBlob> dq;
     dq.push_back(MakeSinglePartBodyReadBlob(seqNo, fill));
@@ -4795,10 +4796,12 @@ void AddHeadKeyWithBatch(
 
     const TKey key = TKey::ForHead(TKeyPrefix::TypeData, partitionId, offset, 0, 1, 0);
 
-    if (encoder.DataKeysHead.empty()) {
-        encoder.DataKeysHead.emplace_back(levelBorder);
+    if (encoder.DataKeysHead.size() <= levelIndex) {
+        while (encoder.DataKeysHead.size() <= levelIndex) {
+            encoder.DataKeysHead.emplace_back(levelBorder);
+        }
     }
-    encoder.DataKeysHead[0].AddKey(key, blobSize);
+    encoder.DataKeysHead[levelIndex].AddKey(key, blobSize);
     encoder.HeadKeys.push_back(TDataKey{key, blobSize, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
     encoder.Head.AddBatch(batch);
 }
@@ -4807,8 +4810,8 @@ Y_UNIT_TEST(PopFrontHeadKeySyncsHeadWithRemainingHeadKeys) {
     const TPartitionId partitionId(1);
     TPartitionBlobEncoder encoder(partitionId, false);
 
-    AddHeadKeyWithBatch(encoder, 8_MB, partitionId, 10, 'a', 1);
-    AddHeadKeyWithBatch(encoder, 8_MB, partitionId, 11, 'b', 2);
+    AddHeadKeyWithBatch(encoder, 8_MB, partitionId, 10, 'a', 1, 0);
+    AddHeadKeyWithBatch(encoder, 8_MB, partitionId, 11, 'b', 2, 0);
 
     encoder.Head.Offset = 10;
     encoder.Head.PartNo = 0;

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -4956,6 +4956,43 @@ Y_UNIT_TEST_F(FinalizeEmptyBlobEncoderResetsHeadPartNo, TPartitionFixture) {
     UNIT_ASSERT_VALUES_EQUAL(encoder.Head.Offset, 100u);
 }
 
+Y_UNIT_TEST_F(FinalizeEmptyBlobEncoderClearsNewHead, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    const TPartitionId partitionId(1);
+    auto& encoder = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    while (encoder.DataKeysHead.size() < 4) {
+        encoder.DataKeysHead.emplace_back(8_MB);
+    }
+
+    std::deque<TClientBlob> dq;
+    dq.push_back(MakeSinglePartBodyReadBlob(1, 'n'));
+    TBatch newHeadBatch = TBatch::FromBlobs(50, std::move(dq));
+    newHeadBatch.Pack();
+    const ui32 newHeadBatchSize = newHeadBatch.GetPackedSize();
+
+    encoder.NewHead.Offset = 50;
+    encoder.NewHead.PartNo = 1;
+    encoder.NewHead.PackedSize = newHeadBatchSize;
+    encoder.NewHead.AddBatch(newHeadBatch);
+
+    const TKey newHeadKey = TKey::ForHead(TKeyPrefix::TypeData, partitionId, 50, 1, 1, 0);
+    encoder.NewHeadKey = TDataKey{newHeadKey, newHeadBatchSize, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()};
+
+    UNIT_ASSERT(!encoder.NewHead.GetBatches().empty());
+    UNIT_ASSERT_VALUES_UNEQUAL(encoder.NewHeadKey.Size, 0u);
+
+    TPartitionTestWrapper::FinalizeEmptyBlobEncoder(*partition, encoder, 100, true);
+
+    UNIT_ASSERT(encoder.NewHead.GetBatches().empty());
+    UNIT_ASSERT_VALUES_EQUAL(encoder.NewHead.PackedSize, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.NewHead.PartNo, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.NewHead.Offset, 100u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.NewHeadKey.Size, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.NewHeadKey.Key.GetOffset(), 0u);
+}
+
 Y_UNIT_TEST_F(CleanUpBlobsResetsStaleCompactionZoneHeadPartNo, TPartitionFixture) {
     UNIT_ASSERT(Ctx.Defined());
     Ctx->Runtime->GetAppData(0).FeatureFlags.SetEnableTopicRetentionDeleteLastBlob(true);

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -91,6 +91,17 @@ public:
         return partition.BlobEncoder;
     }
 
+    static void FinalizeEmptyBlobEncoder(TPartition& partition,
+                                         TPartitionBlobEncoder& encoder,
+                                         ui64 startOffset,
+                                         bool updateEndOffset) {
+        partition.FinalizeEmptyBlobEncoder(encoder, startOffset, updateEndOffset);
+    }
+
+    static bool CleanUpBlobs(TPartition& partition, const TActorContext& ctx) {
+        return partition.CleanUpBlobs(nullptr, ctx);
+    }
+
 private:
     TInitMetaStep* MetaStep;
 };
@@ -4905,6 +4916,75 @@ Y_UNIT_TEST_F(GetCompactionZoneEmptyStartOffsetPrefersCzhHead, TPartitionFixture
     TPartitionTestWrapper::BlobEncoder(*partition).EndOffset = 202;
 
     UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetCompactionZoneEmptyStartOffset(*partition), 5u);
+}
+
+class TPartitionMethodTestActor : public TActorBootstrapped<TPartitionMethodTestActor> {
+public:
+    TPartitionMethodTestActor(TActorId edge, std::function<void(const TActorContext&)> body)
+        : Edge(edge)
+        , Body(std::move(body))
+    {}
+
+    void Bootstrap(const TActorContext& ctx) {
+        Body(ctx);
+        Send(Edge, new NActors::TEvents::TEvWakeup());
+        PassAway();
+    }
+
+private:
+    TActorId Edge;
+    std::function<void(const TActorContext&)> Body;
+};
+
+Y_UNIT_TEST_F(FinalizeEmptyBlobEncoderResetsHeadPartNo, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    const TPartitionId partitionId(1);
+    auto& encoder = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    while (encoder.DataKeysHead.size() < 4) {
+        encoder.DataKeysHead.emplace_back(8_MB);
+    }
+    AddHeadKeyWithPartNo(encoder, 8_MB, partitionId, 4, 2, 'h', 1);
+    encoder.Head.PartNo = 2;
+
+    TPartitionTestWrapper::FinalizeEmptyBlobEncoder(*partition, encoder, 100, true);
+
+    UNIT_ASSERT(encoder.HeadKeys.empty());
+    UNIT_ASSERT(encoder.Head.GetBatches().empty());
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.PartNo, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.Offset, 100u);
+}
+
+Y_UNIT_TEST_F(CleanUpBlobsResetsStaleCompactionZoneHeadPartNo, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    Ctx->Runtime->GetAppData(0).FeatureFlags.SetEnableTopicRetentionDeleteLastBlob(true);
+
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    auto& czEncoder = TPartitionTestWrapper::CompactionBlobEncoder(*partition);
+    czEncoder.DataKeysBody.clear();
+    czEncoder.HeadKeys.clear();
+    czEncoder.Head.Clear();
+    czEncoder.Head.Offset = 200;
+    czEncoder.Head.PartNo = 2;
+
+    auto& fwzEncoder = TPartitionTestWrapper::BlobEncoder(*partition);
+    fwzEncoder.StartOffset = 200;
+    fwzEncoder.EndOffset = 202;
+
+    auto probe = [&](const TActorContext& ctx) {
+        TPartitionTestWrapper::CleanUpBlobs(*partition, ctx);
+        UNIT_ASSERT_VALUES_EQUAL(czEncoder.Head.PartNo, 0u);
+    };
+
+    Ctx->Runtime->Register(new TPartitionMethodTestActor(Ctx->Edge, std::move(probe)));
+
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+    Ctx->Runtime->DispatchEvents(options);
 }
 
 Y_UNIT_TEST(PopFrontHeadKeySyncsHeadWithRemainingHeadKeys) {

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -1,8 +1,10 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/keyvalue/keyvalue_events.h>
-#include <ydb/core/persqueue/common/key.h>
+#include <ydb/core/persqueue/common/blob_refcounter.h>
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/persqueue/pqtablet/partition/partition.h>
+#include <ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.h>
+#include <ydb/core/persqueue/pqtablet/partition/partition_util.h>
 #include <ydb/core/persqueue/pqtablet/partition/blob_key_filter.h>
 #include <ydb/core/persqueue/ut/common/pq_ut_common.h>
 #include <ydb/core/protos/counters_keyvalue.pb.h>
@@ -28,6 +30,7 @@
 
 #include <deque>
 #include <functional>
+#include <memory>
 
 template<>
 void Out<NKikimrPQ::TEvProposeTransactionResult_EStatus>(IOutputStream& out, NKikimrPQ::TEvProposeTransactionResult_EStatus v) {
@@ -4768,6 +4771,66 @@ Y_UNIT_TEST_F(AddBlobsFromBodyLastOffsetAndUpdateUsageSkips, TPartitionFixture) 
         return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
     });
     Ctx->Runtime->DispatchEvents(options);
+}
+
+TBlobKeyTokenPtr MakeTestBlobKeyToken() {
+    auto token = std::make_shared<TBlobKeyToken>();
+    token->NeedDelete = false;
+    return token;
+}
+
+void AddHeadKeyWithBatch(
+    TPartitionBlobEncoder& encoder,
+    ui32 levelBorder,
+    const TPartitionId& partitionId,
+    ui64 offset,
+    char fill,
+    ui64 seqNo)
+{
+    std::deque<TClientBlob> dq;
+    dq.push_back(MakeSinglePartBodyReadBlob(seqNo, fill));
+    TBatch batch = TBatch::FromBlobs(offset, std::move(dq));
+    batch.Pack();
+    const ui32 blobSize = batch.GetPackedSize();
+
+    const TKey key = TKey::ForHead(TKeyPrefix::TypeData, partitionId, offset, 0, 1, 0);
+
+    if (encoder.DataKeysHead.empty()) {
+        encoder.DataKeysHead.emplace_back(levelBorder);
+    }
+    encoder.DataKeysHead[0].AddKey(key, blobSize);
+    encoder.HeadKeys.push_back(TDataKey{key, blobSize, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
+    encoder.Head.AddBatch(batch);
+}
+
+Y_UNIT_TEST(PopFrontHeadKeySyncsHeadWithRemainingHeadKeys) {
+    const TPartitionId partitionId(1);
+    TPartitionBlobEncoder encoder(partitionId, false);
+
+    AddHeadKeyWithBatch(encoder, 8_MB, partitionId, 10, 'a', 1);
+    AddHeadKeyWithBatch(encoder, 8_MB, partitionId, 11, 'b', 2);
+
+    encoder.Head.Offset = 10;
+    encoder.Head.PartNo = 0;
+    encoder.Head.PackedSize = encoder.HeadKeys[0].Size + encoder.HeadKeys[1].Size;
+
+    UNIT_ASSERT_VALUES_EQUAL(encoder.HeadKeys.size(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.GetBatches().size(), 2u);
+
+    encoder.PopFrontHeadKey();
+
+    UNIT_ASSERT_VALUES_EQUAL(encoder.HeadKeys.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.HeadKeys.front().Key.GetOffset(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.Offset, 11u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.PartNo, 0u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.GetBatches().size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.GetBatch(0).GetOffset(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL(encoder.Head.PackedSize, encoder.HeadKeys.front().Size);
+
+    TVector<TClientBlob> remaining;
+    encoder.Head.GetBatch(0).UnpackTo(&remaining);
+    UNIT_ASSERT_VALUES_EQUAL(remaining.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(remaining[0].Data[0], 'b');
 }
 
 } // End of suite

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -78,6 +78,19 @@ public:
     {}
 
     void LoadMeta(const NKikimrPQ::TPartitionCounterData& data);
+
+    static ui64 GetCompactionZoneEmptyStartOffset(TPartition& partition) {
+        return partition.GetCompactionZoneEmptyStartOffset();
+    }
+
+    static TPartitionBlobEncoder& CompactionBlobEncoder(TPartition& partition) {
+        return partition.CompactionBlobEncoder;
+    }
+
+    static TPartitionBlobEncoder& BlobEncoder(TPartition& partition) {
+        return partition.BlobEncoder;
+    }
+
 private:
     TInitMetaStep* MetaStep;
 };
@@ -4804,6 +4817,94 @@ void AddHeadKeyWithBatch(
     encoder.DataKeysHead[levelIndex].AddKey(key, blobSize);
     encoder.HeadKeys.push_back(TDataKey{key, blobSize, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
     encoder.Head.AddBatch(batch);
+}
+
+void AddBodyKeyToEncoder(
+    TPartitionBlobEncoder& encoder,
+    const TPartitionId& partitionId,
+    ui64 offset,
+    ui32 size)
+{
+    const TKey key = TKey::ForBody(TKeyPrefix::TypeData, partitionId, offset, 0, 1, 0);
+    encoder.DataKeysBody.push_back(TDataKey{key, size, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
+    encoder.BodySize += size;
+}
+
+void AddHeadKeyWithPartNo(
+    TPartitionBlobEncoder& encoder,
+    ui32 levelBorder,
+    const TPartitionId& partitionId,
+    ui64 offset,
+    ui16 partNo,
+    char fill,
+    ui64 seqNo,
+    ui32 levelIndex = 0)
+{
+    std::deque<TClientBlob> dq;
+    dq.push_back(MakeSinglePartBodyReadBlob(seqNo, fill));
+    TBatch batch = TBatch::FromBlobs(offset, std::move(dq));
+    batch.Pack();
+    const ui32 blobSize = batch.GetPackedSize();
+
+    const TKey key = TKey::ForHead(TKeyPrefix::TypeData, partitionId, offset, partNo, 1, 0);
+
+    if (encoder.DataKeysHead.size() <= levelIndex) {
+        while (encoder.DataKeysHead.size() <= levelIndex) {
+            encoder.DataKeysHead.emplace_back(levelBorder);
+        }
+    }
+    encoder.DataKeysHead[levelIndex].AddKey(key, blobSize);
+    encoder.HeadKeys.push_back(TDataKey{key, blobSize, TInstant::MilliSeconds(1), 0, MakeTestBlobKeyToken()});
+    encoder.Head.AddBatch(batch);
+    encoder.Head.Offset = offset;
+    encoder.Head.PartNo = partNo;
+}
+
+Y_UNIT_TEST_F(GetCompactionZoneEmptyStartOffsetUsesFwzBodyStart, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    const TPartitionId partitionId(1);
+    TPartitionTestWrapper::CompactionBlobEncoder(*partition).DataKeysBody.clear();
+    TPartitionTestWrapper::CompactionBlobEncoder(*partition).HeadKeys.clear();
+
+    AddBodyKeyToEncoder(TPartitionTestWrapper::BlobEncoder(*partition), partitionId, 100, 1000);
+    TPartitionTestWrapper::BlobEncoder(*partition).StartOffset = 100;
+    TPartitionTestWrapper::BlobEncoder(*partition).EndOffset = 202;
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetCompactionZoneEmptyStartOffset(*partition), 100u);
+}
+
+Y_UNIT_TEST_F(GetCompactionZoneEmptyStartOffsetUsesFwzHeadPartNo, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    const TPartitionId partitionId(1);
+    TPartitionTestWrapper::CompactionBlobEncoder(*partition).DataKeysBody.clear();
+    TPartitionTestWrapper::CompactionBlobEncoder(*partition).HeadKeys.clear();
+
+    TPartitionTestWrapper::BlobEncoder(*partition).DataKeysBody.clear();
+    TPartitionTestWrapper::BlobEncoder(*partition).StartOffset = 8;
+    TPartitionTestWrapper::BlobEncoder(*partition).EndOffset = 10;
+
+    AddHeadKeyWithPartNo(TPartitionTestWrapper::BlobEncoder(*partition), 8_MB, partitionId, 8, 2, 'm', 1);
+
+    // Old bug used GetEndOffset()==10; correct boundary is offset + 1 when PartNo > 0.
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetCompactionZoneEmptyStartOffset(*partition), 9u);
+}
+
+Y_UNIT_TEST_F(GetCompactionZoneEmptyStartOffsetPrefersCzhHead, TPartitionFixture) {
+    UNIT_ASSERT(Ctx.Defined());
+    TPartition* partition = CreatePartition({.Partition = TPartitionId{1}, .Begin = 0, .End = 0});
+
+    const TPartitionId partitionId(1);
+    AddHeadKeyWithPartNo(TPartitionTestWrapper::CompactionBlobEncoder(*partition), 8_MB, partitionId, 4, 1, 'h', 1);
+
+    AddBodyKeyToEncoder(TPartitionTestWrapper::BlobEncoder(*partition), partitionId, 100, 1000);
+    TPartitionTestWrapper::BlobEncoder(*partition).StartOffset = 100;
+    TPartitionTestWrapper::BlobEncoder(*partition).EndOffset = 202;
+
+    UNIT_ASSERT_VALUES_EQUAL(TPartitionTestWrapper::GetCompactionZoneEmptyStartOffset(*partition), 5u);
 }
 
 Y_UNIT_TEST(PopFrontHeadKeySyncsHeadWithRemainingHeadKeys) {

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -290,15 +290,22 @@ TMaybe<ui64> PQGetStartOffset(TTestContext& tc)
 
 // TSchedulingLimitReachedException means the scheduled-event budget was exhausted,
 // not that dispatch failed. PQ UT relies on partial progress here (see pq_ut_common.cpp).
-void DispatchWithRetry(TTestContext& tc, i32 retriesLeft = 2) {
+void DispatchUntilWakeup(TTestContext& tc, i32 retriesLeft = 2) {
+    TDispatchOptions options;
+    options.FinalEvents.emplace_back([](IEventHandle& ev) {
+        return ev.GetTypeRewrite() == NActors::TEvents::TEvWakeup::EventType;
+    });
+
     while (retriesLeft-- > 0) {
         tc.Runtime->ResetScheduledCount();
         try {
-            tc.Runtime->DispatchEvents();
+            tc.Runtime->DispatchEvents(options);
             return;
         } catch (const NActors::TSchedulingLimitReachedException&) {
         }
     }
+
+    UNIT_FAIL("DispatchEvents did not complete within retry budget");
 }
 
 bool TryPQGetPartInfo(ui64 expectedStartOffset, ui64 expectedEndOffset, TTestContext& tc) {
@@ -341,13 +348,13 @@ void WaitRetentionCleanup(TTestContext& tc,
     tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
 
     for (ui32 attempt = 0; attempt < maxAttempts; ++attempt) {
-        DispatchWithRetry(tc);
+        DispatchUntilWakeup(tc);
         if (TryPQGetPartInfo(expectedStartOffset, expectedEndOffset, tc)) {
             return;
         }
 
         tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
-        DispatchWithRetry(tc);
+        DispatchUntilWakeup(tc);
         if (TryPQGetPartInfo(expectedStartOffset, expectedEndOffset, tc)) {
             return;
         }

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -40,6 +40,36 @@ void SetEnableTopicRetentionDeleteLastBlob(TTestContext& tc) {
     }
 }
 
+void TestPartitionMetaOffsetsSurviveRestart(TTestContext& tc, bool enableRetentionDeleteLastBlob) {
+    if (enableRetentionDeleteLastBlob) {
+        SetEnableTopicRetentionDeleteLastBlob(tc);
+    }
+    tc.Runtime->SetScheduledLimit(5000);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+
+    // Retention behaviour is covered by *TestRetention*; here we only check meta round-trip.
+    PQTabletPrepare({.deleteTime = 10'000, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    PQGetPartInfo(0, 0, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(7_MB, 'x'));
+    CmdWrite(0, "sourceid_czh_1", data, tc, false, {}, true, "", -1, 100);
+
+    CmdRunCompaction(0, tc);
+
+    data[0].second = TString(1_KB, 'x');
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_2", data, tc, false, {}, true, "", -1, 200);
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_3", data, tc, false, {}, true, "", -1, 201);
+
+    CmdRunCompaction(0, tc);
+    PQGetPartInfo(100, 202, tc);
+
+    PQTabletRestart(tc);
+    PQGetPartInfo(100, 202, tc);
+}
+
 TString MakeKafkaBatchPayload(
     const TVector<TString>& values,
     NKafka::ECompressionType compression = NKafka::ECompressionType::NONE)
@@ -4100,6 +4130,21 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
     PQGetPartInfo(100, 202, tc);
     WaitRetentionCleanup(tc, retentionSeconds);
     PQGetPartInfo(202, 202, tc);
+}
+
+Y_UNIT_TEST(TestPartitionMetaOffsetsSurviveRestartWithoutRetentionFlag) {
+    // AddMetaKey / meta load are not gated by EnableTopicRetentionDeleteLastBlob.
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    TestPartitionMetaOffsetsSurviveRestart(tc, false);
+}
+
+Y_UNIT_TEST(TestPartitionMetaOffsetsSurviveRestartWithRetentionFlag) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    TestPartitionMetaOffsetsSurviveRestart(tc, true);
 }
 
 Y_UNIT_TEST(TestRetentionCrossZoneMessages) {

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -290,7 +290,6 @@ TMaybe<ui64> PQGetStartOffset(TTestContext& tc)
 
 // TSchedulingLimitReachedException means the scheduled-event budget was exhausted,
 // not that dispatch failed. PQ UT relies on partial progress here (see pq_ut_common.cpp).
-// Retention tests assert the outcome via PQGetPartInfo after WaitRetentionCleanup.
 void DispatchWithRetry(TTestContext& tc, i32 retriesLeft = 2) {
     while (retriesLeft-- > 0) {
         tc.Runtime->ResetScheduledCount();
@@ -302,15 +301,59 @@ void DispatchWithRetry(TTestContext& tc, i32 retriesLeft = 2) {
     }
 }
 
-void DispatchPartitionWakeup(TTestContext& tc, ui32 wakeTimeoutSeconds = 5) {
-    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
-    DispatchWithRetry(tc);
+bool TryPQGetPartInfo(ui64 expectedStartOffset, ui64 expectedEndOffset, TTestContext& tc) {
+    TAutoPtr<IEventHandle> handle;
+    TEvPersQueue::TEvOffsetsResponse* result = nullptr;
+    THolder<TEvPersQueue::TEvOffsets> request;
+
+    for (i32 retriesLeft = 3; retriesLeft > 0; --retriesLeft) {
+        try {
+            tc.Runtime->ResetScheduledCount();
+            request.Reset(new TEvPersQueue::TEvOffsets);
+
+            tc.Runtime->SendToPipe(tc.TabletId, tc.Edge, request.Release(), 0, GetPipeConfigWithRetries());
+            result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(handle);
+            if (!result) {
+                return false;
+            }
+
+            if (result->Record.PartResultSize() == 0 ||
+                result->Record.GetPartResult(0).GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                return false;
+            }
+
+            const ui64 startOffset = result->Record.GetPartResult(0).GetStartOffset();
+            const ui64 endOffset = result->Record.GetPartResult(0).GetEndOffset();
+            return startOffset == expectedStartOffset && endOffset == expectedEndOffset;
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+        }
+    }
+
+    return false;
 }
 
-void WaitRetentionCleanup(TTestContext& tc, ui32 retentionSeconds = 5, ui32 wakeTimeoutSeconds = 5) {
+void WaitRetentionCleanup(TTestContext& tc,
+                          ui64 expectedStartOffset,
+                          ui64 expectedEndOffset,
+                          ui32 retentionSeconds = 5,
+                          ui32 wakeTimeoutSeconds = 5,
+                          ui32 maxAttempts = 10) {
     tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
-    DispatchWithRetry(tc);
-    DispatchPartitionWakeup(tc, wakeTimeoutSeconds);
+
+    for (ui32 attempt = 0; attempt < maxAttempts; ++attempt) {
+        DispatchWithRetry(tc);
+        if (TryPQGetPartInfo(expectedStartOffset, expectedEndOffset, tc)) {
+            return;
+        }
+
+        tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
+        DispatchWithRetry(tc);
+        if (TryPQGetPartInfo(expectedStartOffset, expectedEndOffset, tc)) {
+            return;
+        }
+    }
+
+    PQGetPartInfo(expectedStartOffset, expectedEndOffset, tc);
 }
 
 Y_UNIT_TEST(TestCompaction) {
@@ -4034,8 +4077,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
     writeSmall(1, true);
     PQGetPartInfo(0, 1, tc);
 
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(1, 1, tc);
+    WaitRetentionCleanup(tc, 1, 1, retentionSeconds);
 
     PQTabletRestart(tc);
     PQGetPartInfo(1, 1, tc);
@@ -4043,8 +4085,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
     writeSmall(2, false);
     PQGetPartInfo(1, 2, tc);
 
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(2, 2, tc);
+    WaitRetentionCleanup(tc, 2, 2, retentionSeconds);
 }
 
 Y_UNIT_TEST(TestRetentionDeletesLastBlobInFwz) {
@@ -4066,8 +4107,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInFwz) {
     CmdWrite(0, "sourceid_fwz", data, tc, false, {}, true);
 
     PQGetPartInfo(0, 1, tc);
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(1, 1, tc);
+    WaitRetentionCleanup(tc, 1, 1, retentionSeconds);
 }
 
 Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzb) {
@@ -4091,8 +4131,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzb) {
     PQTabletRestart(tc);
 
     PQGetPartInfo(0, 1, tc);
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(1, 1, tc);
+    WaitRetentionCleanup(tc, 1, 1, retentionSeconds);
 }
 
 Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
@@ -4126,8 +4165,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
     PQTabletRestart(tc);
 
     PQGetPartInfo(100, 202, tc);
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(202, 202, tc);
+    WaitRetentionCleanup(tc, 202, 202, retentionSeconds);
 }
 
 Y_UNIT_TEST(TestPartitionMetaOffsetsSurviveRestartWithoutRetentionFlag) {
@@ -4175,8 +4213,7 @@ Y_UNIT_TEST(TestRetentionCrossZoneMessages) {
     PQGetPartInfo(100, 202, tc);
 
     PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(202, 202, tc);
+    WaitRetentionCleanup(tc, 202, 202, retentionSeconds);
 
     PQTabletPrepare({.deleteTime = 10'000, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
@@ -4189,8 +4226,7 @@ Y_UNIT_TEST(TestRetentionCrossZoneMessages) {
     PQGetPartInfo(202, 203, tc);
 
     PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
-    WaitRetentionCleanup(tc, retentionSeconds);
-    PQGetPartInfo(203, 203, tc);
+    WaitRetentionCleanup(tc, 203, 203, retentionSeconds);
 }
 
 } // Y_UNIT_TEST_SUITE(TPQTest)

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -299,13 +299,14 @@ void DispatchUntilWakeup(TTestContext& tc, i32 retriesLeft = 2) {
     while (retriesLeft-- > 0) {
         tc.Runtime->ResetScheduledCount();
         try {
-            tc.Runtime->DispatchEvents(options);
-            return;
+            if (tc.Runtime->DispatchEvents(options)) {
+                return;
+            }
         } catch (const NActors::TSchedulingLimitReachedException&) {
         }
     }
 
-    UNIT_FAIL("DispatchEvents did not complete within retry budget");
+    UNIT_FAIL("DispatchEvents did not observe TEvWakeup within retry budget");
 }
 
 bool TryPQGetPartInfo(ui64 expectedStartOffset, ui64 expectedEndOffset, TTestContext& tc) {

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -288,31 +288,26 @@ TMaybe<ui64> PQGetStartOffset(TTestContext& tc)
     return Nothing();
 }
 
-void WaitRetentionCleanup(TTestContext& tc, ui32 retentionSeconds = 5, ui32 wakeTimeoutSeconds = 5) {
-    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
-    tc.Runtime->ResetScheduledCount();
-    try {
-        tc.Runtime->DispatchEvents();
-    } catch (const NActors::TSchedulingLimitReachedException&) {
+void DispatchWithRetry(TTestContext& tc, i32 retriesLeft = 2) {
+    while (retriesLeft-- > 0) {
         tc.Runtime->ResetScheduledCount();
-    }
-    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
-    tc.Runtime->ResetScheduledCount();
-    try {
-        tc.Runtime->DispatchEvents();
-    } catch (const NActors::TSchedulingLimitReachedException&) {
-        tc.Runtime->ResetScheduledCount();
+        try {
+            tc.Runtime->DispatchEvents();
+            return;
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+        }
     }
 }
 
 void DispatchPartitionWakeup(TTestContext& tc, ui32 wakeTimeoutSeconds = 5) {
     tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
-    tc.Runtime->ResetScheduledCount();
-    try {
-        tc.Runtime->DispatchEvents();
-    } catch (const NActors::TSchedulingLimitReachedException&) {
-        tc.Runtime->ResetScheduledCount();
-    }
+    DispatchWithRetry(tc);
+}
+
+void WaitRetentionCleanup(TTestContext& tc, ui32 retentionSeconds = 5, ui32 wakeTimeoutSeconds = 5) {
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
+    DispatchWithRetry(tc);
+    DispatchPartitionWakeup(tc, wakeTimeoutSeconds);
 }
 
 Y_UNIT_TEST(TestCompaction) {

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -252,6 +252,23 @@ TMaybe<ui64> PQGetStartOffset(TTestContext& tc)
     return Nothing();
 }
 
+void WaitRetentionCleanup(TTestContext& tc, ui32 retentionSeconds = 5, ui32 wakeTimeoutSeconds = 5) {
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
+    tc.Runtime->ResetScheduledCount();
+    try {
+        tc.Runtime->DispatchEvents();
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+        tc.Runtime->ResetScheduledCount();
+    }
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
+    tc.Runtime->ResetScheduledCount();
+    try {
+        tc.Runtime->DispatchEvents();
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+        tc.Runtime->ResetScheduledCount();
+    }
+}
+
 Y_UNIT_TEST(TestCompaction) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;
@@ -3959,24 +3976,6 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
 
     constexpr ui32 retentionSeconds = 5;
-    constexpr ui32 wakeTimeoutSeconds = 5;
-
-    auto waitRetentionCleanup = [&]() {
-        tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
-        tc.Runtime->ResetScheduledCount();
-        try {
-            tc.Runtime->DispatchEvents();
-        } catch (const NActors::TSchedulingLimitReachedException&) {
-            tc.Runtime->ResetScheduledCount();
-        }
-        tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
-        tc.Runtime->ResetScheduledCount();
-        try {
-            tc.Runtime->DispatchEvents();
-        } catch (const NActors::TSchedulingLimitReachedException&) {
-            tc.Runtime->ResetScheduledCount();
-        }
-    };
 
     auto writeSmall = [&](ui64 seqNo, bool isFirst) {
         TVector<std::pair<ui64, TString>> data;
@@ -3990,7 +3989,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
     writeSmall(1, true);
     PQGetPartInfo(0, 1, tc);
 
-    waitRetentionCleanup();
+    WaitRetentionCleanup(tc, retentionSeconds);
     PQGetPartInfo(1, 1, tc);
 
     PQTabletRestart(tc);
@@ -3999,8 +3998,88 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
     writeSmall(2, false);
     PQGetPartInfo(1, 2, tc);
 
-    waitRetentionCleanup();
+    WaitRetentionCleanup(tc, retentionSeconds);
     PQGetPartInfo(2, 2, tc);
+}
+
+Y_UNIT_TEST(TestRetentionDeletesLastBlobInFwz) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(500);
+    // Disable async compaction so the blob stays in the fast-write zone.
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
+
+    constexpr ui32 retentionSeconds = 5;
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .AddDefaultConsumer = false}, {}, tc);
+    PQGetPartInfo(0, 0, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(100, 'x'));
+    CmdWrite(0, "sourceid_fwz", data, tc, false, {}, true);
+
+    PQGetPartInfo(0, 1, tc);
+    WaitRetentionCleanup(tc, retentionSeconds);
+    PQGetPartInfo(1, 1, tc);
+}
+
+Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzb) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(5000);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+
+    constexpr ui32 retentionSeconds = 5;
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    PQGetPartInfo(0, 0, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(7_MB, 'x'));
+    CmdWrite(0, "sourceid_czb", data, tc, false, {}, true, "", -1, -1, false, false, true);
+
+    CmdRunCompaction(0, tc);
+    PQTabletRestart(tc);
+
+    PQGetPartInfo(0, 1, tc);
+    WaitRetentionCleanup(tc, retentionSeconds);
+    PQGetPartInfo(1, 1, tc);
+}
+
+Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
+    // Same layout as Read_From_Different_Zones_What_Was_Written_With_Gaps: CZB is populated
+    // by the first compaction; the second compaction moves new writes into CZH (HeadKeys).
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(5000);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+
+    constexpr ui32 retentionSeconds = 5;
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    PQGetPartInfo(0, 0, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(7_MB, 'x'));
+    CmdWrite(0, "sourceid_czh_1", data, tc, false, {}, true, "", -1, 100);
+
+    CmdRunCompaction(0, tc);
+
+    data[0].second = TString(1_KB, 'x');
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_2", data, tc, false, {}, true, "", -1, 200);
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_3", data, tc, false, {}, true, "", -1, 201);
+
+    CmdRunCompaction(0, tc);
+    PQTabletRestart(tc);
+
+    PQGetPartInfo(100, 202, tc);
+    WaitRetentionCleanup(tc, retentionSeconds);
+    PQGetPartInfo(202, 202, tc);
 }
 
 } // Y_UNIT_TEST_SUITE(TPQTest)

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -288,6 +288,9 @@ TMaybe<ui64> PQGetStartOffset(TTestContext& tc)
     return Nothing();
 }
 
+// TSchedulingLimitReachedException means the scheduled-event budget was exhausted,
+// not that dispatch failed. PQ UT relies on partial progress here (see pq_ut_common.cpp).
+// Retention tests assert the outcome via PQGetPartInfo after WaitRetentionCleanup.
 void DispatchWithRetry(TTestContext& tc, i32 retriesLeft = 2) {
     while (retriesLeft-- > 0) {
         tc.Runtime->ResetScheduledCount();

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -3951,5 +3951,57 @@ Y_UNIT_TEST(TestSizeLag) {
     });
 }
 
+Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(500);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
+
+    constexpr ui32 retentionSeconds = 5;
+    constexpr ui32 wakeTimeoutSeconds = 5;
+
+    auto waitRetentionCleanup = [&]() {
+        tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(retentionSeconds + 1));
+        tc.Runtime->ResetScheduledCount();
+        try {
+            tc.Runtime->DispatchEvents();
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            tc.Runtime->ResetScheduledCount();
+        }
+        tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
+        tc.Runtime->ResetScheduledCount();
+        try {
+            tc.Runtime->DispatchEvents();
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            tc.Runtime->ResetScheduledCount();
+        }
+    };
+
+    auto writeSmall = [&](ui64 seqNo, bool isFirst) {
+        TVector<std::pair<ui64, TString>> data;
+        data.push_back({seqNo, TString(100, 'x')});
+        CmdWrite(0, "sourceid", data, tc, false, {}, isFirst);
+    };
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .AddDefaultConsumer = false}, {}, tc);
+    PQGetPartInfo(0, 0, tc);
+
+    writeSmall(1, true);
+    PQGetPartInfo(0, 1, tc);
+
+    waitRetentionCleanup();
+    PQGetPartInfo(1, 1, tc);
+
+    PQTabletRestart(tc);
+    PQGetPartInfo(1, 1, tc);
+
+    writeSmall(2, false);
+    PQGetPartInfo(1, 2, tc);
+
+    waitRetentionCleanup();
+    PQGetPartInfo(2, 2, tc);
+}
+
 } // Y_UNIT_TEST_SUITE(TPQTest)
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -269,6 +269,16 @@ void WaitRetentionCleanup(TTestContext& tc, ui32 retentionSeconds = 5, ui32 wake
     }
 }
 
+void DispatchPartitionWakeup(TTestContext& tc, ui32 wakeTimeoutSeconds = 5) {
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(wakeTimeoutSeconds));
+    tc.Runtime->ResetScheduledCount();
+    try {
+        tc.Runtime->DispatchEvents();
+    } catch (const NActors::TSchedulingLimitReachedException&) {
+        tc.Runtime->ResetScheduledCount();
+    }
+}
+
 Y_UNIT_TEST(TestCompaction) {
     TTestContext tc;
     tc.EnableDetailedPQLog = true;
@@ -4080,6 +4090,53 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
     PQGetPartInfo(100, 202, tc);
     WaitRetentionCleanup(tc, retentionSeconds);
     PQGetPartInfo(202, 202, tc);
+}
+
+Y_UNIT_TEST(TestRetentionCrossZoneMessages) {
+    // CZB+CZH are removed by retention first; FWZ messages are written afterwards
+    // and removed in a second retention cycle.
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    tc.Runtime->SetScheduledLimit(5000);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+
+    constexpr ui32 retentionSeconds = 5;
+
+    PQTabletPrepare({.deleteTime = 10'000, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(7_MB, 'x'));
+    CmdWrite(0, "sourceid_czb", data, tc, false, {}, true, "", -1, 100);
+    CmdRunCompaction(0, tc);
+
+    data[0].second = TString(1_KB, 'x');
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_1", data, tc, false, {}, true, "", -1, 200);
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_2", data, tc, false, {}, true, "", -1, 201);
+    CmdRunCompaction(0, tc);
+
+    PQTabletRestart(tc);
+    PQGetPartInfo(100, 202, tc);
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    WaitRetentionCleanup(tc, retentionSeconds);
+    PQGetPartInfo(202, 202, tc);
+
+    PQTabletPrepare({.deleteTime = 10'000, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
+    PQTabletRestart(tc);
+    PQGetPartInfo(202, 202, tc);
+
+    TVector<std::pair<ui64, TString>> fwzData;
+    fwzData.emplace_back(1, TString(100, 'x'));
+    CmdWrite(0, "sourceid_fwz", fwzData, tc, false, {}, false);
+    PQGetPartInfo(202, 203, tc);
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    WaitRetentionCleanup(tc, retentionSeconds);
+    PQGetPartInfo(203, 203, tc);
 }
 
 } // Y_UNIT_TEST_SUITE(TPQTest)

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -34,6 +34,12 @@ void SetEnableTopicMessagesBatching(TTestContext& tc) {
     }
 }
 
+void SetEnableTopicRetentionDeleteLastBlob(TTestContext& tc) {
+    for (ui32 nodeIdx = 0; nodeIdx < tc.Runtime->GetNodeCount(); ++nodeIdx) {
+        tc.Runtime->GetAppData(nodeIdx).FeatureFlags.SetEnableTopicRetentionDeleteLastBlob(true);
+    }
+}
+
 TString MakeKafkaBatchPayload(
     const TVector<TString>& values,
     NKafka::ECompressionType compression = NKafka::ECompressionType::NONE)
@@ -3982,6 +3988,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlob) {
     TTestContext tc;
     TFinalizer finalizer(tc);
     tc.Prepare();
+    SetEnableTopicRetentionDeleteLastBlob(tc);
     tc.Runtime->SetScheduledLimit(500);
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
 
@@ -4016,6 +4023,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInFwz) {
     TTestContext tc;
     TFinalizer finalizer(tc);
     tc.Prepare();
+    SetEnableTopicRetentionDeleteLastBlob(tc);
     tc.Runtime->SetScheduledLimit(500);
     // Disable async compaction so the blob stays in the fast-write zone.
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(300);
@@ -4038,6 +4046,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzb) {
     TTestContext tc;
     TFinalizer finalizer(tc);
     tc.Prepare();
+    SetEnableTopicRetentionDeleteLastBlob(tc);
     tc.Runtime->SetScheduledLimit(5000);
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
 
@@ -4064,6 +4073,7 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
     TTestContext tc;
     TFinalizer finalizer(tc);
     tc.Prepare();
+    SetEnableTopicRetentionDeleteLastBlob(tc);
     tc.Runtime->SetScheduledLimit(5000);
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
 
@@ -4098,6 +4108,7 @@ Y_UNIT_TEST(TestRetentionCrossZoneMessages) {
     TTestContext tc;
     TFinalizer finalizer(tc);
     tc.Prepare();
+    SetEnableTopicRetentionDeleteLastBlob(tc);
     tc.Runtime->SetScheduledLimit(5000);
     tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
 

--- a/ydb/core/persqueue/ut/pq_ut.cpp
+++ b/ydb/core/persqueue/ut/pq_ut.cpp
@@ -4176,6 +4176,54 @@ Y_UNIT_TEST(TestRetentionDeletesLastBlobInCzh) {
     WaitRetentionCleanup(tc, 202, 202, retentionSeconds);
 }
 
+Y_UNIT_TEST(TestRetentionDropsBodyBeforeYoungerHeadKeys) {
+    // After CZB data ages out, StartOffset moves to 200 and younger CZH head keys stay.
+    // Old bug: FinalizeEmptyBlobEncoder wiped all HeadKeys → (202, 202).
+    TTestContext tc;
+    TFinalizer finalizer(tc);
+    tc.Prepare();
+    SetEnableTopicRetentionDeleteLastBlob(tc);
+    tc.Runtime->SetScheduledLimit(5000);
+    tc.Runtime->GetAppData(0).PQConfig.MutableCompactionConfig()->SetBlobsCount(0);
+
+    constexpr ui32 retentionSeconds = 5;
+
+    // Long retention during setup so wakeups do not drop data between writes.
+    PQTabletPrepare({.deleteTime = 10'000, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    PQGetPartInfo(0, 0, tc);
+
+    TVector<std::pair<ui64, TString>> data;
+    data.emplace_back(1, TString(7_MB, 'x'));
+    CmdWrite(0, "sourceid_czb", data, tc, false, {}, true, "", -1, 100);
+    CmdRunCompaction(0, tc);
+
+    data[0].second = TString(1_KB, 'y');
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_old", data, tc, false, {}, true, "", -1, 200);
+
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(10));
+
+    ++data[0].first;
+    CmdWrite(0, "sourceid_czh_young", data, tc, false, {}, true, "", -1, 201);
+
+    CmdRunCompaction(0, tc);
+    PQTabletRestart(tc);
+    PQGetPartInfo(100, 202, tc);
+
+    PQTabletPrepare({.deleteTime = retentionSeconds, .partitions = 1, .writeSpeed = 50_MB, .AddDefaultConsumer = false}, {}, tc);
+    tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(4));
+    for (ui32 i = 0; i < 10; ++i) {
+        DispatchUntilWakeup(tc);
+        if (TryPQGetPartInfo(200, 202, tc)) {
+            break;
+        }
+        UNIT_ASSERT(!TryPQGetPartInfo(202, 202, tc));
+    }
+    PQGetPartInfo(200, 202, tc);
+
+    CmdRead(0, 200, 2, Max<i32>(), 2, false, tc, {200, 201});
+}
+
 Y_UNIT_TEST(TestPartitionMetaOffsetsSurviveRestartWithoutRetentionFlag) {
     // AddMetaKey / meta load are not gated by EnableTopicRetentionDeleteLastBlob.
     TTestContext tc;

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -324,4 +324,5 @@ message TFeatureFlags {
     optional bool EnableFulltextIndexPrefix = 282 [default = false];
     optional bool EnableAccessServiceV2Interface = 283 [default = false, (RequireRestart) = true];
     optional bool EnableAnalyzeLongRunningOperation = 284 [default = true];
+    optional bool EnableTopicRetentionDeleteLastBlob = 285 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Added EnableTopicRetentionDeleteLastBlob feature flag to gate the new retention behavior.
- Updated PQ partition cleanup logic to allow deleting the final blob and to persist/load partition meta start/end offsets for restart round-trips.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
