### PR TITLE
table_creator indexed table support

### DIFF
--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -129,6 +129,10 @@ public:
                     auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
                     auto& indexedTable = *modifyScheme.MutableCreateIndexedTable();
                     BuildCreateIndexedTable(indexedTable);
+
+                    if (TableAclDiff) {
+                        BuildModifyACL(modifyScheme);
+                    }
                 } else {
                     auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateTable);
                     BuildCreateTable(modifyScheme);

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -128,21 +128,19 @@ public:
             case NKikimrSchemeOp::ESchemeOpCreateTable: {
                 TableCreateAttempted = true;
                 const bool useIndexedTable = !TableSequences.empty() || !TableIndexes.empty();
+                auto& modifyScheme = *getModifyScheme(useIndexedTable
+                    ? NKikimrSchemeOp::ESchemeOpCreateIndexedTable
+                    : NKikimrSchemeOp::ESchemeOpCreateTable);
+
                 if (useIndexedTable) {
-                    auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
                     auto& indexedTable = *modifyScheme.MutableCreateIndexedTable();
                     BuildCreateIndexedTable(indexedTable);
-
-                    if (TableAclDiff) {
-                        BuildModifyACL(modifyScheme);
-                    }
                 } else {
-                    auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateTable);
                     BuildCreateTable(modifyScheme);
+                }
 
-                    if (TableAclDiff) {
-                        BuildModifyACL(modifyScheme);
-                    }
+                if (TableAclDiff) {
+                    BuildModifyACL(modifyScheme);
                 }
 
                 break;

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -113,7 +113,7 @@ public:
             auto* modifyScheme = request->Record.MutableTransaction()->MutableModifyScheme();
             modifyScheme->SetWorkingDir(CanonizePath(pathComponents));
             LOG_DEBUG_S(*TlsActivationContext, LogService, 
-                LogPrefix << "Created " << NKikimrSchemeOp::EOperationType_Name(OperationType) << " transaction for path: " << modifyScheme->GetWorkingDir() << "/" << TableName());
+                LogPrefix << "Created " << NKikimrSchemeOp::EOperationType_Name(operationType) << " transaction for path: " << modifyScheme->GetWorkingDir() << "/" << TableName());
 
             modifyScheme->SetOperationType(operationType);
             modifyScheme->SetInternal(true);
@@ -405,6 +405,31 @@ private:
         }
         config.MutableKeyColumnNames()->Assign(
             index.GetKeyColumnNames().begin(), index.GetKeyColumnNames().end());
