### PR TITLE
ci: создавать mute-тикеты только по relwithdebinfo-триггеру

### DIFF
--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -33,7 +33,6 @@ jobs:
     outputs:
       base_branch: ${{ steps.resolve.outputs.base_branch }}
       matrix_build_types: ${{ steps.resolve.outputs.matrix_build_types }}
-      should_create_issues: ${{ steps.resolve.outputs.should_create_issues }}
     steps:
       - name: Checkout config
         uses: actions/checkout@v5
@@ -58,10 +57,6 @@ jobs:
               --profiles-config ".github/config/mute_issue_and_digest_config.json" \
               --branch "$1"
           }
-          is_in_json_array() {
-            # $1 = value, stdin = JSON array
-            python3 -c "import json,sys; sys.exit(0 if sys.argv[1] in json.load(sys.stdin) else 1)" "$1"
-          }
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             BASE_BRANCH="$DISPATCH_BASE_BRANCH"
@@ -74,51 +69,29 @@ jobs:
           fi
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          # Deduplicate issue creation without dropping per-build-type DB refresh.
-          # update_muted_ya.yml opens one PR per build type
-          # (update-muted-ya_<base>_<buildtype>: relwithdebinfo, release-asan, release-tsan,
-          # release-msan), all labeled mute-unmute and all targeting main. Every merge triggers
-          # this workflow. The job always runs for the triggering PR's OWN build type (so the DB /
-          # history / test-monitor steps refresh that build type post-merge), but issue creation
-          # is gated on should_create_issues so only build types listed in
-          # mute_issue_and_digest_config.json (relwithdebinfo today) open issues. This way each
-          # build-type PR handles only itself and issues are never created twice.
-          SHOULD_CREATE_ISSUES=true
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ -n "$DISPATCH_BUILD_TYPE" ]; then
-              MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
-            else
-              MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"
-            fi
-          else
+          # Deduplicate issue creation. update_muted_ya.yml opens one PR per build type
+          # (update-muted-ya_<base>_<buildtype>), all labeled mute-unmute -> all trigger this
+          # workflow. Run only for the triggering PR's OWN build type; create_new_muted_ya.py
+          # skips build types absent from mute_issue_and_digest_config.json, so non-configured
+          # build types (asan/tsan/msan today) just refresh their DB data and create no issues.
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUILD_TYPE" ]; then
+            MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
             case "$PR_HEAD_REF" in
-              update-muted-ya_*)
-                TRIGGER_BUILD_TYPE="${PR_HEAD_REF##*_}"
-                MATRIX_BUILD_TYPES="[\"$TRIGGER_BUILD_TYPE\"]"
-                if issue_build_types "$BASE_BRANCH" | is_in_json_array "$TRIGGER_BUILD_TYPE"; then
-                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is configured for issues — will create issues"
-                else
-                  SHOULD_CREATE_ISSUES=false
-                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is not configured for issues — DB refresh only, no issues"
-                fi
-                ;;
-              *)
-                # Non auto-mute PR carrying the mute-unmute label: keep previous behavior
-                # (create issues for all configured build types).
-                MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"
-                echo "Head ref '$PR_HEAD_REF' is not an update-muted-ya branch — using configured build types"
-                ;;
+              update-muted-ya_*) MATRIX_BUILD_TYPES="[\"${PR_HEAD_REF##*_}\"]" ;;
+              *)                 MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")" ;;
             esac
+          else
+            MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"
           fi
           echo "matrix_build_types=$MATRIX_BUILD_TYPES" >> "$GITHUB_OUTPUT"
