### PR TITLE
Inherit connect right within domain up to tenant root in EffectiveAcl

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
@@ -377,7 +377,8 @@ struct TSchemeShard::TTxInitTenantSchemeShard : public TSchemeShard::TRwTxBase {
         Self->ParentDomainEffectiveACLVersion = effectiveACLVersion;
         Self->ParentDomainCachedEffectiveACL.Init(Self->ParentDomainEffectiveACL);
 
-        newPath->CachedEffectiveACL.Update(Self->ParentDomainCachedEffectiveACL, newPath->ACL, newPath->IsContainer());
+        newPath->CachedEffectiveACL.Update(Self->ParentDomainCachedEffectiveACL, newPath->ACL,
+            newPath->IsContainer(), /*isTenantRoot*/ true);
 
         TPathId resourcesDomainId = Self->ParentDomainId;
         if (record.HasResourcesDomainOwnerId() && record.HasResourcesDomainPathId()) {

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -115,10 +115,11 @@ struct TCgi {
     static const TParam OwnerPathId;
     static const TParam LocalPathId;
     static const TParam IsReadOnlyMode;
-    static const TParam UpdateAccessDatabaseRights;
-    static const TParam UpdateAccessDatabaseRightsDryRun;
-    static const TParam FixAccessDatabaseInheritance;
-    static const TParam FixAccessDatabaseInheritanceDryRun;
+    // Deprecated: connect (ConnectDatabase) right is now always inherited via DefaultInheritanceType.
+    // static const TParam UpdateAccessDatabaseRights;
+    // static const TParam UpdateAccessDatabaseRightsDryRun;
+    // static const TParam FixAccessDatabaseInheritance;
+    // static const TParam FixAccessDatabaseInheritanceDryRun;
     static const TParam Page;
     static const TParam BuildIndexId;
     static const TParam UpdateCoordinatorsConfig;
@@ -161,10 +162,11 @@ const TCgi::TParam TCgi::ShardID = TStringBuf("ShardID");
 const TCgi::TParam TCgi::OwnerPathId = TStringBuf("OwnerPathId");
 const TCgi::TParam TCgi::LocalPathId = TStringBuf("LocalPathId");
 const TCgi::TParam TCgi::IsReadOnlyMode = TStringBuf("IsReadOnlyMode");
-const TCgi::TParam TCgi::UpdateAccessDatabaseRights = TStringBuf("UpdateAccessDatabaseRights");
-const TCgi::TParam TCgi::UpdateAccessDatabaseRightsDryRun = TStringBuf("UpdateAccessDatabaseRightsDryRun");
-const TCgi::TParam TCgi::FixAccessDatabaseInheritance = TStringBuf("FixAccessDatabaseInheritance");
-const TCgi::TParam TCgi::FixAccessDatabaseInheritanceDryRun = TStringBuf("FixAccessDatabaseInheritanceDryRun");
+// Deprecated: connect (ConnectDatabase) right is now always inherited via DefaultInheritanceType.
+// const TCgi::TParam TCgi::UpdateAccessDatabaseRights = TStringBuf("UpdateAccessDatabaseRights");
+// const TCgi::TParam TCgi::UpdateAccessDatabaseRightsDryRun = TStringBuf("UpdateAccessDatabaseRightsDryRun");
+// const TCgi::TParam TCgi::FixAccessDatabaseInheritance = TStringBuf("FixAccessDatabaseInheritance");
+// const TCgi::TParam TCgi::FixAccessDatabaseInheritanceDryRun = TStringBuf("FixAccessDatabaseInheritanceDryRun");
 const TCgi::TParam TCgi::Page = TStringBuf("Page");
 const TCgi::TParam TCgi::BuildIndexId = TStringBuf("BuildIndexId");
 const TCgi::TParam TCgi::UpdateCoordinatorsConfig = TStringBuf("UpdateCoordinatorsConfig");
@@ -628,6 +630,9 @@ private:
             Self->IsReadOnlyMode = value;
         }
 
+        // Deprecated: connect (ConnectDatabase) right is now always inherited via DefaultInheritanceType.
+        // These admin actions (UpdateAccessDatabaseRights / FixAccessDatabaseInheritance) are no longer available.
+        /*
         if (cgi.Has(TCgi::UpdateAccessDatabaseRights)) {
             TString rowDryRunStr = cgi.Get(TCgi::UpdateAccessDatabaseRightsDryRun);
             auto valueDryRun = FromStringWithDefault<ui64>(rowDryRunStr, ui64(1));
@@ -731,6 +736,7 @@ private:
 
             return;
         }
+        */
 
         if (cgi.Has(TCgi::UpdateCoordinatorsConfig)) {
             TString rawDryRunStr = cgi.Get(TCgi::UpdateCoordinatorsConfigDryRun);
@@ -1031,6 +1037,9 @@ private:
             str << "</div>";
             str << "</form>" << Endl;
         }
+        // Deprecated: connect (ConnectDatabase) right is now always inherited via DefaultInheritanceType.
+        // These admin sections (UpdateAccessDatabaseRights / FixAccessDatabaseInheritance) are no longer shown.
+        /*
         {
             str << "<form method=\"GET\" id=\"tblMonSSFrm\" name=\"tblMonSSFrm\" class=\"form-group\">" << Endl;
             str << "<legend> Execute upgrade DB's ACL, grant ACCESS to all existed users: </legend>";
@@ -1055,6 +1064,7 @@ private:
             str << "</div>";
             str << "</form>" << Endl;
         }
+        */
         {
             str << "<form method=\"GET\" id=\"tblMonSSFrmUpdateCoordinatorsConfig\" name=\"tblMonSSFrmUpdateCoordinatorsConfig\" class=\"form-group\">" << Endl;
             str << "<legend> Send configuration update to all coordinators: </legend>";

--- a/ydb/core/tx/schemeshard/schemeshard_effective_acl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_effective_acl.cpp
@@ -2,8 +2,24 @@
 
 #include <ydb/library/aclib/protos/identity/user_token.pb.h>
 
+#include <algorithm>
+
 namespace NKikimr {
 namespace NSchemeShard {
+
+TString TEffectiveACL::StripConnectRightACE(const TString& acl) {
+    NACLibProto::TSecurityObject obj;
+    Y_ABORT_UNLESS(obj.MutableACL()->ParseFromString(acl));
+
+    auto* aces = obj.MutableACL()->MutableACE();
+    aces->erase(
+        std::remove_if(aces->begin(), aces->end(), [](const NACLibProto::TACE& ace) {
+            return ace.GetAccessRight() == NACLib::EAccessRights::ConnectDatabase;
+        }),
+        aces->end());
+
+    return obj.GetACL().SerializeAsString();
+}
 
 void TEffectiveACL::Init(const TString &effectiveACL)
 {
@@ -20,12 +36,12 @@ void TEffectiveACL::Init(const TString &effectiveACL)
     ForSelf = effectiveACL;
 }
 
-void TEffectiveACL::Update(const TEffectiveACL &parent, const TString &selfACL, bool isContainer)
+void TEffectiveACL::Update(const TEffectiveACL &parent, const TString &selfACL, bool isContainer, bool isTenantRoot)
 {
     Y_DEBUG_ABORT_UNLESS(parent);
 
     if (!selfACL) {
-        InheritFrom(parent, isContainer);
+        InheritFrom(parent, isContainer, isTenantRoot);
         return;
     }
 
@@ -42,15 +58,31 @@ void TEffectiveACL::Update(const TEffectiveACL &parent, const TString &selfACL, 
     Inited = true;
     Split(effectiveObj);
     ForSelf = effectiveObj.GetACL().SerializeAsString();
+
+    if (isTenantRoot) {
+        // At the tenant boundary strip ConnectDatabase ACEs from children ACLs
+        // so that connect right does not leak into child objects of the tenant.
+        // ForSelf is kept as is: connect must be present on the tenant root.
+        ForContainers = StripConnectRightACE(ForContainers);
+        ForObjects = StripConnectRightACE(ForObjects);
+    }
 }
 
-void TEffectiveACL::InheritFrom(const TEffectiveACL &parent, bool isContainer) {
+void TEffectiveACL::InheritFrom(const TEffectiveACL &parent, bool isContainer, bool isTenantRoot) {
     Inited = parent.Inited;
 
     ForContainers = parent.ForContainers;
     ForObjects = parent.ForObjects;
 
-    ForSelf = isContainer ? ForContainers : ForObjects;
+    ForSelf = parent.GetForChildren(isContainer);
+
+    if (isTenantRoot) {
+        // At the tenant boundary strip ConnectDatabase ACEs from children ACLs
+        // so that connect right does not leak into child objects of the tenant.
+        // ForSelf is kept as is: connect must be present on the tenant root.
+        ForContainers = StripConnectRightACE(ForContainers);
+        ForObjects = StripConnectRightACE(ForObjects);
+    }
 }
 
 void TEffectiveACL::Split(const NACLibProto::TSecurityObject &obj) {

--- a/ydb/core/tx/schemeshard/schemeshard_effective_acl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_effective_acl.h
@@ -19,16 +19,17 @@ public:
     TEffectiveACL() = default;
 
     void Init(const TString& effectiveACL);
-    void Update(const TEffectiveACL& parent, const TString& selfACL, bool isContainer);
+    void Update(const TEffectiveACL& parent, const TString& selfACL, bool isContainer, bool isTenantRoot = false);
 
     operator bool () const { return Inited; }
     const TString& GetForChildren(bool isContainer) const { return isContainer ? ForContainers : ForObjects; }
     const TString& GetForSelf() const { return ForSelf; }
 
 private:
-    void InheritFrom(const TEffectiveACL& parent, bool isContainer);
+    void InheritFrom(const TEffectiveACL& parent, bool isContainer, bool isTenantRoot);
     void Split(const NACLibProto::TSecurityObject& obj);
     bool Filter(const NACLibProto::TSecurityObject& obj, NACLib::EInheritanceType byType, TString& result);
+    static TString StripConnectRightACE(const TString& acl);
 };
 
 }

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -2017,14 +2017,16 @@ TString TPath::GetEffectiveACL() const {
         if (element->CachedEffectiveACLVersion != version || !element->CachedEffectiveACL) {  // path needs actualizing
             if (item == Elements.begin()) { // it is root
                 if (!SS->IsDomainSchemeShard) {
-                    element->CachedEffectiveACL.Update(SS->ParentDomainCachedEffectiveACL, element->ACL, element->IsContainer());
+                    element->CachedEffectiveACL.Update(SS->ParentDomainCachedEffectiveACL,
+                        element->ACL, element->IsContainer(), /*isTenantRoot*/ true);
                 } else {
                     element->CachedEffectiveACL.Init(element->ACL);
                 }
             } else { // path element in the middle
                 auto prevIt = std::prev(item);
                 const auto& prevElement = *prevIt;
-                element->CachedEffectiveACL.Update(prevElement->CachedEffectiveACL, element->ACL, element->IsContainer());
+                element->CachedEffectiveACL.Update(prevElement->CachedEffectiveACL,
+                    element->ACL, element->IsContainer(), /*isTenantRoot*/ element->IsExternalSubDomainRoot());
             }
             element->CachedEffectiveACLVersion = version;
         }

--- a/ydb/core/tx/schemeshard/schemeshard_path.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path.cpp
@@ -2026,7 +2026,8 @@ TString TPath::GetEffectiveACL() const {
                 auto prevIt = std::prev(item);
                 const auto& prevElement = *prevIt;
                 element->CachedEffectiveACL.Update(prevElement->CachedEffectiveACL,
-                    element->ACL, element->IsContainer(), /*isTenantRoot*/ element->IsExternalSubDomainRoot());
+                    element->ACL, element->IsContainer(),
+                    /*isTenantRoot*/ element->IsPlainSubDomainRoot() || element->IsExternalSubDomainRoot());
             }
             element->CachedEffectiveACLVersion = version;
         }

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -150,6 +150,10 @@ bool TPathElement::IsSubDomainRoot() const {
     return PathType == EPathType::EPathTypeSubDomain || IsRoot();
 }
 
+bool TPathElement::IsPlainSubDomainRoot() const {
+    return PathType == EPathType::EPathTypeSubDomain;
+}
+
 bool TPathElement::IsExternalSubDomainRoot() const {
     return PathType == EPathType::EPathTypeExtSubDomain;
 }

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -119,6 +119,7 @@ public:
     bool IsPQGroup() const;
     bool IsDomainRoot() const;
     bool IsSubDomainRoot() const;
+    bool IsPlainSubDomainRoot() const;
     bool IsExternalSubDomainRoot() const;
     bool IsRtmrVolume() const;
     bool IsBlockStoreVolume() const;

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -580,6 +580,119 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
             }
         }
 
+        // Verify the ConnectDatabase right handling in TEffectiveACL::Update
+        {
+            auto aclHasRight = [](const TString& serialized, NACLib::EAccessRights right) {
+                NACLib::TACL acl(serialized);
+                for (const auto& ace : acl.GetACE()) {
+                    if (ace.GetAccessRight() == (ui32)right) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            auto aclHasConnect = [&](const TString& serialized) {
+                return aclHasRight(serialized, NACLib::ConnectDatabase);
+            };
+            auto aclHasRead = [&](const TString& serialized) {
+                return aclHasRight(serialized, NACLib::GenericRead);
+            };
+
+            TEffectiveACL parentACL;
+            {
+                NACLib::TDiffACL diff;
+                diff.AddAccess(NACLib::EAccessType::Allow, NACLib::ConnectDatabase, "user1@staff",
+                    NACLib::DefaultInheritanceType);
+
+                NACLib::TACL input;
+                input.ApplyDiff(diff);
+
+                parentACL.Init(input.SerializeAsString());
+            }
+
+            UNIT_ASSERT(aclHasConnect(parentACL.GetForSelf()));
+            UNIT_ASSERT(aclHasConnect(parentACL.GetForChildren(/*isContainer*/ true)));
+            UNIT_ASSERT(aclHasConnect(parentACL.GetForChildren(/*isContainer*/ false)));
+
+            const TString ownACL = [] {
+                NACLib::TDiffACL diff;
+                diff.AddAccess(NACLib::EAccessType::Allow, NACLib::GenericRead, "user1@staff",
+                    NACLib::DefaultInheritanceType);
+
+                NACLib::TACL input;
+                input.ApplyDiff(diff);
+                return input.SerializeAsString();
+            }();
+            const TString emptyOwnACL;
+
+            for (bool isContainer : {true, false}) {
+                // Case 1: tenant root, empty self acl (InheritFrom branch).
+                // connect right stays in ForSelf but is stripped from children.
+                {
+                    TEffectiveACL tenantRootACL;
+                    tenantRootACL.Update(parentACL, emptyOwnACL, isContainer, /*isTenantRoot*/ true);
+
+                    UNIT_ASSERT_C(aclHasConnect(tenantRootACL.GetForSelf()),
+                        "connect right must be present in tenant root ForSelf, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(!aclHasConnect(tenantRootACL.GetForChildren(/*isContainer*/ true)),
+                        "connect right must be stripped from tenant root ForContainers, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(!aclHasConnect(tenantRootACL.GetForChildren(/*isContainer*/ false)),
+                        "connect right must be stripped from tenant root ForObjects, isContainer=" << isContainer);
+                }
+
+                // Case 2: tenant root, non-empty self acl (MergeWithParent branch).
+                // connect right stays in ForSelf and is stripped from children, but the tenant's own
+                // ordinary read right keeps propagating to children.
+                {
+                    TEffectiveACL tenantRootACL;
+                    tenantRootACL.Update(parentACL, ownACL, isContainer, /*isTenantRoot*/ true);
+
+                    UNIT_ASSERT_C(aclHasConnect(tenantRootACL.GetForSelf()),
+                        "connect right must be present in tenant root ForSelf, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(!aclHasConnect(tenantRootACL.GetForChildren(/*isContainer*/ true)),
+                        "connect right must be stripped from tenant root ForContainers, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(!aclHasConnect(tenantRootACL.GetForChildren(/*isContainer*/ false)),
+                        "connect right must be stripped from tenant root ForObjects, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasRead(tenantRootACL.GetForChildren(/*isContainer*/ true)),
+                        "read right must survive in ForContainers, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasRead(tenantRootACL.GetForChildren(/*isContainer*/ false)),
+                        "read right must survive in ForObjects, isContainer=" << isContainer);
+                }
+
+                // Case 3: in-domain path (not tenant root), empty self acl (InheritFrom branch).
+                // connect right keeps propagating down to children.
+                {
+                    TEffectiveACL childACL;
+                    childACL.Update(parentACL, emptyOwnACL, isContainer, /*isTenantRoot*/ false);
+
+                    UNIT_ASSERT_C(aclHasConnect(childACL.GetForSelf()),
+                        "connect right must be present in ForSelf, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasConnect(childACL.GetForChildren(/*isContainer*/ true)),
+                        "connect right must keep propagating to containers, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasConnect(childACL.GetForChildren(/*isContainer*/ false)),
+                        "connect right must keep propagating to objects, isContainer=" << isContainer);
+                }
+
+                // Case 4: in-domain path (not tenant root), non-empty self acl (MergeWithParent branch).
+                // connect right keeps propagating down and the own ordinary read right propagates too.
+                {
+                    TEffectiveACL childACL;
+                    childACL.Update(parentACL, ownACL, isContainer, /*isTenantRoot*/ false);
+
+                    UNIT_ASSERT_C(aclHasConnect(childACL.GetForSelf()),
+                        "connect right must be present in ForSelf, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasConnect(childACL.GetForChildren(/*isContainer*/ true)),
+                        "connect right must keep propagating to containers, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasConnect(childACL.GetForChildren(/*isContainer*/ false)),
+                        "connect right must keep propagating to objects, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasRead(childACL.GetForChildren(/*isContainer*/ true)),
+                        "ordinary right read right must survive in ForContainers, isContainer=" << isContainer);
+                    UNIT_ASSERT_C(aclHasRead(childACL.GetForChildren(/*isContainer*/ false)),
+                        "ordinary right read right must survive in ForObjects, isContainer=" << isContainer);
+                }
+            }
+        }
+
     }
 
     Y_UNIT_TEST(ModifyACL) {

--- a/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_base.cpp
@@ -686,9 +686,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardTest) {
                     UNIT_ASSERT_C(aclHasConnect(childACL.GetForChildren(/*isContainer*/ false)),
                         "connect right must keep propagating to objects, isContainer=" << isContainer);
                     UNIT_ASSERT_C(aclHasRead(childACL.GetForChildren(/*isContainer*/ true)),
-                        "ordinary right read right must survive in ForContainers, isContainer=" << isContainer);
+                        "ordinary read right must survive in ForContainers, isContainer=" << isContainer);
                     UNIT_ASSERT_C(aclHasRead(childACL.GetForChildren(/*isContainer*/ false)),
-                        "ordinary right read right must survive in ForObjects, isContainer=" << isContainer);
+                        "ordinary read right must survive in ForObjects, isContainer=" << isContainer);
                 }
             }
         }

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
@@ -2343,4 +2343,80 @@ Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
             });
         }
     }
