### PR TITLE
Added AlwaysSetSystemOwner setting in security config

### DIFF
--- a/ydb/core/base/appdata_fwd.h
+++ b/ydb/core/base/appdata_fwd.h
@@ -289,6 +289,7 @@ struct TAppData {
     NKikimrConfig::TLongTxServiceConfig& LongTxServiceConfig;
     bool EnforceUserTokenRequirement = false;
     bool EnforceUserTokenCheckRequirement = false; // check token if it was specified
+    bool AlwaysSetSystemOwner = false;
     bool AllowHugeKeyValueDeletes = true; // delete when all clients limit deletes per request
     bool EnableKqpSpilling = false;
     bool AllowShadowDataInSchemeShardForTests = false;

--- a/ydb/core/base/auth.cpp
+++ b/ydb/core/base/auth.cpp
@@ -1,7 +1,9 @@
 #include <ydb/core/protos/config.pb.h>
+#include <ydb/core/protos/flat_tx_scheme.pb.h>
 #include <ydb/library/aclib/aclib.h>
 
 #include "auth.h"
+#include "appdata.h"
 
 namespace NKikimr {
 
@@ -86,6 +88,12 @@ bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::
         return false;
     }
     return userToken->IsExist(databaseOwner);
+}
+
+void SetSystemOwnerIfNeeded(NKikimrScheme::TEvModifySchemeTransaction& record, const TAppData* appData) {
+    if (appData->AlwaysSetSystemOwner && record.GetOwner() != BUILTIN_ACL_METADATA) {
+        record.SetOwner(BUILTIN_ACL_BASIC_OWNER);
+    }
 }
 
 } // namespace NKikimr

--- a/ydb/core/base/auth.h
+++ b/ydb/core/base/auth.h
@@ -3,6 +3,10 @@
 #include "appdata_fwd.h"
 #include <ydb/library/aclib/aclib.h>
 
+namespace NKikimrScheme {
+    class TEvModifySchemeTransaction;
+}
+
 namespace NKikimr {
 
 // Check token against given list of allowed sids
@@ -19,5 +23,10 @@ bool IsStrictDatabaseOnlyToken(const TAppData* appData, const TString& userToken
 
 // Check token against database owner
 bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::TSID& databaseOwner);
+
+// When the AlwaysSetSystemOwner setting is enabled, forces the owner of a scheme
+// modification record to the system basic owner, unless the record is already owned
+// by the system metadata user (objects created by the system itself keep their owner).
+void SetSystemOwnerIfNeeded(NKikimrScheme::TEvModifySchemeTransaction& record, const TAppData* appData);
 
 } // namespace NKikimr

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -450,6 +450,7 @@ public:
         const auto& securityConfig(Config.GetDomainsConfig().GetSecurityConfig());
         appData->EnforceUserTokenRequirement = securityConfig.GetEnforceUserTokenRequirement();
         appData->EnforceUserTokenCheckRequirement = securityConfig.GetEnforceUserTokenCheckRequirement();
+        appData->AlwaysSetSystemOwner = securityConfig.GetAlwaysSetSystemOwner();
         if (securityConfig.AdministrationAllowedSIDsSize() > 0) {
             TVector<TString> administrationAllowedSIDs(securityConfig.GetAdministrationAllowedSIDs().begin(), securityConfig.GetAdministrationAllowedSIDs().end());
             appData->AdministrationAllowedSIDs = std::move(administrationAllowedSIDs);

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -3699,7 +3699,9 @@ public:
             } else {
                 op.SetValue(settings.Value);
             }
-            op.SetInheritPermissions(settings.InheritPermissions);
+            if (settings.InheritPermissions.has_value()) {
+                op.SetInheritPermissions(*settings.InheritPermissions);
+            }
         }
 
     private:

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -1862,7 +1862,7 @@ public:
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
                         .Value(settings.Value.IsValid() ? settings.Value.Cast() : emptyAtom)
