### PR TITLE
Move quoter PrefetchCoefficient test to tag:manual

### DIFF
--- a/ydb/core/quoter/kesus_quoter_ut.cpp
+++ b/ydb/core/quoter/kesus_quoter_ut.cpp
@@ -86,26 +86,6 @@ Y_UNIT_TEST_SUITE(QuoterWithKesusTest) {
                        TEvQuota::TEvClearance::EResult::Success); // must not starve
     }
 
-    Y_UNIT_TEST(PrefetchCoefficient) {
-        TKesusQuoterTestSetup setup;
-        NKikimrKesus::THierarchicalDRRResourceConfig cfg;
-        double rate = 100.0;
-        double prefetch = 1000.0;
-        cfg.SetMaxUnitsPerSecond(rate);
-        cfg.SetPrefetchCoefficient(prefetch);
-        setup.CreateKesusResource(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root", cfg);
-
-        cfg.ClearMaxUnitsPerSecond();
-        cfg.ClearPrefetchCoefficient(); // should be inherited from root
-        setup.CreateKesusResource(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", cfg);
-
-        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf"); // stabilization
-        // Consume exactly both ticks' worth: rate * prefetch * 2 = 200,000
-        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", rate * prefetch * 2, TDuration::Seconds(10));
-        // Channel is now exhausted and Balance = 0. This must timeout.
-        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", 1, TDuration::MilliSeconds(500), TEvQuota::TEvClearance::EResult::Deadline);
-    }
-
     Y_UNIT_TEST(GetsQuotaAfterPause) {
         TKesusQuoterTestSetup setup;
         setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, TKesusQuoterTestSetup::DEFAULT_KESUS_RESOURCE, 12);

--- a/ydb/core/quoter/ut_manual/kesus_quoter_manual_ut.cpp
+++ b/ydb/core/quoter/ut_manual/kesus_quoter_manual_ut.cpp
@@ -1,0 +1,29 @@
+#include "quoter_service.h"
+#include "kesus_quoter_proxy.h"
+#include "ut_helpers.h"
+
+namespace NKikimr {
+
+Y_UNIT_TEST_SUITE(QuoterWithKesusTest) {
+    Y_UNIT_TEST(PrefetchCoefficient) {
+        TKesusQuoterTestSetup setup;
+        NKikimrKesus::THierarchicalDRRResourceConfig cfg;
+        double rate = 100.0;
+        double prefetch = 1000.0;
+        cfg.SetMaxUnitsPerSecond(rate);
+        cfg.SetPrefetchCoefficient(prefetch);
+        setup.CreateKesusResource(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root", cfg);
+
+        cfg.ClearMaxUnitsPerSecond();
+        cfg.ClearPrefetchCoefficient(); // should be inherited from root
+        setup.CreateKesusResource(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", cfg);
+
+        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf"); // stabilization
+        // Consume exactly both ticks' worth: rate * prefetch * 2 = 200,000
+        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", rate * prefetch * 2, TDuration::Seconds(10));
+        // Channel is now exhausted and Balance = 0. This must timeout.
+        setup.GetQuota(TKesusQuoterTestSetup::DEFAULT_KESUS_PATH, "root/leaf", 1, TDuration::MilliSeconds(500), TEvQuota::TEvClearance::EResult::Deadline);
+    }
+}
+
+} // namespace NKikimr

--- a/ydb/core/quoter/ut_manual/ya.make
+++ b/ydb/core/quoter/ut_manual/ya.make
@@ -1,0 +1,19 @@
+UNITTEST_FOR(ydb/core/quoter)
+
+TAG(ya:manual)
+
+PEERDIR(
+    library/cpp/testing/gmock_in_unittest
+    ydb/core/testlib/default
+)
+
+YQL_LAST_ABI_VERSION()
+
+SRCS(
+    ut_helpers.cpp
+    ut_manual/kesus_quoter_manual_ut.cpp
+)
+
+SIZE(MEDIUM)
+
+END()

--- a/ydb/core/quoter/ya.make
+++ b/ydb/core/quoter/ya.make
@@ -29,5 +29,6 @@ RECURSE(
 
 RECURSE_FOR_TESTS(
     ut
+    ut_manual
     ut_memory
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Moves the `QuoterWithKesusTest.PrefetchCoefficient` test out of the auto-run `ydb/core/quoter/ut` target into a new `ydb/core/quoter/ut_manual` target tagged `ya:manual`, so it no longer runs in regular/CI test runs. Mirrors the existing `ut_memory` pattern.
