### PR TITLE
Fix UniqueIndexKeySize persistence by moving it into PartitionConfig

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -215,6 +215,8 @@ message TPartitionConfig {
     reserved 26; // deprecated -> ByKeyFilterPrefixes
     repeated TByKeyFilterPrefix ByKeyFilterPrefixes = 27; // Bloom filters on PK prefixes
     repeated uint32 DropByKeyFilterPrefixLengths = 28; // Bloom filter prefix lengths to drop
+    // For unique indexes - number of leading PK columns which should have unique values (for correct locking)
+    optional uint32 UniqueIndexKeySize = 29;
 }
 
 message TByKeyFilterPrefix {
@@ -440,8 +442,7 @@ message TTableDescription {
     // Coordinated schema version for backup operations - persisted with AlterData
     optional uint64 CoordinatedSchemaVersion = 49;
 
-    // For unique indexes - number of leading PK columns which should have unique values (for correct locking)
-    optional uint32 UniqueIndexKeySize = 50;
+    reserved 50;
 
     /**
      * The detailed metrics settings for the given table.

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -327,7 +327,9 @@ void TUserTable::ParseProto(const NKikimrSchemeOp::TTableDescription& descr)
     IsBackup = descr.GetIsBackup();
     ReplicationConfig = TReplicationConfig(descr.GetReplicationConfig());
     IncrementalBackupConfig = TIncrementalBackupConfig(descr.GetIncrementalBackupConfig());
-    UniqueIndexKeySize = descr.GetUniqueIndexKeySize();
+    if (descr.GetPartitionConfig().HasUniqueIndexKeySize()) {
+        UniqueIndexKeySize = descr.GetPartitionConfig().GetUniqueIndexKeySize();
+    }
     if (descr.HasTableType()) {
         TableType = descr.GetTableType();
     }

--- a/ydb/core/tx/schemeshard/index/index_utils.cpp
+++ b/ydb/core/tx/schemeshard/index/index_utils.cpp
@@ -312,7 +312,7 @@ auto CalcImplTableDescImpl(
     }
     if (uniqueKeySize > 0 && uniqueKeySize < implTableColumns.Keys.size()) {
         // Unique key may contain all PK columns, then the prefix is not required
-        implTableDesc.SetUniqueIndexKeySize(uniqueKeySize);
+        implTableDesc.MutablePartitionConfig()->SetUniqueIndexKeySize(uniqueKeySize);
     }
 
     return implTableDesc;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -808,15 +808,12 @@ TTableInfo::TAlterDataPtr TTableInfo::CreateAlterData(
         return nullptr;
     }
 
-    if (op.GetUniqueIndexKeySize()) {
-        if (op.GetUniqueIndexKeySize() >= keyColIds.size()) {
-            errStr = TStringBuilder()
-                << "Too many unique key prefix columns"
-                << ": " << op.GetUniqueIndexKeySize()
-                << ", max: " << (keyColIds.size()-1);
-            return nullptr;
-        }
-        alterData->TableDescriptionFull->SetUniqueIndexKeySize(op.GetUniqueIndexKeySize());
+    if (op.GetPartitionConfig().GetUniqueIndexKeySize() >= keyColIds.size()) {
+        errStr = TStringBuilder()
+            << "Too many unique key prefix columns"
+            << ": " << op.GetPartitionConfig().GetUniqueIndexKeySize()
+            << ", max: " << (keyColIds.size()-1);
+        return nullptr;
     }
 
     if (op.HasTableType()) {
@@ -1212,6 +1209,10 @@ bool TPartitionConfigMerger::ApplyChanges(
 
     if (changes.HasKeepSnapshotTimeout()) {
         result.SetKeepSnapshotTimeout(changes.GetKeepSnapshotTimeout());
+    }
+
+    if (changes.HasUniqueIndexKeySize()) {
+        result.SetUniqueIndexKeySize(changes.GetUniqueIndexKeySize());
     }
 
     return true;

--- a/ydb/core/tx/schemeshard/ut_index/ut_unique_index.cpp
+++ b/ydb/core/tx/schemeshard/ut_index/ut_unique_index.cpp
@@ -1,3 +1,4 @@
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
@@ -9,8 +10,6 @@ Y_UNIT_TEST_SUITE(TUniqueIndexTests) {
     Y_UNIT_TEST(CreateTable) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
-        auto& appData = runtime.GetAppData();
-        appData.FeatureFlags.SetEnableUniqConstraint(true);
         ui64 txId = 100;
 
         TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
@@ -33,5 +32,82 @@ Y_UNIT_TEST_SUITE(TUniqueIndexTests) {
              NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
              NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
              NLs::IndexKeys({"indexed"})});
+    }
+
+    Y_UNIT_TEST_FLAG(PersistUniqueIndexKeySize, OnCreate) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        auto& appData = runtime.GetAppData();
+        appData.FeatureFlags.SetEnableAddUniqueIndex(true);
+        appData.FeatureFlags.SetEnableOnlineAddUniqueIndex(true);
+        ui64 txId = 100;
+
+        if (OnCreate) {
+            TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+                TableDescription {
+                    Name: "Table"
+                    Columns { Name: "key" Type: "Uint64" }
+                    Columns { Name: "uniqkey" Type: "Uint64" }
+                    KeyColumnNames: ["key"]
+                }
+                IndexDescription {
+                    Name: "idx_uniq"
+                    KeyColumnNames: ["uniqkey"]
+                    Type: EIndexTypeGlobalUnique
+                }
+            )");
+            env.TestWaitNotification(runtime, txId);
+        } else {
+            TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+                Name: "Table"
+                Columns { Name: "key" Type: "Uint64" }
+                Columns { Name: "uniqkey" Type: "Uint64" }
+                KeyColumnNames: ["key"]
+            )");
+            env.TestWaitNotification(runtime, txId);
+            TestBuildIndex(runtime, ++txId, TTestTxConfig::SchemeShard, "/MyRoot", "/MyRoot/Table", TBuildIndexConfig{
+                "idx_uniq", NKikimrSchemeOp::EIndexTypeGlobalUnique, {"uniqkey"}, {}, {}
+            });
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/idx_uniq"),
+            {NLs::PathExist,
+             NLs::IndexType(NKikimrSchemeOp::EIndexTypeGlobalUnique),
+             NLs::IndexState(NKikimrSchemeOp::EIndexStateReady),
+             NLs::IndexKeys({"uniqkey"})});
+
+        Cerr << "rebooting schemeshard\n";
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Split the index table
+        {
+            auto indexDesc = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Table/idx_uniq/indexImplTable", true, true, true);
+            auto parts = indexDesc.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_EQUAL(parts.size(), 1);
+            TestSplitTable(runtime, TTestTxConfig::SchemeShard, ++txId, "/MyRoot/Table/idx_uniq/indexImplTable", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Uint64: 100 } } } }
+            )", parts[0].GetDatashardId()));
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        // Verify UniqueIndexKeySize at datashards
+        {
+            auto indexDesc = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Table/idx_uniq/indexImplTable", true, true, true);
+            auto parts = indexDesc.GetPathDescription().GetTablePartitions();
+            UNIT_ASSERT_EQUAL(parts.size(), 2);
+            for (auto& x: parts) {
+                auto edge = runtime.AllocateEdgeActor();
+                runtime.SendToPipe(x.GetDatashardId(), edge, new TEvDataShard::TEvGetInfoRequest(), 0, GetPipeConfigWithRetries());
+                TAutoPtr<IEventHandle> handle;
+                auto* resp = runtime.GrabEdgeEventRethrow<TEvDataShard::TEvGetInfoResponse>(handle);
+                UNIT_ASSERT(resp);
+                UNIT_ASSERT_VALUES_EQUAL(resp->Record.UserTablesSize(), 1u);
+                const auto& descr = resp->Record.GetUserTables(0).GetDescription();
+                UNIT_ASSERT_VALUES_EQUAL(descr.GetPartitionConfig().GetUniqueIndexKeySize(), 1u);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

"Упс".

Оказалось, что UniqueIndexKeySize не персистился в Schemeshard вообще. Соответственно, после перезапуска Schemeshard и сплита индексной таблицы у новых шардов терялся признак принадлежности таблицы к уникальному индексу.

Добавлять поле в schemeshard_schema не хочется, вместо этого просто переместил новое поле в PartitionConfig. Ничего не ломаем, т.к. функционал под фича флагом, пока нигде не включен.