-                        .InheritPermissions(settings.InheritPermissions.IsValid() ? settings.InheritPermissions.Cast() : Build<TCoAtom>(ctx, node->Pos()).Value("0").Done())
+                        .InheritPermissions(settings.InheritPermissions.IsValid() ? settings.InheritPermissions.Cast() : emptyAtom)
                         .ValueParamName(settings.ValueParamName.IsValid() ? settings.ValueParamName.Cast() : emptyAtom)
                         .Done()
                         .Ptr();

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -450,7 +450,9 @@ namespace {
         if (auto paramName = TString(createSecret.ValueParamName())) {
             settings.ValueParamName = std::move(paramName);
         }
-        settings.InheritPermissions = FromString<bool>(TString(createSecret.InheritPermissions()));
+        if (auto inheritPermissions = TString(createSecret.InheritPermissions())) {
+            settings.InheritPermissions = FromString<bool>(inheritPermissions);
+        }
         return settings;
     }
 

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -1409,7 +1409,7 @@ struct TSecretSettings {
     TString Name;
     TString Value;
     TString ValueParamName; // when set, the value is taken from parameter at execution
-    bool InheritPermissions = false;
+    std::optional<bool> InheritPermissions; // Not set means the option is not specified explicitly
 };
 
 struct TKikimrListPathItem {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -307,6 +307,7 @@ message TDomainsConfig {
         optional bool DisableBuiltinGroups = 20;
         optional bool DisableBuiltinAccess = 21;
         optional bool HideAuthenticationFailureReasons = 22 [default = true];
+        optional bool AlwaysSetSystemOwner = 23 [default = false];
     }
 
     repeated TDomain Domain = 1;

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -593,6 +593,7 @@ namespace Tests {
             auto& securityConfig = Settings->AppConfig->GetDomainsConfig().GetSecurityConfig();
             appData.EnforceUserTokenRequirement = securityConfig.GetEnforceUserTokenRequirement();
             appData.EnforceUserTokenCheckRequirement = securityConfig.GetEnforceUserTokenCheckRequirement();
+            appData.AlwaysSetSystemOwner = securityConfig.GetAlwaysSetSystemOwner();
             TVector<TString> administrationAllowedSIDs(securityConfig.GetAdministrationAllowedSIDs().begin(), securityConfig.GetAdministrationAllowedSIDs().end());
             appData.AdministrationAllowedSIDs = std::move(administrationAllowedSIDs);
             TVector<TString> registerDynamicNodeAllowedSIDs(securityConfig.GetRegisterDynamicNodeAllowedSIDs().cbegin(), securityConfig.GetRegisterDynamicNodeAllowedSIDs().cend());

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -8,6 +8,7 @@
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/table_index.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
@@ -250,6 +251,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateIndexPropose(
 {
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.InitiateTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
+    SetSystemOwnerIfNeeded(propose->Record, AppData());
 
     NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
     modifyScheme.SetInternal(true);
@@ -307,6 +309,8 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
 
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
+    SetSystemOwnerIfNeeded(propose->Record, AppData());
+
     NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
     modifyScheme.SetInternal(true);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -246,12 +246,18 @@ public:
         if (!acl.empty()) {
             secretPath->ApplyACL(acl);
         } else {
-            /** By default, secrets should not inherit permissions from their parent object, except for the DescribeSchema grant.
-              * This is done to prevent users from accidentally granting permissions to such sensitive objects.
-              * However, the DescribeSchema grant is quite harmless and allows users to view the object's ACL to request access from the owner.
-              * There is also an inherit_permissions flag, which, when set, allows grant inheritance similarly to all other schema objects.
-              */
-            if (!createSecretProto.GetInheritPermissions()) {
+            /*
+            * By default, secrets should not inherit permissions from their parent object, except for the DescribeSchema grant.
+            * This is done to prevent users from accidentally granting permissions to such sensitive objects.
+            *
+            * When the flag is not set explicitly, the default depends on the AlwaysSetSystemOwner setting:
+            * with it enabled, permissions are inherited by default (inherit_permissions = true).
+            */
+            const bool inheritPermissions = createSecretProto.HasInheritPermissions()
+                ? createSecretProto.GetInheritPermissions()
+                : AppData()->AlwaysSetSystemOwner;
+
+            if (!inheritPermissions) {
                 secretPath->ACL = InterruptInheritanceExceptDescribe(dstPath.GetEffectiveACL());
                 secretPath->ACLVersion++;
             }

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -8,6 +8,7 @@
 #include "schemeshard_xxport__helpers.h"
 #include "schemeshard_xxport__tx_base.h"
 
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/table_index.h>
 #include <ydb/public/api/protos/ydb_import.pb.h>
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
@@ -703,6 +704,10 @@ private:
             return false;
         }
 
+        if (AppData()->AlwaysSetSystemOwner) {
+            op.SetNewOwner(BUILTIN_ACL_METADATA);
+        }
+
         Send(Self->SelfId(), std::move(propose));
         return true;
     }
@@ -754,6 +759,8 @@ private:
             record.SetOwner(*importInfo->UserSID);
         }
         FillOwner(record, item.Permissions);
+
+        SetSystemOwnerIfNeeded(record, AppData());
 
         if (TString error; !FillACL(modifyScheme, item.Permissions, error)) {
             NIceDb::TNiceDb db(txc.DB);

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -4,6 +4,7 @@
 #include "schemeshard_path_describer.h"
 #include "schemeshard_xxport__helpers.h"
 
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/persqueue/public/schema/schema_propose.h>
 #include <ydb/core/protos/s3_settings.pb.h>
@@ -106,6 +107,8 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTablePropose(
         record.SetOwner(*importInfo.UserSID);
     }
     FillOwner(record, item.Permissions);
+
+    SetSystemOwnerIfNeeded(record, AppData());
 
     if (!FillACL(modifyScheme, item.Permissions, error)) {
         return nullptr;

--- a/ydb/core/tx/schemeshard/schemeshard_xxport__helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_xxport__helpers.cpp
@@ -1,5 +1,6 @@
 #include "schemeshard_xxport__helpers.h"
 
+#include <ydb/core/base/auth.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_impl.h>
 #include <ydb/core/tx/schemeshard/schemeshard_info_types.h>
@@ -28,6 +29,9 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> MakeModifySchemeTransactionI
         record.SetOwner(*xxportInfo.UserSID);
         record.SetUserSID(*xxportInfo.UserSID);
     }
+
+    SetSystemOwnerIfNeeded(record, AppData());
+
     return propose;
 }
 

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_index_build.cpp
@@ -1084,10 +1084,12 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
         MergeIndexTableShardsOnlyWhenReady(NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique);
     }
 
-    void IndexPartitioningIsPersisted(NKikimrSchemeOp::EIndexType indexType) {
+    void IndexPartitioningIsPersisted(NKikimrSchemeOp::EIndexType indexType, bool alwaysSetSystemOwner = false) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
+
+        runtime.GetAppData().AlwaysSetSystemOwner = alwaysSetSystemOwner;
 
         TestCreateTable(runtime, ++txId, "/MyRoot", R"(
             Name: "Table"
@@ -1142,26 +1144,34 @@ Y_UNIT_TEST_SUITE(IndexBuildTest) {
             NLs::IndexesCount(1)
         });
 
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index"), {
+        TVector<NLs::TCheckFunc> indexChecks = {
             NLs::PathExist,
             NLs::IndexState(NKikimrSchemeOp::EIndexState::EIndexStateReady)
-        });
-
-        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index/indexImplTable", true, true), {
+        };
+        TVector<NLs::TCheckFunc> indexImplTableChecks = {
             NLs::IsTable,
             NLs::PartitionCount(3),
             NLs::MinPartitionsCountEqual(3),
             NLs::MaxPartitionsCountEqual(3),
             NLs::PartitionKeys({"alice", "bob", ""})
-        });
+        };
+        if (alwaysSetSystemOwner) {
+            // When AlwaysSetSystemOwner is enabled the owner of the index
+            // and its implementation table is the system user.
+            indexChecks.push_back(NLs::HasOwner(BUILTIN_ACL_BASIC_OWNER));
+            indexImplTableChecks.push_back(NLs::HasOwner(BUILTIN_ACL_BASIC_OWNER));
+        }
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index"), indexChecks);
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/Index/indexImplTable", true, true), indexImplTableChecks);
     }
 
