### PR TITLE
Fix data race on metrics exchange in BlobDepot

### DIFF
--- a/ydb/core/blob_depot/group_metrics_exchange.cpp
+++ b/ydb/core/blob_depot/group_metrics_exchange.cpp
@@ -100,8 +100,10 @@ namespace NKikimr::NBlobDepot {
             params->SetAllocatedSize(Data->GetTotalStoredDataSize());
 
             // TODO(alexvru): use a better approach
-            const double approximateFreeSpaceShare = (double)params->GetAvailableSize() / (params->GetAvailableSize() +
-                params->GetAllocatedSize());
+            const double available = static_cast<double>(params->GetAvailableSize());
+            const double allocated = static_cast<double>(params->GetAllocatedSize());
+            const double denom = available + allocated;
+            const float approximateFreeSpaceShare = denom ? static_cast<float>(available / denom) : 0.0f;
 
             Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), response.release());
             SpaceMonitor->SetSpaceColor(dataColor, approximateFreeSpaceShare); // the best data channel space color works for the whole depot

--- a/ydb/core/blob_depot/group_metrics_exchange.cpp
+++ b/ydb/core/blob_depot/group_metrics_exchange.cpp
@@ -98,12 +98,12 @@ namespace NKikimr::NBlobDepot {
             }
 
             params->SetAllocatedSize(Data->GetTotalStoredDataSize());
-            Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), response.release());
 
             // TODO(alexvru): use a better approach
             const double approximateFreeSpaceShare = (double)params->GetAvailableSize() / (params->GetAvailableSize() +
                 params->GetAllocatedSize());
 
+            Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), response.release());
             SpaceMonitor->SetSpaceColor(dataColor, approximateFreeSpaceShare); // the best data channel space color works for the whole depot
         }
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix data race / use after free on metrics exchagne in BlobDepot
Race occures when `params`, which is a field of protobuf record in `response`, is accessed after `response` is sent to the ActorSystem
https://github.com/ydb-platform/ydb/issues/45131

### Changelog category <!-- remove all except one -->

* Bugfix 