### PR TITLE
LOGBROKER-10095 split partitions if MinPartitionCount is set to bigger value than current number of active partitions

### DIFF
--- a/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/autoscaling_ut.cpp
@@ -1715,6 +1715,34 @@ Y_UNIT_TEST_SUITE(TopicAutoscaling) {
         }
     }
 
+    Y_UNIT_TEST(PartitionSplit_AutosplitByMinPartitionCount) {
+        TTopicSdkTestSetup setup = CreateSetup();
+        auto tableClient = setup.MakeTableClient();
+        auto session = tableClient.CreateSession().GetValueSync().GetSession();
+
+        ExecuteQuery(session, R"(
+            --!syntax_v1
+            CREATE TOPIC `/Root/dir/origin`
+                WITH (
+                    AUTO_PARTITIONING_STRATEGY = 'SCALE_UP_AND_DOWN',
+                    MIN_ACTIVE_PARTITIONS = 3
+                );
+        )");
+
+        AssertPartitionCount(setup, "/Root/dir/origin", 3);
+
+        // MAX_ACTIVE_PARTITIONS has to be not less than MIN_ACTIVE_PARTITIONS
+        ExecuteQuery(session, R"(
+            --!syntax_v1
+            ALTER TOPIC `/Root/dir/origin`
+                SET (
+                    MAX_ACTIVE_PARTITIONS = 20,
+                    MIN_ACTIVE_PARTITIONS = 20
+                );
+        )");
+        WaitAndAssertPartitionCount(setup, "/Root/dir/origin", 37); // 17 inactive, 20 active
+    }
+
     Y_UNIT_TEST(BalancingAfterSplit_sessionsWithPartition) {
         TTopicSdkTestSetup setup = CreateSetup();
         setup.CreateTopicWithAutoscale(TEST_TOPIC, TEST_CONSUMER, 1, 100);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
@@ -3,6 +3,8 @@
 #include "schemeshard_impl.h"
 #include "schemeshard_pq_helpers.h"  // for PQGroupReserve
 
+#include <library/cpp/containers/top_keeper/top_keeper.h>
+
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/mind/hive/hive.h>
 #include <ydb/core/persqueue/public/config.h>
@@ -87,6 +89,7 @@ public:
     TTopicInfo::TPtr ParseParams(
             TOperationContext& context,
             NKikimrPQ::TPQTabletConfig* tabletConfig,
+            TTopicInfo::TPtr topic,
             const NKikimrSchemeOp::TPersQueueGroupDescription& alter,
             TString& errStr)
     {
@@ -164,6 +167,16 @@ public:
             if (strategy.GetMaxPartitionCount() < strategy.GetMinPartitionCount()) {
                 errStr = Sprintf("Invalid min and max partition count specified: %u > %u", strategy.GetMinPartitionCount(), strategy.GetMaxPartitionCount());
                 return nullptr;
+            }
+            if (strategy.GetMinPartitionCount() > topic->ActivePartitionCount) { // request to increase active partitions
+                if (alter.MergeSize() || alter.SplitSize() || alter.RootPartitionBoundariesSize()) {
+                    errStr = Sprintf("Can't icrease active partitions and Split/Merge or change root boundaries at the same time");
+                    return nullptr;
+                }
+                if (!NPQ::SplitMergeEnabled(*tabletConfig)) {
+                    errStr = Sprintf("Can't icrease active partitions and enable Split/Merge strategy at the same time");
+                    return nullptr;
+                }
             }
         }
         if (alter.HasPartitionPerTablet()) {
@@ -283,7 +296,7 @@ public:
                             << "providing partition " <<  p.GetPartitionId() << " several times in PartitionsToAdd is forbidden";
                     return nullptr;
                 }
-                params->PartitionsToAdd.emplace(p.GetPartitionId(), p.GetGroupId());
+                params->PartitionsToAdd.emplace_back(p.GetPartitionId(), p.GetGroupId());
             }
         }
         if (alter.HasBootstrapConfig()) {
@@ -602,7 +615,7 @@ public:
         NKikimrPQ::TPQTabletConfig tabletConfig = topic->GetTabletConfig();
         NKikimrPQ::TPQTabletConfig newTabletConfig = tabletConfig;
 
-        TTopicInfo::TPtr alterData = ParseParams(context, &newTabletConfig, alter, errStr);
+        TTopicInfo::TPtr alterData = ParseParams(context, &newTabletConfig, topic, alter, errStr);
 
         if (!alterData) {
             result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
@@ -720,7 +733,7 @@ public:
                             result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                             return result;
                         }
-                        alterData->PartitionsToAdd.emplace(partitionIdIndex.value(), partitionIdIndex.value() + 1, range);
+                        alterData->PartitionsToAdd.emplace_back(partitionIdIndex.value(), partitionIdIndex.value() + 1, range);
                         alterData->TotalGroupCount += 1;
                         ++alterData->ActivePartitionCount;
                     }
