### PR TITLE
Add reboot tests for datashard prefix bloom filter operations

### DIFF
--- a/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
@@ -665,29 +665,25 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
                 UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
 
-                // Check scheme objects exist (if migration has occurred)
-                if (table.TableIndexesSize() > 0) {
-                    bool foundIdx1 = false, foundIdx2 = false;
-                    for (const auto& idx : table.GetTableIndexes()) {
-                        if (idx.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
-                            if (idx.GetName() == "idx_bloom_1") {
-                                foundIdx1 = true;
-                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
-                            } else if (idx.GetName() == "idx_bloom_2") {
-                                foundIdx2 = true;
-                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 2);
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "Key2");
-                            }
-                        }
-                    }
-                    // If scheme objects exist, both should be found
-                    if (foundIdx1 || foundIdx2) {
-                        UNIT_ASSERT(foundIdx1);
-                        UNIT_ASSERT(foundIdx2);
+                // Check scheme objects exist
+                UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
+                bool foundIdx1 = false, foundIdx2 = false;
+                for (const auto& idx : table.GetTableIndexes()) {
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
+                    if (idx.GetName() == "idx_bloom_1") {
+                        foundIdx1 = true;
+                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
+                    } else if (idx.GetName() == "idx_bloom_2") {
+                        foundIdx2 = true;
+                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 2);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "Key2");
                     }
                 }
+                UNIT_ASSERT(foundIdx1);
+                UNIT_ASSERT(foundIdx2);
             };
 
             {

--- a/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
@@ -654,38 +654,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
 
-            // Helper to check bloom filter scheme objects exist
-            auto checkBloomSchemeObjects = [&](const TString& tablePath) {
-                auto tableDescr = DescribePath(runtime, tablePath, true);
-                const auto& table = tableDescr.GetPathDescription().GetTable();
-
-                // Check engine prefixes
-                const auto& partitionConfig = table.GetPartitionConfig();
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
-
-                // Check scheme objects exist
-                UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
-                bool foundIdx1 = false, foundIdx2 = false;
-                for (const auto& idx : table.GetTableIndexes()) {
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
-                    if (idx.GetName() == "idx_bloom_1") {
-                        foundIdx1 = true;
-                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
-                    } else if (idx.GetName() == "idx_bloom_2") {
-                        foundIdx2 = true;
-                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 2);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "Key2");
-                    }
-                }
-                UNIT_ASSERT(foundIdx1);
-                UNIT_ASSERT(foundIdx2);
-            };
-
             {
                 TInactiveZone inactive(activeZone);
                 // Create source table with multiple bloom filter prefixes
@@ -708,7 +676,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
                 runtime.SimulateSleep(TDuration::Seconds(5));
 
                 // Verify source has bloom filters after migration
-                checkBloomSchemeObjects("/MyRoot/src");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/src",
+                    {1, 2},
+                    {{"idx_bloom_1", {"Key1"}}, {"idx_bloom_2", {"Key1", "Key2"}}});
             }
 
             // Perform consistent copy operation with reboots
@@ -722,7 +692,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
                 // Verify copy has all bloom filters
-                checkBloomSchemeObjects("/MyRoot/dst");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/dst",
+                    {1, 2},
+                    {{"idx_bloom_1", {"Key1"}}, {"idx_bloom_2", {"Key1", "Key2"}}});
             }
         });
     }

--- a/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/ut_consistent_copy_tables/ut_consistent_copy_tables.cpp
@@ -648,4 +648,86 @@ Y_UNIT_TEST_SUITE(TSchemeShardConsistentCopyTablesTest) {
         // 3. Verify the copied table and both bloom indexes are ready scheme objects
         NLocalIndexes::CheckOlapTableWithBloomAndNgramIndexesReady(runtime, "/MyRoot/ColumnTableWithLocalIndexesCopy");
     }
