### PR TITLE
Add SchemeShard fails retries for secrets and use them in replication

### DIFF
--- a/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
@@ -447,11 +447,11 @@ bool TDescribeSchemaSecretsService::ScheduleSchemeCacheRetry(const ui64& request
     auto requestIt = RequestsInFlight.find(requestId);
     Y_ENSURE(requestIt != RequestsInFlight.end(), "Unregistered requestId: " + ToString(requestId));
 
-    const auto& retryPolicy = requestIt->second.Request->Settings.RetryPolicy
-        ? requestIt->second.Request->Settings.RetryPolicy
-        : MakeShortRetryPolicy();
-
     if (!requestIt->second.SchemeCacheRetryState) {
+        static const auto defaultSchemeCacheRetryPolicy = MakeShortRetryPolicy();
+        const auto& retryPolicy = requestIt->second.Request->Settings.RetryPolicy
+            ? requestIt->second.Request->Settings.RetryPolicy
+            : defaultSchemeCacheRetryPolicy;
         requestIt->second.SchemeCacheRetryState = retryPolicy->CreateRetryState();
     }
 

--- a/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
@@ -144,8 +144,6 @@ Ydb::StatusIds::StatusCode MapSchemeShardStatus(NKikimrScheme::EStatus status) {
     switch (status) {
         case NKikimrScheme::EStatus::StatusNotAvailable:
             return Ydb::StatusIds::UNAVAILABLE;
-        case NKikimrScheme::EStatus::StatusAccessDenied:
-            return Ydb::StatusIds::UNAUTHORIZED;
         default:
             return Ydb::StatusIds::BAD_REQUEST;
     }
@@ -282,22 +280,11 @@ void TDescribeSchemaSecretsService::HandleSchemeShardResponse(NSchemeShard::TEvS
     }
 
     const auto& rec = ev->Get()->GetRecord();
-    const auto& secretName = CanonizePath(rec.GetPath());
-    const auto status = GetSchemeShardPathStatus(SchemeShardStatusGetter, rec);
-    if (status != NKikimrScheme::EStatus::StatusSuccess) {
-        LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId) << "SchemeShard error: " << EStatus_Name(status));
-        if (IsRetryableSchemeShardStatus(status) && ScheduleSchemeShardRetry(requestId, secretName)) {
-            return;
-        }
-
-        const auto errorStatus = MapSchemeShardStatus(status);
-        FillResponse(
-            requestId,
-            TEvDescribeSecretsResponse::TDescription(
-                errorStatus,
-                { NYql::TIssue(MakeSchemeShardErrorMessage(status, secretName)) }));
+    if (HandleSchemeShardErrorsIfAny(requestId, rec)) {
         return;
     }
+
+    const auto& secretName = CanonizePath(rec.GetPath());
 
     if (const auto it = SchemeBoardSubscribers.find(secretName); it == SchemeBoardSubscribers.end()) {
         SchemeBoardSubscribers[secretName] = Register(CreateSchemeBoardSubscriber(SelfId(), secretName));
@@ -319,6 +306,7 @@ void TDescribeSchemaSecretsService::HandleSchemeShardResponse(NSchemeShard::TEvS
 
 void TDescribeSchemaSecretsService::FillResponse(const ui64& requestId, const TEvDescribeSecretsResponse::TDescription& response) {
     auto respIt = ResolveInFlight.find(requestId);
+    Y_ENSURE(respIt != ResolveInFlight.end(), "Unregistered requestId: " + ToString(requestId));
     respIt->second.Result.SetValue(response);
     ResolveInFlight.erase(respIt);
     RequestsInFlight.erase(requestId);
@@ -443,6 +431,46 @@ bool TDescribeSchemaSecretsService::HandleSchemeCacheErrorsIfAny(const ui64& req
     return false; // no Scheme Cache errors
 }
 
+bool TDescribeSchemaSecretsService::HandleSchemeShardErrorsIfAny(
+    const ui64& requestId,
+    const NKikimrScheme::TEvDescribeSchemeResult& record)
+{
+    const auto status = GetSchemeShardPathStatus(SchemeShardStatusGetter, record);
+    if (status == NKikimrScheme::EStatus::StatusSuccess) {
+        return false;
+    }
+
+    const auto secretName = CanonizePath(record.GetPath());
+
+    LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId) << "SchemeShard error: " << EStatus_Name(status));
+    if (IsRetryableSchemeShardStatus(status)) {
+        const auto requestIt = RequestsInFlight.find(requestId);
+        Y_ENSURE(requestIt != RequestsInFlight.end(), "Unregistered requestId: " + ToString(requestId));
+        if (requestIt->second.Request->Settings.RetryPolicy) {
+            if (ScheduleSchemeShardRetry(requestId, secretName)) {
+                return true;
+            }
+
+            LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId)
+                << "retry limit exceeded for secret `" << secretName << "`");
+            FillResponse(
+                requestId,
+                TEvDescribeSecretsResponse::TDescription(
+                    Ydb::StatusIds::UNAVAILABLE,
+                    { NYql::TIssue("Retry limit exceeded for secret `" + secretName + "`") }));
+            return true;
+        }
+    }
+
+    const auto errorStatus = MapSchemeShardStatus(status);
+    FillResponse(
+        requestId,
+        TEvDescribeSecretsResponse::TDescription(
+            errorStatus,
+            { NYql::TIssue(MakeSchemeShardErrorMessage(status, secretName)) }));
+    return true;
+}
+
 bool TDescribeSchemaSecretsService::ScheduleSchemeCacheRetry(const ui64& requestId, const TString& unresolvedSecretPath) {
     auto requestIt = RequestsInFlight.find(requestId);
     Y_ENSURE(requestIt != RequestsInFlight.end(), "Unregistered requestId: " + ToString(requestId));
@@ -486,14 +514,7 @@ bool TDescribeSchemaSecretsService::ScheduleSchemeShardRetry(const ui64& request
         return true;
     }
 
-    LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId)
-        << "retry limit exceeded for secret `" << secretPath << "`");
-    FillResponse(
-        requestId,
-        TEvDescribeSecretsResponse::TDescription(
-            Ydb::StatusIds::UNAVAILABLE,
-            { NYql::TIssue("Retry limit exceeded for secret `" + secretPath + "`") }));
-    return true;
+    return false;
 }
 
 IRetryPolicy<>::TPtr MakeShortRetryPolicy() {

--- a/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
@@ -9,6 +9,8 @@
 #include <ydb/services/metadata/secret/snapshot.h>
 #include <ydb/library/actors/core/log.h>
 
+#include <limits>
+
 #define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::SCHEMA_SECRET_CACHE, stream)
 #define LOG_N(stream) LOG_NOTICE_S(*TlsActivationContext, NKikimrServices::SCHEMA_SECRET_CACHE, stream)
 #define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::SCHEMA_SECRET_CACHE, stream)
@@ -124,6 +126,44 @@ NSchemeCache::TSchemeCacheNavigate::EStatus GetSchemeCacheEntryStatus(
     return entry.Status;
 }
 
+NKikimrScheme::EStatus GetSchemeShardPathStatus(
+    const TDescribeSchemaSecretsService::ISchemeShardStatusGetter* schemeShardStatusGetter,
+    const NKikimrScheme::TEvDescribeSchemeResult& record)
+{
+    if (schemeShardStatusGetter) {
+        return schemeShardStatusGetter->GetStatus(record);
+    }
+    return record.GetStatus();
+}
+
+bool IsRetryableSchemeShardStatus(NKikimrScheme::EStatus status) {
+    return status == NKikimrScheme::EStatus::StatusNotAvailable;
+}
+
+Ydb::StatusIds::StatusCode MapSchemeShardStatus(NKikimrScheme::EStatus status) {
+    switch (status) {
+        case NKikimrScheme::EStatus::StatusNotAvailable:
+            return Ydb::StatusIds::UNAVAILABLE;
+        case NKikimrScheme::EStatus::StatusAccessDenied:
+            return Ydb::StatusIds::UNAUTHORIZED;
+        default:
+            return Ydb::StatusIds::BAD_REQUEST;
+    }
+}
+
+TString MakeSchemeShardErrorMessage(NKikimrScheme::EStatus status, const TString& secretName) {
+    switch (status) {
+        case NKikimrScheme::EStatus::StatusNotAvailable:
+            return "Schemeshard is not available for secret `" + secretName + "`";
+        case NKikimrScheme::EStatus::StatusPathDoesNotExist:
+            return "Secret `" + secretName + "` not found";
+        case NKikimrScheme::EStatus::StatusAccessDenied:
+            return "Access denied to secret `" + secretName + "`";
+        default:
+            return "Failed to resolve secret `" + secretName + "`";
+    }
+}
+
 TString ListSecrets(const TVector<TString>& paths) {
     if (paths.empty()) {
         return "";
@@ -159,13 +199,27 @@ void TDescribeSchemaSecretsService::HandleIncomingRequest(TEvResolveSecret::TPtr
     ++LastRequestId;
 }
 
-void TDescribeSchemaSecretsService::HandleIncomingRetryRequest(TEvResolveSecretRetry::TPtr& ev) {
-    LOG_D(GetLogLabel("TEvResolveSecretRetry", ev->Get()->InitialRequestId));
+void TDescribeSchemaSecretsService::HandleIncomingSchemeCacheRetryRequest(TEvResolveSecretSchemeCacheRetry::TPtr& ev) {
+    LOG_N(GetLogLabel("TEvResolveSecretSchemeCacheRetry", ev->Get()->InitialRequestId));
 
     const auto it = RequestsInFlight.find(ev->Get()->InitialRequestId);
-    Y_ENSURE(it != RequestsInFlight.end(), "Such request requestId was not registered");
+    Y_ENSURE(it != RequestsInFlight.end(), "Unregistered requestId: " + ToString(ev->Get()->InitialRequestId));
     Y_ENSURE(it->second.Request.Get(), "Initial request was not saved");
     SendSchemeCacheRequests(*it->second.Request.Get(), ev->Get()->InitialRequestId);
+}
+
+void TDescribeSchemaSecretsService::HandleIncomingSchemeShardRetryRequest(TEvResolveSecretSchemeShardRetry::TPtr& ev) {
+    LOG_N(GetLogLabel("TEvResolveSecretSchemeShardRetry", ev->Get()->InitialRequestId)
+        << "secret=" << ev->Get()->SecretPath);
+
+    const auto it = RequestsInFlight.find(ev->Get()->InitialRequestId);
+    if (it == RequestsInFlight.end()) {
+        LOG_N(GetLogLabel("TEvResolveSecretSchemeShardRetry", ev->Get()->InitialRequestId)
+            << "retry handling was skipped due to previous errors");
+        return;
+    }
+    Y_ENSURE(it->second.Request.Get(), "Initial request was not saved");
+    SendSchemeShardRequest(*it->second.Request.Get(), ev->Get()->InitialRequestId, ev->Get()->SecretPath);
 }
 
 void TDescribeSchemaSecretsService::HandleSchemeCacheResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
@@ -194,18 +248,27 @@ void TDescribeSchemaSecretsService::HandleSchemeCacheResponse(TEvTxProxySchemeCa
             // some secret version is in cache
             ++respIt->second.FilledSecretsCnt;
         } else {
-            // make TxProxy request
-            TAutoPtr<TEvTxUserProxy::TEvNavigate> navigateRequest(new TEvTxUserProxy::TEvNavigate());
-            Y_ENSURE(!request->DatabaseName.empty(), "Database name must be set in TxProxy requests");
-            navigateRequest->Record.SetDatabaseName(request->DatabaseName);
-            NKikimrSchemeOp::TDescribePath* record = navigateRequest->Record.MutableDescribePath();
-            record->SetPath(secretPath);
-            record->MutableOptions()->SetReturnSecretValue(true);
-            Send(MakeTxProxyID(), navigateRequest.Release(), 0, requestId);
+            const auto requestIt = RequestsInFlight.find(requestId);
+            Y_ENSURE(requestIt != RequestsInFlight.end(), "Unregistered requestId: " + ToString(requestId));
+            SendSchemeShardRequest(*requestIt->second.Request.Get(), requestId, secretPath);
         }
     }
 
     FillResponseIfFinished(requestId, respIt->second);
+}
+
+void TDescribeSchemaSecretsService::SendSchemeShardRequest(
+    const TEvResolveSecret& ev,
+    const ui64 requestId,
+    const TString& secretPath)
+{
+    TAutoPtr<TEvTxUserProxy::TEvNavigate> navigateRequest(new TEvTxUserProxy::TEvNavigate());
+    Y_ENSURE(!ev.Database.empty(), "Database name must be set in TxProxy requests");
+    navigateRequest->Record.SetDatabaseName(ev.Database);
+    NKikimrSchemeOp::TDescribePath* record = navigateRequest->Record.MutableDescribePath();
+    record->SetPath(secretPath);
+    record->MutableOptions()->SetReturnSecretValue(true);
+    Send(MakeTxProxyID(), navigateRequest.Release(), 0, requestId);
 }
 
 void TDescribeSchemaSecretsService::HandleSchemeShardResponse(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev) {
@@ -213,22 +276,26 @@ void TDescribeSchemaSecretsService::HandleSchemeShardResponse(NSchemeShard::TEvS
     LOG_D(GetLogLabel("TEvDescribeSchemeResult", requestId));
 
     const auto respIt = ResolveInFlight.find(requestId);
-    if (respIt == ResolveInFlight.end()) {        
-        Y_ENSURE(respIt->second.Secrets.size() > 1, "This is possible only for batch requests");
+    if (respIt == ResolveInFlight.end()) {
         LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId) << "response handling was skipped due to previous errors");
-        // no need to fill response, since it has been filled on the first SchemeShard error
         return;
     }
 
     const auto& rec = ev->Get()->GetRecord();
     const auto& secretName = CanonizePath(rec.GetPath());
-    if (rec.GetStatus() != NKikimrScheme::EStatus::StatusSuccess) {
-        LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId) << "SchemeShard error: " << EStatus_Name(rec.GetStatus()));
-        const auto errorStatus =
-            rec.GetStatus() == NKikimrScheme::EStatus::StatusNotAvailable
-            ? Ydb::StatusIds::UNAVAILABLE
-            : Ydb::StatusIds::BAD_REQUEST;
-        FillResponse(requestId, TEvDescribeSecretsResponse::TDescription(errorStatus, { NYql::TIssue("secret `" + secretName + "` not found") }));
+    const auto status = GetSchemeShardPathStatus(SchemeShardStatusGetter, rec);
+    if (status != NKikimrScheme::EStatus::StatusSuccess) {
+        LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId) << "SchemeShard error: " << EStatus_Name(status));
+        if (IsRetryableSchemeShardStatus(status) && ScheduleSchemeShardRetry(requestId, secretName)) {
+            return;
+        }
+
+        const auto errorStatus = MapSchemeShardStatus(status);
+        FillResponse(
+            requestId,
+            TEvDescribeSecretsResponse::TDescription(
+                errorStatus,
+                { NYql::TIssue(MakeSchemeShardErrorMessage(status, secretName)) }));
         return;
     }
 
