### PR TITLE
Prevent topic partition metrics for supportive partitions

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -5061,6 +5061,9 @@ IActor* CreatePartitionActor(ui64 tabletId, const TPartitionId& partition, const
 }
 
 ::NMonitoring::TDynamicCounterPtr TPartition::GetPerPartitionCounterSubgroup() const {
+    if (IsSupportive()) {
+        return nullptr;
+    }
     auto counters = AppData(ActorContext())->Counters;
     if (!counters) {
         return nullptr;

--- a/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_init.cpp
@@ -1132,7 +1132,8 @@ void TPartition::Initialize(const TActorContext& ctx) {
                                       DbId,
                                       Config.GetYdbDatabasePath(),
                                       IsServerless,
-                                      FolderId);
+                                      FolderId,
+                                      IsSupportive());
     TotalChannelWritesByHead.resize(NumChannels);
 
     if (!IsSupportive()) {

--- a/ydb/core/persqueue/pqtablet/partition/user_info.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.cpp
@@ -320,7 +320,8 @@ TUsersInfoStorage::TUsersInfoStorage(
     const TString& dbId,
     const TString& dbPath,
     const bool isServerless,
-    const TString& folderId
+    const TString& folderId,
+    bool isSupportive
 )
     : DCId(std::move(dcId))
     , TopicConverter(topicConverter)
@@ -331,6 +332,7 @@ TUsersInfoStorage::TUsersInfoStorage(
     , DbPath(dbPath)
     , IsServerless(isServerless)
     , FolderId(folderId)
+    , IsSupportive(isSupportive)
     , CurReadRuleGeneration(0)
 {
 }
@@ -451,6 +453,9 @@ TUsersInfoStorage::TDetailedCounterSubgroup TUsersInfoStorage::GetPartitionCount
 }
 
 TUsersInfoStorage::TDetailedCounterSubgroup TUsersInfoStorage::GetPartitionCounterSubgroupImpl(const TActorContext& ctx, const TString& monitoringProjectId) const {
+    if (IsSupportive) {
+        return {nullptr, monitoringProjectId};
+    }
     NMonitoring::TDynamicCounterPtr s = AppData(ctx)->Counters;
     if (!s) {
         return {nullptr, monitoringProjectId};

--- a/ydb/core/persqueue/pqtablet/partition/user_info.h
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.h
@@ -196,7 +196,8 @@ public:
         const TString& DbId,
         const TString& DbPath,
         const bool isServerless,
-        const TString& FolderId);
+        const TString& FolderId,
+        bool isSupportive);
 
     void Init(TActorId tabletActor, TActorId partitionActor, const TActorContext& ctx);
 
@@ -294,6 +295,7 @@ private:
     TString DbPath;
     bool IsServerless;
     TString FolderId;
+    bool IsSupportive;
     mutable ui64 CurReadRuleGeneration;
 
     TInstant LastReadMetricsUpdateTime;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Issue  #45735

Summary

Supportive (transaction) topic partitions no longer create topics_per_partition monitoring subgroups.

Problem

TPartition::SetupDetailedMetrics() skipped supportive partitions, but TUsersInfoStorage::GetPartitionCounterSubgroupImpl() and TPartition::GetPerPartitionCounterSubgroup() did not. GetSubgroup("partition_id", ...) created empty counter tree nodes for every supportive partition.

Fix

Guard GetPerPartitionCounterSubgroup() with IsSupportive()
Pass IsSupportive into TUsersInfoStorage and skip subgroup creation in GetPartitionCounterSubgroupImpl()
Note

Existing empty partition_id nodes on running nodes are not removed; restart is required to clear accumulated monitoring data.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