@@ -815,10 +828,10 @@ public:
                             LOG_TRACE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                                         std::format("Skipping split partition {}. Create new partition {}",
                                                     splittedPartitionId, *prescribedChildPartitionId));
-                            alterData->PartitionsToAdd.emplace(childPartitionId.value(), childPartitionId.value() + 1);
+                            alterData->PartitionsToAdd.emplace_back(childPartitionId.value(), childPartitionId.value() + 1);
                         }
                     } else {
-                        alterData->PartitionsToAdd.emplace(childPartitionId.value(), childPartitionId.value() + 1, range, parents);
+                        alterData->PartitionsToAdd.emplace_back(childPartitionId.value(), childPartitionId.value() + 1, range, parents);
                     }
                 }
             }
@@ -899,7 +912,108 @@ public:
                     result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                     return result;
                 }
-                alterData->PartitionsToAdd.emplace(childPartitionId.value(), childPartitionId.value() + 1, rangem, parents);
+                alterData->PartitionsToAdd.emplace_back(childPartitionId.value(), childPartitionId.value() + 1, rangem, parents);
+            }
+
+            if (alter.HasPQTabletConfig() && alter.GetPQTabletConfig().HasPartitionStrategy()) {
+                auto requestedMinPartitionCount = alter.GetPQTabletConfig().GetPartitionStrategy().GetMinPartitionCount();
+                if (requestedMinPartitionCount > alterData->ActivePartitionCount) {
+                    // select exisisting active partitions for split
+                    auto numPartitionsToSplit = requestedMinPartitionCount - alterData->ActivePartitionCount;
+                    struct TPartitionsComparer {
+                        bool operator()(const TTopicTabletInfo::TTopicPartitionInfo* lhs, const TTopicTabletInfo::TTopicPartitionInfo* rhs) const {
+                            return lhs->ParentPartitionIds.size() < rhs->ParentPartitionIds.size(); // for now simply sort by number of parents
+                        }
+                    };
+                    TTopKeeper<const TTopicTabletInfo::TTopicPartitionInfo*, TPartitionsComparer> partitionsToSplit(numPartitionsToSplit);
+                    for (const auto& [partitionId, partition] : topic->Partitions) {
+                        if (partition->Status == NKikimrPQ::ETopicPartitionStatus::Active) {
+                             partitionsToSplit.Insert(partition);
+                        }
+                    }
+
+                    // splitter routine
+                    auto SplitPartition = [&](const TTopicTabletInfo::TKeyRange& keyRange, ui32 parentPartitionId,
+                            TVector<NKikimr::NSchemeShard::TTopicInfo::TPartitionToAdd>& container) -> std::expected<void, TString>
+                    {
+                        auto splitBoundary = NKikimr::NPQ::MiddleOf(keyRange.FromBound.GetOrElse(""), keyRange.ToBound.GetOrElse(""));
+
+                        const THashSet<ui32> parents{parentPartitionId};
+                        const TTopicTabletInfo::TKeyRange childRange[2]{
+                            {
+                                .FromBound = keyRange.FromBound,
+                                .ToBound = splitBoundary,
+                            },
+                            {
+                                .FromBound = splitBoundary,
+                                .ToBound = keyRange.ToBound,
+                            },
+                        };
+
+                        for (const size_t childIndex : {0, 1}) {
+                            const TTopicTabletInfo::TKeyRange& range = childRange[childIndex];
+                            const auto childPartitionId = indexGenerator.GetNextUnreservedId();
+                            if (!childPartitionId.has_value()) {
+                                return std::unexpected("error in reserving next partition ID");
+                            }
+                            container.emplace_back(childPartitionId.value(), childPartitionId.value() + 1, range, parents);
+                        }
+                        alterData->TotalGroupCount += 2;
+                        ++alterData->ActivePartitionCount;
+
+                        return {};
+                    };
+
+                    // start splitting
+                    while(!partitionsToSplit.IsEmpty()) {
+                        auto splittedPartition = partitionsToSplit.ExtractOne();
+                        const auto keyRange = splittedPartition->KeyRange;
+                        if (!keyRange) {
+                            continue;
+                        }
+
+                        auto res = SplitPartition(*keyRange, splittedPartition->PqId, alterData->PartitionsToAdd);
+                        if (!res) {
+                            errStr = TStringBuilder() << "Split error: " << res.error();
+                            result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                            return result;
+                        }
+                    }
+
+                    if (alterData->PartitionsToAdd.empty()) {
+                        errStr = TStringBuilder() << "Split error: iteration produced zero new partitions";
+                        result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                        return result;
+                    }
+
+                    // repeat splitting
+                    while (requestedMinPartitionCount > alterData->ActivePartitionCount) {
+                        TVector<NKikimr::NSchemeShard::TTopicInfo::TPartitionToAdd> partitionsToAdd;
+                        for (const auto& partition : alterData->PartitionsToAdd) {
+                            if (!partition.KeyRange) {
+                                errStr = TStringBuilder() << "Split error: unexpected";
+                                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                                return result;
+                            }
+
+                            auto res = SplitPartition(*partition.KeyRange, partition.PartitionId, partitionsToAdd);
+                            if (!res) {
+                                errStr = TStringBuilder() << "Split error: " << res.error();
+                                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                                return result;
+                            }
+                            if (requestedMinPartitionCount <= alterData->ActivePartitionCount) {
+                                break;
+                            }
+                        }
+                        if (partitionsToAdd.empty()) {
+                            errStr = TStringBuilder() << "Split error: second iteration produced zero new partitions";
+                            result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                            return result;
+                        }
+                        alterData->PartitionsToAdd.insert(alterData->PartitionsToAdd.end(), partitionsToAdd.begin(), partitionsToAdd.end());
+                    }
+                }
             }
 
             if (const auto seq = indexGenerator.ValidateAllocationSequence(); !seq.has_value()) {
@@ -913,7 +1027,7 @@ public:
             ui32 diff = alterData->TotalGroupCount - topic->TotalGroupCount;
 
             for (ui32 i = 0; i < diff; ++i) {
-                alterData->PartitionsToAdd.emplace(topic->NextPartitionId + i, topic->TotalGroupCount + 1 + i);
+                alterData->PartitionsToAdd.emplace_back(topic->NextPartitionId + i, topic->TotalGroupCount + 1 + i);
             }
 
             if (diff > 0) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
@@ -168,9 +168,13 @@ public:
                 errStr = Sprintf("Invalid min and max partition count specified: %u > %u", strategy.GetMinPartitionCount(), strategy.GetMaxPartitionCount());
                 return nullptr;
             }