+
+    Y_UNIT_TEST(ConnectDatabaseRightInheritanceRules) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Grant connect on the root database
+        {
+            NACLib::TDiffACL diffACL;
+            diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::ConnectDatabase, "user@builtin",
+                NACLib::DefaultInheritanceType);
+            TestModifyACL(runtime, ++txId, "/", "MyRoot", diffACL.SerializeAsString(), "");
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // Create a tenant with its own SchemeShard.
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot", R"(Name: "USER_0")");
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterExtSubDomain(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "USER_0"
+                ExternalSchemeShard: true
+                PlanResolution: 50
+                Coordinators: 1
+                Mediators: 1
+                TimeCastBucketsPerMediator: 2
+                StoragePools {
+                    Name: "pool-1"
+                    Kind: "hdd"
+                }
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 tenantSchemeShard = 0;
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0"),
+            NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
+        });
+        UNIT_ASSERT(tenantSchemeShard != 0
+            && tenantSchemeShard != (ui64)-1
+            && tenantSchemeShard != TTestTxConfig::SchemeShard);
+
+
+        const TString connectRight = "+(ConnDB):user@builtin";
+
+        const auto extractEffectiveACL = [](const NKikimrScheme::TEvDescribeSchemeResult& record) -> TString {
+            return record.GetPathDescription().GetSelf().GetEffectiveACL();
+        };
+
+        // Describe the tenant root from BOTH SchemeShards.
+        const auto describeFromDomain = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/USER_0");
+        const auto describeFromTenant = DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0");
+
+        const TString effAclDomainSide = extractEffectiveACL(describeFromDomain);
+        const TString effAclTenantSide = extractEffectiveACL(describeFromTenant);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            NACLib::TACL(effAclDomainSide).DebugString(),
+            NACLib::TACL(effAclTenantSide).DebugString(),
+            "Tenant root EffectiveAcl must be the same from the domain SchemeShard and the tenant SchemeShard");
+
+        TestDescribeResult(describeFromDomain, {NLs::HasEffectiveRight(connectRight)});
+        TestDescribeResult(describeFromTenant, {NLs::HasEffectiveRight(connectRight)});
+
+        // Create an object INSIDE the tenant and verify connect is NOT inherited into it.
+        TestMkDir(runtime, tenantSchemeShard, ++txId, "/MyRoot/USER_0", "InsideDir");
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+
+        TestDescribeResult(DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0/InsideDir"), {
+            NLs::PathExist,
+            NLs::HasNoEffectiveRight(connectRight),
+        });
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_subdomain/ut_subdomain.cpp
@@ -4165,6 +4165,52 @@ Y_UNIT_TEST_SUITE(TSchemeShardSubDomainTest) {
         TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_1"),
                            {LsCheckDiskQuotaExceeded(false, "Topic1 was deleted")});
     }
