### PR TITLE
EXT-2313 Add timeout, precharge and continuation to the tablet_flat DbMon transaction

### DIFF
--- a/ydb/core/tablet/tablet_monitoring_proxy.cpp
+++ b/ydb/core/tablet/tablet_monitoring_proxy.cpp
@@ -12,6 +12,7 @@
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/tx/tx.h>
 #include <library/cpp/monlib/service/pages/templates.h>
+#include <util/string/ascii.h>
 #include <util/string/builder.h>
 
 ////////////////////////////////////////////
@@ -28,6 +29,9 @@ bool IsFormUrlencoded(const NMonitoring::IMonHttpRequest& request) {
     const TStringBuf contentType = value.NextTok(';');
     return contentType == "application/x-www-form-urlencoded";
 }
+
+static constexpr TDuration RequestTimeout = TDuration::Seconds(60);
+static constexpr TStringBuf RequestDeadlineHeader = "x-ydb-monitoring-deadline-us";
 
 class TForwardingActor : public TActorBootstrapped<TForwardingActor> {
 public:
@@ -71,6 +75,9 @@ public:
             pb.SetPostContent(content.data(), content.size());
         }
         for (const auto& header : request.GetHeaders()) {
+            if (AsciiEqualsIgnoreCase(header.Name(), RequestDeadlineHeader)) {
+                continue;
+            }
             auto *p = pb.AddHeaders();
             p->SetName(header.Name());
             p->SetValue(header.Value());
@@ -83,6 +90,11 @@ public:
     }
 
     void Bootstrap(const TActorContext& ctx) {
+        const TInstant deadline = TAppData::TimeProvider->Now() + RequestTimeout;
+        auto* deadlineHeader = Request.AddHeaders();
+        deadlineHeader->SetName(TString(RequestDeadlineHeader));
+        deadlineHeader->SetValue(TStringBuilder() << deadline.MicroSeconds());
+
         NTabletPipe::TClientConfig config;
 
         config.AllowFollower = (FollowerId && (*FollowerId != 0));
@@ -93,7 +105,7 @@ public:
         PipeClient = ctx.Register(NTabletPipe::CreateClient(ctx.SelfID, TargetTablet, config));
         NTabletPipe::SendData(ctx, PipeClient, new NMon::TEvRemoteHttpInfo(std::move(Request)));
 
-        ctx.Schedule(TDuration::Seconds(60), new TEvents::TEvWakeup());
+        ctx.Schedule(RequestTimeout, new TEvents::TEvWakeup());
         Become(&TThis::StateWork);
     }
 

--- a/ydb/core/tablet_flat/flat_executor_db_mon.cpp
+++ b/ydb/core/tablet_flat/flat_executor_db_mon.cpp
@@ -1,5 +1,7 @@
 #include "flat_executor.h"
 
+#include <ydb/core/base/appdata.h>
+
 #include <yql/essentials/types/binary_json/read.h>
 #include <yql/essentials/types/dynumber/dynumber.h>
 
