### PR TITLE
docs: руководство по AI-навыкам ydb-ai-skills для разработчиков

### DIFF
--- a/ydb/docs/en/core/reference/ai/toc_p.yaml
+++ b/ydb/docs/en/core/reference/ai/toc_p.yaml
@@ -1,0 +1,3 @@
+items:
+- name: YDB AI Skills
+  href: ydb-ai-skills.md

--- a/ydb/docs/en/core/reference/ai/ydb-ai-skills.md
+++ b/ydb/docs/en/core/reference/ai/ydb-ai-skills.md
@@ -1,0 +1,85 @@
+# {{ ydb-short-name }} AI skills (ydb-ai-skills)
+
+[ydb-ai-skills](https://github.com/ydb-platform/ydb-ai-skills) is a set of [skills](https://agentskills.io/) for AI coding agents that assist when working with {{ ydb-short-name }}: writing [YQL](../../concepts/glossary.md#yql) queries, designing the data schema, and reviewing application code for correct use of the {{ ydb-short-name }} SDK. Skills plug into your AI agent and activate automatically based on the request context.
+
+{% note warning %}
+
+The project is under active development. The set of skills and their content are expanding, so the composition and behavior may change. See the [project repository](https://github.com/ydb-platform/ydb-ai-skills) for up-to-date information.
+
+{% endnote %}
+
+## What's inside {#whats-inside}
+
+| Skill         | Purpose                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------ |
+| **ydb-core**  | Baseline skill: {{ ydb-short-name }} overview, connection, authentication, schema basics, CLI. Installed automatically. |
+| **ydb-table** | Auditing and reviewing application code that uses the {{ ydb-short-name }} SDK, schema design, writing YQL.   |
+
+## Supported agents {#supported-agents}
+
+Skills are distributed in a universal format and installed into the corresponding agent's directory.
+
+| Agent          | Project directory   | Global directory           |
+| -------------- | ------------------- | -------------------------- |
+| Claude Code    | `.claude/skills/`   | `~/.claude/skills/`        |
+| Cursor         | `.cursor/skills/`   | —                          |
+| Windsurf       | `.windsurf/skills/` | —                          |
+| GitHub Copilot | `.github/skills/`   | `~/.copilot/skills/`       |
+| Codex CLI      | `.agents/skills/`   | `~/.codex/skills/`         |
+| Roo Code       | `.roo/skills/`      | —                          |
+| Gemini CLI     | `.gemini/skills/`   | `~/.gemini/skills/`        |
+| Amp            | `.agents/skills/`   | `~/.config/agents/skills/` |
+| Kiro           | `.kiro/skills/`     | —                          |
+| Trae           | `.trae/skills/`     | —                          |
+| Generic        | `.agents/skills/`   | `~/.agents/skills/`        |
+
+## Installation {#installation}
+
+```bash
+git clone https://github.com/ydb-platform/ydb-ai-skills.git
+cd ydb-ai-skills
+
+# Auto-detect agents in the current project
+./install.sh --detect
+
+# Install for a specific agent
+./install.sh --agent=claude
+
+# Install only ydb-table (ydb-core is added as the baseline skill)
+./install.sh --agent=claude --skills=ydb-table
+
+# Install only ydb-table without the baseline skill
+./install.sh --agent=claude --skills=ydb-table --no-core
+
+# Dry run — show what would be done without making changes
+./install.sh --agent=claude --dry-run
+```
+
+## Usage {#usage}
+
+No separate action is required to start: the agent connects the appropriate skill itself when the task concerns {{ ydb-short-name }}. If the agent does not support auto-activation, specify the skill name (`ydb-core` or `ydb-table`) in the request explicitly.
+
+## Code review {#code-review}
+
+The `ydb-table` skill checks application code for common mistakes when working with the {{ ydb-short-name }} SDK and points to the violated rules. To run a review, point the agent at the file or the range of changes.
+
+## Local run with Ollama {#ollama}
+
+You can use the skills with an agent running on a local model via [Ollama](https://ollama.com/), without calling the cloud API. The `ollama launch` command is available starting from Ollama v0.15.
+
+```bash
+# 1. Pull a local model (tool calling support and a large context are required)
+ollama pull gpt-oss:20b
+
+# 2. Run Claude Code on that model — the skills activate as usual
+ollama launch claude --model gpt-oss:20b
+```
+
+For agentic workflows, a context length of at least 64,000 tokens is recommended (configured in Ollama).
+
+## See also {#see-also}
+
+- [ydb-ai-skills repository](https://github.com/ydb-platform/ydb-ai-skills) — source code, documentation on authoring and testing skills.
+- [{#T}](../../yql/reference/index.md)
+- [{#T}](../ydb-sdk/index.md)
+- [{#T}](../ydb-cli/index.md)

--- a/ydb/docs/en/core/reference/toc_p.yaml
+++ b/ydb/docs/en/core/reference/toc_p.yaml
@@ -33,6 +33,10 @@ items:
   include:
     mode: link
     path: languages-and-apis/toc_p.yaml
+- name: AI tools
+  include:
+    mode: link
+    path: ai/toc_p.yaml
 - name: Kafka API
   href: kafka-api/index.md
   include:

--- a/ydb/docs/ru/core/reference/ai/toc_p.yaml
+++ b/ydb/docs/ru/core/reference/ai/toc_p.yaml
@@ -1,0 +1,3 @@
+items:
+- name: YDB AI Skills
+  href: ydb-ai-skills.md

--- a/ydb/docs/ru/core/reference/ai/ydb-ai-skills.md
+++ b/ydb/docs/ru/core/reference/ai/ydb-ai-skills.md
@@ -1,0 +1,85 @@
+# AI-навыки {{ ydb-short-name }} (ydb-ai-skills)
+
+[ydb-ai-skills](https://github.com/ydb-platform/ydb-ai-skills) — это набор навыков ([skills](https://agentskills.io/)) для AI-агентов разработки, помогающий при работе с {{ ydb-short-name }}: написании запросов на [YQL](../../concepts/glossary.md#yql), проектировании схемы данных и ревью кода приложений на корректность использования {{ ydb-short-name }} SDK. Навыки подключаются к AI-агенту и автоматически активируются в зависимости от контекста запроса.
+
+{% note warning %}
+
+Проект находится в стадии активной разработки. Набор навыков и их наполнение расширяются, поэтому состав и поведение могут меняться. Актуальную информацию смотрите в [репозитории проекта](https://github.com/ydb-platform/ydb-ai-skills).
+
+{% endnote %}
+
+## Что внутри {#whats-inside}
+
+| Навык         | Назначение                                                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **ydb-core**  | Базовый навык: обзор {{ ydb-short-name }}, подключение, аутентификация, основы схемы, CLI. Устанавливается автоматически. |
+| **ydb-table** | Аудит и ревью кода приложений на {{ ydb-short-name }} SDK, проектирование схемы, написание YQL.                           |
+
+## Поддерживаемые агенты {#supported-agents}
+
+Навыки распространяются в универсальном формате и устанавливаются в каталог соответствующего агента.
+
+| Агент          | Каталог в проекте   | Глобальный каталог         |
+| -------------- | ------------------- | -------------------------- |
+| Claude Code    | `.claude/skills/`   | `~/.claude/skills/`        |
+| Cursor         | `.cursor/skills/`   | —                          |
+| Windsurf       | `.windsurf/skills/` | —                          |
+| GitHub Copilot | `.github/skills/`   | `~/.copilot/skills/`       |
+| Codex CLI      | `.agents/skills/`   | `~/.codex/skills/`         |
+| Roo Code       | `.roo/skills/`      | —                          |
+| Gemini CLI     | `.gemini/skills/`   | `~/.gemini/skills/`        |
+| Amp            | `.agents/skills/`   | `~/.config/agents/skills/` |
+| Kiro           | `.kiro/skills/`     | —                          |
+| Trae           | `.trae/skills/`     | —                          |
+| Generic        | `.agents/skills/`   | `~/.agents/skills/`        |
+
+## Установка {#installation}
+
+```bash
+git clone https://github.com/ydb-platform/ydb-ai-skills.git
+cd ydb-ai-skills
+
+# Автоопределение агентов в текущем проекте
+./install.sh --detect
+
+# Установка для конкретного агента
+./install.sh --agent=claude
+
+# Установить только ydb-table (ydb-core добавится как базовый навык)
+./install.sh --agent=claude --skills=ydb-table
+
+# Установить только ydb-table без базового навыка
+./install.sh --agent=claude --skills=ydb-table --no-core
+
+# Пробный запуск — показать, что будет сделано, без изменений
+./install.sh --agent=claude --dry-run
+```
+
+## Использование {#usage}
+
+Отдельных действий для запуска не требуется: агент сам подключает подходящий навык, когда задача относится к {{ ydb-short-name }}. Если агент не поддерживает автоподключение, укажите имя навыка (`ydb-core` или `ydb-table`) в запросе явно.
+
+## Ревью кода {#code-review}
+
+Навык `ydb-table` проверяет код приложения на типичные ошибки работы с {{ ydb-short-name }} SDK и указывает нарушенные правила. Для запуска ревью укажите агенту файл или диапазон изменений.
+
+## Локальный запуск через Ollama {#ollama}
+
+Навыки можно использовать с агентом, работающим на локальной модели через [Ollama](https://ollama.com/), без обращения к облачному API. Команда `ollama launch` доступна начиная с Ollama v0.15.
+
+```bash
+# 1. Загрузить локальную модель (нужны поддержка tool calling и большой контекст)
+ollama pull gpt-oss:20b
+
+# 2. Запустить Claude Code на этой модели — навыки активируются как обычно
+ollama launch claude --model gpt-oss:20b
+```
+
+Для агентных сценариев рекомендуется контекст не меньше 64 000 токенов (настраивается в Ollama).
+
+## Дополнительные материалы {#see-also}
+
+- [Репозиторий ydb-ai-skills](https://github.com/ydb-platform/ydb-ai-skills) — исходный код, документация по написанию навыков и тестированию.
+- [{#T}](../../yql/reference/index.md)
+- [{#T}](../ydb-sdk/index.md)
+- [{#T}](../ydb-cli/index.md)

--- a/ydb/docs/ru/core/reference/toc_p.yaml
+++ b/ydb/docs/ru/core/reference/toc_p.yaml
@@ -32,6 +32,10 @@ items:
   include:
     mode: link
     path: languages-and-apis/toc_p.yaml
+- name: AI-инструменты
+  include:
+    mode: link
+    path: ai/toc_p.yaml
 - name: Kafka API
   href: kafka-api/index.md
   include:


### PR DESCRIPTION
## Что сделано

Добавлена страница документации для разработчиков приложений о наборе AI-навыков [ydb-ai-skills](https://github.com/ydb-platform/ydb-ai-skills).

Страница `ydb/docs/ru/core/dev/ai-skills.md`:
- Описание проекта и предупреждение о статусе разработки.
- Таблица навыков (`ydb-core`, `ydb-table`).
- Таблица поддерживаемых агентов с каталогами установки.
- Инструкции по установке (удалённая через `ai.ydb.sh` и локальная через `install.sh`).
- Раздел об использовании: на каких задачах помогают навыки.
- Ссылки на репозиторий, YQL, SDK и CLI.

Подключение в навигацию (RU):
- `dev/toc_p.yaml` — пункт «AI-навыки» после «Начало работы».
- `dev/index.md` — ссылка в списке основных материалов.

Только русская версия (по согласованию).