### PR TITLE
Alphabetically select index in case of tie

### DIFF
--- a/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
+++ b/ydb/core/kqp/opt/logical/kqp_opt_log_helpers.cpp
@@ -356,8 +356,8 @@ TMaybe<TString> ChooseIndexForLookupJoin(
             ++prefix;
         }
 
-        // the first index in declaration order wins ties (deterministic).
-        if (prefix > bestPrefix) {
+        // Better prefix wins and ties broken alphabetically by index name.
+        if (prefix > bestPrefix || (prefix == bestPrefix && prefix > 0 && index.Name < best)) {
             bestPrefix = prefix;
             best = index.Name;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

To ensure deterministic behavior in selecting indexes, in case of ties, select alphabetically the index.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