@@ -10,24 +12,48 @@
 namespace NKikimr {
 namespace NTabletFlatExecutor {
 
+namespace {
+
+static constexpr TDuration DbMonRequestTimeout = TDuration::Seconds(60);
+static constexpr TStringBuf DbMonRequestDeadlineHeader = "x-ydb-monitoring-deadline-us";
+
+TInstant GetDbMonRequestDeadline(const NMon::TEvRemoteHttpInfo::TPtr& event) {
+    const TString deadlineUs = event->Get()->GetHeader(DbMonRequestDeadlineHeader);
+    const ui64 deadlineValue = FromStringWithDefault<ui64>(deadlineUs);
+    if (deadlineValue) {
+        return TInstant::MicroSeconds(deadlineValue);
+    }
+    return TAppData::TimeProvider->Now() + DbMonRequestTimeout;
+}
+
+}
+
 class TExecutor::TTxExecutorDbMon : public TTransactionBase<TExecutor> {
 public:
     NMon::TEvRemoteHttpInfo::TPtr Event;
 
-    TTxExecutorDbMon(NMon::TEvRemoteHttpInfo::TPtr& event, TSelf *executor)
+    TTxExecutorDbMon(NMon::TEvRemoteHttpInfo::TPtr& event, TSelf *executor, TInstant deadline)
         : TBase(executor)
         , Event(event)
+        , Deadline(deadline)
     {}
 
 private:
+    TInstant Deadline;
     ssize_t RowsScanned = 0;
     ui64 TotalDataSteps = 0;
     std::optional<TSerializedCellVec> LastSeenKey;
     TVector<TString> RenderedRows;
 
+    // We check for timeout every TimeoutCheckRows rows, so that we don't check too often and don't check too rarely.
+    static constexpr ui64 TimeoutCheckRows = 256;
     static constexpr ui64 OffsetScanPrechargeBytes = 16 * 1024 * 1024;
 
 private:
+    bool IsTimedOut() const {
+        return TAppData::TimeProvider->Now() >= Deadline;
+    }
+
     static TVector<TRawTypeValue> MakeRawKey(const NTable::TScheme::TTableInfo& tableInfo, TConstArrayRef<TCell> cells) {
         TVector<TRawTypeValue> key;
         key.reserve(cells.size());
@@ -49,6 +75,10 @@ private:
 
 public:
     bool Execute(TTransactionContext &txc, const TActorContext &ctx) override {
+        if (IsTimedOut()) {
+            return true;
+        }
+
         TStringStream str;
         {
             const auto &scheme = txc.DB.GetScheme();
@@ -229,6 +259,9 @@ public:
                         ++TotalDataSteps;
                         ++RowsScanned;
                         rowCount = RowsScanned;
+                        if (TotalDataSteps % TimeoutCheckRows == 0 && IsTimedOut()) {
+                            return true;
+                        }
                         if (rowCount > rowOffset) {
                             TStringStream rowStr;
                             {
@@ -349,6 +382,10 @@ public:
 
                     rememberIteratorKey();
 
+                    if (IsTimedOut()) {
+                        return true;
+                    }
+
                     if (result->Last() == NTable::EReady::Page) {
                         doPrecharge();
                         return false;
@@ -356,6 +393,9 @@ public:
 
                     // More rows?
                     const auto moreRowsReady = result->Next(NTable::ENext::Data);
+                    if (IsTimedOut()) {
+                        return true;
+                    }
                     if (moreRowsReady == NTable::EReady::Page) {
                         rememberIteratorKey();
                         doPrecharge();
@@ -402,6 +442,9 @@ public:
                 }
             }
         }
+        if (IsTimedOut()) {
+            return true;
+        }
         ctx.Send(Event->Sender, new NMon::TEvRemoteHttpInfoRes(str.Str()));
         return true;
     }
@@ -410,7 +453,7 @@ public:
 };
 
 void TExecutor::RenderHtmlDb(NMon::TEvRemoteHttpInfo::TPtr &ev, const TActorContext &ctx) const {
-    const_cast<TExecutor*>(this)->Execute(new TTxExecutorDbMon(ev, const_cast<TExecutor*>(this)), ctx);
+    const_cast<TExecutor*>(this)->Execute(new TTxExecutorDbMon(ev, const_cast<TExecutor*>(this), GetDbMonRequestDeadline(ev)), ctx);
 }
 
 

--- a/ydb/core/tablet_flat/flat_executor_db_mon.cpp
+++ b/ydb/core/tablet_flat/flat_executor_db_mon.cpp
@@ -19,6 +19,35 @@ public:
         , Event(event)
     {}
 
+private:
+    ssize_t RowsScanned = 0;
+    ui64 TotalDataSteps = 0;
+    std::optional<TSerializedCellVec> LastSeenKey;
+    TVector<TString> RenderedRows;
+
+    static constexpr ui64 OffsetScanPrechargeBytes = 16 * 1024 * 1024;
+
+private:
+    static TVector<TRawTypeValue> MakeRawKey(const NTable::TScheme::TTableInfo& tableInfo, TConstArrayRef<TCell> cells) {
+        TVector<TRawTypeValue> key;
+        key.reserve(cells.size());
+
+        auto itColumn = tableInfo.KeyColumns.begin();
+        for (const auto& cell : cells) {
+            Y_ENSURE(itColumn != tableInfo.KeyColumns.end());
+            const NTable::TColumn& columnInfo = tableInfo.Columns.find(*itColumn)->second;
+            if (cell.IsNull()) {
+                key.emplace_back();
+            } else {
+                key.emplace_back(cell.Data(), cell.Size(), columnInfo.PType.GetTypeId());
+            }
+            ++itColumn;
+        }
+
+        return key;
+    }
+
+public:
     bool Execute(TTransactionContext &txc, const TActorContext &ctx) override {
         TStringStream str;
         {
@@ -122,6 +151,30 @@ public:
                     if (cgi.Get("Lookup") == "Exact") {
                         lookup = NTable::ELookup::ExactMatch;
                     }
+                    const bool disableOffsetScanResume = cgi.Has("DisableOffsetScanResume");
+                    const bool disableOffsetScanPrecharge = cgi.Has("DisableOffsetScanPrecharge");
+                    if (disableOffsetScanResume) {
+                        LastSeenKey.reset();
+                        RowsScanned = 0;
+                        RenderedRows.clear();
+                    }
+                    const bool canResumeByKey = lookup != NTable::ELookup::ExactMatch && !tableInfo->KeyColumns.empty();
+                    if (LastSeenKey && (LastSeenKey->GetCells().size() != tableInfo->KeyColumns.size())) {
+                        // LastSeenKey is captured from iterator GetKey() after a successful step.
+                        // It must always be a full primary key for the same table.
+                        // Better stop here in this case.
+                        Y_TABLET_ERROR("Cannot resume offset scan because key size changed: "
+                            << LastSeenKey->GetCells().size() << " vs " << tableInfo->KeyColumns.size());
+                    }
+                    if (LastSeenKey && !canResumeByKey) {
+                        LastSeenKey.reset();
+                        RowsScanned = 0;
+                        RenderedRows.clear();
+                    }
+                    if (LastSeenKey && canResumeByKey) {
+                        key = MakeRawKey(*tableInfo, LastSeenKey->GetCells());
+                        lookup = NTable::ELookup::GreaterThan;
+                    }
                     auto result = txc.DB.Iterate(tableId, key, columns, lookup);
                     str << "<table class='table table-sortable'>";
                     str << "<thead>";
@@ -142,126 +195,172 @@ public:
                     rowLimit = Max<ssize_t>(rowLimit, 1);
                     ssize_t stringlimit = FromStringWithDefault<ssize_t>(cgi.Get("MaxString"), 1024);
                     stringlimit = Max<ssize_t>(stringlimit, 1);
-                    ssize_t rowCount = 0;
-                    while (result->Next(NTable::ENext::Data) == NTable::EReady::Data && rowCount < rowOffset + rowLimit) {
-                            ++rowCount;
-                            if (rowCount > rowOffset) {
-                                str << "<tr>";
+                    const ssize_t rowsEnd = rowLimit > Max<ssize_t>() - rowOffset
+                        ? Max<ssize_t>()
+                        : rowOffset + rowLimit;
+                    ssize_t rowCount = RowsScanned;
+
+                    auto rememberIteratorKey = [&] {
+                        const auto lastKey = result->GetKey().Cells();
+                        if (lastKey) {
+                            LastSeenKey.emplace(lastKey);
+                        }
+                    };
+
+                    auto doPrecharge = [&] {
+                        if (disableOffsetScanPrecharge) {
+                            return;
+                        }
+
+                        TVector<TRawTypeValue> prechargeKey;
+                        const auto lastKey = result->GetKey().Cells();
+                        if (lastKey) {
+                            prechargeKey = MakeRawKey(*tableInfo, lastKey);
+                        } else if (LastSeenKey) {
+                            prechargeKey = MakeRawKey(*tableInfo, LastSeenKey->GetCells());
+                        } else {
+                            prechargeKey = key;
+                        }
+
+                        txc.DB.Precharge(tableId, prechargeKey, {}, columns, 0, 0, OffsetScanPrechargeBytes);
+                    };
+
+                    while (rowCount < rowsEnd && result->Next(NTable::ENext::Data) == NTable::EReady::Data) {
+                        ++TotalDataSteps;
+                        ++RowsScanned;
+                        rowCount = RowsScanned;
+                        if (rowCount > rowOffset) {
+                            TStringStream rowStr;
+                            {
+                                auto& row = rowStr;
+                                row << "<tr>";
                                 TDbTupleRef tuple = result->GetValues();
                                 for (size_t i = 0; i < columns.size(); ++i) {
                                     const void *data = tuple.Columns[i].Data();
                                     ui32 size = tuple.Columns[i].Size();
-                                    str << "<td>";
+                                    row << "<td>";
                                     const auto& columnInfo = tableInfo->Columns.find(columns[i])->second;
                                     if (columnInfo.IsSensitive) {
                                         // Hide sensitive column value
-                                        str << "<i>&lt;HIDDEN VALUE&gt;</i>";
+                                        row << "<i>&lt;HIDDEN VALUE&gt;</i>";
                                     } else if (data == nullptr) {
-                                        str << "<i>&lt;null&gt;</i>";
+                                        row << "<i>&lt;null&gt;</i>";
                                     } else {
                                         switch(tuple.Types[i].GetTypeId()) {
                                         case NScheme::NTypeIds::Int8:
-                                            str << *(i8*)data;
+                                            row << *(i8*)data;
                                             break;
                                         case NScheme::NTypeIds::Int16:
-                                            str << *(i16*)data;
+                                            row << *(i16*)data;
                                             break;
                                         case NScheme::NTypeIds::Uint16:
-                                            str << *(ui16*)data;
+                                            row << *(ui16*)data;
                                             break;
                                         case NScheme::NTypeIds::Int32:
-                                            str << *(i32*)data;
+                                            row << *(i32*)data;
                                             break;
                                         case NScheme::NTypeIds::Uint32:
-                                            str << *(ui32*)data;
+                                            row << *(ui32*)data;
                                             break;
                                         case NScheme::NTypeIds::Int64:
-                                            str << *(i64*)data;
+                                            row << *(i64*)data;
                                             break;
                                         case NScheme::NTypeIds::Uint64:
-                                            str << *(ui64*)data;
+                                            row << *(ui64*)data;
                                             break;
                                         case NScheme::NTypeIds::Byte:
-                                            str << (ui32)*(ui8*)data;
+                                            row << (ui32)*(ui8*)data;
                                             break;
                                         case NScheme::NTypeIds::Bool:
-                                            str << *(bool*)data;
+                                            row << *(bool*)data;
                                             break;
                                         case NScheme::NTypeIds::Double:
-                                            str << *(double*)data;
+                                            row << *(double*)data;
                                             break;
                                         case NScheme::NTypeIds::Float:
-                                            str << *(float*)data;
+                                            row << *(float*)data;
                                             break;
                                         case NScheme::NTypeIds::Date:
-                                            str << *(ui16*)data;
+                                            row << *(ui16*)data;
                                             break;
                                         case NScheme::NTypeIds::Datetime:
-                                            str << *(ui32*)data;
+                                            row << *(ui32*)data;
                                             break;
                                         case NScheme::NTypeIds::Timestamp:
-                                            str << *(ui64*)data;
+                                            row << *(ui64*)data;
                                             break;
                                         case NScheme::NTypeIds::Interval:
-                                            str << *(i64*)data;
+                                            row << *(i64*)data;
                                             break;
                                         case NScheme::NTypeIds::Date32:
-                                            str << *(i32*)data;
+                                            row << *(i32*)data;
                                             break;
                                         case NScheme::NTypeIds::Datetime64:
                                         case NScheme::NTypeIds::Timestamp64:
                                         case NScheme::NTypeIds::Interval64:
-                                            str << *(i64*)data;
+                                            row << *(i64*)data;
                                             break;
                                         case NScheme::NTypeIds::PairUi64Ui64:
-                                            str << "(" << ((std::pair<ui64,ui64>*)data)->first << "," << ((std::pair<ui64,ui64>*)data)->second << ")";
+                                            row << "(" << ((std::pair<ui64,ui64>*)data)->first << "," << ((std::pair<ui64,ui64>*)data)->second << ")";
                                             break;
                                         case NScheme::NTypeIds::String:
                                         case NScheme::NTypeIds::String4k:
                                         case NScheme::NTypeIds::String2m:
-                                            str << EncodeHtmlPcdata(EscapeC(TStringBuf(static_cast<const char*>(data), Min(size, (ui32)stringlimit))));
+                                            row << EncodeHtmlPcdata(EscapeC(TStringBuf(static_cast<const char*>(data), Min(size, (ui32)stringlimit))));
                                             break;
                                         case NScheme::NTypeIds::ActorId:
-                                            str << *(TActorId*)data;
+                                            row << *(TActorId*)data;
                                             break;
                                         case NScheme::NTypeIds::Utf8:
                                         case NScheme::NTypeIds::Json:
-                                            str << EncodeHtmlPcdata(TStringBuf((const char*)data, size));
+                                            row << EncodeHtmlPcdata(TStringBuf((const char*)data, size));
                                             break;
                                         case NScheme::NTypeIds::JsonDocument: {
                                             const auto json = NBinaryJson::SerializeToJson(TStringBuf((const char*)data, size));
-                                            str << "(JsonDocument) " << EncodeHtmlPcdata(json);
+                                            row << "(JsonDocument) " << EncodeHtmlPcdata(json);
                                             break;
                                         }
                                         case NScheme::NTypeIds::DyNumber: {
                                             const auto number = NDyNumber::DyNumberToString(TStringBuf((const char*)data, size));
-                                            str << "(DyNumber) " << number;
+                                            row << "(DyNumber) " << number;
                                             break;
                                         }
                                         case NScheme::NTypeIds::Decimal: {
-                                            tuple.Types[i].GetDecimalType().CellValueToStream(tuple.Columns[i].AsValue<std::pair<ui64, i64>>(), str);
+                                            tuple.Types[i].GetDecimalType().CellValueToStream(tuple.Columns[i].AsValue<std::pair<ui64, i64>>(), row);
                                             break;
                                         }
                                         case NScheme::NTypeIds::Pg: {
                                             auto convert = NPg::PgNativeTextFromNativeBinary(tuple.Columns[i].AsBuf(), tuple.Types[i].GetPgTypeDesc());
-                                            str << EncodeHtmlPcdata(!convert.Error ? convert.Str : *convert.Error);
+                                            row << EncodeHtmlPcdata(!convert.Error ? convert.Str : *convert.Error);
                                             break;
                                         }
                                         default:
-                                            str << "<i>unknown type " << NScheme::TypeName(tuple.Types[i]) << "</i>";
+                                            row << "<i>unknown type " << NScheme::TypeName(tuple.Types[i]) << "</i>";
                                             break;
                                         }
                                     }
-                                    str << "</td>";
+                                    row << "</td>";
                                 }
-                                str << "</tr>";
+                                row << "</tr>";
                             }
+                            RenderedRows.push_back(rowStr.Str());
+                        }
                     }
-                    str << "</tbody>";
-                    str << "</table>";
 
-                    if (result->Last() == NTable::EReady::Page)
+                    rememberIteratorKey();
+
+                    if (result->Last() == NTable::EReady::Page) {
+                        doPrecharge();
                         return false;
+                    }
+
+                    // More rows?
+                    const auto moreRowsReady = result->Next(NTable::ENext::Data);
+                    if (moreRowsReady == NTable::EReady::Page) {
+                        rememberIteratorKey();
+                        doPrecharge();
+                        return false;
+                    }
 
                     auto fnPrintLink = [this, &str, tableId, &cgi] (ssize_t offset, ssize_t limit, TString caption) {
                         str << "<a href='db?TabletID=" << Self->TabletId()
@@ -277,6 +376,12 @@ public:
                             << "'>" << caption << "</a>";
                     };
 
+                    for (const auto& row : RenderedRows) {
+                        str << row;
+                    }
+                    str << "</tbody>";
+                    str << "</table>";
+
                     // Prev rows?
                     if (rowOffset > 0) {
                         ssize_t off = Max<ssize_t>(0, rowOffset - rowLimit);
@@ -285,13 +390,15 @@ public:
                         str << "<br>";
                     }
 
-                    // More rows?
-                    if (result->Next(NTable::ENext::Data) != NTable::EReady::Gone) {
+                    if (moreRowsReady != NTable::EReady::Gone) {
                         fnPrintLink(rowCount, rowLimit, Sprintf("Next %" PRISZT " rows", rowLimit));
                         str << "<br>";
                     }
 
                     fnPrintLink(0, 1000000000, "All");
+                    if (cgi.Has("TraceOffsetScan")) {
+                        str << "<!-- DbMonOffsetScanDataSteps=" << TotalDataSteps << " -->";
+                    }
                 }
             }
         }

--- a/ydb/core/tablet_flat/ut/ut_db_mon.cpp
+++ b/ydb/core/tablet_flat/ut/ut_db_mon.cpp
@@ -1,0 +1,432 @@
+#include <ydb/core/tablet_flat/flat_executor_ut_common.h>
+#include <ydb/core/base/memory_controller_iface.h>
+#include <ydb/core/tablet_flat/shared_sausagecache.h>
+#include <ydb/core/testlib/actors/wait_events.h>
+
+#include <util/string/cast.h>
+#include <util/system/env.h>
+
+namespace NKikimr {
+namespace NTabletFlatExecutor {
+namespace {
+
+struct TDbMonRowsModel {
+    enum : ui32 {
+        TableId = 101,
+        ColumnKeyId = 1,
+        ColumnValueId = 20,
+    };
+
+    struct TTxSchema : public ITransaction {
+        bool Execute(TTransactionContext& txc, const TActorContext&) override
+        {
+            if (txc.DB.GetScheme().GetTableInfo(TableId)) {
+                return true;
+            }
+
+            TCompactionPolicy policy;
+            txc.DB.Alter()
+                .AddTable("dbmon_test", TableId)
+                .AddColumn(TableId, "key", ColumnKeyId, NScheme::TInt64::TypeId, false, false)
+                .AddColumn(TableId, "value", ColumnValueId, NScheme::TString::TypeId, false, false)
+                .AddColumnToKey(TableId, ColumnKeyId)
+                .SetCompactionPolicy(TableId, policy);
+
+            return true;
+        }
+
+        void Complete(const TActorContext& ctx) override
+        {
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        }
+    };
+
+    struct TTxAddRows : public ITransaction {
+        explicit TTxAddRows(ui32 rows)
+            : Rows(rows)
+        {}
+
+        bool Execute(TTransactionContext& txc, const TActorContext&) override
+        {
+            for (ui32 key = 0; key < Rows; ++key) {
+                const auto keyCell = NScheme::TInt64::TInstance(key);
+                const auto valueCell = NScheme::TString::TInstance(TString(512, 'x'));
+                NTable::TUpdateOp op{ ColumnValueId, NTable::ECellOp::Set, valueCell };
+
+                txc.DB.Update(TableId, NTable::ERowOp::Upsert, { keyCell }, { op });
+            }
+
+            return true;
+        }
+
+        void Complete(const TActorContext& ctx) override
+        {
+            ctx.Send(ctx.SelfID, new NFake::TEvReturn);
+        }
+
+    private:
+        const ui32 Rows;
+    };
+
+    static NFake::TEvExecute* MakeScheme()
+    {
+        return new NFake::TEvExecute{ new TTxSchema };
+    }
+
+    static NFake::TEvExecute* MakeRows(ui32 rows)
+    {
+        return new NFake::TEvExecute{ new TTxAddRows(rows) };
+    }
+};
+
+class TDbMonTablet : public TActor<TDbMonTablet>, public TTabletExecutedFlat {
+public:
+    TDbMonTablet(const TActorId& sender, const TActorId& tablet, TTabletStorageInfo* info)
+        : TActor(&TThis::StateInit)
+        , TTabletExecutedFlat(info, tablet, nullptr)
+        , Sender(sender)
+    {}
+
+private:
+    void CompactionComplete(ui32 table, const TActorContext&) override
+    {
+        Send(Sender, new NFake::TEvCompacted(table));
+    }
+
+    void Handle(NFake::TEvExecute::TPtr& ev, const TActorContext& ctx)
+    {
+        for (auto& tx : ev->Get()->Txs) {
+            Execute(tx.Release(), ctx);
+        }
+        for (auto& lambda : ev->Get()->Lambdas) {
+            std::move(lambda)(Executor(), ctx);
+        }
+    }
+
+    void Handle(NFake::TEvCompact::TPtr& ev, const TActorContext&)
+    {
+        if (ev->Get()->MemOnly) {
+            Executor()->CompactMemTable(ev->Get()->Table);
+        } else {
+            Executor()->CompactTable(ev->Get()->Table);
+        }
+        Send(Sender, new TEvents::TEvWakeup);
+    }
+
+    void Handle(NFake::TEvReturn::TPtr&, const TActorContext&)
+    {
+        Send(Sender, new TEvents::TEvWakeup);
+    }
+
+    void Handle(TEvents::TEvPoison::TPtr&, const TActorContext& ctx)
+    {
+        Become(&TThis::StateBroken);
+        Executor()->DetachTablet();
+        Detach(ctx);
+        ctx.Send(Sender, new TEvents::TEvGone);
+    }
+
+    void DefaultSignalTabletActive(const TActorContext&) override
+    {}
+
+    void OnActivateExecutor(const TActorContext&) override
+    {
+        Executor()->RegisterExternalTabletCounters(new TTabletCountersBase);
+        Become(&TThis::StateWork);
+        SignalTabletActive(SelfId());
+        Send(Sender, new TEvents::TEvWakeup);
+    }
+
+    void OnDetach(const TActorContext& ctx) override
+    {
+        Die(ctx);
+    }
+
+    void OnTabletDead(TEvTablet::TEvTabletDead::TPtr&, const TActorContext& ctx) override
+    {
+        Die(ctx);
+    }
+
+    STFUNC(StateInit)
+    {
+        StateInitImpl(ev, SelfId());
+    }
+
+    STFUNC(StateWork)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(NFake::TEvExecute, Handle);
+            HFunc(NFake::TEvCompact, Handle);
+            HFunc(NFake::TEvReturn, Handle);
+            HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);
+            HFunc(TEvents::TEvPoison, Handle);
+        default:
+            HandleDefaultEvents(ev, SelfId());
+            break;
+        }
+    }
+
+    STFUNC(StateBroken)
+    {
+        switch (ev->GetTypeRewrite()) {
+            HFunc(TEvTablet::TEvTabletDead, HandleTabletDead);
+        }
+    }
+
+private:
+    const TActorId Sender;
+};
+
+class TDbMonEnv : public TMyEnvBase {
+public:
+    TDbMonEnv()
+    {
+        FireTablet(Edge, Tablet, [edge = Edge](const TActorId& tablet, TTabletStorageInfo* info) {
+            return new TDbMonTablet(edge, tablet, info);
+        });
+
+        WaitForWakeUp();
+        SendSync(TDbMonRowsModel::MakeScheme());
+    }
+
+    ~TDbMonEnv()
+    {
+        SendSync(new TEvents::TEvPoison, false, true);
+    }
+
+    void AddRowsAndCompact(ui32 rows)
+    {
+        SendSync(TDbMonRowsModel::MakeRows(rows));
+        SendSync(new NFake::TEvCompact(TDbMonRowsModel::TableId));
+        WaitFor<NFake::TEvCompacted>();
+    }
+
+    TString RequestDbPage(
+            ui64 rowsOffset,
+            ui64 maxRows,
+            bool disableOffsetScanResume,
+            bool disableOffsetScanPrecharge)
+    {
+        TStringBuilder request;
+        request << "/db?TabletID=" << Tablet
+            << "&TableID=" << ui32(TDbMonRowsModel::TableId)
+            << "&RowsOffset=" << rowsOffset
+            << "&MaxRows=" << maxRows
+            << "&MaxString=1"
+            << "&TraceOffsetScan=1";
+        if (disableOffsetScanResume) {
+            request << "&DisableOffsetScanResume=1";
+        }
+        if (disableOffsetScanPrecharge) {
+            request << "&DisableOffsetScanPrecharge=1";
+        }
+
+        SendAsync(new NMon::TEvRemoteHttpInfo(request));
+
+        return GrabEdgeEvent<NMon::TEvRemoteHttpInfoRes>()->Get()->Html;
+    }
+
+    void SetSharedCacheLimit(ui64 memoryLimit)
+    {
+        TWaitForFirstEvent<NMemory::TEvConsumerLimit> wait(Env);
+        Env.Send(NSharedCache::MakeSharedPageCacheId(), TActorId{}, new NMemory::TEvConsumerLimit(memoryLimit));
+        wait.Wait();
+    }
+
+    ui64 GetExecutorCumulativeCounter(TStringBuf name)
+    {
+        SendAsync(new TEvTablet::TEvGetCounters);
+        const auto response = GrabEdgeEvent<TEvTablet::TEvGetCountersResponse>();
+        const auto& counters = response->Get()->Record.GetTabletCounters().GetExecutorCounters();
+        for (const auto& counter : counters.GetCumulativeCounters()) {
+            if (counter.GetName() == name) {
+                return counter.GetValue();
+            }
+        }
+        UNIT_FAIL("Missing executor cumulative counter " << name);
+        return 0;
+    }
+};
+
+struct TDbPageStats {
+    TString Html;
+    ui64 TxPostponed = 0;
+    ui64 TxPageCacheMisses = 0;
+};
+
+TDbPageStats RequestDbPageWithStats(
+        TDbMonEnv& env,
+        ui64 rowsOffset,
+        ui64 maxRows,
+        bool disableOffsetScanResume = false,
+        bool disableOffsetScanPrecharge = false)
+{
+    const ui64 postponedBefore = env.GetExecutorCumulativeCounter("TxPostponed");
+    const ui64 missesBefore = env.GetExecutorCumulativeCounter("TxPageCacheMisses");
+
+    TString html = env.RequestDbPage(
+        rowsOffset,
+        maxRows,
+        disableOffsetScanResume,
+        disableOffsetScanPrecharge);
+
+    const ui64 postponedAfter = env.GetExecutorCumulativeCounter("TxPostponed");
+    const ui64 missesAfter = env.GetExecutorCumulativeCounter("TxPageCacheMisses");
+
+    return {
+        std::move(html),
+        postponedAfter - postponedBefore,
+        missesAfter - missesBefore,
+    };
+}
+
+size_t CountSubstrings(const TString& text, const TString& needle)
+{
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = text.find(needle, pos)) != TString::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+void AssertRenderedWindow(const TString& html, i64 firstKey, ui32 rows)
+{
+    size_t pos = 0;
+    for (ui32 i = 0; i < rows; ++i) {
+        const auto key = firstKey + i;
+        const TString cell = TStringBuilder() << "<td>" << key << "</td>";
+        const size_t nextPos = html.find(cell, pos);
+        UNIT_ASSERT_C(nextPos != TString::npos, "Missing rendered key " << key);
+        UNIT_ASSERT_VALUES_EQUAL_C(CountSubstrings(html, cell), 1, "Duplicated rendered key " << key);
+        pos = nextPos + cell.size();
+    }
+}
+
+ui64 GetOffsetScanDataSteps(const TString& html)
+{
+    const TString prefix = "<!-- DbMonOffsetScanDataSteps=";
+    const size_t begin = html.find(prefix);
+    UNIT_ASSERT_C(begin != TString::npos, "Missing offset scan trace in response");
+    const size_t valueBegin = begin + prefix.size();
+    const size_t valueEnd = html.find(" -->", valueBegin);
+    UNIT_ASSERT_C(valueEnd != TString::npos, "Malformed offset scan trace in response");
+    return FromString<ui64>(html.substr(valueBegin, valueEnd - valueBegin));
+}
+
+bool DisableOffsetScanResumeForValidation(bool defaultValue)
+{
+    const auto envValue = GetEnv("YDB_DBMON_DISABLE_OFFSET_SCAN_RESUME");
+    if (envValue.empty()) {
+        return defaultValue;
+    }
+    return envValue == "1";
+}
+
+bool DisableOffsetScanPrechargeForValidation(bool defaultValue)
+{
+    const auto envValue = GetEnv("YDB_DBMON_DISABLE_OFFSET_SCAN_PRECHARGE");
+    if (envValue.empty()) {
+        return defaultValue;
+    }
+    return envValue == "1";
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TFlatTableExecutor_DbMon) {
+    Y_UNIT_TEST(ExecutorDbMonResumesOffsetScanAfterPageRetry)
+    {
+        constexpr ui32 Rows = 6000;
+        constexpr ui32 RowsOffset = 5000;
+        constexpr ui32 MaxRows = 10;
+
+        TDbMonEnv env;
+        env.AddRowsAndCompact(Rows);
+        env.SetSharedCacheLimit(0);
+
+        const ui64 postponedBefore = env.GetExecutorCumulativeCounter("TxPostponed");
+        const ui64 missesBefore = env.GetExecutorCumulativeCounter("TxPageCacheMisses");
+
+        const TString html = env.RequestDbPage(
+            RowsOffset,
+            MaxRows,
+            DisableOffsetScanResumeForValidation(false),
+            DisableOffsetScanPrechargeForValidation(true));
+
+        const ui64 postponedAfter = env.GetExecutorCumulativeCounter("TxPostponed");
+        const ui64 missesAfter = env.GetExecutorCumulativeCounter("TxPageCacheMisses");
+        UNIT_ASSERT_C(postponedAfter > postponedBefore,
+            "Expected /db request to hit page-cache retry path");
+        UNIT_ASSERT_C(missesAfter > missesBefore,
+            "Expected /db request to load table pages");
+
+        AssertRenderedWindow(html, RowsOffset, MaxRows);
+        UNIT_ASSERT_VALUES_EQUAL(GetOffsetScanDataSteps(html), RowsOffset + MaxRows);
+        UNIT_ASSERT_VALUES_EQUAL(CountSubstrings(html, "<td>4999</td>"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(CountSubstrings(html, "<td>5010</td>"), 0);
+    }
+
+    Y_UNIT_TEST(ExecutorDbMonKeepsRenderedRowsAfterPageRetry)
+    {
+        constexpr ui32 Rows = 2000;
+        constexpr ui32 RowsOffset = 5;
+        constexpr ui32 MaxRows = 1000;
+
+        TDbMonEnv env;
+        env.AddRowsAndCompact(Rows);
+        env.SetSharedCacheLimit(0);
+
+        const TString html = env.RequestDbPage(
+            RowsOffset,
+            MaxRows,
+            DisableOffsetScanResumeForValidation(false),
+            DisableOffsetScanPrechargeForValidation(true));
+
+        AssertRenderedWindow(html, RowsOffset, MaxRows);
+        UNIT_ASSERT_VALUES_EQUAL(GetOffsetScanDataSteps(html), RowsOffset + MaxRows);
+        UNIT_ASSERT_VALUES_EQUAL(CountSubstrings(html, "<td>4</td>"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(CountSubstrings(html, "<td>1005</td>"), 0);
+    }
+
+    Y_UNIT_TEST(ExecutorDbMonPrechargeReducesOffsetScanRetries)
+    {
+        constexpr ui32 Rows = 6000;
+        constexpr ui32 RowsOffset = 5000;
+        constexpr ui32 MaxRows = 10;
+
+        auto runRequest = [] (bool disableOffsetScanPrecharge) {
+            TDbMonEnv env;
+            env.AddRowsAndCompact(Rows);
+            env.SetSharedCacheLimit(0);
+
+            return RequestDbPageWithStats(
+                env,
+                RowsOffset,
+                MaxRows,
+                DisableOffsetScanResumeForValidation(false),
+                disableOffsetScanPrecharge);
+        };
+
+        const TDbPageStats withoutPrecharge = runRequest(true);
+        const TDbPageStats withPrecharge = runRequest(false);
+
+        AssertRenderedWindow(withoutPrecharge.Html, RowsOffset, MaxRows);
+        AssertRenderedWindow(withPrecharge.Html, RowsOffset, MaxRows);
+
+        UNIT_ASSERT_C(withoutPrecharge.TxPostponed > 10,
+            "Expected multiple retries without precharge, got "
+                << withoutPrecharge.TxPostponed);
+        UNIT_ASSERT_C(withPrecharge.TxPostponed > 0,
+            "Expected precharge request to start from a real page miss");
+        UNIT_ASSERT_C(withPrecharge.TxPostponed * 4 < withoutPrecharge.TxPostponed,
+            "Expected precharge to reduce retries, with precharge: "
+                << withPrecharge.TxPostponed
+                << ", without precharge: "
+                << withoutPrecharge.TxPostponed);
+    }
+}
+
+} // namespace NTabletFlatExecutor
+} // namespace NKikimr

--- a/ydb/core/tablet_flat/ut/ut_db_mon.cpp
+++ b/ydb/core/tablet_flat/ut/ut_db_mon.cpp
@@ -1,8 +1,10 @@
 #include <ydb/core/tablet_flat/flat_executor_ut_common.h>
 #include <ydb/core/base/memory_controller_iface.h>
+#include <ydb/core/tablet/tablet_monitoring_proxy.h>
 #include <ydb/core/tablet_flat/shared_sausagecache.h>
 #include <ydb/core/testlib/actors/wait_events.h>
 
+#include <library/cpp/monlib/service/mon_service_http_request.h>
 #include <util/string/cast.h>
 #include <util/system/env.h>
 
@@ -246,6 +248,82 @@ public:
         UNIT_FAIL("Missing executor cumulative counter " << name);
         return 0;
     }
+
+    ui64 GetExecutorSimpleCounter(TStringBuf name)
+    {
+        SendAsync(new TEvTablet::TEvGetCounters);
+        const auto response = GrabEdgeEvent<TEvTablet::TEvGetCountersResponse>();
+        const auto& counters = response->Get()->Record.GetTabletCounters().GetExecutorCounters();
+        for (const auto& counter : counters.GetSimpleCounters()) {
+            if (counter.GetName() == name) {
+                return counter.GetValue();
+            }
+        }
+        UNIT_FAIL("Missing executor simple counter " << name);
+        return 0;
+    }
+};
+
+class TDbMonHttpRequest : public NMonitoring::IHttpRequest {
+public:
+    TDbMonHttpRequest(ui64 tabletId, ui32 tableId, ui64 rowsOffset, ui64 maxRows)
+        : Uri("/tablets/db")
+        , Path("/tablets/db")
+    {
+        Params.InsertUnescaped("TabletID", ToString(tabletId));
+        Params.InsertUnescaped("TableID", ToString(tableId));
+        Params.InsertUnescaped("RowsOffset", ToString(rowsOffset));
+        Params.InsertUnescaped("MaxRows", ToString(maxRows));
+        Params.InsertUnescaped("MaxString", "1");
+        Params.InsertUnescaped("DisableOffsetScanPrecharge", "1");
+    }
+
+    const char* GetURI() const override
+    {
+        return Uri.c_str();
+    }
+
+    const char* GetPath() const override
+    {
+        return Path.c_str();
+    }
+
+    const TCgiParameters& GetParams() const override
+    {
+        return Params;
+    }
+
+    const TCgiParameters& GetPostParams() const override
+    {
+        return PostParams;
+    }
+
+    TStringBuf GetPostContent() const override
+    {
+        return {};
+    }
+
+    HTTP_METHOD GetMethod() const override
+    {
+        return HTTP_METHOD_GET;
+    }
+
+    const THttpHeaders& GetHeaders() const override
+    {
+        return Headers;
+    }
+
+    TString GetRemoteAddr() const override
+    {
+        return {};
+    }
+
+private:
+    TString Uri;
+    TString Path;
+    TCgiParameters Params;
+    TCgiParameters PostParams;
+    THttpHeaders Headers;
 };
 
 struct TDbPageStats {
@@ -335,7 +413,7 @@ bool DisableOffsetScanPrechargeForValidation(bool defaultValue)
 
 } // namespace
 
-Y_UNIT_TEST_SUITE(TFlatTableExecutor_DbMon) {
+Y_UNIT_TEST_SUITE(TabletMon) {
     Y_UNIT_TEST(ExecutorDbMonResumesOffsetScanAfterPageRetry)
     {
         constexpr ui32 Rows = 6000;
@@ -425,6 +503,152 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_DbMon) {
                 << withPrecharge.TxPostponed
                 << ", without precharge: "
                 << withoutPrecharge.TxPostponed);
+    }
+
+    Y_UNIT_TEST(TabletMonitoringProxyTimeoutStopsDbMonTransaction)
+    {
+        constexpr ui32 Rows = 6000;
+        constexpr ui32 RowsOffset = 5000;
+        constexpr ui32 MaxRows = 10;
+
+        TDbMonEnv env;
+        env.AddRowsAndCompact(Rows);
+        env.SetSharedCacheLimit(0);
+
+        auto prevDispatchTimeout = env.Env.SetDispatchTimeout(TDuration::Seconds(5));
+        ui32 registeredActors = 0;
+        ui32 forwardingActors = 0;
+        TActorId forwardingActor;
+        auto prevRegistrationObserver = env.Env.SetRegistrationObserverFunc(
+            [&](TTestActorRuntimeBase& runtime, const TActorId& parentId, const TActorId& actorId) {
+                TTestActorRuntimeBase::DefaultRegistrationObserver(runtime, parentId, actorId);
+                ++registeredActors;
+                if (runtime.GetActorName(actorId).Contains("TForwardingActor")) {
+                    forwardingActor = actorId;
+                    runtime.EnableScheduleForActor(actorId);
+                    ++forwardingActors;
+                }
+            });
+        auto prevScheduledEventsSelector = env.Env.SetScheduledEventsSelectorFunc(
+            [&](TTestActorRuntimeBase&, TScheduledEventsList& scheduledEvents, TEventsList& queue) {
+                auto it = scheduledEvents.begin();
+                while (it != scheduledEvents.end()) {
+                    auto current = it++;
+                    auto& item = *current;
+                    if (item.Event->GetRecipientRewrite() == forwardingActor) {
+                        if (item.Cookie->Get()) {
+                            if (item.Cookie->Detach()) {
+                                queue.push_back(item.Event);
+                            }
+                        } else {
+                            queue.push_back(item.Event);
+                        }
+                    }
+                    scheduledEvents.erase(current);
+                }
+            });
+
+        const TActorId proxy = env.Env.Register(NTabletMonitoringProxy::CreateTabletMonitoringProxy());
+        TDispatchOptions bootstrapOptions;
+        bootstrapOptions.FinalEvents.emplace_back(TEvents::TSystem::Bootstrap, 1);
+        UNIT_ASSERT_C(env.Env.DispatchEvents(bootstrapOptions, TDuration::Seconds(1)),
+            "Expected tablet monitoring proxy actor to bootstrap");
+
+        bool delayBlobResults = true;
+        bool timeoutSeen = false;
+        TString timeoutBody;
+        TVector<THolder<IEventHandle>> delayedBlobResults;
+        ui32 remoteRequests = 0;
+        ui32 delayedBlobResultCount = 0;
+        ui32 remoteResponses = 0;
+
+        auto observer = [&](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case NMon::TEvRemoteHttpInfo::EventType:
+                    ++remoteRequests;
+                    break;
+
+                case TEvBlobStorage::EvGetResult:
+                    if (delayBlobResults) {
+                        ++delayedBlobResultCount;
+                        delayedBlobResults.emplace_back(ev.Release());
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+
+                case NMon::TEvHttpInfoRes::EventType:
+                    if (ev->GetRecipientRewrite() == env.Edge) {
+                        TStringStream body;
+                        ev->Get<NMon::TEvHttpInfoRes>()->Output(body);
+                        timeoutBody = body.Str();
+                        timeoutSeen = true;
+                        return TTestActorRuntime::EEventAction::DROP;
+                    }
+                    break;
+
+                case NMon::TEvRemoteHttpInfoRes::EventType:
+                    ++remoteResponses;
+                    return TTestActorRuntime::EEventAction::DROP;
+            }
+
+            return TTestActorRuntime::EEventAction::PROCESS;
+        };
+        auto prevObserver = env.Env.SetObserverFunc(observer);
+
+        TDbMonHttpRequest httpRequest(env.Tablet, TDbMonRowsModel::TableId, RowsOffset, MaxRows);
+        NMonitoring::TMonService2HttpRequest monRequest(
+            nullptr,
+            &httpRequest,
+            nullptr,
+            nullptr,
+            "/db",
+            nullptr);
+
+        env.Env.Send(new IEventHandle(proxy, env.Edge, new NMon::TEvHttpInfo(monRequest)));
+
+        auto dispatchUntil = [&](std::function<bool()> condition, TDuration timeout) {
+            TDispatchOptions options;
+            options.CustomFinalCondition = std::move(condition);
+            options.FinalEvents.emplace_back([](IEventHandle&) {
+                return false;
+            });
+            env.Env.DispatchEvents(options, timeout);
+        };
+
+        dispatchUntil([&] {
+            return delayedBlobResultCount > 0;
+        }, TDuration::Seconds(5));
+
+        UNIT_ASSERT_C(delayedBlobResultCount > 0,
+            "Expected db monitoring transaction to stop on page miss"
+                << ", registered actors: " << registeredActors
+                << ", forwarding actors: " << forwardingActors
+                << ", remote requests: " << remoteRequests);
+
+        env.Env.AdvanceCurrentTime(TDuration::Seconds(60));
+        dispatchUntil([&] {
+            return timeoutSeen;
+        }, TDuration::Seconds(5));
+
+        UNIT_ASSERT_C(timeoutSeen,
+            "Expected tablet monitoring proxy timeout"
+                << ", delayed blob results: " << delayedBlobResultCount
+                << ", remote responses: " << remoteResponses);
+        UNIT_ASSERT_STRING_CONTAINS(timeoutBody, "Timeout");
+
+        delayBlobResults = false;
+        for (auto& delayed : delayedBlobResults) {
+            env.Env.Send(delayed.Release());
+        }
+        delayedBlobResults.clear();
+
+        UNIT_ASSERT_VALUES_EQUAL(env.GetExecutorSimpleCounter("ExecutorTxInFly"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(remoteResponses, 0);
+
+        env.Env.SetObserverFunc(prevObserver);
+        env.Env.SetScheduledEventsSelectorFunc(prevScheduledEventsSelector);
+        env.Env.SetRegistrationObserverFunc(prevRegistrationObserver);
+        env.Env.SetDispatchTimeout(prevDispatchTimeout);
     }
 }
 

--- a/ydb/core/tablet_flat/ut/ya.make
+++ b/ydb/core/tablet_flat/ut/ya.make
@@ -38,6 +38,7 @@ SRCS(
     ut_compaction.cpp
     ut_compaction_multi.cpp
     ut_datetime.cpp
+    ut_db_mon.cpp
     ut_decimal.cpp    
     ut_charge.cpp
     ut_part.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Opening Executor DB internals with RowsOffset=16842699 caused FLAT_EXECUTOR to consume 100% CPU for hours. 
Adding timeout should help already, since this transaction is internal UI only, it's not that important. 
Next I've added precharge (to avoid reading page by page) and continuation (in order to not start from the beginning each time we retry transaction on page fault)