-          echo "should_create_issues=$SHOULD_CREATE_ISSUES" >> "$GITHUB_OUTPUT"
 
   create-issues-for-muted-tests:
     needs: resolve-build-types
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     # Runs for the triggering PR's own build type to refresh DB / history / test-monitor.
-    # Issue creation itself is gated per-step on should_create_issues so only configured
-    # build types open issues (avoids duplicates across build-type PRs).
+    # The create_issues script itself no-ops for build types not configured for issues,
+    # so non-configured build types just refresh data without opening issues.
     if: |
       ((github.event_name == 'pull_request' &&
         github.event.pull_request.merged == true &&
@@ -161,21 +134,22 @@ jobs:
 
       - name: Create issues for muted tests
         id: create_issues
-        if: needs.resolve-build-types.outputs.should_create_issues == 'true'
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
           ENABLE_NEED_AI_REVIEW_LABEL: ${{ vars.ENABLE_NEED_AI_REVIEW_LABEL || '' }}
         run: .github/scripts/tests/mute/create_new_muted_ya.py create_issues --file_path="${{ env.MUTED_YA_FILE_PATH }}" --branch=${{ env.BASE_BRANCH }} --build-type=${{ matrix.build_type }}
 
       - name: Add issues to PR
-        if: needs.resolve-build-types.outputs.should_create_issues == 'true'
+        # created_issues_file is only set when the build type is configured for issues;
+        # skip for non-configured build types (create_issues no-ops there).
+        if: steps.create_issues.outputs.created_issues_file != ''
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
         run: python .github/scripts/create_or_update_pr.py append_pr_body --pr_number=${{ github.event.pull_request.number || github.event.inputs.pr_number  }} --body=${{ steps.create_issues.outputs.created_issues_file }}
 
       - name: Comment PR
-        if: needs.resolve-build-types.outputs.should_create_issues == 'true'
+        if: steps.create_issues.outputs.created_issues_file != ''
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.GH_TOKEN }}
@@ -209,9 +183,7 @@ jobs:
   sync-manual-fast-unmute:
     needs: [resolve-build-types, create-issues-for-muted-tests]
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
-    # Issue-state sync — only meaningful when issues were (re)created for a configured build type.
     if: |
-      needs.resolve-build-types.outputs.should_create_issues == 'true' &&
       ((github.event_name == 'pull_request' &&
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -61,26 +61,36 @@ jobs:
             local d="d_${RANDOM}${RANDOM}"
             { printf '%s<<%s\n' "$1" "$d"; printf '%s\n' "$2"; printf '%s\n' "$d"; } >> "$GITHUB_OUTPUT"
           }
+          # build_type is interpolated raw into later run: steps, so require a safe, non-empty value.
+          validate_build_type() {
+            case "$1" in
+              ""|*[!a-zA-Z0-9._-]*) echo "invalid build_type: '$1'" >&2; exit 1 ;;
+            esac
+          }
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             BASE_BRANCH="$DISPATCH_BASE_BRANCH"
           else
             BASE_BRANCH="$PR_BASE_REF"
-            if [ -z "$BASE_BRANCH" ]; then
-              echo "BASE_BRANCH is empty for pull_request event" >&2
-              exit 1
-            fi
+          fi
+          if [ -z "$BASE_BRANCH" ]; then
+            echo "BASE_BRANCH is empty (event=$EVENT_NAME)" >&2
+            exit 1
           fi
           emit base_branch "$BASE_BRANCH"
 
           # Run only for the triggering PR's own build type (create_new_muted_ya.py skips
           # build types not configured for issues), so build-type PRs don't duplicate issues.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUILD_TYPE" ]; then
+            validate_build_type "$DISPATCH_BUILD_TYPE"
             MATRIX_BUILD_TYPES="$(json_array "$DISPATCH_BUILD_TYPE")"
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             case "$PR_HEAD_REF" in
-              update-muted-ya_*) MATRIX_BUILD_TYPES="$(json_array "${PR_HEAD_REF##*_}")" ;;
-              *)                 MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")" ;;
+              update-muted-ya_*)
+                BUILD_TYPE="${PR_HEAD_REF##*_}"
+                validate_build_type "$BUILD_TYPE"
+                MATRIX_BUILD_TYPES="$(json_array "$BUILD_TYPE")" ;;
+              *) MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")" ;;
             esac
           else
             MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -41,8 +41,7 @@ jobs:
 
       - name: Resolve build types matrix
         id: resolve
-        # Interpolate untrusted / event inputs via env (not directly into the shell script)
-        # to avoid shell injection through crafted branch names or dispatch inputs.
+        # Untrusted event inputs via env to avoid shell injection.
         env:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_BASE_BRANCH: ${{ github.event.inputs.base_branch }}
