### PR TITLE
DataShard prefix bloom filter as scheme object (KQP part)

### DIFF
--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -1067,7 +1067,42 @@ public:
                                         }
                                     }
                                 }
-                                bloomPrefixes[prefix] = fpp;
+
+                                if (AppData()->FeatureFlags.GetEnableLocalIndexAsSchemeObject()) {
+                                    // The named scheme object stores the index columns explicitly, so they
+                                    // must be a genuine leading prefix of the primary key (the engine prefix
+                                    // is length-only and always covers the first N PK columns).
+                                    const auto& pk = metadata->KeyColumnNames;
+                                    bool validPrefix = index.KeyColumns.size() <= pk.size();
+                                    for (size_t i = 0; validPrefix && i < index.KeyColumns.size(); ++i) {
+                                        validPrefix = (index.KeyColumns[i] == pk[i]);
+                                    }
+                                    if (!validPrefix) {
+                                        tablePromise.SetValue(ResultFromError<TGenericResult>(
+                                            "Bloom filter index columns must be a prefix of the primary key"));
+                                        return;
+                                    }
+
+                                    // Mirror the prefix bloom filter as a named TTableIndex scheme object,
+                                    // in addition to the engine-facing ByKeyFilterPrefixes. Two indexes over
+                                    // the same PK prefix would collapse to a single engine prefix, so reject
+                                    // the duplicate column set.
+                                    if (!bloomPrefixes.emplace(prefix, fpp).second) {
+                                        tablePromise.SetValue(ResultFromError<TGenericResult>(
+                                            "Multiple LocalBloomFilter indexes over the same primary-key prefix are not allowed"));
+                                        return;
+                                    }
+                                    auto* indexDesc = schemeTx.MutableCreateIndexedTable()->AddIndexDescription();
+                                    indexDesc->SetName(index.Name);
+                                    indexDesc->SetType(NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                                    indexDesc->SetState(NKikimrSchemeOp::EIndexState::EIndexStateReady);
+                                    for (const auto& col : index.KeyColumns) {
+                                        indexDesc->AddKeyColumnNames(col);
+                                    }
+                                    indexDesc->MutableBloomFilterDescription()->SetFalsePositiveProbability(fpp);
+                                } else {
+                                    bloomPrefixes[prefix] = fpp;
+                                }
                             }
                             continue;
                         }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1586,23 +1586,35 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         CreateAndAlterTableWithBloomFilter(true);
     }
 
+    // --- Helpers shared by the row-table prefix bloom filter tests below ---
+
+    // The table's persisted partition config (carries ByKeyFilterPrefixes and EnableFilterByKey).
+    static NKikimrSchemeOp::TPartitionConfig BloomFilterPartitionConfig(TKikimrRunner& kikimr, const TString& path = "/Root/T") {
+        return kikimr.GetTestClient().Ls(path)->Record.GetPathDescription().GetTable().GetPartitionConfig();
+    }
+
+    // Run a scheme query, asserting it succeeds.
+    static void BloomSchemeOk(NYdb::NTable::TSession& session, const TString& query) {
+        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    }
+
+    // Run a scheme query, asserting it fails. When `status` is given, the exact code must match.
+    static void BloomSchemeFails(NYdb::NTable::TSession& session, const TString& query, std::optional<EStatus> status = {}) {
+        auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_UNEQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        if (status) {
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), *status, result.GetIssues().ToString());
+        }
+    }
+
     Y_UNIT_TEST(DataShardBloomFilterIndex) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
 
-        auto getPartitionConfig = [&]() {
-            return kikimr.GetTestClient().Ls("/Root/T")->Record
-                .GetPathDescription().GetTable().GetPartitionConfig();
-        };
-
-        auto execScheme = [&](const TString& q) {
-            auto result = session.ExecuteSchemeQuery(q).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
-        };
-
         // CREATE TABLE with two bloom filters at different prefix lengths
-        execScheme(R"(
+        BloomSchemeOk(session, R"(
             --!syntax_v1
             CREATE TABLE `/Root/T` (
                 Key1 Uint64,
@@ -1614,7 +1626,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
             );
         )");
         {
-            auto cfg = getPartitionConfig();
+            auto cfg = BloomFilterPartitionConfig(kikimr);
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
@@ -1623,44 +1635,63 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // KEY_BLOOM_FILTER = DISABLED disables all bloom filters on the table
         AlterTableSetttings(session, "/Root/T", {{"KEY_BLOOM_FILTER", "DISABLED"}}, false);
         {
-            auto cfg = getPartitionConfig();
+            auto cfg = BloomFilterPartitionConfig(kikimr);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetEnableFilterByKey(), false);
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 0);
         }
 
         // ALTER TABLE ADD INDEX accumulates bloom filter prefixes one by one
