### PR TITLE
Fix tests_monitor duplicate full_name crash (minimal)

### DIFF
--- a/.github/scripts/analytics/tests_monitor.py
+++ b/.github/scripts/analytics/tests_monitor.py
@@ -346,10 +346,19 @@ def main():
             date_str = target_date.strftime('%Y-%m-%d')
             query = f"""
                 SELECT *
-                FROM `{read_table_path}`
-                WHERE build_type = '{build_type}'
-                AND branch = '{branch}'
-                AND date_window = Date('{date_str}')
+                FROM (
+                    SELECT
+                        t.*,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY t.full_name
+                            ORDER BY Length(t.suite_folder) DESC
+                        ) AS _dedup_rn
+                    FROM `{read_table_path}` AS t
+                    WHERE t.build_type = '{build_type}'
+                    AND t.branch = '{branch}'
+                    AND t.date_window = Date('{date_str}')
+                )
+                WHERE _dedup_rn = 1
             """
             _max_retries = 5
             _retry_delay = 10  # seconds


### PR DESCRIPTION
## Summary
Минимальный фикс для #45757: при чтении baseline за предыдущий день схлопываем строки с одинаковым `full_name`, оставляя канонический `suite_folder` (самый длинный путь).

Один SQL-запрос в `load_monitor_data_for_date`, без изменений в `flaky_tests_history` и без правок join к `flaky_tests_window`.

## Альтернатива
Более полный вариант: #45756 (дедуп на всех чтениях + `flaky_tests_history`).

## Test plan
- [ ] Re-run `Update Muted tests`


Made with [Cursor](https://cursor.com)