### PR TITLE
Set not null: ListRequest in SchemeShard

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -799,4 +799,6 @@ enum ETxTypes {
     TXTYPE_GET_SET_COLUMN_CONSTRAINT = 125             [(TxTypeOpts) = {Name: "TxGetSetColumnConstraint"}];
 
     TXTYPE_TEST_SHARD_CONTROL = 126 [(TxTypeOpts) = {Name: "TxTestShardControl"}];
+
+    TXTYPE_LIST_SET_COLUMN_CONSTRAINT = 127             [(TxTypeOpts) = {Name: "TxListSetColumnConstraint"}];
 }

--- a/ydb/core/protos/set_column_constraint.proto
+++ b/ydb/core/protos/set_column_constraint.proto
@@ -57,3 +57,16 @@ message TEvCreateResponse {
     optional TSetColumnConstraint SetColumnConstraint = 4;
     optional sint32 SchemeStatus = 5 [default = -1]; // flat_tx_scheme.proto - enum EStatus, -1 is inexistent enum value
 }
+
+message TEvListRequest {
+    optional string DatabaseName = 1;
+    optional uint64 PageSize = 2;
+    optional string PageToken = 3;
+}
+
+message TEvListResponse {
+    optional Ydb.StatusIds.StatusCode Status = 1;
+    repeated Ydb.Issue.IssueMessage Issues = 2;
+    repeated TSetColumnConstraint Entries = 3;
+    optional string NextPageToken = 4;
+}

--- a/ydb/core/tx/datashard/validate_row_condition.cpp
+++ b/ydb/core/tx/datashard/validate_row_condition.cpp
@@ -25,12 +25,14 @@ public:
         const NKikimrTxDataShard::TEvValidateRowConditionRequest& request,
         const TActorId& sender,
         ui64 tabletId,
-        const TUserTable& tableInfo
+        const TUserTable& tableInfo,
+        TScanManager& scanManager
     )
         : TActor(&TThis::StateWork)
         , Request(request)
         , Sender(sender)
         , TabletId(tabletId)
+        , ScanManagerRef(scanManager)
     {
         TVector<TString> columnNames;
         columnNames.reserve(Request.NotNullColumnsSize());
@@ -70,6 +72,15 @@ public:
     }
 
     TAutoPtr<IDestructable> Finish(NTable::IScan::EStatus scanStatus) noexcept final {
+        // Release the shared single-slot scan manager entry registered for
+        // this operation id. Without this, the slot would remain occupied
+        // forever (unlike build_index, which frees it via a dedicated
+        // finalization step), permanently blocking any subsequent
+        // SetColumnConstraint validation on this shard.
+        if (ScanManagerRef.Get(Request.GetId())) {
+            ScanManagerRef.Drop(Request.GetId());
+        }
+
         auto response = MakeHolder<TEvDataShard::TEvValidateRowConditionResponse>();
         response->Record.SetId(Request.GetId());
         response->Record.SetTabletId(TabletId);
@@ -130,6 +141,7 @@ private:
     const TActorId Sender;
     const ui64 TabletId;
     TTags ScanTags;
+    TScanManager& ScanManagerRef;
     NKikimrSetColumnConstraint::EValidateStatus Status = NKikimrSetColumnConstraint::EValidateStatus::INVALID;
     bool IsValid = true;
 };
@@ -225,7 +237,7 @@ void TDataShard::HandleSafe(TEvDataShard::TEvValidateRowConditionRequest::TPtr& 
         << " tabletId# " << TabletID()
         << " localTid# " << userTable.LocalTid);
 
-    auto scan = new TValidateRowConditionScan(record, ev->Sender, TabletID(), userTable);
+    auto scan = new TValidateRowConditionScan(record, ev->Sender, TabletID(), userTable, GetScanManager());
     StartScan(this, scan, id, seqNo, rowVersion, userTable.LocalTid);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5986,6 +5986,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         //namespace NIndexBuilder {
         HFuncTraced(TEvSetColumnConstraint::TEvCreateRequest, Handle);
         HFuncTraced(TEvSetColumnConstraint::TEvGetRequest, Handle);
+        HFuncTraced(TEvSetColumnConstraint::TEvListRequest, Handle);
         HFuncTraced(TEvDataShard::TEvValidateRowConditionResponse, Handle);
         HFuncTraced(TEvIndexBuilder::TEvCreateRequest, Handle);
         HFuncTraced(TEvIndexBuilder::TEvGetRequest, Handle);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1938,6 +1938,7 @@ public:
         class TTxCreateSetColumnConstraint;
         struct TTxProgressSetColumnConstraint;
         struct TTxGetSetColumnConstraint;
+        struct TTxListSetColumnConstraint;
     };
 
     NTabletFlatExecutor::ITransaction* CreateTxCreate(TEvIndexBuilder::TEvCreateRequest::TPtr& ev);