-            if (splitMergeEnabled && (strategy.GetMinPartitionCount() > topic->ActivePartitionCount)) { // request will increase active partitions
+            if (strategy.GetMinPartitionCount() > topic->ActivePartitionCount) { // request will increase active partitions
                 if (alter.MergeSize() || alter.SplitSize() || alter.RootPartitionBoundariesSize()) {
                     errStr = Sprintf("Can't increase active partitions and Split/Merge or change root boundaries at the same time");
+                    return nullptr;
+                }
+                if (!NPQ::SplitMergeEnabled(*tabletConfig) && topic->ActivePartitionCount != 1) {
+                    errStr = Sprintf("Can't icrease active partitions and enable Split/Merge strategy at the same time");
                     return nullptr;
                 }
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_pq.cpp
@@ -168,13 +168,9 @@ public:
                 errStr = Sprintf("Invalid min and max partition count specified: %u > %u", strategy.GetMinPartitionCount(), strategy.GetMaxPartitionCount());
                 return nullptr;
             }
-            if (strategy.GetMinPartitionCount() > topic->ActivePartitionCount) { // request to increase active partitions
+            if (splitMergeEnabled && (strategy.GetMinPartitionCount() > topic->ActivePartitionCount)) { // request will increase active partitions
                 if (alter.MergeSize() || alter.SplitSize() || alter.RootPartitionBoundariesSize()) {
-                    errStr = Sprintf("Can't icrease active partitions and Split/Merge or change root boundaries at the same time");
-                    return nullptr;
-                }
-                if (!NPQ::SplitMergeEnabled(*tabletConfig)) {
-                    errStr = Sprintf("Can't icrease active partitions and enable Split/Merge strategy at the same time");
+                    errStr = Sprintf("Can't increase active partitions and Split/Merge or change root boundaries at the same time");
                     return nullptr;
                 }
             }
@@ -938,6 +934,10 @@ public:
                     {
                         auto splitBoundary = NKikimr::NPQ::MiddleOf(keyRange.FromBound.GetOrElse(""), keyRange.ToBound.GetOrElse(""));
 
+                        if (!involvedPartitions.emplace(parentPartitionId).second) {
+                            return std::unexpected(TStringBuilder()
+                                    << "Partition can be involved only in one split/merge operation: " << parentPartitionId);
+                        }
                         const THashSet<ui32> parents{parentPartitionId};
                         const TTopicTabletInfo::TKeyRange childRange[2]{
                             {
@@ -967,9 +967,14 @@ public:
                     // start splitting
                     while(!partitionsToSplit.IsEmpty()) {
                         auto splittedPartition = partitionsToSplit.ExtractOne();
-                        const auto keyRange = splittedPartition->KeyRange;
+                        auto keyRange = splittedPartition->KeyRange;
                         if (!keyRange) {
-                            continue;
+                            // if there is only one partition then it may not have a key range
+                            if (topic->Partitions.size() == 1) {
+                                keyRange.ConstructInPlace();
+                            } else {
+                                continue;
+                            }
                         }
 
                         auto res = SplitPartition(*keyRange, splittedPartition->PqId, alterData->PartitionsToAdd);
@@ -987,9 +992,12 @@ public:
                     }
 
                     // repeat splitting
+                    size_t startIdx = 0;
                     while (requestedMinPartitionCount > alterData->ActivePartitionCount) {
                         TVector<NKikimr::NSchemeShard::TTopicInfo::TPartitionToAdd> partitionsToAdd;
-                        for (const auto& partition : alterData->PartitionsToAdd) {
+                        auto endIdx = alterData->PartitionsToAdd.size();
+                        for (size_t i = startIdx; i < endIdx; ++i) {
+                            const auto& partition = alterData->PartitionsToAdd[i];
                             if (!partition.KeyRange) {
                                 errStr = TStringBuilder() << "Split error: unexpected";
                                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
@@ -1011,6 +1019,7 @@ public:
                             result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                             return result;
                         }
+                        startIdx = endIdx;
                         alterData->PartitionsToAdd.insert(alterData->PartitionsToAdd.end(), partitionsToAdd.begin(), partitionsToAdd.end());
                     }
                 }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -144,7 +144,7 @@ TTopicInfo::TPtr CreatePersQueueGroup(TOperationContext& context,
             }
         }
 
-        pqGroupInfo->PartitionsToAdd.emplace(i, i + 1, keyRange);
+        pqGroupInfo->PartitionsToAdd.emplace(pqGroupInfo->PartitionsToAdd.end(), i, i + 1, keyRange);
     }
 
     if (partsPerTablet == 0 || partsPerTablet > TSchemeShard::MaxPQTabletPartitionsCount) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -144,7 +144,7 @@ TTopicInfo::TPtr CreatePersQueueGroup(TOperationContext& context,
             }
         }
 
-        pqGroupInfo->PartitionsToAdd.emplace(pqGroupInfo->PartitionsToAdd.end(), i, i + 1, keyRange);
+        pqGroupInfo->PartitionsToAdd.emplace_back(i, i + 1, keyRange);
     }
 
     if (partsPerTablet == 0 || partsPerTablet > TSchemeShard::MaxPQTabletPartitionsCount) {

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -1685,19 +1685,12 @@ struct TTopicInfo : TSimpleRefCount<TTopicInfo> {
             return PartitionId == rhs.PartitionId
                 && GroupId == rhs.GroupId;
         }
-
-        struct THash {
-            inline size_t operator()(const TPartitionToAdd& obj) const {
-                const ::THash<ui32> hashFn;
-                return CombineHashes(hashFn(obj.PartitionId), hashFn(obj.GroupId));
-            }
-        };
     };
 
     ui64 TotalGroupCount = 0;
     ui64 TotalPartitionCount = 0;
     ui32 NextPartitionId = 0;
-    THashSet<TPartitionToAdd, TPartitionToAdd::THash> PartitionsToAdd;
+    TVector<TPartitionToAdd> PartitionsToAdd;
     THashSet<ui32> PartitionsToDelete;
     THashMap<ui32, TMaybe<TTopicTabletInfo::TKeyRange>> KeyRangesToChange;
     ui32 MaxPartsPerTablet = 0;

--- a/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
+++ b/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
@@ -740,6 +740,174 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergeTest) {
         }
     } // Y_UNIT_TEST(EnableSplitMerge)
 
