### PR TITLE
[YQ-5038] Validate ObjectStorage external data source has a non-empty LOCATION

### DIFF
--- a/ydb/core/external_sources/object_storage.cpp
+++ b/ydb/core/external_sources/object_storage.cpp
@@ -29,6 +29,7 @@
 #include <arrow/io/memory.h>
 
 #include <util/string/builder.h>
+#include <util/string/strip.h>
 
 #include <array>
 
@@ -149,6 +150,10 @@ struct TObjectStorageExternalSource : public IExternalSource {
 
         if (!proto.GetProperties().GetProperties().empty()) {
             throw TExternalSourceException() << "ObjectStorage source doesn't support any properties";
+        }
+
+        if (StripString(proto.GetLocation()).empty()) {
+            throw TExternalSourceException() << "ObjectStorage source must specify a non-empty location pointing to a bucket";
         }
 
         ValidateHostname(HostnamePatterns, proto.GetLocation());

--- a/ydb/core/external_sources/object_storage_ut.cpp
+++ b/ydb/core/external_sources/object_storage_ut.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/random/random.h>
 #include <ydb/core/protos/external_sources.pb.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 
 namespace NKikimr {
 
@@ -87,6 +88,33 @@ Y_UNIT_TEST_SUITE(ObjectStorageTest) {
             general.set_location("*");
             general.mutable_attributes()->insert({"partitioned_by", "[year]"});
             UNIT_ASSERT_EXCEPTION_CONTAINS(source->Pack(schema, general), NExternalSource::TExternalSourceException, "Location '*' contains wildcards");
+        }
+    }
+
+    Y_UNIT_TEST(EmptyLocationValidation) {
+        const auto source = NExternalSource::CreateObjectStorageExternalSource({}, nullptr, 1000, nullptr, false, false);
+
+        {  // empty location is rejected with a clear error
+            NKikimrSchemeOp::TExternalDataSourceDescription proto;
+            UNIT_ASSERT_EXCEPTION_CONTAINS(source->ValidateExternalDataSource(proto.SerializeAsString()), NExternalSource::TExternalSourceException, "ObjectStorage source must specify a non-empty location pointing to a bucket");
+        }
+
+        {  // whitespace-only location is rejected as well
+            NKikimrSchemeOp::TExternalDataSourceDescription proto;
+            proto.SetLocation("   ");
+            UNIT_ASSERT_EXCEPTION_CONTAINS(source->ValidateExternalDataSource(proto.SerializeAsString()), NExternalSource::TExternalSourceException, "ObjectStorage source must specify a non-empty location pointing to a bucket");
+        }
+
+        {  // bucket-only location is accepted
+            NKikimrSchemeOp::TExternalDataSourceDescription proto;
+            proto.SetLocation("my-bucket");
+            UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
+        }
+
+        {  // url with a bucket is accepted
+            NKikimrSchemeOp::TExternalDataSourceDescription proto;
+            proto.SetLocation("https://storage.yandexcloud.net/my-bucket/");
+            UNIT_ASSERT_NO_EXCEPTION(source->ValidateExternalDataSource(proto.SerializeAsString()));
         }
     }
 

--- a/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway_ut.cpp
@@ -173,6 +173,7 @@ void TestDropObjectCommon(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGatew
 void TestCreateExternalDataSource(TTestActorRuntime& runtime, TIntrusivePtr<IKikimrGateway> gateway, const TString& path) {
     TCreateObjectSettings settings("EXTERNAL_DATA_SOURCE", path, {
         {"source_type", "ObjectStorage"},
+        {"location", "my-bucket"},
         {"auth_method", "NONE"},
         {"installation", "cloud"}
     });
@@ -182,7 +183,7 @@ void TestCreateExternalDataSource(TTestActorRuntime& runtime, TIntrusivePtr<IKik
     UNIT_ASSERT(externalDataSource.ExternalDataSourceInfo);
     UNIT_ASSERT_VALUES_EQUAL(externalDataSource.ExternalDataSourceInfo->Description.GetSourceType(), "ObjectStorage");
     UNIT_ASSERT_VALUES_EQUAL(externalDataSource.ExternalDataSourceInfo->Description.GetInstallation(), "cloud");
-    UNIT_ASSERT_VALUES_EQUAL(externalDataSource.ExternalDataSourceInfo->Description.GetLocation(), "");
+    UNIT_ASSERT_VALUES_EQUAL(externalDataSource.ExternalDataSourceInfo->Description.GetLocation(), "my-bucket");
     UNIT_ASSERT_VALUES_EQUAL(externalDataSource.ExternalDataSourceInfo->Description.GetName(), SplitPath(path).back());
     UNIT_ASSERT(externalDataSource.ExternalDataSourceInfo->Description.GetAuth().HasNone());
 }

--- a/ydb/core/tx/schemeshard/ut_external_data_source/ut_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/ut_external_data_source/ut_external_data_source.cpp
@@ -309,6 +309,7 @@ Y_UNIT_TEST_SUITE(TExternalDataSourceTest) {
         TestCreateExternalDataSource(runtime, ++txId, "/MyRoot/DirA", Sprintf(R"(
                 Name: "MyExternalDataSource"
                 SourceType: "ObjectStorage"
+                Location: "https://s3.cloud.net/my_bucket"
                 Installation: "%s"
                 Auth {
                     None {

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -251,7 +251,7 @@ def test_external_data_table_with_fail(db_fixture, ydb_cluster):
 
     # drop secret in between
     _test_external_data_table_with_fail(
-        get_eds_for_s3(secrets[0], secrets[1], '', 's3_source_with_removed_secret'),
+        get_eds_for_s3(secrets[0], secrets[1], 'my-bucket', 's3_source_with_removed_secret'),
         's3_source_with_removed_secret',
         f"DROP SECRET `{secrets[1]}`;",
         f"secret `{secrets[1]}` not found",
@@ -259,7 +259,7 @@ def test_external_data_table_with_fail(db_fixture, ydb_cluster):
 
     # revoke grant for a secret in between
     _test_external_data_table_with_fail(
-        get_eds_for_s3(secrets[0], secrets[2], '', 's3_source_with_revoked_grant_secret'),
+        get_eds_for_s3(secrets[0], secrets[2], 'my-bucket', 's3_source_with_revoked_grant_secret'),
         's3_source_with_revoked_grant_secret',
         f"REVOKE 'ydb.granular.select_row' ON `{secrets[2]}` FROM {user2};",
         f"secret `{secrets[2]}` not found",


### PR DESCRIPTION


### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When creating an EXTERNAL DATA SOURCE with SOURCE_TYPE="ObjectStorage", an empty (or whitespace-only) LOCATION previously passed validation and failed later with a confusing error. Reject it at CREATE time with a clear message pointing to the missing bucket.