@@ -1990,9 +1991,11 @@ public:
     // Begin SetColumnConstraint
     void Handle(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvSetColumnConstraint::TEvListRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx);
     NTabletFlatExecutor::ITransaction* CreateTxCreateSetColumnConstraint(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxGetSetColumnConstraint(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxListSetColumnConstraint(TEvSetColumnConstraint::TEvListRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxSetColumnConstraintProgress(TIndexBuildId id);
     NTabletFlatExecutor::ITransaction* CreateTxReplyAllocateSetColumnConstraint(TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxReplyModifySetColumnConstraint(TEvSchemeShard::TEvModifySchemeTransactionResult::TPtr& ev);

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -169,6 +169,10 @@ void TSchemeShard::Handle(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev, const
     Execute(CreateTxGetSetColumnConstraint(ev), ctx);
 }
 
+void TSchemeShard::Handle(TEvSetColumnConstraint::TEvListRequest::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxListSetColumnConstraint(ev), ctx);
+}
+
 void TSchemeShard::Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx) {
     const auto& record = ev->Get()->Record;
     TIndexBuildId operationId = TIndexBuildId(record.GetId());

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -28,6 +28,69 @@ std::vector<TString> DeserializeSetColumnConstraintColumnNames(const TString& se
     return result;
 }
 
+float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
+    const ui64 total = operationInfo.ValidationShards.size();
+    if (total == 0) {
+        return 0.0f;
+    }
+    const ui64 done = operationInfo.DoneValidationShards.size();
+    return static_cast<float>(done) / static_cast<float>(total) * 100.0f;
+}
+
+void FillSetColumnConstraint(
+    NKikimrSetColumnConstraint::TSetColumnConstraint& proto,
+    const TSetColumnConstraintOperationInfo& operationInfo,
+    TSchemeShard* self)
+{
+    proto.SetId(ui64(operationInfo.Id));
+
+    if (operationInfo.UserSID) {
+        proto.SetUserSID(*operationInfo.UserSID);
+    }
+    if (operationInfo.StartTime != TInstant::Zero()) {
+        *proto.MutableStartTime() = SecondsToProtoTimeStamp(operationInfo.StartTime.Seconds());
+    }
+    if (operationInfo.EndTime != TInstant::Zero()) {
+        *proto.MutableEndTime() = SecondsToProtoTimeStamp(operationInfo.EndTime.Seconds());
+    }
+
+    // Map internal state to proto state
+    using EState = TSetColumnConstraintOperationInfo::EOperationState;
+    using ProtoState = Ydb::Table::SetNotNullState;
+    switch (operationInfo.OperationState) {
+    case EState::Locking:
+    case EState::LockingNullWrites:
+        proto.SetState(ProtoState::STATE_PREPARING);
+        proto.SetProgress(0.0f);
+        break;
+    case EState::Validating:
+        proto.SetState(ProtoState::STATE_VALIDATING);
+        proto.SetProgress(CalcSetColumnConstraintValidationProgress(operationInfo));
+        break;
+    case EState::Finishing:
+    case EState::Unlocking:
+        proto.SetState(ProtoState::STATE_APPLYING);
+        proto.SetProgress(99.9f);
+        break;
+    case EState::Done:
+        proto.SetState(operationInfo.ValidationFailed
+            ? ProtoState::STATE_CANCELLED
+            : ProtoState::STATE_DONE);
+        proto.SetProgress(100.0f);
+        break;
+    case EState::Invalid:
+        proto.SetState(ProtoState::STATE_UNSPECIFIED);
+        break;
+    }
+
+    auto* settings = proto.MutableSettings();
+    TPath tablePath = TPath::Init(operationInfo.TablePathId, self);
+    settings->SetTablePath(tablePath.PathString());
+    for (const auto& col : operationInfo.SetNotNullColumns) {
+        settings->AddNotNullColumns(TString(col));
+    }
+}
+
 void TSchemeShard::PersistCreateSetColumnConstraint(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo) {
     TString serializedColumnNames = SerializeSetColumnConstraintColumnNames(operationInfo.SetNotNullColumns);
     db.Table<Schema::SetColumnConstraint>().Key(ui64(operationInfo.Id)).Update(

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -28,6 +28,8 @@ std::vector<TString> DeserializeSetColumnConstraintColumnNames(const TString& se
     return result;
 }
 
+namespace {
+
 float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
     const ui64 total = operationInfo.ValidationShards.size();
     if (total == 0) {
@@ -35,6 +37,8 @@ float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperat
     }
     const ui64 done = operationInfo.DoneValidationShards.size();
     return static_cast<float>(done) / static_cast<float>(total) * 100.0f;
+}
+
 }
 
 void FillSetColumnConstraint(

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -17,6 +17,8 @@ struct TEvSetColumnConstraint {
         EvCreateResponse,
         EvGetRequest,
         EvGetResponse,
+        EvListRequest,
+        EvListResponse,
 
         EvEnd
     };
@@ -58,6 +60,20 @@ struct TEvSetColumnConstraint {
     };
 
     struct TEvGetResponse: public TEventPB<TEvGetResponse, NKikimrSetColumnConstraint::TEvGetResponse, EvGetResponse> {};
+
+    struct TEvListRequest: public TEventPB<TEvListRequest, NKikimrSetColumnConstraint::TEvListRequest, EvListRequest> {
+        TEvListRequest() = default;
+
+        explicit TEvListRequest(const TString& dbName, ui64 pageSize, const TString& pageToken) {
+            Record.SetDatabaseName(dbName);
+            Record.SetPageSize(pageSize);
+            Record.SetPageToken(pageToken);
+        }
+    };
+
+    struct TEvListResponse: public TEventPB<TEvListResponse, NKikimrSetColumnConstraint::TEvListResponse, EvListResponse> {
+        TEvListResponse() = default;
+    };
 }; // TEvSetColumnConstraint
 
 } // NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -7,7 +7,6 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
-// Forward declarations
 class TSchemeShard;
 struct TSetColumnConstraintOperationInfo;
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -14,8 +14,6 @@ struct TSetColumnConstraintOperationInfo;
 TString SerializeSetColumnConstraintColumnNames(const std::vector<TString>& columns);
 std::vector<TString> DeserializeSetColumnConstraintColumnNames(const TString& serialized);
 
-// Common helper functions for filling proto from operation info
-float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo);
 void FillSetColumnConstraint(
     NKikimrSetColumnConstraint::TSetColumnConstraint& proto,
     const TSetColumnConstraintOperationInfo& operationInfo,

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -7,8 +7,19 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
+// Forward declarations
+class TSchemeShard;
+struct TSetColumnConstraintOperationInfo;
+
 TString SerializeSetColumnConstraintColumnNames(const std::vector<TString>& columns);
 std::vector<TString> DeserializeSetColumnConstraintColumnNames(const TString& serialized);
+
+// Common helper functions for filling proto from operation info
+float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo);
+void FillSetColumnConstraint(
+    NKikimrSetColumnConstraint::TSetColumnConstraint& proto,
+    const TSetColumnConstraintOperationInfo& operationInfo,
+    TSchemeShard* self);
 
 
 struct TEvSetColumnConstraint {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__get.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__get.cpp
@@ -53,7 +53,7 @@ public:
         respRecord.SetStatus(Ydb::StatusIds::SUCCESS);
 
         auto* proto = respRecord.MutableSetColumnConstraint();
-        FillSetColumnConstraint(*proto, operationInfo);
+        FillSetColumnConstraint(*proto, operationInfo, Self);
 
         if (operationInfo.ValidationFailed && operationInfo.OperationState == TSetColumnConstraintOperationInfo::EOperationState::Done) {
             TPath tablePath = TPath::Init(operationInfo.TablePathId, Self);
@@ -69,69 +69,6 @@ public:
     }
 
     void DoComplete(const TActorContext&) override {}
-
-private:
-    void FillSetColumnConstraint(
-        NKikimrSetColumnConstraint::TSetColumnConstraint& proto,
-        const TSetColumnConstraintOperationInfo& operationInfo)
-    {
-        proto.SetId(ui64(operationInfo.Id));
-
-        if (operationInfo.UserSID) {
-            proto.SetUserSID(*operationInfo.UserSID);
-        }
-        if (operationInfo.StartTime != TInstant::Zero()) {
-            *proto.MutableStartTime() = SecondsToProtoTimeStamp(operationInfo.StartTime.Seconds());
-        }
-        if (operationInfo.EndTime != TInstant::Zero()) {
-            *proto.MutableEndTime() = SecondsToProtoTimeStamp(operationInfo.EndTime.Seconds());
-        }
-
-        // Map internal state to proto state
-        using EState = TSetColumnConstraintOperationInfo::EOperationState;
-        using ProtoState = Ydb::Table::SetNotNullState;
-        switch (operationInfo.OperationState) {
-        case EState::Locking:
-        case EState::LockingNullWrites:
-            proto.SetState(ProtoState::STATE_PREPARING);
-            proto.SetProgress(0.0f);
-            break;
-        case EState::Validating:
-            proto.SetState(ProtoState::STATE_VALIDATING);
-            proto.SetProgress(CalcValidationProgress(operationInfo));
-            break;
-        case EState::Finishing:
-        case EState::Unlocking:
-            proto.SetState(ProtoState::STATE_APPLYING);
-            proto.SetProgress(99.9f);
-            break;
-        case EState::Done:
-            proto.SetState(operationInfo.ValidationFailed
-                ? ProtoState::STATE_CANCELLED
-                : ProtoState::STATE_DONE);
-            proto.SetProgress(100.0f);
-            break;
-        case EState::Invalid:
-            proto.SetState(ProtoState::STATE_UNSPECIFIED);
-            break;
-        }
-
-        auto* settings = proto.MutableSettings();
-        TPath tablePath = TPath::Init(operationInfo.TablePathId, Self);
-        settings->SetTablePath(tablePath.PathString());
-        for (const auto& col : operationInfo.SetNotNullColumns) {
-            settings->AddNotNullColumns(TString(col));
-        }
-    }
-
-    static float CalcValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
-        const ui64 total = operationInfo.ValidationShards.size();
-        if (total == 0) {
-            return 0.0f;
-        }
-        const ui64 done = operationInfo.DoneValidationShards.size();
-        return static_cast<float>(done) / static_cast<float>(total) * 100.0f;
-    }
 };
 
 ITransaction* TSchemeShard::CreateTxGetSetColumnConstraint(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev) {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
@@ -100,7 +100,7 @@ private:
 
         // Map internal state to proto state
         using EState = TSetColumnConstraintOperationInfo::EOperationState;
-        using ProtoState = Ydb::Table::SetColumnConstraintState;
+        using ProtoState = Ydb::Table::SetNotNullState;
         switch (operationInfo.OperationState) {
         case EState::Locking:
         case EState::LockingNullWrites:

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
@@ -31,7 +31,7 @@ public:
         TPath database = TPath::Resolve(record.GetDatabaseName(), Self);
         if (!database.IsResolved()) {
             return Reply(
-                Ydb::StatusIds::BAD_REQUEST,
+                Ydb::StatusIds::NOT_FOUND,
                 TStringBuilder() << "Database <" << record.GetDatabaseName() << "> not found"
             );
         }

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
@@ -1,0 +1,152 @@
+#include <ydb/core/tx/schemeshard/index/build_index.h>
+#include <ydb/core/tx/schemeshard/index/build_index_helpers.h>
+#include <ydb/core/tx/schemeshard/index/build_index_tx_base.h>
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
+#include <ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h>
+
+namespace NKikimr::NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+struct TSchemeShard::TIndexBuilder::TTxListSetColumnConstraint
+    : public TSchemeShard::TIndexBuilder::TTxSimple<TEvSetColumnConstraint::TEvListRequest, TEvSetColumnConstraint::TEvListResponse>
+{
+private:
+    static constexpr ui64 DefaultPageSize = 10;
+    static constexpr ui64 MinPageSize = 1;
+    static constexpr ui64 MaxPageSize = 100;
+    static constexpr ui64 DefaultPage = 1;
+
+public:
+    explicit TTxListSetColumnConstraint(TSelf* self, TEvSetColumnConstraint::TEvListRequest::TPtr& ev)
+        : TTxSimple(self, InvalidIndexBuildId, ev, TXTYPE_LIST_SET_COLUMN_CONSTRAINT, false)
+    {}
+
+    bool DoExecute(TTransactionContext&, const TActorContext&) override {
+        const auto& record = Request->Get()->Record;
+        LOG_D("TTxListSetColumnConstraint::DoExecute " << record.ShortDebugString());
+
+        Response = MakeHolder<TEvSetColumnConstraint::TEvListResponse>();
+
+        TPath database = TPath::Resolve(record.GetDatabaseName(), Self);
+        if (!database.IsResolved()) {
+            return Reply(
+                Ydb::StatusIds::BAD_REQUEST,
+                TStringBuilder() << "Database <" << record.GetDatabaseName() << "> not found"
+            );
+        }
+        const TPathId domainPathId = database.GetPathIdForDomain();
+
+        ui64 page = DefaultPage;
+        if (record.GetPageToken() && !TryFromString(record.GetPageToken(), page)) {
+            return Reply(
+                Ydb::StatusIds::BAD_REQUEST,
+                TStringBuilder() << "Unable to parse page token"
+            );
+        }
+        page = Max(page, DefaultPage);
+        const ui64 pageSize = Min(record.GetPageSize() ? Max(record.GetPageSize(), MinPageSize) : DefaultPageSize, MaxPageSize);
+
+        auto it = Self->SetColumnConstraintOperationsByTime.end();
+        ui64 skip = (page - 1) * pageSize;
+        while ((it != Self->SetColumnConstraintOperationsByTime.begin()) && skip) {
+            --it;
+            const auto& operationInfo = *Self->SetColumnConstraintOperations.at(it->second);
+            if (operationInfo.DomainPathId == domainPathId) {
+                --skip;
+            }
+        }
+
+        auto& respRecord = Response->Record;
+        respRecord.SetStatus(Ydb::StatusIds::SUCCESS);
+
+        ui64 size = 0;
+        while ((it != Self->SetColumnConstraintOperationsByTime.begin()) && size < pageSize) {
+            --it;
+            const auto& operationInfo = *Self->SetColumnConstraintOperations.at(it->second);
+            if (operationInfo.DomainPathId == domainPathId) {
+                FillSetColumnConstraint(*respRecord.MutableEntries()->Add(), operationInfo);
+                ++size;
+            }
+        }
+
+        if (it == Self->SetColumnConstraintOperationsByTime.begin()) {
+            respRecord.SetNextPageToken("0");
+        } else {
+            respRecord.SetNextPageToken(ToString(page + 1));
+        }
+
+        return Reply();
+    }
+
+    void DoComplete(const TActorContext&) override {}
+
+private:
+    void FillSetColumnConstraint(
+        NKikimrSetColumnConstraint::TSetColumnConstraint& proto,
+        const TSetColumnConstraintOperationInfo& operationInfo)
+    {
+        proto.SetId(ui64(operationInfo.Id));
+
+        if (operationInfo.UserSID) {
+            proto.SetUserSID(*operationInfo.UserSID);
+        }
+        if (operationInfo.StartTime != TInstant::Zero()) {
+            *proto.MutableStartTime() = SecondsToProtoTimeStamp(operationInfo.StartTime.Seconds());
+        }
+        if (operationInfo.EndTime != TInstant::Zero()) {
+            *proto.MutableEndTime() = SecondsToProtoTimeStamp(operationInfo.EndTime.Seconds());
+        }
+
+        // Map internal state to proto state
+        using EState = TSetColumnConstraintOperationInfo::EOperationState;
+        using ProtoState = Ydb::Table::SetColumnConstraintState;
+        switch (operationInfo.OperationState) {
+        case EState::Locking:
+        case EState::LockingNullWrites:
+            proto.SetState(ProtoState::STATE_PREPARING);
+            proto.SetProgress(0.0f);
+            break;
+        case EState::Validating:
+            proto.SetState(ProtoState::STATE_VALIDATING);
+            proto.SetProgress(CalcValidationProgress(operationInfo));
+            break;
+        case EState::Finishing:
+        case EState::Unlocking:
+            proto.SetState(ProtoState::STATE_APPLYING);
+            proto.SetProgress(99.9f);
+            break;
+        case EState::Done:
+            proto.SetState(operationInfo.ValidationFailed
+                ? ProtoState::STATE_CANCELLED
+                : ProtoState::STATE_DONE);
+            proto.SetProgress(100.0f);
+            break;
+        case EState::Invalid:
+            proto.SetState(ProtoState::STATE_UNSPECIFIED);
+            break;
+        }
+
+        auto* settings = proto.MutableSettings();
+        TPath tablePath = TPath::Init(operationInfo.TablePathId, Self);
+        settings->SetTablePath(tablePath.PathString());
+        for (const auto& col : operationInfo.SetNotNullColumns) {
+            settings->AddNotNullColumns(TString(col));
+        }
+    }
+
+    static float CalcValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
+        const ui64 total = operationInfo.ValidationShards.size();
+        if (total == 0) {
+            return 0.0f;
+        }
+        const ui64 done = operationInfo.DoneValidationShards.size();
+        return static_cast<float>(done) / static_cast<float>(total) * 100.0f;
+    }
+};
+
+ITransaction* TSchemeShard::CreateTxListSetColumnConstraint(TEvSetColumnConstraint::TEvListRequest::TPtr& ev) {
+    return new TIndexBuilder::TTxListSetColumnConstraint(this, ev);
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__list.cpp
@@ -65,7 +65,7 @@ public:
             --it;
             const auto& operationInfo = *Self->SetColumnConstraintOperations.at(it->second);
             if (operationInfo.DomainPathId == domainPathId) {
-                FillSetColumnConstraint(*respRecord.MutableEntries()->Add(), operationInfo);
+                FillSetColumnConstraint(*respRecord.MutableEntries()->Add(), operationInfo, Self);
                 ++size;
             }
         }
@@ -80,69 +80,6 @@ public:
     }
 
     void DoComplete(const TActorContext&) override {}
