### PR TITLE
NBS-7446: impl DisabledAuthenticationPaths mon config

### DIFF
--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -670,6 +670,7 @@ void TKikimrRunner::InitializeMonitoring(const TKikimrRunConfig& runConfig, bool
         monConfig.CaFile = appConfig.GetMonitoringConfig().GetMonitoringCaFile();
         monConfig.RedirectMainPageTo = appConfig.GetMonitoringConfig().GetRedirectMainPageTo();
         monConfig.RequireCountersAuthentication = appConfig.GetMonitoringConfig().GetRequireCountersAuthentication();
+        monConfig.DisabledAuthenticationPaths.assign(appConfig.GetMonitoringConfig().GetDisabledAuthenticationPaths().begin(), appConfig.GetMonitoringConfig().GetDisabledAuthenticationPaths().end());
         if (appConfig.GetMonitoringConfig().CompressContentTypesSize() > 0) {
             monConfig.CompressContentTypes.clear();
             std::ranges::copy(appConfig.GetMonitoringConfig().GetCompressContentTypes(), std::back_inserter(monConfig.CompressContentTypes));

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1365,7 +1365,7 @@ public:
 
     void Bootstrap() {
         AuditCtx.InitAudit(Event, NeedAudit);
-        if (Authorizer) {
+        if (AuthMode != TMon::EAuthMode::Disabled && Authorizer) {
             NActors::IEventHandle* handle = Authorizer(SelfId(), Event->Get()->Request.Get());
             if (handle) {
                 Send(handle);
@@ -1669,11 +1669,21 @@ public:
             }
         }
 
-        TStringBuf url = ev->Get()->Request->URL.Before('?');
+        const TString requestUrl(ev->Get()->Request->URL.Before('?'));
+        const bool authDisabled = DisabledAuthenticationPaths.contains(requestUrl);
+
+        TStringBuf url = requestUrl;
         while (!url.empty()) {
             auto it = Handlers.find(TString(url));
             if (it != Handlers.end()) {
-                Register(new THttpMonAuthorizedActorRequest(std::move(ev), it->second, Authorizer));
+                auto fields = it->second;
+                if (authDisabled) {
+                    fields.AuthMode = TMon::EAuthMode::Disabled;
+                }
+                Register(new THttpMonAuthorizedActorRequest(
+                    std::move(ev),
+                    fields,
+                    authDisabled ? TMon::TRequestAuthorizer() : Authorizer));
                 return;
             } else {
                 if (url.EndsWith('/')) {
@@ -1689,11 +1699,16 @@ public:
             }
         }
 
-        TStringBuf requestUrl = ev->Get()->Request->URL.Before('?');
-        TMon::EAuthMode authMode = DisabledAuthenticationPaths.contains(TString(requestUrl))
+        const TMon::EAuthMode authMode = authDisabled
             ? TMon::EAuthMode::Disabled
             : TMon::EAuthMode::Enforce;
-        Register(new THttpMonAuthorizedPageRequest(std::move(ev), IndexMonPage.Get(), AllowedSIDs, Authorizer, NeedMonLegacyAudit, authMode));
+        Register(new THttpMonAuthorizedPageRequest(
+            std::move(ev),
+            IndexMonPage.Get(),
+            AllowedSIDs,
+            authDisabled ? TMon::TRequestAuthorizer() : Authorizer,
+            NeedMonLegacyAudit,
+            authMode));
     }
 
     void Handle(TEvMon::TEvRegisterHandler::TPtr& ev) {

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1716,15 +1716,10 @@ public:
         Send(HttpProxyActorId, new NHttp::TEvHttpProxy::TEvRegisterHandler(ev->Get()->Fields.Path, SelfId()));
     }
 
-    void Handle(TEvMon::TEvAddDisabledAuthenticationPath::TPtr& ev) {
-        DisabledAuthenticationPaths.insert(ev->Get()->Path);
-    }
-
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             hFunc(TEvMon::TEvRegisterHandler, Handle);
-            hFunc(TEvMon::TEvAddDisabledAuthenticationPath, Handle);
             cFunc(TEvents::TSystem::Poison, PassAway);
         }
     }

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -1582,7 +1582,8 @@ THttpMonPageService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring:
 class THttpMonIndexService : public TActor<THttpMonIndexService> {
 public:
     THttpMonIndexService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring::TIndexMonPage> indexMonPage,
-                         TVector<TString> allowedSIDs, TMon::TRequestAuthorizer authorizer, const TString& redirectRoot = {}, bool needMonLegacyAudit = true)
+                         TVector<TString> allowedSIDs, TMon::TRequestAuthorizer authorizer, const TString& redirectRoot = {}, bool needMonLegacyAudit = true,
+                         TVector<TString> disabledAuthenticationPaths = {})
         : TActor(&THttpMonIndexService::StateWork)
         , HttpProxyActorId(httpProxyActorId)
         , IndexMonPage(std::move(indexMonPage))
@@ -1590,6 +1591,7 @@ public:
         , Authorizer(std::move(authorizer))
         , RedirectRoot(redirectRoot)
         , NeedMonLegacyAudit(needMonLegacyAudit)
+        , DisabledAuthenticationPaths(disabledAuthenticationPaths.begin(), disabledAuthenticationPaths.end())
     {
     }
 
@@ -1687,7 +1689,11 @@ public:
             }
         }
 
