### PR TITLE
Fix use-after-free in ydb cli

### DIFF
--- a/ydb/public/lib/ydb_cli/import/import.cpp
+++ b/ydb/public/lib/ydb_cli/import/import.cpp
@@ -1231,6 +1231,7 @@ TStatus TImportFileClient::TImpl::UpsertCsv(IInputStream& input,
                         if (!Failed.exchange(true)) {
                             ErrorStatus = MakeHolder<TStatus>(MakeStatus(EStatus::INTERNAL_ERROR, error));
                         }
+                        jobInflightManager->ReleaseJob();
                     }
                 }
                 break;

--- a/ydb/public/lib/ydb_cli/import/import.cpp
+++ b/ydb/public/lib/ydb_cli/import/import.cpp
@@ -1175,7 +1175,6 @@ TStatus TImportFileClient::TImpl::UpsertCsv(IInputStream& input,
 
                     UpsertTValueBufferOnArena(dbPath, std::move(buildOnArenaFunc))
                         .Apply([&, batchStatus](const TAsyncStatus& asyncStatus) {
-                            jobInflightManager->ReleaseJob();
                             if (asyncStatus.GetValueSync().IsSuccess()) {
                                 batchStatus->Completed = true;
                                 if (!FileProgressPool->AddFunc(saveProgressIfAny) && !Failed.exchange(true)) {
@@ -1183,6 +1182,7 @@ TStatus TImportFileClient::TImpl::UpsertCsv(IInputStream& input,
                                         "Couldn't add worker func to save progress"));
                                 }
                             }
+                            jobInflightManager->ReleaseJob();
                             return asyncStatus;
                         });
                 }
@@ -1207,7 +1207,6 @@ TStatus TImportFileClient::TImpl::UpsertCsv(IInputStream& input,
                                 // batch was read successfully, sending data via Apache Arrow
                                 UpsertTValueBufferParquet(dbPath, std::move(batch), writeOptions)
                                     .Apply([&, batchStatus](const TAsyncStatus& asyncStatus) {
-                                        jobInflightManager->ReleaseJob();
                                         if (asyncStatus.GetValueSync().IsSuccess()) {
                                             batchStatus->Completed = true;
                                             if (!FileProgressPool->AddFunc(saveProgressIfAny) && !Failed.exchange(true)) {
@@ -1215,6 +1214,7 @@ TStatus TImportFileClient::TImpl::UpsertCsv(IInputStream& input,
                                                     "Couldn't add worker func to save progress"));
                                             }
                                         }
+                                        jobInflightManager->ReleaseJob();
                                         return asyncStatus;
                                     });
                             } else {
@@ -1394,7 +1394,6 @@ TStatus TImportFileClient::TImpl::UpsertCsvByBlocks(const TString& filePath,
                             return parser.BuildListOnArena(buffer, filePath, arena);
                         })
                         .Apply([&jobsInflight, &confirmedBytes, &writeProgress, batchSizeBytes](const TAsyncStatus& asyncStatus) {
-                            jobsInflight.release();
                             auto status = asyncStatus.GetValueSync();
                             if (status.IsSuccess()) {
                                 confirmedBytes.fetch_add(batchSizeBytes, std::memory_order_relaxed);
@@ -1402,6 +1401,7 @@ TStatus TImportFileClient::TImpl::UpsertCsvByBlocks(const TString& filePath,
                                     writeProgress();
                                 }
                             }
+                            jobsInflight.release();
                             return asyncStatus;
                         });
                 } catch (const std::exception& e) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
In UpsertCsvByBlocks (import.cpp), the BulkUpsert .Apply() callback captures writeProgress by reference. jobsInflight.release() ran before writeProgress(), so the FileWorker thread could finish and tear down stack locals while the gRPC callback was still running on grpc_client → use-after-free / use-after-return.

Repro: TestImpex.test_big_dataset[csv-additional_args1-row], ASAN build

```
==3146107==ERROR: AddressSanitizer: heap-use-after-free on address 0x7b6087e20020
READ of size 8 at 0x7b6087e20020 thread T143 (ydb)
    #0  … UpsertTValueBufferOnArena …::'lambda'(TFuture<TStatus> const&)
    #2  TFutureState<TStatus>::RunCallbacks()
    #33 TGRpcConnectionsImpl::RunDeferred<…BulkUpsert…>
    #38 TAdaptiveThreadPool::TImpl::TThread::DoExecute()
freed by thread T106 (FileWorker2) here:
    #0 operator delete
    #3 TThreadPool::TImpl::DoExecute()
Thread T143 (ydb) created by T8 (grpc_client) here:
    #5 TGRpcConnectionsImpl::EnqueueResponse
Race: READ on grpc_client thread · FREE on FileWorker2 thread.
```
Race: READ on grpc_client thread · FREE on FileWorker2 thread.
