### PR TITLE
Reduce schemeshard_impl.h compile cost: decouple heavy headers

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_data_source.cpp
@@ -2,6 +2,7 @@
 #include "schemeshard__operation_common_external_data_source.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <ydb/core/tx/tiering/tier/object.h>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_external_table.cpp
@@ -2,6 +2,7 @@
 #include "schemeshard__operation_common_external_table.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <utility>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.cpp
@@ -1,4 +1,5 @@
 #include "schemeshard__operation_common_external_data_source.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <utility>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_data_source.h
@@ -2,6 +2,7 @@
 
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <utility>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_table.cpp
@@ -1,4 +1,5 @@
 #include "schemeshard__operation_common_external_table.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <ydb/core/scheme/scheme_types_proto.h>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_external_table.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_external_table.h
@@ -2,6 +2,7 @@
 
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <utility>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_data_source.cpp
@@ -3,6 +3,7 @@
 #include "schemeshard__operation_common_external_data_source.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <ydb/core/base/subdomain.h>
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_external_table.cpp
@@ -3,6 +3,7 @@
 #include "schemeshard__operation_common_external_table.h"
 #include "schemeshard__operation_part.h"
 #include "schemeshard_impl.h"
+#include <ydb/core/external_sources/external_source_factory.h>
 
 #include <utility>
 

--- a/ydb/core/tx/schemeshard/schemeshard__root_shred_manager.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__root_shred_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/counters.h>
 #include <ydb/core/tx/schemeshard/schemeshard_impl.h>
