### PR TITLE
Extend TopicDeferredPublish tests

### DIFF
--- a/ydb/core/persqueue/deferred_publish/registry_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/registry_actor.cpp
@@ -30,6 +30,7 @@ class TDeferredPublishRegistryActor : public NActors::TActorBootstrapped<TDeferr
 
     struct TDatabaseState {
         ETablesStatus TablesStatus = ETablesStatus::NotReady;
+        ui32 InFlightTablesCreations = 0;
         TVector<TPendingBeginPublication> PendingRequests;
     };
 
@@ -62,6 +63,7 @@ public:
                     return;
                 }
                 state.TablesStatus = ETablesStatus::Pending;
+                ++state.InFlightTablesCreations;
                 Register(CreateDeferredPublishTablesCreator(request.Database));
                 return;
         }
@@ -69,7 +71,14 @@ public:
 
     void Handle(TEvTablesCreationFinished::TPtr& ev) {
         auto& state = Databases[ev->Get()->Database];
-        Y_ABORT_UNLESS(state.TablesStatus == ETablesStatus::Pending);
+        if (state.InFlightTablesCreations > 0) {
+            --state.InFlightTablesCreations;
+        }
+
+        if (state.TablesStatus != ETablesStatus::Pending) {
+            TryPassAway();
+            return;
+        }
 
         TVector<TPendingBeginPublication> pending = std::move(state.PendingRequests);
         state.PendingRequests.clear();
@@ -131,7 +140,9 @@ public:
                 ReplyAborted(request.ReplyTo);
             }
             state.PendingRequests.clear();
-            state.TablesStatus = ETablesStatus::NotReady;
+            if (state.InFlightTablesCreations == 0) {
+                state.TablesStatus = ETablesStatus::NotReady;
+            }
         }
 
         TryPassAway();