+
+    Y_UNIT_TEST(ConsistentCopyRowTableWithMultipleBloomPrefixes) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
+
+            // Helper to check bloom filter scheme objects exist
+            auto checkBloomSchemeObjects = [&](const TString& tablePath) {
+                auto tableDescr = DescribePath(runtime, tablePath, true);
+                const auto& table = tableDescr.GetPathDescription().GetTable();
+
+                // Check engine prefixes
+                const auto& partitionConfig = table.GetPartitionConfig();
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 2);
+
+                // Check scheme objects exist (if migration has occurred)
+                if (table.TableIndexesSize() > 0) {
+                    bool foundIdx1 = false, foundIdx2 = false;
+                    for (const auto& idx : table.GetTableIndexes()) {
+                        if (idx.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
+                            if (idx.GetName() == "idx_bloom_1") {
+                                foundIdx1 = true;
+                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
+                            } else if (idx.GetName() == "idx_bloom_2") {
+                                foundIdx2 = true;
+                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 2);
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "Key1");
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "Key2");
+                            }
+                        }
+                    }
+                    // If scheme objects exist, both should be found
+                    if (foundIdx1 || foundIdx2) {
+                        UNIT_ASSERT(foundIdx1);
+                        UNIT_ASSERT(foundIdx2);
+                    }
+                }
+            };
+
+            {
+                TInactiveZone inactive(activeZone);
+                // Create source table with multiple bloom filter prefixes
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "src"
+                    Columns { Name: "Key1" Type: "Uint64"}
+                    Columns { Name: "Key2" Type: "Uint64"}
+                    Columns { Name: "Value" Type: "Utf8"}
+                    KeyColumnNames: ["Key1", "Key2"]
+                    PartitionConfig {
+                        ByKeyFilterPrefixes { PrefixLength: 1 }
+                        ByKeyFilterPrefixes { PrefixLength: 2 }
+                    }
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                // Restart SchemeShard to trigger migration to scheme objects
+                TActorId sender = runtime.AllocateEdgeActor();
+                GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
+                runtime.SimulateSleep(TDuration::Seconds(5));
+
+                // Verify source has bloom filters after migration
+                checkBloomSchemeObjects("/MyRoot/src");
+            }
+
+            // Perform consistent copy operation with reboots
+            {
+                TInactiveZone inactive(activeZone);
+                TestConsistentCopyTables(runtime, ++t.TxId, "/", R"(
+                    CopyTableDescriptions {
+                      SrcPath: "/MyRoot/src"
+                      DstPath: "/MyRoot/dst"
+                    })");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                // Verify copy has all bloom filters
+                checkBloomSchemeObjects("/MyRoot/dst");
+            }
+        });
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_helpers/local_indexes.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/local_indexes.h
@@ -97,4 +97,62 @@ inline void CheckIndexVersionsConsistent(NActors::TTestActorRuntime& runtime,
         << "' present in scheme tree but missing from column table '" << tablePath << "' schema");
 }
 
+// Helper structure to define expected bloom filter index properties
+struct TBloomIndexExpectation {
+    TString Name;
+    std::vector<TString> KeyColumns;
+};
+
+// Asserts that a row table has the expected bloom filter prefixes
+inline void CheckRowTableBloomSchemeObjects(NActors::TTestActorRuntime& runtime,
+        const TString& tablePath,
+        const std::vector<ui32>& expectedPrefixLengths,
+        const std::vector<TBloomIndexExpectation>& expectedIndexes) {
+    auto tableDescr = DescribePath(runtime, tablePath, true);
+    const auto& table = tableDescr.GetPathDescription().GetTable();
+
+    // Check engine prefixes
+    const auto& partitionConfig = table.GetPartitionConfig();
+    UNIT_ASSERT_VALUES_EQUAL_C(partitionConfig.ByKeyFilterPrefixesSize(), expectedPrefixLengths.size(),
+        TStringBuilder() << "Expected " << expectedPrefixLengths.size() << " prefixes, got "
+        << partitionConfig.ByKeyFilterPrefixesSize());
+
+    for (size_t i = 0; i < expectedPrefixLengths.size(); ++i) {
+        UNIT_ASSERT_VALUES_EQUAL_C(partitionConfig.GetByKeyFilterPrefixes(i).GetPrefixLength(),
+            expectedPrefixLengths[i],
+            TStringBuilder() << "Prefix " << i << " length mismatch");
+    }
+
+    // Check scheme objects exist
+    UNIT_ASSERT_VALUES_EQUAL_C(table.TableIndexesSize(), expectedIndexes.size(),
+        TStringBuilder() << "Expected " << expectedIndexes.size() << " indexes, got "
+        << table.TableIndexesSize());
+
+    std::vector<bool> foundIndexes(expectedIndexes.size(), false);
+    for (const auto& idx : table.GetTableIndexes()) {
+        UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+        UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
+
+        // Find matching expectation
+        for (size_t i = 0; i < expectedIndexes.size(); ++i) {
+            if (idx.GetName() == expectedIndexes[i].Name) {
+                foundIndexes[i] = true;
+                UNIT_ASSERT_VALUES_EQUAL_C(idx.KeyColumnNamesSize(), expectedIndexes[i].KeyColumns.size(),
+                    TStringBuilder() << "Index '" << expectedIndexes[i].Name << "' key column count mismatch");
+
+                for (size_t j = 0; j < expectedIndexes[i].KeyColumns.size(); ++j) {
+                    UNIT_ASSERT_VALUES_EQUAL_C(idx.GetKeyColumnNames(j), expectedIndexes[i].KeyColumns[j],
+                        TStringBuilder() << "Index '" << expectedIndexes[i].Name << "' key column " << j << " mismatch");
+                }
+                break;
+            }
+        }
+    }
+
+    // Verify all expected indexes were found
+    for (size_t i = 0; i < expectedIndexes.size(); ++i) {
+        UNIT_ASSERT_C(foundIndexes[i], TStringBuilder() << "Expected index '" << expectedIndexes[i].Name << "' not found");
+    }
+}
+
 }   // namespace NSchemeShardUT_Private::NLocalIndexes