+#include <ydb/core/blobstorage/base/blobstorage_shred_events.h>
 
 namespace NKikimr::NSchemeShard {
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -1,4 +1,8 @@
 #include "schemeshard_impl.h"
+#include <ydb/core/cms/console/configs_dispatcher.h>
+#include <ydb/core/cms/console/console.h>
+#include <ydb/core/blobstorage/base/blobstorage_shred_events.h>
+#include <ydb/core/external_sources/external_source_factory.h>
 #include "schemeshard__local_index_migration.h"
 #include "schemeshard_login_helper.h"
 #include "schemeshard_svp_migration.h"
@@ -5491,6 +5495,8 @@ TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
         },
         IsLoginCacheEnabled, {})
 {
+    ExternalSourceFactory = NExternalSource::CreateExternalSourceFactory({});
+
     TabletCountersPtr.Reset(new TProtobufTabletCounters<
                             ESimpleCounters_descriptor,
                             ECumulativeCounters_descriptor,

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -31,16 +31,14 @@
 #include <ydb/core/base/subdomain.h>
 #include <ydb/core/base/tx_processing.h>
 #include <ydb/core/blob_depot/events.h>
-#include <ydb/core/blobstorage/base/blobstorage_shred_events.h>
+#include <ydb/core/base/blobstorage.h>
 #include <ydb/core/blockstore/core/blockstore.h>
-#include <ydb/core/cms/console/configs_dispatcher.h>
-#include <ydb/core/cms/console/console.h>
-#include <ydb/core/external_sources/external_source_factory.h>
 #include <ydb/core/filestore/core/filestore.h>
 #include <ydb/core/kesus/tablet/events.h>
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/protos/auth.pb.h>
 #include <ydb/core/protos/blockstore_config.pb.h>
+#include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/counters_schemeshard.pb.h>
 #include <ydb/core/protos/filestore_config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
@@ -83,6 +81,15 @@ namespace NKikimr::TEvKeyValue {
     using TEvVacuumResponse__HandlePtr = TAutoPtr<NActors::TEventHandle<TEvVacuumResponse>>;
 }
 
+namespace NKikimr::NExternalSource {
+    struct IExternalSourceFactory;
+}
+
+namespace NKikimr::NConsole {
+    namespace TEvConfigsDispatcher { struct TEvSetConfigSubscriptionResponse; }
+    namespace TEvConsole { struct TEvConfigNotificationRequest; }
+}
+
 
 namespace NKikimr {
 namespace NSchemeShard {
@@ -97,6 +104,15 @@ struct TIncrementalRestoreState;
 struct TIndexBuildInfo;
 struct TSetColumnConstraintOperationInfo;
 struct TIndexBuildShardStatus;
+
+// Decoupled from blobstorage_shred_events.h: name the handle type without
+// requiring the full TEvControllerShredResponse definition (and its .pb.h).
+using TEvControllerShredResponse__HandlePtr = TAutoPtr<NActors::TEventHandle<TEvBlobStorage::TEvControllerShredResponse>>;
+
+// Decoupled from console.h / configs_dispatcher.h: name the handle types
+// without requiring the full event definitions (and config.pb.h).
+using TEvSetConfigSubscriptionResponse__HandlePtr = TAutoPtr<NActors::TEventHandle<NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse>>;
+using TEvConfigNotificationRequest__HandlePtr = TAutoPtr<NActors::TEventHandle<NConsole::TEvConsole::TEvConfigNotificationRequest>>;
 
 class TSchemeShard
     : public TActor<TSchemeShard>
@@ -471,7 +487,7 @@ public:
     TActorId DelayedInitTenantDestination;
     TAutoPtr<TEvSchemeShard::TEvInitTenantSchemeShardResult> DelayedInitTenantReply;
 
-    NExternalSource::IExternalSourceFactory::TPtr ExternalSourceFactory{NExternalSource::CreateExternalSourceFactory({})};
+    TIntrusivePtr<NExternalSource::IExternalSourceFactory> ExternalSourceFactory;
 
     struct TTablePartitionsFormatSweepState {
         enum class EStatus : ui8 {
@@ -1285,7 +1301,7 @@ public:
     NTabletFlatExecutor::ITransaction* CreateTxCompleteShredTenant(TEvSchemeShard::TEvTenantShredResponse::TPtr& ev);
 
     struct TTxCompleteShredBSC;
-    NTabletFlatExecutor::ITransaction* CreateTxCompleteShredBSC(TEvBlobStorage::TEvControllerShredResponse::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxCompleteShredBSC(TEvControllerShredResponse__HandlePtr& ev);
 
     void PublishToSchemeBoard(THashMap<TTxId, TDeque<TPathId>>&& paths, const TActorContext& ctx);
     void PublishToSchemeBoard(TTxId txId, TDeque<TPathId>&& paths, const TActorContext& ctx);
@@ -1521,7 +1537,7 @@ public:
     void Handle(TEvKeyValue::TEvVacuumResponse__HandlePtr& ev, const TActorContext& ctx);
     void Handle(TEvSchemeShard::TEvTenantShredResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvAddNewShardToShred::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvBlobStorage::TEvControllerShredResponse::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvControllerShredResponse__HandlePtr& ev, const TActorContext& ctx);
     void Handle(TEvBlobDepot::TEvApplyConfigResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSchemeShard::TEvShredInfoRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSchemeShard::TEvShredManualStartupRequest::TPtr& ev, const TActorContext& ctx);
@@ -1568,8 +1584,8 @@ public:
     void ScheduleServerlessStorageBilling(const TActorContext& ctx);
     void Handle(TEvPrivate::TEvServerlessStorageBilling::TPtr& ev, const TActorContext& ctx);
 
-    void Handle(NConsole::TEvConfigsDispatcher::TEvSetConfigSubscriptionResponse::TPtr &ev, const TActorContext &ctx);
-    void Handle(NConsole::TEvConsole::TEvConfigNotificationRequest::TPtr &ev, const TActorContext &ctx);
+    void Handle(TEvSetConfigSubscriptionResponse__HandlePtr &ev, const TActorContext &ctx);
+    void Handle(TEvConfigNotificationRequest__HandlePtr &ev, const TActorContext &ctx);
 
     void Handle(TEvSchemeShard::TEvLogin::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvLoginFinalize::TPtr& ev, const TActorContext& ctx);


### PR DESCRIPTION
schemeshard_impl.h is a god-header included by ~100 TUs in the module. It pulled several heavy subsystem headers (and their protobufs) for a handful of event handlers / a factory pointer, forcing every TU to parse them. Replace those includes with forward declarations and the existing __HandlePtr idiom, moving the real includes to the few .cpp/.h that actually use the symbols:

  - external_source_factory.h  -> fwd-decl IExternalSourceFactory; the inline member initializer is moved into the constructor in .cpp.
  - blobstorage_shred_events.h -> TEvControllerShredResponse__HandlePtr instead of ::TPtr (forward decl already in base/blobstorage.h).
  - console.h + configs_dispatcher.h -> fwd-decl the two events and use __HandlePtr aliases. config.pb.h is now included directly (the header genuinely uses NKikimrConfig::TCompactionConfig et al. by value), but the rest of the config/yaml init subsystem is no longer dragged in.

Measured on schemeshard__background_cleaning.cpp: front-end CPU time 55.5s -> 31.7s (-43%); emitted object is byte-identical in size. The full module (ydb/core/tx/schemeshard) builds and links cleanly.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* New feature
* Experimental feature
* Improvement
* Performance improvement
* User Interface
* Bugfix 
* Backward incompatible change
* Documentation (changelog entry is not required)
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
