### PR TITLE
Fix false-positive VERIFY on key deletion in testshard

### DIFF
--- a/ydb/core/test_tablet/load_actor_impl.cpp
+++ b/ydb/core/test_tablet/load_actor_impl.cpp
@@ -42,7 +42,10 @@ namespace NKikimr::NTestShard {
                 }
                 return TString(sb);
             };
-            Y_VERIFY_S(info.ConfirmedState == ::NTestShard::TStateServer::CONFIRMED
+            // every pending transition from CONFIRMED state immediately sets ConfirmedKeyIndex -> Max<size_t>()
+            const bool shouldBeConfirmed = info.ConfirmedState == ::NTestShard::TStateServer::CONFIRMED
+                && info.PendingState == ::NTestShard::TStateServer::CONFIRMED;
+            Y_VERIFY_S(shouldBeConfirmed
                 ? info.ConfirmedKeyIndex < ConfirmedKeys.size() && ConfirmedKeys[info.ConfirmedKeyIndex] == key
                 : info.ConfirmedKeyIndex == Max<size_t>(), makeError());
             info.ConfirmedKeyIndex = Max<size_t>();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix false-positive VERIFY assertion in testshard triggered by Key deletion.
https://github.com/ydb-platform/ydb/issues/45337

### Changelog category <!-- remove all except one -->

* Bugfix 