### PR TITLE
[NEW RBO] Extract common conjuncts from filter expressions

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_expression.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_expression.cpp
@@ -4,6 +4,7 @@
 #include <yql/essentials/ast/yql_ast_escaping.h>
 #include <yql/essentials/core/yql_expr_optimize.h>
 #include <yql/essentials/core/yql_expr_type_annotation.h>
+#include <yql/essentials/core/yql_opt_utils.h>
 #include <yql/essentials/utils/log/log.h>
 
 #include <util/stream/str.h>
@@ -72,6 +73,117 @@ bool TestAndExtractEqualityPredicate(TExprNode::TPtr pred, TExprNode::TPtr& left
         return true;
     }
     return false;
+}
+
+bool SameExpr(const TExprNode::TPtr& left, const TExprNode::TPtr& right) {
+    if (left.Get() == right.Get()) {
+        return true;
+    }
+
+    const TExprNode* leftPtr = left.Get();
+    const TExprNode* rightPtr = right.Get();
+    return CompareExprTrees(leftPtr, rightPtr);
+}
+
+bool ContainsExpr(const TExprNode::TListType& nodes, const TExprNode::TPtr& needle) {
+    return AnyOf(nodes, [&](const TExprNode::TPtr& node) {
+        return SameExpr(node, needle);
+    });
+}
+
+TExprNode::TPtr MakeLogical(TPositionHandle pos, TStringBuf op, TExprNode::TListType terms, TExprContext& ctx) {
+    if (terms.empty()) {
+        return op == "And" ? MakeBool<true>(pos, ctx) : MakeBool<false>(pos, ctx);
+    }
+
+    if (terms.size() == 1) {
+        return terms.front();
+    }
+
+    return ctx.NewCallable(pos, op, std::move(terms));
+}
+
+TExprNode::TPtr MakeConjunct(TPositionHandle pos, TExprNode::TListType terms, TExprContext& ctx) {
+    return MakeLogical(pos, "And", std::move(terms), ctx);
+}
+
+TExprNode::TPtr MakeDisjunct(TPositionHandle pos, TExprNode::TListType terms, TExprContext& ctx) {
+    return MakeLogical(pos, "Or", std::move(terms), ctx);
+}
+
+struct TExtractedCommonExpressions {
+    TExprNode::TListType Common;
+    TVector<TExprNode::TListType> Residuals;
+};
+
+std::optional<TExtractedCommonExpressions> ExtractCommonExpressions(const TVector<TExprNode::TListType>& branches) {
+    TExtractedCommonExpressions result;
+    if (branches.empty()) {
+        return std::nullopt;
+    }
+
+    auto& common = result.Common;
+    for (const auto& candidate : branches.front()) {
+        if (candidate->HasSideEffects() || ContainsExpr(common, candidate)) {
+            continue;
+        }
+
+        if (AllOf(branches, [&](const auto& branch) { return ContainsExpr(branch, candidate); })) {
+            common.push_back(candidate);
+        }
+    }
+
+    if (common.empty()) {
+        return std::nullopt;
+    }
+
+    result.Residuals.reserve(branches.size());
+    for (const auto& branch : branches) {
+        auto& residual = result.Residuals.emplace_back();
+        for (const auto& term : branch) {
+            if (!ContainsExpr(common, term)) {
+                residual.push_back(term);
+            }
+        }
+    }
+
+    return result;
+}
+
+std::optional<TExprNode::TPtr> FactorCommonExpressions(TExprNode::TPtr node, TExprContext& ctx) {
+    TExprNode::TListType disjuncts;
+    GetOrTerms(node, disjuncts);
+    if (disjuncts.size() < 2) {
+        return std::nullopt;
+    }
+
+    TVector<TExprNode::TListType> branches;
+    branches.reserve(disjuncts.size());
+    for (const auto& disjunct : disjuncts) {
+        GetAndTerms(disjunct, branches.emplace_back());
+    }
+
+    auto extracted = ExtractCommonExpressions(branches);
+    if (!extracted) {
+        return std::nullopt;
+    }
+
+    auto common = std::move(extracted->Common);
+    auto residuals = std::move(extracted->Residuals);
+    TExprNode::TListType residualDisjuncts;
+    residualDisjuncts.reserve(residuals.size());
+
+    for (auto& residual : residuals) {
+        if (residual.empty()) {
+            return MakeConjunct(node->Pos(), std::move(common), ctx);
+        }
+
+        residualDisjuncts.push_back(MakeConjunct(node->Pos(), std::move(residual), ctx));
+    }
+
+    common.push_back(MakeDisjunct(node->Pos(), std::move(residualDisjuncts), ctx));
+
+    return MakeConjunct(node->Pos(), std::move(common), ctx);
 }
 
 TExprNode::TPtr RenameMembers(TExprNode::TPtr input, const THashMap<TInfoUnit, TInfoUnit, TInfoUnit::THashFunction> &renameMap,
@@ -378,23 +490,35 @@ TExpression::TExpression(TExprNode::TPtr node, TExprContext* ctx, TPlanProps* pr
 }
 
 TVector<TExpression> TExpression::SplitConjunct() const {
-    Y_ENSURE(PlanProps);
+    Y_ENSURE(Node->IsLambda(), "Expression node is not a lambda");
+    Y_ENSURE(Ctx, "Expression context is null");
 
-    auto body = Node->ChildPtr(1);
-    if (body->IsCallable("ToPg")) {
-        body = body->ChildPtr(0);
-    }
+    TExprNode::TListType terms;
+    GetAndTerms(GetExpressionBody(), terms);
 
     TVector<TExpression> conjuncts;
-    if (body->IsCallable("And")) {
-        for (auto conj : body->ChildrenList()) {
-            conjuncts.push_back(TExpression(conj, Ctx, PlanProps));
-        }
-    } else {
-        conjuncts.push_back(TExpression(body, Ctx, PlanProps));
+    conjuncts.reserve(terms.size());
+    for (const auto& term : terms) {
+        conjuncts.emplace_back(term, Ctx, PlanProps);
     }
 
     return conjuncts;
+}
+
+TVector<TExpression> TExpression::SplitDisjunct() const {
+    Y_ENSURE(Node->IsLambda(), "Expression node is not a lambda");
+    Y_ENSURE(Ctx, "Expression context is null");
+
+    TExprNode::TListType terms;
+    GetOrTerms(GetExpressionBody(), terms);
+
+    TVector<TExpression> disjuncts;
+    disjuncts.reserve(terms.size());
+    for (const auto& term : terms) {
+        disjuncts.emplace_back(term, Ctx, PlanProps);
+    }
+
+    return disjuncts;
 }
 
 bool TExpression::IsColumnAccess() const {
@@ -504,6 +628,18 @@ TExpression TExpression::ApplyReplaceMap(const TNodeOnNodeOwnedMap& map, TRBOCon
     YQL_CLOG(TRACE, CoreDq) << "After replace " << PrintRBOExpression(output, *Ctx);
 
     return TExpression(output, Ctx, PlanProps);
+}
+
+std::optional<TExpression> TExpression::TryExtractCommonConjuncts() const {
+    Y_ENSURE(Node->IsLambda(), "Expression node is not lambda");
+    Y_ENSURE(Ctx, "Expression context is null");
+
+    auto newPredicate = FactorCommonExpressions(GetExpressionBody(), *Ctx);
+    if (!newPredicate) {
+        return std::nullopt;
+    }
+
+    return TExpression(*newPredicate, Ctx, PlanProps);
 }
 
 TExpression TExpression::PruneCast() const {

--- a/ydb/core/kqp/opt/rbo/kqp_expression.h
+++ b/ydb/core/kqp/opt/rbo/kqp_expression.h
@@ -3,6 +3,9 @@
 #include "kqp_info_unit.h"
 #include "kqp_rbo_context.h"
 #include "kqp_plan_props.h"
+
+#include <optional>
+
 #include <ydb/core/kqp/common/kqp_yql.h>
 
 
@@ -29,8 +32,12 @@ class TExpression {
     ~TExpression() = default;
 
     // Split a conjunct into a vector of expressions. If the is no conjunction at the top level,
-    // just return a vector with this node. Handles pg conversions as well
+    // just return a vector with this node.
     TVector<TExpression> SplitConjunct() const;
+
+    // Split a disjunct into a vector of expressions. If the is no disjunction at the top level,
+    // just return a vector with this node.
+    TVector<TExpression> SplitDisjunct() const;
 
     // Check if the expression is just getting a single column from a tuple
     bool IsColumnAccess() const;
@@ -67,6 +74,9 @@ class TExpression {
 
     // Apply a generic replace map to the lambda of the expression
     TExpression ApplyReplaceMap(const TNodeOnNodeOwnedMap& map, TRBOContext& ctx) const;
+
+    // Extract common conjuncts from OR branches.
+    std::optional<TExpression> TryExtractCommonConjuncts() const;
 
     // Remove a cast from the expression
     TExpression PruneCast() const;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
@@ -315,6 +315,16 @@ class TPushFilterUnderMapRule : public ISimplifiedRule {
 };
 
 /**
+ * Extract common conjuncts from OR branches to expose top-level filters.
+ */
+class TExtractCommonConjunctsRule : public ISimplifiedRule {
+  public:
+    TExtractCommonConjunctsRule() : ISimplifiedRule("Extract common conjuncts", ERuleProperties::RequireParents) {}
+
+    virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
+};
+
+/**
  * Push down filter through joins, adding join conditions to the join operator and potentially
  * converting left join into inner join
  */

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
@@ -451,6 +451,7 @@ void TKqpNewRBOTransformer::InitializeRBOOptimizationStages() {
     // Logical state I
     TVector<std::unique_ptr<IRule>> logicalStage_I_Rules;
     logicalStage_I_Rules.emplace_back(std::make_unique<TExtractJoinExpressionsRule>());
+    logicalStage_I_Rules.emplace_back(std::make_unique<TExtractCommonConjunctsRule>());
     logicalStage_I_Rules.emplace_back(std::make_unique<TPushFilterIntoJoinRule>());
     logicalStage_I_Rules.emplace_back(std::make_unique<TPushFilterUnderMapRule>());
     RBO.AddStage(std::make_unique<TRuleBasedStage>("Logical rewrites I", std::move(logicalStage_I_Rules)));
@@ -461,6 +462,7 @@ void TKqpNewRBOTransformer::InitializeRBOOptimizationStages() {
     logicalStage_II_Rules.emplace_back(std::make_unique<TInlineJoinFiltersRule>());
     logicalStage_II_Rules.emplace_back(std::make_unique<TFuseFiltersRule>());
     logicalStage_II_Rules.emplace_back(std::make_unique<TExtractJoinExpressionsRule>());
+    logicalStage_II_Rules.emplace_back(std::make_unique<TExtractCommonConjunctsRule>());
     logicalStage_II_Rules.emplace_back(std::make_unique<TPushFilterIntoJoinRule>());
     logicalStage_II_Rules.emplace_back(std::make_unique<TPushFilterUnderMapRule>());
     logicalStage_II_Rules.emplace_back(std::make_unique<TEliminateLeftJoinRule>());

--- a/ydb/core/kqp/opt/rbo/rules/extract_common_conjuncts.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/extract_common_conjuncts.cpp
@@ -1,0 +1,24 @@
+#include "kqp_rules_include.h"
+
+namespace NKikimr {
+namespace NKqp {
+
+TIntrusivePtr<IOperator> TExtractCommonConjunctsRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
+    Y_UNUSED(ctx);
+    Y_UNUSED(props);
+
+    if (input->Kind != EOperator::Filter) {
+        return input;
+    }
+
+    auto filter = CastOperator<TOpFilter>(input);
+    auto newFilterExpr = filter->FilterExpr.TryExtractCommonConjuncts();
+    if (!newFilterExpr) {
+        return input;
+    }
+
+    return MakeIntrusive<TOpFilter>(filter->GetInput(), input->Pos, input->Props, *newFilterExpr);
+}
+
+}
+}

--- a/ydb/core/kqp/opt/rbo/rules/ya.make
+++ b/ydb/core/kqp/opt/rbo/rules/ya.make
@@ -9,6 +9,7 @@ SRCS(
     expand_cbo_tree.cpp
     expand_distinct_aggregation.cpp
     extract_join_expressions.cpp
+    extract_common_conjuncts.cpp
     eliminate_left_join.cpp
     fuse_filters.cpp
     inline_cbo_tree.cpp

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -871,6 +871,27 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         UNIT_ASSERT_C(residualPredicate.Contains("b") && residualPredicate.Contains(" < ") && residualPredicate.Contains("c"), plan);
     }
 
+    Y_UNIT_TEST(CommonConjunctExtractionFeedsJoinKey) {
+        TExplainPlanTestContext testContext;
+        auto plan = ExecuteExplain(testContext.GetSession(), R"(
+            PRAGMA YqlSelect = 'force';
+            PRAGMA AnsiImplicitCrossJoin;
+
+            SELECT count(*)
+            FROM `/Root/t1` AS t1, `/Root/t2` AS t2
+            WHERE
+                (t1.a = t2.a AND t1.b = 1)
+                OR
+                (t1.a = t2.a AND t2.b = 2);
+        )");
+
+        const auto simplifiedPlan = GetSimplifiedPlan(plan);
+        const auto* joinOp = FindOperatorByStringField(simplifiedPlan, "JoinKind", "Inner");
+        UNIT_ASSERT_C(joinOp, plan);
+        const auto condition = GetStringField(*joinOp, "Condition");
+        UNIT_ASSERT_C(condition.Contains("t1.a = t2.a") || condition.Contains("t2.a = t1.a"), plan);
+    }
+
     Y_UNIT_TEST(ExplainExpressionPrintingJoinFilters) {
         NYql::TExprContext exprCtx;
         TPlanProps planProps;


### PR DESCRIPTION
This PR simplifies expressions of form `((A and B) or (A and C))` to `(A and (B or C))`. I.e. it extracts common conjuncts from a top-level disjunction. This allows expressions to be later pushed into joins. In TPCH Q9 this prevents a cross join.