### PR TITLE
Forbid Login requests with empty database

### DIFF
--- a/ydb/services/auth/grpc_service.cpp
+++ b/ydb/services/auth/grpc_service.cpp
@@ -29,7 +29,7 @@ void TGRpcAuthService::SetupIncomingRequests(NYdbGrpc::TLoggerPtr logger) {
 #endif
 
 #define SETUP_LOGIN_METHOD(methodName, methodCallback, rlMode, requestType, auditMode) \
-    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, login, auditMode, EEmptyDatabaseMode::EmptyDatabaseAllowed)
+    SETUP_METHOD(methodName, methodCallback, rlMode, requestType, login, auditMode, EEmptyDatabaseMode::EmptyDatabaseForbidden)
 
     SETUP_LOGIN_METHOD(Login, DoLoginRequest, RLMODE(Off), UNSPECIFIED, TAuditMode::Modifying(TAuditMode::TLogClassConfig::Login));
 


### PR DESCRIPTION
Requests with empty database name were forbidden for Login rpc calls
