### PR TITLE
Fix reading column-aware bytesize

### DIFF
--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.cpp
@@ -253,7 +253,7 @@ namespace {
             float l = FromString<float>(left);
             float r = FromString<float>(right);
             return (l < r) ? -1 : (l > r) ? 1 : 0;
-        } else if (columnType == "Double" || columnType == "Decimal(12,2)") {
+        } else if (columnType == "Double" || columnType.StartsWith("Decimal")) {
             double l = FromString<double>(left);
             double r = FromString<double>(right);
             return (l < r) ? -1 : (l > r) ? 1 : 0;
@@ -318,7 +318,7 @@ namespace {
             } else if (columnType == "Int64") {
                 i64 val = FromString<i64>(value);
                 return EstimateInequalityPredicateByType<i64>(eqWidthHistogram, val, predicate);
-            } else if (columnType == "Double" || columnType == "Decimal(12,2)") {
+            } else if (columnType == "Double" || columnType.StartsWith("Decimal")) {
                 double val = FromString<double>(value);
                 return EstimateInequalityPredicateByType<double>(eqWidthHistogram, val, predicate);
             } else if (columnType == "Date") {
@@ -382,7 +382,7 @@ namespace {
                 i64 leftVal = FromString<i64>(leftValue);
                 i64 rightVal = FromString<i64>(rightValue);
                 return EstimateRangePredicateByType<i64>(eqWidthHistogram, leftVal, rightVal, leftPredicate, rightPredicate);
-            } else if (columnType == "Double" || columnType == "Decimal(12,2)") {
+            } else if (columnType == "Double" || columnType.StartsWith("Decimal")) {
                 double leftVal = FromString<double>(leftValue);
                 double rightVal = FromString<double>(rightValue);
                 return EstimateRangePredicateByType<double>(eqWidthHistogram, leftVal, rightVal, leftPredicate, rightPredicate);
@@ -437,7 +437,7 @@ namespace {
             } else if (columnType == "Float") {
                 float val = FromString<float>(value);
                 return countMinSketch->Probe(reinterpret_cast<const char*>(&val), sizeof(val));
-            } else if (columnType == "Double" || columnType == "Decimal(12,2)") {
+            } else if (columnType == "Double" || columnType.StartsWith("Decimal")) {
                 double val = FromString<double>(value);
                 return countMinSketch->Probe(reinterpret_cast<const char*>(&val), sizeof(val));
             } else if (columnType == "Date") {
@@ -491,13 +491,25 @@ namespace NKikimr::NKqp {
 
 
 TMaybe<TString> TPredicateSelectivityComputer::GetAttributeType(const TString& attributeName) {
-    if (Stats && Stats->ColumnStatistics) {
-        auto it = Stats->ColumnStatistics->Data.find(attributeName);
-        if (it != Stats->ColumnStatistics->Data.end()) {
-            return it->second.Type;
-        }
+    if (!Stats || !Stats->ColumnStatistics) {
         return Nothing();
     }
+
+    TString columnName = attributeName;
+    if (Lineage) {
+        const auto& mapping = Lineage->Mapping;
+        if (mapping.contains(TInfoUnit(attributeName).GetFullName())) {
+            const auto& entry = mapping.at(TInfoUnit(attributeName).GetFullName());
+            auto infoUnit = TInfoUnit(entry.TableName, entry.ColumnName);
+            attributeName = infoUnit.GetFullName();
+        }
+    }
+
+    auto it = Stats->ColumnStatistics->Data.find(columnName);
+    if (it != Stats->ColumnStatistics->Data.end()) {
+        return it->second.Type;
+    }
+
     return Nothing();
 }
 
@@ -1281,8 +1293,10 @@ double TPredicateSelectivityComputer::Compute(const NNodes::TExprBase& input) {
 
     TSet<TString> tableAliases;
     double resSelectivity = ComputeSelectivity(rootNode, tableAliases);
-    if (tableAliases.size() != 1) {
-        YQL_CLOG(TRACE, CoreDq) << "No or multiple table aliases in computing selectivity.";
+    if (tableAliases.size() == 0) {
+        YQL_CLOG(TRACE, CoreDq) << "No table aliases in computing selectivity.";
+    } else if (tableAliases.size() != 1) {
+        YQL_CLOG(TRACE, CoreDq) << "Multiple table aliases in computing selectivity.";
     }
 
     return std::min(1.0, resSelectivity);

--- a/ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.cpp
+++ b/ydb/core/kqp/opt/cbo/solver/kqp_opt_predicate_selectivity.cpp
@@ -501,7 +501,7 @@ TMaybe<TString> TPredicateSelectivityComputer::GetAttributeType(const TString& a
         if (mapping.contains(TInfoUnit(attributeName).GetFullName())) {
             const auto& entry = mapping.at(TInfoUnit(attributeName).GetFullName());
             auto infoUnit = TInfoUnit(entry.TableName, entry.ColumnName);
-            attributeName = infoUnit.GetFullName();
+            columnName = infoUnit.GetFullName();
         }
     }
 

--- a/ydb/core/kqp/opt/kqp_column_statistics_utils.cpp
+++ b/ydb/core/kqp/opt/kqp_column_statistics_utils.cpp
@@ -14,6 +14,7 @@ void AddStatRequest(TActorSystem* actorSystem, TVector<NThreading::TFuture<TColu
     struct TTableMeta {
         TString TableName;
         THashMap<ui32, TString> ColumnNameByTag;
+        THashMap<ui32, TString> ColumnTypeByTag;
     };
 
     THashMap<TPathId, TTableMeta> tableMetaByPathId;
@@ -47,6 +48,7 @@ void AddStatRequest(TActorSystem* actorSystem, TVector<NThreading::TFuture<TColu
 
             tableMetaByPathId[pathId].TableName = table;
             tableMetaByPathId[pathId].ColumnNameByTag[req.ColumnTag.value()] = column;
+            tableMetaByPathId[pathId].ColumnTypeByTag[req.ColumnTag.value()] = columnsMeta[column].Type;
         }
     }
 
@@ -72,6 +74,7 @@ void AddStatRequest(TActorSystem* actorSystem, TVector<NThreading::TFuture<TColu
             auto meta = tableMetaByPathId[stat.Req.PathId];
             auto columnName = meta.ColumnNameByTag[stat.Req.ColumnTag.value()];
             auto& columnStatistics = columnStatisticsByTableName[meta.TableName].Data[columnName];
+            columnStatistics.Type = meta.ColumnTypeByTag[stat.Req.ColumnTag.value()];
             if (stat.CountMinSketch.CountMin) {
                 columnStatistics.CountMinSketch = std::move(stat.CountMinSketch.CountMin);
             }

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -154,7 +154,7 @@ void TOpRead::ComputeMetadata(TRBOContext& ctx, TPlanProps& planProps) {
     Props.Metadata = TRBOMetadata();
 
     const auto& tableData = ctx.KqpCtx.Tables->ExistingTable(ctx.KqpCtx.Cluster, path.Value());
-    Props.Metadata->ColumnsCount = tableData.Metadata->Columns.size();
+    Props.Metadata->ColumnsCount = Props.Metadata->ColumnsCount = Columns.size();
 
     // Record lineage: source can rename its columns, so already we need to record that
     auto outputIUs = GetOutputIUs();
@@ -235,6 +235,12 @@ void TOpRead::ComputeStatistics(TRBOContext& ctx, TPlanProps& planProps) {
                 Props.Statistics->EBytes = byteSize->second.GetDoubleSafe();
             }
         }
+    }
+
+    const auto totalColumns = tableData.Metadata->Columns.size();
+    const auto readColumns = Columns.size();
+    if (totalColumns > 0 && readColumns < totalColumns) {
+        Props.Statistics->EBytes *= static_cast<double>(readColumns) / static_cast<double>(totalColumns);
     }
 
     // Overwrite with selectivity for successfully pushed-down filters within the read operator.

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_compute_statistics.cpp
@@ -154,7 +154,7 @@ void TOpRead::ComputeMetadata(TRBOContext& ctx, TPlanProps& planProps) {
     Props.Metadata = TRBOMetadata();
 
     const auto& tableData = ctx.KqpCtx.Tables->ExistingTable(ctx.KqpCtx.Cluster, path.Value());
-    Props.Metadata->ColumnsCount = Props.Metadata->ColumnsCount = Columns.size();
+    Props.Metadata->ColumnsCount = Columns.size();
 
     // Record lineage: source can rename its columns, so already we need to record that
     auto outputIUs = GetOutputIUs();

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_statistics.cpp
@@ -109,8 +109,8 @@ TOptimizerStatistics BuildOptimizerStatistics(TPhysicalOpProps& props, bool with
     }
 
 
-    return TOptimizerStatistics(props.Metadata->Type, 
-        withStatsAndCosts ? props.Statistics->EBytes : 0.0,
+    return TOptimizerStatistics(props.Metadata->Type,
+        withStatsAndCosts ? props.Statistics->ERows : 0.0,
         props.Metadata->ColumnsCount,
         withStatsAndCosts ? props.Statistics->EBytes : 0.0,
         withStatsAndCosts ? cost : 0.0,

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -6342,6 +6342,14 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         query = toDecimal + "\n" + toDecimalMax + "\n" +
             R"(PRAGMA ydb.CostBasedOptimizationLevel = "4";
 PRAGMA ydb.OptShuffleElimination = "true";
+PRAGMA ydb.OptimizerHints = '
+    JoinType(region nation Shuffle)
+    JoinType(region nation supplier Shuffle)
+    JoinType(region nation supplier customer Shuffle)
+    JoinType(region nation supplier customer orders Shuffle)
+    JoinType(region nation supplier customer orders lineitem Shuffle)
+    JoinOrder(((((region nation) supplier) customer) orders) lineitem)
+';
 )" + query;
 
         auto queryClient = kikimr.GetQueryClient();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Instead of reading estimated byte size of entire table, computing byte size only for necessary column is more accurate.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
