### PR TITLE
fq/libs/ydb/local_session: fix HasTransaction tracking

### DIFF
--- a/ydb/core/fq/libs/ydb/local_session.cpp
+++ b/ydb/core/fq/libs/ydb/local_session.cpp
@@ -115,10 +115,10 @@ struct TLocalSession : public ISession {
             execDataQuerySettings,
             promise));
 
-        if (txControl.Begin_) {
-            HasTransaction = true;
-        } else if (txControl.Commit_) {
+        if (txControl.Commit_) { // commit or begin-and-commit
             HasTransaction = false;
+        } else if (txControl.Begin_) {
+            HasTransaction = true;
         }
         return promise.GetFuture();
     }

--- a/ydb/core/fq/libs/ydb/local_session.cpp
+++ b/ydb/core/fq/libs/ydb/local_session.cpp
@@ -115,7 +115,7 @@ struct TLocalSession : public ISession {
             execDataQuerySettings,
             promise));
 
-        if (txControl.Commit_) { // commit or begin-and-commit
+        if (txControl.Commit_) { // commit, or continue-and-commit, or begin-and-commit
             HasTransaction = false;
         } else if (txControl.Begin_) {
             HasTransaction = true;


### PR DESCRIPTION
Begin-and-commit resulted in HasTransaction=true.
Currently appears to be harmless: HasTransaction only used in ydb/ydb.cpp and it never uses begin-and-commit

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...