### PR TITLE
Fix data race on TQueue::IsConnected

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_monactor.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_monactor.cpp
@@ -116,7 +116,7 @@ public:
 
                                                     bool ok = true;
                                                     GroupQueues->DisksByOrderNumber[vdisk.OrderNumber]->Queues.ForEachQueue([&](auto& q) {
-                                                        if (!q.IsConnected) {
+                                                        if (!q.IsConnected.load(std::memory_order_relaxed)) {
                                                             ok = false;
                                                         }
                                                     });
@@ -182,7 +182,7 @@ public:
                                             TABLED() { str << Info->GetActorId(num).NodeId(); }
                                             TABLED() {
                                                 fdom.VDisks[vdisk].Queues.ForEachQueue([&](auto& q) {
-                                                    str << (q.IsConnected ? '+' : '0');
+                                                    str << (q.IsConnected.load(std::memory_order_relaxed) ? '+' : '0');
                                                 });
                                             }
                                         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_put.cpp
@@ -748,7 +748,9 @@ public:
             Y_DEBUG_ABORT_UNLESS(nodeId != SelfId().NodeId());
 
             bool isConnected = false;
-            vdisk->Queues.ForEachQueue([&](auto& queue) { isConnected |= queue.IsConnected; });
+            vdisk->Queues.ForEachQueue([&](auto& queue) {
+                isConnected |= queue.IsConnected.load(std::memory_order_acquire);
+            });
             if (isConnected) {
                 options.push_back(nodeId);
             }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_strategy_base.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_strategy_base.cpp
@@ -177,7 +177,7 @@ void TStrategyBase::LogDisintegrated(TLogContext &logCtx, const char *marker, co
             << " NodeId# " << actorId.NodeId()
             << " Queues# ";
         groupQueues->DisksByOrderNumber[orderNumber]->Queues.ForEachQueue([&](const auto& q) {
-            msg << (q.IsConnected ? '+' : '0');
+            msg << (q.IsConnected.load(std::memory_order_acquire) ? '+' : '0');
         });
         for (const auto& disk : state.Disks) {
             if (disk.OrderNumber == orderNumber) {

--- a/ydb/core/blobstorage/dsproxy/group_sessions.cpp
+++ b/ydb/core/blobstorage/dsproxy/group_sessions.cpp
@@ -147,7 +147,7 @@ void TGroupSessions::QueueConnectUpdate(ui32 orderNumber, NKikimrBlobStorage::EV
             q.CostModel = nullptr;
         }
     }
-    q.IsConnected = connected;
+    q.IsConnected.store(connected, std::memory_order_release);
 
     if (updated) {
         auto iterate = [](auto& currentCostModel, const auto& next) {

--- a/ydb/core/blobstorage/dsproxy/group_sessions.h
+++ b/ydb/core/blobstorage/dsproxy/group_sessions.h
@@ -23,20 +23,19 @@ namespace NKikimr {
                     TIntrusivePtr<NBackpressure::TFlowRecord> FlowRecord;
                     struct AtomicParameter : public std::atomic<bool> {
                         AtomicParameter& operator=(const AtomicParameter& other) {
-                            store(other.load());
+                            store(other.load(std::memory_order_acquire), std::memory_order_release);
                             return *this;
                         }
 
                         AtomicParameter(const AtomicParameter& other) {
-                            store(other.load());
+                            store(other.load(std::memory_order_acquire), std::memory_order_release);
                         }
 
                         AtomicParameter() {
-                            store(false);
+                            store(false, std::memory_order_release);
                         }
-                    } ExtraBlockChecksSupport, Checksumming;
+                    } ExtraBlockChecksSupport, Checksumming, IsConnected;
                     std::shared_ptr<const TCostModel> CostModel = nullptr;
-                    volatile bool IsConnected = false;
                 };
                 TQueue PutTabletLog;
                 TQueue PutAsyncBlob;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make TQueue::IsConnected field atomic to prevent data races
https://github.com/ydb-platform/ydb/issues/45129

### Changelog category <!-- remove all except one -->

* Bugfix 