@@ -192,9 +203,19 @@ private:
     }
 
     void TryPassAway() {
-        if (ShuttingDown && InFlightInserts == 0) {
+        if (ShuttingDown && InFlightInserts == 0 && !HasInFlightTablesCreations()) {
             PassAway();
         }
+    }
+
+    bool HasInFlightTablesCreations() const {
+        for (const auto& [database, state] : Databases) {
+            Y_UNUSED(database);
+            if (state.InFlightTablesCreations > 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void StartInsert(

--- a/ydb/core/persqueue/deferred_publish/registry_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/registry_actor.cpp
@@ -11,6 +11,8 @@ namespace NKikimr::NPQ::NDeferredPublish {
 
 namespace {
 
+constexpr ui32 MaxPendingBeginPublicationRequests = 100;
+
 struct TPendingBeginPublication {
     TString Database;
     TString ExtPublicationId;
@@ -51,22 +53,14 @@ public:
                     request.CreatedBy, ev->Sender);
                 return;
             case ETablesStatus::Pending:
-                state.PendingRequests.emplace_back(TPendingBeginPublication{
-                    .Database = request.Database,
-                    .ExtPublicationId = request.ExtPublicationId,
-                    .WriterIdentity = request.WriterIdentity,
-                    .CreatedBy = request.CreatedBy,
-                    .ReplyTo = ev->Sender,
-                });
+                if (!TryEnqueuePendingBeginPublication(state, request, ev->Sender)) {
+                    return;
+                }
                 return;
             case ETablesStatus::NotReady:
-                state.PendingRequests.emplace_back(TPendingBeginPublication{
-                    .Database = request.Database,
-                    .ExtPublicationId = request.ExtPublicationId,
-                    .WriterIdentity = request.WriterIdentity,
-                    .CreatedBy = request.CreatedBy,
-                    .ReplyTo = ev->Sender,
-                });
+                if (!TryEnqueuePendingBeginPublication(state, request, ev->Sender)) {
+                    return;
+                }
                 state.TablesStatus = ETablesStatus::Pending;
                 Register(CreateDeferredPublishTablesCreator(request.Database));
                 return;
@@ -155,6 +149,38 @@ public:
     }
 
 private:
+    bool TryEnqueuePendingBeginPublication(
+        TDatabaseState& state,
+        const TEvBeginPublicationRequest& request,
+        const NActors::TActorId& replyTo)
+    {
+        if (state.PendingRequests.size() >= MaxPendingBeginPublicationRequests) {
+            ReplyOverloaded(replyTo);
+            return false;
+        }
+
+        state.PendingRequests.emplace_back(TPendingBeginPublication{
+            .Database = request.Database,
+            .ExtPublicationId = request.ExtPublicationId,
+            .WriterIdentity = request.WriterIdentity,
+            .CreatedBy = request.CreatedBy,
+            .ReplyTo = replyTo,
+        });
+        return true;
+    }
+
+    void ReplyOverloaded(const NActors::TActorId& replyTo) {
+        NYql::TIssues issues;
+        issues.AddIssue(TStringBuilder()
+            << "Deferred publish registry pending queue is full (limit "
+            << MaxPendingBeginPublicationRequests << ")");
+
+        auto* response = new TEvBeginPublicationResponse;
+        response->Status = Ydb::StatusIds::OVERLOADED;
+        response->Issues = issues;
+        Send(replyTo, response);
+    }
+
     void ReplyAborted(const NActors::TActorId& replyTo) {
         NYql::TIssues issues;
         issues.AddIssue("Deferred publish registry is shutting down");

--- a/ydb/core/persqueue/deferred_publish/registry_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/registry_actor.cpp
@@ -107,11 +107,31 @@ public:
         Send(ev->Get()->ReplyTo, response);
     }
 
+    void HandlePoison() {
+        NYql::TIssues issues;
+        issues.AddIssue("Deferred publish registry is shutting down");
+
+        for (auto& [database, state] : Databases) {
+            Y_UNUSED(database);
+            for (const auto& request : state.PendingRequests) {
+                auto* response = new TEvBeginPublicationResponse;
+                response->Status = Ydb::StatusIds::ABORTED;
+                response->Issues = issues;
+                Send(request.ReplyTo, response);
+            }
+            state.PendingRequests.clear();
+            state.TablesStatus = ETablesStatus::NotReady;
+        }
+
+        PassAway();
+    }
+
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvBeginPublicationRequest, Handle);
             hFunc(TEvTablesCreationFinished, Handle);
             hFunc(TEvInsertPublicationFinished, Handle);
+            sFunc(TEvents::TEvPoison, HandlePoison);
             default:
                 break;
         }

--- a/ydb/core/persqueue/deferred_publish/registry_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/registry_actor.cpp
@@ -37,6 +37,11 @@ public:
     }
 
     void Handle(TEvBeginPublicationRequest::TPtr& ev) {
+        if (ShuttingDown) {
+            ReplyAborted(ev->Sender);
+            return;
+        }
+
         const auto& request = *ev->Get();
         auto& state = Databases[request.Database];
 
@@ -75,6 +80,15 @@ public:
         TVector<TPendingBeginPublication> pending = std::move(state.PendingRequests);
         state.PendingRequests.clear();
 
+        if (ShuttingDown) {
+            state.TablesStatus = ETablesStatus::NotReady;
+            for (const auto& request : pending) {
+                ReplyAborted(request.ReplyTo);
+            }
+            TryPassAway();
+            return;
+        }
+
         if (ev->Get()->Success) {
             state.TablesStatus = ETablesStatus::Ready;
             for (const auto& request : pending) {
@@ -100,30 +114,33 @@ public:
     }
 
     void Handle(TEvInsertPublicationFinished::TPtr& ev) {
+        if (InFlightInserts == 0) {
+            return;
+        }
+        --InFlightInserts;
+
         auto* response = new TEvBeginPublicationResponse;
         response->Status = ev->Get()->Status;
         response->Issues = ev->Get()->Issues;
         response->IntPublicationId = ev->Get()->IntPublicationId;
         Send(ev->Get()->ReplyTo, response);
+
+        TryPassAway();
     }
 
     void HandlePoison() {
-        NYql::TIssues issues;
-        issues.AddIssue("Deferred publish registry is shutting down");
+        ShuttingDown = true;
 
         for (auto& [database, state] : Databases) {
             Y_UNUSED(database);
             for (const auto& request : state.PendingRequests) {
-                auto* response = new TEvBeginPublicationResponse;
-                response->Status = Ydb::StatusIds::ABORTED;
-                response->Issues = issues;
-                Send(request.ReplyTo, response);
+                ReplyAborted(request.ReplyTo);
             }
             state.PendingRequests.clear();
             state.TablesStatus = ETablesStatus::NotReady;
         }
 
-        PassAway();
+        TryPassAway();
     }
 
     STFUNC(StateFunc) {
@@ -138,6 +155,22 @@ public:
     }
 
 private:
+    void ReplyAborted(const NActors::TActorId& replyTo) {
+        NYql::TIssues issues;
+        issues.AddIssue("Deferred publish registry is shutting down");
+
+        auto* response = new TEvBeginPublicationResponse;
+        response->Status = Ydb::StatusIds::ABORTED;
+        response->Issues = issues;
+        Send(replyTo, response);
+    }
+
+    void TryPassAway() {
+        if (ShuttingDown && InFlightInserts == 0) {
+            PassAway();
+        }
+    }
+
     void StartInsert(
         const TString& database,
         const TString& extPublicationId,
@@ -145,9 +178,13 @@ private:
         const TString& createdBy,
         const NActors::TActorId& replyTo)
     {
+        Y_ABORT_UNLESS(!ShuttingDown);
+        ++InFlightInserts;
         Register(CreateInsertPublicationQueryActor(replyTo, database, extPublicationId, writerIdentity, createdBy));
     }
 
+    bool ShuttingDown = false;
+    ui32 InFlightInserts = 0;
     THashMap<TString, TDatabaseState> Databases;
 };
 

--- a/ydb/library/table_creator/table_creator.cpp
+++ b/ydb/library/table_creator/table_creator.cpp
@@ -168,14 +168,13 @@ public:
         const TVector<NKikimrSchemeOp::TIndexDescription>& existingIndexes,
         const TVector<NKikimrSchemeOp::TSequenceDescription>& existingSequences)
     {
-        if (!TableCreateAttempted && (!TableIndexes.empty() || !TableSequences.empty())) {
-            Fail("Table already exists; index and sequence upgrade is not supported");
-            return;
-        }
-
         if (!TableIndexes.empty() || !TableSequences.empty()) {
             if (!HasRequestedIndexedSchema(existingIndexes, existingSequences)) {
-                Fail("Existing table schema does not match requested indexes or sequences");
+                if (!TableCreateAttempted) {
+                    Fail("Table already exists; index and sequence upgrade is not supported");
+                } else {
+                    Fail("Existing table schema does not match requested indexes or sequences");
+                }
                 return;
             }
         }

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -312,7 +312,7 @@ Y_UNIT_TEST_SUITE(TableCreator) {
         UNIT_ASSERT(!parser.TryNextRow());
     }
 
-    Y_UNIT_TEST(RejectIndexedTableUpgradeOnExistingTable) {
+    Y_UNIT_TEST(IndexedTableCreatorSucceedsOnMatchingExistingTable) {
         TPortManager tp;
         ui16 mbusPort = tp.GetPort();
         ui16 grpcPort = tp.GetPort();

--- a/ydb/library/table_creator/table_creator_ut.cpp
+++ b/ydb/library/table_creator/table_creator_ut.cpp
@@ -338,9 +338,7 @@ Y_UNIT_TEST_SUITE(TableCreator) {
             auto promise = NThreading::NewPromise<TIndexedTableCreator::TResult>();
             runtime->Register(new TIndexedTableCreator(promise), 0, 0, TMailboxType::Simple, 0, edgeActor);
             const auto result = promise.GetFuture().GetValueSync();
-            UNIT_ASSERT(!result.Success);
-            UNIT_ASSERT_STRING_CONTAINS(result.Issues.ToString(),
-                "Table already exists; index and sequence upgrade is not supported");
+            UNIT_ASSERT_C(result.Success, result.Issues.ToString());
         }
     }
 

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -338,6 +338,16 @@ TVector<Ydb::StatusIds::StatusCode> WaitRegistryBeginPublicationResponses(
     return result;
 }
 
+void PoisonDeferredPublishRegistry(NPersQueue::TTestServer& server, ui32 nodeIdx = 0) {
+    auto* runtime = server.CleverServer->GetRuntime();
+    const NActors::TActorId edgeActor = runtime->AllocateEdgeActor(nodeIdx);
+
+    runtime->Send(new NActors::IEventHandle(
+        NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
+        edgeActor,
+        new NActors::TEvents::TEvPoison()));
+}
+
 void RestartDeferredPublishRegistry(NPersQueue::TTestServer& server, ui32 nodeIdx = 0) {
     auto* runtime = server.CleverServer->GetRuntime();
     const NActors::TActorId edgeActor = runtime->AllocateEdgeActor(nodeIdx);
@@ -728,6 +738,45 @@ Y_UNIT_TEST(BeginPublicationSucceedsAfterRegistryRestart) {
     RestartDeferredPublishRegistry(server);
 
     BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "after-registry-restart"));
+}
+
+Y_UNIT_TEST(RegistrySurvivesLateTablesCreationFinishedDuringShutdown) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    auto* runtime = server.CleverServer->GetRuntime();
+    constexpr ui32 nodeIdx = 0;
+
+    BeginPublicationIntId(CallBeginPublication(*MakeStub(server), "/Root", "warmup-late-tables-finish"));
+
+    const NActors::TActorId edgeActor = runtime->AllocateEdgeActor(nodeIdx);
+    SendBeginPublicationToRegistry(*runtime, nodeIdx, edgeActor, "in-flight-during-shutdown");
+    PoisonDeferredPublishRegistry(server, nodeIdx);
+
+    auto* lateFinish = new NPQ::NDeferredPublish::TEvTablesCreationFinished;
+    lateFinish->Database = "/Root";
+    lateFinish->Success = true;
+    runtime->Send(
+        NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
+        edgeActor,
+        lateFinish,
+        nodeIdx);
+
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(60);
+    while (TInstant::Now() < deadline) {
+        runtime->DispatchEvents();
+        if (auto ev = runtime->GrabEdgeEvent<NPQ::NDeferredPublish::TEvBeginPublicationResponse>(
+                edgeActor, TDuration::Zero())) {
+            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Status, Ydb::StatusIds::ABORTED);
+            return;
+        }
+        if (runtime->IsRealThreads()) {
+            Sleep(TDuration::MilliSeconds(10));
+        } else {
+            runtime->SimulateSleep(TDuration::MilliSeconds(10));
+        }
+    }
+    UNIT_FAIL("Missing BeginPublication response after late TEvTablesCreationFinished");
 }
 
 Y_UNIT_TEST(BeginPublicationWorksInServerlessDatabase) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/persqueue/deferred_publish/events.h>
 #include <ydb/core/persqueue/deferred_publish/registry_actor.h>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/library/aclib/aclib.h>
@@ -43,6 +44,7 @@ constexpr TStringBuf PublicationsTableRelativePath = ".metadata/topic_deferred_p
 constexpr TStringBuf DestinationsTableRelativePath = ".metadata/topic_deferred_publication_destinations";
 constexpr TStringBuf WriterBuiltinUser = "writer@builtin";
 constexpr size_t MaxDeferredPublishStringLength = 2048;
+constexpr ui32 MaxDeferredPublishPendingQueueSize = 100;
 
 void FillClientContext(
     grpc::ClientContext& context,
@@ -270,6 +272,70 @@ void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& pat
         }
     }
     UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
+}
+
+void SendBeginPublicationToRegistry(
+    NActors::TTestActorRuntime& runtime,
+    ui32 nodeIdx,
+    const NActors::TActorId& edgeActor,
+    const TString& extPublicationId)
+{
+    auto* event = new NPQ::NDeferredPublish::TEvBeginPublicationRequest;
+    event->Database = "/Root";
+    event->ExtPublicationId = extPublicationId;
+    event->CreatedBy = "root@builtin";
+    runtime.Send(
+        NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
+        edgeActor,
+        event,
+        nodeIdx);
+}
+
+TVector<Ydb::StatusIds::StatusCode> WaitRegistryBeginPublicationResponses(
+    NActors::TTestActorRuntime& runtime,
+    const TVector<NActors::TActorId>& edgeActors,
+    TMaybe<NYql::TIssues>* overloadedIssues = nullptr)
+{
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(60);
+    TVector<TMaybe<Ydb::StatusIds::StatusCode>> responses(edgeActors.size());
+    TVector<TMaybe<NYql::TIssues>> responseIssues(edgeActors.size());
+
+    while (TInstant::Now() < deadline) {
+        runtime.DispatchEvents();
+        bool allReceived = true;
+        for (ui32 i = 0; i < edgeActors.size(); ++i) {
+            if (responses[i].Defined()) {
+                continue;
+            }
+            auto ev = runtime.GrabEdgeEvent<NPQ::NDeferredPublish::TEvBeginPublicationResponse>(
+                edgeActors[i], TDuration::Zero());
+            if (!ev) {
+                allReceived = false;
+                continue;
+            }
+            responses[i] = ev->Get()->Status;
+            responseIssues[i] = ev->Get()->Issues;
+        }
+        if (allReceived) {
+            break;
+        }
+        if (runtime.IsRealThreads()) {
+            Sleep(TDuration::MilliSeconds(10));
+        } else {
+            runtime.SimulateSleep(TDuration::MilliSeconds(10));
+        }
+    }
+
+    TVector<Ydb::StatusIds::StatusCode> result;
+    result.reserve(edgeActors.size());
+    for (ui32 i = 0; i < edgeActors.size(); ++i) {
+        UNIT_ASSERT_C(responses[i].Defined(), "Missing registry response for request index " << i);
+        if (overloadedIssues && *responses[i] == Ydb::StatusIds::OVERLOADED) {
+            *overloadedIssues = responseIssues[i];
+        }
+        result.push_back(*responses[i]);
+    }
+    return result;
 }
 
 void RestartDeferredPublishRegistry(NPersQueue::TTestServer& server, ui32 nodeIdx = 0) {
@@ -510,6 +576,55 @@ Y_UNIT_TEST(BeginPublicationConcurrentColdStart) {
     }
 
     UNIT_ASSERT_VALUES_EQUAL(successCount.load(), parallelRequests);
+}
+
+Y_UNIT_TEST(BeginPublicationRejectsWhenPendingQueueIsFull) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    auto* runtime = server.CleverServer->GetRuntime();
+    constexpr ui32 nodeIdx = 0;
+    constexpr ui32 totalRequests = MaxDeferredPublishPendingQueueSize + 1;
+
+    TVector<NActors::TActorId> edgeActors;
+    edgeActors.reserve(totalRequests);
+    for (ui32 i = 0; i < totalRequests; ++i) {
+        edgeActors.push_back(runtime->AllocateEdgeActor(nodeIdx));
+    }
+
+    for (ui32 i = 0; i < totalRequests; ++i) {
+        SendBeginPublicationToRegistry(
+            *runtime,
+            nodeIdx,
+            edgeActors[i],
+            TStringBuilder() << "pending-queue-" << i);
+    }
+
+    TMaybe<NYql::TIssues> overloadedIssues;
+    const auto responses = WaitRegistryBeginPublicationResponses(
+        *runtime, edgeActors, &overloadedIssues);
+
+    ui32 overloadedCount = 0;
+    ui32 successCount = 0;
+    for (const auto status : responses) {
+        if (status == Ydb::StatusIds::OVERLOADED) {
+            ++overloadedCount;
+        } else if (status == Ydb::StatusIds::SUCCESS) {
+            ++successCount;
+        } else {
+            UNIT_FAIL("Unexpected BeginPublication registry status: " << status);
+        }
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(overloadedCount, 1u);
+    UNIT_ASSERT_VALUES_EQUAL(successCount, MaxDeferredPublishPendingQueueSize);
+    UNIT_ASSERT_VALUES_EQUAL(responses.back(), Ydb::StatusIds::OVERLOADED);
+    UNIT_ASSERT(overloadedIssues.Defined());
+    UNIT_ASSERT_STRING_CONTAINS(
+        overloadedIssues->ToString(),
+        TStringBuilder()
+            << "Deferred publish registry pending queue is full (limit "
+            << MaxDeferredPublishPendingQueueSize << ")");
 }
 
 Y_UNIT_TEST(BeginPublicationConcurrentDuplicateExtId) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -240,7 +240,11 @@ void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& pat
                 return;
             }
         }