--- a/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
+++ b/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
@@ -2040,40 +2040,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
         ui64 txId = 100;
 
-        // Helper to check bloom filter scheme objects exist
-        auto checkBloomSchemeObjects = [&](const TString& tablePath) {
-            auto tableDescr = DescribePath(runtime, tablePath, true);
-            const auto& table = tableDescr.GetPathDescription().GetTable();
-
-            // Check engine prefixes
-            const auto& partitionConfig = table.GetPartitionConfig();
-            UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-            UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
-
-            // Check scheme objects exist
-            UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
-            bool foundIdx1 = false, foundIdx2 = false;
-            for (const auto& idx : table.GetTableIndexes()) {
-                UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
-                UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
-                if (idx.GetName() == "idx_bloom_1") {
-                    foundIdx1 = true;
-                    UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                } else if (idx.GetName() == "idx_bloom_3") {
-                    foundIdx2 = true;
-                    UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
-                }
-            }
-            UNIT_ASSERT(foundIdx1);
-            UNIT_ASSERT(foundIdx2);
-        };
-
         // Create source table with multiple bloom filter prefixes
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
@@ -2113,20 +2079,23 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
                 }
             }
 
-            // Dispatch events to allow migration to progress
-            TDispatchOptions opts;
-            runtime.DispatchEvents(opts, TDuration::MilliSeconds(100));
+            // Use SimulateSleep instead of manual DispatchEvents
+            runtime.SimulateSleep(TDuration::MilliSeconds(100));
         }
 
         // Verify source table has multiple bloom filter prefixes and scheme objects after migration
-        checkBloomSchemeObjects("/MyRoot/Table");
+        NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/Table",
+            {1, 3},
+            {{"idx_bloom_1", {"key1"}}, {"idx_bloom_3", {"key1", "key2", "key3"}}});
 
         // Perform CopyTable operation
         TestCopyTable(runtime, ++txId, "/MyRoot", "TableCopy", "/MyRoot/Table");
         env.TestWaitNotification(runtime, txId);
 
         // Verify copied table has all bloom filter prefixes and scheme objects
-        checkBloomSchemeObjects("/MyRoot/TableCopy");
+        NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/TableCopy",
+            {1, 3},
+            {{"idx_bloom_1", {"key1"}}, {"idx_bloom_3", {"key1", "key2", "key3"}}});
 
         // Perform MoveTable operation on the copied table
         TestMoveTable(runtime, ++txId, "/MyRoot/TableCopy", "/MyRoot/TableMove");
@@ -2137,7 +2106,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
                            {NLs::PathNotExist});
 
         // Verify moved table has all bloom filter prefixes and scheme objects
-        checkBloomSchemeObjects("/MyRoot/TableMove");
+        NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/TableMove",
+            {1, 3},
+            {{"idx_bloom_1", {"key1"}}, {"idx_bloom_3", {"key1", "key2", "key3"}}});
     }
 
 

--- a/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
+++ b/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
@@ -2037,7 +2037,46 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
     Y_UNIT_TEST(CopyMovePreservesMultipleBloomPrefixes) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
+        runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
         ui64 txId = 100;
