### PR TITLE
Select longest prefix deterministically for indexing

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
@@ -50,60 +50,99 @@ bool IsLookupJoinApplicableDetailed(const std::shared_ptr<TRelOptimizerNode>& no
         return true;
     }
 
+    TString tablePath;
+    bool baseTableMatch = true;
     auto readMatch = MatchRead<TKqlReadTable>(expr);
     TMaybeNode<TKqlKeyInc> maybeTablePrefix;
     size_t prefixSize;
 
     if (readMatch) {
-        if (readMatch->FlatMap && !IsPassthroughFlatMap(readMatch->FlatMap.Cast(), nullptr)){
-            return false;
-        }
-        auto read = readMatch->Read.Cast<TKqlReadTable>();
-        maybeTablePrefix = GetRightTableKeyPrefix(read.Range());
+        if (readMatch->FlatMap && !IsPassthroughFlatMap(readMatch->FlatMap.Cast(), nullptr)) {
+            baseTableMatch = false;
+        } else {
+            auto read = readMatch->Read.Cast<TKqlReadTable>();
+            tablePath = read.Table().Path().StringValue();
 
-        if (!maybeTablePrefix) {
-            return false;
-        }
+            maybeTablePrefix = GetRightTableKeyPrefix(read.Range());
 
-         prefixSize = maybeTablePrefix.Cast().ArgCount();
+            if (!maybeTablePrefix) {
+                baseTableMatch = false;
+            } else {
+                prefixSize = maybeTablePrefix.Cast().ArgCount();
 
-        if (!prefixSize) {
-            return true;
+                if (!prefixSize) {
+                    baseTableMatch = true;
+                }
+            }
         }
     } else {
         readMatch = MatchRead<TKqlReadTableRangesBase>(expr);
         if (readMatch) {
-            if (readMatch->FlatMap && !IsPassthroughFlatMap(readMatch->FlatMap.Cast(), nullptr)){
-                return false;
-            }
-            auto read = readMatch->Read.Cast<TKqlReadTableRangesBase>();
-            if (TCoVoid::Match(read.Ranges().Raw())) {
-                return true;
+            if (readMatch->FlatMap && !IsPassthroughFlatMap(readMatch->FlatMap.Cast(), nullptr)) {
+                baseTableMatch = false;
             } else {
-                auto prompt = TKqpReadTableExplainPrompt::Parse(read);
+                auto read = readMatch->Read.Cast<TKqlReadTableRangesBase>();
+                tablePath = read.Table().Path().StringValue();
 
-                if (prompt.PointPrefixLen != prompt.UsedKeyColumns.size()) {
-                    return false;
-                }
+                if (TCoVoid::Match(read.Ranges().Raw())) {
+                    baseTableMatch = false;
+                } else {
+                    auto prompt = TKqpReadTableExplainPrompt::Parse(read);
 
-                if (prompt.ExpectedMaxRanges != TMaybe<ui64>(1)) {
-                    return false;
+                    if (prompt.PointPrefixLen != prompt.UsedKeyColumns.size()) {
+                        baseTableMatch = false;
+                    } else {
+                        if (prompt.ExpectedMaxRanges != TMaybe<ui64>(1)) {
+                            baseTableMatch = false;
+                        } else {
+                            prefixSize = prompt.PointPrefixLen;
+                        }
+                    }
                 }
-                prefixSize = prompt.PointPrefixLen;
             }
         }
     }
-    if (! readMatch) {
+    if (!readMatch) {
         return false;
     }
 
-    if (prefixSize < node->Stats.KeyColumns->Data.size() && (std::find_if(joinColumns.begin(), joinColumns.end(), [&] (const TJoinColumn& c) {
-            return node->Stats.KeyColumns->Data[prefixSize] == c.AttributeName;
-        }) == joinColumns.end())){
-            return false;
+    if(baseTableMatch) {
+        if (prefixSize < node->Stats.KeyColumns->Data.size() && (std::find_if(joinColumns.begin(), joinColumns.end(), [&] (const TJoinColumn& c) {
+                return node->Stats.KeyColumns->Data[prefixSize] == c.AttributeName;
+            }) == joinColumns.end())) {
+                baseTableMatch = false;
+            }
         }
 
-    return true;
+    if (baseTableMatch) {
+        return true;
+    }
+
+    // Check indexes
+    THashSet<TString> rightJoinKeys;
+    for (const auto& col : joinColumns) {
+        rightJoinKeys.insert(col.AttributeName);
+    }
+
+    const auto& tableData = ctx.KqpCtx.Tables->ExistingTable(ctx.KqpCtx.Cluster, tablePath);
+    const auto& meta = *tableData.Metadata;
+    for (const auto& index : meta.Indexes) {
+        if (index.Type == TIndexDescription::EType::GlobalAsync
+            || index.Type == TIndexDescription::EType::GlobalJson
+            || index.Type == TIndexDescription::EType::GlobalJsonCompact)
+        {
+            continue;
+        }
+
+        if (index.State != TIndexDescription::EIndexState::Ready) {
+            continue;
+        }
+
+        if(rightJoinKeys.contains(index.KeyColumns[0])) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool IsLookupJoinApplicable(std::shared_ptr<IBaseOptimizerNode> left,
@@ -128,11 +167,11 @@ bool IsLookupJoinApplicable(std::shared_ptr<IBaseOptimizerNode> left,
         return false;
     }
 
-    for (auto rightCol : rightJoinKeys) {
-        if (find(rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end(), rightCol.AttributeName) == rightStats.KeyColumns->Data.end()) {
-            return false;
-        }
-    }
+    // for (auto rightCol : rightJoinKeys) {
+    //     if (find(rightStats.KeyColumns->Data.begin(), rightStats.KeyColumns->Data.end(), rightCol.AttributeName) == rightStats.KeyColumns->Data.end()) {
+    //         return false;
+    //     }
+    // }
 
     return IsLookupJoinApplicableDetailed(std::static_pointer_cast<TRelOptimizerNode>(right), rightJoinKeys, ctx);
 }
@@ -183,13 +222,13 @@ bool TKqpProviderContext::IsJoinApplicable(const std::shared_ptr<IBaseOptimizerN
     EJoinKind joinKind) {
 
     switch( joinAlgo ) {
-        case EJoinAlgoType::LookupJoin:
+        case EJoinAlgoType::LookupJoin: {
             if ((OptLevel != 3) && (left->Stats.Nrows > 5000)) {
                 return false;
             }
             return IsLookupJoinApplicable(left, right, leftJoinKeys, rightJoinKeys, *this);
-
-        case EJoinAlgoType::LookupJoinReverse:
+        }
+        case EJoinAlgoType::LookupJoinReverse: {
             if (joinKind != EJoinKind::LeftSemi) {
                 return false;
             }
@@ -197,7 +236,7 @@ bool TKqpProviderContext::IsJoinApplicable(const std::shared_ptr<IBaseOptimizerN
                 return false;
             }
             return IsLookupJoinApplicable(right, left, rightJoinKeys, leftJoinKeys, *this);
-
+        }
         case EJoinAlgoType::MapJoin:
             return joinKind != EJoinKind::OuterJoin && joinKind != EJoinKind::Exclusion && right->Stats.ByteSize < 1e6;
         case EJoinAlgoType::GraceJoin:
@@ -228,18 +267,18 @@ double TKqpProviderContext::ComputeJoinCost(
     double estimatedOutputByteSize = outputRows * WeightedRowSize(outputRows, outputByteSize, CONSTS_OUTPUT_SIDE_BYTESIZE_FACTOR);
 
     switch(joinAlgo) {
-        case EJoinAlgoType::LookupJoin:
+        case EJoinAlgoType::LookupJoin: {
             if (OptLevel == 3) {
                 return -1;
             }
-            return leftStats.ByteSize + outputByteSize;
-
-        case EJoinAlgoType::LookupJoinReverse:
+            return leftSideByteSize;
+        }
+        case EJoinAlgoType::LookupJoinReverse: {
             if (OptLevel == 3) {
                 return -1;
             }
-            return rightStats.ByteSize + outputByteSize;
-
+            return rightSideByteSize;
+        }
         case EJoinAlgoType::MapJoin: {
             return 1.5 * (CONSTS_MAPJOIN_LEFT_SIDE_MULT * std::pow(leftSideByteSize, CONSTS_MAPJOIN_LEFT_SIDE_POW)
                 + CONSTS_MAPJOIN_RIGHT_SIDE_MULT * std::pow(rightSideByteSize, CONSTS_MAPJOIN_RIGHT_SIDE_POW)

--- a/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_cbo.cpp
@@ -184,7 +184,7 @@ bool TKqpProviderContext::IsJoinApplicable(const std::shared_ptr<IBaseOptimizerN
 
     switch( joinAlgo ) {
         case EJoinAlgoType::LookupJoin:
-            if ((OptLevel != 3) && (left->Stats.Nrows > 1000)) {
+            if ((OptLevel != 3) && (left->Stats.Nrows > 5000)) {
                 return false;
             }
             return IsLookupJoinApplicable(left, right, leftJoinKeys, rightJoinKeys, *this);
@@ -193,7 +193,7 @@ bool TKqpProviderContext::IsJoinApplicable(const std::shared_ptr<IBaseOptimizerN
             if (joinKind != EJoinKind::LeftSemi) {
                 return false;
             }
-            if ((OptLevel != 3) && (right->Stats.Nrows > 1000)) {
+            if ((OptLevel != 3) && (right->Stats.Nrows > 5000)) {
                 return false;
             }
             return IsLookupJoinApplicable(right, left, rightJoinKeys, leftJoinKeys, *this);

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
@@ -375,18 +375,14 @@ TExprBase RedirectReadToIndex(TExprBase read, const TString& indexName, TExprCon
     auto src = maybeRanges.Cast();
     const auto pos = src.Pos();
 
-    TExprNode::TListType children = src.Ptr()->ChildrenList();
-    TExprNode::TListType newChildren;
-    newChildren.reserve(children.size() + 1);
-    for (size_t i = 0; i < 5 && i < children.size(); ++i) {
-        newChildren.push_back(children[i]);
-    }
-    newChildren.push_back(Build<TCoAtom>(ctx, pos).Value(indexName).Done().Ptr());
-    for (size_t i = 5; i < children.size(); ++i) {
-        newChildren.push_back(children[i]);
-    }
-
-    return TExprBase(ctx.NewCallable(pos, TKqlReadTableIndexRanges::CallableName(), std::move(newChildren)));
+    return Build<TKqlReadTableIndexRanges>(ctx, pos)
+        .Table(src.Table())
+        .Ranges(src.Ranges())
+        .Columns(src.Columns())
+        .Settings(src.Settings())
+        .ExplainPrompt(src.ExplainPrompt())
+        .Index(Build<TCoAtom>(ctx, pos).Value(indexName).Done())
+        .Done();
 }
 
 TCoLambda MakeFilterForRange(TKqlKeyRange range, TExprContext& ctx, TPositionHandle pos, TVector<TString> keyColumns) {

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
@@ -324,6 +324,71 @@ TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(TKqlReadTableRangesBase read, TE
 
 } // anonymous namespace
 
+TMaybe<TString> ChooseIndexForLookupJoin(
+    const TKikimrTableDescription& mainTableDesc,
+    const THashSet<TString>& rightJoinKeys)
+{
+    const auto& meta = *mainTableDesc.Metadata;
+
+    if (!meta.KeyColumnNames.empty() && rightJoinKeys.contains(meta.KeyColumnNames[0])) {
+        return Nothing();
+    }
+
+    TMaybe<TString> best;
+    size_t bestPrefix = 0;
+    for (const auto& index : meta.Indexes) {
+        if (index.Type == TIndexDescription::EType::GlobalAsync
+            || index.Type == TIndexDescription::EType::GlobalJson
+            || index.Type == TIndexDescription::EType::GlobalJsonCompact)
+        {
+            continue;
+        }
+
+        if (index.State != TIndexDescription::EIndexState::Ready) {
+            continue;
+        }
+
+        size_t prefix = 0;
+        for (const auto& keyCol : index.KeyColumns) {
+            if (!rightJoinKeys.contains(keyCol)) {
+                break;
+            }
+            ++prefix;
+        }
+
+        // the first index in declaration order wins ties (deterministic).
+        if (prefix > bestPrefix) {
+            bestPrefix = prefix;
+            best = index.Name;
+        }
+    }
+
+    return best;
+}
+
+TExprBase RedirectReadToIndex(TExprBase read, const TString& indexName, TExprContext& ctx) {
+    auto maybeRanges = read.Maybe<TKqlReadTableRanges>();
+    if (!maybeRanges) {
+        return read;
+    }
+
+    auto src = maybeRanges.Cast();
+    const auto pos = src.Pos();
+
+    TExprNode::TListType children = src.Ptr()->ChildrenList();
+    TExprNode::TListType newChildren;
+    newChildren.reserve(children.size() + 1);
+    for (size_t i = 0; i < 5 && i < children.size(); ++i) {
+        newChildren.push_back(children[i]);
+    }
+    newChildren.push_back(Build<TCoAtom>(ctx, pos).Value(indexName).Done().Ptr());
+    for (size_t i = 5; i < children.size(); ++i) {
+        newChildren.push_back(children[i]);
+    }
+
+    return TExprBase(ctx.NewCallable(pos, TKqlReadTableIndexRanges::CallableName(), std::move(newChildren)));
+}
+
 TCoLambda MakeFilterForRange(TKqlKeyRange range, TExprContext& ctx, TPositionHandle pos, TVector<TString> keyColumns) {
     size_t prefix = 0;
     auto arg = Build<TCoArgument>(ctx, pos).Name("_row_arg").Done();

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_impl.h
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_impl.h
@@ -47,6 +47,10 @@ struct TPrefixLookup {
 // Try to rewrite arbitrary table read to (ExtractMembers (Filter (Lookup LookupColumns) ResultColumns)
 TMaybe<TPrefixLookup> RewriteReadToPrefixLookup(NYql::NNodes::TExprBase read, NYql::TExprContext& ctx, const TKqpOptimizeContext& kqpCtx, TMaybe<size_t> maxKeys);
 
+TMaybe<TString> ChooseIndexForLookupJoin(const NYql::TKikimrTableDescription& mainTableDesc, const THashSet<TString>& rightJoinKeys);
+
+NYql::NNodes::TExprBase RedirectReadToIndex(NYql::NNodes::TExprBase read, const TString& indexName, NYql::TExprContext& ctx);
+
 } // NKikimr::NKqp::NOpt
 
 

--- a/ydb/core/kqp/opt/logical/kqp_opt_log_join.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_join.cpp
@@ -499,7 +499,24 @@ TMaybeNode<TExprBase> KqpJoinToIndexLookupImpl(const TDqJoin& join, TExprContext
     size_t rightPrefixSize;
     TMaybeNode<TExprBase> rightPrefixExpr;
 
-    auto prefixLookup = RewriteReadToPrefixLookup(rightReadMatch->Read, ctx, kqpCtx, kqpCtx.Config->GetIdxLookupJoinPointsLimit());
+    auto rightRead = rightReadMatch->Read;
+    if (!kqpCtx.Config->IsAutoIndexSelectionDisabled()) {
+        if (auto maybeRanges = rightRead.Maybe<TKqlReadTableRanges>()) {
+            const auto& mainTableDesc = kqpCtx.Tables->ExistingTable(kqpCtx.Cluster, maybeRanges.Cast().Table().Path());
+            if (mainTableDesc.Metadata->Kind != NYql::EKikimrTableKind::Olap) {
+                THashSet<TString> rightJoinKeys;
+                for (ui32 i = 0; i < join.JoinKeys().Size(); ++i) {
+                    TString key = TString(join.JoinKeys().Item(i).RightColumn().Value());
+                    rightJoinKeys.insert(key);
+                }
+                if (auto idx = ChooseIndexForLookupJoin(mainTableDesc, rightJoinKeys)) {
+                    rightRead = RedirectReadToIndex(rightRead, *idx, ctx);
+                }
+            }
+        }
+    }
+
+    auto prefixLookup = RewriteReadToPrefixLookup(rightRead, ctx, kqpCtx, kqpCtx.Config->GetIdxLookupJoinPointsLimit());
     if (prefixLookup) {
         lookupTable = prefixLookup->LookupTableName;
         indexName = prefixLookup->IndexName;

--- a/ydb/core/kqp/ut/join/data/join_order/lookupbug.json
+++ b/ydb/core/kqp/ut/join/data/join_order/lookupbug.json
@@ -21,7 +21,7 @@
                 ]
             },
             {
-              "op_name":"TableFullScan",
+              "op_name":"TableLookup",
               "table":"browser_groups"
             }
           ]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Selecting available secondary index if primary keys are not in join keys, for LookupJoin.
Select the longest prefix deterministically.

### Changelog category <!-- remove all except one -->

* Improvement
* Performance improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
