### PR TITLE
YQ-5303 fixed streaming queries behaviour under load

### DIFF
--- a/ydb/core/grpc_services/query/rpc_fetch_script_results.cpp
+++ b/ydb/core/grpc_services/query/rpc_fetch_script_results.cpp
@@ -126,12 +126,12 @@ private:
 
     bool GetExecutionIdFromRequest() {
         TString error;
-        TMaybe<TString> executionId = NKqp::ScriptExecutionIdFromOperation(GetProtoRequest()->operation_id(), error);
+        auto executionId = NKqp::ScriptExecutionIdFromOperation(GetProtoRequest()->operation_id(), error);
         if (!executionId) {
             Reply(Ydb::StatusIds::BAD_REQUEST, error);
             return false;
         }
-        ExecutionId = *executionId;
+        ExecutionId = std::move(*executionId);
         return true;
     }
 

--- a/ydb/core/kqp/common/events/events.h
+++ b/ydb/core/kqp/common/events/events.h
@@ -175,23 +175,23 @@ struct TEvKqp {
     };
 
     struct TEvCancelScriptExecutionResponse : public TEventPB<TEvCancelScriptExecutionResponse, NKikimrKqp::TEvCancelScriptExecutionResponse, TKqpEvents::EvCancelScriptExecutionResponse> {
+        struct TInfo {
+            const bool ExecutionEntryExists = true;
+            const bool AlreadyStopped = false;
+        };
+
         TEvCancelScriptExecutionResponse() = default;
 
-        explicit TEvCancelScriptExecutionResponse(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues = {}) {
+        TEvCancelScriptExecutionResponse(Ydb::StatusIds::StatusCode status, TInfo&& info, const NYql::TIssues& issues = {}) {
             Record.SetStatus(status);
             NYql::IssuesToMessage(issues, Record.MutableIssues());
+            Record.SetAlreadyFinished(info.AlreadyStopped);
+            Record.SetExecutionEntryExists(info.ExecutionEntryExists);
         }
 
-        TEvCancelScriptExecutionResponse(Ydb::StatusIds::StatusCode status, const TString& message)
-            : TEvCancelScriptExecutionResponse(status, TextToIssues(message))
+        TEvCancelScriptExecutionResponse(Ydb::StatusIds::StatusCode status, TInfo&& info, const TString& message)
+            : TEvCancelScriptExecutionResponse(status, std::move(info), {NYql::TIssue(message)})
         {}
-
-    private:
-        static NYql::TIssues TextToIssues(const TString& message) {
-            NYql::TIssues issues;
-            issues.AddIssue(message);
-            return issues;
-        }
     };
 
     struct TEvUpdateDatabaseInfo : public TEventLocal<TEvUpdateDatabaseInfo, TKqpEvents::EvUpdateDatabaseInfo> {

--- a/ydb/core/kqp/common/events/script_executions.cpp
+++ b/ydb/core/kqp/common/events/script_executions.cpp
@@ -1,1 +1,0 @@
-#include "script_executions.h"

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -179,7 +179,7 @@ struct TEvScriptLeaseUpdateResponse : public TEventLocal<TEvScriptLeaseUpdateRes
         , Issues(std::move(issues))
     {}
 
-    const bool ExecutionEntryExists = false;
+    const bool ExecutionEntryExists = true;
     const TInstant CurrentDeadline;
     const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
     const NYql::TIssues Issues;

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -1,20 +1,27 @@
 #pragma once
+
 #include <ydb/core/kqp/common/simple/kqp_event_ids.h>
 #include <ydb/core/protos/kqp.pb.h>
-#include <ydb/core/protos/kqp_stats.pb.h>
 #include <ydb/core/protos/kqp_physical.pb.h>
+#include <ydb/core/protos/kqp_stats.pb.h>
 #include <ydb/library/aclib/aclib.h>
-#include <yql/essentials/public/issue/yql_issue.h>
+#include <ydb/library/actors/core/event_local.h>
 #include <ydb/public/api/protos/ydb_operation.pb.h>
 #include <ydb/public/api/protos/ydb_query.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 
-#include <ydb/library/actors/core/event_local.h>
-
-#include <util/generic/maybe.h>
+#include <yql/essentials/public/issue/yql_issue.h>
 
 #include <google/protobuf/any.pb.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/maybe.h>
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+#include <optional>
+#include <vector>
 
 namespace NKikimr::NKqp {
 
@@ -25,8 +32,8 @@ enum EFinalizationStatus : i32 {
 
 template <typename TEv, ui32 TEventType>
 struct TEventWithDatabaseId : public TEventLocal<TEv, TEventType> {
-    TEventWithDatabaseId(const TString& database)
-        : Database(database)
+    explicit TEventWithDatabaseId(TString database)
+        : Database(std::move(database))
     {}
 
     const TString& GetDatabase() const {
@@ -37,140 +44,135 @@ struct TEventWithDatabaseId : public TEventLocal<TEv, TEventType> {
         return DatabaseId;
     }
 
-    void SetDatabaseId(const TString& databaseId) {
-        DatabaseId = databaseId;
+    void SetDatabaseId(TString databaseId) {
+        DatabaseId = std::move(databaseId);
     }
 
-    const TString Database;
+    TString Database;
     TString DatabaseId;
 };
 
 struct TEvForgetScriptExecutionOperation : public TEventWithDatabaseId<TEvForgetScriptExecutionOperation, TKqpScriptExecutionEvents::EvForgetScriptExecutionOperation> {
-    TEvForgetScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id, const std::optional<TString>& userSID)
-        : TEventWithDatabaseId(database)
-        , OperationId(id)
-        , UserSID(userSID)
+    struct TSettings {
+        const bool FailOnNotFound = true;
+        const bool CancelIfRunning = false;
+    };
+
+    TEvForgetScriptExecutionOperation(TString database, NOperationId::TOperationId id, std::optional<TString> userSID, TSettings&& settings)
+        : TEventWithDatabaseId(std::move(database))
+        , OperationId(std::move(id))
+        , UserSID(std::move(userSID))
+        , Settings(std::move(settings))
+    {}
+
+    TEvForgetScriptExecutionOperation(TString database, NOperationId::TOperationId id, std::optional<TString> userSID)
+        : TEvForgetScriptExecutionOperation(std::move(database), std::move(id), std::move(userSID), {})
     {}
 
     const NOperationId::TOperationId OperationId;
     const std::optional<TString> UserSID;
+    const TSettings Settings;
 };
 
 struct TEvForgetScriptExecutionOperationResponse : public TEventLocal<TEvForgetScriptExecutionOperationResponse, TKqpScriptExecutionEvents::EvForgetScriptExecutionOperationResponse> {
-    TEvForgetScriptExecutionOperationResponse(Ydb::StatusIds::StatusCode status,  NYql::TIssues issues) 
+    TEvForgetScriptExecutionOperationResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues) 
         : Status(status)
-        , Issues(issues)
-    {
-    }
-    
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
+        , Issues(std::move(issues))
+    {}
+
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYql::TIssues Issues;
 };
 
 struct TEvGetScriptExecutionOperation : public TEventWithDatabaseId<TEvGetScriptExecutionOperation, TKqpScriptExecutionEvents::EvGetScriptExecutionOperation> {
-    TEvGetScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id, const std::optional<TString>& userSID)
-        : TEventWithDatabaseId(database)
-        , OperationId(id)
-        , UserSID(userSID)
+    TEvGetScriptExecutionOperation(TString database, NOperationId::TOperationId id, std::optional<TString> userSID, const bool failOnNotFound = true)
+        : TEventWithDatabaseId(std::move(database))
+        , OperationId(std::move(id))
+        , UserSID(std::move(userSID))
+        , FailOnNotFound(failOnNotFound)
     {}
 
-    const NOperationId::TOperationId OperationId;
-    const std::optional<TString> UserSID;
-    bool CheckLeaseState = true;
-};
-
-struct TEvGetScriptExecutionOperationQueryResponse : public TEventLocal<TEvGetScriptExecutionOperationQueryResponse, TKqpScriptExecutionEvents::EvGetScriptExecutionOperationQueryResponse> {
-    explicit TEvGetScriptExecutionOperationQueryResponse(const TString& executionId)
-        : ExecutionId(executionId)
-    {}
-
-    bool Ready = false;
-    bool LeaseExpired = false;
-    TInstant LeaseDeadline;
-    std::optional<EFinalizationStatus> FinalizationStatus;
-    TActorId RunScriptActorId;
-    TString ExecutionId;
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
-    Ydb::Query::ExecuteScriptMetadata Metadata;
-    bool WaitRetry = false;
-    i64 LeaseGeneration = 0;
-    bool StateSaved = false;
-    NKikimrKqp::TScriptExecutionRetryState RetryState;
+    NOperationId::TOperationId OperationId;
+    std::optional<TString> UserSID;
+    const bool FailOnNotFound = true;
 };
 
 struct TEvGetScriptExecutionOperationResponse : public TEventLocal<TEvGetScriptExecutionOperationResponse, TKqpScriptExecutionEvents::EvGetScriptExecutionOperationResponse> {
     struct TInfo {
         TMaybe<google::protobuf::Any> Metadata;
-        bool Ready = false;
-        bool StateSaved = false;
-        ui64 RetryCount = 0;
-        TInstant LastFailAt;
-        TInstant SuspendedUntil;
+        const bool Ready = false;
+        const bool StateSaved = false;
+        const bool ExecutionEntryExists = true;
+        const ui64 RetryCount = 0;
+        const TInstant LastFailAt;
+        const TInstant SuspendedUntil;
+        const Ydb::StatusIds::StatusCode RequestStatus = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
     };
 
-    TEvGetScriptExecutionOperationResponse(Ydb::StatusIds::StatusCode status, TInfo&& info, NYql::TIssues issues)
+    TEvGetScriptExecutionOperationResponse(const Ydb::StatusIds::StatusCode status, TInfo&& info, NYql::TIssues issues)
         : Ready(info.Ready)
         , Status(status)
+        , RequestStatus(info.RequestStatus)
         , Issues(std::move(issues))
         , Metadata(std::move(info.Metadata))
         , StateSaved(info.StateSaved)
+        , ExecutionEntryExists(info.ExecutionEntryExists)
         , RetryCount(info.RetryCount)
         , LastFailAt(info.LastFailAt)
         , SuspendedUntil(info.SuspendedUntil)
     {}
 
-    TEvGetScriptExecutionOperationResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+    TEvGetScriptExecutionOperationResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : Status(status)
         , Issues(std::move(issues))
     {}
 
-    bool Ready = false;
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
+    const bool Ready = false;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const Ydb::StatusIds::StatusCode RequestStatus = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYql::TIssues Issues;
     TMaybe<google::protobuf::Any> Metadata;
-    bool StateSaved = false;
-    ui64 RetryCount = 0;
-    TInstant LastFailAt;
-    TInstant SuspendedUntil;
+    const bool StateSaved = false;
+    const bool ExecutionEntryExists = true;
+    const ui64 RetryCount = 0;
+    const TInstant LastFailAt;
+    const TInstant SuspendedUntil;
 };
 
 struct TEvListScriptExecutionOperations : public TEventWithDatabaseId<TEvListScriptExecutionOperations, TKqpScriptExecutionEvents::EvListScriptExecutionOperations> {
-    TEvListScriptExecutionOperations(const TString& database, const ui64 pageSize, const TString& pageToken, const std::optional<TString>& userSID)
-        : TEventWithDatabaseId(database)
+    TEvListScriptExecutionOperations(TString database, const ui64 pageSize, TString pageToken, std::optional<TString> userSID)
+        : TEventWithDatabaseId(std::move(database))
         , PageSize(pageSize)
-        , PageToken(pageToken)
-        , UserSID(userSID)
+        , PageToken(std::move(pageToken))
+        , UserSID(std::move(userSID))
     {}
 
-    const ui64 PageSize;
-    const TString PageToken;
-    const std::optional<TString> UserSID;
+    const ui64 PageSize = 0;
+    TString PageToken;
+    std::optional<TString> UserSID;
 };
 
 struct TEvListScriptExecutionOperationsResponse : public TEventLocal<TEvListScriptExecutionOperationsResponse, TKqpScriptExecutionEvents::EvListScriptExecutionOperationsResponse> {
-    TEvListScriptExecutionOperationsResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues, const TString& nextPageToken, std::vector<Ydb::Operations::Operation> operations)
+    TEvListScriptExecutionOperationsResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues, TString nextPageToken, std::vector<Ydb::Operations::Operation> operations)
         : Status(status)
         , Issues(std::move(issues))
-        , NextPageToken(nextPageToken)
+        , NextPageToken(std::move(nextPageToken))
         , Operations(std::move(operations))
-    {
-    }
+    {}
 
-    TEvListScriptExecutionOperationsResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+    TEvListScriptExecutionOperationsResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : Status(status)
         , Issues(std::move(issues))
-    {
-    }
+    {}
 
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
-    TString NextPageToken;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYql::TIssues Issues;
+    const TString NextPageToken;
     std::vector<Ydb::Operations::Operation> Operations;
 };
 
 struct TEvScriptLeaseUpdateResponse : public TEventLocal<TEvScriptLeaseUpdateResponse, TKqpScriptExecutionEvents::EvScriptLeaseUpdateResponse> {
-    TEvScriptLeaseUpdateResponse(bool executionEntryExists, TInstant currentDeadline, Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+    TEvScriptLeaseUpdateResponse(const bool executionEntryExists, const TInstant currentDeadline, const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : ExecutionEntryExists(executionEntryExists)
         , CurrentDeadline(currentDeadline)
         , Status(status)
@@ -179,7 +181,7 @@ struct TEvScriptLeaseUpdateResponse : public TEventLocal<TEvScriptLeaseUpdateRes
 
     const bool ExecutionEntryExists = false;
     const TInstant CurrentDeadline;
-    const Ydb::StatusIds::StatusCode Status;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
     const NYql::TIssues Issues;
 };
 
@@ -190,100 +192,125 @@ struct TEvCheckAliveResponse : public TEventPB<TEvCheckAliveResponse, NKikimrKqp
 };
 
 struct TEvCancelScriptExecutionOperation : public TEventWithDatabaseId<TEvCancelScriptExecutionOperation, TKqpScriptExecutionEvents::EvCancelScriptExecutionOperation> {
-    TEvCancelScriptExecutionOperation(const TString& database, const NOperationId::TOperationId& id, const std::optional<TString>& userSID)
-        : TEventWithDatabaseId(database)
-        , OperationId(id)
-        , UserSID(userSID)
+    struct TSettings {
+        const bool FailOnNotFound = true;
+        const bool FailOnAlreadyStopped = true;
+    };
+
+    TEvCancelScriptExecutionOperation(TString database, NOperationId::TOperationId id, std::optional<TString> userSID, TSettings&& settings)
+        : TEventWithDatabaseId(std::move(database))
+        , OperationId(std::move(id))
+        , UserSID(std::move(userSID))
+        , Settings(std::move(settings))
+    {}
+
+    TEvCancelScriptExecutionOperation(TString database, NOperationId::TOperationId id, std::optional<TString> userSID)
+        : TEvCancelScriptExecutionOperation(std::move(database), std::move(id), std::move(userSID), {})
     {}
 
     const NOperationId::TOperationId OperationId;
     const std::optional<TString> UserSID;
+    const TSettings Settings;
 };
 
 struct TEvResetScriptExecutionRetriesResponse : public TEventLocal<TEvResetScriptExecutionRetriesResponse, TKqpScriptExecutionEvents::EvResetScriptExecutionRetriesResponse> {
-    explicit TEvResetScriptExecutionRetriesResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {})
+    struct TInfo {
+        const bool OperationStillRunning = false;
+        const bool ExecutionEntryExists = true;
+        const bool AlreadyStopped = false;
+    };
+
+    TEvResetScriptExecutionRetriesResponse(const Ydb::StatusIds::StatusCode status, TInfo&& info, NYql::TIssues issues)
         : Status(status)
+        , Info(std::move(info))
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const TInfo Info;
+    const NYql::TIssues Issues;
 };
 
 struct TEvCancelScriptExecutionOperationResponse : public TEventLocal<TEvCancelScriptExecutionOperationResponse, TKqpScriptExecutionEvents::EvCancelScriptExecutionOperationResponse> {
-    TEvCancelScriptExecutionOperationResponse() = default;
-
-    TEvCancelScriptExecutionOperationResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {})
+    TEvCancelScriptExecutionOperationResponse(const Ydb::StatusIds::StatusCode status, bool executionEntryExists, NYql::TIssues issues)
         : Status(status)
-        , Issues(std::move(issues))
-    {
-    }
-
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
-};
-
-struct TEvScriptExecutionFinished : public TEventLocal<TEvScriptExecutionFinished, TKqpScriptExecutionEvents::EvScriptExecutionFinished> {
-    TEvScriptExecutionFinished(bool operationAlreadyFinalized, bool waitingRetry, Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {})
-        : OperationAlreadyFinalized(operationAlreadyFinalized)
-        , WaitingRetry(waitingRetry)
-        , Status(status)
+        , ExecutionEntryExists(executionEntryExists)
         , Issues(std::move(issues))
     {}
 
-    bool OperationAlreadyFinalized = false;
-    bool WaitingRetry = false;
-    Ydb::StatusIds::StatusCode Status;
+    TEvCancelScriptExecutionOperationResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+        : Status(status)
+        , Issues(std::move(issues))
+    {}
+
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const bool ExecutionEntryExists = true;
+    const NYql::TIssues Issues;
+};
+
+struct TEvScriptExecutionFinished : public TEventLocal<TEvScriptExecutionFinished, TKqpScriptExecutionEvents::EvScriptExecutionFinished> {
+    struct TInfo {
+        const bool ExecutionEntryExists = true;
+        const bool AlreadyStopped = false;
+    };
+
+    TEvScriptExecutionFinished(const Ydb::StatusIds::StatusCode status, TInfo&& info, NYql::TIssues issues)
+        : Status(status)
+        , Info(std::move(info))
+        , Issues(std::move(issues))
+    {}
+
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const TInfo Info;
     NYql::TIssues Issues;
 };
 
 struct TEvSaveScriptResultMetaFinished : public TEventLocal<TEvSaveScriptResultMetaFinished, TKqpScriptExecutionEvents::EvSaveScriptResultMetaFinished> {
-    TEvSaveScriptResultMetaFinished(Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {})
+    TEvSaveScriptResultMetaFinished(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : Status(status)
         , Issues(std::move(issues))
-    {
-    }
+    {}
 
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYql::TIssues Issues;
 };
 
 struct TEvSaveScriptResultPartFinished : public TEventLocal<TEvSaveScriptResultPartFinished, TKqpScriptExecutionEvents::EvSaveScriptResultPartFinished> {
-    TEvSaveScriptResultPartFinished(Ydb::StatusIds::StatusCode status, i64 savedSize, NYql::TIssues issues = {})
+    TEvSaveScriptResultPartFinished(const Ydb::StatusIds::StatusCode status, const i64 savedSize, NYql::TIssues issues)
         : Status(status)
         , SavedSize(savedSize)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    i64 SavedSize;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const i64 SavedSize = 0;
     NYql::TIssues Issues;
 };
 
 struct TEvSaveScriptResultFinished : public TEventLocal<TEvSaveScriptResultFinished, TKqpScriptExecutionEvents::EvSaveScriptResultFinished> {
-    TEvSaveScriptResultFinished(Ydb::StatusIds::StatusCode status, size_t resultSetId, NYql::TIssues issues = {})
+    TEvSaveScriptResultFinished(const Ydb::StatusIds::StatusCode status, const size_t resultSetId, NYql::TIssues issues)
         : Status(status)
         , ResultSetId(resultSetId)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    size_t ResultSetId = 0;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const size_t ResultSetId = 0;
+    const NYql::TIssues Issues;
 };
 
 struct TEvFetchScriptResultsResponse : public TEventLocal<TEvFetchScriptResultsResponse, TKqpScriptExecutionEvents::EvFetchScriptResultsResponse> {
-    TEvFetchScriptResultsResponse(Ydb::StatusIds::StatusCode status, std::optional<Ydb::ResultSet>&& resultSet, bool hasMoreResults, NYql::TIssues issues)
+    TEvFetchScriptResultsResponse(const Ydb::StatusIds::StatusCode status, std::optional<Ydb::ResultSet>&& resultSet, const bool hasMoreResults, NYql::TIssues issues)
         : Status(status)
         , ResultSet(std::move(resultSet))
         , HasMoreResults(hasMoreResults)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
     std::optional<Ydb::ResultSet> ResultSet;
-    bool HasMoreResults = false;
-    NYql::TIssues Issues;
+    const bool HasMoreResults = false;
+    const NYql::TIssues Issues;
 };
 
 struct TEvStartScriptExecutionBackgroundChecks : public TEventLocal<TEvStartScriptExecutionBackgroundChecks, TKqpScriptExecutionEvents::EvStartScriptExecutionBackgroundChecks> {
@@ -291,36 +318,30 @@ struct TEvStartScriptExecutionBackgroundChecks : public TEventLocal<TEvStartScri
 
 struct TEvSaveScriptExternalEffectRequest : public TEventLocal<TEvSaveScriptExternalEffectRequest, TKqpScriptExecutionEvents::EvSaveScriptExternalEffectRequest> {
     struct TDescription {
-        TDescription(const TString& executionId, const TString& database, const TString& customerSuppliedId)
-            : ExecutionId(executionId)
-            , Database(database)
-            , CustomerSuppliedId(customerSuppliedId)
+        explicit TDescription(TString customerSuppliedId)
+            : CustomerSuppliedId(std::move(customerSuppliedId))
         {}
 
-        TString ExecutionId;
-        TString Database;
-
-        TString CustomerSuppliedId;
-        TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
+        const TString CustomerSuppliedId;
         std::vector<NKqpProto::TKqpExternalSink> Sinks;
         std::vector<TString> SecretNames;
     };
 
-    TEvSaveScriptExternalEffectRequest(const TString& executionId, const TString& database, const TString& customerSuppliedId)
-        : Description(executionId, database, customerSuppliedId)
+    explicit TEvSaveScriptExternalEffectRequest(TString customerSuppliedId)
+        : Description(std::move(customerSuppliedId))
     {}
 
     TDescription Description;
 };
 
 struct TEvSaveScriptExternalEffectResponse : public TEventLocal<TEvSaveScriptExternalEffectResponse, TKqpScriptExecutionEvents::EvSaveScriptExternalEffectResponse> {
-    TEvSaveScriptExternalEffectResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+    TEvSaveScriptExternalEffectResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : Status(status)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYql::TIssues Issues;
 };
 
 struct TEvSaveScriptPhysicalGraphRequest : public TEventLocal<TEvSaveScriptPhysicalGraphRequest, TKqpScriptExecutionEvents::EvSaveScriptPhysicalGraphRequest> {
@@ -332,51 +353,53 @@ struct TEvSaveScriptPhysicalGraphRequest : public TEventLocal<TEvSaveScriptPhysi
 };
 
 struct TEvSaveScriptPhysicalGraphResponse : public TEventLocal<TEvSaveScriptPhysicalGraphResponse, TKqpScriptExecutionEvents::EvSaveScriptPhysicalGraphResponse> {
-    TEvSaveScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+    TEvSaveScriptPhysicalGraphResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : Status(status)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const NYql::TIssues Issues;
 };
 
 struct TEvGetScriptExecutionPhysicalGraph : public TEventWithDatabaseId<TEvGetScriptExecutionPhysicalGraph, TKqpScriptExecutionEvents::EvGetScriptExecutionPhysicalGraph> {
-    TEvGetScriptExecutionPhysicalGraph(const TString& database, const TString& executionId)
-        : TEventWithDatabaseId(database)
-        , ExecutionId(executionId)
+    TEvGetScriptExecutionPhysicalGraph(TString database, TString executionId)
+        : TEventWithDatabaseId(std::move(database))
+        , ExecutionId(std::move(executionId))
     {}
 
     const TString ExecutionId;
 };
 
 struct TEvGetScriptPhysicalGraphResponse : public TEventLocal<TEvGetScriptPhysicalGraphResponse, TKqpScriptExecutionEvents::EvGetScriptPhysicalGraphResponse> {
-    TEvGetScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
-        : Status(status)
-        , Issues(std::move(issues))
-    {}
-
-    TEvGetScriptPhysicalGraphResponse(Ydb::StatusIds::StatusCode status, std::optional<NKikimrKqp::TQueryPhysicalGraph>&& physicalGraph, i64 generation, NYql::TIssues issues)
+    TEvGetScriptPhysicalGraphResponse(const Ydb::StatusIds::StatusCode status, std::optional<NKikimrKqp::TQueryPhysicalGraph>&& physicalGraph, const i64 generation, const bool executionEntryExists, NYql::TIssues issues)
         : Status(status)
         , PhysicalGraph(std::move(physicalGraph))
         , Generation(generation)
+        , ExecutionEntryExists(executionEntryExists)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
-    i64 Generation = 0;
-    NYql::TIssues Issues;
+    TEvGetScriptPhysicalGraphResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+        : Status(status)
+        , Issues(std::move(issues))
+    {}
+
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
+    const i64 Generation = 0;
+    const bool ExecutionEntryExists = true;
+    const NYql::TIssues Issues;
 };
 
 struct TEvScriptFinalizeRequest : public TEventLocal<TEvScriptFinalizeRequest, TKqpScriptExecutionEvents::EvScriptFinalizeRequest> {
     struct TDescription {
-        TDescription(EFinalizationStatus finalizationStatus, const TString& executionId, const TString& database,
-        Ydb::StatusIds::StatusCode operationStatus, Ydb::Query::ExecStatus execStatus, NYql::TIssues issues, std::optional<NKqpProto::TKqpStatsQuery> queryStats,
-        std::optional<TString> queryPlan, std::optional<TString> queryAst, i64 leaseGeneration, bool cancelledByUser = false)
+        TDescription(const EFinalizationStatus finalizationStatus, TString executionId, TString database,
+            const Ydb::StatusIds::StatusCode operationStatus, const Ydb::Query::ExecStatus execStatus, NYql::TIssues issues, std::optional<NKqpProto::TKqpStatsQuery> queryStats,
+            std::optional<TString> queryPlan, std::optional<TString> queryAst, const i64 leaseGeneration, const bool cancelledByUser)
             : FinalizationStatus(finalizationStatus)
-            , ExecutionId(executionId)
-            , Database(database)
+            , ExecutionId(std::move(executionId))
+            , Database(std::move(database))
             , OperationStatus(operationStatus)
             , ExecStatus(execStatus)
             , Issues(std::move(issues))
@@ -387,117 +410,119 @@ struct TEvScriptFinalizeRequest : public TEventLocal<TEvScriptFinalizeRequest, T
             , CancelledByUser(cancelledByUser)
         {}
 
-        EFinalizationStatus FinalizationStatus;
-        TString ExecutionId;
-        TString Database;
-        Ydb::StatusIds::StatusCode OperationStatus;
-        Ydb::Query::ExecStatus ExecStatus;
+        EFinalizationStatus FinalizationStatus = EFinalizationStatus::FS_COMMIT;
+        const TString ExecutionId;
+        const TString Database;
+        const Ydb::StatusIds::StatusCode OperationStatus = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+        const Ydb::Query::ExecStatus ExecStatus = Ydb::Query::EXEC_STATUS_UNSPECIFIED;
         NYql::TIssues Issues;
-        std::optional<NKqpProto::TKqpStatsQuery> QueryStats;
+        const std::optional<NKqpProto::TKqpStatsQuery> QueryStats;
         std::optional<TString> QueryPlan;
         std::optional<TString> QueryAst;
-        i64 LeaseGeneration;
-        bool CancelledByUser = false; // User cancel API; false when status is CANCELLED from execution (e.g. streaming retry).
+        const i64 LeaseGeneration = 0;
+        const bool CancelledByUser = false; // User cancel API; false when status is CANCELLED from execution (e.g. streaming retry).
         std::optional<TString> QueryPlanCompressionMethod;
         std::optional<TString> QueryAstCompressionMethod;
     };
 
-    TEvScriptFinalizeRequest(EFinalizationStatus finalizationStatus, const TString& executionId, const TString& database,
-        Ydb::StatusIds::StatusCode operationStatus, Ydb::Query::ExecStatus execStatus, NYql::TIssues issues, std::optional<NKqpProto::TKqpStatsQuery> queryStats,
-        std::optional<TString> queryPlan, std::optional<TString> queryAst, i64 leaseGeneration, bool cancelledByUser = false)
-        : Description(finalizationStatus, executionId, database, operationStatus, execStatus, issues, queryStats, queryPlan, queryAst, leaseGeneration, cancelledByUser)
+    TEvScriptFinalizeRequest(const EFinalizationStatus finalizationStatus, TString executionId, TString database,
+        const Ydb::StatusIds::StatusCode operationStatus, const Ydb::Query::ExecStatus execStatus, NYql::TIssues issues,
+        std::optional<NKqpProto::TKqpStatsQuery> queryStats, std::optional<TString> queryPlan, std::optional<TString> queryAst,
+        const i64 leaseGeneration, const bool cancelledByUser)
+        : Description(
+            finalizationStatus, std::move(executionId), std::move(database), operationStatus, execStatus, std::move(issues),
+            std::move(queryStats), std::move(queryPlan), std::move(queryAst), leaseGeneration, cancelledByUser
+        )
     {}
 
     TDescription Description;
 };
 
 struct TEvScriptFinalizeResponse : public TEventLocal<TEvScriptFinalizeResponse, TKqpScriptExecutionEvents::EvScriptFinalizeResponse> {
-    explicit TEvScriptFinalizeResponse(const TString& executionId)
-        : ExecutionId(executionId)
+    explicit TEvScriptFinalizeResponse(TString executionId)
+        : ExecutionId(std::move(executionId))
     {}
 
-    TString ExecutionId;
+    const TString ExecutionId;
 };
 
 struct TEvSaveScriptFinalStatusResponse : public TEventLocal<TEvSaveScriptFinalStatusResponse, TKqpScriptExecutionEvents::EvSaveScriptFinalStatusResponse> {
     bool ApplicateScriptExternalEffectRequired = false;
-    bool OperationAlreadyFinalized = false;
-    bool WaitRetry = false;
+    bool FinalStatusAlreadySaved = false;
+    bool ExecutionEntryExists = true;
     TString CustomerSuppliedId;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     std::vector<NKqpProto::TKqpExternalSink> Sinks;
     std::vector<TString> SecretNames;
-    Ydb::StatusIds::StatusCode Status;
+    Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
     NYql::TIssues Issues;
 };
 
 struct TEvDescribeSecretsResponse : public TEventLocal<TEvDescribeSecretsResponse, TKqpScriptExecutionEvents::EvDescribeSecretsResponse> {
     struct TDescription {
-        TDescription(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+        TDescription(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
             : Status(status)
             , Issues(std::move(issues))
         {}
 
-        TDescription(const std::vector<TString>& secretValues)
-            : SecretValues(secretValues)
+        explicit TDescription(std::vector<TString> secretValues)
+            : SecretValues(std::move(secretValues))
             , Status(Ydb::StatusIds::SUCCESS)
         {}
 
-        std::vector<TString> SecretValues;
-        Ydb::StatusIds::StatusCode Status;
-        NYql::TIssues Issues;
+        const std::vector<TString> SecretValues;
+        const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+        const NYql::TIssues Issues;
     };
 
-    TEvDescribeSecretsResponse(const TDescription& description)
-        : Description(description)
+    explicit TEvDescribeSecretsResponse(TDescription description)
+        : Description(std::move(description))
     {}
 
-    TDescription Description;
+    const TDescription Description;
 };
 
 struct TEvDescribeResourceIdResponse : public TEventLocal<TEvDescribeResourceIdResponse, TKqpScriptExecutionEvents::EvDescribeResourceIdResponse> {
     struct TDescription {
-        TDescription(Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+        TDescription(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
             : Status(status)
             , Issues(std::move(issues))
         {}
 
-        TDescription(const TString& resourceId)
-            : ResourceId(resourceId)
+        explicit TDescription(TString resourceId)
+            : ResourceId(std::move(resourceId))
             , Status(Ydb::StatusIds::SUCCESS)
         {}
 
-        TString ResourceId;
-        Ydb::StatusIds::StatusCode Status;
-        NYql::TIssues Issues;
+        const TString ResourceId;
+        const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+        const NYql::TIssues Issues;
     };
 
-    TEvDescribeResourceIdResponse(const TDescription& description)
-        : Description(description)
+    explicit TEvDescribeResourceIdResponse(TDescription description)
+        : Description(std::move(description))
     {}
 
-    TDescription Description;
+    const TDescription Description;
 };
 
 struct TEvScriptExecutionsTablesCreationFinished : public TEventLocal<TEvScriptExecutionsTablesCreationFinished, TKqpScriptExecutionEvents::EvScriptExecutionsTableCreationFinished> {
-    TEvScriptExecutionsTablesCreationFinished(bool success, NYql::TIssues issues)
+    TEvScriptExecutionsTablesCreationFinished(const bool success, NYql::TIssues issues)
         : Success(success)
         , Issues(std::move(issues))
     {}
 
-    const bool Success;
+    const bool Success = true;
     const NYql::TIssues Issues;
 };
 
 struct TEvScriptExecutionRestarted : public TEventLocal<TEvScriptExecutionRestarted, TKqpScriptExecutionEvents::EvScriptExecutionRestarted> {
-    TEvScriptExecutionRestarted(Ydb::StatusIds::StatusCode status, bool leaseGenerationChanged, NYql::TIssues issues)
+    TEvScriptExecutionRestarted(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
         : Status(status)
-        , LeaseGenerationChanged(leaseGenerationChanged)
         , Issues(std::move(issues))
     {}
 
-    const Ydb::StatusIds::StatusCode Status;
-    const bool LeaseGenerationChanged = false;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
     const NYql::TIssues Issues;
 };
 
@@ -507,37 +532,37 @@ struct TEvListExpiredLeasesResponse : public TEventLocal<TEvListExpiredLeasesRes
         TString ExecutionId;
     };
 
-    TEvListExpiredLeasesResponse(Ydb::StatusIds::StatusCode status, std::vector<TLeaseInfo>&& leases, NYql::TIssues issues)
+    TEvListExpiredLeasesResponse(const Ydb::StatusIds::StatusCode status, std::vector<TLeaseInfo>&& leases, NYql::TIssues issues)
         : Status(status)
         , Leases(std::move(leases))
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    std::vector<TLeaseInfo> Leases;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const std::vector<TLeaseInfo> Leases;
+    const NYql::TIssues Issues;
 };
 
 struct TEvRefreshScriptExecutionLeasesResponse : public TEventLocal<TEvRefreshScriptExecutionLeasesResponse, TKqpScriptExecutionEvents::EvRefreshScriptExecutionLeasesResponse> {
-    TEvRefreshScriptExecutionLeasesResponse(bool success, NYql::TIssues issues)
+    TEvRefreshScriptExecutionLeasesResponse(const bool success, NYql::TIssues issues)
         : Success(success)
         , Issues(std::move(issues))
     {}
 
-    bool Success;
-    NYql::TIssues Issues;
+    const bool Success = true;
+    const NYql::TIssues Issues;
 };
 
 struct TEvSaveScriptProgressResponse : public TEventLocal<TEvSaveScriptProgressResponse, TKqpScriptExecutionEvents::EvSaveScriptProgressResponse> {
-    TEvSaveScriptProgressResponse(Ydb::StatusIds::StatusCode status, bool astSaved, NYql::TIssues issues)
+    TEvSaveScriptProgressResponse(const Ydb::StatusIds::StatusCode status, const bool astSaved, NYql::TIssues issues)
         : Status(status)
         , AstSaved(astSaved)
         , Issues(std::move(issues))
     {}
 
-    Ydb::StatusIds::StatusCode Status;
-    bool AstSaved = false;
-    NYql::TIssues Issues;
+    const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+    const bool AstSaved = false;
+    const NYql::TIssues Issues;
 };
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/events/script_executions.h
+++ b/ydb/core/kqp/common/events/script_executions.h
@@ -544,12 +544,14 @@ struct TEvListExpiredLeasesResponse : public TEventLocal<TEvListExpiredLeasesRes
 };
 
 struct TEvRefreshScriptExecutionLeasesResponse : public TEventLocal<TEvRefreshScriptExecutionLeasesResponse, TKqpScriptExecutionEvents::EvRefreshScriptExecutionLeasesResponse> {
-    TEvRefreshScriptExecutionLeasesResponse(const bool success, NYql::TIssues issues)
+    TEvRefreshScriptExecutionLeasesResponse(const bool success, const ui64 expiredLeasesCount, NYql::TIssues issues)
         : Success(success)
+        , ExpiredLeasesCount(expiredLeasesCount)
         , Issues(std::move(issues))
     {}
 
     const bool Success = true;
+    const ui64 ExpiredLeasesCount = 0;
     const NYql::TIssues Issues;
 };
 

--- a/ydb/core/kqp/common/events/ya.make
+++ b/ydb/core/kqp/common/events/ya.make
@@ -3,7 +3,6 @@ LIBRARY()
 SRCS(
     events.cpp
     query.cpp
-    script_executions.cpp
     workload_service.cpp
 )
 
@@ -23,6 +22,8 @@ PEERDIR(
 
     ydb/library/actors/core
 )
+
+GENERATE_ENUM_SERIALIZATION(script_executions.h)
 
 YQL_LAST_ABI_VERSION()
 

--- a/ydb/core/kqp/common/kqp_script_executions.cpp
+++ b/ydb/core/kqp/common/kqp_script_executions.cpp
@@ -17,14 +17,14 @@
 namespace NKikimr::NKqp {
 
 std::string ScriptExecutionOperationFromExecutionId(const std::string& executionId) {
-    return OperationIdFromExecutionId(executionId).ToString();
-}
-
-NOperationId::TOperationId OperationIdFromExecutionId(const std::string& executionId) {
     NOperationId::TOperationId operationId;
     operationId.SetKind(NOperationId::TOperationId::SCRIPT_EXECUTION);
     operationId.AddOptionalValue("id", executionId);
-    return operationId;
+    return operationId.ToString();
+}
+
+NOperationId::TOperationId OperationIdFromExecutionId(const std::string& executionId) {
+    return NOperationId::TOperationId(ScriptExecutionOperationFromExecutionId(executionId));
 }
 
 std::optional<TString> ScriptExecutionIdFromOperation(const std::string& operationId, TString& error) try {

--- a/ydb/core/kqp/common/kqp_script_executions.cpp
+++ b/ydb/core/kqp/common/kqp_script_executions.cpp
@@ -153,24 +153,4 @@ TString CheckScriptExecutionAccess(std::optional<TString>& userSID) {
     return "";
 }
 
-bool GetUserGroupSids(const std::string& serializedUserGroupSids, std::vector<NACLib::TSID>& userGroupSids) {
-    NJson::TJsonValue value;
-    if (!NJson::ReadJsonTree(serializedUserGroupSids, &value) || value.GetType() != NJson::JSON_ARRAY) {
-        return false;
-    }
-
-    const auto sidsSize = value.GetIntegerRobust();
-    userGroupSids.clear();
-    userGroupSids.reserve(sidsSize);
-    for (i64 i = 0; i < sidsSize; ++i) {
-        const NJson::TJsonValue* userSid = nullptr;
-        value.GetValuePointer(i, &userSid);
-        Y_ENSURE(userSid, "Invalid user group sids");
-
-        userGroupSids.emplace_back(userSid->GetString());
-    }
-
-    return true;
-}
-
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/kqp_script_executions.cpp
+++ b/ydb/core/kqp/common/kqp_script_executions.cpp
@@ -1,53 +1,58 @@
 #include "kqp_script_executions.h"
 
+#include <ydb/core/base/appdata_fwd.h>
+#include <ydb/core/base/feature_flags.h>
 #include <ydb/public/api/protos/ydb_issue_message.pb.h>
 #include <ydb/public/sdk/cpp/src/library/operation_id/protos/operation_id.pb.h>
 
 #include <yql/essentials/public/issue/yql_issue_message.h>
 
+#include <google/protobuf/util/time_util.h>
+
+#include <library/cpp/protobuf/json/json2proto.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 
 #include <util/string/builder.h>
 
 namespace NKikimr::NKqp {
 
-TString ScriptExecutionOperationFromExecutionId(const std::string& executionId) {
-    Ydb::TOperationId operationId;
-    operationId.SetKind(Ydb::TOperationId::SCRIPT_EXECUTION);
-    NOperationId::AddOptionalValue(operationId, "id", executionId);
-    return NOperationId::ProtoToString(operationId);
+std::string ScriptExecutionOperationFromExecutionId(const std::string& executionId) {
+    return OperationIdFromExecutionId(executionId).ToString();
 }
 
-NOperationId::TOperationId OperationIdFromExecutionId(const TString& executionId) {
-    return NOperationId::TOperationId(ScriptExecutionOperationFromExecutionId(executionId));
+NOperationId::TOperationId OperationIdFromExecutionId(const std::string& executionId) {
+    NOperationId::TOperationId operationId;
+    operationId.SetKind(NOperationId::TOperationId::SCRIPT_EXECUTION);
+    operationId.AddOptionalValue("id", executionId);
+    return operationId;
 }
 
-TMaybe<TString> ScriptExecutionIdFromOperation(const TString& operationId, TString& error) try {
-    NOperationId::TOperationId operation(operationId);
-    return ScriptExecutionIdFromOperation(operation, error);
+std::optional<TString> ScriptExecutionIdFromOperation(const std::string& operationId, TString& error) try {
+    return ScriptExecutionIdFromOperation(NOperationId::TOperationId(operationId), error);
 } catch (const std::exception& ex) {
     error = TStringBuilder() << "Invalid operation id: " << ex.what();
-    return Nothing();
+    return std::nullopt;
 }
 
-TMaybe<TString> ScriptExecutionIdFromOperation(const NOperationId::TOperationId& operationId, TString& error) try {
+std::optional<TString> ScriptExecutionIdFromOperation(const NOperationId::TOperationId& operationId, TString& error) try {
     if (operationId.GetKind() != NOperationId::TOperationId::SCRIPT_EXECUTION) {
         error = TStringBuilder() << "Invalid operation id, expected SCRIPT_EXECUTION = " << static_cast<int>(NOperationId::TOperationId::SCRIPT_EXECUTION) << " kind, got " << static_cast<int>(operationId.GetKind());
-        return Nothing();
+        return std::nullopt;
     }
 
     const auto& values = operationId.GetValue("id");
     if (values.empty() || !values[0]) {
-        error = TStringBuilder() << "Invalid operation id, please specify key 'id'";
-        return Nothing();
+        error = "Invalid operation id, please specify key 'id'";
+        return std::nullopt;
     }
-    return TString{*values[0]};
+
+    return TString(*values[0]);
 } catch (const std::exception& ex) {
     error = TStringBuilder() << "Invalid operation id: " << ex.what();
-    return Nothing();
+    return std::nullopt;
 }
 
-NYql::TIssues AddRootIssue(const TString& message, const NYql::TIssues& issues, bool addEmptyRoot) {
+NYql::TIssues AddRootIssue(const TString& message, const NYql::TIssues& issues, const bool addEmptyRoot) {
     if (!issues && !addEmptyRoot) {
         return {};
     }
@@ -61,20 +66,61 @@ NYql::TIssues AddRootIssue(const TString& message, const NYql::TIssues& issues, 
 }
 
 TString SerializeIssues(const NYql::TIssues& issues) {
-    NYql::TIssue root;
-    for (const auto& issue : issues) {
-        root.AddSubIssue(MakeIntrusive<NYql::TIssue>(issue));
-    }
-
     Ydb::Issue::IssueMessage rootMessage;
-    if (issues) {
-        NYql::IssueToMessage(root, &rootMessage);
-    }
-
+    NYql::IssuesToMessage(issues, rootMessage.mutable_issues());
     return NProtobufJson::Proto2Json(rootMessage, NProtobufJson::TProto2JsonConfig());
 }
 
-TString SequenceToJsonString(ui64 size, std::function<void(ui64 i, NJson::TJsonValue& value)> valueFiller) {
+NYql::TIssues DeserializeIssues(const TStringBuf& issuesSerialized) {
+    const auto& rootMessage = NProtobufJson::Json2Proto<Ydb::Issue::IssueMessage>(issuesSerialized);
+    NYql::TIssues issues;
+    NYql::IssuesFromMessage(rootMessage.issues(), issues);
+    return issues;
+}
+
+void SerializeBinaryProto(const NProtoBuf::Message& proto, NJson::TJsonValue& value) {
+    value.SetType(NJson::EJsonValueType::JSON_MAP);
+
+    NProtobufJson::TProto2JsonConfig config;
+    config.AddStringTransform(MakeIntrusive<NProtobufJson::TBase64EncodeBytesTransform>());
+    NProtobufJson::Proto2Json(proto, value["encoded_proto"], config);
+}
+
+TString SerializeBinaryProto(const NProtoBuf::Message& proto) {
+    NJson::TJsonValue value;
+    SerializeBinaryProto(proto, value);
+
+    NJsonWriter::TBuf serializedProto;
+    serializedProto.WriteJsonValue(&value, false, PREC_NDIGITS, 17);
+
+    return serializedProto.Str();
+}
+
+void DeserializeBinaryProto(const NJson::TJsonValue& value, NProtoBuf::Message& proto) {
+    const auto& valueMap = value.GetMap();
+    const auto encodedProto = valueMap.find("encoded_proto");
+    if (encodedProto == valueMap.end()) {
+        return NProtobufJson::Json2Proto(value, proto, NProtobufJson::TJson2ProtoConfig());
+    }
+
+    NProtobufJson::TJson2ProtoConfig config;
+    config.AddStringTransform(MakeIntrusive<NProtobufJson::TBase64DecodeBytesTransform>());
+    NProtobufJson::Json2Proto(encodedProto->second, proto, config);
+}
+
+void TimestampToProtoWithSaturation(const TInstant timestamp, google::protobuf::Timestamp* proto) {
+    *proto = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(
+        std::min(timestamp.MicroSeconds(), static_cast<ui64>(google::protobuf::util::TimeUtil::kTimestampMaxSeconds * 1000000))
+    );
+}
+
+void DurationToProtoWithSaturation(const TDuration duration, google::protobuf::Duration* proto) {
+    *proto = google::protobuf::util::TimeUtil::MicrosecondsToDuration(
+        std::min(duration.MicroSeconds(), static_cast<ui64>(google::protobuf::util::TimeUtil::kDurationMaxSeconds * 1000000))
+    );
+}
+
+TString SequenceToJsonString(const ui64 size, std::function<void(const ui64 i, NJson::TJsonValue& value)> valueFiller) {
     NJson::TJsonValue value;
     value.SetType(NJson::EJsonValueType::JSON_ARRAY);
 
@@ -88,6 +134,43 @@ TString SequenceToJsonString(ui64 size, std::function<void(ui64 i, NJson::TJsonV
     serializedJson.WriteJsonValue(&value, false, PREC_NDIGITS, 17);
 
     return serializedJson.Str();
+}
+
+TString CheckScriptExecutionAccess(std::optional<TString>& userSID) {
+    if (!AppData()->FeatureFlags.GetEnableSecureScriptExecutions()) {
+        userSID = std::nullopt;
+        return "";
+    }
+
+    if (!userSID) {
+        return "Access to script execution operations without user token is not allowed";
+    }
+
+    if (NACLib::TUserToken(*userSID, {}).IsSystemUser()) {
+        userSID = std::nullopt;
+    }
+
+    return "";
+}
+
+bool GetUserGroupSids(const std::string& serializedUserGroupSids, std::vector<NACLib::TSID>& userGroupSids) {
+    NJson::TJsonValue value;
+    if (!NJson::ReadJsonTree(serializedUserGroupSids, &value) || value.GetType() != NJson::JSON_ARRAY) {
+        return false;
+    }
+
+    const auto sidsSize = value.GetIntegerRobust();
+    userGroupSids.clear();
+    userGroupSids.reserve(sidsSize);
+    for (i64 i = 0; i < sidsSize; ++i) {
+        const NJson::TJsonValue* userSid = nullptr;
+        value.GetValuePointer(i, &userSid);
+        Y_ENSURE(userSid, "Invalid user group sids");
+
+        userGroupSids.emplace_back(userSid->GetString());
+    }
+
+    return true;
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/kqp_script_executions.h
+++ b/ydb/core/kqp/common/kqp_script_executions.h
@@ -57,6 +57,4 @@ TString SequenceToJsonString(const TContainer& container) {
 
 TString CheckScriptExecutionAccess(std::optional<TString>& userSID);
 
-bool GetUserGroupSids(const std::string& serializedUserGroupSids, std::vector<NACLib::TSID>& userGroupSids);
-
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/kqp_script_executions.h
+++ b/ydb/core/kqp/common/kqp_script_executions.h
@@ -1,32 +1,62 @@
 #pragma once
 
+#include <ydb/library/aclib/aclib.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 
 #include <yql/essentials/public/issue/yql_issue.h>
 
+#include <google/protobuf/message.h>
+#include <google/protobuf/duration.pb.h>
+#include <google/protobuf/timestamp.pb.h>
+
 #include <library/cpp/json/writer/json_value.h>
 
+#include <util/datetime/base.h>
 #include <util/generic/string.h>
-#include <util/generic/maybe.h>
+#include <util/system/types.h>
 
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace NKikimr::NKqp {
 
-TString ScriptExecutionOperationFromExecutionId(const std::string& executionId);
-NOperationId::TOperationId OperationIdFromExecutionId(const TString& executionId);
-TMaybe<TString> ScriptExecutionIdFromOperation(const TString& operationId, TString& error);
-TMaybe<TString> ScriptExecutionIdFromOperation(const NOperationId::TOperationId& operationId, TString& error);
+std::string ScriptExecutionOperationFromExecutionId(const std::string& executionId);
 
-NYql::TIssues AddRootIssue(const TString& message, const NYql::TIssues& issues, bool addEmptyRoot = true);
+NOperationId::TOperationId OperationIdFromExecutionId(const std::string& executionId);
+
+std::optional<TString> ScriptExecutionIdFromOperation(const std::string& operationId, TString& error);
+
+std::optional<TString> ScriptExecutionIdFromOperation(const NOperationId::TOperationId& operationId, TString& error);
+
+NYql::TIssues AddRootIssue(const TString& message, const NYql::TIssues& issues, const bool addEmptyRoot = true);
+
 TString SerializeIssues(const NYql::TIssues& issues);
 
-TString SequenceToJsonString(ui64 size, std::function<void(ui64 i, NJson::TJsonValue& value)> valueFiller);
+NYql::TIssues DeserializeIssues(const TStringBuf& issuesSerialized);
+
+void SerializeBinaryProto(const NProtoBuf::Message& proto, NJson::TJsonValue& value);
+
+TString SerializeBinaryProto(const NProtoBuf::Message& proto);
+
+void DeserializeBinaryProto(const NJson::TJsonValue& value, NProtoBuf::Message& proto);
+
+void TimestampToProtoWithSaturation(const TInstant timestamp, google::protobuf::Timestamp* proto);
+
+void DurationToProtoWithSaturation(const TDuration duration, google::protobuf::Duration* proto);
+
+TString SequenceToJsonString(const ui64 size, std::function<void(const ui64 i, NJson::TJsonValue& value)> valueFiller);
 
 template <typename TContainer>
 TString SequenceToJsonString(const TContainer& container) {
-    return SequenceToJsonString(container.size(), [&](ui64 i, NJson::TJsonValue& value) {
+    return SequenceToJsonString(container.size(), [&](const ui64 i, NJson::TJsonValue& value) {
         value = NJson::TJsonValue(container[i]);
     });
 }
+
+TString CheckScriptExecutionAccess(std::optional<TString>& userSID);
+
+bool GetUserGroupSids(const std::string& serializedUserGroupSids, std::vector<NACLib::TSID>& userGroupSids);
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/kqp_timeouts.cpp
+++ b/ydb/core/kqp/common/kqp_timeouts.cpp
@@ -11,6 +11,8 @@ namespace {
 ui64 GetDefaultQueryTimeoutMs(NKikimrKqp::EQueryType queryType,
                               const NKikimrConfig::TTableServiceConfig& tableServiceConfig,
                               const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
+    constexpr TDuration SCRIPT_TIMEOUT_LIMIT = TDuration::Days(365);
+
     const auto& queryLimits = tableServiceConfig.GetQueryLimits();
 
     switch (queryType) {

--- a/ydb/core/kqp/common/kqp_timeouts.h
+++ b/ydb/core/kqp/common/kqp_timeouts.h
@@ -1,16 +1,17 @@
 #pragma once
 
 #include <ydb/core/protos/kqp.pb.h>
+
 #include <util/datetime/base.h>
 
 namespace NKikimrConfig {
-    class TQueryServiceConfig;
-    class TTableServiceConfig;
-}
+
+class TQueryServiceConfig;
+class TTableServiceConfig;
+
+} // namespace NKikimrConfig
 
 namespace NKikimr::NKqp {
-
-constexpr TDuration SCRIPT_TIMEOUT_LIMIT = TDuration::Days(365);
 
 TDuration GetQueryTimeout(NKikimrKqp::EQueryType queryType, ui64 timeoutMs, const NKikimrConfig::TTableServiceConfig& tableServiceConfig,
     const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, bool disableDefaultTimeout);

--- a/ydb/core/kqp/common/simple/kqp_event_ids.h
+++ b/ydb/core/kqp/common/simple/kqp_event_ids.h
@@ -165,7 +165,6 @@ struct TKqpScriptExecutionEvents {
         EvScriptFinalizeRequest,
         EvScriptFinalizeResponse,
         EvSaveScriptFinalStatusResponse,
-        EvGetScriptExecutionOperationQueryResponse,
         EvDescribeSecretsResponse,
         EvSaveScriptResultPartFinished,
         EvScriptExecutionsTableCreationFinished,

--- a/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_data_executer.cpp
@@ -513,10 +513,7 @@ private:
 
     void DoExecute() {
         const auto& requestContext = GetUserRequestContext();
-        auto scriptExternalEffect = std::make_unique<TEvSaveScriptExternalEffectRequest>(
-            requestContext->CurrentExecutionId, requestContext->Database,
-            requestContext->CustomerSuppliedId
-        );
+        auto scriptExternalEffect = std::make_unique<TEvSaveScriptExternalEffectRequest>(requestContext->CustomerSuppliedId);
         for (const auto& transaction : Request.Transactions) {
             for (const auto& secretName : transaction.Body->GetSecretNames()) {
                 SecretSnapshotRequired = true;

--- a/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
+++ b/ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.cpp
@@ -858,12 +858,12 @@ private:
                                               "DescribeResourceId: SelfId=" << selfId << " key=" << k << " value=" << v);
                                       if (k == "cloud_id") {
                                           LOG_DEBUG_S(*actorSystem, NKikimrServices::KQP_GATEWAY, "DescribeResourceId: SelfId=" << selfId << " Resolved ResourceId=" << v);
-                                          state->Promise.SetValue(TString{v});
+                                          state->Promise.SetValue(TEvDescribeResourceIdResponse::TDescription(TString(v)));
                                           return;
                                       }
                                   }
                                   LOG_WARN_S(*actorSystem, NKikimrServices::KQP_GATEWAY, "DescribeResourceId: SelfId=" << selfId << " cloud_id not found");
-                                  state->Promise.SetValue(TString(""));
+                                  state->Promise.SetValue(TEvDescribeResourceIdResponse::TDescription(""));
                               } catch(const std::exception& ex) {
                                   LOG_WARN_S(*actorSystem, NKikimrServices::KQP_GATEWAY, "DescribeResourceId: SelfId=" << selfId << " got exception: " << ex.what());
                                   state->Promise.SetException(std::current_exception());

--- a/ydb/core/kqp/finalize_script_service/kqp_check_script_lease_actor.cpp
+++ b/ydb/core/kqp/finalize_script_service/kqp_check_script_lease_actor.cpp
@@ -82,10 +82,13 @@ public:
 
     void Handle(TEvRefreshScriptExecutionLeasesResponse::TPtr& ev) {
         WaitRefreshScriptExecutions = false;
+
+        const auto expiredLeasesCount = ev->Get()->ExpiredLeasesCount;
+
         if (!ev->Get()->Success) {
-            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_PROXY, LogPrefix() << "Refresh failed with issues: " << ev->Get()->Issues.ToOneLineString());
+            LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_PROXY, LogPrefix() << "Refresh " << ev->Sender << " failed, found expired leases: " << expiredLeasesCount << ", issues: " << ev->Get()->Issues.ToOneLineString());
         } else {
-            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_PROXY, LogPrefix() << "Refresh successfully completed");
+            LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_PROXY, LogPrefix() << "Refresh " << ev->Sender << " successfully completed, found expired leases: " << expiredLeasesCount);
         }
     }
 

--- a/ydb/core/kqp/finalize_script_service/kqp_finalize_script_actor.cpp
+++ b/ydb/core/kqp/finalize_script_service/kqp_finalize_script_actor.cpp
@@ -1,21 +1,25 @@
 #include "kqp_finalize_script_actor.h"
 
 #include <ydb/core/fq/libs/events/events.h>
+#include <ydb/core/kqp/common/kqp_script_executions.h>
+#include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/federated_query/actors/kqp_federated_query_actors.h>
 #include <ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_compression.h>
 #include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
 #include <ydb/core/tx/datashard/const.h>
 #include <ydb/core/protos/config.pb.h>
-
-#include <yql/essentials/providers/common/provider/yql_provider_names.h>
-#include <yql/essentials/providers/common/structured_token/yql_token_builder.h>
 #include <ydb/library/yql/providers/s3/actors/yql_s3_applicator_actor.h>
 #include <ydb/library/yql/providers/s3/proto/sink.pb.h>
 
+#include <yql/essentials/providers/common/provider/yql_provider_names.h>
+#include <yql/essentials/providers/common/structured_token/yql_token_builder.h>
 
 namespace NKikimr::NKqp {
 
 namespace {
+
+// Actor for performing finalization of script execution external effects (for example commit / roll back S3 uploads).
+// NOTE: if S3 become unavailable and/or secrets unavailable script execution will be newer finalized and therefore can not be removed.
 
 class TScriptFinalizerActor : public TActorBootstrapped<TScriptFinalizerActor> {
 public:
@@ -54,7 +58,8 @@ public:
 
     void Handle(TEvSaveScriptFinalStatusResponse::TPtr& ev) {
         if (!ev->Get()->ApplicateScriptExternalEffectRequired || ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
-            Reply(ev->Get()->OperationAlreadyFinalized, ev->Get()->WaitRetry, ev->Get()->Status, std::move(ev->Get()->Issues));
+            auto& into = *ev->Get();
+            Reply(into.Status, into.ExecutionEntryExists, into.FinalStatusAlreadySaved, std::move(into.Issues));
             return;
         }
 
@@ -169,11 +174,7 @@ private:
 
     void Handle(NFq::TEvents::TEvEffectApplicationResult::TPtr& ev) {
         if (ev->Get()->FatalError) {
-            NYql::TIssue rootIssue("Failed to commit/abort s3 multipart uploads");
-            for (const NYql::TIssue& issue : ev->Get()->Issues) {
-                rootIssue.AddSubIssue(MakeIntrusive<NYql::TIssue>(issue));
-            }
-            FinishScriptFinalization(Ydb::StatusIds::BAD_REQUEST, {rootIssue});
+            FinishScriptFinalization(Ydb::StatusIds::BAD_REQUEST, AddRootIssue("Failed to commit/abort s3 multipart uploads", ev->Get()->Issues));
         } else {
             FinishScriptFinalization();
         }
@@ -188,7 +189,7 @@ private:
     )
 
     void FinishScriptFinalization(std::optional<Ydb::StatusIds::StatusCode> status, NYql::TIssues issues) {
-        Register(CreateScriptFinalizationFinisherActor(SelfId(), ExecutionId, Database, status, std::move(issues), LeaseGeneration));
+        Register(CreateScriptFinalizationFinisherActor(SelfId(), Database, ExecutionId, status, std::move(issues), LeaseGeneration));
         Become(&TScriptFinalizerActor::FinishState);
     }
 
@@ -201,13 +202,16 @@ private:
     }
 
     void Handle(TEvScriptExecutionFinished::TPtr& ev) {
-        Reply(ev->Get()->OperationAlreadyFinalized, ev->Get()->WaitingRetry, ev->Get()->Status, std::move(ev->Get()->Issues));
+        const auto& info = ev->Get()->Info;
+        Reply(ev->Get()->Status, info.ExecutionEntryExists, info.AlreadyStopped, std::move(ev->Get()->Issues));
     }
 
-    void Reply(bool operationAlreadyFinalized, bool waitRetry, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) {
-        Send(ReplyActor, new TEvScriptExecutionFinished(operationAlreadyFinalized, waitRetry, status, std::move(issues)));
+    void Reply(const Ydb::StatusIds::StatusCode status, bool executionEntryExists, bool alreadyStopped, NYql::TIssues&& issues) {
+        Send(ReplyActor, new TEvScriptExecutionFinished(status, {
+            .ExecutionEntryExists = executionEntryExists,
+            .AlreadyStopped = alreadyStopped,
+        }, std::move(issues)));
         Send(MakeKqpFinalizeScriptServiceId(SelfId().NodeId()), new TEvScriptFinalizeResponse(ExecutionId));
-
         PassAway();
     }
 

--- a/ydb/core/kqp/finalize_script_service/kqp_finalize_script_actor.cpp
+++ b/ydb/core/kqp/finalize_script_service/kqp_finalize_script_actor.cpp
@@ -19,7 +19,7 @@ namespace NKikimr::NKqp {
 namespace {
 
 // Actor for performing finalization of script execution external effects (for example commit / roll back S3 uploads).
-// NOTE: if S3 become unavailable and/or secrets unavailable script execution will be newer finalized and therefore can not be removed.
+// NOTE: if S3 become unavailable and/or secrets unavailable script execution will be never finalized and therefore can not be removed.
 
 class TScriptFinalizerActor : public TActorBootstrapped<TScriptFinalizerActor> {
 public:

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1210,9 +1210,13 @@ public:
         switch (static_cast<EWakeup>(ev->Get()->Tag)) {
             case EWakeup::RetryCheckAlive: {
                 WaitRetryCheckAlive = false;
-                LOG_D("Retry check alive request for " << Info.PreviousOwner);
-                Send(Info.PreviousOwner, new TEvPrivate::TEvCheckAliveRequest(), CheckAliveFlags);
-                Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+                if (WaitLock) {
+                    LOG_N("Skipped retry check alive, already waiting query lock");
+                } else {
+                    LOG_D("Retry check alive request for " << Info.PreviousOwner);
+                    Send(Info.PreviousOwner, new TEvPrivate::TEvCheckAliveRequest(), CheckAliveFlags);
+                    Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+                }
                 break;
             }
             case EWakeup::CheckAliveSoftTimeout: {

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1120,12 +1120,14 @@ class TLockStreamingQueryTableActor final : public TActionActorBase<TLockStreami
     using TBase = TActionActorBase<TLockStreamingQueryTableActor>;
     using TRetryPolicy = IRetryPolicy<bool>;
 
-    inline static const TDuration CHECK_ALIVE_REQUEST_TIMEOUT = TDuration::Seconds(60);
+    static constexpr TDuration CHECK_ALIVE_REQUEST_SOFT_TIMEOUT = TDuration::Seconds(30); // Advance on each retry of check alive
+    static constexpr TDuration CHECK_ALIVE_REQUEST_HARD_TIMEOUT = TDuration::Seconds(60); // Hard timeout for all retries
     inline static const ui64 MAX_CHECK_ALIVE_RETRIES = 50;
 
     enum class EWakeup {
         RetryCheckAlive,
-        CheckAliveTimeout,
+        CheckAliveSoftTimeout,
+        CheckAliveHardTimeout,
     };
 
 public:
@@ -1191,7 +1193,8 @@ public:
 
         LOG_D("Start check alive for " << Info.PreviousOwner);
         Send(Info.PreviousOwner, new TEvPrivate::TEvCheckAliveRequest(), CheckAliveFlags);
-        Schedule(CHECK_ALIVE_REQUEST_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveTimeout)));
+        Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+        Schedule(CHECK_ALIVE_REQUEST_HARD_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveHardTimeout)));
     }
 
     void Handle(TEvPrivate::TEvCheckAliveResponse::TPtr& ev) {
@@ -1209,12 +1212,17 @@ public:
                 WaitRetryCheckAlive = false;
                 LOG_D("Retry check alive request for " << Info.PreviousOwner);
                 Send(Info.PreviousOwner, new TEvPrivate::TEvCheckAliveRequest(), CheckAliveFlags);
-                Schedule(CHECK_ALIVE_REQUEST_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveTimeout)));
+                Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
                 break;
             }
-            case EWakeup::CheckAliveTimeout: {
+            case EWakeup::CheckAliveSoftTimeout: {
                 LOG_W("Deliver streaming query owner " << Info.PreviousOwner << " check alive request timeouted, retry check alive");
                 RetryCheckAlive(/* longDelay */ false);
+                break;
+            }
+            case EWakeup::CheckAliveHardTimeout: {
+                LOG_W("Deliver streaming query owner " << Info.PreviousOwner << " check alive request timeouted, start lock");
+                StartLockStreamingQueryRequestActor(Info.PreviousOwner);
                 break;
             }
         }
@@ -1486,17 +1494,18 @@ public:
 
     void Handle(TEvCancelScriptExecutionOperationResponse::TPtr& ev) {
         const auto& executionId = State.GetCurrentExecutionId();
-        const auto status = ev->Get()->Status;
-        if (status != Ydb::StatusIds::NOT_FOUND && status != Ydb::StatusIds::PRECONDITION_FAILED && HandleResult(ev, TStringBuilder() << "Cancel query execution (execution id: " << executionId << ")")) {
+        if (HandleResult(ev, TStringBuilder() << "Cancel query execution (execution id: " << executionId << ")")) {
             return;
         }
 
-        LOG_D("Cancel streaming query execution " << ev->Sender << " finished " << status << ", execution id: " << executionId);
-        if (status != Ydb::StatusIds::NOT_FOUND) {
+        const auto entryExists = ev->Get()->ExecutionEntryExists;
+        LOG_D("Cancel streaming query execution " << ev->Sender << " finished, entry exists: " << entryExists << ", execution id: " << executionId);
+
+        if (entryExists) {
             State.AddPreviousExecutionIds(executionId);
         }
-        State.ClearCurrentExecutionId();
 
+        State.ClearCurrentExecutionId();
         StartUpdateState("clear current execution id");
     }
 
@@ -1504,13 +1513,12 @@ public:
         Y_ABORT_UNLESS(ev->Cookie < State.PreviousExecutionIdsSize());
 
         const auto& executionId = State.GetPreviousExecutionIds(ev->Cookie);
-        const auto status = ev->Get()->Status;
-        if (status != Ydb::StatusIds::NOT_FOUND && HandleResult(ev, TStringBuilder() << "Forget query execution (execution id: " << executionId << ")")) {
+        if (HandleResult(ev, TStringBuilder() << "Forget query execution (execution id: " << executionId << ")")) {
             return;
         }
 
         --OperationsToForget;
-        LOG_D("Forget streaming query execution #" << ev->Cookie << " " << ev->Sender << " finished " << status << ", execution id: " << executionId << ", remains: " << OperationsToForget);
+        LOG_D("Forget streaming query execution #" << ev->Cookie << " " << ev->Sender << " finished, execution id: " << executionId << ", remains: " << OperationsToForget);
 
         if (OperationsToForget == 0) {
             State.ClearPreviousExecutionIds();
@@ -1539,7 +1547,10 @@ private:
         if (State.HasCurrentExecutionId()) {
             const auto& executionId = State.GetCurrentExecutionId();
             LOG_D("Cancel streaming query execution " << executionId);
-            SendToKqpProxy(std::make_unique<TEvCancelScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA));
+            SendToKqpProxy(std::make_unique<TEvCancelScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA, TEvCancelScriptExecutionOperation::TSettings{
+                .FailOnNotFound = false,
+                .FailOnAlreadyStopped = false,
+            }));
             return;
         }
 
@@ -1547,7 +1558,10 @@ private:
             LOG_D("Cleanup #" << State.PreviousExecutionIdsSize() << " previous executions");
 
             for (const auto& executionId : State.GetPreviousExecutionIds()) {
-                SendToKqpProxy(std::make_unique<TEvForgetScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA), OperationsToForget++);
+                SendToKqpProxy(std::make_unique<TEvForgetScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA, TEvForgetScriptExecutionOperation::TSettings{
+                    .FailOnNotFound = false,
+                    .CancelIfRunning = true,
+                }), OperationsToForget++);
                 LOG_D("Forget streaming query execution #" << OperationsToForget << " " << executionId);
             }
             return;
@@ -1569,7 +1583,6 @@ class TStartStreamingQueryTableActor final : public TActionActorBase<TStartStrea
     using TRetryPolicy = IRetryPolicy<>;
 
     inline static constexpr ui64 MAX_QUERY_EXECUTIONS = 3;
-    inline static constexpr TDuration START_REQUEST_TIMEOUT = TDuration::Seconds(30);
 
 public:
     using TBase::LogPrefix;
@@ -1614,8 +1627,7 @@ public:
     }
 
     void HandlePrepare(TEvGetScriptPhysicalGraphResponse::TPtr& ev) {
-        const auto status = ev->Get()->Status;
-        if (status != Ydb::StatusIds::NOT_FOUND && HandleResult(ev, "Load previous query execution state")) {
+        if (HandleResult(ev, "Load previous query execution state")) {
             return;
         }
 
@@ -1623,8 +1635,13 @@ public:
             PreviousPhysicalGraph = std::move(ev->Get()->PhysicalGraph);
         }
 
+        if (!ev->Get()->ExecutionEntryExists) {
+            LOG_W("Previous script execution not found, lease generation and graph was reset");
+            State.ClearCheckpointId(); // We don't know previous generation, so must start from fresh checkpoint
+        }
+
         PreviousGeneration = ev->Get()->Generation;
-        LOG_D("Load previous query execution state " << ev->Sender << " finished " << status << ", generation: " << PreviousGeneration << ", has saved state: " << PreviousPhysicalGraph.has_value());
+        LOG_D("Load previous query execution state " << ev->Sender << " finished, generation: " << PreviousGeneration << ", has saved state: " << PreviousPhysicalGraph.has_value());
 
         PrepareToStart();
     }
@@ -1634,13 +1651,12 @@ public:
         Y_ABORT_UNLESS(ev->Cookie < toCleanup);
 
         const auto& executionId = State.GetPreviousExecutionIds(ev->Cookie);
-        const auto status = ev->Get()->Status;
-        if (status != Ydb::StatusIds::NOT_FOUND && HandleResult(ev, TStringBuilder() << "Forget query execution (execution id: " << executionId << ")")) {
+        if (HandleResult(ev, TStringBuilder() << "Forget query execution (execution id: " << executionId << ")")) {
             return;
         }
 
         --OperationsToForget;
-        LOG_D("Forget streaming query execution #" << ev->Cookie << " " << ev->Sender << " finished " << status << ", execution id: " << executionId << ", remains: " << OperationsToForget);
+        LOG_D("Forget streaming query execution #" << ev->Cookie << " " << ev->Sender << " finished, execution id: " << executionId << ", remains: " << OperationsToForget);
 
         if (OperationsToForget == 0) {
             auto& executionIds = *State.MutablePreviousExecutionIds();
@@ -1678,12 +1694,12 @@ public:
     void HandleStartQuery(TEvents::TEvWakeup::TPtr&) {
         const auto& executionId = State.GetCurrentExecutionId();
         LOG_D("Get streaming query execution " << executionId);
-        SendToKqpProxy(std::make_unique<TEvGetScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA));
+        SendToKqpProxy(std::make_unique<TEvGetScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA, /* failOnNotFound */ true));
     }
 
     void HandleStartQuery(TEvGetScriptExecutionOperationResponse::TPtr& ev) {
         const auto& info = *ev->Get();
-        LOG_D("Got script execution info, StateSaved: " << info.StateSaved << ", Ready: " << info.Ready);
+        LOG_D("Got script execution info, state saved: " << info.StateSaved << ", ready: " << info.Ready);
 
         if (HandleResult(ev, "Query compilation / planing")) {
             return;
@@ -1776,7 +1792,10 @@ private:
 
             for (ui64 i = 0; i < toCleanup; ++i) {
                 const auto& executionId = State.GetPreviousExecutionIds(i);
-                SendToKqpProxy(std::make_unique<TEvForgetScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA), OperationsToForget++);
+                SendToKqpProxy(std::make_unique<TEvForgetScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA, TEvForgetScriptExecutionOperation::TSettings{
+                    .FailOnNotFound = false,
+                    .CancelIfRunning = true
+                }), OperationsToForget++);
                 LOG_D("Forget streaming query execution #" << OperationsToForget << " " << executionId);
             }
             return;
@@ -1843,6 +1862,7 @@ private:
 
     void GetScriptExecutionOperation() {
         if (!GetOperationRetryState) {
+            // We will wait for query start without timeout, because otherwise query may not retry after start
             GetOperationRetryState = TRetryPolicy::GetExponentialBackoffPolicy(
                 []() {
                     return ERetryErrorClass::ShortRetry;
@@ -1851,21 +1871,14 @@ private:
                 TDuration::MilliSeconds(100),
                 TDuration::Seconds(1),
                 std::numeric_limits<size_t>::max(),
-                START_REQUEST_TIMEOUT
+                TDuration::Max()
             )->CreateRetryState();
         }
 
-        if (const auto delay = GetOperationRetryState->GetNextRetryDelay()) {
-            LOG_D("Schedule get script execution operation in " << *delay);
-            Schedule(*delay, new TEvents::TEvWakeup());
-        } else {
-            LOG_W("Script execution operation not started after " << START_REQUEST_TIMEOUT << " send response");
-            Issues.AddIssue(
-                NYql::TIssue(TStringBuilder() << "Streaming query not started after " << START_REQUEST_TIMEOUT << ", try to check query status later")
-                    .SetCode(NYql::TIssuesIds::KIKIMR_TIMEOUT, NYql::TSeverityIds::S_INFO)
-            );
-            Finish(Ydb::StatusIds::SUCCESS);
-        }
+        const auto delay = GetOperationRetryState->GetNextRetryDelay();
+        Y_VALIDATE(delay, "Retries unexpectedly finished");
+        LOG_D("Schedule get script execution operation in " << *delay);
+        Schedule(*delay, new TEvents::TEvWakeup());
     }
 
     static std::vector<NKikimrKqp::TScriptExecutionRetryState::TMapping> CreateDefaultRetryMapping() {
@@ -1990,17 +2003,18 @@ public:
 
     void Handle(TEvCancelScriptExecutionOperationResponse::TPtr& ev) {
         const auto& executionId = State.GetCurrentExecutionId();
-        const auto status = ev->Get()->Status;
-        if (status != Ydb::StatusIds::NOT_FOUND && status != Ydb::StatusIds::PRECONDITION_FAILED && HandleResult(ev, TStringBuilder() << "Cancel query execution (execution id: " << executionId << ")")) {
+        if (HandleResult(ev, TStringBuilder() << "Cancel query execution (execution id: " << executionId << ")")) {
             return;
         }
 
-        LOG_D("Cancel streaming query execution " << ev->Sender << " finished " << status << ", execution id: " << executionId);
-        if (status != Ydb::StatusIds::NOT_FOUND) {
+        const auto entryExists = ev->Get()->ExecutionEntryExists;
+        LOG_D("Cancel streaming query execution " << ev->Sender << " finished, execution id: " << executionId << ", entry exists: " << entryExists);
+
+        if (entryExists) {
             State.AddPreviousExecutionIds(executionId);
         }
-        State.ClearCurrentExecutionId();
 
+        State.ClearCurrentExecutionId();
         SyncQuery();
     }
 
@@ -2108,7 +2122,10 @@ private:
         if (State.HasCurrentExecutionId()) {
             const auto& executionId = State.GetCurrentExecutionId();
             LOG_D("Cancel streaming query execution " << executionId << " (" << info << ")");
-            SendToKqpProxy(std::make_unique<TEvCancelScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA));
+            SendToKqpProxy(std::make_unique<TEvCancelScriptExecutionOperation>(Context.GetDatabase(), OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA, TEvCancelScriptExecutionOperation::TSettings{
+                .FailOnNotFound = false,
+                .FailOnAlreadyStopped = false,
+            }));
             return;
         }
 

--- a/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
+++ b/ydb/core/kqp/gateway/behaviour/streaming_query/queries.cpp
@@ -1216,12 +1216,12 @@ public:
                 break;
             }
             case EWakeup::CheckAliveSoftTimeout: {
-                LOG_W("Deliver streaming query owner " << Info.PreviousOwner << " check alive request timeouted, retry check alive");
+                LOG_W("Deliver streaming query owner " << Info.PreviousOwner << " check alive request timed out, retry check alive");
                 RetryCheckAlive(/* longDelay */ false);
                 break;
             }
             case EWakeup::CheckAliveHardTimeout: {
-                LOG_W("Deliver streaming query owner " << Info.PreviousOwner << " check alive request timeouted, start lock");
+                LOG_W("Deliver streaming query owner " << Info.PreviousOwner << " check alive request timed out, start lock");
                 StartLockStreamingQueryRequestActor(Info.PreviousOwner);
                 break;
             }

--- a/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_proxy_service.cpp
@@ -1803,19 +1803,19 @@ private:
 
     void Handle(NKqp::TEvForgetScriptExecutionOperation::TPtr& ev) {
         if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::ForgetScriptExecutionOperation)) {
-            Register(CreateForgetScriptExecutionOperationActor(std::move(ev), QueryServiceConfig, Counters), TMailboxType::HTSwap, AppData()->SystemPoolId);
+            Register(CreateForgetScriptExecutionOperationActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
 
     void Handle(NKqp::TEvGetScriptExecutionOperation::TPtr& ev) {
         if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::GetScriptExecutionOperation)) {
-            Register(CreateGetScriptExecutionOperationActor(std::move(ev), QueryServiceConfig, Counters), TMailboxType::HTSwap, AppData()->SystemPoolId);
+            Register(CreateGetScriptExecutionOperationActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
 
     void Handle(NKqp::TEvListScriptExecutionOperations::TPtr& ev) {
         if (CheckScriptExecutionsTablesReady(ev, EDelayedRequestType::ListScriptExecutionOperations)) {
-            Register(CreateListScriptExecutionOperationsActor(std::move(ev), QueryServiceConfig, Counters), TMailboxType::HTSwap, AppData()->SystemPoolId);
+            Register(CreateListScriptExecutionOperationsActor(std::move(ev)), TMailboxType::HTSwap, AppData()->SystemPoolId);
         }
     }
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -523,17 +523,18 @@ private:
             DECLARE $graph_compressed AS Optional<String>;
             DECLARE $graph_compression_method AS Optional<Text>;
             DECLARE $lease_generation AS Int64;
+            DECLARE $result_set_metas AS JsonDocument;
 
             UPSERT INTO `.metadata/script_executions` (
                 database, execution_id, run_script_actor_id, execution_status, execution_mode, start_ts,
                 query_text, syntax, meta, streaming_disposition, expire_at, retry_state,
                 user_token, user_group_sids, parameters,
-                graph_compressed, graph_compression_method, lease_generation
+                graph_compressed, graph_compression_method, lease_generation, result_set_metas
             ) VALUES (
                 $database, $execution_id, $run_script_actor_id, $execution_status, $execution_mode, CurrentUtcTimestamp(),
                 $query_text, $syntax, $meta, $streaming_disposition, CurrentUtcTimestamp() + $execution_meta_ttl, $retry_state,
                 $user_sid, $user_group_sids, $parameters,
-                $graph_compressed, $graph_compression_method, $lease_generation
+                $graph_compressed, $graph_compression_method, $lease_generation, $result_set_metas
             );
 
             UPSERT INTO `.metadata/script_execution_leases` (
@@ -611,6 +612,9 @@ private:
                 .Build()
             .AddParam("$lease_generation")
                 .Int64(LeaseGeneration)
+                .Build()
+            .AddParam("$result_set_metas")
+                .JsonDocument("[]")
                 .Build();
 
         RunDataQuery(sql, &params);

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -1533,9 +1533,14 @@ private:
 
         const auto finalizationStatus = event.FinalizationStatus.GetOrElse(EFinalizationStatus::FS_ROLLBACK);
         const auto status = event.OperationStatus.GetOrElse(Ydb::StatusIds::UNAVAILABLE);
-        const auto execStatus = event.ExecutionStatus.GetOrElse(Ydb::Query::EXEC_STATUS_ABORTED);
+
+        auto execStatus = Ydb::Query::EXEC_STATUS_ABORTED;
+        if (event.ExecutionStatus && IsIn({Ydb::Query::EXEC_STATUS_ABORTED, Ydb::Query::EXEC_STATUS_CANCELLED, Ydb::Query::EXEC_STATUS_COMPLETED, Ydb::Query::EXEC_STATUS_FAILED}, *event.ExecutionStatus)) {
+            execStatus = *event.ExecutionStatus;
+        }
+
         KQP_PROXY_LOG_W("Script execution lease is expired"
-            << ", FinalizationStatus: " << static_cast<i32>(finalizationStatus)
+            << ", FinalizationStatus: " << finalizationStatus
             << ", Status: " << status
             << ", ExecStatus: " << Ydb::Query::ExecStatus_Name(execStatus)
             << ", Issues: " << issues.ToOneLineString()
@@ -3850,7 +3855,6 @@ private:
             DECLARE $retry_state AS JsonDocument;
             DECLARE $retry_deadline AS Timestamp;
             DECLARE $lease_state AS Int32;
-            DECLARE $lease_generation AS Int64;
 
             UPSERT INTO `.metadata/script_executions` (
                 database, execution_id, operation_status, execution_status,
@@ -3914,10 +3918,10 @@ private:
         const auto operationTtl = std::min(OperationTtl.MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1);
         KQP_PROXY_LOG_D("Do finalization with status " << Request.OperationStatus
             << ", exec status: " << Ydb::Query::ExecStatus_Name(Request.ExecStatus)
-            << ", finalization status (applicate effect: " << Response->ApplicateScriptExternalEffectRequired << "): " << static_cast<ui64>(Request.FinalizationStatus)
+            << ", finalization status (applicate effect: " << Response->ApplicateScriptExternalEffectRequired << "): " << Request.FinalizationStatus
             << ", issues: " << Request.Issues.ToOneLineString()
             << ", retry deadline: " << retryDeadline
-            << ", lease state: " << static_cast<i32>(leaseState)
+            << ", lease state: " << leaseState
             << ", operation_ttl: " << TDuration::MicroSeconds(operationTtl));
 
         auto params = CreateParams();
@@ -4010,7 +4014,7 @@ public:
         NYql::TIssues operationIssues, const i64 leaseGeneration)
         : TScriptFinalizationActorBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
         , OperationStatus(operationStatus)
-        , OperationIssues(AddRootIssue("Script finalization failed", operationIssues))
+        , OperationIssues(AddRootIssue("Script finalization failed", operationIssues, /* addEmptyRoot */ false))
     {}
 
 private:
@@ -4417,7 +4421,8 @@ public:
 private:
     void Handle(TEvListExpiredLeasesResponse::TPtr& ev) {
         const auto& leases = ev->Get()->Leases;
-        KQP_PROXY_LOG_D("Got list expired leases response " << ev->Sender << ", found " << leases.size() << " expired leases");
+        ExpiredLeasesCount = leases.size();
+        KQP_PROXY_LOG_D("Got list expired leases response " << ev->Sender << ", found " << ExpiredLeasesCount << " expired leases");
 
         for (const auto& lease : leases) {
             const auto& checkerId = Register(new TFinalizeScriptLeaseActor(SelfId(), lease.Database, lease.ExecutionId, QueryServiceConfig, Counters, {.Cookie = CookieId++}));
@@ -4462,7 +4467,7 @@ private:
         }
 
         KQP_PROXY_LOG_D("Finish, success: " << Success << ", issues: " << Issues.ToOneLineString());
-        Send(ReplyActorId, new TEvRefreshScriptExecutionLeasesResponse(Success, std::move(Issues)));
+        Send(ReplyActorId, new TEvRefreshScriptExecutionLeasesResponse(Success, ExpiredLeasesCount, std::move(Issues)));
         PassAway();
     }
 
@@ -4475,6 +4480,7 @@ private:
     const TIntrusivePtr<TKqpCounters> Counters;
     ui64 CookieId = 0;
     ui64 OperationsToCheck = 0;
+    ui64 ExpiredLeasesCount = 0;
     bool Success = true;
     NYql::TIssues Issues;
 };

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -4157,6 +4157,7 @@ private:
             DECLARE $issues AS JsonDocument;
             DECLARE $retry_state AS JsonDocument;
             DECLARE $retry_deadline AS Timestamp;
+            DECLARE $lease_state AS Int32;
 
             UPSERT INTO `.metadata/script_executions` (
                 database, execution_id, operation_status, execution_status,

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -235,6 +235,12 @@ protected:
         });
     }
 
+    std::optional<std::vector<NACLib::TSID>> ParseUserGroupSids(NYdb::TResultSetParser& result) {
+        return ParseJsonArray<NACLib::TSID>(result, "user_group_sids", "User group SIDs are corrupted", [](const NJson::TJsonValue& value, NACLib::TSID& dst) {
+            dst = value.GetString();
+        });
+    }
+
     bool ValidateLease(NYdb::TResultSetParser& result, const ELeaseState expectedLeaseState) {
         Y_VALIDATE(LeaseGeneration, "Lease generation is not set");
 
@@ -1023,15 +1029,12 @@ private:
                 }
             }
 
-            TVector<NACLib::TSID> userGroupSids;
-            if (const auto& serializedUserGroupSids = result.ColumnParser("user_group_sids").GetOptionalJsonDocument()) {
-                if (!GetUserGroupSids(*serializedUserGroupSids, userGroupSids)) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "User group sids are corrupted");
-                    return;
-                }
-            }
-
             if (const std::optional<TString>& userSID = result.ColumnParser("user_token").GetOptionalUtf8()) {
+                TVector<NACLib::TSID> userGroupSids;
+                if (auto userGroupSids = ParseUserGroupSids(result)) {
+                    userGroupSids = std::move(*userGroupSids);
+                }
+
                 queryRequest.SetUserToken(NACLib::TUserToken(*userSID, userGroupSids).SerializeAsString());
             }
 
@@ -3759,12 +3762,10 @@ private:
 
             if (const auto& userToken = result.ColumnParser("user_token").GetOptionalUtf8()) {
                 TVector<NACLib::TSID> userGroupSids;
-                if (const auto serializedUserGroupSids = result.ColumnParser("user_group_sids").GetOptionalJsonDocument()) {
-                    if (!GetUserGroupSids(*serializedUserGroupSids, userGroupSids)) {
-                        Finish(Ydb::StatusIds::INTERNAL_ERROR, "User group sids are corrupted");
-                        return;
-                    }
+                if (auto userGroupSids = ParseUserGroupSids(result)) {
+                    userGroupSids = std::move(*userGroupSids);
                 }
+
                 Response->UserToken = new NACLib::TUserToken(TString(*userToken), userGroupSids);
             }
 

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -1592,10 +1592,14 @@ private:
         switch (static_cast<EWakeup>(ev->Get()->Tag)) {
             case EWakeup::RetryCheckAlive:
                 WaitRetryCheckAlive = false;
-                CheckAliveRetries++;
-                KQP_PROXY_LOG_D("Start check alive request #" << CheckAliveRetries + 1);
-                Send(RunScriptActorId, new TEvCheckAliveRequest(), CheckAliveFlags);
-                Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+                if (WaitFinishQuery) {
+                    KQP_PROXY_LOG_N("Skipped retry check alive query, already waiting finish query");
+                } else {
+                    CheckAliveRetries++;
+                    KQP_PROXY_LOG_D("Start check alive request #" << CheckAliveRetries + 1);
+                    Send(RunScriptActorId, new TEvCheckAliveRequest(), CheckAliveFlags);
+                    Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+                }
                 break;
             case EWakeup::CheckAliveSoftTimeout:
                 KQP_PROXY_LOG_W("Deliver TRunScriptActor check alive request soft timeout, retry check alive");

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -1385,6 +1385,7 @@ private:
                         Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Invalid operation state, retry policy must be specified for lease state " << static_cast<i32>(leaseState));
                         return;
                     }
+                    Response->WaitRetry = true;
                     break;
                 }
             }
@@ -1982,9 +1983,9 @@ private:
         ResultSetMetas = std::move(ev->Get()->ResultSetMetas);
         ExecutionEntryExists = ev->Get()->EntryExists;
 
-        if (ExecutionEntryExists && (!ev->Get()->OperationStatus || ev->Get()->FinalizationStatus || ev->Get()->HasRetryPolicy)) {
+        if (ExecutionEntryExists && (!ev->Get()->OperationStatus || ev->Get()->FinalizationStatus || ev->Get()->WaitRetry)) {
             if (Request->Get()->Settings.CancelIfRunning) {
-                KQP_PROXY_LOG_I("Lease check " << ev->Sender << " finished, but operation is still running. Cancel it");
+                KQP_PROXY_LOG_W("Lease check " << ev->Sender << " finished, but operation is still running. Cancel it");
                 Send(MakeKqpProxyID(SelfId().NodeId()), new TEvCancelScriptExecutionOperation(Database, Request->Get()->OperationId, Request->Get()->UserSID, {
                     .FailOnNotFound = false,
                     .FailOnAlreadyStopped = false,

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -493,6 +493,9 @@ public:
 
 private:
     void OnRunQuery() override {
+        const auto metaTtl = std::min(MaxRunTime.MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1);
+        KQP_PROXY_LOG_D("Creating query in database, meta ttl: " << TDuration::MicroSeconds(metaTtl));
+
         constexpr char sql[] = R"(
             -- TCreateScriptOperationQuery::OnRunQuery
             DECLARE $database AS Text;
@@ -577,7 +580,7 @@ private:
                 .Interval(static_cast<i64>(std::min(NProtoInterop::CastFromProto(Meta.GetLeaseDuration()).MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1)))
                 .Build()
             .AddParam("$execution_meta_ttl")
-                .Interval(std::min(MaxRunTime.MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1))
+                .Interval(metaTtl)
                 .Build()
             .AddParam("$retry_state")
                 .JsonDocument(NProtobufJson::Proto2Json(RetryState, NProtobufJson::TProto2JsonConfig()))
@@ -851,7 +854,10 @@ private:
             return;
         }
 
-        if (LeaseExists = ValidateLease(ResultSets[0], ELeaseState::ScriptRunning)) {
+        LeaseExists = false;
+
+        if (ValidateLease(ResultSets[0], ELeaseState::ScriptRunning)) {
+            LeaseExists = true;
             UpdateLease();
         }
     }
@@ -2079,6 +2085,7 @@ private:
             SELECT
                 operation_status,
                 execution_status,
+                finalization_status,
                 query_text,
                 syntax,
                 execution_mode,
@@ -2202,6 +2209,8 @@ private:
                 LeaseStatus = static_cast<ELeaseState>(result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning)));
                 if (*LeaseStatus == ELeaseState::WaitRetry) {
                     SuspendedUntil = *leaseDeadline;
+                } else if (*LeaseStatus == ELeaseState::ScriptFinalizing) {
+                    Metadata.set_exec_status(Ydb::Query::EXEC_STATUS_RUNNING); // Waiting for finalization
                 }
             } else if (!OperationStatus) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected operation state, lease not found for running query");
@@ -2220,7 +2229,9 @@ private:
         bool ready = !!OperationStatus;
         if (LeaseStatus && OperationStatus) {
             ready = false;
-            OperationIssues.AddIssue(TStringBuilder() << "Execution finished with status " << *OperationStatus << " and wait " << *LeaseStatus);
+            NYql::TIssue finalizationIssue(TStringBuilder() << "Execution finished with status " << *OperationStatus << " and wait " << (*LeaseStatus == ELeaseState::ScriptFinalizing ? "finalization" : "retry"));
+            finalizationIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
+            OperationIssues.AddIssue(finalizationIssue);
             OperationStatus = std::nullopt;
         }
 
@@ -3842,8 +3853,9 @@ private:
             DECLARE $lease_generation AS Int64;
 
             UPSERT INTO `.metadata/script_executions` (
-                database, execution_id, operation_status, execution_status, finalization_status, issues,
-                plan_compressed, plan_compression_method, end_ts, stats, ast_compressed, ast_compression_method,
+                database, execution_id, operation_status, execution_status,
+                finalization_status,
+                issues, plan_compressed, plan_compression_method, end_ts, stats, ast_compressed, ast_compression_method,
                 expire_at,
                 customer_supplied_id,
                 script_sinks,
@@ -3852,8 +3864,7 @@ private:
             ) VALUES (
                 $database, $execution_id, $operation_status, $execution_status,
                 IF($applicate_script_external_effect_required, $finalization_status, NULL),
-                $issues,
-                $plan_compressed, $plan_compression_method, CurrentUtcTimestamp(), $stats, $ast_compressed, $ast_compression_method,
+                $issues, $plan_compressed, $plan_compression_method, CurrentUtcTimestamp(), $stats, $ast_compressed, $ast_compression_method,
                 IF($operation_ttl > CAST(0 AS Interval), CurrentUtcTimestamp() + $operation_ttl, NULL),
                 IF($applicate_script_external_effect_required, $customer_supplied_id, NULL),
                 IF($applicate_script_external_effect_required, $script_sinks, NULL),
@@ -3900,12 +3911,14 @@ private:
             serializedStats = statsStream.Str();
         }
 
+        const auto operationTtl = std::min(OperationTtl.MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1);
         KQP_PROXY_LOG_D("Do finalization with status " << Request.OperationStatus
             << ", exec status: " << Ydb::Query::ExecStatus_Name(Request.ExecStatus)
             << ", finalization status (applicate effect: " << Response->ApplicateScriptExternalEffectRequired << "): " << static_cast<ui64>(Request.FinalizationStatus)
             << ", issues: " << Request.Issues.ToOneLineString()
             << ", retry deadline: " << retryDeadline
-            << ", lease state: " << static_cast<i32>(leaseState));
+            << ", lease state: " << static_cast<i32>(leaseState)
+            << ", operation_ttl: " << TDuration::MicroSeconds(operationTtl));
 
         auto params = CreateParams();
         params
@@ -3937,7 +3950,7 @@ private:
                 .OptionalUtf8(Request.QueryAstCompressionMethod)
                 .Build()
             .AddParam("$operation_ttl")
-                .Interval(std::min(OperationTtl.MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1))
+                .Interval(operationTtl)
                 .Build()
             .AddParam("$customer_supplied_id")
                 .Utf8(Response->CustomerSuppliedId)
@@ -4212,9 +4225,7 @@ public:
         , QueryPlan(std::move(queryPlan))
         , QueryAst(std::move(ast))
         , Compressor(queryServiceConfig.GetQueryArtifactsCompressionMethod(), queryServiceConfig.GetQueryArtifactsCompressionMinSize())
-    {
-        Y_VALIDATE(QueryPlan || QueryAst, "Plan ot ast should be set");
-    }
+    {}
 
 private:
     void OnRunQuery() override {
@@ -4697,8 +4708,12 @@ IActor* CreateCreateScriptOperationQueryActor(TString executionId, const TActorI
     return new TCreateScriptOperationQuery(std::move(executionId), runScriptActorId, std::move(record), std::move(meta), TDuration::Max(), {}, std::nullopt, {}, nullptr, 1);
 }
 
-IActor* CreateCheckLeaseStatusActor(TString database, TString executionId, const ui64 cookie) {
-    return new TCheckLeaseStatusQueryActor(std::move(database), std::move(executionId), {.Cookie = cookie});
+IActor* CreateCheckLeaseStatusActor(TString database, TString executionId) {
+    return new TCheckLeaseStatusQueryActor(std::move(database), std::move(executionId), {});
+}
+
+IActor* CreateFinalizeScriptLeaseActor(const TActorId& replyActorId, TString database, TString executionId) {
+    return new TFinalizeScriptLeaseActor(replyActorId, std::move(database), std::move(executionId), {}, nullptr, {});
 }
 
 } // namespace NPrivate

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -4,12 +4,19 @@
 #include <ydb/core/fq/libs/common/rows_proto_splitter.h>
 #include <ydb/core/grpc_services/rpc_kqp_base.h>
 #include <ydb/core/kqp/common/events/events.h>
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/common/kqp.h>
 #include <ydb/core/kqp/common/kqp_script_executions.h>
+#include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
 #include <ydb/core/kqp/proxy_service/proto/result_set_meta.pb.h>
 #include <ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_compression.h>
 #include <ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_retries.h>
 #include <ydb/core/kqp/run_script_actor/kqp_run_script_actor.h>
-#include <ydb/core/protos/feature_flags.pb.h>
+#include <ydb/core/protos/kqp.pb.h>
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/interconnect.h>
@@ -18,26 +25,39 @@
 #include <ydb/library/services/services.pb.h>
 #include <ydb/library/table_creator/table_creator.h>
 #include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
-#include <ydb/public/api/protos/ydb_issue_message.pb.h>
 #include <ydb/public/api/protos/ydb_operation.pb.h>
+#include <ydb/public/api/protos/ydb_query.pb.h>
+#include <ydb/public/api/protos/ydb_status_codes.pb.h>
+#include <ydb/public/lib/scheme_types/scheme_type_id.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/params/params.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/result.h>
-#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/operation_id/operation_id.h>
 
+#include <yql/essentials/public/issue/yql_issue.h>
 #include <yql/essentials/public/issue/yql_issue_message.h>
 
 #include <contrib/libs/fmt/include/fmt/format.h>
 
-#include <google/protobuf/util/time_util.h>
-
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/writer/json_value.h>
 #include <library/cpp/protobuf/interop/cast.h>
 #include <library/cpp/protobuf/json/json2proto.h>
 #include <library/cpp/protobuf/json/proto2json.h>
 #include <library/cpp/retry/retry_policy.h>
 
 #include <util/system/env.h>
+#include <util/datetime/base.h>
 #include <util/generic/guid.h>
+#include <util/generic/maybe.h>
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
 #include <util/generic/utility.h>
+#include <util/generic/yexception.h>
+#include <util/string/builder.h>
+#include <util/system/types.h>
+
+#include <optional>
+#include <memory>
+#include <vector>
 
 namespace NKikimr::NKqp {
 
@@ -54,99 +74,34 @@ namespace {
 #define KQP_PROXY_LOG_C(stream) LOG_CRIT_S(*TlsActivationContext, NKikimrServices::KQP_PROXY, "[ScriptExecutions] " << LogPrefix() << stream)
 
 constexpr TDuration LEASE_DURATION = TDuration::Seconds(30);
-constexpr TDuration DEADLINE_OFFSET = TDuration::Minutes(20);
-constexpr TDuration BRO_RUN_INTERVAL = TDuration::Minutes(60);
-constexpr ui64 MAX_TRANSIENT_ISSUES_COUNT = 10;
 
-NYql::TIssues DeserializeIssues(const std::string& issuesSerialized) {
-    Ydb::Issue::IssueMessage rootMessage = NProtobufJson::Json2Proto<Ydb::Issue::IssueMessage>(issuesSerialized);
-    NYql::TIssue root = NYql::IssueFromMessage(rootMessage);
-
-    NYql::TIssues issues;
-    for (const auto& issuePtr : root.GetSubIssues()) {
-        issues.AddIssue(*issuePtr);
+Ydb::Query::ExecMode GetExecModeFromAction(const NKikimrKqp::EQueryAction action) {
+    switch (action) {
+        case NKikimrKqp::QUERY_ACTION_EXECUTE:
+            return Ydb::Query::EXEC_MODE_EXECUTE;
+        case NKikimrKqp::QUERY_ACTION_EXPLAIN:
+            return Ydb::Query::EXEC_MODE_EXPLAIN;
+        case NKikimrKqp::QUERY_ACTION_VALIDATE:
+            return Ydb::Query::EXEC_MODE_VALIDATE;
+        case NKikimrKqp::QUERY_ACTION_PARSE:
+            return Ydb::Query::EXEC_MODE_PARSE;
+        case NKikimrKqp::QUERY_ACTION_PREPARE:
+        case NKikimrKqp::QUERY_ACTION_EXECUTE_PREPARED:
+        case NKikimrKqp::QUERY_ACTION_BEGIN_TX:
+        case NKikimrKqp::QUERY_ACTION_COMMIT_TX:
+        case NKikimrKqp::QUERY_ACTION_ROLLBACK_TX:
+        case NKikimrKqp::QUERY_ACTION_TOPIC:
+            throw yexception() << "Unsupported query action: " << NKikimrKqp::EQueryAction_Name(action);
     }
-    return issues;
 }
 
-template <typename TProto>
-void SerializeBinaryProto(const TProto& proto, NJson::TJsonValue& value) {
-    value.SetType(NJson::EJsonValueType::JSON_MAP);
+template<typename TDerived, typename TResponse>
+class TQueryBase : public NKikimr::TQueryBase, public TQueryRetryActorMixin<TDerived, TResponse> {
+    using TBase = NKikimr::TQueryBase;
 
-    const auto config = NProtobufJson::TProto2JsonConfig()
-        .AddStringTransform(MakeIntrusive<NProtobufJson::TBase64EncodeBytesTransform>());
-
-    NProtobufJson::Proto2Json(proto, value["encoded_proto"], config);
-}
-
-template <typename TProto>
-TString SerializeBinaryProto(const TProto& proto) {
-    NJson::TJsonValue value;
-    SerializeBinaryProto(proto, value);
-
-    NJsonWriter::TBuf serializedProto;
-    serializedProto.WriteJsonValue(&value, false, PREC_NDIGITS, 17);
-
-    return serializedProto.Str();
-}
-
-template <typename TProto>
-void DeserializeBinaryProto(const NJson::TJsonValue& value, TProto& proto) {
-    const auto& valueMap = value.GetMap();
-    const auto encodedProto = valueMap.find("encoded_proto");
-    if (encodedProto == valueMap.end()) {
-        return NProtobufJson::Json2Proto(value, proto, NProtobufJson::TJson2ProtoConfig());
-    }
-
-    const auto config = NProtobufJson::TJson2ProtoConfig()
-        .AddStringTransform(MakeIntrusive<NProtobufJson::TBase64DecodeBytesTransform>());
-
-    NProtobufJson::Json2Proto(encodedProto->second, proto, config);
-}
-
-void TimestampToProtoWithSaturation(google::protobuf::Timestamp* proto, TInstant timestamp) {
-    *proto = google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(
-        std::min(timestamp.MicroSeconds(), static_cast<ui64>(google::protobuf::util::TimeUtil::kTimestampMaxSeconds * 1000000))
-    );
-}
-
-bool GetUserGroupSids(const std::string& serializedUserGroupSids, TVector<NACLib::TSID>& userGroupSids) {
-    NJson::TJsonValue value;
-    if (!NJson::ReadJsonTree(serializedUserGroupSids, &value) || value.GetType() != NJson::JSON_ARRAY) {
-        return false;
-    }
-
-    const auto sidsSize = value.GetIntegerRobust();
-    userGroupSids.reserve(sidsSize);
-    for (i64 i = 0; i < sidsSize; ++i) {
-        const NJson::TJsonValue* userSid = nullptr;
-        value.GetValuePointer(i, &userSid);
-        Y_ENSURE(userSid);
-
-        userGroupSids.emplace_back(userSid->GetString());
-    }
-    return true;
-}
-
-TString CheckScriptExecutionAccess(std::optional<TString>& userSID) {
-    if (!AppData()->FeatureFlags.GetEnableSecureScriptExecutions()) {
-        userSID = std::nullopt;
-        return "";
-    }
-
-    if (!userSID) {
-        return "Access to script execution operations without user token is not allowed";
-    }
-
-    if (NACLib::TUserToken(*userSID, {}).IsSystemUser()) {
-        userSID = std::nullopt;
-    }
-
-    return "";
-}
-
-class TQueryBase : public NKikimr::TQueryBase {
 public:
+    using TThis = TDerived;
+
     struct TSettings {
         TString Database;  // Only for logging, request will be executed in AppData()->TenantName
         TString ExecutionId;
@@ -154,13 +109,46 @@ public:
         std::optional<i64> LeaseGeneration;
     };
 
-    TQueryBase(const TString& operationName, const TSettings& settings)
-        : NKikimr::TQueryBase(NKikimrServices::KQP_PROXY, settings.SessionId, {}, /* isSystemUser */ true)
+    TQueryBase(const TString& operationName, TSettings&& settings)
+        : TBase(NKikimrServices::KQP_PROXY, settings.SessionId, {}, /* isSystemUser */ true)
+        , Database(std::move(settings.Database))
+        , ExecutionId(std::move(settings.ExecutionId))
+        , LeaseGeneration(settings.LeaseGeneration.value_or(0))
     {
         SetOperationInfo(operationName, CreateTraceId(settings));
     }
 
 private:
+    template<typename T>
+    std::optional<std::vector<T>> ParseJsonArray(NYdb::TResultSetParser& result, const TString& columnName, const TString& error, std::function<void(const NJson::TJsonValue&, T&)> itemParser) {
+        std::vector<T> parsed;
+
+        if (const auto& serializedJson = result.ColumnParser(columnName).GetOptionalJsonDocument()) {
+            NJson::TJsonValue value;
+            if (!NJson::ReadJsonTree(*serializedJson, &value) || value.GetType() != NJson::JSON_ARRAY) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, error);
+                return std::nullopt;
+            }
+
+            const auto parsedSize = value.GetIntegerRobust();
+            parsed.reserve(parsedSize);
+            for (i64 i = 0; i < parsedSize; ++i) {
+                const NJson::TJsonValue* serializedItem = nullptr;
+                value.GetValuePointer(i, &serializedItem);
+
+                if (!serializedItem) {
+                    Finish(Ydb::StatusIds::INTERNAL_ERROR, error);
+                    return std::nullopt;
+                }
+
+                itemParser(*serializedItem, parsed.emplace_back());
+            }
+        }
+
+        return std::move(parsed);
+    }
+
+protected:
     static TString CreateTraceId(const TSettings& settings) {
         TStringBuilder result;
 
@@ -182,13 +170,157 @@ private:
 
         return result;
     }
+
+    void OnQueryResult() override {
+        Finish();
+    }
+
+    NYdb::TParamsBuilder CreateParams() const {
+        NYdb::TParamsBuilder params;
+        params
+            .AddParam("$database")
+                .Utf8(Database)
+                .Build()
+            .AddParam("$execution_id")
+                .Utf8(ExecutionId)
+                .Build();
+        return params;
+    }
+
+    static NYql::TIssues ParseScriptExecutionIssues(NYdb::TResultSetParser& result) {
+        NYql::TIssues issues;
+
+        if (const auto& issuesSerialized = result.ColumnParser("issues").GetOptionalJsonDocument()) {
+            issues = DeserializeIssues(*issuesSerialized);
+        }
+
+        if (const auto& transientIssuesSerialized = result.ColumnParser("transient_issues").GetOptionalJsonDocument()) {
+            issues.AddIssues(AddRootIssue("Previous query retries", DeserializeIssues(*transientIssuesSerialized), /* addEmptyRoot */ false));
+        }
+
+        return issues;
+    }
+
+    std::optional<NKikimrKqp::TScriptExecutionRetryState> ParseRetryState(NYdb::TResultSetParser& result) {
+        NKikimrKqp::TScriptExecutionRetryState retryState;
+
+        if (const auto& serializedRetryState = result.ColumnParser("retry_state").GetOptionalJsonDocument()) {
+            NJson::TJsonValue value;
+            if (!NJson::ReadJsonTree(*serializedRetryState, &value)) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Retry state is corrupted");
+                return std::nullopt;
+            }
+
+            NProtobufJson::Json2Proto(value, retryState);
+        }
+
+        return std::move(retryState);
+    }
+
+    std::optional<std::vector<Ydb::Query::ResultSetMeta>> ParseResultSetMetas(NYdb::TResultSetParser& result) {
+        return ParseJsonArray<Ydb::Query::ResultSetMeta>(result, "result_set_metas", "Result set meta is corrupted", [](const NJson::TJsonValue& value, Ydb::Query::ResultSetMeta& dst) {
+            NProtobufJson::Json2Proto(value, dst);
+        });
+    }
+
+    std::optional<std::vector<NKqpProto::TKqpExternalSink>> ParseScriptSinks(NYdb::TResultSetParser& result) {
+        return ParseJsonArray<NKqpProto::TKqpExternalSink>(result, "script_sinks", "Script sinks are corrupted", [](const NJson::TJsonValue& value, NKqpProto::TKqpExternalSink& dst) {
+            DeserializeBinaryProto(value, dst);
+        });
+    }
+
+    std::optional<std::vector<TString>> ParseSecretNames(NYdb::TResultSetParser& result) {
+        return ParseJsonArray<TString>(result, "script_secret_names", "Script secret names are corrupted", [](const NJson::TJsonValue& value, TString& dst) {
+            dst = value.GetString();
+        });
+    }
+
+    bool ValidateLease(NYdb::TResultSetParser& result, const ELeaseState expectedLeaseState) {
+        Y_VALIDATE(LeaseGeneration, "Lease generation is not set");
+
+        if (!result.TryNextRow()) {
+            Finish(Ydb::StatusIds::NOT_FOUND, "Script execution operation not found");
+            return false;
+        }
+
+        const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
+        if (!leaseGenerationInDatabase) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation, lease was lost");
+            return false;
+        }
+
+        if (LeaseGeneration != *leaseGenerationInDatabase) {
+            Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
+            return false;
+        }
+
+        const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning));
+        if (leaseState != static_cast<i32>(expectedLeaseState)) {
+            Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Script execution has lease state: " << leaseState << ", when for operation " << OperationName << " expected lease state: " << expectedLeaseState);
+            return false;
+        }
+
+        return true;
+    }
+
+    bool ValidateLease(const NYdb::TResultSet& resultSet, const ELeaseState expectedLeaseState) {
+        NYdb::TResultSetParser result(resultSet);
+        return ValidateLease(result, expectedLeaseState);
+    }
+
+    const TString Database;
+    TString ExecutionId;
+    const i64 LeaseGeneration = 0;
 };
 
-class TScriptExecutionsTablesCreator : public NTableCreator::TMultiTableCreator {
-    using TBase = NTableCreator::TMultiTableCreator;
+template<typename TDerived, typename TResponse>
+class TQueryWithAccessValidationBase : public TQueryBase<TDerived, TResponse> {
+    using TBase = TQueryBase<TDerived, TResponse>;
 
 public:
-    explicit TScriptExecutionsTablesCreator(bool enableSecureScriptExecutions, ui64 generation)
+    using TBase::LogPrefix;
+
+    TQueryWithAccessValidationBase(const TString& operationName, TBase::TSettings&& settings, std::optional<TString> userSID)
+        : TBase(operationName, std::move(settings))
+        , UserSID(std::move(userSID))
+    {}
+
+protected:
+    bool ValidateUserSID() {
+        if (const auto& error = CheckScriptExecutionAccess(UserSID)) {
+            KQP_PROXY_LOG_W("Token validation failed: " << error);
+            TBase::Finish(Ydb::StatusIds::UNAUTHORIZED, error);
+            return false;
+        }
+
+        return true;
+    }
+
+    bool ValidateAccess(NYdb::TResultSetParser& result) {
+        if (!UserSID) {
+            return true;
+        }
+
+        if (const auto& ownerUser = result.ColumnParser("user_token").GetOptionalUtf8(); ownerUser && *ownerUser != *UserSID) {
+            KQP_PROXY_LOG_W("Access denied for user " << *UserSID);
+            TBase::Finish(Ydb::StatusIds::UNAUTHORIZED, "Access denied. User is not owner of script execution operation.");
+            return false;
+        }
+
+        return true;
+    }
+
+    std::optional<TString> UserSID;
+};
+
+class TScriptExecutionsTablesCreator final : public NTableCreator::TMultiTableCreator {
+    using TBase = NTableCreator::TMultiTableCreator;
+
+    static constexpr TDuration TTL_DEADLINE_OFFSET = TDuration::Minutes(20);
+    static constexpr TDuration TTL_BRO_RUN_INTERVAL = TDuration::Minutes(60);
+
+public:
+    TScriptExecutionsTablesCreator(const bool enableSecureScriptExecutions, const ui64 generation)
         : TBase({
             GetScriptExecutionsCreator(enableSecureScriptExecutions),
             GetScriptExecutionLeasesCreator(enableSecureScriptExecutions),
@@ -198,14 +330,14 @@ public:
     {}
 
 private:
-    static TMaybe<NACLib::TDiffACL> GetTableACL(bool enableSecureScriptExecutions) {
+    static NACLib::TDiffACL GetTableACL(const bool enableSecureScriptExecutions) {
         NACLib::TDiffACL acl;
         acl.ClearAccess();
         acl.SetInterruptInheritance(enableSecureScriptExecutions);
         return acl;
     }
 
-    static IActor* GetScriptExecutionsCreator(bool enableSecureScriptExecutions) {
+    static IActor* GetScriptExecutionsCreator(const bool enableSecureScriptExecutions) {
         return CreateTableCreator(
             { ".metadata", "script_executions" },
             {
@@ -246,15 +378,50 @@ private:
             },
             { "database", "execution_id" },
             NKikimrServices::KQP_PROXY,
-            TtlCol("expire_at", DEADLINE_OFFSET, BRO_RUN_INTERVAL),
-            {},
+            TtlCol("expire_at", TTL_DEADLINE_OFFSET, TTL_BRO_RUN_INTERVAL),
+            /* database */ {},
             /* isSystemUser */ enableSecureScriptExecutions,
-            Nothing(),
+            /* partitioningPolicy */ Nothing(),
             GetTableACL(enableSecureScriptExecutions)
         );
     }
 
-    static IActor* GetScriptExecutionLeasesCreator(bool enableSecureScriptExecutions) {
+    static IActor* GetScriptExecutionLeasesCreator(const bool enableSecureScriptExecutions) {
+        // Allowed lease states in `script_execution_leases`, keyed by `execution_id`
+        // (the lease for the script execution operation itself):
+        //
+        // 1. While the script execution operation is running, a runtime lease is stored
+        //    in the table with state `ScriptRunning` and a deadline of approximately
+        //    `now + lease_duration`. `TRunScriptActor` periodically extends the lease
+        //    deadline.
+        //
+        //    - `TScriptExecutionLeaseCheckActor` periodically checks the
+        //      `script_execution_leases` table and finds expired leases. Once a runtime
+        //      lease expires, `TScriptExecutionLeaseCheckActor` checks the availability
+        //      of `TRunScriptActor` and, in case of an error, starts finalization of the
+        //      script execution operation.
+        //
+        // 2. If the script execution has external effects, such as S3 writes, then after
+        //    it finishes successfully or is canceled, the lease state in the table is
+        //    changed to `ScriptFinalizing`, and finalization is started. For example,
+        //    this may roll back S3 uploads after a failure. In this case, the lease
+        //    deadline is equal to the finalization start time plus the lease duration.
+        //    The lease deadline is not extended in this state; we assume that
+        //    finalization will complete within the specified deadline.
+        //
+        //    - If the lease expires in this state,
+        //      `TScriptExecutionLeaseCheckActor` starts finalization of the script
+        //      execution operation.
+        //
+        // 3. If the script execution operation has a retry policy and fails with a
+        //    retriable status, a lease in state `WaitRetry` is created after
+        //    finalization. In this case, the lease deadline represents the retry backoff
+        //    time.
+        //
+        //    - When a lease with status `WaitRetry` expires,
+        //      `TScriptExecutionLeaseCheckActor` restarts the script execution operation
+        //      with the same ID.
+
         return CreateTableCreator(
             { ".metadata", "script_execution_leases" },
             {
@@ -267,15 +434,15 @@ private:
             },
             { "database", "execution_id" },
             NKikimrServices::KQP_PROXY,
-            TtlCol("expire_at", DEADLINE_OFFSET, BRO_RUN_INTERVAL),
-            {},
+            TtlCol("expire_at", TTL_DEADLINE_OFFSET, TTL_BRO_RUN_INTERVAL),
+            /* database */ {},
             /* isSystemUser */ enableSecureScriptExecutions,
-            Nothing(),
+            /* partitioningPolicy */ Nothing(),
             GetTableACL(enableSecureScriptExecutions)
         );
     }
 
-    static IActor* GetScriptResultSetsCreator(bool enableSecureScriptExecutions) {
+    static IActor* GetScriptResultSetsCreator(const bool enableSecureScriptExecutions) {
         return CreateTableCreator(
             { ".metadata", "result_sets" },
             {
@@ -289,90 +456,44 @@ private:
             },
             { "database", "execution_id", "result_set_id", "row_id" },
             NKikimrServices::KQP_PROXY,
-            TtlCol("expire_at", DEADLINE_OFFSET, BRO_RUN_INTERVAL),
-            {},
+            TtlCol("expire_at", TTL_DEADLINE_OFFSET, TTL_BRO_RUN_INTERVAL),
+            /* database */ {},
             /* isSystemUser */ enableSecureScriptExecutions,
-            Nothing(),
+            /* partitioningPolicy */ Nothing(),
             GetTableACL(enableSecureScriptExecutions)
         );
     }
 
-    void OnTablesCreated(bool success, NYql::TIssues issues) override  {
-        Send(Owner, new TEvScriptExecutionsTablesCreationFinished(success, std::move(issues)), 0, Generation);
+    void OnTablesCreated(const bool success, NYql::TIssues issues) override  {
+        Send(Owner, new TEvScriptExecutionsTablesCreationFinished(success, std::move(issues)), /* flags */ 0, Generation);
         Send(MakeKqpFinalizeScriptServiceId(SelfId().NodeId()), new TEvStartScriptExecutionBackgroundChecks());
     }
 
-private:
     const ui64 Generation = 0;
 };
 
-Ydb::Query::ExecMode GetExecModeFromAction(NKikimrKqp::EQueryAction action) {
-    switch (action) {
-        case NKikimrKqp::QUERY_ACTION_EXECUTE:
-            return Ydb::Query::EXEC_MODE_EXECUTE;
-        case NKikimrKqp::QUERY_ACTION_EXPLAIN:
-            return Ydb::Query::EXEC_MODE_EXPLAIN;
-        case NKikimrKqp::QUERY_ACTION_VALIDATE:
-            return Ydb::Query::EXEC_MODE_VALIDATE;
-        case NKikimrKqp::QUERY_ACTION_PARSE:
-            return Ydb::Query::EXEC_MODE_PARSE;
-        case NKikimrKqp::QUERY_ACTION_PREPARE:
-            [[fallthrough]];
-        case NKikimrKqp::QUERY_ACTION_EXECUTE_PREPARED:
-            [[fallthrough]];
-        case NKikimrKqp::QUERY_ACTION_BEGIN_TX:
-            [[fallthrough]];
-        case NKikimrKqp::QUERY_ACTION_COMMIT_TX:
-            [[fallthrough]];
-        case NKikimrKqp::QUERY_ACTION_ROLLBACK_TX:
-            [[fallthrough]];
-        case NKikimrKqp::QUERY_ACTION_TOPIC:
-            throw std::runtime_error(TStringBuilder() << "Unsupported query action: " << NKikimrKqp::EQueryAction_Name(action));
-    }
-}
+// Creates new script execution, may requested from gRPC API / streaming query creation or modification
 
-NKikimrKqp::EQueryAction GetActionFromExecMode(Ydb::Query::ExecMode execMode) {
-    switch (execMode) {
-        case Ydb::Query::EXEC_MODE_EXECUTE:
-            return NKikimrKqp::QUERY_ACTION_EXECUTE;
-        case Ydb::Query::EXEC_MODE_EXPLAIN:
-            return NKikimrKqp::QUERY_ACTION_EXPLAIN;
-        case Ydb::Query::EXEC_MODE_VALIDATE:
-            return NKikimrKqp::QUERY_ACTION_VALIDATE;
-        case Ydb::Query::EXEC_MODE_PARSE:
-            return NKikimrKqp::QUERY_ACTION_PARSE;
-        default:
-            throw std::runtime_error(TStringBuilder() << "Unsupported query execute mode: " << Ydb::Query::ExecMode_Name(execMode));
-    }
-}
-
-class TCreateScriptOperationQuery : public TQueryBase {
+class TCreateScriptOperationQuery final : public TQueryBase<TCreateScriptOperationQuery, TEvPrivate::TEvCreateScriptOperationResponse> {
 public:
-    using TRetry = TQueryRetryActor<TCreateScriptOperationQuery, TEvPrivate::TEvCreateScriptOperationResponse,
-        TString, TActorId, NKikimrKqp::TEvQueryRequest, NKikimrKqp::TScriptExecutionOperationMeta, TDuration,
-        NKikimrKqp::TScriptExecutionRetryState, std::optional<NKikimrKqp::TQueryPhysicalGraph>, NKikimrConfig::TQueryServiceConfig,
-        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition>, i64>;
-
-    TCreateScriptOperationQuery(const TString& executionId, const TActorId& runScriptActorId,
-        const NKikimrKqp::TEvQueryRequest& req, const NKikimrKqp::TScriptExecutionOperationMeta& meta,
-        TDuration maxRunTime, const NKikimrKqp::TScriptExecutionRetryState& retryState,
-        const std::optional<NKikimrKqp::TQueryPhysicalGraph>& physicalGraph, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig,
-        std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> streamingDisposition, i64 generation)
-        : TQueryBase(__func__, {.Database = req.GetRequest().GetDatabase(), .ExecutionId = executionId})
-        , ExecutionId(executionId)
+    TCreateScriptOperationQuery(TString executionId, const TActorId& runScriptActorId, NKikimrKqp::TEvQueryRequest req,
+        NKikimrKqp::TScriptExecutionOperationMeta meta, const TDuration maxRunTime,
+        NKikimrKqp::TScriptExecutionRetryState retryState, std::optional<NKikimrKqp::TQueryPhysicalGraph> physicalGraph,
+        const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> streamingDisposition, const i64 generation)
+        : TQueryBase(__func__, {.Database = req.GetRequest().GetDatabase(), .ExecutionId = std::move(executionId), .LeaseGeneration = generation})
         , RunScriptActorId(runScriptActorId)
-        , Request(req)
-        , Meta(meta)
+        , Request(std::move(req))
+        , Meta(std::move(meta))
         , MaxRunTime(Max(maxRunTime, TDuration::Days(1)))
-        , RetryState(retryState)
-        , PhysicalGraph(physicalGraph)
+        , RetryState(std::move(retryState))
+        , PhysicalGraph(std::move(physicalGraph))
         , StreamingDisposition(std::move(streamingDisposition))
-        , Generation(generation)
         , Compressor(queryServiceConfig.GetQueryArtifactsCompressionMethod(), queryServiceConfig.GetQueryArtifactsCompressionMinSize())
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TCreateScriptOperationQuery::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -429,14 +550,8 @@ public:
             std::tie(graphCompressionMethod, graphCompressed) = Compressor.Compress(PhysicalGraph->SerializeAsString());
         }
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Request.GetRequest().GetDatabase())
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$run_script_actor_id")
                 .Utf8(ScriptExecutionRunnerActorIdString(RunScriptActorId))
                 .Build()
@@ -459,7 +574,7 @@ public:
                 .OptionalJson(StreamingDisposition ? std::optional<std::string>(SerializeBinaryProto(*StreamingDisposition)) : std::nullopt)
                 .Build()
             .AddParam("$lease_duration")
-                .Interval(static_cast<i64>(GetDuration(Meta.GetLeaseDuration()).MicroSeconds()))
+                .Interval(static_cast<i64>(std::min(NProtoInterop::CastFromProto(Meta.GetLeaseDuration()).MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1)))
                 .Build()
             .AddParam("$execution_meta_ttl")
                 .Interval(std::min(MaxRunTime.MicroSeconds(), NYql::NUdf::MAX_TIMESTAMP - 1))
@@ -486,17 +601,13 @@ public:
                 .OptionalUtf8(graphCompressionMethod)
                 .Build()
             .AddParam("$lease_generation")
-                .Int64(Generation)
+                .Int64(LeaseGeneration)
                 .Build();
 
         RunDataQuery(sql, &params);
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         KQP_PROXY_LOG_D("Create script execution operation"
             << ", RetryState: " << RetryState.ShortDebugString()
             << ", has PhysicalGraph: " << PhysicalGraph.has_value()
@@ -504,13 +615,12 @@ public:
             << ", Issues: " << issues.ToOneLineString());
 
         if (status == Ydb::StatusIds::SUCCESS) {
-            Send(Owner, new TEvPrivate::TEvCreateScriptOperationResponse(ExecutionId));
+            Send(Owner, new TEvPrivate::TEvCreateScriptOperationResponse(ExecutionId, std::move(issues)));
         } else {
             Send(Owner, new TEvPrivate::TEvCreateScriptOperationResponse(status, std::move(issues)));
         }
     }
 
-private:
     TString SerializeParameters() const {
         NJson::TJsonValue value;
         value.SetType(NJson::EJsonValueType::JSON_MAP);
@@ -531,8 +641,6 @@ private:
         return serializedParams.Str();
     }
 
-private:
-    const TString ExecutionId;
     const TActorId RunScriptActorId;
     const NKikimrKqp::TEvQueryRequest Request;
     const NKikimrKqp::TScriptExecutionOperationMeta Meta;
@@ -540,39 +648,39 @@ private:
     const NKikimrKqp::TScriptExecutionRetryState RetryState;
     const std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     const std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
-    const i64 Generation = 0;
     const TCompressor Compressor;
 };
 
-class TCreateScriptExecutionActor : public TActorBootstrapped<TCreateScriptExecutionActor> {
+class TCreateScriptExecutionActor final : public TActorBootstrapped<TCreateScriptExecutionActor>, IActorExceptionHandler {
 public:
-    TCreateScriptExecutionActor(TEvKqp::TEvScriptRequest::TPtr&& ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, TDuration maxRunTime, TDuration leaseDuration)
+    TCreateScriptExecutionActor(TEvKqp::TEvScriptRequest::TPtr&& ev, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, const TDuration maxRunTime, const TDuration leaseDuration)
         : Event(std::move(ev))
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
+        , QueryServiceConfig(std::move(queryServiceConfig))
+        , Counters(std::move(counters))
         , ExecutionId(Event->Get()->ExecutionId ? *Event->Get()->ExecutionId : CreateGuidAsString())
         , LeaseDuration(leaseDuration ? leaseDuration : LEASE_DURATION)
         , MaxRunTime(maxRunTime)
     {}
 
     void Bootstrap() {
-        Become(&TCreateScriptExecutionActor::StateFunc);
+        Become(&TThis::StateFunc);
 
         const auto& ev = *Event->Get();
         const auto& eventProto = ev.Record;
         const auto& request = eventProto.GetRequest();
         if (ev.SaveQueryPhysicalGraph) {
             if (request.GetAction() != NKikimrKqp::QUERY_ACTION_EXECUTE) {
-                SendFailResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue(TStringBuilder() << "Save query physical graph is allowed only for execute action (got " << NKikimrKqp::EQueryAction_Name(request.GetAction()) << ")")});
+                SendFailResponse(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Save query physical graph is allowed only for execute action (got " << NKikimrKqp::EQueryAction_Name(request.GetAction()) << ")");
                 return;
             }
+
             if (request.HasTxControl()) {
-                SendFailResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue(TStringBuilder() << "Save query physical graph is not allowed inside not implicit transaction")});
+                SendFailResponse(Ydb::StatusIds::INTERNAL_ERROR, "Save query physical graph is not allowed inside not implicit transaction");
                 return;
             }
         }
 
-        const auto& meta = GetOperationMeta();
+        auto meta = GetOperationMeta();
 
         // Start request
         RunScriptActorId = Register(CreateRunScriptActor(eventProto, {
@@ -580,7 +688,7 @@ public:
             .ExecutionId = ExecutionId,
             .LeaseGeneration = ev.Generation,
             .LeaseDuration = LeaseDuration,
-            .ResultsTtl = GetDuration(meta.GetResultsTtl()),
+            .ResultsTtl = NProtoInterop::CastFromProto(meta.GetResultsTtl()),
             .ProgressStatsPeriod = ev.ProgressStatsPeriod,
             .Counters = Counters,
             .SaveQueryPhysicalGraph = ev.SaveQueryPhysicalGraph,
@@ -597,14 +705,14 @@ public:
             disposition = nullptr; // Do not save disposition if state already saved
         }
 
-        const auto& creatorId = Register(new TCreateScriptOperationQuery::TRetry(SelfId(), ExecutionId, RunScriptActorId, ev.Record, meta, MaxRunTime, GetRetryState(), ev.QueryPhysicalGraph, QueryServiceConfig, std::move(disposition), ev.Generation));
+        const auto& creatorId = Register(TCreateScriptOperationQuery::MakeRetry(SelfId(), ExecutionId, RunScriptActorId, ev.Record, std::move(meta), MaxRunTime, GetRetryState(), ev.QueryPhysicalGraph, QueryServiceConfig, std::move(disposition), ev.Generation));
         KQP_PROXY_LOG_D("Bootstrap. Start TCreateScriptOperationQuery " << creatorId << ", RunScriptActorId: " << RunScriptActorId);
     }
 
     void Handle(TEvPrivate::TEvCreateScriptOperationResponse::TPtr& ev) {
         if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
             KQP_PROXY_LOG_W("Create script operation " << ev->Sender << " failed " << status << ", Issues: " << ev->Get()->Issues.ToOneLineString());
-            SendFailResponse(status, ev->Get()->Issues);
+            SendFailResponse(status, AddRootIssue("Internal error. Failed to save meta information about new script execution", ev->Get()->Issues));
             return;
         }
 
@@ -620,23 +728,27 @@ public:
         PassAway();
     }
 
-    void HandleException(const std::exception& ex) {
+    bool OnUnhandledException(const std::exception& ex) final {
         KQP_PROXY_LOG_E("Got unexpected exception: " << ex.what());
-        SendFailResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue(TStringBuilder() << "Got unexpected exception: " << ex.what())});
+        SendFailResponse(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Got unexpected exception: " << ex.what());
+        return true;
     }
 
-    STRICT_STFUNC_EXC(StateFunc,
-        hFunc(TEvPrivate::TEvCreateScriptOperationResponse, Handle),
-        ExceptionFunc(std::exception, HandleException)
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvPrivate::TEvCreateScriptOperationResponse, Handle)
     )
 
 private:
-    void SendFailResponse(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues) {
-        Send(Event->Sender, new TEvKqp::TEvScriptResponse(status, issues));
+    void SendFailResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
+        Send(Event->Sender, new TEvKqp::TEvScriptResponse(status, std::move(issues)));
         if (RunScriptActorId) {
             Send(RunScriptActorId, new TEvents::TEvPoison());
         }
         PassAway();
+    }
+
+    void SendFailResponse(const Ydb::StatusIds::StatusCode status, const TString& error) {
+        SendFailResponse(status, {NYql::TIssue(error)});
     }
 
     NKikimrKqp::TScriptExecutionOperationMeta GetOperationMeta() const {
@@ -655,25 +767,26 @@ private:
         meta.SetSaveQueryPhysicalGraph(ev.SaveQueryPhysicalGraph);
         meta.SetDisableDefaultTimeout(ev.DisableDefaultTimeout);
         *meta.MutableRlPath() = eventProto.GetRlPath();
-        SetDuration(LeaseDuration, *meta.MutableLeaseDuration());
-        SetDuration(ev.ProgressStatsPeriod, *meta.MutableProgressStatsPeriod());
+        DurationToProtoWithSaturation(LeaseDuration, meta.MutableLeaseDuration());
+        DurationToProtoWithSaturation(ev.ProgressStatsPeriod, meta.MutableProgressStatsPeriod());
 
         const auto operationTtl = ev.ForgetAfter ? ev.ForgetAfter : TDuration::Seconds(QueryServiceConfig.GetScriptForgetAfterDefaultSeconds());
-        SetDuration(operationTtl, *meta.MutableOperationTtl());
+        DurationToProtoWithSaturation(operationTtl, meta.MutableOperationTtl());
 
         auto resultsTtl = ev.ResultsTtl ? ev.ResultsTtl : TDuration::Seconds(QueryServiceConfig.GetScriptResultsTtlDefaultSeconds());
         if (operationTtl) {
             resultsTtl = Min(operationTtl, resultsTtl);
         }
 
-        SetDuration(resultsTtl, *meta.MutableResultsTtl());
+        DurationToProtoWithSaturation(resultsTtl, meta.MutableResultsTtl());
 
+        const auto now = TInstant::Now();
         if (const auto timeout = TDuration::MilliSeconds(request.GetTimeoutMs())) {
-            TimestampToProtoWithSaturation(meta.MutableTimeoutAt(), TInstant::Now() + timeout);
+            TimestampToProtoWithSaturation(now + timeout, meta.MutableTimeoutAt());
         }
 
         if (const auto cancelAfter = TDuration::MilliSeconds(request.GetCancelAfterMs())) {
-            TimestampToProtoWithSaturation(meta.MutableCancelAt(), TInstant::Now() + cancelAfter);
+            TimestampToProtoWithSaturation(now + cancelAfter, meta.MutableCancelAt());
         }
 
         return meta;
@@ -692,7 +805,6 @@ private:
         return TStringBuilder() << "[TCreateScriptExecutionActor] OwnerId: " << Event->Sender << " ActorId: " << SelfId() << " Database: " << Event->Get()->Record.GetRequest().GetDatabase() << " ExecutionId: " << ExecutionId << ". ";
     }
 
-private:
     const TEvKqp::TEvScriptRequest::TPtr Event;
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
     const TIntrusivePtr<TKqpCounters> Counters;
@@ -702,23 +814,21 @@ private:
     const TDuration MaxRunTime;
 };
 
-class TScriptLeaseUpdater : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TScriptLeaseUpdater, TEvScriptLeaseUpdateResponse, TString, TString, TDuration, i64>;
+// Created from TRunScriptActor and advances runtime lease with state ELeaseState::ScriptRunning
 
-    TScriptLeaseUpdater(const TString& database, const TString& executionId, TDuration leaseDuration, i64 leaseGeneration)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId, .LeaseGeneration = leaseGeneration})
-        , Database(database)
-        , ExecutionId(executionId)
+class TScriptLeaseUpdaterQuery final : public TQueryBase<TScriptLeaseUpdaterQuery, TEvScriptLeaseUpdateResponse> {
+public:
+    TScriptLeaseUpdaterQuery(TString database, TString executionId, const TDuration leaseDuration, const i64 leaseGeneration)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
         , LeaseDuration(leaseDuration)
-        , LeaseGeneration(leaseGeneration)
     {}
 
+private:
     void OnRunQuery() override {
         KQP_PROXY_LOG_D("Update lease on duration: " << LeaseDuration);
 
-        TString sql = R"(
-            -- TScriptLeaseUpdater::OnRunQuery
+        constexpr char sql[] = R"(
+            -- TScriptLeaseUpdaterQuery::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
 
@@ -730,52 +840,20 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TScriptLeaseUpdater::OnGetLeaseInfo, "Get lease info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetLeaseInfo, "Get lease info");
         RunDataQuery(sql, &params, TTxControl::BeginTx());
     }
 
     void OnGetLeaseInfo() {
-        LeaseExists = false;
-
         if (ResultSets.size() != 1) {
             Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
             return;
         }
 
-        NYdb::TResultSetParser result(ResultSets[0]);
-        if (!result.TryNextRow()) {
-            Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
-            return;
+        if (LeaseExists = ValidateLease(ResultSets[0], ELeaseState::ScriptRunning)) {
+            UpdateLease();
         }
-
-        const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
-        if (!leaseGenerationInDatabase) {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation, lease was lost");
-            return;
-        }
-
-        if (LeaseGeneration != *leaseGenerationInDatabase) {
-            Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
-            return;
-        }
-
-        const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning));
-        if (leaseState != static_cast<i32>(ELeaseState::ScriptRunning)) {
-            Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Script execution was terminated, expected lease state: " << static_cast<i32>(ELeaseState::ScriptRunning) << ", got: " << leaseState);
-            return;
-        }
-
-        LeaseExists = true;
-        UpdateLease();
     }
 
     void UpdateLease() {
@@ -786,126 +864,55 @@ public:
         LeaseDeadline = TInstant::Now() + LeaseDuration;
 
         TString sql = R"(
-            -- TScriptLeaseUpdater::UpdateLease
+            -- TScriptLeaseUpdaterQuery::UpdateLease
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
             DECLARE $lease_duration AS Interval;
 
-            UPDATE `.metadata/script_execution_leases`
-            SET lease_deadline = (CurrentUtcTimestamp() + $lease_duration)
-            WHERE database = $database AND execution_id = $execution_id;
+            UPSERT INTO `.metadata/script_execution_leases` (
+                database, execution_id, lease_deadline
+            ) VALUES (
+                $database, $execution_id, CurrentUtcTimestamp() + $lease_duration
+            );
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$lease_duration")
                 .Interval(static_cast<i64>(LeaseDuration.MicroSeconds()))
                 .Build();
 
-        SetQueryResultHandler(&TScriptLeaseUpdater::OnQueryResult, "Update lease");
+        SetQueryResultHandler(&TThis::OnQueryResult, "Update lease");
         RunDataQuery(sql, &params, TTxControl::ContinueAndCommitTx());
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvScriptLeaseUpdateResponse(LeaseExists, LeaseDeadline, status, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
     const TDuration LeaseDuration;
-    const i64 LeaseGeneration;
+    const TInstant LeaseUpdateStartTime = TInstant::Now();
     TInstant LeaseDeadline;
     bool LeaseExists = true;
 };
 
-class TScriptLeaseUpdateActor : public TActorBootstrapped<TScriptLeaseUpdateActor> {
+// Restart script execution after expiration of lease with state ELeaseState::WaitRetry (now used only in script executions from streaming queries).
+// Can be runned multiple times in parallel for same script execution operation.
+
+class TRestartScriptOperationQuery final : public TQueryBase<TRestartScriptOperationQuery, TEvScriptExecutionRestarted> {
+    static constexpr ui64 MAX_TRANSIENT_ISSUES_COUNT = 10;
+
 public:
-    TScriptLeaseUpdateActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId,
-        TDuration leaseDuration, i64 leaseGeneration, TIntrusivePtr<TKqpCounters> counters)
-        : RunScriptActorId(runScriptActorId)
-        , Database(database)
-        , ExecutionId(executionId)
-        , LeaseDuration(leaseDuration)
-        , LeaseGeneration(leaseGeneration)
-        , Counters(counters)
-        , LeaseUpdateStartTime(TInstant::Now())
+    TRestartScriptOperationQuery(TString database, TString executionId, const i64 leaseGeneration,
+        NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
+        , QueryServiceConfig(std::move(queryServiceConfig))
+        , Counters(std::move(counters))
     {}
 
-    void Bootstrap() {
-        const auto& updaterId = Register(new TScriptLeaseUpdater::TRetry(
-            SelfId(),
-            TScriptLeaseUpdater::TRetry::IRetryPolicy::GetExponentialBackoffPolicy(
-                TScriptLeaseUpdater::TRetry::Retryable,
-                TDuration::MilliSeconds(10),
-                TDuration::MilliSeconds(200),
-                TDuration::Seconds(1),
-                std::numeric_limits<size_t>::max(),
-                LeaseDuration / 2
-            ),
-            Database, ExecutionId, LeaseDuration, LeaseGeneration
-        ));
-        KQP_PROXY_LOG_D("Bootstrap. Start TLeaseUpdateRetryActor " << updaterId);
-
-        Become(&TScriptLeaseUpdateActor::StateFunc);
-    }
-
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvScriptLeaseUpdateResponse, Handle);
-    )
-
-    void Handle(TEvScriptLeaseUpdateResponse::TPtr& ev) {
-        KQP_PROXY_LOG_D("Lease update " << ev->Sender << " finished " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
-
-        if (Counters) {
-            Counters->ReportLeaseUpdateLatency(TInstant::Now() - LeaseUpdateStartTime);
-        }
-
-        Forward(ev, RunScriptActorId);
-        PassAway();
-    }
-
 private:
-    TString LogPrefix() const {
-        return TStringBuilder() << "[TScriptLeaseUpdateActor] OwnerId: " << RunScriptActorId << " ActorId: " << SelfId() << " Database: " << Database << " ExecutionId: " << ExecutionId << ". ";
-    }
-
-private:
-    const TActorId RunScriptActorId;
-    const TString Database;
-    const TString ExecutionId;
-    const TDuration LeaseDuration;
-    const i64 LeaseGeneration;
-    const TIntrusivePtr<TKqpCounters> Counters;
-    const TInstant LeaseUpdateStartTime;
-};
-
-class TRestartScriptOperationQuery : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TRestartScriptOperationQuery, TEvScriptExecutionRestarted, TString, TString, i64, NKikimrConfig::TQueryServiceConfig, TIntrusivePtr<TKqpCounters>>;
-
-    TRestartScriptOperationQuery(const TString& database, const TString& executionId, i64 leaseGeneration,
-        const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId, .LeaseGeneration = leaseGeneration})
-        , Database(database)
-        , ExecutionId(executionId)
-        , LeaseGeneration(leaseGeneration)
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
-    {}
-
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TRestartScriptOperationQuery::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -938,16 +945,8 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TRestartScriptOperationQuery::OnGetExecutionInfo, "Get execution info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetExecutionInfo, "Get execution info");
         RunDataQuery(sql, &params, TTxControl::BeginTx());
     }
 
@@ -959,20 +958,7 @@ public:
 
         {   // Lease info
             NYdb::TResultSetParser result(ResultSets[1]);
-            if (!result.TryNextRow()) {
-                Finish(Ydb::StatusIds::NOT_FOUND, "Lease not found");
-                return;
-            }
-
-            const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
-            if (!leaseGenerationInDatabase) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation");
-                return;
-            }
-
-            if (LeaseGeneration != *leaseGenerationInDatabase) {
-                LeaseGenerationChanged = true;
-                Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
+            if (!ValidateLease(result, ELeaseState::WaitRetry)) {
                 return;
             }
 
@@ -984,12 +970,6 @@ public:
 
             if (*leaseDeadline > TInstant::Now()) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Lease deadline is in the future");
-                return;
-            }
-
-            const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning));
-            if (leaseState != static_cast<i32>(ELeaseState::WaitRetry)) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Expected lease state WaitRetry, but got state: " << leaseState);
                 return;
             }
         }
@@ -1004,7 +984,7 @@ public:
         {   // Execution info
             NYdb::TResultSetParser result(ResultSets[0]);
             if (!result.TryNextRow()) {
-                Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
+                Finish(Ydb::StatusIds::NOT_FOUND, "Script execution operation not found");
                 return;
             }
 
@@ -1089,13 +1069,13 @@ public:
                 DeserializeBinaryProto(serializedStreamingDispositionJson, *streamingDisposition);
             }
 
-            const std::optional<TString>& queryText = result.ColumnParser("query_text").GetOptionalUtf8();
+            std::optional<TString> queryText = result.ColumnParser("query_text").GetOptionalUtf8();
             if (!queryText) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Query text is not found");
                 return;
             }
 
-            request.SetQuery(*queryText);
+            *request.MutableQuery() = std::move(*queryText);
             request.SetAction(GetActionFromExecMode(static_cast<Ydb::Query::ExecMode>(result.ColumnParser("execution_mode").GetOptionalInt32().value_or(Ydb::Query::EXEC_MODE_UNSPECIFIED))));
             request.SetSyntax(static_cast<Ydb::Query::Syntax>(result.ColumnParser("syntax").GetOptionalInt32().value_or(Ydb::Query::SYNTAX_UNSPECIFIED)));
 
@@ -1114,7 +1094,7 @@ public:
             DeserializeBinaryProto(serializedMetaJson, meta);
         }
 
-        LeaseDuration = GetDuration(meta.GetLeaseDuration());
+        LeaseDuration = NProtoInterop::CastFromProto(meta.GetLeaseDuration());
 
         queryRequest.SetTraceId(meta.GetTraceId());
         *queryRequest.MutableRlPath() = meta.GetRlPath();
@@ -1134,8 +1114,8 @@ public:
             .ExecutionId = ExecutionId,
             .LeaseGeneration = LeaseGeneration + 1,
             .LeaseDuration = LeaseDuration,
-            .ResultsTtl = GetDuration(meta.GetResultsTtl()),
-            .ProgressStatsPeriod = GetDuration(meta.GetProgressStatsPeriod()),
+            .ResultsTtl = NProtoInterop::CastFromProto(meta.GetResultsTtl()),
+            .ProgressStatsPeriod = NProtoInterop::CastFromProto(meta.GetProgressStatsPeriod()),
             .Counters = Counters,
             .SaveQueryPhysicalGraph = meta.GetSaveQueryPhysicalGraph(),
             .PhysicalGraph = std::move(physicalGraph),
@@ -1151,7 +1131,7 @@ public:
     }
 
     void RestartScriptExecution() {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TRestartScriptOperationQuery::RestartScriptExecution
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -1162,41 +1142,33 @@ public:
             DECLARE $execution_status AS Int32;
             DECLARE $transient_issues AS JsonDocument;
 
-            UPDATE `.metadata/script_executions`
-            SET
-                run_script_actor_id = $run_script_actor_id,
-                operation_status = NULL,
-                execution_status = $execution_status,
-                finalization_status = NULL,
-                start_ts = CurrentUtcTimestamp(),
-                end_ts = NULL,
-                ast = NULL,
-                ast_compressed = NULL,
-                ast_compression_method = NULL,
-                issues = NULL,
-                transient_issues = $transient_issues,
-                plan = NULL,
-                result_set_metas = NULL,
-                stats = NULL,
-                lease_generation = $lease_generation
-            WHERE database = $database AND execution_id = $execution_id;
+            UPSERT INTO `.metadata/script_executions` (
+                database, execution_id, run_script_actor_id,
+                operation_status, execution_status, finalization_status,
+                start_ts, end_ts,
+                ast, ast_compressed, ast_compression_method,
+                issues, transient_issues, plan,
+                result_set_metas, stats, lease_generation
+            ) VALUES (
+                $database, $execution_id, $run_script_actor_id,
+                NULL, $execution_status, NULL,
+                CurrentUtcTimestamp(), NULL,
+                NULL, NULL, NULL,
+                NULL, $transient_issues, NULL,
+                NULL, NULL, $lease_generation
+            );
 
-            UPDATE `.metadata/script_execution_leases`
-            SET
-                lease_deadline = (CurrentUtcTimestamp() + $lease_duration),
-                lease_generation = $lease_generation,
-                lease_state = $lease_state
-            WHERE database = $database AND execution_id = $execution_id;
+            UPSERT INTO `.metadata/script_execution_leases` (
+                database, execution_id,
+                lease_deadline, lease_generation, lease_state
+            ) VALUES (
+                $database, $execution_id,
+                CurrentUtcTimestamp() + $lease_duration, $lease_generation, $lease_state
+            );
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$lease_duration")
                 .Interval(static_cast<i64>(LeaseDuration.MicroSeconds()))
                 .Build()
@@ -1216,15 +1188,11 @@ public:
                 .JsonDocument(SerializeIssues(TransientIssues))
                 .Build();
 
-        SetQueryResultHandler(&TRestartScriptOperationQuery::OnQueryResult, "Restart script execution");
+        SetQueryResultHandler(&TThis::OnQueryResult, "Restart script execution");
         RunDataQuery(sql, &params, TTxControl::ContinueAndCommitTx());
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         if (RunScriptActorId) {
             if (status == Ydb::StatusIds::SUCCESS) {
                 Send(RunScriptActorId, new TEvents::TEvWakeup());
@@ -1232,142 +1200,341 @@ public:
                 Send(RunScriptActorId, new TEvents::TEvPoison());
             }
         }
-        Send(Owner, new TEvScriptExecutionRestarted(status, LeaseGenerationChanged, std::move(issues)));
+
+        Send(Owner, new TEvScriptExecutionRestarted(status, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
-    const i64 LeaseGeneration;
+    static NKikimrKqp::EQueryAction GetActionFromExecMode(Ydb::Query::ExecMode execMode) {
+        switch (execMode) {
+            case Ydb::Query::EXEC_MODE_EXECUTE:
+                return NKikimrKqp::QUERY_ACTION_EXECUTE;
+            case Ydb::Query::EXEC_MODE_EXPLAIN:
+                return NKikimrKqp::QUERY_ACTION_EXPLAIN;
+            case Ydb::Query::EXEC_MODE_VALIDATE:
+                return NKikimrKqp::QUERY_ACTION_VALIDATE;
+            case Ydb::Query::EXEC_MODE_PARSE:
+                return NKikimrKqp::QUERY_ACTION_PARSE;
+            default:
+                throw std::runtime_error(TStringBuilder() << "Unsupported query execute mode: " << Ydb::Query::ExecMode_Name(execMode));
+        }
+    }
+
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
     const TIntrusivePtr<TKqpCounters> Counters;
     TDuration LeaseDuration;
     TActorId RunScriptActorId;
     NYql::TIssues TransientIssues;
-    bool LeaseGenerationChanged = false;
 };
 
-class TCheckLeaseStatusActorBase : public TActorBootstrapped<TCheckLeaseStatusActorBase> {
-    using TBase = TActorBootstrapped<TCheckLeaseStatusActorBase>;
+// Get full information about current script execution state and lease state
+
+class TCheckLeaseStatusQueryActor final : public TQueryWithAccessValidationBase<TCheckLeaseStatusQueryActor, NPrivate::TEvPrivate::TEvLeaseCheckResult> {
+public:
+    struct TSettings {
+        ui64 Cookie = 0;
+        std::optional<TString> UserSID = std::nullopt;
+    };
+
+    TCheckLeaseStatusQueryActor(TString database, TString executionId, TSettings settings)
+        : TQueryWithAccessValidationBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId)}, std::move(settings.UserSID))
+        , Cookie(settings.Cookie)
+        , Response(std::make_unique<NPrivate::TEvPrivate::TEvLeaseCheckResult>())
+    {}
+
+private:
+    void OnRunQuery() override {
+        KQP_PROXY_LOG_D("Start, Cookie: " << Cookie);
+
+        constexpr char sql[] = R"(
+            -- TCheckLeaseStatusQueryActor::OnRunQuery
+            DECLARE $database AS Text;
+            DECLARE $execution_id AS Text;
+
+            SELECT
+                operation_status,
+                execution_status,
+                finalization_status,
+                issues,
+                transient_issues,
+                run_script_actor_id,
+                retry_state,
+                result_set_metas,
+                user_token
+            FROM `.metadata/script_executions`
+            WHERE database = $database AND execution_id = $execution_id AND
+                    (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
+
+            SELECT
+                lease_deadline,
+                lease_generation,
+                lease_state
+            FROM `.metadata/script_execution_leases`
+            WHERE database = $database AND execution_id = $execution_id AND
+                    (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
+        )";
+
+        auto params = CreateParams();
+        RunDataQuery(sql, &params);
+    }
+
+    void OnQueryResult() override {
+        if (ResultSets.size() != 2) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
+            return;
+        }
+
+        NYdb::TResultSetParser executionsResult(ResultSets[0]);
+        if (!executionsResult.TryNextRow()) {
+            Response->EntryExists = false;
+            Finish();
+            return;
+        }
+
+        if (!ValidateAccess(executionsResult)) {
+            return;
+        }
+
+        const auto& runScriptActorId = executionsResult.ColumnParser("run_script_actor_id").GetOptionalUtf8();
+        if (!runScriptActorId) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Not found run script actor id for script execution");
+            return;
+        }
+
+        if (!NKqp::ScriptExecutionRunnerActorIdFromString(*runScriptActorId, Response->RunScriptActorId)) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Run script actor id is corrupted");
+            return;
+        }
+
+        const auto operationStatus = executionsResult.ColumnParser("operation_status").GetOptionalInt32();
+        if (operationStatus) {
+            Response->OperationStatus = static_cast<Ydb::StatusIds::StatusCode>(*operationStatus);
+        }
+
+        if (const auto executionStatus = executionsResult.ColumnParser("execution_status").GetOptionalInt32()) {
+            Response->ExecutionStatus = static_cast<Ydb::Query::ExecStatus>(*executionStatus);
+        }
+
+        if (const auto finalizationStatus = executionsResult.ColumnParser("finalization_status").GetOptionalInt32()) {
+            Response->FinalizationStatus = static_cast<EFinalizationStatus>(*finalizationStatus);
+            if (!operationStatus) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Invalid operation state, status should be specified during finalization");
+                return;
+            }
+        }
+
+        Response->OperationIssues = ParseScriptExecutionIssues(executionsResult);
+
+        if (const auto& retryState = ParseRetryState(executionsResult)) {
+            Response->HasRetryPolicy = retryState->RetryPolicyMappingSize() > 0;
+        } else {
+            return;
+        }
+
+        if (auto resultSetMetas = ParseResultSetMetas(executionsResult)) {
+            Response->ResultSetMetas = std::move(*resultSetMetas);
+        } else {
+            return;
+        }
+
+        if (NYdb::TResultSetParser leaseResult(ResultSets[1]); leaseResult.TryNextRow()) {
+            const auto leaseDeadline = leaseResult.ColumnParser("lease_deadline").GetOptionalTimestamp();
+            if (!leaseDeadline) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Not found lease deadline for script execution");
+                return;
+            }
+
+            const auto leaseGeneration = leaseResult.ColumnParser("lease_generation").GetOptionalInt64();
+            if (!leaseGeneration) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Not found lease generation for script execution");
+                return;
+            }
+
+            Response->LeaseGeneration = *leaseGeneration;
+            const auto leaseState = static_cast<ELeaseState>(leaseResult.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning)));
+
+            switch (leaseState) {
+                case ELeaseState::ScriptRunning: {
+                    if (operationStatus) {
+                        Finish(Ydb::StatusIds::INTERNAL_ERROR, "Invalid operation state, status should be empty during query run");
+                        return;
+                    }
+                    break;
+                }
+                case ELeaseState::ScriptFinalizing: {
+                    if (!operationStatus || !Response->FinalizationStatus) {
+                        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Invalid operation state, status and finalization status should be specified for lease state " << static_cast<i32>(leaseState));
+                        return;
+                    }
+                    break;
+                }
+                case ELeaseState::WaitRetry: {
+                    if (!operationStatus || Response->FinalizationStatus) {
+                        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Invalid operation state, status should be specified and finalization must be completed for lease state " << static_cast<i32>(leaseState));
+                        return;
+                    }
+                    if (!Response->HasRetryPolicy) {
+                        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Invalid operation state, retry policy must be specified for lease state " << static_cast<i32>(leaseState));
+                        return;
+                    }
+                    break;
+                }
+            }
+
+            if (*leaseDeadline < RunStartTime) {
+                Response->LeaseExpired = true;
+                Response->RetryRequired = leaseState == ELeaseState::WaitRetry;
+            }
+        } else if (!operationStatus) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Invalid operation state, operation status or lease must be specified");
+            return;
+        }
+
+        Finish();
+    }
+
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        Response->Status = status;
+        Response->Issues = std::move(issues);
+        Send(Owner, Response.release(), /* flags */ 0, Cookie);
+    }
+
+    const TInstant RunStartTime = TInstant::Now();
+    const ui64 Cookie = 0;
+    std::unique_ptr<NPrivate::TEvPrivate::TEvLeaseCheckResult> Response;
+};
+
+// When script execution lease expired TFinalizeScriptLeaseActor will run finalization or retry (depending on lease state)
+// *Assumptions*:
+// 1. Node with run script actor not under blocking load and may respond on ping in 30s
+// 2. If node with run script actor send disconnects during one minute - node assumed as lost and script execution will be finalized
+// 3. Node disconnects doesn't reapeat too often, so in one minute where will be 30s window without disconnects
+// In practice it is almost always correct, but in some cases this may lead to infinite TLI retries on finalization or double start of script execution operation.
+// If actor finished with SUCCESS when lease not expired now or TRunScriptActor still running.
+
+class TFinalizeScriptLeaseActor final : public TActorBootstrapped<TFinalizeScriptLeaseActor> {
+    using TBase = TActorBootstrapped<TFinalizeScriptLeaseActor>;
     using TRetryPolicy = IRetryPolicy<bool>;
 
-    inline static const TDuration CHECK_ALIVE_REQUEST_TIMEOUT = TDuration::Seconds(60);
-    inline static const ui64 MAX_CHECK_ALIVE_RETRIES = 50;
+    static constexpr TDuration CHECK_ALIVE_REQUEST_SOFT_TIMEOUT = TDuration::Seconds(30); // Advance on each retry of check alive
+    static constexpr TDuration CHECK_ALIVE_REQUEST_HARD_TIMEOUT = TDuration::Seconds(60); // Hard timeout for all retries
+    static constexpr ui64 MAX_CHECK_ALIVE_RETRIES = 50;
 
     enum class EWakeup {
         RetryCheckAlive,
-        CheckAliveTimeout,
+        CheckAliveSoftTimeout,
+        CheckAliveHardTimeout,
     };
 
 public:
-    TCheckLeaseStatusActorBase(const TActorId& ownerId, const TString& operationName, const TString& database, const TString& executionId,
-        const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
-        : OwnerId(ownerId)
-        , OperationName(operationName)
-        , Database(database)
-        , ExecutionId(executionId)
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
-    {}
+    // Lease check and script execution finalizations pipeline:
+    // 1. Select lease status from database
+    // 2. If lease expired and where is no finalization status - start lease check by sending TEvLeaseCheckRequest to run script actor
+    // 3. If run script actor respond - lease not expired
+    // 4. Otherwise - script execution is finished, continue script finalization
+
+    struct TSettings {
+        const ui64 Cookie = 0;
+        const bool AllowRestart = true;
+        const bool FailOnNotFound = true;
+    };
+
+    TFinalizeScriptLeaseActor(const TActorId& replyActorId, TString database, TString executionId,
+        NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, TSettings&& settings)
+        : ReplyActorId(replyActorId)
+        , Database(std::move(database))
+        , ExecutionId(std::move(executionId))
+        , QueryServiceConfig(std::move(queryServiceConfig))
+        , Counters(std::move(counters))
+        , Settings(std::move(settings))
+    {
+        Y_VALIDATE(!Settings.AllowRestart || Settings.FailOnNotFound, "Can not handle setting FailOnNotFound when restart allowed");
+    }
 
     void Bootstrap() {
-        OnBootstrap();
-    }
-
-    Ydb::StatusIds::StatusCode GetOperationStatus() const {
-        return FinalOperationStatus;
-    }
-
-    Ydb::Query::ExecStatus GetExecStatus() const {
-        return FinalExecStatus;
-    }
-
-    NYql::TIssues GetIssues() const {
-        return FinalIssues;
-    }
-
-    void StartScriptFinalization(EFinalizationStatus finalizationStatus, TMaybe<Ydb::StatusIds::StatusCode> status, TMaybe<Ydb::Query::ExecStatus> execStatus, NYql::TIssues issues, i64 leaseGeneration) {
-        if (!status || !execStatus) {
-            issues.AddIssue("Finalization is not complete");
-            if (!status) {
-                status = Ydb::StatusIds::UNAVAILABLE;
-            }
-            if (!execStatus) {
-                execStatus = Ydb::Query::EXEC_STATUS_ABORTED;
-            }
-        }
-
-        KQP_PROXY_LOG_I("Try to finalize script execution operation"
-            << ", FinalizationStatus: " << static_cast<i32>(finalizationStatus)
-            << ", Status: " << *status
-            << ", ExecStatus: " << Ydb::Query::ExecStatus_Name(*execStatus)
-            << ", Issues: " << issues.ToOneLineString()
-            << ", LeaseGeneration: " << leaseGeneration);
-
-        SetupFinalizeRequest(finalizationStatus, *status, *execStatus, std::move(issues), leaseGeneration);
-        RunScriptFinalizeRequest();
-
-        Become(&TCheckLeaseStatusActorBase::StateFunc);
-    }
-
-    void StartLeaseChecking(TActorId runScriptActorId, i64 leaseGeneration) {
-        RunScriptActorId = runScriptActorId;
-        KQP_PROXY_LOG_W("Script execution lease is expired, start lease checking, LeaseGeneration: " << leaseGeneration);
-
-        SetupFinalizeRequest(EFinalizationStatus::FS_ROLLBACK, Ydb::StatusIds::UNAVAILABLE, Ydb::Query::EXEC_STATUS_ABORTED, NYql::TIssues{ NYql::TIssue("Lease expired") }, leaseGeneration);
-        Schedule(CHECK_ALIVE_REQUEST_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveTimeout)));
-
-        CheckAliveFlags = IEventHandle::FlagTrackDelivery;
-        if (runScriptActorId.NodeId() != SelfId().NodeId()) {
-            CheckAliveFlags |= IEventHandle::FlagSubscribeOnSession;
-            SubscribedOnSession = runScriptActorId.NodeId();
-        }
-        Send(runScriptActorId, new TEvCheckAliveRequest(), CheckAliveFlags);
-
-        Become(&TCheckLeaseStatusActorBase::StateFunc);
-    }
-
-    void RestartScriptExecution(i64 leaseGeneration) {
-        const auto& restartActorId = Register(new TRestartScriptOperationQuery::TRetry(SelfId(), Database, ExecutionId, leaseGeneration, QueryServiceConfig, Counters));
-        KQP_PROXY_LOG_N("Restarting script execution " << restartActorId << ", lease generation: " << leaseGeneration);
-
-        Become(&TCheckLeaseStatusActorBase::StateFunc);
-    }
-
-    TString LogPrefix() const {
-        auto result = TStringBuilder() << "[" << OperationName << "] OwnerId: " << OwnerId << " ActorId: " << SelfId() << " Database: " << Database << " ExecutionId: " << ExecutionId;
-
-        if (RunScriptActorId) {
-            result << " RunScriptActorId: " << RunScriptActorId;
-        }
-
-        return result << ". ";
+        const auto& checkerId = Register(TCheckLeaseStatusQueryActor::MakeRetry(SelfId(), Database, ExecutionId, TCheckLeaseStatusQueryActor::TSettings{}));
+        KQP_PROXY_LOG_D("Bootstrap, Cookie: " << Settings.Cookie << ". Start TCheckLeaseStatusQueryActor " << checkerId);
+        Become(&TThis::StateFunc);
     }
 
     void PassAway() override {
         if (SubscribedOnSession) {
             Send(TActivationContext::InterconnectProxy(*SubscribedOnSession), new TEvents::TEvUnsubscribe());
+            SubscribedOnSession = std::nullopt;
         }
         TBase::PassAway();
     }
 
-    virtual void OnBootstrap() = 0;
-    virtual void OnLeaseVerified() = 0;
-    virtual void OnScriptExecutionFinished(bool alreadyFinalized, bool waitRetry, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) = 0;
-    virtual void OnScriptExecutionRestarted(bool leaseGenerationChanged, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) = 0;
-
-private:
     STRICT_STFUNC(StateFunc,
+        hFunc(TEvPrivate::TEvLeaseCheckResult, Handle);
         hFunc(TEvCheckAliveResponse, Handle);
         hFunc(TEvents::TEvWakeup, Handle);
         hFunc(TEvents::TEvUndelivered, Handle);
         hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
         IgnoreFunc(TEvInterconnect::TEvNodeConnected);
-        hFunc(TEvScriptExecutionFinished, Handle);
-        hFunc(TEvScriptExecutionRestarted, Handle);
+        hFunc(TEvScriptExecutionRestarted, HandleFinalized);
+        hFunc(TEvScriptExecutionFinished, HandleFinalized);
     )
 
-    void SetupFinalizeRequest(EFinalizationStatus finalizationStatus, Ydb::StatusIds::StatusCode status, Ydb::Query::ExecStatus execStatus, NYql::TIssues issues, i64 leaseGeneration) {
+private:
+    void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
+        auto& event = *ev->Get();
+        if (event.Status != Ydb::StatusIds::SUCCESS) {
+            KQP_PROXY_LOG_W("Failed to check lease " << ev->Sender << " status, Status: " << event.Status << ", Issues: " << event.Issues.ToOneLineString());
+            return Reply(event.Status, std::move(event.Issues));
+        }
+
+        if (!event.EntryExists) {
+            KQP_PROXY_LOG_W("Lease check " << ev->Sender << " finished with not found, Status: " << event.Status << ", Issues: " << event.Issues.ToOneLineString());
+            return ReplyNotFound();
+        }
+
+        RunScriptActorId = event.RunScriptActorId;
+        KQP_PROXY_LOG_D("Extracted script execution operation " << ev->Sender
+            << ", Status: " << event.Status
+            << ", Issues: " << event.Issues.ToOneLineString()
+            << ", LeaseExpired: " << event.LeaseExpired
+            << ", RetryRequired: " << event.RetryRequired
+            << (event.OperationStatus ? ", OperationStatus: " + Ydb::StatusIds::StatusCode_Name(*event.OperationStatus) : "")
+            << (event.ExecutionStatus ? ", ExecutionStatus: " + Ydb::Query::ExecStatus_Name(*event.ExecutionStatus) : "")
+            << ", OperationIssues: " << event.OperationIssues.ToOneLineString()
+            << (event.FinalizationStatus ? (TStringBuilder() << ", FinalizationStatus: " << static_cast<ui64>(*event.FinalizationStatus)) : TStringBuilder())
+            << ", RunScriptActorId: " << RunScriptActorId
+            << ", LeaseGeneration: " << event.LeaseGeneration);
+
+        if (!event.LeaseExpired) {
+            KQP_PROXY_LOG_N("Lease finalization skipped, lease not expired");
+            LeaseVerified = true;
+            return Reply();
+        }
+
+        if (event.RetryRequired) {
+            if (Settings.AllowRestart) {
+                const auto& restartActorId = Register(TRestartScriptOperationQuery::MakeRetry(SelfId(), Database, ExecutionId, event.LeaseGeneration, QueryServiceConfig, Counters));
+                KQP_PROXY_LOG_N("Restarting script execution " << restartActorId << ", lease generation: " << event.LeaseGeneration);
+            } else {
+                KQP_PROXY_LOG_N("Lease finalization skipped, script execution wait retry");
+                Reply();
+            }
+            return;
+        }
+
+        auto issues = event.OperationIssues;
+        if (!issues) {
+            issues.AddIssue(event.FinalizationStatus ? "Finalization is not complete" : "Lease expired");
+        }
+
+        // Script execution lease is expired but TRunScriptActor may be still running, so we should check it availability first
+
+        const auto finalizationStatus = event.FinalizationStatus.GetOrElse(EFinalizationStatus::FS_ROLLBACK);
+        const auto status = event.OperationStatus.GetOrElse(Ydb::StatusIds::UNAVAILABLE);
+        const auto execStatus = event.ExecutionStatus.GetOrElse(Ydb::Query::EXEC_STATUS_ABORTED);
+        KQP_PROXY_LOG_W("Script execution lease is expired"
+            << ", FinalizationStatus: " << static_cast<i32>(finalizationStatus)
+            << ", Status: " << status
+            << ", ExecStatus: " << Ydb::Query::ExecStatus_Name(execStatus)
+            << ", Issues: " << issues.ToOneLineString()
+            << ", LeaseGeneration: " << event.LeaseGeneration);
+
         ScriptFinalizeRequest = std::make_unique<TEvScriptFinalizeRequest>(
             finalizationStatus,
             ExecutionId,
@@ -1378,22 +1545,109 @@ private:
             std::nullopt,  // queryStats
             std::nullopt,  // queryPlan
             std::nullopt,  // queryAst
-            leaseGeneration
+            event.LeaseGeneration,
+            /* cancelledByUser */ false
         );
+
+        CheckAliveFlags = IEventHandle::FlagTrackDelivery;
+        if (RunScriptActorId.NodeId() != SelfId().NodeId()) {
+            CheckAliveFlags |= IEventHandle::FlagSubscribeOnSession;
+            SubscribedOnSession = RunScriptActorId.NodeId();
+        }
+        Send(RunScriptActorId, new TEvCheckAliveRequest(), CheckAliveFlags);
+        Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+        Schedule(CHECK_ALIVE_REQUEST_HARD_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveHardTimeout)));
+    }
+
+    void Handle(TEvCheckAliveResponse::TPtr& ev) {
+        if (WaitFinishQuery) {
+            KQP_PROXY_LOG_W("Script execution " << ev->Sender << " lease was verified after started finalization");
+        } else {
+            KQP_PROXY_LOG_N("Script execution " << ev->Sender << " lease successfully verified");
+            LeaseVerified = true;
+            Reply();
+        }
+    }
+
+    void Handle(TEvents::TEvWakeup::TPtr& ev) {
+        switch (static_cast<EWakeup>(ev->Get()->Tag)) {
+            case EWakeup::RetryCheckAlive:
+                WaitRetryCheckAlive = false;
+                CheckAliveRetries++;
+                KQP_PROXY_LOG_D("Start check alive request #" << CheckAliveRetries + 1);
+                Send(RunScriptActorId, new TEvCheckAliveRequest(), CheckAliveFlags);
+                Schedule(CHECK_ALIVE_REQUEST_SOFT_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveSoftTimeout)));
+                break;
+            case EWakeup::CheckAliveSoftTimeout:
+                KQP_PROXY_LOG_W("Deliver TRunScriptActor check alive request soft timeout, retry check alive");
+                RetryCheckAlive(/* longDelay */ false);
+                break;
+            case EWakeup::CheckAliveHardTimeout:
+                KQP_PROXY_LOG_W("Deliver TRunScriptActor check alive request hard timeout, start finalization");
+                RunScriptFinalizeRequest();
+                break;
+        }
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
+        const auto reason = ev->Get()->Reason;
+        if (reason == TEvents::TEvUndelivered::ReasonActorUnknown) {
+            // Here we know that script execution runtime state was advanced:
+            // 1. Actor may by finished due to node restart
+            // 2. Script execution may be already under finalization
+            // 3. Script execution may be retried
+            // We will start finalization only in first and second cases
+            KQP_PROXY_LOG_W("Got delivery problem to " << ev->Sender << " TRunScriptActor not found, start finalization");
+            RunScriptFinalizeRequest();
+        } else {
+            KQP_PROXY_LOG_W("Got delivery problem to " << ev->Sender << ", node with TRunScriptActor unavailable, reason: " << reason);
+            RetryCheckAlive(/* longDelay */ true);
+        }
+    }
+
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
+        KQP_PROXY_LOG_W("Node " << ev->Get()->NodeId << " with TRunScriptActor was disconnected, retry check alive");
+        RetryCheckAlive(/* longDelay */ false);
+    }
+
+    void HandleFinalized(TEvScriptExecutionRestarted::TPtr& ev) {
+        const auto status = ev->Get()->Status;
+        const auto& issues = ev->Get()->Issues;
+        if (status != Ydb::StatusIds::SUCCESS) {
+            KQP_PROXY_LOG_W("Failed to restart " << ev->Sender << " script execution operation, status: " << status << ", issues: " << issues.ToOneLineString());
+        } else {
+            KQP_PROXY_LOG_D("Successfully restarted " << ev->Sender << " script execution operation");
+        }
+
+        Reply(status, AddRootIssue("Restart script execution operation", issues, /* addEmptyRoot  */ false));
+    }
+
+    void HandleFinalized(TEvScriptExecutionFinished::TPtr& ev) {
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            const auto& issues = ev->Get()->Issues;
+            KQP_PROXY_LOG_W("Failed to finalize " << ev->Sender << " script execution operation, status: " << status << ", issues: " << issues.ToOneLineString());
+            return Reply(status, AddRootIssue("Finish script execution operation failed", issues));
+        }
+
+        const auto& info = ev->Get()->Info;
+        KQP_PROXY_LOG_D("Successfully finalized " << ev->Sender << " script execution operation, entry exists: " << info.ExecutionEntryExists);
+
+        if (info.ExecutionEntryExists) {
+            Reply();
+        } else {
+            ReplyNotFound();
+        }
     }
 
     void RunScriptFinalizeRequest() {
-        if (WaitFinishQuery || LeaseVerified) {
+        if (WaitFinishQuery) {
             return;
         }
 
         WaitFinishQuery = true;
+        Y_VALIDATE(ScriptFinalizeRequest, "Script finalize request is not set");
 
         const auto& description = ScriptFinalizeRequest->Description;
-        FinalOperationStatus = description.OperationStatus;
-        FinalExecStatus = description.ExecStatus;
-        FinalIssues = description.Issues;
-
         KQP_PROXY_LOG_D("Run script finalization request"
             << ", FinalizationStatus: " << static_cast<i32>(description.FinalizationStatus)
             << ", OperationStatus: " << description.OperationStatus
@@ -1405,7 +1659,7 @@ private:
     }
 
     void RetryCheckAlive(bool longDelay) {
-        if (WaitFinishQuery || LeaseVerified || WaitRetryCheckAlive) {
+        if (WaitFinishQuery || WaitRetryCheckAlive) {
             // Already finished checks
             return;
         }
@@ -1432,434 +1686,63 @@ private:
         }
     }
 
-    void Handle(TEvCheckAliveResponse::TPtr& ev) {
-        if (WaitFinishQuery) {
-            KQP_PROXY_LOG_W("Script execution " << ev->Sender << " lease was verified after started finalization");
-        } else if (!LeaseVerified) {
-            KQP_PROXY_LOG_N("Script execution " << ev->Sender << " lease successfully verified");
-            LeaseVerified = true;
-            OnLeaseVerified();
-        }
-    }
-
-    void Handle(TEvents::TEvWakeup::TPtr& ev) {
-        switch (static_cast<EWakeup>(ev->Get()->Tag)) {
-            case EWakeup::RetryCheckAlive:
-                WaitRetryCheckAlive = false;
-                CheckAliveRetries++;
-                KQP_PROXY_LOG_D("Start check alive request #" << CheckAliveRetries + 1);
-                Send(RunScriptActorId, new TEvCheckAliveRequest(), CheckAliveFlags);
-                Schedule(CHECK_ALIVE_REQUEST_TIMEOUT, new TEvents::TEvWakeup(static_cast<ui64>(EWakeup::CheckAliveTimeout)));
-                break;
-            case EWakeup::CheckAliveTimeout:
-                KQP_PROXY_LOG_W("Deliver TRunScriptActor check alive request timeout, retry check alive");
-                RetryCheckAlive(/* longDelay */ false);
-                break;
-        }
-    }
-
-    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
-        const auto reason = ev->Get()->Reason;
-        if (reason == TEvents::TEvUndelivered::ReasonActorUnknown) {
-            KQP_PROXY_LOG_W("Got delivery problem to " << ev->Sender << " TRunScriptActor not found, start finalization");
-            RunScriptFinalizeRequest();
-        } else {
-            KQP_PROXY_LOG_W("Got delivery problem to " << ev->Sender << ", node with TRunScriptActor unavailable, reason: " << reason);
-            RetryCheckAlive(/* longDelay */ true);
-        }
-    }
-
-    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
-        KQP_PROXY_LOG_W("Node " << ev->Get()->NodeId << " with TRunScriptActor was disconnected, retry check alive");
-        RetryCheckAlive(/* longDelay */ false);
-    }
-
-    void Handle(TEvScriptExecutionFinished::TPtr& ev) {
-        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
-            KQP_PROXY_LOG_W("Failed to finalize script execution operation, Status: " << ev->Get()->Status << ", Issues: " << ev->Get()->Issues.ToOneLineString() << ", AlreadyFinalized: " << ev->Get()->OperationAlreadyFinalized << ", WaitingRetry: " << ev->Get()->WaitingRetry);
-        } else if (ev->Get()->OperationAlreadyFinalized) {
-            KQP_PROXY_LOG_W("Failed to finalize script execution operation, already finalized, WaitingRetry: " << ev->Get()->WaitingRetry);
-        } else {
-            KQP_PROXY_LOG_D("Successfully finalized script execution operation, WaitingRetry: " << ev->Get()->WaitingRetry);
-        }
-
-        OnScriptExecutionFinished(ev->Get()->OperationAlreadyFinalized, ev->Get()->WaitingRetry, ev->Get()->Status, AddRootIssue("Finish script execution operation", ev->Get()->Issues));
-    }
-
-    void Handle(TEvScriptExecutionRestarted::TPtr& ev) {
-        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
-            KQP_PROXY_LOG_E("Failed to restart script execution operation, status: " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
-        } else {
-            KQP_PROXY_LOG_D("Successfully restarted script execution operation");
-        }
-
-        OnScriptExecutionRestarted(ev->Get()->LeaseGenerationChanged, ev->Get()->Status, AddRootIssue("Restart script execution operation", ev->Get()->Issues));
-    }
-
-private:
-    std::unique_ptr<TEvScriptFinalizeRequest> ScriptFinalizeRequest;
-    Ydb::StatusIds::StatusCode FinalOperationStatus;
-    Ydb::Query::ExecStatus FinalExecStatus;
-    NYql::TIssues FinalIssues;
-
-    bool WaitFinishQuery = false;
-    bool LeaseVerified = false;
-    bool WaitRetryCheckAlive = false;
-    std::optional<ui32> SubscribedOnSession;
-    ui64 CheckAliveFlags = 0;
-    ui64 CheckAliveRetries = 0;
-    TRetryPolicy::IRetryState::TPtr CheckAliveRetryState;
-    TActorId RunScriptActorId;
-
-protected:
-    const TActorId OwnerId;
-    const TString OperationName;
-    const TString Database;
-    TString ExecutionId;
-    const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
-    const TIntrusivePtr<TKqpCounters> Counters;
-};
-
-class TCheckLeaseStatusQueryActor : public TQueryBase {
-    struct TLeaseInfo {
-        TInstant Deadline;
-        ELeaseState State = ELeaseState::ScriptRunning;
-        i64 Generation = 0;
-    };
-
-public:
-    using TRetry = TQueryRetryActor<TCheckLeaseStatusQueryActor, NPrivate::TEvPrivate::TEvLeaseCheckResult, TString, TString, i64, std::optional<TString>>;
-
-    TCheckLeaseStatusQueryActor(const TString& database, const TString& executionId, ui64 cookie = 0, const std::optional<TString>& userSID = std::nullopt)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , Database(database)
-        , ExecutionId(executionId)
-        , Cookie(cookie)
-        , UserSID(userSID)
-        , Response(std::make_unique<NPrivate::TEvPrivate::TEvLeaseCheckResult>())
-    {}
-
-    void OnRunQuery() override {
-        KQP_PROXY_LOG_D("Start, Cookie: " << Cookie);
-
-        const TString sql = R"(
-            -- TCheckLeaseStatusQueryActor::OnRunQuery
-            DECLARE $database AS Text;
-            DECLARE $execution_id AS Text;
-
-            SELECT
-                operation_status,
-                execution_status,
-                finalization_status,
-                issues,
-                run_script_actor_id,
-                retry_state,
-                result_set_metas,
-                user_token
-            FROM `.metadata/script_executions`
-            WHERE database = $database AND execution_id = $execution_id AND
-                  (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
-
-            SELECT
-                lease_deadline,
-                lease_generation,
-                lease_state
-            FROM `.metadata/script_execution_leases`
-            WHERE database = $database AND execution_id = $execution_id AND
-                  (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
-        )";
-
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        RunDataQuery(sql, &params);
-    }
-
-    void OnQueryResult() override {
-        if (ResultSets.size() != 2) {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
-            return;
-        }
-
-        NYdb::TResultSetParser executionsResult(ResultSets[0]);
-        if (!executionsResult.TryNextRow()) {
-            Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
-            return;
-        }
-
-        if (const auto ownerUser = executionsResult.ColumnParser("user_token").GetOptionalUtf8(); UserSID && ownerUser && *ownerUser != *UserSID) {
-            KQP_PROXY_LOG_W("Access denied for user " << *UserSID);
-            Finish(Ydb::StatusIds::UNAUTHORIZED, "User is not owner of script execution operation");
-            return;
-        }
-
-        const auto runScriptActorId = executionsResult.ColumnParser("run_script_actor_id").GetOptionalUtf8();
-        if (!runScriptActorId) {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Not found run script actor id for script execution");
-            return;
-        }
-
-        if (!NKqp::ScriptExecutionRunnerActorIdFromString(*runScriptActorId, Response->RunScriptActorId)) {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Run script actor id is corrupted");
-            return;
-        }
-
-        const auto operationStatus = executionsResult.ColumnParser("operation_status").GetOptionalInt32();
-
-        if (const auto finalizationStatus = executionsResult.ColumnParser("finalization_status").GetOptionalInt32()) {
-            Response->FinalizationStatus = static_cast<EFinalizationStatus>(*finalizationStatus);
-            if (!operationStatus) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Invalid operation state, status should be specified during finalization");
-                return;
-            }
-        }
-
-        if (const auto& serializedRetryState = executionsResult.ColumnParser("retry_state").GetOptionalJsonDocument()) {
-            NJson::TJsonValue value;
-            if (!NJson::ReadJsonTree(*serializedRetryState, &value)) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Retry state is corrupted");
-                return;
-            }
-
-            NKikimrKqp::TScriptExecutionRetryState retryState;
-            NProtobufJson::Json2Proto(value, retryState);
-            Response->HasRetryPolicy = retryState.RetryPolicyMappingSize() > 0;
-        }
-
-        if (const auto& serializedMetas = executionsResult.ColumnParser("result_set_metas").GetOptionalJsonDocument()) {
-            NJson::TJsonValue value;
-            if (!NJson::ReadJsonTree(*serializedMetas, &value) || value.GetType() != NJson::JSON_ARRAY) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Result set meta is corrupted");
-                return;
-            }
-
-            auto& resultSetMetas = Response->ResultSetMetas.emplace();
-            for (i64 i = 0; i < value.GetIntegerRobust(); ++i) {
-                const NJson::TJsonValue* metaValue;
-                value.GetValuePointer(i, &metaValue);
-                Y_ENSURE(metaValue);
-
-                NProtobufJson::Json2Proto(*metaValue, resultSetMetas.emplace_back());
-            }
-        }
-
-        std::optional<TLeaseInfo> leaseInfo;
-
-        NYdb::TResultSetParser leaseResult(ResultSets[1]);
-        if (leaseResult.TryNextRow()) {
-            const auto leaseDeadline = leaseResult.ColumnParser("lease_deadline").GetOptionalTimestamp();
-            if (!leaseDeadline) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Not found lease deadline for script execution");
-                return;
-            }
-
-            const auto leaseGeneration = leaseResult.ColumnParser("lease_generation").GetOptionalInt64();
-            if (!leaseGeneration) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Not found lease generation for script execution");
-                return;
-            }
-
-            leaseInfo = {
-                .Deadline = *leaseDeadline,
-                .State = static_cast<ELeaseState>(leaseResult.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning))),
-                .Generation = *leaseGeneration,
-            };
-        }
-
-        if (leaseInfo) {
-            switch (leaseInfo->State) {
-                case ELeaseState::ScriptRunning:
-                    if (operationStatus) {
-                        Finish(Ydb::StatusIds::INTERNAL_ERROR, "Invalid operation state, status should be empty during query run");
-                        return;
-                    }
-                    break;
-                case ELeaseState::ScriptFinalizing:
-                    [[fallthrough]];
-                case ELeaseState::WaitRetry:
-                    if (!operationStatus) {
-                        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Invalid operation state, status should be specified for lease state " << static_cast<i32>(leaseInfo->State));
-                        return;
-                    }
-                    Response->WaitFinalizationOrRetry = true;
-                    Response->OperationStatus = static_cast<Ydb::StatusIds::StatusCode>(*operationStatus);
-                    if (const auto executionStatus = executionsResult.ColumnParser("execution_status").GetOptionalInt32()) {
-                        Response->ExecutionStatus = static_cast<Ydb::Query::ExecStatus>(*executionStatus);
-                    }
-                    if (const auto issuesSerialized = executionsResult.ColumnParser("issues").GetOptionalJsonDocument()) {
-                        Response->OperationIssues = DeserializeIssues(*issuesSerialized);
-                    }
-                    break;
-            }
-
-            if (leaseInfo->Deadline < RunStartTime) {
-                Response->LeaseExpired = true;
-                if (leaseInfo->State == ELeaseState::WaitRetry) {
-                    Response->RetryRequired = true;
-                } else {
-                    Response->FinalizationStatus = EFinalizationStatus::FS_ROLLBACK;
-                }
-            }
-
-            Response->LeaseGeneration = leaseInfo->Generation;
-        } else if (operationStatus) {
-            Response->OperationStatus = static_cast<Ydb::StatusIds::StatusCode>(*operationStatus);
-
-            if (const auto executionStatus = executionsResult.ColumnParser("execution_status").GetOptionalInt32()) {
-                Response->ExecutionStatus = static_cast<Ydb::Query::ExecStatus>(*executionStatus);
-            }
-
-            if (const auto issuesSerialized = executionsResult.ColumnParser("issues").GetOptionalJsonDocument()) {
-                Response->OperationIssues = DeserializeIssues(*issuesSerialized);
-            }
-        } else {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Invalid operation state, operation status or lease must be specified");
-            return;
-        }
-
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        Response->Status = status;
-        Response->Issues = std::move(issues);
-        Send(Owner, Response.release(), 0, Cookie);
-    }
-
-private:
-    const TInstant RunStartTime = TInstant::Now();
-    const TString Database;
-    const TString ExecutionId;
-    const ui64 Cookie;
-    const std::optional<TString> UserSID;
-    std::unique_ptr<NPrivate::TEvPrivate::TEvLeaseCheckResult> Response;
-};
-
-class TCheckLeaseStatusActor : public TCheckLeaseStatusActorBase {
-public:
-    TCheckLeaseStatusActor(const TActorId& replyActorId, const TString& database, const TString& executionId,
-        const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, bool canRetry, ui64 cookie = 0,
-        const std::optional<TString>& userSID = std::nullopt)
-        : TCheckLeaseStatusActorBase(replyActorId, __func__, database, executionId, queryServiceConfig, counters)
-        , ReplyActorId(replyActorId)
-        , CanRetry(canRetry)
-        , Cookie(cookie)
-        , UserSID(userSID)
-    {}
-
-    void OnBootstrap() override {
-        const auto& checkerId = Register(new TCheckLeaseStatusQueryActor::TRetry(SelfId(), Database, ExecutionId, Cookie, UserSID));
-        KQP_PROXY_LOG_D("Bootstrap, Cookie: " << Cookie << ". Start TCheckLeaseStatusQueryActor " << checkerId);
-
-        Become(&TCheckLeaseStatusActor::StateFunc);
-    }
-
-    void OnLeaseVerified() override {
-        Reply();
-    }
-
-    void OnScriptExecutionFinished(bool alreadyFinalized, bool waitRetry, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        Y_UNUSED(waitRetry);
-
-        if (status != Ydb::StatusIds::SUCCESS) {
-            Reply(status, std::move(issues));
-            return;
-        }
-
-        if (alreadyFinalized) {
-            // Final status and issues are unknown, the operation must be repeated
-            Response->Get()->OperationStatus = Nothing();
-            Response->Get()->ExecutionStatus = Nothing();
-            Response->Get()->OperationIssues = Nothing();
-        } else {
-            Response->Get()->OperationStatus = GetOperationStatus();
-            Response->Get()->ExecutionStatus = GetExecStatus();
-            Response->Get()->OperationIssues = GetIssues();
-        }
-
-        Reply();
-    }
-
-    void OnScriptExecutionRestarted(bool leaseGenerationChanged, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        if (!leaseGenerationChanged && status != Ydb::StatusIds::SUCCESS) {
-            Reply(status, std::move(issues));
-            return;
-        }
-
-        Response->Get()->OperationStatus = Nothing();
-        Response->Get()->ExecutionStatus = Nothing();
-        Response->Get()->OperationIssues = Nothing();
-        Reply();
-    }
-
-private:
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvPrivate::TEvLeaseCheckResult, Handle);
-    )
-
-    void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
-        Response = std::move(ev);
-        KQP_PROXY_LOG_D("Extracted script execution operation " << Response->Sender
-            << ", Status: " << Response->Get()->Status
-            << ", Issues: " << Response->Get()->Issues.ToOneLineString()
-            << ", LeaseExpired: " << Response->Get()->LeaseExpired
-            << ", RetryRequired: " << Response->Get()->RetryRequired
-            << (Response->Get()->OperationStatus ? ", OperationStatus: " + Ydb::StatusIds::StatusCode_Name(*Response->Get()->OperationStatus) : "")
-            << (Response->Get()->ExecutionStatus ? ", ExecutionStatus: " + Ydb::Query::ExecStatus_Name(*Response->Get()->ExecutionStatus) : "")
-            << (Response->Get()->OperationIssues ? ", OperationIssues: " + Response->Get()->OperationIssues->ToOneLineString() : "")
-            << (Response->Get()->FinalizationStatus ? (TStringBuilder() << ", FinalizationStatus: " << static_cast<ui64>(*Response->Get()->FinalizationStatus)) : TStringBuilder())
-            << ", RunScriptActorId: " << Response->Get()->RunScriptActorId
-            << ", LeaseGeneration: " << Response->Get()->LeaseGeneration);
-
-        const auto& event = *Response->Get();
-        if (event.RetryRequired) {
-            if (CanRetry) {
-                RestartScriptExecution(event.LeaseGeneration);
-            } else {
-                Reply();
-            }
-        } else if (event.LeaseExpired) {
-            StartLeaseChecking(event.RunScriptActorId, event.LeaseGeneration);
-        } else if (const auto finalizationStatus = event.FinalizationStatus) {
-            const bool finalizationInProgress = event.WaitFinalizationOrRetry && !event.LeaseExpired;
-            if (!finalizationInProgress && event.OperationStatus && event.ExecutionStatus) {
-                auto issues = event.OperationIssues ? *event.OperationIssues : event.Issues;
-                StartScriptFinalization(*finalizationStatus, *event.OperationStatus, *event.ExecutionStatus, std::move(issues), event.LeaseGeneration);
-            } else {
-                Reply();
-            }
-        } else {
-            Reply();
-        }
+    void ReplyNotFound() {
+        KQP_PROXY_LOG_W("Script execution operation not found");
+        EntryExists = false;
+        return Reply(Settings.FailOnNotFound ? Ydb::StatusIds::NOT_FOUND : Ydb::StatusIds::SUCCESS, "Script execution operation not found");
     }
 
     void Reply() {
         KQP_PROXY_LOG_D("Reply success");
-        Forward(Response, ReplyActorId);
+        Send(ReplyActorId, new TEvPrivate::TEvFinalizeScriptLeaseResult(Ydb::StatusIds::SUCCESS, {
+            .LeaseVerified = LeaseVerified,
+            .ExecutionEntryExists = EntryExists,
+        }), /* flags */ 0, Settings.Cookie);
         PassAway();
     }
 
-    void Reply(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) {
+    void Reply(const Ydb::StatusIds::StatusCode status, const TString& message) {
+        Reply(status, {NYql::TIssue(message)});
+    }
+
+    void Reply(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
         KQP_PROXY_LOG_W("Reply " << status << ", issues: " << issues.ToOneLineString());
-        Send(ReplyActorId, new TEvPrivate::TEvLeaseCheckResult(status, std::move(issues)), 0, Cookie);
+        Send(ReplyActorId, new TEvPrivate::TEvFinalizeScriptLeaseResult(status, {
+            .LeaseVerified = LeaseVerified,
+            .ExecutionEntryExists = EntryExists,
+        }, std::move(issues)), /* flags */ 0, Settings.Cookie);
         PassAway();
     }
 
-private:
+    TString LogPrefix() const {
+        auto result = TStringBuilder() << "[TFinalizeScriptLeaseActor] OwnerId: " << ReplyActorId << " ActorId: " << SelfId() << " Database: " << Database << " ExecutionId: " << ExecutionId;
+        if (RunScriptActorId) {
+            result << " RunScriptActorId: " << RunScriptActorId;
+        }
+        return result << ". ";
+    }
+
     const TActorId ReplyActorId;
-    const bool CanRetry = true;
-    const ui64 Cookie;
-    const std::optional<TString> UserSID;
-    TEvPrivate::TEvLeaseCheckResult::TPtr Response;
+    const TString Database;
+    const TString ExecutionId;
+    const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
+    const TIntrusivePtr<TKqpCounters> Counters;
+    const TSettings Settings;
+    TActorId RunScriptActorId;
+    std::unique_ptr<TEvScriptFinalizeRequest> ScriptFinalizeRequest;
+    bool WaitFinishQuery = false;
+    bool WaitRetryCheckAlive = false;
+    bool LeaseVerified = false;
+    bool EntryExists = true;
+    std::optional<ui32> SubscribedOnSession;
+    ui64 CheckAliveFlags = 0;
+    ui64 CheckAliveRetries = 0;
+    TRetryPolicy::IRetryState::TPtr CheckAliveRetryState;
 };
 
-class TForgetScriptExecutionOperationQueryActor : public TQueryBase {
+// Cleanup all meta information and results corresponding to script execution operation. NOTE: results removed on best effort
+
+class TForgetScriptExecutionOperationQueryActor : public TQueryBase<TForgetScriptExecutionOperationQueryActor, TEvForgetScriptExecutionOperationResponse> {
     static constexpr i32 NUMBER_ROWS_IN_BATCH = 100'000;
 
     struct TResultSetInfo {
@@ -1869,12 +1752,8 @@ class TForgetScriptExecutionOperationQueryActor : public TQueryBase {
     };
 
 public:
-    using TRetry = TQueryRetryActor<TForgetScriptExecutionOperationQueryActor, TEvForgetScriptExecutionOperationResponse, TString, TString, std::optional<std::vector<Ydb::Query::ResultSetMeta>>>;
-
-    TForgetScriptExecutionOperationQueryActor(const TString& executionId, const TString& database, std::optional<std::vector<Ydb::Query::ResultSetMeta>> resultSetMetas)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , ExecutionId(executionId)
-        , Database(database)
+    TForgetScriptExecutionOperationQueryActor(TString executionId, TString database, std::optional<std::vector<Ydb::Query::ResultSetMeta>> resultSetMetas)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId)})
         , HasResultsInfo(resultSetMetas.has_value())
     {
         if (resultSetMetas) {
@@ -1888,8 +1767,9 @@ public:
         }
     }
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TForgetScriptExecutionOperationQueryActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -1903,16 +1783,8 @@ public:
             WHERE database = $database AND execution_id = $execution_id;
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TForgetScriptExecutionOperationQueryActor::OnOperationDeleted, "Forget script execution operation");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnOperationDeleted, "Forget script execution operation");
         RunDataQuery(sql, &params);
     }
 
@@ -1920,11 +1792,11 @@ public:
         SendResponse(Ydb::StatusIds::SUCCESS, {});
 
         if (HasResultsInfo) {
-            OnGetResultsInfo();
+            DeleteScriptResults();
             return;
         }
 
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TForgetScriptExecutionOperationQueryActor::OnOperationDeleted
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -1939,16 +1811,8 @@ public:
             GROUP BY result_set_id;
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TForgetScriptExecutionOperationQueryActor::OnGetResultsInfo, "Get results info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::DeleteScriptResults, "Get results info");
         RunStreamQuery(sql, &params);
     }
 
@@ -1979,12 +1843,9 @@ public:
         }
     }
 
-    void OnGetResultsInfo() {
-        KQP_PROXY_LOG_D("Start deleting of script results, amount result sets: " << ResultSets.size());
-        DeleteScriptResults();
-    }
-
     void DeleteScriptResults() {
+        KQP_PROXY_LOG_D("Do deleting of script results, amount result sets: " << ResultSets.size());
+
         if (ResultSets.empty()) {
             Finish();
             return;
@@ -1993,7 +1854,7 @@ public:
         auto& resultSet = ResultSets.back();
         KQP_PROXY_LOG_D("Deleting rows from result set #" << resultSet.Id << ", remains rows range [" << resultSet.MinRowId << "; " << resultSet.MaxRowId << "]");
 
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TForgetScriptExecutionOperationQueryActor::DeleteScriptResults
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -2014,14 +1875,8 @@ public:
         )";
 
         const i64 minRowId = std::max(resultSet.MaxRowId - NUMBER_ROWS_IN_BATCH, resultSet.MinRowId);
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$result_set_id")
                 .Int32(resultSet.Id)
                 .Build()
@@ -2032,7 +1887,7 @@ public:
                 .Int64(resultSet.MaxRowId)
                 .Build();
 
-        SetQueryResultHandler(&TForgetScriptExecutionOperationQueryActor::OnResultsDeleted, TStringBuilder() << "Delete script results in range [" << minRowId << "; " << resultSet.MaxRowId << "]");
+        SetQueryResultHandler(&TThis::OnResultsDeleted, TStringBuilder() << "Delete script results in range [" << minRowId << "; " << resultSet.MaxRowId << "]");
         RunDataQuery(sql, &params);
     }
 
@@ -2049,22 +1904,19 @@ public:
         DeleteScriptResults();
     }
 
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         SendResponse(status, std::move(issues));
     }
 
-private:
-    void SendResponse(Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
+    void SendResponse(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
         if (ResponseSent) {
             return;
         }
+
         ResponseSent = true;
         Send(Owner, new TEvForgetScriptExecutionOperationResponse(status, std::move(issues)));
     }
 
-private:
-    const TString ExecutionId;
-    const TString Database;
     const bool HasResultsInfo = false;
     std::vector<TResultSetInfo> ResultSets;
     bool ResponseSent = false;
@@ -2072,10 +1924,9 @@ private:
 
 class TForgetScriptExecutionOperationActor : public TActorBootstrapped<TForgetScriptExecutionOperationActor> {
 public:
-    TForgetScriptExecutionOperationActor(TEvForgetScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
+    explicit TForgetScriptExecutionOperationActor(TEvForgetScriptExecutionOperation::TPtr&& ev)
         : Request(std::move(ev))
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
+        , Database(Request->Get()->Database)
     {}
 
     void Bootstrap() {
@@ -2085,59 +1936,86 @@ public:
         }
 
         TString error;
-        TMaybe<TString> executionId = NKqp::ScriptExecutionIdFromOperation(Request->Get()->OperationId, error);
+        auto executionId = NKqp::ScriptExecutionIdFromOperation(Request->Get()->OperationId, error);
         if (!executionId) {
             Reply(Ydb::StatusIds::BAD_REQUEST, error);
             return;
         }
 
-        ExecutionId = *executionId;
+        ExecutionId = std::move(*executionId);
 
-        const auto& checkerId = Register(new TCheckLeaseStatusActor(SelfId(), Request->Get()->Database, ExecutionId, QueryServiceConfig, Counters, true, 0, userSID));
-        KQP_PROXY_LOG_D("Bootstrap. Start TCheckLeaseStatusActor " << checkerId);
+        const auto& checkerId = Register(TCheckLeaseStatusQueryActor::MakeRetry(SelfId(), Database, ExecutionId, TCheckLeaseStatusQueryActor::TSettings{.UserSID = userSID}));
+        KQP_PROXY_LOG_D("Bootstrap. Start TCheckLeaseStatusQueryActor " << checkerId);
 
-        Become(&TForgetScriptExecutionOperationActor::StateFunc);
+        Become(&TThis::StateFunc);
     }
 
     STRICT_STFUNC(StateFunc,
         hFunc(TEvPrivate::TEvLeaseCheckResult, Handle);
+        hFunc(TEvCancelScriptExecutionOperationResponse, Handle);
         hFunc(TEvForgetScriptExecutionOperationResponse, Handle);
     )
 
+private:
     void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
-        ExecutionEntryExists = ev->Get()->Status != Ydb::StatusIds::NOT_FOUND;
-        if (ExecutionEntryExists) {
-            if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
-                KQP_PROXY_LOG_W("Lease check " << ev->Sender << " failed " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
-                Reply(ev->Get()->Status, AddRootIssue("Check lease status", ev->Get()->Issues));
-                return;
-            }
-
-            if (!ev->Get()->OperationStatus) {
-                KQP_PROXY_LOG_I("Lease check " << ev->Sender << " finished, but operation is still running");
-                Reply(Ydb::StatusIds::PRECONDITION_FAILED, "Operation is still running");
-                return;
-            }
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            const auto& issues = ev->Get()->Issues;
+            KQP_PROXY_LOG_W("Lease check " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
+            Reply(status, AddRootIssue("Check lease status", issues));
+            return;
         }
 
-        const auto& forgetId = Register(new TForgetScriptExecutionOperationQueryActor::TRetry(SelfId(), ExecutionId, Request->Get()->Database, std::move(ev->Get()->ResultSetMetas)));
-        KQP_PROXY_LOG_D("Lease check " << ev->Sender << " success, ExecutionEntryExists: " << ExecutionEntryExists << ". Start TForgetOperationRetryActor " << forgetId);
+        ResultSetMetas = std::move(ev->Get()->ResultSetMetas);
+        ExecutionEntryExists = ev->Get()->EntryExists;
+
+        if (ExecutionEntryExists && (!ev->Get()->OperationStatus || ev->Get()->FinalizationStatus || ev->Get()->HasRetryPolicy)) {
+            if (Request->Get()->Settings.CancelIfRunning) {
+                KQP_PROXY_LOG_I("Lease check " << ev->Sender << " finished, but operation is still running. Cancel it");
+                Send(MakeKqpProxyID(SelfId().NodeId()), new TEvCancelScriptExecutionOperation(Database, Request->Get()->OperationId, Request->Get()->UserSID, {
+                    .FailOnNotFound = false,
+                    .FailOnAlreadyStopped = false,
+                }));
+            } else {
+                KQP_PROXY_LOG_I("Lease check " << ev->Sender << " finished, but operation is still running");
+                Reply(Ydb::StatusIds::PRECONDITION_FAILED, "Operation is still running");
+            }
+            return;
+        }
+
+        KQP_PROXY_LOG_D("Lease check " << ev->Sender << " success, execution entry exists: " << ExecutionEntryExists);
+        StartForgetOperation();
+    }
+
+    void Handle(TEvCancelScriptExecutionOperationResponse::TPtr& ev) {
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            const auto& issues = ev->Get()->Issues;
+            KQP_PROXY_LOG_W("Cancel operation " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
+            Reply(status, AddRootIssue("Cancel script execution operation", issues));
+            return;
+        }
+
+        ExecutionEntryExists = ev->Get()->ExecutionEntryExists;
+
+        KQP_PROXY_LOG_D("Cancel script execution operation " << ev->Sender << " finished, execution entry exists: " << ExecutionEntryExists);
+        StartForgetOperation();
     }
 
     void Handle(TEvForgetScriptExecutionOperationResponse::TPtr& ev) {
         KQP_PROXY_LOG_D("Forget operation " << ev->Sender << " finished " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
-        Reply(ev->Get()->Status, AddRootIssue("Forget script execution operation", ev->Get()->Issues));
+        Reply(ev->Get()->Status, AddRootIssue("Forget script execution operation", ev->Get()->Issues, /* addEmptyRoot */ false));
     }
 
-private:
-    TString LogPrefix() const {
-        return TStringBuilder() << "[TForgetScriptExecutionOperationActor] OwnerId: " << Request->Sender << " ActorId: " << SelfId() << " Database: " << Request->Get()->Database << " ExecutionId: " << ExecutionId << ". ";
+    void StartForgetOperation() {
+        const auto& forgetId = Register(TForgetScriptExecutionOperationQueryActor::MakeRetry(SelfId(), ExecutionId, Database, std::move(ResultSetMetas)));
+        KQP_PROXY_LOG_D("Start TForgetOperationRetryActor " << forgetId);
     }
 
     void Reply(Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
-        if (!ExecutionEntryExists && status == Ydb::StatusIds::SUCCESS) {
+        if (!ExecutionEntryExists && Request->Get()->Settings.FailOnNotFound && status == Ydb::StatusIds::SUCCESS) {
             status = Ydb::StatusIds::NOT_FOUND;
-            issues.AddIssue("No such execution");
+            if (!issues) {
+                issues.AddIssue("Script execution operation not found");
+            }
         }
 
         if (status == Ydb::StatusIds::SUCCESS) {
@@ -2146,72 +2024,61 @@ private:
             KQP_PROXY_LOG_W("Reply " << status << ", issues: " << issues.ToOneLineString());
         }
 
-        Send(Request->Sender, new TEvForgetScriptExecutionOperationResponse(status, std::move(issues)), 0, Request->Cookie);
+        Send(Request->Sender, new TEvForgetScriptExecutionOperationResponse(status, std::move(issues)), /* flags */ 0, Request->Cookie);
         PassAway();
     }
 
-    void Reply(Ydb::StatusIds::StatusCode status, const TString& message) {
-        Reply(status, { NYql::TIssue(message) });
+    void Reply(const Ydb::StatusIds::StatusCode status, const TString& message) {
+        Reply(status, {NYql::TIssue(message)});
     }
 
-private:
+    TString LogPrefix() const {
+        return TStringBuilder() << "[TForgetScriptExecutionOperationActor] OwnerId: " << Request->Sender << " ActorId: " << SelfId() << " Database: " << Database << " ExecutionId: " << ExecutionId << ". ";
+    }
+
     const TEvForgetScriptExecutionOperation::TPtr Request;
-    const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
-    const TIntrusivePtr<TKqpCounters> Counters;
+    const TString& Database;
     TString ExecutionId;
+    std::optional<std::vector<Ydb::Query::ResultSetMeta>> ResultSetMetas;
     bool ExecutionEntryExists = true;
 };
 
-NYql::TIssues ParseScriptExecutionIssues(NYdb::TResultSetParser& result) {
-    NYql::TIssues issues;
+// Fetch current state of script execution operation, used by gRPC API get-operation and streaming queries sys view
 
-    if (const auto issuesSerialized = result.ColumnParser("issues").GetOptionalJsonDocument()) {
-        issues = DeserializeIssues(*issuesSerialized);
-    }
-
-    if (const auto transientIssuesSerialized = result.ColumnParser("transient_issues").GetOptionalJsonDocument()) {
-        issues.AddIssues(AddRootIssue("Previous query retries", DeserializeIssues(*transientIssuesSerialized)));
-    }
-
-    return issues;
-}
-
-std::optional<TString> ParseCompressedColumn(const TString& columnName, NYdb::TResultSetParser& result) {
-    if (const std::optional<TString>& resultCompressed = result.ColumnParser(TStringBuilder() << columnName << "_compressed").GetOptionalString()) {
-        if (const std::optional<TString>& resultCompressionMethod = result.ColumnParser(TStringBuilder() << columnName << "_compression_method").GetOptionalUtf8()) {
-            const TCompressor compressor(*resultCompressionMethod);
-            return compressor.Decompress(*resultCompressed);
-        }
-
-        return *resultCompressed;
-    }
-
-    return std::nullopt;
-}
-
-class TGetScriptExecutionOperationQueryActor : public TQueryBase {
+class TGetScriptExecutionOperationQueryActor final : public TQueryWithAccessValidationBase<TGetScriptExecutionOperationQueryActor, TEvGetScriptExecutionOperationResponse> {
 public:
-    using TRetry = TQueryRetryActor<TGetScriptExecutionOperationQueryActor, TEvGetScriptExecutionOperationQueryResponse, TString, TString, std::optional<TString>>;
-
-    TGetScriptExecutionOperationQueryActor(const TString& database, const TString& executionId, const std::optional<TString>& userSID)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , Database(database)
-        , UserSID(userSID)
-        , StartActorTime(TInstant::Now())
-        , Response(std::make_unique<TEvGetScriptExecutionOperationQueryResponse>(executionId))
+    TGetScriptExecutionOperationQueryActor(TString database, NOperationId::TOperationId operationId, std::optional<TString> userSID, const bool failOnNotFound, const ui64 cookie)
+        : TQueryWithAccessValidationBase(__func__, {.Database = std::move(database)}, std::move(userSID))
+        , OperationId(std::move(operationId))
+        , FailOnNotFound(failOnNotFound)
+        , Cookie(cookie)
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        if (!ValidateUserSID()) {
+            return;
+        }
+
+        TString error;
+        auto executionId = ScriptExecutionIdFromOperation(OperationId, error);
+        if (!executionId) {
+            Finish(Ydb::StatusIds::BAD_REQUEST, error);
+            return;
+        }
+
+        ExecutionId = std::move(*executionId);
+        Metadata.set_execution_id(ExecutionId);
+        SetOperationInfo(OperationName, CreateTraceId({.Database = Database, .ExecutionId = ExecutionId}));
+
+        constexpr char sql[] = R"(
             -- TGetScriptExecutionOperationQueryActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
 
             SELECT
-                run_script_actor_id,
                 operation_status,
                 execution_status,
-                finalization_status,
                 query_text,
                 syntax,
                 execution_mode,
@@ -2234,22 +2101,13 @@ public:
 
             SELECT
                 lease_deadline,
-                lease_generation,
                 lease_state
             FROM `.metadata/script_execution_leases`
             WHERE database = $database AND execution_id = $execution_id AND
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(Response->ExecutionId)
-                .Build();
-
+        auto params = CreateParams();
         RunDataQuery(sql, &params);
     }
 
@@ -2262,13 +2120,12 @@ public:
         {   // Script execution info
             NYdb::TResultSetParser result(ResultSets[0]);
             if (!result.TryNextRow()) {
-                Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
+                ExecutionEntryExists = false;
+                Finish(FailOnNotFound ? Ydb::StatusIds::NOT_FOUND : Ydb::StatusIds::SUCCESS, "Script execution operation not found");
                 return;
             }
 
-            if (const auto ownerUser = result.ColumnParser("user_token").GetOptionalUtf8(); UserSID && ownerUser && *ownerUser != *UserSID) {
-                KQP_PROXY_LOG_W("Access denied for user " << *UserSID);
-                Finish(Ydb::StatusIds::UNAUTHORIZED, "User is not owner of script execution operation");
+            if (!ValidateAccess(result)) {
                 return;
             }
 
@@ -2276,85 +2133,61 @@ public:
                 OperationStatus = static_cast<Ydb::StatusIds::StatusCode>(*operationStatus);
             }
 
-            if (const auto finalizationStatus = result.ColumnParser("finalization_status").GetOptionalInt32()) {
-                Response->FinalizationStatus = static_cast<EFinalizationStatus>(*finalizationStatus);
-            }
-
-            Response->Metadata.set_execution_id(Response->ExecutionId);
-
             if (const auto executionStatus = result.ColumnParser("execution_status").GetOptionalInt32()) {
-                Response->Metadata.set_exec_status(static_cast<Ydb::Query::ExecStatus>(*executionStatus));
+                Metadata.set_exec_status(static_cast<Ydb::Query::ExecStatus>(*executionStatus));
             }
 
-            if (const auto sql = result.ColumnParser("query_text").GetOptionalUtf8()) {
-                Response->Metadata.mutable_script_content()->set_text(*sql);
+            if (auto sql = result.ColumnParser("query_text").GetOptionalUtf8()) {
+                *Metadata.mutable_script_content()->mutable_text() = std::move(*sql);
             }
 
             if (const auto syntax = result.ColumnParser("syntax").GetOptionalInt32()) {
-                Response->Metadata.mutable_script_content()->set_syntax(static_cast<Ydb::Query::Syntax>(*syntax));
+                Metadata.mutable_script_content()->set_syntax(static_cast<Ydb::Query::Syntax>(*syntax));
             }
 
             if (const auto executionMode = result.ColumnParser("execution_mode").GetOptionalInt32()) {
-                Response->Metadata.set_exec_mode(static_cast<Ydb::Query::ExecMode>(*executionMode));
+                Metadata.set_exec_mode(static_cast<Ydb::Query::ExecMode>(*executionMode));
             }
 
-            if (const auto serializedStats = result.ColumnParser("stats").GetOptionalJsonDocument()) {
+            if (const auto& serializedStats = result.ColumnParser("stats").GetOptionalJsonDocument()) {
                 NJson::TJsonValue statsJson;
                 if (!NJson::ReadJsonTree(*serializedStats, &statsJson)) {
                     Finish(Ydb::StatusIds::INTERNAL_ERROR, "Script execution stats is corrupted");
                     return;
                 }
 
-                NProtobufJson::Json2Proto(statsJson, *Response->Metadata.mutable_exec_stats(), NProtobufJson::TJson2ProtoConfig());
+                NProtobufJson::Json2Proto(statsJson, *Metadata.mutable_exec_stats(), NProtobufJson::TJson2ProtoConfig());
             }
 
-            if (const auto& plan = result.ColumnParser("plan").GetOptionalJsonDocument()) {
-                Response->Metadata.mutable_exec_stats()->set_query_plan(*plan);
-            } else if (const auto& plan = ParseCompressedColumn("plan", result)) {
-                Response->Metadata.mutable_exec_stats()->set_query_plan(*plan);
+            if (auto plan = result.ColumnParser("plan").GetOptionalJsonDocument()) {
+                *Metadata.mutable_exec_stats()->mutable_query_plan() = std::move(*plan);
+            } else if (auto plan = ParseCompressedColumn("plan", result)) {
+                *Metadata.mutable_exec_stats()->mutable_query_plan() = std::move(*plan);
             } else {
-                Response->Metadata.mutable_exec_stats()->set_query_plan("{}");
+                Metadata.mutable_exec_stats()->set_query_plan("{}");
             }
 
-            if (const auto& ast = result.ColumnParser("ast").GetOptionalUtf8()) {
-                Response->Metadata.mutable_exec_stats()->set_query_ast(*ast);
-            } else if (const auto& ast = ParseCompressedColumn("ast", result)) {
-                Response->Metadata.mutable_exec_stats()->set_query_ast(*ast);
+            if (auto ast = result.ColumnParser("ast").GetOptionalUtf8()) {
+                *Metadata.mutable_exec_stats()->mutable_query_ast() = std::move(*ast);
+            } else if (auto ast = ParseCompressedColumn("ast", result)) {
+                *Metadata.mutable_exec_stats()->mutable_query_ast() = std::move(*ast);
             }
 
-            Response->Issues = ParseScriptExecutionIssues(result);
+            OperationIssues = ParseScriptExecutionIssues(result);
 
-            if (const auto serializedMetas = result.ColumnParser("result_set_metas").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*serializedMetas, &value) || value.GetType() != NJson::JSON_ARRAY) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Result set meta is corrupted");
-                    return;
-                }
-
-                for (auto i = 0; i < value.GetIntegerRobust(); ++i) {
-                    const NJson::TJsonValue* metaValue;
-                    value.GetValuePointer(i, &metaValue);
-                    Y_ENSURE(metaValue);
-
-                    NProtobufJson::Json2Proto(*metaValue, *Response->Metadata.add_result_sets_meta());
-                }
+            if (auto resultSetMetas = ParseResultSetMetas(result)) {
+                Metadata.mutable_result_sets_meta()->Add(std::make_move_iterator(resultSetMetas->begin()), std::make_move_iterator(resultSetMetas->end()));
+            } else {
+                return;
             }
 
-            if (const auto runScriptActorIdString = result.ColumnParser("run_script_actor_id").GetOptionalUtf8()) {
-                ScriptExecutionRunnerActorIdFromString(*runScriptActorIdString, Response->RunScriptActorId);
+            if (auto retryState = ParseRetryState(result)) {
+                RetryState = std::move(*retryState);
+            } else {
+                return;
             }
 
-            if (const auto& serializedRetryState = result.ColumnParser("retry_state").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*serializedRetryState, &value)) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Retry state is corrupted");
-                    return;
-                }
-
-                NProtobufJson::Json2Proto(value, Response->RetryState);
-            }
-
-            Response->StateSaved = result.ColumnParser("has_graph").GetBool();
+            StateSaved = result.ColumnParser("has_graph").GetBool();
         }
 
         {   // Lease info
@@ -2366,22 +2199,9 @@ public:
                     return;
                 }
 
-                const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
-                if (!leaseGenerationInDatabase) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Lease generation not found");
-                    return;
-                }
-
-                Response->LeaseDeadline = *leaseDeadline;
-                Response->LeaseGeneration = *leaseGenerationInDatabase;
                 LeaseStatus = static_cast<ELeaseState>(result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning)));
-                Response->WaitRetry = *LeaseStatus == ELeaseState::WaitRetry;
-
-                if (*leaseDeadline < StartActorTime) {
-                    Response->LeaseExpired = true;
-                    if (*LeaseStatus != ELeaseState::WaitRetry) {
-                        Response->FinalizationStatus = EFinalizationStatus::FS_ROLLBACK;
-                    }
+                if (*LeaseStatus == ELeaseState::WaitRetry) {
+                    SuspendedUntil = *leaseDeadline;
                 }
             } else if (!OperationStatus) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected operation state, lease not found for running query");
@@ -2392,25 +2212,16 @@ public:
         Finish();
     }
 
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         KQP_PROXY_LOG_D("Finish"
             << ", OperationStatus: " << (OperationStatus ? Ydb::StatusIds::StatusCode_Name(*OperationStatus) : "null")
-            << ", FinalizationStatus: " << (Response->FinalizationStatus ? static_cast<i64>(*Response->FinalizationStatus) : -1)
             << ", LeaseStatus: " << (LeaseStatus ? static_cast<i64>(*LeaseStatus) : -1));
 
-        Response->Ready = !!OperationStatus;
-        if (Response->FinalizationStatus || LeaseStatus && *LeaseStatus == ELeaseState::WaitRetry) {
-            Response->Ready = false;
-            if (OperationStatus) {
-                NYql::TIssue issue(TStringBuilder() << "Execution finished with status " << *OperationStatus << " and wait " << (Response->FinalizationStatus ? "finalization" : "retry"));
-                issue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
-                Response->Issues.AddIssue(std::move(issue));
-                OperationStatus = std::nullopt;
-            }
-            if (Response->FinalizationStatus) {
-                // Keep polling until S3 external effects are applied (e.g. atomic multipart commit).
-                Response->Metadata.set_exec_status(Ydb::Query::EXEC_STATUS_RUNNING);
-            }
+        bool ready = !!OperationStatus;
+        if (LeaseStatus && OperationStatus) {
+            ready = false;
+            OperationIssues.AddIssue(TStringBuilder() << "Execution finished with status " << *OperationStatus << " and wait " << *LeaseStatus);
+            OperationStatus = std::nullopt;
         }
 
         if (!OperationStatus || status != Ydb::StatusIds::SUCCESS) {
@@ -2419,183 +2230,82 @@ public:
 
         if (issues) {
             auto newIssues = AddRootIssue("Get script execution operation info", issues);
-            newIssues.AddIssues(AddRootIssue("Script execution issues", Response->Issues));
-            std::swap(Response->Issues, newIssues);
+            newIssues.AddIssues(AddRootIssue("Script execution issues", OperationIssues, /* addEmptyRoot */ false));
+            std::swap(OperationIssues, newIssues);
         }
 
-        Response->Status = *OperationStatus;
-        Send(Owner, std::move(Response));
+        google::protobuf::Any metadata;
+        metadata.PackFrom(Metadata);
+
+        Send(Owner, new TEvGetScriptExecutionOperationResponse(*OperationStatus, {
+            .Metadata = std::move(metadata),
+            .Ready = ready,
+            .StateSaved = StateSaved,
+            .ExecutionEntryExists = ExecutionEntryExists,
+            .RetryCount = RetryState.GetRetryCounter(),
+            .LastFailAt = NProtoInterop::CastFromProto(RetryState.GetRetryCounterUpdatedAt()),
+            .SuspendedUntil = SuspendedUntil,
+            .RequestStatus = status,
+        }, std::move(OperationIssues)), /* flags */ 0, Cookie);
     }
 
-private:
-    const TString Database;
-    const std::optional<TString> UserSID;
-    const TInstant StartActorTime;
-    std::unique_ptr<TEvGetScriptExecutionOperationQueryResponse> Response;
+    static std::optional<TString> ParseCompressedColumn(const TString& columnName, NYdb::TResultSetParser& result) {
+        if (std::optional<TString> resultCompressed = result.ColumnParser(TStringBuilder() << columnName << "_compressed").GetOptionalString()) {
+            if (const std::optional<TString>& resultCompressionMethod = result.ColumnParser(TStringBuilder() << columnName << "_compression_method").GetOptionalUtf8()) {
+                const TCompressor compressor(*resultCompressionMethod);
+                return compressor.Decompress(*resultCompressed);
+            }
+
+            return resultCompressed;
+        }
+
+        return std::nullopt;
+    }
+
+    const NOperationId::TOperationId OperationId;
+    const bool FailOnNotFound = true;
+    const ui64 Cookie = 0;
+    NYql::TIssues OperationIssues;
+    Ydb::Query::ExecuteScriptMetadata Metadata;
+    NKikimrKqp::TScriptExecutionRetryState RetryState;
     std::optional<Ydb::StatusIds::StatusCode> OperationStatus;
     std::optional<ELeaseState> LeaseStatus;
+    bool StateSaved = false;
+    bool ExecutionEntryExists = true;
+    TInstant SuspendedUntil;
 };
 
-class TGetScriptExecutionOperationActor : public TCheckLeaseStatusActorBase {
+// List all available script execution operations with paging, used by gRPC API list-operations
+
+class TListScriptExecutionOperationsQuery final : public TQueryWithAccessValidationBase<TListScriptExecutionOperationsQuery, TEvListScriptExecutionOperationsResponse> {
 public:
-    TGetScriptExecutionOperationActor(TEvGetScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
-        : TCheckLeaseStatusActorBase(ev->Sender, __func__, ev->Get()->Database, "", queryServiceConfig, counters)
-        , Request(std::move(ev))
-    {}
-
-    void OnBootstrap() override {
-        auto userSID = Request->Get()->UserSID;
-        if (const auto& error = CheckScriptExecutionAccess(userSID)) {
-            return Reply(Ydb::StatusIds::UNAUTHORIZED, error);
-        }
-
-        TString error;
-        const auto executionId = ScriptExecutionIdFromOperation(Request->Get()->OperationId, error);
-        if (!executionId) {
-            Reply(Ydb::StatusIds::BAD_REQUEST, error);
-            return;
-        }
-
-        ExecutionId = *executionId;
-
-        const auto& getterId = Register(new TGetScriptExecutionOperationQueryActor::TRetry(SelfId(), Database, ExecutionId, userSID));
-        KQP_PROXY_LOG_D("Bootstrap. Start TGetScriptExecutionOperationQueryActor " << getterId);
-
-        Become(&TGetScriptExecutionOperationActor::StateFunc);
-    }
-
-    void OnLeaseVerified() override {
-        Reply();
-    }
-
-    void OnScriptExecutionFinished(bool alreadyFinalized, bool waitRetry, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        if (status != Ydb::StatusIds::SUCCESS) {
-            Reply(status, std::move(issues));
-            return;
-        }
-
-        // Otherwise final status and issues are unknown, the operation must be repeated
-        if (!alreadyFinalized && !waitRetry) {
-            Response->Get()->Ready = true;
-            Response->Get()->Status = GetOperationStatus();
-            Response->Get()->Issues = GetIssues();
-            Response->Get()->Metadata.set_exec_status(GetExecStatus());
-        }
-
-        Reply();
-    }
-
-    void OnScriptExecutionRestarted(bool leaseGenerationChanged, Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        if (!leaseGenerationChanged && status != Ydb::StatusIds::SUCCESS) {
-            Reply(status, std::move(issues));
-            return;
-        }
-
-        if (!leaseGenerationChanged) {
-            Response->Get()->Ready = false;
-            Response->Get()->Status = Ydb::StatusIds::SUCCESS;
-            Response->Get()->Metadata.set_exec_status(Ydb::Query::ExecStatus::EXEC_STATUS_STARTING);
-        }
-
-        Reply();
-    }
-
-private:
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvGetScriptExecutionOperationQueryResponse, Handle);
-    )
-
-    void Handle(TEvGetScriptExecutionOperationQueryResponse::TPtr& ev) {
-        Response = std::move(ev);
-        KQP_PROXY_LOG_D("Extracted script execution operation " << Response->Sender
-            << ", Status: " << Response->Get()->Status
-            << ", Issues: " << Response->Get()->Issues.ToOneLineString()
-            << ", Ready: " << Response->Get()->Ready
-            << ", LeaseExpired: " << Response->Get()->LeaseExpired
-            << ", WaitRetry: " << Response->Get()->WaitRetry
-            << (Response->Get()->FinalizationStatus ? (TStringBuilder() << ", FinalizationStatus: " << static_cast<ui64>(*Response->Get()->FinalizationStatus)) : TStringBuilder())
-            << ", RunScriptActorId: " << Response->Get()->RunScriptActorId
-            << ", LeaseGeneration: " << Response->Get()->LeaseGeneration);
-
-        if (!Request->Get()->CheckLeaseState) {
-            Reply();
-            return;
-        }
-
-        const auto& event = *Response->Get();
-        if (event.LeaseExpired) {
-            if (event.WaitRetry) {
-                RestartScriptExecution(event.LeaseGeneration);
-            } else {
-                StartLeaseChecking(event.RunScriptActorId, event.LeaseGeneration);
-            }
-        } else {
-            Reply();
-        }
-    }
-
-    void Reply() {
-        KQP_PROXY_LOG_D("Reply success");
-
-        const auto& event = *Response->Get();
-        TMaybe<google::protobuf::Any> metadata;
-        metadata.ConstructInPlace().PackFrom(event.Metadata);
-
-        const auto& retryState = event.RetryState;
-
-        Send(Request->Sender, new TEvGetScriptExecutionOperationResponse(event.Status, {
-            .Metadata = std::move(metadata),
-            .Ready = event.Ready,
-            .StateSaved = event.StateSaved,
-            .RetryCount = retryState.GetRetryCounter(),
-            .LastFailAt = NProtoInterop::CastFromProto(retryState.GetRetryCounterUpdatedAt()),
-            .SuspendedUntil = event.WaitRetry ? event.LeaseDeadline : TInstant::Zero(),
-        }, event.Issues), 0, Request->Cookie);
-        PassAway();
-    }
-
-    void Reply(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) {
-        KQP_PROXY_LOG_W("Reply " << status << ", issues: " << issues.ToOneLineString());
-        Send(Request->Sender, new TEvGetScriptExecutionOperationResponse(status, std::move(issues)));
-        PassAway();
-    }
-
-    void Reply(Ydb::StatusIds::StatusCode status, const TString& message) {
-        Reply(status, {NYql::TIssue(message)});
-    }
-
-private:
-    TEvGetScriptExecutionOperation::TPtr Request;
-    TEvGetScriptExecutionOperationQueryResponse::TPtr Response;
-};
-
-class TListScriptExecutionOperationsQuery : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TListScriptExecutionOperationsQuery, TEvListScriptExecutionOperationsResponse, TString, std::optional<TString>, TString, ui64>;
-
-    TListScriptExecutionOperationsQuery(const TString& database, const std::optional<TString>& userSID, const TString& pageToken, ui64 pageSize)
-        : TQueryBase(__func__, {.Database = database})
-        , Database(database)
-        , UserSID(userSID)
-        , PageToken(pageToken)
+    TListScriptExecutionOperationsQuery(TString database, std::optional<TString> userSID, TString pageToken, const ui64 pageSize)
+        : TQueryWithAccessValidationBase(__func__, {.Database = std::move(database)}, std::move(userSID))
+        , PageToken(std::move(pageToken))
         , PageSize(pageSize)
     {}
 
+private:
     static std::pair<TInstant, TString> ParsePageToken(const TString& token) {
         const size_t p = token.find('|');
         if (p == TString::npos) {
             throw std::runtime_error("Invalid page token");
         }
+
         const ui64 ts = FromString(TStringBuf(token).SubString(0, p));
         return {TInstant::MicroSeconds(ts), token.substr(p + 1)};
     }
 
-    static TString MakePageToken(TInstant ts, const std::string& executionId) {
+    static TString MakePageToken(const TInstant ts, const std::string& executionId) {
         return TStringBuilder() << ts.MicroSeconds() << '|' << executionId;
     }
 
     void OnRunQuery() override {
         KQP_PROXY_LOG_D("List with PageToken: " << PageToken << ", PageSize: " << PageSize);
+
+        if (!ValidateUserSID()) {
+            return;
+        }
 
         TStringBuilder sql;
         if (PageToken) {
@@ -2615,6 +2325,7 @@ public:
                 start_ts,
                 operation_status,
                 execution_status,
+                finalization_status,
                 query_text,
                 syntax,
                 execution_mode,
@@ -2626,12 +2337,12 @@ public:
         if (UserSID) {
             sql << R"(
                 AND (user_token IS NULL OR user_token = $user_sid)
-                )";
+            )";
         }
         if (PageToken) {
             sql << R"(
                 AND (start_ts, execution_id) <= ($ts, $execution_id)
-                )";
+            )";
         }
         sql << R"(
             ORDER BY start_ts DESC, execution_id DESC
@@ -2661,7 +2372,7 @@ public:
                     .Build();
         }
 
-        RunDataQuery(sql, &params);
+        RunDataQuery(sql, &params, TTxControl::BeginAndCommitTx(/* snapshotRead */ true));
     }
 
     void OnQueryResult() override {
@@ -2674,7 +2385,7 @@ public:
         Operations.reserve(result.RowsCount());
 
         while (result.TryNextRow()) {
-            const auto executionId = result.ColumnParser("execution_id").GetOptionalUtf8();
+            auto executionId = result.ColumnParser("execution_id").GetOptionalUtf8();
             if (!executionId) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Execution id not found");
                 return;
@@ -2692,16 +2403,17 @@ public:
             }
 
             const auto operationStatus = result.ColumnParser("operation_status").GetOptionalInt32();
+            const auto finalizationStatus = result.ColumnParser("finalization_status").GetOptionalInt32();
 
             Ydb::Query::ExecuteScriptMetadata metadata;
-            metadata.set_execution_id(*executionId);
+            *metadata.mutable_execution_id() = std::move(*executionId);
 
             if (const auto executionStatus = result.ColumnParser("execution_status").GetOptionalInt32()) {
                 metadata.set_exec_status(static_cast<Ydb::Query::ExecStatus>(*executionStatus));
             }
 
-            if (const auto sql = result.ColumnParser("query_text").GetOptionalUtf8()) {
-                metadata.mutable_script_content()->set_text(*sql);
+            if (auto sql = result.ColumnParser("query_text").GetOptionalUtf8()) {
+                *metadata.mutable_script_content()->mutable_text() = std::move(*sql);
             }
 
             if (const auto syntax = result.ColumnParser("syntax").GetOptionalInt32()) {
@@ -2713,12 +2425,12 @@ public:
             }
 
             Ydb::Operations::Operation op;
-            op.set_id(ScriptExecutionOperationFromExecutionId(*executionId));
-            op.set_ready(operationStatus.has_value());
+            op.set_id(ScriptExecutionOperationFromExecutionId(metadata.execution_id()));
+            op.set_ready(operationStatus.has_value() && !finalizationStatus.has_value());
             if (operationStatus) {
                 op.set_status(static_cast<Ydb::StatusIds::StatusCode>(*operationStatus));
             }
-            for (const NYql::TIssue& issue : ParseScriptExecutionIssues(result)) {
+            for (const auto& issue : ParseScriptExecutionIssues(result)) {
                 NYql::IssueToMessage(issue, op.add_issues());
             }
             op.mutable_metadata()->PackFrom(metadata);
@@ -2729,153 +2441,34 @@ public:
         Finish();
     }
 
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        Send(Owner, new TEvListScriptExecutionOperationsResponse(status, std::move(issues), NextPageToken, std::move(Operations)));
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        Send(Owner, new TEvListScriptExecutionOperationsResponse(status, std::move(issues), std::move(NextPageToken), std::move(Operations)));
     }
 
-private:
-    const TString Database;
-    const std::optional<TString> UserSID;
     const TString PageToken;
-    const ui64 PageSize;
+    const ui64 PageSize = 0;
     TString NextPageToken;
     std::vector<Ydb::Operations::Operation> Operations;
 };
 
-class TListScriptExecutionOperationsActor : public TActorBootstrapped<TListScriptExecutionOperationsActor> {
+// To cancel script execution operation what currently waiting for retry we should just reset retry policy and update status
+
+class TResetScriptExecutionRetriesQueryActor final : public TQueryBase<TResetScriptExecutionRetriesQueryActor, TEvResetScriptExecutionRetriesResponse> {
 public:
-    TListScriptExecutionOperationsActor(TEvListScriptExecutionOperations::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
-        : Request(std::move(ev))
-        , Database(Request->Get()->Database)
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
+    TResetScriptExecutionRetriesQueryActor(TString database, TString executionId)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId)})
     {}
 
-    void Bootstrap() {
-        auto userSID = Request->Get()->UserSID;
-        if (const auto& error = CheckScriptExecutionAccess(userSID)) {
-            KQP_PROXY_LOG_W("Token validation failed: " << error);
-            Send(Request->Sender, new TEvListScriptExecutionOperationsResponse(Ydb::StatusIds::UNAUTHORIZED, {NYql::TIssue(error)}));
-            return;
-        }
-
-        const auto& pageToken = Request->Get()->PageToken;
-        const ui64 pageSize = ClampVal<ui64>(Request->Get()->PageSize, 1, 100);
-        const auto& listerId = Register(new TListScriptExecutionOperationsQuery::TRetry(SelfId(), Database, userSID, pageToken, pageSize));
-        KQP_PROXY_LOG_D("Bootstrap. Start TListScriptExecutionOperationsQuery " << listerId << ", PageToken: " << pageToken << ", PageSize: " << pageSize);
-
-        Become(&TListScriptExecutionOperationsActor::StateFunc);
-    }
-
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvListScriptExecutionOperationsResponse, Handle);
-        hFunc(TEvPrivate::TEvLeaseCheckResult, Handle);
-    )
-
-    void Handle(TEvListScriptExecutionOperationsResponse::TPtr& ev) {
-        Response = std::move(ev);
-        if (Response->Get()->Status != Ydb::StatusIds::SUCCESS) {
-            KQP_PROXY_LOG_D("Listing failed " << Response->Sender << " " << Response->Get()->Status << ", issues: " << Response->Get()->Issues.ToOneLineString());
-            Reply();
-            return;
-        }
-
-        KQP_PROXY_LOG_D("Listing response " << Response->Sender << " " << Response->Get()->Status << ", issues: " << Response->Get()->Issues.ToOneLineString() << ", NextPageToken: " << Response->Get()->NextPageToken << ", listed #" << Response->Get()->Operations.size() << " operations");
-
-        for (ui64 i = 0; i < Response->Get()->Operations.size(); ++i) {
-            const Ydb::Operations::Operation& op = Response->Get()->Operations[i];
-            if (!op.ready()) {
-                Ydb::Query::ExecuteScriptMetadata metadata;
-                op.metadata().UnpackTo(&metadata);
-
-                const auto& executionId = metadata.execution_id();
-                const auto& checkerId = Register(new TCheckLeaseStatusActor(SelfId(), Database, executionId, QueryServiceConfig, Counters, true, i));
-                KQP_PROXY_LOG_D("Start TCheckLeaseStatusActor #" << i << " " << checkerId << ", for ExecutionId: " << executionId);
-
-                ++OperationsToCheck;
-            }
-        }
-
-        if (OperationsToCheck == 0) {
-            Reply();
-        }
-    }
-
-    void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
-        Y_ABORT_UNLESS(ev->Cookie < Response->Get()->Operations.size());
-
-        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
-            KQP_PROXY_LOG_W("Lease check #" << ev->Cookie << " " << ev->Sender << " failed " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString());
-            Response->Get()->Status = ev->Get()->Status;
-            Response->Get()->Issues = std::move(ev->Get()->Issues);
-            Response->Get()->NextPageToken.clear();
-            Response->Get()->Operations.clear();
-            Reply();
-            return;
-        }
-
-        const auto& operationStatus = ev->Get()->OperationStatus;
-        --OperationsToCheck;
-        KQP_PROXY_LOG_D("Lease check #" << ev->Cookie << " " << ev->Sender << " success" << (operationStatus ? ", operation status: " + Ydb::StatusIds::StatusCode_Name(*operationStatus) : "") << ", OperationsToCheck: " << OperationsToCheck);
-
-        if (operationStatus) {
-            Ydb::Operations::Operation& op = Response->Get()->Operations[ev->Cookie];
-            op.set_status(*operationStatus);
-            Ydb::Query::ExecuteScriptMetadata metadata;
-            op.metadata().UnpackTo(&metadata);
-            Y_ABORT_UNLESS(ev->Get()->ExecutionStatus);
-            metadata.set_exec_status(*ev->Get()->ExecutionStatus);
-            op.mutable_metadata()->PackFrom(metadata);
-            if (ev->Get()->OperationIssues) {
-                for (const NYql::TIssue& issue : *ev->Get()->OperationIssues) {
-                    NYql::IssueToMessage(issue, op.add_issues());
-                }
-            }
-        }
-
-        if (OperationsToCheck == 0) {
-            Reply();
-        }
-    }
-
 private:
-    TString LogPrefix() const {
-        return TStringBuilder() << "[TListScriptExecutionOperationsActor] OwnerId: " << Request->Sender << " ActorId: " << SelfId() << " Database: " << Database << ". ";
-    }
-
-    void Reply() {
-        KQP_PROXY_LOG_D("Reply " << Response->Get()->Status << ", issues: " << Response->Get()->Issues.ToOneLineString());
-        Forward(Response, Request->Sender);
-        PassAway();
-    }
-
-private:
-    const TEvListScriptExecutionOperations::TPtr Request;
-    const TString Database;
-    const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
-    const TIntrusivePtr<TKqpCounters> Counters;
-    TEvListScriptExecutionOperationsResponse::TPtr Response;
-    ui64 OperationsToCheck = 0;
-};
-
-class TResetScriptExecutionRetriesQueryActor : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TResetScriptExecutionRetriesQueryActor, TEvResetScriptExecutionRetriesResponse, TString, TString>;
-
-    TResetScriptExecutionRetriesQueryActor(const TString& database, const TString& executionId)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , Database(database)
-        , ExecutionId(executionId)
-    {}
-
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TResetScriptExecutionRetriesQueryActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
 
             SELECT
                 operation_status,
+                execution_status,
                 finalization_status,
                 retry_state
             FROM `.metadata/script_executions`
@@ -2889,16 +2482,8 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TResetScriptExecutionRetriesQueryActor::OnGetQueryInfo, "Get query info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetQueryInfo, "Get query info");
         RunDataQuery(sql, &params, TTxControl::BeginTx());
     }
 
@@ -2908,21 +2493,31 @@ public:
             return;
         }
 
+        std::optional<i32> executionStatus;
+        std::optional<i32> operationStatus;
+        bool hasRetries = false;
+
         // Script execution info
         if (NYdb::TResultSetParser result(ResultSets[0]); result.TryNextRow()) {
-            if (!result.ColumnParser("operation_status").GetOptionalInt32() || result.ColumnParser("finalization_status").GetOptionalInt32()) {
-                return Finish(Ydb::StatusIds::PRECONDITION_FAILED, "Can not reset retray state then operation is running or not finalized");
+            executionStatus = result.ColumnParser("execution_status").GetOptionalInt32();
+            operationStatus = result.ColumnParser("operation_status").GetOptionalInt32();
+            if (!operationStatus || !executionStatus) {
+                OperationStillRunning = true;
+                KQP_PROXY_LOG_N("Can not reset retry state then operation is running now");
+                return Finish();
             }
 
-            if (const auto& serializedRetryState = result.ColumnParser("retry_state").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*serializedRetryState, &value)) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Retry state is corrupted");
-                    return;
-                }
+            if (result.ColumnParser("finalization_status").GetOptionalInt32()) {
+                OperationStillRunning = true;
+                KQP_PROXY_LOG_N("Can not reset retry state then operation is finalizing now");
+                return Finish();
+            }
 
-                NProtobufJson::Json2Proto(value, RetryState.emplace());
+            if (RetryState = ParseRetryState(result)) {
+                hasRetries = !RetryState->GetRetryPolicyMapping().empty();
                 RetryState->ClearRetryPolicyMapping();
+            } else {
+                return;
             }
         }
 
@@ -2930,104 +2525,110 @@ public:
         if (NYdb::TResultSetParser result(ResultSets[1]); result.TryNextRow()) {
             if (const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32()) {
                 if (static_cast<ELeaseState>(*leaseState) != ELeaseState::WaitRetry) {
-                    return Finish(Ydb::StatusIds::PRECONDITION_FAILED, "Can not reset retry state then operation is running or not finalized");
+                    OperationStillRunning = true;
+                    KQP_PROXY_LOG_N("Can not reset retry state then operation is running or not finalized, lease state: " << static_cast<ELeaseState>(*leaseState));
+                    return Finish();
                 }
 
                 DropLease = true;
             }
         }
 
-        if (RetryState || DropLease) {
-            DropRetryState();
-        } else {
-            Finish();
+        if (!RetryState && !DropLease) {
+            ExecutionEntryExists = false;
+            return Finish();
         }
+
+        if (!DropLease) {
+            Y_VALIDATE(RetryState && executionStatus && operationStatus, "Unexpected operation info");
+
+            if (!hasRetries && static_cast<Ydb::Query::ExecStatus>(*executionStatus) == Ydb::Query::EXEC_STATUS_CANCELLED && static_cast<Ydb::StatusIds_StatusCode>(*operationStatus) == Ydb::StatusIds::CANCELLED) {
+                AlreadyStopped = true;
+                return Finish();
+            }
+        }
+
+        DropRetryState();
     }
 
     void DropRetryState() {
-        TString sql = R"(
+        auto sql = TStringBuilder() << R"(
             -- TResetScriptExecutionRetriesQueryActor::DropRetryState
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
             DECLARE $retry_state AS Optional<JsonDocument>;
+            DECLARE $operation_status AS Int32;
+            DECLARE $execution_status AS Int32;
         )";
 
         if (RetryState) {
-            sql += R"(
+            sql << R"(
                 UPSERT INTO `.metadata/script_executions` (
-                    database, execution_id, retry_state
+                    database, execution_id, retry_state, operation_status, execution_status
                 ) VALUES (
-                    $database, $execution_id, $retry_state
+                    $database, $execution_id, $retry_state, $operation_status, $execution_status
                 );
             )";
         }
 
         if (DropLease) {
-            sql += R"(
+            sql << R"(
                 DELETE FROM `.metadata/script_execution_leases`
                 WHERE database = $database AND execution_id = $execution_id;
             )";
         }
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$retry_state")
                 .OptionalJsonDocument(RetryState ? std::optional<std::string>(NProtobufJson::Proto2Json(*RetryState, NProtobufJson::TProto2JsonConfig())) : std::nullopt)
+                .Build()
+            .AddParam("$operation_status")
+                .Int32(Ydb::StatusIds::CANCELLED)
+                .Build()
+            .AddParam("$execution_status")
+                .Int32(Ydb::Query::EXEC_STATUS_CANCELLED)
                 .Build();
 
-        SetQueryResultHandler(&TResetScriptExecutionRetriesQueryActor::OnQueryResult, "Drop retry state");
+        SetQueryResultHandler(&TThis::OnQueryResult, "Drop retry state");
         RunDataQuery(sql, &params, TTxControl::ContinueAndCommitTx());
     }
 
-    void OnQueryResult() override {
-        Finish();
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        Send(Owner, new TEvResetScriptExecutionRetriesResponse(status, {
+            .OperationStillRunning = OperationStillRunning,
+            .ExecutionEntryExists = ExecutionEntryExists,
+            .AlreadyStopped = AlreadyStopped,
+        }, std::move(issues)));
     }
 
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        Send(Owner, new TEvResetScriptExecutionRetriesResponse(status, std::move(issues)));
-    }
-
-private:
-    const TString Database;
-    const TString ExecutionId;
     std::optional<NKikimrKqp::TScriptExecutionRetryState> RetryState;
     bool DropLease = false;
+    bool OperationStillRunning = false;
+    bool ExecutionEntryExists = true;
+    bool AlreadyStopped = false;
 };
 
-class TCancelScriptExecutionOperationActor : public TActorBootstrapped<TCancelScriptExecutionOperationActor> {
+// Script execution cancellation with handling runtime and retry cancellation
+// *Assumptions*:
+// 1. Retry backoff large enough to cancel script execution operation between retries
+// 2. System not under high load so data transaction can not be executed during backoff period
+
+class TCancelScriptExecutionOperationActor final : public TActorBootstrapped<TCancelScriptExecutionOperationActor> {
     using TBase = TActorBootstrapped<TCancelScriptExecutionOperationActor>;
     using TRetryPolicy = IRetryPolicy<>;
 
-    enum class EState {
-        GetScriptExecutionOperationStatus,
-        ResetRetryPolicy,
-        WaitQueryExecution,
-        CancelScriptExecution,
-        WaitCancelScriptExecution,
-    };
+    static constexpr ui64 MAX_CANCEL_RETRIES = 10;
 
 public:
-    // Cancellation pipeline:
-    // 1. Get script execution operation status and:
-    //    - Finalize script execution if lease expired or there is not finished finalization
-    // 2. If script execution is running now, send cancel request to run script actor [race with script execution finalization and retries]
-    // 3. If script execution has retry state - reset it and also ensure that script execution is stopped
-    // 4. If error occurred - retry from step 1, otherwise reply SUCCESS
-
-    TCancelScriptExecutionOperationActor(TEvCancelScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
+    TCancelScriptExecutionOperationActor(TEvCancelScriptExecutionOperation::TPtr&& ev, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
         : Request(std::move(ev))
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
+        , QueryServiceConfig(std::move(queryServiceConfig))
+        , Counters(std::move(counters))
     {}
 
     void Bootstrap() {
-        Become(&TCancelScriptExecutionOperationActor::StateFunc);
+        Become(&TThis::StateFunc);
         KQP_PROXY_LOG_D("Bootstrap");
 
         UserSID = Request->Get()->UserSID;
@@ -3036,130 +2637,25 @@ public:
         }
 
         TString error;
-        const auto executionId = NKqp::ScriptExecutionIdFromOperation(Request->Get()->OperationId, error);
+        auto executionId = ScriptExecutionIdFromOperation(Request->Get()->OperationId, error);
         if (!executionId) {
             return Reply(Ydb::StatusIds::BAD_REQUEST, error);
         }
 
-        ExecutionId = *executionId;
-        ContinueCancel();
+        ExecutionId = std::move(*executionId);
+        GetScriptExecutionOperationStatus();
     }
 
     STRICT_STFUNC(StateFunc,
-        hFunc(TEvResetScriptExecutionRetriesResponse, Handle);
         hFunc(TEvPrivate::TEvLeaseCheckResult, Handle);
+        hFunc(TEvResetScriptExecutionRetriesResponse, Handle);
+        hFunc(TEvPrivate::TEvFinalizeScriptLeaseResult, Handle);
         hFunc(TEvKqp::TEvCancelScriptExecutionResponse, Handle);
         hFunc(TEvents::TEvUndelivered, Handle);
         hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
         IgnoreFunc(TEvInterconnect::TEvNodeConnected);
-        sFunc(TEvents::TEvWakeup, ContinueCancel);
+        sFunc(TEvents::TEvWakeup, GetScriptExecutionOperationStatus);
     )
-
-    void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
-        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
-            const auto& issues = ev->Get()->Issues;
-            KQP_PROXY_LOG_W("Check lease " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
-            return Reply(status, AddRootIssue("Fetch script execution info failed", issues));
-        }
-
-        RunScriptActor = ev->Get()->RunScriptActorId;
-        HasRetryPolicy = ev->Get()->HasRetryPolicy;
-        const auto& operationStatus = ev->Get()->OperationStatus;
-        const auto finalizationOrRetryInProgress = ev->Get()->WaitFinalizationOrRetry;
-        KQP_PROXY_LOG_D("Check lease " << ev->Sender << " success, operation status: " << (operationStatus ? Ydb::StatusIds::StatusCode_Name(*operationStatus) : "<null>") << ", finalization or retry in progress: " << finalizationOrRetryInProgress << ", has retries: " << HasRetryPolicy);
-
-        if (!operationStatus && !finalizationOrRetryInProgress) {
-            // Cancel running query first, to prevent TLI on retry policy reset
-            State = EState::CancelScriptExecution;
-        } else if (HasRetryPolicy) {
-            // Reset retry policy to prevent further query retries
-            State = EState::ResetRetryPolicy;
-        } else {
-            return Reply(Ydb::StatusIds::PRECONDITION_FAILED, "Script execution operation is already finished");
-        }
-
-        ContinueCancel();
-    }
-
-    void Handle(TEvKqp::TEvCancelScriptExecutionResponse::TPtr& ev) {
-        if (ev->Cookie != CancellationCookie) {
-            return;
-        }
-
-        NYql::TIssues issues;
-        NYql::IssuesFromMessage(ev->Get()->Record.GetIssues(), issues);
-        const auto status = ev->Get()->Record.GetStatus();
-        if (status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::PRECONDITION_FAILED) {
-            KQP_PROXY_LOG_W("Script execution cancel failed " << status << " from RunScriptActor: " << ev->Sender << ", issues: " << issues.ToOneLineString());
-            return Reply(status, std::move(issues));
-        }
-
-        KQP_PROXY_LOG_D("Got cancel response " << status << " from RunScriptActor: " << ev->Sender << ", issues: " << issues.ToOneLineString());
-
-        if (HasRetryPolicy) {
-            // Double check and reset retry policy to prevent further query retries
-            State = EState::ResetRetryPolicy;
-            ContinueCancel();
-        } else {
-            Reply(status, std::move(issues));
-        }
-    }
-
-    void Handle(TEvResetScriptExecutionRetriesResponse::TPtr& ev) {
-        const auto status = ev->Get()->Status;
-        const auto& issues = ev->Get()->Issues;
-        if (status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::PRECONDITION_FAILED && status != Ydb::StatusIds::ABORTED) {
-            KQP_PROXY_LOG_W("Reset retry state " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
-            Reply(status, AddRootIssue("Reset retry state failed", issues));
-            return;
-        }
-
-        KQP_PROXY_LOG_D("Reset retry state " << ev->Sender << " finished " << status << ", issues: " << issues.ToOneLineString());
-
-        if (status == Ydb::StatusIds::SUCCESS) {
-            return Reply(Ydb::StatusIds::SUCCESS);
-        }
-
-        State = EState::GetScriptExecutionOperationStatus;
-        if (const NYql::TIssues resultIssues = AddRootIssue("Failed to cancel script execution, query execution is under retry", issues); !ScheduleRetry(resultIssues)) {
-            // Race with script execution retry
-            Reply(status, resultIssues);
-        }
-    }
-
-    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
-        const auto reason = ev->Get()->Reason;
-        KQP_PROXY_LOG_W("Delivery failed " << reason << " to RunScriptActor: " << ev->Sender);
-
-        if (State != EState::WaitCancelScriptExecution || ev->Sender != RunScriptActor) {
-            return;
-        }
-
-        if (reason == TEvents::TEvUndelivered::ReasonActorUnknown) {
-            // The actor probably had finished before our cancel message arrived
-            State = EState::GetScriptExecutionOperationStatus;
-        } else {
-            State = EState::CancelScriptExecution;
-        }
-
-        if (const TString message(TStringBuilder() << "Failed to deliver cancel request to destination (delivery problem, reason: " << reason << ")"); !ScheduleRetry(message)) {
-            Reply(Ydb::StatusIds::UNAVAILABLE, message);
-        }
-    }
-
-    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
-        const auto nodeId = ev->Get()->NodeId;
-        KQP_PROXY_LOG_W("Delivery failed to RunScriptActor, node " << nodeId << " disconnected");
-
-        if (State != EState::WaitCancelScriptExecution || !RunScriptActor || nodeId != RunScriptActor.NodeId()) {
-            return;
-        }
-
-        State = EState::CancelScriptExecution;
-        if (const TString message("Failed to deliver cancel request to destination (node disconnected)"); !ScheduleRetry(message)) {
-            Reply(Ydb::StatusIds::UNAVAILABLE, message);
-        }
-    }
 
     void PassAway() override {
         ResetSessionSubscribe();
@@ -3167,6 +2663,185 @@ public:
     }
 
 private:
+    void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            const auto& issues = ev->Get()->Issues;
+            KQP_PROXY_LOG_W("Check lease " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
+            return Reply(status, AddRootIssue("Fetch script execution info failed", issues));
+        }
+
+        if (!ev->Get()->EntryExists) {
+            return ReplyNotFound();
+        }
+
+        RunScriptActor = ev->Get()->RunScriptActorId;
+        HasRetryPolicy = ev->Get()->HasRetryPolicy;
+        const auto& operationStatus = ev->Get()->OperationStatus;
+        const auto& finalizationStatus = ev->Get()->FinalizationStatus;
+        const auto leaseExpired = ev->Get()->LeaseExpired;
+        KQP_PROXY_LOG_D("Check lease " << ev->Sender << " success"
+            << ", operation status: " << (operationStatus ? Ydb::StatusIds::StatusCode_Name(*operationStatus) : "<null>")
+            << ", finalization status: " << (finalizationStatus ? ToString(*finalizationStatus) : "<null>")
+            << ", has retries: " << HasRetryPolicy
+            << ", lease expired: " << leaseExpired);
+
+        // Possible script execution states:
+        // 1. Is running now
+        // 2. Finalization in progress
+        // 3. Waiting for retry
+        // 4. Script execution finished
+
+        if (operationStatus && !finalizationStatus) {
+            // Script execution operation was finished, and there is not finalization stage or finalization finished
+
+            if (!HasRetryPolicy) {
+                // No retries is planned for script execution => considered as finalized
+                return ReplyAlreadyStopped();
+            }
+
+            // Reset script execution retries and mark it as cancelled
+            ResetRetryPolicy();
+        } else if (leaseExpired) {
+            // Script execution still in running state but most likely TRunScriptActor was lost, so we should verify it existence
+            FinalizeScriptLease();
+        } else {
+            // Script execution is running or finalization in progress, send cancel to TRunScriptActor
+            SendCancelToRunScriptActor();
+        }
+    }
+
+    void Handle(TEvResetScriptExecutionRetriesResponse::TPtr& ev) {
+        // In case of TLI (status ABORTED) retry cancel operation
+        const auto status = ev->Get()->Status;
+        if (status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::ABORTED) {
+            KQP_PROXY_LOG_W("Reset retry state " << ev->Sender << " failed " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+            return Reply(status, AddRootIssue("Reset retry state failed", ev->Get()->Issues));
+        }
+
+        const auto& issues = ev->Get()->Issues;
+        const auto& info = ev->Get()->Info;
+        KQP_PROXY_LOG_D("Reset retry state " << ev->Sender << " finished " << status
+            << ", execution entry exists: " << info.ExecutionEntryExists
+            << ", operation still running: " << info.OperationStillRunning
+            << ", already stopped: " << info.AlreadyStopped
+            << ", issues: " << issues.ToOneLineString());
+
+        if (status == Ydb::StatusIds::SUCCESS) {
+            if (!info.ExecutionEntryExists) {
+                // Script execution was removed during cancellation
+                return ReplyNotFound();
+            }
+
+            if (info.AlreadyStopped) {
+                // Script execution was already cancelled by another operation
+                return ReplyAlreadyStopped();
+            }
+
+            if (!info.OperationStillRunning) {
+                // Script execution was successfully marked as cancelled
+                return Reply(Ydb::StatusIds::SUCCESS);
+            }
+        }
+
+        // Race with script execution retry, retry immediately because we already know that state of script execution was changed
+        ScheduleRetryOrReply(status, AddRootIssue("Failed to cancel script execution, query execution is under retry", issues), /* immediate */ true);
+    }
+
+    void Handle(TEvPrivate::TEvFinalizeScriptLeaseResult::TPtr& ev) {
+        // In case of TLI (status ABORTED) retry cancel operation
+        const auto status = ev->Get()->Status;
+        if (status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::ABORTED) {
+            KQP_PROXY_LOG_W("Finalize script execution " << ev->Sender << " failed " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+            return Reply(status, AddRootIssue("Finalize script execution failed", ev->Get()->Issues));
+        }
+
+        const auto& issues = ev->Get()->Issues;
+        const auto& info = ev->Get()->Info;
+        KQP_PROXY_LOG_D("Finalize script execution " << ev->Sender << " finished " << status
+            << ", lease verified: " << info.LeaseVerified
+            << ", execution entry exists: " << info.ExecutionEntryExists
+            << ", issues: " << issues.ToOneLineString());
+
+        if (status == Ydb::StatusIds::SUCCESS) {
+            if (!info.ExecutionEntryExists) {
+                // Script execution was removed during finalization
+                return ReplyNotFound();
+            }
+
+            if (info.LeaseVerified) {
+                // TRunScriptActor still alive, so we can send cancel request to it
+                return SendCancelToRunScriptActor();
+            }
+
+            // State of script execution changed (most likely it was finalized), report retry attempt and continue cancel
+        }
+
+        ScheduleRetryOrReply(status, AddRootIssue("Failed to cancel script execution, query execution finalization was not successful", issues), /* immediate */ true);
+    }
+
+    void Handle(TEvKqp::TEvCancelScriptExecutionResponse::TPtr& ev) {
+        if (ev->Cookie != CancellationCookie || !RunScriptActor) {
+            // Skip late events from previous retries
+            return;
+        }
+        RunScriptActor = {};
+
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(ev->Get()->Record.GetIssues(), issues);
+
+        // In case of TLI (status ABORTED) retry cancel operation
+        const auto status = ev->Get()->Record.GetStatus();
+        if (status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::ABORTED) {
+            KQP_PROXY_LOG_W("Script execution cancel failed " << status << " from RunScriptActor: " << ev->Sender << ", issues: " << issues.ToOneLineString());
+            return Reply(status, AddRootIssue("Cancel script execution failed", issues));
+        }
+
+        const auto alreadyFinished = ev->Get()->Record.GetAlreadyFinished();
+        const auto executionEntryExists = ev->Get()->Record.GetExecutionEntryExists();
+        KQP_PROXY_LOG_D("Got cancel response from RunScriptActor: " << ev->Sender << ", status: " << status
+            << ", already finished: " << alreadyFinished
+            << ", issues: " << issues.ToOneLineString());
+
+        if (status == Ydb::StatusIds::SUCCESS) {
+            if (!executionEntryExists) {
+                return ReplyNotFound();
+            }
+
+            if (alreadyFinished) {
+                return ReplyAlreadyStopped();
+            }
+
+            return Reply(Ydb::StatusIds::SUCCESS);
+        }
+
+        ScheduleRetryOrReply(status, AddRootIssue("Failed to cancel script execution, query final status saving was not successful", issues), /* immediate */ true);
+    }
+
+    void Handle(TEvents::TEvUndelivered::TPtr& ev) {
+        const auto reason = ev->Get()->Reason;
+        KQP_PROXY_LOG_W("Delivery failed " << reason << " to RunScriptActor: " << ev->Sender);
+
+        if (ev->Cookie != CancellationCookie || !RunScriptActor) {
+            return;
+        }
+        RunScriptActor = {};
+
+        const bool immediateRetry = reason == TEvents::TEvUndelivered::ReasonActorUnknown; // The actor probably had finished before our cancel message arrived
+        ScheduleRetryOrReply(Ydb::StatusIds::UNAVAILABLE, TStringBuilder() << "Failed to deliver cancel request to destination (delivery problem, reason: " << reason << ")", immediateRetry);
+    }
+
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr& ev) {
+        const auto nodeId = ev->Get()->NodeId;
+        KQP_PROXY_LOG_W("Delivery failed to RunScriptActor, node " << nodeId << " disconnected");
+
+        if (!RunScriptActor || nodeId != RunScriptActor.NodeId()) {
+            return;
+        }
+        RunScriptActor = {};
+
+        ScheduleRetryOrReply(Ydb::StatusIds::UNAVAILABLE, "Failed to deliver cancel request to destination (node disconnected)", /* immediate */ false);
+    }
+
     void ResetSessionSubscribe() {
         if (SubscribedOnSession) {
             Send(TActivationContext::InterconnectProxy(*SubscribedOnSession), new TEvents::TEvUnsubscribe());
@@ -3174,33 +2849,23 @@ private:
         }
     }
 
-    void ContinueCancel() {
+    void GetScriptExecutionOperationStatus() {
         WaitRetry = false;
-        KQP_PROXY_LOG_D("Continue cancel, State: " << static_cast<ui32>(State));
+        const auto& checkerId = Register(TCheckLeaseStatusQueryActor::MakeRetry(SelfId(), Request->Get()->Database, ExecutionId, TCheckLeaseStatusQueryActor::TSettings{.UserSID = UserSID}));
+        KQP_PROXY_LOG_D("Start TCheckLeaseStatusQueryActor " << checkerId);
+    }
 
-        switch (State) {
-            case EState::GetScriptExecutionOperationStatus: {
-                State = EState::WaitQueryExecution;
-                const auto& checkerId = Register(new TCheckLeaseStatusActor(SelfId(), Request->Get()->Database, ExecutionId, QueryServiceConfig, Counters, /* canRetry */ false, 0, UserSID));
-                KQP_PROXY_LOG_D("Start TCheckLeaseStatusActor " << checkerId);
-                break;
-            }
-            case EState::ResetRetryPolicy: {
-                State = EState::WaitQueryExecution;
-                const auto& resetActorId = Register(new TResetScriptExecutionRetriesQueryActor::TRetry(SelfId(), Request->Get()->Database, ExecutionId));
-                KQP_PROXY_LOG_D("Start TResetRetryStateRetryActor " << resetActorId);
-                break;
-            }
-            case EState::CancelScriptExecution: {
-                State = EState::WaitCancelScriptExecution;
-                SendCancelToRunScriptActor();
-                break;
-            }
-            case EState::WaitQueryExecution:
-            case EState::WaitCancelScriptExecution: {
-                break;
-            }
-        }
+    void ResetRetryPolicy() {
+        const auto& resetActorId = Register(TResetScriptExecutionRetriesQueryActor::MakeRetry(SelfId(), Request->Get()->Database, ExecutionId));
+        KQP_PROXY_LOG_D("Start TResetRetryStateRetryActor " << resetActorId);
+    }
+
+    void FinalizeScriptLease() {
+        const auto& finalizeActorId = Register(new TFinalizeScriptLeaseActor(SelfId(), Request->Get()->Database, ExecutionId, QueryServiceConfig, Counters, {
+            .AllowRestart = false,
+            .FailOnNotFound = false,
+        }));
+        KQP_PROXY_LOG_D("Start TFinalizeScriptLeaseActor " << finalizeActorId);
     }
 
     void SendCancelToRunScriptActor() {
@@ -3221,9 +2886,9 @@ private:
         return TStringBuilder() << "[TCancelScriptExecutionOperationActor] OwnerId: " << Request->Sender << " ActorId: " << SelfId() << " Database: " << Request->Get()->Database << " ExecutionId: " << ExecutionId << " RunScriptActor: " << RunScriptActor << ". ";
     }
 
-    bool ScheduleRetry(const NYql::TIssues& issues) {
+    void ScheduleRetryOrReply(const Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues, const bool immediate = false) {
         if (WaitRetry) {
-            return true;
+            return;
         }
 
         if (!RetryState) {
@@ -3234,26 +2899,41 @@ private:
                 TDuration::MilliSeconds(100),
                 TDuration::MilliSeconds(100),
                 TDuration::Seconds(1),
-                10
+                MAX_CANCEL_RETRIES
             )->CreateRetryState();
         }
 
-        if (const auto delay = RetryState->GetNextRetryDelay()) {
+        if (auto delay = RetryState->GetNextRetryDelay()) {
+            if (immediate) {
+                delay = TDuration::Zero();
+            }
+
             KQP_PROXY_LOG_W("Schedule retry for error: " << issues.ToOneLineString() << " in " << *delay);
             Issues.AddIssues(issues);
             Schedule(*delay, new TEvents::TEvWakeup());
             WaitRetry = true;
-            return true;
+            return;
         }
 
-        return false;
+        Reply(status, issues);
     }
 
-    bool ScheduleRetry(const TString& message) {
-        return ScheduleRetry({NYql::TIssue(message)});
+    void ScheduleRetryOrReply(const Ydb::StatusIds::StatusCode status, const TString& message, const bool immediate = false) {
+        ScheduleRetryOrReply(status, {NYql::TIssue(message)}, immediate);
     }
 
-    void Reply(Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues = {}) {
+    void ReplyNotFound() {
+        KQP_PROXY_LOG_W("Script execution operation not found");
+        EntryExists = false;
+        return Reply(Request->Get()->Settings.FailOnNotFound ? Ydb::StatusIds::NOT_FOUND : Ydb::StatusIds::SUCCESS, "Script execution operation not found");
+    }
+
+    void ReplyAlreadyStopped() {
+        KQP_PROXY_LOG_W("Script execution operation is already finished");
+        return Reply(Request->Get()->Settings.FailOnAlreadyStopped ? Ydb::StatusIds::PRECONDITION_FAILED : Ydb::StatusIds::SUCCESS, "Script execution operation is already finished");
+    }
+
+    void Reply(const Ydb::StatusIds::StatusCode status, const NYql::TIssues& issues = {}) {
         Issues.AddIssues(issues);
 
         if (status == Ydb::StatusIds::SUCCESS) {
@@ -3262,44 +2942,41 @@ private:
             KQP_PROXY_LOG_W("Reply failed, status: " << status << ", issues: " << Issues.ToOneLineString());
         }
 
-        Send(Request->Sender, new TEvCancelScriptExecutionOperationResponse(status, std::move(Issues)));
+        Send(Request->Sender, new TEvCancelScriptExecutionOperationResponse(status, EntryExists, std::move(Issues)));
         PassAway();
     }
 
-    void Reply(Ydb::StatusIds::StatusCode status, const TString& message) {
+    void Reply(const Ydb::StatusIds::StatusCode status, const TString& message) {
         Reply(status, {NYql::TIssue(message)});
     }
 
-private:
     const TEvCancelScriptExecutionOperation::TPtr Request;
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
     const TIntrusivePtr<TKqpCounters> Counters;
     std::optional<TString> UserSID;
     TString ExecutionId;
     TActorId RunScriptActor;
+    bool EntryExists = true;
     bool HasRetryPolicy = false;
     ui64 CancellationCookie = 0;
     TMaybe<ui32> SubscribedOnSession;
     TRetryPolicy::IRetryState::TPtr RetryState;
-    EState State = EState::GetScriptExecutionOperationStatus;
     bool WaitRetry = false;
     NYql::TIssues Issues;
 };
 
-class TSaveScriptExecutionResultMetaQuery : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TSaveScriptExecutionResultMetaQuery, TEvSaveScriptResultMetaFinished, TString, TString, TString, i64>;
+// Save information about result sets and column types, started from TRunScriptActor on each new result set
 
-    TSaveScriptExecutionResultMetaQuery(const TString& database, const TString& executionId, const TString& serializedMetas, i64 leaseGeneration)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId, .LeaseGeneration = leaseGeneration})
-        , Database(database)
-        , ExecutionId(executionId)
-        , SerializedMetas(serializedMetas)
-        , LeaseGeneration(leaseGeneration)
+class TSaveScriptExecutionResultMetaQuery final : public TQueryBase<TSaveScriptExecutionResultMetaQuery, TEvSaveScriptResultMetaFinished> {
+public:
+    TSaveScriptExecutionResultMetaQuery(TString database, TString executionId, TString serializedMetas, const i64 leaseGeneration)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
+        , SerializedMetas(std::move(serializedMetas))
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TSaveScriptExecutionResultMetaQuery::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -3310,17 +2987,12 @@ public:
             SET result_set_metas = $result_set_metas
             WHERE database = $database
               AND execution_id = $execution_id
-              AND (lease_generation IS NULL OR lease_generation = $lease_generation);
+              AND (lease_generation IS NULL OR lease_generation = $lease_generation)
+              AND operation_status IS NULL;
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$result_set_metas")
                 .JsonDocument(SerializedMetas)
                 .Build()
@@ -3331,30 +3003,21 @@ public:
         RunDataQuery(sql, &params);
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvSaveScriptResultMetaFinished(status, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
     const TString SerializedMetas;
-    const i64 LeaseGeneration;
 };
 
-class TSaveScriptExecutionResultQuery : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TSaveScriptExecutionResultQuery, TEvSaveScriptResultPartFinished, TString, TString, i32, std::optional<TInstant>, i64, i64, Ydb::ResultSet>;
+// Save result data part from TRunScriptActor as it arrived from DQ
+// (NOTE: lease generation and status is not validated, so should not be used with retries and results may be written after finish)
 
-    TSaveScriptExecutionResultQuery(const TString& database, const TString& executionId, i32 resultSetId,
-        std::optional<TInstant> expireAt, i64 firstRow, i64 accumulatedSize, Ydb::ResultSet resultSet)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , Database(database)
-        , ExecutionId(executionId)
+class TSaveScriptExecutionResultQuery final : public TQueryBase<TSaveScriptExecutionResultQuery, TEvSaveScriptResultPartFinished> {
+public:
+    TSaveScriptExecutionResultQuery(TString database, TString executionId, const i32 resultSetId,
+        const std::optional<TInstant> expireAt, const i64 firstRow, const i64 accumulatedSize, Ydb::ResultSet resultSet)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId)})
         , ResultSetId(resultSetId)
         , ExpireAt(expireAt)
         , FirstRow(firstRow)
@@ -3362,8 +3025,9 @@ public:
         , ResultSet(std::move(resultSet))
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TSaveScriptExecutionResultQuery::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -3383,14 +3047,8 @@ public:
             FROM AS_TABLE($items) AS T;
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$result_set_id")
                 .Int32(ResultSetId)
                 .Build()
@@ -3398,9 +3056,7 @@ public:
                 .OptionalTimestamp(ExpireAt)
                 .Build();
 
-        auto& param = params
-            .AddParam("$items");
-
+        auto& param = params.AddParam("$items");
         param.BeginList();
 
         auto row = FirstRow;
@@ -3427,37 +3083,29 @@ public:
         RunDataQuery(sql, &params);
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvSaveScriptResultPartFinished(status, SavedSize, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
-    const i32 ResultSetId;
+    const i32 ResultSetId = 0;
     const std::optional<TInstant> ExpireAt;
-    const i64 FirstRow;
-    const i64 AccumulatedSize;
+    const i64 FirstRow = 0;
+    const i64 AccumulatedSize = 0;
     const Ydb::ResultSet ResultSet;
     i64 SavedSize = 0;
 };
 
-class TSaveScriptExecutionResultActor : public TActorBootstrapped<TSaveScriptExecutionResultActor> {
+class TSaveScriptExecutionResultActor final : public TActorBootstrapped<TSaveScriptExecutionResultActor> {
     static constexpr ui64 MAX_NUMBER_ROWS_IN_BATCH = 10000;
     static constexpr ui64 PROGRAM_SIZE_LIMIT = 10_MB;
     static constexpr ui64 PROGRAM_BASE_SIZE = 1_MB;  // Depends on MAX_NUMBER_ROWS_IN_BATCH
 
 public:
-    TSaveScriptExecutionResultActor(const TActorId& replyActorId, const TString& database,
-        const TString& executionId, i32 resultSetId, std::optional<TInstant> expireAt,
-        i64 firstRow, i64 accumulatedSize, Ydb::ResultSet&& resultSet)
+    TSaveScriptExecutionResultActor(const TActorId& replyActorId, TString database, TString executionId, const i32 resultSetId,
+        const std::optional<TInstant> expireAt, const i64 firstRow, const i64 accumulatedSize, Ydb::ResultSet&& resultSet)
         : ReplyActorId(replyActorId)
-        , Database(database)
-        , ExecutionId(executionId)
+        , Database(std::move(database))
+        , ExecutionId(std::move(executionId))
         , ResultSetId(resultSetId)
         , ExpireAt(expireAt)
         , FirstRow(firstRow)
@@ -3472,7 +3120,7 @@ public:
         }
 
         i64 numberRows = ResultSets.back().rows_size();
-        const auto& saverId = Register(new TSaveScriptExecutionResultQuery::TRetry(SelfId(), Database, ExecutionId, ResultSetId, ExpireAt, FirstRow, AccumulatedSize, ResultSets.back()));
+        const auto& saverId = Register(TSaveScriptExecutionResultQuery::MakeRetry(SelfId(), Database, ExecutionId, ResultSetId, ExpireAt, FirstRow, AccumulatedSize, ResultSets.back()));
         KQP_PROXY_LOG_D("Start saving rows range [" << FirstRow << "; " << FirstRow + numberRows << "), remains parts: " << ResultSets.size() << ", saver actor: " << saverId);
 
         FirstRow += numberRows;
@@ -3492,17 +3140,18 @@ public:
         std::reverse(ResultSets.begin(), ResultSets.end());
         StartSaveResultQuery();
 
-        Become(&TSaveScriptExecutionResultActor::StateFunc);
+        Become(&TThis::StateFunc);
     }
 
     STRICT_STFUNC(StateFunc,
         hFunc(TEvSaveScriptResultPartFinished, Handle);
     )
 
+private:
     void Handle(TEvSaveScriptResultPartFinished::TPtr& ev) {
-        if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
             KQP_PROXY_LOG_W("Failed to save result part, saver actor: " << ev->Sender);
-            Reply(ev->Get()->Status, std::move(ev->Get()->Issues));
+            Reply(status, std::move(ev->Get()->Issues));
             return;
         }
 
@@ -3512,18 +3161,16 @@ public:
         StartSaveResultQuery();
     }
 
-private:
     TString LogPrefix() const {
         return TStringBuilder() << "[TSaveScriptExecutionResultActor] OwnerId: " << ReplyActorId << " ActorId: " << SelfId() << " Database: " << Database << " ExecutionId: " << ExecutionId << " ResultSetId: " << ResultSetId << ". ";
     }
 
-    void Reply(Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
+    void Reply(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
         KQP_PROXY_LOG_D("Reply " << status << ", issues: " << issues.ToOneLineString());
         Send(ReplyActorId, new TEvSaveScriptResultFinished(status, ResultSetId, std::move(issues)));
         PassAway();
     }
 
-private:
     const TActorId ReplyActorId;
     const TString Database;
     const TString ExecutionId;
@@ -3535,16 +3182,13 @@ private:
     TVector<Ydb::ResultSet> ResultSets;
 };
 
-class TGetScriptExecutionResultQueryActor : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TGetScriptExecutionResultQueryActor, TEvFetchScriptResultsResponse, TString, TString, std::optional<TString>, i32, i64, i64, i64, TInstant>;
+// Fetch script execution result part, called from gRPC API fetch script execution results. Will read only fixed result part reported in result sets meta
 
-    TGetScriptExecutionResultQueryActor(const TString& database, const TString& executionId, const std::optional<TString>& userSID,
-        i32 resultSetIndex, i64 offset, i64 rowsLimit, i64 sizeLimit, TInstant deadline)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , Database(database)
-        , ExecutionId(executionId)
-        , UserSID(userSID)
+class TGetScriptExecutionResultQueryActor final : public TQueryWithAccessValidationBase<TGetScriptExecutionResultQueryActor, TEvFetchScriptResultsResponse> {
+public:
+    TGetScriptExecutionResultQueryActor(TString database, TString executionId, std::optional<TString> userSID,
+        const i32 resultSetIndex, const i64 offset, const i64 rowsLimit, const i64 sizeLimit, const TInstant deadline)
+        : TQueryWithAccessValidationBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId)}, std::move(userSID))
         , ResultSetIndex(resultSetIndex)
         , Offset(offset)
         , RowsLimit(rowsLimit)
@@ -3552,8 +3196,18 @@ public:
         , Deadline(rowsLimit ? TInstant::Max() : deadline)
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        if (!ValidateUserSID()) {
+            return;
+        }
+
+        if (RowsLimit < 0 || SizeLimit < 0) {
+            KQP_PROXY_LOG_W("Invalid fetch result limits, RowsLimit: " << RowsLimit << ", SizeLimit: " << SizeLimit);
+            return Finish(Ydb::StatusIds::BAD_REQUEST, "Result rows limit and size limit should not be negative");
+        }
+
+        constexpr char sql[] = R"(
             -- TGetScriptExecutionResultQueryActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -3571,16 +3225,8 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TGetScriptExecutionResultQueryActor::OnGetResultsInfo, "Get results info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetResultsInfo, "Get results info");
         RunDataQuery(sql, &params);
     }
 
@@ -3596,16 +3242,14 @@ public:
             return;
         }
 
-        if (const auto ownerUser = result.ColumnParser("user_token").GetOptionalUtf8(); UserSID && ownerUser && *ownerUser != *UserSID) {
-            KQP_PROXY_LOG_W("Access denied for user " << *UserSID);
-            Finish(Ydb::StatusIds::UNAUTHORIZED, "User is not owner of script execution operation");
+        if (!ValidateAccess(result)) {
             return;
         }
 
         const auto operationStatus = result.ColumnParser("operation_status").GetOptionalInt32();
 
         if (operationStatus) {
-            const auto serializedMeta = result.ColumnParser("meta").GetOptionalJsonDocument();
+            const auto& serializedMeta = result.ColumnParser("meta").GetOptionalJsonDocument();
             if (!serializedMeta) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Missing operation metainformation");
                 return;
@@ -3626,14 +3270,14 @@ public:
                 return;
             }
 
-            const auto resultsTtl = GetDuration(meta.GetResultsTtl());
+            const auto resultsTtl = NProtoInterop::CastFromProto(meta.GetResultsTtl());
             if (resultsTtl && (*endTs + resultsTtl) < TInstant::Now()){
                 Finish(Ydb::StatusIds::NOT_FOUND, "Results are expired");
                 return;
             }
         }
 
-        const auto serializedMetas = result.ColumnParser("result_set_metas").GetOptionalJsonDocument();
+        const auto& serializedMetas = result.ColumnParser("result_set_metas").GetOptionalJsonDocument();
 
         if (!serializedMetas) {
             if (!operationStatus) {
@@ -3643,11 +3287,7 @@ public:
 
             const auto operationStatusCode = static_cast<Ydb::StatusIds::StatusCode>(*operationStatus);
             if (operationStatusCode != Ydb::StatusIds::SUCCESS) {
-                NYql::TIssue rootIssue("Script execution failed without results");
-                for (const auto& issue : ParseScriptExecutionIssues(result)) {
-                    rootIssue.AddSubIssue(MakeIntrusive<NYql::TIssue>(issue));
-                }
-                Finish(operationStatusCode, NYql::TIssues{rootIssue});
+                Finish(operationStatusCode, AddRootIssue("Script execution failed without results", ParseScriptExecutionIssues(result)));
                 return;
             }
 
@@ -3661,12 +3301,12 @@ public:
             return;
         }
 
-        const NJson::TJsonValue* metaValue;
+        const NJson::TJsonValue* metaValue = nullptr;
         if (!value.GetValuePointer(ResultSetIndex, &metaValue)) {
             Finish(Ydb::StatusIds::BAD_REQUEST, "Result set index is invalid");
             return;
         }
-        Y_ENSURE(metaValue);
+        Y_ENSURE(metaValue, "Result set index is invalid");
 
         Ydb::Query::Internal::ResultSetMeta meta;
         NProtobufJson::Json2Proto(*metaValue, meta);
@@ -3691,7 +3331,7 @@ public:
     void FetchScriptResults() {
         KQP_PROXY_LOG_D("Fetch results #" << ResultSetIndex << " with offset: " << Offset << ", limit: " << RowsLimit << ", saved rows: " << NumberOfSavedRows);
 
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TGetScriptExecutionResultQuery::FetchScriptResults
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -3716,14 +3356,8 @@ public:
             LIMIT $limit;
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
             .AddParam("$result_set_id")
                 .Int32(ResultSetIndex)
                 .Build()
@@ -3737,14 +3371,14 @@ public:
                 .Uint64(RowsLimit ? RowsLimit + 1 : std::numeric_limits<ui64>::max())
                 .Build();
 
-        SetQueryResultHandler(&TGetScriptExecutionResultQueryActor::OnQueryResult, TStringBuilder() << "Fetch results for offset " << Offset << ", limit: " << RowsLimit);
+        SetQueryResultHandler(&TThis::OnQueryResult, TStringBuilder() << "Fetch results for offset " << Offset << ", limit: " << RowsLimit);
         RunStreamQuery(sql, &params, SizeLimit ? SizeLimit : 60_MB);
     }
 
     void OnStreamResult(NYdb::TResultSet&& resultSet) override {
         NYdb::TResultSetParser result(resultSet);
         while (result.TryNextRow()) {
-            const std::optional<TString> serializedRow = result.ColumnParser("result_set").GetOptionalString();
+            const std::optional<TString>& serializedRow = result.ColumnParser("result_set").GetOptionalString();
             if (!serializedRow) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Result set row is null");
                 return;
@@ -3789,11 +3423,7 @@ public:
         }
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         if (status == Ydb::StatusIds::SUCCESS) {
             KQP_PROXY_LOG_D("Successfully fetched " << ResultSet.rows_size() << " rows");
             Send(Owner, new TEvFetchScriptResultsResponse(status, std::move(ResultSet), HasMoreResults, std::move(issues)));
@@ -3802,22 +3432,16 @@ public:
         }
     }
 
-private:
     void CancelFetchQuery() {
         HasMoreResults = true;
         CancelStreamQuery();
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
-    const std::optional<TString> UserSID;
-    const i32 ResultSetIndex;
-    const i64 Offset;
-    const i64 RowsLimit;
-    const i64 SizeLimit;
+    const i32 ResultSetIndex = 0;
+    const i64 Offset = 0;
+    const i64 RowsLimit = 0;
+    const i64 SizeLimit = 0;
     const TInstant Deadline;
-
     i64 NumberOfSavedRows = std::numeric_limits<i64>::max();
     i64 ResultSetSize = 0;
     i64 AdditionalRowSize = 0;
@@ -3825,83 +3449,91 @@ private:
     bool HasMoreResults = false;
 };
 
-class TGetScriptExecutionResultActor : public TActorBootstrapped<TGetScriptExecutionResultActor> {
+// Save information about query effects like S3 writes in order to commit / rollback after operation finish, saved after query compilation in DataExecuter
+
+class TSaveScriptExternalEffectActor final : public TQueryBase<TSaveScriptExternalEffectActor, TEvSaveScriptExternalEffectResponse> {
 public:
-    TGetScriptExecutionResultActor(const TActorId& replyActorId, const TString& database, const TString& executionId,
-        const std::optional<TString>& userSID, i32 resultSetIndex, i64 offset, i64 rowsLimit, i64 sizeLimit, TInstant operationDeadline)
-        : ReplyActorId(replyActorId)
-        , Database(database)
-        , ExecutionId(executionId)
-        , UserSID(userSID)
-        , ResultSetIndex(resultSetIndex)
-        , Offset(offset)
-        , RowsLimit(rowsLimit)
-        , SizeLimit(sizeLimit)
-        , OperationDeadline(operationDeadline)
+    TSaveScriptExternalEffectActor(TString database, TString executionId,
+        TEvSaveScriptExternalEffectRequest::TDescription request, const i64 leaseGeneration)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
+        , Request(std::move(request))
     {}
 
-    void Bootstrap() {
-        if (const auto& error = CheckScriptExecutionAccess(UserSID)) {
-            return Reply(Ydb::StatusIds::UNAUTHORIZED, error);
-        }
-
-        if (RowsLimit < 0 || SizeLimit < 0) {
-            KQP_PROXY_LOG_W("Invalid fetch result limits, RowsLimit: " << RowsLimit << ", SizeLimit: " << SizeLimit);
-            return Reply(Ydb::StatusIds::BAD_REQUEST, "Result rows limit and size limit should not be negative");
-        }
-
-        const auto& fetcherId = Register(new TGetScriptExecutionResultQueryActor::TRetry(SelfId(), Database, ExecutionId, UserSID, ResultSetIndex, Offset, RowsLimit, SizeLimit, OperationDeadline));
-        KQP_PROXY_LOG_D("Bootstrap. Started TGetScriptExecutionResultQueryActor: " << fetcherId << ", Offset: " << Offset << ", RowsLimit: " << RowsLimit << ", SizeLimit: " << SizeLimit);
-        Become(&TGetScriptExecutionResultActor::StateFunc);
-    }
-
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvFetchScriptResultsResponse, Handle);
-    )
-
-    void Handle(TEvFetchScriptResultsResponse::TPtr& ev) {
-        KQP_PROXY_LOG_D("Finished " << ev->Sender << ", status: " << ev->Get()->Status << ", issues: " << ev->Get()->Issues.ToOneLineString() << ", has more: " << ev->Get()->HasMoreResults);
-        Forward(ev, ReplyActorId);
-        PassAway();
-    }
-
 private:
-    void Reply(Ydb::StatusIds::StatusCode status, const TString& message) {
-        KQP_PROXY_LOG_W("Failed with status " << status << ", message: " << message);
-        Send(ReplyActorId, new TEvFetchScriptResultsResponse(status, std::nullopt, true, {NYql::TIssue(message)}));
-        PassAway();
-    }
-
-    TString LogPrefix() const {
-        return TStringBuilder() << "[TGetScriptExecutionResultActor] OwnerId: " << ReplyActorId << " ActorId: " << SelfId() << " Database: " << Database << " ExecutionId: " << ExecutionId << " ResultSetIndex: " << ResultSetIndex << ". ";
-    }
-
-private:
-    const TActorId ReplyActorId;
-    const TString Database;
-    const TString ExecutionId;
-    std::optional<TString> UserSID;
-    const i32 ResultSetIndex;
-    const i64 Offset;
-    const i64 RowsLimit;
-    const i64 SizeLimit;
-    const TInstant OperationDeadline;
-};
-
-class TSaveScriptExternalEffectActor : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TSaveScriptExternalEffectActor, TEvSaveScriptExternalEffectResponse, TEvSaveScriptExternalEffectRequest::TDescription, i64>;
-
-    TSaveScriptExternalEffectActor(const TEvSaveScriptExternalEffectRequest::TDescription& request, i64 leaseGeneration)
-        : TQueryBase(__func__, {.Database = request.Database, .ExecutionId = request.ExecutionId, .LeaseGeneration = leaseGeneration})
-        , Request(request)
-        , LeaseGeneration(leaseGeneration)
-    {}
-
     void OnRunQuery() override {
-        KQP_PROXY_LOG_D("Save #" << Request.Sinks.size() << " sinks, CustomerSuppliedId: " << Request.CustomerSuppliedId);
+        constexpr char sql[] = R"(
+            -- TSaveScriptExternalEffectActor::OnRunQuery
+            DECLARE $database AS Text;
+            DECLARE $execution_id AS Text;
 
-        TString sql = R"(
+            SELECT
+                operation_status,
+                lease_generation,
+                customer_supplied_id,
+                script_sinks,
+                script_secret_names
+            FROM `.metadata/script_executions`
+            WHERE database = $database AND execution_id = $execution_id AND
+                  (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
+        )";
+
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetInfo, "Get operation info");
+        RunDataQuery(sql, &params, TTxControl::BeginTx());
+    }
+
+    void OnGetInfo() {
+        if (ResultSets.size() != 1) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unexpected database response");
+            return;
+        }
+
+        NYdb::TResultSetParser result(ResultSets[0]);
+        if (!result.TryNextRow()) {
+            Finish(Ydb::StatusIds::NOT_FOUND, "Script execution operation not found");
+            return;
+        }
+
+        if (result.ColumnParser("operation_status").GetOptionalInt32()) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Script execution operation already finished");
+            return;
+        }
+
+        const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
+        if (!leaseGenerationInDatabase) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation");
+            return;
+        }
+
+        if (LeaseGeneration != *leaseGenerationInDatabase) {
+            Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
+            return;
+        }
+
+        if (const auto& customerSuppliedId = result.ColumnParser("customer_supplied_id").GetOptionalUtf8(); customerSuppliedId && *customerSuppliedId != Request.CustomerSuppliedId) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Customer supplied id mismatch, expected: " << Request.CustomerSuppliedId << ", got: " << *customerSuppliedId);
+            return;
+        }
+
+        if (auto sinks = ParseScriptSinks(result)) {
+            Request.Sinks.insert(Request.Sinks.end(), sinks->begin(), sinks->end());
+        } else {
+            return;
+        }
+
+        if (auto secretNames = ParseSecretNames(result)) {
+            Request.SecretNames.insert(Request.SecretNames.end(), secretNames->begin(), secretNames->end());
+        } else {
+            return;
+        }
+
+        SaveExternalEffect();
+    }
+
+    void SaveExternalEffect() {
+        KQP_PROXY_LOG_D("Save #" << Request.Sinks.size() << " sinks, #" << Request.SecretNames.size() << " secret names, CustomerSuppliedId: " << Request.CustomerSuppliedId);
+
+        constexpr char sql[] = R"(
             -- TSaveScriptExternalEffectActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -3917,22 +3549,17 @@ public:
                 script_secret_names = $script_secret_names
             WHERE database = $database
               AND execution_id = $execution_id
-              AND (lease_generation IS NULL OR lease_generation = $lease_generation);
+              AND (lease_generation IS NULL OR lease_generation = $lease_generation)
+              AND operation_status IS NULL;
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Request.Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(Request.ExecutionId)
-                .Build()
             .AddParam("$customer_supplied_id")
                 .Utf8(Request.CustomerSuppliedId)
                 .Build()
             .AddParam("$script_sinks")
-                .JsonDocument(SequenceToJsonString(Request.Sinks.size(), [&](ui64 i, NJson::TJsonValue& value) {
+                .JsonDocument(SequenceToJsonString(Request.Sinks.size(), [&](const ui64 i, NJson::TJsonValue& value) {
                     SerializeBinaryProto(Request.Sinks[i], value);
                 }))
                 .Build()
@@ -3943,83 +3570,114 @@ public:
                 .Int64(LeaseGeneration)
                 .Build();
 
-        RunDataQuery(sql, &params);
+        SetQueryResultHandler(&TThis::OnQueryResult, "Save external effect");
+        RunDataQuery(sql, &params, TTxControl::ContinueAndCommitTx());
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvSaveScriptExternalEffectResponse(status, std::move(issues)));
     }
 
-private:
-    const TEvSaveScriptExternalEffectRequest::TDescription Request;
-    const i64 LeaseGeneration;
+    TEvSaveScriptExternalEffectRequest::TDescription Request;
 };
 
-struct LeaseFinalizationInfo {
-    TString Sql;
-    TDuration Backoff;
-    ELeaseState NewLeaseState = ELeaseState::ScriptFinalizing;
-};
+// Script execution finalization first phase: save final status and change leas state from ELeaseState::ScriptRunning to ELeaseState::ScriptFinalizing or ELeaseState::WaitRetry
+// Finalization will continue only if script execution has external effects, otherwise it will be finished on the first phase.
+// Finalization should be idempotent, because it may run multiple times during script execution runtime.
 
-LeaseFinalizationInfo GetLeaseFinalizationSql(TInstant startedAt, TInstant now, Ydb::StatusIds::StatusCode status, NKikimrKqp::TScriptExecutionRetryState& retryState, NYql::TIssues& issues) {
-    const auto& policy = TRetryPolicyItem::FromProto(status, retryState);
-    TRetryLimiter retryLimiter(retryState);
+template<typename TDerived, typename TResponse>
+class TScriptFinalizationActorBase : public TQueryBase<TDerived, TResponse> {
+    using TBase = TQueryBase<TDerived, TResponse>;
 
-    const bool retry = policy && retryLimiter.UpdateOnRetry(startedAt, TInstant::Now(), *policy);
-    retryLimiter.SaveToProto(retryState);
+public:
+    using TBase::TBase;
 
-    if (retry) {
-        issues = AddRootIssue(TStringBuilder()
-            << "Script execution operation failed with code " << Ydb::StatusIds::StatusCode_Name(status)
-            << " and will be restarted (RetryCount: " << retryLimiter.RetryCount << ", Backoff: " << retryLimiter.Backoff << ")"
-            << " at " << now, issues);
+protected:
+    struct TLeaseFinalizationInfo {
+        TString Sql;
+        TDuration Backoff;
+        ELeaseState NewLeaseState = ELeaseState::ScriptFinalizing;
+    };
 
-        return {
-            .Sql = R"(
-                UPSERT INTO `.metadata/script_execution_leases` (
-                    database, execution_id, lease_deadline, lease_state
-                ) VALUES (
-                    $database, $execution_id, $retry_deadline, $lease_state
-                );
-            )",
-            .Backoff = retryLimiter.Backoff,
-            .NewLeaseState = ELeaseState::WaitRetry
-        };
-    } else {
-        if (policy) {
-            TStringBuilder finalIssue;
-            finalIssue << "Script execution operation failed with code " << Ydb::StatusIds::StatusCode_Name(status);
-            if (policy->PolicyInitialized) {
-                finalIssue << " (" << retryLimiter.LastError << ")";
+    TLeaseFinalizationInfo GetLeaseFinalizationSql(TInstant now, Ydb::StatusIds::StatusCode status, NYql::TIssues& issues) {
+        const auto& policy = TRetryPolicyItem::FromProto(status, RetryState);
+        TRetryLimiter retryLimiter(RetryState);
+
+        const bool retry = policy && retryLimiter.UpdateOnRetry(StartedAt, TInstant::Now(), *policy);
+        retryLimiter.SaveToProto(RetryState);
+
+        if (retry) {
+            issues = AddRootIssue(TStringBuilder()
+                << "Script execution operation failed with code " << Ydb::StatusIds::StatusCode_Name(status)
+                << " and will be restarted (RetryCount: " << retryLimiter.RetryCount << ", Backoff: " << retryLimiter.Backoff << ")"
+                << " at " << now, issues);
+
+            return {
+                .Sql = R"(
+                    UPSERT INTO `.metadata/script_execution_leases` (
+                        database, execution_id, lease_deadline, lease_state
+                    ) VALUES (
+                        $database, $execution_id, $retry_deadline, $lease_state
+                    );
+                )",
+                .Backoff = retryLimiter.Backoff,
+                .NewLeaseState = ELeaseState::WaitRetry
+            };
+        } else {
+            if (policy) {
+                TStringBuilder finalIssue;
+                finalIssue << "Script execution operation failed with code " << Ydb::StatusIds::StatusCode_Name(status);
+                if (policy->PolicyInitialized) {
+                    finalIssue << " (" << retryLimiter.LastError << ")";
+                }
+                issues = AddRootIssue(finalIssue << " at " << now, issues);
             }
-            issues = AddRootIssue(finalIssue << " at " << now, issues);
+
+            return {
+                .Sql = R"(
+                    DELETE FROM `.metadata/script_execution_leases`
+                    WHERE database = $database AND execution_id = $execution_id;
+                )"
+            };
+        }
+    }
+
+    bool ValidateLease(NYdb::TResultSetParser& result) {
+        const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
+        if (!leaseGenerationInDatabase) {
+            TBase::Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation");
+            return false;
         }
 
-        return {
-            .Sql = R"(
-                DELETE FROM `.metadata/script_execution_leases`
-                WHERE database = $database AND execution_id = $execution_id;
-            )"
-        };
+        if (TBase::LeaseGeneration != *leaseGenerationInDatabase) {
+            TBase::Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << TBase::LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
+            return false;
+        }
+
+        const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning));
+        if (!IsIn({ELeaseState::ScriptRunning, ELeaseState::ScriptFinalizing}, static_cast<ELeaseState>(leaseState))) {
+            TBase::Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Lease is not in expected state: " << leaseState);
+            return false;
+        }
+
+        return true;
     }
-}
 
-class TSaveScriptFinalStatusActor : public TQueryBase {
+    NKikimrKqp::TScriptExecutionRetryState RetryState;
+    TInstant StartedAt;
+};
+
+class TSaveScriptFinalStatusActor final : public TScriptFinalizationActorBase<TSaveScriptFinalStatusActor, TEvSaveScriptFinalStatusResponse> {
 public:
-    using TRetry = TQueryRetryActor<TSaveScriptFinalStatusActor, TEvSaveScriptFinalStatusResponse, TEvScriptFinalizeRequest::TDescription>;
-
-    explicit TSaveScriptFinalStatusActor(const TEvScriptFinalizeRequest::TDescription& request)
-        : TQueryBase(__func__, {.Database = request.Database, .ExecutionId = request.ExecutionId, .LeaseGeneration = request.LeaseGeneration})
-        , Request(request)
+    explicit TSaveScriptFinalStatusActor(TEvScriptFinalizeRequest::TDescription request)
+        : TScriptFinalizationActorBase(__func__, {.Database = request.Database, .ExecutionId = request.ExecutionId, .LeaseGeneration = request.LeaseGeneration})
+        , Request(std::move(request))
         , Response(std::make_unique<TEvSaveScriptFinalStatusResponse>())
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TSaveScriptFinalStatusActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -4048,16 +3706,8 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Request.Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(Request.ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TSaveScriptFinalStatusActor::OnGetInfo, "Get operation info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetInfo, "Get operation info");
         RunDataQuery(sql, &params, TTxControl::BeginTx());
     }
 
@@ -4070,31 +3720,28 @@ public:
         {   // Execution info
             NYdb::TResultSetParser result(ResultSets[0]);
             if (!result.TryNextRow()) {
-                Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
+                Response->ExecutionEntryExists = false;
+                Finish();
                 return;
             }
 
             const auto finalizationStatus = result.ColumnParser("finalization_status").GetOptionalInt32();
             if (finalizationStatus) {
-                if (Request.FinalizationStatus != *finalizationStatus) {
-                    Finish(Ydb::StatusIds::PRECONDITION_FAILED, "Execution already have different finalization status");
-                    return;
-                }
+                Request.FinalizationStatus = static_cast<EFinalizationStatus>(*finalizationStatus);
                 Response->ApplicateScriptExternalEffectRequired = true;
             }
 
             if (const auto operationStatus = result.ColumnParser("operation_status").GetOptionalInt32()) {
-                FinalStatusAlreadySaved = true;
-                Response->OperationAlreadyFinalized = !finalizationStatus;
+                Response->FinalStatusAlreadySaved = true;
                 CommitTransaction();
                 return;
             }
 
-            if (const auto customerSuppliedId = result.ColumnParser("customer_supplied_id").GetOptionalUtf8()) {
-                Response->CustomerSuppliedId = *customerSuppliedId;
+            if (auto customerSuppliedId = result.ColumnParser("customer_supplied_id").GetOptionalUtf8()) {
+                Response->CustomerSuppliedId = std::move(*customerSuppliedId);
             }
 
-            if (const auto userToken = result.ColumnParser("user_token").GetOptionalUtf8()) {
+            if (const auto& userToken = result.ColumnParser("user_token").GetOptionalUtf8()) {
                 TVector<NACLib::TSID> userGroupSids;
                 if (const auto serializedUserGroupSids = result.ColumnParser("user_group_sids").GetOptionalJsonDocument()) {
                     if (!GetUserGroupSids(*serializedUserGroupSids, userGroupSids)) {
@@ -4105,51 +3752,27 @@ public:
                 Response->UserToken = new NACLib::TUserToken(TString(*userToken), userGroupSids);
             }
 
-            if (SerializedSinks = result.ColumnParser("script_sinks").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*SerializedSinks, &value) || value.GetType() != NJson::JSON_ARRAY) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Script sinks are corrupted");
-                    return;
-                }
-
-                for (auto i = 0; i < value.GetIntegerRobust(); ++i) {
-                    const NJson::TJsonValue* serializedSink;
-                    value.GetValuePointer(i, &serializedSink);
-                    Y_ENSURE(serializedSink);
-
-                    NKqpProto::TKqpExternalSink sink;
-                    DeserializeBinaryProto(*serializedSink, sink);
-                    Response->Sinks.push_back(sink);
-                }
+            if (auto sinks = ParseScriptSinks(result)) {
+                SerializedSinks = result.ColumnParser("script_sinks").GetOptionalJsonDocument();
+                Response->Sinks = std::move(*sinks);
+            } else {
+                return;
             }
 
-            if (SerializedSecretNames = result.ColumnParser("script_secret_names").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*SerializedSecretNames, &value) || value.GetType() != NJson::JSON_ARRAY) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Script secret names are corrupted");
-                    return;
-                }
-
-                for (auto i = 0; i < value.GetIntegerRobust(); i++) {
-                    const NJson::TJsonValue* serializedSecretName;
-                    value.GetValuePointer(i, &serializedSecretName);
-                    Y_ENSURE(serializedSecretName);
-
-                    Response->SecretNames.push_back(serializedSecretName->GetString());
-                }
+            if (auto secretNames = ParseSecretNames(result)) {
+                SerializedSecretNames = result.ColumnParser("script_secret_names").GetOptionalJsonDocument();
+                Response->SecretNames = std::move(*secretNames);
+            } else {
+                return;
             }
 
-            if (const auto serializedRetryState = result.ColumnParser("retry_state").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*serializedRetryState, &value)) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Retry state is corrupted");
-                    return;
-                }
-
-                NProtobufJson::Json2Proto(value, RetryState);
+            if (auto retryState = ParseRetryState(result)) {
+                RetryState = std::move(*retryState);
+            } else {
+                return;
             }
 
-            const auto serializedMeta = result.ColumnParser("meta").GetOptionalJsonDocument();
+            const auto& serializedMeta = result.ColumnParser("meta").GetOptionalJsonDocument();
             if (!serializedMeta) {
                 Finish(Ydb::StatusIds::INTERNAL_ERROR, "Missing operation metainformation");
                 return;
@@ -4163,8 +3786,8 @@ public:
 
             NKikimrKqp::TScriptExecutionOperationMeta meta;
             DeserializeBinaryProto(serializedMetaJson, meta);
-            OperationTtl = GetDuration(meta.GetOperationTtl());
-            LeaseDuration = GetDuration(meta.GetLeaseDuration());
+            OperationTtl = NProtoInterop::CastFromProto(meta.GetOperationTtl());
+            LeaseDuration = NProtoInterop::CastFromProto(meta.GetLeaseDuration());
 
             if (meta.GetSaveQueryPhysicalGraph() && !result.ColumnParser("has_graph").GetBool()) {
                 // Disable retries if state not saved
@@ -4185,20 +3808,7 @@ public:
                 return;
             }
 
-            const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
-            if (!leaseGenerationInDatabase) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation");
-                return;
-            }
-
-            if (Request.LeaseGeneration != *leaseGenerationInDatabase) {
-                Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << Request.LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
-                return;
-            }
-
-            const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning));
-            if (!IsIn({ELeaseState::ScriptRunning, ELeaseState::ScriptFinalizing}, static_cast<ELeaseState>(leaseState))) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Lease is not in expected state: " << leaseState);
+            if (!ValidateLease(result)) {
                 return;
             }
         }
@@ -4229,25 +3839,27 @@ public:
             DECLARE $retry_state AS JsonDocument;
             DECLARE $retry_deadline AS Timestamp;
             DECLARE $lease_state AS Int32;
+            DECLARE $lease_generation AS Int64;
 
-            UPDATE `.metadata/script_executions`
-            SET
-                operation_status = $operation_status,
-                execution_status = $execution_status,
-                finalization_status = IF($applicate_script_external_effect_required, $finalization_status, NULL),
-                issues = $issues,
-                plan_compressed = $plan_compressed,
-                plan_compression_method = $plan_compression_method,
-                end_ts = CurrentUtcTimestamp(),
-                stats = $stats,
-                ast_compressed = $ast_compressed,
-                ast_compression_method = $ast_compression_method,
-                expire_at = IF($operation_ttl > CAST(0 AS Interval), CurrentUtcTimestamp() + $operation_ttl, NULL),
-                customer_supplied_id = IF($applicate_script_external_effect_required, $customer_supplied_id, NULL),
-                script_sinks = IF($applicate_script_external_effect_required, $script_sinks, NULL),
-                script_secret_names = IF($applicate_script_external_effect_required, $script_secret_names, NULL),
-                retry_state = $retry_state
-            WHERE database = $database AND execution_id = $execution_id;
+            UPSERT INTO `.metadata/script_executions` (
+                database, execution_id, operation_status, execution_status, finalization_status, issues,
+                plan_compressed, plan_compression_method, end_ts, stats, ast_compressed, ast_compression_method,
+                expire_at,
+                customer_supplied_id,
+                script_sinks,
+                script_secret_names,
+                retry_state
+            ) VALUES (
+                $database, $execution_id, $operation_status, $execution_status,
+                IF($applicate_script_external_effect_required, $finalization_status, NULL),
+                $issues,
+                $plan_compressed, $plan_compression_method, CurrentUtcTimestamp(), $stats, $ast_compressed, $ast_compression_method,
+                IF($operation_ttl > CAST(0 AS Interval), CurrentUtcTimestamp() + $operation_ttl, NULL),
+                IF($applicate_script_external_effect_required, $customer_supplied_id, NULL),
+                IF($applicate_script_external_effect_required, $script_sinks, NULL),
+                IF($applicate_script_external_effect_required, $script_secret_names, NULL),
+                $retry_state
+            );
         )";
 
         if (Request.CancelledByUser) {
@@ -4257,11 +3869,10 @@ public:
         TInstant retryDeadline = TInstant::Now();
         ELeaseState leaseState = ELeaseState::ScriptFinalizing;
         if (!Response->ApplicateScriptExternalEffectRequired) {
-            const auto leaseInfo = GetLeaseFinalizationSql(StartedAt, retryDeadline, Request.OperationStatus, RetryState, Request.Issues);
+            const auto leaseInfo = GetLeaseFinalizationSql(retryDeadline, Request.OperationStatus, Request.Issues);
             sql << leaseInfo.Sql;
             retryDeadline += leaseInfo.Backoff;
             leaseState = leaseInfo.NewLeaseState;
-            Response->WaitRetry = leaseInfo.NewLeaseState == ELeaseState::WaitRetry;
         } else {
             retryDeadline += LeaseDuration;
             sql <<  R"(
@@ -4293,17 +3904,11 @@ public:
             << ", exec status: " << Ydb::Query::ExecStatus_Name(Request.ExecStatus)
             << ", finalization status (applicate effect: " << Response->ApplicateScriptExternalEffectRequired << "): " << static_cast<ui64>(Request.FinalizationStatus)
             << ", issues: " << Request.Issues.ToOneLineString()
-            << ", retry deadline (wait retry: " << Response->WaitRetry << "): " << retryDeadline
+            << ", retry deadline: " << retryDeadline
             << ", lease state: " << static_cast<i32>(leaseState));
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$database")
-                .Utf8(Request.Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(Request.ExecutionId)
-                .Build()
             .AddParam("$operation_status")
                 .Int32(Request.OperationStatus)
                 .Build()
@@ -4356,16 +3961,12 @@ public:
                 .Int32(static_cast<i32>(leaseState))
                 .Build();
 
-        SetQueryResultHandler(&TSaveScriptFinalStatusActor::OnQueryResult, "Update final status");
+        SetQueryResultHandler(&TThis::OnQueryResult, "Update final status");
         RunDataQuery(sql, &params, TTxControl::ContinueAndCommitTx());
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        if (!FinalStatusAlreadySaved) {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        if (!Response->FinalStatusAlreadySaved) {
             KQP_PROXY_LOG_D("Finish script execution operation"
                 << ". Status: " << Ydb::StatusIds::StatusCode_Name(Request.OperationStatus)
                 << ". Issues: " << Request.Issues.ToOneLineString());
@@ -4373,48 +3974,37 @@ public:
 
         Response->Status = status;
         Response->Issues = std::move(issues);
-
         Send(Owner, Response.release());
     }
 
-private:
     bool HasExternalEffect() const {
         return !Response->Sinks.empty();
     }
 
-private:
     TEvScriptFinalizeRequest::TDescription Request;
     std::unique_ptr<TEvSaveScriptFinalStatusResponse> Response;
-
-    bool FinalStatusAlreadySaved = false;
-
     TDuration OperationTtl;
     TDuration LeaseDuration;
     std::optional<TString> SerializedSinks;
     std::optional<TString> SerializedSecretNames;
-    NKikimrKqp::TScriptExecutionRetryState RetryState;
-    TInstant StartedAt;
 };
 
-class TScriptFinalizationFinisherActor : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TScriptFinalizationFinisherActor, TEvScriptExecutionFinished, TString, TString, std::optional<Ydb::StatusIds::StatusCode>, NYql::TIssues, i64>;
+// Script execution finalization second phase: after commit / rollback of external effects remove finalization status and lease
 
-    TScriptFinalizationFinisherActor(const TString& executionId, const TString& database,
-        std::optional<Ydb::StatusIds::StatusCode> operationStatus, NYql::TIssues operationIssues,
-        i64 leaseGeneration)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId, .LeaseGeneration = leaseGeneration})
-        , ExecutionId(executionId)
-        , Database(database)
+class TScriptFinalizationFinisherActor final : public TScriptFinalizationActorBase<TScriptFinalizationFinisherActor, TEvScriptExecutionFinished>  {
+public:
+    TScriptFinalizationFinisherActor(TString database, TString executionId, const std::optional<Ydb::StatusIds::StatusCode> operationStatus,
+        NYql::TIssues operationIssues, const i64 leaseGeneration)
+        : TScriptFinalizationActorBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
         , OperationStatus(operationStatus)
         , OperationIssues(AddRootIssue("Script finalization failed", operationIssues))
-        , LeaseGeneration(leaseGeneration)
     {}
 
+private:
     void OnRunQuery() override {
         KQP_PROXY_LOG_D("Start" << (OperationStatus ? " with status " + Ydb::StatusIds::StatusCode_Name(*OperationStatus) : "") << ", issues: " << OperationIssues.ToOneLineString());
 
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TScriptFinalizationFinisherActor::OnRunQuery
             DECLARE $database AS Text;
             DECLARE $execution_id AS Text;
@@ -4440,16 +4030,8 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build();
-
-        SetQueryResultHandler(&TScriptFinalizationFinisherActor::OnGetInfo, "Get operation info");
+        auto params = CreateParams();
+        SetQueryResultHandler(&TThis::OnGetInfo, "Get operation info");
         RunDataQuery(sql, &params, TTxControl::BeginTx());
     }
 
@@ -4461,37 +4043,22 @@ public:
 
         {   // Lease info
             NYdb::TResultSetParser result(ResultSets[1]);
-            if (result.TryNextRow()) {
-                const auto leaseGenerationInDatabase = result.ColumnParser("lease_generation").GetOptionalInt64();
-                if (!leaseGenerationInDatabase) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Unknown lease generation");
-                    return;
-                }
-
-                if (LeaseGeneration != *leaseGenerationInDatabase) {
-                    Finish(Ydb::StatusIds::PRECONDITION_FAILED, TStringBuilder() << "Lease was lost, expected generation: " << LeaseGeneration << ", got: " << *leaseGenerationInDatabase);
-                    return;
-                }
-
-                const auto leaseState = result.ColumnParser("lease_state").GetOptionalInt32().value_or(static_cast<i32>(ELeaseState::ScriptRunning));
-                if (!IsIn({ELeaseState::ScriptRunning, ELeaseState::ScriptFinalizing}, static_cast<ELeaseState>(leaseState))) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Lease is not in expected state: " << leaseState);
-                    return;
-                }
+            if (result.TryNextRow() && !ValidateLease(result)) {
+                return;
             }
         }
 
         {   // Execution info
             NYdb::TResultSetParser result(ResultSets[0]);
             if (!result.TryNextRow()) {
-                Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
+                ExecutionEntryExists = false;
+                Finish();
                 return;
             }
 
-            const auto finalizationStatus = result.ColumnParser("finalization_status").GetOptionalInt32();
-            if (!finalizationStatus) {
-                AlreadyFinished = true;
-                Finish(Ydb::StatusIds::PRECONDITION_FAILED, "Already finished");
+            if (!result.ColumnParser("finalization_status").GetOptionalInt32()) {
+                AlreadyFinalized = true;
+                Finish();
                 return;
             }
 
@@ -4514,14 +4081,10 @@ public:
 
             ExecutionStatus = static_cast<Ydb::Query::ExecStatus>(*executionStatus);
 
-            if (const auto serializedRetryState = result.ColumnParser("retry_state").GetOptionalJsonDocument()) {
-                NJson::TJsonValue value;
-                if (!NJson::ReadJsonTree(*serializedRetryState, &value)) {
-                    Finish(Ydb::StatusIds::INTERNAL_ERROR, "Retry state is corrupted");
-                    return;
-                }
-
-                NProtobufJson::Json2Proto(value, RetryState);
+            if (auto retryState = ParseRetryState(result)) {
+                RetryState = std::move(*retryState);
+            } else {
+                return;
             }
 
             if (const auto issuesSerialized = result.ColumnParser("issues").GetOptionalJsonDocument()) {
@@ -4542,11 +4105,9 @@ public:
 
             NKikimrKqp::TScriptExecutionOperationMeta meta;
             DeserializeBinaryProto(serializedMetaJson, meta);
-            if (meta.GetSaveQueryPhysicalGraph()) {
+            if (meta.GetSaveQueryPhysicalGraph() && !result.ColumnParser("has_graph").GetBool()) {
                 // Disable retries if state not saved
-                if (!result.ColumnParser("has_graph").GetBool()) {
-                    RetryState.ClearRetryPolicyMapping();
-                }
+                RetryState.ClearRetryPolicyMapping();
             }
 
             if (const auto startTs = result.ColumnParser("start_ts").GetOptionalTimestamp()) {
@@ -4570,41 +4131,32 @@ public:
             DECLARE $retry_state AS JsonDocument;
             DECLARE $retry_deadline AS Timestamp;
 
-            UPDATE `.metadata/script_executions`
-            SET
-                operation_status = $operation_status,
-                execution_status = $execution_status,
-                finalization_status = NULL,
-                issues = $issues,
-                script_sinks = NULL,
-                customer_supplied_id = NULL,
-                script_secret_names = NULL,
-                retry_state = $retry_state
-            WHERE database = $database AND execution_id = $execution_id;
+            UPSERT INTO `.metadata/script_executions` (
+                database, execution_id, operation_status, execution_status,
+                finalization_status, issues, script_sinks,
+                customer_supplied_id, script_secret_names, retry_state
+            ) VALUES (
+                $database, $execution_id, $operation_status, $execution_status,
+                NULL, $issues, NULL,
+                NULL, NULL, $retry_state
+            );
         )";
 
         Y_ENSURE(OperationStatus);
 
         TInstant retryDeadline = TInstant::Now();
-        const auto leaseInfo = GetLeaseFinalizationSql(StartedAt, retryDeadline, *OperationStatus, RetryState, OperationIssues);
+        const auto leaseInfo = GetLeaseFinalizationSql(retryDeadline, *OperationStatus, OperationIssues);
         sql << leaseInfo.Sql;
         retryDeadline += leaseInfo.Backoff;
-        WaitRetry = leaseInfo.NewLeaseState == ELeaseState::WaitRetry;
 
         KQP_PROXY_LOG_D("Do finalization with status " << *OperationStatus
             << ", exec status: " << Ydb::Query::ExecStatus_Name(ExecutionStatus)
             << ", issues: " << OperationIssues.ToOneLineString()
-            << ", retry deadline (wait retry: " << WaitRetry << "): " << retryDeadline
+            << ", retry deadline: " << retryDeadline
             << ", lease state: " << static_cast<i32>(leaseInfo.NewLeaseState));
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
             .AddParam("$operation_status")
                 .Int32(*OperationStatus)
                 .Build()
@@ -4624,15 +4176,11 @@ public:
                 .Int32(static_cast<i32>(leaseInfo.NewLeaseState))
                 .Build();
 
-        SetQueryResultHandler(&TScriptFinalizationFinisherActor::OnQueryResult, "Update final status");
+        SetQueryResultHandler(&TThis::OnQueryResult, "Update final status");
         RunDataQuery(sql, &params, TTxControl::ContinueAndCommitTx());
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         if (!OperationStatus) {
             OperationStatus = status;
         }
@@ -4641,35 +4189,34 @@ public:
             OperationIssues.AddIssues(AddRootIssue(TStringBuilder() << "Update final status failed " << status, issues));
         }
 
-        Send(Owner, new TEvScriptExecutionFinished(AlreadyFinished, WaitRetry, *OperationStatus, std::move(OperationIssues)));
+        Send(Owner, new TEvScriptExecutionFinished(*OperationStatus, {
+            .ExecutionEntryExists = ExecutionEntryExists,
+            .AlreadyStopped = AlreadyFinalized,
+        }, std::move(OperationIssues)));
     }
 
-private:
-    const TString ExecutionId;
-    const TString Database;
     std::optional<Ydb::StatusIds::StatusCode> OperationStatus;
     Ydb::Query::ExecStatus ExecutionStatus = Ydb::Query::EXEC_STATUS_UNSPECIFIED;
     NYql::TIssues OperationIssues;
-    NKikimrKqp::TScriptExecutionRetryState RetryState;
-    TInstant StartedAt;
-    const i64 LeaseGeneration;
-    bool AlreadyFinished = false;
-    bool WaitRetry = false;
+    bool AlreadyFinalized = false;
+    bool ExecutionEntryExists = true;
 };
 
-class TScriptProgressActor : public TQueryBase {
-public:
-    TScriptProgressActor(const TString& database, const TString& executionId, const TString& queryPlan, i64 leaseGeneration,
-        const std::optional<TString>& ast, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId, .LeaseGeneration = leaseGeneration})
-        , Database(database)
-        , ExecutionId(executionId)
-        , QueryPlan(queryPlan)
-        , LeaseGeneration(leaseGeneration)
-        , QueryAst(ast)
-        , Compressor(queryServiceConfig.GetQueryArtifactsCompressionMethod(), queryServiceConfig.GetQueryArtifactsCompressionMinSize())
-    {}
+// Update runtime statistics of script execution, started from TRunScriptActor
 
+class TScriptProgressActor final : public TQueryBase<TScriptProgressActor, TEvSaveScriptProgressResponse> {
+public:
+    TScriptProgressActor(TString database, TString executionId, std::optional<TString> queryPlan, std::optional<TString> ast,
+        const i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
+        , QueryPlan(std::move(queryPlan))
+        , QueryAst(std::move(ast))
+        , Compressor(queryServiceConfig.GetQueryArtifactsCompressionMethod(), queryServiceConfig.GetQueryArtifactsCompressionMinSize())
+    {
+        Y_VALIDATE(QueryPlan || QueryAst, "Plan ot ast should be set");
+    }
+
+private:
     void OnRunQuery() override {
         const auto& artifacts = CompressScriptArtifacts(QueryAst, QueryPlan, Compressor);
         if (artifacts.Issues) {
@@ -4680,8 +4227,6 @@ public:
             -- TScriptProgressActor::OnRunQuery
             DECLARE $execution_id AS Text;
             DECLARE $database AS Text;
-            DECLARE $plan_compressed AS Optional<String>;
-            DECLARE $plan_compression_method AS Optional<Text>;
             DECLARE $execution_status AS Int32;
             DECLARE $lease_generation AS Int64;
         )";
@@ -4689,31 +4234,37 @@ public:
         auto sql = TStringBuilder() << R"(
             UPDATE `.metadata/script_executions`
             SET
-                plan_compressed = $plan_compressed,
-                plan_compression_method = $plan_compression_method,
                 execution_status = $execution_status
         )";
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
-            .AddParam("$plan_compressed")
-                .OptionalString(artifacts.Plan)
-                .Build()
-            .AddParam("$plan_compression_method")
-                .OptionalUtf8(artifacts.PlanCompressionMethod)
-                .Build()
             .AddParam("$execution_status")
                 .Int32(Ydb::Query::EXEC_STATUS_RUNNING)
                 .Build()
             .AddParam("$lease_generation")
                 .Int64(LeaseGeneration)
                 .Build();
+
+        if (artifacts.Plan) {
+            params
+                .AddParam("$plan_compressed")
+                    .OptionalString(artifacts.Plan)
+                    .Build()
+                .AddParam("$plan_compression_method")
+                    .OptionalUtf8(artifacts.PlanCompressionMethod)
+                    .Build();
+
+            parameters << R"(
+                DECLARE $plan_compressed AS Optional<String>;
+                DECLARE $plan_compression_method AS Optional<Text>;
+            )";
+
+            sql << R"(
+                , plan_compressed = $plan_compressed,
+                plan_compression_method = $plan_compression_method
+            )";
+        }
 
         if (artifacts.Ast) {
             params
@@ -4738,42 +4289,37 @@ public:
         sql << R"(
             WHERE database = $database
               AND execution_id = $execution_id
-              AND (lease_generation IS NULL OR lease_generation = $lease_generation);
+              AND (lease_generation IS NULL OR lease_generation = $lease_generation)
+              AND operation_status IS NULL;
         )";
 
         RunDataQuery(parameters << sql, &params);
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvSaveScriptProgressResponse(status, QueryAst && status == Ydb::StatusIds::SUCCESS, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
-    const TString QueryPlan;
-    const i64 LeaseGeneration;
+    const std::optional<TString> QueryPlan;
     const std::optional<TString> QueryAst;
     const TCompressor Compressor;
 };
 
-class TListExpiredLeasesQueryActor : public TQueryBase {
+// Find all script executions with expired lease in any status and finalize or retry them
+
+class TListExpiredLeasesQueryActor final : public TQueryBase<TListExpiredLeasesQueryActor, TEvListExpiredLeasesResponse> {
     static constexpr ui64 MAX_LISTED_LEASES = 100;
 
 public:
     TListExpiredLeasesQueryActor()
         : TQueryBase(__func__, {})
-        , LeaseDeadline(TInstant::Now())
     {}
 
+private:
     void OnRunQuery() override {
         SetOperationInfo(OperationName, Owner.ToString());
 
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TListExpiredLeasesQueryActor::OnRunQuery
             DECLARE $max_lease_deadline AS Timestamp;
             DECLARE $max_listed_leases AS Uint64;
@@ -4796,7 +4342,7 @@ public:
                 .Uint64(MAX_LISTED_LEASES)
                 .Build();
 
-        RunDataQuery(sql, &params, TTxControl::BeginAndCommitTx(true));
+        RunDataQuery(sql, &params, TTxControl::BeginAndCommitTx(/* snapshotRead */ true));
     }
 
     void OnQueryResult() override {
@@ -4810,73 +4356,70 @@ public:
 
         NYdb::TResultSetParser result(ResultSets[0]);
         while (result.TryNextRow()) {
-            const std::optional<TString> database = result.ColumnParser("database").GetOptionalUtf8();
+            std::optional<TString> database = result.ColumnParser("database").GetOptionalUtf8();
             if (!database) {
                 KQP_PROXY_LOG_E("Database field is null for script execution lease");
                 continue;
             }
 
-            const std::optional<TString> executionId = result.ColumnParser("execution_id").GetOptionalUtf8();
+            std::optional<TString> executionId = result.ColumnParser("execution_id").GetOptionalUtf8();
             if (!executionId) {
                 KQP_PROXY_LOG_E("Execution id field is null for script execution lease in database " << *database);
                 continue;
             }
 
-            Leases.push_back({*database, *executionId});
+            Leases.emplace_back(TEvListExpiredLeasesResponse::TLeaseInfo{std::move(*database), std::move(*executionId)});
         }
 
         KQP_PROXY_LOG_D("Found " << Leases.size() << " expired leases (fetched rows " << rowsCount << ")");
         Finish();
     }
 
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvListExpiredLeasesResponse(status, std::move(Leases), std::move(issues)));
     }
 
-private:
-    const TInstant LeaseDeadline;
+    const TInstant LeaseDeadline = TInstant::Now();
     std::vector<TEvListExpiredLeasesResponse::TLeaseInfo> Leases;
 };
 
-class TRefreshScriptExecutionLeasesActor : public TActorBootstrapped<TRefreshScriptExecutionLeasesActor> {
+class TRefreshScriptExecutionLeasesActor final : public TActorBootstrapped<TRefreshScriptExecutionLeasesActor> {
 public:
-    TRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
+    TRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters)
         : ReplyActorId(replyActorId)
-        , QueryServiceConfig(queryServiceConfig)
-        , Counters(counters)
+        , QueryServiceConfig(std::move(queryServiceConfig))
+        , Counters(std::move(counters))
     {}
 
     void Bootstrap() {
         const auto& listerId = Register(new TListExpiredLeasesQueryActor());
         KQP_PROXY_LOG_D("Bootstrap. Started TListExpiredLeasesQueryActor: " << listerId);
 
-        Become(&TRefreshScriptExecutionLeasesActor::StateFunc);
+        Become(&TThis::StateFunc);
     }
 
     STRICT_STFUNC(StateFunc,
         hFunc(TEvListExpiredLeasesResponse, Handle);
-        hFunc(TEvPrivate::TEvLeaseCheckResult, Handle);
+        hFunc(TEvPrivate::TEvFinalizeScriptLeaseResult, Handle);
     )
 
+private:
     void Handle(TEvListExpiredLeasesResponse::TPtr& ev) {
         const auto& leases = ev->Get()->Leases;
         KQP_PROXY_LOG_D("Got list expired leases response " << ev->Sender << ", found " << leases.size() << " expired leases");
 
         for (const auto& lease : leases) {
-            const auto& checkerId = Register(new TCheckLeaseStatusActor(SelfId(), lease.Database, lease.ExecutionId, QueryServiceConfig, Counters, true, CookieId++));
-            KQP_PROXY_LOG_D("Database: " << lease.Database << "ExecutionId: " << lease.ExecutionId << ", start TCheckLeaseStatusActor #" << CookieId << " " << checkerId);
+            const auto& checkerId = Register(new TFinalizeScriptLeaseActor(SelfId(), lease.Database, lease.ExecutionId, QueryServiceConfig, Counters, {.Cookie = CookieId++}));
+            KQP_PROXY_LOG_D("Database: " << lease.Database << "ExecutionId: " << lease.ExecutionId << ", start TFinalizeScriptLeaseActor #" << CookieId << " " << checkerId);
             ++OperationsToCheck;
         }
 
         if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
-            KQP_PROXY_LOG_W("List expired leases failed with status " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+            const auto& issues = ev->Get()->Issues;
+            KQP_PROXY_LOG_W("List expired leases failed with status " << status << ", issues: " << issues.ToOneLineString());
 
             Success = false;
-            Issues.AddIssues(AddRootIssue(
-                TStringBuilder() << "Failed to list expired leases (" << status << ")",
-                ev->Get()->Issues,
-                true
-            ));
+            Issues.AddIssues(AddRootIssue(TStringBuilder() << "Failed to list expired leases (" << status << ")", issues, true));
         } else {
             KQP_PROXY_LOG_D("List expired leases successfully completed");
         }
@@ -4884,8 +4427,9 @@ public:
         MaybeFinish();
     }
 
-    void Handle(TEvPrivate::TEvLeaseCheckResult::TPtr& ev) {
+    void Handle(TEvPrivate::TEvFinalizeScriptLeaseResult::TPtr& ev) {
         Y_ABORT_UNLESS(ev->Cookie < CookieId);
+        Y_ABORT_UNLESS(OperationsToCheck > 0);
         --OperationsToCheck;
 
         if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
@@ -4893,11 +4437,7 @@ public:
             KQP_PROXY_LOG_W("Lease check #" << ev->Cookie << " " << ev->Sender << " failed, status: " << status << ", issues: " << issues.ToOneLineString() << ", OperationsToCheck: " << OperationsToCheck);
 
             Success = false;
-            Issues.AddIssues(AddRootIssue(
-                TStringBuilder() << "Lease check failed #" << ev->Cookie << " (" << status << ")",
-                ev->Get()->Issues,
-                true
-            ));
+            Issues.AddIssues(AddRootIssue(TStringBuilder() << "Lease check failed #" << ev->Cookie << " (" << status << ")", issues, true));
         } else {
             KQP_PROXY_LOG_D("Lease check #" << ev->Cookie << " " << ev->Sender << " successfully completed, OperationsToCheck: " << OperationsToCheck);
         }
@@ -4905,7 +4445,6 @@ public:
         MaybeFinish();
     }
 
-private:
     void MaybeFinish() {
         if (OperationsToCheck) {
             return;
@@ -4920,32 +4459,27 @@ private:
         return TStringBuilder() << "[TRefreshScriptExecutionLeasesActor] OwnerId: " << ReplyActorId << " ActorId: " << SelfId() << ". ";
     }
 
-private:
     const TActorId ReplyActorId;
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
     const TIntrusivePtr<TKqpCounters> Counters;
-
     ui64 CookieId = 0;
     ui64 OperationsToCheck = 0;
     bool Success = true;
     NYql::TIssues Issues;
 };
 
-class TSaveScriptExecutionPhysicalGraphActor : public TQueryBase {
-public:
-    using TRetry = TQueryRetryActor<TSaveScriptExecutionPhysicalGraphActor, TEvSaveScriptPhysicalGraphResponse, TString, TString, NKikimrKqp::TQueryPhysicalGraph, i64, NKikimrConfig::TQueryServiceConfig>;
+// Fetch / save script execution compilation and planning results, used when enabled checkpoints
 
-    TSaveScriptExecutionPhysicalGraphActor(const TString& database, const TString& executionId,
-        const NKikimrKqp::TQueryPhysicalGraph& physicalGraph, i64 leaseGeneration,
+class TSaveScriptExecutionPhysicalGraphActor final : public TQueryBase<TSaveScriptExecutionPhysicalGraphActor, TEvSaveScriptPhysicalGraphResponse> {
+public:
+    TSaveScriptExecutionPhysicalGraphActor(TString database, TString executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, const i64 leaseGeneration,
         const NKikimrConfig::TQueryServiceConfig& queryServiceConfig)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId, .LeaseGeneration = leaseGeneration})
-        , Database(database)
-        , ExecutionId(executionId)
-        , PhysicalGraph(physicalGraph)
-        , LeaseGeneration(leaseGeneration)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId), .LeaseGeneration = leaseGeneration})
+        , PhysicalGraph(std::move(physicalGraph))
         , Compressor(queryServiceConfig.GetQueryArtifactsCompressionMethod(), queryServiceConfig.GetQueryArtifactsCompressionMinSize())
     {}
 
+private:
     void OnRunQuery() override {
         using namespace fmt::literals;
 
@@ -4970,19 +4504,14 @@ public:
                 graph_compression_method = $graph_compression_method
             WHERE database = $database
               AND execution_id = $execution_id
-              AND (lease_generation IS NULL OR lease_generation = $lease_generation);
+              AND (lease_generation IS NULL OR lease_generation = $lease_generation)
+              AND operation_status IS NULL;
         )", "streaming_disposition"_a = streamingDispositionUpdate);
 
-        const auto [graphCompressionMethod, graphCompressed] = Compressor.Compress(PhysicalGraph.SerializeAsString());
+        const auto& [graphCompressionMethod, graphCompressed] = Compressor.Compress(PhysicalGraph.SerializeAsString());
 
-        NYdb::TParamsBuilder params;
+        auto params = CreateParams();
         params
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build()
             .AddParam("$graph_compressed")
                 .String(graphCompressed)
                 .Build()
@@ -4996,34 +4525,23 @@ public:
         RunDataQuery(sql, &params);
     }
 
-    void OnQueryResult() override {
-        Finish();
-    }
-
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
         Send(Owner, new TEvSaveScriptPhysicalGraphResponse(status, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
     const NKikimrKqp::TQueryPhysicalGraph PhysicalGraph;
-    const i64 LeaseGeneration;
     const TCompressor Compressor;
 };
 
-class TGetScriptExecutionPhysicalGraphActor : public TQueryBase {
+class TGetScriptExecutionPhysicalGraphActor final : public TQueryBase<TGetScriptExecutionPhysicalGraphActor, TEvGetScriptPhysicalGraphResponse> {
 public:
-    using TRetry = TQueryRetryActor<TGetScriptExecutionPhysicalGraphActor, TEvGetScriptPhysicalGraphResponse, TString, TString>;
-
-    TGetScriptExecutionPhysicalGraphActor(const TString& database, const TString& executionId)
-        : TQueryBase(__func__, {.Database = database, .ExecutionId = executionId})
-        , Database(database)
-        , ExecutionId(executionId)
+    TGetScriptExecutionPhysicalGraphActor(TString database, TString executionId)
+        : TQueryBase(__func__, {.Database = std::move(database), .ExecutionId = std::move(executionId)})
     {}
 
+private:
     void OnRunQuery() override {
-        TString sql = R"(
+        constexpr char sql[] = R"(
             -- TGetScriptExecutionPhysicalGraphActor::OnRunQuery
             DECLARE $execution_id AS Text;
             DECLARE $database AS Text;
@@ -5037,15 +4555,7 @@ public:
                   (expire_at > CurrentUtcTimestamp() OR expire_at IS NULL);
         )";
 
-        NYdb::TParamsBuilder params;
-        params
-            .AddParam("$execution_id")
-                .Utf8(ExecutionId)
-                .Build()
-            .AddParam("$database")
-                .Utf8(Database)
-                .Build();
-
+        auto params = CreateParams();
         RunDataQuery(sql, &params);
     }
 
@@ -5057,130 +4567,138 @@ public:
 
         NYdb::TResultSetParser result(ResultSets[0]);
         if (!result.TryNextRow()) {
-            Finish(Ydb::StatusIds::NOT_FOUND, "No such execution");
+            ExecutionEntryExists = false;
+            Finish();
             return;
         }
 
-        const std::optional<TString> graphCompressed = result.ColumnParser("graph_compressed").GetOptionalString();
-        if (!graphCompressed) {
-            Finish(Ydb::StatusIds::NOT_FOUND, "Graph is not saved");
-            return;
-        }
+        if (const std::optional<TString>& graphCompressed = result.ColumnParser("graph_compressed").GetOptionalString()) {
+            const std::optional<TString>& compressionMethod = result.ColumnParser("graph_compression_method").GetOptionalUtf8();
+            if (!compressionMethod) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Graph compression method is not found");
+                return;
+            }
 
-        const std::optional<TString> compressionMethod = result.ColumnParser("graph_compression_method").GetOptionalUtf8();
-        if (!compressionMethod) {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Graph compression method is not found");
-            return;
+            const TCompressor compressor(*compressionMethod);
+            const auto& graph = compressor.Decompress(*graphCompressed);
+            NKikimrKqp::TQueryPhysicalGraph graphProto;
+            if (!graphProto.ParseFromString(graph)) {
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, "Query physical graph is corrupted");
+                return;
+            }
+
+            PhysicalGraph = std::move(graphProto);
         }
 
         LeaseGeneration = result.ColumnParser("lease_generation").GetOptionalInt64().value_or(1);
 
-        const TCompressor compressor(*compressionMethod);
-        const auto& graph = compressor.Decompress(*graphCompressed);
-        NKikimrKqp::TQueryPhysicalGraph graphProto;
-        if (!graphProto.ParseFromString(graph)) {
-            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Query physical graph is corrupted");
-            return;
-        }
-
-        PhysicalGraph = std::move(graphProto);
         Finish();
     }
 
-    void OnFinish(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
-        Send(Owner, new TEvGetScriptPhysicalGraphResponse(status, std::move(PhysicalGraph), LeaseGeneration, std::move(issues)));
+    void OnFinish(const Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues) override {
+        Send(Owner, new TEvGetScriptPhysicalGraphResponse(status, std::move(PhysicalGraph), LeaseGeneration, ExecutionEntryExists, std::move(issues)));
     }
 
-private:
-    const TString Database;
-    const TString ExecutionId;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     i64 LeaseGeneration = 0;
+    bool ExecutionEntryExists = true;
 };
 
 } // anonymous namespace
 
-IActor* CreateScriptExecutionCreatorActor(TEvKqp::TEvScriptRequest::TPtr&& ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, TDuration maxRunTime) {
+IActor* CreateScriptExecutionCreatorActor(TEvKqp::TEvScriptRequest::TPtr&& ev, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, const TDuration maxRunTime) {
     TDuration leaseDuration = LEASE_DURATION;
-    ui64 seconds = 0;
-    if (TryFromString<ui64>(GetEnv("YDB_TEST_LEASE_DURATION_SEC"), seconds) && seconds) {
+
+    if (ui64 seconds = 0; TryFromString<ui64>(GetEnv("YDB_TEST_LEASE_DURATION_SEC"), seconds) && seconds) {
         leaseDuration = TDuration::Seconds(seconds);
     }
-    return new TCreateScriptExecutionActor(std::move(ev), queryServiceConfig, counters, maxRunTime, leaseDuration);
+
+    return new TCreateScriptExecutionActor(std::move(ev), std::move(queryServiceConfig), std::move(counters), maxRunTime, leaseDuration);
 }
 
-IActor* CreateScriptExecutionsTablesCreator(bool enableSecureScriptExecutions, ui64 generation) {
+IActor* CreateScriptExecutionsTablesCreator(const bool enableSecureScriptExecutions, const ui64 generation) {
     return new TScriptExecutionsTablesCreator(enableSecureScriptExecutions, generation);
 }
 
-IActor* CreateForgetScriptExecutionOperationActor(TEvForgetScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
-    return new TForgetScriptExecutionOperationActor(std::move(ev), queryServiceConfig, counters);
+IActor* CreateForgetScriptExecutionOperationActor(TEvForgetScriptExecutionOperation::TPtr&& ev) {
+    return new TForgetScriptExecutionOperationActor(std::move(ev));
 }
 
-IActor* CreateGetScriptExecutionOperationActor(TEvGetScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
-    return new TGetScriptExecutionOperationActor(std::move(ev), queryServiceConfig, counters);
+IActor* CreateGetScriptExecutionOperationActor(TEvGetScriptExecutionOperation::TPtr&& ev) {
+    return TGetScriptExecutionOperationQueryActor::MakeRetry(ev->Sender, std::move(ev->Get()->Database), std::move(ev->Get()->OperationId), std::move(ev->Get()->UserSID), ev->Get()->FailOnNotFound, ev->Cookie);
 }
 
-IActor* CreateListScriptExecutionOperationsActor(TEvListScriptExecutionOperations::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
-    return new TListScriptExecutionOperationsActor(std::move(ev), queryServiceConfig, counters);
+IActor* CreateListScriptExecutionOperationsActor(TEvListScriptExecutionOperations::TPtr&& ev) {
+    return TListScriptExecutionOperationsQuery::MakeRetry(ev->Sender, std::move(ev->Get()->Database), std::move(ev->Get()->UserSID), std::move(ev->Get()->PageToken), ev->Get()->PageSize);
 }
 
-IActor* CreateCancelScriptExecutionOperationActor(TEvCancelScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
-    return new TCancelScriptExecutionOperationActor(std::move(ev), queryServiceConfig, counters);
+IActor* CreateCancelScriptExecutionOperationActor(TEvCancelScriptExecutionOperation::TPtr&& ev, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
+    return new TCancelScriptExecutionOperationActor(std::move(ev), std::move(queryServiceConfig), std::move(counters));
 }
 
-IActor* CreateScriptLeaseUpdateActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId, TDuration leaseDuration, i64 leaseGeneration, TIntrusivePtr<TKqpCounters> counters) {
-    return new TScriptLeaseUpdateActor(runScriptActorId, database, executionId, leaseDuration, leaseGeneration, counters);
+IActor* CreateScriptLeaseUpdateActor(const TActorId& runScriptActorId, TString database, TString executionId, const TDuration leaseDuration, const i64 leaseGeneration) {
+    return TScriptLeaseUpdaterQuery::MakeRetry(
+        runScriptActorId,
+        TQueryRetryActorBase::IRetryPolicy::GetExponentialBackoffPolicy(
+            TQueryRetryActorBase::Retryable,
+            TDuration::MilliSeconds(10),
+            TDuration::MilliSeconds(200),
+            TDuration::Seconds(1),
+            std::numeric_limits<size_t>::max(),
+            leaseDuration / 2
+        ),
+        std::move(database), std::move(executionId), leaseDuration, leaseGeneration
+    );
 }
 
-IActor* CreateSaveScriptExecutionResultMetaActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId, const TString& serializedMeta, i64 leaseGeneration) {
-    return new TSaveScriptExecutionResultMetaQuery::TRetry(runScriptActorId, database, executionId, serializedMeta, leaseGeneration);
+IActor* CreateSaveScriptExecutionResultMetaActor(const TActorId& runScriptActorId, TString database, TString executionId, TString serializedMeta, const i64 leaseGeneration) {
+    return TSaveScriptExecutionResultMetaQuery::MakeRetry(runScriptActorId, std::move(database), std::move(executionId), std::move(serializedMeta), leaseGeneration);
 }
 
-IActor* CreateSaveScriptExecutionResultActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId, i32 resultSetId, std::optional<TInstant> expireAt, i64 firstRow, i64 accumulatedSize, Ydb::ResultSet&& resultSet) {
-    return new TSaveScriptExecutionResultActor(runScriptActorId, database, executionId, resultSetId, expireAt, firstRow, accumulatedSize, std::move(resultSet));
+IActor* CreateSaveScriptExecutionResultActor(const TActorId& runScriptActorId, TString database, TString executionId, const i32 resultSetId, const std::optional<TInstant> expireAt, const i64 firstRow, const i64 accumulatedSize, Ydb::ResultSet&& resultSet) {
+    return new TSaveScriptExecutionResultActor(runScriptActorId, std::move(database), std::move(executionId), resultSetId, expireAt, firstRow, accumulatedSize, std::move(resultSet));
 }
 
-IActor* CreateGetScriptExecutionResultActor(const TActorId& replyActorId, const TString& database, const TString& executionId, const std::optional<TString>& userSID, i32 resultSetIndex, i64 offset, i64 rowsLimit, i64 sizeLimit, TInstant operationDeadline) {
-    return new TGetScriptExecutionResultActor(replyActorId, database, executionId, userSID, resultSetIndex, offset, rowsLimit, sizeLimit, operationDeadline);
+IActor* CreateGetScriptExecutionResultActor(const TActorId& replyActorId, TString database, TString executionId, std::optional<TString> userSID, const i32 resultSetIndex, const i64 offset, const i64 rowsLimit, const i64 sizeLimit, const TInstant operationDeadline) {
+    return TGetScriptExecutionResultQueryActor::MakeRetry(replyActorId, std::move(database), std::move(executionId), std::move(userSID), resultSetIndex, offset, rowsLimit, sizeLimit, operationDeadline);
 }
 
-IActor* CreateSaveScriptExternalEffectActor(TEvSaveScriptExternalEffectRequest::TPtr ev, i64 leaseGeneration) {
-    return new TSaveScriptExternalEffectActor::TRetry(ev->Sender, ev->Get()->Description, leaseGeneration);
+IActor* CreateSaveScriptExternalEffectActor(const TActorId& replyActorId, TString database, TString executionId, TEvSaveScriptExternalEffectRequest::TDescription&& info, const i64 leaseGeneration) {
+    return TSaveScriptExternalEffectActor::MakeRetry(replyActorId, std::move(database), std::move(executionId), std::move(info), leaseGeneration);
 }
 
-IActor* CreateSaveScriptFinalStatusActor(const TActorId& finalizationActorId, TEvScriptFinalizeRequest::TPtr ev) {
-    return new TSaveScriptFinalStatusActor::TRetry(finalizationActorId, ev->Get()->Description);
+IActor* CreateSaveScriptFinalStatusActor(const TActorId& finalizationActorId, TEvScriptFinalizeRequest::TPtr&& ev) {
+    return TSaveScriptFinalStatusActor::MakeRetry(finalizationActorId, std::move(ev->Get()->Description));
 }
 
-IActor* CreateScriptFinalizationFinisherActor(const TActorId& finalizationActorId, const TString& executionId, const TString& database, std::optional<Ydb::StatusIds::StatusCode> operationStatus, NYql::TIssues operationIssues, i64 leaseGeneration) {
-    return new TScriptFinalizationFinisherActor::TRetry(finalizationActorId, executionId, database, operationStatus, operationIssues, leaseGeneration);
+IActor* CreateScriptFinalizationFinisherActor(const TActorId& finalizationActorId, TString database, TString executionId, const std::optional<Ydb::StatusIds::StatusCode> operationStatus, NYql::TIssues operationIssues, const i64 leaseGeneration) {
+    return TScriptFinalizationFinisherActor::MakeRetry(finalizationActorId, std::move(database), std::move(executionId), operationStatus, std::move(operationIssues), leaseGeneration);
 }
 
-IActor* CreateScriptProgressActor(const TString& executionId, const TString& database, const TString& queryPlan, i64 leaseGeneration, const std::optional<TString>& ast, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
-    return new TScriptProgressActor(database, executionId, queryPlan, leaseGeneration, ast, queryServiceConfig);
+IActor* CreateScriptProgressActor(TString database, TString executionId, std::optional<TString> queryPlan, std::optional<TString> ast, const i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
+    return new TScriptProgressActor(std::move(database), std::move(executionId), std::move(queryPlan), std::move(ast), leaseGeneration, queryServiceConfig);
 }
 
-IActor* CreateRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
-    return new TRefreshScriptExecutionLeasesActor(replyActorId, queryServiceConfig, counters);
+IActor* CreateRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters) {
+    return new TRefreshScriptExecutionLeasesActor(replyActorId, std::move(queryServiceConfig), std::move(counters));
 }
 
-IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
-    return new TSaveScriptExecutionPhysicalGraphActor::TRetry(replyActorId, database, executionId, std::move(physicalGraph), leaseGeneration, queryServiceConfig);
+IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, TString database, TString executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, const i64 leaseGeneration, NKikimrConfig::TQueryServiceConfig queryServiceConfig) {
+    return TSaveScriptExecutionPhysicalGraphActor::MakeRetry(replyActorId, std::move(database), std::move(executionId), std::move(physicalGraph), leaseGeneration, std::move(queryServiceConfig));
 }
 
-IActor* CreateGetScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId) {
-    return new TGetScriptExecutionPhysicalGraphActor::TRetry(replyActorId, database, executionId);
+IActor* CreateGetScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, TString database, TString executionId) {
+    return TGetScriptExecutionPhysicalGraphActor::MakeRetry(replyActorId, std::move(database), std::move(executionId));
 }
 
 namespace NPrivate {
 
-IActor* CreateCreateScriptOperationQueryActor(const TString& executionId, const TActorId& runScriptActorId, const NKikimrKqp::TEvQueryRequest& record, const NKikimrKqp::TScriptExecutionOperationMeta& meta) {
-    return new TCreateScriptOperationQuery(executionId, runScriptActorId, record, meta, SCRIPT_TIMEOUT_LIMIT, {}, std::nullopt, {}, nullptr, 1);
+IActor* CreateCreateScriptOperationQueryActor(TString executionId, const TActorId& runScriptActorId, NKikimrKqp::TEvQueryRequest record, NKikimrKqp::TScriptExecutionOperationMeta meta) {
+    return new TCreateScriptOperationQuery(std::move(executionId), runScriptActorId, std::move(record), std::move(meta), TDuration::Max(), {}, std::nullopt, {}, nullptr, 1);
 }
 
-IActor* CreateCheckLeaseStatusActor(const TActorId& replyActorId, const TString& database, const TString& executionId, ui64 cookie) {
-    return new TCheckLeaseStatusActor(replyActorId, database, executionId, {}, MakeIntrusive<TKqpCounters>(MakeIntrusive<NMonitoring::TDynamicCounters>()), true, cookie);
+IActor* CreateCheckLeaseStatusActor(TString database, TString executionId, const ui64 cookie) {
+    return new TCheckLeaseStatusQueryActor(std::move(database), std::move(executionId), {.Cookie = cookie});
 }
 
 } // namespace NPrivate

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -1031,8 +1031,8 @@ private:
 
             if (const std::optional<TString>& userSID = result.ColumnParser("user_token").GetOptionalUtf8()) {
                 TVector<NACLib::TSID> userGroupSids;
-                if (auto userGroupSids = ParseUserGroupSids(result)) {
-                    userGroupSids = std::move(*userGroupSids);
+                if (auto sids = ParseUserGroupSids(result)) {
+                    userGroupSids.assign(std::make_move_iterator(sids->begin()), std::make_move_iterator(sids->end()));
                 }
 
                 queryRequest.SetUserToken(NACLib::TUserToken(*userSID, userGroupSids).SerializeAsString());
@@ -2051,7 +2051,7 @@ private:
     }
 
     const TEvForgetScriptExecutionOperation::TPtr Request;
-    const TString& Database;
+    const TString Database;
     TString ExecutionId;
     std::optional<std::vector<Ydb::Query::ResultSetMeta>> ResultSetMetas;
     bool ExecutionEntryExists = true;
@@ -3762,8 +3762,8 @@ private:
 
             if (const auto& userToken = result.ColumnParser("user_token").GetOptionalUtf8()) {
                 TVector<NACLib::TSID> userGroupSids;
-                if (auto userGroupSids = ParseUserGroupSids(result)) {
-                    userGroupSids = std::move(*userGroupSids);
+                if (auto sids = ParseUserGroupSids(result)) {
+                    userGroupSids.assign(std::make_move_iterator(sids->begin()), std::make_move_iterator(sids->end()));
                 }
 
                 Response->UserToken = new NACLib::TUserToken(TString(*userToken), userGroupSids);

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.cpp
@@ -2298,7 +2298,7 @@ public:
     TListScriptExecutionOperationsQuery(TString database, std::optional<TString> userSID, TString pageToken, const ui64 pageSize)
         : TQueryWithAccessValidationBase(__func__, {.Database = std::move(database)}, std::move(userSID))
         , PageToken(std::move(pageToken))
-        , PageSize(pageSize)
+        , PageSize(ClampVal<ui64>(pageSize, 1, 100))
     {}
 
 private:

--- a/ydb/core/kqp/proxy_service/kqp_script_executions.h
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions.h
@@ -1,47 +1,69 @@
 #pragma once
-#include <ydb/core/kqp/common/events/script_executions.h>
-#include <ydb/core/kqp/common/kqp.h>
-#include <ydb/core/kqp/common/kqp_timeouts.h>
-#include <yql/essentials/public/issue/yql_issue.h>
 
-#include <ydb/library/actors/core/actor.h>
-#include <ydb/library/actors/core/event_local.h>
-#include <ydb/library/actors/core/events.h>
+#include <ydb/core/kqp/common/events/events.h>
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/public/api/protos/ydb_status_codes.pb.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/ptr.h>
+#include <util/system/types.h>
+
+#include <optional>
+
+namespace Ydb {
+
+class ResultSet;
+
+} // namespace Ydb
+
+namespace NKikimrConfig {
+
+class TQueryServiceConfig;
+
+} // namespace NKikimrConfig
+
+namespace NKikimrKqp {
+
+class TQueryPhysicalGraph;
+
+} // namespace NKikimrKqp
 
 namespace NKikimr::NKqp {
 
 // Creates all needed tables.
 // Sends result event back when the work is done.
-IActor* CreateScriptExecutionsTablesCreator(bool enableSecureScriptExecutions, ui64 generation = 0);
+IActor* CreateScriptExecutionsTablesCreator(const bool enableSecureScriptExecutions, const ui64 generation = 0);
 
 // Create script execution and run it.
-IActor* CreateScriptExecutionCreatorActor(TEvKqp::TEvScriptRequest::TPtr&& ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, TDuration maxRunTime = SCRIPT_TIMEOUT_LIMIT);
+IActor* CreateScriptExecutionCreatorActor(TEvKqp::TEvScriptRequest::TPtr&& ev, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters, const TDuration maxRunTime);
 
 // Operation API impl.
-IActor* CreateForgetScriptExecutionOperationActor(TEvForgetScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
-IActor* CreateGetScriptExecutionOperationActor(TEvGetScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
-IActor* CreateListScriptExecutionOperationsActor(TEvListScriptExecutionOperations::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
-IActor* CreateCancelScriptExecutionOperationActor(TEvCancelScriptExecutionOperation::TPtr ev, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
+IActor* CreateForgetScriptExecutionOperationActor(TEvForgetScriptExecutionOperation::TPtr&& ev);
+IActor* CreateGetScriptExecutionOperationActor(TEvGetScriptExecutionOperation::TPtr&& ev);
+IActor* CreateListScriptExecutionOperationsActor(TEvListScriptExecutionOperations::TPtr&& ev);
+IActor* CreateCancelScriptExecutionOperationActor(TEvCancelScriptExecutionOperation::TPtr&& ev, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
 
 // Updates lease deadline in database.
-IActor* CreateScriptLeaseUpdateActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId, TDuration leaseDuration, i64 leaseGeneration, TIntrusivePtr<TKqpCounters> counters);
+IActor* CreateScriptLeaseUpdateActor(const TActorId& runScriptActorId, TString database, TString executionId, const TDuration leaseDuration, const i64 leaseGeneration);
 
 // Store and fetch results.
-IActor* CreateSaveScriptExecutionResultMetaActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId, const TString& serializedMeta, i64 leaseGeneration);
-IActor* CreateSaveScriptExecutionResultActor(const TActorId& runScriptActorId, const TString& database, const TString& executionId, i32 resultSetId, std::optional<TInstant> expireAt, i64 firstRow, i64 accumulatedSize, Ydb::ResultSet&& resultSet);
-IActor* CreateGetScriptExecutionResultActor(const TActorId& replyActorId, const TString& database, const TString& executionId, const std::optional<TString>& userSID, i32 resultSetIndex, i64 offset, i64 rowsLimit, i64 sizeLimit, TInstant operationDeadline);
+IActor* CreateSaveScriptExecutionResultMetaActor(const TActorId& runScriptActorId, TString database, TString executionId, TString serializedMeta, const i64 leaseGeneration);
+IActor* CreateSaveScriptExecutionResultActor(const TActorId& runScriptActorId, TString database, TString executionId, const i32 resultSetId, const std::optional<TInstant> expireAt, const i64 firstRow, const i64 accumulatedSize, Ydb::ResultSet&& resultSet);
+IActor* CreateGetScriptExecutionResultActor(const TActorId& replyActorId, TString database, TString executionId, std::optional<TString> userSID, const i32 resultSetIndex, const i64 offset, const i64 rowsLimit, const i64 sizeLimit, const TInstant operationDeadline);
 
 // Compute external effects and updates status in database
-IActor* CreateSaveScriptExternalEffectActor(TEvSaveScriptExternalEffectRequest::TPtr ev, i64 leaseGeneration);
-IActor* CreateSaveScriptFinalStatusActor(const TActorId& finalizationActorId, TEvScriptFinalizeRequest::TPtr ev);
-IActor* CreateScriptFinalizationFinisherActor(const TActorId& finalizationActorId, const TString& executionId, const TString& database, std::optional<Ydb::StatusIds::StatusCode> operationStatus, NYql::TIssues operationIssues, i64 leaseGeneration);
-IActor* CreateScriptProgressActor(const TString& executionId, const TString& database, const TString& queryPlan, i64 leaseGeneration, const std::optional<TString>& ast, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig);
+IActor* CreateSaveScriptExternalEffectActor(const TActorId& replyActorId, TString database, TString executionId, TEvSaveScriptExternalEffectRequest::TDescription&& info, const i64 leaseGeneration);
+IActor* CreateSaveScriptFinalStatusActor(const TActorId& finalizationActorId, TEvScriptFinalizeRequest::TPtr&& ev);
+IActor* CreateScriptFinalizationFinisherActor(const TActorId& finalizationActorId, TString database, TString executionId, const std::optional<Ydb::StatusIds::StatusCode> operationStatus, NYql::TIssues operationIssues, const i64 leaseGeneration);
+IActor* CreateScriptProgressActor(TString database, TString executionId, std::optional<TString> queryPlan, std::optional<TString> ast, const i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig);
 
 // Check lease expiration for running script execution operations
-IActor* CreateRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
+IActor* CreateRefreshScriptExecutionLeasesActor(const TActorId& replyActorId, NKikimrConfig::TQueryServiceConfig queryServiceConfig, TIntrusivePtr<TKqpCounters> counters);
 
 // Script execution physical graph management
-IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, i64 leaseGeneration, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig);
-IActor* CreateGetScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, const TString& database, const TString& executionId);
+IActor* CreateSaveScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, TString database, TString executionId, NKikimrKqp::TQueryPhysicalGraph physicalGraph, const i64 leaseGeneration, NKikimrConfig::TQueryServiceConfig queryServiceConfig);
+IActor* CreateGetScriptExecutionPhysicalGraphActor(const TActorId& replyActorId, TString database, TString executionId);
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_impl.h
@@ -93,7 +93,10 @@ enum class ELeaseState {
 // If lease duration is zero, default one will be taken.
 IActor* CreateCreateScriptOperationQueryActor(TString executionId, const TActorId& runScriptActorId, NKikimrKqp::TEvQueryRequest record, NKikimrKqp::TScriptExecutionOperationMeta meta);
 
+// Get current status of execution
+IActor* CreateCheckLeaseStatusActor(TString database, TString executionId);
+
 // Checks lease of execution, finishes execution if its lease is off, returns current status
-IActor* CreateCheckLeaseStatusActor(TString database, TString executionId, const ui64 cookie = 0);
+IActor* CreateFinalizeScriptLeaseActor(const TActorId& replyActorId, TString database, TString executionId);
 
 } // namespace NKikimr::NKqp::NPrivate

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_impl.h
@@ -1,65 +1,84 @@
 #pragma once
 
 #include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/protos/kqp.pb.h>
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/event_local.h>
 #include <ydb/public/api/protos/ydb_query.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
 #include <yql/essentials/public/issue/yql_issue.h>
+
+#include <util/generic/maybe.h>
+#include <util/system/types.h>
+
+#include <optional>
+#include <vector>
 
 namespace NKikimr::NKqp::NPrivate {
 
 struct TEvPrivate {
     // Event ids
     enum EEv : ui32 {
-        EvCreateScriptOperationResponse = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+        EvCreateScriptOperationResponse = EventSpaceBegin(TEvents::ES_PRIVATE),
         EvLeaseCheckResult,
-
+        EvFinalizeScriptLeaseResult,
         EvEnd
     };
 
-    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+    static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
 
     // Events
-    struct TEvCreateScriptOperationResponse : public NActors::TEventLocal<TEvCreateScriptOperationResponse, EvCreateScriptOperationResponse> {
+    struct TEvCreateScriptOperationResponse : public TEventLocal<TEvCreateScriptOperationResponse, EvCreateScriptOperationResponse> {
         TEvCreateScriptOperationResponse(Ydb::StatusIds::StatusCode statusCode, NYql::TIssues&& issues)
             : Status(statusCode)
             , Issues(std::move(issues))
-        {
-        }
+        {}
 
-        TEvCreateScriptOperationResponse(TString executionId)
+        TEvCreateScriptOperationResponse(TString executionId, NYql::TIssues&& issues)
             : Status(Ydb::StatusIds::SUCCESS)
             , ExecutionId(std::move(executionId))
-        {
-        }
-
-        const Ydb::StatusIds::StatusCode Status;
-        const NYql::TIssues Issues;
-        const TString ExecutionId;
-    };
-
-    struct TEvLeaseCheckResult : public NActors::TEventLocal<TEvLeaseCheckResult, EvLeaseCheckResult> {
-        TEvLeaseCheckResult() = default;
-
-        TEvLeaseCheckResult(Ydb::StatusIds::StatusCode status, NYql::TIssues&& issues)
-            : Status(status)
             , Issues(std::move(issues))
         {}
 
+        const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+        const TString ExecutionId;
+        const NYql::TIssues Issues;
+    };
+
+    struct TEvLeaseCheckResult : public TEventLocal<TEvLeaseCheckResult, EvLeaseCheckResult> {
         Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
         NYql::TIssues Issues;
         TMaybe<Ydb::StatusIds::StatusCode> OperationStatus;
         TMaybe<Ydb::Query::ExecStatus> ExecutionStatus;
-        TMaybe<NYql::TIssues> OperationIssues;
-        NActors::TActorId RunScriptActorId;
-        bool LeaseExpired = false;
         TMaybe<EFinalizationStatus> FinalizationStatus;
+        NYql::TIssues OperationIssues;
+        TActorId RunScriptActorId;
+        bool EntryExists = true;
+        bool HasRetryPolicy = false;
+        bool LeaseExpired = false;
         bool RetryRequired = false;
         i64 LeaseGeneration = 0;
-        bool HasRetryPolicy = false;
-        bool WaitFinalizationOrRetry = false;
         std::optional<std::vector<Ydb::Query::ResultSetMeta>> ResultSetMetas;
+    };
+
+    struct TEvFinalizeScriptLeaseResult : public TEventLocal<TEvFinalizeScriptLeaseResult, EvFinalizeScriptLeaseResult> {
+        struct TInfo {
+            const bool LeaseVerified = false;
+            const bool ExecutionEntryExists = true;
+        };
+
+        TEvFinalizeScriptLeaseResult(const Ydb::StatusIds::StatusCode status, TInfo&& info, NYql::TIssues issues = {})
+            : Status(status)
+            , Info(std::move(info))
+            , Issues(std::move(issues))
+        {}
+
+        const Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
+        const TInfo Info;
+        const NYql::TIssues Issues;
     };
 };
 
@@ -72,10 +91,9 @@ enum class ELeaseState {
 
 // Writes new script into db.
 // If lease duration is zero, default one will be taken.
-NActors::IActor* CreateCreateScriptOperationQueryActor(const TString& executionId, const NActors::TActorId& runScriptActorId, const NKikimrKqp::TEvQueryRequest& record,
-                                                       const NKikimrKqp::TScriptExecutionOperationMeta& meta);
+IActor* CreateCreateScriptOperationQueryActor(TString executionId, const TActorId& runScriptActorId, NKikimrKqp::TEvQueryRequest record, NKikimrKqp::TScriptExecutionOperationMeta meta);
 
 // Checks lease of execution, finishes execution if its lease is off, returns current status
-NActors::IActor* CreateCheckLeaseStatusActor(const NActors::TActorId& replyActorId, const TString& database, const TString& executionId, ui64 cookie = 0);
+IActor* CreateCheckLeaseStatusActor(TString database, TString executionId, const ui64 cookie = 0);
 
 } // namespace NKikimr::NKqp::NPrivate

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_impl.h
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_impl.h
@@ -60,6 +60,7 @@ struct TEvPrivate {
         bool HasRetryPolicy = false;
         bool LeaseExpired = false;
         bool RetryRequired = false;
+        bool WaitRetry = false;
         i64 LeaseGeneration = 0;
         std::optional<std::vector<Ydb::Query::ResultSetMeta>> ResultSetMetas;
     };

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -109,6 +109,7 @@ struct TScriptExecutionsYdbSetup {
         Client = MakeHolder<Tests::TClient>(*ServerSettings);
 
         GetRuntime()->SetLogPriority(NKikimrServices::KQP_PROXY, NActors::NLog::PRI_DEBUG);
+        GetRuntime()->SetLogPriority(NKikimrServices::KQP_EXECUTER, NActors::NLog::PRI_DEBUG);
         GetRuntime()->SetDispatchTimeout(TestTimeout);
         Server->EnableGRpc(GrpcPort);
         Client->InitRootScheme();
@@ -277,13 +278,25 @@ struct TScriptExecutionsYdbSetup {
         }
     }
 
-    NPrivate::TEvPrivate::TEvLeaseCheckResult::TPtr CheckLeaseStatus(const TString& executionId) {
+    void FinalizeScriptLease(TString executionId, bool entryExists = true) {
         constexpr ui32 node = 0;
-        TActorId edgeActor = GetRuntime()->AllocateEdgeActor(node);
-        GetRuntime()->Register(NPrivate::CreateCheckLeaseStatusActor(TestDatabase, executionId), node, 0, TMailboxType::Simple, 0, edgeActor);
+        const auto& edgeActor = GetRuntime()->AllocateEdgeActor(node);
+        GetRuntime()->Register(NPrivate::CreateFinalizeScriptLeaseActor(edgeActor, TestDatabase, std::move(executionId)), node);
+
+        auto reply = GetRuntime()->GrabEdgeEvent<NPrivate::TEvPrivate::TEvFinalizeScriptLeaseResult>(edgeActor, TestTimeout);
+        UNIT_ASSERT_VALUES_EQUAL_C(reply->Get()->Status, Ydb::StatusIds::SUCCESS, reply->Get()->Issues.ToOneLineString());
+        UNIT_ASSERT_VALUES_EQUAL(reply->Get()->Info.ExecutionEntryExists, entryExists);
+    }
+
+    NPrivate::TEvPrivate::TEvLeaseCheckResult::TPtr CheckLeaseStatus(TString executionId) {
+        FinalizeScriptLease(executionId);
+
+        constexpr ui32 node = 0;
+        const auto& edgeActor = GetRuntime()->AllocateEdgeActor(node);
+        GetRuntime()->Register(NPrivate::CreateCheckLeaseStatusActor(TestDatabase, std::move(executionId)), node, 0, TMailboxType::Simple, 0, edgeActor);
 
         auto reply = GetRuntime()->GrabEdgeEvent<NPrivate::TEvPrivate::TEvLeaseCheckResult>(edgeActor, TestTimeout);
-        UNIT_ASSERT(reply->Get()->Status == Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL_C(reply->Get()->Status, Ydb::StatusIds::SUCCESS, reply->Get()->Issues.ToOneLineString());
         return reply;
     }
 
@@ -354,6 +367,8 @@ struct TScriptExecutionsYdbSetup {
     }
 
     TEvGetScriptExecutionOperationResponse::TPtr GetScriptExecutionOperation(const TString& executionId) {
+        FinalizeScriptLease(executionId);
+
         const auto edgeActor = GetRuntime()->AllocateEdgeActor();
         GetRuntime()->Send(
             MakeKqpProxyID(GetRuntime()->GetFirstNodeId()),

--- a/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
+++ b/ydb/core/kqp/proxy_service/kqp_script_executions_ut.cpp
@@ -278,9 +278,9 @@ struct TScriptExecutionsYdbSetup {
     }
 
     NPrivate::TEvPrivate::TEvLeaseCheckResult::TPtr CheckLeaseStatus(const TString& executionId) {
-        const ui32 node = 0;
+        constexpr ui32 node = 0;
         TActorId edgeActor = GetRuntime()->AllocateEdgeActor(node);
-        GetRuntime()->Register(NPrivate::CreateCheckLeaseStatusActor(edgeActor, TestDatabase, executionId));
+        GetRuntime()->Register(NPrivate::CreateCheckLeaseStatusActor(TestDatabase, executionId), node, 0, TMailboxType::Simple, 0, edgeActor);
 
         auto reply = GetRuntime()->GrabEdgeEvent<NPrivate::TEvPrivate::TEvLeaseCheckResult>(edgeActor, TestTimeout);
         UNIT_ASSERT(reply->Get()->Status == Ydb::StatusIds::SUCCESS);
@@ -345,7 +345,7 @@ struct TScriptExecutionsYdbSetup {
 
     TEvScriptLeaseUpdateResponse::TPtr UpdateLease(const TString& executionId, TDuration leaseDuration, i64 leaseGeneration = 1) {
         const auto edgeActor = GetRuntime()->AllocateEdgeActor();
-        GetRuntime()->Register(CreateScriptLeaseUpdateActor(edgeActor, TestDatabase, executionId, leaseDuration, leaseGeneration, nullptr));
+        GetRuntime()->Register(CreateScriptLeaseUpdateActor(edgeActor, TestDatabase, executionId, leaseDuration, leaseGeneration));
 
         auto reply = GetRuntime()->GrabEdgeEvent<TEvScriptLeaseUpdateResponse>(edgeActor, TestTimeout);
         UNIT_ASSERT_C(reply, "ScriptLeaseUpdate response is empty");
@@ -788,7 +788,7 @@ Y_UNIT_TEST_SUITE(ScriptExecutionsTest) {
 
         const auto leaseCheck = ydb.CheckLeaseStatus(executionId);
         UNIT_ASSERT_VALUES_EQUAL(leaseCheck->Get()->Status, Ydb::StatusIds::SUCCESS);
-        UNIT_ASSERT(leaseCheck->Get()->WaitFinalizationOrRetry);
+        UNIT_ASSERT(leaseCheck->Get()->EntryExists);
         UNIT_ASSERT(leaseCheck->Get()->OperationStatus);
         UNIT_ASSERT_VALUES_EQUAL(*leaseCheck->Get()->OperationStatus, Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT(leaseCheck->Get()->ExecutionStatus);

--- a/ydb/core/kqp/proxy_service/ya.make
+++ b/ydb/core/kqp/proxy_service/ya.make
@@ -49,6 +49,8 @@ PEERDIR(
     yql/essentials/public/issue
 )
 
+GENERATE_ENUM_SERIALIZATION(kqp_script_executions_impl.h)
+
 YQL_LAST_ABI_VERSION()
 
 END()

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -297,12 +297,13 @@ private:
         FinishInfo.Update(status, std::move(issues));
 
         if (ScriptResultHandlerActor.Id) {
+            LOG_D("Stop script result handler " << ScriptResultHandlerActor.Id);
             ScriptResultHandlerActor.Stop(SelfId());
             return;
         }
 
         if (SessionOpen) {
-            SessionOpen = true;
+            SessionOpen = false;
             LOG_D("Close session");
             auto ev = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
             ev->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
@@ -310,6 +311,7 @@ private:
         }
 
         if (ScriptLeaseWatcherActor.Id) {
+            LOG_D("Stop script lease watcher " << ScriptLeaseWatcherActor.Id);
             ScriptLeaseWatcherActor.Stop(SelfId());
             return;
         }
@@ -326,13 +328,16 @@ private:
                 FinishInfo.Status = Ydb::StatusIds::CANCELLED;
             }
 
-            const auto finalizationStatus = !FinishInfo.IsFailed() || cancelledByUser
+            const auto finalizationStatus = FinishInfo.IsSuccess() || cancelledByUser
                 ? EFinalizationStatus::FS_COMMIT
                 : EFinalizationStatus::FS_ROLLBACK;
 
-            const auto execStatus = !FinishInfo.IsFailed()
-                ? Ydb::Query::EXEC_STATUS_COMPLETED
-                : (cancelledByUser ? Ydb::Query::EXEC_STATUS_CANCELLED : Ydb::Query::EXEC_STATUS_FAILED);
+            auto execStatus = Ydb::Query::EXEC_STATUS_COMPLETED;
+            if ((FinishInfo.IsFailed() && cancelledByUser) || *FinishInfo.Status == Ydb::StatusIds::CANCELLED) {
+                execStatus = Ydb::Query::EXEC_STATUS_CANCELLED;
+            } else if (FinishInfo.IsFailed()) {
+                execStatus = Ydb::Query::EXEC_STATUS_FAILED;
+            }
 
             auto scriptFinalizeRequest = std::make_unique<TEvScriptFinalizeRequest>(
                 finalizationStatus, Ctx->UserRequestContext->CurrentExecutionId, Ctx->UserRequestContext->Database,

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -1,1045 +1,372 @@
 #include "kqp_run_script_actor.h"
+#include "kqp_run_script_actor_impl.h"
 
-#include <ydb/core/fq/libs/checkpointing/events/events.h>
 #include <ydb/core/kqp/common/events/events.h>
-#include <ydb/core/kqp/common/kqp.h>
+#include <ydb/core/kqp/common/events/script_executions.h>
 #include <ydb/core/kqp/common/kqp_script_executions.h>
 #include <ydb/core/kqp/common/kqp_timeouts.h>
-#include <ydb/core/kqp/executer_actor/kqp_executer.h>
-#include <ydb/core/kqp/federated_query/kqp_federated_query_helpers.h>
-#include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
-#include <ydb/core/kqp/proxy_service/proto/result_set_meta.pb.h>
+#include <ydb/core/kqp/common/kqp_user_request_context.h>
+#include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/protos/config.pb.h>
+#include <ydb/core/protos/kqp.pb.h>
+#include <ydb/core/protos/table_service_config.pb.h>
+#include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
-#include <ydb/library/ydb_issue/issue_helpers.h>
-#include <ydb/library/ydb_issue/proto/issue_id.pb.h>
+#include <ydb/library/services/services.pb.h>
 #include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
-#include <library/cpp/protobuf/json/json2proto.h>
-#include <library/cpp/protobuf/json/proto2json.h>
+#include <yql/essentials/public/issue/yql_issue_message.h>
+#include <yql/essentials/public/issue/yql_issue.h>
 
-#include <util/generic/size_literals.h>
+#include <util/generic/string.h>
+#include <util/string/builder.h>
 
+#include <exception>
 #include <forward_list>
 
-#define LOG_T(stream) LOG_TRACE_S(NActors::TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
-#define LOG_D(stream) LOG_DEBUG_S(NActors::TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
-#define LOG_I(stream) LOG_INFO_S(NActors::TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
-#define LOG_N(stream) LOG_NOTICE_S(NActors::TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
-#define LOG_W(stream) LOG_WARN_S(NActors::TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
-#define LOG_E(stream) LOG_ERROR_S(NActors::TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_T(stream) LOG_TRACE_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_D(stream) LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_I(stream) LOG_INFO_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_N(stream) LOG_NOTICE_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_W(stream) LOG_WARN_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_E(stream) LOG_ERROR_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
 
 namespace NKikimr::NKqp {
 
 namespace {
 
-constexpr ui32 LEASE_UPDATE_FREQUENCY = 2;
+using namespace NPrivate;
 
-constexpr ui64 MIN_SAVE_RESULT_BATCH_SIZE = 5_MB;
-constexpr i32 MIN_SAVE_RESULT_BATCH_ROWS = 5000;
-constexpr ui64 RUN_SCRIPT_ACTOR_BUFFER_SIZE = 40_MB;
-
-struct TProducerState {
-    TMaybe<ui64> LastSeqNo;
-    i64 AckedFreeSpaceBytes = 0;
-    TActorId ActorId;
-    ui64 ChannelId = 0;
-    bool Enough = false;
-
-    void SendAck(const NActors::TActorIdentity& actor) const {
-        auto resp = MakeHolder<NKqp::TEvKqpExecuter::TEvStreamDataAck>(*LastSeqNo, ChannelId);
-        resp->Record.SetFreeSpace(AckedFreeSpaceBytes);
-        resp->Record.SetEnough(Enough);
-        actor.Send(ActorId, resp.Release());
-    }
-
-    bool ResumeIfStopped(const NActors::TActorIdentity& actor, i64 freeSpaceBytes) {
-        if (LastSeqNo && AckedFreeSpaceBytes <= 0) {
-            AckedFreeSpaceBytes = freeSpaceBytes;
-            SendAck(actor);
-            return true;
-        }
-        return false;
-    }
-};
-
-class TRunScriptActor : public NActors::TActorBootstrapped<TRunScriptActor> {
-    enum class ERunState {
-        Created,
-        Running,
-        Cancelling,
-        Cancelled,
-        Finishing,
-        Finished,
+class TRunScriptActor final : public TActorBootstrapped<TRunScriptActor>, IActorExceptionHandler {
+    struct TSessionState {
+        bool SessionOpen = false;
+        bool WaitClose = false;
     };
 
-    enum EWakeUp {
-        RunEvent,
-        UpdateLeaseEvent,
-    };
+    struct TActorState {
+        bool WaitStop = false;
+        TActorId Id;
 
-    class TResultSetMeta {
-    public:
-        Ydb::Query::Internal::ResultSetMeta& MutableMeta() {
-            JsonMeta = std::nullopt;
-            return Meta;
-        }
-
-        const NJson::TJsonValue& GetJsonMeta() {
-            if (!JsonMeta) {
-                JsonMeta = NJson::TJsonValue();
-                NProtobufJson::Proto2Json(Meta, *JsonMeta, NProtobufJson::TProto2JsonConfig());
+        void Stop(const TActorIdentity& actor) {
+            if (!Id || WaitStop) {
+                return;
             }
-            return *JsonMeta;
+
+            actor.Send(Id, new TEvents::TEvPoison());
+            WaitStop = true;
         }
-
-    private:
-        Ydb::Query::Internal::ResultSetMeta Meta;
-        std::optional<NJson::TJsonValue> JsonMeta;
-    };
-
-    struct TResultSetInfo {
-        bool NewResultSet = true;
-        bool Truncated = false;
-        bool Finished = false;
-        ui64 RowCount = 0;
-        ui64 ByteCount = 0;
-        TResultSetMeta Meta;
-
-        ui64 FirstRowId = 0;
-        ui64 AccumulatedSize = 0;
-        Ydb::ResultSet PendingResult;
     };
 
 public:
-    TRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig&& queryServiceConfig)
-        : ExecutionId(std::move(settings.ExecutionId))
-        , Request(request)
-        , Database(std::move(settings.Database))
-        , LeaseGeneration(settings.LeaseGeneration)
-        , LeaseDuration(settings.LeaseDuration)
-        , ResultsTtl(settings.ResultsTtl)
-        , ProgressStatsPeriod(settings.ProgressStatsPeriod)
-        , QueryServiceConfig(std::move(queryServiceConfig))
-        , SaveQueryPhysicalGraph(settings.SaveQueryPhysicalGraph)
-        , DisableDefaultTimeout(settings.DisableDefaultTimeout)
-        , CheckpointId(settings.CheckpointId)
-        , PhysicalGraph(std::move(settings.PhysicalGraph))
-        , StreamingQueryPath(settings.StreamingQueryPath)
-        , CustomerSuppliedId(std::move(settings.CustomerSuppliedId))
-        , StreamingDisposition(std::move(settings.StreamingDisposition))
-        , Counters(settings.Counters)
-    {}
-
     static constexpr char ActorName[] = "KQP_RUN_SCRIPT_ACTOR";
 
+    TRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig)
+        : Ctx(CreateExecutionContext(request, settings, queryServiceConfig))
+        , QueryServiceConfig(queryServiceConfig)
+        , PhysicalGraph(std::move(settings.PhysicalGraph))
+        , QueryRequest(CreateQueryRequest(request, settings, queryServiceConfig, *Ctx))
+    {}
+
     void Bootstrap() {
-        const auto& traceId = Request.GetTraceId();
-        UserRequestContext = MakeIntrusive<TUserRequestContext>(
-            traceId,
-            Database,
-            /* SessionId*/ "",
-            ExecutionId,
-            /* CustomerSuppliedId */ CustomerSuppliedId ? CustomerSuppliedId : traceId,
-            SelfId()
-        );
-        UserRequestContext->IsStreamingQuery = SaveQueryPhysicalGraph;
-        UserRequestContext->CheckpointId = CheckpointId;
-        UserRequestContext->StreamingQueryPath = StreamingQueryPath;
-        UserRequestContext->StreamingDisposition = StreamingDisposition;
-
-        LOG_I("Bootstrap "
-            << "StreamingQueryPath: " << StreamingQueryPath
-            << ", CheckpointId: " << CheckpointId
-            << ", StreamingDisposition: " << (StreamingDisposition ? StreamingDisposition->DebugString() : "null"));
-
-        Become(&TRunScriptActor::StateFunc);
+        Ctx->UserRequestContext->RunScriptActorId = SelfId();
+        LOG_I("Bootstrap, StreamingDisposition: " << (Ctx->UserRequestContext->StreamingDisposition ? Ctx->UserRequestContext->StreamingDisposition->DebugString() : "null"));
+        Become(&TThis::StateFuncCreating);
     }
 
 private:
-    STRICT_STFUNC(StateFunc,
-        hFunc(NActors::TEvents::TEvWakeup, Handle);
-        hFunc(NActors::TEvents::TEvPoison, Handle);
-        hFunc(TEvKqpExecuter::TEvStreamData, Handle);
-        hFunc(TEvKqpExecuter::TEvExecuterProgress, Handle);
-        hFunc(TEvSaveScriptExternalEffectRequest, Handle);
-        hFunc(TEvSaveScriptPhysicalGraphRequest, Handle);
-        hFunc(TEvSaveScriptPhysicalGraphResponse, Handle);
-        hFunc(NFq::TEvCheckpointCoordinator::TEvZeroCheckpointDone, Handle);
-        hFunc(TEvKqp::TEvQueryResponse, Handle);
-        hFunc(TEvKqp::TEvCreateSessionResponse, Handle);
-        IgnoreFunc(TEvKqp::TEvCloseSessionResponse);
-        hFunc(TEvKqp::TEvCancelQueryResponse, Handle);
-        hFunc(TEvKqp::TEvCancelScriptExecutionRequest, Handle);
-        hFunc(TEvScriptExecutionFinished, Handle);
-        hFunc(TEvScriptLeaseUpdateResponse, Handle);
-        hFunc(TEvSaveScriptResultMetaFinished, Handle);
-        hFunc(TEvSaveScriptResultFinished, Handle);
-        hFunc(TEvSaveScriptProgressResponse, Handle);
-        hFunc(TEvCheckAliveRequest, Handle);
+    static TScriptExecutionContext::TPtr CreateExecutionContext(const NKikimrKqp::TEvQueryRequest& request, const TKqpRunScriptActorSettings& settings, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig) {
+        const auto& traceId = request.GetTraceId();
+        auto userRequestContext = MakeIntrusive<TUserRequestContext>(
+            traceId,
+            settings.Database,
+            /* SessionId*/ "", // Will be set after session creation
+            settings.ExecutionId,
+            settings.CustomerSuppliedId ? settings.CustomerSuppliedId : traceId,
+            TActorId{} // Will be set in actor bootstrap
+        );
+        userRequestContext->IsStreamingQuery = settings.SaveQueryPhysicalGraph;
+        userRequestContext->CheckpointId = settings.CheckpointId;
+        userRequestContext->StreamingQueryPath = settings.StreamingQueryPath;
+        userRequestContext->StreamingDisposition = settings.StreamingDisposition;
+
+        return std::make_shared<TScriptExecutionContext>(TScriptExecutionContext{
+            .UserRequestContext = std::move(userRequestContext),
+            .Counters = settings.Counters,
+            .LeaseGeneration = settings.LeaseGeneration,
+            .LeaseDuration = settings.LeaseDuration,
+            .ResultsTtl = settings.ResultsTtl,
+            .Timeout = GetQueryTimeout(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, request.GetRequest().GetTimeoutMs(), {}, queryServiceConfig, settings.DisableDefaultTimeout),
+        });
+    }
+
+    static std::unique_ptr<TEvKqp::TEvQueryRequest> CreateQueryRequest(const NKikimrKqp::TEvQueryRequest& request, const TKqpRunScriptActorSettings& settings, const NKikimrConfig::TQueryServiceConfig& queryServiceConfig, const TScriptExecutionContext& ctx) {
+        auto ev = std::make_unique<TEvKqp::TEvQueryRequest>();
+        ev->Record = request;
+        ev->SetSaveQueryPhysicalGraph(settings.SaveQueryPhysicalGraph);
+        ev->SetDisableDefaultTimeout(settings.DisableDefaultTimeout);
+        ev->SetUserRequestContext(ctx.UserRequestContext);
+
+        if (settings.PhysicalGraph) {
+            ev->SetQueryPhysicalGraph(*settings.PhysicalGraph);
+        }
+
+        if (request.GetRequest().GetCollectStats() >= Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL) {
+            ev->SetProgressStatsPeriod(settings.ProgressStatsPeriod ? settings.ProgressStatsPeriod : TDuration::MilliSeconds(queryServiceConfig.GetProgressStatsPeriodMs()));
+        }
+
+        ev->SetGeneration(settings.LeaseGeneration);
+        return ev;
+    }
+
+    bool OnUnhandledException(const std::exception& e) final {
+        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Got unexpected exception: " << e.what());
+        return true;
+    }
+
+    // Wait notification that script execution metadata was stored into `script_executions` table
+    STRICT_STFUNC(StateFuncCreating,
+        sFunc(TEvents::TEvWakeup, HandleCreatingFinished);
+        sFunc(TEvents::TEvPoison, HandleCreatingFailed);
     )
 
-    void SendToKqpProxy(THolder<NActors::IEventBase> ev) {
-        if (!Send(MakeKqpProxyID(SelfId().NodeId()), ev.Release())) {
-            Issues.AddIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR, "Internal error, send to kqp proxy failed"));
-            Finish(Ydb::StatusIds::INTERNAL_ERROR);
-        }
+    void HandleCreatingFinished() {
+        LOG_I("Script execution metadata saved, creating new session");
+        Become(&TThis::StateFuncInitialise);
+
+        ScriptLeaseWatcherActor.Id = RegisterWithSameMailbox(CreateScriptLeaseWatcherActor(Ctx));
+        LOG_I("Started ScriptLeaseWatcherActor: " << ScriptLeaseWatcherActor.Id);
+
+        auto ev = std::make_unique<TEvKqp::TEvCreateSessionRequest>();
+        ev->Record.SetTraceId(Ctx->UserRequestContext->TraceId);
+        ev->Record.MutableRequest()->SetDatabase(Ctx->UserRequestContext->Database);
+        Send(MakeKqpProxyID(SelfId().NodeId()), ev.release());
     }
 
-    void CreateSession() {
-        auto ev = MakeHolder<TEvKqp::TEvCreateSessionRequest>();
-        ev->Record.MutableRequest()->SetDatabase(Request.GetRequest().GetDatabase());
-
-        LOG_D("Create new session");
-        SendToKqpProxy(std::move(ev));
+    void HandleCreatingFailed() {
+        Finish(Ydb::StatusIds::INTERNAL_ERROR, "Failed to save script execution entry");
     }
 
-    void Handle(TEvKqp::TEvCreateSessionResponse::TPtr& ev) {
-        const auto& resp = ev->Get()->Record;
-        if (resp.GetYdbStatus() != Ydb::StatusIds::SUCCESS) {
-            LOG_E("Create new session failed: " << resp.GetYdbStatus() << ", ResourceExhausted: " << resp.GetResourceExhausted());
-            auto error = TStringBuilder() << "Create new session failed with " << resp.GetYdbStatus();
-            if (resp.GetResourceExhausted()) {
-                Issues.AddIssue(error << " (resource exhausted)");
-                Finish(Ydb::StatusIds::OVERLOADED);
+    // Create new kqp session
+    STRICT_STFUNC(StateFuncInitialise,
+        hFunc(TEvKqp::TEvCreateSessionResponse, HandleInitialise);
+        hFunc(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished, HandleLeaseWatcherFinished);
+        hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
+        hFunc(TEvCheckAliveRequest, HandleCheckAlive);
+    )
+
+    void HandleInitialise(TEvKqp::TEvCreateSessionResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        if (const auto status = record.GetYdbStatus(); status != Ydb::StatusIds::SUCCESS) {
+            const auto resourceExhausted = record.GetResourceExhausted();
+            LOG_E("Create new session failed: " << status << ", resource exhausted: " << resourceExhausted);
+
+            auto error = TStringBuilder() << "Create new session failed with " << status;
+
+            if (resourceExhausted) {
+                Finish(Ydb::StatusIds::OVERLOADED, error << " (resource exhausted)");
             } else {
-                Issues.AddIssue(error);
-                Finish(Ydb::StatusIds::INTERNAL_ERROR);
+                Finish(Ydb::StatusIds::INTERNAL_ERROR, error);
             }
+
             return;
         }
 
-        const auto& session = resp.GetResponse();
-        SessionId = session.GetSessionId();
-        UserRequestContext->SessionId = SessionId;
+        SessionState.SessionOpen = true;
+        const auto& session = record.GetResponse();
+        Ctx->UserRequestContext->SessionId = session.GetSessionId();
 
         if (session.GetNodeId() != SelfId().NodeId()) {
             LOG_E("New session started on unexpected node: " << session.GetNodeId());
-            Issues.AddIssue(TStringBuilder() << "Session created on wrong node " << session.GetNodeId() << ", expected local session on node " << SelfId().NodeId());
-            Finish(Ydb::StatusIds::INTERNAL_ERROR);
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Session created on wrong node " << session.GetNodeId() << ", expected local session on node " << SelfId().NodeId());
             return;
         }
 
-        LOG_D("New session created");
+        ScriptResultHandlerActor.Id = RegisterWithSameMailbox(CreateScriptResultHandlerActor(Ctx, std::move(PhysicalGraph), QueryServiceConfig));
+        LOG_D("Started ScriptResultHandlerActor: " << ScriptResultHandlerActor.Id << ", starting query, has physical graph: " << PhysicalGraph.has_value());
 
-        if (RunState == ERunState::Running) {
-            Start();
+        QueryRequest->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
+        ActorIdToProto(SelfId(), QueryRequest->Record.MutableRequestActorId());
+        Send(MakeKqpProxyID(SelfId().NodeId()), QueryRequest.release());
+    }
+
+    void HandleLeaseWatcherFinished(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished::TPtr& ev) {
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Got lease watcher finished: " << ev->Sender << " with status " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
         } else {
-            CloseSession();
+            LOG_I("Got lease watcher finished: " << ev->Sender);
         }
+
+        ScriptLeaseWatcherActor.Id = {};
+        Finish(ev->Get()->Status, AddRootIssue("Script lease watcher error", ev->Get()->Issues));
     }
 
-    void CloseSession() {
-        if (SessionId) {
-            LOG_D("Close session");
-
-            auto ev = MakeHolder<TEvKqp::TEvCloseSessionRequest>();
-            ev->Record.MutableRequest()->SetSessionId(SessionId);
-
-            Send(MakeKqpProxyID(SelfId().NodeId()), ev.Release());
-            SessionId.clear();
-        }
+    void HandleCancellation(TEvKqp::TEvCancelScriptExecutionRequest::TPtr& ev) {
+        LOG_I("Got cancel request: " << ev->Sender);
+        CancelRequests.emplace_front(std::move(ev));
+        Finish(Ydb::StatusIds::CANCELLED);
     }
 
-    void Start() {
-        LOG_I("Start script execution, has PhysicalGraph: " << PhysicalGraph.has_value() << ", SaveQueryPhysicalGraph: " << SaveQueryPhysicalGraph);
-
-        // Expecting that session actor and executor started on the same node with run script actor
-        auto ev = MakeHolder<TEvKqp::TEvQueryRequest>();
-        ev->Record = Request;
-        ev->Record.MutableRequest()->SetSessionId(SessionId);
-        ev->SetSaveQueryPhysicalGraph(SaveQueryPhysicalGraph);
-        ev->SetDisableDefaultTimeout(DisableDefaultTimeout);
-        ev->SetUserRequestContext(UserRequestContext);
-        if (PhysicalGraph) {
-            ev->SetQueryPhysicalGraph(*PhysicalGraph);
-        }
-        if (ev->Record.GetRequest().GetCollectStats() >= Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL) {
-            ev->SetProgressStatsPeriod(ProgressStatsPeriod ? ProgressStatsPeriod : TDuration::MilliSeconds(QueryServiceConfig.GetProgressStatsPeriodMs()));
-        }
-        ev->SetGeneration(LeaseGeneration);
-
-        NActors::ActorIdToProto(SelfId(), ev->Record.MutableRequestActorId());
-
-        SendToKqpProxy(std::move(ev));
-
-        if (!SaveQueryPhysicalGraph) {
-            UpdateScriptProgress("{}");
-        }
-    }
-
-    void UpdateScriptProgress(const TString& plan, std::optional<TString> ast = std::nullopt) {
-        if (AstSaved) {
-            ast = std::nullopt;
-        }
-
-        SavedRunningStatus = true;
-        const auto& updaterId = Register(CreateScriptProgressActor(ExecutionId, Database, plan, LeaseGeneration, ast, QueryServiceConfig));
-        LOG_T("Start TScriptProgressActor " << updaterId);
-    }
-
-    void Handle(TEvCheckAliveRequest::TPtr& ev) {
-        LOG_W("Lease was expired in database"
-            << ", LeaseUpdateScheduleTime: " << LeaseUpdateScheduleTime
-            << ", LeaseUpdateQueryRunning: " << LeaseUpdateQueryRunning
-            << ", FinalStatusIsSaved: " << FinalStatusIsSaved
-            << ", FinishAfterLeaseUpdate: " << FinishAfterLeaseUpdate
-            << ", WaitFinalizationRequest: " << WaitFinalizationRequest
-            << ", CancelRequestsCount: " << CancelRequestsCount
-            << ", Status: " << Status
-            << ", Issues: " << Issues.ToOneLineString()
-            << ", SaveResultInflight: " << SaveResultInflight
-            << ", SaveResultMetaInflight: " << SaveResultMetaInflight);
-
+    void HandleCheckAlive(TEvCheckAliveRequest::TPtr& ev) {
+        LOG_W("Lease was expired in database, checker actor: " << ev->Sender);
         Send(ev->Sender, new TEvCheckAliveResponse());
     }
 
-    void RunLeaseUpdater() {
-        const auto& updaterId = Register(CreateScriptLeaseUpdateActor(SelfId(), Database, ExecutionId, LeaseDuration, LeaseGeneration, Counters));
-        LOG_D("Run lease updater " << updaterId);
+    // Wait query execution
+    STRICT_STFUNC(StateFuncExecute,
+        hFunc(TEvKqp::TEvCloseSessionResponse, HandleExecute);
+        hFunc(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished, HandleLeaseWatcherFinished);
+        hFunc(TEvRunScriptPrivate::TEvScriptResultHandlerFinished, HandleResultHandlerFinished);
+        hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
+        hFunc(TEvCheckAliveRequest, HandleCheckAlive);
+    )
 
-        LeaseUpdateQueryRunning = true;
-        Counters->ReportRunActorLeaseUpdateBacklog(TInstant::Now() - LeaseUpdateScheduleTime);
-    }
+    void HandleExecute(TEvKqp::TEvCloseSessionResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(record.GetIssues(), issues);
+        LOG_I("Got close session response: " << ev->Sender << " with status " << record.GetStatus() << ", issues: " << issues.ToOneLineString());
 
-    bool LeaseUpdateRequired() const {
-        return IsExecuting() || SaveResultMetaInflight || SaveResultInflight;
-    }
+        SessionState.SessionOpen = false;
 
-    // TODO: remove this after there will be a normal way to store results and generate execution id
-    void Handle(NActors::TEvents::TEvWakeup::TPtr& ev) {
-        switch (ev->Get()->Tag) {
-        case EWakeUp::RunEvent:
-            LOG_D("Script execution entry saved");
-            LeaseUpdateScheduleTime = TInstant::Now();
-            Schedule(LeaseDuration / LEASE_UPDATE_FREQUENCY, new NActors::TEvents::TEvWakeup(EWakeUp::UpdateLeaseEvent));
-            RunState = ERunState::Running;
-            CreateSession();
-            break;
-
-        case EWakeUp::UpdateLeaseEvent:
-            LOG_D("Try to start lease update");
-            if (LeaseUpdateRequired() && !FinalStatusIsSaved) {
-                RunLeaseUpdater();
-            }
-            break;
+        if (FinishInfo.IsFinished()) {
+            Finish();
         }
     }
 
-    void TerminateActorExecution(Ydb::StatusIds::StatusCode replyStatus, const NYql::TIssues& replyIssues) {
-        if (std::exchange(Terminated, true)) {
-            return;
+    void HandleResultHandlerFinished(TEvRunScriptPrivate::TEvScriptResultHandlerFinished::TPtr& ev) {
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Got result handler finished: " << ev->Sender << " with status " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+        } else {
+            LOG_I("Got result handler finished: " << ev->Sender);
         }
 
-        LOG_I("Script execution finalized, cancel response status: " << replyStatus << ", issues: " << replyIssues.ToOneLineString());
-        for (auto& req : CancelRequests) {
-            Send(req->Sender, new TEvKqp::TEvCancelScriptExecutionResponse(replyStatus, replyIssues), 0, req->Cookie);
+        ScriptResultHandlerActor = {};
+        ExecutionInfo = std::move(ev->Get()->Info);
+        Finish(ev->Get()->Status, std::move(ev->Get()->Issues));
+    }
+
+    // Wait query finalization
+    STRICT_STFUNC(StateFuncFinalize,
+        hFunc(TEvScriptExecutionFinished, HandleFinalize);
+        hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
+        hFunc(TEvCheckAliveRequest, HandleCheckAlive);
+    )
+
+    void HandleFinalize(TEvScriptExecutionFinished::TPtr& ev) {
+        auto guard = PassAwayGuard();
+
+        const auto status = ev->Get()->Status;
+        const auto& issues = ev->Get()->Issues;
+        const auto& info = ev->Get()->Info;
+        if (status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Got finalize: " << ev->Sender << " with status " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+        } else {
+            LOG_I("Got finalize: " << ev->Sender << ", already finished: " << info.AlreadyStopped << ", execution entry exists: " << info.ExecutionEntryExists);
         }
+
+        for (auto& request : CancelRequests) {
+            Send(request->Sender, new TEvKqp::TEvCancelScriptExecutionResponse(status, {
+                .ExecutionEntryExists = info.ExecutionEntryExists,
+                .AlreadyStopped = info.AlreadyStopped,
+            }, issues), /* flags */ 0, request->Cookie);
+        }
+
         PassAway();
     }
 
-    void RunScriptExecutionFinisher() {
-        if (Terminated) {
+    void Finish() {
+        Finish(Ydb::StatusIds::SUCCESS);
+    }
+
+    void Finish(const Ydb::StatusIds::StatusCode status, const TString& message) {
+        Finish(status, {NYql::TIssue(message)});
+    }
+
+    void Finish(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
+        if (status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Finish with error " << status << ", issues: " << issues.ToOneLineString());
+        } else if (!FinishInfo.IsFailed()) {
+            LOG_I("Finish successfully");
+        }
+
+        FinishInfo.Update(status, std::move(issues));
+
+        if (ScriptResultHandlerActor.Id) {
+            ScriptResultHandlerActor.Stop(SelfId());
             return;
         }
 
-        if (!FinalStatusIsSaved) {
-            FinalStatusIsSaved = true;
-            WaitFinalizationRequest = true;
-            const bool cancelledByUser = (RunState == ERunState::Cancelling);
-            RunState = IsExecuting() ? ERunState::Finishing : RunState;
-
-            if (cancelledByUser) {
-                NYql::TIssue cancelIssue("Request was canceled by user");
-                cancelIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
-                Issues.AddIssue(std::move(cancelIssue));
+        if (SessionState.SessionOpen) {
+            if (!SessionState.WaitClose) {
+                LOG_D("Close session");
+                auto ev = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
+                ev->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
+                Send(MakeKqpProxyID(SelfId().NodeId()), ev.release());
+                SessionState.WaitClose = true;
             }
+            return;
+        }
 
+        if (ScriptLeaseWatcherActor.Id) {
+            ScriptLeaseWatcherActor.Stop(SelfId());
+            return;
+        }
+
+        if (!WaitFinalizationRequest) {
             LOG_I("Start script execution finalization");
 
+            const auto cancelledByUser = !CancelRequests.empty();
+            if (FinishInfo.IsFailed() && cancelledByUser) {
+                NYql::TIssue cancelIssue("Request was canceled by user");
+                cancelIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
+                FinishInfo.Issues.AddIssue(cancelIssue);
+                FinishInfo.Status = Ydb::StatusIds::CANCELLED;
+            }
+
+            const auto finalizationStatus = !FinishInfo.IsFailed() || cancelledByUser
+                ? EFinalizationStatus::FS_COMMIT
+                : EFinalizationStatus::FS_ROLLBACK;
+
+            const auto execStatus = !FinishInfo.IsFailed()
+                ? Ydb::Query::EXEC_STATUS_COMPLETED
+                : (cancelledByUser ? Ydb::Query::EXEC_STATUS_CANCELLED : Ydb::Query::EXEC_STATUS_FAILED);
+
             auto scriptFinalizeRequest = std::make_unique<TEvScriptFinalizeRequest>(
-                GetFinalizationStatusFromRunState(), ExecutionId, Database, Status, GetExecStatusFromStatusCode(Status),
-                Issues, std::move(QueryStats), std::move(QueryPlan), std::move(QueryAst), LeaseGeneration, cancelledByUser
+                finalizationStatus, Ctx->UserRequestContext->CurrentExecutionId, Ctx->UserRequestContext->Database,
+                *FinishInfo.Status, execStatus, FinishInfo.Issues, std::move(ExecutionInfo.QueryStats),
+                std::move(ExecutionInfo.QueryPlan), std::move(ExecutionInfo.QueryAst), Ctx->LeaseGeneration, cancelledByUser
             );
             Send(MakeKqpFinalizeScriptServiceId(SelfId().NodeId()), scriptFinalizeRequest.release());
-            return;
-        }
-
-        LOG_N("Script final status is already saved, WaitFinalizationRequest: " << WaitFinalizationRequest);
-
-        if (!WaitFinalizationRequest && RunState != ERunState::Cancelled && RunState != ERunState::Finished) {
-            RunState = ERunState::Finished;
-            TerminateActorExecution(Ydb::StatusIds::PRECONDITION_FAILED, { NYql::TIssue("Already finished") });
-        }
-    }
-
-    void Handle(TEvScriptLeaseUpdateResponse::TPtr& ev) {
-        LeaseUpdateQueryRunning = false;
-
-        const auto& issues = ev->Get()->Issues;
-        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
-            LOG_E("Lease update " << ev->Sender << " failed " << status << ", Issues: " << issues.ToOneLineString() << ", ExecutionEntryExists: " << ev->Get()->ExecutionEntryExists);
+            WaitFinalizationRequest = true;
         } else {
-            LOG_D("Lease updated by " << ev->Sender << ", CurrentDeadline: " << ev->Get()->CurrentDeadline << ", ExecutionEntryExists: " << ev->Get()->ExecutionEntryExists);
+            LOG_N("Skip finish with error " << *FinishInfo.Status << ", issues: " << FinishInfo.Issues.ToOneLineString() << ", already waiting finalization");
         }
-
-        if (!ev->Get()->ExecutionEntryExists) {
-            LOG_E("Script execution entry was lost");
-
-            FinalStatusIsSaved = true;
-            Issues.AddIssues(AddRootIssue("Script execution lease was lost", issues, true));
-
-            if (RunState == ERunState::Running) {
-                CancelRunningQuery();
-            }
-        }
-
-        if (FinishAfterLeaseUpdate) {
-            RunScriptExecutionFinisher();
-        }
-
-        if (LeaseUpdateRequired()) {
-            TInstant leaseUpdateTime = ev->Get()->CurrentDeadline - LeaseDuration / LEASE_UPDATE_FREQUENCY;
-            LOG_D("Schedule lease update on " << leaseUpdateTime);
-
-            LeaseUpdateScheduleTime = TInstant::Now();
-            if (TInstant::Now() >= leaseUpdateTime) {
-                RunLeaseUpdater();
-            } else {
-                Schedule(leaseUpdateTime, new NActors::TEvents::TEvWakeup(EWakeUp::UpdateLeaseEvent));
-            }
-        }
-    }
-
-    // Event in case of error in registering script in database
-    // Just pass away, because we have not started execution.
-    void Handle(NActors::TEvents::TEvPoison::TPtr&) {
-        Y_ABORT_UNLESS(RunState == ERunState::Created);
-        LOG_E("Failed to save script execution entry");
-        PassAway();
-    }
-
-    bool ShouldSaveResult(size_t resultSetId) const {
-        if (SaveResultInflight) {
-            return false;
-        }
-
-        const TResultSetInfo& resultInfo = ResultSetInfos[resultSetId];
-        if (!resultInfo.PendingResult.rows_size()) {
-            return false;
-        }
-        if (resultInfo.Truncated || !IsExecuting()) {
-            return true;
-        }
-        return resultInfo.PendingResult.rows_size() >= MIN_SAVE_RESULT_BATCH_ROWS || resultInfo.ByteCount - resultInfo.AccumulatedSize >= MIN_SAVE_RESULT_BATCH_SIZE;
-    }
-
-    size_t GetBytesToSave(size_t resultSetId) const {
-        const TResultSetInfo& resultInfo = ResultSetInfos[resultSetId];
-        if (!resultInfo.PendingResult.rows_size()) {
-            return 0;
-        }
-        return resultInfo.ByteCount - resultInfo.AccumulatedSize;
-    }
-
-    void SaveResult(size_t resultSetId) {
-        if (!ExpireAt && ResultsTtl > TDuration::Zero()) {
-            ExpireAt = TInstant::Now() + ResultsTtl;
-        }
-
-        auto& resultSetInfo = ResultSetInfos[resultSetId];
-        const auto& saverId = Register(CreateSaveScriptExecutionResultActor(SelfId(), Database, ExecutionId, resultSetId, ExpireAt, resultSetInfo.FirstRowId, resultSetInfo.AccumulatedSize, std::move(resultSetInfo.PendingResult)));
-        LOG_D("Save part for result set #" << resultSetId << ", saver id: " << saverId);
-
-        SaveResultInflight++;
-        const ui64 bytes = resultSetInfo.ByteCount - resultSetInfo.AccumulatedSize;
-        PendingResultSetsSize -= bytes;
-        SaveResultInflightBytes = bytes;
-        resultSetInfo.FirstRowId = resultSetInfo.RowCount;
-        resultSetInfo.AccumulatedSize = resultSetInfo.ByteCount;
-        resultSetInfo.PendingResult = Ydb::ResultSet();
-    }
-
-    void SaveResult() {
-        for (size_t resultSetId = 0; resultSetId < ResultSetInfos.size(); ++resultSetId) {
-            if (ShouldSaveResult(resultSetId)) {
-                SaveResult(resultSetId);
-                break;
-            }
-        }
-    }
-
-    void Handle(TEvKqpExecuter::TEvStreamData::TPtr& ev) {
-        if (RunState != ERunState::Running) {
-            return;
-        }
-
-        LOG_D("Compute stream data"
-            << ", seqNo: " << ev->Get()->Record.GetSeqNo()
-            << ", queryResultIndex: " << ev->Get()->Record.GetQueryResultIndex()
-            << ", rowsCount: " << ev->Get()->Record.GetResultSet().rows_size()
-            << ", from: " << ev->Sender);
-
-        auto& streamData = ev->Get()->Record;
-        auto resultSetIndex = streamData.GetQueryResultIndex();
-
-        if (resultSetIndex >= ResultSetInfos.size()) {
-            // we don't know result set count, so just accept all of them
-            // it's possible to have several result sets per script
-            // they can arrive in any order and may be missed for some indices
-            ResultSetInfos.resize(resultSetIndex + 1);
-        }
-
-        bool savedResult = false;
-        auto& resultSetInfo = ResultSetInfos[resultSetIndex];
-        if (IsExecuting() && !resultSetInfo.Truncated) {
-            auto& rowCount = resultSetInfo.RowCount;
-            auto& byteCount = resultSetInfo.ByteCount;
-
-            for (auto& row : *streamData.MutableResultSet()->mutable_rows()) {
-                if (QueryServiceConfig.GetScriptResultRowsLimit() && rowCount + 1 > QueryServiceConfig.GetScriptResultRowsLimit()) {
-                    resultSetInfo.Truncated = true;
-                    break;
-                }
-
-                auto serializedSize = row.ByteSizeLong();
-                if (QueryServiceConfig.GetScriptResultSizeLimit() && byteCount + serializedSize > QueryServiceConfig.GetScriptResultSizeLimit()) {
-                    resultSetInfo.Truncated = true;
-                    break;
-                }
-
-                rowCount++;
-                byteCount += serializedSize;
-                PendingResultSetsSize += serializedSize;
-                *resultSetInfo.PendingResult.add_rows() = std::move(row);
-            }
-
-            const bool newResultSet = std::exchange(resultSetInfo.NewResultSet, false);
-            resultSetInfo.Finished = streamData.GetFinished();
-            if (newResultSet || resultSetInfo.Truncated) {
-                auto& meta = resultSetInfo.Meta.MutableMeta();
-                if (newResultSet) {
-                    meta.set_enabled_runtime_results(true);
-                    *meta.mutable_columns() = streamData.GetResultSet().columns();
-
-                    if (const auto& issues = NKikimr::NKqp::ValidateResultSetColumns(meta.columns())) {
-                        NYql::TIssue rootIssue(TStringBuilder() << "Invalid result set " << resultSetIndex << " columns, please contact internal support");
-                        for (const NYql::TIssue& issue : issues) {
-                            rootIssue.AddSubIssue(MakeIntrusive<NYql::TIssue>(issue));
-                        }
-                        Issues.AddIssue(rootIssue);
-                        meta.clear_columns();
-                        Finish(Ydb::StatusIds::INTERNAL_ERROR);
-                        return;
-                    }
-                }
-                if (resultSetInfo.Truncated) {
-                    meta.set_truncated(true);
-                }
-                SaveResultMeta();
-            }
-
-            if (ShouldSaveResult(resultSetIndex)) {
-                savedResult = true;
-                SaveResult(resultSetIndex);
-            }
-        }
-
-        const i64 freeSpaceBytes = GetFreeSpaceBytes();
-        const ui32 channelId = streamData.GetChannelId();
-        const ui64 seqNo = streamData.GetSeqNo();
-        auto& channel = StreamChannels[channelId];
-        channel.ActorId = ev->Sender;
-        channel.LastSeqNo = seqNo;
-        channel.AckedFreeSpaceBytes = freeSpaceBytes;
-        channel.ChannelId = channelId;
-        channel.Enough = resultSetInfo.Truncated;
-        channel.SendAck(SelfId());
-
-        if (!savedResult && SaveResultInflight == 0) {
-            CheckInflight();
-        }
-    }
-
-    void SaveResultMeta() {
-        // can't save meta when previous request is not completed for TLI reasons
-        if (SaveResultMetaInflight) {
-            PendingResultMeta = true;
-            return;
-        } 
-        SaveResultMetaInflight++;
-
-        NJson::TJsonValue resultSetMetas;
-        resultSetMetas.SetType(NJson::JSON_ARRAY);
-        for (size_t i = 0; auto& resultSetInfo : ResultSetInfos) {
-            resultSetMetas[i++] = resultSetInfo.Meta.GetJsonMeta();
-        }
-
-        NJsonWriter::TBuf sout;
-        sout.WriteJsonValue(&resultSetMetas);
-        const auto& saverId = Register(
-            CreateSaveScriptExecutionResultMetaActor(SelfId(), Database, ExecutionId, sout.Str(), LeaseGeneration)
-        );
-
-        LOG_D("Save result meta for result sets #" << ResultSetInfos.size() << ", saver id: " << saverId);
-    }
-
-    void Handle(TEvKqpExecuter::TEvExecuterProgress::TPtr& ev) {
-        const bool isExecuting = IsExecuting();
-        LOG_T("Got script progress from " << ev->Sender << ", isExecuting: " << isExecuting);
-
-        if (!isExecuting) {
-            return;
-        }
-
-        const auto& record = ev->Get()->Record;
-        QueryPlan = record.GetQueryPlan();
-        QueryAst = record.GetQueryAst();
-        UpdateScriptProgress(record.GetQueryPlan(), record.GetQueryAst());
-    }
-
-    void Handle(TEvSaveScriptExternalEffectRequest::TPtr& ev) {
-        LOG_I("Got save script external effect request from " << ev->Sender);
-
-        if (RunState != ERunState::Running) {
-            Send(ev->Sender, new TEvSaveScriptPhysicalGraphResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue("Script execution is not running")}));
-            return;
-        }
-
-        auto& sinks = ev->Get()->Description.Sinks;
-        sinks = FilterExternalSinksWithEffects(sinks);
-
-        if (!sinks.empty()) {
-            const auto& saverId = Register(CreateSaveScriptExternalEffectActor(std::move(ev), LeaseGeneration));
-            LOG_D("Save external effect, saver id: " << saverId);
-        } else {
-            Send(ev->Sender, new TEvSaveScriptExternalEffectResponse(Ydb::StatusIds::SUCCESS, {}));
-        }
-    }
-
-    void Handle(TEvSaveScriptPhysicalGraphRequest::TPtr& ev) {
-        LOG_I("Got save script physical graph request from " << ev->Sender);
-
-        if (RunState != ERunState::Running) {
-            Send(ev->Sender, new TEvSaveScriptPhysicalGraphResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue("Script execution is not running")}));
-            return;
-        }
-
-        if (PhysicalGraphSender) {
-            Send(ev->Sender, new TEvSaveScriptPhysicalGraphResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue("Can not save graph twice")}));
-            return;
-        }
-
-        if (PhysicalGraph) {
-            ev->Get()->PhysicalGraph.SetZeroCheckpointSaved(PhysicalGraph->GetZeroCheckpointSaved());
-        } else {
-            PhysicalGraph = ev->Get()->PhysicalGraph;
-        }
-
-        PhysicalGraphSender = ev->Sender;
-        const auto& saverId = Register(CreateSaveScriptExecutionPhysicalGraphActor(SelfId(), Database, ExecutionId, std::move(ev->Get()->PhysicalGraph), LeaseGeneration, QueryServiceConfig));
-        LOG_D("Save script physical graph, saver id: " << saverId);
-        SaveScriptPhysicalGraphInflight++;
-    }
-
-    void Handle(TEvSaveScriptPhysicalGraphResponse::TPtr& ev) {
-        SaveScriptPhysicalGraphInflight--;
-        LOG_D("Script physical graph saved " << ev->Sender << ", Status: " << ev->Get()->Status << ", Issues: " << ev->Get()->Issues.ToOneLineString());
-
-        if (PhysicalGraphSender) {
-            Forward(ev, *PhysicalGraphSender);
-            PhysicalGraphSender = {};
-        } else if (ev->Get()->Status != Ydb::StatusIds::SUCCESS) {
-            Issues.AddIssue("Internal error. Failed to update query physical graph");
-            if (IsExecuting()) {
-                Finish(Ydb::StatusIds::INTERNAL_ERROR);
-            }
-        }
-
-        if (!SavedRunningStatus) {
-            UpdateScriptProgress("{}");
-        }
-
-        CheckInflight();
-    }
-
-    void Handle(NFq::TEvCheckpointCoordinator::TEvZeroCheckpointDone::TPtr& ev) {
-        LOG_I("Zero checkpoint saved by " << ev->Sender);
-
-        if (RunState != ERunState::Running) {
-            LOG_N("Zero checkpoint saved after finalization");
-            return;
-        }
-
-        if (!PhysicalGraph) {
-            Issues.AddIssue("Internal error. Zero checkpoint saved before physical graph saved");
-            Finish(Ydb::StatusIds::INTERNAL_ERROR);
-            return;
-        }
-
-        if (!PhysicalGraph->GetZeroCheckpointSaved()) {
-            PhysicalGraph->SetZeroCheckpointSaved(true);
-            const auto& saverId = Register(CreateSaveScriptExecutionPhysicalGraphActor(SelfId(), Database, ExecutionId, *PhysicalGraph, LeaseGeneration, QueryServiceConfig));
-            LOG_D("Save script physical graph after zero checkpoint saved, saver id: " << saverId);
-            SaveScriptPhysicalGraphInflight++;
-        }
-    }
-
-    void Handle(TEvKqp::TEvQueryResponse::TPtr& ev) {
-        if (RunState != ERunState::Running) {
-            LOG_N("Script query finished from " << ev->Sender << " after finalization");
-            return;
-        }
-
-        auto& record = ev->Get()->Record;
-
-        const auto& issueMessage = record.GetResponse().GetQueryIssues();
-        NYql::TIssues issues;
-        NYql::IssuesFromMessage(issueMessage, issues);
-        Issues.AddIssues(TruncateIssues(issues));
-
-        if (record.GetYdbStatus() == Ydb::StatusIds::SUCCESS) {
-            LOG_I("Script query successfully finished from " << ev->Sender << ", Issues: " << Issues.ToOneLineString());
-        } else {
-            LOG_W("Script query failed from " << ev->Sender << " " << record.GetYdbStatus() << ", Issues: " << Issues.ToOneLineString());
-        }
-
-        if (record.GetYdbStatus() == Ydb::StatusIds::TIMEOUT) {
-            const TDuration timeout = GetQueryTimeout(NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT, Request.GetRequest().GetTimeoutMs(), {}, QueryServiceConfig, DisableDefaultTimeout);
-            NYql::TIssue timeoutIssue(TStringBuilder() << "Current request timeout is " << timeout.MilliSeconds() << "ms");
-            timeoutIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
-            Issues.AddIssue(std::move(timeoutIssue));
-        }
-
-        if (record.GetResponse().HasQueryPlan()) {
-            QueryPlan = record.GetResponse().GetQueryPlan();
-        }
-
-        if (record.GetResponse().HasQueryStats()) {
-            QueryStats = record.GetResponse().GetQueryStats();
-        }
-
-        if (record.GetResponse().HasQueryAst()) {
-            QueryAst = record.GetResponse().GetQueryAst();
-        }
-
-        Finish(record.GetYdbStatus());
-    }
-
-    void Handle(TEvKqp::TEvCancelScriptExecutionRequest::TPtr& ev) {
-        CancelRequestsCount++;
-        LOG_I("Cancel script execution request #" << CancelRequestsCount << " from " << ev->Sender << ", FinalStatusIsSaved: " << FinalStatusIsSaved << ", WaitFinalizationRequest: " << WaitFinalizationRequest);
-
-        switch (RunState) {
-        case ERunState::Created:
-            CancelRequests.emplace_front(std::move(ev));
-            Finish(Ydb::StatusIds::CANCELLED, ERunState::Cancelling);
-            break;
-        case ERunState::Running:
-            CancelRequests.emplace_front(std::move(ev));
-            CancelRunningQuery();
-            break;
-        case ERunState::Cancelling:
-            CancelRequests.emplace_front(std::move(ev));
-            break;
-        case ERunState::Cancelled:
-            Send(ev->Sender, new TEvKqp::TEvCancelScriptExecutionResponse(Ydb::StatusIds::PRECONDITION_FAILED, "Already cancelled"), 0, ev->Cookie);
-            break;
-        case ERunState::Finishing:
-            CancelRequests.emplace_front(std::move(ev));
-            break;
-        case ERunState::Finished:
-            Send(ev->Sender, new TEvKqp::TEvCancelScriptExecutionResponse(Ydb::StatusIds::PRECONDITION_FAILED, "Already finished"), 0, ev->Cookie);
-            break;
-        }
-    }
-
-    void CancelRunningQuery() {
-        if (SessionId.empty()) {
-            Finish(Ydb::StatusIds::CANCELLED, ERunState::Cancelling);
-        } else {
-            LOG_I("Cancel running query");
-
-            RunState = ERunState::Cancelling;
-            auto ev = MakeHolder<TEvKqp::TEvCancelQueryRequest>();
-            ev->Record.MutableRequest()->SetSessionId(SessionId);
-
-            Send(MakeKqpProxyID(SelfId().NodeId()), ev.Release());
-        }
-    }
-
-    void Handle(TEvKqp::TEvCancelQueryResponse::TPtr& ev) {
-        const auto& record = ev->Get()->Record;
-        if (const auto status = record.GetStatus(); ev->Get()->Record.GetStatus() != Ydb::StatusIds::SUCCESS) {
-            const auto& issueMessage = record.GetIssues();
-            NYql::TIssues issues;
-            NYql::IssuesFromMessage(issueMessage, issues);
-
-            LOG_E("Failed to cancel query " << status << ", Issues: " << issues.ToOneLineString() << ", response from: " << ev->Sender);
-
-            Issues.AddIssues(AddRootIssue(TStringBuilder() << "Failed to cancel query (" << status << ")", issues, true));
-        } else {
-            LOG_I("Query cancelled, response from: " << ev->Sender);
-        }
-
-        Finish(Ydb::StatusIds::CANCELLED, ERunState::Cancelling);
-    }
-
-    void Handle(TEvScriptExecutionFinished::TPtr& ev) {
-        LOG_I("Script execution final status saved by " << ev->Sender
-            << ", Status: " << ev->Get()->Status
-            << ", Issues: " << ev->Get()->Issues.ToOneLineString()
-            << ", OperationAlreadyFinalized: " << ev->Get()->OperationAlreadyFinalized
-            << ", WaitingRetry: " << ev->Get()->WaitingRetry);
-
-        WaitFinalizationRequest = false;
-
-        if (RunState == ERunState::Cancelling) {
-            RunState = ERunState::Cancelled;
-        }
-
-        if (RunState == ERunState::Finishing) {
-            RunState = ERunState::Finished;
-        }
-
-        Ydb::StatusIds::StatusCode status = ev->Get()->Status;
-        NYql::TIssues issues = std::move(ev->Get()->Issues);
-        if (RunState == ERunState::Finished) {
-            status = Ydb::StatusIds::PRECONDITION_FAILED;
-            issues.Clear();
-            issues.AddIssue("Already finished");
-        }
-        TerminateActorExecution(status, issues);
-    }
-
-    void Handle(TEvSaveScriptResultMetaFinished::TPtr& ev) {
-        const auto status = ev->Get()->Status;
-        const auto& issues = ev->Get()->Issues;
-        if (status != Ydb::StatusIds::SUCCESS) {
-            LOG_E("Save result meta " << ev->Sender << " failed " << status << ", Issues: " << issues.ToOneLineString());
-        } else {
-            LOG_D("Save result meta " << ev->Sender << " finished");
-        }
-
-        SaveResultMetaInflight--;
-
-        if (PendingResultMeta) {
-            PendingResultMeta = false;
-            SaveResultMeta();
-            return;
-        }
-
-        if (status != Ydb::StatusIds::SUCCESS && (Status == Ydb::StatusIds::SUCCESS || Status == Ydb::StatusIds::STATUS_CODE_UNSPECIFIED)) {
-            Status = status;
-            Issues.AddIssues(AddRootIssue("Failed to save result set meta", ev->Get()->Issues, true));
-        }
-        CheckInflight();
-    }
-
-    void Handle(TEvSaveScriptResultFinished::TPtr& ev) {
-        SaveResultInflight--;
-        SaveResultInflightBytes = 0;
-
-        const auto status = ev->Get()->Status;
-        const auto resultSetId = ev->Get()->ResultSetId;
-        if (status == Ydb::StatusIds::SUCCESS) {
-            LOG_D("Save result set #" << resultSetId << " " << ev->Sender << " finished");
-
-            if (resultSetId >= ResultSetInfos.size()) {
-                Issues.AddIssue(TStringBuilder() << "ResultSetId " << resultSetId << " is out of range [0; " << ResultSetInfos.size() << ")");
-                Finish(Ydb::StatusIds::INTERNAL_ERROR);
-                return;
-            }
-
-            auto& resultSetInfo = ResultSetInfos[resultSetId];
-            auto& meta = resultSetInfo.Meta.MutableMeta();
-            meta.set_number_rows(resultSetInfo.RowCount);
-            if (resultSetInfo.PendingResult.rows().empty() && (resultSetInfo.Truncated || resultSetInfo.Finished)) {
-                meta.set_finished(true);
-            }
-
-            SaveResultMeta();
-        } else {
-            LOG_E("Save result set #" << resultSetId << " " << ev->Sender << " failed " << status << ", Issues: " << ev->Get()->Issues.ToOneLineString());
-        }
-
-        if (Status == Ydb::StatusIds::SUCCESS || Status == Ydb::StatusIds::STATUS_CODE_UNSPECIFIED) {
-            if (status != Ydb::StatusIds::SUCCESS) {
-                Status = status;
-                Issues.AddIssues(AddRootIssue(TStringBuilder() << "Failed to save result set " << resultSetId, ev->Get()->Issues, true));
-            } else {
-                SaveResult();
-            }
-        }
-
-        const i64 freeSpaceBytes = GetFreeSpaceBytes();
-        if (freeSpaceBytes > 0 && IsExecuting()) {
-            for (auto& [channelId, channel] : StreamChannels) {
-                if (channel.ResumeIfStopped(SelfId(), freeSpaceBytes)) {
-                    LOG_D("Resume execution, "
-                        << ", channel: " << channelId
-                        << ", seqNo: " << channel.LastSeqNo
-                        << ", freeSpace: " << freeSpaceBytes);
-                }
-            }
-        }
-
-        CheckInflight();
-    }
-
-    void Handle(TEvSaveScriptProgressResponse::TPtr& ev) {
-        LOG_T("Script progress updated " << ev->Sender << ", Status: " << ev->Get()->Status << ", Issues: " << ev->Get()->Issues.ToOneLineString());
-
-        if (ev->Get()->AstSaved) {
-            AstSaved = true;
-        }
-    }
-
-    static Ydb::Query::ExecStatus GetExecStatusFromStatusCode(Ydb::StatusIds::StatusCode status) {
-        if (status == Ydb::StatusIds::SUCCESS) {
-            return Ydb::Query::EXEC_STATUS_COMPLETED;
-        } else if (status == Ydb::StatusIds::CANCELLED) {
-            return Ydb::Query::EXEC_STATUS_CANCELLED;
-        } else {
-            return Ydb::Query::EXEC_STATUS_FAILED;
-        }
-    }
-
-    EFinalizationStatus GetFinalizationStatusFromRunState() const {
-        if ((Status == Ydb::StatusIds::SUCCESS || Status == Ydb::StatusIds::CANCELLED) && !IsExecuting()) {
-            return EFinalizationStatus::FS_COMMIT;
-        }
-        return EFinalizationStatus::FS_ROLLBACK;
-    }
-
-    void CheckInflight() {
-        if (SaveResultMetaInflight || SaveResultInflight || SaveScriptPhysicalGraphInflight) {
-            return;
-        }
-
-        const int freeSpaceBytes = GetFreeSpaceBytes();
-        if (freeSpaceBytes < 0 && IsExecuting()) {
-            // try to free the space
-            size_t maxBytesToSave = 0;
-            size_t maxResultSet = 0;
-            for (size_t resultSetId = 0; resultSetId < ResultSetInfos.size(); ++resultSetId) {
-                if (size_t bytesToSave = GetBytesToSave(resultSetId); bytesToSave > maxBytesToSave) {
-                    maxBytesToSave = bytesToSave;
-                    maxResultSet = resultSetId;
-                }
-            }
-            SaveResult(maxResultSet);
-        } else {
-            if (Status == Ydb::StatusIds::STATUS_CODE_UNSPECIFIED || IsExecuting()) {
-                // waiting for script completion
-                return;
-            }
-
-            if (PendingResultSetsSize) {
-                // Complete results saving
-                SaveResult();
-                return;
-            }
-
-            if (!LeaseUpdateQueryRunning) {
-                RunScriptExecutionFinisher();
-            } else {
-                FinishAfterLeaseUpdate = true;
-            }
-        }
-    }
-
-    void Finish(Ydb::StatusIds::StatusCode status, ERunState runState = ERunState::Finishing) {
-        LOG_I("Finish script execution, status: " << status << ", new run state: " << static_cast<ui64>(runState));
-
-        RunState = runState;
-        Status = status;
-
-        // if query has no results, save empty json array
-        if (ResultSetInfos.empty()) {
-            SaveResultMeta();
-        } else {
-            CheckInflight();
-        }
-    }
-
-    void PassAway() override {
-        CloseSession();
-        NActors::TActorBootstrapped<TRunScriptActor>::PassAway();
-    }
-
-    bool IsExecuting() const {
-        return RunState != ERunState::Finished
-            && RunState != ERunState::Finishing
-            && RunState != ERunState::Cancelled
-            && RunState != ERunState::Cancelling;
-    }
-
-    i64 GetFreeSpaceBytes() const {
-        return static_cast<i64>(RUN_SCRIPT_ACTOR_BUFFER_SIZE) - static_cast<i64>(PendingResultSetsSize) - static_cast<i64>(SaveResultInflightBytes);
     }
 
     TString LogPrefix() const {
-        return TStringBuilder() << "[" << ActorName << "] " << SelfId() << ". Ctx: " << *UserRequestContext << ". LeaseGeneration: " << LeaseGeneration << ". RunState: " << static_cast<ui64>(RunState) << ". ";
+        return TStringBuilder() << "[" << ActorName << "] " << SelfId() << ". Ctx: " << *Ctx->UserRequestContext << ". LeaseGeneration: " << Ctx->LeaseGeneration << ". ";
     }
 
-private:
-    const TString ExecutionId;
-    NKikimrKqp::TEvQueryRequest Request;
-    const TString Database;
-    const i64 LeaseGeneration;
-    const TDuration LeaseDuration;
-    const TDuration ResultsTtl;
-    const TDuration ProgressStatsPeriod;
+    const TScriptExecutionContext::TPtr Ctx;
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
-    const bool SaveQueryPhysicalGraph = false;
-    const bool DisableDefaultTimeout = false;
-    const TString CheckpointId;
     std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
-    const TString StreamingQueryPath;
-    const TString CustomerSuppliedId;
-    const std::shared_ptr<NYql::NPq::NProto::StreamingDisposition> StreamingDisposition;
-    std::optional<TActorId> PhysicalGraphSender;
-    TIntrusivePtr<TKqpCounters> Counters;
-    TString SessionId;
-    TInstant LeaseUpdateScheduleTime;
-    bool LeaseUpdateQueryRunning = false;
-    bool FinalStatusIsSaved = false;
-    bool FinishAfterLeaseUpdate = false;
-    bool WaitFinalizationRequest = false;
-    bool SavedRunningStatus = false;
-    bool Terminated = false;
-    ERunState RunState = ERunState::Created;
+    std::unique_ptr<TEvKqp::TEvQueryRequest> QueryRequest;
+    TFinishInfo FinishInfo;
+    TExecutionInfo ExecutionInfo;
+    TSessionState SessionState;
+    TActorState ScriptLeaseWatcherActor;
+    TActorState ScriptResultHandlerActor;
     std::forward_list<TEvKqp::TEvCancelScriptExecutionRequest::TPtr> CancelRequests;
-    ui64 CancelRequestsCount = 0;
-
-    // Result info
-    NYql::TIssues Issues;
-    Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::STATUS_CODE_UNSPECIFIED;
-    bool AstSaved = false;
-
-    // Result data
-    std::vector<TResultSetInfo> ResultSetInfos;
-    TMap<ui64, TProducerState> StreamChannels;
-    std::optional<TInstant> ExpireAt;
-    ui32 SaveScriptPhysicalGraphInflight = 0;
-    ui32 SaveResultInflight = 0;
-    ui64 SaveResultInflightBytes = 0;
-    ui32 SaveResultMetaInflight = 0;
-    bool PendingResultMeta = false;
-    ui64 PendingResultSetsSize = 0;
-    std::optional<TString> QueryPlan;
-    std::optional<TString> QueryAst;
-    std::optional<NKqpProto::TKqpStatsQuery> QueryStats;
-    TIntrusivePtr<TUserRequestContext> UserRequestContext;
+    bool WaitFinalizationRequest = false;
 };
 
 } // namespace
 
-NActors::IActor* CreateRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig) {
+IActor* CreateRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig) {
     return new TRunScriptActor(request, std::move(settings), std::move(queryServiceConfig));
 }
 

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -292,6 +292,8 @@ private:
     STRICT_STFUNC(StateFuncFinalize,
         IgnoreFunc(TEvKqp::TEvCloseSessionResponse);
         IgnoreFunc(TEvKqp::TEvQueryResponse); // Ignored because result handler either not started or already finished
+        sFunc(TEvents::TEvWakeup, HandleCreatingFinished);
+        sFunc(TEvents::TEvPoison, HandleCreatingFailed);
         hFunc(TEvKqp::TEvCreateSessionResponse, HandleCreateSession);
         hFunc(TEvScriptExecutionFinished, HandleFinalize);
         hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -170,8 +170,12 @@ private:
 
     void HandleCancellation(TEvKqp::TEvCancelScriptExecutionRequest::TPtr& ev) {
         LOG_I("Got cancel request: " << ev->Sender);
+
         CancelRequests.emplace_front(std::move(ev));
-        Finish(Ydb::StatusIds::CANCELLED);
+
+        if (!FinishInfo.IsSuccess()) {
+            Finish(Ydb::StatusIds::CANCELLED);
+        }
     }
 
     void HandleCheckAlive(TEvCheckAliveRequest::TPtr& ev) {
@@ -306,10 +310,12 @@ private:
             LOG_I("Got finalize: " << ev->Sender << ", already finished: " << info.AlreadyStopped << ", execution entry exists: " << info.ExecutionEntryExists);
         }
 
+        const auto alreadyStopped = info.AlreadyStopped || FinishInfo.IsSuccess();
+
         for (auto& request : CancelRequests) {
             Send(request->Sender, new TEvKqp::TEvCancelScriptExecutionResponse(status, {
                 .ExecutionEntryExists = info.ExecutionEntryExists,
-                .AlreadyStopped = info.AlreadyStopped,
+                .AlreadyStopped = alreadyStopped,
             }, issues), /* flags */ 0, request->Cookie);
         }
     }

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -42,11 +42,6 @@ namespace {
 using namespace NPrivate;
 
 class TRunScriptActor final : public TActorBootstrapped<TRunScriptActor>, IActorExceptionHandler {
-    struct TSessionState {
-        bool SessionOpen = false;
-        bool WaitClose = false;
-    };
-
     struct TActorState {
         bool WaitStop = false;
         TActorId Id;
@@ -67,12 +62,10 @@ public:
     TRunScriptActor(const NKikimrKqp::TEvQueryRequest& request, TKqpRunScriptActorSettings&& settings, NKikimrConfig::TQueryServiceConfig queryServiceConfig)
         : Ctx(CreateExecutionContext(request, settings, queryServiceConfig))
         , QueryServiceConfig(queryServiceConfig)
-        , PhysicalGraph(std::move(settings.PhysicalGraph))
         , QueryRequest(CreateQueryRequest(request, settings, queryServiceConfig, *Ctx))
     {}
 
     void Bootstrap() {
-        Ctx->UserRequestContext->RunScriptActorId = SelfId();
         LOG_I("Bootstrap, StreamingDisposition: " << (Ctx->UserRequestContext->StreamingDisposition ? Ctx->UserRequestContext->StreamingDisposition->DebugString() : "null"));
         Become(&TThis::StateFuncCreating);
     }
@@ -111,7 +104,7 @@ private:
         ev->SetUserRequestContext(ctx.UserRequestContext);
 
         if (settings.PhysicalGraph) {
-            ev->SetQueryPhysicalGraph(*settings.PhysicalGraph);
+            ev->SetQueryPhysicalGraph(std::move(*settings.PhysicalGraph));
         }
 
         if (request.GetRequest().GetCollectStats() >= Ydb::Table::QueryStatsCollection::STATS_COLLECTION_FULL) {
@@ -135,7 +128,7 @@ private:
 
     void HandleCreatingFinished() {
         LOG_I("Script execution metadata saved, creating new session");
-        Become(&TThis::StateFuncInitialise);
+        Become(&TThis::StateFuncInitialize);
 
         ScriptLeaseWatcherActor.Id = RegisterWithSameMailbox(CreateScriptLeaseWatcherActor(Ctx));
         LOG_I("Started ScriptLeaseWatcherActor: " << ScriptLeaseWatcherActor.Id);
@@ -151,14 +144,14 @@ private:
     }
 
     // Create new kqp session
-    STRICT_STFUNC(StateFuncInitialise,
-        hFunc(TEvKqp::TEvCreateSessionResponse, HandleInitialise);
+    STRICT_STFUNC(StateFuncInitialize,
+        hFunc(TEvKqp::TEvCreateSessionResponse, HandleInitialize);
         hFunc(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished, HandleLeaseWatcherFinished);
         hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
         hFunc(TEvCheckAliveRequest, HandleCheckAlive);
     )
 
-    void HandleInitialise(TEvKqp::TEvCreateSessionResponse::TPtr& ev) {
+    void HandleInitialize(TEvKqp::TEvCreateSessionResponse::TPtr& ev) {
         const auto& record = ev->Get()->Record;
         if (const auto status = record.GetYdbStatus(); status != Ydb::StatusIds::SUCCESS) {
             const auto resourceExhausted = record.GetResourceExhausted();
@@ -175,9 +168,10 @@ private:
             return;
         }
 
-        SessionState.SessionOpen = true;
+        SessionOpen = true;
         const auto& session = record.GetResponse();
         Ctx->UserRequestContext->SessionId = session.GetSessionId();
+        QueryRequest->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
 
         if (session.GetNodeId() != SelfId().NodeId()) {
             LOG_E("New session started on unexpected node: " << session.GetNodeId());
@@ -185,23 +179,28 @@ private:
             return;
         }
 
-        ScriptResultHandlerActor.Id = RegisterWithSameMailbox(CreateScriptResultHandlerActor(Ctx, std::move(PhysicalGraph), QueryServiceConfig));
-        LOG_D("Started ScriptResultHandlerActor: " << ScriptResultHandlerActor.Id << ", starting query, has physical graph: " << PhysicalGraph.has_value());
+        Become(&TThis::StateFuncExecute);
 
-        QueryRequest->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
-        ActorIdToProto(SelfId(), QueryRequest->Record.MutableRequestActorId());
+        const auto& physicalGraph = QueryRequest->GetQueryPhysicalGraph();
+        ScriptResultHandlerActor.Id = RegisterWithSameMailbox(CreateScriptResultHandlerActor(Ctx, physicalGraph ? std::optional(*physicalGraph) : std::nullopt, QueryServiceConfig));
+        LOG_D("Started ScriptResultHandlerActor: " << ScriptResultHandlerActor.Id << ", starting query, has physical graph: " << (physicalGraph ? "YES" : "NO"));
+
+        Ctx->UserRequestContext->RunScriptActorId = ScriptResultHandlerActor.Id;
+        ActorIdToProto(ScriptResultHandlerActor.Id, QueryRequest->Record.MutableRequestActorId());
         Send(MakeKqpProxyID(SelfId().NodeId()), QueryRequest.release());
     }
 
     void HandleLeaseWatcherFinished(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished::TPtr& ev) {
-        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
-            LOG_E("Got lease watcher finished: " << ev->Sender << " with status " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+        ScriptLeaseWatcherActor.Id = {};
+
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS || !FinishInfo.IsFinished()) {
+            const auto& issues = ev->Get()->Issues;
+            LOG_E("Got lease watcher finished: " << ev->Sender << " with status " << status << ", issues: " << issues.ToOneLineString());
+            Finish(status, AddRootIssue("Script lease watcher error", issues));
         } else {
             LOG_I("Got lease watcher finished: " << ev->Sender);
+            Finish();
         }
-
-        ScriptLeaseWatcherActor.Id = {};
-        Finish(ev->Get()->Status, AddRootIssue("Script lease watcher error", ev->Get()->Issues));
     }
 
     void HandleCancellation(TEvKqp::TEvCancelScriptExecutionRequest::TPtr& ev) {
@@ -217,40 +216,44 @@ private:
 
     // Wait query execution
     STRICT_STFUNC(StateFuncExecute,
-        hFunc(TEvKqp::TEvCloseSessionResponse, HandleExecute);
+        IgnoreFunc(TEvKqp::TEvCloseSessionResponse);
+        hFunc(TEvKqp::TEvQueryResponse, HandleExecute);
         hFunc(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished, HandleLeaseWatcherFinished);
         hFunc(TEvRunScriptPrivate::TEvScriptResultHandlerFinished, HandleResultHandlerFinished);
         hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
         hFunc(TEvCheckAliveRequest, HandleCheckAlive);
     )
 
-    void HandleExecute(TEvKqp::TEvCloseSessionResponse::TPtr& ev) {
-        const auto& record = ev->Get()->Record;
-        NYql::TIssues issues;
-        NYql::IssuesFromMessage(record.GetIssues(), issues);
-        LOG_I("Got close session response: " << ev->Sender << " with status " << record.GetStatus() << ", issues: " << issues.ToOneLineString());
-
-        SessionState.SessionOpen = false;
-
-        if (FinishInfo.IsFinished()) {
-            Finish();
+    void HandleExecute(TEvKqp::TEvQueryResponse::TPtr& ev) {
+        if (!ScriptResultHandlerActor.Id) {
+            const auto& record = ev->Get()->Record;
+            const auto& response = record.GetResponse();
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(response.GetQueryIssues(), issues);
+            LOG_W("Ignored query response from " << ev->Sender << ", execution already finished, status: " << record.GetYdbStatus() << ", issues: " << issues.ToOneLineString());
+            return;
         }
+
+        LOG_D("Forward query response from " << ev->Sender << " to result handler");
+        Forward(ev, ScriptResultHandlerActor.Id);
     }
 
     void HandleResultHandlerFinished(TEvRunScriptPrivate::TEvScriptResultHandlerFinished::TPtr& ev) {
+        ScriptResultHandlerActor.Id = {};
+
         if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
             LOG_E("Got result handler finished: " << ev->Sender << " with status " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
         } else {
             LOG_I("Got result handler finished: " << ev->Sender);
         }
 
-        ScriptResultHandlerActor = {};
         ExecutionInfo = std::move(ev->Get()->Info);
         Finish(ev->Get()->Status, std::move(ev->Get()->Issues));
     }
 
     // Wait query finalization
     STRICT_STFUNC(StateFuncFinalize,
+        IgnoreFunc(TEvKqp::TEvQueryResponse);
         hFunc(TEvScriptExecutionFinished, HandleFinalize);
         hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
         hFunc(TEvCheckAliveRequest, HandleCheckAlive);
@@ -274,8 +277,6 @@ private:
                 .AlreadyStopped = info.AlreadyStopped,
             }, issues), /* flags */ 0, request->Cookie);
         }
-
-        PassAway();
     }
 
     void Finish() {
@@ -300,15 +301,12 @@ private:
             return;
         }
 
-        if (SessionState.SessionOpen) {
-            if (!SessionState.WaitClose) {
-                LOG_D("Close session");
-                auto ev = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
-                ev->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
-                Send(MakeKqpProxyID(SelfId().NodeId()), ev.release());
-                SessionState.WaitClose = true;
-            }
-            return;
+        if (SessionOpen) {
+            SessionOpen = true;
+            LOG_D("Close session");
+            auto ev = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
+            ev->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
+            Send(MakeKqpProxyID(SelfId().NodeId()), ev.release());
         }
 
         if (ScriptLeaseWatcherActor.Id) {
@@ -318,6 +316,7 @@ private:
 
         if (!WaitFinalizationRequest) {
             LOG_I("Start script execution finalization");
+            Become(&TThis::StateFuncFinalize);
 
             const auto cancelledByUser = !CancelRequests.empty();
             if (FinishInfo.IsFailed() && cancelledByUser) {
@@ -353,11 +352,10 @@ private:
 
     const TScriptExecutionContext::TPtr Ctx;
     const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
-    std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
     std::unique_ptr<TEvKqp::TEvQueryRequest> QueryRequest;
     TFinishInfo FinishInfo;
     TExecutionInfo ExecutionInfo;
-    TSessionState SessionState;
+    bool SessionOpen = false;
     TActorState ScriptLeaseWatcherActor;
     TActorState ScriptResultHandlerActor;
     std::forward_list<TEvKqp::TEvCancelScriptExecutionRequest::TPtr> CancelRequests;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.cpp
@@ -42,6 +42,22 @@ namespace {
 using namespace NPrivate;
 
 class TRunScriptActor final : public TActorBootstrapped<TRunScriptActor>, IActorExceptionHandler {
+    struct TSessionState {
+        bool WaitCreation = false;
+        bool SessionOpen = false;
+
+        void Close(const TActorIdentity& actor, const TScriptExecutionContext& ctx) {
+            if (!SessionOpen) {
+                return;
+            }
+
+            auto ev = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
+            ev->Record.MutableRequest()->SetSessionId(ctx.UserRequestContext->SessionId);
+            actor.Send(MakeKqpProxyID(actor.NodeId()), ev.release());
+            SessionOpen = false;
+        }
+    };
+
     struct TActorState {
         bool WaitStop = false;
         TActorId Id;
@@ -124,9 +140,17 @@ private:
     STRICT_STFUNC(StateFuncCreating,
         sFunc(TEvents::TEvWakeup, HandleCreatingFinished);
         sFunc(TEvents::TEvPoison, HandleCreatingFailed);
+        hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
+        hFunc(TEvCheckAliveRequest, HandleCheckAlive);
     )
 
     void HandleCreatingFinished() {
+        if (FinishInfo.IsFinished()) {
+            LOG_N("Script execution metadata saved after failure, continue finishing");
+            Finish(); // Continue finishing
+            return;
+        }
+
         LOG_I("Script execution metadata saved, creating new session");
         Become(&TThis::StateFuncInitialize);
 
@@ -137,21 +161,35 @@ private:
         ev->Record.SetTraceId(Ctx->UserRequestContext->TraceId);
         ev->Record.MutableRequest()->SetDatabase(Ctx->UserRequestContext->Database);
         Send(MakeKqpProxyID(SelfId().NodeId()), ev.release());
+        SessionState.WaitCreation = true;
     }
 
     void HandleCreatingFailed() {
         Finish(Ydb::StatusIds::INTERNAL_ERROR, "Failed to save script execution entry");
     }
 
+    void HandleCancellation(TEvKqp::TEvCancelScriptExecutionRequest::TPtr& ev) {
+        LOG_I("Got cancel request: " << ev->Sender);
+        CancelRequests.emplace_front(std::move(ev));
+        Finish(Ydb::StatusIds::CANCELLED);
+    }
+
+    void HandleCheckAlive(TEvCheckAliveRequest::TPtr& ev) {
+        LOG_W("Lease was expired in database, checker actor: " << ev->Sender);
+        Send(ev->Sender, new TEvCheckAliveResponse());
+    }
+
     // Create new kqp session
     STRICT_STFUNC(StateFuncInitialize,
-        hFunc(TEvKqp::TEvCreateSessionResponse, HandleInitialize);
+        hFunc(TEvKqp::TEvCreateSessionResponse, HandleCreateSession);
         hFunc(TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished, HandleLeaseWatcherFinished);
         hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
         hFunc(TEvCheckAliveRequest, HandleCheckAlive);
     )
 
-    void HandleInitialize(TEvKqp::TEvCreateSessionResponse::TPtr& ev) {
+    void HandleCreateSession(TEvKqp::TEvCreateSessionResponse::TPtr& ev) {
+        SessionState.WaitCreation = false;
+
         const auto& record = ev->Get()->Record;
         if (const auto status = record.GetYdbStatus(); status != Ydb::StatusIds::SUCCESS) {
             const auto resourceExhausted = record.GetResourceExhausted();
@@ -168,10 +206,16 @@ private:
             return;
         }
 
-        SessionOpen = true;
+        SessionState.SessionOpen = true;
         const auto& session = record.GetResponse();
         Ctx->UserRequestContext->SessionId = session.GetSessionId();
         QueryRequest->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
+
+        if (FinishInfo.IsFinished()) {
+            LOG_N("Session created after finish, continue finishing");
+            Finish();
+            return;
+        }
 
         if (session.GetNodeId() != SelfId().NodeId()) {
             LOG_E("New session started on unexpected node: " << session.GetNodeId());
@@ -201,17 +245,6 @@ private:
             LOG_I("Got lease watcher finished: " << ev->Sender);
             Finish();
         }
-    }
-
-    void HandleCancellation(TEvKqp::TEvCancelScriptExecutionRequest::TPtr& ev) {
-        LOG_I("Got cancel request: " << ev->Sender);
-        CancelRequests.emplace_front(std::move(ev));
-        Finish(Ydb::StatusIds::CANCELLED);
-    }
-
-    void HandleCheckAlive(TEvCheckAliveRequest::TPtr& ev) {
-        LOG_W("Lease was expired in database, checker actor: " << ev->Sender);
-        Send(ev->Sender, new TEvCheckAliveResponse());
     }
 
     // Wait query execution
@@ -253,7 +286,9 @@ private:
 
     // Wait query finalization
     STRICT_STFUNC(StateFuncFinalize,
-        IgnoreFunc(TEvKqp::TEvQueryResponse);
+        IgnoreFunc(TEvKqp::TEvCloseSessionResponse);
+        IgnoreFunc(TEvKqp::TEvQueryResponse); // Ignored because result handler either not started or already finished
+        hFunc(TEvKqp::TEvCreateSessionResponse, HandleCreateSession);
         hFunc(TEvScriptExecutionFinished, HandleFinalize);
         hFunc(TEvKqp::TEvCancelScriptExecutionRequest, HandleCancellation);
         hFunc(TEvCheckAliveRequest, HandleCheckAlive);
@@ -302,12 +337,14 @@ private:
             return;
         }
 
-        if (SessionOpen) {
-            SessionOpen = false;
+        if (SessionState.WaitCreation) {
+            LOG_D("Wait for session creation before exit");
+            return;
+        }
+
+        if (SessionState.SessionOpen) {
             LOG_D("Close session");
-            auto ev = std::make_unique<TEvKqp::TEvCloseSessionRequest>();
-            ev->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
-            Send(MakeKqpProxyID(SelfId().NodeId()), ev.release());
+            SessionState.Close(SelfId(), *Ctx);
         }
 
         if (ScriptLeaseWatcherActor.Id) {
@@ -360,7 +397,7 @@ private:
     std::unique_ptr<TEvKqp::TEvQueryRequest> QueryRequest;
     TFinishInfo FinishInfo;
     TExecutionInfo ExecutionInfo;
-    bool SessionOpen = false;
+    TSessionState SessionState;
     TActorState ScriptLeaseWatcherActor;
     TActorState ScriptResultHandlerActor;
     std::forward_list<TEvKqp::TEvCancelScriptExecutionRequest::TPtr> CancelRequests;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor.h
@@ -1,9 +1,15 @@
 #pragma once
 
-#include <ydb/core/base/appdata.h>
-#include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/protos/kqp.pb.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
 
-#include <ydb/library/actors/core/actor.h>
+#include <util/datetime/base.h>
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+#include <memory>
+#include <optional>
 
 namespace NKikimrConfig {
 
@@ -18,6 +24,8 @@ class StreamingDisposition;
 } // namespace NYql::NPq::NProto
 
 namespace NKikimr::NKqp {
+
+class TKqpCounters;
 
 struct TKqpRunScriptActorSettings {
     TString Database;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.cpp
@@ -1,0 +1,28 @@
+#include "kqp_run_script_actor_impl.h"
+
+namespace NKikimr::NKqp::NPrivate {
+
+void TFinishInfo::Update(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues) {
+    if (!Status) {
+        Status = status;
+        Issues = std::move(issues);
+        return;
+    }
+
+    if (*Status == Ydb::StatusIds::SUCCESS) {
+        Status = status;
+        Issues.AddIssues(issues);
+    }
+
+    return;
+}
+
+bool TFinishInfo::IsFinished() const {
+    return Status.has_value();
+}
+
+bool TFinishInfo::IsFailed() const {
+    return Status.has_value() && *Status != Ydb::StatusIds::SUCCESS;
+}
+
+} // namespace NKikimr::NKqp::NPrivate

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.cpp
@@ -21,6 +21,10 @@ bool TFinishInfo::IsFinished() const {
     return Status.has_value();
 }
 
+bool TFinishInfo::IsSuccess() const {
+    return Status.has_value() && *Status == Ydb::StatusIds::SUCCESS;
+}
+
 bool TFinishInfo::IsFailed() const {
     return Status.has_value() && *Status != Ydb::StatusIds::SUCCESS;
 }

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.cpp
@@ -11,8 +11,9 @@ void TFinishInfo::Update(const Ydb::StatusIds::StatusCode status, NYql::TIssues 
 
     if (*Status == Ydb::StatusIds::SUCCESS) {
         Status = status;
-        Issues.AddIssues(issues);
     }
+
+    Issues.AddIssues(issues);
 
     return;
 }

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.h
@@ -45,6 +45,8 @@ struct TFinishInfo {
 
     bool IsFinished() const;
 
+    bool IsSuccess() const;
+
     bool IsFailed() const;
 
     std::optional<Ydb::StatusIds::StatusCode> Status;

--- a/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.h
+++ b/ydb/core/kqp/run_script_actor/kqp_run_script_actor_impl.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <ydb/core/protos/kqp_stats.pb.h>
+#include <ydb/library/actors/core/actorsystem_fwd.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/event_local.h>
+#include <ydb/public/api/protos/ydb_status_codes.pb.h>
+
+#include <yql/essentials/public/issue/yql_issue.h>
+
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+#include <util/system/types.h>
+
+#include <memory>
+#include <optional>
+
+namespace NKikimrConfig {
+
+class TQueryServiceConfig;
+
+} // namespace NKikimrConfig
+
+namespace NKikimrKqp {
+
+class TQueryPhysicalGraph;
+
+} // namespace NKikimrKqp
+
+namespace NKikimr::NKqp {
+
+class TKqpCounters;
+struct TUserRequestContext;
+
+namespace NPrivate {
+
+struct TExecutionInfo {
+    std::optional<TString> QueryPlan;
+    std::optional<TString> QueryAst;
+    std::optional<NKqpProto::TKqpStatsQuery> QueryStats;
+};
+
+struct TFinishInfo {
+    void Update(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues);
+
+    bool IsFinished() const;
+
+    bool IsFailed() const;
+
+    std::optional<Ydb::StatusIds::StatusCode> Status;
+    NYql::TIssues Issues;
+};
+
+struct TEvRunScriptPrivate {
+    enum EEv : ui32 {
+        EvScriptLeaseWatcherFinished = EventSpaceBegin(NActors::TEvents::ES_PRIVATE),
+        EvScriptResultHandlerFinished,
+        EvEnd
+    };
+
+    static_assert(EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(NActors::TEvents::ES_PRIVATE)");
+
+    struct TEvScriptLeaseWatcherFinished : public NActors::TEventLocal<TEvScriptLeaseWatcherFinished, EvScriptLeaseWatcherFinished> {
+        TEvScriptLeaseWatcherFinished(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues)
+            : Status(status)
+            , Issues(std::move(issues))
+        {}
+
+        const Ydb::StatusIds::StatusCode Status;
+        const NYql::TIssues Issues;
+    };
+
+    struct TEvScriptResultHandlerFinished : public NActors::TEventLocal<TEvScriptResultHandlerFinished, EvScriptResultHandlerFinished> {
+        TEvScriptResultHandlerFinished(const Ydb::StatusIds::StatusCode status, TExecutionInfo&& info, NYql::TIssues issues)
+            : Status(status)
+            , Info(std::move(info))
+            , Issues(std::move(issues))
+        {}
+
+        const Ydb::StatusIds::StatusCode Status;
+        TExecutionInfo Info;
+        NYql::TIssues Issues;
+    };
+};
+
+struct TScriptExecutionContext {
+    using TPtr = std::shared_ptr<TScriptExecutionContext>;
+
+    const TIntrusivePtr<TUserRequestContext> UserRequestContext;
+    const TIntrusivePtr<TKqpCounters> Counters;
+    const i64 LeaseGeneration = 0;
+    const TDuration LeaseDuration;
+    const TDuration ResultsTtl;
+    const TDuration Timeout;
+};
+
+// Periodically update lease deadline in database, and detect lease lost
+NActors::IActor* CreateScriptLeaseWatcherActor(TScriptExecutionContext::TPtr ctx);
+
+// Handle events from kqp session actor and data executor such as result data, progress pings etc.
+NActors::IActor* CreateScriptResultHandlerActor(TScriptExecutionContext::TPtr ctx, std::optional<NKikimrKqp::TQueryPhysicalGraph> physicalGraph, NKikimrConfig::TQueryServiceConfig queryServiceConfig);
+
+} // namespace NPrivate
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
@@ -45,7 +45,7 @@ public:
     explicit TScriptLeaseWatcherActor(TScriptExecutionContext::TPtr ctx)
         : Ctx(std::move(ctx))
     {
-        Y_VALIDATE(Ctx && Ctx->UserRequestContext && Ctx->Counters, "Missing script execution context");
+        Y_VALIDATE(Ctx && Ctx->UserRequestContext, "Missing script execution context");
     }
 
     void Bootstrap() {
@@ -72,7 +72,10 @@ private:
     )
 
     void Handle(const TEvScriptLeaseUpdateResponse::TPtr& ev) {
-        Ctx->Counters->ReportLeaseUpdateLatency(TInstant::Now() - LeaseUpdateStartTime);
+        if (const auto& counters = Ctx->Counters) {
+            counters->ReportLeaseUpdateLatency(TInstant::Now() - LeaseUpdateStartTime);
+        }
+
         LeaseUpdateStartTime = TInstant::Zero();
 
         const auto& issues = ev->Get()->Issues;
@@ -112,7 +115,10 @@ private:
         LOG_D("Run lease updater " << updaterId);
 
         LeaseUpdateStartTime = TInstant::Now();
-        Ctx->Counters->ReportRunActorLeaseUpdateBacklog(TInstant::Now() - LeaseUpdateScheduleTime);
+
+        if (const auto& counters = Ctx->Counters) {
+            counters->ReportRunActorLeaseUpdateBacklog(TInstant::Now() - LeaseUpdateScheduleTime);
+        }
     }
 
     void Finish() {

--- a/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
@@ -1,6 +1,7 @@
 #include "kqp_run_script_actor_impl.h"
 
 #include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/common/kqp_script_executions.h>
 #include <ydb/core/kqp/common/kqp_user_request_context.h>
 #include <ydb/core/kqp/counters/kqp_counters.h>
 #include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
@@ -88,7 +89,7 @@ private:
         }
 
         if (!executionEntryExists) {
-            return Finish(Ydb::StatusIds::INTERNAL_ERROR, "Script execution entry was lost");
+            return Finish(Ydb::StatusIds::INTERNAL_ERROR, AddRootIssue("Script execution entry was lost", issues));
         }
 
         if (FinishInfo.IsFinished()) {

--- a/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
@@ -84,7 +84,7 @@ private:
         if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
             LOG_E("Lease update " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString() << ", execution entry exists: " << executionEntryExists);
         } else {
-            LOG_D("Lease updated by " << ev->Sender << ", current readline: " << currentDeadline << ", execution entry exists: " << executionEntryExists);
+            LOG_D("Lease updated by " << ev->Sender << ", current deadline: " << currentDeadline << ", execution entry exists: " << executionEntryExists);
         }
 
         if (!executionEntryExists) {

--- a/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_lease_watcher_actor.cpp
@@ -1,0 +1,158 @@
+#include "kqp_run_script_actor_impl.h"
+
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/common/kqp_user_request_context.h>
+#include <ydb/core/kqp/counters/kqp_counters.h>
+#include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/services/services.pb.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
+#include <yql/essentials/public/issue/yql_issue.h>
+
+#include <util/generic/string.h>
+#include <util/datetime/base.h>
+#include <util/string/builder.h>
+#include <util/system/types.h>
+
+#include <exception>
+
+namespace NKikimr::NKqp::NPrivate {
+
+namespace {
+
+using namespace NActors;
+
+#define LOG_T(stream) LOG_TRACE_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_D(stream) LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_I(stream) LOG_INFO_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_N(stream) LOG_NOTICE_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_W(stream) LOG_WARN_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_E(stream) LOG_ERROR_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+
+class TScriptLeaseWatcherActor final : public TActorBootstrapped<TScriptLeaseWatcherActor>, IActorExceptionHandler {
+    using TBase = TActorBootstrapped<TScriptLeaseWatcherActor>;
+
+    static constexpr ui32 LEASE_UPDATE_FREQUENCY = 2;
+
+public:
+    static constexpr char ActorName[] = "KQP_SCRIPT_LEASE_WATCHER_ACTOR";
+
+    explicit TScriptLeaseWatcherActor(TScriptExecutionContext::TPtr ctx)
+        : Ctx(std::move(ctx))
+    {
+        Y_VALIDATE(Ctx && Ctx->UserRequestContext && Ctx->Counters, "Missing script execution context");
+    }
+
+    void Bootstrap() {
+        LOG_I("Bootstrap");
+        Become(&TThis::StateFunc);
+        ScheduleLeaseUpdate(TInstant::Now() + Ctx->LeaseDuration);
+    }
+
+private:
+    void Registered(TActorSystem* sys, const TActorId& owner) final {
+        TBase::Registered(sys, owner);
+        Owner = owner;
+    }
+
+    bool OnUnhandledException(const std::exception& e) final {
+        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Got unexpected exception: " << e.what());
+        return true;
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvScriptLeaseUpdateResponse, Handle);
+        sFunc(TEvents::TEvWakeup, StartLeaseUpdate);
+        sFunc(TEvents::TEvPoison, Finish);
+    )
+
+    void Handle(const TEvScriptLeaseUpdateResponse::TPtr& ev) {
+        Ctx->Counters->ReportLeaseUpdateLatency(TInstant::Now() - LeaseUpdateStartTime);
+        LeaseUpdateStartTime = TInstant::Zero();
+
+        const auto& issues = ev->Get()->Issues;
+        const auto executionEntryExists = ev->Get()->ExecutionEntryExists;
+        const auto currentDeadline = ev->Get()->CurrentDeadline;
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Lease update " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString() << ", execution entry exists: " << executionEntryExists);
+        } else {
+            LOG_D("Lease updated by " << ev->Sender << ", current readline: " << currentDeadline << ", execution entry exists: " << executionEntryExists);
+        }
+
+        if (!executionEntryExists) {
+            return Finish(Ydb::StatusIds::INTERNAL_ERROR, "Script execution entry was lost");
+        }
+
+        if (FinishInfo.IsFinished()) {
+            Finish();
+        } else {
+            ScheduleLeaseUpdate(currentDeadline);
+        }
+    }
+
+    void ScheduleLeaseUpdate(const TInstant currentDeadline) {
+        LeaseUpdateScheduleTime = TInstant::Now();
+        const auto leaseUpdateTime = currentDeadline - Ctx->LeaseDuration / LEASE_UPDATE_FREQUENCY;
+        LOG_D("Scheduling lease update on " << leaseUpdateTime);
+
+        if (TInstant::Now() >= leaseUpdateTime) {
+            StartLeaseUpdate();
+        } else {
+            Schedule(leaseUpdateTime, new TEvents::TEvWakeup());
+        }
+    }
+
+    void StartLeaseUpdate() {
+        const auto& updaterId = Register(CreateScriptLeaseUpdateActor(SelfId(), Ctx->UserRequestContext->Database, Ctx->UserRequestContext->CurrentExecutionId, Ctx->LeaseDuration, Ctx->LeaseGeneration));
+        LOG_D("Run lease updater " << updaterId);
+
+        LeaseUpdateStartTime = TInstant::Now();
+        Ctx->Counters->ReportRunActorLeaseUpdateBacklog(TInstant::Now() - LeaseUpdateScheduleTime);
+    }
+
+    void Finish() {
+        Finish(Ydb::StatusIds::SUCCESS);
+    }
+
+    void Finish(const Ydb::StatusIds::StatusCode status, const TString& message) {
+        Finish(status, {NYql::TIssue(message)});
+    }
+
+    void Finish(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
+        if (status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Finish with error " << status << ", issues: " << issues.ToOneLineString());
+        } else if (!FinishInfo.IsFailed()) {
+            LOG_I("Finish successfully");
+        }
+
+        FinishInfo.Update(status, std::move(issues));
+
+        if (!LeaseUpdateStartTime) {
+            Send(Owner, new TEvRunScriptPrivate::TEvScriptLeaseWatcherFinished(*FinishInfo.Status, std::move(FinishInfo.Issues)));
+            PassAway();
+        }
+    }
+
+    TString LogPrefix() const {
+        return TStringBuilder() << "[" << ActorName << "] " << SelfId() << ". Owner: " << Owner << ". Ctx: " << *Ctx->UserRequestContext << ". LeaseGeneration: " << Ctx->LeaseGeneration << ". ";
+    }
+
+    const TScriptExecutionContext::TPtr Ctx;
+    TActorId Owner;
+    TFinishInfo FinishInfo;
+    TInstant LeaseUpdateScheduleTime;
+    TInstant LeaseUpdateStartTime;
+};
+
+} // anonymous namespace
+
+IActor* CreateScriptLeaseWatcherActor(TScriptExecutionContext::TPtr ctx) {
+    return new TScriptLeaseWatcherActor(std::move(ctx));
+}
+
+} // namespace NKikimr::NKqp::NPrivate

--- a/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
@@ -136,6 +136,12 @@ class TScriptResultHandlerActor final : public TActorBootstrapped<TScriptResultH
             });
         }
 
+        bool HasResultsToSave() const {
+            return std::any_of(ResultSetInfos.begin(), ResultSetInfos.end(), [](const TResultSetInfo& info) {
+                return !info.PendingResult.rows().empty();
+            });
+        }
+
         TInstant GetExpireAt(const TScriptExecutionContext& ctx) {
             if (!ExpireAt && ctx.ResultsTtl) {
                 ExpireAt = TInstant::Now() + ctx.ResultsTtl;
@@ -588,7 +594,7 @@ private:
         }
 
         // Check success exit condition
-        if (FinishInfo.IsFinished()) {
+        if (!SaveResultsState.WaitSaveResult && FinishInfo.IsFinished()) {
             return Finish();
         }
     }
@@ -596,12 +602,19 @@ private:
     void TryToDrainResults() {
         Y_VALIDATE(!SaveResultsState.WaitSaveResult, "Unexpected call");
 
+        if (FinishInfo.IsFailed()) {
+            // Skip results saving after failure
+            return;
+        }
+
         const auto freeSpaceBytes = SaveResultsState.GetFreeSpaceBytes();
-        LOG_T("Try to drain results, free space: " << freeSpaceBytes);
+        const auto forceSaveResults = FinishInfo.IsSuccess() || freeSpaceBytes <= 0; 
+        LOG_T("Try to drain results, free space: " << freeSpaceBytes << ", force save: " << forceSaveResults);
 
         // We save results when:
         // - Where is large enough result batch
         // - No free space in buffer
+        // - Query is finished
 
         std::optional<ui64> resultToSave;
         ui64 maxResultSetBytes = 0;
@@ -612,7 +625,8 @@ private:
                 break;
             }
 
-            if (const auto resultSize = info.GetBytesToSave(); freeSpaceBytes <= 0 && resultSize > maxResultSetBytes) {
+            const auto resultSize = info.GetBytesToSave();
+            if (forceSaveResults && (resultSize > maxResultSetBytes || (!resultToSave && info.PendingResult.rows_size()))) {
                 resultToSave = i;
                 maxResultSetBytes = resultSize;
             }
@@ -664,7 +678,6 @@ private:
 
     void UpdateScriptProgress() {
         Y_VALIDATE(SaveProgressState.QueryStatsChanged && !SaveProgressState.WaitSave, "Unexpected call");
-        Y_VALIDATE(ExecutionInfo.QueryPlan || ExecutionInfo.QueryAst, "Plan ot ast should be set");
         SaveProgressState.QueryStatsChanged = false;
 
         const auto& updaterId = Register(CreateScriptProgressActor(
@@ -699,6 +712,7 @@ private:
         if (QueryIsRunning) {
             // We should abort query before finish
             FinishInfo.Update(Ydb::StatusIds::CANCELLED, {NYql::TIssue("Query was cancelled")});
+            LOG_I("Wait for query finish, started cancel: " << QueryIsCancelling);
 
             if (!QueryIsCancelling) {
                 auto ev = MakeHolder<TEvKqp::TEvCancelQueryRequest>();
@@ -709,11 +723,18 @@ private:
             return;
         }
 
-        if (HasOperationInflight()) {
-            // Wait for all inflight queries to complete
+        if (FinishInfo.IsSuccess() && SaveResultsState.HasResultsToSave()) {
+            LOG_D("Wait for results to save");
+            ContinueExecute();
             return;
         }
 
+        if (HasOperationInflight()) {
+            LOG_D("Wait for inflight queries to complete");
+            return;
+        }
+
+        LOG_I("Exit, send response to " << Owner);
         Send(Owner, new TEvRunScriptPrivate::TEvScriptResultHandlerFinished(*FinishInfo.Status, std::move(ExecutionInfo), std::move(FinishInfo.Issues)));
         PassAway();
     }

--- a/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
@@ -242,7 +242,7 @@ private:
             SaveExternalEffectsState.Requests.emplace(ev->Sender, std::move(description));
             ContinueExecute();
         } else {
-            LOG_D("No external effects to save, reply immediately")
+            LOG_D("No external effects to save, reply immediately");
             Send(ev->Sender, new TEvSaveScriptExternalEffectResponse(Ydb::StatusIds::SUCCESS, {}));
         }
     }
@@ -425,7 +425,7 @@ private:
                 }
             }
         } else {
-            LOG_T("Skip truncated result part with #" << rowsCount << " rows")
+            LOG_T("Skip truncated result part with #" << rowsCount << " rows");
         }
 
         const auto channelId = record.GetChannelId();

--- a/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
@@ -1,0 +1,746 @@
+#include "kqp_run_script_actor_impl.h"
+
+#include <ydb/core/fq/libs/checkpointing/events/events.h>
+#include <ydb/core/kqp/common/events/script_executions.h>
+#include <ydb/core/kqp/common/kqp_script_executions.h>
+#include <ydb/core/kqp/common/kqp_user_request_context.h>
+#include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/federated_query/kqp_federated_query_helpers.h>
+#include <ydb/core/kqp/proxy_service/kqp_script_executions.h>
+#include <ydb/core/kqp/proxy_service/proto/result_set_meta.pb.h>
+#include <ydb/core/kqp/executer_actor/kqp_executer.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/services/services.pb.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
+#include <yql/essentials/public/issue/yql_issue_message.h>
+#include <yql/essentials/public/issue/yql_issue.h>
+
+#include <util/generic/size_literals.h>
+#include <util/generic/string.h>
+#include <util/string/builder.h>
+#include <util/system/types.h>
+
+#include <exception>
+#include <queue>
+
+namespace NKikimr::NKqp::NPrivate {
+
+namespace {
+
+using namespace NActors;
+
+#define LOG_T(stream) LOG_TRACE_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_D(stream) LOG_DEBUG_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_I(stream) LOG_INFO_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_N(stream) LOG_NOTICE_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_W(stream) LOG_WARN_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+#define LOG_E(stream) LOG_ERROR_S(TActivationContext::AsActorContext(), NKikimrServices::KQP_EXECUTER, LogPrefix() << stream);
+
+class TScriptResultHandlerActor final : public TActorBootstrapped<TScriptResultHandlerActor>, IActorExceptionHandler {
+    using TBase = TActorBootstrapped<TScriptResultHandlerActor>;
+
+    static constexpr ui64 RUN_SCRIPT_ACTOR_BUFFER_SIZE = 40_MB;
+    static constexpr ui64 MIN_SAVE_RESULT_BATCH_SIZE = 5_MB;
+    static constexpr i32 MIN_SAVE_RESULT_BATCH_ROWS = 5000;
+
+    struct TSaveProgressState {
+        bool WaitSave = false;
+        bool QueryStatsChanged = true; // We should update status once execution was started
+        bool AstSaved = false;
+
+        void UpdateChanged(const std::optional<TString>& from, const TString& to) {
+            if (QueryStatsChanged) {
+                return;
+            }
+
+            QueryStatsChanged = !from || *from != to;
+        }
+    };
+
+    struct TSaveExternalEffectsState {
+        bool WaitSave = false;
+        std::queue<std::pair<TActorId, TEvSaveScriptExternalEffectRequest::TDescription>> Requests;
+    };
+
+    struct TSavePhysicalGraphState {
+        bool WaitSave = false;
+        TActorId Sender;
+        std::queue<std::pair<bool, NKikimrKqp::TQueryPhysicalGraph>> GraphsToSave; // (send response, graph)
+    };
+
+    class TSaveResultsState {
+        class TResultSetMeta {
+        public:
+            Ydb::Query::Internal::ResultSetMeta& MutableMeta() {
+                JsonMeta = std::nullopt;
+                return Meta;
+            }
+
+            const NJson::TJsonValue& SaveJsonMeta() {
+                if (!JsonMeta) {
+                    JsonMeta = NJson::TJsonValue();
+                    NProtobufJson::Proto2Json(Meta, *JsonMeta, NProtobufJson::TProto2JsonConfig());
+                }
+
+                return *JsonMeta;
+            }
+
+            bool IsSaved() const {
+                return JsonMeta.has_value();
+            }
+
+        private:
+            Ydb::Query::Internal::ResultSetMeta Meta;
+            std::optional<NJson::TJsonValue> JsonMeta;
+        };
+
+        struct TResultSetInfo {
+            bool NewResultSet = true;
+            bool Truncated = false;
+            bool Finished = false;
+            ui64 RowCount = 0;
+            ui64 ByteCount = 0;
+            ui64 FirstRowId = 0;
+            ui64 AccumulatedSize = 0;
+            TResultSetMeta Meta;
+            Ydb::ResultSet PendingResult;
+
+            ui64 GetBytesToSave() const {
+                return ByteCount - AccumulatedSize;
+            }
+
+            bool ShouldSaveResult() const {
+                const auto rowsCount = PendingResult.rows_size();
+                return rowsCount && (Truncated || rowsCount >= MIN_SAVE_RESULT_BATCH_ROWS || ByteCount - AccumulatedSize >= MIN_SAVE_RESULT_BATCH_SIZE);
+            }
+        };
+
+    public:
+        std::vector<TResultSetInfo> ResultSetInfos;
+        ui64 PendingResultSetsSize = 0;
+        ui64 SaveResultInflightBytes = 0;
+        bool WaitSaveResult = false;
+        bool WaitSaveMeta = false;
+
+        i64 GetFreeSpaceBytes() const {
+            return static_cast<i64>(RUN_SCRIPT_ACTOR_BUFFER_SIZE) - static_cast<i64>(PendingResultSetsSize) - static_cast<i64>(SaveResultInflightBytes);
+        }
+
+        bool HasMetaToSave() const {
+            return std::any_of(ResultSetInfos.begin(), ResultSetInfos.end(), [](const TResultSetInfo& info) {
+                return !info.Meta.IsSaved();
+            });
+        }
+
+        TInstant GetExpireAt(const TScriptExecutionContext& ctx) {
+            if (!ExpireAt && ctx.ResultsTtl) {
+                ExpireAt = TInstant::Now() + ctx.ResultsTtl;
+            }
+            return ExpireAt;
+        }
+
+    private:
+        TInstant ExpireAt;
+    };
+
+    struct TProducerState {
+        std::optional<ui64> LastSeqNo;
+        i64 AckedFreeSpaceBytes = 0;
+        TActorId ActorId;
+        ui64 ChannelId = 0;
+        bool Enough = false;
+
+        void SendAck(const TActorIdentity& actor) const {
+            auto response = std::make_unique<NKqp::TEvKqpExecuter::TEvStreamDataAck>(*LastSeqNo, ChannelId);
+            response->Record.SetFreeSpace(AckedFreeSpaceBytes);
+            response->Record.SetEnough(Enough);
+            actor.Send(ActorId, response.release());
+        }
+
+        bool ResumeIfStopped(const TActorIdentity& actor, const i64 freeSpaceBytes) {
+            if (LastSeqNo && freeSpaceBytes > 0 && AckedFreeSpaceBytes < freeSpaceBytes) {
+                AckedFreeSpaceBytes = freeSpaceBytes;
+                SendAck(actor);
+                return true;
+            }
+
+            return false;
+        }
+    };
+
+public:
+    static constexpr char ActorName[] = "KQP_SCRIPT_RESULT_HANDLER_ACTOR";
+
+    TScriptResultHandlerActor(TScriptExecutionContext::TPtr ctx, std::optional<NKikimrKqp::TQueryPhysicalGraph> physicalGraph, NKikimrConfig::TQueryServiceConfig queryServiceConfig)
+        : Ctx(std::move(ctx))
+        , QueryServiceConfig(std::move(queryServiceConfig))
+        , PhysicalGraph(std::move(physicalGraph))
+    {
+        Y_VALIDATE(Ctx && Ctx->UserRequestContext, "Missing script execution context");
+        Y_VALIDATE(Ctx->UserRequestContext->SessionId, "Missing session id");
+    }
+
+    void Bootstrap() {
+        LOG_I("Bootstrap");
+        Become(&TThis::StateFunc);
+        ContinueExecute();
+    }
+
+private:
+    void Registered(TActorSystem* sys, const TActorId& owner) final {
+        TBase::Registered(sys, owner);
+        Owner = owner;
+    }
+
+    bool OnUnhandledException(const std::exception& e) final {
+        Finish(Ydb::StatusIds::INTERNAL_ERROR, TStringBuilder() << "Got unexpected exception: " << e.what());
+        return true;
+    }
+
+    // Execution events order for several query transactions (transactions are executed consequently):
+    // - For each transaction:
+    //   1. TEvSaveScriptExternalEffectRequest -- once
+    //   2. If this transaction is last one TEvSaveScriptPhysicalGraphRequest -- once
+    //   3. If this transaction is last one and query was not restored TEvZeroCheckpointDone -- once
+    //   4. TEvExecuterProgress + TEvStreamData -- periodically
+    // - When all transaction are finished:
+    //   1. TEvQueryResponse -- once
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvSaveScriptExternalEffectRequest, Handle);
+        hFunc(TEvSaveScriptExternalEffectResponse, Handle);
+        hFunc(TEvSaveScriptPhysicalGraphRequest, Handle);
+        hFunc(TEvSaveScriptPhysicalGraphResponse, Handle);
+        hFunc(NFq::TEvCheckpointCoordinator::TEvZeroCheckpointDone, Handle);
+        hFunc(TEvKqpExecuter::TEvExecuterProgress, Handle);
+        hFunc(TEvSaveScriptProgressResponse, Handle);
+        hFunc(TEvKqpExecuter::TEvStreamData, Handle);
+        hFunc(TEvSaveScriptResultMetaFinished, Handle);
+        hFunc(TEvSaveScriptResultFinished, Handle);
+        hFunc(TEvKqp::TEvQueryResponse, Handle);
+        hFunc(TEvKqp::TEvCancelQueryResponse, Handle);
+        sFunc(TEvents::TEvPoison, Finish);
+    )
+
+    void Handle(TEvSaveScriptExternalEffectRequest::TPtr& ev) {
+        auto& description = ev->Get()->Description;
+        auto& sinks = description.Sinks;
+        sinks = FilterExternalSinksWithEffects(sinks);
+        LOG_D("Got script external effect request from " << ev->Sender << ", sinks #" << sinks.size() << ", secrets #" << description.SecretNames.size());
+
+        if (!sinks.empty()) {
+            SaveExternalEffectsState.Requests.emplace(ev->Sender, std::move(description));
+            ContinueExecute();
+        } else {
+            LOG_D("No external effects to save, reply immediately")
+            Send(ev->Sender, new TEvSaveScriptExternalEffectResponse(Ydb::StatusIds::SUCCESS, {}));
+        }
+    }
+
+    void Handle(TEvSaveScriptExternalEffectResponse::TPtr& ev) {
+        SaveExternalEffectsState.WaitSave = false;
+        Y_VALIDATE(!SaveExternalEffectsState.Requests.empty(), "Unexpected event");
+
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            LOG_W("Failed to save external effects " << ev->Sender << ", fail: " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+        } else {
+            LOG_D("External effects saved " << ev->Sender);
+        }
+
+        Forward(ev, SaveExternalEffectsState.Requests.front().first);
+        SaveExternalEffectsState.Requests.pop();
+        ContinueExecute();
+    }
+
+    void Handle(TEvSaveScriptPhysicalGraphRequest::TPtr& ev) {
+        LOG_I("Got save script physical graph request from " << ev->Sender);
+
+        if (SavePhysicalGraphState.Sender) {
+            Send(ev->Sender, new TEvSaveScriptPhysicalGraphResponse(Ydb::StatusIds::INTERNAL_ERROR, {NYql::TIssue(TStringBuilder() << "Can not save graph twice, previous sender was: " << SavePhysicalGraphState.Sender << ", got graph from: " << ev->Sender)}));
+            return;
+        }
+
+        auto& evPhysicalGraph = ev->Get()->PhysicalGraph;
+        if (PhysicalGraph) {
+            // If zero checkpoint was done on previous query execution, now checkpointing will continue without zero checkpoint
+            evPhysicalGraph.SetZeroCheckpointSaved(PhysicalGraph->GetZeroCheckpointSaved());
+        } else {
+            PhysicalGraph = evPhysicalGraph;
+        }
+
+        SavePhysicalGraphState.Sender = ev->Sender;
+        SavePhysicalGraphState.GraphsToSave.emplace(true, std::move(evPhysicalGraph));
+        ContinueExecute();
+    }
+
+    void Handle(TEvSaveScriptPhysicalGraphResponse::TPtr& ev) {
+        SavePhysicalGraphState.WaitSave = false;
+        Y_VALIDATE(!SavePhysicalGraphState.GraphsToSave.empty(), "Unexpected event");
+
+        const auto status = ev->Get()->Status;
+        const bool saveFailed = status != Ydb::StatusIds::SUCCESS;
+        const auto& issues = ev->Get()->Issues;
+        if (saveFailed) {
+            LOG_W("Failed to save physical graph " << ev->Sender << ", fail: " << status << ", issues: " << issues.ToOneLineString());
+        } else {
+            LOG_D("Physical graph saved " << ev->Sender);
+        }
+
+        const auto sendResponse = SavePhysicalGraphState.GraphsToSave.front().first;
+        SavePhysicalGraphState.GraphsToSave.pop();
+
+        if (sendResponse) {
+            Y_VALIDATE(SavePhysicalGraphState.Sender, "Can not reply without sender");
+            Forward(ev, SavePhysicalGraphState.Sender);
+        } else if (saveFailed) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, AddRootIssue("Failed to update query physical graph", issues));
+            return;
+        }
+
+        ContinueExecute();
+    }
+
+    void Handle(NFq::TEvCheckpointCoordinator::TEvZeroCheckpointDone::TPtr& ev) {
+        LOG_I("Zero checkpoint saved by " << ev->Sender);
+
+        if (!PhysicalGraph) {
+            Finish(Ydb::StatusIds::INTERNAL_ERROR, "Zero checkpoint saved before physical graph saved");
+            return;
+        }
+
+        if (!PhysicalGraph->GetZeroCheckpointSaved()) {
+            PhysicalGraph->SetZeroCheckpointSaved(true);
+            SavePhysicalGraphState.GraphsToSave.emplace(false, *PhysicalGraph);
+            ContinueExecute();
+        }
+    }
+
+    void Handle(TEvKqpExecuter::TEvExecuterProgress::TPtr& ev) {
+        auto& record = ev->Get()->Record;
+        const bool hasPlan = record.HasQueryPlan();
+        const bool hasAst = record.HasQueryAst();
+        LOG_T("Got script progress from " << ev->Sender << ", has plan: " << hasPlan << ", has ast: " << hasAst);
+
+        if (hasPlan) {
+            SaveProgressState.UpdateChanged(ExecutionInfo.QueryPlan, record.GetQueryPlan());
+            ExecutionInfo.QueryPlan = std::move(*record.MutableQueryPlan());
+        }
+
+        if (!ExecutionInfo.QueryAst && hasAst) {
+            SaveProgressState.UpdateChanged(ExecutionInfo.QueryAst, record.GetQueryAst());
+            ExecutionInfo.QueryAst = std::move(*record.MutableQueryAst());
+        }
+
+        ContinueExecute();
+    }
+
+    void Handle(TEvSaveScriptProgressResponse::TPtr& ev) {
+        SaveProgressState.WaitSave = false;
+
+        const auto astSaved = ev->Get()->AstSaved;
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            LOG_N("Script progress updated " << ev->Sender << ", fail: " << status << ", issues: " << ev->Get()->Issues.ToOneLineString());
+            SaveProgressState.QueryStatsChanged = true;
+        } else {
+            LOG_T("Script progress updated " << ev->Sender << ", ast saved: " << astSaved);
+            SaveProgressState.AstSaved = SaveProgressState.AstSaved || astSaved;
+        }
+
+        ContinueExecute();
+    }
+
+    void Handle(TEvKqpExecuter::TEvStreamData::TPtr& ev) {
+        auto& record = ev->Get()->Record;
+        const auto seqNo = record.GetSeqNo();
+        const auto resultSetIndex = record.GetQueryResultIndex();
+        const auto& resultSet = record.GetResultSet();
+        const auto rowsCount = resultSet.rows_size();
+        const auto finished = record.GetFinished();
+        LOG_D("Compute stream data"
+            << ", seq no: " << record.GetSeqNo()
+            << ", query result index: " << resultSetIndex
+            << ", rows count: " << rowsCount
+            << ", finished: " << finished
+            << ", from: " << ev->Sender);
+
+        auto& resultSetInfos = SaveResultsState.ResultSetInfos;
+        if (resultSetIndex >= resultSetInfos.size()) {
+            // we don't know result set count, so just accept all of them
+            // it's possible to have several result sets per script
+            // they can arrive in any order and may be missed for some indices
+            resultSetInfos.resize(resultSetIndex + 1);
+        }
+
+        auto& resultSetInfo = resultSetInfos[resultSetIndex];
+        if (!resultSetInfo.Truncated) {
+            auto& rowCount = resultSetInfo.RowCount;
+            auto& byteCount = resultSetInfo.ByteCount;
+            const auto rowsLimit = QueryServiceConfig.GetScriptResultRowsLimit();
+            const auto sizeLimit = QueryServiceConfig.GetScriptResultSizeLimit();
+
+            for (auto& row : *record.MutableResultSet()->mutable_rows()) {
+                if (rowsLimit && rowCount + 1 > rowsLimit) {
+                    resultSetInfo.Truncated = true;
+                    break;
+                }
+
+                const auto serializedSize = row.ByteSizeLong();
+                if (sizeLimit && byteCount + serializedSize > sizeLimit) {
+                    resultSetInfo.Truncated = true;
+                    break;
+                }
+
+                rowCount++;
+                byteCount += serializedSize;
+                SaveResultsState.PendingResultSetsSize += serializedSize;
+                *resultSetInfo.PendingResult.add_rows() = std::move(row);
+            }
+
+            resultSetInfo.Finished = finished;
+            if (const auto newResultSet = std::exchange(resultSetInfo.NewResultSet, false); newResultSet || resultSetInfo.Truncated) {
+                auto& meta = resultSetInfo.Meta.MutableMeta();
+                if (newResultSet) {
+                    meta.set_enabled_runtime_results(true);
+                    *meta.mutable_columns() = resultSet.columns();
+
+                    if (const auto& issues = NKikimr::NKqp::ValidateResultSetColumns(meta.columns())) {
+                        meta.clear_columns();
+                        Finish(Ydb::StatusIds::INTERNAL_ERROR, AddRootIssue(TStringBuilder() << "Invalid result set " << resultSetIndex << " columns, please contact internal support", issues));
+                        return;
+                    }
+                }
+
+                if (resultSetInfo.Truncated) {
+                    meta.set_truncated(true);
+                }
+            }
+        } else {
+            LOG_T("Skip truncated result part with #" << rowsCount << " rows")
+        }
+
+        const auto channelId = record.GetChannelId();
+        auto& channel = StreamChannels[channelId];
+        channel.ActorId = ev->Sender;
+        channel.LastSeqNo = seqNo;
+        channel.AckedFreeSpaceBytes = SaveResultsState.GetFreeSpaceBytes();
+        channel.ChannelId = channelId;
+        channel.Enough = resultSetInfo.Truncated;
+        channel.SendAck(SelfId());
+
+        ContinueExecute();
+    }
+
+    void Handle(TEvSaveScriptResultMetaFinished::TPtr& ev) {
+        SaveResultsState.WaitSaveMeta = false;
+
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            const auto& issues = ev->Get()->Issues;
+            LOG_E("Save result meta " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
+            Finish(status, AddRootIssue("Failed to save result set meta", issues));
+            return;
+        }
+
+        LOG_D("Save result meta " << ev->Sender << " finished");
+        ContinueExecute();
+    }
+
+    void Handle(TEvSaveScriptResultFinished::TPtr& ev) {
+        SaveResultsState.WaitSaveResult = false;
+        SaveResultsState.SaveResultInflightBytes = 0;
+
+        const auto resultSetIndex = ev->Get()->ResultSetId;
+        auto& infos = SaveResultsState.ResultSetInfos;
+        Y_VALIDATE(resultSetIndex < infos.size(), "Unexpected result set index: " << resultSetIndex << " amount result sets #" << infos.size());
+
+        if (const auto status = ev->Get()->Status; status != Ydb::StatusIds::SUCCESS) {
+            const auto& issues = ev->Get()->Issues;
+            LOG_E("Save result " << ev->Sender << " set #" << resultSetIndex << " failed " << status << ", issues: " << issues.ToOneLineString());
+            Finish(status, AddRootIssue(TStringBuilder() << "Failed to save result set #" << resultSetIndex, issues));
+            return;
+        }
+
+        LOG_D("Save result " << ev->Sender << " set #" << resultSetIndex << " finished");
+
+        auto& resultSetInfo = infos[resultSetIndex];
+        auto& meta = resultSetInfo.Meta.MutableMeta();
+        meta.set_number_rows(resultSetInfo.RowCount);
+        if (resultSetInfo.PendingResult.rows().empty() && (resultSetInfo.Truncated || resultSetInfo.Finished)) {
+            meta.set_finished(true);
+        }
+
+        if (const auto freeSpaceBytes = SaveResultsState.GetFreeSpaceBytes(); freeSpaceBytes > 0) {
+            for (auto& [channelId, channel] : StreamChannels) {
+                if (channel.ResumeIfStopped(SelfId(), freeSpaceBytes)) {
+                    LOG_D("Resume execution, " << ", channel: " << channelId << ", seqNo: " << channel.LastSeqNo << ", freeSpace: " << freeSpaceBytes);
+                }
+            }
+        }
+
+        ContinueExecute();
+    }
+
+    void Handle(TEvKqp::TEvQueryResponse::TPtr& ev) {
+        QueryIsRunning = false;
+
+        auto& record = ev->Get()->Record;
+        auto& response = *record.MutableResponse();
+
+        NYql::TIssues issues;
+        NYql::IssuesFromMessage(response.GetQueryIssues(), issues);
+        issues = TruncateIssues(issues);
+
+        const auto status = record.GetYdbStatus();
+        if (status == Ydb::StatusIds::SUCCESS) {
+            LOG_I("Script query successfully finished from " << ev->Sender << ", issues: " << issues.ToOneLineString());
+        } else {
+            LOG_W("Script query failed from " << ev->Sender << " " << record.GetYdbStatus() << ", issues: " << issues.ToOneLineString());
+        }
+
+        if (status == Ydb::StatusIds::TIMEOUT) {
+            NYql::TIssue timeoutIssue(TStringBuilder() << "Current request timeout is " << Ctx->Timeout.MilliSeconds() << "ms");
+            timeoutIssue.SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO);
+            issues.AddIssue(timeoutIssue);
+        }
+
+        if (response.HasQueryPlan()) {
+            ExecutionInfo.QueryPlan = std::move(*response.MutableQueryPlan());
+        }
+
+        if (response.HasQueryStats()) {
+            ExecutionInfo.QueryStats = std::move(*response.MutableQueryStats());
+        }
+
+        if (response.HasQueryAst()) {
+            ExecutionInfo.QueryAst = std::move(*response.MutableQueryAst());
+        }
+
+        Finish(status, std::move(issues));
+    }
+
+    void Handle(TEvKqp::TEvCancelQueryResponse::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        if (const auto status = record.GetStatus(); status != Ydb::StatusIds::SUCCESS) {
+            NYql::TIssues issues;
+            NYql::IssuesFromMessage(record.GetIssues(), issues);
+            LOG_E("Failed to cancel query " << status << ", issues: " << issues.ToOneLineString() << ", response from: " << ev->Sender);
+
+            // We can not finish query manually, consider it is already finished
+            QueryIsRunning = false;
+            Finish(status, AddRootIssue(TStringBuilder() << "Failed to cancel query (" << status << ")", issues));
+            return;
+        }
+
+        // Wait for normal query finish
+        LOG_I("Query cancelled, response from: " << ev->Sender);
+    }
+
+    bool HasMetadataOperationInflight() const {
+        return SaveProgressState.WaitSave || SaveExternalEffectsState.WaitSave || SavePhysicalGraphState.WaitSave || SaveResultsState.WaitSaveMeta;
+    }
+
+    bool HasOperationInflight() const {
+        return HasMetadataOperationInflight() || SaveResultsState.WaitSaveResult;
+    }
+
+    void ContinueExecute() {
+        // Check exit condition after failure
+        if (FinishInfo.IsFailed() && !QueryIsRunning && !HasOperationInflight()) {
+            return Finish();
+        }
+
+        // Save info to script execution results table
+
+        if (!SaveResultsState.WaitSaveResult) {
+            TryToDrainResults();
+        } else {
+            LOG_T("Wait for operations on table `result_sets` to finish");
+        }
+
+        // Save info to script execution metadata table
+
+        if (HasMetadataOperationInflight()) {
+            LOG_T("Wait for operations on table `script_executions` to finish"
+                << ", save progress: " << SaveProgressState.WaitSave
+                << ", save external effects: " << SaveExternalEffectsState.WaitSave
+                << ", save physical graph: " << SavePhysicalGraphState.WaitSave
+                << ", save results meta: " << SaveResultsState.WaitSaveMeta);
+            return;
+        }
+
+        if (!SaveExternalEffectsState.Requests.empty()) {
+            return SaveExternalEffects();
+        }
+
+        if (!SavePhysicalGraphState.GraphsToSave.empty()) {
+            return SavePhysicalGraph();
+        }
+
+        if (SaveResultsState.HasMetaToSave()) {
+            return SaveResultsMeta();
+        }
+
+        if (SaveProgressState.QueryStatsChanged) {
+            return UpdateScriptProgress();
+        }
+
+        // Check success exit condition
+        if (FinishInfo.IsFinished()) {
+            return Finish();
+        }
+    }
+
+    void TryToDrainResults() {
+        Y_VALIDATE(!SaveResultsState.WaitSaveResult, "Unexpected call");
+
+        const auto freeSpaceBytes = SaveResultsState.GetFreeSpaceBytes();
+        LOG_T("Try to drain results, free space: " << freeSpaceBytes);
+
+        // We save results when:
+        // - Where is large enough result batch
+        // - No free space in buffer
+
+        std::optional<ui64> resultToSave;
+        ui64 maxResultSetBytes = 0;
+        for (ui64 i = 0; i < SaveResultsState.ResultSetInfos.size(); ++i) {
+            const auto& info = SaveResultsState.ResultSetInfos[i];
+            if (info.ShouldSaveResult()) {
+                resultToSave = i;
+                break;
+            }
+
+            if (const auto resultSize = info.GetBytesToSave(); freeSpaceBytes <= 0 && resultSize > maxResultSetBytes) {
+                resultToSave = i;
+                maxResultSetBytes = resultSize;
+            }
+        }
+
+        if (resultToSave) {
+            auto& info = SaveResultsState.ResultSetInfos[*resultToSave];
+            const auto& saverId = Register(CreateSaveScriptExecutionResultActor(SelfId(), Ctx->UserRequestContext->Database, Ctx->UserRequestContext->CurrentExecutionId, *resultToSave, SaveResultsState.GetExpireAt(*Ctx), info.FirstRowId, info.AccumulatedSize, std::move(info.PendingResult)));
+            LOG_D("Save part for result set #" << *resultToSave << ", saver id: " << saverId);
+            SaveResultsState.WaitSaveResult = true;
+
+            const auto bytes = info.GetBytesToSave();
+            SaveResultsState.PendingResultSetsSize -= bytes;
+            SaveResultsState.SaveResultInflightBytes = bytes;
+            info.FirstRowId = info.RowCount;
+            info.AccumulatedSize = info.ByteCount;
+            info.PendingResult = Ydb::ResultSet();
+        }
+    }
+
+    void SaveExternalEffects() {
+        Y_VALIDATE(!SaveExternalEffectsState.Requests.empty() && !SaveExternalEffectsState.WaitSave, "Unexpected call");
+
+        const auto& saverId = Register(CreateSaveScriptExternalEffectActor(SelfId(), Ctx->UserRequestContext->Database, Ctx->UserRequestContext->CurrentExecutionId, std::move(SaveExternalEffectsState.Requests.front().second), Ctx->LeaseGeneration));
+        LOG_D("Save external effect, saver id: " << saverId);
+        SaveExternalEffectsState.WaitSave = true;
+    }
+
+    void SavePhysicalGraph() {
+        Y_VALIDATE(!SavePhysicalGraphState.GraphsToSave.empty() && !SavePhysicalGraphState.WaitSave, "Unexpected call");
+
+        const auto& saverId = Register(CreateSaveScriptExecutionPhysicalGraphActor(SelfId(), Ctx->UserRequestContext->Database, Ctx->UserRequestContext->CurrentExecutionId, std::move(SavePhysicalGraphState.GraphsToSave.front().second), Ctx->LeaseGeneration, QueryServiceConfig));
+        LOG_D("Save script physical graph, saver id: " << saverId);
+        SavePhysicalGraphState.WaitSave = true;
+    }
+
+    void SaveResultsMeta() {
+        Y_VALIDATE(!SaveResultsState.WaitSaveMeta, "Unexpected call");
+
+        const auto resultsCount = SaveResultsState.ResultSetInfos.size();
+        auto metas = SequenceToJsonString(resultsCount, [infos = &SaveResultsState.ResultSetInfos](const ui64 i, NJson::TJsonValue& value) {
+            value = infos->at(i).Meta.SaveJsonMeta();
+        });
+
+        const auto& saverId = Register(CreateSaveScriptExecutionResultMetaActor(SelfId(), Ctx->UserRequestContext->Database, Ctx->UserRequestContext->CurrentExecutionId, std::move(metas), Ctx->LeaseGeneration));
+        LOG_D("Save result meta for result sets #" << resultsCount << ", saver id: " << saverId);
+        SaveResultsState.WaitSaveMeta = true;
+    }
+
+    void UpdateScriptProgress() {
+        Y_VALIDATE(SaveProgressState.QueryStatsChanged && !SaveProgressState.WaitSave, "Unexpected call");
+        Y_VALIDATE(ExecutionInfo.QueryPlan || ExecutionInfo.QueryAst, "Plan ot ast should be set");
+        SaveProgressState.QueryStatsChanged = false;
+
+        const auto& updaterId = Register(CreateScriptProgressActor(
+            Ctx->UserRequestContext->Database,
+            Ctx->UserRequestContext->CurrentExecutionId,
+            ExecutionInfo.QueryPlan,
+            SaveProgressState.AstSaved ? std::nullopt : ExecutionInfo.QueryAst,
+            Ctx->LeaseGeneration,
+            QueryServiceConfig
+        ));
+        LOG_T("Start TScriptProgressActor " << updaterId);
+        SaveProgressState.WaitSave = true;
+    }
+
+    void Finish() {
+        Finish(Ydb::StatusIds::SUCCESS);
+    }
+
+    void Finish(const Ydb::StatusIds::StatusCode status, const TString& message) {
+        Finish(status, {NYql::TIssue(message)});
+    }
+
+    void Finish(const Ydb::StatusIds::StatusCode status, NYql::TIssues issues = {}) {
+        if (status != Ydb::StatusIds::SUCCESS) {
+            LOG_E("Finish with error " << status << ", issues: " << issues.ToOneLineString());
+        } else if (!FinishInfo.IsFailed()) {
+            LOG_I("Finish successfully");
+        }
+
+        FinishInfo.Update(status, std::move(issues));
+
+        if (QueryIsRunning) {
+            // We should abort query before finish
+            FinishInfo.Update(Ydb::StatusIds::CANCELLED, {NYql::TIssue("Query was cancelled")});
+
+            if (!QueryIsCancelling) {
+                auto ev = MakeHolder<TEvKqp::TEvCancelQueryRequest>();
+                ev->Record.MutableRequest()->SetSessionId(Ctx->UserRequestContext->SessionId);
+                Send(MakeKqpProxyID(SelfId().NodeId()), ev.Release());
+                QueryIsCancelling = true;
+            }
+            return;
+        }
+
+        if (HasOperationInflight()) {
+            // Wait for all inflight queries to complete
+            return;
+        }
+
+        Send(Owner, new TEvRunScriptPrivate::TEvScriptResultHandlerFinished(*FinishInfo.Status, std::move(ExecutionInfo), std::move(FinishInfo.Issues)));
+        PassAway();
+    }
+
+    TString LogPrefix() const {
+        return TStringBuilder() << "[" << ActorName << "] " << SelfId() << ". Owner: " << Owner << ". Ctx: " << *Ctx->UserRequestContext << ". LeaseGeneration: " << Ctx->LeaseGeneration << ". ";
+    }
+
+    const TScriptExecutionContext::TPtr Ctx;
+    const NKikimrConfig::TQueryServiceConfig QueryServiceConfig;
+    std::optional<NKikimrKqp::TQueryPhysicalGraph> PhysicalGraph;
+    TActorId Owner;
+    TFinishInfo FinishInfo;
+    TExecutionInfo ExecutionInfo;
+    TSaveProgressState SaveProgressState;
+    TSaveExternalEffectsState SaveExternalEffectsState;
+    TSavePhysicalGraphState SavePhysicalGraphState;
+    TSaveResultsState SaveResultsState;
+    TMap<ui64, TProducerState> StreamChannels;
+    bool QueryIsRunning = true;
+    bool QueryIsCancelling = false;
+};
+
+} // anonymous namespace
+
+IActor* CreateScriptResultHandlerActor(TScriptExecutionContext::TPtr ctx, std::optional<NKikimrKqp::TQueryPhysicalGraph> physicalGraph, NKikimrConfig::TQueryServiceConfig queryServiceConfig) {
+    return new TScriptResultHandlerActor(std::move(ctx), std::move(physicalGraph), std::move(queryServiceConfig));
+}
+
+} // namespace NKikimr::NKqp::NPrivate

--- a/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
@@ -142,7 +142,7 @@ class TScriptResultHandlerActor final : public TActorBootstrapped<TScriptResultH
             });
         }
 
-        TInstant GetExpireAt(const TScriptExecutionContext& ctx) {
+        std::optional<TInstant> GetExpireAt(const TScriptExecutionContext& ctx) {
             if (!ExpireAt && ctx.ResultsTtl) {
                 ExpireAt = TInstant::Now() + ctx.ResultsTtl;
             }
@@ -150,7 +150,7 @@ class TScriptResultHandlerActor final : public TActorBootstrapped<TScriptResultH
         }
 
     private:
-        TInstant ExpireAt;
+        std::optional<TInstant> ExpireAt;
     };
 
     struct TProducerState {

--- a/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
@@ -24,8 +24,11 @@
 #include <util/string/builder.h>
 #include <util/system/types.h>
 
+#include <algorithm>
 #include <exception>
 #include <queue>
+#include <utility>
+#include <vector>
 
 namespace NKikimr::NKqp::NPrivate {
 

--- a/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
+++ b/ydb/core/kqp/run_script_actor/kqp_script_result_handler.cpp
@@ -365,7 +365,7 @@ private:
     void Handle(TEvKqpExecuter::TEvStreamData::TPtr& ev) {
         auto& record = ev->Get()->Record;
         const auto seqNo = record.GetSeqNo();
-        const auto resultSetIndex = record.GetQueryResultIndex();
+        const ui32 resultSetIndex = record.GetQueryResultIndex();
         const auto& resultSet = record.GetResultSet();
         const auto rowsCount = resultSet.rows_size();
         const auto finished = record.GetFinished();
@@ -381,6 +381,7 @@ private:
             // we don't know result set count, so just accept all of them
             // it's possible to have several result sets per script
             // they can arrive in any order and may be missed for some indices
+            Y_VALIDATE(resultSetIndex < std::numeric_limits<ui32>::max(), "Unexpected result set index: " << resultSetIndex);
             resultSetInfos.resize(resultSetIndex + 1);
         }
 

--- a/ydb/core/kqp/run_script_actor/ya.make
+++ b/ydb/core/kqp/run_script_actor/ya.make
@@ -1,7 +1,10 @@
 LIBRARY()
 
 SRCS(
+    kqp_run_script_actor_impl.cpp
     kqp_run_script_actor.cpp
+    kqp_script_lease_watcher_actor.cpp
+    kqp_script_result_handler.cpp
 )
 
 PEERDIR(

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -10,220 +10,236 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr::NKqp::NFederatedQueryTest {
-    TString GetSymbolsString(char start, char end, const TString& skip) {
-        TStringBuilder result;
-        for (char symbol = start; symbol <= end; ++symbol) {
-            if (skip.Contains(symbol)) {
-                continue;
-            }
-            result << symbol;
+
+TString GetSymbolsString(char start, char end, const TString& skip) {
+    TStringBuilder result;
+    for (char symbol = start; symbol <= end; ++symbol) {
+        if (skip.Contains(symbol)) {
+            continue;
         }
-        return result;
+        result << symbol;
+    }
+    return result;
+}
+
+NYdb::NQuery::TScriptExecutionOperation WaitScriptExecutionOperation(const NYdb::TOperation::TOperationId& operationId, const NYdb::TDriver& ydbDriver, const TString& userSID) {
+    NYdb::TCommonClientSettings settings;
+
+    if (userSID) {
+        settings.AuthToken(userSID);
     }
 
-    NYdb::NQuery::TScriptExecutionOperation WaitScriptExecutionOperation(const NYdb::TOperation::TOperationId& operationId, const NYdb::TDriver& ydbDriver, const TString& userSID) {
-        NYdb::TCommonClientSettings settings;
+    NYdb::NOperation::TOperationClient client(ydbDriver, settings);
+    while (1) {
+        auto op = client.Get<NYdb::NQuery::TScriptExecutionOperation>(operationId).GetValueSync();
 
-        if (userSID) {
-            settings.AuthToken(userSID);
+        if (op.Ready()) {
+            return op;
         }
 
-        NYdb::NOperation::TOperationClient client(ydbDriver, settings);
-        while (1) {
-            auto op = client.Get<NYdb::NQuery::TScriptExecutionOperation>(operationId).GetValueSync();
+        const auto& status = op.Status();
+        UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), NYdb::EStatus::SUCCESS, status.GetIssues().ToString());
+        Sleep(TDuration::MilliSeconds(10));
+    }
+}
 
-            if (op.Ready()) {
-                return op;
-            }
+void WaitResourcesPublish(ui32 nodeId, ui32 expectedNodeCount) {
+    const auto timeout = TInstant::Now() + TDuration::Seconds(10);
+    std::shared_ptr<NKikimr::NKqp::NRm::IKqpResourceManager> resourceManager;
+    while (true) {
+        if (!resourceManager) {
+            resourceManager = NKikimr::NKqp::TryGetKqpResourceManager(nodeId);
+        }
 
-            const auto& status = op.Status();
-            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), NYdb::EStatus::SUCCESS, status.GetIssues().ToString());
-            Sleep(TDuration::MilliSeconds(10));
+        if (resourceManager && resourceManager->GetClusterResources().size() == expectedNodeCount) {
+            return;
+        }
+
+        if (TInstant::Now() > timeout) {
+            UNIT_FAIL("Timeout waiting for resources to publish on node [" << nodeId << "], expectedNodeCount: " << expectedNodeCount << " has resourceManager: " << (resourceManager ? "true" : "false") << ", node count: " << (resourceManager ? resourceManager->GetClusterResources().size() : 0));
+        }
+
+        Sleep(TDuration::MilliSeconds(100));
+    }
+}
+
+void WaitResourcesPublish(const TKikimrRunner& kikimrRunner) {
+    const auto& testServer = kikimrRunner.GetTestServer();
+    const auto nodeCount = testServer.StaticNodes();
+    for (ui32 nodeId = 0; nodeId < nodeCount; ++nodeId) {
+        WaitResourcesPublish(testServer.GetRuntime()->GetNodeId(nodeId), nodeCount);
+    }
+}
+
+std::shared_ptr<TKikimrRunner> MakeKikimrRunner(
+    bool initializeHttpGateway,
+    NYql::NConnector::IClient::TPtr connectorClient,
+    NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver,
+    std::optional<NKikimrConfig::TAppConfig> appConfig,
+    std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory,
+    const TKikimrRunnerOptions& options)
+{
+    // Logger should be initialized before http gateway creation
+    NYql::NLog::InitLogger(new NYql::NLog::TTlsLogBackend(NActors::CreateNullBackend()));
+
+    NKikimrConfig::TFeatureFlags featureFlags;
+    featureFlags.SetEnableExternalDataSources(true);
+    featureFlags.SetEnableScriptExecutionOperations(true);
+    featureFlags.SetEnableExternalSourceSchemaInference(true);
+    featureFlags.SetEnableMoveColumnTable(true);
+    featureFlags.SetEnableSchemaSecrets(true);
+
+    if (appConfig && appConfig->HasFeatureFlags()) {
+        const auto& appFlags = appConfig->GetFeatureFlags();
+        if (appFlags.GetEnableColumnshardBool()) {
+            featureFlags.SetEnableColumnshardBool(true);
+        }
+
+        if (appFlags.GetEnableColumnStore()) {
+            featureFlags.SetEnableColumnStore(true);
         }
     }
 
-    void WaitResourcesPublish(ui32 nodeId, ui32 expectedNodeCount) {
-        const auto timeout = TInstant::Now() + TDuration::Seconds(10);
-        std::shared_ptr<NKikimr::NKqp::NRm::IKqpResourceManager> resourceManager;
-        while (true) {
-            if (!resourceManager) {
-                resourceManager = NKikimr::NKqp::TryGetKqpResourceManager(nodeId);
-            }
-
-            if (resourceManager && resourceManager->GetClusterResources().size() == expectedNodeCount) {
-                return;
-            }
-
-            if (TInstant::Now() > timeout) {
-                UNIT_FAIL("Timeout waiting for resources to publish on node [" << nodeId << "], expectedNodeCount: " << expectedNodeCount << " has resourceManager: " << (resourceManager ? "true" : "false") << ", node count: " << (resourceManager ? resourceManager->GetClusterResources().size() : 0));
-            }
-
-            Sleep(TDuration::MilliSeconds(100));
-        }
+    if (!appConfig) {
+        appConfig.emplace();
+        appConfig->MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(true);
     }
 
-    void WaitResourcesPublish(const TKikimrRunner& kikimrRunner) {
-        const auto& testServer = kikimrRunner.GetTestServer();
-        const auto nodeCount = testServer.StaticNodes();
-        for (ui32 nodeId = 0; nodeId < nodeCount; ++nodeId) {
-            WaitResourcesPublish(testServer.GetRuntime()->GetNodeId(nodeId), nodeCount);
-        }
+    appConfig->MutableQueryServiceConfig()->MutableS3()->SetAllowLocalFiles(true);
+
+    auto settings = TKikimrSettings(*appConfig);
+
+    NYql::IHTTPGateway::TPtr httpGateway;
+    const auto& queryServiceConfig = appConfig->GetQueryServiceConfig();
+    if (initializeHttpGateway) {
+        httpGateway = MakeHttpGateway(queryServiceConfig.GetHttpGateway(), settings.CountersRoot);
     }
 
-    std::shared_ptr<TKikimrRunner> MakeKikimrRunner(
-        bool initializeHttpGateway,
-        NYql::NConnector::IClient::TPtr connectorClient,
-        NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver,
-        std::optional<NKikimrConfig::TAppConfig> appConfig,
-        std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory,
-        const TKikimrRunnerOptions& options)
+    NYdb::TDriverConfig cfg;
+    cfg.SetDiscoveryMode(NYdb::EDiscoveryMode::Async);
+    cfg.SetMaxQueuedRequests(std::numeric_limits<i64>::max());
+    auto driver = std::make_shared<NYdb::TDriver>(cfg);
+
+    const auto& s3Config = queryServiceConfig.GetS3();
+    const auto& solomonConfig = queryServiceConfig.GetSolomon();
+    auto federatedQuerySetupFactory = std::make_shared<TKqpFederatedQuerySetupFactoryMock>(
+        httpGateway,
+        connectorClient,
+        options.CredentialsFactory,
+        databaseAsyncResolver,
+        s3Config,
+        queryServiceConfig.GetGeneric(),
+        queryServiceConfig.GetYt(),
+        nullptr,
+        solomonConfig,
+        nullptr,
+        NYql::NDq::CreateReadActorFactoryConfig(s3Config),
+        nullptr,
+        NYql::TPqGatewayConfig{},
+        options.PqGateway ? NYql::CreatePqFileGatewayFactory(options.PqGateway) : NKqp::MakePqGatewayFactory(driver),
+        nullptr,
+        driver);
+
+    auto logSettings = options.LogSettings;
+    logSettings.DefaultLogPriority = std::max(NLog::PRI_NOTICE, logSettings.DefaultLogPriority);
+    logSettings
+        .AddLogPriority(NKikimrServices::KQP_EXECUTER, NLog::PRI_INFO)
+        .AddLogPriority(NKikimrServices::KQP_PROXY, NLog::PRI_DEBUG)
+        .AddLogPriority(NKikimrServices::KQP_COMPUTE, NLog::PRI_INFO);
+
+    const auto& kqpSettings = appConfig->GetKQPConfig().GetSettings();
+    settings
+        .SetFeatureFlags(featureFlags)
+        .SetFederatedQuerySetupFactory(federatedQuerySetupFactory)
+        .SetKqpSettings({kqpSettings.begin(), kqpSettings.end()})
+        .SetS3ActorsFactory(std::move(s3ActorsFactory))
+        .SetWithSampleTables(false)
+        .SetDomainRoot(options.DomainRoot)
+        .SetNodeCount(options.NodeCount)
+        .SetDynamicNodeCount(options.DynamicNodeCount)
+        .SetEnableStorageProxy(true)
+        .SetStoragePoolTypes(options.StoragePoolTypes)
+        .SetCheckpointPeriod(options.CheckpointPeriod)
+        .SetUseLocalCheckpointsInStreamingQueries(options.UseLocalCheckpointsInStreamingQueries)
+        .SetLogSettings(std::move(logSettings))
+        .SetNeedsStatsCollectors(options.NeedsStatsCollectors)
+        .SetInitFederatedQuerySetupFactory(options.InternalInitFederatedQuerySetupFactory);
+
+    settings.EnableScriptExecutionBackgroundChecks = options.EnableScriptExecutionBackgroundChecks;
+    federatedQuerySetupFactory->SetScriptExecutionSettings({
+        .EnableBackgroundLeaseChecks = options.EnableScriptExecutionBackgroundChecks,
+        .LeaseCheckStartupTimeout = TDuration::Zero(),
+    });
+
+    return std::make_shared<TKikimrRunner>(settings);
+}
+
+class TStaticCredentialsProvider: public NYdb::ICredentialsProvider {
+public:
+    TStaticCredentialsProvider(const TString& yqlToken)
+        : YqlToken_(yqlToken)
     {
-        // Logger should be initialized before http gateway creation
-        NYql::NLog::InitLogger(new NYql::NLog::TTlsLogBackend(NActors::CreateNullBackend()));
-
-        NKikimrConfig::TFeatureFlags featureFlags;
-        featureFlags.SetEnableExternalDataSources(true);
-        featureFlags.SetEnableScriptExecutionOperations(true);
-        featureFlags.SetEnableExternalSourceSchemaInference(true);
-        featureFlags.SetEnableMoveColumnTable(true);
-        featureFlags.SetEnableSchemaSecrets(true);
-
-        if (appConfig && appConfig->HasFeatureFlags()) {
-            const auto& appFlags = appConfig->GetFeatureFlags();
-            if (appFlags.GetEnableColumnshardBool()) {
-                featureFlags.SetEnableColumnshardBool(true);
-            }
-
-            if (appFlags.GetEnableColumnStore()) {
-                featureFlags.SetEnableColumnStore(true);
-            }
-        }
-
-        if (!appConfig) {
-            appConfig.emplace();
-            appConfig->MutableQueryServiceConfig()->SetAllExternalDataSourcesAreAvailable(true);
-        }
-
-        appConfig->MutableQueryServiceConfig()->MutableS3()->SetAllowLocalFiles(true);
-
-        auto settings = TKikimrSettings(*appConfig);
-
-        NYql::IHTTPGateway::TPtr httpGateway;
-        const auto& queryServiceConfig = appConfig->GetQueryServiceConfig();
-        if (initializeHttpGateway) {
-            httpGateway = MakeHttpGateway(queryServiceConfig.GetHttpGateway(), settings.CountersRoot);
-        }
-
-        NYdb::TDriverConfig cfg;
-        cfg.SetDiscoveryMode(NYdb::EDiscoveryMode::Async);
-        cfg.SetMaxQueuedRequests(std::numeric_limits<i64>::max());
-        auto driver = std::make_shared<NYdb::TDriver>(cfg);
-
-        const auto& s3Config = queryServiceConfig.GetS3();
-        const auto& solomonConfig = queryServiceConfig.GetSolomon();
-        auto federatedQuerySetupFactory = std::make_shared<TKqpFederatedQuerySetupFactoryMock>(
-            httpGateway,
-            connectorClient,
-            options.CredentialsFactory,
-            databaseAsyncResolver,
-            s3Config,
-            queryServiceConfig.GetGeneric(),
-            queryServiceConfig.GetYt(),
-            nullptr,
-            solomonConfig,
-            nullptr,
-            NYql::NDq::CreateReadActorFactoryConfig(s3Config),
-            nullptr,
-            NYql::TPqGatewayConfig{},
-            options.PqGateway ? NYql::CreatePqFileGatewayFactory(options.PqGateway) : NKqp::MakePqGatewayFactory(driver),
-            nullptr,
-            driver);
-
-        auto logSettings = options.LogSettings;
-        logSettings.DefaultLogPriority = std::max(NLog::PRI_NOTICE, logSettings.DefaultLogPriority);
-        logSettings
-            .AddLogPriority(NKikimrServices::KQP_EXECUTER, NLog::PRI_INFO)
-            .AddLogPriority(NKikimrServices::KQP_PROXY, NLog::PRI_DEBUG)
-            .AddLogPriority(NKikimrServices::KQP_COMPUTE, NLog::PRI_INFO);
-
-        const auto& kqpSettings = appConfig->GetKQPConfig().GetSettings();
-        settings
-            .SetFeatureFlags(featureFlags)
-            .SetFederatedQuerySetupFactory(federatedQuerySetupFactory)
-            .SetKqpSettings({kqpSettings.begin(), kqpSettings.end()})
-            .SetS3ActorsFactory(std::move(s3ActorsFactory))
-            .SetWithSampleTables(false)
-            .SetDomainRoot(options.DomainRoot)
-            .SetNodeCount(options.NodeCount)
-            .SetDynamicNodeCount(options.DynamicNodeCount)
-            .SetEnableStorageProxy(true)
-            .SetStoragePoolTypes(options.StoragePoolTypes)
-            .SetCheckpointPeriod(options.CheckpointPeriod)
-            .SetUseLocalCheckpointsInStreamingQueries(options.UseLocalCheckpointsInStreamingQueries)
-            .SetLogSettings(std::move(logSettings))
-            .SetNeedsStatsCollectors(options.NeedsStatsCollectors)
-            .SetInitFederatedQuerySetupFactory(options.InternalInitFederatedQuerySetupFactory);
-
-        settings.EnableScriptExecutionBackgroundChecks = options.EnableScriptExecutionBackgroundChecks;
-        federatedQuerySetupFactory->SetScriptExecutionSettings({
-            .EnableBackgroundLeaseChecks = options.EnableScriptExecutionBackgroundChecks,
-            .LeaseCheckStartupTimeout = TDuration::Zero(),
-        });
-
-        return std::make_shared<TKikimrRunner>(settings);
     }
 
-    class TStaticCredentialsProvider: public NYdb::ICredentialsProvider {
-    public:
-        TStaticCredentialsProvider(const TString& yqlToken)
-            : YqlToken_(yqlToken)
-        {
-        }
-
-        std::string GetAuthInfo() const override {
-            return YqlToken_;
-        }
-
-        bool IsValid() const override {
-            return true;
-        }
-
-    private:
-        std::string YqlToken_;
-    };
-
-    class TStaticCredentialsProviderFactory: public NYdb::ICredentialsProviderFactory {
-    public:
-        TStaticCredentialsProviderFactory(const TString& yqlToken)
-            : YqlToken_(yqlToken)
-        {
-        }
-
-        std::shared_ptr<NYdb::ICredentialsProvider> CreateProvider() const override {
-            return std::make_shared<TStaticCredentialsProvider>(YqlToken_);
-        }
-
-    private:
-        TString YqlToken_;
-    };
-
-    class TStaticSecuredCredentialsFactory: public NYql::ISecuredServiceAccountCredentialsFactory {
-    public:
-        TStaticSecuredCredentialsFactory(const TString& yqlToken)
-            : YqlToken_(yqlToken)
-        {
-        }
-
-        std::shared_ptr<NYdb::ICredentialsProviderFactory> Create(const TString&, const TString&) override {
-            return std::make_shared<TStaticCredentialsProviderFactory>(YqlToken_);
-        }
-
-    private:
-        TString YqlToken_;
-    };
-
-    std::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory> CreateCredentialsFactory(const TString& token) {
-        return std::make_shared<TStaticSecuredCredentialsFactory>(token);
+    std::string GetAuthInfo() const override {
+        return YqlToken_;
     }
+
+    bool IsValid() const override {
+        return true;
+    }
+
+private:
+    std::string YqlToken_;
+};
+
+class TStaticCredentialsProviderFactory: public NYdb::ICredentialsProviderFactory {
+public:
+    TStaticCredentialsProviderFactory(const TString& yqlToken)
+        : YqlToken_(yqlToken)
+    {
+    }
+
+    std::shared_ptr<NYdb::ICredentialsProvider> CreateProvider() const override {
+        return std::make_shared<TStaticCredentialsProvider>(YqlToken_);
+    }
+
+private:
+    TString YqlToken_;
+};
+
+class TStaticSecuredCredentialsFactory: public NYql::ISecuredServiceAccountCredentialsFactory {
+public:
+    TStaticSecuredCredentialsFactory(const TString& yqlToken)
+        : YqlToken_(yqlToken)
+    {
+    }
+
+    std::shared_ptr<NYdb::ICredentialsProviderFactory> Create(const TString&, const TString&) override {
+        return std::make_shared<TStaticCredentialsProviderFactory>(YqlToken_);
+    }
+
+private:
+    TString YqlToken_;
+};
+
+std::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory> CreateCredentialsFactory(const TString& token) {
+    return std::make_shared<TStaticSecuredCredentialsFactory>(token);
+}
+
+std::function<void(const std::string&)> AstChecker(ui64 txCount, ui64 stagesCount) {
+    const auto stringCounter = [](const std::string& str, const std::string& subStr) {
+        ui64 count = 0;
+        for (size_t i = str.find(subStr); i != std::string::npos; i = str.find(subStr, i + subStr.size())) {
+            ++count;
+        }
+        return count;
+    };
+
+    return [txCount, stagesCount, stringCounter](const std::string& ast) {
+        UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "KqpPhysicalTx"), txCount);
+        UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "DqPhyStage"), stagesCount);
+    };
+}
 
 } // namespace NKikimr::NKqp::NFederatedQueryTest

--- a/ydb/core/kqp/ut/federated_query/common/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/common/common.cpp
@@ -36,7 +36,8 @@ namespace NKikimr::NKqp::NFederatedQueryTest {
                 return op;
             }
 
-            UNIT_ASSERT_C(op.Status().IsSuccess(), TStringBuilder() << op.Status().GetStatus() << ":" << op.Status().GetIssues().ToString());
+            const auto& status = op.Status();
+            UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), NYdb::EStatus::SUCCESS, status.GetIssues().ToString());
             Sleep(TDuration::MilliSeconds(10));
         }
     }

--- a/ydb/core/kqp/ut/federated_query/common/common.h
+++ b/ydb/core/kqp/ut/federated_query/common/common.h
@@ -7,42 +7,43 @@
 #include <ydb/library/yql/providers/s3/actors_factory/yql_s3_actors_factory.h>
 
 namespace NKikimr::NKqp::NFederatedQueryTest {
-    using namespace NKikimr::NKqp;
 
-    TString GetSymbolsString(char start, char end, const TString& skip = "");
+TString GetSymbolsString(char start, char end, const TString& skip = "");
 
-    NYdb::NQuery::TScriptExecutionOperation WaitScriptExecutionOperation(
-        const NYdb::TOperation::TOperationId& operationId,
-        const NYdb::TDriver& ydbDriver,
-        const TString& userSID = "");
+NYdb::NQuery::TScriptExecutionOperation WaitScriptExecutionOperation(
+    const NYdb::TOperation::TOperationId& operationId,
+    const NYdb::TDriver& ydbDriver,
+    const TString& userSID = "");
 
-    void WaitResourcesPublish(ui32 nodeId, ui32 expectedNodeCount);
-    void WaitResourcesPublish(const TKikimrRunner& kikimrRunner);
+void WaitResourcesPublish(ui32 nodeId, ui32 expectedNodeCount);
+void WaitResourcesPublish(const TKikimrRunner& kikimrRunner);
 
-    struct TKikimrRunnerOptions {
-        TString DomainRoot = "Root";
-        ui32 NodeCount = 1;
-        ui32 DynamicNodeCount = 0;
-        NYql::ISecuredServiceAccountCredentialsFactory::TPtr CredentialsFactory;
-        bool EnableScriptExecutionBackgroundChecks = true;
-        TIntrusivePtr<NYql::IPqGateway> PqGateway;
-        TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
-        TTestLogSettings LogSettings;
-        bool UseLocalCheckpointsInStreamingQueries = false;
-        bool InternalInitFederatedQuerySetupFactory = false;
-        bool NeedsStatsCollectors = false;
-        TVector<TString> StoragePoolTypes;
-    };
+struct TKikimrRunnerOptions {
+    TString DomainRoot = "Root";
+    ui32 NodeCount = 1;
+    ui32 DynamicNodeCount = 0;
+    NYql::ISecuredServiceAccountCredentialsFactory::TPtr CredentialsFactory;
+    bool EnableScriptExecutionBackgroundChecks = true;
+    TIntrusivePtr<NYql::IPqGateway> PqGateway;
+    TDuration CheckpointPeriod = TDuration::MilliSeconds(200);
+    TTestLogSettings LogSettings;
+    bool UseLocalCheckpointsInStreamingQueries = false;
+    bool InternalInitFederatedQuerySetupFactory = false;
+    bool NeedsStatsCollectors = false;
+    TVector<TString> StoragePoolTypes;
+};
 
-    std::shared_ptr<TKikimrRunner> MakeKikimrRunner(
-        bool initializeHttpGateway = false,
-        NYql::NConnector::IClient::TPtr connectorClient = nullptr,
-        NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver = nullptr,
-        std::optional<NKikimrConfig::TAppConfig> appConfig = std::nullopt,
-        std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory = nullptr,
-        const TKikimrRunnerOptions& options = {});
+std::shared_ptr<TKikimrRunner> MakeKikimrRunner(
+    bool initializeHttpGateway = false,
+    NYql::NConnector::IClient::TPtr connectorClient = nullptr,
+    NYql::IDatabaseAsyncResolver::TPtr databaseAsyncResolver = nullptr,
+    std::optional<NKikimrConfig::TAppConfig> appConfig = std::nullopt,
+    std::shared_ptr<NYql::NDq::IS3ActorsFactory> s3ActorsFactory = nullptr,
+    const TKikimrRunnerOptions& options = {});
 
-    std::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory> CreateCredentialsFactory(
-        const TString& token = NYql::NConnector::NTest::DEFAULT_PASSWORD);
+std::shared_ptr<NYql::ISecuredServiceAccountCredentialsFactory> CreateCredentialsFactory(
+    const TString& token = NYql::NConnector::NTest::DEFAULT_PASSWORD);
+
+std::function<void(const std::string&)> AstChecker(ui64 txCount, ui64 stagesCount);
 
 } // namespace NKikimr::NKqp::NFederatedQueryTest

--- a/ydb/core/kqp/ut/federated_query/common/ya.make
+++ b/ydb/core/kqp/ut/federated_query/common/ya.make
@@ -4,8 +4,6 @@ SRCS(
     common.cpp
 )
 
-STYLE_CPP()
-
 PEERDIR(
     ydb/core/kqp/rm_service
     ydb/core/kqp/ut/common

--- a/ydb/core/kqp/ut/federated_query/datastreams/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/common.cpp
@@ -689,6 +689,7 @@ NKikimrKqp::TQueryPhysicalGraph TStreamingTestFixture::LoadPhysicalGraph(const s
 
     const auto& graphProto = graph->Get()->PhysicalGraph;
     UNIT_ASSERT(graphProto);
+    UNIT_ASSERT_VALUES_EQUAL(graphProto->GetPreparedQuery().GetVersion(), static_cast<ui32>(NKikimrKqp::TPreparedQuery::VERSION_PHYSICAL_V1));
 
     return *graphProto;
 }

--- a/ydb/core/kqp/ut/federated_query/datastreams/common.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/common.cpp
@@ -835,23 +835,6 @@ void TStreamingTestFixture::SetupMockConnectorTableData(std::shared_ptr<TConnect
     }
 }
 
-// Other helpers
-
-std::function<void(const std::string&)> TStreamingTestFixture::AstChecker(ui64 txCount, ui64 stagesCount) {
-    const auto stringCounter = [](const std::string& str, const std::string& subStr) {
-        ui64 count = 0;
-        for (size_t i = str.find(subStr); i != std::string::npos; i = str.find(subStr, i + subStr.size())) {
-            ++count;
-        }
-        return count;
-    };
-
-    return [txCount, stagesCount, stringCounter](const std::string& ast) {
-        UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "KqpPhysicalTx"), txCount);
-        UNIT_ASSERT_VALUES_EQUAL(stringCounter(ast, "DqPhyStage"), stagesCount);
-    };
-}
-
 void TStreamingTestFixture::EnsureNotInitialized(const std::string& info) {
     UNIT_ASSERT_C(!Kikimr, "Kikimr runner is already initialized, can not setup " << info);
 }

--- a/ydb/core/kqp/ut/federated_query/datastreams/common.h
+++ b/ydb/core/kqp/ut/federated_query/datastreams/common.h
@@ -204,10 +204,6 @@ public:
     // Should be called at most once
     static void SetupMockConnectorTableData(std::shared_ptr<NYql::NConnector::NTest::TConnectorClientMock> mockClient, const TMockConnectorReadSplitsSettings& settings);
 
-    // Other helpers
-
-    static std::function<void(const std::string&)> AstChecker(ui64 txCount, ui64 stagesCount);
-
 private:
     void EnsureNotInitialized(const std::string& info);
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/datastreams_ut.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 
+#include <ydb/core/kqp/ut/federated_query/common/common.h>
 #include <ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h>
 #include <ydb/library/testlib/solomon_helpers/solomon_emulator_helpers.h>
 #include <ydb/library/yql/providers/s3/actors/yql_s3_actors_factory_impl.h>
@@ -12,6 +13,7 @@ using namespace fmt::literals;
 using namespace NTestUtils;
 using namespace NYdb;
 using namespace NYdb::NQuery;
+using namespace NFederatedQueryTest;
 
 Y_UNIT_TEST_SUITE(KqpFederatedQueryDatastreams) {
     Y_UNIT_TEST_F(CreateExternalDataSource, TStreamingTestFixture) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
@@ -2771,6 +2771,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
         ReadTopicMessage(outputTopic1, "test-A");
         ReadTopicMessage(outputTopic2, "test-B");
 
+        Sleep(TDuration::Seconds(1));
         const auto& results = ExecQuery(fmt::format(R"(
             SELECT * FROM `{row_table}`;
             SELECT * FROM `{column_table}`;)",
@@ -2871,7 +2872,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
             const auto& result = ExecQuery("SELECT Status FROM `.sys/streaming_queries`");
             UNIT_ASSERT_VALUES_EQUAL(result.size(), 1);
             CheckScriptResult(result[0], 1, 1, [&](TResultSetParser& resultSet) {
-                UNIT_ASSERT_VALUES_EQUAL(*resultSet.ColumnParser("Status").GetOptionalUtf8(), "FAILED");
+                UNIT_ASSERT_VALUES_EQUAL(*resultSet.ColumnParser("Status").GetOptionalUtf8(), "STOPPED");
             });
         }
 

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_ddl_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/kqp/common/events/events.h>
 #include <ydb/core/kqp/common/simple/services.h>
+#include <ydb/core/kqp/ut/federated_query/common/common.h>
 #include <ydb/core/sys_view/common/registry.h>
 #include <ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h>
 #include <ydb/library/testlib/solomon_helpers/solomon_emulator_helpers.h>
@@ -17,6 +18,7 @@ using namespace NYdb::NQuery;
 using namespace fmt::literals;
 using namespace NYql::NConnector::NTest;
 using namespace NTestUtils;
+using namespace NFederatedQueryTest;
 
 Y_UNIT_TEST_SUITE(KqpStreamingQueriesDdl) {
     Y_UNIT_TEST_F(CreateAndAlterStreamingQuery, TStreamingWithSchemaSecretsTestFixture) {

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_sys_view_ut.cpp
@@ -436,6 +436,53 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
         Sleep(STATS_WAIT_DURATION);
         CheckSysView(rows);
     }
+
+    Y_UNIT_TEST_F(ReaSysViewWithoutScriptExecutionTables, TStreamingSysViewTestFixture) {
+        Setup();
+
+        StartQuery("A");
+        Sleep(STATS_WAIT_DURATION);
+
+        CheckSysView({{.Name = "A", .CheckPlan = true}});
+
+        auto settings = TExecuteQuerySettings();
+        settings.RetrySettings(NYdb::NRetry::TRetryOperationSettings().MaxRetries(0));
+
+        constexpr ui64 checksCount = 5;
+        constexpr char query[] = "SELECT * FROM `.sys/streaming_queries`";
+        std::vector<TAsyncExecuteQueryResult> resultsAsync;
+        TAsyncExecuteQueryResult dropResultAsync;
+        for (ui64 i = 0; i < checksCount; ++i) {
+            resultsAsync.emplace_back(GetQueryClient()->ExecuteQuery(query, TTxControl::NoTx(), settings));
+
+            if (i == checksCount / 2) {
+                dropResultAsync = GetQueryClient()->ExecuteQuery("DROP TABLE `.metadata/script_executions`;", TTxControl::NoTx());
+            }
+        }
+
+        const auto dropResult = dropResultAsync.ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(dropResult.GetStatus(), EStatus::SUCCESS, dropResult.GetIssues().ToOneLineString());
+
+        for (auto& resultAsync : resultsAsync) {
+            const auto result = resultAsync.ExtractValueSync();
+            if (result.GetStatus() == EStatus::SUCCESS) {
+                UNIT_ASSERT_VALUES_EQUAL(result.GetResultSets().size(), 1);
+
+                auto parser = result.GetResultSetParser(0);
+                UNIT_ASSERT_VALUES_EQUAL(parser.RowsCount(), 1);
+                UNIT_ASSERT(parser.TryNextRow());
+
+                const auto& maybePlan = parser.ColumnParser("Plan").GetOptionalUtf8();
+                UNIT_ASSERT(maybePlan);
+                UNIT_ASSERT_STRING_CONTAINS(*maybePlan, TStringBuilder() << "Write " << PQ_SOURCE);
+            } else {
+                const auto& error = result.GetIssues().ToOneLineString();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::ABORTED, error);
+                UNIT_ASSERT_STRING_CONTAINS(error, ".metadata/script_executions");
+                UNIT_ASSERT_STRING_CONTAINS(error, "because it does not exist or you do not have access permissions");
+            }
+        }
+    }
 }
 
 } // namespace NKikimr::NKqp

--- a/ydb/core/kqp/ut/federated_query/datastreams/streaming_sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/streaming_sys_view_ut.cpp
@@ -437,7 +437,7 @@ Y_UNIT_TEST_SUITE(KqpStreamingQueriesSysView) {
         CheckSysView(rows);
     }
 
-    Y_UNIT_TEST_F(ReaSysViewWithoutScriptExecutionTables, TStreamingSysViewTestFixture) {
+    Y_UNIT_TEST_F(ReadSysViewWithoutScriptExecutionTables, TStreamingSysViewTestFixture) {
         Setup();
 
         StartQuery("A");

--- a/ydb/core/kqp/ut/federated_query/large_results/kqp_scriptexec_results_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/large_results/kqp_scriptexec_results_ut.cpp
@@ -211,7 +211,7 @@ Y_UNIT_TEST_SUITE(KqpScriptExecResults) {
             UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::SUCCESS, status.GetIssues().ToOneLineString());
         } else {
             UNIT_ASSERT_VALUES_EQUAL_C(status.GetStatus(), EStatus::NOT_FOUND, status.GetIssues().ToOneLineString());
-            UNIT_ASSERT_STRING_CONTAINS(status.GetIssues().ToString(), "No such execution");
+            UNIT_ASSERT_STRING_CONTAINS(status.GetIssues().ToString(), "Script execution operation not found");
         }
 
         WaitRemoveScriptResults(db, resOp.Metadata().ExecutionId);

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -3192,6 +3192,86 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
         UNIT_ASSERT_VALUES_EQUAL(GetUncommittedUploadsCount(BUCKET), 0);
     }
 
+    Y_UNIT_TEST(TestAtomicUploadCommitWithMultipleTransactions) {
+        auto kikimr = NTestUtils::MakeKikimrRunner();
+        auto db = kikimr->GetQueryClient();
+
+        constexpr char BUCKET[] = "test_atomic_upload_commit_with_multiple_transactions";
+        constexpr char EXTERNAL_DATA_SOURCE_NAME[] = "test_bucket";
+        CreateBucket(BUCKET);
+
+        {   // Create external data source
+            const TString query = fmt::format(R"(
+                CREATE EXTERNAL DATA SOURCE `{source_name}` WITH (
+                    SOURCE_TYPE="ObjectStorage",
+                    LOCATION="{location}",
+                    AUTH_METHOD="NONE"
+                ))",
+                "location"_a = GetBucketLocation(BUCKET),
+                "source_name"_a = EXTERNAL_DATA_SOURCE_NAME
+            );
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        constexpr char TABLE_NAME[] = "failure_table";
+
+        {   // Create sample table
+            const TString query = fmt::format(R"(
+                CREATE TABLE `{table_name}` (
+                    Key Int32 NOT NULL,
+                    Value String NOT NULL,
+                    PRIMARY KEY (Key)
+                );)",
+                "table_name"_a = TABLE_NAME
+            );
+            const auto result = db.ExecuteQuery(query, TTxControl::NoTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        const TString sql = fmt::format(R"(
+                PRAGMA s3.AtomicUploadCommit = "true";
+
+                INSERT INTO `{table_name}` (Key, Value) VALUES (42, "value");
+
+                INSERT INTO `{source_name}`.`f/` WITH (FORMAT = "json_each_row") SELECT 42;
+
+                SELECT * FROM `{table_name}`;
+
+                INSERT INTO `{source_name}`.`x/` WITH (FORMAT = "json_each_row") SELECT 42;
+            )",
+            "source_name"_a=EXTERNAL_DATA_SOURCE_NAME,
+            "table_name"_a=TABLE_NAME
+        );
+
+        auto scriptExecutionOperation = db.ExecuteScript(sql, TExecuteScriptSettings().StatsMode(EStatsMode::Profile)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(scriptExecutionOperation.Status().GetStatus(), EStatus::SUCCESS, scriptExecutionOperation.Status().GetIssues().ToString());
+        UNIT_ASSERT(!scriptExecutionOperation.Metadata().ExecutionId.empty());
+
+        TScriptExecutionOperation readyOp = WaitScriptExecutionOperation(scriptExecutionOperation.Id(), kikimr->GetDriver());
+        const auto& metadata = readyOp.Metadata();
+        UNIT_ASSERT_VALUES_EQUAL_C(metadata.ExecStatus, EExecStatus::Completed, readyOp.Status().GetIssues().ToOneLineString());
+
+        const auto& ast = metadata.ExecStats.GetAst();
+        UNIT_ASSERT(ast);
+        AstChecker(3, 5)(*ast);
+
+        TFetchScriptResultsResult results = db.FetchScriptResults(scriptExecutionOperation.Id(), 0).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(results.GetStatus(), EStatus::SUCCESS, results.GetIssues().ToString());
+
+        TResultSetParser resultSet(results.ExtractResultSet());
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnsCount(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.RowsCount(), 1);
+
+        UNIT_ASSERT(resultSet.TryNextRow());
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Key").GetInt32(), 42);
+        UNIT_ASSERT_VALUES_EQUAL(resultSet.ColumnParser("Value").GetString(), "value");
+
+        UNIT_ASSERT_VALUES_EQUAL(GetObjectKeys(BUCKET).size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetAllObjects(BUCKET), "{\"column0\":42}\n{\"column0\":42}\n");
+        UNIT_ASSERT_VALUES_EQUAL(GetUncommittedUploadsCount(BUCKET), 0);
+    }
+
     Y_UNIT_TEST(TestScriptExecutionsDisabled) {
         const TString bucket = "test_bucket1";
         CreateBucket(bucket);

--- a/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/s3/kqp_federated_query_ut.cpp
@@ -3037,7 +3037,7 @@ Y_UNIT_TEST_SUITE(KqpFederatedQuery) {
     }
 
     Y_UNIT_TEST(TestRestartQueryAndCleanupWithGetOperation) {
-        auto kikimr = NTestUtils::MakeKikimrRunner(std::nullopt, {.EnableScriptExecutionBackgroundChecks = false});
+        auto kikimr = NTestUtils::MakeKikimrRunner(std::nullopt, {.EnableScriptExecutionBackgroundChecks = true}); // Script execution may be restarted only by background check
         auto db = kikimr->GetQueryClient();
 
         constexpr char BUCKET[] = "test_restart_query_and_cleanup_with_get_operation_bucket";

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -1027,7 +1027,7 @@ message TEvCancelScriptExecutionResponse {
     optional Ydb.StatusIds.StatusCode Status = 1;
     repeated Ydb.Issue.IssueMessage Issues = 2;
     optional bool AlreadyFinished = 3;
-    optional bool ExecutionEntryExists = 4;
+    optional bool ExecutionEntryExists = 4 [default = true];
 }
 
 // Request that is sent to run script actor to check his existence.

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -1026,6 +1026,8 @@ message TEvCancelScriptExecutionRequest {
 message TEvCancelScriptExecutionResponse {
     optional Ydb.StatusIds.StatusCode Status = 1;
     repeated Ydb.Issue.IssueMessage Issues = 2;
+    optional bool AlreadyFinished = 3;
+    optional bool ExecutionEntryExists = 4;
 }
 
 // Request that is sent to run script actor to check his existence.

--- a/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
+++ b/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
@@ -749,18 +749,19 @@ public:
 
         const auto& event = *ev->Get();
         const bool ready = event.Ready;
-        const auto status = event.Status;
-        if (!ready && status != Ydb::StatusIds::SUCCESS && status != Ydb::StatusIds::NOT_FOUND) {
+        const auto operationStatus = event.Status;
+        if (const auto requestStatus = event.RequestStatus; requestStatus != Ydb::StatusIds::SUCCESS) {
             const auto& issues = event.Issues;
-            LOG_E("Get script execution info " << ev->Sender << " failed " << status << ", issues: " << issues.ToOneLineString());
-            ReplyErrorAndDie(status, NKqp::AddRootIssue(TStringBuilder() << "Failed to get last script execution info for query '" << path << "'", issues));
+            LOG_E("Get script execution info " << ev->Sender << " failed " << requestStatus << ", issues: " << issues.ToOneLineString() << ", operation status: " << operationStatus << ", ready: " << ready);
+            ReplyErrorAndDie(requestStatus, NKqp::AddRootIssue(TStringBuilder() << "Failed to get last script execution info for query '" << path << "'", issues));
             return;
         }
 
         ResolvedQueriesCount = std::max(ResolvedQueriesCount, ev->Cookie + 1);
-        LOG_D("Get script execution info " << ev->Sender << " finished " << status << ", ready: " << ready << ", query path: " << path << ", remains #" << InflightScriptExecutionInfoResolve);
+        const bool entyExists = event.ExecutionEntryExists;
+        LOG_D("Get script execution info " << ev->Sender << " finished operation status " << operationStatus << ", ready: " << ready << ", entry exists: " << entyExists << ", query path: " << path << ", remains #" << InflightScriptExecutionInfoResolve);
 
-        if (ready || status != Ydb::StatusIds::NOT_FOUND) {
+        if (entyExists) {
             const auto it = QueriesBatch.find(path);
             if (it == QueriesBatch.end()) {
                 InternalError(TStringBuilder() << "Resolve script execution info for query '" << path << "' which is not in current batch");
@@ -771,7 +772,7 @@ public:
             info.Issues = NKqp::SerializeIssues(event.Issues);
             info.RetryCount = event.RetryCount;
 
-            if (!ready || status != Ydb::StatusIds::SUCCESS) {
+            if (!ready || operationStatus != Ydb::StatusIds::SUCCESS) {
                 info.LastFailAt = event.LastFailAt;
                 info.SuspendedUntil = event.SuspendedUntil;
             }
@@ -788,9 +789,9 @@ public:
             if (info.SuspendedUntil) {
                 info.Status = "SUSPENDED";
             } else if (ready) {
-                if (status == Ydb::StatusIds::SUCCESS) {
+                if (operationStatus == Ydb::StatusIds::SUCCESS) {
                     info.Status = "COMPLETED";
-                } else if (status == Ydb::StatusIds::CANCELLED) {
+                } else if (!info.Run) {
                     info.Status = "STOPPED";
                 } else {
                     info.Status = "FAILED";
@@ -908,9 +909,7 @@ private:
                 }
             }
 
-            auto event = std::make_unique<NKqp::TEvGetScriptExecutionOperation>(DatabaseName, NKqp::OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA);
-            event->CheckLeaseState = false;
-            Send(kqpProxyId, std::move(event), 0, i);
+            Send(kqpProxyId, std::make_unique<NKqp::TEvGetScriptExecutionOperation>(DatabaseName, NKqp::OperationIdFromExecutionId(executionId), BUILTIN_ACL_METADATA, /* failOnNotFound */ false), /* flags */ 0, i);
 
             LOG_D("Resolving script execution info for query '" << path << "', execution id: " << executionId);
             InflightScriptExecutionInfoResolve++;

--- a/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
+++ b/ydb/core/sys_view/streaming_queries/streaming_queries.cpp
@@ -758,10 +758,10 @@ public:
         }
 
         ResolvedQueriesCount = std::max(ResolvedQueriesCount, ev->Cookie + 1);
-        const bool entyExists = event.ExecutionEntryExists;
-        LOG_D("Get script execution info " << ev->Sender << " finished operation status " << operationStatus << ", ready: " << ready << ", entry exists: " << entyExists << ", query path: " << path << ", remains #" << InflightScriptExecutionInfoResolve);
+        const bool entryExists = event.ExecutionEntryExists;
+        LOG_D("Get script execution info " << ev->Sender << " finished operation status " << operationStatus << ", ready: " << ready << ", entry exists: " << entryExists << ", query path: " << path << ", remains #" << InflightScriptExecutionInfoResolve);
 
-        if (entyExists) {
+        if (entryExists) {
             const auto it = QueriesBatch.find(path);
             if (it == QueriesBatch.end()) {
                 InternalError(TStringBuilder() << "Resolve script execution info for query '" << path << "' which is not in current batch");

--- a/ydb/tests/fq/restarts/test_insert_restarts.py
+++ b/ydb/tests/fq/restarts/test_insert_restarts.py
@@ -85,7 +85,7 @@ class TestS3(object):
             current_number_rows = self.run_atomic_upload_check_query(
                 client, bucket, "ibucket", "insert/", "csv_with_names"
             )
-            logger.info(f"Fetched rows {current_number_rows} / {number_rows}")
+            logger.debug(f"Fetched rows {current_number_rows} / {number_rows}")
 
             if current_number_rows == number_rows:
                 break
@@ -93,7 +93,7 @@ class TestS3(object):
             assert current_number_rows == 0, "Unexpected incomplete result in bucket"
 
             number_uploads = len(list(bucket.multipart_uploads.all()))
-            logger.info(f"Fetched upload {number_uploads}")
+            logger.debug(f"Fetched upload {number_uploads}")
 
             if number_uploads > 0:
                 logger.info("Performing kikimr restart")

--- a/ydb/tests/fq/restarts/test_insert_restarts.py
+++ b/ydb/tests/fq/restarts/test_insert_restarts.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import boto3
-
+import logging
 import pytest
 import time
 
@@ -10,6 +10,8 @@ import ydb.public.api.protos.draft.fq_pb2 as fq
 
 from ydb.tests.library.common.helpers import plain_or_under_sanitizer
 from ydb.tests.tools.fq_runner.kikimr_utils import yq_all
+
+logger = logging.getLogger(__name__)
 
 
 class TestS3(object):
@@ -41,24 +43,28 @@ class TestS3(object):
     @pytest.mark.parametrize("client", [{"folder_id": "my_folder"}], indirect=True)
     def test_atomic_upload_commit(self, kikimr, s3, client):
         resource = boto3.resource(
-            "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key"
+            "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key", region_name="us-east-1"
         )
 
         # Creating select content
         bucket = resource.Bucket("insert_bucket")
         bucket.create(ACL='public-read-write')
         bucket.objects.all().delete()
+        logger.info("S3 bucket created")
 
         s3_client = boto3.client(
             "s3", endpoint_url=s3.s3_url, aws_access_key_id="key", aws_secret_access_key="secret_key"
         )
+        logger.info("S3 client created")
 
         number_rows = 10000000
         body = "idx\n" + "0\n" * number_rows
         s3_client.put_object(Body=body, Bucket="insert_bucket", Key="select/test.csv", ContentType="text/plain")
+        logger.info("Uploaded object into S3")
 
         # Creating insert query
         client.create_storage_connection("ibucket", "insert_bucket")
+        logger.info("Created connection")
 
         sql = R'''
             pragma s3.AtomicUploadCommit = "true";
@@ -69,6 +75,7 @@ class TestS3(object):
             ));
         '''
         query_id = client.create_query("simple", sql, type=fq.QueryContent.QueryType.ANALYTICS).result.query_id
+        logger.info("Created new query")
 
         # Checking insert query
         timeout = plain_or_under_sanitizer(250, 250 * 5)
@@ -78,26 +85,38 @@ class TestS3(object):
             current_number_rows = self.run_atomic_upload_check_query(
                 client, bucket, "ibucket", "insert/", "csv_with_names"
             )
+            logger.info(f"Fetched rows {current_number_rows} / {number_rows}")
+
             if current_number_rows == number_rows:
                 break
 
             assert current_number_rows == 0, "Unexpected incomplete result in bucket"
 
             number_uploads = len(list(bucket.multipart_uploads.all()))
+            logger.info(f"Fetched upload {number_uploads}")
+
             if number_uploads > 0:
-                kikimr.compute_plane.kikimr_cluster.restart_nodes()
+                logger.info("Performing kikimr restart")
+                for node in kikimr.compute_plane.kikimr_cluster.nodes.values():
+                    node.stop()
+                    node.set_log_file_prefix("logfile_restarted_")
+                    node.start()
                 break
 
             assert time.time() < deadline, f"Insert not finished for already {time.time() - start} seconds"
             time.sleep(0.001)
 
+        logger.info("Waiting kikimr up")
         kikimr.compute_plane.wait_bootstrap()
+
+        logger.info("Waiting query finish")
         client.wait_query(
             query_id,
             statuses=[fq.QueryMeta.COMPLETED, fq.QueryMeta.ABORTED_BY_SYSTEM, fq.QueryMeta.FAILED],
             timeout=timeout,
         )
 
+        logger.info("Checking query results")
         final_number_rows = self.run_atomic_upload_check_query(client, bucket, "ibucket", "insert/", "csv_with_names")
         query = client.describe_query(query_id).result.query
         final_status = query.meta.status

--- a/ydb/tests/fq/streaming/test_udfs.py
+++ b/ydb/tests/fq/streaming/test_udfs.py
@@ -1,25 +1,46 @@
+import logging
+import json
 import time
+import ydb
 
-from ydb.tests.fq.streaming_common.common import Kikimr, StreamingTestBase
+from typing import Optional
+from ydb.tests.fq.streaming_common.common import Kikimr, StreamingTestBase, YdbClient, set_test_env
+from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.tools.datastreams_helpers.control_plane import Endpoint
 
 import pytest
 import yatest.common
 
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope="module")
 def kikimr_udfs(request):
+    set_test_env(request)
     config = KikimrConfigGenerator(
-        extra_feature_flags={"enable_external_data_sources": True},
+        erasure=Erasure.MIRROR_3_DC,
+        extra_feature_flags=[
+            "enable_external_data_sources",
+            "enable_streaming_queries_counters",
+            "enable_topics_sql_io_operations",
+            "enable_streaming_queries",
+        ],
         query_service_config={"available_external_data_sources": ["Ydb", "YdbTopics"]},
+        pq_client_service_types=["yandex-query"],
         table_service_config={},
         default_clusteradmin="root@builtin",
-        use_in_memory_pdisks=True,
+        use_in_memory_pdisks=False,
         udfs_path=yatest.common.build_path("yql/essentials/udfs/common/python/python3_small")
     )
-    config.yaml_config["log_config"]["default_level"] = 8
+    config.yaml_config["log_config"] = {
+        "default_level": 4,
+        "entry": [
+            {"component": "KQP_PROXY", "level": 7}
+        ]
+    }
 
-    kikimr = Kikimr(config, timeout_seconds=30)
+    kikimr = Kikimr(config, timeout_seconds=30, enable_discovery=False)
     yield kikimr
     kikimr.stop()
 
@@ -59,3 +80,141 @@ def get_all_cgi_params(url):
         self.write_stream(['{"url": "http://kuibyshevsky.sam.sudrf.ru/modules.php?name=information"}'])
 
         assert future.result()[0].rows[0]["name"] == "information"
+
+    @pytest.mark.parametrize("local_topics", [True, False])
+    def test_precompute_recovery(self, kikimr_udfs, local_topics, entity_name):
+        inp, out, endpoint = self.get_io_names(kikimr_udfs, "test_precompute_recovery", local_topics, entity_name)
+        path = f"/Root/test_precompute_recovery_query"
+
+        test_table = "test_table"
+        kikimr_udfs.ydb_client.query(f"""
+            CREATE TABLE `{test_table}` (
+                Key Uint64,
+                Payload String,
+                PRIMARY KEY (Key)
+            );
+        """)
+        kikimr_udfs.ydb_client.query(f"""
+            UPSERT INTO `{test_table}` (Key, Payload) VALUES (1, "test-")
+        """)
+
+        def validate_query(text: str, previous_ids: int, status: str = "RUNNING", check_issues: bool = True, suffix: Optional[str] = None):
+            result_sets = kikimr_udfs.ydb_client.query(f"""
+                SELECT
+                    Path,
+                    Status,
+                    Issues,
+                    Text,
+                    Run,
+                    ResourcePool,
+                    RetryCount,
+                    LastFailAt,
+                    LastExecutionId,
+                    PreviousExecutionIds
+                FROM `.sys/streaming_queries`
+            """)
+            assert len(result_sets) == 1
+
+            result_set_rows = result_sets[0].rows
+            assert len(result_set_rows) == 1
+
+            row = result_set_rows[0]
+
+            if check_issues:
+                assert row.Issues == "{}"
+
+            assert row.Path == path
+            assert row.Status == status
+            assert row.Text.strip() in text.strip()
+            assert row.Run == True
+            assert row.ResourcePool == "default"
+            assert row.RetryCount == 0
+            assert row.LastFailAt is None
+            assert row.LastExecutionId is not None
+            assert len(json.loads(row.PreviousExecutionIds)) == min(previous_ids, 3)
+
+            if suffix is not None:
+                self.wait_completed_checkpoints(kikimr_udfs, path)
+                self.write_stream_with_message_metadata(kikimr_udfs, [("test_data", {"msg_id": "id-1"})], endpoint=endpoint)
+                assert self.read_stream(1, topic_path=self.output_topic, endpoint=endpoint)[0] == f"test_data{suffix}"
+
+        tests_count = 20
+        for i in range(20):
+            sql = f"""
+                CREATE OR REPLACE STREAMING QUERY `{path}` AS DO BEGIN
+                    -- Revision {i}
+                    INSERT INTO {out} SELECT Data || "{i}" FROM {inp}
+                END DO
+            """
+            kikimr_udfs.ydb_client.query(sql)
+
+            validate_query(sql, i, suffix=str(i))
+
+        self.wait_completed_checkpoints(kikimr_udfs, path)
+        kikimr_udfs.ydb_client.query(f"""
+            ALTER STREAMING QUERY `{path}` SET (RUN = FALSE)
+        """)
+        self.write_stream_with_message_metadata(kikimr_udfs, [("test_data", {"msg_id": "id-1"})], endpoint=endpoint)
+        logger.info("Stopped simple query")
+
+        # Start query with heavy precompute
+        precompute_sql = f"""
+CREATE OR REPLACE STREAMING QUERY `{path}` AS DO BEGIN
+$script = @@#py
+import time
+
+def hang():
+    time.sleep(20)
+    return "result"
+@@;
+
+$callable = Python3::hang(Callable<()->String>, $script);
+
+$precompute = SELECT Payload || $callable() FROM `{test_table}` LIMIT 1;
+
+INSERT INTO {out} SELECT * FROM {inp}
+WHERE Data LIKE Unwrap($precompute);
+END DO
+        """
+        future = kikimr_udfs.ydb_client.query_async(precompute_sql, timeout=10)
+        logger.info("Started hanging query")
+
+        time.sleep(5)
+        validate_query(precompute_sql, tests_count, status="STARTING")
+        logger.info("Hanging query validation finished, waiting for query to exit")
+
+        with pytest.raises(ydb.issues.Error) as exc_info:
+            future.result()
+        logger.info(f"Hanging query finished: {exc_info.value}")
+
+        kikimr_udfs.ydb_client.stop()
+        kikimr_udfs.first_node.kill()
+        kikimr_udfs.first_node.start()
+        logger.info("Node with query restarted")
+
+        time.sleep(5)
+        second_node = list(kikimr_udfs.cluster.nodes.values())[1]
+        kikimr_udfs.ydb_client = YdbClient(database=kikimr_udfs.endpoint.database, endpoint=f"grpc://{second_node.host}:{second_node.port}")
+        logger.info("Checking query state after restart")
+
+        validate_query(precompute_sql, tests_count, status="STARTING", check_issues=False)
+        logger.info("Hanging query validated after restart")
+
+        sql = f"""
+            CREATE OR REPLACE STREAMING QUERY `{path}` AS DO BEGIN
+                -- Revision FINAL
+                INSERT INTO {out} SELECT Data || "_final" FROM {inp}
+            END DO
+        """
+        kikimr_udfs.ydb_client.query(sql)
+
+        time.sleep(1)
+        validate_query(sql, tests_count)
+        logger.info("Checked final query info")
+
+        assert self.read_stream(1, topic_path=self.output_topic, endpoint=endpoint)[0] == f"test_data_final"
+        logger.info("Checked checkpoint recovery")
+
+        time.sleep(5)
+        validate_query(sql, tests_count, suffix="_final")
+        logger.info("Checked final status")

--- a/ydb/tests/fq/streaming/test_udfs.py
+++ b/ydb/tests/fq/streaming/test_udfs.py
@@ -194,6 +194,7 @@ END DO
         time.sleep(5)
         second_node = list(kikimr_udfs.cluster.nodes.values())[1]
         kikimr_udfs.ydb_client = YdbClient(database=kikimr_udfs.endpoint.database, endpoint=f"grpc://{second_node.host}:{second_node.port}")
+        kikimr_udfs.ydb_client.wait_connection()
         logger.info("Checking query state after restart")
 
         validate_query(precompute_sql, tests_count, status="STARTING", check_issues=False)

--- a/ydb/tests/fq/streaming/test_udfs.py
+++ b/ydb/tests/fq/streaming/test_udfs.py
@@ -7,7 +7,6 @@ from typing import Optional
 from ydb.tests.fq.streaming_common.common import Kikimr, StreamingTestBase, YdbClient, set_test_env
 from ydb.tests.library.common.types import Erasure
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
-from ydb.tests.tools.datastreams_helpers.control_plane import Endpoint
 
 import pytest
 import yatest.common
@@ -84,7 +83,7 @@ def get_all_cgi_params(url):
     @pytest.mark.parametrize("local_topics", [True, False])
     def test_precompute_recovery(self, kikimr_udfs, local_topics, entity_name):
         inp, out, endpoint = self.get_io_names(kikimr_udfs, "test_precompute_recovery", local_topics, entity_name)
-        path = f"/Root/test_precompute_recovery_query"
+        path = "/Root/test_precompute_recovery_query"
 
         test_table = "test_table"
         kikimr_udfs.ydb_client.query(f"""
@@ -99,7 +98,7 @@ def get_all_cgi_params(url):
         """)
 
         def validate_query(text: str, previous_ids: int, status: str = "RUNNING", check_issues: bool = True, suffix: Optional[str] = None):
-            result_sets = kikimr_udfs.ydb_client.query(f"""
+            result_sets = kikimr_udfs.ydb_client.query("""
                 SELECT
                     Path,
                     Status,
@@ -126,7 +125,7 @@ def get_all_cgi_params(url):
             assert row.Path == path
             assert row.Status == status
             assert row.Text.strip() in text.strip()
-            assert row.Run == True
+            assert row.Run
             assert row.ResourcePool == "default"
             assert row.RetryCount == 0
             assert row.LastFailAt is None
@@ -212,7 +211,7 @@ END DO
         validate_query(sql, tests_count)
         logger.info("Checked final query info")
 
-        assert self.read_stream(1, topic_path=self.output_topic, endpoint=endpoint)[0] == f"test_data_final"
+        assert self.read_stream(1, topic_path=self.output_topic, endpoint=endpoint)[0] == "test_data_final"
         logger.info("Checked checkpoint recovery")
 
         time.sleep(5)

--- a/ydb/tests/fq/streaming/test_udfs.py
+++ b/ydb/tests/fq/streaming/test_udfs.py
@@ -83,9 +83,9 @@ def get_all_cgi_params(url):
     @pytest.mark.parametrize("local_topics", [True, False])
     def test_precompute_recovery(self, kikimr_udfs, local_topics, entity_name):
         inp, out, endpoint = self.get_io_names(kikimr_udfs, "test_precompute_recovery", local_topics, entity_name)
-        path = "/Root/test_precompute_recovery_query"
+        path = f"/Root/{entity_name('test_precompute_recovery_query')}"
 
-        test_table = "test_table"
+        test_table = entity_name("test_table")
         kikimr_udfs.ydb_client.query(f"""
             CREATE TABLE `{test_table}` (
                 Key Uint64,
@@ -138,7 +138,7 @@ def get_all_cgi_params(url):
                 assert self.read_stream(1, topic_path=self.output_topic, endpoint=endpoint)[0] == f"test_data{suffix}"
 
         tests_count = 20
-        for i in range(20):
+        for i in range(tests_count):
             sql = f"""
                 CREATE OR REPLACE STREAMING QUERY `{path}` AS DO BEGIN
                     -- Revision {i}

--- a/ydb/tests/fq/streaming_common/common.py
+++ b/ydb/tests/fq/streaming_common/common.py
@@ -118,7 +118,11 @@ class Kikimr:
 
         self.first_node = list(self.cluster.nodes.values())[0]
         self.endpoint = Endpoint(f"{self.first_node.host}:{self.first_node.port}", f"/{config.domain_name}")
-        self.ydb_client = YdbClient(database=self.endpoint.database, endpoint=f"grpc://{self.endpoint.endpoint}", enable_discovery=enable_discovery)
+        self.ydb_client = YdbClient(
+            database=self.endpoint.database,
+            endpoint=f"grpc://{self.endpoint.endpoint}",
+            enable_discovery=enable_discovery,
+        )
         self.ydb_client.wait_connection()
 
     def stop(self):

--- a/ydb/tests/fq/streaming_common/common.py
+++ b/ydb/tests/fq/streaming_common/common.py
@@ -5,6 +5,7 @@ import yatest.common
 import ydb
 import pytest
 
+from typing import Optional
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
 from ydb.tests.tools.datastreams_helpers.control_plane import Endpoint
@@ -78,9 +79,14 @@ def get_ydb_config(request):
 
 
 class YdbClient:
-    def __init__(self, endpoint: str, database: str, token: str = "root@builtin"):
-        driver_config = ydb.DriverConfig(endpoint, database, auth_token=token)
-        self.driver = ydb.Driver(driver_config)
+    def __init__(self, endpoint: str, database: str, token: str = "root@builtin", enable_discovery: bool = True):
+        self.driver_config = ydb.DriverConfig(endpoint, database, auth_token=token, disable_discovery = not enable_discovery)
+        self.driver = None
+        self.session_pool = None
+        self.start()
+
+    def start(self):
+        self.driver = ydb.Driver(self.driver_config)
         self.session_pool = ydb.QuerySessionPool(self.driver)
 
     def stop(self):
@@ -93,21 +99,24 @@ class YdbClient:
     def query(self, statement: str):
         return self.session_pool.execute_with_retries(statement)
 
-    def query_async(self, statement: str):
-        return self.session_pool.execute_with_retries_async(statement)
+    def query_async(self, statement: str, timeout: Optional[float] = None):
+        settings = None
+        if timeout is not None:
+            settings = ydb.BaseRequestSettings().with_timeout(timeout)
+        return self.session_pool.execute_with_retries_async(statement, settings=settings)
 
 
 class Kikimr:
-    def __init__(self, config: KikimrConfigGenerator, timeout_seconds: int = 240):
+    def __init__(self, config: KikimrConfigGenerator, timeout_seconds: int = 240, enable_discovery: bool = True):
         ydb_path = yatest.common.build_path(os.environ.get("YDB_DRIVER_BINARY"))
         logger.info(yatest.common.execute([ydb_path, "-V"], wait=True).stdout.decode("utf-8"))
 
         self.cluster = KiKiMR(config)
         self.cluster.start(timeout_seconds=timeout_seconds)
 
-        first_node = list(self.cluster.nodes.values())[0]
-        self.endpoint = Endpoint(f"{first_node.host}:{first_node.port}", f"/{config.domain_name}")
-        self.ydb_client = YdbClient(database=self.endpoint.database, endpoint=f"grpc://{self.endpoint.endpoint}")
+        self.first_node = list(self.cluster.nodes.values())[0]
+        self.endpoint = Endpoint(f"{self.first_node.host}:{self.first_node.port}", f"/{config.domain_name}")
+        self.ydb_client = YdbClient(database=self.endpoint.database, endpoint=f"grpc://{self.endpoint.endpoint}", enable_discovery=enable_discovery)
         self.ydb_client.wait_connection()
 
     def stop(self):

--- a/ydb/tests/fq/streaming_common/common.py
+++ b/ydb/tests/fq/streaming_common/common.py
@@ -80,7 +80,9 @@ def get_ydb_config(request):
 
 class YdbClient:
     def __init__(self, endpoint: str, database: str, token: str = "root@builtin", enable_discovery: bool = True):
-        self.driver_config = ydb.DriverConfig(endpoint, database, auth_token=token, disable_discovery = not enable_discovery)
+        self.driver_config = ydb.DriverConfig(
+            endpoint, database, auth_token=token, disable_discovery=not enable_discovery
+        )
         self.driver = None
         self.session_pool = None
         self.start()

--- a/ydb/tests/tools/fq_runner/kikimr_runner.py
+++ b/ydb/tests/tools/fq_runner/kikimr_runner.py
@@ -89,7 +89,7 @@ class BaseTenant(abc.ABC):
             self.config_generator.yaml_config['auth_config'] = {}
         return self.config_generator.yaml_config['auth_config']
 
-    def enable_logging(self, component, level=LogLevels.TRACE):
+    def enable_logging(self, component, level=LogLevels.DEBUG):
         log_config = self.config_generator.yaml_config['log_config']
         if not isinstance(log_config['entry'], list):
             log_config['entry'] = []
@@ -99,7 +99,7 @@ class BaseTenant(abc.ABC):
         self.enable_logging("INTERCONNECT", LogLevels.WARN)  # IC is too verbose
         self.enable_logging("FQ_QUOTA_PROXY")
         self.enable_logging("FQ_QUOTA_SERVICE")
-        self.enable_logging("KQP_COMPUTE", LogLevels.TRACE)
+        self.enable_logging("KQP_COMPUTE", LogLevels.DEBUG)
         self.enable_logging("KQP_YQL")
         self.enable_logging("STREAMS")
         self.enable_logging("STREAMS_STORAGE_SERVICE")  # TODO: rename to YQ_STORAGE_SERVICE
@@ -125,6 +125,8 @@ class BaseTenant(abc.ABC):
         self.enable_logging("PUBLIC_HTTP")
         self.enable_logging("FQ_CONTROL_PLANE_CONFIG")
         self.enable_logging("FQ_ROW_DISPATCHER", LogLevels.TRACE)
+        self.enable_logging("KQP_EXECUTER")
+        self.enable_logging("KQP_PROXY")
         # self.enable_logging("GRPC_SERVER")
 
     @abc.abstractclassmethod

--- a/ydb/tests/tools/kqprun/tests/ya.make
+++ b/ydb/tests/tools/kqprun/tests/ya.make
@@ -10,6 +10,7 @@ TEST_SRCS(
 
 PEERDIR(
     ydb/tests/oss/ydb_sdk_import
+    ydb/public/sdk/python/enable_v3_new_behavior
 )
 
 DEPENDS(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed undefined streaming queries behaviour under load:

- Cancelation failures
- Retry failures

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Mainly fix for: https://st.yandex-team.ru/YQ-5303

Also fixed bugs:

- Streaming query recovery after compilation timeout / node restart during compilation
- Streaming query cancellation undefined behaviour when database may return PRECONDITION_FAILED, this may lead to:
   - Streaming query double start
   - Streaming query state hanging with forbitten DROP operation
- Long streaming query restart after node shutdown (around 5m)
- Streaming query successful creation without retry policy
- Streaming query sys view status FAILED when query was stopped during retries
- Streaming tasks shutdown
- Possible streaming query fail without next retries
- Script execution finalization races, when metadata may be updated after finaluzation
- Incomplete finalization of script execution with multiple transactions