-    Y_UNIT_TEST(IndexPartitioningIsPersisted) {
-        IndexPartitioningIsPersisted(NKikimrSchemeOp::EIndexType::EIndexTypeGlobal);
+    Y_UNIT_TEST_FLAG(IndexPartitioningIsPersisted, AlwaysSetSystemOwner) {
+        IndexPartitioningIsPersisted(NKikimrSchemeOp::EIndexType::EIndexTypeGlobal, AlwaysSetSystemOwner);
     }
 
-    Y_UNIT_TEST(IndexPartitioningIsPersistedUniq) {
-        IndexPartitioningIsPersisted(NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique);
+    Y_UNIT_TEST_FLAG(IndexPartitioningIsPersistedUniq, AlwaysSetSystemOwner) {
+        IndexPartitioningIsPersisted(NKikimrSchemeOp::EIndexType::EIndexTypeGlobalUnique, AlwaysSetSystemOwner);
     }
 
     void DropIndex(NKikimrSchemeOp::EIndexType indexType) {

--- a/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
+++ b/ydb/core/tx/schemeshard/ut_index_build/ut_vector_index_build.cpp
@@ -1929,11 +1929,12 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
 
     }
 
-    Y_UNIT_TEST(BuildTableWithEmptyShard) {
+    Y_UNIT_TEST_FLAG(BuildTableWithEmptyShard, AlwaysSetSystemOwner) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
         ui64 txId = 100;
 
+        runtime.GetAppData().AlwaysSetSystemOwner = AlwaysSetSystemOwner;
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::BUILD_INDEX, NLog::PRI_TRACE);
 
@@ -1989,6 +1990,12 @@ Y_UNIT_TEST_SUITE(VectorIndexBuildTest) {
         {
             const char* buildTable = "/MyRoot/ServerLessDB/Table/index1/indexImplPostingTable1build";
             auto indexDesc = DescribePath(runtime, tenantSchemeShard, buildTable, true, true, true);
+            // When AlwaysSetSystemOwner is enabled the owner of the transient index build
+            // impl tables is the system user.
+            if (AlwaysSetSystemOwner) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    indexDesc.GetPathDescription().GetSelf().GetOwner(), BUILTIN_ACL_BASIC_OWNER);
+            }
             auto parts = indexDesc.GetPathDescription().GetTablePartitions();
             UNIT_ASSERT_EQUAL(parts.size(), 1);
             // There should be only 1 cluster because there are too little rows. So no clusters with ID > 1.

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -421,6 +421,55 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         }
     }
 
