### PR TITLE
Fix YFM build warnings for Ansible inventory examples

### DIFF
--- a/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
@@ -75,7 +75,7 @@ Create the file `inventory/50-inventory.yaml` and fill it according to the chose
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Nodes
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "files/config.yaml"
           ydb_version: "system_version"
 
           # Storage
@@ -138,7 +138,7 @@ Create the file `inventory/50-inventory.yaml` and fill it according to the chose
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Nodes
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "files/config.yaml"
           ydb_version: "system_version"
 
           # Storage
@@ -196,7 +196,7 @@ Create the file `inventory/50-inventory.yaml` and fill it according to the chose
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Nodes
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "files/config.yaml"
           ydb_version: "system_version"
 
           # Storage

--- a/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
+++ b/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
@@ -94,7 +94,7 @@ Create the file `inventory/group_vars/ydb/all.yaml` and fill it.
 
   # YDB
   ydb_version: "system_version"
-  ydb_archive: "{{ ansible_config_file | dirname }}/files/ydbd.tar.gz"
+  ydb_archive: "files/ydbd.tar.gz"
 
   # Additional parameters
   ydb_allow_format_drives: true

--- a/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
@@ -75,7 +75,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище
@@ -138,7 +138,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище
@@ -196,7 +196,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище

--- a/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
+++ b/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
@@ -94,7 +94,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
 
   # YDB
   ydb_version: "версия_системы"
-  ydb_archive: "{{ ansible_config_file | dirname }}/files/ydbd.tar.gz"
+  ydb_archive: "files/ydbd.tar.gz"
 
   # Дополнительные параметры
   ydb_allow_format_drives: true


### PR DESCRIPTION
## Summary

Fix documentation build warnings caused by Ansible Jinja expressions in inventory YAML samples:

- Replace `"{{ ansible_config_file | dirname }}/files/config.yaml"` with `"files/config.yaml"` in deployment-configuration-v1 (EN/RU).
- Replace `"{{ ansible_config_file | dirname }}/files/ydbd.tar.gz"` with `"files/ydbd.tar.gz"` in deployment-configuration-v2 (EN/RU).

YFM treats `{{ ... | dirname }}` as a Liquid filter and emits `SkippedEvalError` / missing variable warnings. Relative paths match the existing v2 inventory example and keep the same meaning for the deployment working directory.

### Changelog category

* Documentation (changelog entry is not required)

