### PR TITLE
[NBS] Time predictor for read and write hedging

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
+++ b/ydb/core/nbs/cloud/blockstore/config/protos/storage.proto
@@ -42,6 +42,15 @@ message TOracleConfig
     // The total size of failed requests after which the host is taken offline.
     // Required to protect PBuffer from overflow.
     optional uint64 ErrorsTotalSizeForGoingOffline = 6;
+
+    // Time prediction history size.
+    // 0 - means do not use time prediction through history.
+    optional uint32 TimePredictionHistorySize = 7;
+
+    // Which element number from the end of the list to use. If take pre-last one
+    // with a queue size of 10, then it is equivalent to the 90th percentile.
+    // 0 - means the last (100th percentile).
+    optional uint32 TimePredictionNthFromEnd = 8;
 }
 
 message TStorageServiceConfig

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -49,8 +49,12 @@ THostIndex TOracleMock::SelectBestPBufferHost(
     return *hosts.First();
 }
 
-TDuration TOracleMock::GetReadHedgingDelay() const
+TDuration TOracleMock::GetReadHedgingDelay(
+    THostIndex host,
+    EDataLocation dataLocation) const
 {
+    Y_UNUSED(host, dataLocation);
+
     return ReadHedgingDelay;
 }
 
@@ -59,8 +63,12 @@ TDuration TOracleMock::GetReadRequestTimeout() const
     return ReadRequestTimeout;
 }
 
-TDuration TOracleMock::GetWriteHedgingDelay() const
+TDuration TOracleMock::GetWriteHedgingDelay(
+    THostMask hosts,
+    bool indirect) const
 {
+    Y_UNUSED(hosts, indirect);
+
     return WriteHedgingDelay;
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -42,9 +42,13 @@ struct TOracleMock: public IOracle
         THostMask hosts,
         EOperation operation) const override;
 
-    [[nodiscard]] TDuration GetReadHedgingDelay() const override;
+    [[nodiscard]] TDuration GetReadHedgingDelay(
+        THostIndex host,
+        EDataLocation dataLocation) const override;
     [[nodiscard]] TDuration GetReadRequestTimeout() const override;
-    [[nodiscard]] TDuration GetWriteHedgingDelay() const override;
+    [[nodiscard]] TDuration GetWriteHedgingDelay(
+        THostMask hosts,
+        bool indirect) const override;
     [[nodiscard]] TDuration GetWriteRequestTimeout() const override;
     [[nodiscard]] TDuration GetIndirectWriteReplyTimeout() const override;
     [[nodiscard]] TDuration GetFlushRequestTimeout() const override;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h
@@ -49,6 +49,13 @@ enum class EHostState
     Offline,
 };
 
+// Determines where the data is located
+enum class EDataLocation
+{
+    PBuffer,
+    DDisk,
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct THostRoute

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -3,9 +3,12 @@
 #include <ydb/core/nbs/cloud/blockstore/config/config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 
+#include <ydb/core/nbs/cloud/storage/core/libs/common/format.h>
+
 #include <util/generic/size_literals.h>
 #include <util/random/random.h>
 #include <util/string/builder.h>
+#include <util/string/cast.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
@@ -38,6 +41,10 @@ EHostState HealthToState(EHostHealth health)
             return EHostState::Offline;
     }
 }
+
+}   // namespace
+
+////////////////////////////////////////////////////////////////////////////////
 
 class TOracleConfig
 {
@@ -84,11 +91,23 @@ public:
             100_MB);
     }
 
+    [[nodiscard]] ui32 GetTimePredictionHistorySize() const
+    {
+        return GetFromConfig(
+            StorageConfig->GetOracleConfig().GetTimePredictionHistorySize(),
+            100);
+    }
+
+    [[nodiscard]] ui32 GetTimePredictionNthFromEnd() const
+    {
+        return GetFromConfig(
+            StorageConfig->GetOracleConfig().GetTimePredictionNthFromEnd(),
+            1);
+    }
+
 private:
     TStorageConfigPtr StorageConfig;
 };
-
-}   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -96,6 +115,7 @@ TOracle::TOracle(
     TStorageConfigPtr storageConfig,
     IHostStateController* hostStateController)
     : StorageConfig(std::move(storageConfig))
+    , OracleConfig(std::make_shared<TOracleConfig>(StorageConfig))
     , HostStateController(hostStateController)
     , DefaultReadHedgingDelay(StorageConfig->GetReadHedgingDelay())
     , DefaultReadRequestTimeout(StorageConfig->GetReadRequestTimeout())
@@ -108,12 +128,19 @@ TOracle::TOracle(
     , DefaultWriteMode(GetWriteModeFromProto(StorageConfig->GetWriteMode()))
     , HostStatistics(DirectBlockGroupHostCount)
     , HostStates(DirectBlockGroupHostCount)
+    , TimePredictors(
+          OperationCount,
+          TTimePredictor(
+              OracleConfig->GetTimePredictionHistorySize(),
+              OracleConfig->GetTimePredictionNthFromEnd()))
 {
     HostsHealths.resize(HostStates.size());
     for (auto& healths: HostsHealths) {
         healths = EHostHealth::Online;
     }
 }
+
+TOracle::~TOracle() = default;
 
 void TOracle::Think(TInstant now)
 {
@@ -185,6 +212,7 @@ void TOracle::OnRequestSucceeded(
     TInstant now,
     TDuration executionTime)
 {
+    AccessTimePredictor(operation).Add(hostIndex, executionTime);
     HostStatistics[hostIndex].OnSuccess(now, executionTime, operation);
 }
 
@@ -241,9 +269,24 @@ THostIndex TOracle::SelectBestPBufferHost(
     return bestHostIndex;
 }
 
-TDuration TOracle::GetReadHedgingDelay() const
+TDuration TOracle::GetReadHedgingDelay(
+    THostIndex host,
+    EDataLocation dataLocation) const
 {
-    return DefaultReadHedgingDelay;
+    TDuration result;
+
+    switch (dataLocation) {
+        case EDataLocation::DDisk: {
+            result = GetTimePredictor(EOperation::ReadFromDDisk).Predict(host);
+            break;
+        }
+        case EDataLocation::PBuffer: {
+            result =
+                GetTimePredictor(EOperation::ReadFromPBuffer).Predict(host);
+            break;
+        }
+    }
+    return result != TDuration::Zero() ? result : DefaultReadHedgingDelay;
 }
 
 TDuration TOracle::GetReadRequestTimeout() const
@@ -251,9 +294,13 @@ TDuration TOracle::GetReadRequestTimeout() const
     return DefaultReadRequestTimeout;
 }
 
-TDuration TOracle::GetWriteHedgingDelay() const
+TDuration TOracle::GetWriteHedgingDelay(THostMask hosts, bool indirect) const
 {
-    return DefaultWriteHedgingDelay;
+    TDuration result = GetTimePredictor(
+                           indirect ? EOperation::WriteToManyPBuffers
+                                    : EOperation::WriteToPBuffer)
+                           .Predict(hosts);
+    return result != TDuration::Zero() ? result : DefaultWriteHedgingDelay;
 }
 
 TDuration TOracle::GetWriteRequestTimeout() const
@@ -293,7 +340,26 @@ TString TOracle::Dump() const
         sb << " H" << i << ": " << HostStates[i].DebugPrint() << " "
            << HostStatistics[i].DebugPrint() << "\n";
     }
