### PR TITLE
[EXT-2298] Fix missing PDisks for unavailable storage nodes (#44149)

### DIFF
--- a/ydb/core/viewer/viewer_nodes.h
+++ b/ydb/core/viewer/viewer_nodes.h
@@ -1166,6 +1166,15 @@ public:
         return nullptr;
     }
 
+    void SetNodeDisconnected(TNodeId nodeId) {
+        if (TNode* node = FindNode(nodeId)) {
+            node->DisconnectNode();
+            if (FieldsRequired.test(+ENodeFields::PDisks) || FieldsRequired.test(+ENodeFields::VDisks)) {
+                node->RemapDisks();
+            }
+        }
+    }
+
     bool PreFilterDone() const {
         return (!PDisksResponse || PDisksProcessed) && !FilterDatabase && FilterPeerRole != EPeerRole::Static && FilterPeerRole != EPeerRole::Other;
     }
@@ -2408,16 +2417,10 @@ public:
                         hasMemoryDetailed |= systemInfo.HasMemoryStats();
                     }
                     for (auto nodeId : nodesWithoutData) {
-                        TNode* node = FindNode(nodeId);
-                        if (node) {
-                            node->DisconnectNode();
-                        }
+                        SetNodeDisconnected(nodeId);
                     }
                 } else {
-                    TNode* node = FindNode(responseNodeId);
-                    if (node) {
-                        node->DisconnectNode();
-                    }
+                    SetNodeDisconnected(responseNodeId);
                 }
             }
             for (const auto& [nodeId, response] : SystemStateResponse) {
@@ -2439,10 +2442,7 @@ public:
                         hasMemoryDetailed |= systemState.GetSystemStateInfo(0).HasMemoryStats();
                     }
                 } else {
-                    TNode* node = FindNode(nodeId);
-                    if (node) {
-                        node->DisconnectNode();
-                    }
+                    SetNodeDisconnected(nodeId);
                 }
             }
             if (!removeNodes.empty()) {
@@ -2890,13 +2890,7 @@ public:
 
     void Disconnected(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
         TNodeId nodeId = ev->Get()->NodeId;
-        TNode* node = FindNode(nodeId);
-        if (node) {
-            node->DisconnectNode();
-            if (FieldsRequired.test(+ENodeFields::PDisks) || FieldsRequired.test(+ENodeFields::VDisks)) {
-                node->RemapDisks();
-            }
-        }
+        SetNodeDisconnected(nodeId);
         TString error("NodeDisconnected");
         {
             auto itSystemStateResponse = SystemStateResponse.find(nodeId);

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -811,12 +811,19 @@ Y_UNIT_TEST_SUITE(Viewer) {
         size_t droppedSystemStateResponses = 0;
         size_t pdiskStateResponses = 0;
 
-        std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
-        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest(
-            "GET /viewer/json/nodes?type=static&fields_required=NodeId,PDisks,SystemState,Memory&storage=true&limit=2&offset=0"
-            "&offload_merge=true&offload_merge_attempts=1&dump_original_node_batches=true&timeout=10 HTTP/1.1\r\n\r\n",
-            endpoint,
-            {});
+        THttpRequest httpReq(HTTP_METHOD_GET);
+        httpReq.CgiParameters.emplace("type", "static");
+        httpReq.CgiParameters.emplace("fields_required", "NodeId,PDisks,SystemState,Memory");
+        httpReq.CgiParameters.emplace("storage", "true");
+        httpReq.CgiParameters.emplace("limit", "2");
+        httpReq.CgiParameters.emplace("offset", "0");
+        httpReq.CgiParameters.emplace("offload_merge", "true");
+        httpReq.CgiParameters.emplace("offload_merge_attempts", "1");
+        httpReq.CgiParameters.emplace("dump_original_node_batches", "true");
+        httpReq.CgiParameters.emplace("timeout", "10");
+        auto page = MakeHolder<TMonPage>("viewer", "title");
+        TMonService2HttpRequest monReq(nullptr, &httpReq, nullptr, page.Get(), "/json/nodes", nullptr);
+        auto request = MakeHolder<NMon::TEvHttpInfo>(monReq);
 
         auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
@@ -853,11 +860,13 @@ Y_UNIT_TEST_SUITE(Viewer) {
         };
         runtime.SetObserverFunc(observerFunc);
 
-        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(request), 0));
-        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* result = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender, request.Release(), 0));
+        NMon::TEvHttpInfoRes* result = runtime.GrabEdgeEvent<NMon::TEvHttpInfoRes>(handle);
 