+
+        // Helper to check bloom filter scheme objects exist
+        auto checkBloomSchemeObjects = [&](const TString& tablePath) {
+            auto tableDescr = DescribePath(runtime, tablePath, true);
+            const auto& table = tableDescr.GetPathDescription().GetTable();
+
+            // Check engine prefixes
+            const auto& partitionConfig = table.GetPartitionConfig();
+            UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
+            UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
+
+            // Check scheme objects exist (if migration has occurred)
+            if (table.TableIndexesSize() > 0) {
+                bool foundIdx1 = false, foundIdx2 = false;
+                for (const auto& idx : table.GetTableIndexes()) {
+                    if (idx.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
+                        if (idx.GetName() == "idx_bloom_1") {
+                            foundIdx1 = true;
+                            UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                        } else if (idx.GetName() == "idx_bloom_2") {
+                            foundIdx2 = true;
+                            UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
+                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
+                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
+                        }
+                    }
+                }
+                // If scheme objects exist, both should be found
+                if (foundIdx1 || foundIdx2) {
+                    UNIT_ASSERT(foundIdx1);
+                    UNIT_ASSERT(foundIdx2);
+                }
+            }
+        };
 
         // Create source table with multiple bloom filter prefixes
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
@@ -2054,29 +2093,20 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        // Verify source table has multiple bloom filter prefixes
-        {
-            auto srcTable = DescribePath(runtime, "/MyRoot/Table", true).GetPathDescription().GetTable();
-            const auto& srcConfig = srcTable.GetPartitionConfig();
-            UNIT_ASSERT_VALUES_EQUAL(srcConfig.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(srcConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(srcConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-            UNIT_ASSERT_DOUBLES_EQUAL(srcConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
-        }
+        // Restart SchemeShard to trigger migration to scheme objects
+        TActorId sender = runtime.AllocateEdgeActor();
+        GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
+        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        // Verify source table has multiple bloom filter prefixes and scheme objects after migration
+        checkBloomSchemeObjects("/MyRoot/Table");
 
         // Perform CopyTable operation
         TestCopyTable(runtime, ++txId, "/MyRoot", "TableCopy", "/MyRoot/Table");
         env.TestWaitNotification(runtime, txId);
 
-        // Verify copied table has all bloom filter prefixes
-        {
-            auto dstTable = DescribePath(runtime, "/MyRoot/TableCopy", true).GetPathDescription().GetTable();
-            const auto& dstConfig = dstTable.GetPartitionConfig();
-            UNIT_ASSERT_VALUES_EQUAL(dstConfig.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(dstConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(dstConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-            UNIT_ASSERT_DOUBLES_EQUAL(dstConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
-        }
+        // Verify copied table has all bloom filter prefixes and scheme objects
+        checkBloomSchemeObjects("/MyRoot/TableCopy");
 
         // Perform MoveTable operation on the copied table
         TestMoveTable(runtime, ++txId, "/MyRoot/TableCopy", "/MyRoot/TableMove");
@@ -2086,15 +2116,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         TestDescribeResult(DescribePath(runtime, "/MyRoot/TableCopy"),
                            {NLs::PathNotExist});
 
-        // Verify moved table has all bloom filter prefixes
-        {
-            auto movedTable = DescribePath(runtime, "/MyRoot/TableMove", true).GetPathDescription().GetTable();
-            const auto& config = movedTable.GetPartitionConfig();
-            UNIT_ASSERT_VALUES_EQUAL(config.ByKeyFilterPrefixesSize(), 2);
-            UNIT_ASSERT_VALUES_EQUAL(config.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(config.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-            UNIT_ASSERT_DOUBLES_EQUAL(config.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
-        }
+        // Verify moved table has all bloom filter prefixes and scheme objects
+        checkBloomSchemeObjects("/MyRoot/TableMove");
     }
 
 

--- a/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
+++ b/ydb/core/tx/schemeshard/ut_move/ut_move.cpp
@@ -2052,30 +2052,26 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
             UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
             UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
 
-            // Check scheme objects exist (if migration has occurred)
-            if (table.TableIndexesSize() > 0) {
-                bool foundIdx1 = false, foundIdx2 = false;
-                for (const auto& idx : table.GetTableIndexes()) {
-                    if (idx.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
-                        if (idx.GetName() == "idx_bloom_1") {
-                            foundIdx1 = true;
-                            UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                        } else if (idx.GetName() == "idx_bloom_2") {
-                            foundIdx2 = true;
-                            UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
-                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
-                            UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
-                        }
-                    }
-                }
-                // If scheme objects exist, both should be found
-                if (foundIdx1 || foundIdx2) {
-                    UNIT_ASSERT(foundIdx1);
-                    UNIT_ASSERT(foundIdx2);
+            // Check scheme objects exist
+            UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
+            bool foundIdx1 = false, foundIdx2 = false;
+            for (const auto& idx : table.GetTableIndexes()) {
+                UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
+                if (idx.GetName() == "idx_bloom_1") {
+                    foundIdx1 = true;
+                    UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                } else if (idx.GetName() == "idx_bloom_3") {
+                    foundIdx2 = true;
+                    UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
                 }
             }
+            UNIT_ASSERT(foundIdx1);
+            UNIT_ASSERT(foundIdx2);
         };
 
         // Create source table with multiple bloom filter prefixes
@@ -2096,7 +2092,31 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTest) {
         // Restart SchemeShard to trigger migration to scheme objects
         TActorId sender = runtime.AllocateEdgeActor();
         GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
-        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        // Wait deterministically for migration to complete by polling for scheme objects
+        int retries = 10;
+        while (retries--) {
+            auto tableDescr = DescribePath(runtime, "/MyRoot/Table", true);
+            const auto& table = tableDescr.GetPathDescription().GetTable();
+
+            // Check if migration has completed (scheme objects exist)
+            if (table.TableIndexesSize() == 2) {
+                bool allReady = true;
+                for (const auto& idx : table.GetTableIndexes()) {
+                    if (idx.GetState() != NKikimrSchemeOp::EIndexStateReady) {
+                        allReady = false;
+                        break;
+                    }
+                }
+                if (allReady) {
+                    break; // Migration complete
+                }
+            }
+
+            // Dispatch events to allow migration to progress
+            TDispatchOptions opts;
+            runtime.DispatchEvents(opts, TDuration::MilliSeconds(100));
+        }
 
         // Verify source table has multiple bloom filter prefixes and scheme objects after migration
         checkBloomSchemeObjects("/MyRoot/Table");

--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -555,30 +555,26 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
                 UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
                 UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
 
-                // Check scheme objects exist (if migration has occurred)
-                if (table.TableIndexesSize() > 0) {
-                    bool foundIdx1 = false, foundIdx2 = false;
-                    for (const auto& idx : table.GetTableIndexes()) {
-                        if (idx.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
-                            if (idx.GetName() == "idx_bloom_1") {
-                                foundIdx1 = true;
-                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                            } else if (idx.GetName() == "idx_bloom_2") {
-                                foundIdx2 = true;
-                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
-                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
-                            }
-                        }
-                    }
-                    // If scheme objects exist, both should be found
-                    if (foundIdx1 || foundIdx2) {
-                        UNIT_ASSERT(foundIdx1);
-                        UNIT_ASSERT(foundIdx2);
+                // Check scheme objects exist
+                UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
+                bool foundIdx1 = false, foundIdx2 = false;
+                for (const auto& idx : table.GetTableIndexes()) {
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                    UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
+                    if (idx.GetName() == "idx_bloom_1") {
+                        foundIdx1 = true;
+                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                    } else if (idx.GetName() == "idx_bloom_2") {
+                        foundIdx2 = true;
+                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
                     }
                 }
+                UNIT_ASSERT(foundIdx1);
+                UNIT_ASSERT(foundIdx2);
             };
 
             {

--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -537,5 +537,100 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
             }
         });
     }
+
+    Y_UNIT_TEST(CopyMovePreservesMultipleBloomPrefixes) {
+        TTestWithReboots t;
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
+
+            // Helper to check bloom filter scheme objects exist
+            auto checkBloomSchemeObjects = [&](const TString& tablePath) {
+                auto tableDescr = DescribePath(runtime, tablePath, true);
+                const auto& table = tableDescr.GetPathDescription().GetTable();
+
+                // Check engine prefixes
+                const auto& partitionConfig = table.GetPartitionConfig();
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
+                UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
+
+                // Check scheme objects exist (if migration has occurred)
+                if (table.TableIndexesSize() > 0) {
+                    bool foundIdx1 = false, foundIdx2 = false;
+                    for (const auto& idx : table.GetTableIndexes()) {
+                        if (idx.GetType() == NKikimrSchemeOp::EIndexTypeLocalBloomFilter) {
+                            if (idx.GetName() == "idx_bloom_1") {
+                                foundIdx1 = true;
+                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                            } else if (idx.GetName() == "idx_bloom_2") {
+                                foundIdx2 = true;
+                                UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
+                                UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
+                            }
+                        }
+                    }
+                    // If scheme objects exist, both should be found
+                    if (foundIdx1 || foundIdx2) {
+                        UNIT_ASSERT(foundIdx1);
+                        UNIT_ASSERT(foundIdx2);
+                    }
+                }
+            };
+
+            {
+                TInactiveZone inactive(activeZone);
+                // Create source table with multiple bloom filter prefixes
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "Table"
+                    Columns { Name: "key1"       Type: "Utf8"}
+                    Columns { Name: "key2"       Type: "Uint32"}
+                    Columns { Name: "key3"       Type: "Utf8"}
+                    Columns { Name: "Value"      Type: "Utf8"}
+                    KeyColumnNames: ["key1", "key2", "key3"]
+                    PartitionConfig {
+                        ByKeyFilterPrefixes { PrefixLength: 1 }
+                        ByKeyFilterPrefixes { PrefixLength: 3 FalsePositiveProbability: 0.001 }
+                    }
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                // Restart SchemeShard to trigger migration to scheme objects
+                TActorId sender = runtime.AllocateEdgeActor();
+                GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
+                runtime.SimulateSleep(TDuration::Seconds(5));
+
+                // Verify source table has multiple bloom filter prefixes and scheme objects after migration
+                checkBloomSchemeObjects("/MyRoot/Table");
+            }
+
+            // Perform CopyTable operation with reboots
+            {
+                TInactiveZone inactive(activeZone);
+                TestCopyTable(runtime, ++t.TxId, "/MyRoot", "TableCopy", "/MyRoot/Table");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                // Verify copied table has all bloom filter prefixes and scheme objects
+                checkBloomSchemeObjects("/MyRoot/TableCopy");
+            }
+
+            // Perform MoveTable operation with reboots
+            {
+                TInactiveZone inactive(activeZone);
+                TestMoveTable(runtime, ++t.TxId, "/MyRoot/TableCopy", "/MyRoot/TableMove");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                // Verify original copied table no longer exists
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/TableCopy"),
+                                   {NLs::PathNotExist});
+
+                // Verify moved table has all bloom filter prefixes and scheme objects
+                checkBloomSchemeObjects("/MyRoot/TableMove");
+            }
+        });
+    }
 }
 

--- a/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_move_reboots/ut_move_reboots.cpp
@@ -543,40 +543,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
 
-            // Helper to check bloom filter scheme objects exist
-            auto checkBloomSchemeObjects = [&](const TString& tablePath) {
-                auto tableDescr = DescribePath(runtime, tablePath, true);
-                const auto& table = tableDescr.GetPathDescription().GetTable();
-
-                // Check engine prefixes
-                const auto& partitionConfig = table.GetPartitionConfig();
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-                UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
-
-                // Check scheme objects exist
-                UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
-                bool foundIdx1 = false, foundIdx2 = false;
-                for (const auto& idx : table.GetTableIndexes()) {
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
-                    UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
-                    if (idx.GetName() == "idx_bloom_1") {
-                        foundIdx1 = true;
-                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                    } else if (idx.GetName() == "idx_bloom_2") {
-                        foundIdx2 = true;
-                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
-                    }
-                }
-                UNIT_ASSERT(foundIdx1);
-                UNIT_ASSERT(foundIdx2);
-            };
-
             {
                 TInactiveZone inactive(activeZone);
                 // Create source table with multiple bloom filter prefixes
@@ -600,7 +566,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
                 runtime.SimulateSleep(TDuration::Seconds(5));
 
                 // Verify source table has multiple bloom filter prefixes and scheme objects after migration
-                checkBloomSchemeObjects("/MyRoot/Table");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/Table",
+                    {1, 3},
+                    {{"idx_bloom_1", {"key1"}}, {"idx_bloom_2", {"key1", "key2", "key3"}}});
             }
 
             // Perform CopyTable operation with reboots
@@ -610,7 +578,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
                 // Verify copied table has all bloom filter prefixes and scheme objects
-                checkBloomSchemeObjects("/MyRoot/TableCopy");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/TableCopy",
+                    {1, 3},
+                    {{"idx_bloom_1", {"key1"}}, {"idx_bloom_2", {"key1", "key2", "key3"}}});
             }
 
             // Perform MoveTable operation with reboots
@@ -624,7 +594,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveRebootsTest) {
                                    {NLs::PathNotExist});
 
                 // Verify moved table has all bloom filter prefixes and scheme objects
-                checkBloomSchemeObjects("/MyRoot/TableMove");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/TableMove",
+                    {1, 3},
+                    {{"idx_bloom_1", {"key1"}}, {"idx_bloom_2", {"key1", "key2", "key3"}}});
             }
         });
     }

