### PR TITLE
fix locking of TDbDriverState

### DIFF
--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -221,6 +221,7 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
             auto [it, inserted] = States_.try_emplace(key); // creates empty weak_ptr
             lock.unlock(); // release lock
 
+            try { // TODO reindent
             Y_ABORT_UNLESS(inserted);
             strongState = std::shared_ptr<TDbDriverState>(
                 new TDbDriverState(
@@ -238,6 +239,12 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
 
             if (discoveryMode != EDiscoveryMode::Off) {
                 DiscoveryClient_->AddPeriodicTask(CreatePeriodicDiscoveryTask(strongState), DISCOVERY_RECHECK_PERIOD);
+            }
+            } catch (...) {
+                lock.lock();
+                Y_ENSURE(it->second.expired());
+                States_.erase(it);
+                throw;
             }
 
             lock.lock();

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -219,27 +219,27 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
             };
 
             auto [it, inserted] = States_.try_emplace(key); // creates empty weak_ptr
-            lock.unlock(); // release lock
+            lock.unlock(); // temporarily release lock
 
-            try { // TODO reindent
-            Y_ABORT_UNLESS(inserted);
-            strongState = std::shared_ptr<TDbDriverState>(
-                new TDbDriverState(
-                    quotedDatabase,
-                    discoveryEndpoint,
-                    discoveryMode,
-                    sslCredentials,
-                    DiscoveryClient_),
-                deleter);
+            try {
+                Y_ABORT_UNLESS(inserted);
+                strongState = std::shared_ptr<TDbDriverState>(
+                    new TDbDriverState(
+                        quotedDatabase,
+                        discoveryEndpoint,
+                        discoveryMode,
+                        sslCredentials,
+                        DiscoveryClient_),
+                    deleter);
 
-            strongState->SetCredentialsProvider(
-                credentialsProviderFactory
-                    ? credentialsProviderFactory->CreateProvider(strongState)
-                    : CreateInsecureCredentialsProviderFactory()->CreateProvider(strongState));
+                strongState->SetCredentialsProvider(
+                    credentialsProviderFactory
+                        ? credentialsProviderFactory->CreateProvider(strongState)
+                        : CreateInsecureCredentialsProviderFactory()->CreateProvider(strongState));
 
-            if (discoveryMode != EDiscoveryMode::Off) {
-                DiscoveryClient_->AddPeriodicTask(CreatePeriodicDiscoveryTask(strongState), DISCOVERY_RECHECK_PERIOD);
-            }
+                if (discoveryMode != EDiscoveryMode::Off) {
+                    DiscoveryClient_->AddPeriodicTask(CreatePeriodicDiscoveryTask(strongState), DISCOVERY_RECHECK_PERIOD);
+                }
             } catch (...) {
                 lock.lock();
                 Y_ENSURE(it->second.expired());
@@ -247,9 +247,9 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
                 throw;
             }
 
-            lock.lock();
+            lock.lock(); // re-acquire lock
             Y_ENSURE(it->second.expired());
-            it->second = strongState; // iterator remains valid (as long as key was not erase'd)
+            it->second = strongState; // iterator remains valid
             break;
         }
     }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -189,31 +189,28 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
         }
     }
     TDbDriverStatePtr strongState;
-    for (;;) {
+    {
         std::unique_lock lock(Lock_);
-        {
+        Notify_.wait(lock, [&]() {
             auto state = States_.find(key);
-            if (state != States_.end()) {
-                auto strong = state->second.lock();
-                if (strong) {
-                    return strong;
-                } else {
-                    // We could find state record, but couldn't promote weak to shared
-                    // this means weak ptr already expired but dtor hasn't been
-                    // called yet. Likely other thread now is waiting on mutex to
-                    // remove expired record from hashmap. So give him chance
-                    // to do it after that we will be able to create new state
-                    lock.unlock();
-                    std::this_thread::yield();
-                    continue;
-                }
+            if (state == States_.end()) {
+                return true;
             }
+            strongState = state->second.lock();
+            if (strongState) {
+                return true;
+            }
+            return false;
+        });
+        if (strongState) {
+            return strongState;
         }
         {
             auto deleter = [this, key](TDbDriverState* p) {
                 {
                     std::unique_lock lock(Lock_);
                     States_.erase(key);
+                    Notify_.notify_all();
                 }
                 delete p;
             };
@@ -245,13 +242,14 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
                 lock.lock();
                 Y_ABORT_UNLESS(weakState.expired());
                 Y_ABORT_UNLESS(States_.erase(key));
+                Notify_.notify_all();
                 throw;
             }
 
             lock.lock(); // re-acquire lock
             Y_ABORT_UNLESS(weakState.expired());
-            weakState = strongState; // references remains valid
-            break;
+            weakState = strongState; // reference remains valid
+            Notify_.notify_all();
         }
     }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -219,6 +219,7 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
             };
 
             auto [it, inserted] = States_.try_emplace(key); // creates empty weak_ptr
+            auto& weakState = it->second;
             lock.unlock(); // temporarily release lock
 
             try {
@@ -242,14 +243,14 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
                 }
             } catch (...) {
                 lock.lock();
-                Y_ENSURE(it->second.expired());
-                States_.erase(it);
+                Y_ABORT_UNLESS(weakState.expired());
+                Y_ABORT_UNLESS(States_.erase(key));
                 throw;
             }
 
             lock.lock(); // re-acquire lock
-            Y_ENSURE(it->second.expired());
-            it->second = strongState; // iterator remains valid
+            Y_ABORT_UNLESS(weakState.expired());
+            weakState = strongState; // references remains valid
             break;
         }
     }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -217,6 +217,11 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
                 }
                 delete p;
             };
+
+            auto [it, inserted] = States_.try_emplace(key); // creates empty weak_ptr
+            lock.unlock(); // release lock
+
+            Y_ABORT_UNLESS(inserted);
             strongState = std::shared_ptr<TDbDriverState>(
                 new TDbDriverState(
                     quotedDatabase,
@@ -234,7 +239,10 @@ TDbDriverStatePtr TDbDriverStateTracker::GetDriverState(
             if (discoveryMode != EDiscoveryMode::Off) {
                 DiscoveryClient_->AddPeriodicTask(CreatePeriodicDiscoveryTask(strongState), DISCOVERY_RECHECK_PERIOD);
             }
-            Y_ABORT_UNLESS(States_.emplace(key, strongState).second);
+
+            lock.lock();
+            Y_ENSURE(it->second.expired());
+            it->second = strongState; // iterator remains valid (as long as key was not erase'd)
             break;
         }
     }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
@@ -112,6 +112,7 @@ private:
     IInternalClient* DiscoveryClient_;
     std::unordered_map<TStateKey, std::weak_ptr<TDbDriverState>, TStateKeyHash> States_;
     std::shared_mutex Lock_;
+    std::condition_variable_any Notify_;
 };
 
 using TDbDriverStatePtr = TDbDriverState::TPtr;


### PR DESCRIPTION
CreateProvider may take a long time; temporarily release map lock meanwhile

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

UNFORTUNATELY, NOT COMPLETE SOLUTION.
This PR release cpu & global lock, but all concurrently-requesting user threads *for same key* are still locked on waiting for CV (though, *different-key* state don't lock each other)