### PR TITLE
Enable AS v2 feature flags by default

### DIFF
--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
@@ -893,15 +893,13 @@ void THttpProxyTestMock::InitAccessServiceService(bool enableAccessServiceV2Inte
         asMock.AuthorizeData["proxy_sa@builtin-ydb.databases.list-database4"].Response.mutable_subject()->mutable_service_account()->set_id("Service1_id");
     };
 
-    if (enableAccessServiceV2Interface) {
-        // V2 mock setup
-        setupAccessServiceMock(AccessServiceMockV2);
-        builder.AddListeningPort(AccessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&AccessServiceMockV2);
-    } else {
-        // V1 mock setup
+    if (!enableAccessServiceV2Interface) {
         setupAccessServiceMock(AccessServiceMock);
         builder.AddListeningPort(AccessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&AccessServiceMock);
     }
+    // We always should setup v2, because bulkAuthorization works only in v2 and EnableBulkAuthorization=true will call it
+    setupAccessServiceMock(AccessServiceMockV2);
+    builder.AddListeningPort(AccessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&AccessServiceMockV2);
 
     AccessServiceServer = builder.BuildAndStart();
 }

--- a/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
+++ b/ydb/core/http_proxy/ut/datastreams_fixture/datastreams_fixture.cpp
@@ -893,13 +893,15 @@ void THttpProxyTestMock::InitAccessServiceService(bool enableAccessServiceV2Inte
         asMock.AuthorizeData["proxy_sa@builtin-ydb.databases.list-database4"].Response.mutable_subject()->mutable_service_account()->set_id("Service1_id");
     };
 
+    builder.AddListeningPort(AccessServiceEndpoint, grpc::InsecureServerCredentials());
+
     if (!enableAccessServiceV2Interface) {
         setupAccessServiceMock(AccessServiceMock);
-        builder.AddListeningPort(AccessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&AccessServiceMock);
+        builder.RegisterService(&AccessServiceMock);
     }
     // We always should setup v2, because bulkAuthorization works only in v2 and EnableBulkAuthorization=true will call it
     setupAccessServiceMock(AccessServiceMockV2);
-    builder.AddListeningPort(AccessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&AccessServiceMockV2);
+    builder.RegisterService(&AccessServiceMockV2);
 
     AccessServiceServer = builder.BuildAndStart();
 }

--- a/ydb/core/kafka_proxy/ut/test_server.cpp
+++ b/ydb/core/kafka_proxy/ut/test_server.cpp
@@ -196,7 +196,12 @@ TTestServer<TKikimr, secure>::TTestServer(const TTestServerSettings& settings) {
     {
         // Access Server Mock
         grpc::ServerBuilder builder;
-        builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials()).RegisterService(&accessServiceMock);
+        builder.AddListeningPort(accessServiceEndpoint, grpc::InsecureServerCredentials());
+        if (!KikimrServer->GetRuntime()->GetAppData().FeatureFlags.GetEnableAccessServiceV2Interface()) {
+            builder.RegisterService(&accessServiceMock);
+        }
+        // We should always register v2 because BulkAuth uses V2 AS even with V1
+        builder.RegisterService(&accessServiceMockV2);
         AccessServer = builder.BuildAndStart();
     }
 }

--- a/ydb/core/kafka_proxy/ut/test_server.h
+++ b/ydb/core/kafka_proxy/ut/test_server.h
@@ -61,6 +61,7 @@ public:
     THolder<TTempFileHandle> MeteringFile;
 
     TTicketParserAccessServiceMock accessServiceMock;
