### PR TITLE
Revert "Use `--cleanup-child-processes` for kill child processes when test finish"

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -192,7 +192,6 @@ runs:
           --test-threads "${{ inputs.test_threads }}" --link-threads "${{ inputs.link_threads }}"
           -DUSE_EAT_MY_DATA
           --add-peerdirs-tests all
-          --cleanup-child-processes
         )
 
         TEST_RETRY_COUNT=${{ inputs.test_retry_count }}


### PR DESCRIPTION
Reverts ydb-platform/ydb#44310

http://st/DEVTOOLSSUPPORT-89744 -- ya make was reverted in arcadia. So, we can't merge rightlib