-        Register(new THttpMonAuthorizedPageRequest(std::move(ev), IndexMonPage.Get(), AllowedSIDs, Authorizer, NeedMonLegacyAudit));
+        TStringBuf requestUrl = ev->Get()->Request->URL.Before('?');
+        TMon::EAuthMode authMode = DisabledAuthenticationPaths.contains(TString(requestUrl))
+            ? TMon::EAuthMode::Disabled
+            : TMon::EAuthMode::Enforce;
+        Register(new THttpMonAuthorizedPageRequest(std::move(ev), IndexMonPage.Get(), AllowedSIDs, Authorizer, NeedMonLegacyAudit, authMode));
     }
 
     void Handle(TEvMon::TEvRegisterHandler::TPtr& ev) {
@@ -1695,10 +1701,15 @@ public:
         Send(HttpProxyActorId, new NHttp::TEvHttpProxy::TEvRegisterHandler(ev->Get()->Fields.Path, SelfId()));
     }
 
+    void Handle(TEvMon::TEvAddDisabledAuthenticationPath::TPtr& ev) {
+        DisabledAuthenticationPaths.insert(ev->Get()->Path);
+    }
+
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(NHttp::TEvHttpProxy::TEvHttpIncomingRequest, Handle);
             hFunc(TEvMon::TEvRegisterHandler, Handle);
+            hFunc(TEvMon::TEvAddDisabledAuthenticationPath, Handle);
             cFunc(TEvents::TSystem::Poison, PassAway);
         }
     }
@@ -1711,6 +1722,7 @@ public:
     TMon::TRequestAuthorizer Authorizer;
     TString RedirectRoot;
     bool NeedMonLegacyAudit;
+    THashSet<TString> DisabledAuthenticationPaths;
 };
 
 class THttpMonPingService : public TActor<THttpMonPingService> {
@@ -1799,11 +1811,11 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
         TMailboxType::ReadAsFilled,
         executorPool);
     HttpMonServiceActorId = ActorSystem->Register(
-        new THttpMonIndexService(HttpProxyActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, Config.RedirectMainPageTo),
+        new THttpMonIndexService(HttpProxyActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, Config.RedirectMainPageTo, true, Config.DisabledAuthenticationPaths),
         TMailboxType::ReadAsFilled,
         executorPool);
     HttpAuthMonServiceActorId = ActorSystem->Register(
-        new THttpMonIndexService(HttpMonServiceActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, Config.RedirectMainPageTo, false),
+        new THttpMonIndexService(HttpMonServiceActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, Config.RedirectMainPageTo, false, Config.DisabledAuthenticationPaths),
         TMailboxType::ReadAsFilled,
         executorPool);
     RegisterLwtrace();

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -68,6 +68,7 @@ public:
         };
         bool RequireCountersAuthentication = false;
         bool RequireHealthcheckAuthentication = false;
+        TVector<TString> DisabledAuthenticationPaths;
     };
 
     TMon(TConfig config);

--- a/ydb/core/mon/mon_events.h
+++ b/ydb/core/mon/mon_events.h
@@ -11,6 +11,7 @@ struct TEvMon {
         EvRegisterHandler,
         EvMonitoringCancelRequest,
         EvCleanupProxy,
+        EvAddDisabledAuthenticationPath,
         End
     };
 
