### PR TITLE
Restoring consumers from a backup is splitted into two stages: restor…

### DIFF
--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -771,6 +771,8 @@ TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const 
         return *error;
     }
 
+    PendingConsumersRestores.clear();
+
     auto dbDesc = ReadDatabaseDescription(fsPath, Log.get());
 
     TString dbPath;
@@ -2219,12 +2221,12 @@ void TRestoreClient::ScheduleConsumersRestore(const TString& topicPath, std::vec
 }
 
 TRestoreResult TRestoreClient::RestorePendingConsumers() {
-    for (const auto& pending : PendingConsumersRestores) {
-        if (auto result = RestoreConsumers(pending.TopicPath, pending.Consumers); !result.IsSuccess()) {
+    auto pending = std::exchange(PendingConsumersRestores, {});
+    for (const auto& entry : pending) {
+        if (auto result = RestoreConsumers(entry.TopicPath, entry.Consumers); !result.IsSuccess()) {
             return result;
         }
     }
-    PendingConsumersRestores.clear();
     return Result<TRestoreResult>();
 }
 

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -224,6 +224,16 @@ TStatus CreateTopic(TTopicClient& client, const TString& dbPath, const Ydb::Topi
     return result;
 }
 
+std::vector<TConsumer> ExtractConsumers(Ydb::Topic::CreateTopicRequest& request) {
+    std::vector<TConsumer> consumers;
+    consumers.reserve(request.consumers_size());
+    for (const auto& consumer : request.consumers()) {
+        consumers.emplace_back(consumer);
+    }
+    request.clear_consumers();
+    return consumers;
+}
+
 TStatus CreateCoordinationNode(
     NCoordination::TClient& client,
     const TString& dbPath,
@@ -472,6 +482,8 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
         ExistingEntries.emplace(TString{entry.Name}, entry.Type);
     }
 
+    PendingConsumersRestores.clear();
+
     // restore
     auto restoreResult = Result<TRestoreResult>();
     if (settings.Replace_) {
@@ -480,6 +492,9 @@ TRestoreResult TRestoreClient::Restore(const TString& fsPath, const TString& dbP
         restoreResult = RestoreFolder(fsPath, dbPath, settings);
     }
     if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
+        restoreResult = result;
+    }
+    if (auto result = RestorePendingConsumers(); !result.IsSuccess()) {
         restoreResult = result;
     }
 
@@ -813,6 +828,9 @@ TRestoreResult TRestoreClient::RestoreDatabaseImpl(const TString& fsPath, const 
         restoreSettings.ReplaceSysACL(true);
         auto restoreResult = RestoreFolder(fsPath, dbPath, restoreSettings);
         if (auto result = DelayedRestoreManager.RestoreDelayed(); !result.IsSuccess()) {
+            restoreResult = result;
+        }
+        if (auto result = RestorePendingConsumers(); !result.IsSuccess()) {
             restoreResult = result;
         }
         return restoreResult;
@@ -1449,10 +1467,12 @@ TRestoreResult TRestoreClient::RestoreTopic(
         return CheckExistenceAndType(dbPath, ESchemeEntryType::Topic);
     }
 
-    const auto request = ReadTopicCreationRequest(fsPath, Log.get());
+    auto request = ReadTopicCreationRequest(fsPath, Log.get());
+    auto consumers = ExtractConsumers(request);
     auto result = CreateTopic(TopicClient, dbPath, request);
     if (result.IsSuccess()) {
         LOG_D("Created " << dbPath.Quote());
+        ScheduleConsumersRestore(dbPath, std::move(consumers));
         return RestorePermissions(fsPath, dbPath, settings, ExistingEntries.contains(dbPath), false);
     }
 
@@ -2184,7 +2204,28 @@ TRestoreResult TRestoreClient::RestoreChangefeeds(const TFsPath& fsPath, const T
     }
 
     const auto topicPath = Join("/", dbPath, fsPath.GetName());
-    return RestoreConsumers(topicPath, topicDesc.GetConsumers());
+    ScheduleConsumersRestore(topicPath, topicDesc.GetConsumers());
+    return Result<TRestoreResult>();
+}
+
+void TRestoreClient::ScheduleConsumersRestore(const TString& topicPath, std::vector<TConsumer> consumers) {
+    if (consumers.empty()) {
+        return;
+    }
+    PendingConsumersRestores.emplace_back(TPendingConsumersRestore{
+        .TopicPath = topicPath,
+        .Consumers = std::move(consumers),
+    });
+}
+
+TRestoreResult TRestoreClient::RestorePendingConsumers() {
+    for (const auto& pending : PendingConsumersRestores) {
+        if (auto result = RestoreConsumers(pending.TopicPath, pending.Consumers); !result.IsSuccess()) {
+            return result;
+        }
+    }
+    PendingConsumersRestores.clear();
+    return Result<TRestoreResult>();
 }
 
 TRestoreResult TRestoreClient::RestoreConsumers(const TString& topicPath, const std::vector<TConsumer>& consumers) {

--- a/ydb/public/lib/ydb_cli/dump/restore_impl.h
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.h
@@ -188,6 +188,11 @@ struct TFsBackupEntry {
     }
 };
 
+struct TPendingConsumersRestore {
+    TString TopicPath;
+    std::vector<NTopic::TConsumer> Consumers;
+};
+
 } // NPrivate
 
 class TRestoreClient {
@@ -212,6 +217,8 @@ class TRestoreClient {
     TRestoreResult RestoreChangefeeds(const TFsPath& path, const TString& dbPath);
     TRestoreResult RestorePermissions(const TFsPath& fsPath, const TString& dbPath, const TRestoreSettings& settings, bool isAlreadyExisting, bool isSystemObject);
     TRestoreResult RestoreConsumers(const TString& topicPath, const std::vector<NTopic::TConsumer>& consumers);
+    void ScheduleConsumersRestore(const TString& topicPath, std::vector<NTopic::TConsumer> consumers);
+    TRestoreResult RestorePendingConsumers();
 
     TRestoreResult FindClusterRootPath();
     TRestoreResult ReplaceClusterRoot(TString& outPath);
@@ -266,6 +273,7 @@ private:
     TDriverConfig DriverConfig;
     TString ClusterRootPath;
     NPrivate::TDelayedRestoreManager DelayedRestoreManager;
+    TVector<NPrivate::TPendingConsumersRestore> PendingConsumersRestores;
     THashMap<TString, NScheme::ESchemeEntryType> ExistingEntries;
 
     friend class NPrivate::TDelayedRestoreManager;


### PR DESCRIPTION
…ing the topic and restoring its consumers

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Восстановление топиков разбито н два этапа:
- создание всех топиков (без консьюмеров)
- добавление консьюмеров топикам

Это требуется т.к. консьюмер топика сейчас может ссылается на другой топик и важно сохранить порядок: на момент добавления консьюмера топик ан который он ссылается, уже должен существовать.

Проверка существования топика будет в следующем ПР (бью большой ПР на части)

Новых тестов не добавляю т.к. уже сейчас есть тесты где восстанавливается топик с консьюмерами