+
+    for (size_t i = 0; i < OperationCount; ++i) {
+        auto op = static_cast<EOperation>(i);
+        sb << " " << ToString(op) << ": ";
+        for (THostIndex h = 0; h < HostStates.size(); ++h) {
+            sb << FormatDuration(GetTimePredictor(op).Predict(h)) << " ";
+        }
+        sb << "\n";
+    }
     return sb;
+}
+
+TTimePredictor& TOracle::AccessTimePredictor(EOperation operation)
+{
+    return TimePredictors[static_cast<size_t>(operation)];
+}
+
+const TTimePredictor& TOracle::GetTimePredictor(EOperation operation) const
+{
+    return TimePredictors[static_cast<size_t>(operation)];
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.cpp
@@ -95,14 +95,14 @@ public:
     {
         return GetFromConfig(
             StorageConfig->GetOracleConfig().GetTimePredictionHistorySize(),
-            100);
+            0);
     }
 
     [[nodiscard]] ui32 GetTimePredictionNthFromEnd() const
     {
         return GetFromConfig(
             StorageConfig->GetOracleConfig().GetTimePredictionNthFromEnd(),
-            1);
+            0);
     }
 
 private:

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h
@@ -6,6 +6,7 @@
 #include "host_mask.h"
 #include "host_stat.h"
 #include "host_state.h"
+#include "time_predictor.h"
 
 #include <ydb/core/nbs/cloud/blockstore/config/config.h>
 #include <ydb/core/nbs/cloud/blockstore/config/public.h>
@@ -23,6 +24,8 @@ enum class EHostHealth
     TemporaryOffline,
     Offline,
 };
+
+////////////////////////////////////////////////////////////////////////////////
 
 class IOracle
 {
@@ -53,9 +56,13 @@ public:
         THostMask hosts,
         EOperation operation) const = 0;
 
-    [[nodiscard]] virtual TDuration GetReadHedgingDelay() const = 0;
+    [[nodiscard]] virtual TDuration GetReadHedgingDelay(
+        THostIndex host,
+        EDataLocation dataLocation) const = 0;
     [[nodiscard]] virtual TDuration GetReadRequestTimeout() const = 0;
-    [[nodiscard]] virtual TDuration GetWriteHedgingDelay() const = 0;
+    [[nodiscard]] virtual TDuration GetWriteHedgingDelay(
+        THostMask hosts,
+        bool indirect) const = 0;
     [[nodiscard]] virtual TDuration GetWriteRequestTimeout() const = 0;
     [[nodiscard]] virtual TDuration GetIndirectWriteReplyTimeout() const = 0;
     [[nodiscard]] virtual TDuration GetFlushRequestTimeout() const = 0;
@@ -67,12 +74,15 @@ public:
     [[nodiscard]] virtual TString Dump() const = 0;
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
 class TOracle: public IOracle
 {
 public:
     TOracle(
         TStorageConfigPtr storageConfig,
         IHostStateController* hostStateController);
+    ~TOracle() override;
 
     void Think(TInstant now);
 
@@ -98,9 +108,13 @@ public:
         THostMask hosts,
         EOperation operation) const override;
 
-    [[nodiscard]] TDuration GetReadHedgingDelay() const override;
+    [[nodiscard]] TDuration GetReadHedgingDelay(
+        THostIndex host,
+        EDataLocation dataLocation) const override;
     [[nodiscard]] TDuration GetReadRequestTimeout() const override;
-    [[nodiscard]] TDuration GetWriteHedgingDelay() const override;
+    [[nodiscard]] TDuration GetWriteHedgingDelay(
+        THostMask hosts,
+        bool indirect) const override;
     [[nodiscard]] TDuration GetWriteRequestTimeout() const override;
     [[nodiscard]] TDuration GetIndirectWriteReplyTimeout() const override;
     [[nodiscard]] TDuration GetFlushRequestTimeout() const override;
@@ -112,7 +126,12 @@ public:
     [[nodiscard]] TString Dump() const override;
 
 private:
+    [[nodiscard]] TTimePredictor& AccessTimePredictor(EOperation operation);
+    [[nodiscard]] const TTimePredictor& GetTimePredictor(
+        EOperation operation) const;
+
     const TStorageConfigPtr StorageConfig;
+    const TOracleConfigPtr OracleConfig;
 
     IHostStateController* const HostStateController;
     const TDuration DefaultReadHedgingDelay;
@@ -127,6 +146,7 @@ private:
     TVector<THostStat> HostStatistics;
     TVector<THostState> HostStates;
     TVector<EHostHealth> HostsHealths;
+    TVector<TTimePredictor> TimePredictors;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -44,6 +44,7 @@ struct THostStateControllerMock: public IHostStateController
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
+
 Y_UNIT_TEST_SUITE(TOracle)
 {
     Y_UNIT_TEST(SelectBestPBufferHostShouldPickHostWithLowestInflight)
@@ -404,6 +405,136 @@ Y_UNIT_TEST_SUITE(TOracle)
         UNIT_ASSERT_VALUES_EQUAL(
             EHostState::Online,
             hostStateController.States[0]);
+    }
+
+    Y_UNIT_TEST(GetReadHedgingDelayReturnsDefaultWhenNoHistory)
+    {
+        NProto::TStorageServiceConfig rawConfig;
+        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+
+        TOracle oracle(storageConfig, nullptr);
+
+        // No read requests recorded → predictor returns zero → fallback to
+        // default. Default ReadHedgingDelay is 1ms when not set in config.
+        const auto defaultDelay = storageConfig->GetReadHedgingDelay();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            defaultDelay,
+            oracle.GetReadHedgingDelay(0, EDataLocation::DDisk));
+        UNIT_ASSERT_VALUES_EQUAL(
+            defaultDelay,
+            oracle.GetReadHedgingDelay(0, EDataLocation::PBuffer));
+    }
+
+    Y_UNIT_TEST(GetReadHedgingDelayDDiskAndPBufferAreIndependent)
+    {
+        NProto::TStorageServiceConfig rawConfig;
+        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+
+        TOracle oracle(storageConfig, nullptr);
+        auto now = TInstant::Now();
+
+        // Feed DDisk reads with 100ms, 200ms on host 0.
+        for (auto duration: {100, 200}) {
+            oracle.OnRequestStarted(0, EOperation::ReadFromDDisk, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::ReadFromDDisk,
+                now,
+                TDuration::MilliSeconds(duration));
+        }
+
+        // Feed PBuffer reads with 300ms, 400ms on host 0.
+        for (auto duration: {300, 400}) {
+            oracle.OnRequestStarted(0, EOperation::ReadFromPBuffer, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::ReadFromPBuffer,
+                now,
+                TDuration::MilliSeconds(duration));
+        }
+
+        // Feed PBuffer reads with 400ms, 500ms on host 1.
+        for (auto duration: {400, 500}) {
+            oracle.OnRequestStarted(0, EOperation::ReadFromPBuffer, now);
+            oracle.OnRequestSucceeded(
+                1,
+                EOperation::ReadFromPBuffer,
+                now,
+                TDuration::MilliSeconds(duration));
+        }
+
+        // H0 DDisk predictor: [100, 200] → predict 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            oracle.GetReadHedgingDelay(0, EDataLocation::DDisk));
+
+        // H0: PBuffer predictor: [300, 400] → predict 300.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(300),
+            oracle.GetReadHedgingDelay(0, EDataLocation::PBuffer));
+
+        // H1: PBuffer predictor: [500, 500] → predict 400.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(400),
+            oracle.GetReadHedgingDelay(1, EDataLocation::PBuffer));
+    }
+
+    Y_UNIT_TEST(GetWriteHedgingDelayReturnsDefaultWhenNoHistory)
+    {
+        NProto::TStorageServiceConfig rawConfig;
+        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+
+        TOracle oracle(storageConfig, nullptr);
+
+        // No write requests recorded → predictor returns zero → fallback to
+        // default. Default WriteHedgingDelay is 1ms when not set in config.
+        const auto defaultDelay = storageConfig->GetWriteHedgingDelay();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            defaultDelay,
+            oracle.GetWriteHedgingDelay(THostMask::MakeOne(0), false));
+        UNIT_ASSERT_VALUES_EQUAL(
+            defaultDelay,
+            oracle.GetWriteHedgingDelay(THostMask::MakeOne(0), true));
+    }
+
+    Y_UNIT_TEST(GetWriteHedgingDelayDirectAndIndirectAreIndependent)
+    {
+        NProto::TStorageServiceConfig rawConfig;
+        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+
+        TOracle oracle(storageConfig, nullptr);
+        auto now = TInstant::Now();
+
+        // WriteToPBuffer (direct): [100, 200] → predict 100ms.
+        for (auto duration: {100, 200}) {
+            oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::WriteToPBuffer,
+                now,
+                TDuration::MilliSeconds(duration));
+        }
+
+        // WriteToManyPBuffers (indirect): [300, 400] → predict 300ms.
+        for (auto duration: {300, 400}) {
+            oracle.OnRequestStarted(0, EOperation::WriteToManyPBuffers, now);
+            oracle.OnRequestSucceeded(
+                0,
+                EOperation::WriteToManyPBuffers,
+                now,
+                TDuration::MilliSeconds(duration));
+        }
+
+        // The direct mode reads only the WriteToPBuffer predictor.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            oracle.GetWriteHedgingDelay(THostMask::MakeOne(0), false));
+        // The indirect mode reads only the WriteToManyPBuffers predictor.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(300),
+            oracle.GetWriteHedgingDelay(THostMask::MakeOne(0), true));
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -422,7 +422,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         TOracle oracle(storageConfig, nullptr);
 
