### PR TITLE
Set not null: ForgetRequest in SchemeShard

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -801,4 +801,5 @@ enum ETxTypes {
     TXTYPE_TEST_SHARD_CONTROL = 126 [(TxTypeOpts) = {Name: "TxTestShardControl"}];
 
     TXTYPE_LIST_SET_COLUMN_CONSTRAINT = 127             [(TxTypeOpts) = {Name: "TxListSetColumnConstraint"}];
+    TXTYPE_FORGET_SET_COLUMN_CONSTRAINT = 128          [(TxTypeOpts) = {Name: "TxForgetSetColumnConstraint"}];
 }

--- a/ydb/core/protos/set_column_constraint.proto
+++ b/ydb/core/protos/set_column_constraint.proto
@@ -70,3 +70,15 @@ message TEvListResponse {
     repeated TSetColumnConstraint Entries = 3;
     optional string NextPageToken = 4;
 }
+
+message TEvForgetRequest {
+    optional uint64 TxId = 1;
+    optional string DatabaseName = 2;
+    optional uint64 OperationId = 3;
+}
+
+message TEvForgetResponse {
+    optional uint64 TxId = 1;
+    optional Ydb.StatusIds.StatusCode Status = 2;
+    repeated Ydb.Issue.IssueMessage Issues = 3;
+}

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5987,6 +5987,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvSetColumnConstraint::TEvCreateRequest, Handle);
         HFuncTraced(TEvSetColumnConstraint::TEvGetRequest, Handle);
         HFuncTraced(TEvSetColumnConstraint::TEvListRequest, Handle);
+        HFuncTraced(TEvSetColumnConstraint::TEvForgetRequest, Handle);
         HFuncTraced(TEvDataShard::TEvValidateRowConditionResponse, Handle);
         HFuncTraced(TEvIndexBuilder::TEvCreateRequest, Handle);
         HFuncTraced(TEvIndexBuilder::TEvGetRequest, Handle);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1938,7 +1938,11 @@ public:
         class TTxCreateSetColumnConstraint;
         struct TTxProgressSetColumnConstraint;
         struct TTxGetSetColumnConstraint;
+<<<<<<< HEAD
         struct TTxListSetColumnConstraint;
+=======
+        struct TTxForgetSetColumnConstraint;
+>>>>>>> 2c2e9baa213 (init)
     };
 
     NTabletFlatExecutor::ITransaction* CreateTxCreate(TEvIndexBuilder::TEvCreateRequest::TPtr& ev);
