### PR TITLE
Fix compatibility test harness regressions after PR #43216

### DIFF
--- a/ydb/tests/compatibility/test_kafka_topic.py
+++ b/ydb/tests/compatibility/test_kafka_topic.py
@@ -10,15 +10,22 @@ from ydb.tests.library.compatibility.fixtures import MixedClusterFixture, Rollin
 
 
 class Workload:
-    def __init__(self, driver, endpoint):
-        self.driver = driver
-        self.endpoint = endpoint
+    def __init__(self, fixture):
+        self.fixture = fixture
         self.id = f"{uuid.uuid1()}".replace("-", "_")
         self.topic_name = f"source_topic_{self.id}"
         self.message_count = 0
         self.processed_message_count = 0
         self.consumers = 1
         self.restart_interval = 10
+
+    @property
+    def driver(self):
+        return self.fixture.driver
+
+    @property
+    def endpoint(self):
+        return self.fixture.endpoint
 
     def get_command(self, subcmds: list[str]) -> list[str]:
         return (
@@ -120,7 +127,7 @@ class TestKafkaTopicMixedClusterFixture(MixedClusterFixture):
         yield from self.setup_cluster()
 
     def test_workload(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic()
 
@@ -137,7 +144,7 @@ class TestKafkaTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
         yield from self.setup_cluster()
 
     def test_workload(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic()
 
@@ -160,7 +167,7 @@ class TestKafkaTopicRestartToAnotherVersion(RestartToAnotherVersionFixture):
         yield from self.setup_cluster()
 
     def test_workload(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic()
         if self.current_binary_paths_index != 0:

--- a/ydb/tests/compatibility/test_simple_reader.py
+++ b/ydb/tests/compatibility/test_simple_reader.py
@@ -7,11 +7,18 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 
 
 class SimpleReaderWorkload:
-    def __init__(self, driver, endpoint):
-        self.driver = driver
-        self.endpoint = endpoint
+    def __init__(self, fixture):
+        self.fixture = fixture
         self.table_name = "/Root/simple_reader_table"
         self.batch_size = 1000
+
+    @property
+    def driver(self):
+        return self.fixture.driver
+
+    @property
+    def endpoint(self):
+        return self.fixture.endpoint
 
     def create_table(self):
         query = f"""
@@ -160,7 +167,7 @@ class TestSimpleReaderMixedCluster(MixedClusterFixture):
         )
 
     def test_simple_reader_mixed_cluster(self):
-        workload = SimpleReaderWorkload(self.driver, self.endpoint)
+        workload = SimpleReaderWorkload(self)
         workload.create_table()
         total_written = workload.write_data_with_overlaps()
         assert total_written > 0
@@ -186,7 +193,7 @@ class TestSimpleReaderRestartToAnotherVersion(RestartToAnotherVersionFixture):
         if min(self.versions) < (25, 1):
             pytest.skip("Test is not supported for this cluster version")
 
-        workload = SimpleReaderWorkload(self.driver, self.endpoint)
+        workload = SimpleReaderWorkload(self)
         workload.create_table()
         workload.write_data_with_overlaps()
         initial_consistency = workload.verify_data_consistency(1)
@@ -220,7 +227,7 @@ class TestSimpleReaderTabletTransfer(RollingUpgradeAndDowngradeFixture):
         if min(self.versions) < (25, 1):
             pytest.skip("Test is not supported for this cluster version")
 
-        workload = SimpleReaderWorkload(self.driver, self.endpoint)
+        workload = SimpleReaderWorkload(self)
         workload.create_table()
         total_written = 0
         for _ in range(8):

--- a/ydb/tests/compatibility/test_stress.py
+++ b/ydb/tests/compatibility/test_stress.py
@@ -13,6 +13,7 @@ class TestStress(MixedClusterFixture):
     @pytest.fixture(autouse=True)
     def setup(self):
         yield from self.setup_cluster(
+            disable_graceful_shutdown=False,
             # uncomment for 64 datetime in tpc-h/tpc-ds
             # extra_feature_flags=["enable_table_datetime64"],
             column_shard_config={

--- a/ydb/tests/compatibility/test_topic.py
+++ b/ydb/tests/compatibility/test_topic.py
@@ -3,7 +3,12 @@ import pytest
 import time
 import uuid
 
-from ydb.tests.library.compatibility.fixtures import RollingUpgradeAndDowngradeFixture, RollingDowngradeAndUpgradeFixture, string_version_to_tuple
+from ydb.tests.library.compatibility.fixtures import (
+    RollingUpgradeAndDowngradeFixture,
+    RollingUpgradeLongLivedClientsFixture,
+    RollingDowngradeAndUpgradeFixture,
+    string_version_to_tuple,
+)
 from ydb.tests.oss.ydb_sdk_import import ydb
 
 
@@ -111,27 +116,10 @@ class Workload:
                 break
 
 
-_LONG_LIVED_CLIENT_TESTS = frozenset({
-    'test_write_and_read_with_long_live_consumer',
-    'test_write_and_read_with_long_live_producer',
-})
-
-
 class TestTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
     @pytest.fixture(autouse=True, scope="function")
-    def setup(self, request):
-        if request.node.name in _LONG_LIVED_CLIENT_TESTS:
-            # Keep driver/topic clients alive; graceful shutdown avoids long node stop delays.
-            yield from self.setup_cluster(disable_graceful_shutdown=False)
-        else:
-            yield from self.setup_cluster()
-
-    @pytest.fixture(autouse=True)
-    def long_lived_clients_mode(self, request):
-        if request.node.name in _LONG_LIVED_CLIENT_TESTS:
-            self.recreate_driver = False
-        yield
-        self.recreate_driver = True
+    def setup(self):
+        yield from self.setup_cluster()
 
     def test_write_and_read(self):
         utils = Workload(self)
@@ -144,6 +132,13 @@ class TestTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
             utils.write_to_topic()
 
         utils.read_from_topic()
+
+
+class TestTopicRollingUpdateLongLivedClients(RollingUpgradeLongLivedClientsFixture):
+    @pytest.fixture(autouse=True, scope="function")
+    def setup(self):
+        # Graceful shutdown avoids long node stop delays when topic clients stay connected.
+        yield from self.setup_cluster(disable_graceful_shutdown=False)
 
     def test_write_and_read_with_long_live_consumer(self):
         utils = Workload(self)

--- a/ydb/tests/compatibility/test_topic.py
+++ b/ydb/tests/compatibility/test_topic.py
@@ -8,13 +8,20 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 
 
 class Workload:
-    def __init__(self, driver, endpoint):
-        self.driver = driver
-        self.endpoint = endpoint
+    def __init__(self, fixture):
+        self.fixture = fixture
         self.id = f"{uuid.uuid1()}".replace("-", "_")
         self.topic_name = f"source_topic_{self.id}"
         self.message_count = 0
         self.processed_message_count = 0
+
+    @property
+    def driver(self):
+        return self.fixture.driver
+
+    @property
+    def endpoint(self):
+        return self.fixture.endpoint
 
     def create_topic(self, *, availability_period=None, partition_count=1):
         consumer_extra_options = []
@@ -113,7 +120,7 @@ class TestTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
         yield from self.setup_cluster()
 
     def test_write_and_read(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic()
 
@@ -125,30 +132,31 @@ class TestTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
         utils.read_from_topic()
 
     def test_write_and_read_with_long_live_consumer(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic()
+        utils.write_to_topic()
 
-        with self.driver.topic_client.reader(utils.topic_name, consumer='test-consumer') as reader:
-            utils.write_to_topic()
-            for _ in self.roll():
+        for _ in self.roll():
+            with self.driver.topic_client.reader(utils.topic_name, consumer='test-consumer') as reader:
                 utils.read_from_topic(topic_reader=reader)
                 utils.write_to_topic()
 
+        with self.driver.topic_client.reader(utils.topic_name, consumer='test-consumer') as reader:
             utils.read_from_topic(topic_reader=reader)
 
     def test_write_and_read_with_long_live_producer(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic()
+        utils.write_to_topic()
 
-        with self.driver.topic_client.writer(utils.topic_name, producer_id="producer-id") as writer:
-            utils.write_to_topic(topic_writer=writer)
-            for _ in self.roll():
+        for _ in self.roll():
+            with self.driver.topic_client.writer(utils.topic_name, producer_id="producer-id") as writer:
                 utils.read_from_topic()
                 utils.write_to_topic(topic_writer=writer)
 
-            utils.read_from_topic()
+        utils.read_from_topic()
 
 
 class TestTopicRollingDowngrade(RollingDowngradeAndUpgradeFixture):
@@ -161,7 +169,7 @@ class TestTopicRollingDowngrade(RollingDowngradeAndUpgradeFixture):
         if self.versions[0] < string_version_to_tuple(MIN_SUPPORTED_VERSION):
             pytest.skip(f"Only available since {MIN_SUPPORTED_VERSION}")
 
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic(availability_period='PT2H')
 
@@ -179,7 +187,7 @@ class TestTopicTransaction(RollingUpgradeAndDowngradeFixture):
         yield from self.setup_cluster()
 
     def test_write_and_read_in_transaction(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic(partition_count=2)
 
@@ -199,7 +207,7 @@ class TestTopicTransaction(RollingUpgradeAndDowngradeFixture):
             )
 
     def test_mixed_write_transaction_and_regular(self):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         utils.create_topic(partition_count=2)
 

--- a/ydb/tests/compatibility/test_topic.py
+++ b/ydb/tests/compatibility/test_topic.py
@@ -111,13 +111,27 @@ class Workload:
                 break
 
 
+_LONG_LIVED_CLIENT_TESTS = frozenset({
+    'test_write_and_read_with_long_live_consumer',
+    'test_write_and_read_with_long_live_producer',
+})
+
+
 class TestTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
     @pytest.fixture(autouse=True, scope="function")
-    def setup(self):
-        #
-        # Setup cluster
-        #
-        yield from self.setup_cluster()
+    def setup(self, request):
+        if request.node.name in _LONG_LIVED_CLIENT_TESTS:
+            # Keep driver/topic clients alive; graceful shutdown avoids long node stop delays.
+            yield from self.setup_cluster(disable_graceful_shutdown=False)
+        else:
+            yield from self.setup_cluster()
+
+    @pytest.fixture(autouse=True)
+    def long_lived_clients_mode(self, request):
+        if request.node.name in _LONG_LIVED_CLIENT_TESTS:
+            self.recreate_driver = False
+        yield
+        self.recreate_driver = True
 
     def test_write_and_read(self):
         utils = Workload(self)
@@ -135,28 +149,27 @@ class TestTopicRollingUpdate(RollingUpgradeAndDowngradeFixture):
         utils = Workload(self)
 
         utils.create_topic()
-        utils.write_to_topic()
 
-        for _ in self.roll():
-            with self.driver.topic_client.reader(utils.topic_name, consumer='test-consumer') as reader:
+        with self.driver.topic_client.reader(utils.topic_name, consumer='test-consumer') as reader:
+            utils.write_to_topic()
+            for _ in self.roll():
                 utils.read_from_topic(topic_reader=reader)
                 utils.write_to_topic()
 
-        with self.driver.topic_client.reader(utils.topic_name, consumer='test-consumer') as reader:
             utils.read_from_topic(topic_reader=reader)
 
     def test_write_and_read_with_long_live_producer(self):
         utils = Workload(self)
 
         utils.create_topic()
-        utils.write_to_topic()
 
-        for _ in self.roll():
-            with self.driver.topic_client.writer(utils.topic_name, producer_id="producer-id") as writer:
+        with self.driver.topic_client.writer(utils.topic_name, producer_id="producer-id") as writer:
+            utils.write_to_topic(topic_writer=writer)
+            for _ in self.roll():
                 utils.read_from_topic()
                 utils.write_to_topic(topic_writer=writer)
 
-        utils.read_from_topic()
+            utils.read_from_topic()
 
 
 class TestTopicRollingDowngrade(RollingDowngradeAndUpgradeFixture):

--- a/ydb/tests/compatibility/test_transfer.py
+++ b/ydb/tests/compatibility/test_transfer.py
@@ -11,14 +11,21 @@ logger = logging.getLogger(__name__)
 
 
 class Workload:
-    def __init__(self, driver, endpoint):
-        self.driver = driver
-        self.endpoint = endpoint
+    def __init__(self, fixture):
+        self.fixture = fixture
         self.id = f"{uuid.uuid1()}".replace("-", "_")
         self.table_name = f"target_table_{self.id}"
         self.topic_name = f"source_topic_{self.id}"
         self.transfer_name = f"transfer_{self.id}"
         self.message_count = 0
+
+    @property
+    def driver(self):
+        return self.fixture.driver
+
+    @property
+    def endpoint(self):
+        return self.fixture.endpoint
 
     def create_table(self, mode):
         with ydb.QuerySessionPool(self.driver) as session_pool:
@@ -130,7 +137,7 @@ class TestTransferRollingUpdate(RollingUpgradeAndDowngradeFixture):
         ("row", True),
     ])
     def test_transfer(self, store, local):
-        utils = Workload(self.driver, self.endpoint)
+        utils = Workload(self)
 
         #
         # 1. Fill table with data

--- a/ydb/tests/compatibility/test_workload_manager.py
+++ b/ydb/tests/compatibility/test_workload_manager.py
@@ -13,11 +13,18 @@ logger = logging.getLogger(__name__)
 
 
 class WorkloadManagerWorkload:
-    def __init__(self, driver, endpoint):
-        self.driver = driver
-        self.endpoint = endpoint
+    def __init__(self, fixture):
+        self.fixture = fixture
         self.table_name = "/Root/simple_reader_table"
         self.batch_size = 1000
+
+    @property
+    def driver(self):
+        return self.fixture.driver
+
+    @property
+    def endpoint(self):
+        return self.fixture.endpoint
 
     def create_resource_pool(self):
         self.execute_query("""
@@ -124,7 +131,7 @@ class TestWorkloadManagerMixedCluster(MixedClusterFixture):
         if min(self.versions) < (25, 1, 4):
             pytest.skip("Test is not supported for this cluster version")
 
-        workload = WorkloadManagerWorkload(self.driver, self.endpoint)
+        workload = WorkloadManagerWorkload(self)
         workload.create_resource_pool()
         workload.validate_resource_pool()
         workload.alter_resource_pool()
@@ -145,7 +152,7 @@ class TestWorkloadManagerRestartToAnotherVersion(RestartToAnotherVersionFixture)
         if min(self.versions) < (25, 1, 4):
             pytest.skip("Test is not supported for this cluster version")
 
-        workload = WorkloadManagerWorkload(self.driver, self.endpoint)
+        workload = WorkloadManagerWorkload(self)
         workload.create_resource_pool()
         workload.validate_resource_pool()
         workload.create_resource_pool_classifier()
@@ -180,7 +187,7 @@ class TestWorkloadManagerTabletTransfer(RollingUpgradeAndDowngradeFixture):
         if min(self.versions) < (25, 1, 4):
             pytest.skip("Test is not supported for this cluster version")
 
-        workload = WorkloadManagerWorkload(self.driver, self.endpoint)
+        workload = WorkloadManagerWorkload(self)
         workload.create_resource_pool()
         workload.validate_resource_pool()
         workload.create_resource_pool_classifier()

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -107,7 +107,8 @@ all_binary_combinations_ids_restart = [
 
 class ClusterOperationsWaitMixin:
     def _wait_for_cluster_operations(self):
-        query = """
+        drop_query = """DROP TABLE IF EXISTS `test_readiness`"""
+        create_query = """
             CREATE TABLE `test_readiness` (
             id Int64 NOT NULL,
             PRIMARY KEY (id)
@@ -120,16 +121,19 @@ class ClusterOperationsWaitMixin:
         while time.time() - start_time < timeout:
             try:
                 with ydb.QuerySessionPool(self.driver) as session_pool:
-                    session_pool.execute_with_retries(query, retry_settings=ydb.RetrySettings(max_retries=1))
+                    session_pool.execute_with_retries(drop_query, retry_settings=ydb.RetrySettings(max_retries=1))
+                    session_pool.execute_with_retries(create_query, retry_settings=ydb.RetrySettings(max_retries=1))
                 break
             except Exception as e:
                 last_exception = e
                 time.sleep(interval)
         else:
             raise last_exception
-        query = """DROP TABLE `test_readiness`"""
-        with ydb.QuerySessionPool(self.driver) as session_pool:
-            session_pool.execute_with_retries(query)
+        try:
+            with ydb.QuerySessionPool(self.driver) as session_pool:
+                session_pool.execute_with_retries(drop_query)
+        except Exception:
+            pass
 
 
 class RestartToAnotherVersionFixture(ClusterOperationsWaitMixin):

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -206,7 +206,11 @@ class RestartToAnotherVersionFixture(ClusterOperationsWaitMixin):
         self.stop_driver()
         self.cluster.update_configurator_and_restart(self.config)
         self.driver = self.create_driver()
-        self._wait_for_cluster_operations()
+
+        # TODO: remove sleep
+        # without sleep there are errors like
+        # ydb.issues.Unavailable: message: "Failed to resolve tablet: 72075186224037909 after several retries." severity: 1 (server_code: 400050)
+        time.sleep(60)
 
 
 all_binary_combinations_mixed = [

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -396,6 +396,11 @@ class RollingUpgradeAndDowngradeFixture(ClusterOperationsWaitMixin):
             yield
 
 
+class RollingUpgradeLongLivedClientsFixture(RollingUpgradeAndDowngradeFixture):
+    # Keep driver and topic clients alive across node restarts to test long-lived consumers/producers.
+    recreate_driver = False
+
+
 # Starts with a new cluster and downgrades it. Useful for testing new features that may be absent from the previous release.
 class RollingDowngradeAndUpgradeFixture(RollingUpgradeAndDowngradeFixture):
     @pytest.fixture(autouse=True, params=all_binary_combinations_rolling, ids=all_binary_combinations_ids_rolling)

--- a/ydb/tests/library/compatibility/fixtures.py
+++ b/ydb/tests/library/compatibility/fixtures.py
@@ -37,10 +37,11 @@ def string_version_to_tuple(s):
     return tuple(result)
 
 
-def prepare_feature_flags(extra_feature_flags, disabled_feature_flags):
+def prepare_feature_flags(extra_feature_flags, disabled_feature_flags, disable_graceful_shutdown=True):
     disabled_feature_flags = copy.copy(disabled_feature_flags)
     assert isinstance(disabled_feature_flags, list), "Feature flags must be list"
-    disabled_feature_flags.append("enable_graceful_shutdown")
+    if disable_graceful_shutdown:
+        disabled_feature_flags.append("enable_graceful_shutdown")
 
     extra_feature_flags = copy.copy(extra_feature_flags)
     assert isinstance(extra_feature_flags, list), "Feature flags must be list"
@@ -104,7 +105,34 @@ all_binary_combinations_ids_restart = [
 ]
 
 
-class RestartToAnotherVersionFixture:
+class ClusterOperationsWaitMixin:
+    def _wait_for_cluster_operations(self):
+        query = """
+            CREATE TABLE `test_readiness` (
+            id Int64 NOT NULL,
+            PRIMARY KEY (id)
+        ) """
+        timeout = 120  # seconds
+        interval = 2  # seconds
+
+        start_time = time.time()
+        last_exception = None
+        while time.time() - start_time < timeout:
+            try:
+                with ydb.QuerySessionPool(self.driver) as session_pool:
+                    session_pool.execute_with_retries(query, retry_settings=ydb.RetrySettings(max_retries=1))
+                break
+            except Exception as e:
+                last_exception = e
+                time.sleep(interval)
+        else:
+            raise last_exception
+        query = """DROP TABLE `test_readiness`"""
+        with ydb.QuerySessionPool(self.driver) as session_pool:
+            session_pool.execute_with_retries(query)
+
+
+class RestartToAnotherVersionFixture(ClusterOperationsWaitMixin):
     @pytest.fixture(autouse=True, params=all_binary_combinations_restart, ids=all_binary_combinations_ids_restart)
     def base_setup(self, request):
         self.current_binary_paths_index = 0
@@ -127,7 +155,12 @@ class RestartToAnotherVersionFixture:
         return driver
 
     def setup_cluster(self, tenant_db=None, **kwargs):
-        extra_feature_flags, disabled_feature_flags = prepare_feature_flags(kwargs.pop("extra_feature_flags", []), kwargs.pop("disabled_feature_flags", []))
+        disable_graceful_shutdown = kwargs.pop("disable_graceful_shutdown", True)
+        extra_feature_flags, disabled_feature_flags = prepare_feature_flags(
+            kwargs.pop("extra_feature_flags", []),
+            kwargs.pop("disabled_feature_flags", []),
+            disable_graceful_shutdown=disable_graceful_shutdown,
+        )
         self.config = KikimrConfigGenerator(
             erasure=kwargs.pop("erasure", Erasure.MIRROR_3_DC),
             binary_paths=[self.all_binary_paths[self.current_binary_paths_index]],
@@ -159,14 +192,17 @@ class RestartToAnotherVersionFixture:
         new_binary_paths = self.all_binary_paths[self.current_binary_paths_index]
         self.config.set_binary_paths([new_binary_paths])
 
+        if self.driver is not None:
+            try:
+                with ydb.QuerySessionPool(self.driver) as session_pool:
+                    session_pool.execute_with_retries("SELECT 1")
+            except Exception:
+                pass
+
         self.stop_driver()
         self.cluster.update_configurator_and_restart(self.config)
         self.driver = self.create_driver()
-
-        # TODO: remove sleep
-        # without sleep there are errors like
-        # ydb.issues.Unavailable: message: "Failed to resolve tablet: 72075186224037909 after several retries." severity: 1 (server_code: 400050)
-        time.sleep(60)
+        self._wait_for_cluster_operations()
 
 
 all_binary_combinations_mixed = [
@@ -205,7 +241,12 @@ class MixedClusterFixture:
         return driver
 
     def setup_cluster(self, tenant_db=None, **kwargs):
-        extra_feature_flags, disabled_feature_flags = prepare_feature_flags(kwargs.pop("extra_feature_flags", []), kwargs.pop("disabled_feature_flags", []))
+        disable_graceful_shutdown = kwargs.pop("disable_graceful_shutdown", True)
+        extra_feature_flags, disabled_feature_flags = prepare_feature_flags(
+            kwargs.pop("extra_feature_flags", []),
+            kwargs.pop("disabled_feature_flags", []),
+            disable_graceful_shutdown=disable_graceful_shutdown,
+        )
         all_versions_numbered = all(
             # +inf == current will be float, all other versions are int
             isinstance(item, int)
@@ -249,7 +290,7 @@ all_binary_combinations_ids_rolling = [
 ]
 
 
-class RollingUpgradeAndDowngradeFixture:
+class RollingUpgradeAndDowngradeFixture(ClusterOperationsWaitMixin):
     recreate_driver = True  # TODO: temporary workaround. We don't want to recreate driver, but not working now
 
     @pytest.fixture(autouse=True, params=all_binary_combinations_rolling, ids=all_binary_combinations_ids_rolling)
@@ -275,33 +316,15 @@ class RollingUpgradeAndDowngradeFixture:
     def _wait_for_readiness(self):
         if self.recreate_driver:
             self.driver = self.create_driver()
-
-        query = """
-            CREATE TABLE `test_readiness` (
-            id Int64 NOT NULL,
-            PRIMARY KEY (id)
-        ) """
-        timeout = 120  # seconds
-        interval = 2  # seconds
-
-        start_time = time.time()
-        last_exception = None
-        while time.time() - start_time < timeout:
-            try:
-                with ydb.QuerySessionPool(self.driver) as session_pool:
-                    session_pool.execute_with_retries(query, retry_settings=ydb.RetrySettings(max_retries=1))
-                break
-            except Exception as e:
-                last_exception = e
-                time.sleep(interval)
-        else:
-            raise last_exception
-        query = """DROP TABLE `test_readiness`"""
-        with ydb.QuerySessionPool(self.driver) as session_pool:
-            session_pool.execute_with_retries(query)
+        self._wait_for_cluster_operations()
 
     def setup_cluster(self, tenant_db=None, **kwargs):
-        extra_feature_flags, disabled_feature_flags = prepare_feature_flags(kwargs.pop("extra_feature_flags", []), kwargs.pop("disabled_feature_flags", []))
+        disable_graceful_shutdown = kwargs.pop("disable_graceful_shutdown", True)
+        extra_feature_flags, disabled_feature_flags = prepare_feature_flags(
+            kwargs.pop("extra_feature_flags", []),
+            kwargs.pop("disabled_feature_flags", []),
+            disable_graceful_shutdown=disable_graceful_shutdown,
+        )
         self.config = KikimrConfigGenerator(
             erasure=kwargs.pop("erasure", Erasure.MIRROR_3_DC),
             binary_paths=[self.all_binary_paths[0]],


### PR DESCRIPTION
## RUN

- Pre-commit: https://github.com/ydb-platform/ydb/actions/runs/28201347366
- Regression-run_compatibility: https://github.com/ydb-platform/ydb/actions/runs/28201422774

## Что чинит этот PR

PR #43216 изменил harness compatibility-тестов: Python driver теперь явно останавливается во время restart/rolling переходов, а `enable_graceful_shutdown` по умолчанию отключается для compatibility-тестов. Это вскрыло проблемы в тестовом коде/harness.

Этот PR чинит регрессии в harness/test-code, не ослабляя compatibility assertions.

### #44052: stale driver/topic clients

Часть тестов кэшировала `self.driver` внутри workload helper-ов. После #43216 `change_cluster_version()` / `roll()` могут остановить и пересоздать driver фикстуры, а workload продолжал использовать старый уже остановленный driver или закрытый topic client.

Отдельно важно: `test_write_and_read_with_long_live_consumer` и `test_write_and_read_with_long_live_producer` по названию и смыслу должны держать один reader/writer через весь rolling upgrade. Если пересоздавать reader/writer на каждом шаге `roll()`, тест перестаёт быть long-lived и фактически превращается в обычный rolling read/write test. Поэтому PR не просто «зеленит» эти тесты, а восстанавливает соответствие поведения их заявленному смыслу.

Что сделано:
- Workload helper-ы в `test_simple_reader`, `test_topic`, `test_transfer`, `test_workload_manager` и `test_kafka_topic` теперь хранят fixture и динамически читают `fixture.driver`.
- Long-lived topic consumer/producer тесты вынесены в `TestTopicRollingUpdateLongLivedClients` с `RollingUpgradeLongLivedClientsFixture`, поэтому один reader/writer по-прежнему живёт через весь `roll()`.
- Обычные rolling topic тесты остаются в быстром режиме с пересозданием driver.

### #44515: OOM на stress teardown и restart race

`test_stress.test_log` падал не на проверках workload, а в teardown: ydbd завершался с `exit_code = -9` после тяжёлой mixed-version нагрузки. Глобальное отключение graceful shutdown из #43216 сделало shutdown слишком агрессивным для этих stress-сценариев. Schema compatibility сценарий из issue также полагается на старый post-restart settle в restart fixture.

Что сделано:
- `test_stress` отключает новое поведение через `disable_graceful_shutdown=False`, то есть graceful shutdown остаётся включённым.
- `RestartToAnotherVersionFixture.change_cluster_version()` делает лёгкий `SELECT 1` перед остановкой driver и сохраняет исходный 60-секундный settle после restart.

## Не входит в scope

Падения `test_fulltext_index` в последнем compatibility прогоне не вызваны этим PR. Они падают ещё в setup, до начала rolling, потому что #44291 добавил `enable_fulltext_index_prefix`, который старые stable-бинарники не знают:

```text
unknown field "enable_fulltext_index_prefix" for "NKikimrConfig.TFeatureFlags"
```

Это надо чинить отдельно в `test_fulltext_index.py`: gated/skip prefixed fulltext coverage для старых бинарников.

## Изменения

- `ydb/tests/library/compatibility/fixtures.py`
  - Добавлен общий readiness helper для rolling readiness checks.
  - Добавлена опция `disable_graceful_shutdown` в `setup_cluster()`.
  - Добавлена `RollingUpgradeLongLivedClientsFixture` с `recreate_driver = False`.
  - Restart fixture сохраняет исходный 60-секундный post-restart settle.
- `test_simple_reader`, `test_topic`, `test_transfer`, `test_workload_manager`, `test_kafka_topic`
  - Используют динамический `fixture.driver` вместо кэширования driver.
- `test_topic`
  - Long-lived topic client тесты вынесены в отдельный класс fixture, где один reader/writer живёт через rolling upgrade.
  - Это сохраняет исходный смысл тестов `long_live_consumer` / `long_live_producer`, а не заменяет их на per-step reconnect сценарий.
- `test_stress`
  - Graceful shutdown остаётся включённым для тяжёлых mixed stress-кластеров.

## Связанные issue

- #44052
- #44515

## Проверка

- [x] Pre-commit relwithdebinfo/ASAN прошёл.
- [x] Regression-run_compatibility был запущен.
- [x] Целевые тесты из #44052 и #44515 прошли в compatibility run.
- [ ] Перезапустить Regression-run_compatibility после возврата restart settle wait.
