### PR TITLE
Escape Ansible Jinja in inventory examples for YFM build

### DIFF
--- a/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
@@ -75,7 +75,7 @@ Create the file `inventory/50-inventory.yaml` and fill it according to the chose
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Nodes
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/config.yaml"
           ydb_version: "system_version"
 
           # Storage
@@ -138,7 +138,7 @@ Create the file `inventory/50-inventory.yaml` and fill it according to the chose
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Nodes
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/config.yaml"
           ydb_version: "system_version"
 
           # Storage
@@ -196,7 +196,7 @@ Create the file `inventory/50-inventory.yaml` and fill it according to the chose
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Nodes
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/config.yaml"
           ydb_version: "system_version"
 
           # Storage

--- a/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
+++ b/ydb/docs/en/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
@@ -94,7 +94,7 @@ Create the file `inventory/group_vars/ydb/all.yaml` and fill it.
 
   # YDB
   ydb_version: "system_version"
-  ydb_archive: "{{ ansible_config_file | dirname }}/files/ydbd.tar.gz"
+  ydb_archive: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/ydbd.tar.gz"
 
   # Additional parameters
   ydb_allow_format_drives: true

--- a/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
+++ b/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v1.md
@@ -75,7 +75,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище
@@ -138,7 +138,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище
@@ -196,7 +196,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
           system_ntp_servers: [time.cloudflare.com, time.google.com, ntp.ripe.net, pool.ntp.org]
           
           # Узлы
-          ydb_config: "{{ ansible_config_file | dirname }}/files/config.yaml"
+          ydb_config: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/config.yaml"
           ydb_version: "версия_системы"
 
           # Хранилище

--- a/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
+++ b/ydb/docs/ru/core/devops/deployment-options/ansible/initial-deployment/deployment-configuration-v2.md
@@ -94,7 +94,7 @@ ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o Contro
 
   # YDB
   ydb_version: "версия_системы"
-  ydb_archive: "{{ ansible_config_file | dirname }}/files/ydbd.tar.gz"
+  ydb_archive: "{% raw %}{{ ansible_config_file | dirname }}{% endraw %}/files/ydbd.tar.gz"
 
   # Дополнительные параметры
   ydb_allow_format_drives: true


### PR DESCRIPTION
## Summary

Fix YFM documentation build warnings for Ansible inventory YAML samples without changing their meaning.

Wrap `{{ ansible_config_file | dirname }}` in `{% raw %}...{% endraw %}` in deployment-configuration-v1/v2 (EN/RU), so YFM does not treat the Ansible Jinja as Liquid templates, while readers still see the original path anchored to the directory with `ansible.cfg`.

Replaces the approach from closed #44102, which simplified paths to `"files/config.yaml"` and dropped the explicit anchoring semantics.

### Changelog category

* Documentation (changelog entry is not required)