### PR TITLE
Skip PR-check for docs-only pull requests

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -9,6 +9,8 @@ on:
       - 'dev-*'
       - 'rc-*'
       - 'q-stable-*'
+    paths-ignore:
+      - 'ydb/docs/**'
     types:
       - 'opened'
       - 'synchronize'


### PR DESCRIPTION
## Summary
- Skip PR-check workflow when a pull request only changes files under ydb/docs/
- Documentation PRs are already validated by Build documentation (docs_build.yaml)

## Test plan
- [ ] Open a docs-only PR and confirm PR-check is skipped
- [ ] Open a PR that changes ydb/docs/ and C++ code and confirm PR-check still runs

Category: Improvement

Made with [Cursor](https://cursor.com)