+    Y_UNIT_TEST(SplitByMinPartitionCount) {
+        TTestBasicRuntime runtime;
+        TTestEnv env = CreateTestEnv(runtime);
+
+        ui64 txId = 100;
+
+        CreateSubDomain(runtime, env, ++txId);
+        // create topic w/t split-merge with 2 partitions
+        CreateTopic(runtime, env, ++txId, 2, false);
+        auto topic = DescribeTopic(runtime);
+        // expect: total 2, active 2
+        UNIT_ASSERT_VALUES_EQUAL(2  , topic.GetPartitions().size());
+
+        // try to change partition strategy to splittable with 3 min partitions - should fail since topic was non-splittable before and we don't allow to increase min partition count and enable split/merge simultaneously
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(3);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        }, {{TEvSchemeShard::EStatus::StatusInvalidParameter}});
+
+        // change partition strategy to splittable
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        });
+
+        const unsigned char b0[] = {0xA};
+        TString boundary0((char*)b0, sizeof(b0));
+
+        // try increase min partition count to 5 and split - should fail since topic was non-splittable before and we don't allow to increase min partition count and enable split/merge simultaneously
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                auto* split = scheme.AddSplit();
+                split->SetPartition(0);
+                split->SetSplitBoundary(boundary0);
+
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(5);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        }, {{TEvSchemeShard::EStatus::StatusInvalidParameter}});
+
+        // split first partition - hence 3 active partitions
+        SplitPartition(runtime, env, txId, 0, boundary0);
+        topic = DescribeTopic(runtime);
+        Cerr << "====================== Topic Before ======================" << Endl << topic.DebugString() << Endl << Flush;
+        // expect: total 4, 3 active
+        UNIT_ASSERT_VALUES_EQUAL(4, topic.GetPartitions().size());
+
+        // increase min partition count to 9
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(10);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        });
+
+        topic = DescribeTopic(runtime);
+        Cerr << "====================== Topic Modified ======================" << Endl << topic.DebugString() << Endl << Flush;
+        // expect: total 18, active 10
+        UNIT_ASSERT_VALUES_EQUAL(18, topic.GetPartitions().size());
+        for (const auto& p : topic.GetPartitions()) {
+            Cerr <<  ">>>>> Verify partition " << p.GetPartitionId() << Endl << Flush;
+            UNIT_ASSERT(p.HasKeyRange());
+
+            switch(p.GetPartitionId()) {
+                case 0:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({2, 3}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().empty());
+                    break;
+                case 1:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({8, 9}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().empty());
+                    break;
+                case 2:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({6, 7}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().size() == 1);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetParentPartitionIds().cbegin(), p.GetParentPartitionIds().cend()), TVector<i32>({0}));
+                    break;
+                case 3:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({4, 5}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().size() == 1);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetParentPartitionIds().cbegin(), p.GetParentPartitionIds().cend()), TVector<i32>({0}));
+                    break;
+                case 4:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({10, 11}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().size() == 1);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetParentPartitionIds().cbegin(), p.GetParentPartitionIds().cend()), TVector<i32>({3}));
+                    break;
+                case 5:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({12, 13}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().size() == 1);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetParentPartitionIds().cbegin(), p.GetParentPartitionIds().cend()), TVector<i32>({3}));
+                    break;
+                case 6:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({14, 15}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().size() == 1);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetParentPartitionIds().cbegin(), p.GetParentPartitionIds().cend()), TVector<i32>({2}));
+                    break;
+                case 7:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetChildPartitionIds().cbegin(), p.GetChildPartitionIds().cend()), TVector<i32>({16, 17}));
+                    UNIT_ASSERT(p.GetParentPartitionIds().size() == 1);
+                    UNIT_ASSERT_VALUES_EQUAL(TVector<i32>(p.GetParentPartitionIds().cbegin(), p.GetParentPartitionIds().cend()), TVector<i32>({2}));
+                    break;
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                case 16:
+                case 17:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Active), static_cast<int>(p.GetStatus()));
+                    break;
+                default:
+                    UNIT_ASSERT_C(false, "Unexpected partition id " << p.GetPartitionId());
+            }
+        }
+
+        // try to change to 1 min partitions
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(1);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        });
+        topic = DescribeTopic(runtime);
+        // expect: total 18, active 10  - no change in partitons number since reducing min active partitions does not merge exisitng partitions now
+        UNIT_ASSERT_VALUES_EQUAL(18, topic.GetPartitions().size());
+
+        // try to split and change to 20 min partitions - should fail since we don't allow splitting and increasing min count at the same time
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                auto* split = scheme.AddSplit();
+                split->SetPartition(5);
+                split->SetSplitBoundary(boundary0);
+
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(20);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        }, {{TEvSchemeShard::EStatus::StatusInvalidParameter}});
+
+    } // Y_UNIT_TEST(SplitByMinPartitionCount)
+
 } // Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergeTest)
 
 Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {

--- a/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
+++ b/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
@@ -908,6 +908,53 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergeTest) {
 
     } // Y_UNIT_TEST(SplitByMinPartitionCount)
 
