### PR TITLE
Always forbid discovery on inner (not database root) paths

### DIFF
--- a/ydb/core/discovery/discovery.cpp
+++ b/ydb/core/discovery/discovery.cpp
@@ -642,21 +642,15 @@ public:
                 "Database resolve failed with no certain result"));
         }
 
-        { // write wrong requests to monitoring to warn clients
-            const auto isDomain = entry.Path.size() == 1;
-            const auto isSubDomain = entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSubdomain
-                || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindExtSubdomain;
+        const auto isDomain = entry.Path.size() == 1;
+        const auto isSubDomain = entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSubdomain
+            || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindExtSubdomain;
 
-            if (!isDomain && !isSubDomain) {
-                const TString path = CanonizePath(Database);
-                GetServiceCounters(AppData()->Counters, "ydb")
-                    ->GetSubgroup("subsystem", "discovery")
-                    ->GetSubgroup("path", path)
-                    ->GetCounter("pathIsNotDatabase", true)->Inc();
-
-                YDB_LOG_ERROR_COMP(NKikimrServices::DISCOVERY, "Path is not database",
-                    {"database", path});
-            }
+        if (!isDomain && !isSubDomain) {
+            YDB_LOG_WARN_COMP(NKikimrServices::DISCOVERY, "Path is not database",
+                {"path", CanonizePath(Database)});
+            return Reply(new TEvDiscovery::TEvError(TEvDiscovery::TEvError::ACCESS_DENIED,
+                "Requested path is not database name"));
         }
 
         auto info = entry.DomainInfo;
@@ -696,21 +690,6 @@ public:
     void MaybeReply() {
         if (!LookupResponse || !SchemeCacheResponse) {
             return;
-        }
-
-        {
-            // check presence of database (acl should be checked here too)
-            const auto& entry = SchemeCacheResponse->Request->ResultSet.front();
-            const auto isDomain = entry.Path.size() == 1;
-            const auto isSubDomain = entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindSubdomain
-                || entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindExtSubdomain;
-
-            if (!isDomain && !isSubDomain) {
-                YDB_LOG_DEBUG_COMP(NKikimrServices::DISCOVERY, "Path is not database",
-                    {"entry", entry.ToString()});
-                return Reply(new TEvDiscovery::TEvError(TEvDiscovery::TEvError::ACCESS_DENIED,
-                    "Requested path is not database name"));
-            }
         }
 
         if (LookupResponse->Status != TEvStateStorage::TEvBoardInfo::EStatus::Ok) {
@@ -767,9 +746,7 @@ public:
             {"path", id});
 
         auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
-        if (AppData()->FeatureFlags.GetForbidDiscoveryInnerDbPaths()) {
-            request->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
-        }
+        request->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
 
         auto& entry = request->ResultSet.emplace_back();
         entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -294,7 +294,7 @@ message TFeatureFlags {
     optional bool UseRealUserIpForBlackbox = 256 [default = false];
     optional bool EnableNodeShutdownHints = 257 [default = false];
     optional bool EnableTopicPartitionSplitBasedOnMessages = 258 [default = false];
-    optional bool ForbidDiscoveryInnerDbPaths = 259 [default = false];
+    reserved 259; // ForbidDiscoveryInnerDbPaths
     optional bool EnableStreamingQueryDisposition = 260 [default = true];
     // Skip persisting partition rows that are not affected by a split/merge operation.
     optional bool EnableSplitMergePartialPersistence = 261 [default = true];

--- a/ydb/tests/functional/serverless/test_serverless.py
+++ b/ydb/tests/functional/serverless/test_serverless.py
@@ -615,9 +615,12 @@ def test_discovery_with_inner_path(ydb_hostel_db, ydb_serverless_db, ydb_endpoin
     driver.scheme_client.make_directory(serverless_inner_path)
 
     logger.debug("List endpoints of '%s' by path '%s'", ydb_serverless_db, serverless_inner_path)
+
+    # discovery must reject inner (non-database) paths: only a domain or a subdomain
     resolver = ydb.DiscoveryEndpointsResolver(ydb.DriverConfig(ydb_endpoint, serverless_inner_path))
     result = resolver.resolve()
-    assert_that(result.endpoints, not_none())
+    assert result is None
+    assert "Requested database does not exist" in resolver.debug_details()
 
 
 def ydbcli_db_schema_exec(cluster, operation_proto):


### PR DESCRIPTION
- Remove the `ForbidDiscoveryInnerDbPaths` feature flag and always fill `SchemeCacheNavigate.DatabaseName` in the discoverer.
- On the SchemeCache response, verify the resolved path is a domain or subdomain and reject non-database paths with `ACCESS_DENIED`; 
- Update `test_discovery_with_inner_path` to expect discovery on an inner path to fail instead of returning endpoints.

