### PR TITLE
[ICRDMA] Disable graceful reconnect for RDMA sessions NBYDB-2307

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -251,6 +251,10 @@ namespace NActors {
                    " SessionVirtualId: %s RemoteSessionVirtualId: %s)", ev->Sender.ToString().data(),
                   ev->Get()->Peer.ToString().data(), ev->Get()->Self.ToString().data(), SessionVirtualId.ToString().data(),
                   RemoteSessionVirtualId.ToString().data());
+        } else if (Session->HasRdmaState()) {
+            LOG_NOTICE_IC("ICRDMA", "(actor %s) rejecting graceful reconnect for RDMA session Self# %s Peer# %s",
+                ev->Sender.ToString().data(), msg->Self.ToString().data(), msg->Peer.ToString().data());
+            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason::NewSession());
         } else {
             // if we already have incoming handshake, then terminate existing one
             DropIncomingHandshake();

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -118,6 +118,10 @@ namespace NActors {
         return false;
     }
 
+    bool TInterconnectSessionTCP::HasRdmaState() const {
+        return Params.UseRdma || RdmaQp || RdmaInflightDataAmount;
+    }
+
     void TInterconnectSessionTCP::Handle(TEvTerminate::TPtr& ev) {
         Terminate(ev->Get()->Reason);
     }
@@ -614,6 +618,11 @@ namespace NActors {
 
     void TInterconnectSessionTCP::StartHandshake() {
         LOG_INFO_IC_SESSION("ICS15", "start handshake");
+        if (HasRdmaState()) {
+            LOG_NOTICE_IC_SESSION("ICRDMA", "start initial handshake instead of graceful reconnect for RDMA session");
+            IActor::InvokeOtherActor(*Proxy, &TInterconnectProxyTCP::StartInitialHandshake);
+            return;
+        }
         IActor::InvokeOtherActor(*Proxy, &TInterconnectProxyTCP::StartResumeHandshake, ReceiveContext->LockLastPacketSerialToConfirm());
     }
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -482,6 +482,7 @@ namespace NActors {
         void Init();
         void CloseInputSession();
         bool IsRdmaInUse();
+        bool HasRdmaState() const;
 
         static TEvTerminate* NewEvTerminate(TDisconnectReason reason) {
             return new TEvTerminate(std::move(reason));

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -1,8 +1,10 @@
+#include <ydb/library/actors/core/event_pb.h>
 #include <ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h>
 #include <ydb/library/actors/interconnect/interconnect_counters.h>
 #include <ydb/library/actors/interconnect/interconnect_metrics_aggregator.h>
 #include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
 #include <ydb/library/actors/testlib/test_runtime.h>
+#include <ydb/library/actors/interconnect/ut/protos/interconnect_test.pb.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 #include <library/cpp/logger/backend.h>
 #include <library/cpp/logger/record.h>
@@ -183,6 +185,316 @@ private:
     const size_t Messages;
     const size_t PayloadSize;
 };
+
+struct TEvXdcCatchReplay
+    : TEventPB<TEvXdcCatchReplay, NInterconnectTest::TEvTestSerialization, EventSpaceBegin(TEvents::ES_PRIVATE) + 100>
+{};
+
+class TXdcCatchReplaySenderActor : public TActorBootstrapped<TXdcCatchReplaySenderActor> {
+public:
+    TXdcCatchReplaySenderActor(TActorId recipient, IEventBase* event)
+        : Recipient(recipient)
+        , Event(event)
+    {}
+
+    void Bootstrap() {
+        Send(Recipient, Event);
+        PassAway();
+    }
+
+private:
+    const TActorId Recipient;
+    IEventBase* const Event;
+};
+
+class TXdcCatchReplayReceiverActor : public TActorBootstrapped<TXdcCatchReplayReceiverActor> {
+public:
+    TXdcCatchReplayReceiverActor(TString expectedPayload, ui32 expectedPayloadCount)
+        : ExpectedPayload(std::move(expectedPayload))
+        , ExpectedPayloadCount(expectedPayloadCount)
+    {}
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+    }
+
+    void Handle(TEvXdcCatchReplay::TPtr& ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 42u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "catch-replay");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), ExpectedPayloadCount);
+        for (ui32 i = 0; i < ExpectedPayloadCount; ++i) {
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].GetSize(), ExpectedPayload.size());
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[i].ConvertToString(), ExpectedPayload);
+        }
+        Received.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    size_t GetReceived() const noexcept {
+        return Received.load(std::memory_order_relaxed);
+    }
+
+private:
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvXdcCatchReplay, Handle);
+    )
+
+private:
+    const TString ExpectedPayload;
+    const ui32 ExpectedPayloadCount;
+    std::atomic<size_t> Received = 0;
+};
+
+enum class EXdcCatchReplayMode {
+    Tcp,
+    Rdma,
+};
+
+enum class EXdcCatchReplayReconnectAction {
+    CloseInputSession,
+    ClosePeerSocket,
+};
+
+TEvXdcCatchReplay* MakeXdcCatchReplayEvent(
+        TStringBuf payload,
+        ui32 payloadCount,
+        const std::shared_ptr<NInterconnect::NRdma::IMemPool>& rdmaMemPool) {
+    auto* event = new TEvXdcCatchReplay;
+    event->Record.SetBlobID(42);
+    event->Record.SetBuffer("catch-replay");
+
+    for (ui32 i = 0; i < payloadCount; ++i) {
+        if (rdmaMemPool) {
+            auto buffer = rdmaMemPool->AllocRcBuf(payload.size(), 0).value();
+            Y_ABORT_UNLESS(buffer);
+            memcpy(buffer.GetDataMut(), payload.data(), payload.size());
+            event->AddPayload(TRope(std::move(buffer)));
+        } else {
+            event->AddPayload(TRope(TString(payload)));
+        }
+    }
+
+    UNIT_ASSERT(event->AllowExternalDataChannel());
+    return event;
+}
+
+void WaitForXdcCatchReplayPreReconnectState(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver,
+        EXdcCatchReplayMode mode) {
+    WaitForCondition(TDuration::Seconds(30), [&] {
+        try {
+            if (receiver->GetReceived() != 0
+                    || GetSessionCounter(cluster, 1, 2, "Params.UseExternalDataChannel") != 1
+                    || GetSessionCounter(cluster, 1, 2, "Context->LastProcessedSerial") == 0) {
+                return false;
+            }
+
+            switch (mode) {
+                case EXdcCatchReplayMode::Tcp: {
+                    const ui64 bytesReadFromXdc = GetSessionCounter(cluster, 1, 2, "BytesReadFromXdcSocket");
+                    return bytesReadFromXdc > 0
+                        && bytesReadFromXdc < 16 * 1024
+                        && GetSessionCounter(cluster, 1, 2, "XdcInputQ.size()") > 0
+                        && GetSessionCounter(cluster, 1, 2, "InboundPacketQ.size()") > 0;
+                }
+
+                case EXdcCatchReplayMode::Rdma:
+                    return GetRdmaChecksumStatus(cluster, 1, 2).StartsWith("On")
+                        && GetSessionCounter(cluster, 1, 2, "RdmaBytesReadScheduled") == 0
+                        && GetSessionCounter(cluster, 1, 2, "RdmaWrReadScheduled") == 0;
+            }
+        } catch (const TPatternNotFound&) {
+            return false;
+        } catch (const TFromStringException&) {
+            return false;
+        }
+    }, mode == EXdcCatchReplayMode::Tcp
+        ? "partial TCP XDC payload read before reconnect"
+        : "partial RDMA XDC section replay state before reconnect");
+}
+
+void WaitForRdmaXdcCatchReplayAfterPartialReadScheduled(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver,
+        ui64 totalRdmaBytes) {
+    WaitForCondition(TDuration::Seconds(30), [&] {
+        try {
+            if (receiver->GetReceived() != 0
+                    || GetSessionCounter(cluster, 1, 2, "Params.UseExternalDataChannel") != 1
+                    || GetSessionCounter(cluster, 1, 2, "Context->LastProcessedSerial") == 0
+                    || !GetRdmaChecksumStatus(cluster, 1, 2).StartsWith("On")) {
+                return false;
+            }
+
+            const ui64 rdmaBytesReadScheduled = GetSessionCounter(cluster, 1, 2, "RdmaBytesReadScheduled");
+            return rdmaBytesReadScheduled > 0
+                && rdmaBytesReadScheduled < totalRdmaBytes
+                && GetSessionCounter(cluster, 1, 2, "RdmaWrReadScheduled") > 0;
+        } catch (const TPatternNotFound&) {
+            return false;
+        } catch (const TFromStringException&) {
+            return false;
+        }
+    }, "partial RDMA XDC read scheduling before reconnect");
+}
+
+void CloseXdcCatchReplayInputSession(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver) {
+    UNIT_ASSERT_VALUES_EQUAL(receiver->GetReceived(), 0u);
+
+    // Freeze the old TCP control transport before closing the input session, so callers exercise reconnect behavior
+    // with a partially consumed XDC/RDMA receive context.
+    cluster.StartBlackhole(1);
+    Sleep(TDuration::MilliSeconds(100));
+    UNIT_ASSERT_VALUES_EQUAL(receiver->GetReceived(), 0u);
+
+    cluster.GetNode(1)->Send(cluster.InterconnectProxy(2, 1), new TEvInterconnect::TEvCloseInputSession);
+    Sleep(TDuration::MilliSeconds(100));
+    cluster.StopBlackhole(1);
+}
+
+void ReconnectXdcCatchReplayInputSession(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver,
+        TStringBuf description) {
+    const TString handshakeBefore = GetSessionTextMetric(cluster, 1, 2, "LastHandshakeDone");
+    CloseXdcCatchReplayInputSession(cluster, receiver);
+
+    WaitForCondition(TDuration::Seconds(30), [&] {
+        try {
+            return GetSessionTextMetric(cluster, 1, 2, "LastHandshakeDone") != handshakeBefore
+                && GetSessionSocketFd(cluster, 1, 2) >= 0;
+        } catch (const TPatternNotFound&) {
+            return false;
+        } catch (const TFromStringException&) {
+            return false;
+        }
+    }, description);
+}
+
+void CloseXdcCatchReplayPeerSocket(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver) {
+    UNIT_ASSERT_VALUES_EQUAL(receiver->GetReceived(), 0u);
+    cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvClosePeerSocket);
+}
+
+bool XdcCatchReplaySessionChangedOrGone(
+        TTestICCluster& cluster,
+        ui32 nodeId,
+        ui32 peerNodeId,
+        const TString& createdBefore) {
+    try {
+        return GetSessionTextMetric(cluster, nodeId, peerNodeId, "Created") != createdBefore;
+    } catch (const TPatternNotFound&) {
+        return true;
+    } catch (const TFromStringException&) {
+        return false;
+    }
+}
+
+void WaitForXdcCatchReplayRdmaReceiveSessionReplacement(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver,
+        const TString& receiveSessionCreatedBefore) {
+    WaitForCondition(TDuration::Seconds(30), [&] {
+        return receiver->GetReceived() == 0
+            && XdcCatchReplaySessionChangedOrGone(cluster, 1, 2, receiveSessionCreatedBefore);
+    }, "RDMA XDC receive session replaced instead of graceful reconnect");
+
+    Sleep(TDuration::Seconds(1));
+    UNIT_ASSERT_VALUES_EQUAL(receiver->GetReceived(), 0u);
+}
+
+void WaitForXdcCatchReplayDelivery(
+        TTestICCluster& cluster,
+        TXdcCatchReplayReceiverActor* receiver,
+        bool useRdma) {
+    WaitForCondition(TDuration::Seconds(30), [&] {
+        return receiver->GetReceived() == 1;
+    }, "XDC catch replay delivery");
+
+    Sleep(TDuration::Seconds(1));
+    UNIT_ASSERT_VALUES_EQUAL(receiver->GetReceived(), 1u);
+    if (useRdma) {
+        UNIT_ASSERT_C(WaitForSessionCounter(cluster, 1, 2, "RdmaBytesReadScheduled") > 0,
+            "replayed session did not schedule RDMA reads");
+    } else {
+        UNIT_ASSERT_C(WaitForSessionCounter(cluster, 1, 2, "XdcRefs") > 0,
+            "replayed session did not parse XDC refs");
+    }
+}
+
+void RunXdcCatchReplayAfterPartialPayloadRead(EXdcCatchReplayMode mode) {
+    const bool useRdma = mode == EXdcCatchReplayMode::Rdma;
+    const TString payload(useRdma ? 4 * 1024 : 32 * 1024, 'x');
+    const ui32 payloadCount = useRdma ? 1400 : 1;
+
+    TTestICCluster::TTrafficInterrupterSettings interrupterSettings{
+        .RejectingTrafficTimeout = TDuration::Zero(),
+        .BandWidth = 8 * 1024,
+        .Disconnect = false,
+    };
+    TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr,
+        useRdma ? TTestICCluster::EMPTY : TTestICCluster::DISABLE_RDMA,
+        {}, TDuration::Seconds(30), useRdma ? 16u << 20 : TNode::DefaultInflight());
+
+    auto* receiverPtr = new TXdcCatchReplayReceiverActor(payload, payloadCount);
+    const TActorId recipient = cluster.RegisterActor(receiverPtr, 1);
+
+    auto* event = MakeXdcCatchReplayEvent(
+        payload,
+        payloadCount,
+        useRdma ? cluster.GetNode(2)->GetRdmaMemPool() : nullptr);
+
+    cluster.RegisterActor(new TXdcCatchReplaySenderActor(recipient, event), 2);
+
+    WaitForXdcCatchReplayPreReconnectState(cluster, receiverPtr, mode);
+
+    if (useRdma) {
+        const TString receiveSessionCreatedBefore = GetSessionTextMetric(cluster, 1, 2, "Created");
+        CloseXdcCatchReplayInputSession(cluster, receiverPtr);
+        WaitForXdcCatchReplayRdmaReceiveSessionReplacement(cluster, receiverPtr, receiveSessionCreatedBefore);
+    } else {
+        ReconnectXdcCatchReplayInputSession(cluster, receiverPtr,
+            "XDC input session reconnected after partial payload read");
+        WaitForXdcCatchReplayDelivery(cluster, receiverPtr, false);
+    }
+}
+
+void RunRdmaXdcCatchReplayAfterPartialRdmaRead(EXdcCatchReplayReconnectAction reconnectAction) {
+    const TString payload(4 * 1024, 'x');
+    const ui32 payloadCount = 1400;
+    const ui64 totalRdmaBytes = ui64(payload.size()) * payloadCount;
+
+    TTestICCluster::TTrafficInterrupterSettings interrupterSettings{
+        .RejectingTrafficTimeout = TDuration::Zero(),
+        .BandWidth = 8 * 1024,
+        .Disconnect = false,
+    };
+    TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr,
+        TTestICCluster::EMPTY, {}, TDuration::Seconds(30), 16u << 20);
+
+    auto* receiverPtr = new TXdcCatchReplayReceiverActor(payload, payloadCount);
+    const TActorId recipient = cluster.RegisterActor(receiverPtr, 1);
+
+    auto* event = MakeXdcCatchReplayEvent(payload, payloadCount, cluster.GetNode(2)->GetRdmaMemPool());
+    cluster.RegisterActor(new TXdcCatchReplaySenderActor(recipient, event), 2);
+
+    WaitForRdmaXdcCatchReplayAfterPartialReadScheduled(cluster, receiverPtr, totalRdmaBytes);
+    const TString receiveSessionCreatedBefore = GetSessionTextMetric(cluster, 1, 2, "Created");
+    switch (reconnectAction) {
+        case EXdcCatchReplayReconnectAction::CloseInputSession:
+            CloseXdcCatchReplayInputSession(cluster, receiverPtr);
+            break;
+
+        case EXdcCatchReplayReconnectAction::ClosePeerSocket:
+            CloseXdcCatchReplayPeerSocket(cluster, receiverPtr);
+            break;
+    }
+    WaitForXdcCatchReplayRdmaReceiveSessionReplacement(cluster, receiverPtr, receiveSessionCreatedBefore);
+}
 
 struct THandshakeFailureLogCounters {
     std::atomic<ui32> Notice = 0;
@@ -366,6 +678,17 @@ bool SkipIfRdmaUnavailable(bool withRdma, TStringBuf testName) {
         return true;
     }
     return false;
+}
+
+void WaitForRdmaQpRts(TTestICCluster& cluster, ui32 nodeId, ui32 peerNodeId, TStringBuf description) {
+    WaitForCondition(TDuration::Seconds(30), [&] {
+        try {
+            const auto tokens = SplitString(GetRdmaQpStatus(cluster, nodeId, peerNodeId), ",");
+            return tokens.size() > 2 && tokens[1] == "QPS_RTS";
+        } catch (const TPatternNotFound&) {
+            return false;
+        }
+    }, description);
 }
 
 ui64 MeasureIdleGeneratedPackets(bool enableKernelLiveness, bool withRdma) {
@@ -617,6 +940,20 @@ void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
 
     waitKernelMode(1ULL, "initial kernel liveness negotiated");
 
+    if (withRdma) {
+        const TString createdBefore = GetSessionTextMetric(cluster, 2, 1, "Created");
+
+        // RDMA sessions must not use same-session continuation. A reconnect request should replace the old session
+        // and negotiate transport params from current local settings through a fresh initial handshake.
+        cluster.GetNode(2)->MutableInterconnectSettings().EnableKernelLiveness = false;
+        reconnectFromNode2("RDMA session recreated with local kernel liveness disabled");
+
+        const TString createdAfter = GetSessionTextMetric(cluster, 2, 1, "Created");
+        UNIT_ASSERT_VALUES_UNEQUAL(createdAfter, createdBefore);
+        UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 0ULL);
+        return;
+    }
+
     bool exercisedSameSessionContinuation = false;
     for (ui32 attempt = 0; attempt < 5; ++attempt) {
         const TString createdBefore = GetSessionTextMetric(cluster, 2, 1, "Created");
@@ -773,6 +1110,132 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         WaitForCondition(TDuration::Seconds(10), [&] {
             return GetHistogramSamples(histogram) > 0;
         }, "poller sync operation histogram has samples");
+    }
+
+    // Scenario: a TCP XDC payload is partially read, the input session is closed without dropping the output session,
+    // and replay must use the saved XDC catch buffer to finish the event exactly once.
+    Y_UNIT_TEST(TcpXdcCatchReplayAfterPartialPayloadRead) {
+        RunXdcCatchReplayAfterPartialPayloadRead(EXdcCatchReplayMode::Tcp);
+    }
+
+    // Scenario: RDMA section declarations are already applied to the receive context, but no RDMA_READ has been
+    // scheduled yet. RDMA sessions must not use graceful reconnect here; the old receive session is replaced instead
+    // of replaying serialized RDMA commands across reconnect.
+    Y_UNIT_TEST(RdmaXdcCatchReplayAfterPartialPayloadRead) {
+        if (SkipIfRdmaUnavailable(true, "RdmaXdcCatchReplayAfterPartialPayloadRead")) {
+            return;
+        }
+        RunXdcCatchReplayAfterPartialPayloadRead(EXdcCatchReplayMode::Rdma);
+    }
+
+    // Scenario: at least one RDMA_READ was already scheduled before reconnect, so the pending event's RDMA buffer
+    // cursor may have moved. RDMA sessions must use a fresh session instead of attempting graceful replay with stale
+    // RDMA state.
+    Y_UNIT_TEST(RdmaXdcCatchReplayAfterPartialRdmaRead) {
+        if (SkipIfRdmaUnavailable(true, "RdmaXdcCatchReplayAfterPartialRdmaRead")) {
+            return;
+        }
+        RunRdmaXdcCatchReplayAfterPartialRdmaRead(EXdcCatchReplayReconnectAction::CloseInputSession);
+    }
+
+    // Scenario: at least one RDMA_READ was already scheduled, then the interconnect socket is closed through the
+    // debug API. RDMA sessions must reject graceful continuation and replace the old receive session instead of
+    // replaying stale RDMA state.
+    Y_UNIT_TEST(RdmaXdcCatchReplayAfterPartialRdmaReadOnPeerSocketClose) {
+        if (SkipIfRdmaUnavailable(true, "RdmaXdcCatchReplayAfterPartialRdmaReadOnPeerSocketClose")) {
+            return;
+        }
+        RunRdmaXdcCatchReplayAfterPartialRdmaRead(EXdcCatchReplayReconnectAction::ClosePeerSocket);
+    }
+
+    // Scenario: both peers close the TCP control socket of an established RDMA interconnect session at nearly the
+    // same time. Both old RDMA sessions must be replaced by fresh handshakes instead of bouncing continuation rejects.
+    Y_UNIT_TEST(RdmaSimultaneousReconnectDoesNotLoop) {
+        if (SkipIfRdmaUnavailable(true, "RdmaSimultaneousReconnectDoesNotLoop")) {
+            return;
+        }
+
+        TTestICCluster::TTrafficInterrupterSettings interrupterSettings{
+            .RejectingTrafficTimeout = TDuration::Zero(),
+            .BandWidth = 0.0,
+            .Disconnect = false,
+        };
+        TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings);
+
+        auto* recipientOnNode1Ptr = new TRecipientActor;
+        const TActorId recipientOnNode1 = cluster.RegisterActor(recipientOnNode1Ptr, 1);
+        auto* recipientOnNode2Ptr = new TRecipientActor;
+        const TActorId recipientOnNode2 = cluster.RegisterActor(recipientOnNode2Ptr, 2);
+
+        cluster.RegisterActor(new TSenderActor(recipientOnNode1, 1), 2);
+        cluster.RegisterActor(new TSenderActor(recipientOnNode2, 1), 1);
+
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            return recipientOnNode1Ptr->GetReceived() >= 1
+                && recipientOnNode2Ptr->GetReceived() >= 1;
+        }, "initial bidirectional RDMA delivery");
+
+        WaitForRdmaQpRts(cluster, 1, 2, "initial RDMA session 1->2 is RTS");
+        WaitForRdmaQpRts(cluster, 2, 1, "initial RDMA session 2->1 is RTS");
+
+        const TString created12Before = GetSessionTextMetric(cluster, 1, 2, "Created");
+        const TString created21Before = GetSessionTextMetric(cluster, 2, 1, "Created");
+
+        const TActorId dropRecipientOnNode1 = cluster.RegisterActor(new TDropRecipientActor, 1);
+        const TActorId dropRecipientOnNode2 = cluster.RegisterActor(new TDropRecipientActor, 2);
+
+        auto sessionStaysAliveOnEof = [&](ui32 fromNode, ui32 toNode) {
+            const ui64 numEventsInQueue = GetSessionCounter(cluster, fromNode, toNode, "NumEventsInQueue");
+            const ui64 outputCounter = GetSessionCounter(cluster, fromNode, toNode, "OutputCounter");
+            const ui64 lastConfirmed = GetSessionCounter(cluster, fromNode, toNode, "LastConfirmed");
+            return numEventsInQueue > 0 || outputCounter != lastConfirmed;
+        };
+
+        cluster.StartBlackhole(1);
+        cluster.StartBlackhole(2);
+        cluster.RegisterActor(new TBurstSenderActor(dropRecipientOnNode1, 4096, 4096), 2);
+        cluster.RegisterActor(new TBurstSenderActor(dropRecipientOnNode2, 4096, 4096), 1);
+
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            try {
+                return sessionStaysAliveOnEof(1, 2) && sessionStaysAliveOnEof(2, 1);
+            } catch (const TPatternNotFound&) {
+                return false;
+            }
+        }, "both RDMA sessions have pending traffic while proxy forwarding is frozen");
+
+        cluster.GetNode(1)->Send(cluster.InterconnectProxy(2, 1), new TEvInterconnect::TEvClosePeerSocket);
+        cluster.GetNode(2)->Send(cluster.InterconnectProxy(1, 2), new TEvInterconnect::TEvClosePeerSocket);
+
+        Sleep(TDuration::MilliSeconds(100));
+        cluster.StopBlackhole(1);
+        cluster.StopBlackhole(2);
+
+        WaitForCondition(TDuration::Seconds(30), [&] {
+            try {
+                return GetSessionTextMetric(cluster, 1, 2, "Created") != created12Before
+                    && GetSessionTextMetric(cluster, 2, 1, "Created") != created21Before
+                    && GetSessionSocketFd(cluster, 1, 2) >= 0
+                    && GetSessionSocketFd(cluster, 2, 1) >= 0;
+            } catch (const TPatternNotFound&) {
+                return false;
+            } catch (const TFromStringException&) {
+                return false;
+            }
+        }, "simultaneous RDMA reconnect replaced both sessions");
+
+        WaitForRdmaQpRts(cluster, 1, 2, "reconnected RDMA session 1->2 is RTS");
+        WaitForRdmaQpRts(cluster, 2, 1, "reconnected RDMA session 2->1 is RTS");
+
+        const size_t receivedOnNode1Before = recipientOnNode1Ptr->GetReceived();
+        const size_t receivedOnNode2Before = recipientOnNode2Ptr->GetReceived();
+        cluster.RegisterActor(new TSenderActor(recipientOnNode1, 1), 2);
+        cluster.RegisterActor(new TSenderActor(recipientOnNode2, 1), 1);
+
+        WaitForCondition(TDuration::Seconds(20), [&] {
+            return recipientOnNode1Ptr->GetReceived() > receivedOnNode1Before
+                && recipientOnNode2Ptr->GetReceived() > receivedOnNode2Before;
+        }, "bidirectional delivery after simultaneous RDMA reconnect");
     }
 
     Y_UNIT_TEST(KernelLivenessMixedConfigFallback) {

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -207,4 +207,8 @@ public:
     TInterconnectSettings& MutableInterconnectSettings() {
         return Common->Settings;
     }
+
+    std::shared_ptr<NInterconnect::NRdma::IMemPool> GetRdmaMemPool() const {
+        return Common->RdmaMemPool;
+    }
 };

