### PR TITLE
Configure the size of blobs protected by PhantomFlagStorage (#43892)

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.cpp
@@ -60,6 +60,7 @@ TNodeWarden::TNodeWarden(const TIntrusivePtr<TNodeWardenConfig> &cfg)
     , MaxInProgressSyncCount(0, 0, 1000)
     , EnablePhantomFlagStorage(0, 0, 1)
     , PhantomFlagStorageLimitPerVDiskBytes(10'000'000, 0, 100'000'000'000)
+    , VolatilePhantomFlagStorageBlobSizeLimitBytes(1'000'000, 1, 10'000'000)
     , EnableChunkKeeper(0, 0, 1)
     , MaxCommonLogChunksHDD(NPDisk::MaxCommonLogChunks, 1, 1'000'000)
     , MaxCommonLogChunksSSD(NPDisk::MaxCommonLogChunks, 1, 1'000'000)
@@ -422,6 +423,8 @@ void TNodeWarden::Bootstrap() {
         TControlBoard::RegisterSharedControl(MaxInProgressSyncCount, icb->VDiskControls.MaxInProgressSyncCount);
         TControlBoard::RegisterSharedControl(EnablePhantomFlagStorage, icb->VDiskControls.EnablePhantomFlagStorage);
         TControlBoard::RegisterSharedControl(PhantomFlagStorageLimitPerVDiskBytes, icb->VDiskControls.PhantomFlagStorageLimitPerVDiskBytes);
+        TControlBoard::RegisterSharedControl(VolatilePhantomFlagStorageBlobSizeLimitBytes,
+                icb->VDiskControls.VolatilePhantomFlagStorageBlobSizeLimitBytes);
         TControlBoard::RegisterSharedControl(EnableChunkKeeper, icb->VDiskControls.EnableChunkKeeper);
 
         TControlBoard::RegisterSharedControl(MaxCommonLogChunksHDD, icb->PDiskControls.MaxCommonLogChunksHDD);

--- a/ydb/core/blobstorage/nodewarden/node_warden_impl.h
+++ b/ydb/core/blobstorage/nodewarden/node_warden_impl.h
@@ -240,6 +240,7 @@ namespace NKikimr::NStorage {
         TControlWrapper MaxInProgressSyncCount;
         TControlWrapper EnablePhantomFlagStorage;
         TControlWrapper PhantomFlagStorageLimitPerVDiskBytes;
+        TControlWrapper VolatilePhantomFlagStorageBlobSizeLimitBytes;
 
         TControlWrapper EnableChunkKeeper;
 

--- a/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_vdisk.cpp
@@ -243,6 +243,7 @@ namespace NKikimr::NStorage {
             vdiskConfig->MaxInProgressSyncCount = MaxInProgressSyncCount;
             vdiskConfig->EnablePhantomFlagStorage = EnablePhantomFlagStorage;
             vdiskConfig->PhantomFlagStorageLimit = PhantomFlagStorageLimitPerVDiskBytes;
+            vdiskConfig->VolatilePhantomFlagStorageBlobSizeLimit = VolatilePhantomFlagStorageBlobSizeLimitBytes;
             vdiskConfig->EnableChunkKeeper = EnableChunkKeeper;
 
             vdiskConfig->CostMetricsParametersByMedia = CostMetricsParametersByMedia;

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -72,6 +72,7 @@ struct TEnvironmentSetup {
         const std::function<TIntrusivePtr<TStateStorageInfo>(std::function<TActorId(ui32, ui32)>, ui32)> StateStorageInfoGenerator = nullptr;
         const bool EnablePhantomFlagStorage = false;
         const ui64 PhantomFlagStorageLimitPerVDiskBytes = 10'000'000; // 10_MB
+        const ui64 VolatilePhantomFlagStorageBlobSizeLimitBytes = 1;
         const bool TinySyncLog = false;
         const TDuration MaxPutTimeoutDSProxy = TDuration::Seconds(60);
         const bool StartFakeWilsonCollectors = false;
@@ -573,6 +574,7 @@ config:
                 ADD_ICB_CONTROL(VDiskControls.GarbageThresholdToRunFullCompactionPerMille, 0, 0, 300, 0);
                 ADD_ICB_CONTROL(VDiskControls.EnablePhantomFlagStorage, false, false, true, Settings.EnablePhantomFlagStorage);
                 ADD_ICB_CONTROL(VDiskControls.PhantomFlagStorageLimitPerVDiskBytes, 10'000'000, 0, 100'000'000'000, Settings.PhantomFlagStorageLimitPerVDiskBytes);
+                ADD_ICB_CONTROL(VDiskControls.VolatilePhantomFlagStorageBlobSizeLimitBytes, 1'000'000, 1, 10'000'000, Settings.VolatilePhantomFlagStorageBlobSizeLimitBytes);
                 ADD_ICB_CONTROL(VDiskControls.EnableChunkKeeper, true, false, true, Settings.EnableChunkKeeper);
 
 #undef ADD_ICB_CONTROL

--- a/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
@@ -288,6 +288,47 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
             }
         }
 
+        ui64 RunBlobSizeLimitTest(ui64 blobSizeLimit, ui64 blobSize, ui32 blobCount) {
+            Initialize();
+
+            for (ui32 nodeId = 1; nodeId <= NodeCount; ++nodeId) {
+                Env->SetIcbControl(nodeId,
+                        "VDiskControls.VolatilePhantomFlagStorageBlobSizeLimitBytes", blobSizeLimit);
+            }
+
+            Ctest << "Write blobs of size# " << blobSize << " count# " << blobCount << Endl;
+            std::vector<TLogoBlobID> blobs = WriteCompressedData(TDataProfile{
+                .GroupId = GroupId,
+                .TotalBlobs = blobCount,
+                .BlobSize = blobSize,
+                .TabletId = TabletId,
+                .Channel = Channel,
+                .Generation = Generation,
+                .Step = Step,
+            });
+
+            Ctest << "Set Keep flags" << Endl;
+            CollectBlobs(new TVector<TLogoBlobID>(blobs.begin(), blobs.end()), nullptr);
+            WaitForSync();
+
+            Ctest << "Stop dead nodes" << Endl;
+            ToggleNodes(true, false, false);
+            WaitForSync();
+
+            Ctest << "Set DoNotKeepFlags on all blobs" << Endl;
+            CollectBlobs(nullptr, new TVector<TLogoBlobID>(blobs.begin(), blobs.end()));
+            WaitForSync();
+
+            WriteUnsyncedBlobs();
+            BaldSyncLog();
+            WaitForSync();
+
+            ui64 storedFlags = Env->AggregateVDiskCounters(Env->StoragePoolName, NodeCount, NodeCount,
+                    GroupId, PDiskLayout, "phantomflagstorage", "StoredFlagsCount");
+            Ctest << "StoredFlagsCount# " << storedFlags << Endl;
+            return storedFlags;
+        }
+
     public:
         const ui64 TabletId = 5000;
         const ui32 Channel = 1;
@@ -451,6 +492,40 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
         auto states2 = GetStates(erasure, EOnline::Alive, true, 100_B);
         states2[0].Online = EOnline::Dead;
         Test(erasure, states1, states2, true);
+    }
+
+    void TestBlobSizeLimit(TBlobStorageGroupType erasure, ui64 blobSize, bool expectStored) {
+        std::vector<TNodeState> nodeStates = GetStatesOneDead(erasure, 10_MB);
+        auto it = std::find_if(nodeStates.begin(), nodeStates.end(),
+                [&](const TNodeState& state) { return state.Online != EOnline::Dead; });
+        Y_VERIFY(it != nodeStates.end());
+        ui32 controllerNodeId = it - nodeStates.begin() + 1;
+        TTestCtx ctx({
+            .NodeCount = erasure.BlobSubgroupSize(),
+            .Erasure = erasure,
+            .ControllerNodeId = controllerNodeId,
+            .PDiskChunkSize = 32_MB,
+            .EnablePhantomFlagStorage = false,
+            .TinySyncLog = true,
+            .EnablePersistentPhantomFlagStorage = false,
+        }, 0, 10000, nodeStates, false);
+
+        ui64 storedFlags = ctx.RunBlobSizeLimitTest(1_MB, blobSize, 50);
+        if (expectStored) {
+            UNIT_ASSERT_C(storedFlags > 0,
+                    "Expected blobs above the size limit to be stored, but StoredFlagsCount# " << storedFlags);
+        } else {
+            UNIT_ASSERT_VALUES_EQUAL_C(storedFlags, 0,
+                    "Expected blobs below the size limit not to occupy space");
+        }
+    }
+
+    Y_UNIT_TEST(TestBlobSizeLimitAboveLimit) {
+        TestBlobSizeLimit(TBlobStorageGroupType::ErasureMirror3dc, 2_MB, true);
+    }
+
+    Y_UNIT_TEST(TestBlobSizeLimitBelowLimit) {
+        TestBlobSizeLimit(TBlobStorageGroupType::ErasureMirror3dc, 200, false);
     }
 
     #undef TEST_PHANTOM_BLOBS

--- a/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/phantom_blobs.cpp
@@ -507,7 +507,6 @@ Y_UNIT_TEST_SUITE(PhantomBlobs) {
             .PDiskChunkSize = 32_MB,
             .EnablePhantomFlagStorage = false,
             .TinySyncLog = true,
-            .EnablePersistentPhantomFlagStorage = false,
         }, 0, 10000, nodeStates, false);
 
         ui64 storedFlags = ctx.RunBlobSizeLimitTest(1_MB, blobSize, 50);

--- a/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
+++ b/ydb/core/blobstorage/ut_vdisk/lib/test_synclog.cpp
@@ -230,7 +230,8 @@ class TSyncLogTestWriteActor : public TActorBootstrapped<TSyncLogTestWriteActor>
                 Db->SyncLogFirstLsnToKeep,
                 false,
                 TControlWrapper(0, 0, 1),
-                TControlWrapper(20'000'000, 1, 100'000'000'000));
+                TControlWrapper(20'000'000, 1, 100'000'000'000),
+                TControlWrapper(1'000'000, 1, 10'000'000));
         TestCtx->SyncLogId = ctx.Register(CreateSyncLogActor(slCtx, Conf->GroupInfo, TestCtx->SelfVDiskId, std::move(repaired)));
         // Send Db birth lsn
         ui64 dbBirthLsn = 0;

--- a/ydb/core/blobstorage/vdisk/common/vdisk_config.h
+++ b/ydb/core/blobstorage/vdisk/common/vdisk_config.h
@@ -278,6 +278,7 @@ namespace NKikimr {
         TControlWrapper MaxInProgressSyncCount;
         TControlWrapper EnablePhantomFlagStorage;
         TControlWrapper PhantomFlagStorageLimit;
+        TControlWrapper VolatilePhantomFlagStorageBlobSizeLimit;
 
         ///////////// CHUNK Keeper //////////////////
         TControlWrapper EnableChunkKeeper;

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -2041,7 +2041,8 @@ namespace NKikimr {
                     Db->SyncLogFirstLsnToKeep,
                     Config->BaseInfo.ReadOnly,
                     Config->EnablePhantomFlagStorage,
-                    Config->PhantomFlagStorageLimit);
+                    Config->PhantomFlagStorageLimit,
+                    Config->VolatilePhantomFlagStorageBlobSizeLimit);
             Db->SyncLogID.Set(ctx.Register(CreateSyncLogActor(slCtx, GInfo, SelfVDiskId, std::move(repairedSyncLog))));
             ActiveActors.Insert(Db->SyncLogID, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE); // keep forever
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_context.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_context.h
@@ -60,6 +60,7 @@ public:
 
     TControlWrapper EnablePhantomFlagStorage;
     TControlWrapper PhantomFlagStorageLimit;
+    TControlWrapper VolatilePhantomFlagStorageBlobSizeLimit;
 
     TSyncLogCtx(TIntrusivePtr<TVDiskContext> vctx,
             TIntrusivePtr<TLsnMngr> lsnMngr,
@@ -74,7 +75,8 @@ public:
             std::shared_ptr<TSyncLogFirstLsnToKeep> syncLogFirstLsnToKeep,
             bool isReadOnlyVDisk,
             const TControlWrapper& enablePhantomFlagStorage,
-            const TControlWrapper& phantomFlagStorageLimit)
+            const TControlWrapper& phantomFlagStorageLimit,
+            const TControlWrapper& volatilePhantomFlagStorageBlobSizeLimit)
         : VCtx(std::move(vctx))
         , LsnMngr(std::move(lsnMngr))
         , PDiskCtx(std::move(pdiskCtx))
@@ -92,6 +94,7 @@ public:
         , IsReadOnlyVDisk(isReadOnlyVDisk)
         , EnablePhantomFlagStorage(enablePhantomFlagStorage)
         , PhantomFlagStorageLimit(phantomFlagStorageLimit)
+        , VolatilePhantomFlagStorageBlobSizeLimit(volatilePhantomFlagStorageBlobSizeLimit)
     {}
 };
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper.cpp
@@ -72,6 +72,8 @@ namespace NKikimr {
             // PERFORM ACTIONS
             ////////////////////////////////////////////////////////////////////////
             void PerformActions(const TActorContext &ctx) {
+                KeepState.UpdateAtomics(TActivationContext::Now());
+
                 if (auto v = KeepState.GetChunksToForget(); !v.empty()) {
                     Send(SlCtx->PDiskCtx->PDiskId, new NPDisk::TEvChunkForget(SlCtx->PDiskCtx->Dsk->Owner,
                         SlCtx->PDiskCtx->Dsk->OwnerRound, std::move(v)));

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -46,6 +46,7 @@ namespace NKikimr {
             , PhantomFlagStorageState(SlCtx)
             , EnablePhantomFlagStorage(SlCtx->EnablePhantomFlagStorage)
             , PhantomFlagStorageLimit(SlCtx->PhantomFlagStorageLimit)
+            , VolatilePhantomFlagStorageBlobSizeLimit(SlCtx->VolatilePhantomFlagStorageBlobSizeLimit)
             , SelfOrderNumber(SlCtx->VCtx->Top->GetOrderNumber(SlCtx->VCtx->ShortSelfVDisk))
         {
             Y_VERIFY_S(SlCtx->VCtx->Top->GetTotalVDisksNum() <= MaxPossibleDisksInGroup,
@@ -87,7 +88,7 @@ namespace NKikimr {
             // Put blob record to PhantomFlagStorage
             if (PhantomFlagStorageState.IsActive() && rec->RecType == TRecordHdr::RecLogoBlob) {
                 PhantomFlagStorageState.ProcessBlobRecordFromSyncLog(rec->GetLogoBlob(),
-                        PhantomFlagStorageLimit);
+                        PhantomFlagStorageLimit, VolatilePhantomFlagStorageBlobSizeLimit);
             }
         }
 
@@ -98,6 +99,7 @@ namespace NKikimr {
                 DelayedActions.MemOverflow = true;
 
             // Put all blob records to PhantomFlagStorage
+            ui64 blobSizeLimit = VolatilePhantomFlagStorageBlobSizeLimit;
             TRecordHdr* rec = (TRecordHdr*)buf;
             ui32 recSize = 0;
             do {
@@ -105,7 +107,7 @@ namespace NKikimr {
                 Y_DEBUG_ABORT_UNLESS(recSize <= size);
                 if (PhantomFlagStorageState.IsActive() && rec->RecType == TRecordHdr::RecLogoBlob) {
                     PhantomFlagStorageState.ProcessBlobRecordFromSyncLog(rec->GetLogoBlob(),
-                            PhantomFlagStorageLimit);
+                            PhantomFlagStorageLimit, blobSizeLimit);
                 }
                 rec = rec->Next();
                 size -= recSize;
@@ -460,7 +462,8 @@ namespace NKikimr {
         }
 
         void TSyncLogKeeperState::FinishPhantomFlagStorageBuilder(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds) {
-            PhantomFlagStorageState.FinishBuilding(std::move(flags), std::move(thresholds), PhantomFlagStorageLimit);
+            PhantomFlagStorageState.FinishBuilding(std::move(flags), std::move(thresholds),
+                    PhantomFlagStorageLimit, VolatilePhantomFlagStorageBlobSizeLimit);
         }
 
         TPhantomFlagStorageSnapshot TSyncLogKeeperState::GetPhantomFlagStorageSnapshot() const {
@@ -496,6 +499,12 @@ namespace NKikimr {
         void TSyncLogKeeperState::UpdateMetrics() {
             PhantomFlagStorageState.UpdateMetrics();
             SlCtx->PhantomFlagStorageGroup.SyncedMask() = SyncedMask.to_ullong();
+        }
+
+        void TSyncLogKeeperState::UpdateAtomics(TInstant now) {
+            VolatilePhantomFlagStorageBlobSizeLimit.Update(now);
+            PhantomFlagStorageLimit.Update(now);
+            EnablePhantomFlagStorage.Update(now);
         }
 
     } // NSyncLog

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.h
@@ -96,6 +96,7 @@ namespace NKikimr {
             void ProcessLocalSyncData(ui32 orderNumber, const TString& data);
 
             void UpdateMetrics();
+            void UpdateAtomics(TInstant now);
 
             TVector<ui32> GetChunksToForget() {
                 return std::exchange(ChunksToForget, {});
@@ -139,6 +140,7 @@ namespace NKikimr {
             TPhantomFlagStorageState PhantomFlagStorageState;
             TMemorizableControlWrapper EnablePhantomFlagStorage;
             TMemorizableControlWrapper PhantomFlagStorageLimit;
+            TMemorizableControlWrapper VolatilePhantomFlagStorageBlobSizeLimit;
 
             ui32 SelfOrderNumber;
 

--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_ut.cpp
@@ -117,7 +117,8 @@ namespace NKikimr {
             nullptr,
             false,
             TControlWrapper(0, 0, 1),
-            TControlWrapper(20'000'000, 1, 100'000'000'000));
+            TControlWrapper(20'000'000, 1, 100'000'000'000),
+            TControlWrapper(1'000'000, 1, 10'000'000));
 
         State = std::make_unique<TSyncLogKeeperState>(slCtx, std::move(repaired), syncLogMaxMemAmount, syncLogMaxDiskAmount,
                 syncLogMaxEntryPointSize);

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.cpp
@@ -27,7 +27,9 @@ void TPhantomFlagStorageState::StartBuilding() {
     Building = true;
 }
 
-void TPhantomFlagStorageState::ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec, ui64 sizeLimit) {
+void TPhantomFlagStorageState::ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec, ui64 sizeLimit,
+        ui64 blobSizeLimit) {
+    BlobSizeLimit = blobSizeLimit;
     AdjustSize(sizeLimit);
     if (!Active) {
         return;
@@ -59,11 +61,13 @@ void TPhantomFlagStorageState::ProcessBarrierRecordFromNeighbour(ui32 orderNumbe
 }
 
 void TPhantomFlagStorageState::FinishBuilding(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds,
-        ui64 sizeLimit) {
+        ui64 sizeLimit, ui64 blobSizeLimit) {
     if (!Active) {
         // PhantomFlagStorage was deactivated while building, do nothing
         return;
     }
+
+    BlobSizeLimit = blobSizeLimit;
 
     AdjustSize(sizeLimit);
     ui64 flagsAdded = 0;
@@ -164,6 +168,9 @@ void TPhantomFlagStorageState::AdjustSize(ui64 sizeLimit) {
 }
 
 bool TPhantomFlagStorageState::AddFlag(const TLogoBlobRec& blobRec) {
+    if (BlobSizeLimit && blobRec.LogoBlobID().BlobSize() < BlobSizeLimit) {
+        return true;
+    }
     if (StoredFlags.size() < StoredFlags.capacity()) {
         StoredFlags.emplace_back(blobRec);
         return true;

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.h
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_state.h
@@ -22,12 +22,13 @@ public:
     void StartBuilding();
 
     // Adds DoNotKeep flags from synclog if needed
-    void ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec, ui64 sizeLimit);
+    void ProcessBlobRecordFromSyncLog(const TLogoBlobRec* blobRec, ui64 sizeLimit, ui64 blobSizeLimit);
 
     // Add all DoNotKeep records from cut synclog snapshot up to sizeLimit
     // Note: in some obscure cases there may be two active builders simultaneously
     // It shouldn't make any difference though, we just add more flags
-    void FinishBuilding(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds, ui64 sizeLimit);
+    void FinishBuilding(TPhantomFlags&& flags, TPhantomFlagThresholds&& thresholds, ui64 sizeLimit,
+            ui64 blobSizeLimit);
     void Deactivate();
 
     // TODO: rebuild thresholds structure after restart. Either write it to VDisk log or rebuild from hull snapshot
@@ -62,6 +63,7 @@ private:
     TPhantomFlags StoredFlags;
     ui64 MaxFlagsStoredCount;
     TSyncedMask SyncedMask;
+    ui64 BlobSizeLimit = 0;
     bool Active = false;
     bool Building = false;
 };

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1846,6 +1846,12 @@ message TImmediateControlsConfig {
             MaxValue: 1,
             DefaultValue: 0,
         }];
+        optional uint64 VolatilePhantomFlagStorageBlobSizeLimitBytes = 48 [(ControlOptions) = {
+            Description: "Minimum size of a blob in bytes covered by PhantomFlagStorage",
+            MinValue: 1,
+            MaxValue: 10000000,     // 10 MB
+            DefaultValue: 1000000,  // 1 MB
+        }];
     }
 
     message TTabletControls {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add configurable minimal size limit for blobs to be covered by PhantomFlagStorage

### Changelog category <!-- remove all except one -->

* Improvement