@@ -42,6 +43,14 @@ struct TEvMon {
 
         TEvCleanupProxy(const TString& address)
             : Address(address)
+        {}
+    };
+
+    struct TEvAddDisabledAuthenticationPath : NActors::TEventLocal<TEvAddDisabledAuthenticationPath, EvAddDisabledAuthenticationPath> {
+        TString Path;
+
+        TEvAddDisabledAuthenticationPath(TString path)
+            : Path(std::move(path))
         {}
     };
 };

--- a/ydb/core/mon/mon_events.h
+++ b/ydb/core/mon/mon_events.h
@@ -11,7 +11,6 @@ struct TEvMon {
         EvRegisterHandler,
         EvMonitoringCancelRequest,
         EvCleanupProxy,
-        EvAddDisabledAuthenticationPath,
         End
     };
 
@@ -43,14 +42,6 @@ struct TEvMon {
 
         TEvCleanupProxy(const TString& address)
             : Address(address)
-        {}
-    };
-
-    struct TEvAddDisabledAuthenticationPath : NActors::TEventLocal<TEvAddDisabledAuthenticationPath, EvAddDisabledAuthenticationPath> {
-        TString Path;
-
-        TEvAddDisabledAuthenticationPath(TString path)
-            : Path(std::move(path))
         {}
     };
 };

--- a/ydb/core/mon/mon_ut.cpp
+++ b/ydb/core/mon/mon_ut.cpp
@@ -33,6 +33,7 @@ struct THttpMonTestEnvOptions {
     TVector<TString> ActorAllowedSIDs;
     TVector<TString> TicketParserGroupSIDs = DEFAULT_TICKET_PARSER_GROUPS;
     TMon::EAuthMode AuthMode = TMon::EAuthMode::Enforce;
+    TVector<TString> DisabledAuthenticationPaths;
 };
 
 class THttpMonTestEnv {
@@ -54,6 +55,10 @@ public:
         auto& securityConfig = *Settings.AppConfig->MutableDomainsConfig()->MutableSecurityConfig();
         securityConfig.SetEnforceUserTokenCheckRequirement(true);
         securityConfig.MutableMonitoringAllowedSIDs()->Add("ydb.clusters.monitor@as");
+
+        for (const auto& path : Options.DisabledAuthenticationPaths) {
+            Settings.AppConfig->MutableMonitoringConfig()->AddDisabledAuthenticationPaths(path);
+        }
 
         Settings.CreateTicketParser = [&](const TTicketParserSettings&) -> NActors::IActor* {
             return TicketParser = new TFakeTicketParserActor(Options.TicketParserGroupSIDs);
@@ -424,6 +429,65 @@ Y_UNIT_TEST_SUITE(Other) {
         UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
         UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketSuccesses, 0);
         UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketFails, 1);
+    }
+}
+
+Y_UNIT_TEST_SUITE(DisabledAuthenticationPaths) {
+    // Exact path in DisabledAuthenticationPaths bypasses auth — no token needed
+    Y_UNIT_TEST(ExactPathNoAuthRequired) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+            .DisabledAuthenticationPaths = {"/test_mon_path"},
+        });
+
+        TStringStream responseStream;
+        // No auth headers — should succeed because path is in DisabledAuthenticationPaths
+        const auto status = env.GetHttpClient().DoGet("/test_mon_path", &responseStream);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 0);
+    }
+
+    // A path that has the disabled path as a PREFIX must still require auth
+    Y_UNIT_TEST(PrefixSubpathStillRequiresAuth) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+            .DisabledAuthenticationPaths = {"/test_mon_path"},
+        });
+
+        TStringStream responseStream;
+        THttpHeaders outHeaders;
+        // /test_mon_path/subpath is NOT in DisabledAuthenticationPaths — must get 401/403
+        const auto status = env.GetHttpClient().DoGet("/test_mon_path/subpath", &responseStream, {}, &outHeaders);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_UNAUTHORIZED);
+    }
+
+    // A path that has the disabled path as a SUFFIX must still require auth
+    Y_UNIT_TEST(SuffixPathStillRequiresAuth) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+            .DisabledAuthenticationPaths = {"/test_mon_path"},
+        });
+
+        TStringStream responseStream;
+        THttpHeaders outHeaders;
+        // /prefix/test_mon_path is NOT in DisabledAuthenticationPaths — must get 401/403
+        const auto status = env.GetHttpClient().DoGet("/prefix/test_mon_path", &responseStream, {}, &outHeaders);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_UNAUTHORIZED);
+    }
+
+    // A path not listed at all still requires auth
+    Y_UNIT_TEST(UnlistedPathRequiresAuth) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+            .DisabledAuthenticationPaths = {"/test_mon_path"},
+        });
+
+        TStringStream responseStream;
+        THttpHeaders outHeaders;
+        const auto status = env.GetHttpClient().DoGet("/other_path", &responseStream, {}, &outHeaders);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_UNAUTHORIZED);
     }
 }
 

