### PR TITLE
[NEW RBO] Recompute properites in rule-based stage lazily

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo.cpp
@@ -28,32 +28,56 @@ TRuleBasedStage::TRuleBasedStage(TString&& stageName, TVector<std::unique_ptr<IR
     }
 }
 
-void ComputeRequiredProps(TOpRoot& root, ui32 props, TRBOContext& ctx, TString stageName) {
-    // FIXME: Parents are currently always required, because we need to update them when a rule fires
-    root.ComputeParents();
-    //if (props & ERuleProperties::RequireParents) {
-    //    root.ComputeParents();
-    //}
-    if (props & (ERuleProperties::RequireTypes | ERuleProperties::RequireStatistics)) {
+namespace {
+
+void EnsureRequiredProps(TOpRoot& root, ui32 props, ui32& computedProps, TRBOContext& ctx, const TString& stageName) {
+    if ((props & ERuleProperties::RequireParents) && !(computedProps & ERuleProperties::RequireParents)) {
+        root.ComputeParents();
+        computedProps |= ERuleProperties::RequireParents;
+    }
+
+    if ((props & (ERuleProperties::RequireTypes | ERuleProperties::RequireStatistics)) &&
+        !(computedProps & ERuleProperties::RequireTypes))
+    {
         if (root.ComputeTypes(ctx) != IGraphTransformer::TStatus::Ok) {
             Y_ENSURE(false, TStringBuilder() << "RBO type annotation failed in stage " << stageName);
         }
+        computedProps |= ERuleProperties::RequireTypes;
     }
-    if (props & (ERuleProperties::RequireMetadata | ERuleProperties::RequireStatistics)) {
+
+    if ((props & (ERuleProperties::RequireMetadata | ERuleProperties::RequireStatistics)) &&
+        !(computedProps & ERuleProperties::RequireMetadata))
+    {
         root.ComputePlanMetadata(ctx);
+        computedProps |= ERuleProperties::RequireMetadata;
     }
-    if (props & ERuleProperties::RequireStatistics) {
+
+    if ((props & ERuleProperties::RequireStatistics) && !(computedProps & ERuleProperties::RequireStatistics)) {
         root.ComputePlanStatistics(ctx);
+        computedProps |= ERuleProperties::RequireStatistics;
     }
-    if (props & ERuleProperties::RequireLiveness) {
+
+    if ((props & ERuleProperties::RequireLiveness) && !(computedProps & ERuleProperties::RequireLiveness)) {
         ComputePlanLiveness(root);
+        computedProps |= ERuleProperties::RequireLiveness;
     }
-    if (props & ERuleProperties::RequireNameConstraints) {
+
+    if ((props & ERuleProperties::RequireNameConstraints) && !(computedProps & ERuleProperties::RequireNameConstraints)) {
         ComputePlanNameConstraints(root);
+        computedProps |= ERuleProperties::RequireNameConstraints;
     }
-    if (props & ERuleProperties::RequireAliases) {
+
+    if ((props & ERuleProperties::RequireAliases) && !(computedProps & ERuleProperties::RequireAliases)) {
         ComputePlanAliases(root);
+        computedProps |= ERuleProperties::RequireAliases;
     }
+}
+
+} // anonymous namespace
+
+void ComputeRequiredProps(TOpRoot& root, ui32 props, TRBOContext& ctx, TString stageName) {
+    ui32 computedProps = 0;
+    EnsureRequiredProps(root, props, computedProps, ctx, stageName);
 }
 
 /**
@@ -62,9 +86,6 @@ void ComputeRequiredProps(TOpRoot& root, ui32 props, TRBOContext& ctx, TString s
  * Currently we obtain an iterator to the operators, match the rules, and if at least one matched we
  * apply it and start again.
  *
- * TODO: We should have a clear list of properties that are required by the rules of current stage and
- * ensure they are computed/maintained properly
- *
  * TODO: Add sanity checks that can be tunred on in debug mode to immediately catch transformation problems
  */
 void TRuleBasedStage::RunStage(TOpRoot& root, TRBOContext& ctx) {
@@ -72,12 +93,15 @@ void TRuleBasedStage::RunStage(TOpRoot& root, TRBOContext& ctx) {
     ui32 numMatches = 0;
     const ui32 maxNumOfMatches = 1000;
     bool needToLog = NYql::NLog::YqlLogger().NeedToLog(NYql::NLog::EComponent::CoreDq, NYql::NLog::ELevel::TRACE);
+    ui32 computedProps = 0;
 
     while (fired && numMatches < maxNumOfMatches) {
         fired = false;
 
         for (auto iter : root) {
             for (const auto& rule : Rules) {
+                EnsureRequiredProps(root, rule->Props, computedProps, ctx, StageName);
+
                 auto op = iter.Current;
 
                 TRuleTraceAttempt traceAttempt(ctx, rule->RuleName);
@@ -94,27 +118,39 @@ void TRuleBasedStage::RunStage(TOpRoot& root, TRBOContext& ctx) {
 
                     YQL_CLOG(TRACE, CoreDq) << "Applied rule:" << rule->RuleName;
 
-                    // If the original operator had parents, update all parents
-                    if (iter.Current->Parents.size()) {
-                        for (auto & [parent, parentIdx] : iter.Current->Parents) {
-                            parent->Children[parentIdx] = op;
+                    if (op != iter.Current) {
+                        Y_ENSURE(computedProps & ERuleProperties::RequireParents,
+                            TStringBuilder() << "Rule " << rule->RuleName << " replaced an operator without requiring parents");
+
+                        // If the original operator had parents, update all parents
+                        if (iter.Current->Parents.size()) {
+                            for (auto & [parent, parentIdx] : iter.Current->Parents) {
+                                parent->Children[parentIdx] = op;
+                            }
                         }
-                    } 
-                    // Otherwise, if its not a subplan, it was root, so update root
-                    else if (!iter.SubplanIU) {
-                        root.SetInput(op);
-                    }
-                    // Finally, it's a subplan, so update the subplan 
-                    else {
-                        root.PlanProps.Subplans.Replace(*iter.SubplanIU, op);
+                        // Otherwise, if its not a subplan, it was root, so update root
+                        else if (!iter.SubplanIU) {
+                            root.SetInput(op);
+                        }
+                        // Finally, it's a subplan, so update the subplan
+                        else {
+                            root.PlanProps.Subplans.Replace(*iter.SubplanIU, op);
+                        }
                     }
 
                     if (needToLog && rule->LogRule) {
                         YQL_CLOG(TRACE, CoreDq) << "Plan after applying rule:\n" << root.PlanToString(ctx.ExprCtx);
                     }
 
-                    ComputeRequiredProps(root, Props, ctx, StageName);
                     traceAttempt.SubmitApplied(root, StageName);
+
+                    // The rule has fired, therefore we invalidate ALL the properties, they will be recomputed
+                    // as soon as they are needed by next rules.
+
+                    // TODO: In the future, we probably want to be smarter here: have API which tells us
+                    // what the rule changed, invalidate partially, recompute incrementally.
+                    computedProps = 0;
+
                     ++numMatches;
                     break;
                 }
@@ -144,7 +180,9 @@ TExprNode::TPtr TRuleBasedOptimizer::Optimize(TOpRoot& root, TRBOContext& rboCtx
             rboCtx.TraceLog.stage(std::string(stage->StageName.c_str()));
         }
         YQL_CLOG(TRACE, CoreDq) << "Running stage: " << stage->StageName;
-        ComputeRequiredProps(root, stage->Props, rboCtx, stage->StageName);
+        if (stage->NeedsInitialProps()) {
+            ComputeRequiredProps(root, stage->Props, rboCtx, stage->StageName);
+        }
         if (needToLog) {
             YQL_CLOG(TRACE, CoreDq) << "Before stage:\n" << root.PlanToString(ctx);
         }

--- a/ydb/core/kqp/opt/rbo/kqp_rbo.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo.h
@@ -64,8 +64,19 @@ class ISimplifiedRule : public IRule {
 class IRBOStage : public NNonCopyable::TNonCopyable {
   public:
     IRBOStage(TString&& stageName) : StageName(std::move(stageName)) {}
-    
+
     virtual void RunStage(TOpRoot &root, TRBOContext &ctx) = 0;
+
+    // If you return true here, then runtime will make sure that all the properties
+    // you set in "Props" are up to date when your stage runs.
+
+    // Some stages might want to control this manually instead. For example,
+    // TRuleBasedStage recomputes properties lazily, only when a particular rule
+    // actually expects them, so it opts out of this system and handles it internally.
+    virtual bool NeedsInitialProps() const {
+        return true;
+    }
+
     virtual ~IRBOStage() = default;
     ui32 Props = 0x00;
 
@@ -79,6 +90,9 @@ class TRuleBasedStage : public IRBOStage {
   public:
     TRuleBasedStage(TString&& stageName, TVector<std::unique_ptr<IRule>>&& rules);
     virtual void RunStage(TOpRoot &root, TRBOContext &ctx) override;
+    virtual bool NeedsInitialProps() const override {
+        return false;
+    }
 
     TVector<std::unique_ptr<IRule>> Rules;
 };


### PR DESCRIPTION
Instead of recomputing all the properties required within a stage, this only recomputes them when they are required by a rule that's going to match next.

This should make rules like `TRemoveIdentityMapRule` (i.e. the ones that don't require many properties) much cheaper.