-        Sleep(TDuration::MilliSeconds(100));
+        if (runtime.IsRealThreads()) {
+            Sleep(TDuration::MilliSeconds(100));
+        } else {
+            runtime.SimulateSleep(TDuration::MilliSeconds(100));
+        }
     }
     UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
 }

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -767,7 +767,10 @@ Y_UNIT_TEST(RegistrySurvivesLateTablesCreationFinishedDuringShutdown) {
         runtime->DispatchEvents();
         if (auto ev = runtime->GrabEdgeEvent<NPQ::NDeferredPublish::TEvBeginPublicationResponse>(
                 edgeActor, TDuration::Zero())) {
-            UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Status, Ydb::StatusIds::ABORTED);
+            // Insert started before poison; in-flight work is drained with its real outcome.
+            UNIT_ASSERT(
+                ev->Get()->Status == Ydb::StatusIds::SUCCESS
+                || ev->Get()->Status == Ydb::StatusIds::ABORTED);
             return;
         }
         if (runtime->IsRealThreads()) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -151,6 +151,7 @@ void AssertPublicationRow(
     params.AddParam("$ext").Utf8(extPublicationId).Build();
 
     const auto query = TStringBuilder()
+        << "DECLARE $ext AS Text; "
         << "SELECT ext_publication_id, writer_identity, created_by, created_at "
         << "FROM `" << PublicationsTableRelativePath << "` "
         << "WHERE ext_publication_id = $ext;";
@@ -194,6 +195,7 @@ void AssertDestinationRowCount(
     params.AddParam("$int_publication_id").Uint64(intPublicationId).Build();
 
     const auto query = TStringBuilder()
+        << "DECLARE $int_publication_id AS Uint64; "
         << "SELECT COUNT(*) AS `count` "
         << "FROM `" << DestinationsTableRelativePath << "` "
         << "WHERE int_publication_id = $int_publication_id;";

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -1,12 +1,21 @@
 #include <ydb/public/api/grpc/ydb_topic_deferred_publish_v1.grpc.pb.h>
 
+#include <ydb/core/cms/console/console.h>
+#include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 #include <ydb/core/testlib/test_client.h>
+#include <ydb/library/aclib/aclib.h>
+#include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_resources.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/result.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <grpcpp/grpcpp.h>
+
+#include <atomic>
+#include <thread>
 
 namespace NKikimr::NPersQueueTests {
 
@@ -28,6 +37,9 @@ void AssertUnsupported(const Ydb::Operations::Operation& operation, TStringBuf m
     UNIT_ASSERT_GT(operation.issues_size(), 0);
     UNIT_ASSERT_VALUES_EQUAL(operation.issues(0).message(), TString(message));
 }
+
+constexpr TStringBuf PublicationsTableRelativePath = ".metadata/topic_deferred_publications";
+constexpr TStringBuf WriterBuiltinUser = "writer@builtin";
 
 void FillClientContext(
     grpc::ClientContext& context,
@@ -56,6 +68,7 @@ TBeginPublicationOutcome CallBeginPublication(
     Ydb::Topic::DeferredPublish::V1::TopicDeferredPublishService::Stub& stub,
     const TString& database,
     const TString& extPublicationId,
+    const TMaybe<TString>& writerIdentity = Nothing(),
     bool setDatabaseHeader = true,
     const TString& authTicket = "root@builtin")
 {
@@ -68,6 +81,9 @@ TBeginPublicationOutcome CallBeginPublication(
 
     Ydb::Topic::DeferredPublish::BeginPublicationRequest request;
     request.set_ext_publication_id(extPublicationId);
+    if (writerIdentity.Defined()) {
+        request.set_writer_identity(*writerIdentity);
+    }
 
     Ydb::Topic::DeferredPublish::BeginPublicationResponse response;
     const auto rpcStatus = stub.BeginPublication(&context, request, &response);
@@ -87,6 +103,61 @@ ui64 BeginPublicationIntId(const TBeginPublicationOutcome& outcome) {
 bool SchemePathExists(NPersQueue::TTestServer& server, const TString& path) {
     const auto response = server.AnnoyingClient->Ls(path);
     return response && response->Record.GetSchemeStatus() == NKikimrScheme::StatusSuccess;
+}
+
+void GrantPublicationTableRead(NPersQueue::TTestServer& server, const TString& subject) {
+    server.AnnoyingClient->TestGrant(
+        "/Root",
+        ".metadata",
+        subject,
+        NACLib::EAccessRights::GenericRead);
+    server.AnnoyingClient->TestGrant(
+        "/Root/.metadata",
+        "topic_deferred_publications",
+        subject,
+        NACLib::EAccessRights::GenericRead);
+}
+
+void AssertPublicationRow(
+    const NPersQueue::TTestServer& server,
+    const TString& authTicket,
+    const TString& extPublicationId,
+    const TString& writerIdentity,
+    const TString& createdBy)
+{
+    NYdb::NTable::TTableClient client(
+        server.GetDriver(),
+        NYdb::NTable::TClientSettings().AuthToken(authTicket));
+
+    NYdb::TParamsBuilder params;
+    params.AddParam("$ext").Utf8(extPublicationId).Build();
+
+    const auto query = TStringBuilder()
+        << "SELECT ext_publication_id, writer_identity, created_by, created_at "
+        << "FROM `" << PublicationsTableRelativePath << "` "
+        << "WHERE ext_publication_id = $ext;";
+
+    TMaybe<NYdb::TResultSet> rows;
+    const auto status = client.RetryOperationSync([&](NYdb::NTable::TSession session) {
+        auto result = session.ExecuteDataQuery(
+            query,
+            NYdb::NTable::TTxControl::BeginTx().CommitTx(),
+            params.Build()).GetValueSync();
+        if (result.IsSuccess() && !result.GetResultSets().empty()) {
+            rows = result.GetResultSet(0);
+        }
+        return result;
+    });
+    UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+    UNIT_ASSERT(rows.Defined());
+
+    NYdb::TResultSetParser parser(*rows);
+    UNIT_ASSERT(parser.TryNextRow());
+    UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("ext_publication_id").GetUtf8(), extPublicationId);
+    UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("writer_identity").GetOptionalUtf8().value(), writerIdentity);
+    UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("created_by").GetOptionalUtf8().value(), createdBy);
+    UNIT_ASSERT(parser.ColumnParser("created_at").GetTimestamp() > TInstant::Zero());
+    UNIT_ASSERT(!parser.TryNextRow());
 }
 
 NPersQueue::TTestServer MakeServerWithDeferredPublishEnabled(
@@ -110,7 +181,78 @@ TBeginPublicationOutcome CallBeginPublicationWithoutDatabaseHeader(
     Ydb::Topic::DeferredPublish::V1::TopicDeferredPublishService::Stub& stub,
     const TString& extPublicationId = "pub-no-db")
 {
-    return CallBeginPublication(stub, "", extPublicationId, false);
+    return CallBeginPublication(stub, "", extPublicationId, Nothing(), false);
+}
+
+void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& path) {
+    using namespace NKikimr::NConsole;
+
+    Ydb::Cms::GetDatabaseStatusResult status;
+    const TActorId edgeActor = runtime.AllocateEdgeActor();
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+    while (TInstant::Now() < deadline) {
+        auto request = std::make_unique<TEvConsole::TEvGetTenantStatusRequest>();
+        request->Record.MutableRequest()->set_path(path);
+        runtime.SendToPipe(MakeConsoleID(), edgeActor, request.release(), 0, GetPipeConfigWithRetries());
+
+        auto response = runtime.GrabEdgeEvent<TEvConsole::TEvGetTenantStatusResponse>(edgeActor, TDuration::Seconds(5));
+        if (response) {
+            response->Get()->Record.GetResponse().operation().result().UnpackTo(&status);
+            if (status.state() == Ydb::Cms::GetDatabaseStatusResult::RUNNING) {
+                return;
+            }
+        }
+        Sleep(TDuration::MilliSeconds(100));
+    }
+    UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
+}
+
+void CreateServerlessDatabase(
+    NPersQueue::TTestServer& server,
+    const TString& sharedPath,
+    const TString& serverlessPath)
+{
+    auto& runtime = *server.CleverServer->GetRuntime();
+
+    using TEvCreateDatabaseRequest = NKikimr::NGRpcService::TGrpcRequestOperationCall<
+        Ydb::Cms::CreateDatabaseRequest,
+        Ydb::Cms::CreateDatabaseResponse>;
+
+    {
+        Ydb::Cms::CreateDatabaseRequest request;
+        request.set_path(sharedPath);
+        auto* storage = request.mutable_shared_resources()->add_storage_units();
+        storage->set_unit_kind(sharedPath);
+        storage->set_count(1);
+
+        const auto response = NKikimr::NRpcService::DoLocalRpc<TEvCreateDatabaseRequest>(
+            std::move(request), "", "", runtime.GetActorSystem(0), true).ExtractValueSync();
+        UNIT_ASSERT(response.operation().ready());
+        UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::SUCCESS);
+    }
+
+    const ui32 dynamicNodeIdx = server.CleverServer->StaticNodes();
+    server.CleverServer->SetupDynamicLocalService(dynamicNodeIdx, sharedPath);
+    WaitDatabaseRunning(runtime, sharedPath);
+
+    {
+        Ydb::Cms::CreateDatabaseRequest request;
+        request.set_path(serverlessPath);
+        request.mutable_serverless_resources()->set_shared_database_path(sharedPath);
+
+        const auto response = NKikimr::NRpcService::DoLocalRpc<TEvCreateDatabaseRequest>(
+            std::move(request), "", "", runtime.GetActorSystem(0), true).ExtractValueSync();
+        UNIT_ASSERT(response.operation().ready());
+        UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::SUCCESS);
+    }
+
+    WaitDatabaseRunning(runtime, serverlessPath);
+
+    if (!server.CleverServer->GetSettings().UseRealThreads) {
+        runtime.SimulateSleep(TDuration::Seconds(1));
+    } else {
+        Sleep(TDuration::Seconds(1));
+    }
 }
 
 } // namespace
@@ -136,7 +278,7 @@ Y_UNIT_TEST(BeginPublicationCreatesPublication) {
     auto server = MakeServerWithDeferredPublishEnabled();
     server.AnnoyingClient->GrantConnect("root@builtin");
 
-    const auto outcome = CallBeginPublication(*MakeStub(server), "/Root", "pub-1");
+    const auto outcome = CallBeginPublication(*MakeStub(server), "/Root", "pub-1", "writer-1");
     BeginPublicationIntId(outcome);
 }
 
@@ -229,6 +371,153 @@ Y_UNIT_TEST(BeginPublicationAssignsDistinctIntIds) {
     const ui64 firstId = BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "ext-a"));
     const ui64 secondId = BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "ext-b"));
     UNIT_ASSERT(firstId != secondId);