-
-private:
-    void FillSetColumnConstraint(
-        NKikimrSetColumnConstraint::TSetColumnConstraint& proto,
-        const TSetColumnConstraintOperationInfo& operationInfo)
-    {
-        proto.SetId(ui64(operationInfo.Id));
-
-        if (operationInfo.UserSID) {
-            proto.SetUserSID(*operationInfo.UserSID);
-        }
-        if (operationInfo.StartTime != TInstant::Zero()) {
-            *proto.MutableStartTime() = SecondsToProtoTimeStamp(operationInfo.StartTime.Seconds());
-        }
-        if (operationInfo.EndTime != TInstant::Zero()) {
-            *proto.MutableEndTime() = SecondsToProtoTimeStamp(operationInfo.EndTime.Seconds());
-        }
-
-        // Map internal state to proto state
-        using EState = TSetColumnConstraintOperationInfo::EOperationState;
-        using ProtoState = Ydb::Table::SetNotNullState;
-        switch (operationInfo.OperationState) {
-        case EState::Locking:
-        case EState::LockingNullWrites:
-            proto.SetState(ProtoState::STATE_PREPARING);
-            proto.SetProgress(0.0f);
-            break;
-        case EState::Validating:
-            proto.SetState(ProtoState::STATE_VALIDATING);
-            proto.SetProgress(CalcValidationProgress(operationInfo));
-            break;
-        case EState::Finishing:
-        case EState::Unlocking:
-            proto.SetState(ProtoState::STATE_APPLYING);
-            proto.SetProgress(99.9f);
-            break;
-        case EState::Done:
-            proto.SetState(operationInfo.ValidationFailed
-                ? ProtoState::STATE_CANCELLED
-                : ProtoState::STATE_DONE);
-            proto.SetProgress(100.0f);
-            break;
-        case EState::Invalid:
-            proto.SetState(ProtoState::STATE_UNSPECIFIED);
-            break;
-        }
-
-        auto* settings = proto.MutableSettings();
-        TPath tablePath = TPath::Init(operationInfo.TablePathId, Self);
-        settings->SetTablePath(tablePath.PathString());
-        for (const auto& col : operationInfo.SetNotNullColumns) {
-            settings->AddNotNullColumns(TString(col));
-        }
-    }
-
-    static float CalcValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
-        const ui64 total = operationInfo.ValidationShards.size();
-        if (total == 0) {
-            return 0.0f;
-        }
-        const ui64 done = operationInfo.DoneValidationShards.size();
-        return static_cast<float>(done) / static_cast<float>(total) * 100.0f;
-    }
 };
 
 ITransaction* TSchemeShard::CreateTxListSetColumnConstraint(TEvSetColumnConstraint::TEvListRequest::TPtr& ev) {

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -3571,6 +3571,25 @@ namespace NSchemeShardUT_Private {
         ForwardToTablet(runtime, schemeShard, sender, request.Release());
     }
 
+    TEvSetColumnConstraint::TEvListRequest* ListSetColumnConstraintRequest(const TString& dbName) {
+        return new TEvSetColumnConstraint::TEvListRequest(dbName, 100, "");
+    }
+
+    NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName) {
+        auto sender = runtime.AllocateEdgeActor();
+        auto request = ListSetColumnConstraintRequest(dbName);
+
+        ForwardToTablet(runtime, schemeShard, sender, request);
+
+        TAutoPtr<IEventHandle> handle;
+        TEvSetColumnConstraint::TEvListResponse* event = runtime.GrabEdgeEvent<TEvSetColumnConstraint::TEvListResponse>(handle);
+        UNIT_ASSERT(event);
+
+        Cerr << "SET COLUMN CONSTRAINT RESPONSE LIST: " << event->ToString() << Endl;
+        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), 400000, event->Record.GetIssues());
+        return event->Record;
+    }
+
     void TestCheckColumnsNotNull(
         TTestActorRuntime& runtime,
         const TString& tablePath,

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -2329,7 +2329,7 @@ namespace NSchemeShardUT_Private {
         UNIT_ASSERT(event);
 
         Cerr << "BUILDINDEX RESPONSE LIST: " << event->ToString() << Endl;
-        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), 400000, event->Record.GetIssues());
+        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), Ydb::StatusIds::SUCCESS, event->Record.GetIssues());
         return event->Record;
     }
 
