### PR TITLE
LOGBROKER-10518 Add metering logic to sqs topics / unit tests

### DIFF
--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -11,6 +11,13 @@
 #include <ydb/library/testlib/service_mocks/iam_token_service_mock.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h>
+#include <ydb/core/metering/stream_ru_calculator.h>
+#include <ydb/core/quoter/public/quoter.h>
+#include <ydb/services/sqs_topic/billing.h>
+
+#include <util/system/mutex.h>
+
+#include <memory>
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/json/writer/json_value.h>
@@ -214,6 +221,141 @@ namespace {
         UNIT_ASSERT(writer->Write(messageBody));
         writer->Close();
     }
+
+    // Serverless rate-limiter path stored in the database user-attributes.
+    // When a topic is metered by Request Units, the sqs_topic actors read these
+    // attributes and build the rate-limiter context from them.
+    struct TRuTopicSetup {
+        TString CoordinationNodePath = "/Root/ru-coordination-node";
+        TString ResourcePath = "root-topic-resource-ru";
+    };
+
+    void SetupServerlessRuAttributes(std::derived_from<THttpProxyTestMock> auto& fixture, const TRuTopicSetup& setup) {
+        NYdb::TClient client(*(fixture.KikimrServer->ServerSettings));
+        UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
+            client.AlterUserAttributes("/", "Root",
+                {{"serverless_rt_coordination_node_path", setup.CoordinationNodePath},
+                 {"serverless_rt_topic_resource_ru", setup.ResourcePath}},
+                {}, {}, "root@builtin"));
+    }
+
+    bool CreateRequestUnitsTopic(NYdb::TDriver& driver, const TString& topicName, const TString& consumerName) {
+        // Force the RAW codec (no compression) so that the payload bytes written
+        // equal the payload bytes read back. This keeps the RU block accounting
+        // deterministic: the metering tests below rely on the exact transferred
+        // size, which compression would otherwise change.
+        return CreateTopic(driver, topicName, NYdb::NTopic::TCreateTopicSettings()
+            .MeteringMode(NYdb::NTopic::EMeteringMode::RequestUnits)
+            .SetSupportedCodecs({NYdb::NTopic::ECodec::RAW})
+            .BeginAddSharedConsumer(consumerName)
+                .KeepMessagesOrder(false)
+                .DefaultProcessingTimeout(TDuration::Seconds(20))
+            .EndAddConsumer());
+    }
+
+    // Replicates TStreamRequestUnitsCalculator::CalcConsumption for a freshly
+    // constructed calculator (Remainder == blockSize). Each RU-metered request
+    // uses its own actor and therefore its own fresh calculator, so a single
+    // charge maps its payload onto blocks with this formula. Used by the
+    // metering tests to predict the block-based part of a write/read charge.
+    ui64 RuPayloadBlocks(ui64 payloadSize, ui64 blockSize) {
+        if (payloadSize <= blockSize) {
+            return 0;
+        }
+        payloadSize -= blockSize;
+        return payloadSize / blockSize + ((payloadSize % blockSize) ? 1 : 0);
+    }
+
+    struct TRuCharge {
+        TString Quoter;
+        TString Resource;
+        ui64 Amount = 0;
+    };
+
+    // Mock quoter service actor. The fixture runs the embedded Kikimr actor
+    // system on real executor threads, where SetObserverFunc cannot intercept
+    // events (observers only see events on the single-threaded dispatcher).
+    // Instead we register this actor under MakeQuoterServiceID(), overriding the
+    // real quoter service, so it receives the TEvQuota::TEvRequest that
+    // TAcquireRateLimiterResourceRPC sends when a RU charge fires. It records the
+    // charged amount / quoter / resource (for requests matching the configured
+    // resource) into a shared, mutex-guarded vector, then grants a Success
+    // clearance so the HTTP request can complete without a real Kesus resource.
+    class TRuQuoterServiceMock : public TActor<TRuQuoterServiceMock> {
+    public:
+        TRuQuoterServiceMock(std::shared_ptr<TMutex> lock,
+                             std::shared_ptr<TVector<TRuCharge>> charges,
+                             TString resourceFilter)
+            : TActor(&TRuQuoterServiceMock::StateWork)
+            , Lock_(std::move(lock))
+            , Charges_(std::move(charges))
+            , ResourceFilter_(std::move(resourceFilter))
+        {}
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvQuota::TEvRequest, Handle);
+            }
+        }
+
+        void Handle(TEvQuota::TEvRequest::TPtr& ev) {
+            {
+                TGuard<TMutex> guard(*Lock_);
+                for (const auto& leaf : ev->Get()->Reqs) {
+                    if (leaf.Resource == ResourceFilter_) {
+                        Charges_->push_back(TRuCharge{leaf.Quoter, leaf.Resource, leaf.Amount});
+                    }
+                }
+            }
+            Send(ev->Sender,
+                 new TEvQuota::TEvClearance(TEvQuota::TEvClearance::EResult::Success),
+                 0, ev->Cookie);
+        }
+
+    private:
+        std::shared_ptr<TMutex> Lock_;
+        std::shared_ptr<TVector<TRuCharge>> Charges_;
+        TString ResourceFilter_;
+    };
+
+    // Registers a TRuQuoterServiceMock in place of the real quoter service and
+    // exposes the recorded charges. Because a RU-metered operation only replies
+    // (and thus the blocking HTTP call only returns) after the quota clearance is
+    // granted, any charge for a completed operation is guaranteed to have been
+    // recorded by the time the corresponding HTTP helper returns. Take() still
+    // polls briefly to be robust against cross-thread memory ordering.
+    class TRuRecorder {
+    public:
+        TRuRecorder(TTestActorRuntime* runtime, TString resourceFilter)
+            : Lock_(std::make_shared<TMutex>())
+            , Charges_(std::make_shared<TVector<TRuCharge>>())
+        {
+            const ui32 nodeIndex = 0;
+            const ui32 systemPoolId = runtime->GetAppData().SystemPoolId;
+            auto* actor = new TRuQuoterServiceMock(Lock_, Charges_, std::move(resourceFilter));
+            const TActorId actorId = runtime->Register(actor, nodeIndex, systemPoolId);
+            runtime->RegisterService(MakeQuoterServiceID(), actorId);
+        }
+
+        TVector<TRuCharge> Take(size_t expected = 1, TDuration timeout = TDuration::Seconds(10)) {
+            const TInstant deadline = TInstant::Now() + timeout;
+            for (;;) {
+                {
+                    TGuard<TMutex> guard(*Lock_);
+                    if (Charges_->size() >= expected || TInstant::Now() >= deadline) {
+                        TVector<TRuCharge> result = std::move(*Charges_);
+                        Charges_->clear();
+                        return result;
+                    }
+                }
+                Sleep(TDuration::MilliSeconds(10));
+            }
+        }
+
+    private:
+        std::shared_ptr<TMutex> Lock_;
+        std::shared_ptr<TVector<TRuCharge>> Charges_;
+    };
 } // namespace
 
 Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
@@ -1611,6 +1753,193 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
 
         UNIT_ASSERT_VALUES_EQUAL(deleteJson["Failed"].GetArray().size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(deleteJson["Failed"][0]["Id"], "delete-invalid");
+    }
+
+    // Number of messages and per-message size shared by the RU metering tests.
+    // The bodies sum to 24 KiB (> 8 KiB) so that a single request transfers more
+    // than one payload block. Each body is exactly READ_BLOCK_SIZE bytes, and the
+    // topic uses the RAW codec (see CreateRequestUnitsTopic), so the bytes read
+    // back equal the bytes written and the block accounting is deterministic.
+    static constexpr size_t RuMetering_MessageCount = 3;
+    static constexpr size_t RuMetering_MessageSize =
+        NKikimr::NSqsTopic::V1::NBilling::READ_BLOCK_SIZE;
+
+    static TVector<TString> MakeRuMeteringBodies() {
+        TVector<TString> bodies;
+        bodies.reserve(RuMetering_MessageCount);
+        for (size_t i = 0; i < RuMetering_MessageCount; ++i) {
+            // Distinct bodies (used as map keys on receive) of identical size.
+            bodies.push_back(TString(RuMetering_MessageSize, static_cast<char>('a' + i)));
+        }
+        return bodies;
+    }
+
+    static NJson::TJsonArray MakeRuMeteringSendEntries(const TVector<TString>& bodies) {
+        NJson::TJsonArray entries;
+        for (size_t i = 0; i < bodies.size(); ++i) {
+            entries.AppendValue(NJson::TJsonMap{
+                {"Id", std::format("Id-{}", i)},
+                {"MessageBody", bodies[i]},
+            });
+        }
+        return entries;
+    }
+
+    Y_UNIT_TEST_F(TestSendMessageChargesRequestUnits, TFixture) {
+        namespace NBilling = NKikimr::NSqsTopic::V1::NBilling;
+
+        const TRuTopicSetup ru;
+        SetupServerlessRuAttributes(*this, ru);
+
+        auto driver = MakeDriver(*this);
+        const TSqsTopicPaths path;
+        UNIT_ASSERT(CreateRequestUnitsTopic(driver, path.TopicName, path.ConsumerName));
+
+        TRuRecorder recorder(ActorRuntime, ru.ResourcePath);
+
+        // Send several messages (total payload > 8 KiB) in a single SendMessage
+        // (batch) call. The whole batch produces exactly one write RU charge.
+        const auto bodies = MakeRuMeteringBodies();
+        auto json = SendMessageBatch({
+            {"QueueUrl", path.QueueUrl},
+            {"Entries", MakeRuMeteringSendEntries(bodies)},
+        });
+        UNIT_ASSERT_VALUES_EQUAL(json["Successful"].GetArray().size(), RuMetering_MessageCount);
+
+        auto charges = recorder.Take();
+        UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one write RU charge");
+        // Total payload = count * size (24 KiB) mapped onto WRITE_BLOCK_SIZE
+        // blocks by a fresh calculator. count messages written; non-FIFO topic
+        // => cost multiplier 1. Cost = base + blocks + count*perMessage.
+        const ui64 blocks = RuPayloadBlocks(
+            RuMetering_MessageCount * RuMetering_MessageSize, NBilling::WRITE_BLOCK_SIZE);
+        const ui64 expected = NBilling::CalcWriteRu(blocks, RuMetering_MessageCount, false, false);
+        UNIT_ASSERT_VALUES_EQUAL(blocks, 5);
+        UNIT_ASSERT_VALUES_EQUAL(expected, 9);
+        UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
+        UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);
+        UNIT_ASSERT_VALUES_EQUAL(charges[0].Resource, ru.ResourcePath);
+    }
+
+    Y_UNIT_TEST_F(TestReceiveMessageChargesRequestUnits, TFixture) {
+        namespace NBilling = NKikimr::NSqsTopic::V1::NBilling;
+
+        const TRuTopicSetup ru;
+        SetupServerlessRuAttributes(*this, ru);
+
+        auto driver = MakeDriver(*this);
+        const TSqsTopicPaths path;
+        UNIT_ASSERT(CreateRequestUnitsTopic(driver, path.TopicName, path.ConsumerName));
+
+        TRuRecorder recorder(ActorRuntime, ru.ResourcePath);
+
+        const auto bodies = MakeRuMeteringBodies();
+        SendMessageBatch({
+            {"QueueUrl", path.QueueUrl},
+            {"Entries", MakeRuMeteringSendEntries(bodies)},
+        });
+        // Drop the single write charge; we only assert on the read charges below.
+        recorder.Take();
+
+        // Receive all messages. Each ReceiveMessage call returns at least one
+        // message (they are all available) and produces exactly one read RU
+        // charge, which the blocking HTTP call has recorded by the time it
+        // returns. Messages may be split across several responses.
+        ui64 totalReadRu = 0;
+        size_t collected = 0;
+        while (collected < RuMetering_MessageCount) {
+            auto json = ReceiveMessage({
+                {"QueueUrl", path.QueueUrl},
+                {"WaitTimeSeconds", 20},
+                {"MaxNumberOfMessages", static_cast<int>(RuMetering_MessageCount)},
+            });
+            const size_t k = json["Messages"].GetArray().size();
+            UNIT_ASSERT_C(k >= 1, "receive returned no messages");
+
+            auto charges = recorder.Take(1);
+            UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one read RU charge");
+            // Payload of this response = k * size mapped onto READ_BLOCK_SIZE
+            // blocks by a fresh calculator; k messages returned; multiplier 1.
+            const ui64 blocks = RuPayloadBlocks(k * RuMetering_MessageSize, NBilling::READ_BLOCK_SIZE);
+            const ui64 expected = NBilling::CalcReadRu(blocks, k, false, false);
+            UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
+            UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);
+            UNIT_ASSERT_VALUES_EQUAL(charges[0].Resource, ru.ResourcePath);
+
+            totalReadRu += charges[0].Amount;
+            collected += k;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(collected, RuMetering_MessageCount);
+        // Each 8 KiB message (== READ_BLOCK_SIZE) costs 2 RU (base+block share 1,
+        // per-message 1), so the total is independent of how the messages were
+        // split across receive responses.
+        UNIT_ASSERT_VALUES_EQUAL(totalReadRu, RuMetering_MessageCount * 2);
+    }
+
+    Y_UNIT_TEST_F(TestDeleteMessageChargesRequestUnits, TFixture) {
+        namespace NBilling = NKikimr::NSqsTopic::V1::NBilling;
+
+        const TRuTopicSetup ru;
+        SetupServerlessRuAttributes(*this, ru);
+
+        auto driver = MakeDriver(*this);
+        const TSqsTopicPaths path;
+        UNIT_ASSERT(CreateRequestUnitsTopic(driver, path.TopicName, path.ConsumerName));
+
+        TRuRecorder recorder(ActorRuntime, ru.ResourcePath);
+
+        const auto bodies = MakeRuMeteringBodies();
+        SendMessageBatch({
+            {"QueueUrl", path.QueueUrl},
+            {"Entries", MakeRuMeteringSendEntries(bodies)},
+        });
+        // Drop the single write charge.
+        recorder.Take();
+
+        // Receive all messages, collecting their receipt handles and dropping the
+        // per-response read charges.
+        THashMap<TString, TString> receipts;
+        while (receipts.size() < RuMetering_MessageCount) {
+            auto json = ReceiveMessage({
+                {"QueueUrl", path.QueueUrl},
+                {"WaitTimeSeconds", 20},
+                {"MaxNumberOfMessages", static_cast<int>(RuMetering_MessageCount)},
+            });
+            const auto& messages = json["Messages"].GetArray();
+            UNIT_ASSERT_C(messages.size() >= 1, "receive returned no messages");
+            for (const auto& message : messages) {
+                receipts.try_emplace(message["Body"].GetString(), message["ReceiptHandle"].GetString());
+            }
+            // Each non-empty receive produces exactly one read charge; drop it.
+            recorder.Take(1);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(receipts.size(), RuMetering_MessageCount);
+
+        // Delete all messages in a single DeleteMessage (batch) call. The whole
+        // batch produces exactly one delete RU charge.
+        NJson::TJsonArray entries;
+        size_t idx = 0;
+        for (const auto& [body, handle] : receipts) {
+            entries.AppendValue(NJson::TJsonMap{
+                {"Id", std::format("del-{}", idx++)},
+                {"ReceiptHandle", handle},
+            });
+        }
+        auto deleteJson = DeleteMessageBatch({
+            {"QueueUrl", path.QueueUrl},
+            {"Entries", entries},
+        });
+        UNIT_ASSERT_VALUES_EQUAL(deleteJson["Successful"].GetArray().size(), RuMetering_MessageCount);
+
+        auto charges = recorder.Take();
+        UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one delete RU charge");
+        // count messages deleted; non-FIFO => multiplier 1.
+        // Cost = base(1) + count*perMessage(1).
+        const ui64 expected = NBilling::CalcDeleteRu(RuMetering_MessageCount, false, false);
+        UNIT_ASSERT_VALUES_EQUAL(expected, 4);
+        UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
+        UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);
+        UNIT_ASSERT_VALUES_EQUAL(charges[0].Resource, ru.ResourcePath);
     }
 
     Y_UNIT_TEST_F(TestChangeMessageVisibilityInvalid, TFixture) {

--- a/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut.cpp
@@ -1755,7 +1755,7 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         UNIT_ASSERT_VALUES_EQUAL(deleteJson["Failed"][0]["Id"], "delete-invalid");
     }
 
