### PR TITLE
EXT-2184: Unexpected encryption mode change diagnostic

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_group.cpp
@@ -135,6 +135,9 @@ namespace NKikimr::NStorage {
         bool groupChanged = false; // did the 'Group' field change somehow?
         if (newGroup) {
             auto& currentGroup = group.Group;
+            const bool hadCurrentGroup = currentGroup.has_value();
+            const ui32 prevCurrentGroupGeneration = hadCurrentGroup ? currentGroup->GetGroupGeneration() : 0;
+            const ui32 prevCurrentGroupEncryptionMode = hadCurrentGroup ? currentGroup->GetEncryptionMode() : 0;
 
             // generate serialized string to compare it to the one after changes
             TString before;
@@ -150,13 +153,47 @@ namespace NKikimr::NStorage {
 
             // apply encryption parameters from new protobuf
             auto& ep = group.EncryptionParams;
-            Y_VERIFY_S(!ep.HasEncryptionMode() || ep.GetEncryptionMode() == newGroup->GetEncryptionMode(),
+            const ui32 incomingEncryptionMode = newGroup->GetEncryptionMode();
+            const bool incomingEncryptionModeIsKnown = incomingEncryptionMode <= static_cast<ui32>(TBlobStorageGroupInfo::EEM_ENC_V1);
+            const bool firstInvalidEncryptionMode = !ep.HasEncryptionMode() && !incomingEncryptionModeIsKnown;
+            const bool encryptionModeChanged = ep.HasEncryptionMode() && ep.GetEncryptionMode() != incomingEncryptionMode;
+            if (firstInvalidEncryptionMode || encryptionModeChanged) {
+                STLOG(PRI_ERROR, BS_NODE, NW113, "ApplyGroupInfo EncryptionMode diagnostics",
+                    (GroupId, groupId),
+                    (GroupGeneration, generation),
+                    (FromController, fromController),
+                    (FromResolver, fromResolver),
+                    (StoredHasEncryptionMode, ep.HasEncryptionMode()),
+                    (StoredEncryptionModeRaw, ep.GetEncryptionMode()),
+                    (IncomingHasEncryptionMode, newGroup->HasEncryptionMode()),
+                    (IncomingEncryptionModeRaw, incomingEncryptionMode),
+                    (StoredLifeCyclePhase, ep.GetLifeCyclePhase()),
+                    (IncomingLifeCyclePhase, newGroup->GetLifeCyclePhase()),
+                    (HadCurrentGroup, hadCurrentGroup),
+                    (PrevCurrentGroupGeneration, prevCurrentGroupGeneration),
+                    (PrevCurrentGroupEncryptionModeRaw, prevCurrentGroupEncryptionMode),
+                    (MaxKnownGeneration, group.MaxKnownGeneration),
+                    (StoredEncryptionParams, ep),
+                    (IncomingGroup, *newGroup));
+            }
+
+            Y_VERIFY_S(!encryptionModeChanged,
                 "sudden EncryptionMode change from# " << static_cast<TBlobStorageGroupInfo::EEncryptionMode>(ep.GetEncryptionMode())
-                << " to# " << static_cast<TBlobStorageGroupInfo::EEncryptionMode>(newGroup->GetEncryptionMode()) << " GroupId# " << groupId);
+                << " to# " << static_cast<TBlobStorageGroupInfo::EEncryptionMode>(incomingEncryptionMode)
+                << " fromRaw# " << ep.GetEncryptionMode()
+                << " toRaw# " << incomingEncryptionMode
+                << " GroupId# " << groupId
+                << " GroupGeneration# " << generation
+                << " FromController# " << fromController
+                << " FromResolver# " << fromResolver
+                << " HadCurrentGroup# " << hadCurrentGroup
+                << " PrevCurrentGroupGeneration# " << prevCurrentGroupGeneration
+                << " PrevCurrentGroupEncryptionModeRaw# " << prevCurrentGroupEncryptionMode
+                << " MaxKnownGeneration# " << group.MaxKnownGeneration);
 
             if (!ep.HasEncryptionMode() || group.EncryptionParams.GetLifeCyclePhase() != TBlobStorageGroupInfo::ELCP_IN_USE) {
                 // copy encryption mode and then copy other parameters if encryption is enabled
-                ep.SetEncryptionMode(newGroup->GetEncryptionMode());
+                ep.SetEncryptionMode(incomingEncryptionMode);
                 if (ep.GetEncryptionMode() != TBlobStorageGroupInfo::EEM_NONE) {
                     ep.SetLifeCyclePhase(newGroup->GetLifeCyclePhase());
                     ep.SetMainKeyId(newGroup->GetMainKeyId());

--- a/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_resource.cpp
@@ -50,6 +50,33 @@ void TNodeWarden::ApplyServiceSet(const NKikimrBlobStorage::TNodeWardenServiceSe
     STLOG(PRI_DEBUG, BS_NODE, NW18, "ApplyServiceSet", (IsStatic, isStatic), (Comprehensive, comprehensive),
         (Origin, origin), (ServiceSet, serviceSet));
 
+    for (const auto& incomingGroup : serviceSet.GetGroups()) {
+        const ui32 groupId = incomingGroup.GetGroupID();
+        if (incomingGroup.GetEntityStatus() != NKikimrBlobStorage::DESTROY) {
+            const auto it = Groups.find(groupId);
+            const auto *ep = it != Groups.end() ? &it->second.EncryptionParams : nullptr;
+            const bool storedHasEncryptionMode = ep && ep->HasEncryptionMode();
+            const ui32 storedEncryptionMode = storedHasEncryptionMode ? ep->GetEncryptionMode() : 0;
+            const ui32 storedLifeCyclePhase = storedHasEncryptionMode ? ep->GetLifeCyclePhase() : 0;
+            const ui32 incomingEncryptionMode = incomingGroup.GetEncryptionMode();
+            const bool incomingEncryptionModeIsKnown = incomingEncryptionMode <= static_cast<ui32>(TBlobStorageGroupInfo::EEM_ENC_V1);
+            const bool firstInvalidEncryptionMode = !storedHasEncryptionMode && !incomingEncryptionModeIsKnown;
+            const bool encryptionModeChanged = storedHasEncryptionMode && storedEncryptionMode != incomingEncryptionMode;
+            if (firstInvalidEncryptionMode || encryptionModeChanged) {
+                STLOG(PRI_ERROR, BS_NODE, NW114, "ApplyServiceSet group EncryptionMode diagnostics",
+                    (Origin, origin),
+                    (GroupId, groupId),
+                    (IncomingGeneration, incomingGroup.GetGroupGeneration()),
+                    (StoredHasEncryptionMode, storedHasEncryptionMode),
+                    (StoredEncryptionModeRaw, storedEncryptionMode),
+                    (IncomingEncryptionModeRaw, incomingEncryptionMode),
+                    (StoredLifeCyclePhase, storedLifeCyclePhase),
+                    (IncomingLifeCyclePhase, incomingGroup.GetLifeCyclePhase()));
+                break;
+            }
+        }
+    }
+
     // apply proxy information before we try to start VDisks/PDisks
     ApplyGroupInfoFromServiceSet(serviceSet);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add diagnostics for NodeWarden EncryptionMode VERIFY

`VERIFY failed (2026-06-28T21:49:02.331703Z): sudden EncryptionMode change from#  to# NONE GroupId# 12345`


The VERIFY can currently fail with an empty printed mode, which hides the
actual raw value and makes it unclear where the conflicting group info came
from.

Add logs on the suspicious paths only:
- NW113 in ApplyGroupInfo, right before the VERIFY, with stored/incoming raw
  EncryptionMode values, generations, lifecycle phases, FromController /
  FromResolver flags, and the relevant group protos.
- NW114 in ApplyServiceSet, with the service set origin, so the next incident
  can distinguish cache vs controller service-set input.

The logs are quiet on normal first-time valid group discovery. They fire only
when the first incoming mode is invalid, or when an already stored mode differs
from the incoming one.
