### PR TITLE
iam generic provider: fix exception handling

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
@@ -249,7 +249,7 @@ private:
                 }
                 try {
                     FillContext(guard);
-                } catch(...) {
+                } catch (...) {
                     const auto now = SysClock::now();
                     LastRequestError_ = TStringBuilder()
                         << "Last request error was at " << FormatSysTimeUtcIsoMicros(now)

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
@@ -189,9 +189,13 @@ private:
             try {
                 RequestFiller_(req);
             } catch (...) {
+                const auto now = SysClock::now();
                 std::lock_guard guard(Lock_);
-                LastRequestError_ = TStringBuilder() << "Request failed: " << CurrentExceptionMessage();
+                LastRequestError_ = TStringBuilder()
+                    << "Last request error was at " << FormatSysTimeUtcIsoMicros(now)
+                    << ". Failed to prepare IAM request: " << CurrentExceptionMessage();
                 ResetContextImpl();
+                RescheduleOnFailure();
                 return;
             }
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
@@ -250,7 +250,10 @@ private:
                 try {
                     FillContext(guard);
                 } catch(...) {
-                    LastRequestError_ = TStringBuilder() << "Request failed: " << CurrentExceptionMessage();
+                    const auto now = SysClock::now();
+                    LastRequestError_ = TStringBuilder()
+                        << "Last request error was at " << FormatSysTimeUtcIsoMicros(now)
+                        << ". Failed to prepare IAM request context: " << CurrentExceptionMessage();
                     ResetContextImpl();
                 }
                 if (NeedStop_) {
@@ -258,6 +261,7 @@ private:
                     return false;
                 }
                 if (!Context_.has_value()) {
+                    RescheduleOnFailure();
                     return true;
                 }
             }
@@ -275,29 +279,38 @@ private:
                     << " Message: \"" << status.error_message()
                     << "\" iam-endpoint: \"" << IamEndpoint_.Endpoint << "\"";
 
-                const auto now = SysClock::now();
-                const auto retryDelay = std::min(BackoffTimeout_, BACKOFF_MAX);
-                NextTicketUpdate_ = SafeAddSystemTime(now, ToBoundedSysDuration(retryDelay));
-                BackoffTimeout_ = std::min(BackoffTimeout_ * 2, BACKOFF_MAX);
+                RescheduleOnFailure();
             } else {
                 LastRequestError_ = "";
                 Ticket_ = result.iam_token();
-                BackoffTimeout_ = BACKOFF_START;
 
-                const auto now = SysClock::now();
-                const SysTimePoint refreshAt = SafeAddSystemTime(now, ToBoundedSysDuration(IamEndpoint_.RefreshPeriod));
                 const SysTimePoint expiresAt = SysClock::from_time_t(result.expires_at().seconds());
-                const SysDuration requestMargin = ToBoundedSysDuration(IamEndpoint_.RequestTimeout);
-
-                SysTimePoint nextUpdate = std::min(refreshAt, expiresAt);
-                nextUpdate = SafeAddSystemTime(nextUpdate, -requestMargin);
-                nextUpdate = std::max(nextUpdate, SafeAddSystemTime(now, ToBoundedSysDuration(MINIMUM_REFRESH_INTERVAL)));
-                NextTicketUpdate_ = nextUpdate;
+                RescheduleOnSuccess(expiresAt);
 
                 TokenReady_.notify_all();
             }
 
             ResetContextImpl();
+        }
+
+        void RescheduleOnFailure() { // call with Lock_
+            const auto now = SysClock::now();
+            const auto retryDelay = std::min(BackoffTimeout_, BACKOFF_MAX);
+            NextTicketUpdate_ = SafeAddSystemTime(now, ToBoundedSysDuration(retryDelay));
+            BackoffTimeout_ = std::min(BackoffTimeout_ * 2, BACKOFF_MAX);
+        }
+
+        void RescheduleOnSuccess(const SysTimePoint expiresAt) { // call with Lock_
+            BackoffTimeout_ = BACKOFF_START;
+
+            const auto now = SysClock::now();
+            const SysTimePoint refreshAt = SafeAddSystemTime(now, ToBoundedSysDuration(IamEndpoint_.RefreshPeriod));
+            const SysDuration requestMargin = ToBoundedSysDuration(IamEndpoint_.RequestTimeout);
+
+            SysTimePoint nextUpdate = std::min(refreshAt, expiresAt);
+            nextUpdate = SafeAddSystemTime(nextUpdate, -requestMargin);
+            nextUpdate = std::max(nextUpdate, SafeAddSystemTime(now, ToBoundedSysDuration(MINIMUM_REFRESH_INTERVAL)));
+            NextTicketUpdate_ = nextUpdate;
         }
 
     private:

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
@@ -247,10 +247,18 @@ private:
                 if (Context_.has_value() || SysClock::now() < NextTicketUpdate_) {
                     return true;
                 }
