### PR TITLE
EXT-2324 Adds a new healthcheck hint for VDisks in PhantomOnly replication mode

### DIFF
--- a/ydb/core/health_check/health_check.cpp
+++ b/ydb/core/health_check/health_check.cpp
@@ -799,6 +799,7 @@ public:
 
     TDuration Timeout = TDuration::MilliSeconds(HealthCheckConfig.GetTimeout());
     bool ReturnHints = false;
+    bool ReturnStorageHints = false;
     static constexpr TStringBuf STATIC_STORAGE_POOL_NAME = "static";
 
     bool IsSpecificDatabaseFilter() const {
@@ -811,6 +812,7 @@ public:
             Timeout = GetDuration(Request->Request.operation_params().operation_timeout());
         }
         ReturnHints = Request->Request.return_hints() && IsSpecificDatabaseFilter();
+        ReturnStorageHints = Request->Request.return_hints();
         TIntrusivePtr<TDomainsInfo> domains = AppData()->DomainsInfo;
         auto *domain = domains->GetDomain();
         DomainPath = "/" + domain->Name;
@@ -1200,6 +1202,7 @@ public:
                 NKikimrWhiteboard::TVDiskStateInfo::kPDiskIdFieldNumber,
                 NKikimrWhiteboard::TVDiskStateInfo::kVDiskStateFieldNumber,
                 NKikimrWhiteboard::TVDiskStateInfo::kReplicatedFieldNumber,
+                NKikimrWhiteboard::TVDiskStateInfo::kDetailedReplicationStatusFieldNumber,
                 NKikimrWhiteboard::TVDiskStateInfo::kDiskSpaceFieldNumber,
         };
     }
@@ -2596,6 +2599,21 @@ public:
         }
     }
 