+    Y_UNIT_TEST_FLAG(CreateSecretDefaultInheritPermissions, AlwaysSetSystemOwner) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.GetAppData().AlwaysSetSystemOwner = AlwaysSetSystemOwner;
+
+        NACLib::TDiffACL diffACL;
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::DescribeSchema, "user1");
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::AlterSchema, "user1");
+        AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), /* newOwner */ "");
+        env.TestWaitNotification(runtime, txId);
+
+        // create a secret without specifying InheritPermissions
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "secret"
+                Value: "value"
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        const auto user1Token = NACLib::TUserToken(NACLib::TUserToken::TUserTokenInitFields{.UserSID = "user1"});
+        const auto describeSecret = DescribePath(runtime, "/MyRoot/secret").GetPathDescription().GetSelf();
+
+        if (AlwaysSetSystemOwner) {
+            const TSecurityObject secObjEffective(describeSecret.GetOwner(), describeSecret.GetEffectiveACL(),
+                /* isContainer */ false);
+            UNIT_ASSERT_C(secObjEffective.CheckAccess(NACLib::DescribeSchema, user1Token),
+                "user1 should have grant (inherited from root)");
+            UNIT_ASSERT_C(secObjEffective.CheckAccess(NACLib::AlterSchema, user1Token),
+                "user1 should have grant (inherited from root)");
+
+            const TSecurityObject secObjOwn(describeSecret.GetOwner(), describeSecret.GetACL(),
+                /* isContainer */ false);
+            UNIT_ASSERT_C(!secObjOwn.CheckAccess(NACLib::AlterSchema, user1Token),
+                "No aces on the created secret expected when inheritance is on");
+        } else {
+            UNIT_ASSERT_EQUAL_C(describeSecret.GetEffectiveACL(), describeSecret.GetACL(),
+                "ACL should be the same, since aces are set on the secret itself");
+
+            const TSecurityObject secObj(describeSecret.GetOwner(), describeSecret.GetACL(), /* isContainer */ false);
+            UNIT_ASSERT_C(secObj.CheckAccess(NACLib::DescribeSchema, user1Token),
+                "user1 should have the DescribeSchema grant (it is always inherited)");
+            UNIT_ASSERT_C(!secObj.CheckAccess(NACLib::AlterSchema, user1Token),
+                "user1 should have no AlterSchema grant (only DescribeSchema grant is inherited)");
+        }
+    }
+
     Y_UNIT_TEST(InheritPermissionsWithDifferentInheritanceTypes) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -125,6 +125,8 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             request->Record.SetOwner(UserToken->GetUserSID());
         }
 