@@ -2348,7 +2348,7 @@ namespace NSchemeShardUT_Private {
         UNIT_ASSERT(event);
 
         Cerr << "BUILDINDEX RESPONSE Get: " << event->ToString() << Endl;
-        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), 400000, event->Record.GetIssues());
+        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), Ydb::StatusIds::SUCCESS, event->Record.GetIssues());
         return event->Record;
     }
 
@@ -3571,13 +3571,20 @@ namespace NSchemeShardUT_Private {
         ForwardToTablet(runtime, schemeShard, sender, request.Release());
     }
 
-    TEvSetColumnConstraint::TEvListRequest* ListSetColumnConstraintRequest(const TString& dbName) {
-        return new TEvSetColumnConstraint::TEvListRequest(dbName, 100, "");
+    TEvSetColumnConstraint::TEvListRequest* ListSetColumnConstraintRequest(const TString& dbName, ui64 pageSize, const TString& pageToken) {
+        return new TEvSetColumnConstraint::TEvListRequest(dbName, pageSize, pageToken);
     }
 
     NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName) {
+        return TestListSetColumnConstraint(runtime, schemeShard, dbName, 100, "", Ydb::StatusIds::SUCCESS);
+    }
+
+    NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(
+        TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName,
+        ui64 pageSize, const TString& pageToken, Ydb::StatusIds::StatusCode expectedStatus)
+    {
         auto sender = runtime.AllocateEdgeActor();
-        auto request = ListSetColumnConstraintRequest(dbName);
+        auto request = ListSetColumnConstraintRequest(dbName, pageSize, pageToken);
 
         ForwardToTablet(runtime, schemeShard, sender, request);
 
@@ -3586,7 +3593,7 @@ namespace NSchemeShardUT_Private {
         UNIT_ASSERT(event);
 
         Cerr << "SET COLUMN CONSTRAINT RESPONSE LIST: " << event->ToString() << Endl;
-        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), 400000, event->Record.GetIssues());
+        UNIT_ASSERT_EQUAL_C(event->Record.GetStatus(), expectedStatus, event->Record.GetIssues());
         return event->Record;
     }
 