--- a/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/local_indexes.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
 
 #include <yql/essentials/minikql/mkql_node.h>
@@ -1240,42 +1241,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
 
-            // Helper to check bloom filter scheme objects exist
-            auto checkBloomSchemeObjects = [&](const TString& tablePath) {
-                auto tableDescr = DescribePath(runtime, tablePath, true);
-                const auto& table = tableDescr.GetPathDescription().GetTable();
-
-                // Check engine prefixes
-                const auto& partitionConfig = table.GetPartitionConfig();
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-                UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
-
-                // Check scheme objects exist
-                UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
-                bool foundIdx1 = false, foundIdx2 = false;
-                for (const auto& idx : table.GetTableIndexes()) {
-                    if (idx.GetName() == "idx_bloom_1") {
-                        foundIdx1 = true;
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                    } else if (idx.GetName() == "idx_bloom_2") {
-                        foundIdx2 = true;
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
-                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
-                    }
-                }
-                UNIT_ASSERT(foundIdx1);
-                UNIT_ASSERT(foundIdx2);
-            };
-
             {
                 TInactiveZone inactive(activeZone);
                 // Create table with multiple bloom filter prefixes
@@ -1302,7 +1267,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
                 runtime.SimulateSleep(TDuration::Seconds(5));
 
                 // Verify multiple bloom filters are configured with scheme objects after migration
-                checkBloomSchemeObjects("/MyRoot/Table");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/Table",
+                    {1, 3},
+                    {{"idx_bloom_1", {"key1"}}, {"idx_bloom_2", {"key1", "key2", "key3"}}});
             }
 
             // Perform split operation - split the single partition
