### PR TITLE
topic write_session: handle exceptions from GetAuthInfo

### DIFF
--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.cpp
@@ -102,7 +102,6 @@ TWriteSessionImpl::TWriteSessionImpl(
     , Client(std::move(client))
     , Connections(std::move(connections))
     , DbDriverState(std::move(dbDriverState))
-    , PrevToken(DbDriverState->CredentialsProvider ? DbDriverState->CredentialsProvider->GetAuthInfo() : "")
     , MaxBlockMessageCount(Settings.BatchFlushMessageCount_)
     , InitSeqNoPromise(NThreading::NewPromise<uint64_t>())
     , WakeupInterval(
@@ -112,6 +111,11 @@ TWriteSessionImpl::TWriteSessionImpl(
                 TDuration::MilliSeconds(100)
     )
 {
+    try {
+        PrevToken = DbDriverState->CredentialsProvider ? DbDriverState->CredentialsProvider->GetAuthInfo() : "";
+    } catch (std::exception&) {
+        LOG_LAZY(DbDriverState->Log, TLOG_ERR, LogPrefixImpl() << "Write session: updating token failed: " << CurrentExceptionMessage());
+    }
     if (!Settings.RetryPolicy_) {
         Settings.RetryPolicy_ = IRetryPolicy::GetDefaultPolicy();
     }
@@ -1576,7 +1580,16 @@ void TWriteSessionImpl::UpdateTokenIfNeededImpl() {
         return;
     }
 
-    auto token = DbDriverState->CredentialsProvider->GetAuthInfo();
+    std::string token;
+    try {
+        token = DbDriverState->CredentialsProvider->GetAuthInfo();
+    } catch (std::exception&) {
+        // XXX Backoff?
+        LOG_LAZY(DbDriverState->Log, TLOG_ERR, LogPrefixImpl() << "Write session: updating token failed: " << CurrentExceptionMessage());
+        return;
+    }
+    LastTokenUpdate = TInstant::Now();
+
     if (token == PrevToken) {
         return;
     }
@@ -1828,7 +1841,7 @@ void TWriteSessionImpl::HandleWakeUpImpl() {
         }
     };
     if (TInstant::Now() - LastTokenUpdate > UPDATE_TOKEN_PERIOD) {
-        LastTokenUpdate = TInstant::Now();
+        // XXX this call is ratelimited (once per hour); others are not; why?
         UpdateTokenIfNeededImpl();
     }
 


### PR DESCRIPTION
Note: write_session constructor may be called from federated_topic write session implementation in the middle of "federated session", we cannot just throw exception from there (or its handling should be also added to federated_topic code -- there are none currently)

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

NOT READY-USE SOLUTION (*probably* works, but feels fragile), just point to problematic code, requires careful redesign
ALSO NOTE: `topic/*write_sessioin*` is mostly copied from persqueue_public, same problem present there too,
