### PR TITLE
DataShard: fix read iterator with ext blobs test

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
@@ -240,9 +240,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
         UNIT_ASSERT_GE(iteratorCounter->Continues, 2);
-        UNIT_ASSERT_LE(iteratorCounter->Continues, 10); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 10); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
         UNIT_ASSERT_GE(iteratorCounter->EvGets, 2);
-        UNIT_ASSERT_LE(iteratorCounter->EvGets, 10);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 10); // can be up to total requested blobs
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 10);
     }
 
@@ -323,9 +323,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
         UNIT_ASSERT_GE(iteratorCounter->Continues, 2);
-        UNIT_ASSERT_LE(iteratorCounter->Continues, 10); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 10); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
         UNIT_ASSERT_GE(iteratorCounter->EvGets, 2);
-        UNIT_ASSERT_LE(iteratorCounter->EvGets, 10);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 10); // can be up to total requested blobs
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 10);
     }
 
@@ -374,9 +374,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
         UNIT_ASSERT_GE(iteratorCounter->Continues, 0);
-        UNIT_ASSERT_LE(iteratorCounter->Continues, 3); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 3); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
         UNIT_ASSERT_GE(iteratorCounter->EvGets, 1);
-        UNIT_ASSERT_LE(iteratorCounter->EvGets, 3);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 3); // can be up to total requested blobs
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 3);
     }
 
@@ -425,9 +425,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
         UNIT_ASSERT_GE(iteratorCounter->Continues, 0);
-        UNIT_ASSERT_LE(iteratorCounter->Continues, 3); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 3); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
         UNIT_ASSERT_GE(iteratorCounter->EvGets, 1);
-        UNIT_ASSERT_LE(iteratorCounter->EvGets, 3);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 3); // can be up to total requested blobs
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 3);
     }
 
@@ -483,9 +483,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
         UNIT_ASSERT_GE(iteratorCounter->Continues, 1);
-        UNIT_ASSERT_LE(iteratorCounter->Continues, 6); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 6); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
         UNIT_ASSERT_GE(iteratorCounter->EvGets, 2);
-        UNIT_ASSERT_LE(iteratorCounter->EvGets, 6);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 6); // can be up to total requested blobs
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 6);
     }
 
@@ -641,9 +641,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
         UNIT_ASSERT_GE(iteratorCounter->Continues, 3);
-        UNIT_ASSERT_LE(iteratorCounter->Continues, 20); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 20); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
         UNIT_ASSERT_GE(iteratorCounter->EvGets, 4);
-        UNIT_ASSERT_LE(iteratorCounter->EvGets, 20);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 20); // can be up to total requested blobs
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 20);
     }
 
@@ -736,9 +736,9 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
             UNIT_ASSERT_VALUES_EQUAL_C(iteratorCounter->Reads, expectedResult.Reads, "test " << test);
             UNIT_ASSERT_GE_C(iteratorCounter->Continues, expectedResult.Continues, "test " << test);
-            UNIT_ASSERT_LE_C(iteratorCounter->Continues, 20, "test " << test); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+            UNIT_ASSERT_LE_C(iteratorCounter->Continues, 20, "test " << test); // can be up to total blobs in response due ShouldStopByElapsedTime() time limit
             UNIT_ASSERT_GE_C(iteratorCounter->EvGets, expectedResult.EvGets, "test " << test);
-            UNIT_ASSERT_LE_C(iteratorCounter->EvGets, expectedResult.BlobsRequested, "test " << test);
+            UNIT_ASSERT_LE_C(iteratorCounter->EvGets, expectedResult.BlobsRequested, "test " << test); // can be up to total requested blobs
             UNIT_ASSERT_VALUES_EQUAL_C(iteratorCounter->BlobsRequested, expectedResult.BlobsRequested, "test " << test);
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
@@ -738,7 +738,7 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
             UNIT_ASSERT_GE_C(iteratorCounter->Continues, expectedResult.Continues, "test " << test);
             UNIT_ASSERT_LE_C(iteratorCounter->Continues, 20, "test " << test); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
             UNIT_ASSERT_GE_C(iteratorCounter->EvGets, expectedResult.EvGets, "test " << test);
