### PR TITLE
Make blob/limits hard-caps env-tunable for tests (YDBAPPTEAM-1302)

### DIFF
--- a/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
+++ b/ydb/core/kqp/compute_actor/kqp_compute_actor_factory.cpp
@@ -5,7 +5,18 @@
 #include <ydb/core/kqp/node_service/kqp_node_state.h>
 #include <ydb/core/kqp/rm_service/kqp_resource_estimation.h>
 
+#include <util/string/cast.h>
+#include <util/system/env.h>
+
 namespace NKikimr::NKqp::NComputeActor {
+
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+namespace {
+    ui64 EnvUi64(const char* name, ui64 def) {
+        ui64 v = 0;
+        return TryFromString<ui64>(GetEnv(name), v) ? v : def;
+    }
+}
 
 class TKqpCaFactory : public IKqpNodeComputeActorFactory {
     std::shared_ptr<NRm::IKqpResourceManager> ResourceManager_;
@@ -28,7 +39,7 @@ class TKqpCaFactory : public IKqpNodeComputeActorFactory {
     std::atomic<ui64> MinChannelBufferSize = 0;
     std::atomic<ui64> MinMemAllocSize = 1_MB;
     std::atomic<ui64> MinMemFreeSize = 32_MB;
-    std::atomic<ui64> ChannelChunkSizeLimit = 48_MB;
+    std::atomic<ui64> ChannelChunkSizeLimit = EnvUi64("YDB_TEST_KQP_CHANNEL_CHUNK_SIZE_LIMIT", 48_MB);
 
 public:
     TKqpCaFactory(const NKikimrConfig::TTableServiceConfig::TResourceManager& config,

--- a/ydb/core/kqp/executer_actor/kqp_planner.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_planner.cpp
@@ -6,6 +6,8 @@
 #include <ydb/core/base/appdata.h>
 
 #include <util/generic/set.h>
+#include <util/string/cast.h>
+#include <util/system/env.h>
 
 #include <ydb/core/kqp/compute_actor/kqp_pure_compute_actor.h>
 #include <ydb/core/kqp/node_service/kqp_query_control_plane.h>
@@ -16,6 +18,14 @@ using namespace NActors;
 
 namespace NKikimr::NKqp {
 
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+namespace {
+    ui64 EnvUi64(const char* name, ui64 def) {
+        ui64 v = 0;
+        return TryFromString<ui64>(GetEnv(name), v) ? v : def;
+    }
+}
+
 #define LOG_T(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_EXECUTER, "TxId: " << TxId << ". " << "Ctx: " << *UserRequestContext << ". " << stream)
 #define LOG_D(stream) LOG_DEBUG_S(*TlsActivationContext, NKikimrServices::KQP_EXECUTER, "TxId: " << TxId << ". " << "Ctx: " << *UserRequestContext << ". " << stream)
 #define LOG_I(stream) LOG_INFO_S(*TlsActivationContext, NKikimrServices::KQP_EXECUTER, "TxId: " << TxId << ". " << "Ctx: " << *UserRequestContext << ". " << stream)
@@ -23,7 +33,7 @@ namespace NKikimr::NKqp {
 #define LOG_E(stream) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_EXECUTER, "TxId: " << TxId << ". " << "Ctx: " << *UserRequestContext << ". " << stream)
 #define LOG_W(stream) LOG_WARN_S(*TlsActivationContext, NKikimrServices::KQP_EXECUTER, "TxId: " << TxId << ". " << "Ctx: " << *UserRequestContext << ". " << stream)
 
-static std::atomic<ui64> MaxTaskSize = 48_MB;
+static std::atomic<ui64> MaxTaskSize = EnvUi64("YDB_TEST_KQP_MAX_TASK_SIZE", 48_MB);
 
 void SetMaxTaskSize(ui64 size) {
     MaxTaskSize.store(size, std::memory_order_relaxed);

--- a/ydb/core/kqp/node_service/kqp_node_service.cpp
+++ b/ydb/core/kqp/node_service/kqp_node_service.cpp
@@ -276,6 +276,8 @@ private:
             FORCE_VALUE(PublishStatisticsIntervalSec);
             FORCE_VALUE(MaxTotalChannelBuffersSize);
             FORCE_VALUE(MinChannelBufferSize);
+            // TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+            FORCE_VALUE(ChannelChunkSizeLimit);
             FORCE_VALUE(MinMemAllocSize);
             FORCE_VALUE(MinMemFreeSize);
 #undef FORCE_VALUE

--- a/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_compression.cpp
+++ b/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_compression.cpp
@@ -60,12 +60,13 @@ TScriptArtifacts CompressScriptArtifacts(const std::optional<TString>& ast, cons
         }
 
         std::tie(resultCompressionMethod, resultValue) = compressor.Compress(*value);
-        if (resultValue->size() > NDataShard::NLimits::MaxWriteValueSize()) {
+        const ui64 limit = NDataShard::NLimits::MaxWriteValueSize();
+        if (resultValue->size() > limit) {
             result.Issues.AddIssue(
-                NYql::TIssue(TStringBuilder() << "Query " << name << " size is " << resultValue->size() << " bytes, that is larger than allowed limit " << NDataShard::NLimits::MaxWriteValueSize() << " bytes, " << name << " was truncated")
+                NYql::TIssue(TStringBuilder() << "Query " << name << " size is " << resultValue->size() << " bytes, that is larger than allowed limit " << limit << " bytes, " << name << " was truncated")
                     .SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO)
             );
-            resultValue = TruncateString(*value, NDataShard::NLimits::MaxWriteValueSize() - 1_KB);
+            resultValue = TruncateString(*value, limit > 1_KB ? limit - 1_KB : 0);
             resultCompressionMethod = std::nullopt;
         }
     };

--- a/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_compression.cpp
+++ b/ydb/core/kqp/proxy_service/script_executions_utils/kqp_script_execution_compression.cpp
@@ -60,12 +60,12 @@ TScriptArtifacts CompressScriptArtifacts(const std::optional<TString>& ast, cons
         }
 
         std::tie(resultCompressionMethod, resultValue) = compressor.Compress(*value);
-        if (resultValue->size() > NDataShard::NLimits::MaxWriteValueSize) {
+        if (resultValue->size() > NDataShard::NLimits::MaxWriteValueSize()) {
             result.Issues.AddIssue(
-                NYql::TIssue(TStringBuilder() << "Query " << name << " size is " << resultValue->size() << " bytes, that is larger than allowed limit " << NDataShard::NLimits::MaxWriteValueSize << " bytes, " << name << " was truncated")
+                NYql::TIssue(TStringBuilder() << "Query " << name << " size is " << resultValue->size() << " bytes, that is larger than allowed limit " << NDataShard::NLimits::MaxWriteValueSize() << " bytes, " << name << " was truncated")
                     .SetCode(NYql::DEFAULT_ERROR, NYql::TSeverityIds::S_INFO)
             );
-            resultValue = TruncateString(*value, NDataShard::NLimits::MaxWriteValueSize - 1_KB);
+            resultValue = TruncateString(*value, NDataShard::NLimits::MaxWriteValueSize() - 1_KB);
             resultCompressionMethod = std::nullopt;
         }
     };

--- a/ydb/core/tx/datashard/check_data_tx_unit.cpp
+++ b/ydb/core/tx/datashard/check_data_tx_unit.cpp
@@ -175,7 +175,7 @@ EExecutionStatus TCheckDataTxUnit::Execute(TOperation::TPtr op,
                     if (col.Operation == TKeyDesc::EColumnOperation::Set ||
                         col.Operation == TKeyDesc::EColumnOperation::InplaceUpdate)
                     {
-                        if (col.ImmediateUpdateSize > NLimits::MaxWriteValueSize) {
+                        if (col.ImmediateUpdateSize > NLimits::MaxWriteValueSize()) {
                             TString err = TStringBuilder()
                                 << "Transaction write column value of " << col.ImmediateUpdateSize
                                 << " bytes is larger than the allowed threshold";

--- a/ydb/core/tx/datashard/const.h
+++ b/ydb/core/tx/datashard/const.h
@@ -2,6 +2,9 @@
 
 #include "defs.h"
 
+#include <util/string/cast.h>
+#include <util/system/env.h>
+
 namespace NKikimr {
 namespace NDataShard {
 
@@ -13,7 +16,16 @@ constexpr ui64 MAX_REORDER_TX_KEYS = 1000;
 
 namespace NLimits {
     static constexpr ui64 MaxWriteKeySize = 1024 * 1024 + 1024; // 1MB + small delta (for old ugc tests)
-    static constexpr ui64 MaxWriteValueSize = 16 * 1024 * 1024; // 16MB
+
+    // Runtime-tunable via YDB_TEST_DATASHARD_MAX_WRITE_VALUE_SIZE env var; default 16 MiB.
+    // TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+    inline ui64 MaxWriteValueSize() {
+        static const ui64 value = []() -> ui64 {
+            ui64 v = 0;
+            return TryFromString<ui64>(GetEnv("YDB_TEST_DATASHARD_MAX_WRITE_VALUE_SIZE"), v) ? v : (16ULL * 1024 * 1024);
+        }();
+        return value;
+    }
 }
 
 } // namespace NDataShard

--- a/ydb/core/tx/datashard/datashard__kqp_scan.cpp
+++ b/ydb/core/tx/datashard/datashard__kqp_scan.cpp
@@ -1,6 +1,8 @@
 #include "datashard_impl.h"
 #include "range_ops.h"
+#include <util/string/cast.h>
 #include <util/string/vector.h>
+#include <util/system/env.h>
 
 #include <ydb/core/actorlib_impl/long_timer.h>
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
@@ -464,7 +466,12 @@ private:
                 << ", bytes: " << sendBytes << ", rows: " << Rows << ", page faults: " << Result->PageFaults
                 << ", finished: " << Result->Finished << ", pageFault: " << Result->PageFault);
 
-            if (sendBytes >= 48_MB) {
+            // TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+            static const ui64 sendBytesLimit = []() -> ui64 {
+                ui64 v = 0;
+                return TryFromString<ui64>(GetEnv("YDB_TEST_KQP_SCAN_SEND_BYTES_LIMIT"), v) ? v : (48ULL * 1024 * 1024);
+            }();
+            if (sendBytes >= sendBytesLimit) {
                 LOG_ERROR_S(*TlsActivationContext, NKikimrServices::TX_DATASHARD, "Query size limit exceeded.");
                 if (finish) {
                     bool sent = Send(ComputeActorId, new TEvKqp::TEvAbortExecution(NYql::NDqProto::StatusIds::PRECONDITION_FAILED,

--- a/ydb/core/tx/datashard/datashard_change_receiving.cpp
+++ b/ydb/core/tx/datashard/datashard_change_receiving.cpp
@@ -283,12 +283,12 @@ class TDataShard::TTxApplyChangeRecords: public TTransactionBase<TDataShard> {
                     }
 
                     const auto& cell = ValueCells.GetCells().at(i);
-                    if (cell.Size() > NLimits::MaxWriteValueSize) {
+                    if (cell.Size() > NLimits::MaxWriteValueSize()) {
                         AddRecordStatus(ctx, record.GetOrder(), NKikimrChangeExchange::TEvStatus::STATUS_REJECT,
                             NKikimrChangeExchange::TEvStatus::REASON_SCHEME_ERROR,
                             TStringBuilder() << "Value cell is too big"
                                 << ": actual " << cell.Size() << " bytes"
-                                << ", limit " << NLimits::MaxWriteValueSize << " bytes");
+                                << ", limit " << NLimits::MaxWriteValueSize() << " bytes");
                         return false;
                     }
 

--- a/ydb/core/tx/datashard/datashard_common_upload.cpp
+++ b/ydb/core/tx/datashard/datashard_common_upload.cpp
@@ -183,10 +183,10 @@ bool TCommonUploadOps<TEvRequest, TEvResponse>::Execute(TDataShard* self, TTrans
         value.clear();
         size_t vi = 0;
         for (const auto& vt : valueCols) {
-            if (valueCells.GetCells()[vi].Size() > NLimits::MaxWriteValueSize) {
+            if (valueCells.GetCells()[vi].Size() > NLimits::MaxWriteValueSize()) {
                 SetError(NKikimrTxDataShard::TError::BAD_ARGUMENT,
                          Sprintf("Row cell size of %" PRISZT " bytes is larger than the allowed threshold %" PRIu64,
-                                 valueCells.GetBuffer().size(), NLimits::MaxWriteValueSize));
+                                 valueCells.GetBuffer().size(), NLimits::MaxWriteValueSize()));
                 return true;
             }
 

--- a/ydb/core/tx/datashard/datashard_write_operation.cpp
+++ b/ydb/core/tx/datashard/datashard_write_operation.cpp
@@ -203,8 +203,8 @@ std::tuple<NKikimrTxDataShard::TError::EKind, TString> TValidatedWriteTxOperatio
 
         for (ui16 valueColIdx = tableInfo.KeyColumnIds.size(); valueColIdx < Matrix.GetColCount(); ++valueColIdx) {
             const TCell& cell = Matrix.GetCell(rowIdx, valueColIdx);
-            if (cell.Size() > NLimits::MaxWriteValueSize)
-                return {NKikimrTxDataShard::TError::BAD_ARGUMENT, TStringBuilder() << "Row cell size of " << cell.Size() << " bytes is larger than the allowed threshold " << NLimits::MaxWriteValueSize};
+            if (cell.Size() > NLimits::MaxWriteValueSize())
+                return {NKikimrTxDataShard::TError::BAD_ARGUMENT, TStringBuilder() << "Row cell size of " << cell.Size() << " bytes is larger than the allowed threshold " << NLimits::MaxWriteValueSize()};
         }
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_consistent_copy_tables.cpp
@@ -163,7 +163,7 @@ bool CreateConsistentCopyTables(
 
     const auto& limits = firstPath.DomainInfo()->GetSchemeLimits();
     const auto limit = allForBackup
-        ? Max(limits.MaxObjectsInBackup, limits.MaxConsistentCopyTargets)
+        ? Max(limits.MaxObjectsInBackup(), limits.MaxConsistentCopyTargets)
         : limits.MaxConsistentCopyTargets;
 
     if (op.CopyTableDescriptionsSize() > limit) {

--- a/ydb/core/tx/schemeshard/schemeshard_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_types.cpp
@@ -1,6 +1,33 @@
 #include "schemeshard_types.h"
 
+#include <util/string/cast.h>
+#include <util/system/env.h>
+
 namespace NKikimr::NSchemeShard {
+
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+namespace {
+    ui64 EnvUi64(const char* name, ui64 def) {
+        ui64 v = 0;
+        return TryFromString<ui64>(GetEnv(name), v) ? v : def;
+    }
+}
+
+ui64 SchemeLimitsDefaultMaxObjectsInBackup() {
+    static const ui64 value = EnvUi64("YDB_TEST_SCHEMESHARD_MAX_OBJECTS_IN_BACKUP", 10*1000);
+    return value;
+}
+
+ui64 SchemeLimitsDefaultMaxTableColumns() {
+    static const ui64 value = EnvUi64("YDB_TEST_SCHEMESHARD_MAX_TABLE_COLUMNS", 200);
+    return value;
+}
+
+ui64 SchemeLimitsDefaultMaxTableIndices() {
+    static const ui64 value = EnvUi64("YDB_TEST_SCHEMESHARD_MAX_TABLE_INDICES", 20);
+    return value;
+}
+
 
 void TSchemeLimits::MergeFromProto(const NKikimrSubDomains::TSchemeLimits& proto) {
     if (proto.HasMaxDepth()) {

--- a/ydb/core/tx/schemeshard/schemeshard_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_types.h
@@ -25,29 +25,38 @@ struct EventTypeFromTEvPtr {
     // It would help if TEventHandle* had an explicit type alias to wrapped TEventType
 };
 
+// Defaults for TSchemeLimits are runtime-tunable via YDB_TEST_SCHEMESHARD_* env vars
+// (see schemeshard_types.cpp). Defaults match historical compile-time values when env unset.
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+ui64 SchemeLimitsDefaultMaxObjectsInBackup();
+ui64 SchemeLimitsDefaultMaxTableColumns();
+ui64 SchemeLimitsDefaultMaxTableIndices();
+
 struct TSchemeLimits {
     // Used for backward compatability in case of old databases without explicit limits
     static constexpr ui64 MaxPathsCompat = 200*1000;
-    static constexpr ui64 MaxObjectsInBackup = 10*1000;
+    // Function (not data member) to avoid static-init ordering issues with
+    // TSchemeShard::DefaultLimits, which is itself a global.
+    static ui64 MaxObjectsInBackup() { return SchemeLimitsDefaultMaxObjectsInBackup(); }
 
     // path
     ui64 MaxDepth = 32;
-    ui64 MaxPaths = MaxObjectsInBackup;
+    ui64 MaxPaths = MaxObjectsInBackup();
     ui64 MaxChildrenInDir = 100*1000;
     ui64 MaxAclBytesSize = 10 << 10;
     ui64 MaxPathElementLength = 255;
     TString ExtraPathSymbolsAllowed = "!\"#$%&'()*+,-.:;<=>?@[\\]^_`{|}~";
 
     // table
-    ui64 MaxTableColumns = 200;
+    ui64 MaxTableColumns = SchemeLimitsDefaultMaxTableColumns();
     ui64 MaxColumnTableColumns = 10000;
     ui64 MaxTableColumnNameLength = 255;
     ui64 MaxTableKeyColumns = 30;
-    ui64 MaxTableIndices = 20;
+    ui64 MaxTableIndices = SchemeLimitsDefaultMaxTableIndices();
     ui64 MaxTableCdcStreams = 5;
     ui64 MaxShards = 200*1000; // In each database
     ui64 MaxShardsInPath = 35*1000; // In each path in database
-    ui64 MaxConsistentCopyTargets = MaxObjectsInBackup;
+    ui64 MaxConsistentCopyTargets = MaxObjectsInBackup();
 
     // pq group
     ui64 MaxPQPartitions = 1000000;

--- a/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
+++ b/ydb/library/yql/dq/actors/compute/dq_compute_actor.h
@@ -16,8 +16,22 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 
+#include <util/string/cast.h>
+#include <util/system/env.h>
+
 namespace NYql {
 namespace NDq {
+
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+namespace NDqComputeMemoryLimitsEnv {
+    inline ui64 GetChunkSizeLimit() {
+        static const ui64 value = []() -> ui64 {
+            ui64 v = 0;
+            return TryFromString<ui64>(GetEnv("YDB_TEST_DQ_COMPUTE_CHUNK_SIZE_LIMIT"), v) ? v : (48ULL * 1024 * 1024);
+        }();
+        return value;
+    }
+}
 
 namespace TEvDqCompute {
     struct TEvState : public NActors::TEventPB<TEvState, NDqProto::TEvComputeActorState, TDqComputeEvents::EvState> {};
@@ -378,7 +392,7 @@ struct TComputeMemoryLimits {
     ui64 MinMemAllocSize = 30_MB;
     ui64 MinMemFreeSize = 30_MB;
     ui64 OutputChunkMaxSize = GetDqExecutionSettings().FlowControl.MaxOutputChunkSize;
-    ui64 ChunkSizeLimit = 48_MB;
+    ui64 ChunkSizeLimit = NDqComputeMemoryLimitsEnv::GetChunkSizeLimit();
     TMaybe<ui8> ArrayBufferMinFillPercentage; // Used by DqOutputHashPartitionConsumer and DqOutputChannel
     TMaybe<size_t> BufferPageAllocSize;
 

--- a/ydb/library/yql/dq/runtime/dq_channel_settings.h
+++ b/ydb/library/yql/dq/runtime/dq_channel_settings.h
@@ -10,8 +10,21 @@
 #include <yql/essentials/minikql/mkql_node.h>
 
 #include <util/generic/size_literals.h>
+#include <util/string/cast.h>
+#include <util/system/env.h>
 
 namespace NYql::NDq {
+
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+namespace NDqChannelSettingsEnv {
+    inline ui64 GetChunkSizeLimit() {
+        static const ui64 value = []() -> ui64 {
+            ui64 v = 0;
+            return TryFromString<ui64>(GetEnv("YDB_TEST_DQ_CHANNEL_CHUNK_SIZE_LIMIT"), v) ? v : (48ULL * 1024 * 1024);
+        }();
+        return value;
+    }
+}
 
 struct TDqChannelSettings {
 
@@ -31,7 +44,7 @@ struct TDqChannelSettings {
     // Output channels settings (may changed in future)
 
     ui64 MaxChunkBytes = 2_MB;
-    ui64 ChunkSizeLimit = 48_MB;
+    ui64 ChunkSizeLimit = NDqChannelSettingsEnv::GetChunkSizeLimit();
     IDqChannelStorage::TPtr ChannelStorage;
     TMaybe<ui8> ArrayBufferMinFillPercentage;
     TMaybe<size_t> BufferPageAllocSize;

--- a/ydb/library/yql/dq/runtime/dq_tasks_runner.h
+++ b/ydb/library/yql/dq/runtime/dq_tasks_runner.h
@@ -26,6 +26,8 @@
 #include <library/cpp/monlib/metrics/histogram_collector.h>
 
 #include <util/generic/size_literals.h>
+#include <util/string/cast.h>
+#include <util/system/env.h>
 #include <util/system/types.h>
 
 namespace NActors {
@@ -230,10 +232,21 @@ struct TDqTaskRunnerSettings {
     TVector<TString> ReadRanges;
 };
 
+// TODO(YDBAPPTEAM-773): revert this override after the ticket is closed.
+namespace NDqTaskRunnerMemoryLimitsEnv {
+    inline ui32 GetChunkSizeLimit() {
+        static const ui32 value = []() -> ui32 {
+            ui32 v = 0;
+            return TryFromString<ui32>(GetEnv("YDB_TEST_DQ_TASK_RUNNER_CHUNK_SIZE_LIMIT"), v) ? v : (48u * 1024u * 1024u);
+        }();
+        return value;
+    }
+}
+
 struct TDqTaskRunnerMemoryLimits {
     ui32 ChannelBufferSize = 0;
     ui32 OutputChunkMaxSize = 0;
-    ui32 ChunkSizeLimit = 48_MB;
+    ui32 ChunkSizeLimit = NDqTaskRunnerMemoryLimitsEnv::GetChunkSizeLimit();
     TMaybe<ui8> ArrayBufferMinFillPercentage;
     TMaybe<size_t> BufferPageAllocSize;
     IMemoryQuotaManager::TPtr ChannelQuotaManager;

--- a/ydb/public/api/protos/ydb_import.proto
+++ b/ydb/public/api/protos/ydb_import.proto
@@ -396,8 +396,8 @@ message ImportDataRequest {
     // - sorted by primary key;
     // - all keys must be from the same partition;
     // - table has no global secondary indexes;
-    // - size of serialized data is limited to 16 MB.
-    bytes data = 3 [(length).le = 16777216];
+    // - size of serialized data is limited to 20 MB.
+    bytes data = 3 [(length).le = 20971520];
     oneof format {
         // Result of `ydb tools dump`
         YdbDumpFormat ydb_dump = 4;


### PR DESCRIPTION
Replace hardcoded constants for max blob/chunk sizes and several TSchemeLimits defaults with values read from environment variables at startup. Defaults match current main values, so unset envs reproduce stock behaviour.

New YDB_TEST_* env vars (all bytes, except scheme limits in counts):
  YDB_TEST_DATASHARD_MAX_WRITE_VALUE_SIZE    (default 16 MiB)
  YDB_TEST_KQP_CHANNEL_CHUNK_SIZE_LIMIT      (default 48 MiB)
  YDB_TEST_KQP_MAX_TASK_SIZE                 (default 48 MiB)
  YDB_TEST_KQP_SCAN_SEND_BYTES_LIMIT         (default 48 MiB)
  YDB_TEST_DQ_COMPUTE_CHUNK_SIZE_LIMIT       (default 48 MiB)
  YDB_TEST_DQ_CHANNEL_CHUNK_SIZE_LIMIT       (default 48 MiB)
  YDB_TEST_DQ_TASK_RUNNER_CHUNK_SIZE_LIMIT   (default 48 MiB)
  YDB_TEST_SCHEMESHARD_MAX_OBJECTS_IN_BACKUP (default 10000)
  YDB_TEST_SCHEMESHARD_MAX_TABLE_COLUMNS     (default 200)
  YDB_TEST_SCHEMESHARD_MAX_TABLE_INDICES     (default 20)

Also:
  - Bump ImportDataRequest.data proto length cap 16 MB -> 20 MB so that runtime tunables can take effect (the cap is declarative and cannot itself be env-driven).
  - Forward ChannelChunkSizeLimit through TKqpNodeService::ApplyConfig so the env-set default isn't overwritten by missing proto config.
  - TSchemeLimits::MaxObjectsInBackup becomes a static method to avoid a static-init order race with the global TSchemeShard::DefaultLimits.

Each env-reading site carries a TODO(YDBAPPTEAM-773) comment so the override can be removed once the ticket is closed.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
