### PR TITLE
Always copy data in TCoroutineChunkSerializer::WriteAliasedRaw

### DIFF
--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -81,14 +81,9 @@ namespace NActors {
         NSan::CheckMemIsInitialized(data, size);
         while (size) {
             if (const size_t bytesToAppend = Min<size_t>(size, SizeRemain)) {
-                const void *produce = data;
-                if ((reinterpret_cast<uintptr_t>(data) & 63) + bytesToAppend <= 64 &&
-                        (Chunks.empty() || data != Chunks.back().first + Chunks.back().second)) {
-                    memcpy(BufferPtr, data, bytesToAppend);
-                    produce = BufferPtr;
-                    BufferPtr += bytesToAppend;
-                }
-                Produce(produce, bytesToAppend);
+                memcpy(BufferPtr, data, bytesToAppend);
+                Produce(BufferPtr, bytesToAppend);
+                BufferPtr += bytesToAppend;
                 data = static_cast<const char*>(data) + bytesToAppend;
                 size -= bytesToAppend;
             } else {


### PR DESCRIPTION
With USE_COW=no TString is std::string without ref-counting. WriteAliasedRaw in TCoroutineChunkSerializer stored raw pointers into TString buffers in Chunks instead of copying when data didn't fit in one 64-byte cache line. With the old ref-counted TString this was safe because the buffer stayed alive as long as any alias existed. With std::string the buffer is freed as soon as the owning object is destroyed.

[5844](https://github.com/ydb-platform/nbs/issues/5844#issue-4334506876)

cloud/blockstore/tests/mount:test.py
cloud/blockstore/tests/mount:py3test
