### PR TITLE
Don't hide node info from UI for database_allowed level

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -271,10 +271,8 @@ public:
                     {"/viewer/json/render", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/cluster", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/json/cluster", {EViewerEndpointAccessType::Viewer}},
-                    {"/viewer/sysinfo", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/config", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/json/config", {EViewerEndpointAccessType::Viewer}},
-                    {"/viewer/json/sysinfo", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/compute", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/json/compute", {EViewerEndpointAccessType::Viewer}},
                     {"/viewer/netinfo", {EViewerEndpointAccessType::Viewer}},
@@ -293,6 +291,8 @@ public:
                     {"/viewer/json/topic_data", {EViewerEndpointAccessType::Administration}},
 
                     // Database-level endpoints that require explicit database parameter for strict database tokens.
+                    {"/viewer/sysinfo", {EViewerEndpointAccessType::Database, true}},
+                    {"/viewer/json/sysinfo", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/autocomplete", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/json/autocomplete", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/nodelist", {EViewerEndpointAccessType::Database, true}},

--- a/ydb/tests/functional/security/canondata/result.json
+++ b/ydb/tests/functional/security/canondata/result.json
@@ -1,14 +1,14 @@
 {
     "test_mon_endpoints_auth.test_mon_endpoints_auth[enforce_user_token_disabled]": {
-        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth-enforce_user_token_disabled/mon_endpoints_auth-enforce_user_token_disabled.json"
+        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth_enforce_user_token_disabled_/mon_endpoints_auth-enforce_user_token_disabled.json"
     },
     "test_mon_endpoints_auth.test_mon_endpoints_auth[enforce_user_token_enabled]": {
-        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth-enforce_user_token_enabled/mon_endpoints_auth-enforce_user_token_enabled.json"
+        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth_enforce_user_token_enabled_/mon_endpoints_auth-enforce_user_token_enabled.json"
     },
     "test_mon_endpoints_auth.test_mon_endpoints_auth[require_counters_authentication]": {
-        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth-require_counters_authentication/mon_endpoints_auth-require_counters_authentication.json"
+        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth_require_counters_authentication_/mon_endpoints_auth-require_counters_authentication.json"
     },
     "test_mon_endpoints_auth.test_mon_endpoints_auth[require_healthcheck_authentication]": {
-        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth-require_healthcheck_authentication/mon_endpoints_auth-require_healthcheck_authentication.json"
+        "uri": "file://test_mon_endpoints_auth.test_mon_endpoints_auth_require_healthcheck_authentication_/mon_endpoints_auth-require_healthcheck_authentication.json"
     }
 }

--- a/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_enforce_user_token_disabled_/mon_endpoints_auth-enforce_user_token_disabled.json
+++ b/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_enforce_user_token_disabled_/mon_endpoints_auth-enforce_user_token_disabled.json
@@ -1024,15 +1024,15 @@
         "root@builtin": 200
       },
       "?format=prometheus": {
-        "__none__": 401,
-        "user@builtin": 403,
-        "database@builtin": 403,
+        "__none__": 200,
+        "user@builtin": 200,
+        "database@builtin": 200,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root": {
-        "__none__": 401,
+        "__none__": 200,
         "user@builtin": 403,
         "database@builtin": 403,
         "viewer@builtin": 403,
@@ -1048,20 +1048,20 @@
         "root@builtin": 401
       },
       "?database=/Root&format=prometheus": {
-        "__none__": 401,
-        "user@builtin": 403,
-        "database@builtin": 403,
+        "__none__": 200,
+        "user@builtin": 200,
+        "database@builtin": 200,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root/Tenant&format=prometheus": {
-        "__none__": 401,
-        "user@builtin": 401,
-        "database@builtin": 401,
-        "viewer@builtin": 401,
-        "monitoring@builtin": 401,
-        "root@builtin": 401
+        "__none__": 200,
+        "user@builtin": 200,
+        "database@builtin": 200,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
       }
     },
     "/internal": {
@@ -3460,7 +3460,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3468,7 +3468,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -3798,7 +3798,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3806,7 +3806,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -4950,15 +4950,15 @@
         "root@builtin": 200
       },
       "?format=prometheus": {
-        "__none__": 401,
-        "user@builtin": 403,
-        "database@builtin": 403,
+        "__none__": 200,
+        "user@builtin": 200,
+        "database@builtin": 200,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root": {
-        "__none__": 401,
+        "__none__": 200,
         "user@builtin": 403,
         "database@builtin": 403,
         "viewer@builtin": 403,
@@ -4974,20 +4974,20 @@
         "root@builtin": 401
       },
       "?database=/Root&format=prometheus": {
-        "__none__": 401,
-        "user@builtin": 403,
-        "database@builtin": 403,
+        "__none__": 200,
+        "user@builtin": 200,
+        "database@builtin": 200,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root/Tenant&format=prometheus": {
-        "__none__": 401,
-        "user@builtin": 401,
-        "database@builtin": 401,
-        "viewer@builtin": 401,
-        "monitoring@builtin": 401,
-        "root@builtin": 401
+        "__none__": 200,
+        "user@builtin": 200,
+        "database@builtin": 200,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
       }
     },
     "/internal": {
@@ -7386,7 +7386,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7394,7 +7394,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -7724,7 +7724,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7732,7 +7732,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200

--- a/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_enforce_user_token_enabled_/mon_endpoints_auth-enforce_user_token_enabled.json
+++ b/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_enforce_user_token_enabled_/mon_endpoints_auth-enforce_user_token_enabled.json
@@ -3460,7 +3460,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3468,7 +3468,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -3798,7 +3798,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3806,7 +3806,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -7386,7 +7386,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7394,7 +7394,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -7724,7 +7724,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7732,7 +7732,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200

--- a/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_require_counters_authentication_/mon_endpoints_auth-require_counters_authentication.json
+++ b/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_require_counters_authentication_/mon_endpoints_auth-require_counters_authentication.json
@@ -3460,7 +3460,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3468,7 +3468,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -3798,7 +3798,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3806,7 +3806,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -7386,7 +7386,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7394,7 +7394,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -7724,7 +7724,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7732,7 +7732,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200

--- a/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_require_healthcheck_authentication_/mon_endpoints_auth-require_healthcheck_authentication.json
+++ b/ydb/tests/functional/security/canondata/test_mon_endpoints_auth.test_mon_endpoints_auth_require_healthcheck_authentication_/mon_endpoints_auth-require_healthcheck_authentication.json
@@ -1024,15 +1024,15 @@
         "root@builtin": 200
       },
       "?format=prometheus": {
-        "__none__": 200,
-        "user@builtin": 200,
-        "database@builtin": 200,
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root": {
-        "__none__": 200,
+        "__none__": 401,
         "user@builtin": 403,
         "database@builtin": 403,
         "viewer@builtin": 403,
@@ -1048,20 +1048,20 @@
         "root@builtin": 401
       },
       "?database=/Root&format=prometheus": {
-        "__none__": 200,
-        "user@builtin": 200,
-        "database@builtin": 200,
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root/Tenant&format=prometheus": {
-        "__none__": 200,
-        "user@builtin": 200,
-        "database@builtin": 200,
-        "viewer@builtin": 200,
-        "monitoring@builtin": 200,
-        "root@builtin": 200
+        "__none__": 401,
+        "user@builtin": 401,
+        "database@builtin": 401,
+        "viewer@builtin": 401,
+        "monitoring@builtin": 401,
+        "root@builtin": 401
       }
     },
     "/internal": {
@@ -3460,7 +3460,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3468,7 +3468,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -3798,7 +3798,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -3806,7 +3806,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -4950,15 +4950,15 @@
         "root@builtin": 200
       },
       "?format=prometheus": {
-        "__none__": 200,
-        "user@builtin": 200,
-        "database@builtin": 200,
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root": {
-        "__none__": 200,
+        "__none__": 401,
         "user@builtin": 403,
         "database@builtin": 403,
         "viewer@builtin": 403,
@@ -4974,20 +4974,20 @@
         "root@builtin": 401
       },
       "?database=/Root&format=prometheus": {
-        "__none__": 200,
-        "user@builtin": 200,
-        "database@builtin": 200,
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
       },
       "?database=/Root/Tenant&format=prometheus": {
-        "__none__": 200,
-        "user@builtin": 200,
-        "database@builtin": 200,
-        "viewer@builtin": 200,
-        "monitoring@builtin": 200,
-        "root@builtin": 200
+        "__none__": 401,
+        "user@builtin": 401,
+        "database@builtin": 401,
+        "viewer@builtin": 401,
+        "monitoring@builtin": 401,
+        "root@builtin": 401
       }
     },
     "/internal": {
@@ -7386,7 +7386,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7394,7 +7394,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200
@@ -7724,7 +7724,7 @@
       "": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 200,
         "monitoring@builtin": 200,
         "root@builtin": 200
@@ -7732,7 +7732,7 @@
       "?database=/Root": {
         "__none__": 401,
         "user@builtin": 403,
-        "database@builtin": 403,
+        "database@builtin": 400,
         "viewer@builtin": 400,
         "monitoring@builtin": 400,
         "root@builtin": 200

--- a/ydb/tests/functional/security/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/test_mon_viewer_access_controls.py
@@ -49,22 +49,71 @@ def test_viewer_v2_aliases_access_controls(ydb_cluster_with_external_access_cont
     base_url = f'https://{node.host}:{node.mon_port}'
     db_qs = f'?database={DATABASE.replace("/", "%2F")}'
 
+    grant_query = (
+        f"GRANT 'ydb.granular.describe_schema' ON `{DATABASE}` "
+        f"TO `database@builtin`, `viewer@builtin`, `monitoring@builtin`;"
+    )
+    grant_response = requests.post(
+        base_url + '/viewer/query',
+        headers={'Authorization': 'root@builtin'},
+        params={'database': DATABASE, 'query': grant_query, 'schema': 'multi'},
+        verify=False,
+        timeout=30,
+    )
+    assert grant_response.status_code == 200, grant_response.text
+
     for ep in ['/viewer/v2/json/config', '/viewer/v2/json/config' + db_qs]:
+        # no access
         _assert_status(base_url, ep, 'database@builtin', 403)
         _assert_status(base_url, ep, 'viewer@builtin', 403)
-        _assert_not_status(base_url, ep, 'monitoring@builtin', 403)
-        _assert_not_status(base_url, ep, 'root@builtin', 403)
+        # with access
+        _assert_status(base_url, ep, 'monitoring@builtin', 200)
+        _assert_status(base_url, ep, 'root@builtin', 200)
 
-    for ep in ['/viewer/sysinfo', '/viewer/json/sysinfo', '/viewer/v2/json/sysinfo']:
+    SYSINFO_V2_ENDPOINT = '/viewer/v2/json/sysinfo'
+    # no database CGI-param for database_allowed_sids level
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT, 'database@builtin', 400)
+    # with database CGI-param for database_allowed_sids level
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT + db_qs, 'database@builtin', 200)
+    # check with and without database CGI-params for different access levels
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT, 'viewer@builtin', 200)
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT + db_qs, 'viewer@builtin', 200)
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT, 'monitoring@builtin', 200)
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT + db_qs, 'monitoring@builtin', 200)
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT + db_qs, 'root@builtin', 200)
+    _assert_status(base_url, SYSINFO_V2_ENDPOINT, 'root@builtin', 200)
+
+
+def test_viewer_sysinfo_access_controls(ydb_cluster_with_external_access_controls):
+    node = ydb_cluster_with_external_access_controls.nodes[1]
+    base_url = f'https://{node.host}:{node.mon_port}'
+    db_qs = f'?database={DATABASE.replace("/", "%2F")}'
+
+    grant_query = (
+        f"GRANT 'ydb.granular.describe_schema' ON `{DATABASE}` "
+        f"TO `database@builtin`, `viewer@builtin`, `monitoring@builtin`;"
+    )
+    grant_response = requests.post(
+        base_url + '/viewer/query',
+        headers={'Authorization': 'root@builtin'},
+        params={'database': DATABASE, 'query': grant_query, 'schema': 'multi'},
+        verify=False,
+        timeout=30,
+    )
+    assert grant_response.status_code == 200, grant_response.text
+
+    for ep in ['/viewer/sysinfo', '/viewer/json/sysinfo']:
         # no database CGI-param for database_allowed_sids level
         _assert_status(base_url, ep, 'database@builtin', 400)
         # with database CGI-param for database_allowed_sids level
