### PR TITLE
Fix fast-unmute grace race that caused re-mute after unmute

### DIFF
--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -38,6 +38,12 @@ from mute.constants import (
 from mute.naming import mute_file_line_to_tests_monitor_full_name
 from mute.mute_utils import dedicated_relative
 from mute.llm_debug_comment import post_llm_debug_comment
+from mute.fast_unmute_pipeline import grace_ttl_calendar_days
+from mute.fast_unmute_ydb import (
+    _coerce_dt,
+    create_fast_unmute_grace_table,
+    upsert_fast_unmute_grace_row,
+)
 from ydb_wrapper import YDBWrapper
 from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 
@@ -203,6 +209,101 @@ def delete_fast_unmute_grace_rows(ydb_wrapper, branch, build_type, test_strings)
                 full_name,
                 exc,
             )
+
+
+def load_fast_unmute_active_row_map(ydb_wrapper, branch, build_type):
+    """Map ``full_name`` -> fast_unmute_active row for this (branch, build_type)."""
+    try:
+        table_path = ydb_wrapper.get_table_path('fast_unmute_active')
+    except KeyError:
+        return {}
+
+    branch_esc = str(branch).replace("'", "''")
+    build_type_esc = str(build_type).replace("'", "''")
+    query = f"""
+    SELECT full_name, github_issue_number, requested_at
+    FROM `{table_path}`
+    WHERE branch = '{branch_esc}'
+        AND build_type = '{build_type_esc}'
+    """
+    try:
+        rows = ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_load_rows')
+    except Exception as exc:
+        logging.warning('Failed to load fast_unmute_active rows: %s', exc)
+        return {}
+
+    out = {}
+    for row in rows:
+        fn = row.get('full_name')
+        if fn:
+            out[fn] = row
+    return out
+
+
+def record_fast_unmute_grace_for_unmute_lines(
+    ydb_wrapper,
+    branch,
+    build_type,
+    test_lines,
+    active_row_map,
+):
+    """Upsert ``fast_unmute_grace`` when fast-unmute decides to unmute.
+
+    Job 1 ``cleanup_manual_unmute`` only sees ``tests_monitor`` from the previous
+    workflow hour, so grace may be missing on the first run after unmute. Writing
+    grace here closes that gap before the next mute aggregation.
+    """
+    if not test_lines or not ydb_wrapper or not branch or not build_type:
+        return
+
+    try:
+        grace_table_path = ydb_wrapper.get_table_path('fast_unmute_grace')
+    except KeyError:
+        logging.info('fast_unmute_grace not registered — skip grace upsert on unmute')
+        return
+
+    create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    grace_ttl = grace_ttl_calendar_days(get_mute_window_days(), get_manual_unmute_window_days())
+    recorded = 0
+
+    for line in test_lines:
+        if '*' in line or '?' in line:
+            continue
+        full_name = mute_file_line_to_tests_monitor_full_name(line)
+        active_row = active_row_map.get(full_name)
+        if not active_row:
+            logging.warning(
+                'fast-unmute grace: skip %r — no fast_unmute_active row for %s',
+                line,
+                full_name,
+            )
+            continue
+        requested_at = _coerce_dt(active_row.get('requested_at'))
+        fast_track_at = requested_at or now
+        try:
+            upsert_fast_unmute_grace_row(
+                ydb_wrapper,
+                grace_table_path,
+                full_name,
+                branch,
+                build_type,
+                int(active_row.get('github_issue_number') or 0),
+                fast_track_at,
+                now,
+                grace_ttl,
+            )
+            recorded += 1
+        except Exception as exc:
+            logging.warning('Failed to upsert fast-unmute grace for %s: %s', full_name, exc)
+
+    if recorded:
+        logging.info(
+            'Recorded fast-unmute grace for %d test(s) on branch=%s build_type=%s',
+            recorded,
+            branch,
+            build_type,
+        )
 
 
 def load_manual_unmute_full_names(ydb_wrapper, branch, build_type):
@@ -710,6 +811,7 @@ def apply_and_add_mutes(
     ydb_wrapper=None,
     branch=None,
     build_type=None,
+    fast_unmute_active_row_map=None,
 ):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
