### PR TITLE
row_dispatcher: reuse same credentials provider for all partitions

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/row_dispatcher.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/row_dispatcher.cpp
@@ -926,6 +926,8 @@ void TRowDispatcher::Handle(NFq::TEvRowDispatcher::TEvStartSession::TPtr& ev) {
         return;
     }
 
+    std::shared_ptr<NYdb::ICredentialsProviderFactory> credentialsProviderFactory;
+
     for (auto partitionId : ev->Get()->Record.GetPartitionIds()) {
         TActorId sessionActorId;
         TTopicSessionKey topicKey{source.GetReadGroup(), source.GetEndpoint(), source.GetDatabase(), source.GetTopicPath(), partitionId};
@@ -933,6 +935,12 @@ void TRowDispatcher::Handle(NFq::TEvRowDispatcher::TEvStartSession::TPtr& ev) {
         Y_ENSURE(topicSessionInfo.Sessions.size() <= 1);
 
         if (topicSessionInfo.Sessions.empty()) {
+            if (!credentialsProviderFactory) {
+                credentialsProviderFactory = CreateCredentialsProviderFactoryForStructuredToken(
+                    CredentialsFactory,
+                    ev->Get()->Record.GetToken(),
+                    source.GetAddBearerToToken());
+            }
             LOG_ROW_DISPATCHER_DEBUG("Create new session: read group " << source.GetReadGroup() << " topic " << source.GetTopicPath() 
                 << " part id " << partitionId);
             sessionActorId = ActorFactory->RegisterTopicSession(
@@ -946,10 +954,7 @@ void TRowDispatcher::Handle(NFq::TEvRowDispatcher::TEvStartSession::TPtr& ev) {
                 CompileServiceActorId,
                 partitionId,
                 Driver,
-                CreateCredentialsProviderFactoryForStructuredToken(
-                    CredentialsFactory,
-                    ev->Get()->Record.GetToken(),
-                    source.GetAddBearerToToken()),
+                credentialsProviderFactory,
                 Counters,
                 CountersRoot,
                 PqGateway,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Saves some cycles wasted in (re)parsing structured token and a call to CreateProvider.
Only affects first topic session creation for single read actor (assuming 4k partitions and 32 tasks-per-stage, ~100 calls)