### PR TITLE
Logbroker 10499

### DIFF
--- a/ydb/core/http_proxy/ut/ymq_ut.cpp
+++ b/ydb/core/http_proxy/ut/ymq_ut.cpp
@@ -3238,5 +3238,131 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         UNIT_ASSERT_VALUES_EQUAL(json["Messages"][0]["Body"], "MessageBody-1");
     }
 
+    Y_UNIT_TEST_F(NoBillingRecordsOnJsonApiAuthFailure, THttpProxyTestMockWithMetering) {
+        PrepareConfigs(KikimrServer.Get());
+        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableSQSMigrationTopicCreation(true);
+        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableSQSMigrationCompatibility(true);
+
+        auto meteringLogFilePath = KikimrServer->ServerSettings->AppConfig->GetSqsConfig().GetMeteringLogFilePath();
+
+        auto loadBillingRecords = [](const TString& filepath) -> TVector<NSc::TValue> {
+            TString data = TFileInput(filepath).ReadAll();
+            auto rawRecords = SplitString(data, "\n");
+            TVector<NSc::TValue> records;
+            for (auto& record : rawRecords) {
+                records.push_back(NSc::TValue::FromJson(record));
+            }
+            return records;
+        };
+
+        // First, create a queue with valid auth to generate baseline billing records
+        // Each successful SQS request generates 3 billing records (2 traffic + 1 request)
+        auto json = CreateQueue({{"QueueName", "MeteringTestQueue"}});
+
+        // Wait for billing records from the successful CreateQueue request
+        TVector<NSc::TValue> records;
+        while (records.size() != 3) {
+            Sleep(TDuration::Seconds(1));
+            records = loadBillingRecords(meteringLogFilePath);
+        }
+        const size_t baselineRecordCount = records.size();
+
+        // Disable authorization so that subsequent requests are sent without an
+        // Authorization header (FormAuthorizationStr returns an empty string).
+        DisableAuthorization();
+
+        // Send a JSON API CreateQueue request without authorization header.
+        // This triggers an IAM auth failure in TYmqHttpRequestActor::HandleYmqCloudAuthorizationResponse,
+        // which sets IamAuthFailed_ = true, causing DoMetering() to skip billing record generation.
+        // Auth failures are reported with HTTP code 400.
+        CreateQueue({{"QueueName", "AuthFailQueue"}}, 400);
+
+        // Wait for metering flush interval to pass (flush interval is 100ms, wait 2 seconds to be safe)
+        Sleep(TDuration::Seconds(2));
+
+        // Verify no additional billing records were generated for the failed auth request
+        records = loadBillingRecords(meteringLogFilePath);
+        UNIT_ASSERT_VALUES_EQUAL_C(records.size(), baselineRecordCount,
+            "Auth failure should not generate billing records, but got "
+            << records.size() << " records instead of " << baselineRecordCount);
+
+        // Re-enable authorization and verify that metering resumes: a successful
+        // request must again produce billing records (3 per request).
+        EnableAuthorization();
+        CreateQueue({{"QueueName", "AuthReenabledQueue"}});
+
+        const size_t expectedAfterReenable = baselineRecordCount + 3;
+        while (records.size() != expectedAfterReenable) {
+            Sleep(TDuration::Seconds(1));
+            records = loadBillingRecords(meteringLogFilePath);
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(records.size(), expectedAfterReenable,
+            "Metering should resume after authorization is re-enabled, but got "
+            << records.size() << " records instead of " << expectedAfterReenable);
+    }
+
+    Y_UNIT_TEST_F(NoBillingRecordsOnXmlApiAuthFailure, THttpProxyTestMockWithMetering) {
+        PrepareConfigs(KikimrServer.Get());
+        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableSQSMigrationTopicCreation(true);
+        KikimrServer->GetRuntime()->GetAppData().FeatureFlags.SetEnableSQSMigrationCompatibility(true);
+
+        auto meteringLogFilePath = KikimrServer->ServerSettings->AppConfig->GetSqsConfig().GetMeteringLogFilePath();
+
+        auto loadBillingRecords = [](const TString& filepath) -> TVector<NSc::TValue> {
+            TString data = TFileInput(filepath).ReadAll();
+            auto rawRecords = SplitString(data, "\n");
+            TVector<NSc::TValue> records;
+            for (auto& record : rawRecords) {
+                records.push_back(NSc::TValue::FromJson(record));
+            }
+            return records;
+        };
+
+        // First, create a queue with valid auth (via JSON API) to generate baseline billing records
+        auto json = CreateQueue({{"QueueName", "MeteringTestQueue"}});
+
+        // Wait for billing records from the successful CreateQueue request
+        TVector<NSc::TValue> records;
+        while (records.size() != 3) {
+            Sleep(TDuration::Seconds(1));
+            records = loadBillingRecords(meteringLogFilePath);
+        }
+        const size_t baselineRecordCount = records.size();
+
+        // Disable authorization so that subsequent requests are sent without an
+        // Authorization header (FormAuthorizationStr returns an empty string).
+        DisableAuthorization();
+
+        // Send an XML API CreateQueue request without authorization header.
+        // This triggers the XML API auth path (TCloudAuthRequestProxy) which calls
+        // Callback_->OnIamAuthError(), setting SkipMetering on the response.
+        // Auth failures are reported with HTTP code 400 and an IncompleteSignature error.
+        auto json2 = CreateQueueXml({{"QueueName", "XmlAuthFailQueue"}}, 400);
+        UNIT_ASSERT_STRING_CONTAINS(GetByPath<TString>(json2, "__type"), "IncompleteSignature");
+
+        // Wait for metering flush interval to pass
+        Sleep(TDuration::Seconds(2));
+
+        // Verify no additional billing records were generated for the failed auth request
+        records = loadBillingRecords(meteringLogFilePath);
+        UNIT_ASSERT_VALUES_EQUAL_C(records.size(), baselineRecordCount,
+            "Auth failure on XML API should not generate billing records, but got "
+            << records.size() << " records instead of " << baselineRecordCount);
+
+        // Re-enable authorization and verify that metering resumes: a successful
+        // XML API request must again produce billing records (3 per request).
+        EnableAuthorization();
+        CreateQueueXml({{"QueueName", "XmlAuthReenabledQueue"}});
+
+        const size_t expectedAfterReenable = baselineRecordCount + 3;
+        while (records.size() != expectedAfterReenable) {
+            Sleep(TDuration::Seconds(1));
+            records = loadBillingRecords(meteringLogFilePath);
+        }
+        UNIT_ASSERT_VALUES_EQUAL_C(records.size(), expectedAfterReenable,
+            "Metering should resume after authorization is re-enabled, but got "
+            << records.size() << " records instead of " << expectedAfterReenable);
+    }
+
 
 } // Y_UNIT_TEST_SUITE(TestYmqHttpProxy)

