### PR TITLE
destroy the driver on a detached thread

### DIFF
--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -13,7 +13,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/common_client/ssl_credentials.h>
 #include <util/stream/file.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_ca.h>
-
+#include <thread>
 namespace NYdb::inline Dev {
 
 using NYdbGrpc::TGRpcClientLow;
@@ -361,7 +361,12 @@ TDriver::TDriver(const TDriverConfig& config) {
         ythrow yexception() << "Invalid config object";
     }
 
-    Impl_.reset(new TGRpcConnectionsImpl(config.Impl_));
+    Impl_ = std::shared_ptr<TGRpcConnectionsImpl>(new TGRpcConnectionsImpl(config.Impl_), [] (TGRpcConnectionsImpl* impl) {
+        std::thread([impl] {
+            impl->Stop(true);
+            delete impl;
+        }).detach();
+    });
 }
 
 void TDriver::Stop(bool wait) {

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -23,6 +23,7 @@ using NYdbGrpc::TGRpcClientConfig;
 using NYdbGrpc::TResponseCallback;
 using NYdbGrpc::TGrpcStatus;
 using NYdbGrpc::TTcpKeepAliveSettings;
+using NYdbGrpc::IsGRpcCompletionThread;
 
 using Ydb::StatusIds;
 
@@ -362,10 +363,16 @@ TDriver::TDriver(const TDriverConfig& config) {
     }
 
     Impl_ = std::shared_ptr<TGRpcConnectionsImpl>(new TGRpcConnectionsImpl(config.Impl_), [] (TGRpcConnectionsImpl* impl) {
-        std::thread([impl] {
+        auto destroyImpl = [impl] {
             impl->Stop(true);
             delete impl;
-        }).detach();
+        };
+
+        if (IsGRpcCompletionThread()) {
+            std::thread(std::move(destroyImpl)).detach();
+        } else {
+            destroyImpl();
+        }
     });
 }
 

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.cpp
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.cpp
@@ -216,7 +216,32 @@ void TChannelPool::EraseFromQueueByTime(const TInstant& lastUseTime, const std::
     LastUsedQueue_.erase(pos);
 }
 
+namespace {
+
+thread_local bool IsGrpcWorkerThread = false;
+
+class TGrpcWorkerThreadGuard {
+public:
+    TGrpcWorkerThreadGuard() {
+        IsGrpcWorkerThread = true;
+    }
+
+    ~TGrpcWorkerThreadGuard() {
+        IsGrpcWorkerThread = PreviousValue_;
+    }
+
+private:
+    const bool PreviousValue_ = IsGrpcWorkerThread;
+};
+
+} // namespace
+
+bool IsGRpcCompletionThread() {
+    return IsGrpcWorkerThread;
+}
+
 static void PullEvents(grpc::CompletionQueue* cq) {
+    TGrpcWorkerThreadGuard guard;
     TThread::SetCurrentThreadName("grpc_client");
     while (true) {
         void* tag;

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
@@ -34,6 +34,8 @@ const size_t DEFAULT_NUM_THREADS = 2;
 
 void EnableGRpcTracing();
 
+bool IsGRpcCompletionThread();
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TTcpKeepAliveSettings {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->
Driver is a long-lived abstraction which manages grpc completion queue. Right now if not manually stopped, the destruction on a grpc thread can cause deadlocks or self-thread joins. 
Destruction in a detached thread fixes this issues once and for all.
...
