### PR TITLE
Exclude incremental backups from schemeshard object/path limits

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2119,6 +2119,11 @@ message TModifyScheme {
 
     optional TCreateFullBackupOp CreateFullBackupOp = 95;
 
+    // Internal marker: skip schemeshard object/path limit checks for this operation. Set only by
+    // system-generated decomposed sub-operations (e.g. the per-increment CDC stream and PQ topic of an
+    // incremental backup), never by direct user requests. Like Internal (field 36), not user-generated.
+    optional bool OmitObjectLimitChecks = 96 [default = false];
+
     // Some entries are grouped by semantics, so are out of order
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4715,7 +4715,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             path->IncShardsInside();
 
             auto domainInfo = Self->ResolveDomainInfo(pathId); //domain should't be dropped?
-            domainInfo->AddInternalShard(shardIdx, Self, Self->IsBackupTable(pathId));
+            domainInfo->AddInternalShard(shardIdx, Self, Self->IsBackupObject(path));
 
             switch (si.second.TabletType) {
             case ETabletType::DataShard:
@@ -4827,7 +4827,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
 
             if (!path->IsRoot()) {
-                bool isBackupTable = Self->IsBackupTable(item.first);
+                bool isBackupTable = Self->IsBackupObject(path);
                 EPathCategory pathCategory;
                 if (isBackupTable) {
                     pathCategory = EPathCategory::Backup;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_continuous_backup.cpp
@@ -41,6 +41,9 @@ void DoCreateIncrBackupTable(const TOperationId& opId, const TPath& dst, NKikimr
     // outTx.SetFailOnExist(!acceptExisted);
 
     outTx.SetAllowAccessToPrivatePaths(true);
+    // Bypass schemeshard object/path limits for the incremental backup table without marking it
+    // IsBackup, so it stays a readable table (matching the full backup-collection table).
+    outTx.SetOmitObjectLimitChecks(true);
 
     auto& desc = *outTx.MutableCreateTable();
     desc.CopyFrom(tableDesc);
@@ -183,7 +186,10 @@ bool CreateAlterContinuousBackup(TOperationId opId, const TTxTransaction& tx, TO
 
         rotateCdcStreamOp.MutableNewStream()->CopyFrom(createCdcStreamOp);
 
-        NCdc::DoRotateStream(result, rotateCdcStreamOp, opId, workingDirPath, tablePath);
+        // All incremental backup objects (destination table, per-increment CDC stream and PQ topic)
+        // bypass the schemeshard object/path limits via the internal OmitObjectLimitChecks marker, so
+        // the backup is never blocked. They stay regular, readable paths accounted as Regular.
+        NCdc::DoRotateStream(result, rotateCdcStreamOp, opId, workingDirPath, tablePath, /* omitObjectLimitChecks */ true);
         DoCreateIncrBackupTable(opId, backupTablePath, schema, result);
         DoAlterPqPart(opId, backupTablePath, topicPath, topic, result);
 
@@ -198,7 +204,7 @@ bool CreateAlterContinuousBackup(TOperationId opId, const TTxTransaction& tx, TO
             }
         }
 
-        NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, newStreamPath, newStreamName, table, boundaries, false);
+        NCdc::DoCreatePqPart(result, createCdcStreamOp, opId, newStreamPath, newStreamName, table, boundaries, false, /* omitObjectLimitChecks */ true);
     } else if (cbOp.GetActionCase() == NKikimrSchemeOp::TAlterContinuousBackup::kStop) {
         NKikimrSchemeOp::TAlterCdcStream alterCdcStreamOp;
         alterCdcStreamOp.SetTableName(tableName);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -609,7 +609,6 @@ public:
 
         auto schema = Transaction.GetCreateTable();
         const bool isBackup = schema.GetIsBackup();
-        const EPathCategory pathCategory = isBackup ? EPathCategory::Backup : EPathCategory::Regular;
 
         TPath dstPath = parent.Child(name);
         {
@@ -900,10 +899,15 @@ public:
         const ui32 shardsToCreate = tableInfo->GetPartitions().size();
         Y_VERIFY_S(shardsToCreate <= maxShardsToCreate, "shardsToCreate: " << shardsToCreate << " maxShardsToCreate: " << maxShardsToCreate);
 
-        dstPath.DomainInfo()->IncPathsInside(context.SS, 1, pathCategory);
-        dstPath.DomainInfo()->AddInternalShards(txState, context.SS, isBackup);
+        // Export-backup tables (IsBackup) and any table copied into a backup collection (full backup)
+        // are accounted as Backup so they do not consume the user object/path quota. UncountNode and
+        // restart rebuild derive the same classification (IsBackupObject).
+        const bool isBackupObject = isBackup || context.SS->IsBackupObject(dstPath.Base());
+        const EPathCategory commitCategory = isBackupObject ? EPathCategory::Backup : EPathCategory::Regular;
+        dstPath.DomainInfo()->IncPathsInside(context.SS, 1, commitCategory);
+        dstPath.DomainInfo()->AddInternalShards(txState, context.SS, isBackupObject);
         dstPath.Base()->IncShardsInside(shardsToCreate);
-        IncAliveChildrenSafeWithUndo(OperationId, parent, context, isBackup);
+        IncAliveChildrenSafeWithUndo(OperationId, parent, context, isBackupObject);
 
         LOG_TRACE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "TCopyTable Propose creating new table"

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.cpp
@@ -679,10 +679,12 @@ void DoCreatePqPart(
         const TString& streamName,
         TTableInfo::TCPtr table,
         const TVector<TString>& boundaries,
-        const bool acceptExisted)
+        const bool acceptExisted,
+        const bool omitObjectLimitChecks)
 {
     auto outTx = TransactionTemplate(streamPath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpCreatePersQueueGroup);
     outTx.SetFailOnExist(!acceptExisted);
+    outTx.SetOmitObjectLimitChecks(omitObjectLimitChecks);
 
     auto& desc = *outTx.MutableCreatePersQueueGroup();
     desc.SetName("streamImpl");

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_cdc_stream.h
@@ -48,6 +48,7 @@ void DoCreatePqPart(
     const TString& streamName,
     TTableInfo::TCPtr table,
     const TVector<TString>& boundaries,
-    const bool acceptExisted);
+    const bool acceptExisted,
+    const bool omitObjectLimitChecks = false);
 
 } // namespace NKikimr::NSchemesShard::NCdc

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -359,10 +359,18 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName(context.UserToken.Get())
-                    .DepthLimit()
-                    .PathsLimit()
-                    .DirChildrenLimit()
+                    .IsValidLeafName(context.UserToken.Get());
+
+                // Incremental backup creates a CDC topic per increment; skip the object/path limits so
+                // the backup is not blocked (the topic is accounted as Regular, like full-backup topics).
+                if (!Transaction.GetOmitObjectLimitChecks()) {
+                    checks
+                        .DepthLimit()
+                        .PathsLimit()
+                        .DirChildrenLimit();
+                }
+
+                checks
                     .IsValidACL(acl);
             }
 
@@ -403,7 +411,7 @@ public:
 
         const PQGroupReserve reserve(config, partitionsToCreate);
 
-        {
+        if (!Transaction.GetOmitObjectLimitChecks()) {
             NSchemeShard::TPath::TChecker checks = dstPath.Check();
             checks
                 .ShardsLimit(shardsToCreate)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_table.cpp
@@ -505,6 +505,11 @@ public:
         const TString acl = Transaction.GetModifyACL().GetDiffACL();
 
         NSchemeShard::TPath dstPath = parentPath.Child(name);
+        // The incremental backup decomposition marks its sub-operations with OmitObjectLimitChecks so
+        // creating an incremental backup is never blocked by the schemeshard object/path limits. The
+        // table itself stays a regular, readable table (no IsBackup), matching the full backup-collection
+        // table; it is accounted as Regular. This is an internal-only marker (never set by user requests).
+        const bool omitObjectLimitChecks = Transaction.GetOmitObjectLimitChecks();
         {
             NSchemeShard::TPath::TChecker checks = dstPath.Check();
             checks.IsAtLocalSchemeShard();
@@ -520,17 +525,23 @@ public:
             }
 
             if (checks) {
-                if (!parentPath.Base()->IsTableIndex()) {
+                if (!parentPath.Base()->IsTableIndex() && !omitObjectLimitChecks) {
                     checks.DepthLimit();
                 }
 
                 checks
-                    .IsValidLeafName(context.UserToken.Get())
-                    .PathsLimit()
-                    .DirChildrenLimit()
+                    .IsValidLeafName(context.UserToken.Get());
+
+                if (!omitObjectLimitChecks) {
+                    checks
+                        .PathsLimit()
+                        .DirChildrenLimit();
+                }
+
+                checks
                     .IsValidACL(acl);
 
-                if (!Transaction.GetInternal()) {
+                if (!Transaction.GetInternal() && !omitObjectLimitChecks) {
                     checks
                         .ShardsLimit(shardsToCreate)
                         .PathShardsLimit(shardsToCreate);
@@ -787,11 +798,18 @@ public:
         context.OnComplete.PublishToSchemeBoard(OperationId, dstPath.Base()->PathId);
 
         Y_ABORT_UNLESS(shardsToCreate == txState.Shards.size());
-        dstPath.DomainInfo()->IncPathsInside(context.SS);
-        dstPath.DomainInfo()->AddInternalShards(txState, context.SS);
+        // Objects stored inside a backup collection are accounted as EPathCategory::Backup so they do
+        // not consume the user-visible path/children/shard quota (otherwise accumulating increments
+        // would eventually block the user's own DDL). The classification is structural (derived from the
+        // persisted path tree), so drop/uncount and restart rebuild derive the same category and the
+        // accounting stays symmetric.
+        const bool isBackupObject = context.SS->IsBackupObject(dstPath.Base());
+        const EPathCategory pathCategory = isBackupObject ? EPathCategory::Backup : EPathCategory::Regular;
+        dstPath.DomainInfo()->IncPathsInside(context.SS, 1, pathCategory);
+        dstPath.DomainInfo()->AddInternalShards(txState, context.SS, isBackupObject);
 
         dstPath.Base()->IncShardsInside(shardsToCreate);
-        IncAliveChildrenDirect(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+        IncAliveChildrenDirect(OperationId, parentPath, context, isBackupObject); // for correct discard of ChildrenExist prop
 
         LOG_TRACE_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                 "TCreateTable Propose creating new table"

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_table.cpp
@@ -37,7 +37,9 @@ void DropPath(NIceDb::TNiceDb& db,
     context.SS->TabletCounters->Simple()[COUNTER_USER_ATTRIBUTES_COUNT].Sub(path->UserAttrs->Size());
     context.SS->PersistUserAttributes(db, path->PathId, path->UserAttrs, nullptr);
 
-    const auto isBackupTable = context.SS->IsBackupTable(path->PathId);
+    // IsBackupObject covers export-backup tables (IsBackup) and backup-collection objects, so the
+    // decrement category matches the create-time classification (no backup-counter drift).
+    const auto isBackupTable = context.SS->IsBackupObject(path.Base());
     const EPathCategory pathCategory = isBackupTable ? EPathCategory::Backup : EPathCategory::Regular;
 
     auto domainInfo = context.SS->ResolveDomainInfo(path->PathId);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_mkdir.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_mkdir.cpp
@@ -266,15 +266,20 @@ public:
                 newDir->TempDirOwnerActorId, newDir->PathId);
         }
 
+        // Per-run backup directories live inside a backup collection; account them as Backup so the
+        // accumulating backup storage does not consume the user object/path quota.
+        const bool isBackupDir = context.SS->IsBackupObject(dstPath.Base());
         EPathCategory pathCategory;
         if (isSystemDir) {
             pathCategory = EPathCategory::System;
+        } else if (isBackupDir) {
+            pathCategory = EPathCategory::Backup;
         } else {
             pathCategory = EPathCategory::Regular;
         }
 
         dstPath.DomainInfo()->IncPathsInside(context.SS, 1, pathCategory);
-        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context); // for correct discard of ChildrenExist prop
+        IncAliveChildrenSafeWithUndo(OperationId, parentPath, context, isBackupDir); // for correct discard of ChildrenExist prop
 
         context.OnComplete.ActivateTx(OperationId);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rmdir.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rmdir.cpp
@@ -157,10 +157,14 @@ public:
         path->SetDropped(step, OperationId.GetTxId());
         context.SS->PersistDropStep(db, pathId, step, OperationId);
 
-        const EPathCategory pathCategory = path->IsSystemDirectory() ? EPathCategory::System : EPathCategory::Regular;
+        // Per-run backup directories are accounted as Backup; match that at drop to avoid counter drift.
+        const bool isBackupDir = context.SS->IsBackupObject(path);
+        const EPathCategory pathCategory = path->IsSystemDirectory()
+            ? EPathCategory::System
+            : (isBackupDir ? EPathCategory::Backup : EPathCategory::Regular);
         auto domainInfo = context.SS->ResolveDomainInfo(pathId);
         domainInfo->DecPathsInside(context.SS, 1, pathCategory);
-        DecAliveChildrenDirect(OperationId, parentDir, context); // for correct discard of ChildrenExist prop
+        DecAliveChildrenDirect(OperationId, parentDir, context, isBackupDir); // for correct discard of ChildrenExist prop
 
         ++parentDir->DirAlterVersion;
         context.SS->PersistPathDirAlterVersion(db, parentDir);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.cpp
@@ -204,9 +204,15 @@ public:
 
             if (checks) {
                 checks
-                    .IsValidLeafName(context.UserToken.Get())
-                    .PathsLimit()
-                    .DirChildrenLimit();
+                    .IsValidLeafName(context.UserToken.Get());
+
+                // Incremental backup rotates a CDC stream per increment; skip the object/path limits so
+                // the backup is not blocked (the stream is accounted as Regular, like full-backup streams).
+                if (!Transaction.GetOmitObjectLimitChecks()) {
+                    checks
+                        .PathsLimit()
+                        .DirChildrenLimit();
+                }
             }
 
             if (!checks) {
@@ -682,11 +688,13 @@ void DoRotateStream(
         const NKikimrSchemeOp::TRotateCdcStream& op,
         const TOperationId& opId,
         const TPath& workingDirPath,
-        const TPath& tablePath)
+        const TPath& tablePath,
+        const bool omitObjectLimitChecks)
 {
     {
         auto outTx = TransactionTemplate(tablePath.PathString(), NKikimrSchemeOp::EOperationType::ESchemeOpRotateCdcStreamImpl);
         outTx.MutableRotateCdcStream()->CopyFrom(op);
+        outTx.SetOmitObjectLimitChecks(omitObjectLimitChecks);
         result.push_back(CreateRotateCdcStreamImpl(NextPartId(opId, result), outTx));
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_rotate_cdc_stream.h
@@ -9,6 +9,7 @@ void DoRotateStream(
     const NKikimrSchemeOp::TRotateCdcStream& op,
     const TOperationId& opId,
     const TPath& workingDirPath,
-    const TPath& tablePath);
+    const TPath& tablePath,
+    const bool omitObjectLimitChecks = false);
 
 } // namespace NKikimr::NSchemesShard::NCdc

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1897,6 +1897,33 @@ bool TSchemeShard::IsBackupTable(TPathId pathId) const {
     return it->second->IsBackup;
 }
 
+bool TSchemeShard::IsBackupObject(TPathElement::TPtr node) const {
+    if (!node) {
+        return false;
+    }
+    if (IsBackupTable(node->PathId)) {
+        return true;
+    }
+    // Walk the node and its ancestors: everything stored inside a backup collection (backup tables and
+    // the per-run directories, full and incremental) is backup data and must not consume the user
+    // object/path quota. The check is purely structural over the persisted path tree, so create-commit,
+    // drop/uncount and restart rebuild all derive the same category (the backup counters never drift).
+    for (TPathElement::TPtr cur = node; ; ) {
+        if (cur->IsBackupCollection()) {
+            return true;
+        }
+        if (cur->IsRoot()) {
+            break;
+        }
+        auto it = PathsById.find(cur->ParentPathId);
+        if (it == PathsById.end() || !it->second || it->second == cur) {
+            break;
+        }
+        cur = it->second;
+    }
+    return false;
+}
+
 TPathElement::EPathState TSchemeShard::CalcPathState(TTxState::ETxType txType, TPathElement::EPathState oldState) {
     // Do not change state if PathId is dropped. It can't become alive.
     switch (oldState) {
@@ -6261,7 +6288,9 @@ THashSet<TShardIdx> TSchemeShard::CollectAllShards(const THashSet<TPathId> &path
 }
 
 void TSchemeShard::UncountNode(TPathElement::TPtr node) {
-    const auto isBackupTable = IsBackupTable(node->PathId);
+    // Objects stored inside a backup collection (backup tables + per-run dirs, full and incremental)
+    // are accounted as Backup, like full-backup tables, so they are subtracted from the user limits.
+    const auto isBackupTable = IsBackupObject(node);
     EPathCategory pathCategory;
     if (isBackupTable) {
         pathCategory = EPathCategory::Backup;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -709,6 +709,12 @@ public:
 
     const TTableInfo* GetMainTableForIndex(TPathId indexTableId) const;
     bool IsBackupTable(TPathId pathId) const;
+    // True if the path is an export-backup table (IsBackup) or is stored inside a backup collection
+    // (backup tables and the per-run directories, full and incremental). Such objects are accounted as
+    // EPathCategory::Backup so they do not consume the user object/path quota. The classification is
+    // purely structural over the persisted path tree, so create-commit, drop/uncount and restart rebuild
+    // all derive the same category and the backup counters never drift.
+    bool IsBackupObject(TPathElement::TPtr node) const;
 
     TPathId ResolvePathIdForDomain(TPathId pathId) const;
     TPathId ResolvePathIdForDomain(TPathElement::TPtr pathEl) const;

--- a/ydb/core/tx/schemeshard/ut_backup_collection/ut_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/ut_backup_collection/ut_backup_collection.cpp
@@ -585,6 +585,223 @@ Y_UNIT_TEST_SUITE(TBackupCollectionTests) {
                               {NLs::PathNotExist});
         }
 
+        TString FindChildEndingWith(TTestBasicRuntime& runtime, const TString& parent, const TString& suffix) {
+            auto desc = DescribePath(runtime, parent, false, false, true);
+            const auto& pd = desc.GetPathDescription();
+            for (ui32 i = 0; i < pd.ChildrenSize(); ++i) {
+                const auto& name = pd.GetChildren(i).GetName();
+                if (name.EndsWith(suffix)) {
+                    return name;
+                }
+            }
+            UNIT_ASSERT_C(false, "no child of " << parent << " ending with " << suffix);
+            return {};
+        }
+
+        // The incremental backup destination table must stay a regular, readable table (NOT IsBackup),
+        // matching the full backup-collection table; limit bypass is done via OmitObjectLimitChecks, not
+        // by marking it a backup table (which would make it unreadable).
+        Y_UNIT_TEST(IncrementalBackupTableIsNotMarkedBackup) {
+            TTestBasicRuntime runtime;
+            TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));
+            ui64 txId = 100;
+
+            SetupLogging(runtime);
+            PrepareDirs(runtime, env, txId);
+
+            TString collectionSettingsWithIncremental = R"(
+                Name: ")" DEFAULT_NAME_1 R"("
+
+                ExplicitEntryList {
+                    Entries {
+                        Type: ETypeTable
+                        Path: "/MyRoot/Table1"
+                    }
+                }
+                Cluster: {}
+                IncrementalBackupConfig: {}
+            )";
+
+            TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections/", collectionSettingsWithIncremental);
+            env.TestWaitNotification(runtime, txId);
+
+            TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint32" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            )");
+            env.TestWaitNotification(runtime, txId);
+
+            TestBackupBackupCollection(runtime, ++txId, "/MyRoot",
+                R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+            env.TestWaitNotification(runtime, txId);
+
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
+            TestBackupIncrementalBackupCollection(runtime, ++txId, "/MyRoot",
+                R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+            env.TestWaitNotification(runtime, txId);
+
+            const TString collectionPath = "/MyRoot/.backups/collections/" DEFAULT_NAME_1;
+            const TString incrDir = FindChildEndingWith(runtime, collectionPath, "_incremental");
+
+            // The incremental backup table is created with IsBackup=true (this is what excludes it from
+            // the path/children/shard limits and drives drop/rebuild accounting symmetrically).
+            TestDescribeResult(DescribePath(runtime, collectionPath + "/" + incrDir + "/Table1", false, false, true), {
+                NLs::PathExist,
+                NLs::IsBackupTable(false),
+            });
+        }
+
+        void GetDomainCounters(TTestBasicRuntime& runtime, ui64& paths, ui64& shards, ui64& pqParts) {
+            auto desc = DescribePath(runtime, "/MyRoot");
+            const auto& d = desc.GetPathDescription().GetDomainDescription();
+            paths = d.GetPathsInside();
+            shards = d.GetShardsInside();
+            pqParts = d.GetPQPartitionsInside();
+        }
+
+        // Phases 1-3 end to end: an incremental backup must succeed even when the domain has no headroom
+        // for the per-increment shards/partitions (the topic) — proving the table (IsBackup) and the CDC
+        // stream / PQ topic (OmitObjectLimitChecks) all bypass the schemeshard object/path limits.
+        Y_UNIT_TEST(IncrementalBackupBypassesObjectLimits) {
+            TTestBasicRuntime runtime;
+            TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));
+            ui64 txId = 100;
+
+            SetupLogging(runtime);
+            PrepareDirs(runtime, env, txId);
+
+            TString collectionSettingsWithIncremental = R"(
+                Name: ")" DEFAULT_NAME_1 R"("
+
+                ExplicitEntryList {
+                    Entries {
+                        Type: ETypeTable
+                        Path: "/MyRoot/Table1"
+                    }
+                }
+                Cluster: {}
+                IncrementalBackupConfig: {}
+            )";
+
+            TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections/", collectionSettingsWithIncremental);
+            env.TestWaitNotification(runtime, txId);
+
+            TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint32" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            )");
+            env.TestWaitNotification(runtime, txId);
+
+            TestBackupBackupCollection(runtime, ++txId, "/MyRoot",
+                R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+            env.TestWaitNotification(runtime, txId);
+
+            // Tighten the limits to current usage: zero headroom for shards and PQ partitions (only the
+            // increment's topic would add those), and only a little path headroom for the per-run dir.
+            ui64 paths = 0, shards = 0, pqParts = 0;
+            GetDomainCounters(runtime, paths, shards, pqParts);
+
+            NKikimr::NSchemeShard::TSchemeLimits limits;
+            limits.MaxPaths = paths + 3;
+            limits.MaxShards = shards;
+            limits.MaxPQPartitions = pqParts;
+            SetSchemeshardSchemaLimits(runtime, limits);
+
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
+            // Without the bypass this fails with StatusResourceExhausted; with it, it succeeds.
+            TestBackupIncrementalBackupCollection(runtime, ++txId, "/MyRoot",
+                R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")",
+                {NKikimrScheme::StatusAccepted});
+            env.TestWaitNotification(runtime, txId);
+
+            const TString collectionPath = "/MyRoot/.backups/collections/" DEFAULT_NAME_1;
+            const TString incrDir = FindChildEndingWith(runtime, collectionPath, "_incremental");
+            TestDescribeResult(DescribePath(runtime, collectionPath + "/" + incrDir + "/Table1", false, false, true), {
+                NLs::PathExist,
+                NLs::IsBackupTable(false),
+            });
+        }
+
+        // Proves backup objects do NOT consume the user object/path quota: after an incremental backup,
+        // set MaxPaths to the current raw PathsInside (which now includes the not-counted backup table
+        // and dir). A regular user MkDir must still succeed, because the backup objects are subtracted
+        // from the limit check. Without not-counting this MkDir would fail with StatusResourceExhausted.
+        Y_UNIT_TEST(IncrementalBackupDoesNotConsumeUserQuota) {
+            TTestBasicRuntime runtime;
+            TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));
+            ui64 txId = 100;
+
+            SetupLogging(runtime);
+            PrepareDirs(runtime, env, txId);
+
+            TString collectionSettingsWithIncremental = R"(
+                Name: ")" DEFAULT_NAME_1 R"("
+
+                ExplicitEntryList {
+                    Entries {
+                        Type: ETypeTable
+                        Path: "/MyRoot/Table1"
+                    }
+                }
+                Cluster: {}
+                IncrementalBackupConfig: {}
+            )";
+
+            TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections/", collectionSettingsWithIncremental);
+            env.TestWaitNotification(runtime, txId);
+
+            TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+                Name: "Table1"
+                Columns { Name: "key" Type: "Uint32" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            )");
+            env.TestWaitNotification(runtime, txId);
+
+            TestBackupBackupCollection(runtime, ++txId, "/MyRoot",
+                R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+            env.TestWaitNotification(runtime, txId);
+
+            runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+
+            TestBackupIncrementalBackupCollection(runtime, ++txId, "/MyRoot",
+                R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+            env.TestWaitNotification(runtime, txId);
+
+            ui64 paths = 0, shards = 0, pqParts = 0;
+            GetDomainCounters(runtime, paths, shards, pqParts);
+
+            // No room for any *regular* object beyond what already exists as regular...
+            NKikimr::NSchemeShard::TSchemeLimits limits;
+            limits.MaxPaths = paths;
+            SetSchemeshardSchemaLimits(runtime, limits);
+
+            // ...yet a user dir still fits, because the backup table + dir are not counted.
+            TestMkDir(runtime, ++txId, "/MyRoot", "UserDir", {NKikimrScheme::StatusAccepted});
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // Negative control: a plain user CreateTable must still NOT be able to set IsBackup. The
+        // relaxation only applies when IncrementalBackupConfig is present (the incremental backup path).
+        Y_UNIT_TEST(UserCannotCreateBackupTable) {
+            TTestBasicRuntime runtime;
+            TTestEnv env(runtime);
+            ui64 txId = 100;
+
+            TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+                Name: "UserBackup"
+                Columns { Name: "key" Type: "Uint32" }
+                KeyColumnNames: ["key"]
+                IsBackup: true
+            )", {NKikimrScheme::StatusInvalidParameter});
+        }
+
         Y_UNIT_TEST(DropCollectionDuringActiveBackup) {
             TTestBasicRuntime runtime;
             TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));

--- a/ydb/core/tx/schemeshard/ut_incr_backup_reboots/ut_incr_backup_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_incr_backup_reboots/ut_incr_backup_reboots.cpp
@@ -172,6 +172,96 @@ Y_UNIT_TEST_SUITE(TBackupWithRebootsTests) {
                     NLs::CheckPathState(NKikimrSchemeOp::EPathStateNoChanges),
                     NLs::Finished,
                 });
+
+                // The incremental backup table must stay a regular, readable table (NOT IsBackup) across
+                // reboots; the limit bypass uses the transient OmitObjectLimitChecks marker at create
+                // time and does not change the persisted table at all.
+                TestDescribeResult(DescribePath(runtime,
+                    "/MyRoot/.backups/collections/MyCollection1/19700101000001Z_incremental/Table1",
+                    false, false, true), {
+                    NLs::PathExist,
+                    NLs::IsBackupTable(false),
+                });
+            }
+        });
+    }
+
+    // Verifies that an incremental backup is never blocked by the schemeshard object/path limits across
+    // reboots: the in-collection table + dir are not counted (EPathCategory::Backup) and the
+    // under-source-table CDC stream + PQ topic/streamImpl are check-skipped (OmitObjectLimitChecks).
+    // MaxShards/MaxPQPartitions are pinned to current usage (only the new topic adds those), so the
+    // backup can only succeed if the topic bypasses them; the reboot framework replays this at every
+    // persistence point, also catching any backup-counter drift.
+    Y_UNIT_TEST_WITH_REBOOTS_BUCKETS(IncrementalBackupBypassesLimitsAcrossReboots, 2, 1, false) {
+        t.GetTestEnvOptions() = TTestEnvOptions().EnableBackupService(true);
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestMkDir(runtime, ++t.TxId, "/MyRoot", ".backups/collections");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                TestCreateBackupCollection(runtime, ++t.TxId, "/MyRoot/.backups/collections", R"(
+                    Name: "MyCollection1"
+                    ExplicitEntryList {
+                        Entries {
+                            Type: ETypeTable
+                            Path: "/MyRoot/Table1"
+                        }
+                    }
+                    Cluster {}
+                    IncrementalBackupConfig {}
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "Table1"
+                    Columns { Name: "key" Type: "Uint32" }
+                    Columns { Name: "value" Type: "Uint32" }
+                    KeyColumnNames: ["key"]
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                TestBackupBackupCollection(runtime, ++t.TxId, "/MyRoot",
+                    R"(Name: ".backups/collections/MyCollection1")");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                // Pin limits to current usage so the incremental backup can only succeed by bypassing
+                // them. MaxShards/MaxPQPartitions are consumed only by the (under-source-table) topic.
+                auto domain = DescribePath(runtime, "/MyRoot").GetPathDescription().GetDomainDescription();
+                TSchemeLimits limits;
+                limits.MaxShards = domain.GetShardsInside();
+                limits.MaxPQPartitions = domain.GetPQPartitionsInside();
+                limits.MaxPaths = domain.GetPathsInside() + 2; // small headroom for the per-run dir
+                SetSchemeshardSchemaLimits(runtime, limits);
+
+                runtime.AdvanceCurrentTime(TDuration::Seconds(1));
+            }
+
+            TestBackupIncrementalBackupCollection(runtime, ++t.TxId, "/MyRoot",
+                R"(Name: ".backups/collections/MyCollection1")");
+            const ui64 backupId = t.TxId;
+            t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                WaitForIncrementalBackupDone(runtime, t.TestEnv.Get(), backupId, "/MyRoot");
+
+                TestDescribeResult(DescribePath(runtime, "/MyRoot/.backups/collections/MyCollection1"), {
+                    NLs::PathExist,
+                    NLs::IsBackupCollection,
+                    NLs::ChildrenCount(2),
+                    NLs::Finished,
+                });
+
+                // The increment table is readable (not IsBackup) and was created despite the pinned limits.
+                TestDescribeResult(DescribePath(runtime,
+                    "/MyRoot/.backups/collections/MyCollection1/19700101000001Z_incremental/Table1",
+                    false, false, true), {
+                    NLs::PathExist,
+                    NLs::IsBackupTable(false),
+                });
             }
         });
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Creating incremental backups previously counted every created object against the subdomain limits (`MaxPaths` / `MaxChildrenInDir` / `MaxShards` / `MaxPQPartitions`) and could be rejected once the limits were reached. The accumulating per-increment backup tables and directories also permanently consumed the user's object quota, eventually blocking the user's own DDL.

