### PR TITLE
Restore release notes and downloads for stable-25-1

### DIFF
--- a/ydb/docs/en/core/changelog-server.md
+++ b/ydb/docs/en/core/changelog-server.md
@@ -2,9 +2,9 @@
 
 ## Version 25.1 {#25-1}
 
-### Version 25.1.4.7 {#25-1-4-7}
+### Version 25.1.4.18 {#25-1-4-18}
 
-Release date: September 15, 2025.
+Release date: May 12, 2026.
 
 #### Functionality
 
@@ -27,6 +27,7 @@ Release date: September 15, 2025.
 
 #### Bug fixes
 
+* [Fixed](https://github.com/ydb-platform/ydb/pull/38425) an [LDAP authentication](./security/authentication.md) vulnerability: knowing the login and password of any LDAP user (including one not in a group with access to {{ ydb-short-name }}), an attacker could bypass group membership checks and gain access to the cluster (injection into the LDAP user search filter; added escaping of special characters per RFC 2254).
 * [Added support](https://github.com/ydb-platform/ydb/pull/21918) for a new kind of change record in asynchronous replication — `reset` record (in addition to `update` & `erase` records).
 * [Fixed](https://github.com/ydb-platform/ydb/pull/21836) an [issue](https://github.com/ydb-platform/ydb/issues/21814) where a replication instance with an unspecified `COMMIT_INTERVAL` option caused the process to crash.
 * [Fixed](https://github.com/ydb-platform/ydb/pull/21652) rare errors when reading from a topic during partition balancing.
@@ -40,7 +41,7 @@ Release date: July 14, 2025.
 
 #### Functionality
 
-* [Implemented](https://github.com/ydb-platform/ydb/issues/19504) a [vector index](./dev/vector-indexes.md?version=v25.1) for approximate vector similarity search. This mode is enabled by setting the `enable_vector_index` flag in the [cluster configuration](./reference/configuration/?version=v25.1#feature_flags). Attention! After enabling the flag, rollback to previous versions of {{ ydb-short-name }} is not possible.
+* [Implemented](https://github.com/ydb-platform/ydb/issues/19504) a [vector index](./dev/vector-indexes.md?version=v25.1) for approximate vector similarity search.
 * [Added](https://github.com/ydb-platform/ydb/issues/11454) support for [consistent asynchronous replication](./concepts/async-replication.md?version=v25.1).
 * Added [configuration mechanism V2](./devops/configuration-management/configuration-v2/config-overview?version=v25.1) that simplifies the deployment of new {{ ydb-short-name }} clusters and further work with them. [Comparison](./devops/configuration-management/compare-configs?version=v25.1) of configuration mechanisms V1 and V2.
 * Added support for the parameterized [Decimal type](./yql/reference/types/primitive.md?version=v25.1#numeric).

--- a/ydb/docs/en/core/downloads/ydb-open-source-database.md
+++ b/ydb/docs/en/core/downloads/ydb-open-source-database.md
@@ -11,7 +11,7 @@ See also [{#T}](./yandex-enterprise-database.md).
 #|
 || Version |  Release date | Download | Changelog ||
 || **v25.1** | > | > | > ||
-|| v.25.1.4.7 | 15.09.25 | [Binary file](https://binaries.ydb.tech/release/25.1.4.7/ydbd-25.1.4.7-linux-amd64.tar.gz) | [See list](../changelog-server.md#25-1-4-7) ||
+|| v.25.1.4.18 | 12.05.26 | [Binary file](https://binaries.ydb.tech/release/25.1.4.18/ydbd-25.1.4.18-linux-amd64.tar.gz) | [See list](../changelog-server.md#25-1-4-18) ||
 || v.25.1.2.7-rc | 14.07.25 | [Binary file](https://binaries.ydb.tech/release/25.1.2.7-rc/ydbd-25.1.2.7-rc-linux-amd64.tar.gz) | [See list](../changelog-server.md#25-1-2-7-rc) ||
 || **v24.4** | > | > | > ||
 || v.24.4.4.12  | 03.06.25 | [Binary file](https://binaries.ydb.tech/release/24.4.4.12/ydbd-24.4.4.12-linux-amd64.tar.gz) | [See list](../changelog-server.md#24-4-4-12) ||
@@ -27,7 +27,7 @@ See also [{#T}](./yandex-enterprise-database.md).
 || **v23.4** | > | > | > ||
 || v.23.4.11 | 14.05.24 | [Binary file](https://binaries.ydb.tech/release/23.4.11/ydbd-23.4.11-linux-amd64.tar.gz) | [See list](../changelog-server.md#23-4) ||
 || **v23.3** | > | > | > ||
-|| v.23.3.17 | 14.12.23 | [Binary file](https://binaries.ydb.tech/release/23.3.17/ydbd-23.3.17-linux-amd64.tar.gz) | — ||
+|| v.23.3.17 | 14.12.23 | [Binary file](https://binaries.ydb.tech/release/23.3.17/ydbd-23.3.17-linux-amd64.tar.gz) | ||
 || v.23.3.13 | 12.10.23 | [Binary file](https://binaries.ydb.tech/release/23.3.13/ydbd-23.3.13-linux-amd64.tar.gz) | [See list](../changelog-server.md#23-3) ||
 || **v23.2** | > | > | > ||
 || v.23.2.12 | 14.08.23 | [Binary file](https://binaries.ydb.tech/release/23.2.12/ydbd-23.2.12-linux-amd64.tar.gz) | [See list](../changelog-server.md#23-2) ||
@@ -36,9 +36,9 @@ See also [{#T}](./yandex-enterprise-database.md).
 ## Docker
 
 #|
-|| Version |  Release date | Download | Changelog ||
+|| Version |  Release date | Docker `registry/image:tag` | Changelog ||
 || **v25.1** | > | > | > ||
-|| v.25.1.4.7  | 15.09.25  | `cr.yandex/crptqonuodf51kdj7a7d/ydb:25.1.4.7` | [See list](../changelog-server.md#25-1-4-7) ||
+|| v.25.1.4.18  | 12.05.26 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:25.1.4.18` | [See list](../changelog-server.md#25-1-4-18) ||
 || v.25.1.2.7-rc  | 14.07.25  | `cr.yandex/crptqonuodf51kdj7a7d/ydb:25.1.2.7-rc` | [See list](../changelog-server.md#25-1-2-7-rc) ||
 || **v24.4** | > | > | > ||
 || v.24.4.4.12 | 03.06.25 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:24.4.4.12` | [See list](../changelog-server.md#24-4-4-12) ||
@@ -54,7 +54,7 @@ See also [{#T}](./yandex-enterprise-database.md).
 || **v23.4** | > | > | > ||
 || v.23.4.11 | 14.05.24 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:23.4.11` | [See list](../changelog-server.md#23-4) ||
 || **v23.3** | > | > | > ||
-|| v.23.3.17 | 14.12.23 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:23.3.17` | — ||
+|| v.23.3.17 | 14.12.23 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:23.3.17` | ||
 || v.23.3.13 | 12.10.23 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:23.3.13` | [See list](../changelog-server.md#23-3) ||
 || **v23.2** | > | > | > ||
 || v.23.2.12 | 14.08.23 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:23.2.12` | [See list](../changelog-server.md#23-2) ||
@@ -65,10 +65,10 @@ See also [{#T}](./yandex-enterprise-database.md).
 #|
 || Version |  Release date | Link | Changelog ||
 || **v25.1** | > | > | > ||
-|| v.25.1.4.7  | 15.09.25 | [https://github.com/ydb-platform/ydb/tree/25.1.4.7](https://github.com/ydb-platform/ydb/tree/25.1.4.7) | [See list](../changelog-server.md#25-1-4-7) ||
+|| v.25.1.4.18  | 12.05.26 | [https://github.com/ydb-platform/ydb/tree/25.1.4.18](https://github.com/ydb-platform/ydb/tree/25.1.4.18) | [See list](../changelog-server.md#25-1-4-18) ||
 || v.25.1.2.7-rc  | 14.07.25 | [https://github.com/ydb-platform/ydb/tree/25.1.2.7-rc](https://github.com/ydb-platform/ydb/tree/25.1.2.7-rc) | [See list](../changelog-server.md#25-1-2-7-rc) ||
 || **v24.4** | > | > | > ||
-|| v.24.4.4.2  | 03.06.25 | [https://github.com/ydb-platform/ydb/tree/24.4.4.12](https://github.com/ydb-platform/ydb/tree/24.4.4.12) | [See list](../changelog-server.md#24-4-4-12) ||
+|| v.24.4.4.12  | 03.06.25 | [https://github.com/ydb-platform/ydb/tree/24.4.4.12](https://github.com/ydb-platform/ydb/tree/24.4.4.12) | [See list](../changelog-server.md#24-4-4-12) ||
 || v.24.4.4.2  | 15.04.25 | [https://github.com/ydb-platform/ydb/tree/24.4.4.2](https://github.com/ydb-platform/ydb/tree/24.4.4.2) | [See list](../changelog-server.md#24-4-4-2) ||
 || **v24.3** | > | > | > ||
 || v.24.3.15.5  | 06.02.25 | [https://github.com/ydb-platform/ydb/tree/24.3.15.5](https://github.com/ydb-platform/ydb/tree/24.3.15.5) | [See list](../changelog-server.md#24-3-15-5) ||
@@ -81,7 +81,7 @@ See also [{#T}](./yandex-enterprise-database.md).
 || **v23.4** | > | > | > ||
 || v.23.4.11 | 14.05.24 | [https://github.com/ydb-platform/ydb/tree/23.4.11](https://github.com/ydb-platform/ydb/tree/23.4.11) | [See list](../changelog-server.md#23-4) ||
 || **v23.3** | > | > | > ||
-|| v.23.3.17 | 14.12.23 | [https://github.com/ydb-platform/ydb/tree/23.3.17](https://github.com/ydb-platform/ydb/tree/23.3.17) | — ||
+|| v.23.3.17 | 14.12.23 | [https://github.com/ydb-platform/ydb/tree/23.3.17](https://github.com/ydb-platform/ydb/tree/23.3.17) | ||
 || v.23.3.13 | 12.10.23 | [https://github.com/ydb-platform/ydb/tree/23.3.13](https://github.com/ydb-platform/ydb/tree/23.3.13) | [See list](../changelog-server.md#23-3) ||
 || **v23.2** | > | > | > ||
 || v.23.2.12 | 14.08.23 | [https://github.com/ydb-platform/ydb/tree/23.2.12](https://github.com/ydb-platform/ydb/tree/23.2.12) | [See list](../changelog-server.md#23-2) ||

--- a/ydb/docs/ru/core/changelog-server.md
+++ b/ydb/docs/ru/core/changelog-server.md
@@ -9,7 +9,7 @@
 #### Функциональность
 
 * [Добавлена](https://github.com/ydb-platform/ydb/pull/21119) возможность использовать привычные инструменты потоковой обработки данных –  Kafka Connect, Confluent Schema Registry, Kafka Streams, Apache Flink, AKH через [Kafka API](./reference/kafka-api/index.md) при работе с YDB Topics. Теперь YDB Topics Kafka API поддерживает:
-  * клиентскую балансировку читателей – включается установкой флага `enable_kafka_native_balancing` в [конфигурации кластера](./reference/configuration/feature_flags.md). [Как работает балансировка читателей в Apache Kafka](https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb). Теперь балансировка читателей в Kafka API YDB Topics будет работать точно так же,
+  * клиентскую балансировку читателей – включается установкой флага `enable_kafka_native_balancing` в [конфигурации кластера](./reference/configuration/index.md#feature_flags). [Как работает балансировка читателей в Apache Kafka](https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb). Теперь балансировка читателей в Kafka API YDB Topics будет работать точно так же,
   * [компактифицированные топики](https://docs.confluent.io/kafka/design/log_compaction.html) – включается установкой флага `enable_topic_compactification_by_key`,
   * [транзакции](https://www.confluent.io/blog/transactions-apache-kafka) – включается установкой флага `enable_kafka_transactions`.
 * [Добавлен](https://github.com/ydb-platform/ydb/pull/20982) [новый протокол](https://github.com/ydb-platform/ydb/issues/11064) в [Node Broker](./concepts/glossary.md#node-broker), устраняющий всплески сетевого трафика на больших кластерах (более 1000 серверов), связанного с рассылкой информации об узлах.

--- a/ydb/docs/ru/core/changelog-server.md
+++ b/ydb/docs/ru/core/changelog-server.md
@@ -2,14 +2,14 @@
 
 ## Версия 25.1 {#25-1}
 
-### Версия 25.1.4.7 {#25-1-4-7}
+### Версия 25.1.4.18 {#25-1-4-18}
 
-Дата выхода: 15 сентября 2025.
+Дата выхода: 12 мая 2026.
 
 #### Функциональность
 
 * [Добавлена](https://github.com/ydb-platform/ydb/pull/21119) возможность использовать привычные инструменты потоковой обработки данных –  Kafka Connect, Confluent Schema Registry, Kafka Streams, Apache Flink, AKH через [Kafka API](./reference/kafka-api/index.md) при работе с YDB Topics. Теперь YDB Topics Kafka API поддерживает:
-  * клиентскую балансировку читателей – включается установкой флага `enable_kafka_native_balancing` в [конфигурации кластера](./reference/configuration/index.md#feature_flags). [Как работает балансировка читателей в Apache Kafka](https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb). Теперь балансировка читателей в Kafka API YDB Topics будет работать точно так же,
+  * клиентскую балансировку читателей – включается установкой флага `enable_kafka_native_balancing` в [конфигурации кластера](./reference/configuration/feature_flags.md). [Как работает балансировка читателей в Apache Kafka](https://www.confluent.io/blog/cooperative-rebalancing-in-kafka-streams-consumer-ksqldb). Теперь балансировка читателей в Kafka API YDB Topics будет работать точно так же,
   * [компактифицированные топики](https://docs.confluent.io/kafka/design/log_compaction.html) – включается установкой флага `enable_topic_compactification_by_key`,
   * [транзакции](https://www.confluent.io/blog/transactions-apache-kafka) – включается установкой флага `enable_kafka_transactions`.
 * [Добавлен](https://github.com/ydb-platform/ydb/pull/20982) [новый протокол](https://github.com/ydb-platform/ydb/issues/11064) в [Node Broker](./concepts/glossary.md#node-broker), устраняющий всплески сетевого трафика на больших кластерах (более 1000 серверов), связанного с рассылкой информации об узлах.
@@ -27,6 +27,7 @@
 
 #### Исправления ошибок
 
+* [Исправлена](https://github.com/ydb-platform/ydb/pull/38425) уязвимость [LDAP-аутентификации](./security/authentication.md): зная логин и пароль любого LDAP-пользователя (в том числе не входящего в группу с доступом к {{ ydb-short-name }}), можно было обойти проверку членства в группе и получить доступ к кластеру (инъекция в LDAP-фильтр поиска пользователя; добавлено экранирование спецсимволов по RFC 2254).
 * [Добавлена](https://github.com/ydb-platform/ydb/pull/21918) поддержка в асинхронной репликации нового типа записи об изменениях — `reset`-записи (в дополнение к `update`- и `erase`-записям).
 * [Исправлена](https://github.com/ydb-platform/ydb/pull/21836) [ошибка](https://github.com/ydb-platform/ydb/issues/21814), из-за которой экземпляр репликации с неуказанным параметром `COMMIT_INTERVAL` приводил к сбою процесса.
 * [Исправлены](https://github.com/ydb-platform/ydb/pull/21652) редкие ошибки при чтении из топика во время балансировки партиций.
@@ -41,7 +42,7 @@
 
 #### Функциональность
 
-* [Реализован](https://github.com/ydb-platform/ydb/pull/19504) [векторный индекс](./dev/vector-indexes.md?version=v25.1) для приближённого векторного поиска. Для векторного поиска опубликованы рецепты для [YDB CLI и YQL](./recipes/vector-search?version=v25.1), а также примеры работы [на С++ и Python](./recipes/ydb-sdk/vector-search?version=v25.1). Включается установкой флага `enable_vector_index` в [конфигурации кластера](./reference/configuration/?version=v25.1#feature_flags). Внимание! После включения флага откат на предыдущие версии {{ ydb-short-name }} невозможен.
+* [Реализован](https://github.com/ydb-platform/ydb/pull/19504) [векторный индекс](./dev/vector-indexes.md?version=v25.1) для приближённого векторного поиска. Для векторного поиска опубликованы рецепты для [YDB CLI и YQL](./recipes/vector-search?version=v25.1), а также примеры работы [на С++ и Python](./recipes/ydb-sdk/vector-search?version=v25.1).
 * [Добавлена](https://github.com/ydb-platform/ydb/issues/11454) поддержка [консистентной асинхронной репликации](./concepts/async-replication.md?version=v25.1).
 * Добавлен [механизм конфигурации V2](./devops/configuration-management/configuration-v2/config-overview?version=v25.1), упрощающий развёртывание новых кластеров {{ ydb-short-name }} и дальнейшую работу с ними. [Сравнение](./devops/configuration-management/compare-configs?version=v25.1) механизмов конфигурации V1 и V2.
 * Добавлена поддержка параметризованного [типа Decimal](./yql/reference/types/primitive.md?version=v25.1#numeric).


### PR DESCRIPTION
## Summary

- Restore correct patch version in `changelog-server.md` (EN/RU): **25.1.4.18** (replacing 25.1.4.7).
- Sync EN `ydb-open-source-database.md` from `main` without 25.2+ blocks; Docker tag `ydb:25.1.4.18`.
- RU downloads on `stable-25-1` already had the correct version; no change needed.