@@ -69,11 +68,8 @@ jobs:
           fi
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          # Deduplicate issue creation. update_muted_ya.yml opens one PR per build type
-          # (update-muted-ya_<base>_<buildtype>), all labeled mute-unmute -> all trigger this
-          # workflow. Run only for the triggering PR's OWN build type; create_new_muted_ya.py
-          # skips build types absent from mute_issue_and_digest_config.json, so non-configured
-          # build types (asan/tsan/msan today) just refresh their DB data and create no issues.
+          # Run only for the triggering PR's own build type (create_new_muted_ya.py skips
+          # build types not configured for issues), so build-type PRs don't duplicate issues.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUILD_TYPE" ]; then
             MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
           elif [ "$EVENT_NAME" = "pull_request" ]; then
@@ -89,9 +85,6 @@ jobs:
   create-issues-for-muted-tests:
     needs: resolve-build-types
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
-    # Runs for the triggering PR's own build type to refresh DB / history / test-monitor.
-    # The create_issues script itself no-ops for build types not configured for issues,
-    # so non-configured build types just refresh data without opening issues.
     if: |
       ((github.event_name == 'pull_request' &&
         github.event.pull_request.merged == true &&
@@ -140,8 +133,7 @@ jobs:
         run: .github/scripts/tests/mute/create_new_muted_ya.py create_issues --file_path="${{ env.MUTED_YA_FILE_PATH }}" --branch=${{ env.BASE_BRANCH }} --build-type=${{ matrix.build_type }}
 
       - name: Add issues to PR
-        # created_issues_file is only set when the build type is configured for issues;
-        # skip for non-configured build types (create_issues no-ops there).
+        # created_issues_file is set only when issues were produced (configured build types).
         if: steps.create_issues.outputs.created_issues_file != ''
         continue-on-error: true
         env:

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -52,6 +52,17 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
+
+          issue_build_types() {
+            python3 .github/scripts/tests/mute/mute_helper.py issue-build-types \
+              --profiles-config ".github/config/mute_issue_and_digest_config.json" \
+              --branch "$1"
+          }
+          is_in_json_array() {
+            # $1 = value, stdin = JSON array
+            python3 -c "import json,sys; sys.exit(0 if sys.argv[1] in json.load(sys.stdin) else 1)" "$1"
+          }
+
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             BASE_BRANCH="$DISPATCH_BASE_BRANCH"
           else
@@ -63,41 +74,43 @@ jobs:
           fi
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUILD_TYPE" ]; then
-            MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
-          else
-            MATRIX_BUILD_TYPES="$(python3 .github/scripts/tests/mute/mute_helper.py issue-build-types \
-              --profiles-config ".github/config/mute_issue_and_digest_config.json" \
-              --branch "$BASE_BRANCH")"
-          fi
-          echo "matrix_build_types=$MATRIX_BUILD_TYPES" >> "$GITHUB_OUTPUT"
-
-          # Guard against duplicate issue creation.
-          # update_muted_ya.yml opens one PR per build type (relwithdebinfo, release-asan,
-          # release-tsan, release-msan), all labeled mute-unmute and all targeting main. Every
-          # merge triggers this workflow, but the issue matrix is always taken from the config
-          # (relwithdebinfo only), so each trigger would create the SAME relwithdebinfo issues
-          # -> duplicate issues opened seconds apart. Only proceed when the triggering PR's own
-          # build type is one we create issues for, so exactly one PR drives issue creation.
+          # Deduplicate issue creation.
+          # update_muted_ya.yml opens one PR per build type
+          # (update-muted-ya_<base>_<buildtype>: relwithdebinfo, release-asan, release-tsan,
+          # release-msan), all labeled mute-unmute and all targeting main. Every merge triggers
+          # this workflow. To avoid every build-type PR creating the SAME issues (duplicates
+          # opened seconds apart), each PR creates issues only for ITS OWN build type. The issue
+          # script skips build types that are not in mute_issue_and_digest_config.json, so PRs of
+          # non-configured build types (asan/tsan/msan today) become no-ops. should_run lets us
+          # skip such runs entirely instead of spinning up a runner just to no-op.
           SHOULD_RUN=true
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            HEAD_REF="$PR_HEAD_REF"
-            case "$HEAD_REF" in
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -n "$DISPATCH_BUILD_TYPE" ]; then
+              MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
+            else
+              MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"
+            fi
+          else
+            case "$PR_HEAD_REF" in
               update-muted-ya_*)
