### PR TITLE
implement GetClientIdentity for several CredentialProviders

### DIFF
--- a/ydb/library/yql/providers/common/token_accessor/client/bearer_credentials_provider.cpp
+++ b/ydb/library/yql/providers/common/token_accessor/client/bearer_credentials_provider.cpp
@@ -34,7 +34,7 @@ public:
     }
 
     std::string GetClientIdentity() const override {
-        return "BEARER_CRED_PROV_FACTORY" + ToString((ui64)this);
+        return "BEARER_CRED_PROV_FACTORY\t" + Delegatee->GetClientIdentity();
     }
 
     std::shared_ptr<NYdb::ICredentialsProvider> CreateProvider() const override {

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -115,6 +115,12 @@ public:
         return std::make_shared<TIAMCredentialsProvider>(Params_);
     }
 
+    std::string GetClientIdentity() const final {
+        return TStringBuilder() <<
+                "TIamServiceCredentialsProviderFactory" << '\t' <<
+                Params_.Host << ':' << Params_.Port << '@' << Params_.RefreshPeriod;
+    }
+
 private:
     TIamHost Params_;
 };

--- a/ydb/public/sdk/cpp/src/client/iam/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam/iam.cpp
@@ -117,7 +117,7 @@ public:
 
     std::string GetClientIdentity() const final {
         return TStringBuilder() <<
-                "TIamServiceCredentialsProviderFactory" << '\t' <<
+                "TIamCredentialsProviderFactory" << '\t' <<
                 Params_.Host << ':' << Params_.Port << '@' << Params_.RefreshPeriod;
     }
 

--- a/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
+++ b/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
@@ -2,8 +2,6 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h>
 
-#include <util/string/join.h>
-
 namespace NYdb::inline Dev {
 
 template<typename TRequest, typename TResponse, typename TService>
@@ -74,15 +72,15 @@ public:
     }
 
     std::string GetClientIdentity() const override final {
-        return TStringBuilder() << JoinSeq('\t', std::initializer_list<std::string_view> {
-                "TIamServiceCredentialsProviderFactory",
-                Params_.ServiceId,
-                Params_.MicroserviceId,
-                Params_.ResourceId,
-                Params_.ResourceType,
-                Params_.TargetServiceAccountId,
-                Params_.SystemServiceAccountCredentials->GetClientIdentity()
-        });
+        return TStringBuilder()
+                << "TIamServiceCredentialsProviderFactory"
+                << '\t' << Params_.ServiceId
+                << '\t' << Params_.MicroserviceId
+                << '\t' << Params_.ResourceId
+                << '\t' << Params_.ResourceType
+                << '\t' << Params_.TargetServiceAccountId
+                << '\t' << Params_.SystemServiceAccountCredentials->GetClientIdentity()
+                ;
     }
 
 private:

--- a/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
+++ b/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
@@ -2,6 +2,8 @@
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/iam/common/generic_provider.h>
 
+#include <util/string/join.h>
+
 namespace NYdb::inline Dev {
 
 template<typename TRequest, typename TResponse, typename TService>
@@ -69,6 +71,18 @@ public:
 
     TCredentialsProviderPtr CreateProvider(std::weak_ptr<ICoreFacility> facility) const override {
         return std::make_shared<TCredentialsProvider>(Params_, std::move(facility));
+    }
+
+    std::string GetClientIdentity() const override final {
+        return TStringBuilder() << JoinSeq('\t', std::initializer_list<std::string_view> {
+                "TIamServiceCredentialsProviderFactory",
+                Params_.ServiceId,
+                Params_.MicroserviceId,
+                Params_.ResourceId,
+                Params_.ResourceType,
+                Params_.TargetServiceAccountId,
+                Params_.SystemServiceAccountCredentials->GetClientIdentity()
+        });
     }
 
 private:


### PR DESCRIPTION
Otherwise GetDriverState is prone to create new client state for each call
Potential risk: may expose bugs by sharing single DriverState

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

RFC: should I also add it to OAuth2 and Login cred providers?
ydb/public/sdk/cpp/src/client/types/credentials/oauth2_token_exchange/credentials.cpp
(note: Params_ contains SubjecTokenSource_ and ActorTokenSource_, not sure how they can be handled)
ydb/public/sdk/cpp/src/client/types/credentials/login/login.cpp
(note: this one lacks legacy CreateProvider() fallback)