--- a/ydb/core/http_proxy/ut/ymq_ut.cpp
+++ b/ydb/core/http_proxy/ut/ymq_ut.cpp
@@ -3259,12 +3259,10 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         // Each successful SQS request generates 3 billing records (2 traffic + 1 request)
         auto json = CreateQueue({{"QueueName", "MeteringTestQueue"}});
 
-        // Wait for billing records from the successful CreateQueue request
-        TVector<NSc::TValue> records;
-        while (records.size() != 3) {
-            Sleep(TDuration::Seconds(1));
-            records = loadBillingRecords(meteringLogFilePath);
-        }
+        // Wait for metering flush interval to pass (flush interval is 100ms, wait 2 seconds to be safe)
+        Sleep(TDuration::Seconds(2));
+        TVector<NSc::TValue> records = loadBillingRecords(meteringLogFilePath);
+
         const size_t baselineRecordCount = records.size();
 
         // Disable authorization so that subsequent requests are sent without an
@@ -3291,11 +3289,11 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         EnableAuthorization();
         CreateQueue({{"QueueName", "AuthReenabledQueue"}});
 
+        // Wait for metering flush interval to pass (flush interval is 100ms, wait 2 seconds to be safe)
+        Sleep(TDuration::Seconds(2));
         const size_t expectedAfterReenable = baselineRecordCount + 3;
-        while (records.size() != expectedAfterReenable) {
-            Sleep(TDuration::Seconds(1));
-            records = loadBillingRecords(meteringLogFilePath);
-        }
+        records = loadBillingRecords(meteringLogFilePath);
+
         UNIT_ASSERT_VALUES_EQUAL_C(records.size(), expectedAfterReenable,
             "Metering should resume after authorization is re-enabled, but got "
             << records.size() << " records instead of " << expectedAfterReenable);
@@ -3321,12 +3319,10 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         // First, create a queue with valid auth (via JSON API) to generate baseline billing records
         auto json = CreateQueue({{"QueueName", "MeteringTestQueue"}});
 
