### PR TITLE
Update timestamp in the TryUpdateWriteTimetsamp if consumer's commit offset reaches the end of topic

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -577,16 +577,20 @@ void TMirrorer::RequestSourcePartitionStatus() {
 }
 
 void TMirrorer::TryUpdateWriteTimetsamp(const TActorContext &ctx) {
-    if (Config.GetSyncWriteTime() && !WriteRequestInFlight && StreamStatus && EndOffset == StreamStatus->GetEndOffset()) {
-        LOG_I("update write timestamp from original topic: " << StreamStatus->DebugString());
-        THolder<TEvPersQueue::TEvRequest> request = MakeHolder<TEvPersQueue::TEvRequest>();
-        auto req = request->Record.MutablePartitionRequest();
-        req->SetTopic(TopicConverter->GetClientsideName());
-        req->SetPartition(Partition);
-        req->SetCookie(UPDATE_WRITE_TIMESTAMP);
-        req->MutableCmdUpdateWriteTimestamp()->SetWriteTimeMS(StreamStatus->GetWriteTimeHighWatermark().MilliSeconds());
-        ctx.Send(TabletActorId, request.Release());
+    if (!Config.GetSyncWriteTime() || WriteRequestInFlight || !StreamStatus) {
+        return;
     }
+    if (EndOffset != StreamStatus->GetEndOffset()) {
+        return;
+    }
+    LOG_I("update write timestamp from original topic: " << StreamStatus->DebugString());
+    THolder<TEvPersQueue::TEvRequest> request = MakeHolder<TEvPersQueue::TEvRequest>();
+    auto req = request->Record.MutablePartitionRequest();
+    req->SetTopic(TopicConverter->GetClientsideName());
+    req->SetPartition(Partition);
+    req->SetCookie(UPDATE_WRITE_TIMESTAMP);
+    req->MutableCmdUpdateWriteTimestamp()->SetWriteTimeMS(StreamStatus->GetWriteTimeHighWatermark().MilliSeconds());
+    ctx.Send(TabletActorId, request.Release());
 }
 
 void TMirrorer::AddMessagesToQueue(std::vector<TPersQueueReadEvent::TDataReceivedEvent::TCompressedMessage>&& messages) {

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -593,7 +593,7 @@ enum class EStaleReadStatus {
     AllCommitted,  // all data has been read and commited offset points to the end of topic
 };
 
-EStaleReadStatus ReadSessionStaleStatus(const TActorContext& ctx, bool hasLastReadOffset, TInstant init, const NYdb::NTopic::TReadSessionEvent::TPartitionSessionStatusEvent* streamStatus) {
+static EStaleReadStatus ReadSessionStaleStatus(const TActorContext& ctx, bool hasLastReadOffset, TInstant init, const NYdb::NTopic::TReadSessionEvent::TPartitionSessionStatusEvent* streamStatus) {
     if (hasLastReadOffset) { /* seen some data in this read session */
         return EStaleReadStatus::NonStale;
     }

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -594,7 +594,7 @@ enum class EStaleReadStatus {
 };
 
 EStaleReadStatus ReadSessionStaleStatus(const TActorContext& ctx, bool hasLastReadOffset, TInstant init, const NYdb::NTopic::TReadSessionEvent::TPartitionSessionStatusEvent* streamStatus) {
-    if (hasLastReadOffset) { /* seen some data is this read session */
+    if (hasLastReadOffset) { /* seen some data in this read session */
         return EStaleReadStatus::NonStale;
     }
     if (!streamStatus) {

--- a/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/mirrorer/mirrorer.cpp
@@ -576,11 +576,48 @@ void TMirrorer::RequestSourcePartitionStatus() {
     }
 }
 
+static TDuration GetRewindCommitDelay(const TActorContext& ctx) {
+    const auto& mirrorConfig = AppData(ctx)->PQConfig.GetMirrorConfig();
+    if (!mirrorConfig.HasRewindCommitDelaySeconds()) {
+        return DEFAULT_REWIND_COMMIT_OFFSET_DELAY;
+    }
+    return TDuration::Seconds(mirrorConfig.GetRewindCommitDelaySeconds());
+}
+
+enum class EStaleReadStatus {
+    Unknown,
+    ForceDelay,    // postpone decision
+    NonStale,      // the reading session has some data
+    HasUnreadData, // the reading session hasn't reached the end of the topic yet.
+    CommitLag,     // all data has been read, but the commit is missing
+    AllCommitted,  // all data has been read and commited offset points to the end of topic
+};
+
+EStaleReadStatus ReadSessionStaleStatus(const TActorContext& ctx, bool hasLastReadOffset, TInstant init, const NYdb::NTopic::TReadSessionEvent::TPartitionSessionStatusEvent* streamStatus) {
+    if (hasLastReadOffset) { /* seen some data is this read session */
+        return EStaleReadStatus::NonStale;
+    }
+    if (!streamStatus) {
+        return EStaleReadStatus::Unknown;
+    }
+    if (streamStatus->GetReadOffset() != streamStatus->GetEndOffset()) {
+        return EStaleReadStatus::HasUnreadData;
+    }
+    if (ctx.Now() - init <= GetRewindCommitDelay(ctx)) {
+        return EStaleReadStatus::ForceDelay;
+    }
+    if (streamStatus->GetCommittedOffset() < streamStatus->GetEndOffset()) {
+        return EStaleReadStatus::CommitLag;
+    }
+    return EStaleReadStatus::AllCommitted;
+}
+
 void TMirrorer::TryUpdateWriteTimetsamp(const TActorContext &ctx) {
     if (!Config.GetSyncWriteTime() || WriteRequestInFlight || !StreamStatus) {
         return;
     }
-    if (EndOffset != StreamStatus->GetEndOffset()) {
+    const EStaleReadStatus staleStatus = ReadSessionStaleStatus(ctx, LastReadOffset.Defined(), LastInitStageTimestamp, StreamStatus.Get());
+    if (EndOffset != StreamStatus->GetEndOffset() && staleStatus != EStaleReadStatus::AllCommitted) {
         return;
     }
     LOG_I("update write timestamp from original topic: " << StreamStatus->DebugString());
@@ -767,25 +804,13 @@ void TMirrorer::DoProcessNextReaderEvent(const TActorContext& ctx, bool wakeup) 
     ConsumerInitInterval = CONSUMER_INIT_INTERVAL_START;
 }
 
-static TDuration GetRewindCommitDelay(const TActorContext& ctx) {
-    const auto& mirrorConfig = AppData(ctx)->PQConfig.GetMirrorConfig();
-    if (!mirrorConfig.HasRewindCommitDelaySeconds()) {
-        return DEFAULT_REWIND_COMMIT_OFFSET_DELAY;
-    }
-    return TDuration::Seconds(mirrorConfig.GetRewindCommitDelaySeconds());
-}
-
 bool TMirrorer::TryRewindCommittedOffset(const TActorContext& ctx) {
     LOG_T("TryRewindCommittedOffset " << LabeledOutput(OffsetToRead, StreamStatus->GetCommittedOffset(),  StreamStatus->GetReadOffset(), StreamStatus->GetEndOffset(), (ctx.Now() - LastInitStageTimestamp).Seconds(), (ctx.Now() - LastRewindCommitTimestamp).Seconds()));
-    if (!(LastReadOffset.Empty() /* never seen any data is this read session */
-        && StreamStatus->GetCommittedOffset() < StreamStatus->GetEndOffset()
-        && StreamStatus->GetReadOffset() == StreamStatus->GetEndOffset())) {
+    const EStaleReadStatus staleStatus = ReadSessionStaleStatus(ctx, LastReadOffset.Defined(), LastInitStageTimestamp, StreamStatus.Get());
+    if (staleStatus != EStaleReadStatus::CommitLag) {
         return false;
     }
     const auto now = ctx.Now();
-    if (now - LastInitStageTimestamp <= GetRewindCommitDelay(ctx)) {
-        return false;
-    }
     if (now - LastRewindCommitTimestamp <= REWIND_COMMIT_INTERVAL) {
         return false;
     }

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -637,6 +637,8 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         }
         UNIT_ASSERT_C(committed, "mirror_consumer did not commit all skipped messages within timeout");
 
+        const TInstant allCommitedTimestamp = TInstant::Now();
+
         // Read from the destination topic; nothing must be there except the prefill messages
         auto dstReader = topicClient.CreateReadSession(
             NYdb::NTopic::TReadSessionSettings()
@@ -644,6 +646,7 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
                 .ConsumerName("reader")
         );
 
+        NYdb::NTopic::TPartitionSession::TPtr session;
         size_t messageCount = 0;
         TInstant dstDeadline = TInstant::Max();
         while (TInstant::Now() < dstDeadline) {
@@ -657,10 +660,53 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
             if (auto* data = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
                 messageCount += data->GetMessagesCount();
             } else if (auto* start = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event)) {
+                session = start->GetPartitionSession();
                 start->Confirm();
                 dstDeadline = TDuration::Seconds(10).ToDeadLine();
             } else if (auto* stop = std::get_if<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>(&*event)) {
+                session.Reset();
                 stop->Confirm();
+            } else if (std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event)) {
+                break;
+            }
+        }
+
+        UNIT_ASSERT(session != nullptr);
+        session->RequestStatus();
+
+        dstDeadline = TInstant::Max();
+        while (TInstant::Now() < dstDeadline) {
+            if (!dstReader->WaitEvent().Wait(TDuration::MilliSeconds(400))) {
+                break;
+            }
+            auto event = dstReader->GetEvent(false);
+            if (!event) {
+                if (session) {
+                    session->RequestStatus();
+                }
+                continue;
+            }
+            if (auto* data = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
+                UNIT_ASSERT_VALUES_EQUAL(data->GetMessagesCount(), 0);
+                messageCount += data->GetMessagesCount();
+            } else if (auto* start = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event)) {
+                session = start->GetPartitionSession();
+                start->Confirm();
+                dstDeadline = TDuration::Seconds(10).ToDeadLine();
+            } else if (auto* stop = std::get_if<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>(&*event)) {
+                session.Reset();
+                stop->Confirm();
+            } else if (auto* status = std::get_if<NYdb::NTopic::TReadSessionEvent::TPartitionSessionStatusEvent>(&*event)) {
+                Cerr << "Status event:"
+                    << " " << status->DebugString()
+                    << " " << LabeledOutput(allCommitedTimestamp)
+                    << " " << "diff_ms=" << (allCommitedTimestamp - status->GetWriteTimeHighWatermark()).MilliSeconds()
+                    << "\n";
+                if (status->GetWriteTimeHighWatermark() >= allCommitedTimestamp) {
+                    break;
+                }
+                UNIT_ASSERT(session);
+                session->RequestStatus();
             } else if (std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event)) {
                 break;
             }

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -649,45 +649,19 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         NYdb::NTopic::TPartitionSession::TPtr session;
         size_t messageCount = 0;
         TInstant dstDeadline = TInstant::Max();
-        while (TInstant::Now() < dstDeadline) {
-            if (!dstReader->WaitEvent().Wait(dstDeadline)) {
-                break;
-            }
+        TInstant lastStatusRequest = TInstant::Zero();
+        bool actualWriteTimeHighWatermark = false;
+        while (TInstant::Now() < dstDeadline || !actualWriteTimeHighWatermark) {
+            dstReader->WaitEvent().Wait(Min(dstDeadline, TDuration::MilliSeconds(100).ToDeadLine()));
             auto event = dstReader->GetEvent(false);
             if (!event) {
-                continue;
-            }
-            if (auto* data = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
-                messageCount += data->GetMessagesCount();
-            } else if (auto* start = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event)) {
-                session = start->GetPartitionSession();
-                start->Confirm();
-                dstDeadline = TDuration::Seconds(10).ToDeadLine();
-            } else if (auto* stop = std::get_if<NYdb::NTopic::TReadSessionEvent::TStopPartitionSessionEvent>(&*event)) {
-                session.Reset();
-                stop->Confirm();
-            } else if (std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event)) {
-                break;
-            }
-        }
-
-        UNIT_ASSERT(session != nullptr);
-        session->RequestStatus();
-
-        dstDeadline = TInstant::Max();
-        while (TInstant::Now() < dstDeadline) {
-            if (!dstReader->WaitEvent().Wait(TDuration::MilliSeconds(400))) {
-                break;
-            }
-            auto event = dstReader->GetEvent(false);
-            if (!event) {
-                if (session) {
+                if (TInstant::Now() - lastStatusRequest > TDuration::Seconds(1) && session) {
+                    lastStatusRequest = TInstant::Now();
                     session->RequestStatus();
                 }
                 continue;
             }
             if (auto* data = std::get_if<NYdb::NTopic::TReadSessionEvent::TDataReceivedEvent>(&*event)) {
-                UNIT_ASSERT_VALUES_EQUAL(data->GetMessagesCount(), 0);
                 messageCount += data->GetMessagesCount();
             } else if (auto* start = std::get_if<NYdb::NTopic::TReadSessionEvent::TStartPartitionSessionEvent>(&*event)) {
                 session = start->GetPartitionSession();
@@ -702,11 +676,7 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
                     << " " << LabeledOutput(allCommitedTimestamp)
                     << " " << "diff_ms=" << (allCommitedTimestamp - status->GetWriteTimeHighWatermark()).MilliSeconds()
                     << "\n";
-                if (status->GetWriteTimeHighWatermark() >= allCommitedTimestamp) {
-                    break;
-                }
-                UNIT_ASSERT(session);
-                session->RequestStatus();
+                actualWriteTimeHighWatermark = (status->GetWriteTimeHighWatermark() >= allCommitedTimestamp);
             } else if (std::get_if<NYdb::NTopic::TSessionClosedEvent>(&*event)) {
                 break;
             }

--- a/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
+++ b/ydb/core/persqueue/ut/ut_with_sdk/mirrorer_ut.cpp
@@ -469,7 +469,7 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         }
     }
 
-    void SkipMessagesWithObsoleteTimestampImpl(TMaybe<TDuration> retentionPeriod, const ui32 dstTopicPrefillSize) {
+    void SkipMessagesWithObsoleteTimestampImpl(TMaybe<TDuration> retentionPeriod, const ui32 dstTopicPrefillSize, TExplicitType<bool> withRestart) {
         NKikimrConfig::TFeatureFlags ff;
         ff.SetEnableSkipMessagesWithObsoleteTimestamp(true);
 
@@ -637,6 +637,11 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
         }
         UNIT_ASSERT_C(committed, "mirror_consumer did not commit all skipped messages within timeout");
 
+        if (withRestart) {
+            server.KillTopicPqTablets("/Root/PQ/" + dstTopicFullName);
+            Sleep(TDuration::Seconds(1));
+        }
+
         const TInstant allCommitedTimestamp = TInstant::Now();
 
         // Read from the destination topic; nothing must be there except the prefill messages
@@ -686,19 +691,35 @@ Y_UNIT_TEST_SUITE(TPersQueueMirrorer) {
     }
 
     Y_UNIT_TEST(SkipMessagesWithObsoleteTimestamp) {
-        SkipMessagesWithObsoleteTimestampImpl(Nothing(), 0);
+        SkipMessagesWithObsoleteTimestampImpl(Nothing(), 0, false);
     }
 
     Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampWithRetention) {
-        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1), 0);
+        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1), 0, false);
     }
 
     Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampInNonEmptyDestinationTopic) {
-        SkipMessagesWithObsoleteTimestampImpl(Nothing(), 250);
+        SkipMessagesWithObsoleteTimestampImpl(Nothing(), 250, false);
     }
 
     Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampWithRetentionInNonEmptyDestinationTopic) {
-        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1), 250);
+        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1), 250, false);
+    }
+
+    Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampWithRestart) {
+        SkipMessagesWithObsoleteTimestampImpl(Nothing(), 0, true);
+    }
+
+    Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampWithRetentionWithRestart) {
+        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1), 0, true);
+    }
+
+    Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampInNonEmptyDestinationTopicWithRestart) {
+        SkipMessagesWithObsoleteTimestampImpl(Nothing(), 250, true);
+    }
+
+    Y_UNIT_TEST(SkipMessagesWithObsoleteTimestampWithRetentionInNonEmptyDestinationTopicWithRestart) {
+        SkipMessagesWithObsoleteTimestampImpl(TDuration::Seconds(1), 250, true);
     }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Когда зеркалятор обнаруживает отсутствие данных из-за фильтрации по времени, то он делает commit для читателя и перереставляет EndOffset, чтобы в целевом топика обновлялся WriteTimestampEstimate.
Лучше не смотреть на EndOffset, чтобы на рестартах таблетки требовать вызова commit для читателя.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

LOGBROKER-10492