@@ -3620,3 +3627,4 @@ namespace NSchemeShardUT_Private {
         }
     }
 }
+

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -810,5 +810,6 @@ namespace NSchemeShardUT_Private {
     NKikimrSetColumnConstraint::TEvCreateResponse TestSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, ui64 schemeShard, const TString& dbName, const TString& tablePath, const TVector<TString>& notNullColumns, const TString& userSID);
     NKikimrSetColumnConstraint::TEvCreateResponse TestSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, ui64 schemeShard, const TString& dbName, const TString& tablePath, const TVector<TString>& notNullColumns, const TString& userSID, bool skipSettings);
     void AsyncSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, ui64 schemeShard, const TString& dbName, const TString& tablePath, const TVector<TString>& notNullColumns);
+    NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName);
     void TestCheckColumnsNotNull(TTestActorRuntime& runtime, const TString& tablePath, const std::map<TString, bool>& expectedColumnNotNullStates);
 } //NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -811,5 +811,7 @@ namespace NSchemeShardUT_Private {
     NKikimrSetColumnConstraint::TEvCreateResponse TestSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, ui64 schemeShard, const TString& dbName, const TString& tablePath, const TVector<TString>& notNullColumns, const TString& userSID, bool skipSettings);
     void AsyncSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, ui64 schemeShard, const TString& dbName, const TString& tablePath, const TVector<TString>& notNullColumns);
     NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName);