-        // No read requests recorded → predictor returns zero → fallback to
+        // No read requests recorded -> predictor returns zero -> fallback to
         // default. Default ReadHedgingDelay is 1ms when not set in config.
         const auto defaultDelay = storageConfig->GetReadHedgingDelay();
 
@@ -463,7 +463,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         // Feed PBuffer reads with 400ms, 500ms on host 1.
         for (auto duration: {400, 500}) {
-            oracle.OnRequestStarted(0, EOperation::ReadFromPBuffer, now);
+            oracle.OnRequestStarted(1, EOperation::ReadFromPBuffer, now);
             oracle.OnRequestSucceeded(
                 1,
                 EOperation::ReadFromPBuffer,
@@ -471,17 +471,17 @@ Y_UNIT_TEST_SUITE(TOracle)
                 TDuration::MilliSeconds(duration));
         }
 
-        // H0 DDisk predictor: [100, 200] → predict 100.
+        // H0 DDisk predictor: [100, 200] -> predict 100.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(100),
             oracle.GetReadHedgingDelay(0, EDataLocation::DDisk));
 
-        // H0: PBuffer predictor: [300, 400] → predict 300.
+        // H0: PBuffer predictor: [300, 400] -> predict 300.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(300),
             oracle.GetReadHedgingDelay(0, EDataLocation::PBuffer));
 
-        // H1: PBuffer predictor: [500, 500] → predict 400.
+        // H1: PBuffer predictor: [400, 500] -> predict 400.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(400),
             oracle.GetReadHedgingDelay(1, EDataLocation::PBuffer));
@@ -493,7 +493,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
         TOracle oracle(storageConfig, nullptr);
 
-        // No write requests recorded → predictor returns zero → fallback to
+        // No write requests recorded -> predictor returns zero -> fallback to
         // default. Default WriteHedgingDelay is 1ms when not set in config.
         const auto defaultDelay = storageConfig->GetWriteHedgingDelay();
 
@@ -512,7 +512,7 @@ Y_UNIT_TEST_SUITE(TOracle)
         TOracle oracle(storageConfig, nullptr);
         auto now = TInstant::Now();
 
-        // WriteToPBuffer (direct): [100, 200] → predict 100ms.
+        // WriteToPBuffer (direct): [100, 200] -> predict 100ms.
         for (auto duration: {100, 200}) {
             oracle.OnRequestStarted(0, EOperation::WriteToPBuffer, now);
             oracle.OnRequestSucceeded(
@@ -522,7 +522,7 @@ Y_UNIT_TEST_SUITE(TOracle)
                 TDuration::MilliSeconds(duration));
         }
 
-        // WriteToManyPBuffers (indirect): [300, 400] → predict 300ms.
+        // WriteToManyPBuffers (indirect): [300, 400] -> predict 300ms.
         for (auto duration: {300, 400}) {
             oracle.OnRequestStarted(0, EOperation::WriteToManyPBuffers, now);
             oracle.OnRequestSucceeded(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle_ut.cpp
@@ -41,6 +41,14 @@ struct THostStateControllerMock: public IHostStateController
     }
 };
 