@@ -835,6 +937,13 @@ def apply_and_add_mutes(
                 logging.info(
                     'Manual fast-unmute added %d test(s) to to_unmute [fast-unmute]',
                     len(to_unmute_manual_stable),
+                )
+                record_fast_unmute_grace_for_unmute_lines(
+                    ydb_wrapper,
+                    branch,
+                    build_type,
+                    to_unmute_manual_stable,
+                    fast_unmute_active_row_map or {},
                 )
             if manual_fast_delete_lines:
                 logging.info(
@@ -1482,10 +1591,14 @@ def mute_worker(args):
 
         manual_unmute_window_days, manual_unmute_min_runs = load_manual_unmute_config()
         manual_unmute_full_names = set()
+        fast_unmute_active_row_map = {}
         aggregated_for_manual_unmute = None
         if manual_unmute_window_days and manual_unmute_min_runs:
             manual_unmute_full_names = load_manual_unmute_full_names(ydb_wrapper, args.branch, build_type)
             if manual_unmute_full_names:
+                fast_unmute_active_row_map = load_fast_unmute_active_row_map(
+                    ydb_wrapper, args.branch, build_type
+                )
                 aggregated_for_manual_unmute = aggregate_test_data(all_data, manual_unmute_window_days)
                 logging.info(
                     f"Manual fast-unmute: window={manual_unmute_window_days}d, min_runs={manual_unmute_min_runs}, "
@@ -1537,6 +1650,7 @@ def mute_worker(args):
                 ydb_wrapper=ydb_wrapper,
                 branch=args.branch,
                 build_type=build_type,
+                fast_unmute_active_row_map=fast_unmute_active_row_map,
             )
 
         elif args.mode == 'sync_fast_unmute_grace':

--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -38,12 +38,7 @@ from mute.constants import (
 from mute.naming import mute_file_line_to_tests_monitor_full_name
 from mute.mute_utils import dedicated_relative
 from mute.llm_debug_comment import post_llm_debug_comment
-from mute.fast_unmute_pipeline import grace_ttl_calendar_days
-from mute.fast_unmute_ydb import (
-    _coerce_dt,
-    create_fast_unmute_grace_table,
-    upsert_fast_unmute_grace_row,
-)
+from mute.fast_unmute_pipeline import enter_fast_unmute_grace_for_unmuted_tests
 from ydb_wrapper import YDBWrapper
 from github_issue_utils import DEFAULT_BUILD_TYPE, canonical_team_slug, make_profile_id
 
@@ -209,101 +204,6 @@ def delete_fast_unmute_grace_rows(ydb_wrapper, branch, build_type, test_strings)
                 full_name,
                 exc,
             )
-
-
-def load_fast_unmute_active_row_map(ydb_wrapper, branch, build_type):
-    """Map ``full_name`` -> fast_unmute_active row for this (branch, build_type)."""
-    try:
-        table_path = ydb_wrapper.get_table_path('fast_unmute_active')
-    except KeyError:
-        return {}
-
-    branch_esc = str(branch).replace("'", "''")
-    build_type_esc = str(build_type).replace("'", "''")
-    query = f"""
-    SELECT full_name, github_issue_number, requested_at
-    FROM `{table_path}`
-    WHERE branch = '{branch_esc}'
-        AND build_type = '{build_type_esc}'
-    """
-    try:
-        rows = ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_load_rows')
-    except Exception as exc:
-        logging.warning('Failed to load fast_unmute_active rows: %s', exc)
-        return {}
-
-    out = {}
-    for row in rows:
-        fn = row.get('full_name')
-        if fn:
-            out[fn] = row
-    return out
-
-
-def record_fast_unmute_grace_for_unmute_lines(
-    ydb_wrapper,
-    branch,
-    build_type,
-    test_lines,
-    active_row_map,
-):
-    """Upsert ``fast_unmute_grace`` when fast-unmute decides to unmute.
-
-    Job 1 ``cleanup_manual_unmute`` only sees ``tests_monitor`` from the previous
-    workflow hour, so grace may be missing on the first run after unmute. Writing
-    grace here closes that gap before the next mute aggregation.
-    """
-    if not test_lines or not ydb_wrapper or not branch or not build_type:
-        return
-
-    try:
-        grace_table_path = ydb_wrapper.get_table_path('fast_unmute_grace')
-    except KeyError:
-        logging.info('fast_unmute_grace not registered — skip grace upsert on unmute')
-        return
-
-    create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    grace_ttl = grace_ttl_calendar_days(get_mute_window_days(), get_manual_unmute_window_days())
-    recorded = 0
-
-    for line in test_lines:
-        if '*' in line or '?' in line:
-            continue
-        full_name = mute_file_line_to_tests_monitor_full_name(line)
-        active_row = active_row_map.get(full_name)
-        if not active_row:
-            logging.warning(
-                'fast-unmute grace: skip %r — no fast_unmute_active row for %s',
-                line,
-                full_name,
-            )
-            continue
-        requested_at = _coerce_dt(active_row.get('requested_at'))
-        fast_track_at = requested_at or now
-        try:
-            upsert_fast_unmute_grace_row(
-                ydb_wrapper,
-                grace_table_path,
-                full_name,
-                branch,
-                build_type,
-                int(active_row.get('github_issue_number') or 0),
-                fast_track_at,
-                now,
-                grace_ttl,
-            )
-            recorded += 1
-        except Exception as exc:
-            logging.warning('Failed to upsert fast-unmute grace for %s: %s', full_name, exc)
-
-    if recorded:
-        logging.info(
-            'Recorded fast-unmute grace for %d test(s) on branch=%s build_type=%s',
-            recorded,
-            branch,
-            build_type,
-        )
 
 
 def load_manual_unmute_full_names(ydb_wrapper, branch, build_type):
@@ -811,7 +711,6 @@ def apply_and_add_mutes(
     ydb_wrapper=None,
     branch=None,
     build_type=None,
-    fast_unmute_active_row_map=None,
 ):
     output_path = os.path.join(output_path, 'mute_update')
     logging.info(f"Creating mute files in directory: {output_path}")
@@ -937,13 +836,6 @@ def apply_and_add_mutes(
                 logging.info(
                     'Manual fast-unmute added %d test(s) to to_unmute [fast-unmute]',
                     len(to_unmute_manual_stable),
-                )
-                record_fast_unmute_grace_for_unmute_lines(
-                    ydb_wrapper,
-                    branch,
-                    build_type,
-                    to_unmute_manual_stable,
-                    fast_unmute_active_row_map or {},
                 )
             if manual_fast_delete_lines:
                 logging.info(
@@ -1573,6 +1465,17 @@ def mute_worker(args):
             return 1
 
         build_type = getattr(args, 'build_type', DEFAULT_BUILD_TYPE)
+
+        if args.mode == 'enter_fast_unmute_grace':
+            logging.info(
+                'Starting enter_fast_unmute_grace for branch=%s build_type=%s',
+                args.branch,
+                build_type,
+            )
+            enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, args.branch, build_type)
+            logging.info('enter_fast_unmute_grace completed successfully')
+            return 0
+
         logging.info(f"Starting mute worker with mode: {args.mode}")
         logging.info(f"Branch: {args.branch}")
         logging.info(f"build_type: {build_type}")
@@ -1591,14 +1494,10 @@ def mute_worker(args):
 
         manual_unmute_window_days, manual_unmute_min_runs = load_manual_unmute_config()
         manual_unmute_full_names = set()
-        fast_unmute_active_row_map = {}
         aggregated_for_manual_unmute = None
         if manual_unmute_window_days and manual_unmute_min_runs:
             manual_unmute_full_names = load_manual_unmute_full_names(ydb_wrapper, args.branch, build_type)
             if manual_unmute_full_names:
-                fast_unmute_active_row_map = load_fast_unmute_active_row_map(
-                    ydb_wrapper, args.branch, build_type
-                )
                 aggregated_for_manual_unmute = aggregate_test_data(all_data, manual_unmute_window_days)
                 logging.info(
                     f"Manual fast-unmute: window={manual_unmute_window_days}d, min_runs={manual_unmute_min_runs}, "
@@ -1650,7 +1549,6 @@ def mute_worker(args):
                 ydb_wrapper=ydb_wrapper,
                 branch=args.branch,
                 build_type=build_type,
-                fast_unmute_active_row_map=fast_unmute_active_row_map,
             )
 
         elif args.mode == 'sync_fast_unmute_grace':
@@ -1721,6 +1619,18 @@ if __name__ == "__main__":
     )
     sync_fast_unmute_grace_parser.add_argument('--branch', default='main', help='Branch to get history')
     sync_fast_unmute_grace_parser.add_argument(
+        '--build-type',
+        default=DEFAULT_BUILD_TYPE,
+        dest='build_type',
+        help='tests_monitor build_type slice (default: relwithdebinfo)',
+    )
+
+    enter_fast_unmute_grace_parser = subparsers.add_parser(
+        'enter_fast_unmute_grace',
+        help='start fast_unmute_grace when tests left mute on branch (after tests_monitor refresh)',
+    )
+    enter_fast_unmute_grace_parser.add_argument('--branch', default='main', help='Branch to get history')
+    enter_fast_unmute_grace_parser.add_argument(
         '--build-type',
         default=DEFAULT_BUILD_TYPE,
         dest='build_type',

--- a/.github/scripts/tests/mute/create_new_muted_ya.py
+++ b/.github/scripts/tests/mute/create_new_muted_ya.py
@@ -1473,7 +1473,12 @@ def mute_worker(args):
                 build_type,
             )
             enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, args.branch, build_type)
-            logging.info('enter_fast_unmute_grace completed successfully')
+            logging.info(
+                'enter_fast_unmute_grace step finished for branch=%s build_type=%s '
+                '(see log above for recorded/skipped rows and any warnings)',
+                args.branch,
+                build_type,
+            )
             return 0
 
         logging.info(f"Starting mute worker with mode: {args.mode}")

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -97,13 +97,13 @@ def enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, branch, build_type):
 
     create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
 
