### PR TITLE
Fix PQ partition AlterVersion on create to restore domain counters after reboot

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_pq.cpp
@@ -233,7 +233,9 @@ void ApplySharding(TTxId txId,
         partition->PqId = it->PartitionId;
         partition->GroupId = it->GroupId;
         partition->KeyRange = it->KeyRange;
-        partition->AlterVersion = 1;
+        // Must match pqGroup->AlterVersion: init counts partitions with
+        // partition->AlterVersion <= alterData->AlterVersion when rebuilding PQPartitionsInside.
+        partition->AlterVersion = pqGroup->AlterVersion;
         partition->CreateVersion = 1;
         partition->Status = NKikimrPQ::ETopicPartitionStatus::Active;
         partition->CreationTimestamp = TInstant::Seconds(TAppData::TimeProvider->Now().Seconds());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue #45431

New partitions were created with AlterVersion=1 while the pending group alter stayed at 0, so init after reboot skipped them when rebuilding PQPartitionsInside.

No new test was added - the fix is covered by an existing test that was failing
before this change:
- **`TPqGroupTestReboots::Create*`** in ydb/core/tx/schemeshard/ut_pq_reboots

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