**Not-counting — accumulating in-collection objects.** Objects stored inside a backup collection — the backup tables and the per-run directories, **full and incremental** — are now accounted as `EPathCategory::Backup`, so the limit checkers subtract them and they do not consume the user object/path quota. The classification is **structural**: `TSchemeShard::IsBackupObject()` walks the persisted path tree for a backup-collection ancestor. Because it reads only persisted structure, create-commit, drop/uncount and restart rebuild all derive the same category and the backup counters never drift. The tables stay **regular, readable** tables (no `IsBackup`), matching the existing full backup-collection table — so `SELECT` from a backup table keeps working.

Accounting sites, all using the same structural predicate:
- create: `create_table.cpp`, `copy_table.cpp`, `mkdir.cpp`
- drop: `drop_table.cpp`, `rmdir.cpp`, and force-drop via `TSchemeShard::UncountNode`
- restart rebuild: `schemeshard__init.cpp` (paths + shards)

**Not-blocking — bounded under-source-table objects.** The per-increment CDC stream and its `streamImpl` topic live under the *source* table (not inside the collection) and are bounded by stream rotation/drop. They are marked with a new internal-only `TModifyScheme.OmitObjectLimitChecks` (set only by the incremental-backup decomposition) so their creation is never blocked by the limits — this also covers `MaxPQPartitions` / `PQReservedStorage`, which have no backup counter to subtract. They remain accounted as `Regular` (like full-backup streams), which keeps their create/drop/rebuild trivially consistent (no drift).

