### PR TITLE
#44414 Relax passedRows check for ExtBlobsWithFirstRowPreloadedWithReboot

### DIFF
--- a/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_read_iterator_ext_blobs.cpp
@@ -558,7 +558,8 @@ Y_UNIT_TEST_SUITE(ReadIteratorExternalBlobs) {
         runtime.WaitFor("blocked results", [&]{ return blockedResults.size() > 0 || finished; });
 
         if (!finished) {
-            UNIT_ASSERT_VALUES_EQUAL(passedRows, 1u);
+            UNIT_ASSERT_GE(passedRows, 1u);
+            UNIT_ASSERT_LT(passedRows, 5u);
 
             if (withReboot) {
                 dropReadId.emplace(


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

I suspect that prior to https://github.com/ydb-platform/ydb/pull/42748 ExtBlobsWithFirstRowPreloadedWithReboot never actually triggered `if (!finished) {` and reboot as it always read data in one batch. Even though the assertion in question was always time-sensitive, it simply never triggered before