+        size_t pos = result->Answer.find('{');
+        TString jsonResult = result->Answer.substr(pos);
         NJson::TJsonValue json;
-        NJson::ReadJsonTree(result->Response->Body, &json, true);
+        NJson::ReadJsonTree(jsonResult, &json, true);
 
         const auto& nodes = json.GetMap().at("Nodes").GetArray();
         UNIT_ASSERT_VALUES_EQUAL_C(json.GetMap().at("TotalNodes"), "2", NJson::WriteJson(json, false));

--- a/ydb/core/viewer/viewer_ut.cpp
+++ b/ydb/core/viewer/viewer_ut.cpp
@@ -225,6 +225,33 @@ Y_UNIT_TEST_SUITE(Viewer) {
         ev->Swap(newEv);
     }
 
+    void SetNodesLocation(TEvInterconnect::TEvNodesInfo::TPtr* ev, const TString& dataCenter) {
+        auto nodes = MakeIntrusive<TIntrusiveVector<TEvInterconnect::TNodeInfo>>((*ev)->Get()->Nodes);
+        for (auto& nodeInfo : *nodes) {
+            NActorsInterconnect::TNodeLocation location;
+            location.SetDataCenter(dataCenter);
+            location.SetRack("rack-1");
+            location.SetUnit("1");
+            nodeInfo.Location = TNodeLocation(location);
+        }
+        auto newEv = IEventHandle::Downcast<TEvInterconnect::TEvNodesInfo>(
+            new IEventHandle((*ev)->Recipient, (*ev)->Sender, new TEvInterconnect::TEvNodesInfo(nodes))
+        );
+        ev->Swap(newEv);
+    }
+
+    void AddSysViewPDisk(NSysView::TEvSysView::TEvGetPDisksResponse::TPtr* ev, ui32 nodeId, ui32 pdiskId) {
+        auto* entry = (*ev)->Get()->Record.AddEntries();
+        entry->MutableKey()->SetNodeId(nodeId);
+        entry->MutableKey()->SetPDiskId(pdiskId);
+        entry->MutableInfo()->SetPath(Sprintf("/dev/pdisk-%u-%u", nodeId, pdiskId));
+        entry->MutableInfo()->SetGuid(nodeId * 100 + pdiskId);
+        entry->MutableInfo()->SetTotalSize(1024);
+        entry->MutableInfo()->SetAvailableSize(512);
+        entry->MutableInfo()->SetExpectedSlotCount(1);
+        entry->MutableInfo()->SetStatusV2("ACTIVE");
+    }
+
     void ChangeTabletStateResponse(TEvWhiteboard::TEvTabletStateResponse::TPtr* ev, int tabletsTotal, int& tabletId, int& nodeId) {
         ui64* cookie = const_cast<ui64*>(&(ev->Get()->Cookie));
         *cookie = nodeId;
@@ -757,6 +784,108 @@ Y_UNIT_TEST_SUITE(Viewer) {
         }
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("TotalNodes"), "1");
         UNIT_ASSERT_VALUES_EQUAL(json.GetMap().at("FoundNodes"), "1");