-                TRIGGER_BUILD_TYPE="${HEAD_REF##*_}"
-                if printf '%s' "$MATRIX_BUILD_TYPES" | python3 -c "import json,sys; sys.exit(0 if sys.argv[1] in json.load(sys.stdin) else 1)" "$TRIGGER_BUILD_TYPE"; then
-                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is in issue build types $MATRIX_BUILD_TYPES — proceeding"
+                TRIGGER_BUILD_TYPE="${PR_HEAD_REF##*_}"
+                MATRIX_BUILD_TYPES="[\"$TRIGGER_BUILD_TYPE\"]"
+                if issue_build_types "$BASE_BRANCH" | is_in_json_array "$TRIGGER_BUILD_TYPE"; then
+                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is configured for issues — proceeding"
                 else
                   SHOULD_RUN=false
-                  echo "Skipping: trigger build type '$TRIGGER_BUILD_TYPE' is not in issue build types $MATRIX_BUILD_TYPES"
+                  echo "Skipping: trigger build type '$TRIGGER_BUILD_TYPE' is not configured for issues"
                 fi
                 ;;
               *)
-                # Non auto-mute PR carrying the mute-unmute label: keep previous behavior.
-                echo "Head ref '$HEAD_REF' is not an update-muted-ya branch — proceeding"
+                # Non auto-mute PR carrying the mute-unmute label: keep previous behavior
+                # (create issues for all configured build types).
+                MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"
+                echo "Head ref '$PR_HEAD_REF' is not an update-muted-ya branch — using configured build types"
                 ;;
             esac
           fi
+          echo "matrix_build_types=$MATRIX_BUILD_TYPES" >> "$GITHUB_OUTPUT"
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
 
   create-issues-for-muted-tests:

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -42,12 +42,20 @@ jobs:
 
       - name: Resolve build types matrix
         id: resolve
+        # Interpolate untrusted / event inputs via env (not directly into the shell script)
+        # to avoid shell injection through crafted branch names or dispatch inputs.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_BASE_BRANCH: ${{ github.event.inputs.base_branch }}
+          DISPATCH_BUILD_TYPE: ${{ github.event.inputs.build_type }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref || github.base_ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BASE_BRANCH="${{ github.event.inputs.base_branch }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            BASE_BRANCH="$DISPATCH_BASE_BRANCH"
           else
-            BASE_BRANCH="${{ github.event.pull_request.base.ref || github.base_ref }}"
+            BASE_BRANCH="$PR_BASE_REF"
             if [ -z "$BASE_BRANCH" ]; then
               echo "BASE_BRANCH is empty for pull_request event" >&2
               exit 1
@@ -55,8 +63,8 @@ jobs:
           fi
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.build_type }}" ]; then
-            MATRIX_BUILD_TYPES='["${{ github.event.inputs.build_type }}"]'
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUILD_TYPE" ]; then
+            MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
           else
             MATRIX_BUILD_TYPES="$(python3 .github/scripts/tests/mute/mute_helper.py issue-build-types \
               --profiles-config ".github/config/mute_issue_and_digest_config.json" \
@@ -72,8 +80,8 @@ jobs:
           # -> duplicate issues opened seconds apart. Only proceed when the triggering PR's own
           # build type is one we create issues for, so exactly one PR drives issue creation.
           SHOULD_RUN=true
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            HEAD_REF="${{ github.event.pull_request.head.ref }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            HEAD_REF="$PR_HEAD_REF"
             case "$HEAD_REF" in
               update-muted-ya_*)
                 TRIGGER_BUILD_TYPE="${HEAD_REF##*_}"
