### PR TITLE
Fixing SnapshotRegistry

### DIFF
--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -431,11 +431,10 @@ void TLongTxServiceActor::Handle(TEvPrivate::TEvAcquireSnapshotFinished::TPtr& e
     Y_ABORT_UNLESS(state && state->ActiveRequests.contains(ev->Cookie), "Unexpected database snapshot state");
 
     if (msg->Status == Ydb::StatusIds::SUCCESS) {
-        const auto now = AppData()->TimeProvider->Now();
         for (auto& userReq : req->UserRequests) {
             auto snapshotHandle = [&]() {
                 if (AppData()->FeatureFlags.GetEnableSnapshotsLocking()) {
-                    TLocalSnapshotInfo snapshotInfo(msg->Snapshot, userReq.Sender, std::move(userReq.TableIds), now);
+                    TLocalSnapshotInfo snapshotInfo(msg->Snapshot, userReq.Sender, std::move(userReq.TableIds));
                     NKqp::TSnapshotHandle snapshotHandle(snapshotInfo.AliveFlag);
                     LocalSnapshotsStorage->Insert(std::move(snapshotInfo));
 

--- a/ydb/core/tx/long_tx_service/snapshots_exchange.cpp
+++ b/ydb/core/tx/long_tx_service/snapshots_exchange.cpp
@@ -232,8 +232,9 @@ namespace {
 
     class TSnapshotCollectorActor : public TTreeNodeActor<TEvLongTxService::TEvCollectSnapshots, TEvLongTxService::TEvCollectSnapshotsResult> {
     public:
-        TSnapshotCollectorActor(const TLocalSnapshotsStorage::TView& localSnapshotsView, TActorId parentActorId, TEvLongTxService::TEvCollectSnapshots* event, const TSubtreeSplitter& subtreeSplitter)
-            : TTreeNodeActor(parentActorId, event, subtreeSplitter) {
+        TSnapshotCollectorActor(const TLocalSnapshotsStorage::TView& localSnapshotsView, TInstant now, TActorId parentActorId, TEvLongTxService::TEvCollectSnapshots* event, const TSubtreeSplitter& subtreeSplitter)
+            : TTreeNodeActor(parentActorId, event, subtreeSplitter)
+            , LocalCollectionTime(now) {
             for (const auto& localSnapshot : localSnapshotsView) {
                 TRemoteSnapshotInfo remoteSnapshot(
                     localSnapshot.Snapshot,
@@ -242,7 +243,6 @@ namespace {
 
                 AddToCollectedSnapshots(remoteSnapshot);
             }
-            LocalCollectionTime = AppData()->TimeProvider->Now();
             TXLOG_DEBUG("Finished creating TSnapshotCollectorActor, local collection time: " << LocalCollectionTime.MilliSeconds());
         }
 
@@ -368,10 +368,11 @@ namespace {
 
 IActor* CreateSnapshotCollectorActor(
         const TLocalSnapshotsStorage::TView& localSnapshotsView,
+        TInstant now,
         TActorId parentActorId,
         TEvLongTxService::TEvCollectSnapshots* event,
         const TSubtreeSplitter& subtreeSplitter) {
-    return new TSnapshotCollectorActor(localSnapshotsView, parentActorId, event, subtreeSplitter);
+    return new TSnapshotCollectorActor(localSnapshotsView, now, parentActorId, event, subtreeSplitter);
 }
 
 IActor* CreateSnapshotPropagatorActor(
@@ -603,8 +604,10 @@ private:
     void Handle(TEvLongTxService::TEvCollectSnapshots::TPtr& ev) {
         TXLOG_DEBUG("Handling TEvCollectSnapshots event from " << ev->Sender
             << " with " << ev->Get()->Record.GetTree().GetChildrenActorIds().size() << " children");
+        const auto now = AppData()->TimeProvider->Now();
         auto* collectorActor = CreateSnapshotCollectorActor(
-            LocalSnapshotsStorage->View(),
+            LocalSnapshotsStorage->View(now),
+            now,
             ev->Sender,
             ev->Get(),
             TSubtreeSplitter(
@@ -728,7 +731,8 @@ private:
             addToCollectedSnapshots(remoteSnapshot);
         }
 
-        for (const auto& localSnapshot : LocalSnapshotsStorage->View()) {
+        const auto now = AppData()->TimeProvider->Now();
+        for (const auto& localSnapshot : LocalSnapshotsStorage->View(now)) {
             TRemoteSnapshotInfo remoteSnapshot(
                 localSnapshot.Snapshot,
                 localSnapshot.SessionActorId,
@@ -763,7 +767,7 @@ private:
         // This node's own snapshots are known as of now.
         auto* localNodeInfoProto = resultEvent->Record.MutableSnapshots()->AddNodesCollectionInfo();
         localNodeInfoProto->SetNodeId(SelfId().NodeId());
-        localNodeInfoProto->SetUpdateTime(AppData()->TimeProvider->Now().Seconds());
+        localNodeInfoProto->SetUpdateTime(now.Seconds());
 
         TXLOG_DEBUG("Sending TEvRemoteSnapshotsPrefillResult to " << ev->Sender
             << " with " << resultEvent->Record.GetSnapshots().GetSnapshots().size() << " snapshots");

--- a/ydb/core/tx/long_tx_service/snapshots_storage.cpp
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.cpp
@@ -26,7 +26,7 @@ void TLocalSnapshotsStorage::Clear() {
 }
 
 const TLocalSnapshotInfo* TLocalSnapshotsStorage::TView::Next() {
-    while (Iter != End && (Iter->CreationTime > MaxCreationTime || !Iter->AliveFlag->load())) {
+    while (Iter != End && (Iter->Snapshot.Step > MaxSnapshotStep || !Iter->AliveFlag->load())) {
         ++Iter;
     }
 
@@ -37,11 +37,18 @@ const TLocalSnapshotInfo* TLocalSnapshotsStorage::TView::Next() {
 }
 
 TLocalSnapshotsStorage::TView TLocalSnapshotsStorage::View() const {
-    auto now = AppData()->TimeProvider->Now();
+    return View(AppData()->TimeProvider->Now());
+}
+
+TLocalSnapshotsStorage::TView TLocalSnapshotsStorage::View(TInstant now) const {
+    const ui64 promotionMs =
+        TDuration::Seconds(AppData()->LongTxServiceConfig.GetLocalSnapshotPromotionTimeSeconds()).MilliSeconds();
+    const ui64 nowMs = now.MilliSeconds();
+    const ui64 maxSnapshotStep = nowMs > promotionMs ? nowMs - promotionMs : 0;
     return TLocalSnapshotsStorage::TView{
         LocalSnapshots.begin(),
         LocalSnapshots.end(),
-        now - TDuration::Seconds(AppData()->LongTxServiceConfig.GetLocalSnapshotPromotionTimeSeconds())};
+        maxSnapshotStep};
 }
 
 void TRemoteSnapshotsStorage::Init(const TVector<TRemoteSnapshotInfo>& snapshots, const THashMap<ui32, TInstant>& nodeIdToCollectionTime) {

--- a/ydb/core/tx/long_tx_service/snapshots_storage.cpp
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.cpp
@@ -26,12 +26,16 @@ void TLocalSnapshotsStorage::Clear() {
 }
 
 const TLocalSnapshotInfo* TLocalSnapshotsStorage::TView::Next() {
-    while (Iter != End && (Iter->Snapshot.Step > MaxSnapshotStep || !Iter->AliveFlag->load())) {
+    while (Iter != End) {
+        if (Iter->Snapshot.Step > MaxSnapshotStep) {
+            // LocalSnapshots is ordered by Snapshot (Step primary)
+            Iter = End;
+            break;
+        }
+        if (Iter->AliveFlag->load()) {
+            return &*(Iter++);
+        }
         ++Iter;
-    }
-
-    if (Iter != End) {
-        return &*(Iter++);
     }
     return nullptr;
 }

--- a/ydb/core/tx/long_tx_service/snapshots_storage.h
+++ b/ydb/core/tx/long_tx_service/snapshots_storage.h
@@ -12,7 +12,6 @@ namespace NLongTxService {
 
 struct TLocalSnapshotInfo {
     TRowVersion Snapshot;
-    TInstant CreationTime;
     NActors::TActorId SessionActorId;
     TVector<NKikimr::TTableId> TableIds;
     std::shared_ptr<std::atomic<bool>> AliveFlag = nullptr;
@@ -22,18 +21,16 @@ struct TLocalSnapshotInfo {
     TLocalSnapshotInfo(
         const TRowVersion& snapshot,
         const NActors::TActorId& sessionActorId,
-        TVector<NKikimr::TTableId> tableIds,
-        const TInstant creationTime)
+        TVector<NKikimr::TTableId> tableIds)
         : Snapshot(snapshot)
-        , CreationTime(creationTime)
         , SessionActorId(sessionActorId)
         , TableIds(std::move(tableIds))
         , AliveFlag(std::make_shared<std::atomic<bool>>(true))
     {}
 
-    struct TComparatorByCreateTimeFirst {
+    struct TComparatorBySnapshotAndSessionId {
         bool operator()(const TLocalSnapshotInfo& lhs, const TLocalSnapshotInfo& rhs) const {
-            return std::tie(lhs.CreationTime, lhs.Snapshot, lhs.SessionActorId) < std::tie(rhs.CreationTime, rhs.Snapshot, rhs.SessionActorId);
+            return std::tie(lhs.Snapshot, lhs.SessionActorId) < std::tie(rhs.Snapshot, rhs.SessionActorId);
         }
     };
 };
@@ -70,28 +67,29 @@ public:
         friend class TInputRangeAdaptor<TView>;
         friend class TLocalSnapshotsStorage;
 
-        using TConstIter = TSet<TLocalSnapshotInfo, TLocalSnapshotInfo::TComparatorByCreateTimeFirst>::const_iterator;
+        using TConstIter = TSet<TLocalSnapshotInfo, TLocalSnapshotInfo::TComparatorBySnapshotAndSessionId>::const_iterator;
 
         TView(
                 TConstIter begin,
                 TConstIter end,
-                TInstant maxCreationTime)
+                ui64 maxSnapshotStep)
             : Iter(begin)
             , End(end)
-            , MaxCreationTime(maxCreationTime)
+            , MaxSnapshotStep(maxSnapshotStep)
         {}
 
         const TLocalSnapshotInfo* Next();
 
         TConstIter Iter;
         const TConstIter End;
-        const TInstant MaxCreationTime;
+        const ui64 MaxSnapshotStep;
     };
 
     TView View() const;
+    TView View(TInstant now) const;
 
 private:
-    TSet<TLocalSnapshotInfo, TLocalSnapshotInfo::TComparatorByCreateTimeFirst> LocalSnapshots;
+    TSet<TLocalSnapshotInfo, TLocalSnapshotInfo::TComparatorBySnapshotAndSessionId> LocalSnapshots;
 };
 
 using TLocalSnapshotsStoragePtr = TIntrusivePtr<TLocalSnapshotsStorage>;


### PR DESCRIPTION
fixes #41937

Previously, snapshot were filtered by SnapshotRegistry looking at their CreationTime. CreationTime is the time when the snapshot gets to LongTxService, that is CreationTime >= snapshot.step.

If there are delays in the system, snapshot may get to LongTxService much later, so CreationTime >> snapshot.step. So, such snapshot will be distributed in the cluster, later than it should be, and the clients (shards) may already delete the data that snapshot needs.

In fact, the clients do not care about CreationTime, they care about snapshot.step. So, here we get rid of CreationTime completely and use instead of it just snapshot.step. So, snapshots get distributed when now - snapshot.step >= LocalSnapshotPromotionTime (30 seconds by default).

The system as the whole is still not guaranteedly correct. We have problems from two sides:
- From the SnapshotRegistry side. Too old snapshots can come to clients. "Too old" means that clients might have cleaned the data for them when they arrive. There is no known feasible/reasonable ways to fix that guaranteedly. We can only reduce the probability of such events. This particular PR does exactly that.
- From the client's side. When a too old snapshot arrives, the client (columnshard) may do the following:
  - Trust SnapshotRegistry and serve the scan. Current behavior. In this case, customers get corrupted data (worst case)
  - Do not trust SnapshotRegistry and reject the scan "snapshot is too old". Desirable behavior. In this case, customers get just an error (much better than corrupted result).

So, keeping that in mind, further improvements for this whole story will be:
- From the SnapshotRegistry side. Use the mediator time instead of wall-clock for CollectionTime. Decreases the probability of accidental "too old snapshots". 
- From the columnshard side. Track what exactly have already been cleaned on every cleanup. Makes returning corrupted data impossible. An algorithm of O(1) memory and cpu complexity is already designed for that.