-        execScheme(R"(
+        BloomSchemeOk(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1);
         )");
         {
-            auto cfg = getPartitionConfig();
+            auto cfg = BloomFilterPartitionConfig(kikimr);
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 1);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
         }
 
-        execScheme(R"(
+        BloomSchemeOk(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bloom2 LOCAL USING bloom_filter ON (Key1, Key2);
         )");
         {
-            auto cfg = getPartitionConfig();
+            auto cfg = BloomFilterPartitionConfig(kikimr);
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
         }
 
-        // ALTER TABLE ADD INDEX with custom false_positive_probability
-        execScheme(R"(
+        // Each bloom filter is now a named TTableIndex scheme object, so adding a second index
+        // over the same PK prefix as an existing one is rejected (duplicate column set).
+        BloomSchemeFails(session, R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T`
+            ADD INDEX idx_bloom3 LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0.05);
+        )");
+
+        // DROP INDEX by name removes both the scheme object and the engine ByKeyFilterPrefix.
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T` DROP INDEX idx_bloom1;
+        )");
+        {
+            auto cfg = BloomFilterPartitionConfig(kikimr);
+            // only prefix 2 (idx_bloom2) remains
+            UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 2);
+        }
+
+        // After dropping the prefix-1 index, the same prefix can be re-added with a new FPP.
+        BloomSchemeOk(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bloom3 LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0.05);
         )");
         {
-            auto cfg = getPartitionConfig();
-            // prefix 1 already existed, FPP should be updated to 0.05
+            auto cfg = BloomFilterPartitionConfig(kikimr);
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
             UNIT_ASSERT_DOUBLES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetFalsePositiveProbability(), 0.05, 1e-9);
@@ -1670,56 +1701,261 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         // KEY_BLOOM_FILTER = DISABLED clears all bloom filters including ByKeyFilterPrefixes
         AlterTableSetttings(session, "/Root/T", {{"KEY_BLOOM_FILTER", "DISABLED"}}, false);
         {
-            auto cfg = getPartitionConfig();
+            auto cfg = BloomFilterPartitionConfig(kikimr);
             UNIT_ASSERT_VALUES_EQUAL(cfg.GetEnableFilterByKey(), false);
             UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 0);
         }
 
-        // Non-prefix columns must be rejected
-        auto expectError = [&](const TString& q) {
-            auto result = session.ExecuteSchemeQuery(q).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::GENERIC_ERROR, result.GetIssues().ToString());
-        };
+        // Non-prefix columns must be rejected.
         // Key2 alone is not a prefix of (Key1, Key2)
-        expectError(R"(
+        BloomSchemeFails(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key2);
-        )");
+        )", EStatus::GENERIC_ERROR);
         // (Key2, Key1) is not a prefix of (Key1, Key2)
-        expectError(R"(
+        BloomSchemeFails(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key2, Key1);
-        )");
+        )", EStatus::GENERIC_ERROR);
         // data_columns are not supported for local bloom filter index
-        expectError(R"(
+        BloomSchemeFails(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) COVER (Value);
-        )");
+        )", EStatus::GENERIC_ERROR);
         // false_positive_probability must be in (0, 1)
-        auto expectBadRequest = [&](const TString& q) {
-            auto result = session.ExecuteSchemeQuery(q).GetValueSync();
-            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
-        };
-        expectBadRequest(R"(
+        BloomSchemeFails(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0);
-        )");
-        expectBadRequest(R"(
+        )", EStatus::BAD_REQUEST);
+        BloomSchemeFails(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
             ADD INDEX idx_bad LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=1);
-        )");
+        )", EStatus::BAD_REQUEST);
         // Mixing a LocalBloomFilter index with a regular secondary index in a single ALTER TABLE
         // The bloom path and the BuildOperation path are dispatched mutually exclusively.