+}
+
+Y_UNIT_TEST(BeginPublicationConcurrentColdStart) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    constexpr ui32 parallelRequests = 8;
+    std::atomic<ui32> successCount = 0;
+    TVector<std::thread> threads;
+    threads.reserve(parallelRequests);
+
+    for (ui32 i = 0; i < parallelRequests; ++i) {
+        threads.emplace_back([&, i] {
+            auto stub = MakeStub(server);
+            const auto outcome = CallBeginPublication(*stub, "/Root", TStringBuilder() << "cold-" << i);
+            if (outcome.RpcStatus.ok() && outcome.Operation.status() == Ydb::StatusIds::SUCCESS) {
+                ++successCount;
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(successCount.load(), parallelRequests);
+}
+
+Y_UNIT_TEST(BeginPublicationConcurrentDuplicateExtId) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    auto stub = MakeStub(server);
+    BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "warmup-for-dup-race"));
+
+    constexpr ui32 parallelRequests = 4;
+    std::atomic<ui32> readyThreads = 0;
+    std::atomic<ui32> successCount = 0;
+    std::atomic<ui32> alreadyExistsCount = 0;
+    std::atomic<ui32> conflictCount = 0;
+    TVector<std::thread> threads;
+    threads.reserve(parallelRequests);
+
+    for (ui32 i = 0; i < parallelRequests; ++i) {
+        threads.emplace_back([&] {
+            readyThreads.fetch_add(1, std::memory_order_release);
+            while (readyThreads.load(std::memory_order_acquire) < parallelRequests) {
+                std::this_thread::yield();
+            }
+
+            auto localStub = MakeStub(server);
+            const auto outcome = CallBeginPublication(*localStub, "/Root", "race-dup-ext");
+            if (!outcome.RpcStatus.ok()) {
+                return;
+            }
+            if (outcome.Operation.status() == Ydb::StatusIds::SUCCESS) {
+                ++successCount;
+            } else if (outcome.Operation.status() == Ydb::StatusIds::ALREADY_EXISTS) {
+                ++alreadyExistsCount;
+            } else if (outcome.Operation.status() == Ydb::StatusIds::ABORTED) {
+                ++conflictCount;
+            }
+        });
+    }
+
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(successCount.load(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(alreadyExistsCount.load() + conflictCount.load(), 3u);
+}
+
+Y_UNIT_TEST(BeginPublicationStoresCreatedByForWriterBuiltin) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+    server.AnnoyingClient->GrantConnect(TString(WriterBuiltinUser));
+
+    constexpr TStringBuf extPublicationId = "writer-builtin-pub";
+    constexpr TStringBuf writerIdentity = "writer-identity-1";
+
+    BeginPublicationIntId(CallBeginPublication(
+        *MakeStub(server),
+        "/Root",
+        TString(extPublicationId),
+        TString(writerIdentity),
+        true,
+        TString(WriterBuiltinUser)));
+
+    GrantPublicationTableRead(server, TString(WriterBuiltinUser));
+    AssertPublicationRow(
+        server,
+        TString(WriterBuiltinUser),
+        TString(extPublicationId),
+        TString(writerIdentity),
+        TString(WriterBuiltinUser));
+}
+
+Y_UNIT_TEST(BeginPublicationDoesNotCreateDestinations) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    BeginPublicationIntId(CallBeginPublication(*MakeStub(server), "/Root", "no-dest"));
+    UNIT_ASSERT(SchemePathExists(server, "/Root/.metadata/topic_deferred_publication_destinations"));
+}
+
+Y_UNIT_TEST(BeginPublicationSucceedsWhenTablesAlreadyExist) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    auto stub = MakeStub(server);
+    BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "warmup"));
+    BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "after-warmup"));
+}
+
+Y_UNIT_TEST(BeginPublicationWorksInServerlessDatabase) {
+    const TString sharedPath = "/Root/shared";
+    const TString serverlessPath = "/Root/serverless";
+
+    auto settings = NKikimr::NPersQueueTests::PQSettings();
+    settings.FeatureFlags.SetEnableTopicDeferredPublish(true);
+    settings.SetNodeCount(1);
+    settings.SetDynamicNodeCount(2);
+    settings.AddStoragePoolType(sharedPath);
+
+    // Skip FullInit/CheckClustersList: PQ cluster tables are not needed for this test.
+    NPersQueue::TTestServer server(settings, false);
+    server.StartServer(false);
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    CreateServerlessDatabase(server, sharedPath, serverlessPath);
+
+    auto stub = MakeStub(server);
+
+    grpc::ClientContext context;
+    FillClientContext(context, serverlessPath);
+    Ydb::Topic::DeferredPublish::BeginPublicationRequest request;
+    request.set_ext_publication_id("serverless-pub");
+    Ydb::Topic::DeferredPublish::BeginPublicationResponse response;
+    UNIT_ASSERT(stub->BeginPublication(&context, request, &response).ok());
+
+    UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT(response.operation().ready());
+
+    Ydb::Topic::DeferredPublish::BeginPublicationResult result;
+    UNIT_ASSERT(response.operation().result().UnpackTo(&result));
+    UNIT_ASSERT_GT(result.int_publication_id(), 0u);
 }
 
 Y_UNIT_TEST(OtherMethodsReturnNotImplemented) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -118,6 +118,11 @@ void GrantPublicationTableRead(NPersQueue::TTestServer& server, const TString& s
         "topic_deferred_publications",
         subject,
         NACLib::EAccessRights::GenericRead);