@@ -98,6 +106,7 @@ jobs:
     if: |
       needs.resolve-build-types.outputs.should_run == 'true' &&
       ((github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
        github.event_name == 'workflow_dispatch')
     strategy:
@@ -185,6 +194,7 @@ jobs:
     if: |
       needs.resolve-build-types.outputs.should_run == 'true' &&
       ((github.event_name == 'pull_request' &&
+        github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
        github.event_name == 'workflow_dispatch')
     steps:

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -92,7 +92,6 @@ jobs:
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
       ((github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
        github.event_name == 'workflow_dispatch')
     strategy:
@@ -182,7 +181,6 @@ jobs:
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
       ((github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
        github.event_name == 'workflow_dispatch')
     steps:

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -56,6 +56,11 @@ jobs:
               --profiles-config ".github/config/mute_issue_and_digest_config.json" \
               --branch "$1"
           }
+          json_array() { python3 -c "import json,sys; print(json.dumps(sys.argv[1:]))" "$@"; }
+          emit() {  # newline-safe GITHUB_OUTPUT writer: emit <name> <value>
+            local d="d_${RANDOM}${RANDOM}"
+            { printf '%s<<%s\n' "$1" "$d"; printf '%s\n' "$2"; printf '%s\n' "$d"; } >> "$GITHUB_OUTPUT"
+          }
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             BASE_BRANCH="$DISPATCH_BASE_BRANCH"
@@ -66,21 +71,21 @@ jobs:
               exit 1
             fi
           fi
-          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+          emit base_branch "$BASE_BRANCH"
 
           # Run only for the triggering PR's own build type (create_new_muted_ya.py skips
           # build types not configured for issues), so build-type PRs don't duplicate issues.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_BUILD_TYPE" ]; then
-            MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
+            MATRIX_BUILD_TYPES="$(json_array "$DISPATCH_BUILD_TYPE")"
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             case "$PR_HEAD_REF" in
-              update-muted-ya_*) MATRIX_BUILD_TYPES="[\"${PR_HEAD_REF##*_}\"]" ;;
+              update-muted-ya_*) MATRIX_BUILD_TYPES="$(json_array "${PR_HEAD_REF##*_}")" ;;
               *)                 MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")" ;;
             esac
           else
             MATRIX_BUILD_TYPES="$(issue_build_types "$BASE_BRANCH")"
           fi
-          echo "matrix_build_types=$MATRIX_BUILD_TYPES" >> "$GITHUB_OUTPUT"
+          emit matrix_build_types "$MATRIX_BUILD_TYPES"
 
   create-issues-for-muted-tests:
     needs: resolve-build-types

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       base_branch: ${{ steps.resolve.outputs.base_branch }}
       matrix_build_types: ${{ steps.resolve.outputs.matrix_build_types }}
-      should_run: ${{ steps.resolve.outputs.should_run }}
+      should_create_issues: ${{ steps.resolve.outputs.should_create_issues }}
     steps:
       - name: Checkout config
         uses: actions/checkout@v5
@@ -74,16 +74,16 @@ jobs:
           fi
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          # Deduplicate issue creation.
+          # Deduplicate issue creation without dropping per-build-type DB refresh.
           # update_muted_ya.yml opens one PR per build type
           # (update-muted-ya_<base>_<buildtype>: relwithdebinfo, release-asan, release-tsan,
           # release-msan), all labeled mute-unmute and all targeting main. Every merge triggers
-          # this workflow. To avoid every build-type PR creating the SAME issues (duplicates
-          # opened seconds apart), each PR creates issues only for ITS OWN build type. The issue
-          # script skips build types that are not in mute_issue_and_digest_config.json, so PRs of
-          # non-configured build types (asan/tsan/msan today) become no-ops. should_run lets us
-          # skip such runs entirely instead of spinning up a runner just to no-op.
-          SHOULD_RUN=true
+          # this workflow. The job always runs for the triggering PR's OWN build type (so the DB /
+          # history / test-monitor steps refresh that build type post-merge), but issue creation
+          # is gated on should_create_issues so only build types listed in
+          # mute_issue_and_digest_config.json (relwithdebinfo today) open issues. This way each
+          # build-type PR handles only itself and issues are never created twice.
+          SHOULD_CREATE_ISSUES=true
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ -n "$DISPATCH_BUILD_TYPE" ]; then
               MATRIX_BUILD_TYPES="[\"$DISPATCH_BUILD_TYPE\"]"
@@ -96,10 +96,10 @@ jobs:
                 TRIGGER_BUILD_TYPE="${PR_HEAD_REF##*_}"
                 MATRIX_BUILD_TYPES="[\"$TRIGGER_BUILD_TYPE\"]"
                 if issue_build_types "$BASE_BRANCH" | is_in_json_array "$TRIGGER_BUILD_TYPE"; then