-        expectBadRequest(R"(
+        BloomSchemeFails(session, R"(
             --!syntax_v1
             ALTER TABLE `/Root/T`
                 ADD INDEX idx_bloom_mix LOCAL USING bloom_filter ON (Key1),
                 ADD INDEX idx_global_mix GLOBAL ON (Value);
+        )", EStatus::BAD_REQUEST);
+    }
+
+    Y_UNIT_TEST(DataShardBloomFilterIndexSchemeObject) {
+        // A row-table prefix bloom filter is mirrored as a named TTableIndex scheme object while the
+        // engine keeps its length-only ByKeyFilterPrefix. From a single CREATE, verify every
+        // observable of that mirror: schemeshard children, DescribeTable (no double-listing) and
+        // SHOW CREATE rendering; then that DROP INDEX by name removes both the object and the prefix.
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            CREATE TABLE `/Root/T` (
+                Key1 Uint64,
+                Key2 Uint64,
+                Value String,
+                PRIMARY KEY (Key1, Key2),
+                INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1),
+                INDEX idx_bloom2 LOCAL USING bloom_filter ON (Key1, Key2)
+            );
+        )");
+
+        // (1) Both bloom filters are TTableIndex scheme objects (children of the table), and the
+        // engine artifact (ByKeyFilterPrefixes) is present.
+        auto pathType = [&](const TString& path) {
+            return kikimr.GetTestClient().Ls(path)->Record.GetPathDescription().GetSelf().GetPathType();
+        };
+        UNIT_ASSERT_VALUES_EQUAL(pathType("/Root/T/idx_bloom1"), NKikimrSchemeOp::EPathTypeTableIndex);
+        UNIT_ASSERT_VALUES_EQUAL(pathType("/Root/T/idx_bloom2"), NKikimrSchemeOp::EPathTypeTableIndex);
+        UNIT_ASSERT_VALUES_EQUAL(BloomFilterPartitionConfig(kikimr).ByKeyFilterPrefixesSize(), 2);
+
+        // (2) DescribeTable lists each named bloom filter exactly once: the per-index engine prefix
+        // must NOT also synthesize an "idx_bloom_<N>" entry for a prefix backed by a scheme object.
+        {
+            auto describe = session.DescribeTable("/Root/T").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
+            TMap<TString, EIndexType> byName;
+            for (const auto& index : describe.GetTableDescription().GetIndexDescriptions()) {
+                UNIT_ASSERT_C(byName.emplace(index.GetIndexName(), index.GetIndexType()).second,
+                    "index listed more than once: " << index.GetIndexName());
+            }
+            UNIT_ASSERT_VALUES_EQUAL(byName.size(), 2u);
+            UNIT_ASSERT(byName.contains("idx_bloom1"));
+            UNIT_ASSERT(byName.contains("idx_bloom2"));
+            UNIT_ASSERT_VALUES_EQUAL(byName.at("idx_bloom1"), EIndexType::LocalBloomFilter);
+            UNIT_ASSERT_VALUES_EQUAL(byName.at("idx_bloom2"), EIndexType::LocalBloomFilter);
+        }
+
+        // (3) SHOW CREATE TABLE renders each named bloom filter as a LOCAL index.
+        {
+            auto qSession = kikimr.GetQueryClient().GetSession().GetValueSync().GetSession();
+            auto showResult = qSession.ExecuteQuery(
+                "SHOW CREATE TABLE `/Root/T`;",
+                NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(showResult.GetStatus(), EStatus::SUCCESS, showResult.GetIssues().ToString());
+            UNIT_ASSERT(!showResult.GetResultSets().empty());
+
+            NYdb::TResultSetParser parser(showResult.GetResultSet(0));
+            UNIT_ASSERT_C(parser.TryNextRow(), "SHOW CREATE must return at least one row");
+            TString createText = parser.ColumnParser(0).GetOptionalUtf8().value_or("");
+            UNIT_ASSERT_C(createText.Contains("idx_bloom1") && createText.Contains("idx_bloom2"),
+                "SHOW CREATE should list both bloom indexes, got: " << createText);
+            UNIT_ASSERT_C(createText.Contains("LOCAL USING bloom_filter"),
+                "SHOW CREATE should render the bloom filter index clause, got: " << createText);
+        }
+
+        // (4) DROP INDEX by name removes both the scheme object and the engine prefix.
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T` DROP INDEX idx_bloom1;
+        )");
+        {
+            auto cfg = BloomFilterPartitionConfig(kikimr);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 2);
+        }
+    }
+
+    Y_UNIT_TEST(DataShardBloomFilterIndexDropLast) {
+        // Dropping the *last* prefix bloom index makes ByKeyFilterPrefixes empty. The schemeshard
+        // clears its config and the alter still reaches the datashard, which must drop its engine
+        // filter (previously it kept a stale filter because an empty prefix list looked like
+        // "no change"). The table must remain fully queryable, and a bloom index can be re-added.
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            CREATE TABLE `/Root/T` (
+                Key1 Uint64,
+                Key2 Uint64,
+                Value String,
+                PRIMARY KEY (Key1, Key2),
+                INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1)
+            );
+        )");
+        UNIT_ASSERT_VALUES_EQUAL(BloomFilterPartitionConfig(kikimr).ByKeyFilterPrefixesSize(), 1);
+
+        // Write data so the drop alter must actually be applied by the datashard engine.
+        {
+            auto r = queryClient.ExecuteQuery(R"(
+                UPSERT INTO `/Root/T` (Key1, Key2, Value) VALUES
+                    (1u, 1u, "a"), (2u, 2u, "b"), (3u, 3u, "c");
+            )", NYdb::NQuery::TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(r.GetStatus(), EStatus::SUCCESS, r.GetIssues().ToString());
+        }
+
+        // Drop the only bloom index -> ByKeyFilterPrefixes becomes empty.
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T` DROP INDEX idx_bloom1;
+        )");
+        UNIT_ASSERT_VALUES_EQUAL(BloomFilterPartitionConfig(kikimr).ByKeyFilterPrefixesSize(), 0);
+
+        // Table stays correct after the engine filter is cleared.
+        {
+            auto r = queryClient.ExecuteQuery(R"(
+                SELECT Value FROM `/Root/T` WHERE Key1 = 2u AND Key2 = 2u;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(r.GetStatus(), EStatus::SUCCESS, r.GetIssues().ToString());
+            CompareYson(R"([[["b"]]])", FormatResultSetYson(r.GetResultSet(0)));
+        }
+
+        // A bloom index can be re-added after the table had none (engine re-enables the filter).
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T` ADD INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1);
+        )");
+        UNIT_ASSERT_VALUES_EQUAL(BloomFilterPartitionConfig(kikimr).ByKeyFilterPrefixesSize(), 1);
+    }
+
+    Y_UNIT_TEST(DataShardBloomFilterIndexCreateBadPrefix) {
+        // CREATE-time validation: bloom filter columns must be a left prefix of the primary key,
+        // because the named scheme object stores the columns while the engine prefix is length-only.
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        // Key2 alone is not a left prefix of (Key1, Key2).
+        BloomSchemeFails(session, R"(
+            --!syntax_v1
+            CREATE TABLE `/Root/Bad1` (
+                Key1 Uint64,
+                Key2 Uint64,
+                Value String,
+                PRIMARY KEY (Key1, Key2),
+                INDEX idx_bad LOCAL USING bloom_filter ON (Key2)
+            );
+        )");
+
+        // (Key2, Key1) is not a left prefix of (Key1, Key2).
+        BloomSchemeFails(session, R"(
+            --!syntax_v1
+            CREATE TABLE `/Root/Bad2` (
+                Key1 Uint64,
+                Key2 Uint64,
+                Value String,
+                PRIMARY KEY (Key1, Key2),
+                INDEX idx_bad LOCAL USING bloom_filter ON (Key2, Key1)
+            );
+        )");
+
+        // Two bloom indexes over the same PK prefix collapse to one engine prefix -> rejected.
+        BloomSchemeFails(session, R"(
+            --!syntax_v1
+            CREATE TABLE `/Root/Bad3` (
+                Key1 Uint64,
+                Key2 Uint64,
+                Value String,
+                PRIMARY KEY (Key1, Key2),
+                INDEX idx_a LOCAL USING bloom_filter ON (Key1),
+                INDEX idx_b LOCAL USING bloom_filter ON (Key1)
+            );
+        )");
+    }
+
+    Y_UNIT_TEST(DataShardBloomFilterIndexFlagOff) {
+        // With EnableLocalIndexAsSchemeObject OFF, a row-table bloom filter index drives only the
+        // engine ByKeyFilterPrefixes (unchanged legacy behavior) and is NOT registered as a named
+        // TTableIndex scheme object, so DROP INDEX by name is rejected.
+        auto serverSettings = TKikimrSettings();
+        serverSettings.AppConfig.MutableFeatureFlags()->SetEnableLocalIndexAsSchemeObject(false);
+        TKikimrRunner kikimr(serverSettings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        BloomSchemeOk(session, R"(
+            --!syntax_v1
+            CREATE TABLE `/Root/T` (
+                Key1 Uint64,
+                Key2 Uint64,
+                Value String,
+                PRIMARY KEY (Key1, Key2),
+                INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1)
+            );
+        )");
+
+        // Engine prefix present, but no TTableIndex scheme object child on the schemeshard.
+        auto pathDescr = kikimr.GetTestClient().Ls("/Root/T")->Record.GetPathDescription();
+        UNIT_ASSERT_VALUES_EQUAL(pathDescr.GetTable().GetPartitionConfig().ByKeyFilterPrefixesSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(pathDescr.GetTable().TableIndexesSize(), 0);
+        for (const auto& child : pathDescr.GetChildren()) {
+            UNIT_ASSERT_VALUES_UNEQUAL(child.GetPathType(), NKikimrSchemeOp::EPathTypeTableIndex);
+        }
+
+        // No scheme object => DROP INDEX by name cannot resolve it.
+        BloomSchemeFails(session, R"(
+            --!syntax_v1
+            ALTER TABLE `/Root/T` DROP INDEX idx_bloom1;
         )");
     }
 

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -1755,6 +1755,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         auto db = kikimr.GetTableClient();
         auto session = db.CreateSession().GetValueSync().GetSession();
 
+        // idx_bloom1 carries an explicit FPP; idx_bloom2 leaves it default (unspecified).
         BloomSchemeOk(session, R"(
             --!syntax_v1
             CREATE TABLE `/Root/T` (
@@ -1762,7 +1763,7 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
                 Key2 Uint64,
                 Value String,
                 PRIMARY KEY (Key1, Key2),
-                INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1),
+                INDEX idx_bloom1 LOCAL USING bloom_filter ON (Key1) WITH (false_positive_probability=0.03),
                 INDEX idx_bloom2 LOCAL USING bloom_filter ON (Key1, Key2)
             );
         )");
@@ -1776,21 +1777,29 @@ Y_UNIT_TEST_SUITE(KqpScheme) {
         UNIT_ASSERT_VALUES_EQUAL(pathType("/Root/T/idx_bloom2"), NKikimrSchemeOp::EPathTypeTableIndex);
         UNIT_ASSERT_VALUES_EQUAL(BloomFilterPartitionConfig(kikimr).ByKeyFilterPrefixesSize(), 2);
 
-        // (2) DescribeTable lists each named bloom filter exactly once: the per-index engine prefix
-        // must NOT also synthesize an "idx_bloom_<N>" entry for a prefix backed by a scheme object.
+        // (2) DescribeTable lists each named bloom filter exactly once (the per-index engine prefix
+        // must NOT also synthesize an "idx_bloom_<N>" entry for a prefix backed by a scheme object).
+        // The explicit FPP is preserved; the unspecified one is left unset, NOT surfaced as a default.
         {
             auto describe = session.DescribeTable("/Root/T").GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(describe.GetStatus(), EStatus::SUCCESS, describe.GetIssues().ToString());
-            TMap<TString, EIndexType> byName;
-            for (const auto& index : describe.GetTableDescription().GetIndexDescriptions()) {
-                UNIT_ASSERT_C(byName.emplace(index.GetIndexName(), index.GetIndexType()).second,
+            const auto indexes = describe.GetTableDescription().GetIndexDescriptions();
+            UNIT_ASSERT_VALUES_EQUAL(indexes.size(), 2u);
+
+            THashSet<TString> seen;
+            for (const auto& index : indexes) {
+                UNIT_ASSERT_C(seen.emplace(index.GetIndexName()).second,
                     "index listed more than once: " << index.GetIndexName());
+                UNIT_ASSERT_VALUES_EQUAL(index.GetIndexType(), EIndexType::LocalBloomFilter);
+                const auto& settings = std::get<TLocalBloomFilterSettings>(index.GetIndexSettings());
+                if (index.GetIndexName() == "idx_bloom1") {
+                    UNIT_ASSERT(settings.FalsePositiveProbability.has_value());
+                    UNIT_ASSERT_DOUBLES_EQUAL(*settings.FalsePositiveProbability, 0.03, 1e-9);
+                } else {
+                    UNIT_ASSERT_VALUES_EQUAL(index.GetIndexName(), "idx_bloom2");
+                    UNIT_ASSERT(!settings.FalsePositiveProbability.has_value());
+                }
             }
-            UNIT_ASSERT_VALUES_EQUAL(byName.size(), 2u);
-            UNIT_ASSERT(byName.contains("idx_bloom1"));
-            UNIT_ASSERT(byName.contains("idx_bloom2"));
-            UNIT_ASSERT_VALUES_EQUAL(byName.at("idx_bloom1"), EIndexType::LocalBloomFilter);
-            UNIT_ASSERT_VALUES_EQUAL(byName.at("idx_bloom2"), EIndexType::LocalBloomFilter);
         }
 
         // (3) SHOW CREATE TABLE renders each named bloom filter as a LOCAL index.

--- a/ydb/core/sys_view/show_create/create_table_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_table_formatter.cpp
@@ -451,7 +451,9 @@ TFormatResult TCreateTableFormatter::Format(const TString& tablePath, const TStr
     if (!tableDesc.GetTableIndexes().empty()) {
         try {
             for (const auto& indexDesc: tableDesc.GetTableIndexes()) {
-                if (indexDesc.GetType() != NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree) {
+                // Local indexes (e.g. row-table prefix bloom filter) have no impl table.
+                if (indexDesc.GetType() != NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree
+                    && indexDesc.IndexImplTableDescriptionsSize() > 0) {
                     FormatIndexImplTable(tablePath, indexDesc.GetName(), indexDesc.GetIndexImplTableDescriptions(0));
                 }
             }

--- a/ydb/core/sys_view/show_create/create_table_formatter.cpp
+++ b/ydb/core/sys_view/show_create/create_table_formatter.cpp
@@ -451,7 +451,8 @@ TFormatResult TCreateTableFormatter::Format(const TString& tablePath, const TStr
     if (!tableDesc.GetTableIndexes().empty()) {
         try {
             for (const auto& indexDesc: tableDesc.GetTableIndexes()) {
-                // Local indexes (e.g. row-table prefix bloom filter) have no impl table.
+                // Row-table local indexes represented as named scheme objects (e.g. prefix bloom
+                // filter) have no impl table. (Column-table/OLAP local indexes use a separate path.)
                 if (indexDesc.GetType() != NKikimrSchemeOp::EIndexType::EIndexTypeGlobalVectorKmeansTree
                     && indexDesc.IndexImplTableDescriptionsSize() > 0) {
                     FormatIndexImplTable(tablePath, indexDesc.GetName(), indexDesc.GetIndexImplTableDescriptions(0));

--- a/ydb/core/tx/datashard/datashard_ut_bloom_filter.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_bloom_filter.cpp
@@ -9,7 +9,7 @@ using namespace NKikimr::NDataShard;
 using namespace NKikimr::NDataShard::NKqpHelpers;
 using namespace Tests;
 
-// Datashard-level coverage for the bloom filter logic
+// Datashard-level coverage for bloom filter logic
 Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
 
     std::tuple<TTestActorRuntime&, Tests::TServer::TPtr, TActorId> CreateServer() {
@@ -53,10 +53,8 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
         return out;
     }
 
-    // The engine ByKeyFilterPrefixes the shard persists must track CREATE / ALTER ADD INDEX, and
-    // must be cleared when KEY_BLOOM_FILTER=DISABLED wipes the whole config. The clear case is the
-    // important one: the shard had prefixes and ApplyAlter must drop them from the engine, not keep
-    // a stale filter.
+    // Verify that ByKeyFilterPrefixes tracks CREATE/ALTER ADD INDEX/DROP INDEX.
+    // In particular, dropping the LAST prefix must clear the filter entirely.
     Y_UNIT_TEST(PrefixesUpdatedOnAlter) {
         auto [runtime, server, sender] = CreateServer();
 
@@ -83,10 +81,14 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
             )"), "SUCCESS");
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1, 2}));
 
-        // KEY_BLOOM_FILTER = DISABLED clears the whole bloom config -> ApplyAlter must drop every
-        // prefix from the engine.
+        // DROP one of two indexes -> ApplyAlter removes just that prefix.
         UNIT_ASSERT_VALUES_EQUAL(
-            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = DISABLED);"), "SUCCESS");
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` DROP INDEX idx1;"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{2}));
+
+        // DROP the LAST index -> ApplyAlter must clear the filter entirely (regression target).
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` DROP INDEX idx2;"), "SUCCESS");
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{}));
 
         // Re-adding a bloom index after disable should correctly re-establish bloom state.
@@ -95,9 +97,8 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1}));
     }
 
-    // The EnableFilterByKey (whole-key KEY_BLOOM_FILTER) branch: the whole-key filter is unified
-    // into the engine prefix list as an entry of length == number of key columns, must coexist with
-    // shorter prefix blooms, and be cleared by KEY_BLOOM_FILTER=DISABLED.
+    // Verify that whole-key KEY_BLOOM_FILTER coexists with prefix blooms,
+    // survives dropping shorter prefixes, and is cleared by KEY_BLOOM_FILTER=DISABLED.
     Y_UNIT_TEST(FullKeyCoexistsWithPrefix) {
         auto [runtime, server, sender] = CreateServer();
 
@@ -120,6 +121,11 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
             KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = ENABLED);"), "SUCCESS");
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1, 2}));
 
+        // Drop the only shorter prefix bloom -> whole-key (length 2) must remain, NOT clear to empty.
+        UNIT_ASSERT_VALUES_EQUAL(
+            KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` DROP INDEX idx1;"), "SUCCESS");
+        UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{2}));
+
         // Disabling KEY_BLOOM_FILTER clears all bloom state on the shard.
         UNIT_ASSERT_VALUES_EQUAL(
             KqpSchemeExec(runtime, "ALTER TABLE `/Root/T` SET (KEY_BLOOM_FILTER = DISABLED);"), "SUCCESS");