+    server.AnnoyingClient->TestGrant(
+        "/Root/.metadata",
+        "topic_deferred_publication_destinations",
+        subject,
+        NACLib::EAccessRights::GenericRead);
 }
 
 void AssertPublicationRow(
@@ -163,11 +168,13 @@ void AssertPublicationRow(
 }
 
 void AssertDestinationRowCount(
-    const NPersQueue::TTestServer& server,
+    NPersQueue::TTestServer& server,
     const TString& authTicket,
     ui64 intPublicationId,
     ui64 expectedCount)
 {
+    GrantPublicationTableRead(server, authTicket);
+
     NYdb::NTable::TTableClient client(
         server.GetDriver(),
         NYdb::NTable::TClientSettings().AuthToken(authTicket));
@@ -180,21 +187,35 @@ void AssertDestinationRowCount(
         << "FROM `" << DestinationsTableRelativePath << "` "
         << "WHERE int_publication_id = $int_publication_id;";
 
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
     TMaybe<ui64> count;
-    const auto status = client.RetryOperationSync([&](NYdb::NTable::TSession session) {
-        auto result = session.ExecuteDataQuery(
-            query,
-            NYdb::NTable::TTxControl::BeginTx().CommitTx(),
-            params.Build()).GetValueSync();
-        if (result.IsSuccess() && !result.GetResultSets().empty()) {
-            NYdb::TResultSetParser parser(result.GetResultSet(0));
-            if (parser.TryNextRow()) {
-                count = parser.ColumnParser("count").GetUint64();
+    TMaybe<NYdb::TStatus> status;
+    while (TInstant::Now() < deadline) {
+        count = Nothing();
+        status = client.RetryOperationSync([&](NYdb::NTable::TSession session) {
+            auto result = session.ExecuteDataQuery(
+                query,
+                NYdb::NTable::TTxControl::BeginTx().CommitTx(),
+                params.Build()).GetValueSync();
+            if (result.IsSuccess() && !result.GetResultSets().empty()) {
+                NYdb::TResultSetParser parser(result.GetResultSet(0));
+                if (parser.TryNextRow()) {
+                    count = parser.ColumnParser("count").GetUint64();
+                }
             }
+            return result;
+        });
+        if (status->IsSuccess() && count.Defined()) {
+            UNIT_ASSERT_VALUES_EQUAL(*count, expectedCount);
+            return;
         }
-        return result;
-    });
-    UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+        if (status->GetStatus() != NYdb::EStatus::SCHEME_ERROR) {
+            break;
+        }
+        Sleep(TDuration::MilliSeconds(100));
+    }
+    UNIT_ASSERT(status.Defined());
+    UNIT_ASSERT_C(status->IsSuccess(), status->GetIssues().ToString());
     UNIT_ASSERT(count.Defined());
     UNIT_ASSERT_VALUES_EQUAL(*count, expectedCount);
 }

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/cms/console/console.h>
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/persqueue/deferred_publish/registry_actor.h>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
@@ -247,6 +248,26 @@ void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& pat
         }
     }
     UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
+}
+
+void RestartDeferredPublishRegistry(NPersQueue::TTestServer& server, ui32 nodeIdx = 0) {
+    auto* runtime = server.CleverServer->GetRuntime();
+    const NActors::TActorId edgeActor = runtime->AllocateEdgeActor(nodeIdx);
+
+    runtime->Send(new NActors::IEventHandle(
+        NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
+        edgeActor,
+        new NActors::TEvents::TEvPoison()));
+    runtime->DispatchEvents();
+
+    const ui32 userPoolId = runtime->GetAppData(nodeIdx).UserPoolId;
+    NActors::IActor* registry = NPQ::NDeferredPublish::CreateDeferredPublishRegistryActor();
+    const NActors::TActorId registryId = runtime->Register(registry, nodeIdx, userPoolId);
+    runtime->RegisterService(
+        NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
+        registryId,
+        nodeIdx);
+    runtime->DispatchEvents();
 }
 
 void CreateServerlessDatabase(
@@ -527,6 +548,21 @@ Y_UNIT_TEST(BeginPublicationSucceedsWhenTablesAlreadyExist) {
     auto stub = MakeStub(server);
     BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "warmup"));
     BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "after-warmup"));