+    Y_UNIT_TEST(SplitByMinPartitionCountWithTwoIter) {
+        TTestBasicRuntime runtime;
+        TTestEnv env = CreateTestEnv(runtime);
+
+        ui64 txId = 100;
+
+        CreateSubDomain(runtime, env, ++txId);
+        // create topic with split-merge with 1 partitions
+        CreateTopic(runtime, env, ++txId, 1);
+
+        // increase min partition count to 5 - should cause double splitting loop inside
+        ModifyTopic(runtime, env, ++txId, [&](auto& scheme) {
+            {
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(5);
+                scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+            }
+        });
+
+        auto topic = DescribeTopic(runtime);
+        Cerr << "====================== Topic Modified ======================" << Endl << topic.DebugString() << Endl << Flush;
+        // expect: total 9, active 5
+        UNIT_ASSERT_VALUES_EQUAL(9, topic.GetPartitions().size());
+        for (const auto& p : topic.GetPartitions()) {
+            Cerr <<  ">>>>> Verify partition " << p.GetPartitionId() << Endl << Flush;
+            switch(p.GetPartitionId()) {
+                case 0:
+                case 1:
+                case 2:
+                case 3:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Inactive), static_cast<int>(p.GetStatus()));
+                    UNIT_ASSERT(p.GetChildPartitionIds().size() == 2);
+                    break;
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                    UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(::NKikimrPQ::ETopicPartitionStatus::Active), static_cast<int>(p.GetStatus()));
+                    break;
+                default:
+                    UNIT_ASSERT_C(false, "Unexpected partition id " << p.GetPartitionId());
+            }
+        }
+
+    } // Y_UNIT_TEST(SplitByMinPartitionCountWithTwoIter)
+
 } // Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergeTest)
 
 Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {

--- a/ydb/services/persqueue_v1/topic_yql_ut.cpp
+++ b/ydb/services/persqueue_v1/topic_yql_ut.cpp
@@ -170,7 +170,7 @@ Y_UNIT_TEST_SUITE(TTopicYqlTest) {
         {
             const auto& describe = pqGroup2.GetPQTabletConfig();
             Cerr <<"=== PATH DESCRIPTION: \n" << pqGroup2.DebugString();
-            UNIT_ASSERT_VALUES_EQUAL(pqGroup2.GetTotalGroupCount(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(pqGroup2.GetTotalGroupCount(), 4);
             UNIT_ASSERT_VALUES_EQUAL(describe.GetPartitionConfig().GetLifetimeSeconds(), 7200);
             UNIT_ASSERT_VALUES_EQUAL(describe.GetPartitionConfig().GetBurstSize(), 100501);
             UNIT_ASSERT_VALUES_EQUAL(describe.GetPartitionConfig().GetWriteSpeedInBytesPerSecond(), 9001);


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

`ALTER TOPIC SET (MIN_ACTIVE_PARTITIONS =<new_value>);`
- if new value is bigger than current active partition count then split existing partitions to match the requested value

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

```sql
ALTER TOPIC `/Root/dir/origin` SET (
    MAX_ACTIVE_PARTITIONS = 20,
    MIN_ACTIVE_PARTITIONS = 20
)
```

For now `MAX_ACTIVE_PARTITIONS` should also be present in query and not less than `MIN_ACTIVE_PARTITIONS` .