+        SetSystemOwnerIfNeeded(request->Record, AppData());
+
         request->Record.SetPeerName(GetRequestProto().GetPeerName());
         if (GetRequestEv().HasModifyScheme()) {
             request->Record.AddTransaction()->MergeFrom(GetModifyScheme());

--- a/ydb/library/aclib/aclib.h
+++ b/ydb/library/aclib/aclib.h
@@ -15,6 +15,7 @@ namespace NACLib {
 
 #define BUILTIN_ACL_METADATA "metadata@" BUILTIN_SYSTEM_DOMAIN
 #define BUILTIN_ACL_TMP "tmp@" BUILTIN_SYSTEM_DOMAIN
+#define BUILTIN_ACL_BASIC_OWNER "owner@" BUILTIN_SYSTEM_DOMAIN
 
 
 // This definition used to mark anonymous user sid

--- a/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
+++ b/ydb/services/ydb/backup_ut/ydb_backup_ut.cpp
@@ -3991,7 +3991,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
         TDataShardExportFactory DataShardExportFactory;
 
     public:
-        TS3TestEnv()
+        explicit TS3TestEnv(bool alwaysSetSystemOwner = false)
             : Server([&] {
                     NKikimrConfig::TAppConfig appConfig;
                     appConfig.MutableFeatureFlags()->SetEnableVectorIndex(true);
@@ -4001,6 +4001,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
                     appConfig.MutableFeatureFlags()->SetEnableCsDictionaryEncoding(true);
                     appConfig.MutableFeatureFlags()->SetEnableColumnStatistics(true);
                     appConfig.MutableTableServiceConfig()->SetEnableOlapSink(true);
+                    appConfig.MutableDomainsConfig()->MutableSecurityConfig()->SetAlwaysSetSystemOwner(alwaysSetSystemOwner);
                     return appConfig;
                 }())
             , Driver(TDriverConfig().SetEndpoint(Sprintf("localhost:%u", Server.GetPort())).SetDatabase("/Root"))
@@ -4447,8 +4448,18 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
 
     // TO DO: test view restoration to a different database
 
-    void TestTableBackupRestore() {
-        TS3TestEnv testEnv;
+    void CheckObjectOwnerIsSystem(const TDriver& driver, const TString& path, bool alwaysSetSystemOwner) {
+        if (!alwaysSetSystemOwner) {
+            return;
+        }
+        TSchemeClient schemeClient(driver);
+        auto result = schemeClient.DescribePath(path).ExtractValueSync();
+        UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetEntry().Owner, BUILTIN_ACL_BASIC_OWNER, "unexpected owner for " << path);
+    }
+
+    void TestTableBackupRestore(bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         constexpr const char* table = "/Root/table";
 
         TestTableContentIsPreserved(
@@ -4458,10 +4469,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "table" }),
             false
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), table, alwaysSetSystemOwner);
     }
 
-    void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal, bool prefix = false) {
-        TS3TestEnv testEnv;
+    void TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexType indexType = NKikimrSchemeOp::EIndexTypeGlobal, bool prefix = false, bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         if (indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompact ||
             indexType == NKikimrSchemeOp::EIndexTypeGlobalFulltextCompactRelevance ||
             indexType == NKikimrSchemeOp::EIndexTypeGlobalJsonCompact) {
@@ -4479,10 +4491,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "table" })
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), table, alwaysSetSystemOwner);
     }
 
-    void TestTableWithSerialBackupRestore() {
-        TS3TestEnv testEnv;
+    void TestTableWithSerialBackupRestore(bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         constexpr const char* table = "/Root/table";
 
         TestRestoreTableWithSerial(
@@ -4491,6 +4504,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "table" })
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), table, alwaysSetSystemOwner);
     }
 
     void TestTableWithMultiColumnStatisticsBackupRestore() {
@@ -4505,8 +4519,8 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
         );
     }
 
-    void TestViewBackupRestore() {
-        TS3TestEnv testEnv;
+    void TestViewBackupRestore(bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         constexpr const char* view = "/Root/view";
 
         TestViewOutputIsPreserved(
@@ -4515,6 +4529,7 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "view" })
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), view, alwaysSetSystemOwner);
     }
 
     void TestSystemViewBackupRestore() {
@@ -4531,8 +4546,8 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
         );
     }
 
