### PR TITLE
Structured log writing supports various TString() method result types

### DIFF
--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -257,6 +257,26 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
+    struct TTestTypeToStringRef {
+        const TString& ToString() const {
+            static TString result("some value");
+            return result;
+        }
+    };
+
+    struct TTestTypeToStdString {
+        std::string ToString() const {
+            return "some value";
+        }
+    };
+
+    struct TTestTypeToStdStringRef {
+        const std::string& ToString() const {
+            static std::string result("some value");
+            return result;
+        }
+    };
+
     struct TTestTypeToStructuredMessage {
         TStructuredMessage ToStructuredMessage() const {
             return YDB_LOG_CREATE_MESSAGE({"value1", 1}, {"value2", 2});
@@ -275,6 +295,9 @@ Y_UNIT_TEST_SUITE(StructLog) {
 
     Y_UNIT_TEST(CreateMessageToMethods) {
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToString{}}), "value=some value");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringRef{}}), "value=some value");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStdString{}}), "value=some value");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStdStringRef{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStructuredMessage{}}), "value.value1=1, value.value2=2");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToBoth{}}), "value.value1=1, value.value2=2");
     }

--- a/ydb/library/actors/core/ut/struct_log_ut.cpp
+++ b/ydb/library/actors/core/ut/struct_log_ut.cpp
@@ -264,6 +264,12 @@ Y_UNIT_TEST_SUITE(StructLog) {
         }
     };
 
+    struct TTestTypeToStringBuf {
+        TStringBuf ToString() const {
+            return "some value";
+        }
+    };
+
     struct TTestTypeToStdString {
         std::string ToString() const {
             return "some value";
@@ -274,6 +280,12 @@ Y_UNIT_TEST_SUITE(StructLog) {
         const std::string& ToString() const {
             static std::string result("some value");
             return result;
+        }
+    };
+
+    struct TTestTypeToStdStringView {
+        std::string_view ToString() const {
+            return "some value";
         }
     };
 
@@ -296,8 +308,10 @@ Y_UNIT_TEST_SUITE(StructLog) {
     Y_UNIT_TEST(CreateMessageToMethods) {
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToString{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringRef{}}), "value=some value");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStringBuf{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStdString{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStdStringRef{}}), "value=some value");
+        TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStdStringView{}}), "value=some value");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToStructuredMessage{}}), "value.value1=1, value.value2=2");
         TEST_MESSAGE(YDB_LOG_CREATE_MESSAGE({"value", TTestTypeToBoth{}}), "value.value1=1, value.value2=2");
     }

--- a/ydb/library/actors/struct_log/create_message_impl.h
+++ b/ydb/library/actors/struct_log/create_message_impl.h
@@ -47,8 +47,10 @@ public:
         // check the signature if it exists
         template <typename X> static constexpr decltype(static_cast<TString (X::*)() const>(&X::ToString), std::true_type{}) check(int);
         template <typename X> static constexpr decltype(static_cast<const TString& (X::*)() const>(&X::ToString), std::true_type{}) check(int);
+        template <typename X> static constexpr decltype(static_cast<TStringBuf (X::*)() const>(&X::ToString), std::true_type{}) check(int);
         template <typename X> static constexpr decltype(static_cast<std::string (X::*)() const>(&X::ToString), std::true_type{}) check(int);
         template <typename X> static constexpr decltype(static_cast<const std::string& (X::*)() const>(&X::ToString), std::true_type{}) check(int);
+        template <typename X> static constexpr decltype(static_cast<std::string_view (X::*)() const>(&X::ToString), std::true_type{}) check(int);
         // in case when there is no such signature
         template <typename>   static constexpr std::false_type check(...);
     public:

--- a/ydb/library/actors/struct_log/create_message_impl.h
+++ b/ydb/library/actors/struct_log/create_message_impl.h
@@ -46,6 +46,9 @@ public:
     class THasToStringMethod {
         // check the signature if it exists
         template <typename X> static constexpr decltype(static_cast<TString (X::*)() const>(&X::ToString), std::true_type{}) check(int);
+        template <typename X> static constexpr decltype(static_cast<const TString& (X::*)() const>(&X::ToString), std::true_type{}) check(int);
+        template <typename X> static constexpr decltype(static_cast<std::string (X::*)() const>(&X::ToString), std::true_type{}) check(int);
+        template <typename X> static constexpr decltype(static_cast<const std::string& (X::*)() const>(&X::ToString), std::true_type{}) check(int);
         // in case when there is no such signature
         template <typename>   static constexpr std::false_type check(...);
     public:


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When writing information to a structured log, can be called the `ToString` method with different result types (not only `TString`)