+    NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName,
+            ui64 pageSize, const TString& pageToken, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
     void TestCheckColumnsNotNull(TTestActorRuntime& runtime, const TString& tablePath, const std::map<TString, bool>& expectedColumnNotNullStates);
 } //NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1334,7 +1334,6 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         )");
         env.TestWaitNotification(runtime, txId);
 
-        // Start first set column constraint operation
         ui64 setConstraintTxId1 = ++txId;
         auto response1 = TestSetColumnConstraint(
             runtime, setConstraintTxId1,
@@ -1346,7 +1345,6 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT_VALUES_EQUAL(response1.GetStatus(), Ydb::StatusIds::SUCCESS);
         env.TestWaitNotification(runtime, setConstraintTxId1, TTestTxConfig::SchemeShard);
 
-        // Start first set column constraint operation
         ui64 setConstraintTxId2 = ++txId;
         auto response2 = TestSetColumnConstraint(
             runtime, setConstraintTxId2,
@@ -1358,7 +1356,6 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT_VALUES_EQUAL(response2.GetStatus(), Ydb::StatusIds::SUCCESS);
         env.TestWaitNotification(runtime, setConstraintTxId2, TTestTxConfig::SchemeShard);
 
-        // Start second set column constraint operation
         ui64 setConstraintTxId3 = ++txId;
         auto response3 = TestSetColumnConstraint(
             runtime, setConstraintTxId3,
@@ -1370,13 +1367,13 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT_VALUES_EQUAL(response3.GetStatus(), Ydb::StatusIds::SUCCESS);
         env.TestWaitNotification(runtime, setConstraintTxId3, TTestTxConfig::SchemeShard);
 
-        // Test list operations
+        // =========================================
+
         auto listResponse = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
 
         UNIT_ASSERT_VALUES_EQUAL(listResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
         UNIT_ASSERT_GE(listResponse.GetEntries().size(), 3);
 
-        // Check that both operations are in the list
         bool foundOp1 = false, foundOp2 = false, foundOp3 = false;
         for (const auto& entry : listResponse.GetEntries()) {
             const auto& columns = entry.GetSettings().GetNotNullColumns();
@@ -1388,15 +1385,15 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             }
             if (entry.GetId() == setConstraintTxId2) {
                 foundOp2 = true;
-                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_CANCELLED));
                 UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value2");
             }
             if (entry.GetId() == setConstraintTxId3) {
                 foundOp3 = true;
-                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_CANCELLED));
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_DONE));
                 UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
-                UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value2");
+                UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value");
             }
         }
 

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1415,4 +1415,177 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT_VALUES_EQUAL(listResponse.GetEntries().size(), 0);
         UNIT_ASSERT_VALUES_EQUAL(listResponse.GetNextPageToken(), "0");
     }
