### PR TITLE
Add hanging SelectGroups fix test

### DIFF
--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -467,9 +467,26 @@ public:
         auto& record = ev->Record;
         auto *p = record.AddPDisksMetrics();
         p->SetPDiskId(Impl.PDiskId);
-        p->SetAvailableSize((Impl.TotalChunks - usedChunks) * Impl.ChunkSize);
-        p->SetTotalSize(Impl.TotalChunks * Impl.ChunkSize);
+        p->SetAvailableSize((ui64)(Impl.TotalChunks - usedChunks) * Impl.ChunkSize);
+        p->SetTotalSize((ui64)Impl.TotalChunks * Impl.ChunkSize);
         p->SetState(NKikimrBlobStorage::TPDiskState::Normal);
+        // report a full performance metrics set (like a real PDisk does) so that BSC considers the PDisk complete
+        p->SetMaxIOPS(1000);
+        p->SetMaxReadThroughput(1'000'000'000);
+        p->SetMaxWriteThroughput(1'000'000'000);
+
+        // report per-VDisk metrics with normalized occupancy; deliberately do not touch status flags
+        for (const auto& [ownerId, owner] : Impl.Owners) {
+            auto *m = record.AddVDisksMetrics();
+            VDiskIDFromVDiskID(owner.VDiskId, m->MutableVDiskId());
+            auto *vslotId = m->MutableVSlotId();
+            vslotId->SetNodeId(Impl.NodeId);
+            vslotId->SetPDiskId(Impl.PDiskId);
+            vslotId->SetVSlotId(owner.SlotId);
+            m->SetNormalizedOccupancy(GetOccupancy());
+            m->SetAllocatedSize((ui64)owner.CommittedChunks.size() * Impl.ChunkSize);
+            m->SetAvailableSize(p->GetAvailableSize());
+        }
         Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), ev.release());
 
         Schedule(TDuration::Seconds(5), new TEvents::TEvWakeup);

--- a/ydb/core/blobstorage/ut_blobstorage/select_groups.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/select_groups.cpp
@@ -1,0 +1,37 @@
+#include <ydb/core/blobstorage/ut_blobstorage/lib/env.h>
+
+Y_UNIT_TEST_SUITE(SelectGroups) {
+
+    // Regression test for a hanging blocking SelectGroups (fixed in d437868).
+    // A freshly created group has no VDisk metrics yet, so a SelectGroups request with
+    // BlockUntilAllResourcesAreComplete parks until the group obtains full metrics. The bug was that
+    // arriving VDisk metrics (normalized occupancy) did not re-check the parked request unless the
+    // VDisk status flags changed too -- which they don't for a fresh empty disk -- so the request hung
+    // forever.
+    Y_UNIT_TEST(BlockUntilAllResourcesAreComplete) {
+        TEnvironmentSetup env(false);
+
+        // create a fresh group; at this point it has no VDisk metrics yet
+        env.CreateBoxAndPool();
+
+        // issue a blocking SelectGroups immediately -- the group is not complete yet, so it parks
+        const TActorId edge = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId, __FILE__, __LINE__);
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerSelectGroups>();
+        auto& r = ev->Record;
+        r.SetReturnAllMatchingGroups(true);
+        r.SetBlockUntilAllResourcesAreComplete(true);
+        r.AddGroupParameters()->MutableStoragePoolSpecifier()->SetName(env.StoragePoolName);
+        env.Runtime->SendToPipe(env.TabletId, edge, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+
+        // wait for the response with a deadline; on buggy code no response ever arrives and this returns nullptr
+        auto response = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerSelectGroupsResult>(
+            edge, true, env.Runtime->GetClock() + TDuration::Minutes(2));
+        UNIT_ASSERT_C(response, "BSC hung on blocking SelectGroups for a freshly created group");
+
+        const auto& record = response->Get()->Record;
+        UNIT_ASSERT_VALUES_EQUAL(record.GetStatus(), NKikimrProto::OK);
+        UNIT_ASSERT_VALUES_EQUAL(record.MatchingGroupsSize(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(record.GetMatchingGroups(0).GroupsSize(), 1);
+    }
+
+}

--- a/ydb/core/blobstorage/ut_blobstorage/ya.make
+++ b/ydb/core/blobstorage/ut_blobstorage/ya.make
@@ -45,6 +45,7 @@ SRCS(
     recovery.cpp
     sanitize_groups.cpp
     scrub_fast.cpp
+    select_groups.cpp
     self_heal.cpp
     shred.cpp
     snapshots.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add hanging SelectGroups fix test

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds a test for SelectGroups hanging command and also fixes some issues related to PDisk mock.
