### PR TITLE
[YQ-5334] Document CREATE OR REPLACE / IF NOT EXISTS for external data source and external table

### DIFF
--- a/ydb/docs/ru/core/yql/reference/syntax/create-external-data-source.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/create-external-data-source.md
@@ -5,7 +5,7 @@
 Вызов `CREATE EXTERNAL DATA SOURCE` создает [внешний источник данных](../../../concepts/datamodel/external_data_source.md).
 
 ```yql
-CREATE EXTERNAL DATA SOURCE external_data_source WITH (
+CREATE [OR REPLACE] EXTERNAL DATA SOURCE [IF NOT EXISTS] external_data_source WITH (
   SOURCE_TYPE="source_type",
   LOCATION="ip_address_or_fqdn:port",
   USE_TLS="use_tls",
@@ -17,6 +17,8 @@ CREATE EXTERNAL DATA SOURCE external_data_source WITH (
 
 Где:
 
+* `OR REPLACE` - если внешний источник данных с таким именем уже существует, он будет заменён новым определением; версия объекта при этом увеличивается.
+* `IF NOT EXISTS` - не выводить ошибку, если внешний источник данных с таким именем уже существует; существующий объект останется без изменений.
 * `external_data_source` - название внешнего источника данных.
 * `source_type` - тип внешнего источника данных. Возможные значения: [`ClickHouse`](#clickhouse), [`PostgreSQL`](#postgresql), [`ObjectStorage`](#object_storage).
 * `ip_address_or_fqdn:port` - полный сетевой адрес внешнего источника данных, включая порт. В качестве сетевого адреса можно указывать IP-адрес или FQDN.

--- a/ydb/docs/ru/core/yql/reference/syntax/create-external-table.md
+++ b/ydb/docs/ru/core/yql/reference/syntax/create-external-table.md
@@ -3,7 +3,7 @@
 Вызов `CREATE EXTERNAL TABLE` создает [внешнюю таблицу](../../../concepts/datamodel/external_table.md) с указанной схемой данных.
 
 ```yql
-CREATE EXTERNAL TABLE table_name (
+CREATE [OR REPLACE] EXTERNAL TABLE [IF NOT EXISTS] table_name (
   column1 type1,
   column2 type2 NOT NULL,
   ...
@@ -18,6 +18,8 @@ CREATE EXTERNAL TABLE table_name (
 
 Где:
 
+* `OR REPLACE` - если внешняя таблица с таким именем уже существует, она будет заменена новым определением; версия объекта при этом увеличивается.
+* `IF NOT EXISTS` - не выводить ошибку, если внешняя таблица с таким именем уже существует; существующая таблица останется без изменений.
 * `column1 type1`, `columnN typeN NULL` - колонка данных и ее тип;
 * `data_source_name` - имя [подключения](../../../concepts/datamodel/external_data_source.md) к S3 ({{ objstorage-name }}).
 * `path` - путь внутри бакета с данными. Путь должен вести на существующий каталог внутри бакета.


### PR DESCRIPTION
## Summary

Documents the `OR REPLACE` and `IF NOT EXISTS` modifiers for `CREATE EXTERNAL DATA SOURCE` (EDS) and `CREATE EXTERNAL TABLE` (EDT) in the RU YQL reference. The feature is implemented and tested in SchemeShard, but the docs only described plain `CREATE`. Mirrors how `CREATE STREAMING QUERY` documents these modifiers.

### Changes (RU only)

- `ydb/docs/ru/core/yql/reference/syntax/create-external-data-source.md`
- `ydb/docs/ru/core/yql/reference/syntax/create-external-table.md`

For each page: the syntax block now shows `CREATE [OR REPLACE] ... [IF NOT EXISTS] ...`, plus two bullets in the `Где:` list describing each modifier.

### Notes

- `OR REPLACE` is documented as an atomic in-place replace with object version increment; `IF NOT EXISTS` as a no-error / leave-unchanged path — grounded in the SchemeShard create operations.
- Deliberately omits a mutual-exclusivity claim: unlike streaming query, EDS/EDT do **not** error when both modifiers are given (the parser lets `IF NOT EXISTS` take precedence).
- Follows the YDB docs `.ruler` conventions (no em dashes — matches each page's existing space-hyphen style). EN tree untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)