### PR TITLE
Add Cursor skills and CI/analytics architecture docs for agents

### DIFF
--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -74,7 +74,7 @@ PY
 
 Do not rely on a hardcoded table list below — read config or query YDB.
 
-Current aliases in `databases.main.tables`:
+All aliases in `databases.main.tables` (mirror of `ydb_qa_config.json` — update both when adding tables):
 
 | Alias | Path | Description |
 |-------|------|-------------|
@@ -84,14 +84,27 @@ Current aliases in `databases.main.tables`:
 | `testowners` | `test_results/analytics/testowners` | Test owners (codeowners) |
 | `flaky_tests_window` | `test_results/analytics/flaky_tests_window_1_days` | Flaky tests in 1-day window |
 | `all_tests_with_owner_and_mute` | `test_results/all_tests_with_owner_and_mute` | All tests + owner + mute status |
-| `pr_blocked_by_failed_tests_rich` | `test_results/analytics/pr_blocked_by_failed_tests_rich` | PRs blocked by test failures |
+| `muted_tests_daily_by_team` | `test_results/analytics/muted_tests_daily_by_team` | Daily muted test counts by team |
+| `muted_tests_with_issue_and_area` | `test_results/analytics/muted_tests_with_issue_and_area` | Muted tests with linked GitHub issue and area |
+| `pr_blocked_by_failed_tests_rich` | `test_results/analytics/pr_blocked_by_failed_tests_rich` | PRs blocked by test failures (rich) |
+| `pr_blocked_by_tests` | `test_results/analytics/pr_blocked_by_tests` | PRs blocked by test failures |
 | `pr_check_failures_by_attempt` | `test_results/analytics/pr_check_failures_by_attempt` | PR-check failures per attempt |
 | `issues` | `github_data/issues` | Exported GitHub issues |
 | `pull_requests` | `github_data/pull_requests` | Exported GitHub pull requests |
+| `github_issue_mapping` | `test_results/analytics/github_issue_mapping` | Test ↔ GitHub issue mapping |
+| `github_issues_timeline` | `test_results/analytics/github_issues_timeline` | GitHub issue timeline events |
+| `area_to_owner_mapping` | `test_results/analytics/area_to_owner_mapping` | Area → owner mapping for issues |
 | `mute_events` | `test_results/analytics/mute_events` | Mute/unmute events |
 | `mute_latency` | `test_results/analytics/mute_latency` | Delay between failure and mute |
+| `mute_latency_affected_prs` | `test_results/analytics/mute_latency_affected_prs` | PRs affected by mute latency |
+| `fast_unmute_active` | `test_mute/fast_unmute_active` | Active fast-unmute candidates |
+| `fast_unmute_grace` | `test_mute/fast_unmute_grace` | Fast-unmute grace period tracking |
+| `binary_size` | `binary_size` | Binary size stats from CI builds |
+| `digest_queue` | `test_results/analytics/digest_queue` | Queue for Telegram digest notifications |
 
-Additional data marts (see `collect_analytics_fast.yml` for full list): `test_results/analytics/github_issues_timeline`, `test_results/analytics/muted_tests_daily_by_team`, `perfomance/olap/fast_results`, `nemesis/aggregated_mart`, etc.
+Statistics DB (`databases.statistics.tables`): `query_statistics` → `analytics/query_statistics` (YDBWrapper query logging).
+
+Additional data marts **not** in `ydb_qa_config.json` (see `collect_analytics_fast.yml`): `perfomance/olap/fast_results`, `nemesis/aggregated_mart`, etc.
 
 ### Column schemas (use these, do not invent)
 

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -14,7 +14,7 @@ alwaysApply: false
 
 # Analytics Skill (router)
 
-**Canonical map:** [`.github/scripts/analytics/ARCHITECTURE.md`](../../.github/scripts/analytics/ARCHITECTURE.md) — diagram, workflow→table→consumer, maintenance checklist.
+**Canonical map:** [`.github/scripts/analytics/ARCHITECTURE.md`](../../.github/scripts/analytics/ARCHITECTURE.md) — overview diagram, **table dependency maps** (mute/github/PR chains), mart SQL registry, maintenance checklist.
 
 **Table registry (source of truth):** `.github/config/ydb_qa_config.json` **and** GitHub var `YDB_QA_CONFIG` (CI reads var, not repo file). Never invent paths.
 
@@ -79,6 +79,7 @@ Then: `gh pr list --search "merged:>=<DATE>"` · `gh pr diff <N>` · mute: `mute
 | `ydb_wrapper.py` | YDB client |
 | `data_mart_executor.py` | SQL file → YDB table |
 | `check_architecture_sync.py` | Fail if analytics changed without ARCHITECTURE.md |
+| `list_mart_dependencies.py` | Print mart SQL reads/writes (`--markdown` for registry table) |
 
 ## Cross-links
 

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -3,6 +3,7 @@ description: "Analytics skill: YDB QA data, SQL data marts, CI test results, Git
 globs:
   - ".github/scripts/analytics/**/*.sql"
   - ".github/scripts/analytics/**/*.py"
+  - ".github/scripts/analytics/ARCHITECTURE.md"
   - ".github/config/ydb_qa_config.json"
   - ".github/workflows/collect_analytics*.yml"
   - ".github/workflows/update_muted_ya.yml"
@@ -25,6 +26,7 @@ YDB (YQL/SQL) + Python + GitHub Actions + MCP `user-ydb-qa`
 | Location | Purpose |
 |----------|---------|
 | `.github/scripts/analytics/` | SQL queries, Python collectors, YDB wrapper |
+| `.github/scripts/analytics/ARCHITECTURE.md` | **Pipeline map** (layers, colors, workflow→table→consumer) — update with every analytics change |
 | `.github/scripts/analytics/data_mart_queries/` | Data mart SQL (PR failures, mute stats, GitHub issues) |
 | `.github/scripts/analytics/monitoring_queries/` | Monitoring / ad-hoc SQL |
 | `.github/config/ydb_qa_config.json` | **Canonical table registry** (aliases → YDB paths) |
@@ -74,9 +76,55 @@ Schema source: `mute_latency_from_failure.py` → `create_mute_events_table`.
 
 ## Querying YDB
 
-### MCP (preferred in Cursor)
+### YDB MCP (strongly recommended)
 
-Use MCP server `user-ydb-qa`:
+Live CI analytics (test failures, marts, mute events) **requires** querying YDB. In Cursor this should be done via MCP — much faster and fewer YQL mistakes than guessing from repo SQL alone.
+
+**If MCP is not available:** tell the user to configure it before investigations that need live data. Fallback without MCP: `gh` CLI for Actions/PRs only; local Python scripts only if the user has `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS` set.
+
+**Check MCP is working** (first step of any data task):
+
+```
+CallMcpTool server=user-ydb-qa tool=ydb_query arguments={"sql": "SELECT 1 AS ok"}
+```
+
+Expected: `ok = 1`. If tools are missing or auth fails, stop and help with setup below.
+
+#### How to get YDB MCP in Cursor
+
+1. **Credentials** — service account JSON with read access to the QA YDB cluster (same class of access as CI `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS`; ask the CI/analytics team if you don't have a key).
+2. **Endpoint** — from `.github/config/ydb_qa_config.json` → `databases.main.endpoint` + `databases.main.path` (see example).
+3. **Install** [ydb-mcp](https://github.com/ydb-platform/ydb-mcp) (`pip install ydb-mcp` or `uvx ydb-mcp`). Docs: `ydb/docs/en/core/reference/languages-and-apis/mcp/index.md`.
+4. **Cursor MCP config** — create `.cursor/mcp.json` locally (**gitignored**, do not commit secrets):
+
+```json
+{
+  "mcpServers": {
+    "ydb-qa": {
+      "command": "uvx",
+      "args": [
+        "ydb-mcp",
+        "--ydb-endpoint",
+        "grpcs://<host>:2135/ru-central1/<folder>/<database-id>"
+      ],
+      "env": {
+        "YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS": "/absolute/path/to/ydb-qa-sa-key.json"
+      }
+    }
+  }
+}
+```
+
+Build `--ydb-endpoint` from config: `{endpoint without trailing slash}{path}` — e.g. `grpcs://lb….ydb.mdb.yandexcloud.net:2135` + `/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8`.
+
+5. **Enable in Cursor:** Settings → MCP → ensure the server is on; restart Cursor if tools don't appear.
+6. **Verify:** `ydb_query` with `SELECT 1`. Server name in UI may differ (e.g. `user-ydb-qa`); tool names are `ydb_query`, `ydb_explain_query`, etc.
+
+Tracked template (no secrets): `.github/scripts/analytics/mcp.ydb-qa.example.json`.
+
+### MCP tools (preferred in Cursor)
+
+Use MCP server `user-ydb-qa` (or your local name for the same ydb-mcp config):
 
 - `ydb_query` — **primary tool** for all reads
 - `ydb_explain_query` — explain plan (optional, after query compiles)
@@ -161,6 +209,28 @@ LIMIT 50
 
 For mute-related regressions also check `tests_monitor`, `mute_events`, `flaky_tests_window`.
 
+## Architecture doc (keep in sync)
+
+**Source of truth for pipeline mental model:** `.github/scripts/analytics/ARCHITECTURE.md`
+
+- Layered diagram with **color legend** (L0 sources → L6 consumers; legacy in gray)
+- Tables: workflow → script → YDB table → consumer
+- Mart dependency subgraph for ordering inside `collect_analytics_fast`
+
+### When to update ARCHITECTURE.md (same PR)
+
+Any change to: analytics scripts/SQL, analytics workflows, `ydb_qa_config.json` tables, or new consumers (DataLens, Telegram, mute).
+
+Agents: after editing analytics code, update diagram and/or table in `ARCHITECTURE.md` before finishing the task.
+
+### Verify doc was updated
+
+```bash
+python3 .github/scripts/analytics/check_architecture_sync.py --base origin/main
+```
+
+Optional CI hook: run the same command on PRs that touch watched paths.
+
 ## Helpers in Repo
 
 | Script | Usage |
@@ -173,6 +243,9 @@ For mute-related regressions also check `tests_monitor`, `mute_events`, `flaky_t
 | `.github/scripts/analytics/flaky_tests_history.py` | Collect flaky test history |
 | `.github/scripts/analytics/export_issues_to_ydb.py` | Export GitHub issues → YDB |
 | `.github/scripts/analytics/export_pull_requests_to_ydb.py` | Export GitHub PRs → YDB |
+| `.github/scripts/analytics/check_architecture_sync.py` | Ensures ARCHITECTURE.md updated when analytics paths change |
+| `.github/scripts/analytics/ARCHITECTURE.md` | Colored pipeline map — maintain with every analytics change |
+| `.github/scripts/analytics/mcp.ydb-qa.example.json` | Cursor MCP config template (copy to `.cursor/mcp.json`, add SA key path) |
 
 ## Conventions
 

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -1,0 +1,190 @@
+---
+description: "Analytics skill: YDB QA data, SQL data marts, CI test results, GitHub Actions, mute/unmute workflows"
+globs:
+  - ".github/scripts/analytics/**/*.sql"
+  - ".github/scripts/analytics/**/*.py"
+  - ".github/config/ydb_qa_config.json"
+  - ".github/workflows/collect_analytics*.yml"
+  - ".github/workflows/update_muted_ya.yml"
+  - ".github/workflows/create_issues_for_muted_tests.yml"
+alwaysApply: false
+---
+
+# Analytics Skill
+
+## Stack
+
+YDB (YQL/SQL) + Python + GitHub Actions + MCP `user-ydb-qa`
+
+- SQL dialect: **YQL** (backtick-quoted paths: `` `test_results/test_runs_column` ``)
+- Config: `vars.YDB_QA_CONFIG` in CI; local dev uses `.github/config/ydb_qa_config.json`
+- Naming: snake_case for table aliases and columns
+
+## Where Analytics Lives
+
+| Location | Purpose |
+|----------|---------|
+| `.github/scripts/analytics/` | SQL queries, Python collectors, YDB wrapper |
+| `.github/scripts/analytics/data_mart_queries/` | Data mart SQL (PR failures, mute stats, GitHub issues) |
+| `.github/scripts/analytics/monitoring_queries/` | Monitoring / ad-hoc SQL |
+| `.github/config/ydb_qa_config.json` | **Canonical table registry** (aliases → YDB paths) |
+| `.github/workflows/collect_analytics_fast.yml` | Every 30 min: fast history, GitHub export, data marts |
+| `.github/workflows/update_muted_ya.yml` | Hourly: mute/unmute, flaky history, tests_monitor |
+| `.github/workflows/create_issues_for_muted_tests.yml` | After merge of mute-unmute PR: create GitHub issues |
+
+## Key Tables
+
+**Always read `.github/config/ydb_qa_config.json` first** — new tables are added there; do not rely on a hardcoded list.
+
+Current aliases in `databases.main.tables`:
+
+| Alias | Path | Description |
+|-------|------|-------------|
+| `test_results` | `test_results/test_runs_column` | Raw CI test run results (primary source) |
+| `test_history_fast` | `test_results/analytics/test_history_fast` | Fast daily test history |
+| `tests_monitor` | `test_results/analytics/tests_monitor` | Test state for mute/unmute decisions |
+| `testowners` | `test_results/analytics/testowners` | Test owners (codeowners) |
+| `flaky_tests_window` | `test_results/analytics/flaky_tests_window_1_days` | Flaky tests in 1-day window |
+| `all_tests_with_owner_and_mute` | `test_results/all_tests_with_owner_and_mute` | All tests + owner + mute status |
+| `pr_blocked_by_failed_tests_rich` | `test_results/analytics/pr_blocked_by_failed_tests_rich` | PRs blocked by test failures |
+| `pr_check_failures_by_attempt` | `test_results/analytics/pr_check_failures_by_attempt` | PR-check failures per attempt |
+| `issues` | `github_data/issues` | Exported GitHub issues |
+| `pull_requests` | `github_data/pull_requests` | Exported GitHub pull requests |
+| `mute_events` | `test_results/analytics/mute_events` | Mute/unmute events |
+| `mute_latency` | `test_results/analytics/mute_latency` | Delay between failure and mute |
+
+Additional data marts (see `collect_analytics_fast.yml` for full list): `test_results/analytics/github_issues_timeline`, `test_results/analytics/muted_tests_daily_by_team`, `perfomance/olap/fast_results`, `nemesis/aggregated_mart`, etc.
+
+### Column schemas (use these, do not invent)
+
+**`test_results/test_runs_column`** — raw CI results. Key columns:
+
+- `suite_folder`, `test_name` — separate fields; full test id = `suite_folder || '/' || test_name`
+- `status` — `passed` | `failure` | `mute` | `skipped`
+- `job_name` — e.g. `PR-check`, `Postcommit_relwithdebinfo`, `Postcommit_asan`, `Nightly-run`, `Regression-run`, `Regression-run_Small_and_Medium`, `Regression-run_stress`, `Regression-whitelist-run`
+- `branch`, `build_type` (usually `relwithdebinfo`), `run_timestamp`, `pull`, `job_id`, `commit`, `duration`
+
+**`test_results/analytics/test_history_fast`** — denormalized history (has `full_name`, logs, TTL 60d). Same status/job_name semantics; prefer for per-test timelines with `status_description`, `log`.
+
+**`test_results/analytics/mute_events`** — mute rule changes (NOT `event_timestamp`):
+
+- `branch`, `build_type`, `commit_time`, `commit_sha`, `event` (`added` | `removed`), `full_name`, `suite_folder`, `test_name`
+
+Schema source: `mute_latency_from_failure.py` → `create_mute_events_table`.
+
+## Querying YDB
+
+### MCP (preferred in Cursor)
+
+Use MCP server `user-ydb-qa`:
+
+- `ydb_query` — **primary tool** for all reads
+- `ydb_explain_query` — explain plan (optional, after query compiles)
+- `ydb_describe_path` / `ydb_list_directory` — **often fail** (`Root not found` on table paths). Do **not** rely on them; discover schema via `ydb_query` or repo scripts below.
+
+**Before writing a non-trivial query:** run a probe query first:
+
+```sql
+SELECT * FROM `test_results/test_runs_column` LIMIT 1
+```
+
+Or read the `CREATE TABLE` in the matching Python collector (see Helpers). Never guess column names from table names.
+
+### MCP pitfalls (avoid these errors)
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Root not found` (400070) on `ydb_describe_path` | MCP describe/list expects a different path format than SQL table paths | Use `ydb_query` + `LIMIT 1`, or read schema from `.github/scripts/analytics/*.py` |
+| `Member not found: full_name` | `test_runs_column` has no `full_name` column | Compute it: `suite_folder \|\| '/' \|\| test_name AS full_name`. Filter with `suite_folder` + `test_name`, not `full_name` |
+| `Member not found: event_timestamp` / `event_type` / `reason` | Wrong schema for `mute_events` | Use columns below (actual schema) |
+| `Column X must either be a key column in GROUP BY or used in aggregation` in HAVING | YQL does not allow SELECT aliases in HAVING | Repeat the aggregate in HAVING, or wrap in a subquery/CTE and filter outside |
+| Empty/wrong results for test lookup | `test_name` format varies (`TPersQueueTest.TopicServiceCommitOffset` vs `TopicServiceCommitOffset`; Python: `TestViewer.test_topic_data_cdc` vs `test_topic_data_cdc`) | Prefer `String::Contains(test_name, 'TopicServiceCommitOffset')`; match `suite_folder` with `String::StartsWith` / `String::Contains` |
+| Empty results for stress tests | `suite_folder` is inconsistent (`ydb/tests/stress/topic/tests/test_workload_topic.py` vs `ydb/tests/stress/topic/tests`) | Filter with `String::Contains(suite_folder, 'stress/topic')`, not exact path |
+
+### Python (local / CI)
+
+```bash
+# Requires YDB_QA_CONFIG env or local .github/config/ydb_qa_config.json
+python3 .github/scripts/analytics/data_mart_executor.py \
+  --query_path .github/scripts/analytics/data_mart_queries/pr_check_stats.sql \
+  --table_path analytics/pr_check_stats \
+  --store_type column \
+  --partition_keys date \
+  --primary_keys date
+```
+
+`YDBWrapper` in `.github/scripts/analytics/ydb_wrapper.py` — shared client for all analytics scripts.
+
+## GitHub Integration
+
+- Repo: `ydb-platform/ydb`
+
+```bash
+gh run list --repo ydb-platform/ydb --limit 20
+gh run view <RUN_ID> --repo ydb-platform/ydb
+gh pr list --repo ydb-platform/ydb --state merged --search "merged:>=2026-01-01"
+gh pr view <PR_NUMBER> --repo ydb-platform/ydb
+gh pr diff <PR_NUMBER> --repo ydb-platform/ydb
+```
+
+Key workflows to inspect: `Collect-analytics-fast-run`, `Update Muted tests`, `Create issues for muted tests`, `PR-check`.
+
+## Investigating Test Regressions
+
+When finding problems after a merged PR (merge at `<MERGE_TS>`):
+
+1. Get merge time: `gh pr view <N> --repo ydb-platform/ydb --json mergedAt,mergeCommit,files`
+2. Query failures after merge — **working template** (adapt filters, never filter on alias `full_name` in WHERE):
+
+```sql
+SELECT
+    suite_folder || '/' || test_name AS full_name,
+    status,
+    job_name,
+    MIN(run_timestamp) AS first_seen,
+    COUNT(*) AS cnt
+FROM `test_results/test_runs_column`
+WHERE branch = 'main'
+  AND build_type = 'relwithdebinfo'
+  AND status IN ('failure', 'mute')
+  AND run_timestamp >= DateTime('<MERGE_TS>')   -- e.g. '2026-06-18T11:38:59Z'
+  AND String::Contains(suite_folder, '<path_fragment>')  -- e.g. 'topic', 'persqueue'
+GROUP BY suite_folder, test_name, status, job_name
+ORDER BY first_seen
+LIMIT 50
+```
+
+3. For postcommit-only signal, add: `AND job_name IN ('Postcommit_relwithdebinfo', 'Postcommit_asan')`
+4. List merged PRs around first failure: `gh pr list --repo ydb-platform/ydb --state merged --search "merged:>=<DATE>"`
+5. Inspect suspect PR: `gh pr diff <PR_NUMBER>` (one PR per command)
+6. Mute follow-ups: `mute_events` by `commit_time >= Timestamp('<MERGE_TS>')` and `event = 'added'`
+
+For mute-related regressions also check `tests_monitor`, `mute_events`, `flaky_tests_window`.
+
+## Helpers in Repo
+
+| Script | Usage |
+|--------|-------|
+| `.github/config/ydb_qa_config.json` | Table aliases and YDB endpoint — **source of truth** |
+| `.github/scripts/analytics/ydb_wrapper.py` | YDB client (`YDBWrapper` context manager) |
+| `.github/scripts/analytics/data_mart_executor.py` | Run SQL file → upsert into YDB table |
+| `.github/scripts/analytics/test_history_fast.py` | Upload fast test history |
+| `.github/scripts/analytics/tests_monitor.py` | Update tests_monitor table |
+| `.github/scripts/analytics/flaky_tests_history.py` | Collect flaky test history |
+| `.github/scripts/analytics/export_issues_to_ydb.py` | Export GitHub issues → YDB |
+| `.github/scripts/analytics/export_pull_requests_to_ydb.py` | Export GitHub PRs → YDB |
+
+## Conventions
+
+- SQL dialect: YQL (YDB Query Language); use backticks for table paths: `` `test_results/test_runs_column` ``
+- Table paths: relative to YDB database root (same as in `ydb_qa_config.json`)
+- Resolve alias → path via `ydb_qa_config.json` → `databases.main.tables.<alias>`
+- Copy patterns from `.github/scripts/analytics/data_mart_queries/` (CTEs as `$name = (SELECT ...)`, `PRAGMA AnsiInForEmptyOrNullableItemsCollections`)
+- Time filters: prefer `CurrentUtcDate() - N * Interval("P1D")` for rolling windows; use `DateTime('YYYY-MM-DDTHH:MM:SSZ')` for fixed merge timestamps; `mute_events` uses `commit_time` + `Timestamp('...')`
+- YQL rules:
+  - No SELECT alias in WHERE/HAVING of the same query — use subquery or repeat expression
+  - `full_name` exists only in marts like `test_history_fast`, not in `test_runs_column`
+  - Use `String::Contains` / `String::StartsWith`, not exact `test_name =` for C++/Python tests
+  - Always add `LIMIT` on exploratory queries
+- GitHub CLI: `gh pr view` / `gh issue view` accept **one** number per invocation; loop for multiple
+- CI sets `YDB_QA_CONFIG` from GitHub vars; locally use config file or export the same JSON

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -306,6 +306,7 @@ Optional CI hook: run the same command on PRs that touch watched paths.
 | PR-check, test_ya, GitHub statuses | `.cursor/rules/ci-testing.mdc`, `.github/docs/CI_PIPELINE.md` |
 | Mute/unmute rules | `.github/config/mute_rules.md` |
 | Raw data ingestion | `upload_tests_results.py` in `test_ya` action (CI skill) |
