### PR TITLE
[NEW RBO] Add QuickMatches to prevent unnecessary property recomputations

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo.cpp
@@ -10,6 +10,9 @@ namespace NKikimr {
 namespace NKqp {
 
 bool ISimplifiedRule::MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
+    if (!QuickMatch(input)) {
+        return false;
+    }
 
     auto output = SimpleMatchAndApply(input, ctx, props);
     if (input != output) {
@@ -100,9 +103,12 @@ void TRuleBasedStage::RunStage(TOpRoot& root, TRBOContext& ctx) {
 
         for (auto iter : root) {
             for (const auto& rule : Rules) {
-                EnsureRequiredProps(root, rule->Props, computedProps, ctx, StageName);
-
                 auto op = iter.Current;
+                if (!rule->QuickMatch(op)) {
+                    continue;
+                }
+
+                EnsureRequiredProps(root, rule->Props, computedProps, ctx, StageName);
 
                 TRuleTraceAttempt traceAttempt(ctx, rule->RuleName);
                 const bool ruleApplied = rule->MatchAndApply(op, ctx, root.PlanProps);

--- a/ydb/core/kqp/opt/rbo/kqp_rbo.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo.h
@@ -32,6 +32,9 @@ class IRule {
     IRule(TString name) : RuleName(name) {}
     IRule(TString name, ui32 props, bool logRule = true) : RuleName(name), Props(props), LogRule(logRule) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>&) const {
+        return true;
+    }
     virtual bool MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) = 0;
 
     virtual ~IRule() = default;

--- a/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_rules.h
@@ -18,6 +18,7 @@ namespace NKqp {
   public:
     TRemoveIdenityMapRule() : ISimplifiedRule("Remove identity map", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -30,6 +31,7 @@ class TExtractJoinExpressionsRule : public IRule {
   public:
     TExtractJoinExpressionsRule() : IRule("Extract join expressions") {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -43,6 +45,7 @@ class TExtractJoinExpressionsRule : public IRule {
   public:
     TPullUpCorrelatedFilterRule() : IRule("Pull up correlated filter", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
  };
 
@@ -60,6 +63,7 @@ class TInlineSimpleInExistsSubplanRule : public ISimplifiedRule {
   public:
     TInlineSimpleInExistsSubplanRule() : ISimplifiedRule("Inline simple in or exists subplan", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -67,6 +71,7 @@ class TInlineGenericInExistsSubplanRule : public ISimplifiedRule {
   public:
     TInlineGenericInExistsSubplanRule() : ISimplifiedRule("Inline generic in or exists subplan", ERuleProperties::RequireParents | ERuleProperties::RequireTypes | ERuleProperties::RequireMetadata) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -77,6 +82,7 @@ class TInlineJoinFiltersRule : public ISimplifiedRule {
   public:
     TInlineJoinFiltersRule() : ISimplifiedRule("Inline join filters", ERuleProperties::RequireParents | ERuleProperties::RequireTypes | ERuleProperties::RequireMetadata) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -88,6 +94,7 @@ class TRewriteRightJoinRule : public ISimplifiedRule {
   public:
     TRewriteRightJoinRule() : ISimplifiedRule("Rewrite right join", ERuleProperties::RequireParents ) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -99,6 +106,7 @@ class TEliminateLeftJoinRule : public ISimplifiedRule {
   public:
     TEliminateLeftJoinRule() : ISimplifiedRule("Eliminate left join", ERuleProperties::RequireParents | ERuleProperties::RequireMetadata | ERuleProperties::RequireLiveness) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -111,6 +119,7 @@ public:
         : ISimplifiedRule("Expand distinct aggregation rule", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {
     }
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -121,6 +130,7 @@ class TFuseFiltersRule : public ISimplifiedRule {
   public:
     TFuseFiltersRule() : ISimplifiedRule("Fuse filters", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -133,6 +143,7 @@ class TPushMapElementsIntoMapRule : public ISimplifiedRule {
     TPushMapElementsIntoMapRule()
         : ISimplifiedRule("Push map elements into map", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -142,6 +153,7 @@ class TPushMapElementsThroughInputRule : public ISimplifiedRule {
         : ISimplifiedRule("Push map elements through input operator", ERuleProperties::RequireParents)
         , PushExpressions(pushExpressions) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 
   private:
@@ -155,6 +167,7 @@ class TPushMapElementsThroughAggregateRule : public ISimplifiedRule {
                           ERuleProperties::RequireParents | ERuleProperties::RequireLiveness | ERuleProperties::RequireNameConstraints |
                               ERuleProperties::RequireAliases) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -163,6 +176,7 @@ class TPushMapElementsThroughUnionAllRule : public ISimplifiedRule {
     TPushMapElementsThroughUnionAllRule()
         : ISimplifiedRule("Push map elements through UnionAll", ERuleProperties::RequireParents | ERuleProperties::RequireLiveness) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -174,6 +188,7 @@ class TRenameToAppendRule : public IRule {
     TRenameToAppendRule()
         : IRule("Convert safe renames to appends", ERuleProperties::RequireParents | ERuleProperties::RequireLiveness | ERuleProperties::RequireNameConstraints) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -182,6 +197,7 @@ class TPushRenameIntoProducerRule : public IRule {
     TPushRenameIntoProducerRule()
         : IRule("Push semantic rename into producer", ERuleProperties::RequireParents | ERuleProperties::RequireLiveness | ERuleProperties::RequireNameConstraints) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -206,6 +222,7 @@ class TPushLimitIntoSortRule : public ISimplifiedRule {
   public:
     TPushLimitIntoSortRule() : ISimplifiedRule("Push limit into sort operator", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -216,6 +233,7 @@ class TPushFilterUnderMapRule : public ISimplifiedRule {
   public:
     TPushFilterUnderMapRule() : ISimplifiedRule("Push filter under map", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -226,6 +244,7 @@ class TExtractCommonConjunctsRule : public ISimplifiedRule {
   public:
     TExtractCommonConjunctsRule() : ISimplifiedRule("Extract common conjuncts", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -237,6 +256,7 @@ class TPushFilterIntoJoinRule : public ISimplifiedRule {
   public:
     TPushFilterIntoJoinRule() : ISimplifiedRule("Push filter into join", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -247,6 +267,7 @@ class TPeepholePredicate : public ISimplifiedRule {
   public:
       TPeepholePredicate() : ISimplifiedRule("Peephole predicate", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {}
 
+      virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
       virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -257,6 +278,7 @@ class TPushRangesRule : public ISimplifiedRule {
   public:
       TPushRangesRule() : ISimplifiedRule("Push ranges", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {}
 
+      virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
       virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -267,6 +289,7 @@ class TPushOlapFilterRule : public ISimplifiedRule {
   public:
       TPushOlapFilterRule() : ISimplifiedRule("Push olap filter", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {}
 
+      virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
       virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -277,6 +300,7 @@ class TPushOlapProjectionRule : public ISimplifiedRule {
   public:
       TPushOlapProjectionRule() : ISimplifiedRule("Push olap projection", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {}
 
+      virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
       virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -287,6 +311,7 @@ class TDisableBlocksOnColumnsLimitRule : public ISimplifiedRule {
   public:
       TDisableBlocksOnColumnsLimitRule() : ISimplifiedRule("Disable blocks on columns limit", ERuleProperties::RequireParents) {}
 
+      virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
       virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -297,6 +322,7 @@ class TBuildInitialCBOTreeRule : public ISimplifiedRule {
   public:
     TBuildInitialCBOTreeRule() : ISimplifiedRule("Building initial CBO tree", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -307,6 +333,7 @@ class TExpandCBOTreeRule : public ISimplifiedRule {
   public:
     TExpandCBOTreeRule() : ISimplifiedRule("Expand CBO tree", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -317,6 +344,7 @@ class TOptimizeCBOTreeRule : public ISimplifiedRule {
   public:
     TOptimizeCBOTreeRule() : ISimplifiedRule("Optimize CBO tree", ERuleProperties::RequireParents | ERuleProperties::RequireStatistics) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -327,6 +355,7 @@ class TInlineCBOTreeRule : public ISimplifiedRule {
   public:
     TInlineCBOTreeRule() : ISimplifiedRule("Inline unoptimized CBO tree", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -359,6 +388,7 @@ class TPruneDeadMapElementsRule : public IRule {
         PruneKeyColumns(pruneKeyColumns) 
     {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
     bool PruneKeyColumns = true;
 };
@@ -373,6 +403,7 @@ class TPruneDeadReadColumnsRule : public IRule {
         PruneKeyColumns(pruneKeyColumns) 
     {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
     bool PruneKeyColumns = true;
 };
@@ -385,6 +416,7 @@ class TPruneDeadAggregateTraitsRule : public IRule {
     TPruneDeadAggregateTraitsRule()
         : IRule("Prune dead aggregate traits", ERuleProperties::RequireLiveness) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -398,6 +430,7 @@ class TPruneDeadUnionAllColumnsRule : public IRule {
     TPruneDeadUnionAllColumnsRule()
         : IRule("Prune dead UnionAll columns", ERuleProperties::RequireLiveness) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual bool MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -419,6 +452,7 @@ public:
         : ISimplifiedRule("Propagate aggregate operator through stages", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {
     }
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) override;
 };
 
@@ -429,6 +463,7 @@ class TPropagateTopSortThroughStageRule : public ISimplifiedRule {
   public:
     TPropagateTopSortThroughStageRule() : ISimplifiedRule("Propagate topsort operator through stages", ERuleProperties::RequireParents | ERuleProperties::RequireTypes) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 
@@ -439,6 +474,7 @@ class TPropagateLimitThroughStageRule : public ISimplifiedRule {
   public:
     TPropagateLimitThroughStageRule() : ISimplifiedRule("Propagate limit operator through stages", ERuleProperties::RequireParents) {}
 
+    virtual bool QuickMatch(const TIntrusivePtr<IOperator>& input) const override;
     virtual TIntrusivePtr<IOperator> SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) override;
 };
 

--- a/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/apply_cbo.cpp
@@ -42,6 +42,10 @@ void LogAndTraceJoinTree(
 
 } // anonymous namespace
 
+bool TOptimizeCBOTreeRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::CBOTree;
+}
+
 /**
  * Run dynamic programming CBO and convert the resulting tree into operator tree
  *

--- a/ydb/core/kqp/opt/rbo/rules/build_initial_cbo_tree.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/build_initial_cbo_tree.cpp
@@ -3,6 +3,10 @@
 namespace NKikimr {
 namespace NKqp {
 
+bool TBuildInitialCBOTreeRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Join;
+}
+
 /**
  * Initially we build CBO only for joins that don't have other joins or CBO trees as arguments
  * There could be an intermediate filter in between, we also check that

--- a/ydb/core/kqp/opt/rbo/rules/correlated_filter_pullup.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/correlated_filter_pullup.cpp
@@ -6,6 +6,11 @@ namespace NKqp {
 // Pull up correlated filter inside a subplan
 // We match the parent of the filter, currently we support only Map and Aggregate
 
+bool TPullUpCorrelatedFilterRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return (input->Kind == EOperator::Map || input->Kind == EOperator::Aggregate) &&
+        input->Children.front()->Kind == EOperator::Filter;
+}
+
 bool TPullUpCorrelatedFilterRule::MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);

--- a/ydb/core/kqp/opt/rbo/rules/disable_blocks_on_columns_limit.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/disable_blocks_on_columns_limit.cpp
@@ -16,6 +16,10 @@ bool IsSuitableToDisableOlapBlocks(const TIntrusivePtr<IOperator>& input, TTypeA
 
 } // anonymous namespace
 
+bool TDisableBlocksOnColumnsLimitRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Limit;
+}
+
 TIntrusivePtr<IOperator> TDisableBlocksOnColumnsLimitRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& rboCtx, TPlanProps& props) {
     Y_UNUSED(props);
     auto& typesCtx = rboCtx.TypeCtx;

--- a/ydb/core/kqp/opt/rbo/rules/eliminate_left_join.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/eliminate_left_join.cpp
@@ -3,6 +3,10 @@
 namespace NKikimr {
 namespace NKqp {
 
+bool TEliminateLeftJoinRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Join;
+}
+
 // Given this shape:
 // Left Join (L_keys = R_keys)
 //     |- L

--- a/ydb/core/kqp/opt/rbo/rules/expand_cbo_tree.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/expand_cbo_tree.cpp
@@ -45,6 +45,10 @@ TIntrusivePtr<TOpFilter> FuseFilters(const TIntrusivePtr<TOpFilter>& top, const 
 namespace NKikimr {
 namespace NKqp {
 
+bool TExpandCBOTreeRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Join;
+}
+
 /**
  * Expanding CBO tree is more tricky:
  *  - We can have a join that joins a CBOtree with something else, and there could be a filter in between that we

--- a/ydb/core/kqp/opt/rbo/rules/expand_distinct_aggregation.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/expand_distinct_aggregation.cpp
@@ -241,6 +241,10 @@ TIntrusivePtr<IOperator> ExpandMultiDistinct(const TIntrusivePtr<TOpAggregate>& 
 
 } // anonymous namespace
 
+bool TExpandDistinctAggregationRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Aggregate;
+}
+
 TIntrusivePtr<IOperator> TExpandDistinctAggregationRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& rboCtx, TPlanProps& props) {
     if (!IsSuitableToExpandDistinctAggregation(input)) {
         return input;

--- a/ydb/core/kqp/opt/rbo/rules/extract_common_conjuncts.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/extract_common_conjuncts.cpp
@@ -3,6 +3,10 @@
 namespace NKikimr {
 namespace NKqp {
 
+bool TExtractCommonConjunctsRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter;
+}
+
 TIntrusivePtr<IOperator> TExtractCommonConjunctsRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);

--- a/ydb/core/kqp/opt/rbo/rules/extract_join_expressions.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/extract_join_expressions.cpp
@@ -5,6 +5,10 @@ namespace NKqp {
 
 // Currently we only extract simple expressions where there is only one variable on either side
 
+bool TExtractJoinExpressionsRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter;
+}
+
 bool TExtractJoinExpressionsRule::MatchAndApply(TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
     Y_UNUSED(props);
 

--- a/ydb/core/kqp/opt/rbo/rules/fuse_filters.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/fuse_filters.cpp
@@ -2,7 +2,12 @@
 
 namespace NKikimr {
 namespace NKqp {
-    
+
+bool TFuseFiltersRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter &&
+        input->Children.front()->Kind == EOperator::Filter;
+}
+
 // Match two consequtive filters and fuse them into a single conjunction
 
 TIntrusivePtr<IOperator> TFuseFiltersRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {

--- a/ydb/core/kqp/opt/rbo/rules/inline_cbo_tree.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_cbo_tree.cpp
@@ -2,7 +2,11 @@
 
 namespace NKikimr {
 namespace NKqp {
-    
+
+bool TInlineCBOTreeRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::CBOTree;
+}
+
 /**
  * Convert unoptimized CBOTrees back into normal operators
  */

--- a/ydb/core/kqp/opt/rbo/rules/inline_generic_in_exists_subplan.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_generic_in_exists_subplan.cpp
@@ -22,7 +22,11 @@ bool CheckNonNullKeys(const TIntrusivePtr<IOperator> &input, const TVector<TInfo
 
 namespace NKikimr {
 namespace NKqp {
-    
+
+bool TInlineGenericInExistsSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter;
+}
+
 TIntrusivePtr<IOperator> TInlineGenericInExistsSubplanRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Filter) {
         return input;

--- a/ydb/core/kqp/opt/rbo/rules/inline_join_filters.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_join_filters.cpp
@@ -25,7 +25,11 @@ bool CheckNonNullKeys(const TIntrusivePtr<IOperator> &input, const TVector<TInfo
 
 namespace NKikimr {
 namespace NKqp {
-    
+
+bool TInlineJoinFiltersRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Join;
+}
+
 // Inline join filters. In case of inner join, replace the join with a filter on top of inner or cross join
 // More complex logic for other types of joins
 

--- a/ydb/core/kqp/opt/rbo/rules/inline_simple_in_exists_subplan.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/inline_simple_in_exists_subplan.cpp
@@ -2,7 +2,11 @@
 
 namespace NKikimr {
 namespace NKqp {
-    
+
+bool TInlineSimpleInExistsSubplanRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter;
+}
+
 TIntrusivePtr<IOperator> TInlineSimpleInExistsSubplanRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Filter || props.PgSyntax) {
         return input;

--- a/ydb/core/kqp/opt/rbo/rules/map/prune_dead_outputs.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/prune_dead_outputs.cpp
@@ -149,6 +149,10 @@ bool PruneAggregateTraits(const TIntrusivePtr<TOpAggregate>& aggregate, const TI
 
 } // anonymous namespace
 
+bool TPruneDeadMapElementsRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map;
+}
+
 bool TPruneDeadMapElementsRule::MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);
@@ -183,6 +187,10 @@ bool TPruneDeadMapElementsRule::MatchAndApply(TIntrusivePtr<IOperator>& input, T
     return true;
 }
 
+bool TPruneDeadReadColumnsRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Source;
+}
+
 bool TPruneDeadReadColumnsRule::MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);
@@ -203,6 +211,10 @@ bool TPruneDeadReadColumnsRule::MatchAndApply(TIntrusivePtr<IOperator>& input, T
     }
 
     return NarrowReadColumns(read, liveOut, keepKeyColumns);
+}
+
+bool TPruneDeadUnionAllColumnsRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::UnionAll;
 }
 
 bool TPruneDeadUnionAllColumnsRule::MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
@@ -239,6 +251,10 @@ bool TPruneDeadUnionAllColumnsRule::MatchAndApply(TIntrusivePtr<IOperator>& inpu
 
     unionAll->Columns = std::move(newColumns);
     return true;
+}
+
+bool TPruneDeadAggregateTraitsRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Aggregate;
 }
 
 bool TPruneDeadAggregateTraitsRule::MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {

--- a/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_into_map.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_into_map.cpp
@@ -210,6 +210,11 @@ TRenameMap BuildRenameMap(const TVector<TMapElement>& elements, const TElementMa
 
 } // anonymous namespace
 
+bool TPushMapElementsIntoMapRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map &&
+        input->Children.front()->Kind == EOperator::Map;
+}
+
 TIntrusivePtr<IOperator>
 TPushMapElementsIntoMapRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Map) {

--- a/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_through_aggregate.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_through_aggregate.cpp
@@ -158,6 +158,11 @@ void PruneCollidingTargets(const TVector<TInfoUnit>& aggregateOutput, TVector<TC
 
 } // anonymous namespace
 
+bool TPushMapElementsThroughAggregateRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map &&
+        input->Children.front()->Kind == EOperator::Aggregate;
+}
+
 TIntrusivePtr<IOperator>
 TPushMapElementsThroughAggregateRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Map) {

--- a/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_through_input.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_through_input.cpp
@@ -100,6 +100,10 @@ bool CanPushAppendToChild(
 
 } // anonymous namespace
 
+bool TPushMapElementsThroughInputRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map;
+}
+
 TIntrusivePtr<IOperator>
 TPushMapElementsThroughInputRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Map) {

--- a/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_through_union_all.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/push_map_elements_through_union_all.cpp
@@ -207,6 +207,11 @@ bool ResidualIsValid(
 
 } // anonymous namespace
 
+bool TPushMapElementsThroughUnionAllRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map &&
+        input->Children.front()->Kind == EOperator::UnionAll;
+}
+
 TIntrusivePtr<IOperator>
 TPushMapElementsThroughUnionAllRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Map) {

--- a/ydb/core/kqp/opt/rbo/rules/map/push_rename_into_producer.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/push_rename_into_producer.cpp
@@ -120,6 +120,10 @@ bool TryRenameProducerOutput(const TIntrusivePtr<IOperator>& producer, const TIn
 
 } // anonymous namespace
 
+bool TPushRenameIntoProducerRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map;
+}
+
 bool TPushRenameIntoProducerRule::MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     if (input->Kind != EOperator::Map) {
         return false;

--- a/ydb/core/kqp/opt/rbo/rules/map/remove_identity_map.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/remove_identity_map.cpp
@@ -32,6 +32,10 @@ TInfoUnitSet GetInputIUs(const TIntrusivePtr<TOpMap>& map) {
 // Remove extra maps that arrise during translation.
 // Identity renames carry no semantic rename and should not block map rewrites.
 
+bool TRemoveIdenityMapRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map;
+}
+
 TIntrusivePtr<IOperator> TRemoveIdenityMapRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);

--- a/ydb/core/kqp/opt/rbo/rules/map/rename_to_append.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/map/rename_to_append.cpp
@@ -40,6 +40,10 @@ TRenameSourceCounts CountRenameSources(const TOpMap& map) {
 
 } // anonymous namespace
 
+bool TRenameToAppendRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map;
+}
+
 bool TRenameToAppendRule::MatchAndApply(TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);

--- a/ydb/core/kqp/opt/rbo/rules/peephole_predicate.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/peephole_predicate.cpp
@@ -29,6 +29,10 @@ bool IsSuitableToApplyPeephole(const TIntrusivePtr<IOperator>& input) {
 namespace NKikimr {
 namespace NKqp {
 
+bool TPeepholePredicate::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter;
+}
+
 TIntrusivePtr<IOperator> TPeepholePredicate::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(props);
     if (!IsSuitableToApplyPeephole(input)) {

--- a/ydb/core/kqp/opt/rbo/rules/propagate_aggregate_through_stage.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/propagate_aggregate_through_stage.cpp
@@ -86,6 +86,10 @@ TIntrusivePtr<TOpAggregate> EmitFinalAndIntermediateAggregates(const TIntrusiveP
 
 } // namespace
 
+bool TPropagateAggregateThroughStageRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Aggregate;
+}
+
 TIntrusivePtr<IOperator> TPropagateAggregateThroughStageRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
 

--- a/ydb/core/kqp/opt/rbo/rules/propagate_limit_through_stage.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/propagate_limit_through_stage.cpp
@@ -45,6 +45,10 @@ TIntrusivePtr<TOpLimit> EmitFinalAndIntermediateLimits(const TIntrusivePtr<TOpLi
 
 } // namespace
 
+bool TPropagateLimitThroughStageRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Limit;
+}
+
 TIntrusivePtr<IOperator> TPropagateLimitThroughStageRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);

--- a/ydb/core/kqp/opt/rbo/rules/propagate_topsort_through_stage.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/propagate_topsort_through_stage.cpp
@@ -177,6 +177,10 @@ bool CanPushSortToOlapRead(const TIntrusivePtr<TOpSort>& sort, const TIntrusiveP
 
 } // namespace
 
+bool TPropagateTopSortThroughStageRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Sort;
+}
+
 TIntrusivePtr<IOperator> TPropagateTopSortThroughStageRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);
 

--- a/ydb/core/kqp/opt/rbo/rules/push_filter_into_join.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_filter_into_join.cpp
@@ -59,6 +59,11 @@ bool IsNullRejectingPredicate(const TExpression& filter) {
 namespace NKikimr {
 namespace NKqp {
 
+bool TPushFilterIntoJoinRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter &&
+        input->Children.front()->Kind == EOperator::Join;
+}
+
 // FIXME: We currently support pushing filter into Inner, Cross and Left Join
 TIntrusivePtr<IOperator> TPushFilterIntoJoinRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(ctx);

--- a/ydb/core/kqp/opt/rbo/rules/push_filter_under_map.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_filter_under_map.cpp
@@ -3,6 +3,11 @@
 namespace NKikimr {
 namespace NKqp {
 
+bool TPushFilterUnderMapRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter &&
+        input->Children.front()->Kind == EOperator::Map;
+}
+
 TIntrusivePtr<IOperator> TPushFilterUnderMapRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
 
     Y_UNUSED(ctx);

--- a/ydb/core/kqp/opt/rbo/rules/push_limit_into_sort.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_limit_into_sort.cpp
@@ -2,7 +2,12 @@
 
 namespace NKikimr {
 namespace NKqp {
-    
+
+bool TPushLimitIntoSortRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Limit &&
+        input->Children.front()->Kind == EOperator::Sort;
+}
+
 TIntrusivePtr<IOperator> TPushLimitIntoSortRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_filter.cpp
@@ -85,6 +85,11 @@ TExprNode::TPtr ApplyPeephole(TExprNode::TPtr input, TExprNode::TPtr lambdaArg, 
 
 } // anonymous namespace
 
+bool TPushOlapFilterRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter &&
+        input->Children.front()->Kind == EOperator::Source;
+}
+
 TIntrusivePtr<IOperator> TPushOlapFilterRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(props);
     if (!ctx.KqpCtx.Config->HasOptEnableOlapPushdown()) {

--- a/ydb/core/kqp/opt/rbo/rules/push_olap_projection.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_olap_projection.cpp
@@ -25,6 +25,11 @@ bool IsSuitableToPushProjectionToColumnTables(const TIntrusivePtr<IOperator>& in
 
 } // anonymous namespace
 
+bool TPushOlapProjectionRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Map &&
+        input->Children.front()->Kind == EOperator::Source;
+}
+
 TIntrusivePtr<IOperator> TPushOlapProjectionRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& ctx, TPlanProps& props) {
     Y_UNUSED(props);
     if (!(ctx.KqpCtx.Config->HasOptEnableOlapPushdown() && ctx.KqpCtx.Config->GetEnableOlapPushdownProjections())) {

--- a/ydb/core/kqp/opt/rbo/rules/push_ranges.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/push_ranges.cpp
@@ -190,6 +190,11 @@ const TStructExprType* PrepareSchemeType(const TOpRead& read, const TStructExprT
 
 } // anonymous namespace
 
+bool TPushRangesRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Filter &&
+        input->Children.front()->Kind == EOperator::Source;
+}
+
 TIntrusivePtr<IOperator> TPushRangesRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator>& input, TRBOContext& rboCtx, TPlanProps& props) {
     Y_UNUSED(props);
     auto& kqpCtx = rboCtx.KqpCtx;

--- a/ydb/core/kqp/opt/rbo/rules/rewrite_right_join.cpp
+++ b/ydb/core/kqp/opt/rbo/rules/rewrite_right_join.cpp
@@ -3,6 +3,10 @@
 namespace NKikimr {
 namespace NKqp {
 
+bool TRewriteRightJoinRule::QuickMatch(const TIntrusivePtr<IOperator>& input) const {
+    return input->Kind == EOperator::Join;
+}
+
 TIntrusivePtr<IOperator> TRewriteRightJoinRule::SimpleMatchAndApply(const TIntrusivePtr<IOperator> &input, TRBOContext &ctx, TPlanProps &props) {
     Y_UNUSED(ctx);
     Y_UNUSED(props);


### PR DESCRIPTION
Recomputing properties can be expensive (e.g. statistics, types, metadata, aliases, constraints, etc), before this PR we had to recompute all of the required ones before calling `SimpleMatchAndApply`.

This PR introduces another method `QuickMatch`, which you can optionally override. In this method you can quickly check that match is at least somewhat plausible. For example, a rule that simplifies Maps can check here that target operator is a Map.