@@ -1993,9 +1997,11 @@ public:
     void Handle(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSetColumnConstraint::TEvListRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev, const TActorContext& ctx);
     NTabletFlatExecutor::ITransaction* CreateTxCreateSetColumnConstraint(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxGetSetColumnConstraint(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxListSetColumnConstraint(TEvSetColumnConstraint::TEvListRequest::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxForgetSetColumnConstraint(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxSetColumnConstraintProgress(TIndexBuildId id);
     NTabletFlatExecutor::ITransaction* CreateTxReplyAllocateSetColumnConstraint(TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxReplyModifySetColumnConstraint(TEvSchemeShard::TEvModifySchemeTransactionResult::TPtr& ev);
@@ -2025,6 +2031,8 @@ public:
     void PersistSetColumnConstraintUnlockTxDone(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo);
     void PersistSetColumnConstraintValidationFailedValue(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo);
     void PersistSetColumnConstraintShardDone(NIceDb::TNiceDb& db, TIndexBuildId operationId, TShardIdx shardIdx, const TSetColumnConstraintOperationInfo& operationInfo);
+    void PersistSetColumnConstraintForget(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info);
+    void ForgetSetColumnConstraint(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info);
 
     void AddSetColumnConstraintOperation(const std::shared_ptr<TSetColumnConstraintOperationInfo>& indexInfo);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1938,11 +1938,8 @@ public:
         class TTxCreateSetColumnConstraint;
         struct TTxProgressSetColumnConstraint;
         struct TTxGetSetColumnConstraint;
-<<<<<<< HEAD
         struct TTxListSetColumnConstraint;
-=======
         struct TTxForgetSetColumnConstraint;
->>>>>>> 2c2e9baa213 (init)
     };
 
     NTabletFlatExecutor::ITransaction* CreateTxCreate(TEvIndexBuilder::TEvCreateRequest::TPtr& ev);

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -228,6 +228,28 @@ void TSchemeShard::PersistSetColumnConstraintShardDone(
         );
 }
 
+void TSchemeShard::PersistSetColumnConstraintForget(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info) {
+    db.Table<Schema::SetColumnConstraint>().Key(ui64(info.Id)).Delete();
+    
+    for (const auto& [shardIdx, _] : info.ValidationShards) {
+        db.Table<Schema::SetColumnConstraintShardStatus>()
+            .Key(info.Id, shardIdx.GetOwnerId(), shardIdx.GetLocalId())
+            .Delete();
+    }
+}
+
+void TSchemeShard::ForgetSetColumnConstraint(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info) {
+    const auto id = info.Id;
+    const auto byTimeKey = std::make_pair(info.StartTime, id);
+
+    PersistSetColumnConstraintForget(db, info);
+    SetColumnConstraintOperationsByTime.erase(byTimeKey);
+    SetColumnConstraintOperations.erase(id);
+    if (info.Uid) {
+        SetColumnConstraintOperationsByUid.erase(info.Uid);
+    }
+}
+
 void TSchemeShard::Handle(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxCreateSetColumnConstraint(ev), ctx);
 }
@@ -244,6 +266,10 @@ void TSchemeShard::Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& e
     const auto& record = ev->Get()->Record;
     TIndexBuildId operationId = TIndexBuildId(record.GetId());
     Execute(CreateTxReplyValidateRowCondition(operationId, ev), ctx);
+}
+
+void TSchemeShard::Handle(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxForgetSetColumnConstraint(ev), ctx);
 }
 
 } // NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -230,7 +230,7 @@ void TSchemeShard::PersistSetColumnConstraintShardDone(
 
 void TSchemeShard::PersistSetColumnConstraintForget(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info) {
     db.Table<Schema::SetColumnConstraint>().Key(ui64(info.Id)).Delete();
-    
+
     for (const auto& [shardIdx, _] : info.ValidationShards) {
         db.Table<Schema::SetColumnConstraintShardStatus>()
             .Key(info.Id, shardIdx.GetOwnerId(), shardIdx.GetLocalId())
@@ -243,11 +243,18 @@ void TSchemeShard::ForgetSetColumnConstraint(NIceDb::TNiceDb& db, const TSetColu
     const auto byTimeKey = std::make_pair(info.StartTime, id);
 
     PersistSetColumnConstraintForget(db, info);
+
     SetColumnConstraintOperationsByTime.erase(byTimeKey);
-    SetColumnConstraintOperations.erase(id);
     if (info.Uid) {
         SetColumnConstraintOperationsByUid.erase(info.Uid);
     }
+
+    TxIdToSetColumnConstraintOperations.erase(info.LockTxId);
+    TxIdToSetColumnConstraintOperations.erase(info.LockNullWritesTxId);
+    TxIdToSetColumnConstraintOperations.erase(info.UnlockNullWritesTxId);
+    TxIdToSetColumnConstraintOperations.erase(info.UnlockTxId);
+
+    SetColumnConstraintOperations.erase(id);
 }
 
 void TSchemeShard::Handle(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -27,6 +27,8 @@ struct TEvSetColumnConstraint {
         EvGetResponse,
         EvListRequest,
         EvListResponse,
+        EvForgetRequest,
+        EvForgetResponse,
 
         EvEnd
     };
@@ -69,6 +71,7 @@ struct TEvSetColumnConstraint {
 
     struct TEvGetResponse: public TEventPB<TEvGetResponse, NKikimrSetColumnConstraint::TEvGetResponse, EvGetResponse> {};
 
+<<<<<<< HEAD
     struct TEvListRequest: public TEventPB<TEvListRequest, NKikimrSetColumnConstraint::TEvListRequest, EvListRequest> {
         TEvListRequest() = default;
 
@@ -81,6 +84,28 @@ struct TEvSetColumnConstraint {
 
     struct TEvListResponse: public TEventPB<TEvListResponse, NKikimrSetColumnConstraint::TEvListResponse, EvListResponse> {
         TEvListResponse() = default;
+=======
+    struct TEvForgetRequest: public TEventPB<TEvForgetRequest, NKikimrSetColumnConstraint::TEvForgetRequest, EvForgetRequest> {
+        TEvForgetRequest() = default;
+
+        explicit TEvForgetRequest(
+            const ui64 txId,
+            const TString& dbName,
+            ui64 operationId)
+        {
+            Record.SetTxId(txId);
+            Record.SetDatabaseName(dbName);
+            Record.SetOperationId(operationId);
+        }
+    };
+
+    struct TEvForgetResponse: public TEventPB<TEvForgetResponse, NKikimrSetColumnConstraint::TEvForgetResponse, EvForgetResponse> {
+        TEvForgetResponse() = default;
+
+        explicit TEvForgetResponse(const ui64 txId) {
+            Record.SetTxId(txId);
+        }
+>>>>>>> 2c2e9baa213 (init)
     };
 }; // TEvSetColumnConstraint
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -71,7 +71,6 @@ struct TEvSetColumnConstraint {
 
     struct TEvGetResponse: public TEventPB<TEvGetResponse, NKikimrSetColumnConstraint::TEvGetResponse, EvGetResponse> {};
 
-<<<<<<< HEAD
     struct TEvListRequest: public TEventPB<TEvListRequest, NKikimrSetColumnConstraint::TEvListRequest, EvListRequest> {
         TEvListRequest() = default;
 
@@ -84,7 +83,8 @@ struct TEvSetColumnConstraint {
 
     struct TEvListResponse: public TEventPB<TEvListResponse, NKikimrSetColumnConstraint::TEvListResponse, EvListResponse> {
         TEvListResponse() = default;
-=======
+    };
+
     struct TEvForgetRequest: public TEventPB<TEvForgetRequest, NKikimrSetColumnConstraint::TEvForgetRequest, EvForgetRequest> {
         TEvForgetRequest() = default;
 
@@ -105,7 +105,6 @@ struct TEvSetColumnConstraint {
         explicit TEvForgetResponse(const ui64 txId) {
             Record.SetTxId(txId);
         }
->>>>>>> 2c2e9baa213 (init)
     };
 }; // TEvSetColumnConstraint
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__forget.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__forget.cpp
@@ -1,0 +1,101 @@
+#include "schemeshard_impl.h"
+#include "schemeshard_set_column_constraint.h"
+#include "index/index_build_info.h"
+
+#define LOG_D(stream) LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << Self->SelfTabletId() << "][SetColumnConstraint] " << stream)
+
+namespace NKikimr::NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+struct TSchemeShard::TIndexBuilder::TTxForgetSetColumnConstraint: public TRwTxBase {
+    explicit TTxForgetSetColumnConstraint(TSelf* self, TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev)
+        : TRwTxBase(self)
+        , Request(ev)
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_FORGET_SET_COLUMN_CONSTRAINT;
+    }
+
+    void DoExecute(TTransactionContext &txc, const TActorContext &ctx) override {
+        const auto& request = Request->Get()->Record;
+        LOG_D("TIndexBuilder::TTxForgetSetColumnConstraint DoExecute " << request.ShortDebugString());
+
+        auto response = MakeHolder<TEvSetColumnConstraint::TEvForgetResponse>(request.GetTxId());
+        TPath database = TPath::Resolve(request.GetDatabaseName(), Self);
+        if (!database.IsResolved()) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Database " << request.GetDatabaseName() << " not found"
+            );
+        }
+        const TPathId subdomainPathId = database.GetPathIdForDomain();
+
+        auto operationId = TIndexBuildId(request.GetOperationId());
+        const auto* operationInfoPtr = Self->SetColumnConstraintOperations.FindPtr(operationId);
+        if (!operationInfoPtr) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Set column constraint operation with id " << operationId << " not found"
+            );
+        }
+        auto& operationInfo = *operationInfoPtr->get();
+        if (operationInfo.DomainPathId != subdomainPathId) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Set column constraint operation with id " << operationId << " not found in database " << request.GetDatabaseName()
+            );
+        }
+
+        if (!operationInfo.IsFinished()) {
+            return Reply(
+                std::move(response),
+                Ydb::StatusIds::PRECONDITION_FAILED,
+                TStringBuilder() << "Set column constraint operation with id " << operationId << " hasn't been finished yet"
+            );
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+        Self->ForgetSetColumnConstraint(db, operationInfo);
+
+        Reply(std::move(response));
+
+        SideEffects.ApplyOnExecute(Self, txc, ctx);
+    }
+
+    void DoComplete(const TActorContext &ctx) override {
+        LOG_D("TIndexBuilder::TTxForgetSetColumnConstraint DoComplete " << Request->Get()->Record.ShortDebugString());
+        SideEffects.ApplyOnComplete(Self, ctx);
+    }
+
+private:
+    void Reply(
+        THolder<TEvSetColumnConstraint::TEvForgetResponse> response,
+        const Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS,
+        const TString& errorMessage = TString())
+    {
+        auto& record = response->Record;
+        record.SetStatus(status);
+        if (errorMessage) {
+            auto& issue = *record.MutableIssues()->Add();
+            issue.set_severity(NYql::TSeverityIds::S_ERROR);
+            issue.set_message(errorMessage);
+        }
+
+        SideEffects.Send(Request->Sender, std::move(response), 0, Request->Cookie);
+    }
+
+private:
+    TSideEffects SideEffects;
+    TEvSetColumnConstraint::TEvForgetRequest::TPtr Request;
+};
+
+ITransaction* TSchemeShard::CreateTxForgetSetColumnConstraint(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev) {
+    return new TIndexBuilder::TTxForgetSetColumnConstraint(this, ev);
+}
+
+} // namespace NKikimr::NSchemeShard

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -3597,6 +3597,34 @@ namespace NSchemeShardUT_Private {
         return event->Record;
     }
 
+    NKikimrSetColumnConstraint::TEvForgetResponse TestForgetSetColumnConstraint(
+        TTestActorRuntime& runtime,
+        ui64 schemeshardId,
+        ui64 txId,
+        const TString& dbName,
+        ui64 operationId,
+        Ydb::StatusIds::StatusCode expectedStatus)
+    {
+        ForwardToTablet(runtime, schemeshardId, runtime.AllocateEdgeActor(), new TEvSetColumnConstraint::TEvForgetRequest(txId, dbName, operationId));
+
+        TAutoPtr<IEventHandle> handle;
+        auto ev = runtime.GrabEdgeEvent<TEvSetColumnConstraint::TEvForgetResponse>(handle);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(ev->Record.GetStatus(), expectedStatus, ev->Record.GetIssues());
+
+        return ev->Record;
+    }
+
+    NKikimrSetColumnConstraint::TEvForgetResponse TestForgetSetColumnConstraint(
+        TTestActorRuntime& runtime,
+        ui64 txId,
+        const TString& dbName,
+        ui64 operationId,
+        Ydb::StatusIds::StatusCode expectedStatus)
+    {
+        return TestForgetSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, txId, dbName, operationId, expectedStatus);
+    }
+
     void TestCheckColumnsNotNull(
         TTestActorRuntime& runtime,
         const TString& tablePath,

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -813,5 +813,9 @@ namespace NSchemeShardUT_Private {
     NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName);
     NKikimrSetColumnConstraint::TEvListResponse TestListSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString &dbName,
             ui64 pageSize, const TString& pageToken, Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    NKikimrSetColumnConstraint::TEvForgetResponse TestForgetSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeshardId, ui64 txId, const TString& dbName, ui64 operationId,
+            Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    NKikimrSetColumnConstraint::TEvForgetResponse TestForgetSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 operationId,
+            Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
     void TestCheckColumnsNotNull(TTestActorRuntime& runtime, const TString& tablePath, const std::map<TString, bool>& expectedColumnNotNullStates);
 } //NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1585,4 +1585,87 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
 
         TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
     }