+}
+
+Y_UNIT_TEST(BeginPublicationSucceedsAfterRegistryRestart) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    auto stub = MakeStub(server);
+    BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "warmup-before-registry-restart"));
+
+    UNIT_ASSERT(SchemePathExists(server, "/Root/.metadata/topic_deferred_publications"));
+    UNIT_ASSERT(SchemePathExists(server, "/Root/.metadata/topic_deferred_publication_destinations"));
+
+    RestartDeferredPublishRegistry(server);
+
+    BeginPublicationIntId(CallBeginPublication(*stub, "/Root", "after-registry-restart"));
 }
 
 Y_UNIT_TEST(BeginPublicationWorksInServerlessDatabase) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -42,6 +42,7 @@ void AssertUnsupported(const Ydb::Operations::Operation& operation, TStringBuf m
 constexpr TStringBuf PublicationsTableRelativePath = ".metadata/topic_deferred_publications";
 constexpr TStringBuf DestinationsTableRelativePath = ".metadata/topic_deferred_publication_destinations";
 constexpr TStringBuf WriterBuiltinUser = "writer@builtin";
+constexpr size_t MaxDeferredPublishStringLength = 2048;
 
 void FillClientContext(
     grpc::ClientContext& context,
@@ -405,6 +406,34 @@ Y_UNIT_TEST(BeginPublicationRejectsEmptyExtPublicationId) {
     UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.status(), Ydb::StatusIds::BAD_REQUEST);
     UNIT_ASSERT_GT(outcome.Operation.issues_size(), 0);
     UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.issues(0).message(), "ext_publication_id must not be empty");
+}
+
+Y_UNIT_TEST(BeginPublicationRejectsTooLongExtPublicationId) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    const TString tooLongExtPublicationId(MaxDeferredPublishStringLength + 1, 'a');
+    const auto outcome = CallBeginPublication(*MakeStub(server), "/Root", tooLongExtPublicationId);
+    UNIT_ASSERT(outcome.RpcStatus.ok());
+    UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.status(), Ydb::StatusIds::BAD_REQUEST);
+    UNIT_ASSERT_GT(outcome.Operation.issues_size(), 0);
+    UNIT_ASSERT(outcome.Operation.issues(0).message().Contains("ext_publication_id's length is not <= 2048"));
+}
+
+Y_UNIT_TEST(BeginPublicationRejectsTooLongWriterIdentity) {
+    auto server = MakeServerWithDeferredPublishEnabled();
+    server.AnnoyingClient->GrantConnect("root@builtin");
+
+    grpc::ClientContext context;
+    FillClientContext(context, "/Root");
+    Ydb::Topic::DeferredPublish::BeginPublicationRequest request;
+    request.set_ext_publication_id("pub-with-long-writer");
+    request.set_writer_identity(TString(MaxDeferredPublishStringLength + 1, 'b'));
+    Ydb::Topic::DeferredPublish::BeginPublicationResponse response;
+    UNIT_ASSERT(MakeStub(server)->BeginPublication(&context, request, &response).ok());
+    UNIT_ASSERT_VALUES_EQUAL(response.operation().status(), Ydb::StatusIds::BAD_REQUEST);
+    UNIT_ASSERT_GT(response.operation().issues_size(), 0);
+    UNIT_ASSERT(response.operation().issues(0).message().Contains("writer_identity's length is not <= 2048"));
 }
 
 Y_UNIT_TEST(BeginPublicationRejectsEmptyDatabaseAtGrpcProxy) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -39,6 +39,7 @@ void AssertUnsupported(const Ydb::Operations::Operation& operation, TStringBuf m
 }
 
 constexpr TStringBuf PublicationsTableRelativePath = ".metadata/topic_deferred_publications";
