### PR TITLE
Fix agg cross join cost

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_tasks_graph_ut.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_tasks_graph_ut.cpp
@@ -1530,11 +1530,11 @@ Y_UNIT_TEST_SUITE(TKqpTasksGraphBuild) {
         UNIT_ASSERT_VALUES_EQUAL(dist.TasksPerStage.size(), 8u);
         UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  0), 1920);
         UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  1), 1920);
-        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  2), 256);
-        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  3), 256);
-        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  4), 1);
-        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  5), 1);
-        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  6), 240);
+        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  2), 1);
+        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  3), 1);
+        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  4), 1920);
+        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  5), 256);
+        UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  6), 256);
         UNIT_ASSERT_VALUES_EQUAL(dist.Count(0,  7), 1);
     }
 

--- a/ydb/core/kqp/opt/cbo/kqp_statistics.cpp
+++ b/ydb/core/kqp/opt/cbo/kqp_statistics.cpp
@@ -64,6 +64,8 @@ TString ConvertToStatisticsTypeString(EStatisticsType type) {
             return "FilteredFactTable";
         case EStatisticsType::ManyManyJoin:
             return "ManyManyJoin";
+        case EStatisticsType::Constant:
+            return "Constant";
     }
 }
 

--- a/ydb/core/kqp/opt/cbo/kqp_statistics.h
+++ b/ydb/core/kqp/opt/cbo/kqp_statistics.h
@@ -26,7 +26,8 @@ namespace NKikimr::NKqp {
 enum EStatisticsType : ui32 {
     BaseTable,
     FilteredFactTable,
-    ManyManyJoin
+    ManyManyJoin,
+    Constant
 };
 
 enum EStorageType : ui32 {

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_stat.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_stat.cpp
@@ -801,8 +801,15 @@ void InferStatisticsForAggregateBase(const TExprNode::TPtr& input, TKqpStatsStor
     }
 
     double selectivity = AggregateSelectivity(aggStats, strKeys);
-    aggStats->Nrows = aggStats->Nrows * selectivity;
-    aggStats->ByteSize = aggStats->ByteSize * selectivity;
+    if (strKeys.empty()) {
+        double rowBytes = aggStats->Nrows > 0.0 ? aggStats->ByteSize / aggStats->Nrows : aggStats->ByteSize;
+        aggStats->Nrows = 1.0;
+        aggStats->ByteSize = rowBytes;
+        aggStats->Type = EStatisticsType::Constant;
+    } else {
+        aggStats->Nrows = aggStats->Nrows * selectivity;
+        aggStats->ByteSize = aggStats->ByteSize * selectivity;
+    }
 
     YQL_CLOG(TRACE, CoreDq) << "Infer statistics for AggregateBase with keys: " << JoinSeq(", ", strKeys) << ", with stats: " << aggStats->ToString();
     kqpStats->SetStats(input.Get(), std::move(aggStats));
@@ -832,8 +839,15 @@ void InferStatisticsForAggregateMergeFinalize(const TExprNode::TPtr& input, TKqp
     }
 
     double selectivity = AggregateSelectivity(aggStats, strKeys);
-    aggStats->Nrows = aggStats->Nrows * selectivity;
-    aggStats->ByteSize = aggStats->ByteSize * selectivity;
+    if (strKeys.empty()) {
+        double rowBytes = aggStats->Nrows > 0.0 ? aggStats->ByteSize / aggStats->Nrows : aggStats->ByteSize;
+        aggStats->Nrows = 1.0;
+        aggStats->ByteSize = rowBytes;
+        aggStats->Type = EStatisticsType::Constant;
+    } else {
+        aggStats->Nrows = aggStats->Nrows * selectivity;
+        aggStats->ByteSize = aggStats->ByteSize * selectivity;
+    }
 
     kqpStats->SetStats( input.Get(), aggStats );
 }

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_stat.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_stat.cpp
@@ -805,6 +805,7 @@ void InferStatisticsForAggregateBase(const TExprNode::TPtr& input, TKqpStatsStor
         double rowBytes = aggStats->Nrows > 0.0 ? aggStats->ByteSize / aggStats->Nrows : aggStats->ByteSize;
         aggStats->Nrows = 1.0;
         aggStats->ByteSize = rowBytes;
+        aggStats->Selectivity = 1.0;
         aggStats->Type = EStatisticsType::Constant;
     } else {
         aggStats->Nrows = aggStats->Nrows * selectivity;

--- a/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
@@ -509,7 +509,14 @@ TOptimizerStatistics TKqpProviderContext::ComputeJoinStats(
         }
     } else if (isCrossJoin) {
         selectivity = std::min(1.0, leftStats.Selectivity * rightStats.Selectivity);
-        newCard = leftStats.Nrows * rightStats.Nrows * selectivity;
+        const bool lhsConst = leftStats.Type == EStatisticsType::Constant;
+        const bool rhsConst = rightStats.Type == EStatisticsType::Constant;
+        if (lhsConst != rhsConst) {
+            const auto& largeSide = lhsConst ? rightStats : leftStats;
+            newCard = largeSide.Nrows * selectivity;
+        } else {
+            newCard = leftStats.Nrows * rightStats.Nrows * selectivity;
+        }
 
         newByteSize = ComputeBothSidesByteSize(newCard, leftStats, rightStats, commonJoinKeys);
         outputType = EStatisticsType::ManyManyJoin;
@@ -543,6 +550,9 @@ TOptimizerStatistics TKqpProviderContext::ComputeJoinStats(
             newCard = effectiveRight * (effectiveLeft / std::max(lhsUniqueVals.GetRef(), 1.0));
         } else if (rhsUniqueVals.Defined()) {
             newCard = effectiveLeft * (effectiveRight / std::max(rhsUniqueVals.GetRef(), 1.0));
+        } else if (leftStats.Type == EStatisticsType::Constant || rightStats.Type == EStatisticsType::Constant) {
+            const bool lhsConst = leftStats.Type == EStatisticsType::Constant;
+            newCard = 0.2 * (lhsConst ? effectiveRight : effectiveLeft);
         } else {
             /* for example, join predicate between a column and a scalar aggregate */
             newCard = 0.2 * effectiveLeft * effectiveRight;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
@@ -136,6 +136,9 @@ TString TRBOMetadata::ToString(ui32 printOptions) {
             case EStatisticsType::ManyManyJoin:
                 metadataType = "ManyManyJoin";
                 break;
+            case EStatisticsType::Constant:
+                metadataType = "Constant";
+                break;
         default:
             Y_ENSURE(false,"Unknown EStatisticsType");
         }

--- a/ydb/core/kqp/opt/rbo/traces/kqp_rbo_trace.cpp
+++ b/ydb/core/kqp/opt/rbo/traces/kqp_rbo_trace.cpp
@@ -115,6 +115,7 @@ std::string FormatStatisticsType(EStatisticsType type) {
         case NKikimr::NKqp::BaseTable: return "BaseTable";
         case NKikimr::NKqp::FilteredFactTable: return "FilteredFactTable";
         case NKikimr::NKqp::ManyManyJoin: return "ManyManyJoin";
+        case NKikimr::NKqp::Constant: return "Constant";
         default: return "Unknown";
     }
 }

--- a/ydb/core/kqp/ut/join/data/join_order/tpch15_1000s_column_store.json
+++ b/ydb/core/kqp/ut/join/data/join_order/tpch15_1000s_column_store.json
@@ -7,7 +7,7 @@
         "args":
           [
             {
-              "op_name":"InnerJoin (BlockHash)",
+              "op_name":"InnerJoin (Map)",
               "args":
                 [
                   {
@@ -15,40 +15,28 @@
                     "args":
                       [
                         {
-                          "op_name":"HashShuffle",
-                          "args":
-                            [
-                              {
-                                "op_name":"TableFullScan",
-                                "table":"lineitem"
-                              }
-                            ]
+                          "op_name":"TableFullScan",
+                          "table":"lineitem"
                         }
                       ]
                   },
                   {
-                    "op_name":"TableFullScan",
-                    "table":"supplier"
+                    "op_name":"HashShuffle",
+                    "args":
+                      [
+                        {
+                          "op_name":"TableFullScan",
+                          "table":"lineitem"
+                        }
+                      ]
                   }
                 ]
             }
           ]
       },
       {
-        "op_name":"HashShuffle",
-        "args":
-          [
-            {
-              "op_name":"HashShuffle",
-              "args":
-                [
-                  {
-                    "op_name":"TableFullScan",
-                    "table":"lineitem"
-                  }
-                ]
-            }
-          ]
+        "op_name":"TableFullScan",
+        "table":"supplier"
       }
     ]
 }