-    // Number of messages and per-message size shared by the RU metering tests.
+    // Per-message size shared by the RU metering tests.
     // The bodies sum to 24 KiB (> 8 KiB) so that a single request transfers more
     // than one payload block. Each body is exactly READ_BLOCK_SIZE bytes, and the
     // topic uses the RAW codec (see CreateRequestUnitsTopic), so the bytes read
@@ -1809,13 +1809,13 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
         auto charges = recorder.Take();
         UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one write RU charge");
         // Total payload = count * size (24 KiB) mapped onto WRITE_BLOCK_SIZE
-        // blocks by a fresh calculator. count messages written; non-FIFO topic
-        // => cost multiplier 1. Cost = base + blocks + count*perMessage.
+        // blocks by a fresh calculator. 
+        // => Cost = base + blocks
         const ui64 blocks = RuPayloadBlocks(
             RuMetering_MessageCount * RuMetering_MessageSize, NBilling::WRITE_BLOCK_SIZE);
-        const ui64 expected = NBilling::CalcWriteRu(blocks, RuMetering_MessageCount, false, false);
+        const ui64 expected = NBilling::CalcRu(blocks, NBilling::WRITE_BASE_COST, NBilling::WRITE_COST_PER_BLOCK, false, false);
         UNIT_ASSERT_VALUES_EQUAL(blocks, 5);
-        UNIT_ASSERT_VALUES_EQUAL(expected, 9);
+        UNIT_ASSERT_VALUES_EQUAL(expected, 7);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Resource, ru.ResourcePath);
@@ -1858,11 +1858,6 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
 
             auto charges = recorder.Take(1);
             UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one read RU charge");
-            // Payload of this response = k * size mapped onto READ_BLOCK_SIZE
-            // blocks by a fresh calculator; k messages returned; multiplier 1.
-            const ui64 blocks = RuPayloadBlocks(k * RuMetering_MessageSize, NBilling::READ_BLOCK_SIZE);
-            const ui64 expected = NBilling::CalcReadRu(blocks, k, false, false);
-            UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
             UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);
             UNIT_ASSERT_VALUES_EQUAL(charges[0].Resource, ru.ResourcePath);
 
@@ -1870,10 +1865,13 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
             collected += k;
         }
         UNIT_ASSERT_VALUES_EQUAL(collected, RuMetering_MessageCount);
-        // Each 8 KiB message (== READ_BLOCK_SIZE) costs 2 RU (base+block share 1,
-        // per-message 1), so the total is independent of how the messages were
-        // split across receive responses.
-        UNIT_ASSERT_VALUES_EQUAL(totalReadRu, RuMetering_MessageCount * 2);
+        // Total payload = count * size (24 KiB) mapped onto READ_BLOCK_SIZE
+        // blocks by a fresh calculator. 
+        // => Cost = base + blocks
+        const ui64 blocks = RuPayloadBlocks(
+            RuMetering_MessageCount * RuMetering_MessageSize, NBilling::READ_BLOCK_SIZE);
+        const ui64 expected = NBilling::CalcRu(blocks, NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, false, false);
+        UNIT_ASSERT_VALUES_EQUAL(totalReadRu, expected);
     }
 
     Y_UNIT_TEST_F(TestDeleteMessageChargesRequestUnits, TFixture) {
@@ -1933,10 +1931,10 @@ Y_UNIT_TEST_SUITE(TestSqsTopicHttpProxy) {
 
         auto charges = recorder.Take();
         UNIT_ASSERT_VALUES_EQUAL_C(charges.size(), 1, "expected exactly one delete RU charge");
-        // count messages deleted; non-FIFO => multiplier 1.
-        // Cost = base(1) + count*perMessage(1).
-        const ui64 expected = NBilling::CalcDeleteRu(RuMetering_MessageCount, false, false);
-        UNIT_ASSERT_VALUES_EQUAL(expected, 4);
+        // adjunct 0.
+        // Cost = base(2).
+        const ui64 expected = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
+        UNIT_ASSERT_VALUES_EQUAL(expected, 2);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Amount, expected);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Quoter, ru.CoordinationNodePath);
         UNIT_ASSERT_VALUES_EQUAL(charges[0].Resource, ru.ResourcePath);