-                FillContext(guard);
+                try {
+                    FillContext(guard);
+                } catch(...) {
+                    LastRequestError_ = TStringBuilder() << "Request failed: " << CurrentExceptionMessage();
+                    ResetContextImpl();
+                }
                 if (NeedStop_) {
                     ResetContextImpl();
                     return false;
+                }
+                if (!Context_.has_value()) {
+                    return true;
                 }
             }
             UpdateTicket();

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/grpc_iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/grpc_iam_ut.cpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <future>
@@ -15,6 +16,8 @@
 #include <mutex>
 #include <string>
 #include <thread>
+
+#include <util/generic/yexception.h>
 
 using namespace NYdb;
 using namespace NYdb::NTest;
@@ -125,6 +128,32 @@ private:
     bool Released_ = false;
 };
 
+class TFailThenSucceedAuthProvider final : public ICredentialsProvider {
+public:
+    explicit TFailThenSucceedAuthProvider(int failCount)
+        : FailCount_(failCount)
+    {}
+
+    std::string GetAuthInfo() const override {
+        if (CallCount_.fetch_add(1) < FailCount_) {
+            ythrow yexception() << "auth failure";
+        }
+        return "auth-token";
+    }
+
+    bool IsValid() const override {
+        return true;
+    }
+
+    int GetCallCount() const {
+        return CallCount_.load();
+    }
+
+private:
+    const int FailCount_;
+    mutable std::atomic<int> CallCount_{0};
+};
+
 } // namespace
 
 TEST(GrpcIamCredentialsProvider, StopDuringFillContextDoesNotHang) {
@@ -174,6 +203,36 @@ TEST(GrpcIamCredentialsProvider, StopDuringFillContextDoesNotHang) {
     ASSERT_EQ(stopDone.wait_for(std::chrono::seconds(20)), std::future_status::ready)
         << "provider destructor (Stop()) must complete while FillContext is blocked in GetAuthInfo()";
     stopDone.get();
+
+    server.Stop();
+}
+
+TEST(GrpcIamCredentialsProvider, FillContextAuthExceptionSurvivesAndRecovers) {
+    TIamTokenServiceStub iamStub;
+    iamStub.SetResponseToken("unit-test-iam-token");
+    TIamGrpcServer server(&iamStub);
+    ASSERT_TRUE(server.Start());
+
+    auto authProvider = std::make_shared<TFailThenSucceedAuthProvider>(2);
+
+    TIamOAuth params = MakeOAuthParams(server.Endpoint());
+    auto facility = std::make_shared<TSimpleCoreFacility>();
+
+    TGrpcIamCredentialsProvider<CreateIamTokenRequest, CreateIamTokenResponse, IamTokenService> provider(
+        params,
+        [token = params.OAuthToken](CreateIamTokenRequest& req) {
+            req.set_yandex_passport_oauth_token(TStringType{token});
+        },
+        [](IamTokenService::Stub* stub, grpc::ClientContext* context, const CreateIamTokenRequest* request,
+           CreateIamTokenResponse* response, std::function<void(grpc::Status)> cb) {
+            stub->async()->Create(context, request, response, std::move(cb));
+        },
+        facility,
+        authProvider);
+
+    EXPECT_EQ(provider.GetAuthInfo(), "unit-test-iam-token");
+    EXPECT_EQ(iamStub.GetRequestCount(), 1);
+    EXPECT_GE(authProvider->GetCallCount(), 3);
 
     server.Stop();
 }


### PR DESCRIPTION
When FillContext throws exception, it (probably) cancel periodic task (or worse).

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

When PeriodicTask throws exception, 
ydb/public/sdk/cpp/src/client/types/core_facility/simple_core_facility.cpp#L72
catches and reshedules, but "regular" core facility, apparently, not:
ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp#L266
ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.cpp