-        _assert_not_status(base_url, ep + db_qs, 'database@builtin', 403)
-
-        _assert_not_status(base_url, ep, 'viewer@builtin', 403)
-        _assert_not_status(base_url, ep + db_qs, 'viewer@builtin', 403)
-        _assert_not_status(base_url, ep, 'monitoring@builtin', 403)
-        _assert_not_status(base_url, ep, 'root@builtin', 403)
+        _assert_status(base_url, ep + db_qs, 'database@builtin', 200)
+        # check with and without database CGI-params for different access levels
+        _assert_status(base_url, ep, 'viewer@builtin', 200)
+        _assert_status(base_url, ep + db_qs, 'viewer@builtin', 200)
+        _assert_status(base_url, ep, 'monitoring@builtin', 200)
+        _assert_status(base_url, ep + db_qs, 'monitoring@builtin', 200)
+        _assert_status(base_url, ep + db_qs, 'root@builtin', 200)
+        _assert_status(base_url, ep, 'root@builtin', 200)
 
 
 # database@builtin is a strict database-only token and must be rejected when path is out of database scope.

--- a/ydb/tests/functional/security/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/test_mon_viewer_access_controls.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import requests
 
-
 requests.packages.urllib3.disable_warnings()
 
 DATABASE = '/Root'