+    static bool IsPhantomOnly(const NKikimrWhiteboard::TVDiskStateInfo& vDiskInfo) {
+        return vDiskInfo.HasDetailedReplicationStatus()
+            && vDiskInfo.GetDetailedReplicationStatus() == NKikimrWhiteboard::TVDiskDetailedReplicationStatus::PhantomsOnly;
+    }
+
+    static bool IsPhantomOnly(const NKikimrSysView::TVSlotEntry* vSlot) {
+        return vSlot->GetInfo().HasPhantomOnly() && vSlot->GetInfo().GetPhantomOnly();
+    }
+
+    static void ReportPhantomOnlyHint(TSelfCheckContext& context) {
+        TSelfCheckContext hintContext(&context, "HINT-PHANTOM-ONLY-VDISK");
+        hintContext.ReportStatus(Ydb::Monitoring::StatusFlag::UNSPECIFIED,
+            "Only phantom blobs remain to replicate");
+    }
+
     void FillVDiskStatus(const NKikimrSysView::TVSlotEntry* vSlot, Ydb::Monitoring::StorageVDiskStatus& storageVDiskStatus, TSelfCheckContext context) {
         context.Location.mutable_storage()->mutable_pool()->mutable_group()->mutable_vdisk()->mutable_id()->Clear();
         context.Location.mutable_storage()->mutable_pool()->mutable_group()->clear_id(); // you can see VDisks Group Id in vSlotId field
@@ -2660,6 +2678,9 @@ public:
                 break;
             }
             case NKikimrBlobStorage::REPLICATING: { // the disk accepts queries, but not all the data was replicated
+                if (ReturnStorageHints && IsPhantomOnly(vSlot)) {
+                    ReportPhantomOnlyHint(context);
+                }
                 context.ReportStatus(Ydb::Monitoring::StatusFlag::BLUE, TStringBuilder() << "Replication in progress", ETags::VDiskState);
                 storageVDiskStatus.set_overall(context.GetOverallStatus());
                 return;
@@ -2800,6 +2821,9 @@ public:
 
         if (!vDiskInfo.GetReplicated()) {
             context.IssueRecords.clear();
+            if (ReturnStorageHints && IsPhantomOnly(vDiskInfo)) {
+                ReportPhantomOnlyHint(context);
+            }
             context.ReportStatus(Ydb::Monitoring::StatusFlag::BLUE, "Replication in progress", ETags::VDiskState);
             storageVDiskStatus.set_overall(context.GetOverallStatus());
             return;

--- a/ydb/core/health_check/health_check_ut.cpp
+++ b/ydb/core/health_check/health_check_ut.cpp
@@ -86,6 +86,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         ui32 Generation = DEFAULT_GROUP_GENERATION;
         std::optional<NKikimrBlobStorage::TPDiskState::E> PDiskState;
         NKikimrBlobStorage::EDriveStatus PDiskStatus = NKikimrBlobStorage::ACTIVE;
+        bool PhantomOnly = false;
 
         TTestVSlotInfo(std::optional<NKikimrBlobStorage::EVDiskStatus> status = NKikimrBlobStorage::READY,
                        ui32 generation = DEFAULT_GROUP_GENERATION)
@@ -108,6 +109,12 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
     };
 
     using TVDisks = TVector<TTestVSlotInfo>;
+
+    TTestVSlotInfo PhantomOnlyVDisk() {
+        TTestVSlotInfo vdisk{std::optional<NKikimrBlobStorage::EVDiskStatus>(NKikimrBlobStorage::REPLICATING)};
+        vdisk.PhantomOnly = true;
+        return vdisk;
+    }
 
     void ChangeDescribeSchemeResult(TEvSchemeShard::TEvDescribeSchemeResult::TPtr* ev, ui64 size = 20000000, ui64 quota = 90000000) {
         auto record = (*ev)->Get()->MutableRecord();
@@ -242,7 +249,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
     void AddVSlotsToSysViewResponse(NSysView::TEvSysView::TEvGetVSlotsResponse::TPtr* ev, size_t groupCount,
                                     const TVDisks& vslots, ui32 groupStartId = GROUP_START_ID,
-                                    bool rewrite = true, bool withPdisk = false) {
+                                    bool rewrite = true, bool withPdisk = false, bool withPhantomOnly = true) {
         auto& record = (*ev)->Get()->Record;
         auto entrySample = record.entries(0);
         if (rewrite) {
@@ -268,6 +275,11 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                 entry->mutable_info()->set_failrealm(vslotId);
                 if (vslot.Status) {
                     entry->mutable_info()->set_statusv2(descriptor->FindValueByNumber(*vslot.Status)->name());
+                }
+                if (withPhantomOnly) {
+                    entry->mutable_info()->set_phantomonly(vslot.PhantomOnly);
+                } else {
+                    entry->mutable_info()->clear_phantomonly();
                 }
                 entry->mutable_info()->set_groupgeneration(vslot.Generation);
                 entry->mutable_info()->set_vdisk(vslotId);
@@ -380,7 +392,8 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         sPool->set_name(STORAGE_POOL_NAME);
     };
 
-    void AddVSlotInVDiskStateResponse(TEvWhiteboard::TEvVDiskStateResponse::TPtr* ev, int groupCount, int vslotCount, ui32 groupStartId = GROUP_START_ID) {
+    void AddVSlotInVDiskStateResponse(TEvWhiteboard::TEvVDiskStateResponse::TPtr* ev, int groupCount, const TVDisks& vslots,
+                                      ui32 groupStartId = GROUP_START_ID) {
         auto& pbRecord = (*ev)->Get()->Record;
 
         auto sample = pbRecord.vdiskstateinfo(0);
@@ -389,12 +402,20 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         auto groupId = groupStartId;
         for (int i = 0; i < groupCount; i++) {
             auto slotId = VCARD_START_ID;
-            for (int j = 0; j < vslotCount; j++) {
+            for (const auto& vslot : vslots) {
                 auto state = pbRecord.add_vdiskstateinfo();
                 state->CopyFrom(sample);
-                state->mutable_vdiskid()->set_vdisk(slotId++);
                 state->mutable_vdiskid()->set_groupid(groupId);
+                state->mutable_vdiskid()->set_groupgeneration(DEFAULT_GROUP_GENERATION);
+                state->mutable_vdiskid()->set_ring(slotId);
+                state->mutable_vdiskid()->set_domain(0);
+                state->mutable_vdiskid()->set_vdisk(slotId++);
                 state->set_vdiskstate(NKikimrWhiteboard::EVDiskState::SyncGuidRecovery);
+                if (vslot.PhantomOnly) {
+                    state->set_detailedreplicationstatus(NKikimrWhiteboard::TVDiskDetailedReplicationStatus::PhantomsOnly);
+                } else {
+                    state->clear_detailedreplicationstatus();
+                }
                 state->set_nodeid(1);
             }
             groupId++;
@@ -530,7 +551,9 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
         CheckHcResult(result, groupNumber, vdiscPerGroupNumber, isMergeRecords);
     }
 
-    Ydb::Monitoring::SelfCheckResult RequestHcWithVdisks(const NKikimrBlobStorage::TGroupStatus::E groupStatus, const TVDisks& vdisks, bool forStaticGroup = false, double occupancy = 0) {
+    Ydb::Monitoring::SelfCheckResult RequestHcWithVdisks(const NKikimrBlobStorage::TGroupStatus::E groupStatus, const TVDisks& vdisks,
+                                                         bool forStaticGroup = false, double occupancy = 0, bool withPhantomOnly = true,
+                                                         bool returnHints = false) {
         TPortManager tp;
         ui16 port = tp.GetPort(2134);
         ui16 grpcPort = tp.GetPort(2135);
@@ -566,9 +589,9 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                 case NSysView::TEvSysView::EvGetVSlotsResponse: {
                     auto* x = reinterpret_cast<NSysView::TEvSysView::TEvGetVSlotsResponse::TPtr*>(&ev);
                     if (forStaticGroup) {
-                        AddVSlotsToSysViewResponse(x, 1, vdisks, 0, true, true);
+                        AddVSlotsToSysViewResponse(x, 1, vdisks, 0, true, true, withPhantomOnly);
                     } else {
-                        AddVSlotsToSysViewResponse(x, 1, vdisks, GROUP_START_ID, true, true);
+                        AddVSlotsToSysViewResponse(x, 1, vdisks, GROUP_START_ID, true, true, withPhantomOnly);
                     }
                     break;
                 }
@@ -590,9 +613,9 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
                 case NNodeWhiteboard::TEvWhiteboard::EvVDiskStateResponse: {
                     auto *x = reinterpret_cast<NNodeWhiteboard::TEvWhiteboard::TEvVDiskStateResponse::TPtr*>(&ev);
                     if (forStaticGroup) {
-                        AddVSlotInVDiskStateResponse(x, 1, vdisks.size(), 0);
+                        AddVSlotInVDiskStateResponse(x, 1, vdisks, 0);
                     } else {
-                        AddVSlotInVDiskStateResponse(x, 1, vdisks.size());
+                        AddVSlotInVDiskStateResponse(x, 1, vdisks);
                     }
                     break;
                 }
@@ -608,6 +631,7 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
 
         auto *request = new NHealthCheck::TEvSelfCheckRequest;
         request->Request.set_merge_records(true);
+        request->Request.set_return_hints(returnHints);
 
         runtime.Send(new IEventHandle(NHealthCheck::MakeHealthCheckID(), sender, request, 0));
         return runtime.GrabEdgeEvent<NHealthCheck::TEvSelfCheckResult>(handle)->Result;
@@ -848,6 +872,30 @@ Y_UNIT_TEST_SUITE(THealthCheckTest) {
     Y_UNIT_TEST(BlueGroupIssueWhenPartialGroupStatusAndReplicationDisks) {
         auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{NKikimrBlobStorage::REPLICATING});
         CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+    }
+
+    Y_UNIT_TEST(NonStaticGroupKeepsBlueIssueAndGetsPhantomOnlyHintFromSysView) {
+        auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{PhantomOnlyVDisk()},
+            false, 0, true, true);
+        CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+        CheckHcResultHasIssuesWithStatus(result, "VDISK", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+        CheckHcResultHasIssuesWithStatus(result, "HINT-PHANTOM-ONLY-VDISK", Ydb::Monitoring::StatusFlag::UNSPECIFIED, 1, TLocationFilter().Pool("/Root:test"));
+    }
+
+    Y_UNIT_TEST(NonStaticGroupDoesNotUseWhiteboardFallbackForPhantomOnlyHint) {
+        auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{PhantomOnlyVDisk()},
+            false, 0, false, true);
+        CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+        CheckHcResultHasIssuesWithStatus(result, "VDISK", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+        CheckHcResultHasIssuesWithStatus(result, "HINT-PHANTOM-ONLY-VDISK", Ydb::Monitoring::StatusFlag::UNSPECIFIED, 0, TLocationFilter().Pool("/Root:test"));
+    }
+
+    Y_UNIT_TEST(PhantomOnlyHintRequiresReturnHints) {
+        auto result = RequestHcWithVdisks(NKikimrBlobStorage::TGroupStatus::PARTIAL, TVDisks{PhantomOnlyVDisk()},
+            false, 0, true);
+        CheckHcResultHasIssuesWithStatus(result, "STORAGE_GROUP", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+        CheckHcResultHasIssuesWithStatus(result, "VDISK", Ydb::Monitoring::StatusFlag::BLUE, 1, TLocationFilter().Pool("/Root:test"));
+        CheckHcResultHasIssuesWithStatus(result, "HINT-PHANTOM-ONLY-VDISK", Ydb::Monitoring::StatusFlag::UNSPECIFIED, 0, TLocationFilter().Pool("/Root:test"));
     }
 
     Y_UNIT_TEST(OrangeGroupIssueWhenDegradedGroupStatus) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds a new healthcheck hint for VDisks in PhantomOnly replication mode, as requested in issue https://github.com/ydb-platform/ydb/issues/44539, without changing storage group severity/availability calculations.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Returns `HINT-PHANTOM-ONLY-VDISK` when `PhantomOnly` is detected (SysView phantomonly or Whiteboard `detailedReplicationStatus=PhantomsOnly`) and `return_hints=true`.
- Expands `Whiteboard` VDisk state field selection to include `DetailedReplicationStatus` for `PhantomOnly` detection.
- Adds unit tests covering hint emission, `return_hints` gating.