+TStorageConfigPtr MakeStorageConfig()
+{
+    NProto::TStorageServiceConfig rawConfig;
+    rawConfig.MutableOracleConfig()->SetTimePredictionHistorySize(10);
+    rawConfig.MutableOracleConfig()->SetTimePredictionNthFromEnd(1);
+    return std::make_shared<TStorageConfig>(rawConfig);
+}
+
 }   // namespace
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -428,8 +436,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
     Y_UNIT_TEST(GetReadHedgingDelayDDiskAndPBufferAreIndependent)
     {
-        NProto::TStorageServiceConfig rawConfig;
-        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+        auto storageConfig = MakeStorageConfig();
 
         TOracle oracle(storageConfig, nullptr);
         auto now = TInstant::Now();
@@ -482,8 +489,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
     Y_UNIT_TEST(GetWriteHedgingDelayReturnsDefaultWhenNoHistory)
     {
-        NProto::TStorageServiceConfig rawConfig;
-        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+        auto storageConfig = MakeStorageConfig();
 
         TOracle oracle(storageConfig, nullptr);
 
@@ -501,8 +507,7 @@ Y_UNIT_TEST_SUITE(TOracle)
 
     Y_UNIT_TEST(GetWriteHedgingDelayDirectAndIndirectAreIndependent)
     {
-        NProto::TStorageServiceConfig rawConfig;
-        auto storageConfig = std::make_shared<TStorageConfig>(rawConfig);
+        auto storageConfig = MakeStorageConfig();
 
         TOracle oracle(storageConfig, nullptr);
         auto now = TInstant::Now();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/public.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/public.h
@@ -9,6 +9,9 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 class IOracle;
 using IOraclePtr = IOracle*;
 
+class TOracleConfig;
+using TOracleConfigPtr = std::shared_ptr<TOracleConfig>;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.cpp
@@ -1,0 +1,81 @@
+#include "time_predictor.h"
+
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+
+#include <util/generic/algorithm.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTimePredictor::THistory::THistory(size_t capacity)
+    : History(capacity)
+{}
+
+void TTimePredictor::THistory::Add(TDuration time)
+{
+    auto extractred = History.PushBack(time);
+    if (extractred) {
+        Durations.erase(Durations.find(*extractred));
+    }
+    Durations.insert(time);
+}
+
+TDuration TTimePredictor::THistory::Predict(size_t nthFromEnd) const
+{
+    auto it = Durations.rbegin();
+    for (size_t i = 0; i < nthFromEnd; ++i) {
+        if (it == Durations.rend()) {
+            return {};
+        }
+        ++it;
+    }
+    return it == Durations.rend() ? TDuration() : *it;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TTimePredictor::TTimePredictor(size_t capacity, size_t nthFromEnd)
+    : Capacity(capacity)
+    , NthFromEnd(nthFromEnd)
+    , History(DirectBlockGroupHostCount, THistory(capacity))
+{
+    Y_ABORT_UNLESS(Capacity > 0);
+    Y_ABORT_UNLESS(NthFromEnd < Capacity);
+}
+
+void TTimePredictor::Add(THostIndex host, TDuration time)
+{
+    if (host >= History.size()) {
+        History.resize(host + 1, THistory(Capacity));
+    }
+    History[host].Add(time);
+}
+
+void TTimePredictor::Add(THostMask hostMask, TDuration time)
+{
+    for (auto host: hostMask) {
+        Add(host, time);
+    }
+}
+
+TDuration TTimePredictor::Predict(THostIndex host) const
+{
+    if (host >= History.size()) {
+        return {};
+    }
+    return History[host].Predict(NthFromEnd);
+}
+
+TDuration TTimePredictor::Predict(THostMask hostMask) const
+{
+    TDuration result;
+    for (auto host: hostMask) {
+        result = Max(result, Predict(host));
+    }
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.cpp
@@ -14,11 +14,11 @@ TTimePredictor::THistory::THistory(size_t capacity)
 
 void TTimePredictor::THistory::Add(TDuration time)
 {
+    Durations.insert(time);
     auto extractred = History.PushBack(time);
     if (extractred) {
         Durations.erase(Durations.find(*extractred));
     }
-    Durations.insert(time);
 }
 
 TDuration TTimePredictor::THistory::Predict(size_t nthFromEnd) const
@@ -39,10 +39,7 @@ TTimePredictor::TTimePredictor(size_t capacity, size_t nthFromEnd)
     : Capacity(capacity)
     , NthFromEnd(nthFromEnd)
     , History(DirectBlockGroupHostCount, THistory(capacity))
-{
-    Y_ABORT_UNLESS(Capacity > 0);
-    Y_ABORT_UNLESS(NthFromEnd < Capacity);
-}
+{}
 
 void TTimePredictor::Add(THostIndex host, TDuration time)
 {
@@ -69,6 +66,10 @@ TDuration TTimePredictor::Predict(THostIndex host) const
 
 TDuration TTimePredictor::Predict(THostMask hostMask) const
 {
+    if (NthFromEnd >= Capacity) {
+        return {};
+    }
+
     TDuration result;
     for (auto host: hostMask) {
         result = Max(result, Predict(host));

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.cpp
@@ -15,9 +15,8 @@ TTimePredictor::THistory::THistory(size_t capacity)
 void TTimePredictor::THistory::Add(TDuration time)
 {
     Durations.insert(time);
-    auto extractred = History.PushBack(time);
-    if (extractred) {
-        Durations.erase(Durations.find(*extractred));
+    if (auto extracted = History.PushBack(time)) {
+        Durations.erase(Durations.find(*extracted));
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "host_mask.h"
+
+#include <ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/set.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTimePredictor
+{
+public:
+    TTimePredictor(size_t capacity, size_t nthFromEnd);
+
+    void Add(THostIndex host, TDuration time);
+    void Add(THostMask hostMask, TDuration time);
+
+    [[nodiscard]] TDuration Predict(THostIndex host) const;
+    [[nodiscard]] TDuration Predict(THostMask hostMask) const;
+
+private:
+    struct THistory
+    {
+        TRingBuffer<TDuration> History;
+        TMultiSet<TDuration> Durations;
+
+        explicit THistory(size_t capacity);
+
+        void Add(TDuration time);
+        [[nodiscard]] TDuration Predict(size_t nthFromEnd) const;
+    };
+
+    const size_t Capacity;
+    const size_t NthFromEnd;
+    TVector<THistory> History;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor_ut.cpp
@@ -1,0 +1,377 @@
+#include "time_predictor.h"
+
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TTimePredictorTest)
+{
+    constexpr ui32 TimePredictionHistorySize = 10;
+    constexpr ui32 TimePredictionNthFromEnd = 1;
+
+    Y_UNIT_TEST(PredictReturnsZeroForEmptyHistory)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(0));
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(1));
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(4));
+    }
+
+    Y_UNIT_TEST(PredictReturnsZeroForOutOfRangeHost)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        // Host index beyond initial DirectBlockGroupHostCount (5) and never
+        // added — should return zero without crashing.
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(100));
+    }
+
+    Y_UNIT_TEST(AddSingleValue)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+
+        // With nthFromEnd == 1 and only 1 element, we skip 1 from the end
+        // and hit rend → returns zero.
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(AddTwoValues)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
+
+        // Sorted: [100, 200]. NthFromEnd=1 means skip last (200), return 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(PredictReturnsSecondLargest)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(50));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(300));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+
+        // Sorted: [50, 100, 300]. NthFromEnd=1 → skip 300, return 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(PredictWithDuplicateValues)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+
+        // Sorted (multiset): [100, 100, 100]. NthFromEnd=1 → skip last 100,
+        // return 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(HostsAreIndependent)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
+
+        predictor.Add(THostIndex(1), TDuration::MilliSeconds(500));
+        predictor.Add(THostIndex(1), TDuration::MilliSeconds(600));
+
+        // Host 0: sorted [100, 200] → predict 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(0));
+
+        // Host 1: sorted [500, 600] → predict 500.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(500),
+            predictor.Predict(1));
+    }
+
+    Y_UNIT_TEST(RingBufferEvictsOldValues)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        // Fill the ring buffer (capacity == 10) with small values.
+        for (size_t i = 0; i < TimePredictionHistorySize; ++i) {
+            predictor.Add(THostIndex(0), TDuration::MilliSeconds(10));
+        }
+
+        // Sorted: 10 x [10ms]. Predict → 10ms (second from end).
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(10),
+            predictor.Predict(0));
+
+        // Now push one large value — it evicts one old 10ms.
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(1000));
+
+        // Sorted: 9 x [10ms], 1 x [1000ms]. NthFromEnd=1 → skip 1000,
+        // return 10.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(10),
+            predictor.Predict(0));
+
+        // Now push one large value — it evicts one old 10ms.
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(500));
+
+        // Sorted: 5 x [10ms], 1 x [500ms], 1 x [1000ms]. NthFromEnd=1 → skip
+        // 1000, return 500.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(500),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(AddWithHostMask)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        auto mask = THostMask::MakeOne(0).Include(THostMask::MakeOne(2));
+
+        predictor.Add(mask, TDuration::MilliSeconds(100));
+        predictor.Add(mask, TDuration::MilliSeconds(200));
+
+        // Both host 0 and host 2 should have [100, 200].
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(0));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(2));
+
+        // Host 1 was not in the mask — should be zero.
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(1));
+    }
+
+    Y_UNIT_TEST(PredictWithHostMaskReturnsMax)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        // Host 0: sorted [100, 200] → predict 100.
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
+
+        // Host 1: sorted [300, 400] → predict 300.
+        predictor.Add(THostIndex(1), TDuration::MilliSeconds(300));
+        predictor.Add(THostIndex(1), TDuration::MilliSeconds(400));
+
+        auto mask = THostMask::MakeOne(0).Include(THostMask::MakeOne(1));
+
+        // Predict(mask) = max(100, 300) = 300.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(300),
+            predictor.Predict(mask));
+    }
+
+    Y_UNIT_TEST(PredictWithEmptyMaskReturnsZero)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration(),
+            predictor.Predict(THostMask::MakeEmpty()));
+    }
+
+    Y_UNIT_TEST(AddResizesHistoryForLargeHostIndex)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        // Host index beyond initial DirectBlockGroupHostCount (5).
+        THostIndex largeHost = 10;
+
+        predictor.Add(largeHost, TDuration::MilliSeconds(100));
+        predictor.Add(largeHost, TDuration::MilliSeconds(200));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(largeHost));
+    }
+
+    Y_UNIT_TEST(EvictionRemovesCorrectValueFromMultiset)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        // Fill with ascending values: 10, 20, ..., 100.
+        for (size_t i = 0; i < TimePredictionHistorySize; ++i) {
+            predictor.Add(THostIndex(0), TDuration::MilliSeconds(10 * (i + 1)));
+        }
+
+        // Predict: second-from-end of [10..100] → 90ms.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(90),
+            predictor.Predict(0));
+
+        // Push 5ms — evicts the oldest, which is 10ms (first pushed).
+        // New sorted set: [5, 20, 30, 40, 50, 60, 70, 80, 90, 100].
+        // NthFromEnd=1 → skip 100, return 90.
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(5));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(90),
+            predictor.Predict(0));
+
+        // Push 95ms — evicts 20ms.
+        // New sorted set: [5, 30, 40, 50, 60, 70, 80, 90, 95, 100].
+        // NthFromEnd=1 → skip 100, return 95.
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(95));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(95),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(PredictWithMaskIncludingUnseenHost)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
+
+        // Host 1 has no data. Mask includes both.
+        auto mask = THostMask::MakeOne(0).Include(THostMask::MakeOne(1));
+
+        // max(Predict(0), Predict(1)) = max(100, 0) = 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(mask));
+    }
+
+    Y_UNIT_TEST(PredictWithMaskIncludingOutOfRangeHost)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
+
+        // Host 20 is beyond History.size(), never added.
+        auto mask = THostMask::MakeOne(0).Include(THostMask::MakeOne(20));
+
+        // max(100, 0) = 100.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(100),
+            predictor.Predict(mask));
+    }
+
+    Y_UNIT_TEST(ZeroDurationsAreHandledCorrectly)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration());
+        predictor.Add(THostIndex(0), TDuration());
+
+        // Sorted: [0, 0]. NthFromEnd=1 → skip last 0, return 0.
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(MixedZeroAndNonZeroDurations)
+    {
+        TTimePredictor predictor(
+            TimePredictionHistorySize,
+            TimePredictionNthFromEnd);
+
+        predictor.Add(THostIndex(0), TDuration());
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(50));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+
+        // Sorted: [0, 50, 100]. NthFromEnd=1 → skip 100, return 50.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(50),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(NthFromEndZeroReturnsMax)
+    {
+        // nthFromEnd=0 means return the absolute maximum (100th percentile).
+        TTimePredictor predictor(TimePredictionHistorySize, 0);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(50));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(300));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
+
+        // Sorted: [50, 100, 300]. NthFromEnd=0 → return 300.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(300),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(NthFromEndTwo)
+    {
+        // nthFromEnd=2 skips the two largest.
+        TTimePredictor predictor(TimePredictionHistorySize, 2);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(10));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(20));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(30));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(40));
+
+        // Sorted: [10, 20, 30, 40]. Skip 40, 30 → return 20.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TDuration::MilliSeconds(20),
+            predictor.Predict(0));
+    }
+
+    Y_UNIT_TEST(NthFromEndExceedsSizeReturnsZero)
+    {
+        // nthFromEnd=5, but only 3 elements → returns zero.
+        TTimePredictor predictor(TimePredictionHistorySize, 5);
+
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(10));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(20));
+        predictor.Add(THostIndex(0), TDuration::MilliSeconds(30));
+
+        UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(0));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor_ut.cpp
@@ -44,7 +44,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
 
         // With nthFromEnd == 1 and only 1 element, we skip 1 from the end
