### PR TITLE
Fail docs build workflow on lint warnings

### DIFF
--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -90,6 +90,24 @@ jobs:
           cli-version: "4.59.12"
           use-ya-opensource: ${{ steps.ya.outputs.use }}
 
+      - name: Fail on documentation build issues
+        run: |
+          set -euo pipefail
+          if [[ ! -f build-html.log ]]; then
+            echo "::error::Documentation build log (build-html.log) not found"
+            exit 1
+          fi
+          issue_count=$(grep -cE '^(ERR|WARN)' build-html.log || true)
+          if [[ "$issue_count" -gt 0 ]]; then
+            echo "::error::Documentation build has ${issue_count} error(s)/warning(s)"
+            grep -E '^(ERR|WARN)' build-html.log | sort -u | head -20
+            if [[ "$issue_count" -gt 20 ]]; then
+              echo "... and $((issue_count - 20)) more (see PR comment for full log)"
+            fi
+            exit 1
+          fi
+          echo "No documentation build warnings or errors"
+
       # docs-build-action writes github.event.number to inputs/pr-number.
       # For workflow_dispatch this field is empty, so patch the artifact.
       - name: Download inputs artifact

--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -79,6 +79,25 @@ jobs:
           cli-version: "4.59.12"
           use-ya-opensource: ${{ steps.ya.outputs.use }}
 
+      - name: Fail on documentation build issues
+        if: steps.docs-changes.outputs.has_docs == 'true'
+        run: |
+          set -euo pipefail
+          if [[ ! -f build-html.log ]]; then
+            echo "::error::Documentation build log (build-html.log) not found"
+            exit 1
+          fi
+          issue_count=$(grep -cE '^(ERR|WARN)' build-html.log || true)
+          if [[ "$issue_count" -gt 0 ]]; then
+            echo "::error::Documentation build has ${issue_count} error(s)/warning(s)"
+            grep -E '^(ERR|WARN)' build-html.log | sort -u | head -20
+            if [[ "$issue_count" -gt 20 ]]; then
+              echo "... and $((issue_count - 20)) more (see PR comment for full log)"
+            fi
+            exit 1
+          fi
+          echo "No documentation build warnings or errors"
+
       - name: Remove rebuild_docs label
         if: always()
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary
- After `diplodoc-platform/docs-build-action`, scan `build-html.log` for `WARN`/`ERR` lines (same format as the PR comment from `docs-message-action`).
- Fail the `Build documentation` / `Rebuild documentation` job when at least one issue is found, so the PR check turns red instead of staying green with warnings.

## Context
`docs-build-action` exits 0 even when yfm reports YFM003 and other lint issues; only hard build errors fail the job. The preview comment still lists warnings (e.g. PR #44110 had 59 warnings while the check was green).

## Test plan
- [ ] Open a docs PR with a known lint issue — `Build documentation` check should fail
- [ ] Open a clean docs PR — check stays green, preview comment unchanged
- [ ] Confirm `Build documentation` is a required check in branch protection (otherwise merge is not blocked)


Made with [Cursor](https://cursor.com)