@@ -1322,7 +1289,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
             // Verify all bloom filter prefixes and scheme objects are preserved after split
             {
                 TInactiveZone inactive(activeZone);
-                checkBloomSchemeObjects("/MyRoot/Table");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/Table",
+                    {1, 3},
+                    {{"idx_bloom_1", {"key1"}}, {"idx_bloom_2", {"key1", "key2", "key3"}}});
             }
 
             // Perform merge operation with reboots
@@ -1338,7 +1307,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
             // Verify all bloom filter prefixes and scheme objects are preserved after merge
             {
                 TInactiveZone inactive(activeZone);
-                checkBloomSchemeObjects("/MyRoot/Table");
+                NLocalIndexes::CheckRowTableBloomSchemeObjects(runtime, "/MyRoot/Table",
+                    {1, 3},
+                    {{"idx_bloom_1", {"key1"}}, {"idx_bloom_2", {"key1", "key2", "key3"}}});
             }
 
         });

--- a/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
@@ -1236,8 +1236,45 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
     }
 
     /* Test that multiple bloom filter prefixes are preserved during split and merge operations */
-    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(SplitMergePreservesMultipleBloomPrefixes, 2, 1, false) {
+    Y_UNIT_TEST(SplitMergePreservesMultipleBloomPrefixes) {
+        TTestWithReboots t;
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
+
+            // Helper to check bloom filter scheme objects exist
+            auto checkBloomSchemeObjects = [&](const TString& tablePath) {
+                auto tableDescr = DescribePath(runtime, tablePath, true);
+                const auto& table = tableDescr.GetPathDescription().GetTable();
+
+                // Check engine prefixes
+                const auto& partitionConfig = table.GetPartitionConfig();
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
+                UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
+
+                // Check scheme objects exist
+                UNIT_ASSERT_VALUES_EQUAL(table.TableIndexesSize(), 2);
+                bool foundIdx1 = false, foundIdx2 = false;
+                for (const auto& idx : table.GetTableIndexes()) {
+                    if (idx.GetName() == "idx_bloom_1") {
+                        foundIdx1 = true;
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                    } else if (idx.GetName() == "idx_bloom_2") {
+                        foundIdx2 = true;
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(2), "key3");
+                    }
+                }
+                UNIT_ASSERT(foundIdx1);
+                UNIT_ASSERT(foundIdx2);
+            };
+
             {
                 TInactiveZone inactive(activeZone);
                 // Create table with multiple bloom filter prefixes
@@ -1258,12 +1295,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
                 )");
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
 
-                // Verify multiple bloom filters are configured
-                auto cfg = DescribePath(runtime, "/MyRoot/Table", true).GetPathDescription().GetTable().GetPartitionConfig();
-                UNIT_ASSERT_VALUES_EQUAL(cfg.ByKeyFilterPrefixesSize(), 2);
-                UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-                UNIT_ASSERT_DOUBLES_EQUAL(cfg.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
+                // Restart SchemeShard to trigger migration to scheme objects
+                TActorId sender = runtime.AllocateEdgeActor();
+                GracefulRestartTablet(runtime, TTestTxConfig::SchemeShard, sender);
+                runtime.SimulateSleep(TDuration::Seconds(5));
+
+                // Verify multiple bloom filters are configured with scheme objects after migration
+                checkBloomSchemeObjects("/MyRoot/Table");
             }
 
             // Perform split operation - split the single partition
@@ -1280,18 +1318,26 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
                 t.TestEnv->TestWaitNotification(runtime, t.TxId);
             }
 