-        // and hit rend → returns zero.
+        // and hit rend -> returns zero.
         UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(0));
     }
 
@@ -73,7 +73,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(300));
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
 
-        // Sorted: [50, 100, 300]. NthFromEnd=1 → skip 300, return 100.
+        // Sorted: [50, 100, 300]. NthFromEnd=1 -> skip 300, return 100.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(100),
             predictor.Predict(0));
@@ -89,7 +89,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
 
-        // Sorted (multiset): [100, 100, 100]. NthFromEnd=1 → skip last 100,
+        // Sorted (multiset): [100, 100, 100]. NthFromEnd=1 -> skip last 100,
         // return 100.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(100),
@@ -108,12 +108,12 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(1), TDuration::MilliSeconds(500));
         predictor.Add(THostIndex(1), TDuration::MilliSeconds(600));
 
-        // Host 0: sorted [100, 200] → predict 100.
+        // Host 0: sorted [100, 200] -> predict 100.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(100),
             predictor.Predict(0));
 
-        // Host 1: sorted [500, 600] → predict 500.
+        // Host 1: sorted [500, 600] -> predict 500.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(500),
             predictor.Predict(1));
@@ -130,7 +130,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
             predictor.Add(THostIndex(0), TDuration::MilliSeconds(10));
         }
 
-        // Sorted: 10 x [10ms]. Predict → 10ms (second from end).
+        // Sorted: 10 x [10ms]. Predict -> 10ms (second from end).
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(10),
             predictor.Predict(0));
@@ -138,7 +138,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         // Now push one large value — it evicts one old 10ms.
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(1000));
 
-        // Sorted: 9 x [10ms], 1 x [1000ms]. NthFromEnd=1 → skip 1000,
+        // Sorted: 9 x [10ms], 1 x [1000ms]. NthFromEnd=1 -> skip 1000,
         // return 10.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(10),
@@ -147,7 +147,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         // Now push one large value — it evicts one old 10ms.
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(500));
 
-        // Sorted: 5 x [10ms], 1 x [500ms], 1 x [1000ms]. NthFromEnd=1 → skip
+        // Sorted: 8 x [10ms], 1 x [500ms], 1 x [1000ms]. NthFromEnd=1 -> skip
         // 1000, return 500.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(500),
@@ -183,11 +183,11 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
             TimePredictionHistorySize,
             TimePredictionNthFromEnd);
 
-        // Host 0: sorted [100, 200] → predict 100.
+        // Host 0: sorted [100, 200] -> predict 100.
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(200));
 
-        // Host 1: sorted [300, 400] → predict 300.
+        // Host 1: sorted [300, 400] -> predict 300.
         predictor.Add(THostIndex(1), TDuration::MilliSeconds(300));
         predictor.Add(THostIndex(1), TDuration::MilliSeconds(400));
 
@@ -241,14 +241,14 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
             predictor.Add(THostIndex(0), TDuration::MilliSeconds(10 * (i + 1)));
         }
 