--- a/ydb/core/mon/mon_ut.cpp
+++ b/ydb/core/mon/mon_ut.cpp
@@ -437,12 +437,27 @@ Y_UNIT_TEST_SUITE(DisabledAuthenticationPaths) {
     Y_UNIT_TEST(ExactPathNoAuthRequired) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
-            .DisabledAuthenticationPaths = {"/test_mon_path"},
+            .DisabledAuthenticationPaths = {TEST_MON_URL},
         });
 
         TStringStream responseStream;
         // No auth headers — should succeed because path is in DisabledAuthenticationPaths
-        const auto status = env.GetHttpClient().DoGet("/test_mon_path", &responseStream);
+        const auto status = env.GetHttpClient().DoGet(TEST_MON_URL, &responseStream);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 0);
+    }
+
+    // Query parameters are stripped before matching DisabledAuthenticationPaths
+    Y_UNIT_TEST(ExactPathWithQueryNoAuthRequired) {
+        THttpMonTestEnv env({
+            .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
+            .DisabledAuthenticationPaths = {TEST_MON_URL},
+        });
+
+        TStringStream responseStream;
+        const auto status = env.GetHttpClient().DoGet(TEST_MON_URL + "?foo=bar", &responseStream);
         UNIT_ASSERT_VALUES_EQUAL(status, HTTP_OK);
 
         TFakeTicketParserActor* ticketParser = env.GetTicketParser();
@@ -453,41 +468,56 @@ Y_UNIT_TEST_SUITE(DisabledAuthenticationPaths) {
     Y_UNIT_TEST(PrefixSubpathStillRequiresAuth) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
-            .DisabledAuthenticationPaths = {"/test_mon_path"},
+            .DisabledAuthenticationPaths = {TEST_MON_URL},
         });
 
         TStringStream responseStream;
         THttpHeaders outHeaders;
-        // /test_mon_path/subpath is NOT in DisabledAuthenticationPaths — must get 401/403
-        const auto status = env.GetHttpClient().DoGet("/test_mon_path/subpath", &responseStream, {}, &outHeaders);
-        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_UNAUTHORIZED);
+        const TString invalidToken = TString("Bearer invalid");
+        // /test_mon/subpath is NOT in DisabledAuthenticationPaths — auth must not be bypassed
+        const auto status = env.GetHttpClient().DoGet(
+            TEST_MON_URL + "/subpath", &responseStream, env.MakeAuthHeaders(invalidToken), &outHeaders);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
     }
 
     // A path that has the disabled path as a SUFFIX must still require auth
     Y_UNIT_TEST(SuffixPathStillRequiresAuth) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
-            .DisabledAuthenticationPaths = {"/test_mon_path"},
+            .DisabledAuthenticationPaths = {TEST_MON_URL},
         });
 
         TStringStream responseStream;
         THttpHeaders outHeaders;
-        // /prefix/test_mon_path is NOT in DisabledAuthenticationPaths — must get 401/403
-        const auto status = env.GetHttpClient().DoGet("/prefix/test_mon_path", &responseStream, {}, &outHeaders);
-        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_UNAUTHORIZED);
+        const TString invalidToken = TString("Bearer invalid");
+        // /prefix/test_mon is NOT in DisabledAuthenticationPaths — auth must not be bypassed
+        const auto status = env.GetHttpClient().DoGet(
+            "/prefix" + TEST_MON_URL, &responseStream, env.MakeAuthHeaders(invalidToken), &outHeaders);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
     }
 
     // A path not listed at all still requires auth
     Y_UNIT_TEST(UnlistedPathRequiresAuth) {
         THttpMonTestEnv env({
             .RegKind = THttpMonTestEnvOptions::ERegKind::MonPage,
-            .DisabledAuthenticationPaths = {"/test_mon_path"},
+            .DisabledAuthenticationPaths = {TEST_MON_URL},
         });
 
         TStringStream responseStream;
         THttpHeaders outHeaders;
-        const auto status = env.GetHttpClient().DoGet("/other_path", &responseStream, {}, &outHeaders);
-        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_UNAUTHORIZED);
+        const TString invalidToken = TString("Bearer invalid");
+        const auto status = env.GetHttpClient().DoGet(
+            "/other_path", &responseStream, env.MakeAuthHeaders(invalidToken), &outHeaders);
+        UNIT_ASSERT_VALUES_EQUAL(status, HTTP_FORBIDDEN);
+
+        TFakeTicketParserActor* ticketParser = env.GetTicketParser();
+        UNIT_ASSERT_VALUES_EQUAL(ticketParser->AuthorizeTicketRequests, 1);
     }
 }
 