--- a/ydb/core/http_proxy/ut/sqs_topic_ut/ya.make
+++ b/ydb/core/http_proxy/ut/sqs_topic_ut/ya.make
@@ -13,7 +13,9 @@ PEERDIR(
     ydb/core/base
     ydb/core/http_proxy
     ydb/core/http_proxy/ut/datastreams_fixture
+    ydb/core/metering
     ydb/core/persqueue/ut/common
+    ydb/core/quoter/public
     ydb/core/testlib/default
     ydb/public/sdk/cpp/src/library/kafka
     ydb/library/aclib

--- a/ydb/core/persqueue/public/pq_rl_helpers.cpp
+++ b/ydb/core/persqueue/public/pq_rl_helpers.cpp
@@ -37,7 +37,16 @@ bool TRlHelpers::IsQuotaInflight() const {
 
 bool TRlHelpers::IsQuotaRequired() const {
     Y_ENSURE(MeteringMode.Defined());
-    return MeteringMode == NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS && Ctx;
+    return IsRequestUnitsMeteringMode() && Ctx;
+}
+
+bool TRlHelpers::IsRequestUnitsMeteringMode() const {
+    Y_ENSURE(MeteringMode.Defined());
+    return MeteringMode == NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS;
+}
+
+void TRlHelpers::SetRlContext(const TRlContext& ctx) {
+    Ctx = ctx;
 }
 
 void TRlHelpers::RequestInitQuota(ui64 amount, const TActorContext& ctx, NWilson::TTraceId traceId) {

--- a/ydb/core/persqueue/public/pq_rl_helpers.cpp
+++ b/ydb/core/persqueue/public/pq_rl_helpers.cpp
@@ -37,12 +37,7 @@ bool TRlHelpers::IsQuotaInflight() const {
 
 bool TRlHelpers::IsQuotaRequired() const {
     Y_ENSURE(MeteringMode.Defined());
-    return IsRequestUnitsMeteringMode() && Ctx;
-}
-
-bool TRlHelpers::IsRequestUnitsMeteringMode() const {
-    Y_ENSURE(MeteringMode.Defined());
-    return MeteringMode == NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS;
+    return MeteringMode == NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS && Ctx;
 }
 
 void TRlHelpers::SetRlContext(const TRlContext& ctx) {

--- a/ydb/core/persqueue/public/pq_rl_helpers.h
+++ b/ydb/core/persqueue/public/pq_rl_helpers.h
@@ -61,6 +61,17 @@ protected:
     bool IsQuotaRequired() const;
     bool IsQuotaInflight() const;
 
+    // True when the topic is metered by Request Units. Unlike IsQuotaRequired()
+    // this does not require the rate-limiter context to be resolved yet, so it
+    // can be used to decide whether the RL path has to be looked up.
+    bool IsRequestUnitsMeteringMode() const;
+
+    // Rate-limiter context is normally taken from the request in the
+    // constructor. Requests dispatched via DoLocalRpc (e.g. the SQS-over-topic
+    // HTTP proxy) carry no RlPath, so the context has to be built from the
+    // database serverless attributes and injected afterwards.
+    void SetRlContext(const TRlContext& ctx);
+
     void RequestInitQuota(ui64 amount, const TActorContext& ctx, NWilson::TTraceId traceId = {});
     void RequestDataQuota(ui64 amount, const TActorContext& ctx, NWilson::TTraceId traceId = {});
 
@@ -78,7 +89,7 @@ protected:
 
 private:
     const std::optional<TString> TopicPath;
-    const TRlContext Ctx;
+    TRlContext Ctx;
     const bool Subscribe;
     const TDuration WaitDuration;
 

--- a/ydb/core/persqueue/public/pq_rl_helpers.h
+++ b/ydb/core/persqueue/public/pq_rl_helpers.h
@@ -61,11 +61,6 @@ protected:
     bool IsQuotaRequired() const;
     bool IsQuotaInflight() const;
 
-    // True when the topic is metered by Request Units. Unlike IsQuotaRequired()
-    // this does not require the rate-limiter context to be resolved yet, so it
-    // can be used to decide whether the RL path has to be looked up.
-    bool IsRequestUnitsMeteringMode() const;
-
     // Rate-limiter context is normally taken from the request in the
     // constructor. Requests dispatched via DoLocalRpc (e.g. the SQS-over-topic
     // HTTP proxy) carry no RlPath, so the context has to be built from the

--- a/ydb/services/persqueue_v1/persqueue_ut.cpp
+++ b/ydb/services/persqueue_v1/persqueue_ut.cpp
@@ -46,6 +46,9 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/resources/ydb_resources.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/coordination/coordination.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/rate_limiter/rate_limiter.h>
+
 #include <thread>
 
 
@@ -7577,6 +7580,260 @@ Y_UNIT_TEST_SUITE(TPersQueueTest) {
     Y_UNIT_TEST(DefaultMeteringMode) {
         DefaultMeteringMode(false);
         DefaultMeteringMode(true);
+    }
+
+    // Complete end-to-end test: write to a topic via the Topics API and observe the
+    // resulting billing record (schema "ydb.serverless.requests.v1") produced by the
+    // Kesus rate-accounting subsystem.
+    //
+    // Path exercised:
+    //   TopicClient write session (StreamWrite, RLSWITCH(RuTopic))
+    //     -> gRPC check actor selects ruRlTopicConfig, reads DB user-attributes
+    //        serverless_rt_coordination_node_path + serverless_rt_topic_resource_ru
+    //        and calls SetRlPath()
+    //     -> write session (TRlHelpers) with MeteringMode == REQUEST_UNITS acquires RU
+    //        against the coordination-node resource
+    //     -> Kesus TRateAccounting (OnDemand.Enabled) emits a TBillRecord and sends
+    //        TEvWriteMeteringJson to MakeMeteringServiceID()
+    Y_UNIT_TEST(BillingRequestUnits) {
+        // Use a metering file to capture billing records emitted by the Kesus
+        // accounting actor. The TMeteringSink sends TEvWriteMeteringJson to the
+        // named metering service actor (YDB_METER), which is only registered when
+        // SetMeteringFilePath is configured.
+        auto meteringFile = MakeHolder<TTempFileHandle>();
+
+        TServerSettings serverSettings = PQSettings(0);
+        serverSettings.PQConfig.SetTopicsAreFirstClassCitizen(true);
+        serverSettings.PQConfig.SetRoot("/" + serverSettings.DomainName);
+        serverSettings.PQConfig.SetDatabase("/" + serverSettings.DomainName);
+        serverSettings.PQConfig.MutableBillingMeteringConfig()->SetEnabled(true);
+        serverSettings.PQConfig.MutableQuotingConfig()->SetQuotaWaitDurationMs(100);
+
+        serverSettings.SetMeteringFilePath(meteringFile->Name());
+        NPersQueue::TTestServer server(serverSettings);
+
+        server.EnableLogs({
+            NKikimrServices::PQ_WRITE_PROXY,
+            NKikimrServices::QUOTER_SERVICE,
+            NKikimrServices::QUOTER_PROXY,
+            NKikimrServices::KESUS_PROXY,
+            NKikimrServices::KESUS_PROXY_SERVICE,
+            NKikimrServices::KESUS_TABLET,
+            NKikimrServices::METERING_WRITER
+        }, NActors::NLog::PRI_DEBUG);
+
+        const TString coordinationNodePath = "/Root/RtCoordNode";
+        const TString resourcePath = "write_quota";
+        const TString topicPath = "billed-topic";
+        const TString DEFAULT_CLOUD_ID = "somecloud";
+        const TString DEFAULT_FOLDER_ID = "somefolder";
+
+        NYdb::TDriverConfig driverCfg;
+        driverCfg.SetEndpoint(TStringBuilder() << "localhost:" << server.GrpcPort)
+                 .SetDatabase("/" + serverSettings.DomainName)
+                 .SetAuthToken("root@builtin");
+        NYdb::TDriver driver(driverCfg);
+        // 1. Tell the database which coordination-node resource backs topic RU billing.
+        //    The gRPC request-check actor reads these database user attributes and, for
+        //    RuTopic-mode requests (StreamWrite), builds the rate-limiter path via
+        //    MakeRlPath() using the "serverless_rt_coordination_node_path" and
+        //    "serverless_rt_topic_resource_ru" keys. That RlPath propagates into the
+        //    write session actor's TRlContext, enabling RU quota acquisition/metering.
+        {
+            TClient alterClient(server.ServerSettings);
+            UNIT_ASSERT_VALUES_EQUAL(NMsgBusProxy::MSTATUS_OK,
+                alterClient.AlterUserAttributes("/", "Root",
+                    {
+                        {"serverless_rt_coordination_node_path", coordinationNodePath},
+                        {"serverless_rt_topic_resource_ru", resourcePath},
+                        {"cloud_id", DEFAULT_CLOUD_ID},
+                        {"database_id", "root"}
+                    }));
+            Sleep(TDuration::Seconds(5));
+        }
+
+        // 2. Create the coordination node and the metered resource with OnDemand billing.
+        {
+            NYdb::NCoordination::TClient coordinationClient(driver);
+            auto res = coordinationClient.CreateNode(coordinationNodePath).ExtractValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+        }
+        {
+            using namespace NYdb::NRateLimiter;
+            NYdb::NRateLimiter::TRateLimiterClient rateLimiterClient(driver);
+
+            const TString metricFieldsJson = TStringBuilder()
+                << R"({"version":"version",)"
+                << R"("schema":"ydb.serverless.requests.v1",)"
+                << R"("cloud_id":")" << DEFAULT_CLOUD_ID << R"(",)"
+                << R"("folder_id":")" << DEFAULT_FOLDER_ID << R"(",)"
+                << R"("resource_id":"/Root/)" << topicPath << R"(",)"
+                << R"("source_id":"mysource"})";
+
+            auto res = rateLimiterClient.CreateResource(coordinationNodePath, resourcePath,
+                TCreateResourceSettings()
+                    .MaxUnitsPerSecond(1000.0)
+                    // OnDemand accounting bucket capacity is
+                    //   OvershootCoefficient(default 1.1) * MaxUnitsPerSecond * PrefetchCoefficient.
+                    // For a root resource PrefetchCoefficient is NOT defaulted (only inherited from a
+                    // parent), so leaving it unset yields a zero-capacity OnDemand bucket and all the
+                    // consumption is classified as "overshoot" (which we don't meter) instead of
+                    // "ondemand" - no bill would ever be emitted. Set it explicitly (mirrors the
+                    // tablet-level reference test TestQuoterAccountResourcesOnDemand).
+                    .PrefetchCoefficient(300.0)
+                    // Accounting/billing time grid (mapped into the Kesus TAccountingConfig):
+                    //   ReportPeriod -> report_period_ms   (how often the quoter reports consumption)
+                    //   MeterPeriod  -> AccountPeriodMs     (accounting granularity)
+                    //   CollectPeriod-> collect_period_sec  (how far accounting lags wall clock)
+                    //   OnDemand.BillingPeriod -> billing_period_sec (bill cell width)
+                    // These MUST be small so that, within the test lifetime, accounting time
+                    // advances past whole billing cells and flushes bills while the session is
+                    // still reporting. The Kesus billing period is clamped to a minimum of 2s
+                    // (TimeGridForPeriod), so BillingPeriod must be >= 2s to avoid a grid reset.
+                    // Values mirror the reference tablet test TestQuoterAccountResourcesOnDemand.
+                    .MeteringConfig(TMeteringConfig()
+                        .Enabled(true)
+                        .ReportPeriod(std::chrono::milliseconds(1000))
+                        .MeterPeriod(std::chrono::milliseconds(1000))
+                        .CollectPeriod(std::chrono::seconds(2))
+                        .OnDemand(TMetric()
+                            .Enabled(true)
+                            .BillingPeriod(std::chrono::seconds(2))
+                            .MetricFieldsJson(metricFieldsJson))
+                        .Provisioned(TMetric()
+                            .Enabled(true)
+                            .BillingPeriod(std::chrono::seconds(2))
+                            .MetricFieldsJson(metricFieldsJson))
+                        .Overshoot(TMetric()
+                            .Enabled(true)
+                            .BillingPeriod(std::chrono::seconds(2))
+                            .MetricFieldsJson(metricFieldsJson)))
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+            Sleep(TDuration::Seconds(5));
+        }
+
+        // 3. Create a topic that meters in request units.
+        {
+            using namespace NYdb::NTopic;
+            auto topicClient = TTopicClient(driver);
+            auto res = topicClient.CreateTopic(topicPath, TCreateTopicSettings()
+                .MeteringMode(EMeteringMode::RequestUnits)
+                .BeginAddConsumer("reader").EndAddConsumer()
+            ).ExtractValueSync();
+            UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+        }
+        server.WaitInit(topicPath);
+
+        // 4. Write data to consume request units (WRITE_BLOCK_SIZE == 4KB per RU).
+        //    Spread the writes over many accounting/billing periods (with pauses between
+        //    batches) so the Kesus OnDemand accounting history accumulates non-zero
+        //    consumption across several complete billing periods.
+        //
+        //    IMPORTANT timing subtlety: the Kesus accounting lags real time by CollectPeriod
+        //    (2s), and TBillingMetric::SendBill (rate_accounting.cpp) only flushes an
+        //    accumulated 2s billing cell once accounting time advances into a *strictly
+        //    later* cell. The resource stops ticking its accounting as soon as the write
+        //    session disconnects, so the tail periods never flush. We therefore keep the
+        //    session writing across enough billing periods that earlier cells are flushed
+        //    *while the session is still active*.
+        const ui32 numBatches = 4;
+         using namespace NYdb::NTopic;
+        auto topicClient = TTopicClient(driver);
+        TWriteSessionSettings wSettings;
+        wSettings.Path(topicPath);
+        wSettings.ProducerId("srcId");
+        wSettings.DirectWriteToPartition(false);
+        wSettings.Codec(ECodec::RAW);
+        auto writer = topicClient.CreateSimpleBlockingWriteSession(wSettings);
+        Sleep(TDuration::MilliSeconds(5000));
+        for (ui32 batch = 0; batch < numBatches; ++batch) {
+            TString payload = NUnitTest::RandomString(5_KB, std::rand());
+            Sleep(TDuration::MilliSeconds(500));
+
+            UNIT_ASSERT(writer->Write(payload));
+        }
+        Sleep(TDuration::Seconds(2));
+
+        // 5. Read data back.
+        //    Billing on the read path is driven by TReadSessionActor via NPQ::TRlHelpers:
+        //    it acquires init quota (IsQuotaRequired) and per-response data quota
+        //    (CalcRuConsumption + MaybeRequestQuota), which reports RU consumption to the
+        //    same Kesus resource used for writes (serverless_rt_topic_resource_ru).
+        //
+        //    Same timing subtlety as writes: the read-consumption cells only flush once
+        //    accounting time advances into a strictly later billing cell *while the resource
+        //    is still active/reporting*. A tight read burst followed by an immediate session
+        //    close would leave the read cells unaccounted. We therefore keep the read session
+        //    open and pace the reads across several billing periods so earlier read cells are
+        //    flushed while the session is still alive.
+
+        TReadSessionSettings rSettings;
+        rSettings.ConsumerName("reader").AppendTopics({topicPath});
+        auto readSession = topicClient.CreateReadSession(rSettings);
+
+        ui32 totalMessages = 0;
+        Cerr << "Start reads" << Endl;
+        while (totalMessages < numBatches) {
+            auto ev = readSession->GetEvent(true);
+            UNIT_ASSERT(ev.has_value());
+
+            auto spsEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*ev);
+            if (spsEv) {
+                spsEv->Confirm();
+                Cerr << "Got start stream event" << Endl;
+                continue;
+            }
+            auto dataEv = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*ev);
+            UNIT_ASSERT(dataEv);
+            const auto& messages = dataEv->GetMessages();
+            totalMessages += messages.size();
+            Cerr << "Got data event with total " << messages.size() << " messages, current total messages: " << totalMessages << Endl;
+        }
+
+        Sleep(TDuration::Seconds(5));
+
+        // 6. Read the metering file and find our billing record.
+        //    The metering writer actor (registered via SetMeteringFilePath) writes each
+        //    TEvWriteMeteringJson as a single JSON line to the file.
+        if (meteringFile->IsOpen()) {
+            meteringFile->Flush();
+            meteringFile->Close();
+        }
+        auto input = TFileInput(TFile(meteringFile->Name(), RdOnly | OpenExisting));
+
+        TString line;
+        bool found = false;
+        while (input.ReadLine(line)) {
+            Cerr << "Metering file line: " << line << Endl;
+            NJson::TJsonValue lineJson;
+            if (!NJson::ReadJsonTree(line, &lineJson)) {
+                continue;
+            }
+            auto& map = lineJson.GetMap();
+            if (map.contains("schema") &&
+                map.at("schema").GetString() == "ydb.serverless.requests.v1") {
+
+                UNIT_ASSERT_C(!line.empty(), "No billing record with schema 'ydb.serverless.requests.v1' found in the metering file");
+                Cerr << "Captured bill record: " << line << Endl;
+
+                NJson::TJsonValue json;
+                UNIT_ASSERT(NJson::ReadJsonTree(line, &json));
+
+                UNIT_ASSERT_VALUES_EQUAL(json["schema"].GetString(), "ydb.serverless.requests.v1");
+                UNIT_ASSERT_VALUES_EQUAL(json["cloud_id"].GetString(), DEFAULT_CLOUD_ID);
+                UNIT_ASSERT_VALUES_EQUAL(json["folder_id"].GetString(), DEFAULT_FOLDER_ID);
+                UNIT_ASSERT_VALUES_EQUAL(json["resource_id"].GetString(), TString("/Root/") + topicPath);
+                UNIT_ASSERT_VALUES_EQUAL(json["source_id"].GetString(), "mysource");
+                UNIT_ASSERT_VALUES_EQUAL(json["usage"]["unit"].GetString(), "request_unit");
+                UNIT_ASSERT_C(json["usage"]["quantity"].GetInteger() > 0,
+                    "Expected a positive billed quantity, got: " << line);
+                found = true;
+            }
+        }
+        UNIT_ASSERT_C(found, "No billing record with schema 'ydb.serverless.requests.v1' found in the metering file");
+
+        writer->Close(TDuration::Seconds(30));
     }
 
     Y_UNIT_TEST(ConsumerAdvancedMonitoringSettings) {

--- a/ydb/services/persqueue_v1/ut/ya.make
+++ b/ydb/services/persqueue_v1/ut/ya.make
@@ -56,6 +56,8 @@ PEERDIR(
     ydb/public/sdk/cpp/src/client/persqueue_public
     ydb/public/sdk/cpp/src/client/table
     ydb/public/sdk/cpp/src/client/topic
+    ydb/public/sdk/cpp/src/client/coordination
+    ydb/public/sdk/cpp/src/client/rate_limiter
     ydb/public/sdk/cpp/src/client/proto
     ydb/services/persqueue_v1
 )

--- a/ydb/services/sqs_topic/actor.h
+++ b/ydb/services/sqs_topic/actor.h
@@ -1,12 +1,22 @@
 #pragma once
 
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
 #include <ydb/core/persqueue/public/describer/describer.h>
+#include <ydb/core/persqueue/public/pq_rl_helpers.h>
 #include <ydb/core/protos/sqs.pb.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/aclib/aclib.h>
 #include <ydb/library/http_proxy/error/error.h>
 #include <ydb/services/lib/actors/pq_schema_actor.h>
 
 namespace NKikimr::NSqsTopic::V1 {
+
+    // Database user-attribute keys that carry the rate-limiter (RU billing)
+    // coordination node and topic resource paths. Kept in sync with the gRPC
+    // request check actor (ruRlTopicConfig).
+    inline constexpr TStringBuf RL_COORDINATION_NODE_ATTR = "serverless_rt_coordination_node_path";
+    inline constexpr TStringBuf RL_TOPIC_RESOURCE_ATTR = "serverless_rt_topic_resource_ru";
 
     template<class TDerived, class TRequest>
     class TGrpcActorBase: public NGRpcProxy::V1::TPQGrpcSchemaBase<TDerived, TRequest> {
@@ -49,6 +59,58 @@ namespace NKikimr::NSqsTopic::V1 {
                 return MakeIntrusive<NACLib::TUserToken>(token);
             }
             return nullptr;
+        }
+
+        // Requests dispatched via DoLocalRpc carry no RlPath, so the rate-limiter
+        // coordination node / resource path have to be resolved from the database
+        // user-attributes (Kafka-proxy does the same for its RU billing). The
+        // navigate is tagged with a distinct scheme-cache cookie so the shared
+        // TEvNavigateKeySetResult handler can tell it apart from the topic
+        // describe navigate (which uses the default cookie 0).
+        static constexpr ui64 RlPathNavigateCookie = 1;
+
+        void SendRlPathNavigate() {
+            auto request = MakeHolder<NSchemeCache::TSchemeCacheNavigate>();
+            NSchemeCache::TSchemeCacheNavigate::TEntry entry;
+            entry.Path = NKikimr::SplitPath(this->Database);
+            entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpPath;
+            entry.SyncVersion = false;
+            request->ResultSet.emplace_back(std::move(entry));
+            request->DatabaseName = this->Database;
+            request->Cookie = RlPathNavigateCookie;
+            this->Send(MakeSchemeCacheID(), new TEvTxProxySchemeCache::TEvNavigateKeySet(request.Release()));
+        }
+
+        static bool IsRlPathNavigateResponse(const TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            return ev->Get()->Request->Cookie == RlPathNavigateCookie;
+        }
+
+        // Builds a rate-limiter context from the serverless_rt_* database
+        // attributes. Returns Nothing() when the attributes are absent, in which
+        // case the topic is simply not RU-metered and no quota is charged.
+        TMaybe<NPQ::TRlContext> ExtractRlContext(const TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) const {
+            const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
+            if (result->ResultSet.empty()) {
+                return Nothing();
+            }
+            const auto& entry = result->ResultSet.front();
+            if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                return Nothing();
+            }
+
+            TString coordinationNode;
+            TString resourcePath;
+            if (const auto* value = entry.Attributes.FindPtr(TString(RL_COORDINATION_NODE_ATTR))) {
+                coordinationNode = *value;
+            }
+            if (const auto* value = entry.Attributes.FindPtr(TString(RL_TOPIC_RESOURCE_ATTR))) {
+                resourcePath = *value;
+            }
+            if (coordinationNode.empty() || resourcePath.empty()) {
+                return Nothing();
+            }
+
+            return NPQ::TRlContext(coordinationNode, resourcePath, this->Database, this->Request_->GetSerializedToken());
         }
     };
 }

--- a/ydb/services/sqs_topic/billing.h
+++ b/ydb/services/sqs_topic/billing.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <util/generic/size_literals.h>
+#include <util/system/types.h>
+
+#include <cmath>
+
+namespace NKikimr::NSqsTopic::V1::NBilling {
+
+    // Block sizes used to convert a transferred payload into a number of
+    // Request Units (one block == one RU). Kept in sync with the persqueue
+    // read/write session actors. Reads are billed in coarser 8 KiB blocks than
+    // writes.
+    inline constexpr ui64 WRITE_BLOCK_SIZE = 4_KB;
+    inline constexpr ui64 READ_BLOCK_SIZE = 8_KB;
+
+    // Costs are expressed as floating-point RU amounts so that fractional
+    // per-message / per-block / base prices can be configured. The final charge
+    // is rounded to a whole number of Request Units before it is sent to the
+    // rate limiter.
+
+    // Base RU cost charged for a request regardless of the transferred amount.
+    inline constexpr double WRITE_BASE_COST = 1.0;
+    inline constexpr double READ_BASE_COST = 1.0;
+    inline constexpr double DELETE_BASE_COST = 1.0;
+
+    // RU cost charged per payload block (see WRITE_BLOCK_SIZE / READ_BLOCK_SIZE).
+    inline constexpr double WRITE_COST_PER_BLOCK = 1.0;
+    inline constexpr double READ_COST_PER_BLOCK = 1.0;
+
+    // Flat RU cost charged per message handled by the request, on top of the
+    // base and block-based payload costs. Charged for every successfully written
+    // message (write) or every returned message (read).
+    inline constexpr double WRITE_COST_PER_MESSAGE = 1.0;
+    inline constexpr double READ_COST_PER_MESSAGE = 1.0;
+
+    // Flat RU cost charged per successfully deleted message.
+    inline constexpr double DELETE_COST_PER_MESSAGE = 1.0;
+
+    // FIFO ordering and content-based deduplication require extra work on the
+    // server side, so the corresponding requests are charged more.
+    inline constexpr double FIFO_COST_MULTIPLIER = 2.0;
+    inline constexpr double DEDUP_COST_MULTIPLIER = 2.0;
+
+    inline double CostMultiplier(bool fifo, bool dedup) {
+        double multiplier = 1.0;
+        if (fifo) {
+            multiplier *= FIFO_COST_MULTIPLIER;
+        }
+        if (dedup) {
+            multiplier *= DEDUP_COST_MULTIPLIER;
+        }
+        return multiplier;
+    }
+
+    // Rounds a floating-point RU amount to the whole number of Request Units
+    // that is actually charged.
+    inline ui64 RoundRu(double ru) {
+        if (ru <= 0.0) {
+            return 0;
+        }
+        return static_cast<ui64>(std::llround(ru));
+    }
+
+    // payloadBlocks is the block-based consumption produced by
+    // TRlHelpers::CalcRuConsumption(payloadSize). messageCount is the number of
+    // messages handled by the request, charged on top of the base and payload
+    // costs.
+    inline ui64 CalcWriteRu(ui64 payloadBlocks, ui64 messageCount, bool fifo, bool dedup) {
+        const double ru = (WRITE_BASE_COST
+                + payloadBlocks * WRITE_COST_PER_BLOCK
+                + messageCount * WRITE_COST_PER_MESSAGE)
+            * CostMultiplier(fifo, dedup);
+        return RoundRu(ru);
+    }
+
+    inline ui64 CalcReadRu(ui64 payloadBlocks, ui64 messageCount, bool fifo, bool dedup) {
+        const double ru = (READ_BASE_COST
+                + payloadBlocks * READ_COST_PER_BLOCK
+                + messageCount * READ_COST_PER_MESSAGE)
+            * CostMultiplier(fifo, dedup);
+        return RoundRu(ru);
+    }
+
+    inline ui64 CalcDeleteRu(ui64 messageCount, bool fifo, bool dedup) {
+        const double ru = (DELETE_BASE_COST + messageCount * DELETE_COST_PER_MESSAGE)
+            * CostMultiplier(fifo, dedup);
+        return RoundRu(ru);
+    }
+
+} // namespace NKikimr::NSqsTopic::V1::NBilling

--- a/ydb/services/sqs_topic/billing.h
+++ b/ydb/services/sqs_topic/billing.h
@@ -11,46 +11,37 @@ namespace NKikimr::NSqsTopic::V1::NBilling {
     // Request Units (one block == one RU). Kept in sync with the persqueue
     // read/write session actors. Reads are billed in coarser 8 KiB blocks than
     // writes.
-    inline constexpr ui64 WRITE_BLOCK_SIZE = 4_KB;
-    inline constexpr ui64 READ_BLOCK_SIZE = 8_KB;
+    constexpr ui64 WRITE_BLOCK_SIZE = 4_KB;
+    constexpr ui64 READ_BLOCK_SIZE = 8_KB;
 
     // Costs are expressed as floating-point RU amounts so that fractional
-    // per-message / per-block / base prices can be configured. The final charge
+    // per-block / base prices can be configured. The final charge
     // is rounded to a whole number of Request Units before it is sent to the
     // rate limiter.
 
     // Base RU cost charged for a request regardless of the transferred amount.
-    inline constexpr double WRITE_BASE_COST = 1.0;
-    inline constexpr double READ_BASE_COST = 1.0;
-    inline constexpr double DELETE_BASE_COST = 1.0;
+    constexpr double WRITE_BASE_COST = 2.0;
+    constexpr double READ_BASE_COST = 2.0;
+    constexpr double DELETE_BASE_COST = 2.0;
 
     // RU cost charged per payload block (see WRITE_BLOCK_SIZE / READ_BLOCK_SIZE).
-    inline constexpr double WRITE_COST_PER_BLOCK = 1.0;
-    inline constexpr double READ_COST_PER_BLOCK = 1.0;
-
-    // Flat RU cost charged per message handled by the request, on top of the
-    // base and block-based payload costs. Charged for every successfully written
-    // message (write) or every returned message (read).
-    inline constexpr double WRITE_COST_PER_MESSAGE = 1.0;
-    inline constexpr double READ_COST_PER_MESSAGE = 1.0;
-
-    // Flat RU cost charged per successfully deleted message.
-    inline constexpr double DELETE_COST_PER_MESSAGE = 1.0;
+    constexpr double WRITE_COST_PER_BLOCK = 1.0;
+    constexpr double READ_COST_PER_BLOCK = 1.0;
 
     // FIFO ordering and content-based deduplication require extra work on the
     // server side, so the corresponding requests are charged more.
-    inline constexpr double FIFO_COST_MULTIPLIER = 2.0;
-    inline constexpr double DEDUP_COST_MULTIPLIER = 2.0;
+    constexpr double FIFO_COST_ADJUNCT = 1.0;
+    constexpr double DEDUP_COST_ADJUNCT = 1.0;
 
-    inline double CostMultiplier(bool fifo, bool dedup) {
-        double multiplier = 1.0;
+    inline double CostAdjunct(bool fifo, bool dedup) {
+        double adjunct = 0.0;
         if (fifo) {
-            multiplier *= FIFO_COST_MULTIPLIER;
+            adjunct += FIFO_COST_ADJUNCT;
         }
         if (dedup) {
-            multiplier *= DEDUP_COST_MULTIPLIER;
+            adjunct += DEDUP_COST_ADJUNCT;
         }
-        return multiplier;
+        return adjunct;
     }
 
     // Rounds a floating-point RU amount to the whole number of Request Units
@@ -63,28 +54,10 @@ namespace NKikimr::NSqsTopic::V1::NBilling {
     }
 
     // payloadBlocks is the block-based consumption produced by
-    // TRlHelpers::CalcRuConsumption(payloadSize). messageCount is the number of
-    // messages handled by the request, charged on top of the base and payload
-    // costs.
-    inline ui64 CalcWriteRu(ui64 payloadBlocks, ui64 messageCount, bool fifo, bool dedup) {
-        const double ru = (WRITE_BASE_COST
-                + payloadBlocks * WRITE_COST_PER_BLOCK
-                + messageCount * WRITE_COST_PER_MESSAGE)
-            * CostMultiplier(fifo, dedup);
-        return RoundRu(ru);
-    }
-
-    inline ui64 CalcReadRu(ui64 payloadBlocks, ui64 messageCount, bool fifo, bool dedup) {
-        const double ru = (READ_BASE_COST
-                + payloadBlocks * READ_COST_PER_BLOCK
-                + messageCount * READ_COST_PER_MESSAGE)
-            * CostMultiplier(fifo, dedup);
-        return RoundRu(ru);
-    }
-
-    inline ui64 CalcDeleteRu(ui64 messageCount, bool fifo, bool dedup) {
-        const double ru = (DELETE_BASE_COST + messageCount * DELETE_COST_PER_MESSAGE)
-            * CostMultiplier(fifo, dedup);
+    // TRlHelpers::CalcRuConsumption(payloadSize). 
+    inline ui64 CalcRu(ui64 payloadBlocks, double baseCost, double costPerBlock, bool fifo, bool dedup) {
+        const double ru = baseCost
+                + payloadBlocks * costPerBlock + CostAdjunct(fifo, dedup);
         return RoundRu(ru);
     }
 

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -34,6 +34,9 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
+#include <ydb/core/persqueue/public/pq_rl_helpers.h>
+
+#include <ydb/services/sqs_topic/billing.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
@@ -57,15 +60,17 @@ namespace NKikimr::NSqsTopic::V1 {
     }
 
     template <class TDerived, class TServiceRequest>
-    class TDeleteMessageActorBase: public TQueueUrlHolder, public TGrpcActorBase<TDeleteMessageActorBase<TDerived, TServiceRequest>, TServiceRequest> {
+    class TDeleteMessageActorBase: public TQueueUrlHolder, public TGrpcActorBase<TDeleteMessageActorBase<TDerived, TServiceRequest>, TServiceRequest>, private NPQ::TRlHelpers {
     protected:
         using TBase = TGrpcActorBase<TDeleteMessageActorBase, TServiceRequest>;
         using TProtoRequest = typename TBase::TProtoRequest;
+        using EWakeupTag = NPQ::TRlHelpers::EWakeupTag;
 
     public:
         TDeleteMessageActorBase(NKikimr::NGRpcService::IRequestOpCtx* request)
             : TQueueUrlHolder(ParseQueueUrlFromRequest<TProtoRequest>(request))
             , TBase(request, GetTopicPath().value_or(""))
+            , NPQ::TRlHelpers({}, request, NBilling::WRITE_BLOCK_SIZE, false)
         {
         }
 
@@ -73,6 +78,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Bootstrap(const NActors::TActorContext& ctx) {
             TBase::Bootstrap(ctx);
+            NPQ::TRlHelpers::Bootstrap(this->SelfId(), ctx);
 
             if (this->Request().queue_url().empty()) {
                 return this->ReplyWithError(MakeError(NSQS::NErrors::MISSING_PARAMETER, "No QueueUrl parameter."));
@@ -123,7 +129,7 @@ namespace NKikimr::NSqsTopic::V1 {
                         TDerived::Method)
                 });
 
-            NPQ::NMLP::TCommitterSettings committerSettings{
+            CommitterSettings_ = NPQ::NMLP::TCommitterSettings{
                 .DatabasePath = this->QueueUrl_->Database,
                 .TopicName = FullTopicPath_,
                 .Consumer = ResolveConsumerNameFromQueueUrl(this->QueueUrl_->Consumer, ctx),
@@ -131,16 +137,28 @@ namespace NKikimr::NSqsTopic::V1 {
                 .UserToken = this->Request_->GetInternalToken(),
             };
 
-            std::unique_ptr<IActor> actorPtr{NKikimr::NPQ::NMLP::CreateCommitter(this->SelfId(), std::move(committerSettings))};
-            CommiterActorId_ = ctx.RegisterWithSameMailbox(actorPtr.release());
+            this->SendDescribeProposeRequest(ctx);
         }
 
         void StateWork(TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
-                hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse); // override for testing
+                hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse);
                 HFunc(NPQ::NMLP::TEvChangeResponse, Handle);
+                HFunc(TEvents::TEvWakeup, HandleWakeupTag);
                 default:
                     TBase::StateWork(ev);
+            }
+        }
+
+        void HandleWakeupTag(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
+            switch (static_cast<EWakeupTag>(ev->Get()->Tag)) {
+                case EWakeupTag::RlAllowed:
+                    return static_cast<TDerived*>(this)->ReplyAndDie(ctx);
+                case EWakeupTag::RlNoResource:
+                    return this->ReplyWithError(MakeError(NSQS::NErrors::THROTTLING_EXCEPTION, "Request was throttled by the rate limiter"));
+                default:
+                    OnWakeup(static_cast<EWakeupTag>(ev->Get()->Tag));
+                    return;
             }
         }
 
@@ -200,6 +218,12 @@ namespace NKikimr::NSqsTopic::V1 {
                         "failed")
                 });
 
+            if (IsQuotaRequired() && successCount > 0) {
+                const ui64 ru = NBilling::CalcDeleteRu(static_cast<ui64>(successCount), Fifo_, Dedup_);
+                Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
+                return;
+            }
+
             static_cast<TDerived*>(this)->ReplyAndDie(ctx);
         }
 
@@ -207,11 +231,54 @@ namespace NKikimr::NSqsTopic::V1 {
             if (CommiterActorId_) {
                 ctx.Send(CommiterActorId_, new TEvents::TEvPoison);
             }
+            NPQ::TRlHelpers::PassAway(this->SelfId());
             this->TBase::Die(ctx);
         }
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-            Y_UNUSED(ev);
+            // Second navigate: resolve the rate-limiter path from the database
+            // serverless attributes, then start the committer.
+            if (TBase::IsRlPathNavigateResponse(ev)) {
+                if (auto rlContext = this->ExtractRlContext(ev)) {
+                    SetRlContext(*rlContext);
+                }
+                CreateCommitter();
+                return;
+            }
+
+            const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
+            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            const auto& response = result->ResultSet.front();
+            if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                if (response.Kind != NSchemeCache::TSchemeCacheNavigate::KindTopic) {
+                    return this->ReplyWithError(MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, TStringBuilder() << "Queue name used by another scheme object"));
+                }
+                // ok
+            } else if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown) {
+                return this->ReplyWithError(MakeError(NKikimr::NSQS::NErrors::NON_EXISTENT_QUEUE, std::format("The specified queue doesn't exist")));
+            } else {
+                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                                                TStringBuilder() << "Failed to describe topic: " << response.Status));
+            }
+
+            const auto& pqTabletConfig = response.PQGroupInfo->Description.GetPQTabletConfig();
+            SetMeteringMode(pqTabletConfig.GetMeteringMode());
+            Fifo_ = QueueUrl_->Fifo;
+            Dedup_ = Fifo_ && pqTabletConfig.GetContentBasedDeduplication();
+
+            // RU-metered topics need the rate-limiter path, which is not carried
+            // by DoLocalRpc requests. Resolve it from the database attributes
+            // before committing so the charge in Handle(TEvChangeResponse) can fire.
+            if (IsRequestUnitsMeteringMode()) {
+                this->SendRlPathNavigate();
+                return;
+            }
+            CreateCommitter();
+        }
+
+        void CreateCommitter() {
+            std::unique_ptr<IActor> actorPtr{NKikimr::NPQ::NMLP::CreateCommitter(this->SelfId(), std::move(*CommitterSettings_))};
+            CommiterActorId_ = this->ActorContext().RegisterWithSameMailbox(actorPtr.release());
         }
 
     protected:
@@ -224,6 +291,9 @@ namespace NKikimr::NSqsTopic::V1 {
         THashMap<TString, NSQS::TError> Failed_;
         THashSet<TString> Success_;
         TMap<NPQ::NMLP::TMessageId, TString, TMessageIdLess> PositionToIdMap_;
+        TMaybe<NPQ::NMLP::TCommitterSettings> CommitterSettings_;
+        bool Fifo_ = false;
+        bool Dedup_ = false;
     };
 
     class TDeleteMessageActor: public TDeleteMessageActorBase<TDeleteMessageActor, TEvSqsTopicDeleteMessageRequest> {

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -60,7 +60,11 @@ namespace NKikimr::NSqsTopic::V1 {
     }
 
     template <class TDerived, class TServiceRequest>
-    class TDeleteMessageActorBase: public TQueueUrlHolder, public TGrpcActorBase<TDeleteMessageActorBase<TDerived, TServiceRequest>, TServiceRequest>, private NPQ::TRlHelpers {
+    class TDeleteMessageActorBase:
+        public TQueueUrlHolder,
+        public TGrpcActorBase<TDeleteMessageActorBase<TDerived, TServiceRequest>, TServiceRequest>,
+        private NPQ::TRlHelpers,
+        public TCdcStreamCompatible {
     protected:
         using TBase = TGrpcActorBase<TDeleteMessageActorBase, TServiceRequest>;
         using TProtoRequest = typename TBase::TProtoRequest;
@@ -112,8 +116,6 @@ namespace NKikimr::NSqsTopic::V1 {
                 }
             }
 
-            this->Become(&TDeleteMessageActorBase::StateWork);
-
             if (requestList.empty()) {
                 static_cast<TDerived*>(this)->ReplyAndDie(ctx);
                 return;
@@ -137,23 +139,28 @@ namespace NKikimr::NSqsTopic::V1 {
                 .UserToken = this->Request_->GetInternalToken(),
             };
 
+            NACLib::TUserToken token(this->Request_->GetSerializedToken());
+            ShouldBeCharged_ = FindPtr(AppData(ctx)->PQConfig.GetNonChargeableUser(), token.GetUserSID()) == nullptr;
+
             this->SendDescribeProposeRequest(ctx);
+            this->Become(&TDeleteMessageActorBase::StateWork);
         }
 
         void StateWork(TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse);
                 HFunc(NPQ::NMLP::TEvChangeResponse, Handle);
-                HFunc(TEvents::TEvWakeup, HandleWakeupTag);
+                hFunc(TEvents::TEvWakeup, HandleWakeupTag);
                 default:
                     TBase::StateWork(ev);
             }
         }
 