@@ -380,25 +447,75 @@ bool TDescribeSchemaSecretsService::ScheduleSchemeCacheRetry(const ui64& request
     auto requestIt = RequestsInFlight.find(requestId);
     Y_ENSURE(requestIt != RequestsInFlight.end(), "Unregistered requestId: " + ToString(requestId));
 
-    if (!requestIt->second.RetryState) {
-        requestIt->second.RetryState = TRetryPolicy::GetExponentialBackoffPolicy(
-            [](){ return ERetryErrorClass::ShortRetry; },
-            /* minDelay */ TDuration::MilliSeconds(100),
-            /* minLongRetryDelay */ TDuration::MilliSeconds(500),
-            /* maxDelay */ TDuration::Seconds(5),
-            /* maxRetries */ 10,
-            /* maxTime */ TDuration::Seconds(10)
-        )->CreateRetryState();
+    const auto& retryPolicy = requestIt->second.Request->Settings.RetryPolicy
+        ? requestIt->second.Request->Settings.RetryPolicy
+        : MakeShortRetryPolicy();
+
+    if (!requestIt->second.SchemeCacheRetryState) {
+        requestIt->second.SchemeCacheRetryState = retryPolicy->CreateRetryState();
     }
 
-    if (const auto delay = requestIt->second.RetryState->GetNextRetryDelay()) {
+    if (const auto delay = requestIt->second.SchemeCacheRetryState->GetNextRetryDelay()) {
         LOG_N(GetLogLabel("TEvNavigateKeySetResult", requestId) << "secret `" << unresolvedSecretPath
             << "` not found. Request will be retried in: " << *delay);
-        this->Schedule(*delay, new TEvResolveSecretRetry(requestId));
+        this->Schedule(*delay, new TEvResolveSecretSchemeCacheRetry(requestId));
         return true;
     }
 
     return false;
+}
+
+bool TDescribeSchemaSecretsService::ScheduleSchemeShardRetry(const ui64& requestId, const TString& secretPath) {
+    const auto requestIt = RequestsInFlight.find(requestId);
+    Y_ENSURE(requestIt != RequestsInFlight.end(), "Unregistered requestId: " + ToString(requestId));
+
+    const auto& retryPolicy = requestIt->second.Request->Settings.RetryPolicy;
+    if (!retryPolicy) {
+        return false;
+    }
+
+    auto& retryState = requestIt->second.SchemeShardRetryStates[secretPath];
+    if (!retryState) {
+        retryState = retryPolicy->CreateRetryState();
+    }
+
+    if (const auto delay = retryState->GetNextRetryDelay()) {
+        LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId) << "secret `" << secretPath
+            << "` is unavailable. Request will be retried in: " << *delay);
+        this->Schedule(*delay, new TEvResolveSecretSchemeShardRetry(requestId, secretPath));
+        return true;
+    }
+
+    LOG_N(GetLogLabel("TEvDescribeSchemeResult", requestId)
+        << "retry limit exceeded for secret `" << secretPath << "`");
+    FillResponse(
+        requestId,
+        TEvDescribeSecretsResponse::TDescription(
+            Ydb::StatusIds::UNAVAILABLE,
+            { NYql::TIssue("Retry limit exceeded for secret `" + secretPath + "`") }));
+    return true;
+}
+
+IRetryPolicy<>::TPtr MakeShortRetryPolicy() {
+    return IRetryPolicy<>::GetExponentialBackoffPolicy(
+        [](){ return ERetryErrorClass::ShortRetry; },
+        /* minDelay */ TDuration::MilliSeconds(100),
+        /* minLongRetryDelay */ TDuration::MilliSeconds(500),
+        /* maxDelay */ TDuration::Seconds(5),
+        /* maxRetries */ 10,
+        /* maxTime */ TDuration::Seconds(10)
+    );
+}
+
+IRetryPolicy<>::TPtr MakeLongRetryPolicy() {
+    return IRetryPolicy<>::GetExponentialBackoffPolicy(
+        [](){ return ERetryErrorClass::LongRetry; },
+        /* minDelay */ TDuration::Seconds(1),
+        /* minLongRetryDelay */ TDuration::Seconds(10),
+        /* maxDelay */ TDuration::Seconds(30),
+        /* maxRetries */ std::numeric_limits<size_t>::max(),
+        /* maxTime */ TDuration::Minutes(60)
+    );
 }
 
 void TDescribeSchemaSecretsService::FillResponseIfFinished(const ui64& requestId, const TResponseContext& responseCtx) {
@@ -446,13 +563,14 @@ NThreading::TFuture<TEvDescribeSecretsResponse::TDescription> DescribeSecret(
     const TVector<TString>& secretNames,
     const TIntrusiveConstPtr<NACLib::TUserToken> userToken,
     const TString& database,
-    TActorSystem* actorSystem
+    TActorSystem* actorSystem,
+    TDescribeSecretSettings settings
 ) {
     auto promise = NThreading::NewPromise<TEvDescribeSecretsResponse::TDescription>();
     if (UseSchemaSecrets(AppData()->FeatureFlags, secretNames)) {
         actorSystem->Send(
             MakeKqpDescribeSchemaSecretServiceId(actorSystem->NodeId),
-            new TDescribeSchemaSecretsService::TEvResolveSecret(userToken, database, secretNames, promise)
+            new TDescribeSchemaSecretsService::TEvResolveSecret(userToken, database, secretNames, promise, std::move(settings))
         );
         return promise.GetFuture();
     }

--- a/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.h
@@ -18,13 +18,21 @@
 
 namespace NKikimr::NKqp {
 
+struct TDescribeSecretSettings {
+    IRetryPolicy<>::TPtr RetryPolicy;
+};
+
+IRetryPolicy<>::TPtr MakeShortRetryPolicy();
+IRetryPolicy<>::TPtr MakeLongRetryPolicy();
+
 class TDescribeSchemaSecretsService: public NActors::TActorBootstrapped<TDescribeSchemaSecretsService> {
 public:
     using TRetryPolicy = IRetryPolicy<>;
 
     enum ESecretEvents {
         EvResolveSecret = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
-        EvResolveSecretRetry,
+        EvResolveSecretSchemeCacheRetry,
+        EvResolveSecretSchemeShardRetry,
         EvEnd,
     };
 
@@ -34,18 +42,20 @@ public:
             const TIntrusiveConstPtr<NACLib::TUserToken> userToken,
             const TString& database,
             const TVector<TString>& secretNames,
-            NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> promise
+            NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> promise,
+            TDescribeSecretSettings settings = {}
         )
             : UserToken(userToken)
             , Database(database)
             , SecretNames(secretNames)
             , Promise(promise)
+            , Settings(std::move(settings))
         {
             Y_ENSURE(!Database.empty(), "Database name must be set in secret requests");
         }
 
         THolder<TEvResolveSecret> MakeCopy() const {
-            return MakeHolder<TEvResolveSecret>(UserToken, Database, SecretNames, Promise);
+            return MakeHolder<TEvResolveSecret>(UserToken, Database, SecretNames, Promise, Settings);
         }
 
     public:
@@ -53,14 +63,25 @@ public:
         const TString Database;
         const TVector<TString> SecretNames;
         NThreading::TPromise<TEvDescribeSecretsResponse::TDescription> Promise;
+        const TDescribeSecretSettings Settings;
     };
 
-    struct TEvResolveSecretRetry : public NActors::TEventLocal<TEvResolveSecretRetry, EvResolveSecretRetry> {
-        TEvResolveSecretRetry(ui64 initialRequestId)
+    struct TEvResolveSecretSchemeCacheRetry : public NActors::TEventLocal<TEvResolveSecretSchemeCacheRetry, EvResolveSecretSchemeCacheRetry> {
+        TEvResolveSecretSchemeCacheRetry(ui64 initialRequestId)
             : InitialRequestId(initialRequestId)
         {}
 
         const ui64 InitialRequestId = 0;
+    };
+
+    struct TEvResolveSecretSchemeShardRetry : public NActors::TEventLocal<TEvResolveSecretSchemeShardRetry, EvResolveSecretSchemeShardRetry> {
+        TEvResolveSecretSchemeShardRetry(ui64 initialRequestId, TString secretPath)
+            : InitialRequestId(initialRequestId)
+            , SecretPath(std::move(secretPath))
+        {}
+
+        const ui64 InitialRequestId = 0;
+        const TString SecretPath;
     };
 
 private:
@@ -80,7 +101,10 @@ private:
 
     struct TRequestContext {
         THolder<TEvResolveSecret> Request;
-        TRetryPolicy::IRetryState::TPtr RetryState;
+        // SchemeCache support batch requests, so there's a single retry state for the whole batch
+        TRetryPolicy::IRetryState::TPtr SchemeCacheRetryState;
+        // SchemeShard does not support batch requests, so there's a separate retry state for each secret
+        THashMap<TString, TRetryPolicy::IRetryState::TPtr> SchemeShardRetryStates;
 
         TRequestContext(THolder<TEvResolveSecret> request)
             : Request(std::move(request))
@@ -91,7 +115,8 @@ private:
 private:
     STRICT_STFUNC(StateWait,
         hFunc(TEvResolveSecret, HandleIncomingRequest);
-        hFunc(TEvResolveSecretRetry, HandleIncomingRetryRequest);
+        hFunc(TEvResolveSecretSchemeCacheRetry, HandleIncomingSchemeCacheRetryRequest);
+        hFunc(TEvResolveSecretSchemeShardRetry, HandleIncomingSchemeShardRetryRequest);
         hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleSchemeCacheResponse);
         hFunc(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult, HandleSchemeShardResponse);
         hFunc(TSchemeBoardEvents::TEvNotifyDelete, HandleNotifyDelete);
@@ -100,7 +125,8 @@ private:
     )
 
     void HandleIncomingRequest(TEvResolveSecret::TPtr& ev);
-    void HandleIncomingRetryRequest(TEvResolveSecretRetry::TPtr& ev);
+    void HandleIncomingSchemeCacheRetryRequest(TEvResolveSecretSchemeCacheRetry::TPtr& ev);
+    void HandleIncomingSchemeShardRetryRequest(TEvResolveSecretSchemeShardRetry::TPtr& ev);
     void HandleSchemeCacheResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
     void HandleSchemeShardResponse(NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult::TPtr& ev);
     void HandleNotifyDelete(TSchemeBoardEvents::TEvNotifyDelete::TPtr& ev);
@@ -109,11 +135,13 @@ private:
     void FillResponse(const ui64& requestId, const TEvDescribeSecretsResponse::TDescription& response);
     void SaveIncomingRequestInfo(const TEvResolveSecret& ev);
     void SendSchemeCacheRequests(const TEvResolveSecret& ev, const ui64 requestId);
+    void SendSchemeShardRequest(const TEvResolveSecret& ev, const ui64 requestId, const TString& secretPath);
     bool LocalCacheHasActualVersion(const TVersionedSecret& secret, const ui64& cacheSecretVersion);
     bool LocalCacheHasActualObject(const TVersionedSecret& secret, const ui64& cacheSecretPathId);
     bool HandleSchemeCacheErrorsIfAny(const ui64& requestId, NSchemeCache::TSchemeCacheNavigate& result);
     void FillResponseIfFinished(const ui64& requestId, const TResponseContext& responseCtx);
     bool ScheduleSchemeCacheRetry(const ui64& requestId, const TString& unresolvedSecretPath);
+    bool ScheduleSchemeShardRetry(const ui64& requestId, const TString& secretPath);
 
 public:
     TDescribeSchemaSecretsService() = default;
@@ -144,6 +172,18 @@ public:
         SchemeCacheStatusGetter = schemeCacheStatusGetter;
     }
 
+    // For tests only
+    class ISchemeShardStatusGetter : public TThrRefBase {
+    public:
+        virtual NKikimrScheme::EStatus GetStatus(
+            const NKikimrScheme::TEvDescribeSchemeResult& record) const = 0;
+        virtual ~ISchemeShardStatusGetter() = default;
+    };
+    // For tests only
+    void SetSchemeShardStatusGetter(ISchemeShardStatusGetter* schemeShardStatusGetter) {
+        SchemeShardStatusGetter = schemeShardStatusGetter;
+    }
+
 private:
     ui64 LastRequestId = 0;
     THashMap<ui64, TRequestContext> RequestsInFlight;
@@ -152,6 +192,7 @@ private:
     THashMap<TString, TActorId> SchemeBoardSubscribers;
     ISecretUpdateListener* SecretUpdateListener = nullptr;
     ISchemeCacheStatusGetter* SchemeCacheStatusGetter = nullptr;
+    ISchemeShardStatusGetter* SchemeShardStatusGetter = nullptr;
 };
 
 void RegisterDescribeSecretsActor(
@@ -188,7 +229,8 @@ NThreading::TFuture<TEvDescribeSecretsResponse::TDescription> DescribeSecret(
     const TVector<TString>& secretNames,
     const TIntrusiveConstPtr<NACLib::TUserToken> userToken,
     const TString& database,
-    TActorSystem* actorSystem
+    TActorSystem* actorSystem,
+    TDescribeSecretSettings settings = {}
 );
 
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TVector<TString>& secretNames);

--- a/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.h
+++ b/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.h
@@ -139,6 +139,7 @@ private:
     bool LocalCacheHasActualVersion(const TVersionedSecret& secret, const ui64& cacheSecretVersion);
     bool LocalCacheHasActualObject(const TVersionedSecret& secret, const ui64& cacheSecretPathId);
     bool HandleSchemeCacheErrorsIfAny(const ui64& requestId, NSchemeCache::TSchemeCacheNavigate& result);
+    bool HandleSchemeShardErrorsIfAny(const ui64& requestId, const NKikimrScheme::TEvDescribeSchemeResult& record);
     void FillResponseIfFinished(const ui64& requestId, const TResponseContext& responseCtx);
     bool ScheduleSchemeCacheRetry(const ui64& requestId, const TString& unresolvedSecretPath);
     bool ScheduleSchemeShardRetry(const ui64& requestId, const TString& secretPath);

--- a/ydb/core/kqp/federated_query/actors/ut_service/common/helpers.cpp
+++ b/ydb/core/kqp/federated_query/actors/ut_service/common/helpers.cpp
@@ -26,17 +26,28 @@ namespace NKikimr::NKqp {
     }
 
     TDescriptionPromise
-    ResolveSecrets(const TVector<TString>& secretNames, TKikimrRunner& kikimr, const TIntrusiveConstPtr<NACLib::TUserToken> userToken) {
+    ResolveSecrets(
+        const TVector<TString>& secretNames,
+        TKikimrRunner& kikimr,
+        const TIntrusiveConstPtr<NACLib::TUserToken> userToken,
+        TDescribeSecretSettings settings)
+    {
         auto promise = NThreading::NewPromise<TEvDescribeSecretsResponse::TDescription>();
-        const auto evResolveSecret = new TDescribeSchemaSecretsService::TEvResolveSecret(userToken, "/Root", secretNames, promise);
+        const auto evResolveSecret = new TDescribeSchemaSecretsService::TEvResolveSecret(
+            userToken, "/Root", secretNames, promise, std::move(settings));
         auto actorSystem = kikimr.GetTestServer().GetRuntime()->GetActorSystem(0);
         actorSystem->Send(MakeKqpDescribeSchemaSecretServiceId(actorSystem->NodeId), evResolveSecret);
         return promise;
     }
 
     TDescriptionPromise
-    ResolveSecret(const TString& secretName, TKikimrRunner& kikimr, const TIntrusiveConstPtr<NACLib::TUserToken> userToken) {
-        return ResolveSecrets(TVector<TString>{secretName}, kikimr, userToken);
+    ResolveSecret(
+        const TString& secretName,
+        TKikimrRunner& kikimr,
+        const TIntrusiveConstPtr<NACLib::TUserToken> userToken,
+        TDescribeSecretSettings settings)
+    {
+        return ResolveSecrets(TVector<TString>{secretName}, kikimr, userToken, std::move(settings));
     }
 
     void AssertBadRequest(TDescriptionPromise promise, const TString& err, Ydb::StatusIds::StatusCode status) {
@@ -64,10 +75,12 @@ namespace NKikimr::NKqp {
 
     TTestDescribeSchemaSecretsServiceFactory::TTestDescribeSchemaSecretsServiceFactory(
         TDescribeSchemaSecretsService::ISecretUpdateListener* secretUpdateListener,
-        TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* schemeCacheStatusGetter
+        TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* schemeCacheStatusGetter,
+        TDescribeSchemaSecretsService::ISchemeShardStatusGetter* schemeShardStatusGetter
     )
         : SecretUpdateListener(secretUpdateListener)
         , SchemeCacheStatusGetter(schemeCacheStatusGetter)
+        , SchemeShardStatusGetter(schemeShardStatusGetter)
     {
     }
 
@@ -75,6 +88,7 @@ namespace NKikimr::NKqp {
         auto* service = new TDescribeSchemaSecretsService();
         service->SetSecretUpdateListener(SecretUpdateListener);
         service->SetSchemeCacheStatusGetter(SchemeCacheStatusGetter);
+        service->SetSchemeShardStatusGetter(SchemeShardStatusGetter);
         return service;
     }
 
@@ -105,6 +119,25 @@ namespace NKikimr::NKqp {
 
     void TTestSchemeCacheStatusGetter::SetFailProbability(EFailProbability failProbability) {
         FailProbability = failProbability;
+    }
+
+    TTestSchemeShardStatusGetter::TTestSchemeShardStatusGetter(
+        const ui32 statusOverwriteRemainingCount,
+        const NKikimrScheme::EStatus overwrittenStatus
+    )
+        : OverwrittenStatus(overwrittenStatus)
+        , StatusOverwriteRemainingCount(statusOverwriteRemainingCount)
+    {
+    }
+
+    NKikimrScheme::EStatus TTestSchemeShardStatusGetter::GetStatus(
+        const NKikimrScheme::TEvDescribeSchemeResult& record) const
+    {
+        if (StatusOverwriteRemainingCount > 0) {
+            --StatusOverwriteRemainingCount;
+            return OverwrittenStatus;
+        }
+        return record.GetStatus();
     }
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/actors/ut_service/common/helpers.h
+++ b/ydb/core/kqp/federated_query/actors/ut_service/common/helpers.h
@@ -18,9 +18,19 @@ namespace NKikimr::NKqp {
     void DropSchemaSecret(const TString& secretName, NYdb::NTable::TSession& session);
 
     TDescriptionPromise
-    ResolveSecrets(const TVector<TString>& secretNames, TKikimrRunner& kikimr, const TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr);
+    ResolveSecrets(
+        const TVector<TString>& secretNames,
+        TKikimrRunner& kikimr,
+        const TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr,
+        TDescribeSecretSettings settings = {}
+    );
     TDescriptionPromise
-    ResolveSecret(const TString& secretName, TKikimrRunner& kikimr, const TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr);
+    ResolveSecret(
+        const TString& secretName,
+        TKikimrRunner& kikimr,
+        const TIntrusiveConstPtr<NACLib::TUserToken> userToken = nullptr,
+        TDescribeSecretSettings settings = {}
+    );
 
     void AssertBadRequest(TDescriptionPromise promise, const TString& err, Ydb::StatusIds::StatusCode status = Ydb::StatusIds::BAD_REQUEST);
 
@@ -33,7 +43,8 @@ namespace NKikimr::NKqp {
     public:
         TTestDescribeSchemaSecretsServiceFactory(
             TDescribeSchemaSecretsService::ISecretUpdateListener* secretUpdateListener,
-            TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* schemeCacheStatusGetter
+            TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* schemeCacheStatusGetter,
+            TDescribeSchemaSecretsService::ISchemeShardStatusGetter* schemeShardStatusGetter = nullptr
         );
 
         NActors::IActor* CreateService() override;
@@ -41,6 +52,7 @@ namespace NKikimr::NKqp {
     private:
         TDescribeSchemaSecretsService::ISecretUpdateListener* SecretUpdateListener;
         TDescribeSchemaSecretsService::ISchemeCacheStatusGetter* SchemeCacheStatusGetter;
+        TDescribeSchemaSecretsService::ISchemeShardStatusGetter* SchemeShardStatusGetter;
     };
 
     class TTestSchemeCacheStatusGetter : public TDescribeSchemaSecretsService::ISchemeCacheStatusGetter {
@@ -61,6 +73,20 @@ namespace NKikimr::NKqp {
     private:
         EFailProbability FailProbability;
         mutable std::mt19937 RandomGen;
+    };
+
+    class TTestSchemeShardStatusGetter : public TDescribeSchemaSecretsService::ISchemeShardStatusGetter {
+    public:
+        TTestSchemeShardStatusGetter(
+            const ui32 statusOverwriteRemainingCount,
+            const NKikimrScheme::EStatus overwrittenStatus);
+
+        NKikimrScheme::EStatus GetStatus(
+            const NKikimrScheme::TEvDescribeSchemeResult& record) const override;
+
+    private:
+        const NKikimrScheme::EStatus OverwrittenStatus;
+        mutable ui32 StatusOverwriteRemainingCount = 0;
     };
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/actors/ut_service/fast/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/actors/ut_service/fast/kqp_federated_query_actors_ut.cpp
@@ -450,9 +450,9 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsService) {
     Y_UNIT_TEST(SchemeShardRetryManySecrets) {
         TKikimrSettings settings;
         static const auto SECRETS_CNT = 20;
-        static const auto FAILS_PER_SECRET = 2;
+        static const auto FAILS_BUDGET_PER_SECRET = 2;
         auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
-            /* statusOverwriteRemainingCount */ SECRETS_CNT * FAILS_PER_SECRET,
+            /* statusOverwriteRemainingCount */ SECRETS_CNT * FAILS_BUDGET_PER_SECRET,
             NKikimrScheme::EStatus::StatusNotAvailable);
         auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
             /* secretUpdateListener */ nullptr,

--- a/ydb/core/kqp/federated_query/actors/ut_service/fast/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/actors/ut_service/fast/kqp_federated_query_actors_ut.cpp
@@ -395,6 +395,170 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsService) {
         AssertBadRequest(promise, "<main>: Error: secrets `/Root/s1`, `/Root/s3` not found\n");
     }
 
+    Y_UNIT_TEST(SchemeShardRetrySingleSecret) {
+        TKikimrSettings settings;
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ 2,
+            NKikimrScheme::EStatus::StatusNotAvailable);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            /* schemeCacheStatusGetter */ nullptr,
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        const TString secretName = "/Root/secret-name";
+        const TString secretValue = "secret-value";
+        CreateSchemaSecret(secretName, secretValue, session);
+
+        TDescribeSecretSettings describeSettings;
+        describeSettings.RetryPolicy = MakeShortRetryPolicy();
+        auto promise = ResolveSecret(secretName, kikimr, /* userToken */ nullptr, std::move(describeSettings));
+        AssertSecretValue(secretValue, promise);
+    }
+
+    Y_UNIT_TEST(SchemeCacheAndSchemeShardRetryErrors) {
+        TKikimrSettings settings;
+        auto schemeCacheStatusGetter = MakeHolder<TTestSchemeCacheStatusGetter>(
+            TTestSchemeCacheStatusGetter::EFailProbability::OneTenth);
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ 1,
+            NKikimrScheme::EStatus::StatusNotAvailable);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            schemeCacheStatusGetter.Get(),
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        const TVector<TString> secretNames = {"/Root/secret-name-0", "/Root/secret-name-1"};
+        const TVector<TString> secretValues = {"secret-value-0", "secret-value-1"};
+        for (size_t i = 0; i < secretNames.size(); ++i) {
+            CreateSchemaSecret(secretNames[i], secretValues[i], session);
+        }
+
+        TDescribeSecretSettings describeSettings;
+        describeSettings.RetryPolicy = MakeShortRetryPolicy();
+        auto promise = ResolveSecrets(secretNames, kikimr, /* userToken */ nullptr, describeSettings);
+        AssertSecretValues(secretValues, promise);
+    }
+
+    Y_UNIT_TEST(SchemeShardRetryManySecrets) {
+        TKikimrSettings settings;
+        static const auto SECRETS_CNT = 20;
+        static const auto FAILS_PER_SECRET = 2;
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ SECRETS_CNT * FAILS_PER_SECRET,
+            NKikimrScheme::EStatus::StatusNotAvailable);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            /* schemeCacheStatusGetter */ nullptr,
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        TVector<TString> secretNames;
+        TVector<TString> secretValues;
+        secretNames.reserve(SECRETS_CNT);
+        secretValues.reserve(SECRETS_CNT);
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            secretNames.push_back("/Root/secret-name-" + ToString(i));
+            secretValues.push_back("secret-value-" + ToString(i));
+            CreateSchemaSecret(secretNames.back(), secretValues.back(), session);
+        }
+
+        TDescribeSecretSettings describeSettings;
+        describeSettings.RetryPolicy = MakeShortRetryPolicy();
+        auto promise = ResolveSecrets(secretNames, kikimr, /* userToken */ nullptr, describeSettings);
+        AssertSecretValues(secretValues, promise);
+    }
+
+    Y_UNIT_TEST(SchemeShardRetryManySecretsPartialFailures) {
+        TKikimrSettings settings;
+        static const auto SECRETS_CNT = 20;
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ SECRETS_CNT / 2,
+            NKikimrScheme::EStatus::StatusNotAvailable);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            /* schemeCacheStatusGetter */ nullptr,
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        TVector<TString> secretNames;
+        TVector<TString> secretValues;
+        secretNames.reserve(SECRETS_CNT);
+        secretValues.reserve(SECRETS_CNT);
+        for (int i = 0; i < SECRETS_CNT; ++i) {
+            secretNames.push_back("/Root/secret-name-" + ToString(i));
+            secretValues.push_back("secret-value-" + ToString(i));
+            CreateSchemaSecret(secretNames.back(), secretValues.back(), session);
+        }
+
+        TDescribeSecretSettings describeSettings;
+        describeSettings.RetryPolicy = MakeShortRetryPolicy();
+        auto promise = ResolveSecrets(secretNames, kikimr, /* userToken */ nullptr, describeSettings);
+        AssertSecretValues(secretValues, promise);
+    }
+
+    Y_UNIT_TEST(SchemeShardNonRetryableErrorWithLongRetryPolicy) {
+        // We expect that RetryPolicy will not be applied,
+        // since the SchemeShard error is not retryable
+        TKikimrSettings settings;
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ 100,
+            NKikimrScheme::EStatus::StatusPathDoesNotExist);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            /* schemeCacheStatusGetter */ nullptr,
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        const TString secretName = "/Root/secret-name";
+        CreateSchemaSecret(secretName, "secret-value", session);
+
+        TDescribeSecretSettings describeSettings;
+        describeSettings.RetryPolicy = MakeLongRetryPolicy();
+        auto promise = ResolveSecret(secretName, kikimr, /* userToken */ nullptr, describeSettings);
+        AssertBadRequest(promise, "<main>: Error: Secret `/Root/secret-name` not found\n");
+    }
+
+    Y_UNIT_TEST(SchemeShardNotAvailableWithoutRetryPolicy) {
+        TKikimrSettings settings;
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ 1,
+            NKikimrScheme::EStatus::StatusNotAvailable);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            /* schemeCacheStatusGetter */ nullptr,
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        const TString secretName = "/Root/secret-name";
+        CreateSchemaSecret(secretName, "secret-value", session);
+
+        auto promise = ResolveSecret(secretName, kikimr);
+        AssertBadRequest(
+            promise,
+            "<main>: Error: Schemeshard is not available for secret `/Root/secret-name`\n",
+            Ydb::StatusIds::UNAVAILABLE);
+    }
+
 }
 
 } // NKikimr::NKqp