-    void TestChangefeedBackupRestore() {
-        TS3TestEnv testEnv;
+    void TestChangefeedBackupRestore(bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         NTopic::TTopicClient topicClient(testEnv.GetDriver());
 
         constexpr const char* table = "/Root/table";
@@ -4547,10 +4562,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "table" }),
             {"a", "b", "c"}
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), table, alwaysSetSystemOwner);
     }
 
-    void TestReplicationBackupRestore( const TMaybe<ESecretType>& tokenSecretType) {
-        TS3TestEnv testEnv;
+    void TestReplicationBackupRestore(const TMaybe<ESecretType>& tokenSecretType, bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         auto& featureFlags = testEnv.GetServer().GetRuntime()->GetAppData().FeatureFlags;
         featureFlags.SetEnableSchemaSecrets(tokenSecretType == ESecretType::SecretTypeScheme);
 
@@ -4581,11 +4597,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), {"replication"}),
             tokenSecretType
         );
-
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), "/Root/replication", alwaysSetSystemOwner);
     }
 
-    void TestTransferBackupRestore(const TMaybe<ESecretType>& tokenSecretType) {
-        TS3TestEnv testEnv;
+    void TestTransferBackupRestore(const TMaybe<ESecretType>& tokenSecretType, bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         auto& featureFlags = testEnv.GetServer().GetRuntime()->GetAppData().FeatureFlags;
         featureFlags.SetEnableSchemaSecrets(tokenSecretType == ESecretType::SecretTypeScheme);
 
@@ -4622,10 +4638,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             tempDir.Path(),
             config
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), "/Root/test_transfer", alwaysSetSystemOwner);
     }
 
-    void TestExternalTableBackupRestore() {
-        TS3TestEnv testEnv;
+    void TestExternalTableBackupRestore(bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         auto& featureFlags = testEnv.GetServer().GetRuntime()->GetAppData().FeatureFlags;
         featureFlags.SetEnableExternalDataSources(true);
 
@@ -4646,10 +4663,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateBackupLambda(driver, testEnv.GetS3Port()),
             CreateRestoreLambda(driver, testEnv.GetS3Port(), {"externalTable", "externalDataSource"})
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), "/Root/externalTable", alwaysSetSystemOwner);
     }
 
-    void TestExternalDataSourceBackupRestore(const TMaybe<ESecretType>& secretType, EAuthType authType) {
-        TS3TestEnv testEnv;
+    void TestExternalDataSourceBackupRestore(const TMaybe<ESecretType>& secretType, EAuthType authType, bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         auto& featureFlags = testEnv.GetServer().GetRuntime()->GetAppData().FeatureFlags;
         featureFlags.SetEnableExternalDataSources(true);
         featureFlags.SetEnableSchemaSecrets(secretType == ESecretType::SecretTypeScheme);
@@ -4685,10 +4703,11 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             secretType,
             authType
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), "/Root/externalDataSource", alwaysSetSystemOwner);
     }
 