+
+    Y_UNIT_TEST(ForgetOperationTwice) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 setConstraintTxId = ++txId;
+        auto createResponse = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(createResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        ui64 operationId = setConstraintTxId;
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        auto forgetResponse1 = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, operationId, Ydb::StatusIds::SUCCESS);
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse1.GetStatus(), Ydb::StatusIds::SUCCESS);
+
+        auto forgetResponse2 = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, operationId, Ydb::StatusIds::NOT_FOUND);
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse2.GetStatus(), Ydb::StatusIds::NOT_FOUND);
+        UNIT_ASSERT(forgetResponse2.IssuesSize() > 0);
+    }
+
+    Y_UNIT_TEST(ForgetOperationWrongDatabase) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 setConstraintTxId = ++txId;
+        auto createResponse = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(createResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        ui64 operationId = setConstraintTxId;
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        auto forgetResponse = TestForgetSetColumnConstraint(
+            runtime, ++txId, "/WrongRoot", operationId, Ydb::StatusIds::NOT_FOUND);
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse.GetStatus(), Ydb::StatusIds::NOT_FOUND);
+        UNIT_ASSERT(forgetResponse.IssuesSize() > 0);
+    }
 } // Y_UNIT_TEST_SUITE(SetNotNullTest)

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1586,6 +1586,181 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
     }
 