-    try:
-        active_rows = fetch_fast_unmute_active_rows(
-            ydb_wrapper, active_table_path, branch, build_type
-        )
-    except Exception as exc:
-        logging.warning('enter_fast_unmute_grace: failed to load fast_unmute_active: %s', exc)
-        return
+    # NB: intentionally do NOT swallow YDB/query errors below. This step guards the
+    # re-mute decision that runs later in the same job, so silently skipping grace on a
+    # transient failure would re-introduce the race (#45582) with no signal. Let it fail
+    # loudly so the scheduled job can be retried/investigated instead.
+    active_rows = fetch_fast_unmute_active_rows(
+        ydb_wrapper, active_table_path, branch, build_type
+    )
 
     if not active_rows:
         logging.info(
@@ -113,22 +113,19 @@ def enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, branch, build_type):
         )
         return
 
-    try:
-        currently_muted = fetch_currently_muted(
-            ydb_wrapper, tests_monitor_path, branch, build_type
-        )
-        existing_grace = fetch_grace_full_names(
-            ydb_wrapper, grace_table_path, branch, build_type
-        )
-    except Exception as exc:
-        logging.warning('enter_fast_unmute_grace: failed to load monitor/grace state: %s', exc)
-        return
+    currently_muted = fetch_currently_muted(
+        ydb_wrapper, tests_monitor_path, branch, build_type
+    )
+    existing_grace = fetch_grace_full_names(
+        ydb_wrapper, grace_table_path, branch, build_type
+    )
 
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     grace_ttl = grace_ttl_calendar_days(
         get_mute_window_days(), get_manual_unmute_window_days()
     )
     recorded = 0