-        // Predict: second-from-end of [10..100] → 90ms.
+        // Predict: second-from-end of [10..100] -> 90ms.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(90),
             predictor.Predict(0));
 
         // Push 5ms — evicts the oldest, which is 10ms (first pushed).
         // New sorted set: [5, 20, 30, 40, 50, 60, 70, 80, 90, 100].
-        // NthFromEnd=1 → skip 100, return 90.
+        // NthFromEnd=1 -> skip 100, return 90.
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(5));
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(90),
@@ -256,7 +256,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
 
         // Push 95ms — evicts 20ms.
         // New sorted set: [5, 30, 40, 50, 60, 70, 80, 90, 95, 100].
-        // NthFromEnd=1 → skip 100, return 95.
+        // NthFromEnd=1 -> skip 100, return 95.
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(95));
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(95),
@@ -308,7 +308,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration());
         predictor.Add(THostIndex(0), TDuration());
 
-        // Sorted: [0, 0]. NthFromEnd=1 → skip last 0, return 0.
+        // Sorted: [0, 0]. NthFromEnd=1 -> skip last 0, return 0.
         UNIT_ASSERT_VALUES_EQUAL(TDuration(), predictor.Predict(0));
     }
 
@@ -322,7 +322,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(50));
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
 
-        // Sorted: [0, 50, 100]. NthFromEnd=1 → skip 100, return 50.
+        // Sorted: [0, 50, 100]. NthFromEnd=1 -> skip 100, return 50.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(50),
             predictor.Predict(0));
@@ -337,7 +337,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(300));
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(100));
 
-        // Sorted: [50, 100, 300]. NthFromEnd=0 → return 300.
+        // Sorted: [50, 100, 300]. NthFromEnd=0 -> return 300.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(300),
             predictor.Predict(0));
@@ -353,7 +353,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(30));
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(40));
 
-        // Sorted: [10, 20, 30, 40]. Skip 40, 30 → return 20.
+        // Sorted: [10, 20, 30, 40]. Skip 40, 30 -> return 20.
         UNIT_ASSERT_VALUES_EQUAL(
             TDuration::MilliSeconds(20),
             predictor.Predict(0));
@@ -361,7 +361,7 @@ Y_UNIT_TEST_SUITE(TTimePredictorTest)
 
     Y_UNIT_TEST(NthFromEndExceedsSizeReturnsZero)
     {
-        // nthFromEnd=5, but only 3 elements → returns zero.
+        // nthFromEnd=5, but only 3 elements -> returns zero.
         TTimePredictor predictor(TimePredictionHistorySize, 5);
 
         predictor.Add(THostIndex(0), TDuration::MilliSeconds(10));

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ut/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ut/ya.make
@@ -5,6 +5,7 @@ SRCS(
     host_roles_ut.cpp
     host_stat_ut.cpp
     oracle_ut.cpp
+    time_predictor_ut.cpp
     vchunk_config_ut.cpp
 )
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/ya.make
@@ -11,6 +11,7 @@ SRCS(
     host_state.cpp
     host.cpp
     oracle.cpp
+    time_predictor.cpp
     vchunk_config.cpp
 )
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
@@ -35,7 +35,6 @@ TReadSingleLocationRequestExecutor::TReadSingleLocationRequestExecutor(
     , CallContext(std::move(callContext))
     , Request(std::move(request))
     , TraceId(std::move(traceId))
-    , HedgingDelay(DirectBlockGroup->GetOracle()->GetReadHedgingDelay())
     , RequestTimeout(DirectBlockGroup->GetOracle()->GetReadRequestTimeout())
     , ReadHint(std::move(readHint))
 {
@@ -110,15 +109,22 @@ void TReadSingleLocationRequestExecutor::StartReading()
 
     const bool fromDDisk = ReadHint.Lsn == 0;
 
+    const size_t tryCount = Requested.Count();
+    NActors::NLog::EPriority printPriority =
+        tryCount == 1 ? NActors::NLog::PRI_DEBUG : NActors::NLog::PRI_TRACE;
+    if (!Failed.Empty()) {
+        printPriority = NActors::NLog::PRI_INFO;
+    }
+
     LOG_LOG(
         *ActorSystem,
-        Requested.Count() == 1 ? NActors::NLog::PRI_DEBUG
-                               : NActors::NLog::PRI_INFO,
+        printPriority,
         NKikimrServices::NBS_PARTITION,
-        "%s Will read from %s of %s",
+        "%s Will read from %s of %s, try %lu",
         LogTitle.GetWithTime().c_str(),
         fromDDisk ? "DDisk" : "PBuffer",
-        PrintHostIndex(*host).c_str());
+        PrintHostIndex(*host).c_str(),
+        tryCount);
 
     auto onReadResponse = [self = shared_from_this(), host = *host]   //
         (const NThreading::TFuture<TDBGReadBlocksResponse>& f)
@@ -141,7 +147,9 @@ void TReadSingleLocationRequestExecutor::StartReading()
                                   TraceId);
     future.Subscribe(std::move(onReadResponse));
 
-    ScheduleHedging();
+    ScheduleHedging(DirectBlockGroup->GetOracle()->GetReadHedgingDelay(
+        *host,
+        ReadHint.Lsn == 0 ? EDataLocation::DDisk : EDataLocation::PBuffer));
 }
 
 void TReadSingleLocationRequestExecutor::OnReadResponse(
@@ -194,9 +202,9 @@ void TReadSingleLocationRequestExecutor::Reply(NProto::TError error)
     Promise.TrySetValue(TResponse{.Error = std::move(error)});
 }
 
