### PR TITLE
NBS-7459: functional test for data survival across a tablet restart

### DIFF
--- a/ydb/tests/functional/nbs/test_nbs.py
+++ b/ydb/tests/functional/nbs/test_nbs.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from common import NbsTestBase
 from vhost_user_blk_client import (
     VIRTIO_BLK_S_OK,
@@ -186,3 +188,46 @@ class TestNbs(NbsTestBase):
         # Verify the data matches (trimmed to the original length)
         assert read_data_1[: len(test_data_1)] == test_data_1
         assert read_data_2[: len(test_data_2)] == test_data_2
+
+    def _restart_tenant_slots(self):
+        """
+        Restart the NBS tenant slots (the processes hosting the partition
+        tablet) and wait until the tenant is back up.
+        """
+        for slot in self.cluster.slots.values():
+            slot.stop()
+        for slot in self.cluster.slots.values():
+            slot.start()
+        self.cluster.wait_tenant_up("/Root/NBS")
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason="data safety: after a tablet restart the read succeeds but "
+        "returns garbage instead of the written block; the restore path "
+        "is broken (its unit test is disabled with #if 0). Kept as a live "
+        "repro for the fix.",
+    )
+    def test_nbs_data_survives_tablet_restart(self):
+        """
+        Data safety: write a block, restart the NBS tenant slot (the
+        partition tablet process), read the block back. The static storage
+        nodes keep running, so PBuffers and DDisks keep their content: this
+        exercises the tablet restore path in a real cluster (the functional
+        counterpart of the red ShouldRestorePartitionAfterRestart unit test).
+        """
+        disk_id = self.generate_disk_id()
+        self.create_ddisk_pool()
+        self.create_disk(disk_id)
+        actor_id = self.get_load_actor_adapter_actor_id(disk_id)
+
+        test_data = self.generate_random_data(1024)
+        self.write(actor_id, 0, test_data)
+        assert self.read(actor_id, 0)[: len(test_data)] == test_data
+
+        self._restart_tenant_slots()
+
+        # The load actor adapter is re-created after the restart.
+        actor_id = self.get_load_actor_adapter_actor_id(disk_id)
+        read_data = self.read(actor_id, 0)
+        assert read_data[: len(test_data)] == test_data, (
+            "block content lost or corrupted across a tablet restart")


### PR DESCRIPTION
## What

Functional data-safety test for NBS 2 on a real cluster — the functional counterpart of the unit restore test that is currently disabled with `#if 0 // Temporarily disabled until restore is working correctly`:

- `test_nbs_data_survives_tablet_restart` — write a block, restart the NBS tenant slots (the partition tablet process) while the storage nodes keep running, read the block back. Exercises the tablet restore path.

## What the test found

The tablet-restart scenario reproduces a real, **silent** data corruption on a live cluster: after the restart the read completes successfully but returns garbage instead of the written block:

```
AssertionError: block content lost or corrupted across a tablet restart
assert '\xa8Y[\x1f\x00...0\x00\x00\x00' == 'sLAatvEkxcMO...KdO0YYcJsRZ5p'
```

This is a stronger symptom than the disabled unit test (which fails with `E_REJECTED`/`MISSING_RECORD`): here the corruption is invisible to the client. The test is marked `xfail(strict=False)` so it stays a live self-documenting repro without breaking CI; it will flip to XPASS when the restore path is fixed.

## Testing

`ya make --build relwithdebinfo -tA ydb/tests/functional/nbs -F '*data_survives*'`: 1 XFAIL (the repro), suite GOOD.
