### PR TITLE
docs: set 26.1.1.20 release date in downloads tables

### DIFF
--- a/ydb/docs/en/core/downloads/ydb-open-source-database.md
+++ b/ydb/docs/en/core/downloads/ydb-open-source-database.md
@@ -9,7 +9,7 @@ See also [{#T}](yandex-enterprise-database.md).
 #|
 || Version |  Release date | Download | Changelog ||
 || **v26.1** | > | > | > ||
-|| v.26.1.1.20 | TBD | [Binary file](https://storage.yandexcloud.net/binaries.ydb.tech/release/26.1.1.20/ydbd-26.1.1.20-linux-amd64.tar.gz) | [See list](../changelog-server.md#26-1-1-20) ||
+|| v.26.1.1.20 | 02.07.26 | [Binary file](https://storage.yandexcloud.net/binaries.ydb.tech/release/26.1.1.20/ydbd-26.1.1.20-linux-amd64.tar.gz) | [See list](../changelog-server.md#26-1-1-20) ||
 || **v25.4** | > | > | > ||
 || v.25.4.1.15 | 24.04.26 | [Binary file](https://storage.yandexcloud.net/binaries.ydb.tech/release/25.4.1.15/ydbd-25.4.1.15-linux-amd64.tar.gz) | [See list](../changelog-server.md#25-4-1-15) ||
 || **v25.3** | > | > | > ||
@@ -45,7 +45,7 @@ See also [{#T}](yandex-enterprise-database.md).
 #|
 || Version |  Release date | Docker `registry/image:tag` | Changelog ||
 || **v26.1** | > | > | > ||
-|| v.26.1.1.20 | TBD | `cr.yandex/crptqonuodf51kdj7a7d/ydb:26.1.1.20` | [See list](../changelog-server.md#26-1-1-20) ||
+|| v.26.1.1.20 | 02.07.26 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:26.1.1.20` | [See list](../changelog-server.md#26-1-1-20) ||
 || **v25.4** | > | > | > ||
 || v.25.4.1.15 | 24.04.26 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:25.4.1.15` | [See list](../changelog-server.md#25-4-1-15) ||
 || **v25.3** | > | > | > ||
@@ -81,7 +81,7 @@ See also [{#T}](yandex-enterprise-database.md).
 #|
 || Version |  Release date | Link | Changelog ||
 || **v26.1** | > | > | > ||
-|| v.26.1.1.20 | TBD | [https://github.com/ydb-platform/ydb/tree/26.1.1.20](https://github.com/ydb-platform/ydb/tree/26.1.1.20) | [See list](../changelog-server.md#26-1-1-20) ||
+|| v.26.1.1.20 | 02.07.26 | [https://github.com/ydb-platform/ydb/tree/26.1.1.20](https://github.com/ydb-platform/ydb/tree/26.1.1.20) | [See list](../changelog-server.md#26-1-1-20) ||
 || **v25.4** | > | > | > ||
 || v.25.4.1.15 | 24.04.26 | [https://github.com/ydb-platform/ydb/tree/25.4.1.15](https://github.com/ydb-platform/ydb/tree/25.4.1.15) | [See list](../changelog-server.md#25-4-1-15) ||
 || **v25.3** | > | > | > ||

--- a/ydb/docs/ru/core/downloads/ydb-open-source-database.md
+++ b/ydb/docs/ru/core/downloads/ydb-open-source-database.md
@@ -9,7 +9,7 @@
 #|
 || Версия |  Дата выпуска | Скачать | Список изменений ||
 || **v26.1** | > | > | > ||
-|| v.26.1.1.20 | уточняется | [Бинарный файл](https://storage.yandexcloud.net/binaries.ydb.tech/release/26.1.1.20/ydbd-26.1.1.20-linux-amd64.tar.gz) | [См. список](../changelog-server.md#26-1-1-20) ||
+|| v.26.1.1.20 | 02.07.26 | [Бинарный файл](https://storage.yandexcloud.net/binaries.ydb.tech/release/26.1.1.20/ydbd-26.1.1.20-linux-amd64.tar.gz) | [См. список](../changelog-server.md#26-1-1-20) ||
 || **v25.4** | > | > | > ||
 || v.25.4.1.15 | 24.04.26 | [Бинарный файл](https://storage.yandexcloud.net/binaries.ydb.tech/release/25.4.1.15/ydbd-25.4.1.15-linux-amd64.tar.gz) | [См. список](../changelog-server.md#25-4-1-15) ||
 || **v25.3** | > | > | > ||
@@ -45,7 +45,7 @@
 #|
 || Версия |  Дата выпуска | Docker `registry/image:tag` | Список изменений ||
 || **v26.1** | > | > | > ||
-|| v.26.1.1.20 | уточняется | `cr.yandex/crptqonuodf51kdj7a7d/ydb:26.1.1.20` | [См. список](../changelog-server.md#26-1-1-20) ||
+|| v.26.1.1.20 | 02.07.26 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:26.1.1.20` | [См. список](../changelog-server.md#26-1-1-20) ||
 || **v25.4** | > | > | > ||
 || v.25.4.1.15 | 24.04.26 | `cr.yandex/crptqonuodf51kdj7a7d/ydb:25.4.1.15` | [См. список](../changelog-server.md#25-4-1-15) ||
 || **v25.3** | > | > | > ||
@@ -81,7 +81,7 @@
 #|
 || Версия |  Дата выпуска | Ссылка | Список изменений ||
 || **v26.1** | > | > | > ||
-|| v.26.1.1.20 | уточняется | [https://github.com/ydb-platform/ydb/tree/26.1.1.20](https://github.com/ydb-platform/ydb/tree/26.1.1.20) | [См. список](../changelog-server.md#26-1-1-20) ||
+|| v.26.1.1.20 | 02.07.26 | [https://github.com/ydb-platform/ydb/tree/26.1.1.20](https://github.com/ydb-platform/ydb/tree/26.1.1.20) | [См. список](../changelog-server.md#26-1-1-20) ||
 || **v25.4** | > | > | > ||
 || v.25.4.1.15 | 24.04.26 | [https://github.com/ydb-platform/ydb/tree/25.4.1.15](https://github.com/ydb-platform/ydb/tree/25.4.1.15) | [См. список](../changelog-server.md#25-4-1-15) ||
 || **v25.3** | > | > | > ||


### PR DESCRIPTION
### Changelog entry

(not required)

### Changelog category

* Documentation (changelog entry is not required)

### Description for reviewers

Set release date **02.07.26** for **v26.1.1.20** in EN/RU downloads tables (Linux, Docker, Source).


Made with [Cursor](https://cursor.com)