-            UNIT_ASSERT_LE_C(iteratorCounter->EvGets, 20, "test " << test);
+            UNIT_ASSERT_LE_C(iteratorCounter->EvGets, expectedResult.BlobsRequested, "test " << test);
             UNIT_ASSERT_VALUES_EQUAL_C(iteratorCounter->BlobsRequested, expectedResult.BlobsRequested, "test " << test);
         }
     }

--- a/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
@@ -239,8 +239,10 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         ValidateReadResult(runtime, std::move(readFuture), 10);
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Continues, 2);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->EvGets, 2);
+        UNIT_ASSERT_GE(iteratorCounter->Continues, 2);
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 10); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_GE(iteratorCounter->EvGets, 2);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 10);
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 10);
     }
 
@@ -320,8 +322,10 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         UNIT_ASSERT_EQUAL(resultSet.rows_size(), 10);
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Continues, 2);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->EvGets, 2);
+        UNIT_ASSERT_GE(iteratorCounter->Continues, 2);
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 10); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_GE(iteratorCounter->EvGets, 2);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 10);
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 10);
     }
 
@@ -369,8 +373,10 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         ValidateReadResult(runtime, std::move(readFuture), 3, 7);
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Continues, 0);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->EvGets, 1);
+        UNIT_ASSERT_GE(iteratorCounter->Continues, 0);
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 3); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_GE(iteratorCounter->EvGets, 1);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 3);
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 3);
     }
 
@@ -418,8 +424,10 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         ValidateReadResult(runtime, std::move(readFuture), 3);
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Continues, 0);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->EvGets, 1);
+        UNIT_ASSERT_GE(iteratorCounter->Continues, 0);
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 3); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_GE(iteratorCounter->EvGets, 1);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 3);
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 3);
     }
 
@@ -474,8 +482,10 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         ValidateReadResult(runtime, std::move(readFuture), {1, 5, 6, 7, 8, 9});
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Continues, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->EvGets, 2);
+        UNIT_ASSERT_GE(iteratorCounter->Continues, 1);
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 6); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_GE(iteratorCounter->EvGets, 2);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 6);
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 6);
     }
 
@@ -630,8 +640,10 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         ValidateReadResult(runtime, std::move(readFuture), 10, 0, 2);
 
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Reads, 1);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->Continues, 3);
-        UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->EvGets, 4);
+        UNIT_ASSERT_GE(iteratorCounter->Continues, 3);
+        UNIT_ASSERT_LE(iteratorCounter->Continues, 20); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+        UNIT_ASSERT_GE(iteratorCounter->EvGets, 4);
+        UNIT_ASSERT_LE(iteratorCounter->EvGets, 20);
         UNIT_ASSERT_VALUES_EQUAL(iteratorCounter->BlobsRequested, 20);
     }
 
@@ -722,7 +734,12 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
 
             auto& expectedResult = expectedResults[test];
 
-            UNIT_ASSERT_VALUES_EQUAL_C(*iteratorCounter, expectedResult, "test " << test);
+            UNIT_ASSERT_VALUES_EQUAL_C(iteratorCounter->Reads, expectedResult.Reads, "test " << test);
+            UNIT_ASSERT_GE_C(iteratorCounter->Continues, expectedResult.Continues, "test " << test);
+            UNIT_ASSERT_LE_C(iteratorCounter->Continues, 20, "test " << test); // can be up to total requested blobs due ShouldStopByElapsedTime() time limit
+            UNIT_ASSERT_GE_C(iteratorCounter->EvGets, expectedResult.EvGets, "test " << test);
+            UNIT_ASSERT_LE_C(iteratorCounter->EvGets, 20, "test " << test);
+            UNIT_ASSERT_VALUES_EQUAL_C(iteratorCounter->BlobsRequested, expectedResult.BlobsRequested, "test " << test);
         }
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

There can be more EvReadContinue and EvRead messages because batch of several 1MB ext blobs may not be processed within the time limit:  https://github.com/ydb-platform/ydb/blob/main/ydb/core/tx/datashard/datashard__read_iterator.cpp#L1406

Closes #43551