-            // Verify all bloom filter prefixes are preserved after split
+            // Verify all bloom filter prefixes and scheme objects are preserved after split
             {
                 TInactiveZone inactive(activeZone);
-                auto tableDescr = DescribePath(runtime, "/MyRoot/Table", true);
-                const auto& table = tableDescr.GetPathDescription().GetTable();
+                checkBloomSchemeObjects("/MyRoot/Table");
+            }
 
-                // Check that all bloom filter configurations are preserved at table level
-                const auto& partitionConfig = table.GetPartitionConfig();
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.ByKeyFilterPrefixesSize(), 2);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(0).GetPrefixLength(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetPrefixLength(), 3);
-                UNIT_ASSERT_DOUBLES_EQUAL(partitionConfig.GetByKeyFilterPrefixes(1).GetFalsePositiveProbability(), 0.001, 1e-9);
+            // Perform merge operation with reboots
+            {
+                TInactiveZone inactive(activeZone);
+                TestSplitTable(runtime, ++t.TxId, "/MyRoot/Table", R"(
+                    SourceTabletId: 72075186233409546
+                    SourceTabletId: 72075186233409547
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+            }
+
+            // Verify all bloom filter prefixes and scheme objects are preserved after merge
+            {
+                TInactiveZone inactive(activeZone);
+                checkBloomSchemeObjects("/MyRoot/Table");
             }
 
         });