+
+    Y_UNIT_TEST(ListOperationsWithPagination) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+
+        // =============================
+
+        TVector<TString> tablePaths;
+        TVector<ui64> operationIds;
+
+        for (ui32 i = 1; i <= 5; ++i) {
+            TString tablePath = root + "/Table" + ToString(i);
+            tablePaths.push_back(tablePath);
+
+            TestCreateTable(runtime, ++txId, root, Sprintf(R"(
+                  Name: "Table%d"
+                  Columns { Name: "key"   Type: "Uint32" }
+                  Columns { Name: "value" Type: "Utf8"   }
+                  KeyColumnNames: ["key"]
+            )", i));
+            env.TestWaitNotification(runtime, txId);
+
+            ui64 setConstraintTxId = ++txId;
+            auto response = TestSetColumnConstraint(
+                runtime, setConstraintTxId,
+                TTestTxConfig::SchemeShard,
+                root,
+                tablePath,
+                {"value"});
+
+            UNIT_ASSERT_VALUES_EQUAL(response.GetStatus(), Ydb::StatusIds::SUCCESS);
+            operationIds.push_back(setConstraintTxId);
+            env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+        }
+
+        // =============================
+
+        TVector<ui64> foundOperationIds;
+        TString pageToken = "";
+        ui32 pageCount = 0;
+        const ui64 pageSize = 1;
+
+        do {
+            auto listResponse = TestListSetColumnConstraint(
+                runtime,
+                TTestTxConfig::SchemeShard,
+                root,
+                pageSize,
+                pageToken);
+
+            UNIT_ASSERT_VALUES_EQUAL(listResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+            
+            UNIT_ASSERT_LE(static_cast<ui64>(listResponse.GetEntries().size()), pageSize);
+
+            // Collect operation IDs from this page
+            for (const auto& entry : listResponse.GetEntries()) {
+                foundOperationIds.push_back(entry.GetId());
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().Get(0), "value");
+            }
+
+            pageToken = listResponse.GetNextPageToken();
+            ++pageCount;
+        } while (pageToken != "0" && !pageToken.empty());
+
+        UNIT_ASSERT_GE(foundOperationIds.size(), 5);
+
+        // =============================
+
+        for (ui64 expectedId : operationIds) {
+            bool found = false;
+            for (ui64 foundId : foundOperationIds) {
+                if (foundId == expectedId) {
+                    found = true;
+                    break;
+                }
+            }
+            UNIT_ASSERT_C(found, "Operation ID " << expectedId << " not found in paginated results");
+        }
+
+        Cerr << "Pagination test completed successfully with " << pageCount << " pages" << Endl;
+    }
+
+    Y_UNIT_TEST(ListAfterReboot) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        // =================================
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // =================================
+
+        ui64 setConstraintTxId = ++txId;
+        auto createResponse = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(createResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        // =================================
+
+        auto listResponseBeforeReboot = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
+
+        UNIT_ASSERT_VALUES_EQUAL(listResponseBeforeReboot.GetStatus(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_GE(listResponseBeforeReboot.GetEntries().size(), 1);
+
+        bool foundBeforeReboot = false;
+        for (const auto& entry : listResponseBeforeReboot.GetEntries()) {
+            if (entry.GetId() == setConstraintTxId) {
+                foundBeforeReboot = true;
+                UNIT_ASSERT_VALUES_EQUAL(
+                    static_cast<int>(entry.GetState()),
+                    static_cast<int>(Ydb::Table::SetNotNullState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().Get(0), "value");
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetTablePath(), tablePath);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(foundBeforeReboot, "Operation not found before reboot");
+
+        Cerr << "List operation verified successfully before reboot" << Endl;
+
+        // =================================
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        Cerr << "SchemeShard rebooted successfully" << Endl;
+
+        // =================================
+        auto listResponseAfterReboot = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
+
+        UNIT_ASSERT_VALUES_EQUAL(listResponseAfterReboot.GetStatus(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_GE(listResponseAfterReboot.GetEntries().size(), 1);
+
+        bool foundAfterReboot = false;
+        for (const auto& entry : listResponseAfterReboot.GetEntries()) {
+            if (entry.GetId() == setConstraintTxId) {
+                foundAfterReboot = true;
+                UNIT_ASSERT_VALUES_EQUAL(
+                    static_cast<int>(entry.GetState()),
+                    static_cast<int>(Ydb::Table::SetNotNullState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().Get(0), "value");
+                UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetTablePath(), tablePath);
+                break;
+            }
+        }
+        UNIT_ASSERT_C(foundAfterReboot, "Operation not found after reboot - persistence failed!");
+
+        Cerr << "List operation verified successfully after reboot - persistence works!" << Endl;
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+    }
 } // Y_UNIT_TEST_SUITE(SetNotNullTest)

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1303,7 +1303,6 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         TString tablePath1 = root + "/Table1";
         TString tablePath2 = root + "/Table2";
 
-        // Create test tables
         TestCreateTable(runtime, ++txId, root, R"(
               Name: "Table1"
               Columns { Name: "key"    Type: "Uint32" }
@@ -1408,7 +1407,6 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
 
         TString root = "/MyRoot";
 
-        // Test list operations when no operations exist
         auto listResponse = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
 
         UNIT_ASSERT_VALUES_EQUAL(listResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
@@ -1472,7 +1470,6 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             
             UNIT_ASSERT_LE(static_cast<ui64>(listResponse.GetEntries().size()), pageSize);
 
-            // Collect operation IDs from this page
             for (const auto& entry : listResponse.GetEntries()) {
                 foundOperationIds.push_back(entry.GetId());
                 UNIT_ASSERT_VALUES_EQUAL(entry.GetSettings().GetNotNullColumns().size(), 1);

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1379,19 +1379,19 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             const auto& columns = entry.GetSettings().GetNotNullColumns();
             if (entry.GetId() == setConstraintTxId1) {
                 foundOp1 = true;
-                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetNotNullState::STATE_DONE));
                 UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value");
             }
             if (entry.GetId() == setConstraintTxId2) {
                 foundOp2 = true;
-                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_CANCELLED));
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetNotNullState::STATE_CANCELLED));
                 UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value2");
             }
             if (entry.GetId() == setConstraintTxId3) {
                 foundOp3 = true;
-                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetNotNullState::STATE_DONE));
                 UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value");
             }

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1293,4 +1293,129 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT(getResponse.GetStartTime().seconds() > 0);
         UNIT_ASSERT(getResponse.GetEndTime().seconds() > getResponse.GetStartTime().seconds());
     }
