### PR TITLE
[EXT-2298] Fix missing PDisks for unavailable storage nodes

### DIFF
--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -1251,6 +1251,15 @@ public:
         return nullptr;
     }
 
+    void SetNodeDisconnected(TNodeId nodeId) {
+        if (TNode* node = FindNode(nodeId)) {
+            node->DisconnectNode();
+            if (FieldsRequired.test(+ENodeFields::PDisks) || FieldsRequired.test(+ENodeFields::VDisks)) {
+                node->RemapDisks();
+            }
+        }
+    }
+
     bool PreFilterDone() const {
         return (!PDisksResponse || PDisksProcessed) && !FilterDatabase && FilterPeerRole != EPeerRole::Static && FilterPeerRole != EPeerRole::Other;
     }
@@ -2570,16 +2579,10 @@ public:
                         hasMemoryDetailed |= systemInfo.HasMemoryStats();
                     }
                     for (auto nodeId : nodesWithoutData) {
-                        TNode* node = FindNode(nodeId);
-                        if (node) {
-                            node->DisconnectNode();
-                        }
+                        SetNodeDisconnected(nodeId);
                     }
                 } else {
-                    TNode* node = FindNode(responseNodeId);
-                    if (node) {
-                        node->DisconnectNode();
-                    }
+                    SetNodeDisconnected(responseNodeId);
                 }
             }
             for (const auto& [nodeId, response] : SystemStateResponse) {
@@ -2601,10 +2604,7 @@ public:
                         hasMemoryDetailed |= systemState.GetSystemStateInfo(0).HasMemoryStats();
                     }
                 } else {
-                    TNode* node = FindNode(nodeId);
-                    if (node) {
-                        node->DisconnectNode();
-                    }
+                    SetNodeDisconnected(nodeId);
                 }
             }
             if (!removeNodes.empty()) {
@@ -3054,13 +3054,7 @@ public:
 
     void Disconnected(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
         TNodeId nodeId = ev->Get()->NodeId;
-        TNode* node = FindNode(nodeId);
-        if (node) {
-            node->DisconnectNode();
-            if (FieldsRequired.test(+ENodeFields::PDisks) || FieldsRequired.test(+ENodeFields::VDisks)) {
-                node->RemapDisks();
-            }
-        }
+        SetNodeDisconnected(nodeId);
         TString error("NodeDisconnected");
         {
             auto itSystemStateResponse = SystemStateResponse.find(nodeId);

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -246,6 +246,33 @@ Y_UNIT_TEST_SUITE(Viewer) {
         ev->Swap(newEv);
     }
 
+    void SetNodesLocation(TEvInterconnect::TEvNodesInfo::TPtr* ev, const TString& dataCenter) {
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*ev)->Get()->Nodes);
+        for (auto& nodeInfo : *nodes) {
+            NActorsInterconnect::TNodeLocation location;
+            location.SetDataCenter(dataCenter);
+            location.SetRack("rack-1");
+            location.SetUnit("1");
+            nodeInfo.Location = TNodeLocation(location);
+        }
+        auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
+            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
+        );
+        ev->Swap(newEv);
+    }
+
+    void AddSysViewPDisk(NSysView::TEvSysView::TEvGetPDisksResponse::TPtr* ev, ui32 nodeId, ui32 pdiskId) {
+        auto* entry = (*ev)->Get()->Record.AddEntries();
+        entry->MutableKey()->SetNodeId(nodeId);
+        entry->MutableKey()->SetPDiskId(pdiskId);
+        entry->MutableInfo()->SetPath(Sprintf("/dev/pdisk-%u-%u", nodeId, pdiskId));
+        entry->MutableInfo()->SetGuid(nodeId * 100 + pdiskId);
+        entry->MutableInfo()->SetTotalSize(1024);
+        entry->MutableInfo()->SetAvailableSize(512);
+        entry->MutableInfo()->SetExpectedSlotCount(1);
+        entry->MutableInfo()->SetStatusV2("ACTIVE");
+    }
+
     void ChangeTabletStateResponse(TEvWhiteboard::TEvTabletStateResponse::TPtr* ev, int tabletsTotal, int& tabletId, int& nodeId) {
         ui64* cookie = const_cast<ui64*>(&(ev->Get()->Cookie));
         *cookie = nodeId;
@@ -886,6 +913,108 @@ Y_UNIT_TEST_SUITE(Viewer) {
         }
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("TotalNodes"), "1");
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("FoundNodes"), "1");
+    }
+
+    Y_UNIT_TEST(NodesPageKeepsPDisksForDisconnectedNode)
+    {
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        auto settings = TServerSettings(port)
+                .SetNodeCount(2)
+                .SetUseRealThreads(false)
+                .SetDomainName("Root")
+                .SetUseSectorMap(true)
+                .InitKikimrRunConfig();
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+
+        TClient client(settings);
+        TTestActorRuntime& runtime = *server.GetRuntime();
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+        const TNodeId disconnectedNodeId = runtime.GetNodeId(1);
+        size_t pdisksSysViewResponses = 0;
+        size_t systemStateResponses = 0;
+        size_t droppedSystemStateResponses = 0;
+        size_t pdiskStateResponses = 0;
+
+        std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest(
+            "GET /viewer/json/nodes?type=static&fields_required=NodeId,PDisks,SystemState,Memory&storage=true&limit=2&offset=0"
+            "&offload_merge=true&offload_merge_attempts=1&dump_original_node_batches=true&timeout=10 HTTP/1.1\r\n\r\n",
+            endpoint,
+            {});
+
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvInterconnect::EvNodesInfo: {
+                    auto* x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
+                    SetNodesLocation(x, "dc-1");
+                    break;
+                }
+                case NSysView::TEvSysView::EvGetPDisksResponse: {
+                    auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetPDisksResponse::TPtr*>(&ev);
+                    ++pdisksSysViewResponses;
+                    (*x)->Get()->Record.ClearEntries();
+                    AddSysViewPDisk(x, runtime.GetNodeId(0), 1);
+                    AddSysViewPDisk(x, runtime.GetNodeId(1), 1);
+                    break;
+                }
+                case TEvWhiteboard::EvSystemStateResponse: {
+                    auto* x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
+                    ++systemStateResponses;
+                    if ((*x)->Cookie == disconnectedNodeId) {
+                        ++droppedSystemStateResponses;
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+                }
+                case TEvWhiteboard::EvPDiskStateResponse: {
+                    auto* x = reinterpret_cast<TEvWhiteboard::TEvPDiskStateResponse::TPtr*>(&ev);
+                    ++pdiskStateResponses;
+                    (*x)->Get()->Record.ClearPDiskStateInfo();
+                    break;
+                }
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(request), 0));
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* result = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(result->Response->Body, &json, true);
+
+        const auto& nodes = json.GetMap().at("Nodes").GetArray();
+        UNIT_ASSERT_VALUES_EQUAL_C(json.GetMap().at("TotalNodes"), "2", NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(json.GetMap().at("FoundNodes"), "2", NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(nodes.size(), 2, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(pdisksSysViewResponses, 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(systemStateResponses, 2, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(droppedSystemStateResponses, 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(pdiskStateResponses, 2, NJson::WriteJson(json, false));
+        const auto& originalNodeBatches = json.GetMap().at("OriginalNodeBatches").GetArray();
+        UNIT_ASSERT_VALUES_EQUAL_C(originalNodeBatches.size(), 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(originalNodeBatches[0].GetMap().at("NodesToAskFor").GetArray().size(), 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(originalNodeBatches[0].GetMap().at("NodesToAskAbout").GetArray().size(), 2, NJson::WriteJson(json, false));
+        UNIT_ASSERT_C(originalNodeBatches[0].GetMap().at("HasStaticNodes").GetBoolean(), NJson::WriteJson(json, false));
+
+        const NJson::TJsonValue* disconnectedNode = nullptr;
+        for (const auto& node : nodes) {
+            const auto& nodeMap = node.GetMap();
+            if (nodeMap.at("NodeId").GetUInteger() == disconnectedNodeId) {
+                disconnectedNode = &node;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(disconnectedNode, NJson::WriteJson(json, false));
+        const auto& disconnectedNodeMap = disconnectedNode->GetMap();
+        UNIT_ASSERT_C(disconnectedNodeMap.at("Disconnected").GetBoolean(), NJson::WriteJson(*disconnectedNode, false));
+        UNIT_ASSERT_C(disconnectedNodeMap.contains("PDisks"), NJson::WriteJson(*disconnectedNode, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(disconnectedNodeMap.at("PDisks").GetArray().size(), 1, NJson::WriteJson(*disconnectedNode, false));
     }
 
     Y_UNIT_TEST(ServerlessWithExclusiveNodes)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Unavailable storage nodes could be returned without `PDisks` on the `Storage -> Nodes` page.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Users noticed a difference in the backend response for unavailable storage nodes. This was visible on the UI as an unstable `PDisks` column on the `Storage -> Nodes` page: unavailable nodes sometimes had `PDisks`, and sometimes the field was empty.

**Two variants of the same request were compared:**

- `limit=120&offset=0`: returned 120 nodes. Nodes `1..100` were available, nodes `101..120` were unavailable. For nodes `101..120`, `PDisks` was empty.
- `limit=120&offset=0&offload_merge=false`: returned the same nodes, but `PDisks` was present for unavailable nodes `101..120`.

This shows that disk data is available, but the result depends on the offload request flow.

With default offload behavior, the backend selected an available node as an offload candidate. The offload request succeeded. The unavailable nodes were reported later inside the `Whiteboard` response processing. In this path, the nodes were marked as unavailable, but disk data already received from `BSC` was not copied into the final `PDisks` field.

With `offload_merge=false`, this offload path is skipped, and the unavailable nodes are returned with `PDisks`.

The fix makes the default offload path behave the same way: when a node is marked as unavailable, already received disk data from `BSC` is also copied into the final `PDisks` field.