-        // Wait for billing records from the successful CreateQueue request
-        TVector<NSc::TValue> records;
-        while (records.size() != 3) {
-            Sleep(TDuration::Seconds(1));
-            records = loadBillingRecords(meteringLogFilePath);
-        }
+        // Wait for metering flush interval to pass (flush interval is 100ms, wait 2 seconds to be safe)
+        Sleep(TDuration::Seconds(2));
+        TVector<NSc::TValue> records = loadBillingRecords(meteringLogFilePath);
+
         const size_t baselineRecordCount = records.size();
 
         // Disable authorization so that subsequent requests are sent without an
@@ -3355,10 +3351,11 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         CreateQueueXml({{"QueueName", "XmlAuthReenabledQueue"}});
 
         const size_t expectedAfterReenable = baselineRecordCount + 3;
-        while (records.size() != expectedAfterReenable) {
-            Sleep(TDuration::Seconds(1));
-            records = loadBillingRecords(meteringLogFilePath);
-        }
+
+        // Wait for metering flush interval to pass (flush interval is 100ms, wait 2 seconds to be safe)
+        Sleep(TDuration::Seconds(2));
+        records = loadBillingRecords(meteringLogFilePath);
+
         UNIT_ASSERT_VALUES_EQUAL_C(records.size(), expectedAfterReenable,
             "Metering should resume after authorization is re-enabled, but got "
             << records.size() << " records instead of " << expectedAfterReenable);