--- a/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge_reboots/ut_split_merge_reboots.cpp
@@ -1236,8 +1236,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
     }
 
     /* Test that multiple bloom filter prefixes are preserved during split and merge operations */
-    Y_UNIT_TEST(SplitMergePreservesMultipleBloomPrefixes) {
-        TTestWithReboots t;
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(SplitMergePreservesMultipleBloomPrefixes, 2, 1, false) {
         t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
             runtime.GetAppData().FeatureFlags.SetEnableLocalIndexAsSchemeObject(true);
 
@@ -1260,11 +1259,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardSplitTestReboots) {
                     if (idx.GetName() == "idx_bloom_1") {
                         foundIdx1 = true;
                         UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
                         UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 1);
                         UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
                     } else if (idx.GetName() == "idx_bloom_2") {
                         foundIdx2 = true;
                         UNIT_ASSERT_VALUES_EQUAL(idx.GetType(), NKikimrSchemeOp::EIndexTypeLocalBloomFilter);
+                        UNIT_ASSERT_VALUES_EQUAL(idx.GetState(), NKikimrSchemeOp::EIndexStateReady);
                         UNIT_ASSERT_VALUES_EQUAL(idx.KeyColumnNamesSize(), 3);
                         UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(0), "key1");
                         UNIT_ASSERT_VALUES_EQUAL(idx.GetKeyColumnNames(1), "key2");


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added reboot tests for datashard prefix bloom filters
covering consistent copy, move, split, and merge operations in schemeshard.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