@@ -38,7 +37,7 @@ def test_viewer_config_access_controls(ydb_cluster_with_external_access_controls
     node = ydb_cluster_with_external_access_controls.nodes[1]
     base_url = f'https://{node.host}:{node.mon_port}'
 
-    for ep in ['/viewer/config', '/viewer/json/config', '/viewer/json/sysinfo']:
+    for ep in ['/viewer/config', '/viewer/json/config']:
         _assert_status(base_url, ep, 'database@builtin', 403)
         _assert_not_status(base_url, ep, 'viewer@builtin', 403)
         _assert_not_status(base_url, ep, 'monitoring@builtin', 403)
@@ -56,9 +55,14 @@ def test_viewer_v2_aliases_access_controls(ydb_cluster_with_external_access_cont
         _assert_not_status(base_url, ep, 'monitoring@builtin', 403)
         _assert_not_status(base_url, ep, 'root@builtin', 403)
 
-    for ep in ['/viewer/v2/json/sysinfo', '/viewer/v2/json/sysinfo' + db_qs]:
-        _assert_status(base_url, ep, 'database@builtin', 403)
+    for ep in ['/viewer/sysinfo', '/viewer/json/sysinfo', '/viewer/v2/json/sysinfo']:
+        # no database CGI-param for database_allowed_sids level
+        _assert_status(base_url, ep, 'database@builtin', 400)
+        # with database CGI-param for database_allowed_sids level
+        _assert_not_status(base_url, ep + db_qs, 'database@builtin', 403)
+
         _assert_not_status(base_url, ep, 'viewer@builtin', 403)
+        _assert_not_status(base_url, ep + db_qs, 'viewer@builtin', 403)
         _assert_not_status(base_url, ep, 'monitoring@builtin', 403)
         _assert_not_status(base_url, ep, 'root@builtin', 403)
 


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Ручка `/viewer/json/sysinfo` вызывается в UI (например, на странице ноды типа `/node/<ID>`) и данные из неё не являются чем-то приватным, поэтому отдаём данные уровню `database_allowed_sids` при указании базы в запросе. В запросах из UI база туда передаётся.