+
+    Y_UNIT_TEST(ListOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath1 = root + "/Table1";
+        TString tablePath2 = root + "/Table2";
+
+        // Create test tables
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table1"
+              Columns { Name: "key"    Type: "Uint32" }
+              Columns { Name: "value"  Type: "Utf8"   }
+              Columns { Name: "value2" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        {
+            TString notnullVal = "hello";
+            TVector<TCell> cells = {
+                TCell::Make((ui32)1),
+                TCell(notnullVal.data(), notnullVal.size()),
+                TCell() // NULL
+            };
+
+            WriteOp(runtime, TTestTxConfig::SchemeShard, ++txId, tablePath1,
+                0, NKikimrDataEvents::TEvWrite::TOperation::OPERATION_UPSERT,
+                {1, 2, 3}, TSerializedCellMatrix(cells, 1, 3), true);
+        }
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table2"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Start first set column constraint operation
+        ui64 setConstraintTxId1 = ++txId;
+        auto response1 = TestSetColumnConstraint(
+            runtime, setConstraintTxId1,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath1,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(response1.GetStatus(), Ydb::StatusIds::SUCCESS);
+        env.TestWaitNotification(runtime, setConstraintTxId1, TTestTxConfig::SchemeShard);
+
+        // Start first set column constraint operation
+        ui64 setConstraintTxId2 = ++txId;
+        auto response2 = TestSetColumnConstraint(
+            runtime, setConstraintTxId2,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath1,
+            {"value2"});
+
+        UNIT_ASSERT_VALUES_EQUAL(response2.GetStatus(), Ydb::StatusIds::SUCCESS);
+        env.TestWaitNotification(runtime, setConstraintTxId2, TTestTxConfig::SchemeShard);
+
+        // Start second set column constraint operation
+        ui64 setConstraintTxId3 = ++txId;
+        auto response3 = TestSetColumnConstraint(
+            runtime, setConstraintTxId3,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath2,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(response3.GetStatus(), Ydb::StatusIds::SUCCESS);
+        env.TestWaitNotification(runtime, setConstraintTxId3, TTestTxConfig::SchemeShard);
+
+        // Test list operations
+        auto listResponse = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
+
+        UNIT_ASSERT_VALUES_EQUAL(listResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_GE(listResponse.GetEntries().size(), 3);
+
+        // Check that both operations are in the list
+        bool foundOp1 = false, foundOp2 = false, foundOp3 = false;
+        for (const auto& entry : listResponse.GetEntries()) {
+            const auto& columns = entry.GetSettings().GetNotNullColumns();
+            if (entry.GetId() == setConstraintTxId1) {
+                foundOp1 = true;
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value");
+            }
+            if (entry.GetId() == setConstraintTxId2) {
+                foundOp2 = true;
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_DONE));
+                UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value2");
+            }
+            if (entry.GetId() == setConstraintTxId3) {
+                foundOp3 = true;
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetColumnConstraintState::STATE_CANCELLED));
+                UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
+                UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value2");
+            }
+        }
+
+        UNIT_ASSERT(foundOp1);
+        UNIT_ASSERT(foundOp2);
+        UNIT_ASSERT(foundOp3);
+    }
+
+    Y_UNIT_TEST(ListEmptyOperations) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TString root = "/MyRoot";
+
+        // Test list operations when no operations exist
+        auto listResponse = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
+
+        UNIT_ASSERT_VALUES_EQUAL(listResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(listResponse.GetEntries().size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(listResponse.GetNextPageToken(), "0");
+    }
 } // Y_UNIT_TEST_SUITE(SetNotNullTest)

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -316,6 +316,7 @@ SRCS(
     schemeshard_set_column_constraint.h
     schemeshard_set_column_constraint__create.cpp
     schemeshard_set_column_constraint__get.cpp
+    schemeshard_set_column_constraint__list.cpp
     schemeshard_set_column_constraint__progress.cpp
     schemeshard_shard_deleter.cpp
     schemeshard_shard_deleter.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

As part of the SET NOT NULL implementation, a basic pull request was created (https://github.com/ydb-platform/ydb/pull/36152). It left a large number of gaps. This pull request addresses one of them.

Each long-running operation should primarily be implemented using five types of requests:

1. Create  
2. Get  
3. Cancel  
4. Forget  
5. List  

See [here](https://ydb.tech/docs/en/reference/ydb-cli/operation-list?version=main).

This pull request implements the `List` request for the new operation at the `SchemeShard` level.

Additionally, as part of this pull request, a bug in DataShard was fixed that prevented multiple constraint-setting operations from being performed on the same shard before the next reboot.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

It will be added on grpc_level and sdk levels later.