+| CI platform traps (merge SHA, stable wf from main) | `.cursor/rules/ci-testing.mdc` → GitHub platform behavior |
 
 ## Conventions
 

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Analytics skill: YDB QA data, SQL data marts, CI test results, GitHub Actions, mute/unmute workflows"
+description: "YDB QA analytics: YQL investigations, marts, MCP ydb-qa — read ARCHITECTURE.md and ydb_qa_config.json first"
 globs:
   - ".github/scripts/analytics/**/*.sql"
   - ".github/scripts/analytics/**/*.py"
@@ -8,318 +8,82 @@ globs:
   - ".github/workflows/collect_analytics*.yml"
   - ".github/workflows/update_muted_ya.yml"
   - ".github/workflows/create_issues_for_muted_tests.yml"
+  - ".github/workflows/monitoring_queries.yml"
 alwaysApply: false
 ---
 
-# Analytics Skill
+# Analytics Skill (router)
+
+**Canonical map:** [`.github/scripts/analytics/ARCHITECTURE.md`](../../.github/scripts/analytics/ARCHITECTURE.md) — diagram, workflow→table→consumer, maintenance checklist.
+
+**Table registry (source of truth):** `.github/config/ydb_qa_config.json` **and** GitHub var `YDB_QA_CONFIG` (CI reads var, not repo file). Never invent paths.
 
 ## Stack
 
-YDB (YQL/SQL) + Python + GitHub Actions + MCP `user-ydb-qa`
+YQL + Python collectors + MCP `user-ydb-qa` · Repo: `ydb-platform/ydb`
 
-- SQL dialect: **YQL** (backtick-quoted paths: `` `test_results/test_runs_column` ``)
-- Config: `vars.YDB_QA_CONFIG` in CI; local dev uses `.github/config/ydb_qa_config.json`
-- Naming: snake_case for table aliases and columns
+## Agent rules
 
-## Where Analytics Lives
+1. **New table / mart / workflow** → update `ARCHITECTURE.md` + config JSON + `YDB_QA_CONFIG` var (same PR).
+2. Verify sync: `python3 .github/scripts/analytics/check_architecture_sync.py --base origin/main`
+3. **Live data** → MCP `ydb_query` first; setup: [`.github/scripts/analytics/mcp.ydb-qa.example.json`](../../.github/scripts/analytics/mcp.ydb-qa.example.json)
+4. **Probe before non-trivial YQL:** `SELECT * FROM \`test_results/test_runs_column\` LIMIT 1`
+5. Copy SQL patterns from `data_mart_queries/` (CTEs `$name = (SELECT ...)`, `PRAGMA AnsiInForEmptyOrNullableItemsCollections`)
 
-| Location | Purpose |
-|----------|---------|
-| `.github/scripts/analytics/` | SQL queries, Python collectors, YDB wrapper |
-| `.github/scripts/analytics/ARCHITECTURE.md` | **Pipeline map** (layers, colors, workflow→table→consumer) — update with every analytics change |
-| `.github/docs/CI_PIPELINE.md` | **Test CI map** (PR-check, test_ya, statuses) — see `.cursor/rules/ci-testing.mdc` |
-| `.github/scripts/analytics/data_mart_queries/` | Data mart SQL (PR failures, mute stats, GitHub issues) |
-| `.github/scripts/analytics/monitoring_queries/` | Monitoring / ad-hoc SQL |
-| `.github/config/ydb_qa_config.json` | **Canonical table registry** (aliases → YDB paths) |
-| `.github/workflows/collect_analytics_fast.yml` | Every 30 min: fast history, GitHub export, data marts |
-| `.github/workflows/update_muted_ya.yml` | Hourly: mute/unmute, flaky history, tests_monitor |
-| `.github/workflows/create_issues_for_muted_tests.yml` | After merge of mute-unmute PR: create GitHub issues |
+## Key tables (examples only — full list in config)
 
-## Key Tables
+| Alias | Role |
+|-------|------|
+| `test_results` | Raw CI runs (`test_results/test_runs_column`) |
+| `test_history_fast` | Per-test history with logs |
+| `tests_monitor` | Mute/unmute decisions input |
+| `mute_events` | Mute rule changes (`commit_time`, not `event_timestamp`) |
+| `pr_blocked_by_failed_tests_rich` | PR blocked by failures |
 
-**Always read table registry first** — paths live in two places that must stay in sync:
+## YQL pitfalls
 
-| Where | Used by |
-|-------|---------|
-| `.github/config/ydb_qa_config.json` | Local dev, docs, agents reading the repo |
-| GitHub repo variable **`YDB_QA_CONFIG`** (`vars.YDB_QA_CONFIG` in workflows) | **CI** — analytics workflows pass it to `setup_ci_ydb_service_account_key_file_credentials` → `YDBWrapper` |
+| Error | Fix |
+|-------|-----|
+| `Member not found: full_name` on `test_runs_column` | Use `suite_folder \|\| '/' \|\| test_name`; no `full_name` in WHERE on raw table |
+| Wrong `mute_events` columns | `commit_time`, `event` (`added`\|`removed`) — not `event_timestamp` |
+| Alias in HAVING | Repeat expression or subquery |
+| Empty test lookup | `String::Contains(test_name, '…')`, not exact `=` |
+| `ydb_describe_path` Root not found | Use `ydb_query LIMIT 1` or read Python collector schema |
 
-Adding a new table alias: update **both** the JSON file in the repo **and** the `YDB_QA_CONFIG` variable (Settings → Secrets and variables → Actions → Variables, or `gh variable set`).
+## `test_runs_column` columns
 
-**Agents with `gh` access** — compare local file vs CI var before/after table changes:
+`suite_folder`, `test_name`, `status` (passed|failure|mute|skipped), `job_name`, `branch`, `build_type`, `run_timestamp`, `pull`, `job_id`, `commit`
 