--- a/ydb/core/kqp/federated_query/actors/ut_service/slow/kqp_federated_query_actors_ut.cpp
+++ b/ydb/core/kqp/federated_query/actors/ut_service/slow/kqp_federated_query_actors_ut.cpp
@@ -6,6 +6,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <limits>
+
 namespace NKikimr::NKqp {
 
 using TDescriptionPromise = NThreading::TPromise<TEvDescribeSecretsResponse::TDescription>;
@@ -55,6 +57,33 @@ Y_UNIT_TEST_SUITE(DescribeSchemaSecretsServiceSlow) {
         for (int i = 0; i < SECRETS_CNT; ++i) {
             AssertSecretValue(secrets[i].second, promises[i]);
         }
+    }
+
+    Y_UNIT_TEST(SchemeShardRecoverAfterNotAvailableFails) {
+        TKikimrSettings settings;
+        auto schemeShardStatusGetter = MakeHolder<TTestSchemeShardStatusGetter>(
+            /* statusOverwriteRemainingCount */ std::numeric_limits<ui32>::max(),
+            NKikimrScheme::EStatus::StatusNotAvailable);
+        auto factory = std::make_shared<TTestDescribeSchemaSecretsServiceFactory>(
+            /* secretUpdateListener */ nullptr,
+            /* schemeCacheStatusGetter */ nullptr,
+            schemeShardStatusGetter.Get());
+        settings.SetDescribeSchemaSecretsServiceFactory(factory);
+        TKikimrRunner kikimr(settings);
+        kikimr.GetTestServer().GetRuntime()->GetAppData(0).FeatureFlags.SetEnableSchemaSecrets(true);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        const TString secretName = "/Root/secret-name";
+        CreateSchemaSecret(secretName, "secret-value", session);
+
+        TDescribeSecretSettings describeSettings;
+        describeSettings.RetryPolicy = MakeShortRetryPolicy();
+        auto promise = ResolveSecret(secretName, kikimr, /* userToken */ nullptr, describeSettings);
+        AssertBadRequest(
+            promise,
+            "<main>: Error: Retry limit exceeded for secret `/Root/secret-name`\n",
+            Ydb::StatusIds::UNAVAILABLE);
     }
 }
 