-        void HandleWakeupTag(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
+        void HandleWakeupTag(TEvents::TEvWakeup::TPtr& ev) {
             switch (static_cast<EWakeupTag>(ev->Get()->Tag)) {
                 case EWakeupTag::RlAllowed:
-                    return static_cast<TDerived*>(this)->ReplyAndDie(ctx);
+                    CreateCommitter();
+                    return;
                 case EWakeupTag::RlNoResource:
                     return this->ReplyWithError(MakeError(NSQS::NErrors::THROTTLING_EXCEPTION, "Request was throttled by the rate limiter"));
                 default:
@@ -218,12 +225,6 @@ namespace NKikimr::NSqsTopic::V1 {
                         "failed")
                 });
 
-            if (IsQuotaRequired() && successCount > 0) {
-                const ui64 ru = NBilling::CalcDeleteRu(static_cast<ui64>(successCount), Fifo_, Dedup_);
-                Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
-                return;
-            }
-
             static_cast<TDerived*>(this)->ReplyAndDie(ctx);
         }
 
@@ -241,6 +242,11 @@ namespace NKikimr::NSqsTopic::V1 {
             if (TBase::IsRlPathNavigateResponse(ev)) {
                 if (auto rlContext = this->ExtractRlContext(ev)) {
                     SetRlContext(*rlContext);
+                    if (IsQuotaRequired()) {
+                        const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
+                        Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
+                        return;
+                    }
                 }
                 CreateCommitter();
                 return;
@@ -250,6 +256,12 @@ namespace NKikimr::NSqsTopic::V1 {
             Y_ABORT_UNLESS(result->ResultSet.size() == 1);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
+                    if (this->ProcessCdc(response)) {
+                        return;
+                    }
+                    return this->ReplyWithError(MakeError(NSQS::NErrors::UNSUPPORTED_OPERATION, TStringBuilder() << "Deleting from the Changefeed is not supported"));
+                }
                 if (response.Kind != NSchemeCache::TSchemeCacheNavigate::KindTopic) {
                     return this->ReplyWithError(MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, TStringBuilder() << "Queue name used by another scheme object"));
                 }
@@ -261,24 +273,21 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
 
-            const auto& pqTabletConfig = response.PQGroupInfo->Description.GetPQTabletConfig();
-            SetMeteringMode(pqTabletConfig.GetMeteringMode());
-            Fifo_ = QueueUrl_->Fifo;
-            Dedup_ = Fifo_ && pqTabletConfig.GetContentBasedDeduplication();
+            if (ShouldBeCharged_) {
+                // Always put in request units metering mode
+                SetMeteringMode(NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS);
 
-            // RU-metered topics need the rate-limiter path, which is not carried
-            // by DoLocalRpc requests. Resolve it from the database attributes
-            // before committing so the charge in Handle(TEvChangeResponse) can fire.
-            if (IsRequestUnitsMeteringMode()) {
+                // RU-metered topics need the rate-limiter path, which is not carried
+                // by DoLocalRpc requests. Resolve it from the database attributes
+                // before committing so the charge in Handle(TEvChangeResponse) can fire.
                 this->SendRlPathNavigate();
-                return;
+            } else {
+                CreateCommitter();
             }
-            CreateCommitter();
         }
 
         void CreateCommitter() {
-            std::unique_ptr<IActor> actorPtr{NKikimr::NPQ::NMLP::CreateCommitter(this->SelfId(), std::move(*CommitterSettings_))};
-            CommiterActorId_ = this->ActorContext().RegisterWithSameMailbox(actorPtr.release());
+            CommiterActorId_ = this->ActorContext().RegisterWithSameMailbox(NKikimr::NPQ::NMLP::CreateCommitter(this->SelfId(), std::move(*CommitterSettings_)));
         }
 
     protected:
@@ -287,13 +296,12 @@ namespace NKikimr::NSqsTopic::V1 {
         }
 
     protected:
+        bool ShouldBeCharged_{};
         TActorId CommiterActorId_;
         THashMap<TString, NSQS::TError> Failed_;
         THashSet<TString> Success_;
         TMap<NPQ::NMLP::TMessageId, TString, TMessageIdLess> PositionToIdMap_;
         TMaybe<NPQ::NMLP::TCommitterSettings> CommitterSettings_;
-        bool Fifo_ = false;
-        bool Dedup_ = false;
     };
 
     class TDeleteMessageActor: public TDeleteMessageActorBase<TDeleteMessageActor, TEvSqsTopicDeleteMessageRequest> {

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -39,6 +39,9 @@
 
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/mlp/mlp.h>
+#include <ydb/core/persqueue/public/pq_rl_helpers.h>
+
+#include <ydb/services/sqs_topic/billing.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <library/cpp/digest/md5/md5.h>
@@ -53,15 +56,17 @@ namespace NKikimr::NSqsTopic::V1 {
 
 
 
-    class TReceiveMessageActor: public TQueueUrlHolder, public TGrpcActorBase<TReceiveMessageActor, TEvSqsTopicReceiveMessageRequest> {
+    class TReceiveMessageActor: public TQueueUrlHolder, public TGrpcActorBase<TReceiveMessageActor, TEvSqsTopicReceiveMessageRequest>, private NPQ::TRlHelpers {
     protected:
         using TBase = TGrpcActorBase<TReceiveMessageActor, TEvSqsTopicReceiveMessageRequest>;
         using TProtoRequest = typename TBase::TProtoRequest;
+        using EWakeupTag = NPQ::TRlHelpers::EWakeupTag;
 
     public:
         TReceiveMessageActor(NKikimr::NGRpcService::IRequestOpCtx* request)
             : TQueueUrlHolder(ParseQueueUrl(GetRequest<TProtoRequest>(request).queue_url()))
             , TBase(request, TQueueUrlHolder::GetTopicPath().value_or(""))
+            , NPQ::TRlHelpers({}, request, NBilling::READ_BLOCK_SIZE, false)
         {
         }
 
@@ -69,6 +74,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Bootstrap(const NActors::TActorContext& ctx) {
             TBase::Bootstrap(ctx);
+            NPQ::TRlHelpers::Bootstrap(this->SelfId(), ctx);
 
             if (this->Request().queue_url().empty()) {
                 return this->ReplyWithError(MakeError(NSQS::NErrors::MISSING_PARAMETER, "No QueueUrl parameter."));
@@ -81,9 +87,9 @@ namespace NKikimr::NSqsTopic::V1 {
             if (!readerSettings.Defined()) {
                 return;
             }
+            ReaderSettings_ = std::move(readerSettings);
 
-            std::unique_ptr<IActor> actorPtr{NKikimr::NPQ::NMLP::CreateReader(this->SelfId(), std::move(*readerSettings))};
-            ReaderActorId_ = ctx.RegisterWithSameMailbox(actorPtr.release());
+            this->SendDescribeProposeRequest(ctx);
             this->Become(&TReceiveMessageActor::StateWork);
         }
 
@@ -136,10 +142,23 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void StateWork(TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
-                hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse); // override for testing
+                hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse);
                 HFunc(NKikimr::NPQ::NMLP::TEvReadResponse, Handle);
+                HFunc(TEvents::TEvWakeup, HandleWakeupTag);
                 default:
                     TBase::StateWork(ev);
+            }
+        }
+
+        void HandleWakeupTag(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
+            switch (static_cast<EWakeupTag>(ev->Get()->Tag)) {
+                case EWakeupTag::RlAllowed:
+                    return SendReply(ctx);
+                case EWakeupTag::RlNoResource:
+                    return ReplyWithError(MakeError(NSQS::NErrors::THROTTLING_EXCEPTION, "Request was throttled by the rate limiter"));
+                default:
+                    OnWakeup(static_cast<EWakeupTag>(ev->Get()->Tag));
+                    return;
             }
         }
 
@@ -212,6 +231,13 @@ namespace NKikimr::NSqsTopic::V1 {
         void Handle(NKikimr::NPQ::NMLP::TEvReadResponse::TPtr& ev, const TActorContext& ctx) {
             ReaderActorId_ = {};
             auto& response = *ev->Get();
+
+            // The message payload must be measured before ConvertMessage() moves
+            // the data out of the response.
+            PayloadSize_ = 0;
+            for (const auto& message : response.Messages) {
+                PayloadSize_ += message.Data.size();
+            }
             switch (response.Status) {
                 case Ydb::StatusIds::SUCCESS: {
                     break;
@@ -249,24 +275,78 @@ namespace NKikimr::NSqsTopic::V1 {
                     });
             }
 
-            Ydb::Ymq::V1::ReceiveMessageResult result;
+            Result_.Clear();
             for (auto& message : response.Messages) {
                 Ydb::Ymq::V1::Message m = ConvertMessage(std::move(message), ctx);
-                *result.add_messages() = std::move(m);
+                *Result_.add_messages() = std::move(m);
             }
 
-            return this->ReplyWithResult(Ydb::StatusIds::SUCCESS, result, ctx);
+            if (IsQuotaRequired()) {
+                const ui64 ru = NBilling::CalcReadRu(
+                    CalcRuConsumption(PayloadSize_), Result_.messages_size(), Fifo_, Dedup_);
+                Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
+                return;
+            }
+
+            return SendReply(ctx);
+        }
+
+        void SendReply(const TActorContext& ctx) {
+            return this->ReplyWithResult(Ydb::StatusIds::SUCCESS, Result_, ctx);
         }
 
         void Die(const TActorContext& ctx) override {
             if (ReaderActorId_) {
                 ctx.Send(ReaderActorId_, new TEvents::TEvPoison);
             }
+            NPQ::TRlHelpers::PassAway(this->SelfId());
             this->TBase::Die(ctx);
         }
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-            Y_UNUSED(ev);
+            // Second navigate: resolve the rate-limiter path from the database
+            // serverless attributes, then start the reader.
+            if (TBase::IsRlPathNavigateResponse(ev)) {
+                if (auto rlContext = this->ExtractRlContext(ev)) {
+                    SetRlContext(*rlContext);
+                }
+                CreateReader();
+                return;
+            }
+
+            const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
+            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            const auto& response = result->ResultSet.front();
+            if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                if (response.Kind != NSchemeCache::TSchemeCacheNavigate::KindTopic) {
+                    return this->ReplyWithError(MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, TStringBuilder() << "Queue name used by another scheme object"));
+                }
+                // ok
+            } else if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown) {
+                return this->ReplyWithError(MakeError(NKikimr::NSQS::NErrors::NON_EXISTENT_QUEUE, std::format("The specified queue doesn't exist")));
+            } else {
+                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                                                TStringBuilder() << "Failed to describe topic: " << response.Status));
+            }
+
+            const auto& pqTabletConfig = response.PQGroupInfo->Description.GetPQTabletConfig();
+            SetMeteringMode(pqTabletConfig.GetMeteringMode());
+            Fifo_ = QueueUrl_->Fifo;
+            Dedup_ = Fifo_ && pqTabletConfig.GetContentBasedDeduplication();
+
+            // RU-metered topics need the rate-limiter path, which is not carried
+            // by DoLocalRpc requests. Resolve it from the database attributes
+            // before reading so the charge in Handle(TEvReadResponse) can fire.
+            if (IsRequestUnitsMeteringMode()) {
+                this->SendRlPathNavigate();
+                return;
+            }
+            CreateReader();
+        }
+
+        void CreateReader() {
+            std::unique_ptr<IActor> actorPtr{NKikimr::NPQ::NMLP::CreateReader(this->SelfId(), std::move(*ReaderSettings_))};
+            ReaderActorId_ = this->ActorContext().RegisterWithSameMailbox(actorPtr.release());
         }
 
     private:
@@ -277,6 +357,11 @@ namespace NKikimr::NSqsTopic::V1 {
 
     private:
         TActorId ReaderActorId_;
+        TMaybe<NKikimr::NPQ::NMLP::TReaderSettings> ReaderSettings_;
+        Ydb::Ymq::V1::ReceiveMessageResult Result_;
+        ui64 PayloadSize_{};
+        bool Fifo_{};
+        bool Dedup_{};
     };
 
     std::unique_ptr<NActors::IActor> CreateReceiveMessageActor(NKikimr::NGRpcService::IRequestOpCtx* msg) {

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -56,7 +56,11 @@ namespace NKikimr::NSqsTopic::V1 {
 
 
 
-    class TReceiveMessageActor: public TQueueUrlHolder, public TGrpcActorBase<TReceiveMessageActor, TEvSqsTopicReceiveMessageRequest>, private NPQ::TRlHelpers {
+    class TReceiveMessageActor:
+        public TQueueUrlHolder,
+        public TGrpcActorBase<TReceiveMessageActor, TEvSqsTopicReceiveMessageRequest>,
+        private NPQ::TRlHelpers,
+        public TCdcStreamCompatible {
     protected:
         using TBase = TGrpcActorBase<TReceiveMessageActor, TEvSqsTopicReceiveMessageRequest>;
         using TProtoRequest = typename TBase::TProtoRequest;
@@ -88,6 +92,9 @@ namespace NKikimr::NSqsTopic::V1 {
                 return;
             }
             ReaderSettings_ = std::move(readerSettings);
+
+            NACLib::TUserToken token(this->Request_->GetSerializedToken());
+            ShouldBeCharged_ = FindPtr(AppData(ctx)->PQConfig.GetNonChargeableUser(), token.GetUserSID()) == nullptr;
 
             this->SendDescribeProposeRequest(ctx);
             this->Become(&TReceiveMessageActor::StateWork);
@@ -232,12 +239,6 @@ namespace NKikimr::NSqsTopic::V1 {
             ReaderActorId_ = {};
             auto& response = *ev->Get();
 
-            // The message payload must be measured before ConvertMessage() moves
-            // the data out of the response.
-            PayloadSize_ = 0;
-            for (const auto& message : response.Messages) {
-                PayloadSize_ += message.Data.size();
-            }
             switch (response.Status) {
                 case Ydb::StatusIds::SUCCESS: {
                     break;
@@ -275,15 +276,17 @@ namespace NKikimr::NSqsTopic::V1 {
                     });
             }
 
+            ui64 payloadSize = 0;
             Result_.Clear();
             for (auto& message : response.Messages) {
+                payloadSize += message.Data.size();
                 Ydb::Ymq::V1::Message m = ConvertMessage(std::move(message), ctx);
                 *Result_.add_messages() = std::move(m);
             }
 
-            if (IsQuotaRequired()) {
-                const ui64 ru = NBilling::CalcReadRu(
-                    CalcRuConsumption(PayloadSize_), Result_.messages_size(), Fifo_, Dedup_);
+            if (ShouldBeCharged_ && IsQuotaRequired()) {
+                const ui64 ru = NBilling::CalcRu(
+                    CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
                 Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
                 return;
             }
@@ -318,6 +321,12 @@ namespace NKikimr::NSqsTopic::V1 {
             Y_ABORT_UNLESS(result->ResultSet.size() == 1);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+                if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
+                    if (this->ProcessCdc(response)) {
+                        return;
+                    }
+                    return this->ReplyWithError(MakeError(NSQS::NErrors::UNSUPPORTED_OPERATION, TStringBuilder() << "Reading from the Changefeed is not supported"));
+                }
                 if (response.Kind != NSchemeCache::TSchemeCacheNavigate::KindTopic) {
                     return this->ReplyWithError(MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, TStringBuilder() << "Queue name used by another scheme object"));
                 }
@@ -329,24 +338,22 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
 
-            const auto& pqTabletConfig = response.PQGroupInfo->Description.GetPQTabletConfig();
-            SetMeteringMode(pqTabletConfig.GetMeteringMode());
-            Fifo_ = QueueUrl_->Fifo;
-            Dedup_ = Fifo_ && pqTabletConfig.GetContentBasedDeduplication();
+            if (ShouldBeCharged_) {
+                // Always put in request units metering mode
+                SetMeteringMode(NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS);
+                Fifo_ = QueueUrl_->Fifo;
 
-            // RU-metered topics need the rate-limiter path, which is not carried
-            // by DoLocalRpc requests. Resolve it from the database attributes
-            // before reading so the charge in Handle(TEvReadResponse) can fire.
-            if (IsRequestUnitsMeteringMode()) {
+                // RU-metered topics need the rate-limiter path, which is not carried
+                // by DoLocalRpc requests. Resolve it from the database attributes
+                // before reading so the charge in Handle(TEvReadResponse) can fire.
                 this->SendRlPathNavigate();
-                return;
+            } else {
+                CreateReader();
             }
-            CreateReader();
         }
 
         void CreateReader() {
-            std::unique_ptr<IActor> actorPtr{NKikimr::NPQ::NMLP::CreateReader(this->SelfId(), std::move(*ReaderSettings_))};
-            ReaderActorId_ = this->ActorContext().RegisterWithSameMailbox(actorPtr.release());
+            ReaderActorId_ = this->ActorContext().RegisterWithSameMailbox(NKikimr::NPQ::NMLP::CreateReader(this->SelfId(), std::move(*ReaderSettings_)));
         }
 
     private:
@@ -356,12 +363,11 @@ namespace NKikimr::NSqsTopic::V1 {
         }
 
     private:
+        bool ShouldBeCharged_{};
         TActorId ReaderActorId_;
         TMaybe<NKikimr::NPQ::NMLP::TReaderSettings> ReaderSettings_;
         Ydb::Ymq::V1::ReceiveMessageResult Result_;
-        ui64 PayloadSize_{};
         bool Fifo_{};
-        bool Dedup_{};
     };
 
     std::unique_ptr<NActors::IActor> CreateReceiveMessageActor(NKikimr::NGRpcService::IRequestOpCtx* msg) {

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -37,6 +37,9 @@
 
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/describer/describer.h>
+#include <ydb/core/persqueue/public/pq_rl_helpers.h>
+
+#include <ydb/services/sqs_topic/billing.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
@@ -73,15 +76,17 @@ namespace NKikimr::NSqsTopic::V1 {
     }
 
     template <class TDerived, class TServiceRequest>
-    class TSendMessageActorBase: public TQueueUrlHolder, public TGrpcActorBase<TSendMessageActorBase<TDerived, TServiceRequest>, TServiceRequest> {
+    class TSendMessageActorBase: public TQueueUrlHolder, public TGrpcActorBase<TSendMessageActorBase<TDerived, TServiceRequest>, TServiceRequest>, private NPQ::TRlHelpers {
     protected:
         using TBase = TGrpcActorBase<TSendMessageActorBase, TServiceRequest>;
         using TProtoRequest = typename TBase::TProtoRequest;
+        using EWakeupTag = NPQ::TRlHelpers::EWakeupTag;
 
     public:
         TSendMessageActorBase(NKikimr::NGRpcService::IRequestOpCtx* request)
             : TQueueUrlHolder(ParseQueueUrlFromRequest<TProtoRequest>(request))
             , TBase(request, GetTopicPath().value_or(""))
+            , NPQ::TRlHelpers({}, request, NBilling::WRITE_BLOCK_SIZE, false)
         {
         }
 
@@ -90,6 +95,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void Bootstrap(const NActors::TActorContext& ctx) {
             TBase::CheckAccessWithWriteTopicPermission = true;
             TBase::Bootstrap(ctx);
+            NPQ::TRlHelpers::Bootstrap(this->SelfId(), ctx);
 
             if (this->Request().queue_url().empty()) {
                 return this->ReplyWithError(MakeError(NSQS::NErrors::MISSING_PARAMETER, "No QueueUrl parameter."));
@@ -154,11 +160,22 @@ namespace NKikimr::NSqsTopic::V1 {
                         TDerived::Method)
                 });
 
+            // Accumulate the payload size (message bodies + user attributes) for
+            // RU-based charging. When quota is charged via the RateLimiter the
+            // MLP writer must not charge again through the reserved-capacity path.
+            PayloadSize_ = 0;
+            for (const auto& item : validItems) {
+                PayloadSize_ += item.MessageBody.size();
+                for (const auto& [key, value] : item.Attributes) {
+                    PayloadSize_ += key.size() + value.size();
+                }
+            }
+
             NPQ::NMLP::TWriterSettings writerSettings{
                 .DatabasePath = QueueUrl_->Database,
                 .TopicName = FullTopicPath_,
                 .Messages = std::move(validItems),
-                .ShouldBeCharged = ShouldBeCharged_,
+                .ShouldBeCharged = ShouldBeCharged_ && !IsQuotaRequired(),
                 .UserToken = this->Request_->GetInternalToken(),
             };
             WriterActor_ = this->RegisterWithSameMailbox(NPQ::NMLP::CreateWriter(this->SelfId(), std::move(writerSettings)));
@@ -206,13 +223,34 @@ namespace NKikimr::NSqsTopic::V1 {
                         "failed")
                 });
 
-            static_cast<TDerived*>(this)->ReplyAndDie(TlsActivationContext->AsActorContext());
+            auto& ctx = TlsActivationContext->AsActorContext();
+            if (IsQuotaRequired()) {
+                const ui64 ru = NBilling::CalcWriteRu(
+                    CalcRuConsumption(PayloadSize_), static_cast<ui64>(successCount), Fifo_, Dedup_);
+                Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
+                return;
+            }
+
+            static_cast<TDerived*>(this)->ReplyAndDie(ctx);
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
+            switch (static_cast<EWakeupTag>(ev->Get()->Tag)) {
+                case EWakeupTag::RlAllowed:
+                    return static_cast<TDerived*>(this)->ReplyAndDie(ctx);
+                case EWakeupTag::RlNoResource:
+                    return this->ReplyWithError(MakeError(NSQS::NErrors::THROTTLING_EXCEPTION, "Request was throttled by the rate limiter"));
+                default:
+                    OnWakeup(static_cast<EWakeupTag>(ev->Get()->Tag));
+                    return;
+            }
         }
 
         void StateWork(TAutoPtr<IEventHandle>& ev) {
             switch (ev->GetTypeRewrite()) {
                 hFunc(NPQ::NMLP::TEvWriteResponse, Handle);
                 hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse);
+                HFunc(TEvents::TEvWakeup, Handle);
                 default:
                     TBase::StateWork(ev);
             }
@@ -248,6 +286,16 @@ namespace NKikimr::NSqsTopic::V1 {
         }
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+            // Second navigate: resolve the rate-limiter path from the database
+            // serverless attributes, then proceed with the write.
+            if (TBase::IsRlPathNavigateResponse(ev)) {
+                if (auto rlContext = this->ExtractRlContext(ev)) {
+                    SetRlContext(*rlContext);
+                }
+                DoWrite();
+                return;
+            }
+
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
             Y_ABORT_UNLESS(result->ResultSet.size() == 1);
             const auto& response = result->ResultSet.front();
@@ -259,11 +307,23 @@ namespace NKikimr::NSqsTopic::V1 {
                     return this->ReplyWithError(MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, TStringBuilder() << "Queue name used by another scheme object"));
                 }
                 // ok
+                const auto& pqTabletConfig = response.PQGroupInfo->Description.GetPQTabletConfig();
+                SetMeteringMode(pqTabletConfig.GetMeteringMode());
+                Fifo_ = QueueUrl_->Fifo;
+                Dedup_ = Fifo_ && pqTabletConfig.GetContentBasedDeduplication();
             } else if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown) {
                 return this->ReplyWithError(MakeError(NKikimr::NSQS::NErrors::NON_EXISTENT_QUEUE, std::format("The specified queue doesn't exist")));
             } else {
                 return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
+            }
+
+            // RU-metered topics need the rate-limiter path, which is not carried
+            // by DoLocalRpc requests. Resolve it from the database attributes
+            // before writing so the charge in Handle(TEvWriteResponse) can fire.
+            if (IsRequestUnitsMeteringMode()) {
+                this->SendRlPathNavigate();
+                return;
             }
             DoWrite();
         }
@@ -275,6 +335,7 @@ namespace NKikimr::NSqsTopic::V1 {
             if (WriterActor_) {
                 ctx.Send(WriterActor_, new TEvents::TEvPoison);
             }
+            NPQ::TRlHelpers::PassAway(this->SelfId());
             this->TBase::Die(ctx);
         }
 
@@ -308,6 +369,9 @@ namespace NKikimr::NSqsTopic::V1 {
         TActorId DescriptorActorId_;
         bool ShouldBeCharged_{};
         TActorId WriterActor_;
+        ui64 PayloadSize_{};
+        bool Fifo_{};
+        bool Dedup_{};
     };
 
     static TString GetBatchId(const Ydb::Ymq::V1::SendMessageBatchRequestEntry& batchEntry) {

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -107,11 +107,13 @@ namespace NKikimr::NSqsTopic::V1 {
             NACLib::TUserToken token(this->Request_->GetSerializedToken());
             ShouldBeCharged_ = FindPtr(AppData(ctx)->PQConfig.GetNonChargeableUser(), token.GetUserSID()) == nullptr;
 
+            PrepareWrite();
+
             this->SendDescribeProposeRequest(ctx);
             this->Become(&TSendMessageActorBase::StateWork);
         }
 
-        void DoWrite() {
+        void PrepareWrite() {
             const auto& request = Request();
             Items = ConvertRequestToWriteItems(request);
             for (ui32 i = 0; i < Items.size(); ++i) {
@@ -160,25 +162,19 @@ namespace NKikimr::NSqsTopic::V1 {
                         TDerived::Method)
                 });
 
-            // Accumulate the payload size (message bodies + user attributes) for
-            // RU-based charging. When quota is charged via the RateLimiter the
-            // MLP writer must not charge again through the reserved-capacity path.
+            // Accumulate the payload size (message bodies + user attributes) for RU-based charging.
             PayloadSize_ = 0;
             for (const auto& item : validItems) {
                 PayloadSize_ += item.MessageBody.size();
-                for (const auto& [key, value] : item.Attributes) {
-                    PayloadSize_ += key.size() + value.size();
-                }
             }
 
-            NPQ::NMLP::TWriterSettings writerSettings{
+            WriterSettings_ = NPQ::NMLP::TWriterSettings {
                 .DatabasePath = QueueUrl_->Database,
                 .TopicName = FullTopicPath_,
                 .Messages = std::move(validItems),
-                .ShouldBeCharged = ShouldBeCharged_ && !IsQuotaRequired(),
+                .ShouldBeCharged = false,
                 .UserToken = this->Request_->GetInternalToken(),
             };
-            WriterActor_ = this->RegisterWithSameMailbox(NPQ::NMLP::CreateWriter(this->SelfId(), std::move(writerSettings)));
         }
 
         void Handle(NPQ::NMLP::TEvWriteResponse::TPtr& ev) {
@@ -223,21 +219,14 @@ namespace NKikimr::NSqsTopic::V1 {
                         "failed")
                 });
 
-            auto& ctx = TlsActivationContext->AsActorContext();
-            if (IsQuotaRequired()) {
-                const ui64 ru = NBilling::CalcWriteRu(
-                    CalcRuConsumption(PayloadSize_), static_cast<ui64>(successCount), Fifo_, Dedup_);
-                Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
-                return;
-            }
-
-            static_cast<TDerived*>(this)->ReplyAndDie(ctx);
+            static_cast<TDerived*>(this)->ReplyAndDie(TlsActivationContext->AsActorContext());
         }
 
-        void Handle(TEvents::TEvWakeup::TPtr& ev, const TActorContext& ctx) {
+        void Handle(TEvents::TEvWakeup::TPtr& ev) {
             switch (static_cast<EWakeupTag>(ev->Get()->Tag)) {
                 case EWakeupTag::RlAllowed:
-                    return static_cast<TDerived*>(this)->ReplyAndDie(ctx);
+                    CreateWriter();
+                    return;
                 case EWakeupTag::RlNoResource:
                     return this->ReplyWithError(MakeError(NSQS::NErrors::THROTTLING_EXCEPTION, "Request was throttled by the rate limiter"));
                 default:
@@ -250,7 +239,7 @@ namespace NKikimr::NSqsTopic::V1 {
             switch (ev->GetTypeRewrite()) {
                 hFunc(NPQ::NMLP::TEvWriteResponse, Handle);
                 hFunc(TEvTxProxySchemeCache::TEvNavigateKeySetResult, HandleCacheNavigateResponse);
-                HFunc(TEvents::TEvWakeup, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
                 default:
                     TBase::StateWork(ev);
             }
@@ -291,8 +280,13 @@ namespace NKikimr::NSqsTopic::V1 {
             if (TBase::IsRlPathNavigateResponse(ev)) {
                 if (auto rlContext = this->ExtractRlContext(ev)) {
                     SetRlContext(*rlContext);
+                    if (IsQuotaRequired()) {
+                        const ui64 ru = NBilling::CalcRu(CalcRuConsumption(PayloadSize_), NBilling::WRITE_BASE_COST, NBilling::WRITE_COST_PER_BLOCK, Fifo_, false);
+                        Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
+                        return;
+                    }
                 }
-                DoWrite();
+                CreateWriter();
                 return;
             }
 
@@ -307,10 +301,6 @@ namespace NKikimr::NSqsTopic::V1 {
                     return this->ReplyWithError(MakeError(NSQS::NErrors::NON_EXISTENT_QUEUE, TStringBuilder() << "Queue name used by another scheme object"));
                 }
                 // ok
-                const auto& pqTabletConfig = response.PQGroupInfo->Description.GetPQTabletConfig();
-                SetMeteringMode(pqTabletConfig.GetMeteringMode());
-                Fifo_ = QueueUrl_->Fifo;
-                Dedup_ = Fifo_ && pqTabletConfig.GetContentBasedDeduplication();
             } else if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown) {
                 return this->ReplyWithError(MakeError(NKikimr::NSQS::NErrors::NON_EXISTENT_QUEUE, std::format("The specified queue doesn't exist")));
             } else {
@@ -318,14 +308,18 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
 
-            // RU-metered topics need the rate-limiter path, which is not carried
-            // by DoLocalRpc requests. Resolve it from the database attributes
-            // before writing so the charge in Handle(TEvWriteResponse) can fire.
-            if (IsRequestUnitsMeteringMode()) {
+            if (ShouldBeCharged_) {
+                // Always put in request units metering mode
+                SetMeteringMode(NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS);
+                Fifo_ = QueueUrl_->Fifo;
+
+                // RU-metered topics need the rate-limiter path, which is not carried
+                // by DoLocalRpc requests. Resolve it from the database attributes
+                // before writing so the charge in Handle(TEvWriteResponse) can fire.
                 this->SendRlPathNavigate();
-                return;
+            } else {
+                CreateWriter();
             }
-            DoWrite();
         }
 
         void Die(const TActorContext& ctx) override {
@@ -358,6 +352,10 @@ namespace NKikimr::NSqsTopic::V1 {
             return static_cast<TDerived*>(this)->ConvertRequestToWriteItemsImpl(request);
         }
 
+        void CreateWriter() {
+            WriterActor_ = this->RegisterWithSameMailbox(NPQ::NMLP::CreateWriter(this->SelfId(), std::move(*WriterSettings_)));
+        }
+
         const TProtoRequest& Request() const {
             return GetRequest<TProtoRequest>(this->Request_.get());
         }
@@ -371,7 +369,7 @@ namespace NKikimr::NSqsTopic::V1 {
         TActorId WriterActor_;
         ui64 PayloadSize_{};
         bool Fifo_{};
-        bool Dedup_{};
+        TMaybe<NPQ::NMLP::TWriterSettings> WriterSettings_;
     };
 
     static TString GetBatchId(const Ydb::Ymq::V1::SendMessageBatchRequestEntry& batchEntry) {

--- a/ydb/services/sqs_topic/ya.make
+++ b/ydb/services/sqs_topic/ya.make
@@ -42,6 +42,8 @@ PEERDIR(
     ydb/services/sqs_topic/queue_url/holder
     ydb/services/sqs_topic/protos/receipt
     ydb/services/ydb
+    ydb/core/metering
+    ydb/core/persqueue/public
     ydb/core/persqueue/public/describer
     ydb/core/persqueue/public/mlp
     ydb/core/persqueue/public/schema


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added metering to SQS topics

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

# Pull Request Summary

## RU-based billing for the `sqs_topic` service

Adds Request-Units (RU) metering to the SQS-over-Topic HTTP proxy, charging quota through the RateLimiter for Write (SendMessage), Read (ReceiveMessage) and Delete (DeleteMessage) operations on RU-metered topics.

### Core changes
- **RU charging wired into send/receive/delete actors** — each operation computes an RU cost and charges it via `TRlHelpers::MaybeRequestQuota()` before replying.
- **Rate-limiter context resolution** — added `SetRlContext()`  on `TRlHelpers` and DB-attribute navigate helpers on `TGrpcActorBase`. Since DoLocalRpc requests carry no `RlPath`, the coordination-node/resource paths are resolved from the database serverless attributes before charging.
- **Billing formulas** ([`billing.h`](services/sqs_topic/billing.h)):
  - `CalcRu` = `(base + payloadBlocks*perBlock + costAdjunct(fifo, dedup)`.
  - Write payload billed in 4 KiB blocks, read payload in 8 KiB blocks.
  - Costs are floating-point (`double`) to allow fractional prices; the final charge is rounded to a whole RU via `RoundRu()`.
  - FIFO and content-based-dedup requests carry extra 1 RU each.
- **ya.make PEERDIR** updated for the new metering dependency.

### Tests
- Added a **mock quoter service** (`TRuQuoterServiceMock` + `TRuRecorder`) registered under `MakeQuoterServiceID()` that records charged amount/quoter/resource and grants clearance, so metering can be asserted without a real Kesus resource.
- Added three metering tests (write/read/delete) that:
  - create an RU-metered topic with **RAW-only supported codecs** (no compression, so read payload sizes equal written sizes and block accounting is deterministic);
  - send multiple messages (3 × 8 KiB = 24 KiB, > 8 KiB) in a single batch call;