-```bash
-# Read CI config (JSON string)
-gh api repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG --jq '.value' | python3 -m json.tool
+**`job_name` examples:** `PR-check`, `Postmerge`, `Postcommit_relwithdebinfo`, `Postcommit_asan`, `Regression-run`, … — see CI skill when adding new workflow names.
 
-# Diff table aliases: local repo file vs GitHub variable
-python3 <<'PY'
-import json, subprocess
-local = json.load(open(".github/config/ydb_qa_config.json"))
-remote = json.loads(subprocess.check_output(
-    ["gh", "api", "repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG", "--jq", ".value"],
-    text=True,
-))
-lt = local["databases"]["main"]["tables"]
-rt = remote["databases"]["main"]["tables"]
-only_local = sorted(set(lt) - set(rt))
-only_ci = sorted(set(rt) - set(lt))
-if only_local:
-    print("ONLY in repo file (missing in YDB_QA_CONFIG var):", only_local)
-if only_ci:
-    print("ONLY in CI var (missing in repo file):", only_ci)
-if not only_local and not only_ci:
-    print("Table aliases match between repo file and YDB_QA_CONFIG")
-PY
-```
-
-Do not rely on a hardcoded table list below — read config or query YDB.
-
-All aliases in `databases.main.tables` (mirror of `ydb_qa_config.json` — update both when adding tables):
-
-| Alias | Path | Description |
-|-------|------|-------------|
-| `test_results` | `test_results/test_runs_column` | Raw CI test run results (primary source) |
-| `test_history_fast` | `test_results/analytics/test_history_fast` | Fast daily test history |
-| `tests_monitor` | `test_results/analytics/tests_monitor` | Test state for mute/unmute decisions |
-| `testowners` | `test_results/analytics/testowners` | Test owners (codeowners) |
-| `flaky_tests_window` | `test_results/analytics/flaky_tests_window_1_days` | Flaky tests in 1-day window |
-| `all_tests_with_owner_and_mute` | `test_results/all_tests_with_owner_and_mute` | All tests + owner + mute status |
-| `muted_tests_daily_by_team` | `test_results/analytics/muted_tests_daily_by_team` | Daily muted test counts by team |
-| `muted_tests_with_issue_and_area` | `test_results/analytics/muted_tests_with_issue_and_area` | Muted tests with linked GitHub issue and area |
-| `pr_blocked_by_failed_tests_rich` | `test_results/analytics/pr_blocked_by_failed_tests_rich` | PRs blocked by test failures (rich) |
-| `pr_blocked_by_tests` | `test_results/analytics/pr_blocked_by_tests` | PRs blocked by test failures |
-| `pr_check_failures_by_attempt` | `test_results/analytics/pr_check_failures_by_attempt` | PR-check failures per attempt |
-| `issues` | `github_data/issues` | Exported GitHub issues |
-| `pull_requests` | `github_data/pull_requests` | Exported GitHub pull requests |
-| `github_issue_mapping` | `test_results/analytics/github_issue_mapping` | Test ↔ GitHub issue mapping |
-| `github_issues_timeline` | `test_results/analytics/github_issues_timeline` | GitHub issue timeline events |
-| `area_to_owner_mapping` | `test_results/analytics/area_to_owner_mapping` | Area → owner mapping for issues |
-| `mute_events` | `test_results/analytics/mute_events` | Mute/unmute events |
-| `mute_latency` | `test_results/analytics/mute_latency` | Delay between failure and mute |
-| `mute_latency_affected_prs` | `test_results/analytics/mute_latency_affected_prs` | PRs affected by mute latency |
-| `fast_unmute_active` | `test_mute/fast_unmute_active` | Active fast-unmute candidates |
-| `fast_unmute_grace` | `test_mute/fast_unmute_grace` | Fast-unmute grace period tracking |
-| `binary_size` | `binary_size` | Binary size stats from CI builds |
-| `digest_queue` | `test_results/analytics/digest_queue` | Queue for Telegram digest notifications |
-
-Statistics DB (`databases.statistics.tables`): `query_statistics` → `analytics/query_statistics` (YDBWrapper query logging).
-
-Additional data marts **not** in `ydb_qa_config.json` (see `collect_analytics_fast.yml`): `perfomance/olap/fast_results`, `nemesis/aggregated_mart`, etc.
-
-### Column schemas (use these, do not invent)
-
-**`test_results/test_runs_column`** — raw CI results. Key columns:
-
-- `suite_folder`, `test_name` — separate fields; full test id = `suite_folder || '/' || test_name`
-- `status` — `passed` | `failure` | `mute` | `skipped`
-- `job_name` — e.g. `PR-check`, `Postcommit_relwithdebinfo`, `Postcommit_asan`, `Nightly-run`, `Regression-run`, `Regression-run_Small_and_Medium`, `Regression-run_stress`, `Regression-whitelist-run`
-- `branch`, `build_type` (usually `relwithdebinfo`), `run_timestamp`, `pull`, `job_id`, `commit`, `duration`
-
-**`test_results/analytics/test_history_fast`** — denormalized history (has `full_name`, logs, TTL 60d). Same status/job_name semantics; prefer for per-test timelines with `status_description`, `log`.
-
-**`test_results/analytics/mute_events`** — mute rule changes (NOT `event_timestamp`):
-
-- `branch`, `build_type`, `commit_time`, `commit_sha`, `event` (`added` | `removed`), `full_name`, `suite_folder`, `test_name`
-
-Schema source: `mute_latency_from_failure.py` → `create_mute_events_table`.
-
-## Querying YDB
-
-### YDB MCP (strongly recommended)
-
-Live CI analytics (test failures, marts, mute events) **requires** querying YDB. In Cursor this should be done via MCP — much faster and fewer YQL mistakes than guessing from repo SQL alone.
-
-**If MCP is not available:** tell the user to configure it before investigations that need live data. Fallback without MCP: `gh` CLI for Actions/PRs only; local Python scripts only if the user has `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS` set.
-
-**Check MCP is working** (first step of any data task):
-
-```
-CallMcpTool server=user-ydb-qa tool=ydb_query arguments={"sql": "SELECT 1 AS ok"}
-```
-
-Expected: `ok = 1`. If tools are missing or auth fails, stop and help with setup below.
-
-#### How to get YDB MCP in Cursor
-
-1. **Install** [ydb-mcp](https://github.com/ydb-platform/ydb-mcp) into a venv you control (e.g. repo `veydb/`) or use `pip install ydb-mcp` / `uvx`. Docs: `ydb/docs/en/core/reference/languages-and-apis/mcp/index.md`.
-2. **Credentials** — service account JSON with read access to QA YDB (`--ydb-sa-key-file`; same class of key as CI).
-3. **Endpoint / database** — from `.github/config/ydb_qa_config.json` → `databases.main.endpoint` and `databases.main.path` (**separate** MCP args).
-4. **Cursor MCP config** — `.cursor/mcp.json` locally (**gitignored**). Recommended shape (matches team setup):
-
-```json
-{
-  "mcpServers": {
-    "ydb-qa": {
-      "command": "/path/to/python-with-ydb-mcp",
-      "args": [
-        "-m", "ydb_mcp",
-        "--ydb-endpoint", "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135",
-        "--ydb-database", "/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8",
-        "--ydb-auth-mode", "service-account",
-        "--ydb-sa-key-file", "/absolute/path/to/service-account.json"
-      ]
-    }
-  }
-}
-```
-
-Use `endpoint` and `path` from config as **two args** (`--ydb-endpoint`, `--ydb-database`), not concatenated into one URL.
-
-5. **Enable in Cursor:** Settings → MCP → server on; restart if tools missing.
-6. **Verify:** `ydb_query` with `SELECT 1 AS ok`. Cursor may show the server as `ydb-qa` or `user-ydb-qa` depending on your config name; tool names are always `ydb_query`, `ydb_explain_query`, etc.
-
-Tracked template: `.github/scripts/analytics/mcp.ydb-qa.example.json`.
-
-### MCP tools (preferred in Cursor)
-
-Use MCP server `user-ydb-qa` (or your local name for the same ydb-mcp config):
-
-- `ydb_query` — **primary tool** for all reads
-- `ydb_explain_query` — explain plan (optional, after query compiles)
-- `ydb_describe_path` / `ydb_list_directory` — **often fail** (`Root not found` on table paths). Do **not** rely on them; discover schema via `ydb_query` or repo scripts below.
-
-**Before writing a non-trivial query:** run a probe query first:
+## Investigating regressions (template)
 
 ```sql
-SELECT * FROM `test_results/test_runs_column` LIMIT 1
-```
-
-Or read the `CREATE TABLE` in the matching Python collector (see Helpers). Never guess column names from table names.
-
-### MCP pitfalls (avoid these errors)
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `Root not found` (400070) on `ydb_describe_path` | MCP describe/list expects a different path format than SQL table paths | Use `ydb_query` + `LIMIT 1`, or read schema from `.github/scripts/analytics/*.py` |
-| `Member not found: full_name` | `test_runs_column` has no `full_name` column | Compute it: `suite_folder \|\| '/' \|\| test_name AS full_name`. Filter with `suite_folder` + `test_name`, not `full_name` |
-| `Member not found: event_timestamp` / `event_type` / `reason` | Wrong schema for `mute_events` | Use columns below (actual schema) |
-| `Column X must either be a key column in GROUP BY or used in aggregation` in HAVING | YQL does not allow SELECT aliases in HAVING | Repeat the aggregate in HAVING, or wrap in a subquery/CTE and filter outside |
-| Empty/wrong results for test lookup | `test_name` format varies (`TPersQueueTest.TopicServiceCommitOffset` vs `TopicServiceCommitOffset`; Python: `TestViewer.test_topic_data_cdc` vs `test_topic_data_cdc`) | Prefer `String::Contains(test_name, 'TopicServiceCommitOffset')`; match `suite_folder` with `String::StartsWith` / `String::Contains` |
-| Empty results for stress tests | `suite_folder` is inconsistent (`ydb/tests/stress/topic/tests/test_workload_topic.py` vs `ydb/tests/stress/topic/tests`) | Filter with `String::Contains(suite_folder, 'stress/topic')`, not exact path |
-
-### Python (local / CI)
-
-```bash
-# Requires YDB_QA_CONFIG env or local .github/config/ydb_qa_config.json
-python3 .github/scripts/analytics/data_mart_executor.py \
-  --query_path .github/scripts/analytics/data_mart_queries/pr_check_stats.sql \
-  --table_path analytics/pr_check_stats \
-  --store_type column \
-  --partition_keys date \
-  --primary_keys date
-```
-
-`YDBWrapper` in `.github/scripts/analytics/ydb_wrapper.py` — shared client for all analytics scripts.
-
-## GitHub Integration
-
-- Repo: `ydb-platform/ydb`
-
-```bash
-gh run list --repo ydb-platform/ydb --limit 20
-gh run view <RUN_ID> --repo ydb-platform/ydb
-gh pr list --repo ydb-platform/ydb --state merged --search "merged:>=2026-01-01"
-gh pr view <PR_NUMBER> --repo ydb-platform/ydb
-gh pr diff <PR_NUMBER> --repo ydb-platform/ydb
-
-# CI table registry (compare with .github/config/ydb_qa_config.json)
-gh api repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG --jq '.value' | python3 -m json.tool
-```
-
-Key workflows to inspect: `Collect-analytics-fast-run`, `Update Muted tests`, `Create issues for muted tests`, `PR-check`.
-
-## Investigating Test Regressions
-
-When finding problems after a merged PR (merge at `<MERGE_TS>`):
-
-1. Get merge time: `gh pr view <N> --repo ydb-platform/ydb --json mergedAt,mergeCommit,files`
-2. Query failures after merge — **working template** (adapt filters, never filter on alias `full_name` in WHERE):
-
-```sql
-SELECT
-    suite_folder || '/' || test_name AS full_name,
-    status,
-    job_name,
-    MIN(run_timestamp) AS first_seen,
-    COUNT(*) AS cnt
+SELECT suite_folder || '/' || test_name AS full_name, status, job_name,
+       MIN(run_timestamp) AS first_seen, COUNT(*) AS cnt
 FROM `test_results/test_runs_column`
-WHERE branch = 'main'
-  AND build_type = 'relwithdebinfo'
+WHERE branch = 'main' AND build_type = 'relwithdebinfo'
   AND status IN ('failure', 'mute')
-  AND run_timestamp >= DateTime('<MERGE_TS>')   -- e.g. '2026-06-18T11:38:59Z'
-  AND String::Contains(suite_folder, '<path_fragment>')  -- e.g. 'topic', 'persqueue'
+  AND run_timestamp >= DateTime('<MERGE_TS>')
+  AND String::Contains(suite_folder, '<fragment>')
 GROUP BY suite_folder, test_name, status, job_name
-ORDER BY first_seen
-LIMIT 50
+ORDER BY first_seen LIMIT 50
 ```
 
-3. For postcommit-only signal, add: `AND job_name IN ('Postcommit_relwithdebinfo', 'Postcommit_asan')`
-4. List merged PRs around first failure: `gh pr list --repo ydb-platform/ydb --state merged --search "merged:>=<DATE>"`
-5. Inspect suspect PR: `gh pr diff <PR_NUMBER>` (one PR per command)
-6. Mute follow-ups: `mute_events` by `commit_time >= Timestamp('<MERGE_TS>')` and `event = 'added'`
+Then: `gh pr list --search "merged:>=<DATE>"` · `gh pr diff <N>` · mute: `mute_events` where `event = 'added'`.
 
-For mute-related regressions also check `tests_monitor`, `mute_events`, `flaky_tests_window`.
+## Helpers
 
-## Architecture doc (keep in sync)
-
-**Source of truth for pipeline mental model:** `.github/scripts/analytics/ARCHITECTURE.md`
-
-- Layered diagram with **color legend** (L0 sources → L6 consumers; legacy in gray)
-- Tables: workflow → script → YDB table → consumer
-- Mart dependency subgraph for ordering inside `collect_analytics_fast`
-
-### When to update ARCHITECTURE.md (same PR)
-
-Any change to: analytics scripts/SQL, analytics workflows, **`ydb_qa_config.json` + GitHub `YDB_QA_CONFIG` var**, or new consumers (DataLens, Telegram, mute).
-
-Agents: after editing analytics code, update diagram and/or table in `ARCHITECTURE.md` before finishing the task.
-
-### Verify doc was updated
-
-```bash
-python3 .github/scripts/analytics/check_architecture_sync.py --base origin/main
-```
-
-Optional CI hook: run the same command on PRs that touch watched paths.
-
-## Helpers in Repo
-
-| Script | Usage |
-|--------|-------|
-| `.github/config/ydb_qa_config.json` | Table aliases and endpoint — **repo copy**; CI uses `vars.YDB_QA_CONFIG` (must match) |
-| `.github/scripts/analytics/ydb_wrapper.py` | YDB client (`YDBWrapper` context manager) |
-| `.github/scripts/analytics/data_mart_executor.py` | Run SQL file → upsert into YDB table |
-| `.github/scripts/analytics/test_history_fast.py` | Upload fast test history |
-| `.github/scripts/analytics/tests_monitor.py` | Update tests_monitor table |
-| `.github/scripts/analytics/flaky_tests_history.py` | Collect flaky test history |
-| `.github/scripts/analytics/export_issues_to_ydb.py` | Export GitHub issues → YDB |
-| `.github/scripts/analytics/export_pull_requests_to_ydb.py` | Export GitHub PRs → YDB |
-| `.github/scripts/analytics/check_architecture_sync.py` | Ensures ARCHITECTURE.md updated when analytics paths change |
-| `.github/scripts/analytics/ARCHITECTURE.md` | Colored pipeline map — maintain with every analytics change |
-| `.github/scripts/analytics/mcp.ydb-qa.example.json` | Cursor MCP config template (copy to `.cursor/mcp.json`, add SA key path) |
+| Path | Role |
+|------|------|
+| `ydb_wrapper.py` | YDB client |
+| `data_mart_executor.py` | SQL file → YDB table |
+| `check_architecture_sync.py` | Fail if analytics changed without ARCHITECTURE.md |
 
 ## Cross-links
 
-| Topic | Doc / skill |
-|-------|-------------|
-| PR-check, test_ya, GitHub statuses | `.cursor/rules/ci-testing.mdc`, `.github/docs/CI_PIPELINE.md` |
-| Mute/unmute rules | `.github/config/mute_rules.md` |
-| Raw data ingestion | `upload_tests_results.py` in `test_ya` action (CI skill) |
-| CI platform traps (merge SHA, stable wf from main) | `.cursor/rules/ci-testing.mdc` → GitHub platform behavior |
-
-## Conventions
-
-- SQL dialect: YQL (YDB Query Language); use backticks for table paths: `` `test_results/test_runs_column` ``
-- Table paths: relative to YDB database root (same as in `ydb_qa_config.json`)
-- Resolve alias → path via `ydb_qa_config.json` or `YDB_QA_CONFIG` → `databases.main.tables.<alias>`
-- New table alias: edit repo JSON **and** update GitHub variable `YDB_QA_CONFIG`; verify with `gh api` diff (see Key Tables section)
-- Copy patterns from `.github/scripts/analytics/data_mart_queries/` (CTEs as `$name = (SELECT ...)`, `PRAGMA AnsiInForEmptyOrNullableItemsCollections`)
-- Time filters: prefer `CurrentUtcDate() - N * Interval("P1D")` for rolling windows; use `DateTime('YYYY-MM-DDTHH:MM:SSZ')` for fixed merge timestamps; `mute_events` uses `commit_time` + `Timestamp('...')`
-- YQL rules:
-  - No SELECT alias in WHERE/HAVING of the same query — use subquery or repeat expression
-  - `full_name` exists only in marts like `test_history_fast`, not in `test_runs_column`
-  - Use `String::Contains` / `String::StartsWith`, not exact `test_name =` for C++/Python tests
-  - Always add `LIMIT` on exploratory queries
-- GitHub CLI: `gh pr view` / `gh issue view` accept **one** number per invocation; loop for multiple
-- **CI config:** workflows inject `vars.YDB_QA_CONFIG` as env `YDB_QA_CONFIG` (not the repo file). Local default: repo file when env unset (`ydb_wrapper.py`)
+| Topic | Where |
+|-------|--------|
+| PR-check, test_ya, merge SHA | `.cursor/rules/ci-testing.mdc`, `CI_PIPELINE.md`, `CI_PLATFORM.md` |
+| Mute rules | `.github/config/mute_rules.md` |
+| Ingestion from CI | `upload_tests_results.py` in `test_ya` |

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -27,6 +27,7 @@ YDB (YQL/SQL) + Python + GitHub Actions + MCP `user-ydb-qa`
 |----------|---------|
 | `.github/scripts/analytics/` | SQL queries, Python collectors, YDB wrapper |
 | `.github/scripts/analytics/ARCHITECTURE.md` | **Pipeline map** (layers, colors, workflow→table→consumer) — update with every analytics change |
+| `.github/docs/CI_PIPELINE.md` | **Test CI map** (PR-check, test_ya, statuses) — see `.cursor/rules/ci-testing.mdc` |
 | `.github/scripts/analytics/data_mart_queries/` | Data mart SQL (PR failures, mute stats, GitHub issues) |
 | `.github/scripts/analytics/monitoring_queries/` | Monitoring / ad-hoc SQL |
 | `.github/config/ydb_qa_config.json` | **Canonical table registry** (aliases → YDB paths) |
@@ -297,6 +298,14 @@ Optional CI hook: run the same command on PRs that touch watched paths.
 | `.github/scripts/analytics/check_architecture_sync.py` | Ensures ARCHITECTURE.md updated when analytics paths change |
 | `.github/scripts/analytics/ARCHITECTURE.md` | Colored pipeline map — maintain with every analytics change |
 | `.github/scripts/analytics/mcp.ydb-qa.example.json` | Cursor MCP config template (copy to `.cursor/mcp.json`, add SA key path) |
+
+## Cross-links
+
+| Topic | Doc / skill |
+|-------|-------------|
+| PR-check, test_ya, GitHub statuses | `.cursor/rules/ci-testing.mdc`, `.github/docs/CI_PIPELINE.md` |
+| Mute/unmute rules | `.github/config/mute_rules.md` |
+| Raw data ingestion | `upload_tests_results.py` in `test_ya` action (CI skill) |
 
 ## Conventions
 

--- a/.cursor/rules/analytics.mdc
+++ b/.cursor/rules/analytics.mdc
@@ -36,7 +36,43 @@ YDB (YQL/SQL) + Python + GitHub Actions + MCP `user-ydb-qa`
 
 ## Key Tables
 
-**Always read `.github/config/ydb_qa_config.json` first** — new tables are added there; do not rely on a hardcoded list.
+**Always read table registry first** — paths live in two places that must stay in sync:
+
+| Where | Used by |
+|-------|---------|
+| `.github/config/ydb_qa_config.json` | Local dev, docs, agents reading the repo |
+| GitHub repo variable **`YDB_QA_CONFIG`** (`vars.YDB_QA_CONFIG` in workflows) | **CI** — analytics workflows pass it to `setup_ci_ydb_service_account_key_file_credentials` → `YDBWrapper` |
+
+Adding a new table alias: update **both** the JSON file in the repo **and** the `YDB_QA_CONFIG` variable (Settings → Secrets and variables → Actions → Variables, or `gh variable set`).
+
+**Agents with `gh` access** — compare local file vs CI var before/after table changes:
+
+```bash
+# Read CI config (JSON string)
+gh api repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG --jq '.value' | python3 -m json.tool
+
+# Diff table aliases: local repo file vs GitHub variable
+python3 <<'PY'
+import json, subprocess
+local = json.load(open(".github/config/ydb_qa_config.json"))
+remote = json.loads(subprocess.check_output(
+    ["gh", "api", "repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG", "--jq", ".value"],
+    text=True,
+))
+lt = local["databases"]["main"]["tables"]
+rt = remote["databases"]["main"]["tables"]
+only_local = sorted(set(lt) - set(rt))
+only_ci = sorted(set(rt) - set(lt))
+if only_local:
+    print("ONLY in repo file (missing in YDB_QA_CONFIG var):", only_local)
+if only_ci:
+    print("ONLY in CI var (missing in repo file):", only_ci)
+if not only_local and not only_ci:
+    print("Table aliases match between repo file and YDB_QA_CONFIG")
+PY
+```
+
+Do not rely on a hardcoded table list below — read config or query YDB.
 
 Current aliases in `databases.main.tables`:
 
@@ -92,35 +128,34 @@ Expected: `ok = 1`. If tools are missing or auth fails, stop and help with setup
 
 #### How to get YDB MCP in Cursor
 
-1. **Credentials** — service account JSON with read access to the QA YDB cluster (same class of access as CI `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS`; ask the CI/analytics team if you don't have a key).
-2. **Endpoint** — from `.github/config/ydb_qa_config.json` → `databases.main.endpoint` + `databases.main.path` (see example).
-3. **Install** [ydb-mcp](https://github.com/ydb-platform/ydb-mcp) (`pip install ydb-mcp` or `uvx ydb-mcp`). Docs: `ydb/docs/en/core/reference/languages-and-apis/mcp/index.md`.
-4. **Cursor MCP config** — create `.cursor/mcp.json` locally (**gitignored**, do not commit secrets):
+1. **Install** [ydb-mcp](https://github.com/ydb-platform/ydb-mcp) into a venv you control (e.g. repo `veydb/`) or use `pip install ydb-mcp` / `uvx`. Docs: `ydb/docs/en/core/reference/languages-and-apis/mcp/index.md`.
+2. **Credentials** — service account JSON with read access to QA YDB (`--ydb-sa-key-file`; same class of key as CI).
+3. **Endpoint / database** — from `.github/config/ydb_qa_config.json` → `databases.main.endpoint` and `databases.main.path` (**separate** MCP args).
+4. **Cursor MCP config** — `.cursor/mcp.json` locally (**gitignored**). Recommended shape (matches team setup):
 
 ```json
 {
   "mcpServers": {
     "ydb-qa": {
-      "command": "uvx",
+      "command": "/path/to/python-with-ydb-mcp",
       "args": [
-        "ydb-mcp",
-        "--ydb-endpoint",
-        "grpcs://<host>:2135/ru-central1/<folder>/<database-id>"
-      ],
-      "env": {
-        "YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS": "/absolute/path/to/ydb-qa-sa-key.json"
-      }
+        "-m", "ydb_mcp",
+        "--ydb-endpoint", "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135",
+        "--ydb-database", "/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8",
+        "--ydb-auth-mode", "service-account",
+        "--ydb-sa-key-file", "/absolute/path/to/service-account.json"
+      ]
     }
   }
 }
 ```
 
-Build `--ydb-endpoint` from config: `{endpoint without trailing slash}{path}` — e.g. `grpcs://lb….ydb.mdb.yandexcloud.net:2135` + `/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8`.
+Use `endpoint` and `path` from config as **two args** (`--ydb-endpoint`, `--ydb-database`), not concatenated into one URL.
 
-5. **Enable in Cursor:** Settings → MCP → ensure the server is on; restart Cursor if tools don't appear.
-6. **Verify:** `ydb_query` with `SELECT 1`. Server name in UI may differ (e.g. `user-ydb-qa`); tool names are `ydb_query`, `ydb_explain_query`, etc.
+5. **Enable in Cursor:** Settings → MCP → server on; restart if tools missing.
+6. **Verify:** `ydb_query` with `SELECT 1 AS ok`. Cursor may show the server as `ydb-qa` or `user-ydb-qa` depending on your config name; tool names are always `ydb_query`, `ydb_explain_query`, etc.
 
-Tracked template (no secrets): `.github/scripts/analytics/mcp.ydb-qa.example.json`.
+Tracked template: `.github/scripts/analytics/mcp.ydb-qa.example.json`.
 
 ### MCP tools (preferred in Cursor)
 
@@ -173,6 +208,9 @@ gh run view <RUN_ID> --repo ydb-platform/ydb
 gh pr list --repo ydb-platform/ydb --state merged --search "merged:>=2026-01-01"
 gh pr view <PR_NUMBER> --repo ydb-platform/ydb
 gh pr diff <PR_NUMBER> --repo ydb-platform/ydb
+
+# CI table registry (compare with .github/config/ydb_qa_config.json)
+gh api repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG --jq '.value' | python3 -m json.tool
 ```
 
 Key workflows to inspect: `Collect-analytics-fast-run`, `Update Muted tests`, `Create issues for muted tests`, `PR-check`.
@@ -219,7 +257,7 @@ For mute-related regressions also check `tests_monitor`, `mute_events`, `flaky_t
 
 ### When to update ARCHITECTURE.md (same PR)
 
-Any change to: analytics scripts/SQL, analytics workflows, `ydb_qa_config.json` tables, or new consumers (DataLens, Telegram, mute).
+Any change to: analytics scripts/SQL, analytics workflows, **`ydb_qa_config.json` + GitHub `YDB_QA_CONFIG` var**, or new consumers (DataLens, Telegram, mute).
 
 Agents: after editing analytics code, update diagram and/or table in `ARCHITECTURE.md` before finishing the task.
 
@@ -235,7 +273,7 @@ Optional CI hook: run the same command on PRs that touch watched paths.
 
 | Script | Usage |
 |--------|-------|
-| `.github/config/ydb_qa_config.json` | Table aliases and YDB endpoint — **source of truth** |
+| `.github/config/ydb_qa_config.json` | Table aliases and endpoint — **repo copy**; CI uses `vars.YDB_QA_CONFIG` (must match) |
 | `.github/scripts/analytics/ydb_wrapper.py` | YDB client (`YDBWrapper` context manager) |
 | `.github/scripts/analytics/data_mart_executor.py` | Run SQL file → upsert into YDB table |
 | `.github/scripts/analytics/test_history_fast.py` | Upload fast test history |
@@ -251,7 +289,8 @@ Optional CI hook: run the same command on PRs that touch watched paths.
 
 - SQL dialect: YQL (YDB Query Language); use backticks for table paths: `` `test_results/test_runs_column` ``
 - Table paths: relative to YDB database root (same as in `ydb_qa_config.json`)
-- Resolve alias → path via `ydb_qa_config.json` → `databases.main.tables.<alias>`
+- Resolve alias → path via `ydb_qa_config.json` or `YDB_QA_CONFIG` → `databases.main.tables.<alias>`
+- New table alias: edit repo JSON **and** update GitHub variable `YDB_QA_CONFIG`; verify with `gh api` diff (see Key Tables section)
 - Copy patterns from `.github/scripts/analytics/data_mart_queries/` (CTEs as `$name = (SELECT ...)`, `PRAGMA AnsiInForEmptyOrNullableItemsCollections`)
 - Time filters: prefer `CurrentUtcDate() - N * Interval("P1D")` for rolling windows; use `DateTime('YYYY-MM-DDTHH:MM:SSZ')` for fixed merge timestamps; `mute_events` uses `commit_time` + `Timestamp('...')`
 - YQL rules:
@@ -260,4 +299,4 @@ Optional CI hook: run the same command on PRs that touch watched paths.
   - Use `String::Contains` / `String::StartsWith`, not exact `test_name =` for C++/Python tests
   - Always add `LIMIT` on exploratory queries
 - GitHub CLI: `gh pr view` / `gh issue view` accept **one** number per invocation; loop for multiple
-- CI sets `YDB_QA_CONFIG` from GitHub vars; locally use config file or export the same JSON
+- **CI config:** workflows inject `vars.YDB_QA_CONFIG` as env `YDB_QA_CONFIG` (not the repo file). Local default: repo file when env unset (`ydb_wrapper.py`)

--- a/.cursor/rules/ci-testing.mdc
+++ b/.cursor/rules/ci-testing.mdc
@@ -16,6 +16,10 @@ globs:
   - ".github/scripts/tests/**"
   - ".github/config/muted_ya*.txt"
   - ".github/config/stable_tests_branches.json"
+  - ".github/workflows/automerge_pr.yaml"
+  - ".github/workflows/rebase.yml"
+  - ".github/workflows/automerge*.yaml"
+  - "ydb/ci/rightlib/automerge.py"
 alwaysApply: false
 ---
 
@@ -141,7 +145,78 @@ Local repo file `.github/config/ydb_qa_config.json` is **not** read by CI upload
 | YDB tables, marts, investigations | `.cursor/rules/analytics.mdc`, `ARCHITECTURE.md` |
 | Mute/unmute rules & automation | `.github/config/mute_rules.md`, `update_muted_ya.yml` |
 | Build bloat in CI | `ydb/ci/build_bloat/`, `test_bloat.py` in test_ya |
-| Release / docs / cherry-pick CI | Out of scope — no skill yet |
+| PR merge commit staleness | [issue #36673](https://github.com/ydb-platform/ydb/issues/36673) |
+| Automerge base refresh / cron polling | [PR #44180](https://github.com/ydb-platform/ydb/pull/44180), `automerge_pr.yaml` |
+| Release / docs / cherry-pick CI | Out of scope — see [Security](#security-supply-chain) for docs build |
+
+## GitHub platform behavior (read before changing `.github/`)
+
+**Do not assume GitHub Actions semantics from memory.** Re-read current docs when touching workflows, composite actions, or action scripts:
+
+- [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
+- [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
+- [Workflow syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
+- [Scheduled workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
+
+### Known YDB-specific traps (verified in production)
+
+| Trap | What happens | Mitigation / reference |
+|------|----------------|------------------------|
+| **`pull_request_target` workflow file from default branch** | For PRs into `stable-*`, the **workflow definition runs from `main`**, not from the target branch. Changing `.github/workflows` on `main` affects all base branches immediately. | Before merge: list who still relies on old layout on stable branches; plan backport or keep action inputs backward-compatible. |
+| **Stale `merge_commit_sha`** | `GET /pulls/{N}` and `context.payload.pull_request` can return an **outdated** synthetic merge SHA; CI may test code merged with weeks-old base. | [issue #36673](https://github.com/ydb-platform/ydb/issues/36673): re-fetch PR via API in gate steps; consider local `prepare-merge` / `refs/pr-ci/{N}/merge`; do not trust cached `merge_commit_sha` alone. |
+| **`rebase-and-check` label** | Re-triggers PR-check; workflow `context` PR object may still carry stale fields until API refresh. | Same as above — refresh PR object after label/push tricks. |
+| **Scheduled workflow gaps** | GitHub `schedule` cron is **best-effort** (delays, skipped runs during outages). Hourly jobs may not fire exactly once per hour. | Example: `automerge_pr.yaml` runs cron at `:17` but **polls inside the job for ~55 min** ([PR #44180](https://github.com/ydb-platform/ydb/pull/44180)) so automerge is not idle between cron ticks. Apply similar pattern for critical scheduled workflows. |
+| **Automerge push race** | Base branch moves between clone and push → false `automerge-blocked`. | [PR #44180](https://github.com/ydb-platform/ydb/pull/44180): `refresh_base_and_merge()` — fetch latest `origin/<base>` immediately before merge/push. |
+
+When proposing a workflow fix, cite **which GitHub doc section** your behavior relies on (or note if it is an undocumented quirk we already workaround).
+
+## Multi-branch & shared actions
+
+Shared composite actions (e.g. `build_and_test_ya`, future `ya_ci_core_build_test`) may exist in **different versions** on `main` vs `stable-*` / `q-stable-*`. Workflow YAML on a branch must match the action API on **that same branch**.
+
+### Checklist when changing `.github/actions/**` or callers
+
+1. **Find all callers on this branch:**
+   ```bash
+   rg "uses:.*\\.github/actions/" .github/workflows
+   rg "uses:.*\\.github/actions/" .github/actions
+   ```
+2. **Breaking change?** (removed/renamed inputs, different checkout ref semantics)
+   - Keep backward-compatible inputs, **or**
+   - Update **every** workflow on the branch in the **same PR**, **or**
+   - Document required cherry-picks into active stable branches.
+3. **`pull_request_target` on stable PRs** still executes workflow YAML from **`main`** — a new action on `main` is used even when the PR targets `stable-25-4`. Verify stable PRs are not broken by main-only action changes.
+4. **Cherry-pick / backport PRs:** `.github/` in the cherry-pick must match the action version on the **target** branch, not only source branch.
+5. **Fork PRs:** workflow definition from base repo; checkout ref comes from merge commit / gate job — see PR-check section.
+
+### PR description block (copy when touching shared CI)
+
+```markdown
+**CI layer:** Trigger | Gate | Orchestrator | composite action | test_ya | script
+**Consumers:** (workflows that call this action)
+**Branches:** main only | needs backport to stable-* (list)
+**GitHub semantics:** (e.g. pull_request_target from main, merge_commit_sha refresh)
+**Docs updated:** CI_PIPELINE.md | ARCHITECTURE.md (if job_name / analytics)
+```
+
+## Security (supply chain)
+
+### Docs / build hooks (out of test CI but affects CI runners)
+
+Docs build loads `.yfm` extensions — any `require()` runs **on the machine building docs** (CI or locally).
+
+| Red flag | Example |
+|---------|---------|
+| New `.yfm` `extensions:` entry | [PR #43915](https://github.com/ydb-platform/ydb/pull/43915) — `loader.cjs` with `curl \| sh` |
+| `exec` / `execSync` / remote URL in build assets | Treat as **block merge** until reviewed by a human |
+| Whitespace-only diff hiding config additions | Review full file, not just diff hunks |
+
+**Rule:** never merge new docs extensions or CI `run:` scripts that download and execute remote code without pinned hashes and explicit review.
+
+### `.github/` changes
+
+- Do not add steps that run PR head code in `pull_request_target` without the same guards as `rebase.yml` (collaborator checks, no untrusted build).
+- Prefer pinned action versions (`actions/checkout@v5`) and pinned pip packages in CI scripts.
 
 ## Conventions for changes
 
@@ -151,13 +226,19 @@ Local repo file `.github/config/ydb_qa_config.json` is **not** read by CI upload
 - **New `job_name` in upload:** update analytics `ARCHITECTURE.md` and YDB queries using `job_name`.
 - **`pull_request_target` changes:** consider fork/external contributor flow and token scopes.
 - Update **`CI_PIPELINE.md`** in the same PR as structural changes.
+- Re-read **GitHub Actions docs** for the event type you touch (`pull_request_target`, `schedule`, `workflow_call`).
+- If changing a **shared action**, complete the [multi-branch checklist](#multi-branch--shared-actions).
 
 ## Common pitfalls
 
 | Mistake | Fix |
 |---------|-----|
-| Checkout PR head on `pull_request_target` | Use merge commit SHA from gate job |
+| Checkout PR head on `pull_request_target` | Use merge commit SHA from gate job; refresh via API ([#36673](https://github.com/ydb-platform/ydb/issues/36673)) |
+| Trust `context.payload.pull_request.merge_commit_sha` without refresh | Re-fetch PR in gate step; consider `prepare-merge` job |
+| Change action on `main` only; stable PRs break | Remember `pull_request_target` uses workflow from **default branch** |
+| Rely on hourly cron firing exactly once | Add in-job polling like `automerge_pr.yaml` ([PR #44180](https://github.com/ydb-platform/ydb/pull/44180)) |
 | Call `test_ya` without `setup_ci_ydb_service_account_key_file_credentials` | Upload step fails silently or skips |
 | Assume `muted_ya.txt` change mutes instantly | Needs merge + next CI run; decisions come from mute workflow |
 | Add workflow job without `CHECKS_SWITCH` guard | May run when CI intentionally disabled |
 | Wrong runner labels | Match `build-preset-{preset}` on auto-provisioned pool |
+| Merge docs `.yfm` extension from external contributor without audit | Block — supply chain risk ([#43915](https://github.com/ydb-platform/ydb/pull/43915)) |

--- a/.cursor/rules/ci-testing.mdc
+++ b/.cursor/rules/ci-testing.mdc
@@ -1,0 +1,163 @@
+---
+description: "CI testing skill: PR-check, ya make, test_ya, build_and_test_ya, regression, mute enforcement, GitHub statuses"
+globs:
+  - ".github/docs/CI_PIPELINE.md"
+  - ".github/workflows/pr_check.yml"
+  - ".github/workflows/run_tests.yml"
+  - ".github/workflows/run_and_debug_tests.yml"
+  - ".github/workflows/postcommit_*.yml"
+  - ".github/workflows/regression_*.yml"
+  - ".github/workflows/regression_whitelist_run.yml"
+  - ".github/workflows/build_and_test_ya.yml"
+  - ".github/actions/test_ya/**"
+  - ".github/actions/build_and_test_ya/**"
+  - ".github/actions/s3cmd/**"
+  - ".github/actions/prepare_vm/**"
+  - ".github/scripts/tests/**"
+  - ".github/config/muted_ya*.txt"
+  - ".github/config/stable_tests_branches.json"
+alwaysApply: false
+---
+
+# CI Testing Skill
+
+## Stack
+
+GitHub Actions (self-hosted runners) + composite actions + `./ya make` + S3 public artifacts + GitHub commit statuses.
+
+**Not in scope here:** YDB analytics marts, mute decision workflows, docs/release CI — see cross-links below.
+
+## Pipeline map (read first)
+
+**Human overview:** `.github/docs/CI_PIPELINE.md` — update with every structural CI change.
+
+```text
+Trigger → Gate (PR-check) → build_and_test_ya → test_ya → ya make / retry
+  → transform_build_results (muted_ya.txt) → generate-summary / comment-pr
+  → GitHub statuses + S3 artifacts + upload_tests_results (YDB)
+```
+
+## Where CI testing lives
+
+| Location | Purpose |
+|----------|---------|
+| `.github/docs/CI_PIPELINE.md` | **Pipeline map** (workflows, actions, scripts, outputs) |
+| `.github/workflows/pr_check.yml` | Pre-commit on PRs (`pull_request_target`) |
+| `.github/workflows/postcommit_*.yml` | Post-merge checks on main/stable |
+| `.github/workflows/run_tests.yml` | Reusable runner (`workflow_call`) for regression/manual |
+| `.github/workflows/regression_*.yml` | Large/regression test matrices |
+| `.github/actions/build_and_test_ya/` | Standard wrapper: s3cmd + test_ya |
+| `.github/actions/test_ya/` | Core: ya make, retry, reports, YDB upload |
+| `.github/scripts/tests/` | Report post-processing, PR comments, mute helpers |
+| `.github/config/muted_ya*.txt` | Mute rules applied during test report transform |
+
+## Action stack (conventions)
+
+1. Workflows call **`build_and_test_ya`**, not `test_ya` directly.
+2. `build_and_test_ya` sets up **`s3cmd`** (folder prefix, preset) then delegates to **`test_ya`**.
+3. Secrets/vars passed as JSON strings: `secs='{"AWS_KEY_ID":...}'`, `vars='{"AWS_BUCKET":...}'` — see `pr_check.yml` for template.
+4. Build presets: `relwithdebinfo`, `release-asan`, `release-tsan`, `release-msan`.
+
+## PR-check (`pr_check.yml`)
+
+| Topic | Detail |
+|-------|--------|
+| Event | `pull_request_target` — workflow runs with base repo permissions |
+| Checkout | `needs.check-running-allowed.outputs.commit_sha` (merge commit, not PR head alone) |
+| Who can run | Repo owner, collaborator, or PR with `ok-to-test` label |
+| Re-trigger | Labels `ok-to-test`, `rebase-and-check` only (other labels must not cancel in-progress run) |
+| Enable flag | `vars.CHECKS_SWITCH` → JSON field `pr_check` |
+| Runners | `[self-hosted, auto-provisioned, build-preset-{preset}]` |
+| Default matrix | relwithdebinfo + release-asan; `ydb/`; sizes small,medium; `increment: true` |
+| Extra sanitizers | Labels `run-tsan-tests`, `run-msan-tests`, `run-sanitizer-tests` |
+| Integrated check | `checks_integrated` = all 4 contexts green: `build_*` + `test_*` for relwithdebinfo and release-asan |
+
+### Debugging a PR-check failure
+
+1. Open the job log link from the PR comment (via `comment-pr.py`).
+2. S3 artifact index: `PUBLIC_DIR_URL/index.html` — ya output, `ya-test.html`, fail_summary.
+3. GitHub statuses on HEAD: `build_{preset}`, `test_{preset}`.
+4. For test data after the run: analytics skill + YDB (`job_name = 'PR-check'`).
+
+```bash
+gh run list --repo ydb-platform/ydb --workflow pr_check.yml --limit 10
+gh run view <RUN_ID> --repo ydb-platform/ydb
+gh pr checks <PR_NUMBER> --repo ydb-platform/ydb
+```
+
+## `test_ya` key behaviors
+
+| Input | Effect |
+|-------|--------|
+| `increment: true` | `graph_compare.py` limits tests to graph delta vs previous commit |
+| `test_size` | Comma list → `--test-size=small` etc. |
+| `test_retry_count` | Retry failed tests; TSAN/MSAN default 1 retry |
+| `run_tests: false` | Build only |
+| `pull_number` | Passed to upload for PR attribution |
+
+Important scripts inside the action (do not duplicate logic in workflows):
+
+| Script | When |
+|--------|------|
+| `transform_build_results.py` | After each ya make try; applies `muted_ya.txt` |
+| `fail-checker.py` | Count failures; drives retry loop |
+| `generate-summary.py` | Final PR summary table |
+| `comment-pr.py` | Rewrites/updates PR status comment |
+| `upload_tests_results.py` | YDB ingest (requires YDB setup step in workflow) |
+| `send_build_stats.py` | Binary size stats |
+
+## Mute in CI (enforcement only)
+
+- **File:** `.github/config/muted_ya.txt` (+ `muted_ya_asan.txt`, etc.)
+- **Applied in:** `transform_build_results.py` during `test_ya`
+- **Decisions / automation:** `update_muted_ya.yml`, `mute_rules.md` — see **analytics skill**, not this file
+
+Do not edit mute decision logic in `test_ya`; change rules file or mute workflow instead.
+
+## Regression & manual runs
+
+| Workflow | Entry |
+|----------|-------|
+| `run_tests.yml` | `workflow_call` from regression workflows; branch selection via `branches` or `stable_tests_branches.json` |
+| `regression_run.yml` | Dispatches full matrix across presets |
+| `run_and_debug_tests.yml` | Debug runs, optional coredumps |
+| ydbbot "Run Extra Tests" | Triggers `run_tests.yml` with PR number |
+
+## Config & secrets
+
+| Name | Purpose |
+|------|---------|
+| `CHECKS_SWITCH` | Per-workflow toggles (JSON in repo variables) |
+| `YDB_QA_CONFIG` | Required for `upload_tests_results` in CI |
+| `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS` | YDB SA for upload step |
+| `AWS_BUCKET`, `AWS_ENDPOINT`, `REMOTE_CACHE_URL_YA` | S3 logs + ya cache |
+
+Local repo file `.github/config/ydb_qa_config.json` is **not** read by CI upload — CI uses `vars.YDB_QA_CONFIG`.
+
+## Cross-links
+
+| Topic | Doc / skill |
+|-------|-------------|
+| YDB tables, marts, investigations | `.cursor/rules/analytics.mdc`, `ARCHITECTURE.md` |
+| Mute/unmute rules & automation | `.github/config/mute_rules.md`, `update_muted_ya.yml` |
+| Build bloat in CI | `ydb/ci/build_bloat/`, `test_bloat.py` in test_ya |
+| Release / docs / cherry-pick CI | Out of scope — no skill yet |
+
+## Conventions for changes
+
+- **Minimal diff:** one concern per PR (workflow gate vs test_ya retry vs script output).
+- **PR description:** layer (Trigger / Gate / Orchestrator / test_ya / script), upstream workflow, downstream (statuses, S3, YDB, mute).
+- **New status context:** update `update_integrated_status` in `pr_check.yml` if it must gate merge.
+- **New `job_name` in upload:** update analytics `ARCHITECTURE.md` and YDB queries using `job_name`.
+- **`pull_request_target` changes:** consider fork/external contributor flow and token scopes.
+- Update **`CI_PIPELINE.md`** in the same PR as structural changes.
+
+## Common pitfalls
+
+| Mistake | Fix |
+|---------|-----|
+| Checkout PR head on `pull_request_target` | Use merge commit SHA from gate job |
+| Call `test_ya` without `setup_ci_ydb_service_account_key_file_credentials` | Upload step fails silently or skips |
+| Assume `muted_ya.txt` change mutes instantly | Needs merge + next CI run; decisions come from mute workflow |
+| Add workflow job without `CHECKS_SWITCH` guard | May run when CI intentionally disabled |
+| Wrong runner labels | Match `build-preset-{preset}` on auto-provisioned pool |

--- a/.cursor/rules/ci-testing.mdc
+++ b/.cursor/rules/ci-testing.mdc
@@ -29,7 +29,7 @@ alwaysApply: false
 | Doc | When |
 |-----|------|
 | [`.github/docs/CI_PIPELINE.md`](../../.github/docs/CI_PIPELINE.md) | Workflows, action stack, PR-check, test_ya, config, maintenance checklist |
-| [`.github/docs/CI_PLATFORM.md`](../../.github/docs/CI_PLATFORM.md) | GitHub traps (#36673, #44180), multi-branch, security (#43915), PR template |
+| [`.github/docs/CI_PLATFORM.md`](../../.github/docs/CI_PLATFORM.md) | GitHub traps (#36673, #44180), multi-branch, security principles |
 
 ## Stack (one line)
 
@@ -55,7 +55,7 @@ Full table in `CI_PLATFORM.md`. Highest-impact:
 | Change workflow on `main`; break stable PRs | `pull_request_target` always uses **main** YAML |
 | `test_ya` without YDB setup step | `setup_ci_ydb_service_account_key_file_credentials` required for upload |
 | Rely on hourly cron exactly once | In-job polling — `automerge_pr.yaml` ([#44180](https://github.com/ydb-platform/ydb/pull/44180)) |
-| Merge docs `.yfm` extension unreviewed | Block — [#43915](https://github.com/ydb-platform/ydb/pull/43915) |
+| Introduce untrusted execution or remote code in CI/build | See security principles in `CI_PLATFORM.md` |
 
 ## Debug PR-check
 

--- a/.cursor/rules/ci-testing.mdc
+++ b/.cursor/rules/ci-testing.mdc
@@ -1,244 +1,76 @@
 ---
-description: "CI testing skill: PR-check, ya make, test_ya, build_and_test_ya, regression, mute enforcement, GitHub statuses"
+description: "CI test pipeline & GitHub Actions: PR-check, test_ya, platform traps, multi-branch — read CI_PIPELINE.md first"
 globs:
   - ".github/docs/CI_PIPELINE.md"
+  - ".github/docs/CI_PLATFORM.md"
   - ".github/workflows/pr_check.yml"
   - ".github/workflows/run_tests.yml"
   - ".github/workflows/run_and_debug_tests.yml"
-  - ".github/workflows/postcommit_*.yml"
+  - ".github/workflows/postcommit*.yml"
   - ".github/workflows/regression_*.yml"
   - ".github/workflows/regression_whitelist_run.yml"
   - ".github/workflows/build_and_test_ya.yml"
   - ".github/actions/test_ya/**"
   - ".github/actions/build_and_test_ya/**"
+  - ".github/actions/ya_ci_core_build_test/**"
   - ".github/actions/s3cmd/**"
-  - ".github/actions/prepare_vm/**"
   - ".github/scripts/tests/**"
   - ".github/config/muted_ya*.txt"
-  - ".github/config/stable_tests_branches.json"
   - ".github/workflows/automerge_pr.yaml"
   - ".github/workflows/rebase.yml"
-  - ".github/workflows/automerge*.yaml"
   - "ydb/ci/rightlib/automerge.py"
 alwaysApply: false
 ---
 
-# CI Testing Skill
+# CI Testing Skill (router)
 
-## Stack
+**Do not duplicate pipeline details here.** Read canonical docs first:
 
-GitHub Actions (self-hosted runners) + composite actions + `./ya make` + S3 public artifacts + GitHub commit statuses.
+| Doc | When |
+|-----|------|
+| [`.github/docs/CI_PIPELINE.md`](../../.github/docs/CI_PIPELINE.md) | Workflows, action stack, PR-check, test_ya, config, maintenance checklist |
+| [`.github/docs/CI_PLATFORM.md`](../../.github/docs/CI_PLATFORM.md) | GitHub traps (#36673, #44180), multi-branch, security (#43915), PR template |
 
-**Not in scope here:** YDB analytics marts, mute decision workflows, docs/release CI — see cross-links below.
+## Stack (one line)
 
-## Pipeline map (read first)
+`workflow → build_and_test_ya → test_ya → ya make → transform_build_results → statuses / S3 / upload_tests_results`
 
-**Human overview:** `.github/docs/CI_PIPELINE.md` — update with every structural CI change.
+Workflows call **`build_and_test_ya`**, not `test_ya` directly. Mute **enforcement** = `muted_ya.txt` in `test_ya`; mute **decisions** = analytics skill + `mute_rules.md`.
 
-```text
-Trigger → Gate (PR-check) → build_and_test_ya → test_ya → ya make / retry
-  → transform_build_results (muted_ya.txt) → generate-summary / comment-pr
-  → GitHub statuses + S3 artifacts + upload_tests_results (YDB)
-```
+## Agent rules
 
-## Where CI testing lives
+1. **Structural CI change** → update `CI_PIPELINE.md` (same PR). Platform/security/multi-branch → also `CI_PLATFORM.md`.
+2. **New `job_name` in upload** → update analytics `ARCHITECTURE.md` + SQL `job_name` filters.
+3. **Shared action API change** → complete multi-branch checklist in `CI_PLATFORM.md`.
+4. **Before changing events** → re-read [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows); cite section in PR.
+5. **Minimal diff** — one layer per PR (gate / orchestrator / test_ya / script).
 
-| Location | Purpose |
-|----------|---------|
-| `.github/docs/CI_PIPELINE.md` | **Pipeline map** (workflows, actions, scripts, outputs) |
-| `.github/workflows/pr_check.yml` | Pre-commit on PRs (`pull_request_target`) |
-| `.github/workflows/postcommit_*.yml` | Post-merge checks on main/stable |
-| `.github/workflows/run_tests.yml` | Reusable runner (`workflow_call`) for regression/manual |
-| `.github/workflows/regression_*.yml` | Large/regression test matrices |
-| `.github/actions/build_and_test_ya/` | Standard wrapper: s3cmd + test_ya |
-| `.github/actions/test_ya/` | Core: ya make, retry, reports, YDB upload |
-| `.github/scripts/tests/` | Report post-processing, PR comments, mute helpers |
-| `.github/config/muted_ya*.txt` | Mute rules applied during test report transform |
+## Pitfalls (quick reference)
 
-## Action stack (conventions)
-
-1. Workflows call **`build_and_test_ya`**, not `test_ya` directly.
-2. `build_and_test_ya` sets up **`s3cmd`** (folder prefix, preset) then delegates to **`test_ya`**.
-3. Secrets/vars passed as JSON strings: `secs='{"AWS_KEY_ID":...}'`, `vars='{"AWS_BUCKET":...}'` — see `pr_check.yml` for template.
-4. Build presets: `relwithdebinfo`, `release-asan`, `release-tsan`, `release-msan`.
-
-## PR-check (`pr_check.yml`)
-
-| Topic | Detail |
-|-------|--------|
-| Event | `pull_request_target` — workflow runs with base repo permissions |
-| Checkout | `needs.check-running-allowed.outputs.commit_sha` (merge commit, not PR head alone) |
-| Who can run | Repo owner, collaborator, or PR with `ok-to-test` label |
-| Re-trigger | Labels `ok-to-test`, `rebase-and-check` only (other labels must not cancel in-progress run) |
-| Enable flag | `vars.CHECKS_SWITCH` → JSON field `pr_check` |
-| Runners | `[self-hosted, auto-provisioned, build-preset-{preset}]` |
-| Default matrix | relwithdebinfo + release-asan; `ydb/`; sizes small,medium; `increment: true` |
-| Extra sanitizers | Labels `run-tsan-tests`, `run-msan-tests`, `run-sanitizer-tests` |
-| Integrated check | `checks_integrated` = all 4 contexts green: `build_*` + `test_*` for relwithdebinfo and release-asan |
-
-### Debugging a PR-check failure
-
-1. Open the job log link from the PR comment (via `comment-pr.py`).
-2. S3 artifact index: `PUBLIC_DIR_URL/index.html` — ya output, `ya-test.html`, fail_summary.
-3. GitHub statuses on HEAD: `build_{preset}`, `test_{preset}`.
-4. For test data after the run: analytics skill + YDB (`job_name = 'PR-check'`).
-
-```bash
-gh run list --repo ydb-platform/ydb --workflow pr_check.yml --limit 10
-gh run view <RUN_ID> --repo ydb-platform/ydb
-gh pr checks <PR_NUMBER> --repo ydb-platform/ydb
-```
-
-## `test_ya` key behaviors
-
-| Input | Effect |
-|-------|--------|
-| `increment: true` | `graph_compare.py` limits tests to graph delta vs previous commit |
-| `test_size` | Comma list → `--test-size=small` etc. |
-| `test_retry_count` | Retry failed tests; TSAN/MSAN default 1 retry |
-| `run_tests: false` | Build only |
-| `pull_number` | Passed to upload for PR attribution |
-
-Important scripts inside the action (do not duplicate logic in workflows):
-
-| Script | When |
-|--------|------|
-| `transform_build_results.py` | After each ya make try; applies `muted_ya.txt` |
-| `fail-checker.py` | Count failures; drives retry loop |
-| `generate-summary.py` | Final PR summary table |
-| `comment-pr.py` | Rewrites/updates PR status comment |
-| `upload_tests_results.py` | YDB ingest (requires YDB setup step in workflow) |
-| `send_build_stats.py` | Binary size stats |
-
-## Mute in CI (enforcement only)
-
-- **File:** `.github/config/muted_ya.txt` (+ `muted_ya_asan.txt`, etc.)
-- **Applied in:** `transform_build_results.py` during `test_ya`
-- **Decisions / automation:** `update_muted_ya.yml`, `mute_rules.md` — see **analytics skill**, not this file
-
-Do not edit mute decision logic in `test_ya`; change rules file or mute workflow instead.
-
-## Regression & manual runs
-
-| Workflow | Entry |
-|----------|-------|
-| `run_tests.yml` | `workflow_call` from regression workflows; branch selection via `branches` or `stable_tests_branches.json` |
-| `regression_run.yml` | Dispatches full matrix across presets |
-| `run_and_debug_tests.yml` | Debug runs, optional coredumps |
-| ydbbot "Run Extra Tests" | Triggers `run_tests.yml` with PR number |
-
-## Config & secrets
-
-| Name | Purpose |
-|------|---------|
-| `CHECKS_SWITCH` | Per-workflow toggles (JSON in repo variables) |
-| `YDB_QA_CONFIG` | Required for `upload_tests_results` in CI |
-| `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS` | YDB SA for upload step |
-| `AWS_BUCKET`, `AWS_ENDPOINT`, `REMOTE_CACHE_URL_YA` | S3 logs + ya cache |
-
-Local repo file `.github/config/ydb_qa_config.json` is **not** read by CI upload — CI uses `vars.YDB_QA_CONFIG`.
-
-## Cross-links
-
-| Topic | Doc / skill |
-|-------|-------------|
-| YDB tables, marts, investigations | `.cursor/rules/analytics.mdc`, `ARCHITECTURE.md` |
-| Mute/unmute rules & automation | `.github/config/mute_rules.md`, `update_muted_ya.yml` |
-| Build bloat in CI | `ydb/ci/build_bloat/`, `test_bloat.py` in test_ya |
-| PR merge commit staleness | [issue #36673](https://github.com/ydb-platform/ydb/issues/36673) |
-| Automerge base refresh / cron polling | [PR #44180](https://github.com/ydb-platform/ydb/pull/44180), `automerge_pr.yaml` |
-| Release / docs / cherry-pick CI | Out of scope — see [Security](#security-supply-chain) for docs build |
-
-## GitHub platform behavior (read before changing `.github/`)
-
-**Do not assume GitHub Actions semantics from memory.** Re-read current docs when touching workflows, composite actions, or action scripts:
-
-- [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows)
-- [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)
-- [Workflow syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
-- [Scheduled workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
-
-### Known YDB-specific traps (verified in production)
-
-| Trap | What happens | Mitigation / reference |
-|------|----------------|------------------------|
-| **`pull_request_target` workflow file from default branch** | For PRs into `stable-*`, the **workflow definition runs from `main`**, not from the target branch. Changing `.github/workflows` on `main` affects all base branches immediately. | Before merge: list who still relies on old layout on stable branches; plan backport or keep action inputs backward-compatible. |
-| **Stale `merge_commit_sha`** | `GET /pulls/{N}` and `context.payload.pull_request` can return an **outdated** synthetic merge SHA; CI may test code merged with weeks-old base. | [issue #36673](https://github.com/ydb-platform/ydb/issues/36673): re-fetch PR via API in gate steps; consider local `prepare-merge` / `refs/pr-ci/{N}/merge`; do not trust cached `merge_commit_sha` alone. |
-| **`rebase-and-check` label** | Re-triggers PR-check; workflow `context` PR object may still carry stale fields until API refresh. | Same as above — refresh PR object after label/push tricks. |
-| **Scheduled workflow gaps** | GitHub `schedule` cron is **best-effort** (delays, skipped runs during outages). Hourly jobs may not fire exactly once per hour. | Example: `automerge_pr.yaml` runs cron at `:17` but **polls inside the job for ~55 min** ([PR #44180](https://github.com/ydb-platform/ydb/pull/44180)) so automerge is not idle between cron ticks. Apply similar pattern for critical scheduled workflows. |
-| **Automerge push race** | Base branch moves between clone and push → false `automerge-blocked`. | [PR #44180](https://github.com/ydb-platform/ydb/pull/44180): `refresh_base_and_merge()` — fetch latest `origin/<base>` immediately before merge/push. |
-
-When proposing a workflow fix, cite **which GitHub doc section** your behavior relies on (or note if it is an undocumented quirk we already workaround).
-
-## Multi-branch & shared actions
-
-Shared composite actions (e.g. `build_and_test_ya`, future `ya_ci_core_build_test`) may exist in **different versions** on `main` vs `stable-*` / `q-stable-*`. Workflow YAML on a branch must match the action API on **that same branch**.
-
-### Checklist when changing `.github/actions/**` or callers
-
-1. **Find all callers on this branch:**
-   ```bash
-   rg "uses:.*\\.github/actions/" .github/workflows
-   rg "uses:.*\\.github/actions/" .github/actions
-   ```
-2. **Breaking change?** (removed/renamed inputs, different checkout ref semantics)
-   - Keep backward-compatible inputs, **or**
-   - Update **every** workflow on the branch in the **same PR**, **or**
-   - Document required cherry-picks into active stable branches.
-3. **`pull_request_target` on stable PRs** still executes workflow YAML from **`main`** — a new action on `main` is used even when the PR targets `stable-25-4`. Verify stable PRs are not broken by main-only action changes.
-4. **Cherry-pick / backport PRs:** `.github/` in the cherry-pick must match the action version on the **target** branch, not only source branch.
-5. **Fork PRs:** workflow definition from base repo; checkout ref comes from merge commit / gate job — see PR-check section.
-
-### PR description block (copy when touching shared CI)
-
-```markdown
-**CI layer:** Trigger | Gate | Orchestrator | composite action | test_ya | script
-**Consumers:** (workflows that call this action)
-**Branches:** main only | needs backport to stable-* (list)
-**GitHub semantics:** (e.g. pull_request_target from main, merge_commit_sha refresh)
-**Docs updated:** CI_PIPELINE.md | ARCHITECTURE.md (if job_name / analytics)
-```
-
-## Security (supply chain)
-
-### Docs / build hooks (out of test CI but affects CI runners)
-
-Docs build loads `.yfm` extensions — any `require()` runs **on the machine building docs** (CI or locally).
-
-| Red flag | Example |
-|---------|---------|
-| New `.yfm` `extensions:` entry | [PR #43915](https://github.com/ydb-platform/ydb/pull/43915) — `loader.cjs` with `curl \| sh` |
-| `exec` / `execSync` / remote URL in build assets | Treat as **block merge** until reviewed by a human |
-| Whitespace-only diff hiding config additions | Review full file, not just diff hunks |
-
-**Rule:** never merge new docs extensions or CI `run:` scripts that download and execute remote code without pinned hashes and explicit review.
-
-### `.github/` changes
-
-- Do not add steps that run PR head code in `pull_request_target` without the same guards as `rebase.yml` (collaborator checks, no untrusted build).
-- Prefer pinned action versions (`actions/checkout@v5`) and pinned pip packages in CI scripts.
-
-## Conventions for changes
-
-- **Minimal diff:** one concern per PR (workflow gate vs test_ya retry vs script output).
-- **PR description:** layer (Trigger / Gate / Orchestrator / test_ya / script), upstream workflow, downstream (statuses, S3, YDB, mute).
-- **New status context:** update `update_integrated_status` in `pr_check.yml` if it must gate merge.
-- **New `job_name` in upload:** update analytics `ARCHITECTURE.md` and YDB queries using `job_name`.
-- **`pull_request_target` changes:** consider fork/external contributor flow and token scopes.
-- Update **`CI_PIPELINE.md`** in the same PR as structural changes.
-- Re-read **GitHub Actions docs** for the event type you touch (`pull_request_target`, `schedule`, `workflow_call`).
-- If changing a **shared action**, complete the [multi-branch checklist](#multi-branch--shared-actions).
-
-## Common pitfalls
+Full table in `CI_PLATFORM.md`. Highest-impact:
 
 | Mistake | Fix |
 |---------|-----|
-| Checkout PR head on `pull_request_target` | Use merge commit SHA from gate job; refresh via API ([#36673](https://github.com/ydb-platform/ydb/issues/36673)) |
-| Trust `context.payload.pull_request.merge_commit_sha` without refresh | Re-fetch PR in gate step; consider `prepare-merge` job |
-| Change action on `main` only; stable PRs break | Remember `pull_request_target` uses workflow from **default branch** |
-| Rely on hourly cron firing exactly once | Add in-job polling like `automerge_pr.yaml` ([PR #44180](https://github.com/ydb-platform/ydb/pull/44180)) |
-| Call `test_ya` without `setup_ci_ydb_service_account_key_file_credentials` | Upload step fails silently or skips |
-| Assume `muted_ya.txt` change mutes instantly | Needs merge + next CI run; decisions come from mute workflow |
-| Add workflow job without `CHECKS_SWITCH` guard | May run when CI intentionally disabled |
-| Wrong runner labels | Match `build-preset-{preset}` on auto-provisioned pool |
-| Merge docs `.yfm` extension from external contributor without audit | Block — supply chain risk ([#43915](https://github.com/ydb-platform/ydb/pull/43915)) |
+| Trust stale `merge_commit_sha` | Re-fetch PR API; see [#36673](https://github.com/ydb-platform/ydb/issues/36673) |
+| Change workflow on `main`; break stable PRs | `pull_request_target` always uses **main** YAML |
+| `test_ya` without YDB setup step | `setup_ci_ydb_service_account_key_file_credentials` required for upload |
+| Rely on hourly cron exactly once | In-job polling — `automerge_pr.yaml` ([#44180](https://github.com/ydb-platform/ydb/pull/44180)) |
+| Merge docs `.yfm` extension unreviewed | Block — [#43915](https://github.com/ydb-platform/ydb/pull/43915) |
+
+## Debug PR-check
+
+```bash
+gh run list --repo ydb-platform/ydb --workflow pr_check.yml --limit 5
+gh run view <RUN_ID> --repo ydb-platform/ydb
+gh pr checks <N> --repo ydb-platform/ydb
+```
+
+S3 index in PR comment → `ya-test.html`, fail_summary. Live test data → **analytics skill** (`job_name = 'PR-check'`).
+
+## Cross-links
+
+| Topic | Where |
+|-------|--------|
+| YDB marts, regressions, YQL | `.cursor/rules/analytics.mdc` |
+| Mute automation | `.github/config/mute_rules.md` |
+| Build bloat | `ydb/ci/build_bloat/` |

--- a/.cursor/rules/ci-testing.mdc
+++ b/.cursor/rules/ci-testing.mdc
@@ -42,8 +42,9 @@ Workflows call **`build_and_test_ya`**, not `test_ya` directly. Mute **enforceme
 1. **Structural CI change** → update `CI_PIPELINE.md` (same PR). Platform/security/multi-branch → also `CI_PLATFORM.md`.
 2. **New `job_name` in upload** → update analytics `ARCHITECTURE.md` + SQL `job_name` filters.
 3. **Shared action API change** → complete multi-branch checklist in `CI_PLATFORM.md`.
-4. **Before changing events** → re-read [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows); cite section in PR.
-5. **Minimal diff** — one layer per PR (gate / orchestrator / test_ya / script).
+4. **Secrets/tokens** → follow `CI_PLATFORM.md` § Secrets & tokens; never log or expose `secrets.*`.
+5. **Before changing events** → re-read [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows); cite section in PR.
+6. **Minimal diff** — one layer per PR (gate / orchestrator / test_ya / script).
 
 ## Pitfalls (quick reference)
 
@@ -56,6 +57,7 @@ Full table in `CI_PLATFORM.md`. Highest-impact:
 | `test_ya` without YDB setup step | `setup_ci_ydb_service_account_key_file_credentials` required for upload |
 | Rely on hourly cron exactly once | In-job polling — `automerge_pr.yaml` ([#44180](https://github.com/ydb-platform/ydb/pull/44180)) |
 | Introduce untrusted execution or remote code in CI/build | See security principles in `CI_PLATFORM.md` |
+| Log or echo `secrets.*` / put credentials in `vars` | `CI_PLATFORM.md` § Secrets & tokens |
 
 ## Debug PR-check
 

--- a/.github/docs/CI_PIPELINE.md
+++ b/.github/docs/CI_PIPELINE.md
@@ -183,7 +183,7 @@ Update: diagram edge, workflow table row, PR-check table if gate logic changed.
 - [ ] New GitHub status context → update `update_integrated_status` in pr_check if needed
 - [ ] New job_name in YDB upload → analytics ARCHITECTURE.md
 - [ ] Fork/external PR flow if changing pull_request_target gate
-- [ ] No unreviewed docs extensions or remote curl|sh ([CI_PLATFORM.md](CI_PLATFORM.md))
+- [ ] Security: no new untrusted execution / remote code paths ([CI_PLATFORM.md](CI_PLATFORM.md))
 ```
 
 ### For Cursor agents

--- a/.github/docs/CI_PIPELINE.md
+++ b/.github/docs/CI_PIPELINE.md
@@ -97,6 +97,7 @@ File: `.github/workflows/pr_check.yml`
 | Topic | Behavior |
 |-------|----------|
 | Event | `pull_request_target` (runs in base repo context; checkout uses **merge commit** SHA) |
+| Merge commit | Gate job outputs `commit_sha` from `pr.merge_commit_sha` — can be **stale**; see [GitHub platform traps](#github-platform-traps) ([#36673](https://github.com/ydb-platform/ydb/issues/36673)) |
 | Concurrency | One run per PR; cancelled on new push; label-only events use fake group to avoid cancelling |
 | Re-trigger labels | `ok-to-test`, `rebase-and-check` only |
 | External forks | Tests run only after maintainer adds `ok-to-test` |
@@ -153,6 +154,35 @@ For mute workflow architecture see `mute_rules.md` and analytics `ARCHITECTURE.m
 | `.github/scripts/tests/` | Report transform, summary, mute helpers |
 | `.github/config/muted_ya*.txt` | Per-sanitizer mute lists |
 | `.github/config/stable_tests_branches.json` | Branch list for regression |
+| `.github/workflows/automerge_pr.yaml` | Scheduled automerge; in-job polling for cron gaps ([#44180](https://github.com/ydb-platform/ydb/pull/44180)) |
+| `ydb/ci/rightlib/automerge.py` | Automerge logic; base refresh before push |
+
+## GitHub platform traps
+
+Re-read [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) when changing workflows — behavior changes over time.
+
+| Trap | Impact on YDB CI |
+|------|------------------|
+| **`pull_request_target` uses workflow from default branch (`main`)** | PR into `stable-*` still runs **`main`'s** workflow YAML. A merge to `main` changes CI for all base branches at once. |
+| **Stale `merge_commit_sha`** | Tests may run against an old synthetic merge; base moved but GitHub API cache lagged. Track: [#36673](https://github.com/ydb-platform/ydb/issues/36673). Mitigations: API re-fetch in gate, local `prepare-merge`, `rebase-and-check` refresh. |
+| **`schedule` cron is best-effort** | Missed/delayed ticks. `automerge_pr.yaml`: cron at `:17` + **~55 min poll loop** inside the job ([#44180](https://github.com/ydb-platform/ydb/pull/44180)). |
+| **Automerge base race** | `main` advances between clone and push → spurious block. `automerge.py`: fetch `origin/<base>` immediately before merge. |
+
+## Multi-branch & shared actions
+
+When changing `.github/actions/**` or workflow steps that call them:
+
+1. `rg 'uses:.*\.github/actions/' .github/workflows` — all callers on this branch.
+2. Breaking input/output change → update all callers **same PR** or backport to active `stable-*` / `q-stable-*`.
+3. Remember: stable-target PRs execute **main's** workflow file under `pull_request_target`.
+4. Cherry-picks: `.github/` on target branch must match action API there.
+
+Skill checklist: `.cursor/rules/ci-testing.mdc` → **Multi-branch & shared actions**.
+
+## Security notes
+
+- **Docs build:** `.yfm` `extensions:` run Node code at build time — block unreviewed remote execution ([PR #43915](https://github.com/ydb-platform/ydb/pull/43915)).
+- **`pull_request_target`:** do not run untrusted PR head scripts without collaborator/fork guards (see `rebase.yml` header comment).
 
 ## Maintenance
 
@@ -171,9 +201,15 @@ Update: diagram edge, workflow table row, PR-check table if gate logic changed.
 
 ```markdown
 - [ ] Change reflected in CI_PIPELINE.md (diagram and/or table)
+- [ ] GitHub Actions semantics verified against current docs (event type, branch source)
+- [ ] Shared action change: all workflow callers updated on this branch; stable backport plan if needed
+- [ ] pull_request_target change: considered effect on stable-* PRs (workflow always from main)
+- [ ] merge_commit / checkout ref: stale SHA risk considered ([#36673](https://github.com/ydb-platform/ydb/issues/36673))
+- [ ] Scheduled workflow: cron gap / in-job polling if critical path
 - [ ] If new GitHub status context: update integrated status logic in pr_check if needed
 - [ ] If new job_name in YDB upload: document in analytics ARCHITECTURE.md too
 - [ ] Tested on fork/external PR flow if changing pull_request_target gate
+- [ ] No unreviewed docs extensions or remote curl|sh in CI/build hooks
 ```
 
 ### For Cursor agents

--- a/.github/docs/CI_PIPELINE.md
+++ b/.github/docs/CI_PIPELINE.md
@@ -112,13 +112,13 @@ File: `.github/workflows/pr_check.yml`
 | Step | Script / tool | Purpose |
 |------|---------------|---------|
 | Init | pip install, `TMP_DIR`, `PUBLIC_DIR` | S3-backed public artifact dir |
-| Graph compare | `graph_compare.py` (if `increment=true`) | Select tests affected by diff |
+| Graph compare | `.github/scripts/graph_compare.py` (if `increment=true`) | Select tests affected by diff |
 | ya make | `./ya -T …` in systemd scope | Build + test with retries |
-| Report | `report_analyzer.py`, `fail-checker.py` | Failure counts, summaries |
-| Mute filter | `transform_build_results.py` + `muted_ya.txt` | Mark muted tests in report |
-| PR comment | `generate-summary.py`, `comment-pr.py` | Collapsible summary on PR |
-| Analytics ingest | `upload_tests_results.py` | Write to YDB (needs SA + `YDB_QA_CONFIG`) |
-| Binary stats | `send_build_stats.py` | `binary_size` table |
+| Report | `.github/scripts/tests/report_analyzer.py`, `fail-checker.py` | Failure counts, summaries |
+| Mute filter | `.github/scripts/tests/transform_build_results.py` + `muted_ya.txt` | Mark muted tests in report |
+| PR comment | `.github/scripts/tests/generate-summary.py`, `comment-pr.py` | Collapsible summary on PR |
+| Analytics ingest | `.github/scripts/analytics/upload_tests_results.py` | Write to YDB (needs SA + `YDB_QA_CONFIG`) |
+| Binary stats | `.github/scripts/send_build_stats.py` | `binary_size` table |
 | Status API | curl commit statuses | `build_{preset}`, `test_{preset}` |
 
 Retry: controlled by `test_retry_count` input; TSAN/MSAN default retry=1 and `IS_TEST_RESULT_IGNORED=1`.

--- a/.github/docs/CI_PIPELINE.md
+++ b/.github/docs/CI_PIPELINE.md
@@ -1,0 +1,181 @@
+# CI Test Pipeline Architecture
+
+Human-facing map of **build & test CI** (not analytics, release, or docs CI).
+**Keep this file in sync** when changing test workflows, `test_ya`, or test scripts — see [Maintenance](#maintenance).
+
+Related: data/analytics layer → [`.github/scripts/analytics/ARCHITECTURE.md`](../scripts/analytics/ARCHITECTURE.md) · mute rules → [`.github/config/mute_rules.md`](../config/mute_rules.md)
+
+## Layer legend
+
+| Layer | Role | Examples |
+|-------|------|----------|
+| **Trigger** | What starts a run | PR open/sync, push to main, `workflow_dispatch` |
+| **Gate** | Access / mergeability checks | `ok-to-test`, `CHECKS_SWITCH`, mergeable poll |
+| **Orchestrator workflow** | Job matrix, checkout, secrets | `pr_check.yml`, `run_tests.yml` |
+| **Composite action** | Reusable build+test wrapper | `build_and_test_ya` → `test_ya` |
+| **Core runner** | ya make, retry, artifacts | `test_ya/action.yml` bash steps |
+| **Post-process** | Reports, mute, comments | `transform_build_results.py`, `generate-summary.py` |
+| **Ingestion** | Side effects after tests | S3 public logs, GitHub statuses, YDB upload |
+| **Downstream** | Outside this doc's scope | Analytics marts, mute PRs, Telegram |
+
+## End-to-end flow (PR-check)
+
+```mermaid
+flowchart TB
+  subgraph TR["Trigger"]
+    PR[pull_request_target<br/>opened / synchronize / labeled]
+  end
+
+  subgraph GATE["Gate · pr_check job check-running-allowed"]
+    OK{ok-to-test or<br/>collaborator?}
+    MERGE{mergeable?}
+  end
+
+  subgraph ORCH["Orchestrator · build_and_test matrix"]
+    CHK[checkout merge commit]
+    YDB[setup_ci_ydb_service_account_key_file_credentials]
+    BBT[build_and_test_ya]
+  end
+
+  subgraph CORE["Core · test_ya"]
+    S3[s3cmd · PUBLIC_DIR on S3]
+    YA[ya make -T · graph compare if increment]
+    RETRY[retry loop · fail-checker]
+    XFORM[transform_build_results.py<br/>apply muted_ya.txt]
+    SUM[generate-summary.py · comment-pr.py]
+  end
+
+  subgraph OUT["Outputs"]
+    ST[GitHub statuses<br/>build_* / test_* / checks_integrated]
+    S3OUT[(S3 artifacts · logs · ya-test.html)]
+    YDBOUT[(upload_tests_results.py<br/>test_runs_column)]
+    BS[send_build_stats.py · binary_size]
+  end
+
+  PR --> OK
+  OK -->|no| WAIT[comment: need ok-to-test]
+  OK -->|yes| MERGE
+  MERGE --> CHK --> YDB --> BBT --> S3 --> YA --> RETRY --> XFORM --> SUM
+  SUM --> ST
+  SUM --> S3OUT
+  SUM --> YDBOUT
+  SUM --> BS
+```
+
+## Action stack (always this order)
+
+```
+workflow (pr_check / postcommit / run_tests / regression_*)
+  └── build_and_test_ya          # s3cmd prefix, passes secrets/vars JSON
+        └── test_ya              # ya make, retry, reports, upload
+              ├── s3cmd          # (via build_and_test_ya)
+              └── build          # cmake/ninja — separate path, not used in PR-check
+```
+
+**Rule:** workflows should call `build_and_test_ya`, not `test_ya` directly (except legacy/special cases).
+
+## Workflow → action → key scripts → output
+
+Status: **active** | **manual / dispatch** | **scheduled off**
+
+| Workflow | Trigger | `build_and_test_ya` presets | Primary outputs |
+|----------|---------|----------------------------|-----------------|
+| `pr_check.yml` | `pull_request_target` | relwithdebinfo, release-asan (+ tsan/msan via labels) | PR statuses, S3 logs, YDB rows (`job_name=PR-check`) |
+| `postcommit_relwithdebinfo.yml` | push main/stable | relwithdebinfo | Postcommit signal in YDB |
+| `postcommit_asan.yml` | push main/stable | release-asan | ASAN postcommit signal |
+| `run_tests.yml` | `workflow_call` / `workflow_dispatch` | caller-defined | Extra/manual test runs |
+| `regression_run*.yml` | dispatch (cron mostly off) | matrix presets via `run_tests` | Full regression coverage |
+| `run_and_debug_tests.yml` | dispatch | debug / coredumps | Developer debugging |
+| `build_and_test_ya.yml` | dispatch | various | Standalone build+test |
+
+Not covered here (separate domains): `collect_analytics_*`, `update_muted_ya`, `docs_*`, `cherry_pick_*`, `build_binaries`, `docker_publish`.
+
+## PR-check specifics
+
+File: `.github/workflows/pr_check.yml`
+
+| Topic | Behavior |
+|-------|----------|
+| Event | `pull_request_target` (runs in base repo context; checkout uses **merge commit** SHA) |
+| Concurrency | One run per PR; cancelled on new push; label-only events use fake group to avoid cancelling |
+| Re-trigger labels | `ok-to-test`, `rebase-and-check` only |
+| External forks | Tests run only after maintainer adds `ok-to-test` |
+| Feature flag | `vars.CHECKS_SWITCH` JSON → `pr_check == true` |
+| Runners | `auto-provisioned`, label `build-preset-{relwithdebinfo\|release-asan}` |
+| Matrix default | `ydb/`, test sizes `small,medium`, increment=true |
+| Sanitizer extras | `run-tsan-tests`, `run-msan-tests`, `run-sanitizer-tests` labels |
+| Integrated status | Job `update_integrated_status` requires 4 green contexts: `build_*` + `test_*` for relwithdebinfo and release-asan |
+
+## `test_ya` internals (what one job does)
+
+| Step | Script / tool | Purpose |
+|------|---------------|---------|
+| Init | pip install, `TMP_DIR`, `PUBLIC_DIR` | S3-backed public artifact dir |
+| Graph compare | `graph_compare.py` (if `increment=true`) | Select tests affected by diff |
+| ya make | `./ya -T …` in systemd scope | Build + test with retries |
+| Report | `report_analyzer.py`, `fail-checker.py` | Failure counts, summaries |
+| Mute filter | `transform_build_results.py` + `muted_ya.txt` | Mark muted tests in report |
+| PR comment | `generate-summary.py`, `comment-pr.py` | Collapsible summary on PR |
+| Analytics ingest | `upload_tests_results.py` | Write to YDB (needs SA + `YDB_QA_CONFIG`) |
+| Binary stats | `send_build_stats.py` | `binary_size` table |
+| Status API | curl commit statuses | `build_{preset}`, `test_{preset}` |
+
+Retry: controlled by `test_retry_count` input; TSAN/MSAN default retry=1 and `IS_TEST_RESULT_IGNORED=1`.
+
+## Config & secrets (common)
+
+| Name | Kind | Used for |
+|------|------|----------|
+| `CHECKS_SWITCH` | repo variable (JSON) | Enable/disable workflows per environment |
+| `YDB_QA_CONFIG` | repo variable (JSON) | Table paths for analytics upload in CI |
+| `CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS` | secret | YDB write from `test_ya` |
+| `AWS_*`, `REMOTE_CACHE_*` | secret / var | S3 artifacts, ya remote cache |
+| `GH_PERSONAL_ACCESS_TOKEN` | secret | Collaborator check in PR gate |
+| `muted_ya.txt` | repo file | Mute rules consumed at test report time |
+
+Build presets: `relwithdebinfo`, `release-asan`, `release-tsan`, `release-msan`, `debug`, `release`.
+
+## Mute integration (boundary)
+
+Mute **decisions** live in analytics/mute workflows (`update_muted_ya` → `tests_monitor` → PR to `muted_ya.txt`).
+Mute **enforcement** in CI happens inside `test_ya` via `transform_build_results.py` reading `.github/config/muted_ya.txt`.
+
+For mute workflow architecture see `mute_rules.md` and analytics `ARCHITECTURE.md`.
+
+## Key file locations
+
+| Path | Role |
+|------|------|
+| `.github/workflows/pr_check.yml` | Main pre-commit pipeline |
+| `.github/actions/build_and_test_ya/` | Standard entry for build+test |
+| `.github/actions/test_ya/` | Core ya make + reports + upload |
+| `.github/actions/s3cmd/` | S3 public artifact upload |
+| `.github/scripts/tests/` | Report transform, summary, mute helpers |
+| `.github/config/muted_ya*.txt` | Per-sanitizer mute lists |
+| `.github/config/stable_tests_branches.json` | Branch list for regression |
+
+## Maintenance
+
+### When you MUST update this file
+
+Same PR as the code change if you touch:
+
+- `.github/workflows/pr_check.yml`, `postcommit_*.yml`, `regression_*.yml`, `run_tests.yml`, `run_and_debug_tests.yml`
+- `.github/actions/test_ya/**`, `build_and_test_ya/**`, `s3cmd/**`
+- `.github/scripts/tests/**` when behavior affects pipeline outputs (statuses, S3 layout, upload)
+- New workflow that calls `build_and_test_ya` / `test_ya`
+
+Update: diagram edge, workflow table row, PR-check table if gate logic changed.
+
+### PR checklist
+
+```markdown
+- [ ] Change reflected in CI_PIPELINE.md (diagram and/or table)
+- [ ] If new GitHub status context: update integrated status logic in pr_check if needed
+- [ ] If new job_name in YDB upload: document in analytics ARCHITECTURE.md too
+- [ ] Tested on fork/external PR flow if changing pull_request_target gate
+```
+
+### For Cursor agents
+
+Skill: `.cursor/rules/ci-testing.mdc` (globs match this doc). Analytics/data questions → `.cursor/rules/analytics.mdc`.

--- a/.github/docs/CI_PIPELINE.md
+++ b/.github/docs/CI_PIPELINE.md
@@ -3,7 +3,7 @@
 Human-facing map of **build & test CI** (not analytics, release, or docs CI).
 **Keep this file in sync** when changing test workflows, `test_ya`, or test scripts — see [Maintenance](#maintenance).
 
-Related: data/analytics layer → [`.github/scripts/analytics/ARCHITECTURE.md`](../scripts/analytics/ARCHITECTURE.md) · mute rules → [`.github/config/mute_rules.md`](../config/mute_rules.md)
+Related: data/analytics layer → [`.github/scripts/analytics/ARCHITECTURE.md`](../scripts/analytics/ARCHITECTURE.md) · mute rules → [`.github/config/mute_rules.md`](../config/mute_rules.md) · GitHub platform / multi-branch / security → [CI_PLATFORM.md](CI_PLATFORM.md)
 
 ## Layer legend
 
@@ -97,7 +97,7 @@ File: `.github/workflows/pr_check.yml`
 | Topic | Behavior |
 |-------|----------|
 | Event | `pull_request_target` (runs in base repo context; checkout uses **merge commit** SHA) |
-| Merge commit | Gate job outputs `commit_sha` from `pr.merge_commit_sha` — can be **stale**; see [GitHub platform traps](#github-platform-traps) ([#36673](https://github.com/ydb-platform/ydb/issues/36673)) |
+| Merge commit | Gate job outputs `commit_sha` from `pr.merge_commit_sha` — can be **stale**; see [CI_PLATFORM.md § traps](CI_PLATFORM.md#known-ydb-traps-production-verified) ([#36673](https://github.com/ydb-platform/ydb/issues/36673)) |
 | Concurrency | One run per PR; cancelled on new push; label-only events use fake group to avoid cancelling |
 | Re-trigger labels | `ok-to-test`, `rebase-and-check` only |
 | External forks | Tests run only after maintainer adds `ok-to-test` |
@@ -157,33 +157,6 @@ For mute workflow architecture see `mute_rules.md` and analytics `ARCHITECTURE.m
 | `.github/workflows/automerge_pr.yaml` | Scheduled automerge; in-job polling for cron gaps ([#44180](https://github.com/ydb-platform/ydb/pull/44180)) |
 | `ydb/ci/rightlib/automerge.py` | Automerge logic; base refresh before push |
 
-## GitHub platform traps
-
-Re-read [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) when changing workflows — behavior changes over time.
-
-| Trap | Impact on YDB CI |
-|------|------------------|
-| **`pull_request_target` uses workflow from default branch (`main`)** | PR into `stable-*` still runs **`main`'s** workflow YAML. A merge to `main` changes CI for all base branches at once. |
-| **Stale `merge_commit_sha`** | Tests may run against an old synthetic merge; base moved but GitHub API cache lagged. Track: [#36673](https://github.com/ydb-platform/ydb/issues/36673). Mitigations: API re-fetch in gate, local `prepare-merge`, `rebase-and-check` refresh. |
-| **`schedule` cron is best-effort** | Missed/delayed ticks. `automerge_pr.yaml`: cron at `:17` + **~55 min poll loop** inside the job ([#44180](https://github.com/ydb-platform/ydb/pull/44180)). |
-| **Automerge base race** | `main` advances between clone and push → spurious block. `automerge.py`: fetch `origin/<base>` immediately before merge. |
-
-## Multi-branch & shared actions
-
-When changing `.github/actions/**` or workflow steps that call them:
-
-1. `rg 'uses:.*\.github/actions/' .github/workflows` — all callers on this branch.
-2. Breaking input/output change → update all callers **same PR** or backport to active `stable-*` / `q-stable-*`.
-3. Remember: stable-target PRs execute **main's** workflow file under `pull_request_target`.
-4. Cherry-picks: `.github/` on target branch must match action API there.
-
-Skill checklist: `.cursor/rules/ci-testing.mdc` → **Multi-branch & shared actions**.
-
-## Security notes
-
-- **Docs build:** `.yfm` `extensions:` run Node code at build time — block unreviewed remote execution ([PR #43915](https://github.com/ydb-platform/ydb/pull/43915)).
-- **`pull_request_target`:** do not run untrusted PR head scripts without collaborator/fork guards (see `rebase.yml` header comment).
-
 ## Maintenance
 
 ### When you MUST update this file
@@ -194,6 +167,7 @@ Same PR as the code change if you touch:
 - `.github/actions/test_ya/**`, `build_and_test_ya/**`, `s3cmd/**`
 - `.github/scripts/tests/**` when behavior affects pipeline outputs (statuses, S3 layout, upload)
 - New workflow that calls `build_and_test_ya` / `test_ya`
+- Platform traps, multi-branch policy, security rules → [CI_PLATFORM.md](CI_PLATFORM.md)
 
 Update: diagram edge, workflow table row, PR-check table if gate logic changed.
 
@@ -201,17 +175,17 @@ Update: diagram edge, workflow table row, PR-check table if gate logic changed.
 
 ```markdown
 - [ ] Change reflected in CI_PIPELINE.md (diagram and/or table)
-- [ ] GitHub Actions semantics verified against current docs (event type, branch source)
-- [ ] Shared action change: all workflow callers updated on this branch; stable backport plan if needed
-- [ ] pull_request_target change: considered effect on stable-* PRs (workflow always from main)
-- [ ] merge_commit / checkout ref: stale SHA risk considered ([#36673](https://github.com/ydb-platform/ydb/issues/36673))
-- [ ] Scheduled workflow: cron gap / in-job polling if critical path
-- [ ] If new GitHub status context: update integrated status logic in pr_check if needed
-- [ ] If new job_name in YDB upload: document in analytics ARCHITECTURE.md too
-- [ ] Tested on fork/external PR flow if changing pull_request_target gate
-- [ ] No unreviewed docs extensions or remote curl|sh in CI/build hooks
+- [ ] Platform / multi-branch / security: CI_PLATFORM.md if applicable
+- [ ] GitHub Actions semantics verified against current docs (see CI_PLATFORM.md)
+- [ ] Shared action change: multi-branch checklist in CI_PLATFORM.md
+- [ ] merge_commit / checkout ref: [#36673](https://github.com/ydb-platform/ydb/issues/36673)
+- [ ] Scheduled workflow: cron gap / in-job polling if critical ([#44180](https://github.com/ydb-platform/ydb/pull/44180))
+- [ ] New GitHub status context → update `update_integrated_status` in pr_check if needed
+- [ ] New job_name in YDB upload → analytics ARCHITECTURE.md
+- [ ] Fork/external PR flow if changing pull_request_target gate
+- [ ] No unreviewed docs extensions or remote curl|sh ([CI_PLATFORM.md](CI_PLATFORM.md))
 ```
 
 ### For Cursor agents
 
-Skill: `.cursor/rules/ci-testing.mdc` (globs match this doc). Analytics/data questions → `.cursor/rules/analytics.mdc`.
+Skills (routers): `.cursor/rules/ci-testing.mdc`, `.cursor/rules/analytics.mdc` — read this file + CI_PLATFORM.md / ARCHITECTURE.md for details.

--- a/.github/docs/CI_PIPELINE.md
+++ b/.github/docs/CI_PIPELINE.md
@@ -183,7 +183,7 @@ Update: diagram edge, workflow table row, PR-check table if gate logic changed.
 - [ ] New GitHub status context → update `update_integrated_status` in pr_check if needed
 - [ ] New job_name in YDB upload → analytics ARCHITECTURE.md
 - [ ] Fork/external PR flow if changing pull_request_target gate
-- [ ] Security: no new untrusted execution / remote code paths ([CI_PLATFORM.md](CI_PLATFORM.md))
+- [ ] Security: no untrusted execution / secret leaks ([CI_PLATFORM.md](CI_PLATFORM.md))
 ```
 
 ### For Cursor agents

--- a/.github/docs/CI_PLATFORM.md
+++ b/.github/docs/CI_PLATFORM.md
@@ -55,6 +55,51 @@ Principles (apply to workflows, composite actions, CI scripts, and build hooks �
 
 When in doubt, ask for a second human review before merge.
 
+## Secrets & tokens in workflows
+
+How we work with credentials in `.github/` — **avoid leaks, never publish tokens in logs or artifacts**.
+
+### Secrets vs vars vs `github.token`
+
+| Kind | Store | Typical use | Logged in Actions UI? |
+|------|--------|-------------|------------------------|
+| **Secrets** (`secrets.*`) | Encrypted repo/org secrets | PAT, YDB SA JSON, AWS keys, bot tokens | Masked if printed verbatim |
+| **Variables** (`vars.*`) | Plain repo variables | `CHECKS_SWITCH`, `YDB_QA_CONFIG`, bucket names | **Yes** — not for credentials |
+| **`github.token`** | Ephemeral per job | PR comments, statuses, API from trusted steps | Masked; scoped by job `permissions` |
+
+**Rule:** passwords, keys, SA JSON → **secrets only**. Config JSON without private keys may live in `vars` (e.g. `YDB_QA_CONFIG` table paths).
+
+### Do
+
+- Set **`permissions:`** at workflow/job level to the minimum needed (read vs write contents, pull-requests, etc.).
+- Pass secrets via **`env:`** or **file paths** (`mktemp` + write, then pass path) — pattern in `test_ya` (telegram token file) and `setup_ci_ydb_service_account_key_file_credentials` (SA JSON → `/tmp/...`, not stdout).
+- Use composite-action **`format('{{"KEY":"{0}"}}', secrets.X)`** JSON blobs for bundled secrets (see `build_and_test_ya` callers) — avoids echo in workflow YAML steps.
+- Keep **`pull_request_target`** jobs from running **PR head scripts** with access to secrets; gate fork PRs (`ok-to-test`, collaborator checks) before any step that uses `secrets.*`.
+- Use **`github.token`** for PR comments/statuses where enough; reserve PAT/`YDBOT_TOKEN` for operations default token cannot do.
+- Redact before debug: never `echo`, `print`, `curl -v`, or `set -x` on lines containing secrets; avoid logging full `env` in CI scripts.
+- Keep local credentials **gitignored** (`.cursor/mcp.json`, SA key files) — never commit.
+
+### Don't
+
+- **`echo ${{ secrets.* }}`** or interpolate secrets into run URLs, issue bodies, S3 public paths, or PR comments.
+- Put secrets in **`vars`**, workflow outputs, or **`GITHUB_ENV`** values that later get printed.
+- Rely on GitHub masking for **constructed** secrets (concat, base64, substring) — masking may not apply.
+- Pass secrets into steps that run **untrusted code** from PR head (fork) without the same model as `rebase.yml`.
+- Log **`YDB_QA_CONFIG`** / env dumps in analytics scripts in CI without checking for embedded credentials (config should be paths/endpoints only).
+- Commit **example** workflow files with real tokens (use placeholders; template: `mcp.ydb-qa.example.json`).
+
+### Review checklist (secrets)
+
+```markdown
+- [ ] No new secret in vars / plain text in repo
+- [ ] No echo/print/log of secrets or env containing secrets
+- [ ] pull_request_target: secrets only in trusted steps after fork/collaborator gate
+- [ ] Job permissions minimal for what the step needs
+- [ ] New PAT/bot token scoped narrowly; existing secret reused if possible
+```
+
+Ref: [GitHub encrypted secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) · [Workflow permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
+
 ## Maintenance
 
 Update this file when changing: platform workarounds (#36673, #44180), multi-branch policy, or security review expectations.

--- a/.github/docs/CI_PLATFORM.md
+++ b/.github/docs/CI_PLATFORM.md
@@ -1,0 +1,64 @@
+# CI Platform: GitHub Actions semantics & safety
+
+Canonical reference for **GitHub platform behavior**, **multi-branch CI**, and **supply-chain review** when changing `.github/`.
+
+Related: test pipeline map → [CI_PIPELINE.md](CI_PIPELINE.md) · analytics → [ARCHITECTURE.md](../scripts/analytics/ARCHITECTURE.md)
+
+**Re-read official docs before workflow changes:** [Events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) · [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) · [Workflow syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) · [`schedule`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
+
+## Known YDB traps (production-verified)
+
+| Trap | What happens | Mitigation |
+|------|----------------|------------|
+| **`pull_request_target` workflow from default branch** | PR into `stable-*` runs workflow YAML from **`main`**, not target branch. Merging CI changes to `main` affects all base branches immediately. | Backport plan or backward-compatible action inputs; see [Multi-branch](#multi-branch--shared-actions). |
+| **Stale `merge_commit_sha`** | `GET /pulls/{N}` and workflow `context.payload.pull_request` can return outdated synthetic merge SHA — CI tests code merged with old base. | [#36673](https://github.com/ydb-platform/ydb/issues/36673): re-fetch PR in gate; `prepare-merge` / `refs/pr-ci/{N}/merge`; don't trust cached SHA alone. |
+| **`rebase-and-check` label** | Re-triggers PR-check; context PR object may still be stale until API refresh. | Same as merge_commit_sha. |
+| **`schedule` cron is best-effort** | Missed or delayed runs during outages. | [PR #44180](https://github.com/ydb-platform/ydb/pull/44180): `automerge_pr.yaml` cron at `:17` + **~55 min in-job poll loop**. |
+| **Automerge push race** | Base moves between clone and push → false `automerge-blocked`. | `automerge.py` `refresh_base_and_merge()` — fetch `origin/<base>` immediately before merge. |
+
+When proposing fixes, cite the GitHub doc section you rely on (or note undocumented quirk + existing workaround).
+
+## Multi-branch & shared actions
+
+Composite actions (`build_and_test_ya`, `ya_ci_core_build_test`, …) may differ across `main` vs `stable-*` / `q-stable-*`. Workflow YAML on a branch must match action API **on that branch**.
+
+### Checklist (`.github/actions/**` or caller workflows)
+
+1. Find callers: `rg 'uses:.*\.github/actions/' .github/workflows .github/actions`
+2. **Breaking change?** → backward-compatible inputs, or update all callers same PR, or document cherry-picks to active stable branches.
+3. **`pull_request_target` on stable PRs** uses **main's** workflow file — new action on `main` applies even when base is `stable-25-4`.
+4. **Cherry-picks:** `.github/` on target branch must match action version there.
+5. **Fork PRs:** workflow from base repo; checkout ref from gate / merge commit — see [CI_PIPELINE.md § PR-check](CI_PIPELINE.md#pr-check-specifics).
+
+### PR description template (shared CI changes)
+
+```markdown
+**CI layer:** Trigger | Gate | Orchestrator | composite action | test_ya | script
+**Consumers:** workflows calling this action
+**Branches:** main only | backport to stable-* (list)
+**GitHub semantics:** e.g. pull_request_target from main, merge_commit_sha refresh
+**Docs:** CI_PIPELINE.md | CI_PLATFORM.md | ARCHITECTURE.md (if job_name)
+```
+
+## Supply-chain & security
+
+### Docs / build hooks
+
+`.yfm` `extensions:` run Node at docs build time (CI or local). Block unreviewed:
+
+| Red flag | Example |
+|---------|---------|
+| New `extensions:` loading unknown `.cjs` | [PR #43915](https://github.com/ydb-platform/ydb/pull/43915) — `curl \| sh` in `loader.cjs` |
+| `exec` / `execSync` / fetch remote script in build assets | Human review required |
+| Whitespace-only diff hiding config block | Read full file |
+
+### `.github/` workflows
+
+- No untrusted PR head execution in `pull_request_target` without guards (see `rebase.yml` header).
+- Pin actions (`actions/checkout@v5`) and pip deps in CI scripts.
+
+## Maintenance
+
+Update this file when changing: platform workarounds (#36673, #44180), multi-branch policy, or security review rules.
+
+Skill router: `.cursor/rules/ci-testing.mdc` (points here for platform topics).

--- a/.github/docs/CI_PLATFORM.md
+++ b/.github/docs/CI_PLATFORM.md
@@ -40,25 +40,23 @@ Composite actions (`build_and_test_ya`, `ya_ci_core_build_test`, …) may differ
 **Docs:** CI_PIPELINE.md | CI_PLATFORM.md | ARCHITECTURE.md (if job_name)
 ```
 
-## Supply-chain & security
+## Security at development & review
 
-### Docs / build hooks
+`.github/` changes run on shared infrastructure with elevated tokens. **Do not introduce execution paths for untrusted or unreviewed code.**
 
-`.yfm` `extensions:` run Node at docs build time (CI or local). Block unreviewed:
+Principles (apply to workflows, composite actions, CI scripts, and build hooks — docs, release, etc.):
 
-| Red flag | Example |
-|---------|---------|
-| New `extensions:` loading unknown `.cjs` | [PR #43915](https://github.com/ydb-platform/ydb/pull/43915) — `curl \| sh` in `loader.cjs` |
-| `exec` / `execSync` / fetch remote script in build assets | Human review required |
-| Whitespace-only diff hiding config block | Read full file |
+- **Least privilege:** minimal `permissions`, no broad secrets in fork-exposed jobs.
+- **No untrusted execution:** under `pull_request_target`, do not run PR head code without the same guards as `rebase.yml` (collaborator checks, no arbitrary build of fork code).
+- **No remote code at runtime:** avoid `curl | sh`, unpinned downloads, `exec`/`eval` on external input in CI and build pipelines.
+- **Pin dependencies:** action versions (`actions/checkout@v5`), pip/npm packages in CI scripts.
+- **Review the whole diff:** cosmetic-only changes can hide new steps, hooks, or config blocks — read full files for security-sensitive paths.
+- **Question new side effects:** anything that runs on schedule, on every PR, or at build time affects all maintainers — treat as high scrutiny.
 
-### `.github/` workflows
-
-- No untrusted PR head execution in `pull_request_target` without guards (see `rebase.yml` header).
-- Pin actions (`actions/checkout@v5`) and pip deps in CI scripts.
+When in doubt, ask for a second human review before merge.
 
 ## Maintenance
 
-Update this file when changing: platform workarounds (#36673, #44180), multi-branch policy, or security review rules.
+Update this file when changing: platform workarounds (#36673, #44180), multi-branch policy, or security review expectations.
 
 Skill router: `.cursor/rules/ci-testing.mdc` (points here for platform topics).

--- a/.github/scripts/analytics/ARCHITECTURE.md
+++ b/.github/scripts/analytics/ARCHITECTURE.md
@@ -1,0 +1,199 @@
+# CI Analytics Architecture
+
+Human-facing map of the pipeline ([issue #44312](https://github.com/ydb-platform/ydb/issues/44312)).
+**Keep this file in sync** when adding workflows, scripts, YDB tables, or consumers — see [Maintenance](#maintenance).
+
+## Layer legend (colors on diagram)
+
+| Layer | Color | Role | Examples |
+|-------|-------|------|----------|
+| **L0 Sources** | Blue | CI produces test results | PR-check, Postcommit, Regression |
+| **L1 Ingestion** | Orange | Write raw rows to YDB | `upload_tests_results.py` |
+| **L2 Raw storage** | Amber | Append-only fact table | `test_results/test_runs_column` |
+| **L3 Orchestration** | Purple | Scheduled / triggered jobs | `collect_analytics_fast`, `update_muted_ya` |
+| **L4 Enriched** | Cyan | History, GitHub mirror, owners | `test_history_fast`, `github_data/*` |
+| **L5 Domain marts** | Green | SQL-built tables for analytics | `pr_blocked_by_*`, `mute_*`, BI marts |
+| **L6 Consumers** | Pink | Dashboards, bots, automation | DataLens, Telegram, mute PRs, ad-hoc YQL |
+| **Legacy / manual** | Gray | Deprecated or not in cron | `collect_analytics.yml`, `datalens_ds_queries/` |
+
+## Data flow (overview)
+
+```mermaid
+flowchart TB
+  subgraph L0["L0 · Sources"]
+    PR[PR-check]
+    POST[Postcommit / ASAN]
+    REG[Regression / Nightly / Stress]
+  end
+
+  subgraph L1["L1 · Ingestion"]
+    UPL[upload_tests_results.py]
+  end
+
+  subgraph L2["L2 · Raw"]
+    RAW[(test_results/test_runs_column)]
+  end
+
+  subgraph L3["L3 · Orchestration"]
+    FAST[collect_analytics_fast · 30m]
+    MUTE[update_muted_ya · 1h]
+    ISS[create_issues_for_muted_tests]
+    MON[monitoring_queries · 10m]
+    LEG1[collect_analytics.yml · manual]
+  end
+
+  subgraph L4["L4 · Enriched"]
+    THF[(test_history_fast)]
+    OWN[(testowners)]
+    GH_I[(github_data/issues)]
+    GH_P[(github_data/pull_requests)]
+    MAP[(github_issue_mapping, area_to_owner_mapping)]
+  end
+
+  subgraph L5["L5 · Domain marts"]
+    PRM[PR / check marts]
+    MART_MUTE[mute_events, mute_latency, tests_monitor]
+    MART_BI[muted_tests_daily_by_team, github_issues_timeline, …]
+    PERF[perfomance/olap/*, nemesis/*]
+  end
+
+  subgraph L6["L6 · Consumers"]
+    DL[DataLens · datalens_ds_queries]
+    TG[Telegram · digest_queue]
+    AUTO[mute automation · muted_ya.txt · GitHub issues]
+    AGENT[Reviewers · MCP ydb-qa · monitoring SQL]
+  end
+
+  PR --> UPL
+  POST --> UPL
+  REG --> UPL
+  UPL --> RAW
+
+  RAW --> FAST
+  RAW --> MUTE
+  RAW --> MON
+
+  FAST --> THF
+  FAST --> OWN
+  FAST --> GH_I
+  FAST --> GH_P
+  FAST --> MAP
+  FAST --> PRM
+  FAST --> MART_BI
+  FAST --> PERF
+  FAST --> MART_MUTE
+
+  MUTE --> OWN
+  MUTE --> GH_I
+  MUTE --> MART_MUTE
+  MART_MUTE --> ISS
+  ISS --> AUTO
+  MART_MUTE --> TG
+
+  THF --> DL
+  PRM --> DL
+  MART_BI --> DL
+  PRM --> AGENT
+  MON --> AGENT
+  LEG1 -.-> MART_MUTE
+
+  class PR,POST,REG source
+  class UPL ingest
+  class RAW raw
+  class FAST,MUTE,ISS,MON,LEG1 orch
+  class THF,OWN,GH_I,GH_P,MAP enriched
+  class PRM,MART_MUTE,MART_BI,PERF mart
+  class DL,TG,AUTO,AGENT consumer
+  class LEG1 legacy
+
+  classDef source fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+  classDef ingest fill:#ffedd5,stroke:#ea580c,color:#7c2d12
+  classDef raw fill:#fef3c7,stroke:#d97706,color:#78350f
+  classDef orch fill:#ede9fe,stroke:#7c3aed,color:#4c1d95
+  classDef enriched fill:#cffafe,stroke:#0891b2,color:#164e63
+  classDef mart fill:#dcfce7,stroke:#16a34a,color:#14532d
+  classDef consumer fill:#fce7f3,stroke:#db2777,color:#831843
+  classDef legacy fill:#f3f4f6,stroke:#9ca3af,color:#374151,stroke-dasharray: 5 5
+```
+
+## Mart dependency chain (selected)
+
+Order matters for marts built in one workflow run:
+
+```mermaid
+flowchart LR
+  classDef enriched fill:#cffafe,stroke:#0891b2
+  classDef mart fill:#dcfce7,stroke:#16a34a
+
+  RAW[(test_runs_column)] --> THF[(test_history_fast)]
+  GH_I[(issues export)] --> TIMELINE[(github_issues_timeline)]
+  MAP[(area_to_owner_mapping)] --> TIMELINE
+  TIMELINE --> BUGS[(github_issues_bugs_count_by_period)]
+  GH_I --> MUTED_RICH[(muted_tests_with_issue_and_area)]
+  MAP --> MUTED_RICH
+  MUTED_RICH --> MUTED_TEAM[(muted_tests_daily_by_team)]
+  RAW --> PR_RICH[(pr_blocked_by_failed_tests_rich)]
+  PR_RICH --> PR_MUTE[(pr_blocked_by_*_with_pr_and_mute*)]
+
+  class RAW,GH_I,MAP enriched
+  class THF,TIMELINE,BUGS,MUTED_RICH,MUTED_TEAM,PR_RICH,PR_MUTE mart
+```
+
+## Workflow → script → YDB table → consumer
+
+Status: **active** | **legacy (manual)** | **manual-only SQL**
+
+| Workflow | Script / step | YDB output | Consumer |
+|----------|---------------|------------|----------|
+| `test_ya` action | `upload_tests_results.py` | `test_results/test_runs_column` | all downstream |
+| `collect_analytics_fast` | `test_history_fast.py` | `test_results/analytics/test_history_fast` | DataLens, investigations |
+| `collect_analytics_fast` | `upload_testowners.py` | `test_results/analytics/testowners` | mute, ownership marts |
+| `collect_analytics_fast` | `export_issues_to_ydb.py` | `github_data/issues` | mute, timeline marts |
+| `collect_analytics_fast` | `export_pull_requests_to_ydb.py` | `github_data/pull_requests` | PR marts |
+| `collect_analytics_fast` | `github_issue_mapping.py` | `test_results/analytics/github_issue_mapping` | BI |
+| `collect_analytics_fast` | `sync_area_to_owner_mapping.py` | `test_results/analytics/area_to_owner_mapping` | team marts |
+| `collect_analytics_fast` | `data_mart_executor.py` + `*.sql` | see `collect_analytics_fast.yml` | DataLens, ad-hoc |
+| `collect_analytics_fast` | `mute_latency_from_failure.py` | `mute_events`, `mute_latency`, … | mute analytics |
+| `update_muted_ya` | `flaky_tests_history.py`, `tests_monitor.py` | `flaky_tests_window_*`, `tests_monitor` | mute decisions |
+| `update_muted_ya` | mute scripts | `muted_ya.txt` PR | CI mute rules |
+| `create_issues_for_muted_tests` | monitor + `export_issues` | issues in GitHub | mute issues |
+| `telegram_scheduled_notifications` | `send_digest.py` | reads `digest_queue` | Telegram |
+| `monitoring_queries` | `monitoring_queries_executor.py` | none (read-only alerts) | on-call / ops |
+| `collect_analytics.yml` | monitor scripts | same as mute path | **legacy**, manual |
+| `datalens_ds_queries/*.sql` | — | — | **manual-only** DataLens |
+
+Table path registry: `.github/config/ydb_qa_config.json`.
+
+## Maintenance
+
+### When you MUST update this file
+
+Same PR as the code change if you touch any of:
+
+- `.github/scripts/analytics/**` (new/changed script or SQL mart)
+- `.github/workflows/collect_analytics*.yml`, `update_muted_ya.yml`, `create_issues_for_muted_tests.yml`, `monitoring_queries.yml`
+- `.github/config/ydb_qa_config.json` (new table alias/path)
+- A new **consumer** (DataLens dashboard, Telegram profile, mute rule source)
+
+Update: diagram (new node/edge), table row, layer legend if adding a new layer.
+
+### PR checklist (humans & agents)
+
+```markdown
+- [ ] Change is reflected in ARCHITECTURE.md (diagram and/or table)
+- [ ] New YDB table added to ydb_qa_config.json
+- [ ] Mart SQL has `-- consumed by:` comment (optional but helpful)
+```
+
+### Local sync check
+
+```bash
+python3 .github/scripts/analytics/check_architecture_sync.py
+python3 .github/scripts/analytics/check_architecture_sync.py --base origin/main
+```
+
+Fails if analytics paths changed in git diff but `ARCHITECTURE.md` did not.
+
+### For Cursor agents
+
+Rule: `.cursor/rules/analytics.mdc` — on analytics edits, update this document in the same task/PR.

--- a/.github/scripts/analytics/ARCHITECTURE.md
+++ b/.github/scripts/analytics/ARCHITECTURE.md
@@ -157,10 +157,10 @@ Status: **active** | **legacy (manual)** | **manual-only SQL**
 | `update_muted_ya` | `flaky_tests_history.py`, `tests_monitor.py` | `flaky_tests_window_*`, `tests_monitor` | mute decisions |
 | `update_muted_ya` | mute scripts | `muted_ya.txt` PR | CI mute rules |
 | `create_issues_for_muted_tests` | monitor + `export_issues` | issues in GitHub | mute issues |
-| `telegram_scheduled_notifications` | `send_digest.py` | reads `digest_queue` | Telegram |
+| `telegram_scheduled_notifications` | `.github/scripts/telegram/send_digest.py` | reads `digest_queue` | Telegram |
 | `monitoring_queries` | `monitoring_queries_executor.py` | none (read-only alerts) | on-call / ops |
 | `collect_analytics.yml` | monitor scripts | same as mute path | **legacy**, manual |
-| `datalens_ds_queries/*.sql` | — | — | **manual-only** DataLens |
+| `data_mart_queries/datalens_ds_queries/*.sql` | — | — | **manual-only** DataLens |
 
 Table path registry: `.github/config/ydb_qa_config.json` (repo) and GitHub variable **`YDB_QA_CONFIG`** (CI — must stay in sync).
 

--- a/.github/scripts/analytics/ARCHITECTURE.md
+++ b/.github/scripts/analytics/ARCHITECTURE.md
@@ -197,4 +197,4 @@ Fails if analytics paths changed in git diff but `ARCHITECTURE.md` did not.
 
 ### For Cursor agents
 
-Rule: `.cursor/rules/analytics.mdc` — on analytics edits, update this document in the same task/PR.
+Router: `.cursor/rules/analytics.mdc` (pitfalls, templates). **Canonical detail stays in this file** — update diagram/table in the same PR as code changes.

--- a/.github/scripts/analytics/ARCHITECTURE.md
+++ b/.github/scripts/analytics/ARCHITECTURE.md
@@ -51,8 +51,9 @@ flowchart TB
   end
 
   subgraph L5["L5 · Domain marts"]
+    TM[(tests_monitor)]
     PRM[PR / check marts]
-    MART_MUTE[mute_events, mute_latency, tests_monitor]
+    MART_MUTE[mute_events, mute_latency]
     MART_BI[muted_tests_daily_by_team, github_issues_timeline, …]
     PERF[perfomance/olap/*, nemesis/*]
   end
@@ -82,11 +83,14 @@ flowchart TB
   FAST --> MART_BI
   FAST --> PERF
   FAST --> MART_MUTE
+  FAST --> TM
 
   MUTE --> OWN
   MUTE --> GH_I
+  MUTE --> TM
   MUTE --> MART_MUTE
-  MART_MUTE --> ISS
+  TM --> ISS
+  TM --> MART_BI
   ISS --> AUTO
   MART_MUTE --> TG
 
@@ -102,7 +106,7 @@ flowchart TB
   class RAW raw
   class FAST,MUTE,ISS,MON,LEG1 orch
   class THF,OWN,GH_I,GH_P,MAP enriched
-  class PRM,MART_MUTE,MART_BI,PERF mart
+  class TM,PRM,MART_MUTE,MART_BI,PERF mart
   class DL,TG,AUTO,AGENT consumer
   class LEG1 legacy
 
@@ -116,28 +120,158 @@ flowchart TB
   classDef legacy fill:#f3f4f6,stroke:#9ca3af,color:#374151,stroke-dasharray: 5 5
 ```
 
-## Mart dependency chain (selected)
+## Table dependency maps
 
-Order matters for marts built in one workflow run:
+Overview diagram above shows **workflows and layers**. This section shows **YDB table-level reads/writes** for SQL marts and Python collectors.
+
+**Cross-workflow note:** `tests_monitor` is **written** by `update_muted_ya` (hourly) and **read** by many marts in `collect_analytics_fast` (every 30m). Timeline/mute BI marts assume `tests_monitor` is already populated.
+
+**Execution order** in `collect_analytics_fast.yml` (same job, order matters for dependent marts):
+
+1. Enriched exports: `testowners`, `test_history_fast`, GitHub `issues` / `pull_requests`, `github_issue_mapping`, `area_to_owner_mapping`
+2. `github_issues_timeline.sql` ← needs `issues`, `area_to_owner_mapping`, **`tests_monitor`**
+3. `github_issues_bugs_count_by_period.sql` ← needs `github_issues_timeline`
+4. `muted_tests_with_issue_and_area.sql`, `muted_tests_daily_by_team.sql` ← need **`tests_monitor`**, `github_issues_timeline` (daily mart also)
+5. PR-blocked marts (mostly from `test_runs_column`; `*_with_pr_and_mute*` also need `tests_monitor` + `pull_requests`)
+
+DataLens chain order is documented in `data_mart_queries/datalens_ds_queries/team_view_data_pipes.sql`.
+
+### Mute decision chain
+
+```mermaid
+flowchart TB
+  classDef raw fill:#fef3c7,stroke:#d97706
+  classDef enriched fill:#cffafe,stroke:#0891b2
+  classDef mart fill:#dcfce7,stroke:#16a34a
+  classDef action fill:#ffedd5,stroke:#ea580c
+
+  RAW[(test_runs_column)]
+  RAW --> FLK[flaky_tests_history.py]
+  FLK --> FTW[(flaky_tests_window)]
+  RAW --> GMT[get_muted_tests.py · upload_muted_tests]
+  GMT --> AT[(all_tests_with_owner_and_mute)]
+  MAP[(area_to_owner_mapping<br/>github_issue_mapping)]
+  FTW --> MON[tests_monitor.py]
+  AT --> MON
+  RAW --> MON
+  MAP --> MON
+  MON --> TM[(tests_monitor)]
+  TM --> MUTE_PR[create_new_muted_ya.py → muted_ya.txt PR]
+  MUTE_PR --> CI[CI · transform_build_results.py]
+  TM --> MART1[(muted_tests_with_issue_and_area)]
+  TM --> MART2[(muted_tests_daily_by_team)]
+  TM --> TL_IN[github_issues_timeline.sql]
+  TM --> PRM[pr_blocked_* · pr_check_failures_by_attempt]
+
+  class RAW raw
+  class FTW,AT,MAP enriched
+  class TM,MART1,MART2 mart
+  class FLK,GMT,MON,MUTE_PR,CI,TL_IN,PRM action
+```
+
+### GitHub / issues chain
 
 ```mermaid
 flowchart LR
   classDef enriched fill:#cffafe,stroke:#0891b2
   classDef mart fill:#dcfce7,stroke:#16a34a
 
-  RAW[(test_runs_column)] --> THF[(test_history_fast)]
-  GH_I[(issues export)] --> TIMELINE[(github_issues_timeline)]
-  MAP[(area_to_owner_mapping)] --> TIMELINE
-  TIMELINE --> BUGS[(github_issues_bugs_count_by_period)]
-  GH_I --> MUTED_RICH[(muted_tests_with_issue_and_area)]
-  MAP --> MUTED_RICH
-  MUTED_RICH --> MUTED_TEAM[(muted_tests_daily_by_team)]
-  RAW --> PR_RICH[(pr_blocked_by_failed_tests_rich)]
-  PR_RICH --> PR_MUTE[(pr_blocked_by_*_with_pr_and_mute*)]
+  EXP[export_issues_to_ydb.py] --> ISS[(github_data/issues)]
+  GIM[github_issue_mapping.py] --> GIMT[(github_issue_mapping)]
+  SYNC[sync_area_to_owner_mapping.py] --> A2O[(area_to_owner_mapping)]
+  ISS --> TL[github_issues_timeline.sql]
+  A2O --> TL
+  TM[(tests_monitor)] --> TL
+  TL --> TIM[(github_issues_timeline)]
+  TIM --> BUGS[github_issues_bugs_count_by_period.sql]
+  A2O --> BUGS
+  TIM --> MUTED_TEAM[muted_tests_daily_by_team.sql]
+  TM --> MUTED_TEAM
+  A2O --> MUTED_TEAM
+  GIMT --> MUTED_RICH[muted_tests_with_issue_and_area.sql]
+  TM --> MUTED_RICH
 
-  class RAW,GH_I,MAP enriched
-  class THF,TIMELINE,BUGS,MUTED_RICH,MUTED_TEAM,PR_RICH,PR_MUTE mart
+  class ISS,GIMT,A2O,TM enriched
+  class TIM,BUGS,MUTED_TEAM,MUTED_RICH mart
 ```
+
+### PR-blocked chain
+
+```mermaid
+flowchart LR
+  classDef raw fill:#fef3c7,stroke:#d97706
+  classDef mart fill:#dcfce7,stroke:#16a34a
+  classDef enriched fill:#cffafe,stroke:#0891b2
+
+  RAW[(test_runs_column)] --> RICH[pr_blocked_by_failed_tests_rich.sql]
+  RICH --> RICH_T[(pr_blocked_by_failed_tests_rich)]
+  RICH_T --> WITH[pr_blocked_*_with_pr_and_mute.sql]
+  GH_P[(github_data/pull_requests)] --> WITH
+  TM[(tests_monitor)] --> WITH
+  WITH --> WITH_T[(pr_blocked_*_with_pr_and_mute)]
+  WITH_T --> ALL[pr_blocked_*_all_runs_on_last_commit.sql]
+  RAW --> ALL
+  RAW --> OTHER[pr_with_test_failures · pr_check_failures_by_attempt · pr_failed_in_attempt…]
+  GH_P --> OTHER
+  TM --> OTHER
+  OWN[(testowners)] --> OTHER
+
+  class RAW raw
+  class GH_P,TM,OWN enriched
+  class RICH_T,WITH_T mart
+```
+
+### Perf / nemesis (separate domain)
+
+| Source | Mart SQL | Output |
+|--------|----------|--------|
+| `perfomance/olap/tests_results` | `perfomance_olap_suites_mart.sql`, `perfomance_olap_mart.sql` | `perfomance/olap/fast_results*` |
+| `nemesis/tests_results` | `stability_aggregate_mart.sql` | `nemesis/aggregated_mart` |
+
+Monitoring SQL under `monitoring_queries/` reads these marts and core tables (read-only alerts).
+
+### Python collectors (non-SQL writes)
+
+| Script | Workflow | Writes | Main reads |
+|--------|----------|--------|------------|
+| `upload_tests_results.py` | `test_ya` | `test_runs_column` | CI artifacts |
+| `test_history_fast.py` | `collect_analytics_fast` | `test_history_fast` | `test_runs_column` |
+| `upload_testowners.py` | `collect_analytics_fast`, `update_muted_ya` | `testowners` | repo `CODEOWNERS` |
+| `export_issues_to_ydb.py` | both | `github_data/issues` | GitHub API |
+| `export_pull_requests_to_ydb.py` | `collect_analytics_fast` | `github_data/pull_requests` | GitHub API |
+| `github_issue_mapping.py` | `collect_analytics_fast` | `github_issue_mapping` | GitHub API |
+| `sync_area_to_owner_mapping.py` | `collect_analytics_fast` | `area_to_owner_mapping` | config / GitHub |
+| `flaky_tests_history.py` | `update_muted_ya` | `flaky_tests_window_*` | `test_runs_column` |
+| `get_muted_tests.py` | `update_muted_ya` | `all_tests_with_owner_and_mute` | `muted_ya.txt`, YDB |
+| `tests_monitor.py` | `update_muted_ya`, `create_issues_for_muted_tests` | `tests_monitor` | `test_runs_column`, `flaky_tests_window`, `all_tests_with_owner_and_mute`, mappings, prior `tests_monitor` |
+| `mute_latency_from_failure.py` | `collect_analytics_fast` | `mute_events`, `mute_latency`, … | `test_runs_column`, mute state |
+
+### Mart SQL registry (`collect_analytics_fast` + manual)
+
+Cron marts only (`datalens_ds_queries/` are manual DataLens layers on top). Regenerate reads column:
+
+```bash
+python3 .github/scripts/analytics/list_mart_dependencies.py --markdown
+```
+
+| SQL | Writes (`--table_path`) | Reads (`FROM`/`JOIN`) |
+|-----|-------------------------|------------------------|
+| `datamart_postcommit_retry.sql` | `test_results/test_results/analytics/postcommit_retry` | `test_runs_column` |
+| `github_issues_timeline.sql` | `test_results/analytics/github_issues_timeline` | `github_data/issues`, `area_to_owner_mapping`, **`tests_monitor`** |
+| `github_issues_bugs_count_by_period.sql` | `test_results/analytics/github_issues_bugs_count_by_period` | `area_to_owner_mapping`, `github_issues_timeline` |
+| `muted_tests_with_issue_and_area.sql` | `test_results/analytics/muted_tests_with_issue_and_area` | `area_to_owner_mapping`, `github_issue_mapping`, `fast_unmute_active`, **`tests_monitor`** |
+| `muted_tests_daily_by_team.sql` | `test_results/analytics/muted_tests_daily_by_team` | `area_to_owner_mapping`, `github_issues_timeline`, **`tests_monitor`** |
+| `perfomance_olap_suites_mart.sql` | `perfomance/olap/fast_results_siutes` | `perfomance/olap/tests_results` |
+| `perfomance_olap_mart.sql` | `perfomance/olap/fast_results` | `perfomance/olap/tests_results` |
+| `pr_check_stats.sql` | `analytics/pr_check_stats` | `test_runs_column` |
+| `pr_blocked_by_failed_tests_rich.sql` | `test_results/analytics/pr_blocked_by_failed_tests_rich` | `test_runs_column` |
+| `pr_blocked_by_failed_tests_rich_with_pr_and_mute.sql` | `test_results/analytics/pr_blocked_by_failed_tests_rich_with_pr_and_mute` | `pr_blocked_by_failed_tests_rich`, `pull_requests`, **`tests_monitor`** |
+| `pr_blocked_by_failed_tests_rich_with_pr_and_mute_all_runs_on_last_commit.sql` | `test_results/analytics/pr_blocked_by_failed_tests_rich_all_runs_on_last_commit` | `pr_blocked_by_failed_tests_rich_with_pr_and_mute`, `test_runs_column` |
+| `pr_with_test_failures.sql` | `test_results/analytics/pr_blocked_by_tests` | `test_runs_column`, `pull_requests`, `testowners` |
+| `pr_check_failures_by_attempt.sql` | `test_results/analytics/pr_check_failures_by_attempt` | `test_runs_column`, `pull_requests`, `testowners`, **`tests_monitor`** |
+| `pr_failed_in_attempt_but_not_run_in_next.sql` | `test_results/analytics/pr_failed_in_attempt_but_not_run_in_next` | `test_runs_column`, `pull_requests` |
+| `pr_failed_tests_validation_through_mute_rules.sql` | — (**manual** / ad-hoc) | `test_runs_column`, `pull_requests`, **`tests_monitor`** |
+| `stability_aggregate_mart.sql` | `nemesis/aggregated_mart` | `nemesis/tests_results` |
 
 ## Workflow → script → YDB table → consumer
 
@@ -175,12 +309,13 @@ Same PR as the code change if you touch any of:
 - `.github/config/ydb_qa_config.json` (new table alias/path) — **and** GitHub Actions variable `YDB_QA_CONFIG`
 - A new **consumer** (DataLens dashboard, Telegram profile, mute rule source)
 
-Update: diagram (new node/edge), table row, layer legend if adding a new layer.
+Update: diagram (new node/edge), **table dependency maps** (mart registry / domain DAG), table row, layer legend if adding a new layer.
 
 ### PR checklist (humans & agents)
 
 ```markdown
-- [ ] Change is reflected in ARCHITECTURE.md (diagram and/or table)
+- [ ] Change is reflected in ARCHITECTURE.md (diagram, **mart registry**, and/or workflow table)
+- [ ] New mart SQL: update domain DAG + run `list_mart_dependencies.py --markdown` to verify registry reads
 - [ ] New YDB table: alias in `.github/config/ydb_qa_config.json` **and** in repo variable `YDB_QA_CONFIG` (CI reads vars, not the file)
 - [ ] Verified alias sync: `gh api repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG --jq '.value'` vs local JSON
 - [ ] Mart SQL has `-- consumed by:` comment (optional but helpful)
@@ -197,4 +332,4 @@ Fails if analytics paths changed in git diff but `ARCHITECTURE.md` did not.
 
 ### For Cursor agents
 
-Router: `.cursor/rules/analytics.mdc` (pitfalls, templates). **Canonical detail stays in this file** — update diagram/table in the same PR as code changes.
+**Canonical detail stays in this file** — overview + [table dependency maps](#table-dependency-maps). Update in the same PR as code changes.

--- a/.github/scripts/analytics/ARCHITECTURE.md
+++ b/.github/scripts/analytics/ARCHITECTURE.md
@@ -122,7 +122,26 @@ flowchart TB
 
 ## Table dependency maps
 
-Overview diagram above shows **workflows and layers**. This section shows **YDB table-level reads/writes** for SQL marts and Python collectors.
+Overview diagram above shows **workflows and layers** (legend: [Layer legend](#layer-legend-colors-on-diagram) · L0–L6). This section shows **YDB table-level reads/writes** for SQL marts and Python collectors.
+
+### Diagram legend (shapes & colors)
+
+Read domain diagrams **top → bottom** (TB) or **left → right** (LR). Arrow **`A → B`** = B **reads** A (A must exist / be fresh first).
+
+| Shape in diagram | Meaning |
+|------------------|---------|
+| Cylinder `[(…)]` | **YDB table** — persisted rows |
+| Rectangle `[…]` | **Process** — Python (`.py`) or mart SQL (`.sql` via `data_mart_executor.py`) |
+| `script.sql` → `[(table)]` | SQL **reads** upstream tables, **writes** the green cylinder |
+
+| Color | Role | Examples |
+|-------|------|----------|
+| Amber | Raw CI facts | `test_runs_column` |
+| Cyan | Enriched / reference / upstream | `github_data/issues`, `area_to_owner_mapping`, `flaky_tests_window`, `tests_monitor` *(when used as input to another mart)* |
+| Green | Mart output table | `tests_monitor`, `github_issues_timeline`, `muted_tests_daily_by_team`, `pr_blocked_by_*` |
+| Orange | Script or SQL step (not storage) | `tests_monitor.py`, `github_issues_timeline.sql`, `create_new_muted_ya.py` |
+
+**Workflow vs table:** purple nodes in the [overview](#data-flow-overview) are GitHub Actions jobs; orange/green/cyan here are **files and YDB paths** inside those jobs.
 
 **Cross-workflow note:** `tests_monitor` is **written** by `update_muted_ya` (hourly) and **read** by many marts in `collect_analytics_fast` (every 30m). Timeline/mute BI marts assume `tests_monitor` is already populated.
 

--- a/.github/scripts/analytics/ARCHITECTURE.md
+++ b/.github/scripts/analytics/ARCHITECTURE.md
@@ -162,7 +162,7 @@ Status: **active** | **legacy (manual)** | **manual-only SQL**
 | `collect_analytics.yml` | monitor scripts | same as mute path | **legacy**, manual |
 | `datalens_ds_queries/*.sql` | — | — | **manual-only** DataLens |
 
-Table path registry: `.github/config/ydb_qa_config.json`.
+Table path registry: `.github/config/ydb_qa_config.json` (repo) and GitHub variable **`YDB_QA_CONFIG`** (CI — must stay in sync).
 
 ## Maintenance
 
@@ -172,7 +172,7 @@ Same PR as the code change if you touch any of:
 
 - `.github/scripts/analytics/**` (new/changed script or SQL mart)
 - `.github/workflows/collect_analytics*.yml`, `update_muted_ya.yml`, `create_issues_for_muted_tests.yml`, `monitoring_queries.yml`
-- `.github/config/ydb_qa_config.json` (new table alias/path)
+- `.github/config/ydb_qa_config.json` (new table alias/path) — **and** GitHub Actions variable `YDB_QA_CONFIG`
 - A new **consumer** (DataLens dashboard, Telegram profile, mute rule source)
 
 Update: diagram (new node/edge), table row, layer legend if adding a new layer.
@@ -181,7 +181,8 @@ Update: diagram (new node/edge), table row, layer legend if adding a new layer.
 
 ```markdown
 - [ ] Change is reflected in ARCHITECTURE.md (diagram and/or table)
-- [ ] New YDB table added to ydb_qa_config.json
+- [ ] New YDB table: alias in `.github/config/ydb_qa_config.json` **and** in repo variable `YDB_QA_CONFIG` (CI reads vars, not the file)
+- [ ] Verified alias sync: `gh api repos/ydb-platform/ydb/actions/variables/YDB_QA_CONFIG --jq '.value'` vs local JSON
 - [ ] Mart SQL has `-- consumed by:` comment (optional but helpful)
 ```
 

--- a/.github/scripts/analytics/check_architecture_sync.py
+++ b/.github/scripts/analytics/check_architecture_sync.py
@@ -32,26 +32,25 @@ SKIP_UNDER_ANALYTICS = (
 
 def changed_files(base: str | None) -> set[str]:
     if base:
-        cmd = ["git", "diff", "--name-only", f"{base}...HEAD"]
-        out = subprocess.check_output(cmd, cwd=REPO_ROOT, text=True)
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
+            cwd=REPO_ROOT,
+            text=True,
+        )
     else:
         out = subprocess.check_output(
             ["git", "diff", "--name-only", "HEAD"], cwd=REPO_ROOT, text=True
         )
-    staged = subprocess.check_output(
-        ["git", "diff", "--name-only", "--cached"], cwd=REPO_ROOT, text=True
-    )
-    untracked = subprocess.check_output(
-        ["git", "ls-files", "--others", "--exclude-standard"],
-        cwd=REPO_ROOT,
-        text=True,
-    )
-    names = {
-        line.strip()
-        for line in (out + staged + untracked).splitlines()
-        if line.strip()
-    }
-    return names
+        staged = subprocess.check_output(
+            ["git", "diff", "--name-only", "--cached"], cwd=REPO_ROOT, text=True
+        )
+        untracked = subprocess.check_output(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            cwd=REPO_ROOT,
+            text=True,
+        )
+        out = out + staged + untracked
+    return {line.strip() for line in out.splitlines() if line.strip()}
 
 
 def touches_analytics(paths: set[str]) -> bool:
@@ -84,10 +83,10 @@ def main() -> int:
 
     print(
         f"ERROR: analytics paths changed but {arch_rel} was not updated.\n"
-        f"Changed files:\n  " + "\n  ".join(sorted(paths & set(
-            p for p in paths
-            if any(p.startswith(w) for w in WATCH_PREFIXES)
-        ))),
+        f"Changed files:\n  "
+        + "\n  ".join(
+            sorted(p for p in paths if any(p.startswith(w) for w in WATCH_PREFIXES))
+        ),
         file=sys.stderr,
     )
     print(f"\nUpdate {arch_rel} (diagram + table) in the same PR.", file=sys.stderr)

--- a/.github/scripts/analytics/check_architecture_sync.py
+++ b/.github/scripts/analytics/check_architecture_sync.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Fail if analytics code changed without ARCHITECTURE.md update.
+
+Usage:
+  python3 check_architecture_sync.py              # vs HEAD (staged + unstaged)
+  python3 check_architecture_sync.py --base origin/main
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARCHITECTURE = REPO_ROOT / ".github/scripts/analytics/ARCHITECTURE.md"
+
+WATCH_PREFIXES = (
+    ".github/scripts/analytics/",
+    ".github/workflows/collect_analytics",
+    ".github/workflows/update_muted_ya.yml",
+    ".github/workflows/create_issues_for_muted_tests.yml",
+    ".github/workflows/monitoring_queries.yml",
+    ".github/config/ydb_qa_config.json",
+)
+
+SKIP_UNDER_ANALYTICS = (
+    ".github/scripts/analytics/check_architecture_sync.py",
+)
+
+
+def changed_files(base: str | None) -> set[str]:
+    if base:
+        cmd = ["git", "diff", "--name-only", f"{base}...HEAD"]
+        out = subprocess.check_output(cmd, cwd=REPO_ROOT, text=True)
+    else:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", "HEAD"], cwd=REPO_ROOT, text=True
+        )
+    staged = subprocess.check_output(
+        ["git", "diff", "--name-only", "--cached"], cwd=REPO_ROOT, text=True
+    )
+    untracked = subprocess.check_output(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        text=True,
+    )
+    names = {
+        line.strip()
+        for line in (out + staged + untracked).splitlines()
+        if line.strip()
+    }
+    return names
+
+
+def touches_analytics(paths: set[str]) -> bool:
+    for path in paths:
+        if path in SKIP_UNDER_ANALYTICS:
+            continue
+        if any(path.startswith(prefix) for prefix in WATCH_PREFIXES):
+            return True
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Compare branch to base (e.g. origin/main). Default: working tree vs HEAD",
+    )
+    args = parser.parse_args()
+
+    paths = changed_files(args.base)
+    if not touches_analytics(paths):
+        print("OK: no watched analytics paths changed")
+        return 0
+
+    arch_rel = ARCHITECTURE.relative_to(REPO_ROOT).as_posix()
+    if arch_rel in paths:
+        print(f"OK: {arch_rel} updated together with analytics changes")
+        return 0
+
+    print(
+        f"ERROR: analytics paths changed but {arch_rel} was not updated.\n"
+        f"Changed files:\n  " + "\n  ".join(sorted(paths & set(
+            p for p in paths
+            if any(p.startswith(w) for w in WATCH_PREFIXES)
+        ))),
+        file=sys.stderr,
+    )
+    print(f"\nUpdate {arch_rel} (diagram + table) in the same PR.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/analytics/list_mart_dependencies.py
+++ b/.github/scripts/analytics/list_mart_dependencies.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""List mart SQL read dependencies and workflow write targets.
+
+Helper to refresh the «Mart SQL registry» table in ARCHITECTURE.md:
+
+  python3 .github/scripts/analytics/list_mart_dependencies.py
+  python3 .github/scripts/analytics/list_mart_dependencies.py --markdown
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+QUERIES_DIR = REPO_ROOT / ".github/scripts/analytics/data_mart_queries"
+WORKFLOW = REPO_ROOT / ".github/workflows/collect_analytics_fast.yml"
+
+TABLE_REF = re.compile(r"(?:FROM|JOIN)\s+`([^`]+)`", re.IGNORECASE)
+EXECUTOR_LINE = re.compile(
+    r"data_mart_executor\.py\s+.*--query_path\s+(\S+\.sql)\s+.*--table_path\s+(\S+)"
+)
+
+
+def extract_reads(sql_path: Path) -> list[str]:
+    text = sql_path.read_text(encoding="utf-8")
+    return sorted(set(TABLE_REF.findall(text)))
+
+
+def parse_workflow_writes() -> dict[str, str]:
+    writes: dict[str, str] = {}
+    for line in WORKFLOW.read_text(encoding="utf-8").splitlines():
+        match = EXECUTOR_LINE.search(line)
+        if not match:
+            continue
+        query_rel = match.group(1)
+        if query_rel.startswith(".github/"):
+            key = Path(query_rel).name
+        else:
+            key = Path(query_rel).name
+        writes[key] = match.group(2)
+    return writes
+
+
+def collect_rows() -> list[tuple[str, str, str]]:
+    writes = parse_workflow_writes()
+    rows: list[tuple[str, str, str]] = []
+    for sql_path in sorted(QUERIES_DIR.rglob("*.sql")):
+        if "datalens_ds_queries" in sql_path.parts:
+            continue
+        rel = sql_path.relative_to(REPO_ROOT).as_posix()
+        reads = ", ".join(extract_reads(sql_path)) or "—"
+        write = writes.get(sql_path.name, "— (manual / other workflow)")
+        rows.append((rel, write, reads))
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Print markdown table rows for ARCHITECTURE.md",
+    )
+    args = parser.parse_args()
+
+    rows = collect_rows()
+    if args.markdown:
+        print("| SQL | Writes (`--table_path`) | Reads (`FROM`/`JOIN`) |")
+        print("|-----|-------------------------|------------------------|")
+        for sql, write, reads in rows:
+            print(f"| `{sql}` | `{write}` | {reads} |")
+        return
+
+    for sql, write, reads in rows:
+        print(f"{sql}\n  writes: {write}\n  reads:  {reads}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/analytics/mcp.ydb-qa.example.json
+++ b/.github/scripts/analytics/mcp.ydb-qa.example.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "ydb-qa": {
+      "command": "uvx",
+      "args": [
+        "ydb-mcp",
+        "--ydb-endpoint",
+        "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8"
+      ],
+      "env": {
+        "YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS": "/absolute/path/to/ydb-qa-service-account.json"
+      }
+    }
+  }
+}

--- a/.github/scripts/analytics/mcp.ydb-qa.example.json
+++ b/.github/scripts/analytics/mcp.ydb-qa.example.json
@@ -1,15 +1,14 @@
 {
   "mcpServers": {
     "ydb-qa": {
-      "command": "uvx",
+      "command": "/path/to/python-with-ydb-mcp-installed",
       "args": [
-        "ydb-mcp",
-        "--ydb-endpoint",
-        "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8"
-      ],
-      "env": {
-        "YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS": "/absolute/path/to/ydb-qa-service-account.json"
-      }
+        "-m", "ydb_mcp",
+        "--ydb-endpoint", "grpcs://lb.etnvsjbk7kh1jc6bbfi8.ydb.mdb.yandexcloud.net:2135",
+        "--ydb-database", "/ru-central1/b1ggceeul2pkher8vhb6/etnvsjbk7kh1jc6bbfi8",
+        "--ydb-auth-mode", "service-account",
+        "--ydb-sa-key-file", "/absolute/path/to/service-account.json"
+      ]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -104,8 +104,10 @@ path.bash.inc
 # Editor config
 /.editorconfig
 
-# Cursor ignore
-.cursor/
+# Cursor ignore (track shared rules under .cursor/rules/)
+.cursor/*
+!.cursor/rules/
+!.cursor/rules/**
 .cursorignore
 .cursorindexingignore
 


### PR DESCRIPTION
## Summary

Добавляет инфраструктуру для AI-агентов и ревьюеров: два тонких Cursor skill (router rules) и три канонических markdown-документа с картой пайплайнов.

**Cursor rules (router-only, без дублирования таблиц):**
- `.cursor/rules/analytics.mdc` — YDB QA analytics: куда смотреть в ARCHITECTURE.md, YQL pitfalls, шаблон regression SQL
- `.cursor/rules/ci-testing.mdc` — CI testing: ссылки на CI_PIPELINE.md и CI_PLATFORM.md

**Canonical docs:**
- `.github/scripts/analytics/ARCHITECTURE.md` — карта analytics pipeline (workflows → scripts → YDB tables → consumers)
- `.github/docs/CI_PIPELINE.md` — карта test CI (PR-check, test_ya, integrated status)
- `.github/docs/CI_PLATFORM.md` — GitHub traps (#36673 stale merge_commit_sha, #44180 cron polling), multi-branch, security, secrets vs vars

**Guardrail:**
- `.github/scripts/analytics/check_architecture_sync.py` — падает, если меняются analytics paths без обновления ARCHITECTURE.md
- `.github/scripts/analytics/mcp.ydb-qa.example.json` — шаблон MCP для ydb-qa

**`.gitignore`:** track `.cursor/rules/**`, ignore остальные локальные Cursor-файлы.

Связано с [#44312](https://github.com/ydb-platform/ydb/issues/44312) (tech debt assessment).

## Test plan

- [x] Skills tested on [PR #39206](https://github.com/ydb-platform/ydb/pull/39206) review (pipeline framing)
- [x] `python3 .github/scripts/analytics/check_architecture_sync.py --base origin/main` passes on this branch
- [ ] Reviewer: agents find tables/workflows via ARCHITECTURE.md / CI_PIPELINE.md without reading entire `.github/`