+    }
+
+    Y_UNIT_TEST(NodesPageKeepsPDisksForDisconnectedNode)
+    {
+        TPortManager tp;
+        ui16 port = tp.GetPort(2134);
+        ui16 grpcPort = tp.GetPort(2135);
+        auto settings = TServerSettings(port)
+                .SetNodeCount(2)
+                .SetUseRealThreads(false)
+                .SetDomainName("Root")
+                .SetUseSectorMap(true)
+                .InitKikimrRunConfig();
+        TServer server(settings);
+        server.EnableGRpc(grpcPort);
+
+        TClient client(settings);
+        TTestActorRuntime& runtime = *server.GetRuntime();
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        TAutoPtr<IEventHandle> handle;
+        const TNodeId disconnectedNodeId = runtime.GetNodeId(1);
+        size_t pdisksSysViewResponses = 0;
+        size_t systemStateResponses = 0;
+        size_t droppedSystemStateResponses = 0;
+        size_t pdiskStateResponses = 0;
+
+        std::shared_ptr<NHttp::THttpEndpointInfo> endpoint = std::make_shared<NHttp::THttpEndpointInfo>();
+        NHttp::THttpIncomingRequestPtr request = new NHttp::THttpIncomingRequest(
+            "GET /viewer/json/nodes?type=static&fields_required=NodeId,PDisks,SystemState,Memory&storage=true&limit=2&offset=0"
+            "&offload_merge=true&offload_merge_attempts=1&dump_original_node_batches=true&timeout=10 HTTP/1.1\r\n\r\n",
+            endpoint,
+            {});
+
+        auto observerFunc = [&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvInterconnect::EvNodesInfo: {
+                    auto* x = reinterpret_cast<TEvInterconnect::TEvNodesInfo::TPtr*>(&ev);
+                    SetNodesLocation(x, "dc-1");
+                    break;
+                }
+                case NSysView::TEvSysView::EvGetPDisksResponse: {
+                    auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetPDisksResponse::TPtr*>(&ev);
+                    ++pdisksSysViewResponses;
+                    (*x)->Get()->Record.ClearEntries();
+                    AddSysViewPDisk(x, runtime.GetNodeId(0), 1);
+                    AddSysViewPDisk(x, runtime.GetNodeId(1), 1);
+                    break;
+                }
+                case TEvWhiteboard::EvSystemStateResponse: {
+                    auto* x = reinterpret_cast<TEvWhiteboard::TEvSystemStateResponse::TPtr*>(&ev);
+                    ++systemStateResponses;
+                    if ((*x)->Cookie == disconnectedNodeId) {
+                        ++droppedSystemStateResponses;
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+                }
+                case TEvWhiteboard::EvPDiskStateResponse: {
+                    auto* x = reinterpret_cast<TEvWhiteboard::TEvPDiskStateResponse::TPtr*>(&ev);
+                    ++pdiskStateResponses;
+                    (*x)->Get()->Record.ClearPDiskStateInfo();
+                    break;
+                }
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        runtime.SetObserverFunc(observerFunc);
+
+        runtime.Send(new IEventHandle(NKikimr::NViewer::MakeViewerID(0), sender, new NHttp::TEvHttpProxy::TEvHttpIncomingRequest(request), 0));
+        NHttp::TEvHttpProxy::TEvHttpOutgoingResponse* result = runtime.GrabEdgeEvent<NHttp::TEvHttpProxy::TEvHttpOutgoingResponse>(handle);
+
+        NJson::TJsonValue json;
+        NJson::ReadJsonTree(result->Response->Body, &json, true);
+
+        const auto& nodes = json.GetMap().at("Nodes").GetArray();
+        UNIT_ASSERT_VALUES_EQUAL_C(json.GetMap().at("TotalNodes"), "2", NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(json.GetMap().at("FoundNodes"), "2", NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(nodes.size(), 2, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(pdisksSysViewResponses, 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(systemStateResponses, 2, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(droppedSystemStateResponses, 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(pdiskStateResponses, 2, NJson::WriteJson(json, false));
+        const auto& originalNodeBatches = json.GetMap().at("OriginalNodeBatches").GetArray();
+        UNIT_ASSERT_VALUES_EQUAL_C(originalNodeBatches.size(), 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(originalNodeBatches[0].GetMap().at("NodesToAskFor").GetArray().size(), 1, NJson::WriteJson(json, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(originalNodeBatches[0].GetMap().at("NodesToAskAbout").GetArray().size(), 2, NJson::WriteJson(json, false));
+        UNIT_ASSERT_C(originalNodeBatches[0].GetMap().at("HasStaticNodes").GetBoolean(), NJson::WriteJson(json, false));
+
+        const NJson::TJsonValue* disconnectedNode = nullptr;
+        for (const auto& node : nodes) {
+            const auto& nodeMap = node.GetMap();
+            if (nodeMap.at("NodeId").GetUInteger() == disconnectedNodeId) {
+                disconnectedNode = &node;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(disconnectedNode, NJson::WriteJson(json, false));
+        const auto& disconnectedNodeMap = disconnectedNode->GetMap();
+        UNIT_ASSERT_C(disconnectedNodeMap.at("Disconnected").GetBoolean(), NJson::WriteJson(*disconnectedNode, false));
+        UNIT_ASSERT_C(disconnectedNodeMap.contains("PDisks"), NJson::WriteJson(*disconnectedNode, false));
+        UNIT_ASSERT_VALUES_EQUAL_C(disconnectedNodeMap.at("PDisks").GetArray().size(), 1, NJson::WriteJson(*disconnectedNode, false));
     }
 
     Y_UNIT_TEST(ServerlessWithExclusiveNodes)


### PR DESCRIPTION
(cherry picked from commit https://github.com/ydb-platform/ydb/commit/08bc5b0902d80fb2b8bb6217866d7f0844eed302)

Test was adapted during backport.