-    void TestTopicBackupRestoreWithoutData() {
-        TS3TestEnv testEnv;
+    void TestTopicBackupRestoreWithoutData(bool alwaysSetSystemOwner = false) {
+        TS3TestEnv testEnv(alwaysSetSystemOwner);
         NTopic::TTopicClient topicClient(testEnv.GetDriver());
         constexpr const char* topic = "/Root/topic";
 
@@ -4699,54 +4718,59 @@ Y_UNIT_TEST_SUITE(BackupRestoreS3) {
             CreateBackupLambda(testEnv.GetDriver(), testEnv.GetS3Port()),
             CreateRestoreLambda(testEnv.GetDriver(), testEnv.GetS3Port(), { "topic" })
         );
+        CheckObjectOwnerIsSystem(testEnv.GetDriver(), topic, alwaysSetSystemOwner);
     }
 
-    Y_UNIT_TEST_ALL_PROTO_ENUM_VALUES(TestAllSchemeObjectTypes, NKikimrSchemeOp::EPathType) {
+    Y_UNIT_TEST_ALL_PROTO_ENUM_VALUES_WITH_FLAG(TestAllSchemeObjectTypes, NKikimrSchemeOp::EPathType, AlwaysSetSystemOwner) {
         using namespace NKikimrSchemeOp;
 
         switch (Value) {
             case EPathTypeTable:
-                TestTableBackupRestore();
+                TestTableBackupRestore(AlwaysSetSystemOwner);
                 break;
             case EPathTypeTableIndex:
-                TestTableWithIndexBackupRestore();
+                TestTableWithIndexBackupRestore(NKikimrSchemeOp::EIndexTypeGlobal, false, AlwaysSetSystemOwner);
                 break;
             case EPathTypeSequence:
-                TestTableWithSerialBackupRestore();
+                TestTableWithSerialBackupRestore(AlwaysSetSystemOwner);
                 break;
             case EPathTypeDir:
                 break; // https://github.com/ydb-platform/ydb/issues/10430
             case EPathTypePersQueueGroup:
-                TestTopicBackupRestoreWithoutData();
+                TestTopicBackupRestoreWithoutData(AlwaysSetSystemOwner);
                 break;
             case EPathTypeSubDomain:
             case EPathTypeExtSubDomain:
                 break; // https://github.com/ydb-platform/ydb/issues/10432
             case EPathTypeView:
-                TestViewBackupRestore();
+                TestViewBackupRestore(AlwaysSetSystemOwner);
                 break;
             case EPathTypeCdcStream:
-                TestChangefeedBackupRestore();
+                TestChangefeedBackupRestore(AlwaysSetSystemOwner);
                 break;
             case EPathTypeReplication:
-                TestReplicationBackupRestore(ESecretType::SecretTypeOld);
-                TestReplicationBackupRestore(ESecretType::SecretTypeScheme);
+                if (!AlwaysSetSystemOwner) { // Replications with old secrets don't support the owner change
+                    TestReplicationBackupRestore(ESecretType::SecretTypeOld, AlwaysSetSystemOwner);
+                }
+                TestReplicationBackupRestore(ESecretType::SecretTypeScheme, AlwaysSetSystemOwner);
                 return;
             case EPathTypeTransfer:
-                TestTransferBackupRestore(ESecretType::SecretTypeOld);
-                TestTransferBackupRestore(ESecretType::SecretTypeScheme);
+                if (!AlwaysSetSystemOwner) { // Transfers with old secrets don't support the owner change
+                    TestTransferBackupRestore(ESecretType::SecretTypeOld, AlwaysSetSystemOwner);
+                }
+                TestTransferBackupRestore(ESecretType::SecretTypeScheme, AlwaysSetSystemOwner);
                 break;
             case EPathTypeSysView:
                 TestSystemViewBackupRestore();
                 break;
             case EPathTypeExternalTable:
-                return TestExternalTableBackupRestore();
+                return TestExternalTableBackupRestore(AlwaysSetSystemOwner);
             case EPathTypeExternalDataSource: {
-                TestExternalDataSourceBackupRestore(/* secretType */ Nothing(), EAuthType::AuthTypeNone);
-                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeOld, EAuthType::AuthTypeToken);
-                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeScheme, EAuthType::AuthTypeToken);
-                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeOld, EAuthType::AuthTypeAws);
-                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeScheme, EAuthType::AuthTypeAws);
+                TestExternalDataSourceBackupRestore(/* secretType */ Nothing(), EAuthType::AuthTypeNone, AlwaysSetSystemOwner);
+                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeOld, EAuthType::AuthTypeToken, AlwaysSetSystemOwner);
+                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeScheme, EAuthType::AuthTypeToken, AlwaysSetSystemOwner);
+                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeOld, EAuthType::AuthTypeAws, AlwaysSetSystemOwner);
+                TestExternalDataSourceBackupRestore(ESecretType::SecretTypeScheme, EAuthType::AuthTypeAws, AlwaysSetSystemOwner);
                 return;
             }
             case EPathTypeResourcePool:


### PR DESCRIPTION
- Introduce the new `AlwaysSetSystemOwner` security config setting (the `BUILTIN_ACL_BASIC_OWNER` alias `owner@builtin`); when enabled, system-created objects get a system owner instead of the requesting user.
- Apply `AlwaysSetSystemOwner` across the object-creation paths — tx_proxy `schemereq`, import creation/flow proposals, index build proposals, and export/import helpers — so the owner is forced to a builtin system SID when the flag is on.
- Change the default of the scheme secret `inherit_permissions` option to depend on `AlwaysSetSystemOwner`: when the flag is enabled, permissions are inherited by default; when disabled, the previous behavior (inheritance interrupted) is preserved.
- Add a parameterized test `CreateSecretDefaultInheritPermissions` covering both default scenarios.