+    failed = 0
 
     for row in active_rows:
         full_name = row.get('full_name')
@@ -157,6 +154,7 @@ def enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, branch, build_type):
                 build_type,
             )
         except Exception as exc:
+            failed += 1
             logging.warning(
                 'enter_fast_unmute_grace: failed to upsert grace for %s: %s',
                 full_name,
@@ -169,6 +167,15 @@ def enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, branch, build_type):
             recorded,
             branch,
             build_type,
+        )
+
+    # Fail the step if any grace write was lost: proceeding would let update_muted_ya
+    # make the re-mute decision with missing grace for these tests.
+    if failed:
+        raise RuntimeError(
+            'enter_fast_unmute_grace: failed to record grace for '
+            f'{failed} test(s) on branch={branch} build_type={build_type} '
+            '(see warnings above); failing the step to avoid a re-mute with missing grace'
         )
 
 

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -50,6 +50,8 @@ from mute.fast_unmute_ydb import (
     fetch_all_rows,
     fetch_candidate_issues,
     fetch_currently_muted,
+    fetch_fast_unmute_active_rows,
+    fetch_grace_full_names,
     upsert_fast_unmute_grace_row,
     upsert_rows,
 )
@@ -77,6 +79,97 @@ def grace_ttl_calendar_days(mute_window_days, manual_unmute_window_days):
     Stored on insert so dashboards and TTL stay interpretable even if ``mute_config.json`` changes later.
     """
     return max(1, int(mute_window_days) - int(manual_unmute_window_days))
+
+
+def enter_fast_unmute_grace_for_unmuted_tests(ydb_wrapper, branch, build_type):
+    """Start grace when fast-unmute tests are no longer muted on branch (merged ``muted_ya``).
+
+    Runs in Job 2 after ``tests_monitor`` refresh so ``grace_started_at`` reflects the actual
+    unmute on main, not the hour when an unmute PR was opened (that PR may merge much later).
+    """
+    try:
+        active_table_path = ydb_wrapper.get_table_path('fast_unmute_active')
+        grace_table_path = ydb_wrapper.get_table_path('fast_unmute_grace')
+        tests_monitor_path = ydb_wrapper.get_table_path('tests_monitor')
+    except KeyError:
+        logging.info('fast_unmute tables not configured — skip enter_fast_unmute_grace')
+        return
+
+    create_fast_unmute_grace_table(ydb_wrapper, grace_table_path)
+
+    try:
+        active_rows = fetch_fast_unmute_active_rows(
+            ydb_wrapper, active_table_path, branch, build_type
+        )
+    except Exception as exc:
+        logging.warning('enter_fast_unmute_grace: failed to load fast_unmute_active: %s', exc)
+        return
+
+    if not active_rows:
+        logging.info(
+            'enter_fast_unmute_grace: no fast_unmute_active rows for branch=%s build_type=%s',
+            branch,
+            build_type,
+        )
+        return
+
+    try:
+        currently_muted = fetch_currently_muted(
+            ydb_wrapper, tests_monitor_path, branch, build_type
+        )
+        existing_grace = fetch_grace_full_names(
+            ydb_wrapper, grace_table_path, branch, build_type
+        )
+    except Exception as exc:
+        logging.warning('enter_fast_unmute_grace: failed to load monitor/grace state: %s', exc)
+        return
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    grace_ttl = grace_ttl_calendar_days(
+        get_mute_window_days(), get_manual_unmute_window_days()
+    )
+    recorded = 0
+
+    for row in active_rows:
+        full_name = row.get('full_name')
+        if not full_name or full_name in currently_muted:
+            continue
+        if full_name in existing_grace:
+            continue
+        requested_at = _coerce_dt(row.get('requested_at'))
+        try:
+            upsert_fast_unmute_grace_row(
+                ydb_wrapper,
+                grace_table_path,
+                full_name,
+                branch,
+                build_type,
+                int(row.get('github_issue_number') or 0),
+                requested_at or now,
+                now,
+                grace_ttl,
+            )
+            recorded += 1
+            logging.info(
+                'enter_fast_unmute_grace: started grace for %s (branch=%s build_type=%s)',
+                full_name,
+                branch,
+                build_type,
+            )
+        except Exception as exc:
+            logging.warning(
+                'enter_fast_unmute_grace: failed to upsert grace for %s: %s',
+                full_name,
+                exc,
+            )
+
+    if recorded:
+        logging.info(
+            'enter_fast_unmute_grace: recorded grace for %d test(s) on branch=%s build_type=%s',
+            recorded,
+            branch,
+            build_type,
+        )
 
 
 def load_config():
@@ -373,6 +466,19 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
 
     for (branch, build_type), group_rows in grouped.items():
         currently_muted = fetch_currently_muted(ydb_wrapper, tests_monitor_path, branch, build_type)
+        existing_grace = set()
+        if grace_table_path:
+            try:
+                existing_grace = fetch_grace_full_names(
+                    ydb_wrapper, grace_table_path, branch, build_type
+                )
+            except Exception as exc:
+                logging.warning(
+                    'manual_unmute_cleanup: failed to load grace names for %s/%s: %s',
+                    branch,
+                    build_type,
+                    exc,
+                )
         for row in group_rows:
             full_name = row.get('full_name')
             if not full_name:
@@ -381,7 +487,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             issue_number = row.get('github_issue_number')
 
             if full_name not in currently_muted:
-                if grace_table_path:
+                if grace_table_path and full_name not in existing_grace:
                     try:
                         ft_at = requested_at or now
                         upsert_fast_unmute_grace_row(

--- a/.github/scripts/tests/mute/fast_unmute_pipeline.py
+++ b/.github/scripts/tests/mute/fast_unmute_pipeline.py
@@ -474,14 +474,19 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
     for (branch, build_type), group_rows in grouped.items():
         currently_muted = fetch_currently_muted(ydb_wrapper, tests_monitor_path, branch, build_type)
         existing_grace = set()
+        # None ⇒ we could not read existing grace rows; in that case skip recording grace
+        # from Job 1 so we never overwrite an already-anchored grace_started_at (#45582).
+        grace_lookup_ok = True
         if grace_table_path:
             try:
                 existing_grace = fetch_grace_full_names(
                     ydb_wrapper, grace_table_path, branch, build_type
                 )
             except Exception as exc:
+                grace_lookup_ok = False
                 logging.warning(
-                    'manual_unmute_cleanup: failed to load grace names for %s/%s: %s',
+                    'manual_unmute_cleanup: failed to load grace names for %s/%s: %s '
+                    '(skipping grace recording this run to avoid resetting grace_started_at)',
                     branch,
                     build_type,
                     exc,
@@ -494,7 +499,7 @@ def cleanup_manual_unmute(ydb_wrapper, table_path, tests_monitor_path):
             issue_number = row.get('github_issue_number')
 
             if full_name not in currently_muted:
-                if grace_table_path and full_name not in existing_grace:
+                if grace_table_path and grace_lookup_ok and full_name not in existing_grace:
                     try:
                         ft_at = requested_at or now
                         upsert_fast_unmute_grace_row(

--- a/.github/scripts/tests/mute/fast_unmute_ydb.py
+++ b/.github/scripts/tests/mute/fast_unmute_ydb.py
@@ -131,7 +131,7 @@ def fetch_fast_unmute_active_rows(ydb_wrapper, table_path, branch, build_type):
     WHERE branch = '{br}'
         AND build_type = '{bt}'
     """
