### PR TITLE
docs(ru): fix Rust SDK examples for ydb 0.16 breaking changes

### DIFF
--- a/ydb/docs/ru/core/dev/example-app/rust/index.md
+++ b/ydb/docs/ru/core/dev/example-app/rust/index.md
@@ -33,7 +33,7 @@ async fn main() -> YdbResult<()> {
     let client = ClientBuilder::new_from_connection_string(connection_string)?.client()?;
     client.wait().await?;
 
-    let mut qc = client.query_client().clone_with_idempotent_operations(true);
+    let mut qc = client.query_client();
     // ...
     Ok(())
 }
@@ -51,7 +51,7 @@ async fn main() -> YdbResult<()> {
 - `qc.query_row(yql)` — одна строка.
 - `qc.query(yql).await?` — потоковый [`QueryStream`](https://docs.rs/ydb/latest/ydb/struct.QueryStream.html).
 
-Повторы при ошибках: `clone_with_idempotent_operations(true)` для идемпотентных чтений и DDL.
+Повторы при ошибках: `.idempotent(true)` на builder каждого идемпотентного запроса (чтения, DDL).
 
 {% include [steps/02_create_table.md](../_includes/steps/02_create_table.md) %}
 
@@ -91,11 +91,11 @@ qc.exec("UPSERT INTO ... FROM AS_TABLE($seriesData);")
 Чтение материализованного результата в режиме изоляции snapshot read-only:
 
 ```rust
-use ydb::QueryTxMode;
+use ydb::TxMode;
 
 let mut result = qc
     .query("SELECT series_id, title, release_date FROM `native/query/series`")
-    .with_tx_mode(QueryTxMode::SnapshotReadOnly)
+    .with_tx_mode(TxMode::SnapshotReadOnly)
     .idempotent(true)
     .await?;
 
@@ -131,17 +131,17 @@ qc.exec("UPSERT INTO `native/query/series` (series_id, title) VALUES ($id, $titl
 
 {% include [steps/10_transaction_control.md](../_includes/steps/10_transaction_control.md) %}
 
-В Rust SDK явное управление транзакциями (через `Begin` и `Commit`) недоступно для клиентского кода. Вместо этого используйте `retry_transaction` с [`QueryTransactionOptions`](https://docs.rs/ydb/latest/ydb/struct.QueryTransactionOptions.html) для интерактивных транзакций. Для одиночного SQL-запроса режим изоляции задаётся через `.with_tx_mode(...)`.
+В Rust SDK явное управление транзакциями (через `Begin` и `Commit`) недоступно для клиентского кода. Вместо этого используйте [`retry_tx`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html#method.retry_tx) с `.isolation(TxMode::…)` для интерактивных транзакций. Для одиночного SQL-запроса режим изоляции задаётся через `.with_tx_mode(...)`.
 
 Один запрос в режиме snapshot read-only:
 
 ```rust
-use ydb::QueryTxMode;
+use ydb::TxMode;
 
 let mut row = qc
     .query_row("SELECT title FROM `native/query/series` WHERE series_id = $id")
     .param("$id", b"series-1".to_vec())
-    .with_tx_mode(QueryTxMode::SnapshotReadOnly)
+    .with_tx_mode(TxMode::SnapshotReadOnly)
     .idempotent(true)
     .await?;
 ```
@@ -149,20 +149,18 @@ let mut row = qc
 Интерактивная транзакция с несколькими операциями:
 
 ```rust
-use ydb::{QueryTransactionOptions, QueryTxMode};
-
-let mut qc = qc.clone_with_transaction_options(
-    QueryTransactionOptions::new().with_mode(QueryTxMode::SerializableReadWrite),
-);
+use ydb::TxMode;
 
 let title: String = qc
-    .retry_transaction(async |tx| {
+    .retry_tx(async |tx| {
         let mut row = tx
             .query_row("SELECT title FROM `native/query/series` WHERE series_id = $id")
             .param("$id", b"series-1".to_vec())
             .await?;
         Ok(row.remove_field_by_name("title")?.try_into()?)
     })
+    .isolation(TxMode::SerializableReadWrite)
+    .idempotent(true)
     .await?;
 ```
 

--- a/ydb/docs/ru/core/recipes/ydb-sdk/bulk-upsert.md
+++ b/ydb/docs/ru/core/recipes/ydb-sdk/bulk-upsert.md
@@ -532,7 +532,8 @@
 
       client
           .table_client()
-          .retry_execute_bulk_upsert("/local/tablename".into(), rows)
+          .bulk_upsert("/local/tablename", rows)
+          .idempotent(true)
           .await?;
 
       Ok(())

--- a/ydb/docs/ru/core/recipes/ydb-sdk/retry.md
+++ b/ydb/docs/ru/core/recipes/ydb-sdk/retry.md
@@ -782,7 +782,7 @@
 
 - Rust
 
-  Повторные попытки для запросов через Query Service выполняет `QueryClient`: вспомогательные методы для выполнения одного транзакционного SQL-запроса (`query_row`, `exec` и т.д.) ретраятся автоматически; для нескольких операций в одной транзакции — `retry_transaction`.
+  Повторные попытки для запросов через Query Service выполняет `QueryClient`: вспомогательные методы для выполнения одного транзакционного SQL-запроса (`query_row`, `exec` и т.д.) ретраятся автоматически; для нескольких операций в одной транзакции — [`retry_tx`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html#method.retry_tx).
 
   ```rust
   use ydb::{AccessTokenCredentials, ClientBuilder, YdbResult};
@@ -797,21 +797,23 @@
 
       client.wait().await?;
 
-      let mut qc = client.query_client().clone_with_idempotent_operations(true);
+      let mut qc = client.query_client();
 
       // один SQL-запрос на query-клиенте: внутренние повторные попытки
       let mut row = qc
           .query_row("SELECT series_id, title FROM series WHERE series_id = 1")
+          .idempotent(true)
           .await?;
 
       // несколько операций в одной транзакции с ретраями
       let title: String = qc
-          .retry_transaction(async |tx| {
+          .retry_tx(async |tx| {
               let mut row = tx
                   .query_row("SELECT series_id, title FROM series WHERE series_id = 1")
                   .await?;
               Ok(row.remove_field_by_name("title")?.try_into()?)
           })
+          .idempotent(true)
           .await?;
 
       Ok(())

--- a/ydb/docs/ru/core/recipes/ydb-sdk/session-pool-limit.md
+++ b/ydb/docs/ru/core/recipes/ydb-sdk/session-pool-limit.md
@@ -212,10 +212,10 @@
 
 - Rust
 
-  Для `QueryClient` размер пула задаётся через [`QuerySessionPoolSettings::with_limit`](https://docs.rs/ydb/latest/ydb/struct.QuerySessionPoolSettings.html#method.with_limit) и [`with_implicit_session_pool`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html#method.with_implicit_session_pool) (или [`with_session_pool`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html#method.with_session_pool) для явных сессий):
+  Размер пула сессий задаётся на драйвере через [`Client::with_session_pool`](https://docs.rs/ydb/latest/ydb/struct.Client.html#method.with_session_pool) и [`SessionPoolSettings::with_limit`](https://docs.rs/ydb/latest/ydb/struct.SessionPoolSettings.html#method.with_limit). Пул общий для table- и query-клиентов:
 
   ```rust
-  use ydb::{ClientBuilder, QuerySessionPoolSettings, YdbResult};
+  use ydb::{ClientBuilder, SessionPoolSettings, YdbResult};
 
   #[tokio::main]
   async fn main() -> YdbResult<()> {
@@ -225,12 +225,11 @@
       .client()?;
       client.wait().await?;
 
-      let mut qc = client
-          .query_client()
-          .with_implicit_session_pool(
-              QuerySessionPoolSettings::new().with_limit(500),
-          );
+      let client = client
+          .with_session_pool(SessionPoolSettings::new().with_limit(500))
+          .await?;
 
+      let mut qc = client.query_client();
       let mut row = qc.query_row("SELECT 1 AS one").await?;
       Ok(())
   }

--- a/ydb/docs/ru/core/recipes/ydb-sdk/tx-control.md
+++ b/ydb/docs/ru/core/recipes/ydb-sdk/tx-control.md
@@ -632,18 +632,17 @@
 - Rust
 
   ```rust
-  use ydb::{QueryTransactionOptions, QueryTxMode};
+  use ydb::TxMode;
 
-  let qc = client
+  client
       .query_client()
-      .clone_with_transaction_options(
-          QueryTransactionOptions::new().with_mode(QueryTxMode::SerializableReadWrite),
-      );
-  qc.retry_transaction(async |tx| {
-      tx.query_row("SELECT 1 AS one").await?;
-      Ok(())
-  })
-  .await?;
+      .retry_tx(async |tx| {
+          tx.query_row("SELECT 1 AS one").await?;
+          Ok(())
+      })
+      .isolation(TxMode::SerializableReadWrite)
+      .idempotent(true)
+      .await?;
   ```
 
 - PHP
@@ -962,20 +961,20 @@
 - Rust
 
   ```rust
-  use ydb::QueryTxMode;
+  use ydb::TxMode;
 
   let mut qc = client.query_client();
 
   // Online RO — согласованное чтение (allow_inconsistent_reads = false)
   let mut row = qc
       .query_row("SELECT 1 AS one")
-      .with_tx_mode(QueryTxMode::OnlineReadOnly)
+      .with_tx_mode(TxMode::OnlineReadOnly)
       .await?;
 
   // Online inconsistent RO — максимальная производительность (allow_inconsistent_reads = true)
   let mut row = qc
       .query_row("SELECT 1 AS one")
-      .with_tx_mode(QueryTxMode::OnlineReadOnlyInconsistent)
+      .with_tx_mode(TxMode::OnlineReadOnlyInconsistent)
       .await?;
   ```
 
@@ -1281,13 +1280,13 @@
 - Rust
 
   ```rust
-  use ydb::QueryTxMode;
+  use ydb::TxMode;
 
   let mut qc = client.query_client();
-  // Режим Stale Read-Only поддерживается только для таких вызовов на query-клиенте (не для retry_transaction).
+  // Режим Stale Read-Only поддерживается только для one-shot вызовов на query-клиенте (не для retry_tx).
   let mut row = qc
       .query_row("SELECT 1 AS one")
-      .with_tx_mode(QueryTxMode::StaleReadOnly)
+      .with_tx_mode(TxMode::StaleReadOnly)
       .await?;
   ```
 
@@ -1585,20 +1584,19 @@
 - Rust
 
   ```rust
-  use ydb::{QueryTransactionOptions, QueryTxMode};
+  use ydb::TxMode;
 
   let mut qc = client.query_client();
   qc.query_row("SELECT 1 AS one")
-      .with_tx_mode(QueryTxMode::SnapshotReadOnly)
+      .with_tx_mode(TxMode::SnapshotReadOnly)
       .await?;
 
-  let qc = qc.clone_with_transaction_options(
-      QueryTransactionOptions::new().with_mode(QueryTxMode::SnapshotReadOnly),
-  );
-  qc.retry_transaction(async |tx| {
+  qc.retry_tx(async |tx| {
       tx.query_row("SELECT 1 AS one").await?;
       Ok(())
   })
+  .isolation(TxMode::SnapshotReadOnly)
+  .idempotent(true)
   .await?;
   ```
 
@@ -1955,20 +1953,19 @@
 - Rust
 
   ```rust
-  use ydb::{QueryTransactionOptions, QueryTxMode};
+  use ydb::TxMode;
 
   let mut qc = client.query_client();
   qc.query_row("SELECT 1 AS one")
-      .with_tx_mode(QueryTxMode::SnapshotReadWrite)
+      .with_tx_mode(TxMode::SnapshotReadWrite)
       .await?;
 
-  let qc = qc.clone_with_transaction_options(
-      QueryTransactionOptions::new().with_mode(QueryTxMode::SnapshotReadWrite),
-  );
-  qc.retry_transaction(async |tx| {
+  qc.retry_tx(async |tx| {
       tx.query_row("SELECT 1 AS one").await?;
       Ok(())
   })
+  .isolation(TxMode::SnapshotReadWrite)
+  .idempotent(true)
   .await?;
   ```
 

--- a/ydb/docs/ru/core/recipes/ydb-sdk/vector-search.md
+++ b/ydb/docs/ru/core/recipes/ydb-sdk/vector-search.md
@@ -158,7 +158,7 @@
 
     let client = ClientBuilder::new_from_connection_string(connection_string)?.client()?;
     client.wait().await?;
-    let mut qc = client.query_client().clone_with_idempotent_operations(true);
+    let mut qc = client.query_client();
     ```
 
 - PHP


### PR DESCRIPTION
## Summary

Audit of all ` ```rust ` blocks under `ydb/docs/ru/` against **ydb-rs-sdk 0.16** API.

**18 files** with Rust examples reviewed; **6 files** had compile-breaking outdated API; **12 files** were already correct.

### Breaking API migrations applied

| Removed (pre-0.16) | Replacement |
|--------------------|-------------|
| `clone_with_idempotent_operations` | `.idempotent(true)` on call builders |
| `clone_with_transaction_options` + `retry_transaction` | `retry_tx(...).isolation(TxMode::…)` |
| `QueryTxMode` | `TxMode` |
| `QueryTransactionOptions` | removed (options on `retry_tx` builder) |
| `QuerySessionPoolSettings` / `QueryClient::with_implicit_session_pool` | `Client::with_session_pool(SessionPoolSettings::…)` |
| `retry_execute_bulk_upsert` | `table_client().bulk_upsert(...).idempotent(true)` |

### Files updated

- `core/dev/example-app/rust/index.md`
- `core/recipes/ydb-sdk/tx-control.md` (5 Rust blocks)
- `core/recipes/ydb-sdk/retry.md`
- `core/recipes/ydb-sdk/vector-search.md`
- `core/recipes/ydb-sdk/session-pool-limit.md`
- `core/recipes/ydb-sdk/bulk-upsert.md`

### Files verified OK (no changes)

`topic.md`, `coordination.md`, `logging.md`, `upsert.md`, `init.md`, `distributed-lock.md`, all `auth-*.md` — credentials and topic/coordination APIs match current SDK.

## Test plan

- [x] Grep: no remaining `clone_with_*`, `retry_transaction`, `QueryTxMode`, `QuerySessionPoolSettings`, `retry_execute_bulk_upsert` in `docs/ru`
- [ ] Examples cross-checked against `ydb-rs-sdk` master (`retry_tx`, `TxMode`, `SessionPoolSettings`, table `bulk_upsert`)

Made with [Cursor](https://cursor.com)