-void TReadSingleLocationRequestExecutor::ScheduleHedging()
+void TReadSingleLocationRequestExecutor::ScheduleHedging(TDuration hedgingDelay)
 {
-    if (!HedgingDelay) {
+    if (!hedgingDelay) {
         return;
     }
 
@@ -205,10 +213,10 @@ void TReadSingleLocationRequestExecutor::ScheduleHedging()
         NKikimrServices::NBS_PARTITION,
         "%s Schedule OnHedgingTimeout %s",
         LogTitle.GetWithTime().c_str(),
-        FormatDuration(HedgingDelay).c_str());
+        FormatDuration(hedgingDelay).c_str());
 
     DirectBlockGroup->Schedule(
-        HedgingDelay,
+        hedgingDelay,
         [weakSelf = weak_from_this()]()
         {
             if (auto self = weakSelf.lock()) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.h
@@ -49,7 +49,7 @@ private:
         const TDBGReadBlocksResponse& response);
     void Reply(NProto::TError error);
 
-    void ScheduleHedging();
+    void ScheduleHedging(TDuration hedgingDelay);
     void ScheduleRequestTimeout();
     void OnHedgingTimeout();
     void OnRequestTimeout();
@@ -61,7 +61,6 @@ private:
     const TCallContextPtr CallContext;
     const std::shared_ptr<TReadBlocksLocalRequest> Request;
     const NWilson::TTraceId TraceId;
-    const TDuration HedgingDelay;
     const TDuration RequestTimeout;
 
     TReadRangeHint ReadHint;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
@@ -32,7 +32,6 @@ TWriteRequestExecutor::TWriteRequestExecutor(
     , VChunkConfig(vChunkConfig)
     , DirectBlockGroup(std::move(directBlockGroup))
     , Bundle(std::move(bundle))
-    , HedgingDelay(DirectBlockGroup->GetOracle()->GetWriteHedgingDelay())
     , RequestTimeout(DirectBlockGroup->GetOracle()->GetWriteRequestTimeout())
     , IndirectWriteReplyTimeout(
           DirectBlockGroup->GetOracle()->GetIndirectWriteReplyTimeout())
@@ -63,7 +62,9 @@ void TWriteRequestExecutor::Run()
     }
 
     ScheduleRequestTimeout();
-    ScheduleHedging();
+    ScheduleHedging(DirectBlockGroup->GetOracle()->GetWriteHedgingDelay(
+        hosts,
+        WriteMode == EWriteMode::IndirectWrite));
 
     switch (WriteMode) {
         case EWriteMode::IndirectWrite: {
@@ -166,7 +167,7 @@ void TWriteRequestExecutor::SendAdditionalDirectWrites()
         return;
     }
 
-    LOG_INFO(
+    LOG_TRACE(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,
         "%s SendAdditionalDirectWrites %s",
@@ -236,6 +237,13 @@ void TWriteRequestExecutor::SendDirectWriteRequestsToHandoffs(size_t count)
                            .Exclude(IndirectCoordinator);
 
     for (THostIndex host: hosts) {
+        LOG_TRACE(
+            *ActorSystem,
+            NKikimrServices::NBS_PARTITION,
+            "%s SendAdditionalDirectWrites %s",
+            LogTitle.GetWithTime().c_str(),
+            ExtendedDebugState().c_str());
+
         SendDirectWriteRequest(host);
         if (--count == 0) {
             break;
@@ -397,9 +405,9 @@ void TWriteRequestExecutor::NotifyBelated(THostMask completedOnCurrentResponse)
     Bundle->NotifyBelated(completedOnCurrentResponse);
 }
 
-void TWriteRequestExecutor::ScheduleHedging()
+void TWriteRequestExecutor::ScheduleHedging(TDuration hedgingDelay)
 {
-    if (!HedgingDelay) {
+    if (!hedgingDelay) {
         return;
     }
 
@@ -408,10 +416,10 @@ void TWriteRequestExecutor::ScheduleHedging()
         NKikimrServices::NBS_PARTITION,
         "%s Schedule OnHedgingTimeout() %s",
         LogTitle.GetWithTime().c_str(),
-        FormatDuration(HedgingDelay).c_str());
+        FormatDuration(hedgingDelay).c_str());
 
     DirectBlockGroup->Schedule(
-        HedgingDelay,
+        hedgingDelay,
         [weakSelf = weak_from_this()]()
         {
             if (auto self = weakSelf.lock()) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.h
@@ -58,7 +58,7 @@ private:
     void Reply(NProto::TError error);
     void NotifyBelated(THostMask completedOnCurrentResponse);
 
-    void ScheduleHedging();
+    void ScheduleHedging(TDuration hedgingDelay);
     void ScheduleRequestTimeout();
     void OnHedgingTimeout();
     void OnRequestTimeout();
@@ -76,7 +76,6 @@ private:
     const TVChunkConfig VChunkConfig;
     const IDirectBlockGroupPtr DirectBlockGroup;
     const TWriteRequestBundlePtr Bundle;
-    const TDuration HedgingDelay;
     const TDuration RequestTimeout;
     const TDuration IndirectWriteReplyTimeout;
 

--- a/ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer.cpp
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer.cpp
@@ -1,0 +1,1 @@
+#include "ring_buffer.h"

--- a/ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <util/generic/vector.h>
+#include <util/system/yassert.h>
+
+#include <cstddef>
+#include <optional>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+class TRingBuffer
+{
+public:
+    TRingBuffer(size_t capacity, std::optional<T> defaultValue = std::nullopt)
+        : DefaultValue(std::move(defaultValue))
+        , Buffer(capacity)
+    {}
+
+    void Reset(size_t capacity)
+    {
+        Buffer = TVector<T>(capacity);
+        Clear();
+    }
+
+    std::optional<T> PopFront()
+    {
+        if (IsEmpty()) {
+            return std::nullopt;
+        }
+        std::optional<T> result = std::move(Buffer[BeginIndex]);
+        if (BeginIndex == EndIndex) {
+            Clear();
+        } else {
+            BeginIndex = GetNext(BeginIndex);
+        }
+        return result;
+    }
+
+    std::optional<T> PopBack()
+    {
+        if (IsEmpty()) {
+            return std::nullopt;
+        }
+        std::optional<T> result = std::move(Buffer[EndIndex]);
+        if (BeginIndex == EndIndex) {
+            Clear();
+        } else {
+            EndIndex = GetPrevious(EndIndex);
+        }
+        return result;
+    }
+
+    std::optional<T> PushFront(T val)
+    {
+        if (Capacity() == 0) {
+            return val;
+        }
+
+        if (EndIndex == InvalidIndex) {
+            BeginIndex = EndIndex = 0;
+            Buffer[EndIndex] = std::move(val);
+            return std::nullopt;
+        }
+
+        Y_DEBUG_ABORT_UNLESS(EndIndex != InvalidIndex);
+        Y_DEBUG_ABORT_UNLESS(BeginIndex != InvalidIndex);
+
+        BeginIndex = GetPrevious(BeginIndex);
+        std::optional<T> result = std::nullopt;
+        if (BeginIndex == EndIndex) {
+            result = std::move(Buffer[EndIndex]);
+            EndIndex = GetPrevious(EndIndex);
+        }
+        Buffer[BeginIndex] = std::move(val);
+        return result;
+    }
+
+    std::optional<T> PushBack(T val)
+    {
+        if (Capacity() == 0) {
+            return val;
+        }
+
+        if (EndIndex == InvalidIndex) {
+            BeginIndex = EndIndex = 0;
+            Buffer[EndIndex] = std::move(val);
+            return std::nullopt;
+        }
+
+        Y_DEBUG_ABORT_UNLESS(EndIndex != InvalidIndex);
+        Y_DEBUG_ABORT_UNLESS(BeginIndex != InvalidIndex);
+
+        EndIndex = GetNext(EndIndex);
+        std::optional<T> result = std::nullopt;
+        if (BeginIndex == EndIndex) {
+            result = std::move(Buffer[BeginIndex]);
+            BeginIndex = GetNext(BeginIndex);
+        }
+        Buffer[EndIndex] = std::move(val);
+        return result;
+    }
+
+    [[nodiscard]] const T& Front(size_t offset = 0) const
+    {
+        if (IsEmpty() || offset >= Size()) {
+            if (!DefaultValue) {
+                Y_ABORT();
+            }
+            return *DefaultValue;
+        }
+        return Buffer[RealIndex(BeginIndex + offset)];
+    }
+
+    [[nodiscard]] const T& Back(size_t offset = 0) const
+    {
+        if (IsEmpty() || offset >= Size()) {
+            if (!DefaultValue) {
+                Y_ABORT();
+            }
+            return *DefaultValue;
+        }
+        return Buffer[RealIndex(EndIndex + Capacity() - offset)];
+    }
+
+    void Clear()
+    {
+        BeginIndex = EndIndex = InvalidIndex;
+    }
+
+    [[nodiscard]] bool IsEmpty() const
+    {
+        return EndIndex == InvalidIndex;
+    }
+
+    [[nodiscard]] bool IsFull() const
+    {
+        return Size() == Capacity();
+    }
+
+    [[nodiscard]] size_t Size() const
+    {
+        if (EndIndex == InvalidIndex) {
+            return 0;
+        }
+
+        Y_DEBUG_ABORT_UNLESS(BeginIndex != InvalidIndex);
+
+        if (EndIndex >= BeginIndex) {
+            return EndIndex - BeginIndex + 1;
+        } else {
+            return (Capacity() - BeginIndex) + (EndIndex + 1);
+        }
+    }
+
+    [[nodiscard]] size_t Capacity() const
+    {
+        return Buffer.size();
+    }
+
+private:
+    static constexpr size_t InvalidIndex = std::numeric_limits<size_t>::max();
+
+    size_t RealIndex(size_t index) const
+    {
+        return index % Capacity();
+    }
+
+    size_t GetNext(size_t index) const
+    {
+        return RealIndex(index + 1);
+    }
+
+    size_t GetPrevious(size_t index) const
+    {
+        return RealIndex(index + Capacity() - 1);
+    }
+
+    std::optional<T> DefaultValue;
+    TVector<T> Buffer;
+    size_t BeginIndex = InvalidIndex;
+    size_t EndIndex = InvalidIndex;
+};
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer_ut.cpp
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/ring_buffer_ut.cpp
@@ -1,0 +1,437 @@
+#include "ring_buffer.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYdb::NBS {
+
+////////////////////////////////////////////////////////////////////////////////
+
+Y_UNIT_TEST_SUITE(TRingBufferTest)
+{
+    Y_UNIT_TEST(ShouldReturnCorrectCapacity)
+    {
+        {
+            auto ringBuffer = TRingBuffer<int>(1);
+            UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Capacity(), 1);
+        }
+
+        {
+            auto ringBuffer = TRingBuffer<int>(123);
+            UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Capacity(), 123);
+        }
+    }
+
+    Y_UNIT_TEST(ShouldReturnCorrectSize)
+    {
+        auto ringBuffer = TRingBuffer<int>(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+
+        ringBuffer.PushBack(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+
+        ringBuffer.PushFront(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+
+        ringBuffer.PushFront(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+
+        ringBuffer.PushBack(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+    }
+
+    Y_UNIT_TEST(ShouldReturnCorrectIsEmpty)
+    {
+        auto ringBuffer = TRingBuffer<int>(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), true);
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), false);
+
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), false);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), false);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), false);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), true);
+    }
+
+    Y_UNIT_TEST(ShouldReturnCorrectIsFull)
+    {
+        auto ringBuffer = TRingBuffer<int>(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), false);
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), false);
+
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), true);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), true);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), false);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), false);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyClear)
+    {
+        auto ringBuffer = TRingBuffer<int>(2);
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), false);
+
+        ringBuffer.Clear();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), true);
+
+        ringBuffer.PushBack(1);
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), true);
+
+        ringBuffer.Clear();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsEmpty(), true);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.IsFull(), false);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyPushPopBack)
+    {
+        auto ringBuffer = TRingBuffer<int>(3);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+
+        ringBuffer.PushBack(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PushBack(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyPushPopFrontFront)
+    {
+        auto ringBuffer = TRingBuffer<int>(3);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PushFront(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 0);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyBack)
+    {
+        auto ringBuffer = TRingBuffer<int>(3);
+
+        ringBuffer.PushBack(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 3);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PushBack(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 4);
+
+        ringBuffer.PushBack(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 5);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 4);
+
+        ringBuffer.Clear();
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.Clear();
+
+        ringBuffer.PushBack(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushFront(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 3);
+
+        ringBuffer.PushFront(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 1);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PushFront(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PushBack(6);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 6);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 2);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Back(), 4);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyFront)
+    {
+        auto ringBuffer = TRingBuffer<int>(3);
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushFront(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PushFront(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 3);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PushFront(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 4);
+
+        ringBuffer.PushFront(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 5);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 4);
+
+        ringBuffer.Clear();
+
+        ringBuffer.PushBack(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+
+        ringBuffer.Clear();
+
+        ringBuffer.PushFront(1);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(2);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushFront(3);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 3);
+
+        ringBuffer.PushBack(4);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PopBack();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushBack(5);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PushFront(6);
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 6);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 1);
+
+        ringBuffer.PopFront();
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Front(), 2);
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyReturnPoppedValue)
+    {
+        auto ringBuffer = TRingBuffer<int>(3);
+
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushFront(1));
+        UNIT_ASSERT_EQUAL(1, ringBuffer.PopFront());
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PopFront());
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PopBack());
+
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushFront(2));
+        UNIT_ASSERT_EQUAL(2, *ringBuffer.PopBack());
+
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushBack(3));
+        UNIT_ASSERT_EQUAL(3, *ringBuffer.PopFront());
+
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushBack(4));
+        UNIT_ASSERT_EQUAL(4, *ringBuffer.PopBack());
+
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushBack(5));
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushBack(6));
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PushFront(7));
+        UNIT_ASSERT_EQUAL(6, *ringBuffer.PushFront(8));
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(5, *ringBuffer.PopBack());
+        UNIT_ASSERT_VALUES_EQUAL(7, *ringBuffer.PopBack());
+        UNIT_ASSERT_VALUES_EQUAL(8, *ringBuffer.PopBack());
+        UNIT_ASSERT_EQUAL(std::nullopt, ringBuffer.PopBack());
+    }
+
+    Y_UNIT_TEST(ShouldCorrectlyGetWithOffset)
+    {
+        auto ringBuffer = TRingBuffer<int>(5);
+
+        ringBuffer.PushBack(1);
+        ringBuffer.PushBack(2);
+        ringBuffer.PushBack(3);
+        ringBuffer.PushBack(4);
+        ringBuffer.PushBack(5);
+
+        UNIT_ASSERT_EQUAL(5, ringBuffer.Back());
+        UNIT_ASSERT_EQUAL(1, ringBuffer.Back(4));
+
+        UNIT_ASSERT_EQUAL(1, ringBuffer.Front());
+        UNIT_ASSERT_EQUAL(5, ringBuffer.Front(4));
+    }
+
+    Y_UNIT_TEST(ShouldCorrectPushAndPopWithZeroCapacity)
+    {
+        auto ringBuffer = TRingBuffer<int>(0);
+        UNIT_ASSERT_VALUES_EQUAL(100, ringBuffer.PushBack(100).value());
+        UNIT_ASSERT_VALUES_EQUAL(200, ringBuffer.PushFront(200).value());
+        UNIT_ASSERT_VALUES_EQUAL(ringBuffer.Capacity(), 0);
+    }
+}
+
+}   // namespace NYdb::NBS

--- a/ydb/core/nbs/cloud/storage/core/libs/common/ut/ya.make
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/ut/ya.make
@@ -13,6 +13,7 @@ SRCS(
     block_data_ref_ut.cpp
     context_ut.cpp
     guarded_sglist_ut.cpp
+    ring_buffer_ut.cpp
     scheduler_ut.cpp
     sglist_iter_ut.cpp
     sglist_ut.cpp

--- a/ydb/core/nbs/cloud/storage/core/libs/common/ya.make
+++ b/ydb/core/nbs/cloud/storage/core/libs/common/ya.make
@@ -13,6 +13,7 @@ SRCS(
     guarded_sglist.cpp
     helpers.cpp
     page_size.cpp
+    ring_buffer.cpp
     scheduler_test.cpp
     scheduler.cpp
     sglist_iter.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Time predictor for read and write hedging. 

We save the time of the last executed requests and sort it. If we store 100 elements and take the second-to-last element from the end, then this is the time of the 99.9 percentile. The count of elements and the number from the end can be customized. If the count of elements is 0, then the prediction is disabled.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