--- a/ydb/core/tx/replication/controller/secret_resolver.cpp
+++ b/ydb/core/tx/replication/controller/secret_resolver.cpp
@@ -51,7 +51,12 @@ class TSecretResolver: public TActorBootstrapped<TSecretResolver> {
             auto userToken = MakeIntrusiveConst<NACLib::TUserToken>(userSID, TVector<TString>());
             const auto actorSystem = ActorContext().ActorSystem();
             const auto replyActorId = SelfId();
-            auto future = NKqp::DescribeSecret(secretNames, userToken, Database, actorSystem);
+            auto future = NKqp::DescribeSecret(
+                secretNames,
+                userToken,
+                Database,
+                actorSystem,
+                {.RetryPolicy = NKqp::MakeLongRetryPolicy()});
             future.Subscribe([actorSystem, replyActorId](const NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription>& result) {
                 actorSystem->Send(replyActorId, new NKqp::TEvDescribeSecretsResponse(result.GetValue()));
             });


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Для получения секретов ходят в схемный кеш за номером актуальной версии и затем в схемный шард непосредственно за значением. Раньше были ретраи только в походах в кеш.

Сейчас добавлена настройка ретраев в схемный шард. Проблему видим в репликации, поэтому добавляем пока ретраи только там – будет хотфикс. Затем отдельно добавим ретраи в для других клиентов.

Сейчас если политика ретраев не выставлена клиентом, то ретраи есть только в схемный кеш. Если политика выставлена, то она будет использоваться для ретраев и в кеш, и в схемный шард. Выставляется она сейчас только для репликаций, причём очень длительная: ретраи после экспоненциального роста будут делаться каждые 30с в течение часа.