--- a/ydb/core/mon/ut_utils/ut_utils.cpp
+++ b/ydb/core/mon/ut_utils/ut_utils.cpp
@@ -14,6 +14,7 @@ using namespace NActors;
 using namespace NKikimr;
 
 const TString TEST_MON_PATH = "test_mon";
+const TString TEST_MON_URL = "/test_mon";
 const TString TEST_RESPONSE = "Test actor";
 const TString AUTHORIZATION_HEADER = "Authorization";
 const TString VALID_TOKEN = "Bearer token";

--- a/ydb/core/mon/ut_utils/ut_utils.h
+++ b/ydb/core/mon/ut_utils/ut_utils.h
@@ -16,6 +16,7 @@ using namespace NActors;
 using namespace NKikimr;
 
 extern const TString TEST_MON_PATH;
+extern const TString TEST_MON_URL;
 extern const TString TEST_RESPONSE;
 extern const TString AUTHORIZATION_HEADER;
 extern const TString VALID_TOKEN;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -634,6 +634,7 @@ message TMonitoringConfig {
     optional bool RequireHealthcheckAuthentication = 22 [default = false];
     optional string MonitoringCaFile = 23;
     repeated string CompressContentTypes = 24; // by default most text types are compressed
+    repeated string DisabledAuthenticationPaths = 25;
 }
 
 message TRestartsCountConfig {

--- a/ydb/tests/functional/security/lib/cluster_config.py
+++ b/ydb/tests/functional/security/lib/cluster_config.py
@@ -108,6 +108,7 @@ def create_ydb_configurator(
     enable_tablet_dev_ui_secure_path=None,
     binary_paths=None,
     extra_feature_flags=None,
+    disabled_authentication_paths=None,
 ):
     cluster_config = {
         'default_clusteradmin': 'root@builtin',
@@ -154,6 +155,13 @@ def create_ydb_configurator(
             config_generator.yaml_config['monitoring_config'][
                 'require_healthcheck_authentication'
             ] = require_healthcheck_authentication
+
+    if disabled_authentication_paths is not None:
+        if 'monitoring_config' not in config_generator.yaml_config:
+            config_generator.yaml_config['monitoring_config'] = {}
+        config_generator.yaml_config['monitoring_config'][
+            'disabled_authentication_paths'
+        ] = list(disabled_authentication_paths)
 
     if enable_tablet_dev_ui_secure_path is not None:
         if 'feature_flags' not in config_generator.yaml_config:

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -107,7 +107,7 @@ def ydb_cluster_with_disabled_authentication_paths(certificates):
     configurator = create_ydb_configurator(
         certificates,
         enforce_user_token_requirement=True,
-        disabled_authentication_paths=['/ver', '/blockstore/user_stats/spack'],
+        disabled_authentication_paths=['/ver', '/trace'],
     )
     cluster = KiKiMR(configurator)
     cluster.start()

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -100,3 +100,16 @@ def ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag(certif
     cluster.start()
     yield cluster
     cluster.stop()
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_with_disabled_authentication_paths(certificates):
+    configurator = create_ydb_configurator(
+        certificates,
+        enforce_user_token_requirement=True,
+        disabled_authentication_paths=['/ver', '/blockstore/user_stats/spack'],
+    )
+    cluster = KiKiMR(configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()

--- a/ydb/tests/functional/security/mon/functional/test_disabled_authentication_paths.py
+++ b/ydb/tests/functional/security/mon/functional/test_disabled_authentication_paths.py
@@ -3,7 +3,7 @@ import requests
 
 requests.packages.urllib3.disable_warnings()
 
-DISABLED_AUTHENTICATION_PATHS = ['/ver', '/blockstore/user_stats/spack']
+DISABLED_AUTHENTICATION_PATHS = ['/ver', '/trace']
 
 
 def _base_url(cluster):

--- a/ydb/tests/functional/security/mon/functional/test_disabled_authentication_paths.py
+++ b/ydb/tests/functional/security/mon/functional/test_disabled_authentication_paths.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import requests
+
+requests.packages.urllib3.disable_warnings()
+
+DISABLED_AUTHENTICATION_PATHS = ['/ver', '/blockstore/user_stats/spack']
+
+
+def _base_url(cluster):
+    node = cluster.nodes[1]
+    return f'https://{node.host}:{node.mon_port}'
+
+
+def _get_status(base_url, path, token=None):
+    headers = {}
+    if token is not None:
+        headers['Authorization'] = token
+    response = requests.get(base_url + path, headers=headers, verify=False, timeout=5)
+    return response.status_code
+
+
+def _assert_status(base_url, path, token, status):
+    actual = _get_status(base_url, path, token)
+    token_desc = token if token is not None else '__none__'
+    assert actual == status, (
+        f'Expected {path} with token={token_desc} to return {status}, got {actual}'
+    )
+
+
+def test_exact_path_no_auth_required(ydb_cluster_with_disabled_authentication_paths):
+    base_url = _base_url(ydb_cluster_with_disabled_authentication_paths)
+
+    for path in DISABLED_AUTHENTICATION_PATHS:
+        _assert_status(base_url, path, None, 200)
+
+
+def test_exact_path_with_query_no_auth_required(ydb_cluster_with_disabled_authentication_paths):
+    base_url = _base_url(ydb_cluster_with_disabled_authentication_paths)
+
+    for path in DISABLED_AUTHENTICATION_PATHS:
+        _assert_status(base_url, path + '?foo=bar', None, 200)
+
+
+def test_prefix_subpath_still_requires_auth(ydb_cluster_with_disabled_authentication_paths):
+    base_url = _base_url(ydb_cluster_with_disabled_authentication_paths)
+
+    for path in DISABLED_AUTHENTICATION_PATHS:
+        _assert_status(base_url, path + '/subpath', None, 401)
+
+
+def test_suffix_path_still_requires_auth(ydb_cluster_with_disabled_authentication_paths):
+    base_url = _base_url(ydb_cluster_with_disabled_authentication_paths)
+
+    for path in DISABLED_AUTHENTICATION_PATHS:
+        _assert_status(base_url, '/prefix' + path, None, 401)
+
+
+def test_unlisted_path_still_requires_auth(ydb_cluster_with_disabled_authentication_paths):
+    base_url = _base_url(ydb_cluster_with_disabled_authentication_paths)
+
+    # /actors/ normally requires auth when enforce_user_token is enabled.
+    _assert_status(base_url, '/actors/', None, 401)
+
+
+def test_disabled_paths_still_work_with_token(ydb_cluster_with_disabled_authentication_paths):
+    base_url = _base_url(ydb_cluster_with_disabled_authentication_paths)
+
+    for path in DISABLED_AUTHENTICATION_PATHS:
+        _assert_status(base_url, path, 'monitoring@builtin', 200)
+        _assert_status(base_url, path, 'root@builtin', 200)

--- a/ydb/tests/functional/security/mon/functional/ya.make
+++ b/ydb/tests/functional/security/mon/functional/ya.make
@@ -4,6 +4,7 @@ INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)
 
 TEST_SRCS(
     conftest.py
+    test_disabled_authentication_paths.py
     test_mon_mtls_auth.py
     test_mon_viewer_access_controls.py
     test_tablets_dev_ui_mon_auth.py


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
Добавлена возможность отключать аутентификацию для заданного списка путей HTTP monitoring (exact match), задаваемого через конфиг `MonitoringConfig.DisabledAuthenticationPaths`.
### Changelog category <!-- remove all except one -->
* Improvement
### Description for reviewers <!-- (optional) description for those who read this PR -->
- Добавлено новое конфигурационное поле `DisabledAuthenticationPaths` в `TMonitoringConfig` и прокинуто в `TMon::TConfig`.
- В `THttpMonIndexService` для запросов к monitoring index вычисляется `AuthMode` на основе точного совпадения `Request->URL.Before('?')` со списком путей (prefix/suffix не отключает auth).
- Добавлены unit-тесты, проверяющие:
  - отсутствие требования токена для exact path из списка;
  - что `/path/subpath`, `/prefix/path` и не перечисленные пути по-прежнему требуют аутентификацию.
