### PR TITLE
Fix repeated single-node quickstart start in disk mode (#44485)

### DIFF
--- a/ydb/deploy/local_binary/linux/start.sh
+++ b/ydb/deploy/local_binary/linux/start.sh
@@ -85,8 +85,12 @@ fi
 echo Registering database...
 $YDBD_PATH -s grpc://localhost:2136 admin database /Root/test create ssd:1 > "$LOGS_PATH/db_reg.log" 2>&1
 if [[ $? -ge 1 ]]; then
-  echo Errors found when registering database, cancelling start script, check "$LOGS_PATH/db_reg.log"
-  exit
+  if grep -q ALREADY_EXISTS "$LOGS_PATH/db_reg.log"; then
+    echo Database /Root/test already exists, skipping registration.
+  else
+    echo Errors found when registering database, cancelling start script, check "$LOGS_PATH/db_reg.log"
+    exit
+  fi
 fi
 echo Starting database process...
 $YDBD_PATH server --yaml-config "$CONFIG_PATH/$cfg" --tenant /Root/test --node-broker localhost:2136 --grpc-port 31001 --ic-port 31003 --mon-port 31002 \

--- a/ydb/deploy/local_binary/linux/start.sh
+++ b/ydb/deploy/local_binary/linux/start.sh
@@ -89,7 +89,7 @@ if [[ $? -ge 1 ]]; then
     echo Database /Root/test already exists, skipping registration.
   else
     echo Errors found when registering database, cancelling start script, check "$LOGS_PATH/db_reg.log"
-    exit
+    exit 1
   fi
 fi
 echo Starting database process...


### PR DESCRIPTION
## Problem

Following the [quickstart](https://ydb.tech/docs/en/quickstart) in **disk** mode, a repeated start of the single-node cluster fails:

```
$ ./start.sh disk
Starting storage process...
Registering database ...
Errors found when registering database, cancelling start script, check logs/db_reg.log

$ cat ./logs/db_reg.log
ERROR: ALREADY_EXISTS
Database '/Root/test' already exists
```

Steps: `./start.sh disk` → `./stop.sh` → `./start.sh disk`.

Fixes #44485 (KIKIMR-25892). Reproduced on build `26.1.1.20`.

## Root cause

In `ydb/deploy/local_binary/linux/start.sh` the storage-initialization step is guarded by `need_init` (so it only runs on a fresh data file), but the database-registration step is unconditional:

```bash
echo Registering database...
$YDBD_PATH ... admin database /Root/test create ssd:1 > "$LOGS_PATH/db_reg.log" 2>&1
if [[ $? -ge 1 ]]; then
  echo Errors found when registering database, cancelling start script ...
  exit
fi
```

On every start after the first, the database already exists in the persistent disk/drive storage, so `create` returns `ALREADY_EXISTS` and the script aborts before launching the database process.

## Fix

Treat `ALREADY_EXISTS` as a non-fatal condition; any other registration error still aborts the script.

```bash
if [[ $? -ge 1 ]]; then
  if grep -q ALREADY_EXISTS "$LOGS_PATH/db_reg.log"; then
    echo Database /Root/test already exists, skipping registration.
  else
    echo Errors found when registering database, cancelling start script, check "$LOGS_PATH/db_reg.log"
    exit
  fi
fi
```

## Verification

Tested end-to-end on a clean Ubuntu 24.04 VM with the published `26.1.1.20` artifacts (`ydbd` + `local_scripts`). Reproduced the original failure on the shipped script, then applied this fix:

```
########## START #1 (DB already exists) ##########
Starting storage process...
Registering database ...
Database /Root/test already exists, skipping registration.
Starting database process...
Database started. Connection options for YDB CLI:
-e grpc://localhost:2136 -d /Root/test
########## STOP -> START #2 ##########
... Database /Root/test already exists, skipping registration. ... Database started.
```

Both the storage and database processes come up, and the start/stop/start cycle is now idempotent.

> Note: the artifact currently published at `binaries.ydb.tech/local_scripts/linux.tar.gz` is an older revision of this script than the one in the repository, but it has the same unconditional-registration bug, and this same change fixes it.