-    return ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_fetch_profile')
+    return ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_fetch')
 
 
 def fetch_grace_full_names(ydb_wrapper, table_path, branch, build_type):

--- a/.github/scripts/tests/mute/fast_unmute_ydb.py
+++ b/.github/scripts/tests/mute/fast_unmute_ydb.py
@@ -122,6 +122,31 @@ def fetch_currently_muted(ydb_wrapper, tests_monitor_path, branch, build_type):
     return result
 
 
+def fetch_fast_unmute_active_rows(ydb_wrapper, table_path, branch, build_type):
+    br = _escape(branch)
+    bt = _escape(build_type)
+    query = f"""
+    SELECT full_name, github_issue_number, requested_at
+    FROM `{table_path}`
+    WHERE branch = '{br}'
+        AND build_type = '{bt}'
+    """
+    return ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_active_fetch_profile')
+
+
+def fetch_grace_full_names(ydb_wrapper, table_path, branch, build_type):
+    br = _escape(branch)
+    bt = _escape(build_type)
+    query = f"""
+    SELECT full_name
+    FROM `{table_path}`
+    WHERE branch = '{br}'
+        AND build_type = '{bt}'
+    """
+    rows = ydb_wrapper.execute_scan_query(query, query_name='fast_unmute_grace_fetch_names')
+    return {row['full_name'] for row in rows if row.get('full_name')}
+
+
 def create_fast_unmute_grace_table(ydb_wrapper, table_path):
     create_sql = f"""
     CREATE TABLE IF NOT EXISTS `{table_path}` (

--- a/.github/workflows/update_muted_ya.yml
+++ b/.github/workflows/update_muted_ya.yml
@@ -131,6 +131,12 @@ jobs:
       - name: Update test monitor
         run: python3 .github/scripts/analytics/tests_monitor.py --branch=${{ env.BASE_BRANCH }} --build_type=${{ env.BUILD_TYPE }}
 
+      - name: Record fast-unmute grace for tests unmuted on branch
+        run: |
+          .github/scripts/tests/mute/create_new_muted_ya.py enter_fast_unmute_grace \
+            --branch=${{ env.BASE_BRANCH }} \
+            --build-type=${{ env.BUILD_TYPE }}
+
       - name: Sync fast-unmute grace for re-muted tests
         run: |
           .github/scripts/tests/mute/create_new_muted_ya.py sync_fast_unmute_grace \


### PR DESCRIPTION
Fixes #45582 — исправляет ложный повторный mute только что размьюченных тестов.

## Зачем

После fast-unmute тест иногда **повторно мьютился уже на следующем часовом прогоне**, хотя должен был отработать grace-период. Это обесценивает fast-unmute: команда чинит тест и снимает mute, а автоматика откатывает это назад по старым фейлам. Фикс делает поведение предсказуемым — размьюченный тест не возвращается в mute из-за истории, которая и была причиной первого mute.

## Что меняется

Grace-период теперь фиксируется в тот момент, когда тест **фактически** ушёл из mute на ветке (после merge unmute-PR и обновления `tests_monitor`), а не с опозданием на прогон. Раньше запись grace происходила в отдельном шаге до обновления данных, из-за чего на первом прогоне после размьюта grace отсутствовал и включалось полное окно повторного mute.

## Эффект

- Fast-unmute доводится до конца без ложных откатов.
- Меньше лишних mute/unmute-PR и шума в issue.
- Поведение не меняется для тестов вне fast-unmute.
