### PR TITLE
Fix cli admin cluster restore failure

### DIFF
--- a/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
+++ b/ydb/public/lib/ydb_cli/dump/restore_impl.cpp
@@ -622,7 +622,7 @@ TRestoreResult TRestoreClient::WaitForAvailableNodes(const TString& database, TD
     TDuration retrySleep = TDuration::MilliSeconds(1000);
     while (true) {
         auto result = client.ListEndpoints().GetValueSync();
-        if (result.GetStatus() == EStatus::UNAVAILABLE) {
+        if (result.GetStatus() == EStatus::UNAVAILABLE || (result.IsSuccess() && result.GetEndpointsInfo().empty())) {
             auto timeSpent = TDuration::Seconds(timer.Passed());
             if (timeSpent > waitDuration) {
                 auto error = TStringBuilder()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
failure happens during ydb admin cluster restore: the CLI waits for database nodes, but it treated discovery SUCCESS as ready even when discovery returned an empty endpoint list.
 Fix: WaitForAvailableNodes() now continues waiting if discovery is SUCCESS but GetEndpointsInfo() is empty. So restore proceeds only after there is at least one usable database endpoint.