### PR TITLE
ActorSystem uoptimizations

### DIFF
--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -189,7 +189,7 @@ namespace NActors {
     }
 
     TExecutorThread::TProcessingResult TExecutorThread::Execute(TMailbox* mailbox, bool isTailExecution,
-            NHPTimer::STime mailboxScheduledTimestampTs) {
+            NHPTimer::STime mailboxScheduledTimestampTs, NHPTimer::STime timeNow) {
         EXECUTOR_THREAD_DEBUG(EDebugLevel::Activation, "Execute mailbox");
         Y_ABORT_UNLESS(mailbox, "mailbox must be not null");
         Y_DEBUG_ABORT_UNLESS(DyingActors.empty());
@@ -198,7 +198,7 @@ namespace NActors {
 
         if (!isTailExecution) {
             execCtx.ExecutedEvents = 0;
-            execCtx.HPStart = GetCycleCountFast();
+            execCtx.HPStart = timeNow;
         }
 
         IActor* actor = nullptr;
@@ -221,7 +221,7 @@ namespace NActors {
         Y_ABORT_UNLESS(mailboxScheduledTimestampTs, "mailbox scheduled timestamp must be set");
         ThreadCtx.SetMailboxScheduledTimestampTs(mailboxScheduledTimestampTs);
         for (; execCtx.ExecutedEvents < ThreadCtx.OverwrittenEventsPerMailbox(); execCtx.ExecutedEvents++) {
-            if (std::unique_ptr<IEventHandle> evExt = mailbox->Pop()) {
+            if (IEventHandle* evExt = mailbox->Pop()) {
                 EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "mailbox->Pop()");
                 ThreadCtx.SetEventEnqueuedTimestampTs(evExt->SendTime);
                 ThreadCtx.SetEventDeliveryTimeUs(CalculateWaitingTimeUs(evExt->SendTime, hpprev));
@@ -238,7 +238,7 @@ namespace NActors {
                 TActorContext ctx(*mailbox, *this, eventStart, recipient);
                 TlsActivationContext = &ctx; // ensure dtor (if any) is called within actor system
                 // move for destruct before ctx;
-                TAutoPtr<IEventHandle> ev = evExt.release();
+                TAutoPtr<IEventHandle> ev(evExt);
                 if (actor) {
                     EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is not null");
                     wasWorking = true;
@@ -465,7 +465,7 @@ namespace NActors {
                     nonExecCycles += hpnow - hpprev;
                     hpprev = hpnow;
                     {
-                        auto result = Execute(mailbox, isTailExecution, mailboxScheduledTimestampTs);
+                        auto result = Execute(mailbox, isTailExecution, mailboxScheduledTimestampTs, hpnow);
                         if (result.IsPreempted) {
                             TlsThreadContext->ChangeCapturedSendingType(ESendingType::Lazy);
                         }

--- a/ydb/library/actors/core/executor_thread.h
+++ b/ydb/library/actors/core/executor_thread.h
@@ -87,7 +87,7 @@ namespace NActors {
     protected:
         void ProcessExecutorPool();
 
-        TProcessingResult Execute(TMailbox* mailbox, bool isTailExecution, NHPTimer::STime mailboxScheduledTimestampTs);
+        TProcessingResult Execute(TMailbox* mailbox, bool isTailExecution, NHPTimer::STime mailboxScheduledTimestampTs, NHPTimer::STime npNow);
 
         void UpdateThreadStats();
 

--- a/ydb/library/actors/core/mailbox_lockfree.cpp
+++ b/ydb/library/actors/core/mailbox_lockfree.cpp
@@ -461,7 +461,7 @@ namespace NActors {
         return nullptr;
     }
 
-    std::unique_ptr<IEventHandle> TMailbox::Pop() noexcept {
+    IEventHandle* TMailbox::Pop() noexcept {
         if (!EventHead) {
             PreProcessEvents();
         }
@@ -474,7 +474,7 @@ namespace NActors {
             }
             SetNextPtr(ev, nullptr);
         }
-        return std::unique_ptr<IEventHandle>(ev);
+        return ev;
     }
 
     std::pair<ui32, ui32> TMailbox::CountMailboxEvents(ui64 localActorId, ui32 maxTraverse) noexcept {

--- a/ydb/library/actors/core/mailbox_lockfree.h
+++ b/ydb/library/actors/core/mailbox_lockfree.h
@@ -135,7 +135,7 @@ namespace NActors {
          * Removes the next event from the mailbox. Returns nullptr for an
          * empty mailbox, which stays locked.
          */
-        std::unique_ptr<IEventHandle> Pop() noexcept;
+        IEventHandle* Pop() noexcept;
 
         /**
          * Counts the number of events for the given localActorId

--- a/ydb/library/actors/core/ut/mailbox_lockfree_ut.cpp
+++ b/ydb/library/actors/core/ut/mailbox_lockfree_ut.cpp
@@ -31,7 +31,7 @@ Y_UNIT_TEST_SUITE(LockFreeMailbox) {
         UNIT_ASSERT(!ev1);
 
         // Check that we pop the event we just pushed
-        std::unique_ptr<IEventHandle> ev2 = m.Pop();
+        std::unique_ptr<IEventHandle> ev2(m.Pop());
         UNIT_ASSERT(ev2.get() == ev1raw);
 
         // Check that the mailbox is now empty
@@ -59,9 +59,15 @@ Y_UNIT_TEST_SUITE(LockFreeMailbox) {
         std::unique_ptr<IEventHandle> ev4 = std::make_unique<IEventHandle>(TActorId(), TActorId(), new TEvents::TEvPing);
         UNIT_ASSERT(m.Push(ev4) == EMailboxPush::Free);
 
-        UNIT_ASSERT(m.Pop().get() == ev1raw);
-        UNIT_ASSERT(m.Pop().get() == ev2raw);
-        UNIT_ASSERT(m.Pop().get() == ev3raw);
+        IEventHandle* p = m.Pop();
+        UNIT_ASSERT(p == ev1raw);
+        delete p;
+        p = m.Pop();
+        UNIT_ASSERT(p == ev2raw);
+        delete p;
+        p = m.Pop();
+        UNIT_ASSERT(p == ev3raw);
+        delete p;
         UNIT_ASSERT(!m.Pop());
 
         // We shouldn't be able to unlock a free mailbox
@@ -196,6 +202,7 @@ Y_UNIT_TEST_SUITE(LockFreeMailbox) {
                         }
                         // Only one thread is supposed to be a consumer
                         observed.push_back(ev->Cookie);
+                        delete ev;
                     }
                 }
             });


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->



* Do not allocate smart ptr wrapper just to pop IEventHandle from mainbox.
* Do not call GetCycleCountFast twice to start execution

Benchmark results, 12runs 95%CI:
SendActivateReceive1Pool1ThreadNoAlloc

Common: 485.51 -> 473.38 ns, -2.50%, delta -12.13 ± 7.24 ns
Lazy: 480.68 -> 473.94 ns, -1.40%, delta -6.73 ± 3.91 ns
Tail: 415.48 -> 408.24 ns, -1.74%, delta -7.25 ± 4.16 ns

LockFreeMailbox::MultiThreadedPushPop
0.33875 -> 0.33495 s -1.12%, delta -0.00380 ± 0.00624 s



### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
