### PR TITLE
fix: too early provider lock can keep it alive on grpc thread

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h
@@ -168,7 +168,6 @@ private:
                     }
                 };
                 auto facility = weakFacility.lock();
-                auto self = weakSelf.lock();
 
                 try {
                     if (facility) {
@@ -178,7 +177,7 @@ private:
                 } catch (...) {
                 }
 
-                if (self) {
+                if (auto self = weakSelf.lock()) {
                     std::lock_guard guard(self->Lock_);
                     self->ResetContextImpl();
                 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

The sdk cannot depend on the ydb internal libraries. The action automatically checks for the dependencies and blocks merges if it finds one.
...