--- a/ydb/library/actors/interconnect/ut_fat/main.cpp
+++ b/ydb/library/actors/interconnect/ut_fat/main.cpp
@@ -172,7 +172,7 @@ Y_UNIT_TEST_SUITE(InterconnectUnstableConnection) {
         ui16 flags = IEventHandle::FlagTrackDelivery | IEventHandle::FlagGenerateUnsureUndelivered;
         TTestICCluster::TTrafficInterrupterSettings interrupterSettings{TDuration::Seconds(2), bandWidth, true};
 
-        TTestICCluster testCluster(numNodes, TChannelsConfig(), &interrupterSettings);
+        TTestICCluster testCluster(numNodes, TChannelsConfig(), &interrupterSettings, nullptr, TTestICCluster::DISABLE_RDMA);
 
         TReceiverActor* receiverActor = new TReceiverActor(testCluster.GetNode(1));
         const TActorId recipient = testCluster.RegisterActor(receiverActor, 2);
@@ -188,7 +188,7 @@ Y_UNIT_TEST_SUITE(InterconnectUnstableConnection) {
         ui16 flags = IEventHandle::FlagTrackDelivery | IEventHandle::FlagGenerateUnsureUndelivered;
         TTestICCluster::TTrafficInterrupterSettings interrupterSettings{TDuration::Seconds(2), bandWidth, true};
 
-        TTestICCluster testCluster(numNodes, TChannelsConfig(), &interrupterSettings);
+        TTestICCluster testCluster(numNodes, TChannelsConfig(), &interrupterSettings, nullptr, TTestICCluster::DISABLE_RDMA);
 
         TReceiverActor* receiverActor = new TReceiverActor(testCluster.GetNode(1));
         const TActorId recipient = testCluster.RegisterActor(receiverActor, 2);
@@ -204,7 +204,8 @@ Y_UNIT_TEST_SUITE(InterconnectUnstableConnection) {
         ui16 flags = IEventHandle::FlagTrackDelivery | IEventHandle::FlagGenerateUnsureUndelivered;
         TTestICCluster::TTrafficInterrupterSettings interrupterSettings{TDuration::Seconds(2), bandWidth, true};
 
-        TTestICCluster testCluster(numNodes, TChannelsConfig(), &interrupterSettings, nullptr, TTestICCluster::USE_TLS);
+        TTestICCluster testCluster(numNodes, TChannelsConfig(), &interrupterSettings, nullptr,
+            TTestICCluster::Flags(TTestICCluster::USE_TLS | TTestICCluster::DISABLE_RDMA));
 
         TReceiverActor* receiverActor = new TReceiverActor(testCluster.GetNode(1));
         const TActorId recipient = testCluster.RegisterActor(receiverActor, 2);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Graceful reconnect keeps the same interconnect session instance and asks the peer to continue from the last confirmed packet. That is fine for the TCP/XDC path where replay is based on serialized bytes and the receive context can consume the catch buffer idempotently.

RDMA adds transport state that is not stable across such continuation. A reconnect creates a new RDMA QP on the receiving side, while the peer and replayed XDC stream may still describe RDMA_READ commands, rkeys, and buffer cursors from the previous connection. If a reconnect happens after RDMA sections were parsed or after RDMA_READ scheduling advanced the receive-side cursor, replaying the old bytes can bind the event to a stale or unpaired QP, corrupt the reconstructed event, or leave delivery stuck.

Make RDMA sessions use a full reconnect instead of graceful continuation. Local reconnect now starts an initial handshake when the current session has RDMA state, which replaces the old session and drops its pending RDMA receive/send state. Incoming continuation requests that match an existing RDMA session are rejected and the local RDMA session is terminated so that the peer also falls back to a fresh session.

Add regression coverage for partial XDC/RDMA replay states and for simultaneous RDMA reconnects. The TCP XDC baseline still verifies graceful replay delivery. RDMA variants verify that the old receive session is replaced and no corrupted event is delivered. Disable RDMA in fat unstable-connection tests that assert legacy TCP/XDC unsure-undelivered ordering, because RDMA now intentionally performs a full session break instead of preserving graceful reconnect semantics.




### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