--- a/ydb/core/http_proxy/ymq.cpp
+++ b/ydb/core/http_proxy/ymq.cpp
@@ -192,6 +192,14 @@ namespace NKikimr::NHttpProxy {
             }
 
             void DoMetering(const THttpResponseData& data, THolder<THashMap<TString, TString>>&& queueTags, const TActorContext& ctx) {
+                if (IamAuthFailed_) {
+                    LOG_SP_DEBUG_S(
+                        ctx,
+                        NKikimrServices::HTTP_PROXY,
+                        TStringBuilder() << "Skip metering event due to IAM auth failure."
+                    );
+                    return;
+                }
                 if (HttpContext.ServiceConfig.GetHttpConfig().GetYandexCloudMode()) {
                     // Send request attributes to the metering actor
                     auto reportRequestAttributes = MakeHolder<::NKikimr::NSQS::TSqsEvents::TEvReportProcessedRequestAttributes>();
@@ -332,6 +340,7 @@ namespace NKikimr::NHttpProxy {
                         << " ErrorCode: " << ev->Get()->Error->ErrorCode
                         << " Message: " << ev->Get()->Error->Message
                     );
+                    IamAuthFailed_ = true;
                     ReplyWithError(
                         ctx,
                         ev->Get()->Error->HttpStatusCode,
@@ -434,6 +443,7 @@ namespace NKikimr::NHttpProxy {
             TRetryCounter RetryCounter;
             TActorId AuthActor;
             bool InputCountersReported = false;
+            bool IamAuthFailed_ = false;
             TString FolderId;
             TString CloudId;
             TString ResourceId;

--- a/ydb/core/ymq/actor/actor.h
+++ b/ydb/core/ymq/actor/actor.h
@@ -11,6 +11,7 @@ public:
     virtual ~IReplyCallback() = default;
 
     virtual void DoSendReply(const NKikimrClient::TSqsResponse& resp) = 0;
+    virtual void OnIamAuthError() {}
 };
 
 class IPingReplyCallback {

--- a/ydb/core/ymq/actor/auth_multi_factory.cpp
+++ b/ydb/core/ymq/actor/auth_multi_factory.cpp
@@ -516,6 +516,9 @@ void TCloudAuthRequestProxy::DoReply() {
 void TCloudAuthRequestProxy::SetError(const TErrorClass& errorClass, const TString& message) {
     auto* error = MakeMutableError();
     ::NKikimr::NSQS::MakeError(error, errorClass, Sprintf("%s Request id to report: %s.", message.c_str(), RequestId_.c_str()));
+    if (Callback_) {
+        Callback_->OnIamAuthError();
+    }
 }
 
 void TCloudAuthRequestProxy::OnSuccessfulAuth() {

--- a/ydb/core/ymq/http/http.cpp
+++ b/ydb/core/ymq/http/http.cpp
@@ -77,11 +77,16 @@ public:
         response.FolderId = resp.GetFolderId();
         response.IsFifo = resp.GetIsFifo();
         response.ResourceId = resp.GetResourceId();
+        response.SkipMetering = IamAuthFailed_;
         for (const auto& tag : resp.GetQueueTags()) {
             response.QueueTags[tag.GetKey()] = tag.GetValue();
         }
 
         Request_->SendResponse(response);
+    }
+
+    void OnIamAuthError() override {
+        IamAuthFailed_ = true;
     }
 
 private:
@@ -102,6 +107,7 @@ private:
 private:
     THttpRequest* const Request_;
     const TSqsRequest RequestParams_;
+    bool IamAuthFailed_ = false;
 };
 
 class TPingHttpCallback : public IPingReplyCallback {
@@ -153,7 +159,7 @@ void THttpRequest::WriteResponse(const TReplyParams& replyParams, const TSqsHttp
         httpResponse.SetContent(response.Body, response.ContentType);
     }
 
-    if (Parent_->Config.GetYandexCloudMode() && !IsPrivateRequest_) {
+    if (Parent_->Config.GetYandexCloudMode() && !IsPrivateRequest_ && !response.SkipMetering) {
         // Send request attributes to the metering actor
         auto reportRequestAttributes = MakeHolder<TSqsEvents::TEvReportProcessedRequestAttributes>();
 

--- a/ydb/core/ymq/http/types.h
+++ b/ydb/core/ymq/http/types.h
@@ -18,6 +18,7 @@ struct TSqsHttpResponse {
     TString FolderId;
     TString ResourceId;
     bool    IsFifo = false;
+    bool    SkipMetering = false;
 
     NSc::TValue QueueTags;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Billing will not be applied to requests if authentication fail

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

**AI generated**

Here is the commit description covering all changes:

**SQS: пропуск метеринга при ошибке IAM-аутентификации**

**Проблема**

При сбое IAM-аутентификации в SQS HTTP-прокси записи биллинга (metering records) всё равно генерировались, что приводило к некорректному тарификации запросов, завершившихся ошибкой авторизации.

**Изменения**

`core/ymq/actor/actor.h`
- Добавлен виртуальный метод `OnIamAuthError()` в интерфейс `IReplyCallback` для уведомления обработчика запроса об ошибке IAM-аутентификации.

`core/ymq/http/types.h`
- Добавлено поле `SkipMetering = false` в структуру `TSqsHttpResponse` для передачи флага пропуска метеринга из обратного вызова в `WriteResponse()`.

`core/ymq/actor/auth_multi_factory.cpp`
- В методе `TCloudAuthRequestProxy::SetError` добавлен вызов `Callback_->OnIamAuthError()` при ошибке аутентификации в XML API-пути.

`core/ymq/http/http.cpp`
- В классе `THttpCallback` добавлены поле `IamAuthFailed_` и реализация метода `OnIamAuthError()`, устанавливающая этот флаг.
- В методе `DoSendReply` флаг `IamAuthFailed_` передаётся в `response.SkipMetering`.
- В методе `WriteResponse` добавлена проверка `!response.SkipMetering` перед отправкой события метеринга (XML API-путь).

`core/http_proxy/ymq.cpp`
- В классе `TYmqHttpRequestActor` добавлен флаг `IamAuthFailed_`.
- В обработчике `HandleYmqCloudAuthorizationResponse` флаг устанавливается в `true` при получении ответа с ошибкой авторизации (JSON API-путь).
- В методе `DoMetering` добавлена ранняя проверка флага `IamAuthFailed_`: при его установке метеринг пропускается с записью отладочного лога.

`core/http_proxy/ut/ymq_ut.cpp`
- Добавлен тест `NoBillingRecordsOnJsonApiAuthFailure` (`THttpProxyTestMockWithMetering`): создаёт очередь с корректной авторизацией (базовые 3 записи биллинга), затем отключает авторизацию через `DisableAuthorization()`, отправляет неаутентифицированный JSON API-запрос (ожидается HTTP 400), проверяет что новых записей биллинга не появилось, после чего включает авторизацию обратно и проверяет что метеринг возобновился (3 новые записи).
- Добавлен тест `NoBillingRecordsOnXmlApiAuthFailure` (`THttpProxyTestMockWithMetering`): аналогичная проверка для XML API-пути — неаутентифицированный `CreateQueueXml` запрос должен возвращать `IncompleteSignature` (HTTP 400) без генерации записей биллинга, а после повторного включения авторизации метеринг должен возобновиться.