+        config.MutableDataColumnNames()->Assign(
+            index.GetDataColumnNames().begin(), index.GetDataColumnNames().end());
+        config.MutableIndexImplTableDescriptions()->Assign(
+            index.GetIndexImplTableDescriptions().begin(),
+            index.GetIndexImplTableDescriptions().end());
+
+        switch (index.GetSpecializedIndexDescriptionCase()) {
+            case NKikimrSchemeOp::TIndexDescription::kVectorIndexKmeansTreeDescription:
+                *config.MutableVectorIndexKmeansTreeDescription() =
+                    index.GetVectorIndexKmeansTreeDescription();
+                break;
+            case NKikimrSchemeOp::TIndexDescription::kFulltextIndexDescription:
+                *config.MutableFulltextIndexDescription() = index.GetFulltextIndexDescription();
+                break;
+            case NKikimrSchemeOp::TIndexDescription::kBloomFilterDescription:
+                *config.MutableBloomFilterDescription() = index.GetBloomFilterDescription();
+                break;
+            case NKikimrSchemeOp::TIndexDescription::kBloomNGrammFilterDescription:
+                *config.MutableBloomNGrammFilterDescription() =
+                    index.GetBloomNGrammFilterDescription();
+                break;
+            default:
+                break;
+        }
+
         return config;
     }
 

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -124,6 +124,7 @@ public:
 
         switch (OperationType) {
             case NKikimrSchemeOp::ESchemeOpCreateTable: {
+                TableCreateAttempted = true;
                 const bool useIndexedTable = !TableSequences.empty() || !TableIndexes.empty();
                 if (useIndexedTable) {
                     auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
@@ -162,6 +163,11 @@ public:
     }
 
     void RunTableModification(const THashMap<ui32, TSysTables::TTableColumnInfo>& existingColumns, TIntrusivePtr<TSecurityObject> securityObject) {
+        if (!TableCreateAttempted && (!TableIndexes.empty() || !TableSequences.empty())) {
+            Fail("Table already exists; index and sequence upgrade is not supported");
+            return;
+        }
+
         ExcludeExistingColumns(existingColumns);
         bool aclChanged = false;
 
@@ -554,6 +560,7 @@ private:
     const TVector<NKikimrSchemeOp::TIndexDescription> TableIndexes;
     const TVector<NKikimrSchemeOp::TSequenceDescription> TableSequences;
     NKikimrSchemeOp::EOperationType OperationType = NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable;
+    bool TableCreateAttempted = false;
     bool PartialModification = false;
     NActors::TActorId Owner;
     NActors::TActorId SchemePipeActorId;

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -447,7 +447,7 @@ private:
     }
 
     void BuildAlterTable(NKikimrSchemeOp::TModifyScheme& modifyScheme) const {
-        BuildTableOperation(*modifyScheme.MutableAlterTable());
+        BuildTableOperation(*modifyScheme.MutableAlterTable(), false);
     }
 
     void BuildModifyACL(NKikimrSchemeOp::TModifyScheme& modifyScheme) const {

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -21,6 +21,8 @@
 #include <util/generic/utility.h>
 #include <util/random/random.h>
 
+#include <algorithm>
+
 namespace NKikimr {
 
 namespace {
@@ -162,7 +164,12 @@ public:
         Send(MakeTxProxyID(), std::move(request));
     }
 
-    void RunTableModification(const THashMap<ui32, TSysTables::TTableColumnInfo>& existingColumns, TIntrusivePtr<TSecurityObject> securityObject) {
+    void RunTableModification(
+        const THashMap<ui32, TSysTables::TTableColumnInfo>& existingColumns,
+        TIntrusivePtr<TSecurityObject> securityObject,
+        const TVector<NKikimrSchemeOp::TIndexDescription>& existingIndexes,
+        const TVector<NKikimrSchemeOp::TSequenceDescription>& existingSequences)
+    {
         if (!TableCreateAttempted && (!TableIndexes.empty() || !TableSequences.empty())) {
             Fail("Table already exists; index and sequence upgrade is not supported");
             return;
@@ -178,6 +185,10 @@ public:
         }
 
         if (Columns.empty() && !aclChanged) {
+            if (!HasRequestedIndexedSchema(existingIndexes, existingSequences)) {
+                Fail("Existing table schema does not match requested indexes or sequences");
+                return;
+            }
             Success();
             return;
         }
@@ -240,7 +251,7 @@ public:
             case EStatus::Ok:
                 LOG_DEBUG_S(*TlsActivationContext, LogService,
                     LogPrefix << "Table already exists, number of columns: " << result.Columns.size() << ", has SecurityObject: " << (result.SecurityObject ? "true" : "false"));
-                RunTableModification(result.Columns, result.SecurityObject);
+                RunTableModification(result.Columns, result.SecurityObject, result.Indexes, result.Sequences);
                 break;
         }
     }
@@ -254,7 +265,11 @@ public:
                 [[fallthrough]];
             case NTxProxy::TResultStatus::ExecAlready:
                 if (ssStatus == NKikimrScheme::EStatus::StatusSuccess || ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists) {
-                    if (PartialModification) {
+                    if (ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists
+                        && (!TableIndexes.empty() || !TableSequences.empty()))
+                    {
+                        FallBack();
+                    } else if (PartialModification) {
                         // Apply next modification
                         FallBack();
                     } else {
@@ -397,6 +412,38 @@ public:
 
     const TString& TableName() const {
         return PathComponents.back();
+    }
+
+    bool HasRequestedIndexedSchema(
+        const TVector<NKikimrSchemeOp::TIndexDescription>& existingIndexes,
+        const TVector<NKikimrSchemeOp::TSequenceDescription>& existingSequences) const
+    {
+        if (TableIndexes.empty() && TableSequences.empty()) {
+            return true;
+        }
+
+        for (const auto& requiredIndex : TableIndexes) {
+            const auto it = std::find_if(existingIndexes.begin(), existingIndexes.end(),
+                [&](const NKikimrSchemeOp::TIndexDescription& index) {
+                    return index.GetName() == requiredIndex.GetName()
+                        && index.GetType() == requiredIndex.GetType();
+                });
+            if (it == existingIndexes.end()) {
+                return false;
+            }
+        }
+
+        for (const auto& requiredSequence : TableSequences) {
+            const auto it = std::find_if(existingSequences.begin(), existingSequences.end(),
+                [&](const NKikimrSchemeOp::TSequenceDescription& sequence) {
+                    return sequence.GetName() == requiredSequence.GetName();
+                });
+            if (it == existingSequences.end()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 private:

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -175,6 +175,13 @@ public:
             return;
         }
 
+        if (!TableIndexes.empty() || !TableSequences.empty()) {
+            if (!HasRequestedIndexedSchema(existingIndexes, existingSequences)) {
+                Fail("Existing table schema does not match requested indexes or sequences");
+                return;
+            }
+        }
+
         ExcludeExistingColumns(existingColumns);
         bool aclChanged = false;
 
@@ -185,10 +192,6 @@ public:
         }
 
         if (Columns.empty() && !aclChanged) {
-            if (!HasRequestedIndexedSchema(existingIndexes, existingSequences)) {
-                Fail("Existing table schema does not match requested indexes or sequences");
-                return;
-            }
             Success();
             return;
         }

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -39,7 +39,9 @@ public:
         const TString& database = {},
         bool isSystemUser = false,
         TMaybe<NKikimrSchemeOp::TPartitioningPolicy> partitioningPolicy = Nothing(),
-        TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing())
+        TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing(),
+        TVector<NKikimrSchemeOp::TIndexDescription> tableIndexes = {},
+        TVector<NKikimrSchemeOp::TSequenceDescription> tableSequences = {})
         : PathComponents(std::move(pathComponents))
         , Columns(std::move(columns))
         , KeyColumns(std::move(keyColumns))
@@ -49,6 +51,8 @@ public:
         , IsSystemUser(isSystemUser)
         , PartitioningPolicy(std::move(partitioningPolicy))
         , TableAclDiff(std::move(tableAclDiff))
+        , TableIndexes(std::move(tableIndexes))
+        , TableSequences(std::move(tableSequences))
         , LogPrefix("Table " + TableName() + " updater. ")
     {
         Y_ABORT_UNLESS(!PathComponents.empty());
@@ -120,11 +124,18 @@ public:
 
         switch (OperationType) {
             case NKikimrSchemeOp::ESchemeOpCreateTable: {
-                auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateTable);
-                BuildCreateTable(modifyScheme);
+                const bool useIndexedTable = !TableSequences.empty() || !TableIndexes.empty();
+                if (useIndexedTable) {
+                    auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateIndexedTable);
+                    auto& indexedTable = *modifyScheme.MutableCreateIndexedTable();
+                    BuildCreateIndexedTable(indexedTable);
+                } else {
+                    auto& modifyScheme = *getModifyScheme(NKikimrSchemeOp::ESchemeOpCreateTable);
+                    BuildCreateTable(modifyScheme);
 
-                if (TableAclDiff) {
-                    BuildModifyACL(modifyScheme);
+                    if (TableAclDiff) {
+                        BuildModifyACL(modifyScheme);
+                    }
                 }
 
                 break;
@@ -379,7 +390,35 @@ public:
     }
 
 private:
-    void BuildTableOperation(NKikimrSchemeOp::TTableDescription& tableDesc) const {
+    static NKikimrSchemeOp::TIndexCreationConfig ToIndexCreationConfig(
+        const NKikimrSchemeOp::TIndexDescription& index)
+    {
+        NKikimrSchemeOp::TIndexCreationConfig config;
+        config.SetName(index.GetName());
+        config.SetType(index.GetType());
+        if (index.HasState()) {
+            config.SetState(index.GetState());
+        }
+        config.MutableKeyColumnNames()->Assign(
+            index.GetKeyColumnNames().begin(), index.GetKeyColumnNames().end());
+        return config;
+    }
+
+    void BuildCreateIndexedTable(NKikimrSchemeOp::TIndexedTableCreationConfig& indexedTable) const {
+        auto& tableDesc = *indexedTable.MutableTableDescription();
+        BuildTableOperation(tableDesc, false);
+        tableDesc.MutableKeyColumnNames()->Assign(KeyColumns.begin(), KeyColumns.end());
+
+        for (const auto& index : TableIndexes) {
+            *indexedTable.AddIndexDescription() = ToIndexCreationConfig(index);
+        }
+
+        for (const auto& sequence : TableSequences) {
+            *indexedTable.AddSequenceDescription() = sequence;
+        }
+    }
+
+    void BuildTableOperation(NKikimrSchemeOp::TTableDescription& tableDesc, bool includeTableIndexes = true) const {
         tableDesc.SetName(TableName());
         tableDesc.MutableColumns()->Assign(Columns.begin(), Columns.end());
 
@@ -389,6 +428,10 @@ private:
 
         if (PartitioningPolicy) {
             *tableDesc.MutablePartitionConfig()->MutablePartitioningPolicy() = *PartitioningPolicy;
+        }
+
+        if (includeTableIndexes && !TableIndexes.empty()) {
+            tableDesc.MutableTableIndexes()->Assign(TableIndexes.begin(), TableIndexes.end());
         }
     }
 
@@ -479,6 +522,8 @@ private:
     bool IsSystemUser = false;
     const TMaybe<NKikimrSchemeOp::TPartitioningPolicy> PartitioningPolicy;
     const TMaybe<NACLib::TDiffACL> TableAclDiff;
+    const TVector<NKikimrSchemeOp::TIndexDescription> TableIndexes;
+    const TVector<NKikimrSchemeOp::TSequenceDescription> TableSequences;
     NKikimrSchemeOp::EOperationType OperationType = NKikimrSchemeOp::EOperationType::ESchemeOpCreateTable;
     bool PartialModification = false;
     NActors::TActorId Owner;
@@ -537,6 +582,12 @@ NKikimrSchemeOp::TTTLSettings TMultiTableCreator::TtlCol(const TString& columnNa
     return settings;
 }
 
+NKikimrSchemeOp::TPartitioningPolicy TMultiTableCreator::AutoPartitioningByLoadPolicy() {
+    NKikimrSchemeOp::TPartitioningPolicy policy;
+    policy.MutableSplitByLoadSettings()->SetEnabled(true);
+    return policy;
+}
+
 TMultiTableCreator::TMultiTableCreator(std::vector<NActors::IActor*> tableCreators)
     : TableCreators(std::move(tableCreators))
 {}
@@ -583,11 +634,14 @@ NActors::IActor* CreateTableCreator(
     const TString& database,
     bool isSystemUser,
     TMaybe<NKikimrSchemeOp::TPartitioningPolicy> partitioningPolicy,
-    TMaybe<NACLib::TDiffACL> tableAclDiff)
+    TMaybe<NACLib::TDiffACL> tableAclDiff,
+    TVector<NKikimrSchemeOp::TIndexDescription> tableIndexes,
+    TVector<NKikimrSchemeOp::TSequenceDescription> tableSequences)
 {
     return new TTableCreator(std::move(pathComponents), std::move(columns),
         std::move(keyColumns), logService, std::move(ttlSettings), database,
-        isSystemUser, std::move(partitioningPolicy), std::move(tableAclDiff));
+        isSystemUser, std::move(partitioningPolicy), std::move(tableAclDiff),
+        std::move(tableIndexes), std::move(tableSequences));
 }
 
 } // namespace NKikimr

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -428,10 +428,9 @@ public:
         for (const auto& requiredIndex : TableIndexes) {
             const auto it = std::find_if(existingIndexes.begin(), existingIndexes.end(),
                 [&](const NKikimrSchemeOp::TIndexDescription& index) {
-                    return index.GetName() == requiredIndex.GetName()
-                        && index.GetType() == requiredIndex.GetType();
+                    return index.GetName() == requiredIndex.GetName();
                 });
-            if (it == existingIndexes.end()) {
+            if (it == existingIndexes.end() || !IndexDefinitionsMatch(requiredIndex, *it)) {
                 return false;
             }
         }
@@ -441,7 +440,7 @@ public:
                 [&](const NKikimrSchemeOp::TSequenceDescription& sequence) {
                     return sequence.GetName() == requiredSequence.GetName();
                 });
-            if (it == existingSequences.end()) {
+            if (it == existingSequences.end() || !SequenceDefinitionsMatch(requiredSequence, *it)) {
                 return false;
             }
         }
@@ -450,6 +449,118 @@ public:
     }
 
 private:
+    template <typename TRepeated>
+    static bool RepeatedStringFieldsEqual(const TRepeated& left, const TRepeated& right)
+    {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (int i = 0; i < left.size(); ++i) {
+            if (left.Get(i) != right.Get(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool IndexDefinitionsMatch(
+        const NKikimrSchemeOp::TIndexDescription& required,
+        const NKikimrSchemeOp::TIndexDescription& existing)
+    {
+        if (required.GetType() != existing.GetType()) {
+            return false;
+        }
+        if (required.HasState() && required.GetState() != existing.GetState()) {
+            return false;
+        }
+        if (!RepeatedStringFieldsEqual(required.GetKeyColumnNames(), existing.GetKeyColumnNames())) {
+            return false;
+        }
+        if (!RepeatedStringFieldsEqual(required.GetDataColumnNames(), existing.GetDataColumnNames())) {
+            return false;
+        }
+        if (required.GetSpecializedIndexDescriptionCase() != existing.GetSpecializedIndexDescriptionCase()) {
+            if (required.GetSpecializedIndexDescriptionCase()
+                != NKikimrSchemeOp::TIndexDescription::SPECIALIZEDINDEXDESCRIPTION_NOT_SET)
+            {
+                return false;
+            }
+        } else {
+            switch (required.GetSpecializedIndexDescriptionCase()) {
+                case NKikimrSchemeOp::TIndexDescription::kVectorIndexKmeansTreeDescription:
+                    if (required.GetVectorIndexKmeansTreeDescription().SerializeAsString()
+                        != existing.GetVectorIndexKmeansTreeDescription().SerializeAsString())
+                    {
+                        return false;
+                    }
+                    break;
+                case NKikimrSchemeOp::TIndexDescription::kFulltextIndexDescription:
+                    if (required.GetFulltextIndexDescription().SerializeAsString()
+                        != existing.GetFulltextIndexDescription().SerializeAsString())
+                    {
+                        return false;
+                    }
+                    break;
+                case NKikimrSchemeOp::TIndexDescription::kBloomFilterDescription:
+                    if (required.GetBloomFilterDescription().SerializeAsString()
+                        != existing.GetBloomFilterDescription().SerializeAsString())
+                    {
+                        return false;
+                    }
+                    break;
+                case NKikimrSchemeOp::TIndexDescription::kBloomNGrammFilterDescription:
+                    if (required.GetBloomNGrammFilterDescription().SerializeAsString()
+                        != existing.GetBloomNGrammFilterDescription().SerializeAsString())
+                    {
+                        return false;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (!required.GetIndexImplTableDescriptions().empty()) {
+            if (required.GetIndexImplTableDescriptions().size()
+                != existing.GetIndexImplTableDescriptions().size())
+            {
+                return false;
+            }
+            for (int i = 0; i < required.GetIndexImplTableDescriptions().size(); ++i) {
+                if (required.GetIndexImplTableDescriptions(i).SerializeAsString()
+                    != existing.GetIndexImplTableDescriptions(i).SerializeAsString())
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    static bool SequenceDefinitionsMatch(
+        const NKikimrSchemeOp::TSequenceDescription& required,
+        const NKikimrSchemeOp::TSequenceDescription& existing)
+    {
+#define REQUIRE_MATCHING_SEQUENCE_FIELD(field) \
+        if (required.Has##field() && required.Get##field() != existing.Get##field()) { \
+            return false; \
+        }
+
+        REQUIRE_MATCHING_SEQUENCE_FIELD(MinValue);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(MaxValue);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(StartValue);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(Cache);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(Increment);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(Cycle);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(DataType);
+        REQUIRE_MATCHING_SEQUENCE_FIELD(Restart);
+
+#undef REQUIRE_MATCHING_SEQUENCE_FIELD
+
+        return true;
+    }
+
     static NKikimrSchemeOp::TIndexCreationConfig ToIndexCreationConfig(
         const NKikimrSchemeOp::TIndexDescription& index)
     {

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -266,12 +266,10 @@ public:
                 [[fallthrough]];
             case NTxProxy::TResultStatus::ExecAlready:
                 if (ssStatus == NKikimrScheme::EStatus::StatusSuccess || ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists) {
-                    if (ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists
-                        && (!TableIndexes.empty() || !TableSequences.empty()))
+                    if ((ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists
+                            && (!TableIndexes.empty() || !TableSequences.empty()))
+                        || PartialModification)
                     {
-                        FallBack();
-                    } else if (PartialModification) {
-                        // Apply next modification
                         FallBack();
                     } else {
                         Success(ev);

--- a/ydb/library/table_creator/table_creator.h
+++ b/ydb/library/table_creator/table_creator.h
@@ -49,6 +49,8 @@ protected:
 
     static NKikimrSchemeOp::TTTLSettings TtlCol(const TString& columnName, TDuration expireAfter, TDuration runInterval);
 
+    static NKikimrSchemeOp::TPartitioningPolicy AutoPartitioningByLoadPolicy();
+
 private:
     void Registered(NActors::TActorSystem* sys, const NActors::TActorId& owner) override;
 
@@ -80,6 +82,8 @@ NActors::IActor* CreateTableCreator(
     const TString& database = {},
     bool isSystemUser = false,
     TMaybe<NKikimrSchemeOp::TPartitioningPolicy> partitioningPolicy = Nothing(),
-    TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing());
+    TMaybe<NACLib::TDiffACL> tableAclDiff = Nothing(),
+    TVector<NKikimrSchemeOp::TIndexDescription> tableIndexes = {},
+    TVector<NKikimrSchemeOp::TSequenceDescription> tableSequences = {});
 
 } // namespace NKikimr

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -57,6 +57,57 @@ private:
     NThreading::TPromise<void> Promise;
 };
 
+class TIndexedTableCreator : public NTableCreator::TMultiTableCreator {
+    using TBase = NTableCreator::TMultiTableCreator;
+
+public:
+    explicit TIndexedTableCreator(NThreading::TPromise<void> promise)
+        : TBase({ GetCreator() })
+        , Promise(promise)
+    {}
+
+private:
+    static IActor* GetCreator() {
+        NKikimrSchemeOp::TSequenceDescription sequence;
+        sequence.SetName("id_seq");
+
+        NKikimrSchemeOp::TIndexDescription index;
+        index.SetName("ext_id_uniq");
+        index.AddKeyColumnNames("ext_id");
+        index.SetType(NKikimrSchemeOp::EIndexTypeGlobalUnique);
+        index.SetState(NKikimrSchemeOp::EIndexStateReady);
+
+        auto idColumn = Col("id", NScheme::NTypeIds::Uint64);
+        idColumn.SetNotNull(true);
+        idColumn.SetDefaultFromSequence("id_seq");
+
+        auto extIdColumn = Col("ext_id", NScheme::NTypeIds::Text);
+        extIdColumn.SetNotNull(true);
+
+        return CreateTableCreator(
+            { "path", "to", "indexed", "table" },
+            { idColumn, extIdColumn },
+            { "id" },
+            NKikimrServices::STATISTICS,
+            Nothing(),
+            {},
+            false,
+            Nothing(),
+            Nothing(),
+            { index },
+            { sequence }
+        );
+    }
+
+    void OnTablesCreated(bool success, NYql::TIssues issues) override {
+        UNIT_ASSERT_C(success, issues.ToString());
+        Promise.SetValue();
+    }
+
+private:
+    NThreading::TPromise<void> Promise;
+};
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TableCreator) {
@@ -109,6 +160,67 @@ Y_UNIT_TEST_SUITE(TableCreator) {
             UNIT_ASSERT_VALUES_EQUAL_C(createdColumns[1].Name, "expire_at", "expected expire_at column");
             UNIT_ASSERT_VALUES_EQUAL_C(createdColumns[1].Type.ToString(), "Timestamp?", "expected type timestamp");
         }
+    }
+
+    Y_UNIT_TEST(CreateIndexedTableWithSequenceAndUniqueIndex) {
+        TPortManager tp;
+        ui16 mbusPort = tp.GetPort();
+        ui16 grpcPort = tp.GetPort();
+        auto settings = Tests::TServerSettings(mbusPort);
+        settings.SetNodeCount(1);
+
+        Tests::TServer server(settings);
+        Tests::TClient client(settings);
+
+        server.EnableGRpc(grpcPort);
+        client.InitRootScheme();
+        auto runtime = server.GetRuntime();
+
+        auto promise = NThreading::NewPromise();
+        TActorId edgeActor = runtime->AllocateEdgeActor(0);
+        runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+        promise.GetFuture().GetValueSync();
+
+        NYdb::TDriverConfig cfg;
+        cfg.SetEndpoint(TStringBuilder() << "localhost:" << grpcPort).SetDatabase(Tests::TestDomainName);
+        NYdb::TDriver driver(cfg);
+        NYdb::NTable::TTableClient tableClient(driver);
+        auto createSessionResult = tableClient.CreateSession().ExtractValueSync();
+        UNIT_ASSERT_C(createSessionResult.IsSuccess(), createSessionResult.GetIssues().ToString());
+        NYdb::NTable::TSession session(createSessionResult.GetSession());
+
+        const auto path = TStringBuilder() << "/" << Tests::TestDomainName << "/path/to/indexed/table";
+        auto describeResult = session.DescribeTable(path).ExtractValueSync();
+        UNIT_ASSERT_C(describeResult.IsSuccess(), describeResult.GetIssues().ToString());
+
+        const auto& indexes = describeResult.GetTableDescription().GetIndexDescriptions();
+        UNIT_ASSERT_VALUES_EQUAL(indexes.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(indexes[0].GetIndexName(), "ext_id_uniq");
+        UNIT_ASSERT_VALUES_EQUAL(indexes[0].GetIndexType(), NYdb::NTable::EIndexType::GlobalUnique);
+        UNIT_ASSERT_VALUES_EQUAL(indexes[0].GetIndexColumns().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(indexes[0].GetIndexColumns()[0], "ext_id");
+
+        NYdb::TParamsBuilder insertParams;
+        insertParams.AddParam("$ext").Utf8("ext-1").Build();
+        const auto insertResult = session.ExecuteDataQuery(
+            TStringBuilder() << "DECLARE $ext AS Text; INSERT INTO `" << path << "` (ext_id) VALUES ($ext);",
+            NYdb::NTable::TTxControl::BeginTx().CommitTx(),
+            insertParams.Build()).ExtractValueSync();
+        UNIT_ASSERT_C(insertResult.IsSuccess(), insertResult.GetIssues().ToString());
+
+        NYdb::TParamsBuilder selectParams;
+        selectParams.AddParam("$ext").Utf8("ext-1").Build();
+        const auto selectResult = session.ExecuteDataQuery(
+            TStringBuilder() << "DECLARE $ext AS Text; SELECT id FROM `" << path << "` WHERE ext_id = $ext;",
+            NYdb::NTable::TTxControl::BeginTx().CommitTx(),
+            selectParams.Build()).ExtractValueSync();
+        UNIT_ASSERT_C(selectResult.IsSuccess(), selectResult.GetIssues().ToString());
+        UNIT_ASSERT(!selectResult.GetResultSets().empty());
+
+        NYdb::TResultSetParser parser(selectResult.GetResultSet(0));
+        UNIT_ASSERT(parser.TryNextRow());
+        UNIT_ASSERT_GT(parser.ColumnParser("id").GetUint64(), 0u);
+        UNIT_ASSERT(!parser.TryNextRow());
     }
 }
 

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -112,6 +112,56 @@ private:
     NThreading::TPromise<TResult> Promise;
 };
 
+class TIndexedTableCreatorWithWrongIndexKey : public NTableCreator::TMultiTableCreator {
+    using TBase = NTableCreator::TMultiTableCreator;
+
+public:
+    explicit TIndexedTableCreatorWithWrongIndexKey(NThreading::TPromise<TIndexedTableCreator::TResult> promise)
+        : TBase({ GetCreator() })
+        , Promise(std::move(promise))
+    {}
+
+private:
+    static IActor* GetCreator() {
+        NKikimrSchemeOp::TSequenceDescription sequence;
+        sequence.SetName("id_seq");
+
+        NKikimrSchemeOp::TIndexDescription index;
+        index.SetName("ext_id_uniq");
+        index.AddKeyColumnNames("id");
+        index.SetType(NKikimrSchemeOp::EIndexTypeGlobalUnique);
+        index.SetState(NKikimrSchemeOp::EIndexStateReady);
+
+        auto idColumn = Col("id", NScheme::NTypeIds::Uint64);
+        idColumn.SetNotNull(true);
+        idColumn.SetDefaultFromSequence("id_seq");
+
+        auto extIdColumn = Col("ext_id", NScheme::NTypeIds::Text);
+        extIdColumn.SetNotNull(true);
+
+        return CreateTableCreator(
+            { "path", "to", "indexed", "table" },
+            { idColumn, extIdColumn },
+            { "id" },
+            NKikimrServices::STATISTICS,
+            Nothing(),
+            {},
+            false,
+            Nothing(),
+            Nothing(),
+            { index },
+            { sequence }
+        );
+    }
+
+    void OnTablesCreated(bool success, NYql::TIssues issues) override {
+        Promise.SetValue({success, std::move(issues)});
+    }
+
+private:
+    NThreading::TPromise<TIndexedTableCreator::TResult> Promise;
+};
+
 class TPlainIndexedPathTableCreator : public NTableCreator::TMultiTableCreator {
     using TBase = NTableCreator::TMultiTableCreator;
 
@@ -323,6 +373,35 @@ Y_UNIT_TEST_SUITE(TableCreator) {
             UNIT_ASSERT_STRING_CONTAINS(result.Issues.ToString(),
                 "Table already exists; index and sequence upgrade is not supported");
         }
+    }
+
+    Y_UNIT_TEST(RejectMismatchedIndexedSchemaOnCreateRace) {
+        TPortManager tp;
+        ui16 mbusPort = tp.GetPort();
+        ui16 grpcPort = tp.GetPort();
+        auto settings = Tests::TServerSettings(mbusPort);
+        settings.SetNodeCount(1);
+
+        Tests::TServer server(settings);
+        Tests::TClient client(settings);
+
+        server.EnableGRpc(grpcPort);
+        client.InitRootScheme();
+        auto runtime = server.GetRuntime();
+        TActorId edgeActor = runtime->AllocateEdgeActor(0);
+
+        auto correctPromise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
+        auto wrongPromise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
+        runtime->Register(new TIndexedTableCreator(correctPromise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+        runtime->Register(new TIndexedTableCreatorWithWrongIndexKey(wrongPromise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+
+        const auto correctResult = correctPromise.GetFuture().GetValueSync();
+        const auto wrongResult = wrongPromise.GetFuture().GetValueSync();
+
+        UNIT_ASSERT(correctResult.Success != wrongResult.Success);
+        const auto& failedResult = correctResult.Success ? wrongResult : correctResult;
+        UNIT_ASSERT_STRING_CONTAINS(failedResult.Issues.ToString(),
+            "Existing table schema does not match requested indexes or sequences");
     }
 }
 

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -112,6 +112,40 @@ private:
     NThreading::TPromise<TResult> Promise;
 };
 
+class TPlainIndexedPathTableCreator : public NTableCreator::TMultiTableCreator {
+    using TBase = NTableCreator::TMultiTableCreator;
+
+public:
+    explicit TPlainIndexedPathTableCreator(NThreading::TPromise<void> promise)
+        : TBase({ GetCreator() })
+        , Promise(promise)
+    {}
+
+private:
+    static IActor* GetCreator() {
+        auto idColumn = Col("id", NScheme::NTypeIds::Uint64);
+        idColumn.SetNotNull(true);
+
+        auto extIdColumn = Col("ext_id", NScheme::NTypeIds::Text);
+        extIdColumn.SetNotNull(true);
+
+        return CreateTableCreator(
+            { "path", "to", "indexed", "table" },
+            { idColumn, extIdColumn },
+            { "id" },
+            NKikimrServices::STATISTICS
+        );
+    }
+
+    void OnTablesCreated(bool success, NYql::TIssues issues) override {
+        UNIT_ASSERT_C(success, issues.ToString());
+        Promise.SetValue();
+    }
+
+private:
+    NThreading::TPromise<void> Promise;
+};
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TableCreator) {
@@ -248,6 +282,37 @@ Y_UNIT_TEST_SUITE(TableCreator) {
             runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
             const auto result = promise.GetFuture().GetValueSync();
             UNIT_ASSERT_C(result.Success, result.Issues.ToString());
+        }
+
+        {
+            auto promise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
+            runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+            const auto result = promise.GetFuture().GetValueSync();
+            UNIT_ASSERT(!result.Success);
+            UNIT_ASSERT_STRING_CONTAINS(result.Issues.ToString(),
+                "Table already exists; index and sequence upgrade is not supported");
+        }
+    }
+
+    Y_UNIT_TEST(RejectIndexedTableOnPlainExistingTable) {
+        TPortManager tp;
+        ui16 mbusPort = tp.GetPort();
+        ui16 grpcPort = tp.GetPort();
+        auto settings = Tests::TServerSettings(mbusPort);
+        settings.SetNodeCount(1);
+
+        Tests::TServer server(settings);
+        Tests::TClient client(settings);
+
+        server.EnableGRpc(grpcPort);
+        client.InitRootScheme();
+        auto runtime = server.GetRuntime();
+        TActorId edgeActor = runtime->AllocateEdgeActor(0);
+
+        {
+            auto promise = NThreading::NewPromise();
+            runtime->Register(new TPlainIndexedPathTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+            promise.GetFuture().GetValueSync();
         }
 
         {

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -118,7 +118,7 @@ class TPlainIndexedPathTableCreator : public NTableCreator::TMultiTableCreator {
 public:
     explicit TPlainIndexedPathTableCreator(NThreading::TPromise<void> promise)
         : TBase({ GetCreator() })
-        , Promise(promise)
+        , Promise(std::move(promise))
     {}
 
 private:

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -61,9 +61,14 @@ class TIndexedTableCreator : public NTableCreator::TMultiTableCreator {
     using TBase = NTableCreator::TMultiTableCreator;
 
 public:
-    explicit TIndexedTableCreator(NThreading::TPromise<void> promise)
+    struct TResult {
+        bool Success = false;
+        NYql::TIssues Issues;
+    };
+
+    explicit TIndexedTableCreator(NThreading::TPromise<TResult> promise)
         : TBase({ GetCreator() })
-        , Promise(promise)
+        , Promise(std::move(promise))
     {}
 
 private:
@@ -100,12 +105,11 @@ private:
     }
 
     void OnTablesCreated(bool success, NYql::TIssues issues) override {
-        UNIT_ASSERT_C(success, issues.ToString());
-        Promise.SetValue();
+        Promise.SetValue({success, std::move(issues)});
     }
 
 private:
-    NThreading::TPromise<void> Promise;
+    NThreading::TPromise<TResult> Promise;
 };
 
 } // namespace
@@ -176,10 +180,11 @@ Y_UNIT_TEST_SUITE(TableCreator) {
         client.InitRootScheme();
         auto runtime = server.GetRuntime();
 
-        auto promise = NThreading::NewPromise();
+        auto promise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
         TActorId edgeActor = runtime->AllocateEdgeActor(0);
         runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
-        promise.GetFuture().GetValueSync();
+        const auto result = promise.GetFuture().GetValueSync();
+        UNIT_ASSERT_C(result.Success, result.Issues.ToString());
 
         NYdb::TDriverConfig cfg;
         cfg.SetEndpoint(TStringBuilder() << "localhost:" << grpcPort).SetDatabase(Tests::TestDomainName);
@@ -221,6 +226,38 @@ Y_UNIT_TEST_SUITE(TableCreator) {
         UNIT_ASSERT(parser.TryNextRow());
         UNIT_ASSERT_GT(parser.ColumnParser("id").GetUint64(), 0u);
         UNIT_ASSERT(!parser.TryNextRow());
+    }
+
+    Y_UNIT_TEST(RejectIndexedTableUpgradeOnExistingTable) {
+        TPortManager tp;
+        ui16 mbusPort = tp.GetPort();
+        ui16 grpcPort = tp.GetPort();
+        auto settings = Tests::TServerSettings(mbusPort);
+        settings.SetNodeCount(1);
+
+        Tests::TServer server(settings);
+        Tests::TClient client(settings);
+
+        server.EnableGRpc(grpcPort);
+        client.InitRootScheme();
+        auto runtime = server.GetRuntime();
+        TActorId edgeActor = runtime->AllocateEdgeActor(0);
+
+        {
+            auto promise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
+            runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+            const auto result = promise.GetFuture().GetValueSync();
+            UNIT_ASSERT_C(result.Success, result.Issues.ToString());
+        }
+
+        {
+            auto promise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
+            runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
+            const auto result = promise.GetFuture().GetValueSync();
+            UNIT_ASSERT(!result.Success);
+            UNIT_ASSERT_STRING_CONTAINS(result.Issues.ToString(),
+                "Table already exists; index and sequence upgrade is not supported");
+        }
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Extend `table_creator` to create indexed tables via `ESchemeOpCreateIndexedTable`
- Add support for table indexes and sequences (needed for deferred publish metadata tables)
- Add unit test: global unique index in DescribeTable + auto-generated PK on INSERT without id column

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
