### PR TITLE
Enable identical code folding (ICF) for ydb builds

### DIFF
--- a/ya.conf
+++ b/ya.conf
@@ -28,9 +28,11 @@ OPENSOURCE = "yes"
 USE_PREBUILT_TOOLS = "no"
 APPLE_SDK_LOCAL = "yes"
 USE_CLANG_CL = "yes"
+LINKER_ICF = "yes"
 
 [flags]
 OPENSOURCE = "yes"
 USE_PREBUILT_TOOLS = "no"
 APPLE_SDK_LOCAL = "yes"
 USE_CLANG_CL = "yes"
+LINKER_ICF = "yes"


### PR DESCRIPTION
## Summary
- Enable `LINKER_ICF=yes` in `ya.conf` so lld applies `--icf=safe` during linking.
- Folds identical functions/data from separate translation units (templates, generated protobuf code, etc.), reducing stripped binary size without splitting the monolith.

## Test plan
- [ ] CI `linux-x86_64-release-asan` and `linux-x86_64-relwithdebinfo` complete successfully
- [ ] Compare `ydbd` stripped size in the build size bot comment vs main
- [ ] Spot-check that no new linker warnings appear in ya make output


Made with [Cursor](https://cursor.com)