### PR TITLE
Fix broken enterprise changelog anchors from PR #43272

### DIFF
--- a/ydb/docs/en/core/changelog-enterprise.md
+++ b/ydb/docs/en/core/changelog-enterprise.md
@@ -50,7 +50,7 @@ Release date: June 12, 2026.
 * Fixed a bug where the query limit was not applied to the index table, causing it to read far more records than necessary.
 * [Fixed](https://github.com/ydb-platform/ydb/pull/38425) an [LDAP authentication](./security/authentication.md) vulnerability: knowing the login and password of any LDAP user (including one who is not a member of a group allowed to access {{ ydb-short-name }}), an attacker could bypass group membership checks and gain access to the cluster (LDAP search filter injection; special characters are now escaped per RFC 2254).
 
-### Version 25.2.1.ent.4 {#24-2-1-ent-4}
+### Version 25.2.1.ent.4 {#25-2-1-ent-4}
 
 Release date: February 12, 2026.
 

--- a/ydb/docs/ru/core/downloads/yandex-enterprise-database.md
+++ b/ydb/docs/ru/core/downloads/yandex-enterprise-database.md
@@ -181,8 +181,8 @@
 || **v25.3** |  |  |  |  ||
 || v.25.3.1.ent.3 | 12.06.2026 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.3.1.ent.3` | [См. список](../changelog-enterprise.md#25-3-1-ent-3) ||
 || **v25.2** |  |  |  |  ||
-|| v.25.2.1.ent.13 | 12.06.2026 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.2.1.ent.13` | [См. список](../changelog-enterprise.md#25-1-4-ent-13) ||
-|| v.25.2.1.ent.4 | 12.02.2026 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.2.1.ent.4` | [См. список](../changelog-enterprise.md#25-1-4-ent-4) ||
+|| v.25.2.1.ent.13 | 12.06.2026 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.2.1.ent.13` | [См. список](../changelog-enterprise.md#25-2-1-ent-13) ||
+|| v.25.2.1.ent.4 | 12.02.2026 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.2.1.ent.4` | [См. список](../changelog-enterprise.md#25-2-1-ent-4) ||
 || **v25.1** |  |  |  |  ||
 || v.25.1.4.ent.8 | 12.02.2026 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.1.4.ent.8` | [См. список](../changelog-enterprise.md#25-1-4-ent-8) ||
 || v.25.1.4.ent.3 | 25.11.2025 | `cr.yandex/crptqonuodf51kdj7a7d/ydb-enterpise:25.1.4.ent.3` | [См. список](../changelog-enterprise.md#25-1-4-ent-3) ||


### PR DESCRIPTION
## Summary

Follow-up to #43272. Fix broken changelog anchor links in enterprise documentation:

- RU Docker downloads: use `#25-2-1-ent-13` and `#25-2-1-ent-4` instead of incorrect `#25-1-4-ent-*` anchors for 25.2.1.ent.13 and 25.2.1.ent.4.
- EN changelog: fix typo in the heading anchor for 25.2.1.ent.4 (`{#24-2-1-ent-4}` → `{#25-2-1-ent-4}`), so EN download links resolve correctly.

### Changelog category

* Documentation (changelog entry is not required)