### PR TITLE
[stable-26-2] Fix repeated single-node quickstart start in disk mode (#44485)

### DIFF
--- a/ydb/deploy/local_binary/linux/start.sh
+++ b/ydb/deploy/local_binary/linux/start.sh
@@ -85,8 +85,12 @@ fi
 echo Registering database...
 $YDBD_PATH -s grpc://localhost:2136 admin database /Root/test create ssd:1 > "$LOGS_PATH/db_reg.log" 2>&1
 if [[ $? -ge 1 ]]; then
-  echo Errors found when registering database, cancelling start script, check "$LOGS_PATH/db_reg.log"
-  exit
+  if grep -q ALREADY_EXISTS "$LOGS_PATH/db_reg.log"; then
+    echo Database /Root/test already exists, skipping registration.
+  else
+    echo Errors found when registering database, cancelling start script, check "$LOGS_PATH/db_reg.log"
+    exit 1
+  fi
 fi
 echo Starting database process...
 $YDBD_PATH server --yaml-config "$CONFIG_PATH/$cfg" --tenant /Root/test --node-broker localhost:2136 --grpc-port 31001 --ic-port 31003 --mon-port 31002 \


### PR DESCRIPTION
Backport of #44488 to the stable branch.

Fixes the quickstart bug where a repeated `./start.sh disk` (after `./stop.sh`) aborts with `ERROR: ALREADY_EXISTS / Database '/Root/test' already exists`, because the database-registration step runs unconditionally. The fix treats `ALREADY_EXISTS` as non-fatal so the local cluster restarts on existing disk/drive storage.

Cherry-pick of `603c42109d6288af7e34e5426984b35d6b867638` (clean, single-file change to `ydb/deploy/local_binary/linux/start.sh`).

Original issue: #44485. Full root-cause analysis and end-to-end verification (reproduced and fixed on build `26.1.1.20`): #44488.
