### PR TITLE
Fix dstool GroupsForEstimatedUsage@85 calculation

### DIFF
--- a/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
@@ -26,6 +26,7 @@ def calculate_estimated_usage(pdisk_map, vslot_map, groups):
     max_used_size = 0
     min_fair_size = 0
     vslot_fair_usages = []
+    total_size_in_units = 0
     for group in groups:
         vslot_fair_sizes = []
         vslot_used_sizes = []
@@ -55,11 +56,13 @@ def calculate_estimated_usage(pdisk_map, vslot_map, groups):
         else:
             vslot_fair_usages.append(0.0)
 
+        total_size_in_units += group.GroupSizeInUnits if group.GroupSizeInUnits else 1
+
     estimated_usage = max_used_size / min_fair_size if min_fair_size else 0.0
     max_vslot_fair_usage = apply_func(max, vslot_fair_usages)
     mean_vslot_fair_usage = apply_func(sum, vslot_fair_usages) / len(vslot_fair_usages) if len(vslot_fair_usages) > 0 else 0.0
     std_dev_vslot_fair_usage = math.sqrt(sum((x - mean_vslot_fair_usage)**2 for x in vslot_fair_usages) / len(vslot_fair_usages)) if len(vslot_fair_usages) > 0 else 0.0
-    groups_fair_count = math.ceil(len(vslot_fair_usages) * estimated_usage / 0.85)
+    groups_fair_count = math.ceil(total_size_in_units * estimated_usage / 0.85)
 
     res = {}
     res['EstimatedUsage'] = estimated_usage

--- a/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_pool_list.py
@@ -56,7 +56,7 @@ def calculate_estimated_usage(pdisk_map, vslot_map, groups):
         else:
             vslot_fair_usages.append(0.0)
 
-        total_size_in_units += group.GroupSizeInUnits if group.GroupSizeInUnits else 1
+        total_size_in_units += group.GroupSizeInUnits or 1
 
     estimated_usage = max_used_size / min_fair_size if min_fair_size else 0.0
     max_vslot_fair_usage = apply_func(max, vslot_fair_usages)


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix `dstool pool list --show-vdisk-estimated-usage` client-side calculation of column `GroupsForEstimatedUsage@85` to account `GroupSizeInUnits`