+
+    Y_UNIT_TEST(ConnectRightNotInheritedIntoSubDomain) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Grant connect on the root database.
+        {
+            NACLib::TDiffACL diffACL;
+            diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::ConnectDatabase, "connector@builtin",
+                NACLib::DefaultInheritanceType);
+            TestModifyACL(runtime, ++txId, "/", "MyRoot", diffACL.SerializeAsString(), "");
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot",
+            "PlanResolution: 50 "
+            "Coordinators: 1 "
+            "Mediators: 1 "
+            "TimeCastBucketsPerMediator: 2 "
+            "Name: \"USER_0\"");
+        env.TestWaitNotification(runtime, txId);
+
+
+        TestMkDir(runtime, ++txId, "/MyRoot/USER_0", "InsideDir");
+        env.TestWaitNotification(runtime, txId);
+
+        const TString connectRight = "+(ConnDB):connector@builtin";
+        const TString readRight = "+R:reader@builtin";
+
+        TestDescribeResult(DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot"), {
+            NLs::PathExist,
+            NLs::HasEffectiveRight(connectRight),
+        });
+
+        TestDescribeResult(DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::HasEffectiveRight(connectRight),
+        });
+
+        // Connect must NOT leak into objects inside the subdomain.
+        TestDescribeResult(DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/USER_0/InsideDir"), {
+            NLs::PathExist,
+            NLs::HasNoEffectiveRight(connectRight),
+        });
+    }
 }
 
 Y_UNIT_TEST_SUITE(TStoragePoolsQuotasTest) {

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -27,12 +27,6 @@
                 "effective_permissions": [
                     {
                         "permission_names": [
-                            "ydb.database.connect"
-                        ],
-                        "subject": "USERS"
-                    },
-                    {
-                        "permission_names": [
                             "ydb.generic.list"
                         ],
                         "subject": "METADATA-READERS"
@@ -1681,12 +1675,6 @@
                     "tx_id": "not-zero-number-text"
                 },
                 "effective_permissions": [
-                    {
-                        "permission_names": [
-                            "ydb.database.connect"
-                        ],
-                        "subject": "USERS"
-                    },
                     {
                         "permission_names": [
                             "ydb.generic.list"

--- a/ydb/core/ydb_convert/ydb_convert.cpp
+++ b/ydb/core/ydb_convert/ydb_convert.cpp
@@ -879,7 +879,7 @@ const TString& GetAclName(const TString& name) {
 } // namespace
 
 const THashMap<TString, TACLAttrs> AccessMap_  = {
-    { YDB_DATABASE_CONNECT, TACLAttrs(EAccessRights::ConnectDatabase, EInheritanceType::InheritNone) },
+    { YDB_DATABASE_CONNECT, TACLAttrs(EAccessRights::ConnectDatabase) },
     { YDB_TABLES_MODIFY, TACLAttrs(EAccessRights(UpdateRow | EraseRow)) },
     { YDB_TABLES_READ, TACLAttrs(EAccessRights::SelectRow | EAccessRights::ReadAttributes) },
     { YDB_GENERIC_LIST, EAccessRights::GenericList},

--- a/ydb/core/ydb_convert/ydb_convert_ut.cpp
+++ b/ydb/core/ydb_convert/ydb_convert_ut.cpp
@@ -1051,7 +1051,7 @@ Y_UNIT_TEST(SimpleConvertGood) {
     using namespace NACLib;
     auto aclAttr = ConvertYdbPermissionNameToACLAttrs("ydb.database.connect");
     UNIT_ASSERT_EQUAL(aclAttr.AccessMask, EAccessRights::ConnectDatabase);
-    UNIT_ASSERT_EQUAL(aclAttr.InheritanceType, EInheritanceType::InheritNone);
+    UNIT_ASSERT_EQUAL(aclAttr.InheritanceType, EInheritanceType::InheritObject | EInheritanceType::InheritContainer);
 
     aclAttr = ConvertYdbPermissionNameToACLAttrs("ydb.tables.modify");
     UNIT_ASSERT_EQUAL(aclAttr.AccessMask, EAccessRights(UpdateRow | EraseRow));

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -779,3 +779,56 @@ def test_seamless_migration_to_exclusive_nodes(ydb_serverless_db_with_exclusive_
         f"UPSERT INTO `{path}` (id) VALUES (10), (11), (12);",
         commit_tx=True
     )
+
+
+def get_effective_permission_names(scheme_client, path, subject):
+    desc = scheme_client.describe_path(path)
+    names = set()
+    for p in desc.effective_permissions:
+        if p.subject == subject:
+            names.update(p.permission_names)
+    return names
+
+
+def test_connect_permission_not_inherited_in_serverless(ydb_hostel_db, ydb_serverless_db, ydb_endpoint, ydb_root):
+    connect_permission = 'ydb.database.connect'
+    inheritable_permission = 'ydb.generic.read'
+
+    root_domain_driver = ydb.Driver(ydb.DriverConfig(ydb_endpoint, database=ydb_root))
+    root_domain_driver.wait(120)
+    root_domain_sc = root_domain_driver.scheme_client
+
+    serverless_subdomain_driver = ydb.Driver(ydb.DriverConfig(ydb_endpoint, database=ydb_serverless_db))
+    serverless_subdomain_driver.wait(120)
+    serverless_subdomain_sc = serverless_subdomain_driver.scheme_client
+
+    root_domain_sc.modify_permissions(
+        ydb_root,
+        ydb.ModifyPermissionsSettings().grant_permissions('user1', (connect_permission,))
+    )
+
+    root_domain_sc.modify_permissions(
+        ydb_root,
+        ydb.ModifyPermissionsSettings().grant_permissions('user1', (inheritable_permission,))
+    )
+
+    inner_path = os.path.join(ydb_serverless_db, "dirA0")
+    serverless_subdomain_sc.make_directory(inner_path)
+
+    # at the serverless database root user1 must have both connect (inherited from /Root)
+    # and the ordinary inheritable permission
+    serverless_root_perms = get_effective_permission_names(root_domain_sc, ydb_serverless_db, 'user1')
+    logger.info("effective permissions of user1 at serverless root %s: %s", ydb_serverless_db, serverless_root_perms)
+    assert connect_permission in serverless_root_perms, \
+        "connect permission granted on /Root must be inherited down to the serverless database root"
+    assert inheritable_permission in serverless_root_perms, \
+        "ordinary inheritable permission granted on /Root must be inherited down to the serverless database root"
+
+    # inside the serverless database the connect permission must NOT leak,
+    # while the ordinary inheritable permission must still be inherited
+    inner_perms = get_effective_permission_names(serverless_subdomain_sc, inner_path, 'user1')
+    logger.info("effective permissions of user1 at inner %s: %s", inner_path, inner_perms)
+    assert connect_permission not in inner_perms, \
+        "connect permission must NOT be inherited into objects inside a serverless database"
+    assert inheritable_permission in inner_perms, \
+        "ordinary inheritable permission must still be inherited inside a serverless database"


### PR DESCRIPTION
- Removed InheritNone flag from the connect right mapping so it inherits with DefaultInheritanceType
- Added StripConnectRightACE to remove ConnectDatabase ACEs from inherited children ACLs at the tenant boundary, keeping composite masks intact
- Passed isTenantRoot flag into TEffectiveACL::Update/InheritFrom for ExtSubDomain roots in TPath::GetEffectiveACL and tenant SchemeShard init
- Kept connect right in the tenant root ForSelf while stripping it from ForContainers/ForObjects so tenant child objects do not inherit it
- Added unit and ExtSubDomain integration tests asserting domain-side and tenant-side EffectiveAcl of the tenant root match
- Disabled deprecated ACL connect admin actions in monitoring UI