--- a/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
@@ -1376,11 +1376,11 @@ Y_UNIT_TEST_SUITE(KqpJoinOrder) {
         );
     }
 
-    // Y_UNIT_TEST(CanonizedJoinOrderTPCH15) {
-    //     CanonizedJoinOrderTest(
-    //         "queries/tpch15.sql", "stats/tpch1000s.json", "join_order/tpch15_1000s.json", false, true
-    //     );
-    // }
+    Y_UNIT_TEST(CanonizedJoinOrderTPCH15) {
+        CanonizedJoinOrderTest(
+            "queries/tpch15.sql", "stats/tpch1000s.json", "join_order/tpch15_1000s.json", false, true
+        );
+    }
 
     Y_UNIT_TEST(CanonizedJoinOrderTPCH16) {
         CanonizedJoinOrderTest(

--- a/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
+++ b/ydb/core/kqp/ut/join/kqp_join_order_ut.cpp
@@ -1376,11 +1376,11 @@ Y_UNIT_TEST_SUITE(KqpJoinOrder) {
         );
     }
 
-    Y_UNIT_TEST(CanonizedJoinOrderTPCH15) {
-        CanonizedJoinOrderTest(
-            "queries/tpch15.sql", "stats/tpch1000s.json", "join_order/tpch15_1000s.json", false, true
-        );
-    }
+    // Y_UNIT_TEST(CanonizedJoinOrderTPCH15) {
+    //     CanonizedJoinOrderTest(
+    //         "queries/tpch15.sql", "stats/tpch1000s.json", "join_order/tpch15_1000s.json", false, true
+    //     );
+    // }
 
     Y_UNIT_TEST(CanonizedJoinOrderTPCH16) {
         CanonizedJoinOrderTest(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixing the cross join evaluation. When one side is a scalar, there is no cross-join thus need to adjust the number of rows to 1.

### Changelog category <!-- remove all except one -->

* Improvement
* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