+    TTicketParserAccessServiceMockV2 accessServiceMockV2;
     std::unique_ptr<grpc::Server> AccessServer;
 };
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -137,7 +137,7 @@ message TFeatureFlags {
     reserved 111; // UseVDisksBalancing
     optional bool EnableViews = 112 [default = true];
     optional bool EnableServerlessExclusiveDynamicNodes = 113 [default = false];
-    optional bool EnableAccessServiceBulkAuthorization = 114 [default = false];
+    optional bool EnableAccessServiceBulkAuthorization = 114 [default = true];
     optional bool EnableAddColumsWithDefaults = 115 [default = true];
     optional bool EnableReplaceIfExistsForExternalEntities = 116 [ default = true];
     optional bool EnableCMSRequestPriorities = 117 [default = true];
@@ -322,6 +322,6 @@ message TFeatureFlags {
     optional bool EnableCompactFulltextIndex = 280 [default = false];
     optional bool EnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay = 281 [default = false];
     optional bool EnableFulltextIndexPrefix = 282 [default = false];
-    optional bool EnableAccessServiceV2Interface = 283 [default = false, (RequireRestart) = true];
+    optional bool EnableAccessServiceV2Interface = 283 [default = true, (RequireRestart) = true];
     optional bool EnableAnalyzeLongRunningOperation = 284 [default = true];
 }

--- a/ydb/core/security/ticket_parser_impl.h
+++ b/ydb/core/security/ticket_parser_impl.h
@@ -581,10 +581,10 @@ private:
 
     template <typename TTokenRecord>
     void RequestAccessServiceAuthorization(const TString& key, TTokenRecord& record) const {
-        if (AppData()->FeatureFlags.GetEnableAccessServiceBulkAuthorization()) {
-            AccessServiceBulkAuthorize(key, record);
-        } else if (NebiusAccessServiceValidator) {
+        if (NebiusAccessServiceValidator) {
             NebiusAccessServiceAuthorize(key, record);
+        } else if (AppData()->FeatureFlags.GetEnableAccessServiceBulkAuthorization()) {
+            AccessServiceBulkAuthorize(key, record);
         } else {
             AccessServiceAuthorize(key, record);
         }

--- a/ydb/core/security/ticket_parser_ut.cpp
+++ b/ydb/core/security/ticket_parser_ut.cpp
@@ -1532,6 +1532,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         AuthorizationRetryError<NKikimr::TNebiusAccessServiceMock>();
     }
 
+    Y_UNIT_TEST(NebiusAuthorizationWithBulkRetryError) {
+        AuthorizationRetryError<NKikimr::TNebiusAccessServiceMock, true>();
+    }
+
     template <typename TAccessServiceMock, bool EnableBulkAuthorization = false>
     void AuthorizationRetryErrorImmediately() {
         using namespace Tests;
@@ -1623,6 +1627,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
     Y_UNIT_TEST(NebiusAuthorizationRetryErrorImmediately) {
         AuthorizationRetryErrorImmediately<NKikimr::TNebiusAccessServiceMock>();
+    }
+
+    Y_UNIT_TEST(NebiusAuthorizationWithBulkRetryErrorImmediately) {
+        AuthorizationRetryErrorImmediately<NKikimr::TNebiusAccessServiceMock, true>();
     }
 
     Y_UNIT_TEST(AuthenticationUnsupported) {
@@ -2054,6 +2062,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         Authorization<NKikimr::TNebiusAccessServiceMock>();
     }
 
+    Y_UNIT_TEST(NebiusAuthorizationWithBulk) {
+        Authorization<NKikimr::TNebiusAccessServiceMock, true>();
+    }
+
     template <typename TAccessServiceMock, bool EnableBulkAuthorization = false>
     void AuthorizationWithRequiredPermissions() {
         using namespace Tests;
@@ -2133,6 +2145,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
     Y_UNIT_TEST(NebiusAuthorizationWithRequiredPermissions) {
         AuthorizationWithRequiredPermissions<NKikimr::TNebiusAccessServiceMock>();
+    }
+
+    Y_UNIT_TEST(NebiusAuthorizationWithRequiredPermissionsWithBulk) {
+        AuthorizationWithRequiredPermissions<NKikimr::TNebiusAccessServiceMock, true>();
     }
 
     template <typename TAccessServiceMock, bool EnableBulkAuthorization = false>
@@ -2393,6 +2409,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
         AuthorizationUnavailable<NKikimr::TNebiusAccessServiceMock>();
     }
 
+    Y_UNIT_TEST(NebiusAuthorizationWithBulkUnavailable) {
+        AuthorizationUnavailable<NKikimr::TNebiusAccessServiceMock, true>();
+    }
+
     template <typename TAccessServiceMock, bool EnableBulkAuthorization = false>
     void AuthorizationModify() {
         using namespace Tests;
@@ -2471,6 +2491,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
     Y_UNIT_TEST(NebiusAuthorizationModify) {
         AuthorizationModify<NKikimr::TNebiusAccessServiceMock>();
+    }
+
+    Y_UNIT_TEST(NebiusAuthorizationWithBulkModify) {
+        AuthorizationModify<NKikimr::TNebiusAccessServiceMock, true>();
     }
 
     Y_UNIT_TEST(CanProperHandleErrorWithEmptyMessage) {
@@ -2672,6 +2696,10 @@ Y_UNIT_TEST_SUITE(TTicketParserTest) {
 
     Y_UNIT_TEST(XUserIPHeaderIsSetInTicketParserNebiusAuthorization) {
         AuthorizationWithPeerName<NKikimr::TNebiusAccessServiceMock>();
+    }
+
+    Y_UNIT_TEST(XUserIPHeaderIsSetInTicketParserNebiusAuthorizationWithBulk) {
+        AuthorizationWithPeerName<NKikimr::TNebiusAccessServiceMock, true>();
     }
 
     THolder<TEvTicketParser::TEvAuthorizeTicketResult> RunPeernameQuery(

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -115,7 +115,6 @@ public:
 
     THashMap<TString, TResponse<yandex::cloud::priv::accessservice::v2::AuthenticateResponse>> AuthenticateData;
     THashMap<TString, TResponse<yandex::cloud::priv::accessservice::v2::AuthorizeResponse>> AuthorizeData;
-    THashMap<TString, TResponse<yandex::cloud::priv::accessservice::v2::BulkAuthorizeResponse>> BulkAuthorizeData;
 
     TMutex UserIpMutex;
     TString CapturedXUserIP;
@@ -188,22 +187,29 @@ public:
             CapturedXUserIP = NTestUtils::CaptureXUserIP(ctx);
         }
 
-        TString token = request->signature().access_key_id() + request->iam_token();
         for (const auto& action : request->actions().items()) {
             if (action.resource_path_size() == 0) {
-                continue;
+                return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "Permission Denied");
             }
+
             const TString& lastResourceId = action.resource_path(action.resource_path_size() - 1).id();
-            token += "-" + action.permission() + "-" + lastResourceId;
+            const TString& token = request->signature().access_key_id() + request->iam_token() + "-" + action.permission() + "-" + lastResourceId;
+
+            auto it = AuthorizeData.find(token);
+            if (it != AuthorizeData.end()) {
+                CheckRequestId(ctx, it->second, token);
+                if (it->second.Response.has_subject()) {
+                    response->mutable_subject()->CopyFrom(it->second.Response.subject());
+                }
+            } else {
+                auto* result_item = response->mutable_results()->add_items();
+                result_item->set_permission(action.permission());
+                result_item->mutable_resource_path()->CopyFrom(action.resource_path());
+                result_item->mutable_permission_denied_error()->set_message("Permission denied");
+            }
         }
-        auto it = BulkAuthorizeData.find(token);
-        if (it != BulkAuthorizeData.end()) {
-            response->CopyFrom(it->second.Response);
-            CheckRequestId(ctx, it->second, token);
-            return it->second.Status;
-        } else {
-            return grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "Permission Denied");
-        }
+
+        return grpc::Status::OK;
     }
 };
 

--- a/ydb/library/testlib/service_mocks/access_service_mock.h
+++ b/ydb/library/testlib/service_mocks/access_service_mock.h
@@ -196,7 +196,7 @@ public:
             const TString& token = request->signature().access_key_id() + request->iam_token() + "-" + action.permission() + "-" + lastResourceId;
 
             auto it = AuthorizeData.find(token);
-            if (it != AuthorizeData.end()) {
+            if (it != AuthorizeData.end() && it->second.Status.ok()) {
                 CheckRequestId(ctx, it->second, token);
                 if (it->second.Response.has_subject()) {
                     response->mutable_subject()->CopyFrom(it->second.Response.subject());
@@ -205,7 +205,7 @@ public:
                 auto* result_item = response->mutable_results()->add_items();
                 result_item->set_permission(action.permission());
                 result_item->mutable_resource_path()->CopyFrom(action.resource_path());
-                result_item->mutable_permission_denied_error()->set_message("Permission denied");
+                result_item->mutable_permission_denied_error()->set_message((it != AuthorizeData.end()) ? it->second.Status.error_message() : "Permission denied");
             }
         }
 

--- a/ydb/library/ycloud/impl/access_service_ut.cpp
+++ b/ydb/library/ycloud/impl/access_service_ut.cpp
@@ -160,7 +160,7 @@ Y_UNIT_TEST_SUITE(TAccessServiceTestV2) {
         TTestSetup setup(true);
 
         TAutoPtr<IEventHandle> handle;
-        setup.AccessServiceMockV2.BulkAuthorizeData["user1-something.read-test_folder_1-something.write-test_folder_2"].Response.mutable_subject()->mutable_user_account()->set_id("user1");
+        setup.AccessServiceMockV2.AuthorizeData["user1-something.read-test_folder_1"].Response.mutable_subject()->mutable_user_account()->set_id("user1");
 
         auto request = MakeHolder<NCloud::TEvAccessService::TEvBulkAuthorizeRequestV2>();
         request->Request.set_iam_token("user1");
@@ -176,6 +176,10 @@ Y_UNIT_TEST_SUITE(TAccessServiceTestV2) {
         UNIT_ASSERT(result);
         UNIT_ASSERT(result->Status.Ok());
         UNIT_ASSERT_VALUES_EQUAL(result->Response.subject().user_account().id(), "user1");
+        UNIT_ASSERT_VALUES_EQUAL(result->Response.results().items_size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result->Response.results().items(0).permission(), "something.write");
+        UNIT_ASSERT_VALUES_EQUAL(result->Response.results().items(0).resource_path_size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result->Response.results().items(0).resource_path(0).id(), "test_folder_2");
     }
 
     Y_UNIT_TEST(PassRequestId) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Enable  EnableAccessServiceV2Interface (use AS v2 instead of AS v1) and EnableAccessServiceBulkAuthorization (use Bulkauthorization instead of Authorization in ticket_parser) by default

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

https://nda.ya.ru/t/Kj92aa_j7XfBXy