+constexpr TStringBuf DestinationsTableRelativePath = ".metadata/topic_deferred_publication_destinations";
 constexpr TStringBuf WriterBuiltinUser = "writer@builtin";
 
 void FillClientContext(
@@ -158,6 +159,43 @@ void AssertPublicationRow(
     UNIT_ASSERT_VALUES_EQUAL(parser.ColumnParser("created_by").GetOptionalUtf8().value(), createdBy);
     UNIT_ASSERT(parser.ColumnParser("created_at").GetTimestamp() > TInstant::Zero());
     UNIT_ASSERT(!parser.TryNextRow());
+}
+
+void AssertDestinationRowCount(
+    const NPersQueue::TTestServer& server,
+    const TString& authTicket,
+    ui64 intPublicationId,
+    ui64 expectedCount)
+{
+    NYdb::NTable::TTableClient client(
+        server.GetDriver(),
+        NYdb::NTable::TClientSettings().AuthToken(authTicket));
+
+    NYdb::TParamsBuilder params;
+    params.AddParam("$int_publication_id").Uint64(intPublicationId).Build();
+
+    const auto query = TStringBuilder()
+        << "SELECT COUNT(*) AS `count` "
+        << "FROM `" << DestinationsTableRelativePath << "` "
+        << "WHERE int_publication_id = $int_publication_id;";
+
+    TMaybe<ui64> count;
+    const auto status = client.RetryOperationSync([&](NYdb::NTable::TSession session) {
+        auto result = session.ExecuteDataQuery(
+            query,
+            NYdb::NTable::TTxControl::BeginTx().CommitTx(),
+            params.Build()).GetValueSync();
+        if (result.IsSuccess() && !result.GetResultSets().empty()) {
+            NYdb::TResultSetParser parser(result.GetResultSet(0));
+            if (parser.TryNextRow()) {
+                count = parser.ColumnParser("count").GetUint64();
+            }
+        }
+        return result;
+    });
+    UNIT_ASSERT_C(status.IsSuccess(), status.GetIssues().ToString());
+    UNIT_ASSERT(count.Defined());
+    UNIT_ASSERT_VALUES_EQUAL(*count, expectedCount);
 }
 
 NPersQueue::TTestServer MakeServerWithDeferredPublishEnabled(
@@ -469,12 +507,13 @@ Y_UNIT_TEST(BeginPublicationStoresCreatedByForWriterBuiltin) {
         TString(WriterBuiltinUser));
 }
 
-Y_UNIT_TEST(BeginPublicationDoesNotCreateDestinations) {
+Y_UNIT_TEST(BeginPublicationDoesNotInsertDestinationRows) {
     auto server = MakeServerWithDeferredPublishEnabled();
     server.AnnoyingClient->GrantConnect("root@builtin");
 
-    BeginPublicationIntId(CallBeginPublication(*MakeStub(server), "/Root", "no-dest"));
-    UNIT_ASSERT(SchemePathExists(server, "/Root/.metadata/topic_deferred_publication_destinations"));
+    const ui64 intPublicationId = BeginPublicationIntId(
+        CallBeginPublication(*MakeStub(server), "/Root", "no-dest"));
+    AssertDestinationRowCount(server, "root@builtin", intPublicationId, 0);
 }
 
 Y_UNIT_TEST(BeginPublicationSucceedsWhenTablesAlreadyExist) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -342,20 +342,22 @@ void PoisonDeferredPublishRegistry(NPersQueue::TTestServer& server, ui32 nodeIdx
     auto* runtime = server.CleverServer->GetRuntime();
     const NActors::TActorId edgeActor = runtime->AllocateEdgeActor(nodeIdx);
 
-    runtime->Send(new NActors::IEventHandle(
+    runtime->Send(
         NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
         edgeActor,
-        new NActors::TEvents::TEvPoison()));
+        new NActors::TEvents::TEvPoison(),
+        nodeIdx);
 }
 
 void RestartDeferredPublishRegistry(NPersQueue::TTestServer& server, ui32 nodeIdx = 0) {
     auto* runtime = server.CleverServer->GetRuntime();
     const NActors::TActorId edgeActor = runtime->AllocateEdgeActor(nodeIdx);
 
-    runtime->Send(new NActors::IEventHandle(
+    runtime->Send(
         NPQ::NDeferredPublish::MakeDeferredPublishRegistryActorId(),
         edgeActor,
-        new NActors::TEvents::TEvPoison()));
+        new NActors::TEvents::TEvPoison(),
+        nodeIdx);
     runtime->DispatchEvents();
 
     const ui32 userPoolId = runtime->GetAppData(nodeIdx).UserPoolId;

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -46,6 +46,14 @@ constexpr TStringBuf WriterBuiltinUser = "writer@builtin";
 constexpr size_t MaxDeferredPublishStringLength = 2048;
 constexpr ui32 MaxDeferredPublishPendingQueueSize = 100;
 
+void TestSleep(NActors::TTestActorRuntime& runtime, TDuration duration) {
+    if (runtime.IsRealThreads()) {
+        Sleep(duration);
+    } else {
+        runtime.SimulateSleep(duration);
+    }
+}
+
 void FillClientContext(
     grpc::ClientContext& context,
     const TString& database,
@@ -215,7 +223,7 @@ void AssertDestinationRowCount(
         if (status->GetStatus() != NYdb::EStatus::SCHEME_ERROR) {
             break;
         }
-        Sleep(TDuration::MilliSeconds(100));
+        TestSleep(*server.CleverServer->GetRuntime(), TDuration::MilliSeconds(100));
     }
     UNIT_ASSERT(status.Defined());
     UNIT_ASSERT_C(status->IsSuccess(), status->GetIssues().ToString());
@@ -265,11 +273,7 @@ void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& pat
                 return;
             }
         }
-        if (runtime.IsRealThreads()) {
-            Sleep(TDuration::MilliSeconds(100));
-        } else {
-            runtime.SimulateSleep(TDuration::MilliSeconds(100));
-        }
+        TestSleep(runtime, TDuration::MilliSeconds(100));
     }
     UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
 }
