### PR TITLE
Added authentication and database checks in config service

### DIFF
--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -274,11 +274,14 @@ public:
         if (shim.MainConfig) {
             if (NYamlConfig::IsDatabaseConfig(*shim.MainConfig)) {
                 DatabaseConfig = shim.MainConfig;
-                CheckDatabaseAuthorization();
+                if (!ResolveTargetDatabase()) {
+                    return;
+                }
+                CheckDatabaseAuthorization(*TargetDatabase);
                 return;
             }
         }
-        if (!NKikimr::IsAdministrator(AppData(), Request_->GetSerializedToken())) {
+        if (!NKikimr::IsAdministrator(AppData(), Request_->GetInternalToken().Get())) {
             self->Reply(Ydb::StatusIds::UNAUTHORIZED, "User is not a cluster administrator.",
                   NKikimrIssues::TIssuesIds::ACCESS_DENIED, self->ActorContext());
             return;
@@ -366,57 +369,6 @@ public:
         );
     }
 
-private:
-    std::optional<TString> DatabaseConfig;
-    std::optional<TString> TargetDatabase;
-
-    void CheckDatabaseAuthorization() {
-        const auto& metadata = NYamlConfig::GetDatabaseMetadata(*DatabaseConfig);
-
-        if (metadata.Database) {
-            TargetDatabase = metadata.Database;
-        } else {
-            Reply(Ydb::StatusIds::BAD_REQUEST, "No database name found in metadata",
-                    NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
-            return;
-        }
-
-        if (*TargetDatabase == ("/" + AppData()->DomainsInfo->Domain->Name) ||
-            *TargetDatabase == AppData()->DomainsInfo->Domain->Name) {
-            Reply(Ydb::StatusIds::BAD_REQUEST, "Provided database is a domain database.",
-                    NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
-            return;
-        }
-
-        {
-            const auto& maybeDatabaseName = Request_->GetDatabaseName();
-            if (maybeDatabaseName && !maybeDatabaseName.GetRef().empty()) {
-                if (NKikimr::CanonizePath(*TargetDatabase) != NKikimr::CanonizePath(maybeDatabaseName.GetRef())) {
-                    Reply(Ydb::StatusIds::BAD_REQUEST,
-                        "Database in config metadata does not match the requested database.",
-                        NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
-                    return;
-                }
-            }
-        }
-
-        bool isAdministrator = NKikimr::IsAdministrator(AppData(), Request_->GetSerializedToken());
-        if (!isAdministrator) {
-            auto request = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
-            request->DatabaseName = *TargetDatabase;
-
-            auto& entry = request->ResultSet.emplace_back();
-            entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
-            entry.Path = NKikimr::SplitPath(*TargetDatabase);
-
-            auto* self = Self();
-            self->Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.release()));
-            self->Become(&TReplaceStorageConfigRequest::StateWaitResolveDatabase);
-            return;
-        }
-        SendRequestToConsole();
-    }
-
     void SendRequestToConsole() {
         NTabletPipe::TClientConfig pipeConfig;
         pipeConfig.RetryPolicy = {
@@ -447,39 +399,39 @@ private:
         Self()->Become(&TReplaceStorageConfigRequest::StateConsoleReplaceFunc);
     }
 
-    STFUNC(StateWaitResolveDatabase) {
-        switch (ev->GetTypeRewrite()) {
-            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleResolveDatabase);
-            default:
-                return TBase::StateFuncBase(ev);
-        }
-    }
+private:
+    std::optional<TString> DatabaseConfig;
+    std::optional<TString> TargetDatabase;
 
-    void HandleResolveDatabase(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-        const NSchemeCache::TSchemeCacheNavigate& request = *ev->Get()->Request.Get();
-        auto *self = Self();
-        if (request.ResultSet.empty() || request.ErrorCount > 0) {
-            self->Reply(Ydb::StatusIds::SCHEME_ERROR, "Error resolving database",
-                  NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, self->ActorContext());
-            return;
+    bool ResolveTargetDatabase() {
+        const auto& metadata = NYamlConfig::GetDatabaseMetadata(*DatabaseConfig);
+
+        if (metadata.Database) {
+            TargetDatabase = CanonizePath(*metadata.Database);
+        } else {
+            Reply(Ydb::StatusIds::BAD_REQUEST, "No database name found in metadata",
+                    NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
+            return false;
         }
 
-        const auto& entry = request.ResultSet.front();
-        const auto& databaseOwner = entry.Self->Info.GetOwner();
-
-        NACLibProto::TUserToken tokenPb;
-        if (!tokenPb.ParseFromString(Request_->GetSerializedToken())) {
-            tokenPb = NACLibProto::TUserToken();
+        if (*TargetDatabase == ("/" + AppData()->DomainsInfo->Domain->Name) ||
+            *TargetDatabase == AppData()->DomainsInfo->Domain->Name) {
+            Reply(Ydb::StatusIds::BAD_REQUEST, "Provided database is a domain database.",
+                    NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
+            return false;
         }
-        const auto& parsedToken = NACLib::TUserToken(tokenPb);
 
-        bool isDatabaseAdmin = NKikimr::IsDatabaseAdministrator(&parsedToken, databaseOwner);
-        if (!isDatabaseAdmin) {
-            self->Reply(Ydb::StatusIds::UNAUTHORIZED, "User is not a database administrator.",
-                  NKikimrIssues::TIssuesIds::ACCESS_DENIED, self->ActorContext());
-            return;
+        const auto& maybeDatabaseName = Request_->GetDatabaseName();
+        if (maybeDatabaseName && !maybeDatabaseName.GetRef().empty()) {
+            if (*TargetDatabase != CanonizePath(maybeDatabaseName.GetRef())) {
+                Reply(Ydb::StatusIds::BAD_REQUEST,
+                    "Database in config metadata does not match the requested database.",
+                    NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
+                return false;
+            }
         }
-        SendRequestToConsole();
+
+        return true;
     }
 
     STFUNC(StateConsoleReplaceFunc) {
@@ -544,10 +496,10 @@ public:
         auto *self = Self();
         self->OnBootstrap();
 
-        if (self->Request_->GetDatabaseName()) {
+        if (const auto& databaseName = self->Request_->GetDatabaseName()) {
             // Database YAML config (Ydb::DynamicConfig::ConfigIdentity::TypeCase::kDatabase)
             // is requested directly from Console (like legacy API)
-            SendRequestToConsole();
+            CheckDatabaseAuthorization(*databaseName);
             return;
         }
 
@@ -649,7 +601,6 @@ public:
         return ev;
     }
 
-private:
     void SendRequestToConsole() {
         NTabletPipe::TClientConfig pipeConfig;
         pipeConfig.RetryPolicy = {
@@ -670,6 +621,7 @@ private:
         Self()->Become(&TFetchStorageConfigRequest::StateConsoleFetchFunc);
     }
 
+private:
     STFUNC(StateConsoleFetchFunc) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NConsole::TEvConsole::TEvGetAllConfigsResponse, Handle);

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -375,8 +375,7 @@ private:
 
         if (metadata.Database) {
             TargetDatabase = metadata.Database;
-        }
-        else {
+        } else {
             Reply(Ydb::StatusIds::BAD_REQUEST, "No database name found in metadata",
                     NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
             return;
@@ -388,6 +387,19 @@ private:
                     NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
             return;
         }
+
+        {
+            const auto& maybeDatabaseName = Request_->GetDatabaseName();
+            if (maybeDatabaseName && !maybeDatabaseName.GetRef().empty()) {
+                if (NKikimr::CanonizePath(*TargetDatabase) != NKikimr::CanonizePath(maybeDatabaseName.GetRef())) {
+                    Reply(Ydb::StatusIds::BAD_REQUEST,
+                        "Database in config metadata does not match the requested database.",
+                        NKikimrIssues::TIssuesIds::DEFAULT_ERROR, ActorContext());
+                    return;
+                }
+            }
+        }
+
         bool isAdministrator = NKikimr::IsAdministrator(AppData(), Request_->GetSerializedToken());
         if (!isAdministrator) {
             auto request = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();

--- a/ydb/core/grpc_services/rpc_config_base.h
+++ b/ydb/core/grpc_services/rpc_config_base.h
@@ -8,6 +8,8 @@
 #include <ydb/core/blobstorage/base/blobstorage_console_events.h>
 #include <ydb/core/blobstorage/nodewarden/node_warden_events.h>
 #include <ydb/core/protos/blobstorage_base3.pb.h>
+#include <ydb/core/base/auth.h>
+#include <ydb/core/base/path.h>
 #include <ydb/core/base/tabletid.h>
 #include <ydb/core/mind/bscontroller/bsc.h>
 #include <ydb/library/ydb_issue/issue_helpers.h>
@@ -16,6 +18,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_resources.h>
 #include <ydb/core/cms/console/console.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 
 namespace NKikimr::NGRpcService {
 
@@ -30,7 +33,7 @@ public:
         return Type;
     }
 
-    TDriveDevice(TString path, NKikimrBlobStorage::EPDiskType type) 
+    TDriveDevice(TString path, NKikimrBlobStorage::EPDiskType type)
         : Path(path), Type(type) {}
 
     auto operator<=>(const TDriveDevice &) const = default;
@@ -381,7 +384,7 @@ protected:
         auto *self = Self();
         self->Reply(ev->Get()->Record.GetYdbStatus(), ev->Get()->Record.GetIssues(), self->ActorContext());
     }
-    
+
     void HandleConsole(TEvTabletPipe::TEvClientDestroyed::TPtr&) {
         auto *self = Self();
         self->Reply(Ydb::StatusIds::UNAVAILABLE, "Connection to Console was lost",
@@ -394,6 +397,63 @@ protected:
             self->Reply(Ydb::StatusIds::UNAVAILABLE, "Failed to connect to Console",
                        NKikimrIssues::TIssuesIds::SHARD_NOT_AVAILABLE, self->ActorContext());
         }
+    }
+
+    void CheckDatabaseAuthorization(const TString& database) {
+        auto *self = Self();
+        if (NKikimr::IsAdministrator(AppData(), self->Request_->GetInternalToken().Get())) {
+            self->SendRequestToConsole();
+            return;
+        }
+
+        if (!AppData()->FeatureFlags.GetEnableDatabaseAdmin()) {
+            self->Reply(Ydb::StatusIds::UNAUTHORIZED, "User is not a cluster administrator.",
+                NKikimrIssues::TIssuesIds::ACCESS_DENIED, self->ActorContext());
+            return;
+        }
+
+        auto request = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
+        request->DatabaseName = database;
+
+        auto& entry = request->ResultSet.emplace_back();
+        entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
+        entry.Path = NKikimr::SplitPath(database);
+
+        self->Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.release()));
+        self->Become(&TBSConfigRequestGrpc::StateWaitResolveDatabase);
+    }
+
+    STFUNC(StateWaitResolveDatabase) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleResolveDatabase);
+            default:
+                return TBase::StateFuncBase(ev);
+        }
+    }
+
+    void HandleResolveDatabase(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+        auto *self = Self();
+        const NSchemeCache::TSchemeCacheNavigate& request = *ev->Get()->Request.Get();
+        if (request.ResultSet.empty() || request.ErrorCount > 0) {
+            self->Reply(Ydb::StatusIds::SCHEME_ERROR, "Error resolving database",
+                NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, self->ActorContext());
+            return;
+        }
+
+        const auto& entry = request.ResultSet.front();
+        if (!entry.Self) {
+            self->Reply(Ydb::StatusIds::SCHEME_ERROR, "Error resolving database",
+                NKikimrIssues::TIssuesIds::GENERIC_RESOLVE_ERROR, self->ActorContext());
+            return;
+        }
+        const auto& databaseOwner = entry.Self->Info.GetOwner();
+
+        if (!NKikimr::IsDatabaseAdministrator(self->Request_->GetInternalToken().Get(), databaseOwner)) {
+            self->Reply(Ydb::StatusIds::UNAUTHORIZED, "User is not a database administrator.",
+                NKikimrIssues::TIssuesIds::ACCESS_DENIED, self->ActorContext());
+            return;
+        }
+        self->SendRequestToConsole();
     }
 
     virtual bool ValidateRequest(Ydb::StatusIds::StatusCode& status, NYql::TIssues& issues) = 0;


### PR DESCRIPTION
Added authorization check to config fetch.

Fetching a database config now requires the caller to be a cluster administrator or, when EnableDatabaseAdmin flag is set, the database administrator.
