### PR TITLE
Fix TBuffer leak in pdisk on bad Chunk0

### DIFF
--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_impl.cpp
@@ -213,6 +213,7 @@ TCheckDiskFormatResult TPDisk::ReadChunk0Format(ui8* formatSectors, const NPDisk
                         REQUEST_VALGRIND_CHECK_MEM_IS_DEFINED(buffer->Data(), FormatSectorSize);
                         BlockDevice->PwriteSync(buffer->Data(), FormatSectorSize, targetOffset,
                                 TReqId(TReqId::RestoreFormatOnRead, 0), nullptr);
+                        buffer->ReturnToPool();
                     }
                 }
                 //BlockDevice->FlushAsync(nullptr);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Return buffer to pool after pwrite to prevent it from being leaked.
https://github.com/ydb-platform/ydb/issues/45133

### Changelog category <!-- remove all except one -->

* Bugfix 