### PR TITLE
Fix leak on DynamicNameserver shutdown

### DIFF
--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -303,8 +303,6 @@ void TDynamicNameserver::Die(const TActorContext &ctx)
     for (auto &config : DynamicConfigs) {
         if (config->NodeBrokerPipe)
             NTabletPipe::CloseClient(ctx, config->NodeBrokerPipe);
-        config->PendingCacheMisses.Clear();
-        config->CacheMissHolders.clear();
     }
     TBase::Die(ctx);
 }

--- a/ydb/core/mind/dynamic_nameserver.cpp
+++ b/ydb/core/mind/dynamic_nameserver.cpp
@@ -303,6 +303,8 @@ void TDynamicNameserver::Die(const TActorContext &ctx)
     for (auto &config : DynamicConfigs) {
         if (config->NodeBrokerPipe)
             NTabletPipe::CloseClient(ctx, config->NodeBrokerPipe);
+        config->PendingCacheMisses.Clear();
+        config->CacheMissHolders.clear();
     }
     TBase::Die(ctx);
 }

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -208,6 +208,7 @@ public:
 
     ~TDynamicNameserver() {
         for (auto& config : DynamicConfigs) {
+            config->PendingCacheMisses.Clear();
             config->CacheMissHolders.clear();
         }
     }

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -206,6 +206,13 @@ public:
         DynamicConfigs[domain]->DynamicNodes.emplace(node.GetNodeId(), info);
     }
 
+    ~TDynamicNameserver() {
+        for (auto& config : DynamicConfigs) {
+            config->PendingCacheMisses.Clear();
+            config->CacheMissHolders.clear();
+        }
+    }
+
     STFUNC(StateFunc) {
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvInterconnect::TEvResolveNode, Handle);

--- a/ydb/core/mind/dynamic_nameserver_impl.h
+++ b/ydb/core/mind/dynamic_nameserver_impl.h
@@ -208,7 +208,6 @@ public:
 
     ~TDynamicNameserver() {
         for (auto& config : DynamicConfigs) {
-            config->PendingCacheMisses.Clear();
             config->CacheMissHolders.clear();
         }
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Проблема:

Цикл managed указателей – Config эксклюзивно держит указатель на кэш-миссы, кэш-миссы держат интрузивный указатель на Config. Во время работы ноды память не утекает – кэш-миссы удаляются из Config при ответах NodeBroker или по таймауту, сам Config живет с момента старта ноды и до ее смерти.

Проблема стреляет при остановке акторной системы и попытке удалить Config. Так как акторная система остановлена, то кэш-миссы не удаляются, а это в свою очередь мешает удалить Config.

Здесь минимальный фикс, в будущем лучше провести рефакторинг – избавиться от лишних managed указателей.