-                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is configured for issues — proceeding"
+                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is configured for issues — will create issues"
                 else
-                  SHOULD_RUN=false
-                  echo "Skipping: trigger build type '$TRIGGER_BUILD_TYPE' is not configured for issues"
+                  SHOULD_CREATE_ISSUES=false
+                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is not configured for issues — DB refresh only, no issues"
                 fi
                 ;;
               *)
@@ -111,13 +111,15 @@ jobs:
             esac
           fi
           echo "matrix_build_types=$MATRIX_BUILD_TYPES" >> "$GITHUB_OUTPUT"
-          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          echo "should_create_issues=$SHOULD_CREATE_ISSUES" >> "$GITHUB_OUTPUT"
 
   create-issues-for-muted-tests:
     needs: resolve-build-types
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
+    # Runs for the triggering PR's own build type to refresh DB / history / test-monitor.
+    # Issue creation itself is gated per-step on should_create_issues so only configured
+    # build types open issues (avoids duplicates across build-type PRs).
     if: |
-      needs.resolve-build-types.outputs.should_run == 'true' &&
       ((github.event_name == 'pull_request' &&
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
@@ -159,18 +161,21 @@ jobs:
 
       - name: Create issues for muted tests
         id: create_issues
+        if: needs.resolve-build-types.outputs.should_create_issues == 'true'
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
           ENABLE_NEED_AI_REVIEW_LABEL: ${{ vars.ENABLE_NEED_AI_REVIEW_LABEL || '' }}
         run: .github/scripts/tests/mute/create_new_muted_ya.py create_issues --file_path="${{ env.MUTED_YA_FILE_PATH }}" --branch=${{ env.BASE_BRANCH }} --build-type=${{ matrix.build_type }}
 
       - name: Add issues to PR
+        if: needs.resolve-build-types.outputs.should_create_issues == 'true'
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ env.GH_TOKEN }}
         run: python .github/scripts/create_or_update_pr.py append_pr_body --pr_number=${{ github.event.pull_request.number || github.event.inputs.pr_number  }} --body=${{ steps.create_issues.outputs.created_issues_file }}
 
       - name: Comment PR
+        if: needs.resolve-build-types.outputs.should_create_issues == 'true'
         uses: actions/github-script@v8
         with:
           github-token: ${{ env.GH_TOKEN }}
@@ -204,8 +209,9 @@ jobs:
   sync-manual-fast-unmute:
     needs: [resolve-build-types, create-issues-for-muted-tests]
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
+    # Issue-state sync — only meaningful when issues were (re)created for a configured build type.
     if: |