+    Y_UNIT_TEST(ForgetNonExistentOperation) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+
+        auto forgetResponse = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, 999999, Ydb::StatusIds::NOT_FOUND);
+
+        Cerr << "FORGET RESPONSE: " << forgetResponse.ShortDebugString() << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse.GetStatus(), Ydb::StatusIds::NOT_FOUND);
+        UNIT_ASSERT(forgetResponse.IssuesSize() > 0);
+    }
+
+    Y_UNIT_TEST(ForgetOperationInProgress) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        THolder<IEventHandle> delayedValidateRequest;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!delayedValidateRequest && ev->GetTypeRewrite() == TEvDataShard::TEvValidateRowConditionRequest::EventType) {
+                delayedValidateRequest.Reset(ev.Release());
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        ui64 setConstraintTxId = ++txId;
+        auto createResponse = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(createResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        ui64 operationId = setConstraintTxId;
+
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&delayedValidateRequest](IEventHandle&) -> bool {
+                return bool(delayedValidateRequest);
+            });
+            runtime.DispatchEvents(opts);
+        }
+
+        UNIT_ASSERT_C(delayedValidateRequest, "Failed to intercept TEvValidateRowConditionRequest");
+
+        auto forgetResponse = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, operationId, Ydb::StatusIds::PRECONDITION_FAILED);
+
+        Cerr << "FORGET IN PROGRESS RESPONSE: " << forgetResponse.ShortDebugString() << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse.GetStatus(), Ydb::StatusIds::PRECONDITION_FAILED);
+        UNIT_ASSERT(forgetResponse.IssuesSize() > 0);
+
+        runtime.SetObserverFunc(prevObserver);
+        runtime.Send(delayedValidateRequest.Release(), 0, true);
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+    }
+
+    Y_UNIT_TEST(ForgetCompletedOperation) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 setConstraintTxId = ++txId;
+        auto createResponse = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(createResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        ui64 operationId = setConstraintTxId;
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+
+        // check that operation exists
+        DoGetRequest(operationId, runtime, root, Ydb::StatusIds::SUCCESS);
+
+        auto forgetResponse = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, operationId, Ydb::StatusIds::SUCCESS);
+
+        Cerr << "FORGET COMPLETED RESPONSE: " << forgetResponse.ShortDebugString() << Endl;
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+
+        DoGetRequest(operationId, runtime, root, Ydb::StatusIds::NOT_FOUND);
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+    }
+
+    Y_UNIT_TEST(ForgetOperationPersistsAfterReboot) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 setConstraintTxId = ++txId;
+        auto createResponse = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL(createResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+        ui64 operationId = setConstraintTxId;
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        auto forgetResponse = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, operationId, Ydb::StatusIds::SUCCESS);
+
+        UNIT_ASSERT_VALUES_EQUAL(forgetResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        DoGetRequest(operationId, runtime, root, Ydb::StatusIds::NOT_FOUND);
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+    }
+
     Y_UNIT_TEST(ForgetOperationTwice) {
         TTestBasicRuntime runtime;
         runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -315,6 +315,7 @@ SRCS(
     schemeshard_set_column_constraint.cpp
     schemeshard_set_column_constraint.h
     schemeshard_set_column_constraint__create.cpp
+    schemeshard_set_column_constraint__forget.cpp
     schemeshard_set_column_constraint__get.cpp
     schemeshard_set_column_constraint__list.cpp
     schemeshard_set_column_constraint__progress.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

As part of the SET NOT NULL implementation, a basic pull request was created (https://github.com/ydb-platform/ydb/pull/36152). It left a large number of gaps. This pull request addresses one of them.

Each long-running operation should primarily be implemented using five types of requests:

1. Create  
2. Get  
3. Cancel  
4. Forget  
5. List  

See [here](https://ydb.tech/docs/en/reference/ydb-cli/operation-list?version=main).

This pull request implements the `Forget` request for the new operation at the `SchemeShard` level.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

It will be added on grpc_level and sdk levels later.
