### PR TITLE
iam credentials provider: error propagation

### DIFF
--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -29,6 +29,7 @@ public:
         std::string ticket;
         TInstant nextTicketUpdate;
         auto now = TInstant::Now();
+        std::optional<TString> lastErrorMessage;
         {
             std::lock_guard lock(Lock_);
             if (LastErrorMessage_.has_value() && now > ExpiresAt_) {
@@ -36,16 +37,18 @@ public:
             }
             ticket = Ticket_;
             nextTicketUpdate = NextTicketUpdate_;
+            lastErrorMessage = LastErrorMessage_;
         }
         if (now >= nextTicketUpdate) {
             GetTicket();
             {
                 std::lock_guard lock(Lock_);
                 ticket = Ticket_;
+                lastErrorMessage = LastErrorMessage_;
             }
         }
-        if (ticket.empty() && LastErrorMessage_.has_value()) {
-            throw yexception() << *LastErrorMessage_;
+        if (ticket.empty() && lastErrorMessage.has_value()) {
+            throw yexception() << *lastErrorMessage;
         }
         return ticket;
     }
@@ -85,7 +88,6 @@ private:
             TInstant nextUpdate;
             TDuration expiresIn;
             TInstant expiresAt = TInstant::Max();
-            std::optional<std::string> lastError;
             if (auto it = respMap.find("expires_in"); it != respMap.end()) {
                 auto seconds = it->second.GetUInteger();
                 if (seconds > 0) {

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -28,17 +28,24 @@ public:
     std::string GetAuthInfo() const override {
         std::string ticket;
         TInstant nextTicketUpdate;
+        auto now = TInstant::Now();
         {
             std::lock_guard lock(Lock_);
+            if (LastErrorMessage_.has_value() && now > ExpiresAt_) {
+                Ticket_.clear();
+            }
             ticket = Ticket_;
             nextTicketUpdate = NextTicketUpdate_;
         }
-        if (TInstant::Now() >= nextTicketUpdate) {
+        if (now >= nextTicketUpdate) {
             GetTicket();
             {
                 std::lock_guard lock(Lock_);
                 ticket = Ticket_;
             }
+        }
+        if (ticket.empty() && LastErrorMessage_.has_value()) {
+            throw yexception() << *LastErrorMessage_;
         }
         return ticket;
     }
@@ -53,6 +60,8 @@ private:
     mutable std::mutex Lock_;
     mutable std::string Ticket_;
     mutable TInstant NextTicketUpdate_;
+    mutable TInstant ExpiresAt_ = TInstant::Zero();
+    mutable std::optional<TString> LastErrorMessage_;
     TDuration RefreshPeriod_;
 
     void GetTicket() const {
@@ -75,18 +84,23 @@ private:
             const auto now = TInstant::Now();
             TInstant nextUpdate;
             TDuration expiresIn;
+            TInstant expiresAt = TInstant::Max();
+            std::optional<std::string> lastError;
             if (auto it = respMap.find("expires_in"); it != respMap.end()) {
                 auto seconds = it->second.GetUInteger();
                 if (seconds > 0) {
                     expiresIn = TDuration::Seconds(seconds);
+                    expiresAt = now + expiresIn;
                 }
             } else if (auto it = respMap.find("expiry"); it != respMap.end()) {
                 try {
                     TInstant expiry;
                     if (TInstant::TryParseIso8601(it->second.GetStringSafe(), expiry) && expiry > now) {
                         expiresIn = expiry - now;
+                        expiresAt = expiry;
                     }
                 } catch (...) {
+                    expiresAt = now;
                 }
             }
             if (expiresIn > TDuration::Zero()) {
@@ -101,8 +115,12 @@ private:
                 std::lock_guard lock(Lock_);
                 Ticket_ = std::move(ticket);
                 NextTicketUpdate_ = nextUpdate;
+                ExpiresAt_ = expiresAt;
+                LastErrorMessage_.reset();
             }
         } catch (...) {
+            std::lock_guard lock(Lock_);
+            LastErrorMessage_ = CurrentExceptionMessage();
         }
     }
 };

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -122,6 +122,7 @@ private:
             }
         } catch (...) {
             std::lock_guard lock(Lock_);
+            NextTicketUpdate_ = TInstant::Now() + std::min(RefreshPeriod_, TDuration::Seconds(10));
             LastErrorMessage_ = CurrentExceptionMessage();
         }
     }

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -43,7 +43,7 @@ public:
             GetTicket();
             {
                 std::lock_guard lock(Lock_);
-                if (now > ExpiresAt_ || LastErrorMessage_.has_value()) {
+                if (LastErrorMessage_.has_value() && now > ExpiresAt_) {
                     Ticket_.clear();
                 }
                 ticket = Ticket_;

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -43,6 +43,9 @@ public:
             GetTicket();
             {
                 std::lock_guard lock(Lock_);
+                if (now > ExpiresAt_ || LastErrorMessage_.has_value()) {
+                    Ticket_.clear();
+                }
                 ticket = Ticket_;
                 lastErrorMessage = LastErrorMessage_;
             }

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/http_iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/http_iam_ut.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <util/datetime/base.h>
+
 #include <atomic>
 #include <thread>
 #include <vector>
@@ -57,6 +59,67 @@ TEST(IamCredentialsProvider, ServerError) {
     auto provider = factory->CreateProvider();
 
     EXPECT_THROW(provider->GetAuthInfo(), yexception);
+}
+
+TEST(IamCredentialsProvider, GracePeriodOnRefreshError) {
+    TMetadataServer server;
+    server.SetStrictMode(false);
+    server.SetResponse(HTTP_OK, MakeTokenResponse("old-token", 3600));
+
+    TIamHost params = MakeMetadataParams(server.Port);
+    params.RefreshPeriod = TDuration::MilliSeconds(100);
+
+    auto provider = CreateIamCredentialsProviderFactory(params)->CreateProvider();
+    EXPECT_EQ(provider->GetAuthInfo(), "old-token");
+
+    int countBeforeRefresh = server.GetRequestCount();
+    Sleep(TDuration::MilliSeconds(150));
+
+    server.SetResponse(HTTP_INTERNAL_SERVER_ERROR, "");
+    EXPECT_EQ(provider->GetAuthInfo(), "old-token");
+    EXPECT_GT(server.GetRequestCount(), countBeforeRefresh);
+}
+
+TEST(IamCredentialsProvider, ThrowAfterTokenExpiredOnRefreshError) {
+    TMetadataServer server;
+    server.SetStrictMode(false);
+    server.SetResponse(HTTP_OK, MakeTokenResponse("old-token", 1));
+
+    TIamHost params = MakeMetadataParams(server.Port);
+    params.RefreshPeriod = TDuration::MilliSeconds(100);
+
+    auto provider = CreateIamCredentialsProviderFactory(params)->CreateProvider();
+    EXPECT_EQ(provider->GetAuthInfo(), "old-token");
+
+    Sleep(TDuration::MilliSeconds(150));
+    server.SetResponse(HTTP_INTERNAL_SERVER_ERROR, "");
+    EXPECT_EQ(provider->GetAuthInfo(), "old-token");
+
+    Sleep(TDuration::Seconds(1));
+    EXPECT_THROW(provider->GetAuthInfo(), yexception);
+}
+
+TEST(IamCredentialsProvider, RecoveryAfterRefreshError) {
+    TMetadataServer server;
+    server.SetStrictMode(false);
+    server.SetResponse(HTTP_OK, MakeTokenResponse("token-1", 3600));
+
+    TIamHost params = MakeMetadataParams(server.Port);
+    params.RefreshPeriod = TDuration::MilliSeconds(100);
+
+    auto provider = CreateIamCredentialsProviderFactory(params)->CreateProvider();
+    EXPECT_EQ(provider->GetAuthInfo(), "token-1");
+
+    Sleep(TDuration::MilliSeconds(150));
+    server.SetResponse(HTTP_INTERNAL_SERVER_ERROR, "");
+    EXPECT_EQ(provider->GetAuthInfo(), "token-1");
+
+    server.SetResponse(HTTP_OK, MakeTokenResponse("token-2", 3600));
+    int countBeforeRecovery = server.GetRequestCount();
+    Sleep(TDuration::MilliSeconds(150));
+
+    EXPECT_EQ(provider->GetAuthInfo(), "token-2");
+    EXPECT_GT(server.GetRequestCount(), countBeforeRecovery);
 }
 
 TEST(IamCredentialsProvider, ConcurrentAccess) {

--- a/ydb/public/sdk/cpp/tests/unit/client/iam/http_iam_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/iam/http_iam_ut.cpp
@@ -56,7 +56,7 @@ TEST(IamCredentialsProvider, ServerError) {
     auto factory = CreateIamCredentialsProviderFactory(params);
     auto provider = factory->CreateProvider();
 
-    EXPECT_EQ(provider->GetAuthInfo(), "");
+    EXPECT_THROW(provider->GetAuthInfo(), yexception);
 }
 
 TEST(IamCredentialsProvider, ConcurrentAccess) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

IAM provider drops all errors rendering debugging problems impossible
Propagate errors once token is definitely expired (note that there are time span between scheduled update time and token expire time; if we got an error during that time span, we just return last obtained token)

TODO:
- [ ] fix tests (have not verified yet, but I guess AI is correct they are broken)