-      needs.resolve-build-types.outputs.should_run == 'true' &&
+      needs.resolve-build-types.outputs.should_create_issues == 'true' &&
       ((github.event_name == 'pull_request' &&
         github.event.pull_request.merged == true &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       base_branch: ${{ steps.resolve.outputs.base_branch }}
       matrix_build_types: ${{ steps.resolve.outputs.matrix_build_types }}
+      should_run: ${{ steps.resolve.outputs.should_run }}
     steps:
       - name: Checkout config
         uses: actions/checkout@v5
@@ -63,10 +64,39 @@ jobs:
           fi
           echo "matrix_build_types=$MATRIX_BUILD_TYPES" >> "$GITHUB_OUTPUT"
 
+          # Guard against duplicate issue creation.
+          # update_muted_ya.yml opens one PR per build type (relwithdebinfo, release-asan,
+          # release-tsan, release-msan), all labeled mute-unmute and all targeting main. Every
+          # merge triggers this workflow, but the issue matrix is always taken from the config
+          # (relwithdebinfo only), so each trigger would create the SAME relwithdebinfo issues
+          # -> duplicate issues opened seconds apart. Only proceed when the triggering PR's own
+          # build type is one we create issues for, so exactly one PR drives issue creation.
+          SHOULD_RUN=true
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            HEAD_REF="${{ github.event.pull_request.head.ref }}"
+            case "$HEAD_REF" in
+              update-muted-ya_*)
+                TRIGGER_BUILD_TYPE="${HEAD_REF##*_}"
+                if printf '%s' "$MATRIX_BUILD_TYPES" | python3 -c "import json,sys; sys.exit(0 if sys.argv[1] in json.load(sys.stdin) else 1)" "$TRIGGER_BUILD_TYPE"; then
+                  echo "Trigger build type '$TRIGGER_BUILD_TYPE' is in issue build types $MATRIX_BUILD_TYPES — proceeding"
+                else
+                  SHOULD_RUN=false
+                  echo "Skipping: trigger build type '$TRIGGER_BUILD_TYPE' is not in issue build types $MATRIX_BUILD_TYPES"
+                fi
+                ;;
+              *)
+                # Non auto-mute PR carrying the mute-unmute label: keep previous behavior.
+                echo "Head ref '$HEAD_REF' is not an update-muted-ya branch — proceeding"
+                ;;
+            esac
+          fi
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+
   create-issues-for-muted-tests:
     needs: resolve-build-types
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
+      needs.resolve-build-types.outputs.should_run == 'true' &&
       ((github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
        github.event_name == 'workflow_dispatch')
@@ -153,6 +183,7 @@ jobs:
     needs: [resolve-build-types, create-issues-for-muted-tests]
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
+      needs.resolve-build-types.outputs.should_run == 'true' &&
       ((github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
        github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
## Суть проблемы

`update_muted_ya.yml` заводит по одному PR с лейблом `mute-unmute` на каждый build type (`relwithdebinfo`, `release-asan`, `release-tsan`, `release-msan`), и все они нацелены в `main`. Мёрж любого из них триггерит `create_issues_for_muted_tests.yml`, но матрица build type там всегда бралась из `mute_issue_and_digest_config.json` (**только relwithdebinfo**) — независимо от того, какой PR его дёрнул.

В итоге каждый мёрж build-type-PR запускал одно и то же создание relwithdebinfo-тикетов. Когда два авто-PR мёржатся с разницей в секунды, два параллельных рана создают один и тот же тикет, не увидев друг друга, — получаются дубликаты (например, #45227 и #45229, ~1 минута разницы).

## Что сделано

Каждый PR теперь работает **только со своим build type**:
- build type берётся из имени ветки триггерящего PR (`update-muted-ya_<base>_<buildtype>`), и матрица = именно этот build type (а не весь конфиг);
- скрипт `create_new_muted_ya.py create_issues` и так пропускает build type'ы, которых нет в `mute_issue_and_digest_config.json`, поэтому для неконфигурированных build type'ов (сейчас asan/tsan/msan) тикеты не заводятся, а шаги линковки в PR гейтятся по `created_issues_file != ''`;
- обновление тестового состояния в YDB (`Update muted tests in DB`, history, monitor, sync fast-unmute) при этом выполняется для **всех** build type'ов — глушится только дублирующее заведение тикетов;
- `workflow_dispatch` (с/без `build_type`) и ручные PR с лейблом сохраняют прежнее поведение.

Так дубликаты устраняются и на будущее: даже если в конфиг добавят ещё build type'ы, каждый PR заводит тикеты только под себя, без пересечений.

## Доп. правки по ревью (Copilot)
- event/PR-инпуты (в т.ч. head ref) прокинуты через `env:`, чтобы исключить shell-инъекцию через имя ветки;
- матрица собирается через `json.dumps`, а job-outputs пишутся в `$GITHUB_OUTPUT` в newline-safe `<<delimiter`-форме — крафтовые `workflow_dispatch`-инпуты не ломают `fromJson` и не инжектят лишние outputs;
- `build_type` из ветки/инпута валидируется по безопасному набору символов перед попаданием в матрицу (он потом сырым интерполируется в `run:`-шаги);
- `BASE_BRANCH` проверяется на непустоту для обоих триггеров.

## План проверки
- [ ] Мёрж `update-muted-ya_main_relwithdebinfo` → тикеты создаются (matrix=`["relwithdebinfo"]`).
- [ ] Мёрж `update-muted-ya_main_release-asan`/`tsan`/`msan` → тикеты не заводятся, но состояние в YDB обновляется.
- [ ] `workflow_dispatch` работает как раньше.