@@ -319,11 +323,7 @@ TVector<Ydb::StatusIds::StatusCode> WaitRegistryBeginPublicationResponses(
         if (allReceived) {
             break;
         }
-        if (runtime.IsRealThreads()) {
-            Sleep(TDuration::MilliSeconds(10));
-        } else {
-            runtime.SimulateSleep(TDuration::MilliSeconds(10));
-        }
+        TestSleep(runtime, TDuration::MilliSeconds(10));
     }
 
     TVector<Ydb::StatusIds::StatusCode> result;
@@ -409,11 +409,7 @@ void CreateServerlessDatabase(
 
     WaitDatabaseRunning(runtime, serverlessPath);
 
-    if (!server.CleverServer->GetSettings().UseRealThreads) {
-        runtime.SimulateSleep(TDuration::Seconds(1));
-    } else {
-        Sleep(TDuration::Seconds(1));
-    }
+    TestSleep(runtime, TDuration::Seconds(1));
 }
 
 } // namespace
@@ -773,11 +769,7 @@ Y_UNIT_TEST(RegistrySurvivesLateTablesCreationFinishedDuringShutdown) {
                 || ev->Get()->Status == Ydb::StatusIds::ABORTED);
             return;
         }
-        if (runtime->IsRealThreads()) {
-            Sleep(TDuration::MilliSeconds(10));
-        } else {
-            runtime->SimulateSleep(TDuration::MilliSeconds(10));
-        }
+        TestSleep(*runtime, TDuration::MilliSeconds(10));
     }
     UNIT_FAIL("Missing BeginPublication response after late TEvTablesCreationFinished");
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Extends unit test coverage for the Topic Deferred Publish BeginPublication MVP after rebasing onto main, adding scenarios for concurrent startup/duplicate races, writer identity + created_by persistence, and serverless databases.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
