### PR TITLE
Return BAD_REQUEST instead of UNAUTHORIZED when database is empty in grpc request proxy

### DIFF
--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -196,7 +196,9 @@ private:
                             && emptyDatabaseMode == EEmptyDatabaseMode::EmptyDatabaseForbidden)
                         )
                     ) {
-                        requestBaseCtx->ReplyUnauthenticated("Requests without specified database are not allowed");
+                        const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::GENERIC_TXPROXY_ERROR, "Requests without specified database are not allowed");
+                        requestBaseCtx->RaiseIssue(issue);
+                        requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::BAD_REQUEST);
                         return;
                     }
                 }
@@ -207,7 +209,9 @@ private:
             }
             if (databaseName.empty()) {
                 Counters->IncDatabaseUnavailableCounter();
-                requestBaseCtx->ReplyUnauthenticated("Empty database name");
+                const auto issue = MakeIssue(NKikimrIssues::TIssuesIds::GENERIC_TXPROXY_ERROR, "Empty database name");
+                requestBaseCtx->RaiseIssue(issue);
+                requestBaseCtx->ReplyWithYdbStatus(Ydb::StatusIds::BAD_REQUEST);
                 return;
             }
             auto it = Databases.find(databaseName);

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -186,8 +186,10 @@ Y_UNIT_TEST(BeginPublicationRejectsEmptyDatabaseAtGrpcProxy) {
     server.AnnoyingClient->GrantConnect("root@builtin");
 
     const auto outcome = CallBeginPublicationWithEmptyDatabaseHeader(*MakeStub(server));
-    UNIT_ASSERT(!outcome.RpcStatus.ok());
-    UNIT_ASSERT_VALUES_EQUAL(outcome.RpcStatus.error_code(), grpc::StatusCode::UNAUTHENTICATED);
+    UNIT_ASSERT(outcome.RpcStatus.ok());
+    UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.status(), Ydb::StatusIds::BAD_REQUEST);
+    UNIT_ASSERT_GT(outcome.Operation.issues_size(), 0);
+    UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.issues(0).message(), "Requests without specified database are not allowed");
 }
 
 Y_UNIT_TEST(BeginPublicationRejectsEmptyDatabaseInHandler) {
@@ -206,8 +208,10 @@ Y_UNIT_TEST(BeginPublicationRejectsMissingDatabaseAtGrpcProxy) {
     server.AnnoyingClient->GrantConnect("root@builtin");
 
     const auto outcome = CallBeginPublicationWithoutDatabaseHeader(*MakeStub(server));
-    UNIT_ASSERT(!outcome.RpcStatus.ok());
-    UNIT_ASSERT_VALUES_EQUAL(outcome.RpcStatus.error_code(), grpc::StatusCode::UNAUTHENTICATED);
+    UNIT_ASSERT(outcome.RpcStatus.ok());
+    UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.status(), Ydb::StatusIds::BAD_REQUEST);
+    UNIT_ASSERT_GT(outcome.Operation.issues_size(), 0);
+    UNIT_ASSERT_VALUES_EQUAL(outcome.Operation.issues(0).message(), "Requests without specified database are not allowed");
 }
 
 Y_UNIT_TEST(BeginPublicationRejectsMissingDatabaseInHandler) {


### PR DESCRIPTION
Change error status to BAD_REQUEST for requests with missing or empty database name in the gRPC request proxy.