@@ -136,8 +142,7 @@ Y_UNIT_TEST_SUITE(DataShardBloomFilter) {
         UNIT_ASSERT_VALUES_EQUAL(ShardBloomPrefixLengths(runtime, shard), (TVector<ui32>{1, 2}));
     }
 
-    // The per-prefix false-positive probability resolved by ApplyConfig
-    // (explicit value, or NTable::DefaultBloomFilterFpp when unspecified) must reach the shard.
+    // Verify that per-prefix false-positive probability reaches the shard.
     Y_UNIT_TEST(FppPropagatedToShard) {
         auto [runtime, server, sender] = CreateServer();
 

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -384,6 +384,12 @@ bool BuildAlterTableBloomFilterModifyScheme(const TString& path, const Ydb::Tabl
         if (asSchemeObject) {
             // Mirror the prefix bloom filter as a named TTableIndex scheme object. Two indexes
             // over the same PK prefix collapse to a single engine prefix, so reject duplicates.
+
+            if (index.name().empty()) {
+                code = Ydb::StatusIds::BAD_REQUEST;
+                error = "Bloom filter index name must not be empty";
+                return false;
+            }
             if (bloomPrefixes.contains(prefixLen)) {
                 code = Ydb::StatusIds::BAD_REQUEST;
                 error = "Multiple LocalBloomFilter indexes over the same primary-key prefix are not allowed";
@@ -1781,7 +1787,11 @@ void FillLocalBloomFilterIndexSettings(Ydb::Table::LocalBloomFilterIndex& settin
 ) {
     if (tableIndex.HasBloomFilterDescription()) {
         const auto& desc = tableIndex.GetBloomFilterDescription();
-        if (desc.HasFalsePositiveProbability()) {
+        // The scheme object always stores a resolved FPP, but a default value is an implementation
+        // detail: suppress it so DescribeTable / SHOW CREATE only surface an explicitly chosen FPP
+        // (matching the synthesized "idx_bloom_<N>" path below).
+        if (desc.HasFalsePositiveProbability()
+            && desc.GetFalsePositiveProbability() != NTable::DefaultBloomFilterFpp) {
             settings.set_false_positive_probability(desc.GetFalsePositiveProbability());
         }
     }
@@ -1931,6 +1941,10 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
     // GetTableIndexes(); skip those prefix lengths here to avoid double-listing.
     if (in.HasPartitionConfig() && in.GetPartitionConfig().ByKeyFilterPrefixesSize() > 0) {
         const auto& pkCols = in.GetKeyColumnNames();
+        // Dedup by prefix length (column count), not column identity. This is exact only because a
+        // bloom filter's columns must be a left prefix of the PK, so a given length maps to exactly
+        // one valid column set. If that invariant is ever relaxed (arbitrary column subsets), this
+        // would need to key on the column set itself.
         THashSet<ui32> prefixesWithSchemeObject;
         for (const auto& tableIndex : in.GetTableIndexes()) {
             if (tableIndex.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {

--- a/ydb/core/ydb_convert/table_description.cpp
+++ b/ydb/core/ydb_convert/table_description.cpp
@@ -353,6 +353,8 @@ bool BuildAlterTableBloomFilterModifyScheme(const TString& path, const Ydb::Tabl
     auto* tableDesc = modifyScheme->MutableAlterTable();
     tableDesc->SetName(pathPair.second);
 
+    const bool asSchemeObject = AppData()->FeatureFlags.GetEnableLocalIndexAsSchemeObject();
+
     // Deduplicate prefix lengths: multiple bloom indexes with the same column count collapse into one.
     // Last specified FPP wins for each prefix length; 0 means "not set, use default".
     TMap<ui32, double> bloomPrefixes;
@@ -368,6 +370,7 @@ bool BuildAlterTableBloomFilterModifyScheme(const TString& path, const Ydb::Tabl
 
         const ui32 prefixLen = static_cast<ui32>(index.index_columns_size());
         const auto& bloomSettings = index.local_bloom_filter_index();
+        double resolvedFpp = 0.0;
         if (bloomSettings.has_false_positive_probability()) {
             const double fpp = bloomSettings.false_positive_probability();
             if (fpp <= 0.0 || fpp >= 1.0) {
@@ -375,10 +378,29 @@ bool BuildAlterTableBloomFilterModifyScheme(const TString& path, const Ydb::Tabl
                 error = "false_positive_probability must be in range (0, 1)";
                 return false;
             }
-            bloomPrefixes[prefixLen] = fpp;
-        } else {
-            bloomPrefixes.emplace(prefixLen, 0.0);
+            resolvedFpp = fpp;
         }
+
+        if (asSchemeObject) {
+            // Mirror the prefix bloom filter as a named TTableIndex scheme object. Two indexes
+            // over the same PK prefix collapse to a single engine prefix, so reject duplicates.
+            if (bloomPrefixes.contains(prefixLen)) {
+                code = Ydb::StatusIds::BAD_REQUEST;
+                error = "Multiple LocalBloomFilter indexes over the same primary-key prefix are not allowed";
+                return false;
+            }
+            auto* indexDesc = modifyScheme->MutableAlterTable()->AddTableIndexes();
+            indexDesc->SetName(index.name());
+            indexDesc->SetType(NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+            indexDesc->SetState(NKikimrSchemeOp::EIndexState::EIndexStateReady);
+            for (const auto& col : index.index_columns()) {
+                indexDesc->AddKeyColumnNames(col);
+            }
+            indexDesc->MutableBloomFilterDescription()->SetFalsePositiveProbability(
+                resolvedFpp > 0.0 ? resolvedFpp : NTable::DefaultBloomFilterFpp);
+        }
+
+        bloomPrefixes[prefixLen] = resolvedFpp;
     }
 
     for (auto&& [prefixLen, fpp] : bloomPrefixes) {
@@ -1904,12 +1926,23 @@ void FillIndexDescriptionImpl(TYdbProto& out, const NKikimrSchemeOp::TTableDescr
 
     // Synthesize LocalBloomFilter index entries for DataShard tables.
     // ByKeyFilterPrefixes stores prefix lengths (not index names), so names are generated
-    // as "idx_bloom_<prefixLen>".
+    // as "idx_bloom_<prefixLen>". When the bloom filter is already registered as a named
+    // TTableIndex scheme object (EnableLocalIndexAsSchemeObject), it was rendered above from
+    // GetTableIndexes(); skip those prefix lengths here to avoid double-listing.
     if (in.HasPartitionConfig() && in.GetPartitionConfig().ByKeyFilterPrefixesSize() > 0) {
         const auto& pkCols = in.GetKeyColumnNames();
+        THashSet<ui32> prefixesWithSchemeObject;
+        for (const auto& tableIndex : in.GetTableIndexes()) {
+            if (tableIndex.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
+                prefixesWithSchemeObject.insert(tableIndex.GetKeyColumnNames().size());
+            }
+        }
         for (auto&& filterPrefix : in.GetPartitionConfig().GetByKeyFilterPrefixes()) {
             const ui32 prefixLen = filterPrefix.GetPrefixLength();
             if (prefixLen == 0 || static_cast<int>(prefixLen) > pkCols.size()) {
+                continue;
+            }
+            if (prefixesWithSchemeObject.contains(prefixLen)) {
                 continue;
             }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Implement row-table bloom filter indexes as named scheme objects when EnableLocalIndexAsSchemeObject feature flag is enabled.

Changes:

* Mirror bloom filter indexes as TTableIndex scheme objects alongside engine ByKeyFilterPrefixes
* Add validation: bloom filter columns must be a left prefix of the primary key
* Prevent duplicate bloom filters over the same PK prefix
* Support DROP INDEX by name for bloom filters
* Fix SHOW CREATE to skip local indexes without implementation tables
* Update DescribeTable to avoid double-listing scheme-backed bloom filters

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://github.com/ydb-platform/ydb/pull/43144
https://github.com/ydb-platform/ydb/pull/39689
https://github.com/ydb-platform/ydb/pull/35716