Notes:
- `OmitObjectLimitChecks` is system-internal (like `Internal`, never set by direct user requests).
- This also stops **full** backup-collection objects from consuming the user object quota (same principle) — a deliberate behavior change.
- An earlier iteration marked the incremental table `IsBackup` for not-counting; that was dropped because it made the table unreadable (the datashard rejects reads of backup tables) and diverged from the full backup-collection table. Counter-routing the under-source-table CDC stream/topic via a `__incremental_backup` attribute was also tried and dropped: the attribute is not reliably applied on the CDC rotate path, so it caused backup-counter drift across the CDC/PQ drop paths.

Tests (`ut_backup_collection`, `ut_incr_backup_reboots`):
- `IncrementalBackupBypassesObjectLimits` — incremental backup succeeds with usage **over** the shard / PQ-partition limits.
- `IncrementalBackupDoesNotConsumeUserQuota` — a user `MkDir` still succeeds at `MaxPaths == current usage`, proving backup objects are not counted.
- `IncrementalBackupTableIsNotMarkedBackup` — destination table is NOT `IsBackup` (stays readable).
- `IncrementalBackupBypassesLimitsAcrossReboots` (reboot suite) — limit bypass and counter consistency hold across reboots.
- `UserCannotCreateBackupTable` — negative control: a plain user `CreateTable` with `IsBackup` is still rejected.

Regression: `ut_backup_collection`, `ut_incr_backup_reboots`, `ut_cdc_stream`, `ut_continuous_backup`, `ut_subdomain`, `ut_base`, `ut_export`, `ut_consistent_copy_tables`, and datashard `ut_incremental_backup` all green.
