### PR TITLE
Introduce Interconnect TCP session v2 stub

### DIFF
--- a/ydb/library/actors/core/interconnect.h
+++ b/ydb/library/actors/core/interconnect.h
@@ -7,7 +7,13 @@
 #include <util/string/cast.h>
 #include <util/string/builder.h>
 
+#include <memory>
+
 namespace NActors {
+    // Defined in ydb/library/actors/interconnect/interconnect_direct_session.h; forward declared here to
+    // avoid a dependency from actors/core onto actors/interconnect. Only referenced through shared_ptr.
+    class IDirectSession;
+
     class TNodeLocation {
     public:
         struct TKeys {
@@ -179,7 +185,15 @@ namespace NActors {
                 : NodeId(node)
             {
             }
+            TEvNodeConnected(ui32 node, std::shared_ptr<IDirectSession> directSession) noexcept
+                : NodeId(node)
+                , DirectSession(std::move(directSession))
+            {
+            }
             const ui32 NodeId;
+            // Set only for TInterconnectSessionTCPv2 sessions; carries a thread-safe direct send/receive
+            // interface that bypasses the actor system. Null for classic (v1) sessions.
+            std::shared_ptr<IDirectSession> DirectSession;
         };
 
         struct TEvNodeDisconnected: public TEventLocal<TEvNodeDisconnected, EvNodeDisconnected> {

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -83,6 +83,9 @@ namespace NActors {
         bool CollectSubscriptionStackTrace = false;
         bool UseUring = false;
         bool EnableUringSQPOLL = false; // only effective when UseUring is set
+        // Enables negotiation and usage of TInterconnectSessionTCPv2 (no session continuation, no encryption).
+        // v2 is used only when both peers have this enabled and encryption is not in effect.
+        bool EnableInterconnectSessionV2 = false;
     };
 
     struct TWhiteboardSessionStatus {

--- a/ydb/library/actors/interconnect/interconnect_direct_session.h
+++ b/ydb/library/actors/interconnect/interconnect_direct_session.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <ydb/library/actors/core/actorid.h>
+#include <ydb/library/actors/core/event.h>
+
+#include <util/generic/hash.h>
+#include <util/system/mutex.h>
+
+#include <functional>
+#include <memory>
+
+namespace NActors {
+
+    // Thread-safe handle to an established interconnect session (v2) that allows sending and receiving
+    // events to/from the remote peer without going through the actor system. It is delivered to
+    // subscribers inside TEvInterconnect::TEvNodeConnected as a std::shared_ptr.
+    //
+    // Lifecycle / races: both the session actor and every user hold a std::shared_ptr to the same
+    // object. When the connection is lost the session calls Shutdown(), which atomically transitions
+    // the handle into a disconnected state (Send() starts returning false and all registered callbacks
+    // are dropped). All methods are safe to call concurrently from arbitrary threads.
+    class IDirectSession {
+    public:
+        // Invoked (on the session actor thread) for an incoming event addressed to a registered ActorId.
+        using TReceiveCallback = std::function<void(TAutoPtr<IEventHandle>)>;
+
+        virtual ~IDirectSession() = default;
+
+        // Sends an event to the remote peer. The event's Recipient identifies the destination actor on
+        // the peer node. Returns false if the session is no longer connected. Thread-safe.
+        virtual bool Send(TAutoPtr<IEventHandle> ev) = 0;
+
+        // Registers (or replaces) a callback invoked for incoming events addressed to localActorId.
+        // Has no effect once the session is disconnected. Thread-safe.
+        virtual void RegisterReceiveCallback(const TActorId& localActorId, TReceiveCallback callback) = 0;
+
+        // Removes a previously registered callback. Thread-safe.
+        virtual void UnregisterReceiveCallback(const TActorId& localActorId) = 0;
+    };
+
+    // Concrete implementation of IDirectSession backing a TInterconnectSessionTCPv2 connection.
+    // The data-plane transfer (actual serialization / socket handoff of outgoing events and decoding
+    // of incoming ones) is intentionally left as a stub; the thread-safe registration table and the
+    // connect/disconnect lifecycle are fully implemented.
+    class TDirectSession final : public IDirectSession {
+    public:
+        bool Send(TAutoPtr<IEventHandle> ev) override {
+            TGuard<TMutex> guard(Mutex);
+            if (!Connected) {
+                return false;
+            }
+            // TODO(v2 data plane): hand the event off to the session's outgoing stream.
+            Y_UNUSED(ev);
+            return true;
+        }
+
+        void RegisterReceiveCallback(const TActorId& localActorId, TReceiveCallback callback) override {
+            TGuard<TMutex> guard(Mutex);
+            if (!Connected) {
+                return;
+            }
+            Callbacks[localActorId] = std::move(callback);
+        }
+
+        void UnregisterReceiveCallback(const TActorId& localActorId) override {
+            TGuard<TMutex> guard(Mutex);
+            Callbacks.erase(localActorId);
+        }
+
+        // Delivers an incoming event to the callback registered for its Recipient, if any. Intended to
+        // be called on the session actor thread by the (future) v2 data plane. Returns true if a
+        // callback consumed the event. Thread-safe.
+        bool DeliverIncoming(TAutoPtr<IEventHandle> ev) {
+            TReceiveCallback callback;
+            {
+                TGuard<TMutex> guard(Mutex);
+                if (!Connected) {
+                    return false;
+                }
+                const auto it = Callbacks.find(ev->GetRecipientRewrite());
+                if (it == Callbacks.end()) {
+                    return false;
+                }
+                callback = it->second;
+            }
+            // invoke outside the lock to avoid re-entrancy/deadlocks
+            callback(std::move(ev));
+            return true;
+        }
+
+        // Transitions the handle into the disconnected state. Called by the session on teardown.
+        // After this returns, Send() fails and no callbacks remain registered. Thread-safe.
+        void Shutdown() {
+            TGuard<TMutex> guard(Mutex);
+            Connected = false;
+            Callbacks.clear();
+        }
+
+        bool IsConnected() const {
+            TGuard<TMutex> guard(Mutex);
+            return Connected;
+        }
+
+    private:
+        mutable TMutex Mutex;
+        bool Connected = true;
+        THashMap<TActorId, TReceiveCallback, TActorId::THash> Callbacks;
+    };
+
+}

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -960,6 +960,9 @@ namespace NActors {
                 request.SetRequestXxhash(true);
                 request.SetRequestXdcShuffle(true);
                 request.SetRequestAllowDisablingPayloadChecksums(true);
+                // v2 session is incompatible with encryption; only request it when encryption is disabled locally
+                request.SetRequestSessionV2(Common->Settings.EnableInterconnectSessionV2 &&
+                    Common->Settings.EncryptionMode == EEncryptionMode::DISABLED);
                 request.SetHandshakeId(*HandshakeId);
 
                 ui32 pending = 0;
@@ -1054,6 +1057,7 @@ namespace NActors {
                 Params.UseXxhash = success.GetUseXxhash();
                 Params.UseXdcShuffle = success.GetUseXdcShuffle();
                 Params.AllowDisablingPayloadChecksums = success.GetAllowDisablingPayloadChecksums();
+                Params.UseSessionV2 = success.GetUseSessionV2();
                 // Kernel liveness mode is a local transport decision: it depends on whether this side
                 // configured keepalive/user-timeout on its own socket.
                 Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady();
@@ -1356,6 +1360,9 @@ namespace NActors {
                 Params.UseXdcShuffle = request.GetRequestXdcShuffle();
                 Params.UseKernelLiveness = MainChannel.IsKernelLivenessReady(); 
                 Params.AllowDisablingPayloadChecksums = request.GetRequestAllowDisablingPayloadChecksums();
+                // v2 session is used only when both peers enabled it and encryption is not in effect
+                Params.UseSessionV2 = request.GetRequestSessionV2() &&
+                    Common->Settings.EnableInterconnectSessionV2 && !Params.Encryption;
 
                 if (Params.UseExternalDataChannel) {
                     if (request.HasHandshakeId()) {
@@ -1429,6 +1436,7 @@ namespace NActors {
                     success.SetUseXxhash(Params.UseXxhash);
                     success.SetUseXdcShuffle(Params.UseXdcShuffle);
                     success.SetAllowDisablingPayloadChecksums(Params.AllowDisablingPayloadChecksums);
+                    success.SetUseSessionV2(Params.UseSessionV2);
 
                     ui32 pending = 0;
                     auto& actors = Common->ConnectionCheckerActorIds;

--- a/ydb/library/actors/interconnect/interconnect_session_iface.h
+++ b/ydb/library/actors/interconnect/interconnect_session_iface.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/mon.h>
+
+#include "types.h"
+#include "events_local.h"
+
+#include <optional>
+
+namespace NActors {
+
+    // Abstraction over the interconnect session actor implementations (TInterconnectSessionTCP and
+    // TInterconnectSessionTCPv2). The proxy holds a pointer to this interface and performs all of its
+    // synchronous (same-mailbox) calls through it. Implementations are also actors; SessionActor()
+    // provides the bridge required by IActor::InvokeOtherActor.
+    struct IInterconnectSession {
+        virtual ~IInterconnectSession() = default;
+
+        // bridge to the underlying actor object (both implementations derive from TActor<>)
+        virtual IActor& SessionActor() noexcept = 0;
+
+        // synchronous call surface used by the proxy (invoked via InvokeOtherActor within actor context)
+        virtual void Init() = 0;
+        virtual void SetNewConnection(TEvHandshakeDone::TPtr& ev) = 0;
+        virtual void Terminate(TDisconnectReason reason) = 0;
+        virtual THolder<TEvHandshakeAck> ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) = 0;
+        virtual void StartHandshake() = 0;
+        virtual void ReestablishConnectionWithHandshake(TDisconnectReason reason) = 0;
+        virtual void CloseInputSession() = 0;
+        virtual bool IsRdmaInUse() = 0;
+        virtual bool HasRdmaState() const = 0;
+
+        // Whether this session type supports resuming over consecutive TCP connections (continuation).
+        // TInterconnectSessionTCP returns true; TInterconnectSessionTCPv2 returns false.
+        virtual bool SupportsContinuation() const = 0;
+
+        // field-like accessors used by the proxy (replacing former direct member access)
+        virtual const TSessionParams& GetParams() const = 0;
+        virtual const TIntrusivePtr<NInterconnect::TStreamSocket>& GetSocket() const = 0;
+        virtual ui64 GetTotalOutputQueueSize() const = 0;
+        virtual std::optional<ui8> GetXDCFlags() const = 0;
+        virtual TDuration GetPingRTT() const = 0;
+        virtual i64 GetClockSkew() const = 0;
+        virtual void GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev) = 0;
+    };
+
+}

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -1,6 +1,7 @@
 #include "interconnect_tcp_proxy.h"
 #include "interconnect_handshake.h"
 #include "interconnect_tcp_session.h"
+#include "interconnect_tcp_session_v2.h"
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 #include <library/cpp/monlib/service/pages/templates.h>
@@ -190,7 +191,7 @@ namespace NActors {
 
         // create and register handshake actor
         OutgoingHandshakeActor = Register(CreateOutgoingHandshakeActor(Common, SessionVirtualId,
-            RemoteSessionVirtualId, PeerNodeId, inputCounter, TechnicalPeerHostName, Session->Params),
+            RemoteSessionVirtualId, PeerNodeId, inputCounter, TechnicalPeerHostName, Session->GetParams()),
             TMailboxType::ReadAsFilled);
         OutgoingHandshakeActorCreated = TActivationContext::Now();
     }
@@ -251,16 +252,22 @@ namespace NActors {
                    " SessionVirtualId: %s RemoteSessionVirtualId: %s)", ev->Sender.ToString().data(),
                   ev->Get()->Peer.ToString().data(), ev->Get()->Self.ToString().data(), SessionVirtualId.ToString().data(),
                   RemoteSessionVirtualId.ToString().data());
+        } else if (!Session->SupportsContinuation()) {
+            // v2 sessions do not support continuation; reject the resume request so the peer establishes
+            // a brand new session instead
+            LOG_NOTICE_IC("ICP14", "(actor %s) rejecting resume for session that does not support continuation"
+                " Self# %s Peer# %s", ev->Sender.ToString().data(), msg->Self.ToString().data(),
+                msg->Peer.ToString().data());
         } else if (Session->HasRdmaState()) {
             LOG_NOTICE_IC("ICRDMA", "(actor %s) rejecting graceful reconnect for RDMA session Self# %s Peer# %s",
                 ev->Sender.ToString().data(), msg->Self.ToString().data(), msg->Peer.ToString().data());
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason::NewSession());
+            InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason::NewSession());
         } else {
             // if we already have incoming handshake, then terminate existing one
             DropIncomingHandshake();
 
             // issue reply to the sender, possibly holding it while outgoing handshake is at race
-            THolder<IEventBase> reply = IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::ProcessHandshakeRequest, ev);
+            THolder<IEventBase> reply = InvokeSession(&IInterconnectSession::ProcessHandshakeRequest, ev);
             return IssueIncomingHandshakeReply(ev->Sender, RemoteSessionVirtualId.LocalId(), std::move(reply));
         }
 
@@ -393,8 +400,13 @@ namespace NActors {
 
             // Create new session actor.
             ++RdmaRetryWatchdogCookie;
-            SessionID = RegisterWithSameMailbox(Session = new TInterconnectSessionTCP(this, msg->Params));
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Init);
+            if (msg->Params.UseSessionV2) {
+                Session = new TInterconnectSessionTCPv2(this, msg->Params);
+            } else {
+                Session = new TInterconnectSessionTCP(this, msg->Params);
+            }
+            SessionID = RegisterWithSameMailbox(&Session->SessionActor());
+            InvokeSession(&IInterconnectSession::Init);
             SessionVirtualId = msg->Self;
             RemoteSessionVirtualId = msg->Peer;
             LOG_INFO_IC("ICP22", "created new session: %s", SessionID.ToString().data());
@@ -404,7 +416,7 @@ namespace NActors {
         Y_ABORT_UNLESS(Session && SessionVirtualId && RemoteSessionVirtualId);
 
         // Set up new connection for the session.
-        IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::SetNewConnection, ev);
+        InvokeSession(&IInterconnectSession::SetNewConnection, ev);
 
         // Reset retry timer
         HoldByErrorWakeupDuration = TDuration::Zero();
@@ -492,13 +504,13 @@ namespace NActors {
                         // return back to initial state as we have no session and no pending handshakes
                         SwitchToInitialState();
                     }
-                } else if (Session->Socket) {
+                } else if (Session->GetSocket()) {
                     // try to reestablish connection -- meaning restart handshake from the last known position
-                    IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::ReestablishConnectionWithHandshake,
+                    InvokeSession(&IInterconnectSession::ReestablishConnectionWithHandshake,
                         TDisconnectReason::HandshakeFailTransient());
                 } else {
                     // we have no active connection in that session, so just restart handshake from last known position
-                    IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::StartHandshake);
+                    InvokeSession(&IInterconnectSession::StartHandshake);
                 }
                 break;
 
@@ -511,7 +523,7 @@ namespace NActors {
                                           ? " LastSessionDieTime# " + LastSessionDieTime.ToString()
                                           : TString();
                 if (Session) {
-                    InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate,
+                    InvokeSession(&IInterconnectSession::Terminate,
                         TDisconnectReason::HandshakeFailPermanent());
                 }
                 TransitToErrorState(ev->Get()->Explanation + timeExplanation, false, ev->Get());
@@ -595,7 +607,7 @@ namespace NActors {
         }
     }
 
-    void TInterconnectProxyTCP::UnregisterSession(TInterconnectSessionTCP* session) {
+    void TInterconnectProxyTCP::UnregisterSession(IInterconnectSession* session) {
         ICPROXY_PROFILED;
 
         Y_ABORT_UNLESS(Session && Session == session && SessionID);
@@ -680,7 +692,7 @@ namespace NActors {
 
         Y_ABORT_UNLESS(Session && SessionID);
         ValidateEvent(ev, "ForwardSessionEventToSession");
-        InvokeOtherActor(*Session, &TInterconnectSessionTCP::Receive, ev);
+        IActor::InvokeOtherActor(Session->SessionActor(), &IActor::Receive, ev);
     }
 
     void TInterconnectProxyTCP::SetRdmaRetryWatchdogPending(bool pending) {
@@ -768,8 +780,8 @@ namespace NActors {
         if (CurrentStateFunc() == &TThis::StateWork) {
             SetRdmaRetryWatchdogPending(false);
             // There is a chance that session was promouted to use RDMA without us.
-            if (!InvokeOtherActor(*Session, &TInterconnectSessionTCP::IsRdmaInUse)) {
-                InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason::NewSession());
+            if (!InvokeSession(&IInterconnectSession::IsRdmaInUse)) {
+                InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason::NewSession());
             }
         } else {
             LOG_WARN_IC("ICP39", "restart delayed rdma handshake for session: %s", SessionID.ToString().data());
@@ -1112,7 +1124,7 @@ namespace NActors {
         DropHandshakes();
 
         if (Session) {
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason::UserRequest());
+            InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason::UserRequest());
         } else {
             TransitToErrorState("forced disconnect");
         }
@@ -1161,9 +1173,9 @@ namespace NActors {
     void TInterconnectProxyTCP::HandleClosePeerSocket(std::span<const char> logEntry) {
         ICPROXY_PROFILED;
 
-        if (Session && Session->Socket) {
+        if (Session && Session->GetSocket()) {
             LOG_INFO_IC("ICP34", logEntry.data());
-            Session->Socket->Shutdown(SHUT_RDWR);
+            Session->GetSocket()->Shutdown(SHUT_RDWR);
         }
     }
 
@@ -1171,7 +1183,7 @@ namespace NActors {
         ICPROXY_PROFILED;
 
         if (Session) {
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::CloseInputSession);
+            InvokeSession(&IInterconnectSession::CloseInputSession);
         }
     }
 
@@ -1179,7 +1191,7 @@ namespace NActors {
         ICPROXY_PROFILED;
 
         if (Session) {
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason::Debug());
+            InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason::Debug());
         }
     }
 
@@ -1188,7 +1200,7 @@ namespace NActors {
 
         ui64 bufSize = 0;
         if (Session) {
-            bufSize = Session->TotalOutputQueueSize;
+            bufSize = Session->GetTotalOutputQueueSize();
         }
 
         Send(ev->Sender, new TEvSessionBufferSizeResponse(SessionID, bufSize));
@@ -1200,10 +1212,10 @@ namespace NActors {
         TProxyStats stats;
         stats.Path = Sprintf("peer%04" PRIu32, PeerNodeId);
         stats.State = State;
-        stats.PeerScopeId = Session ? Session->Params.PeerScopeId : TScopeId();
+        stats.PeerScopeId = Session ? Session->GetParams().PeerScopeId : TScopeId();
         stats.LastSessionDieTime = LastSessionDieTime;
-        stats.TotalOutputQueueSize = Session ? Session->TotalOutputQueueSize : 0;
-        stats.Connected = Session ? (bool)Session->Socket : false;
+        stats.TotalOutputQueueSize = Session ? Session->GetTotalOutputQueueSize() : 0;
+        stats.Connected = Session ? (bool)Session->GetSocket() : false;
         if (Session) {
             if (const auto xdcFlags = Session->GetXDCFlags()) {
                 stats.ExternalDataChannel = true;
@@ -1225,7 +1237,7 @@ namespace NActors {
         stats.Ping = Session ? Session->GetPingRTT() : TDuration::Zero();
         stats.ClockSkew = Session ? Session->GetClockSkew() : 0;
         if (Session) {
-            if (auto *x = dynamic_cast<NInterconnect::TSecureSocket*>(Session->Socket.Get())) {
+            if (auto *x = dynamic_cast<NInterconnect::TSecureSocket*>(Session->GetSocket().Get())) {
                 stats.Encryption = Sprintf("%s/%u", x->GetCipherName().data(), x->GetCipherBits());
             } else {
                 stats.Encryption = "none";
@@ -1245,7 +1257,7 @@ namespace NActors {
         SetRdmaRetryWatchdogPending(false);
 
         if (Session) {
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason());
+            InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason());
         }
         Terminated = true;
         TransitToErrorState("terminated");
@@ -1256,7 +1268,7 @@ namespace NActors {
         SetRdmaRetryWatchdogPending(false);
 
         if (Session) {
-            IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason());
+            InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason());
         }
         if (DynamicPtr) {
             Y_ABORT_UNLESS(*DynamicPtr == this);

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
@@ -82,11 +82,22 @@ namespace NActors {
 
     private:
         friend class TInterconnectSessionTCP;
-        friend class TInterconnectSessionTCPv0;
+        friend class TInterconnectSessionTCPv2;
         friend class THandshake;
         friend class TInputSessionTCP;
 
-        void UnregisterSession(TInterconnectSessionTCP* session);
+        void UnregisterSession(IInterconnectSession* session);
+
+        // Forwards a synchronous call to the current session through the IInterconnectSession interface,
+        // while setting up the session's actor recurse-context (as IActor::InvokeOtherActor would do for a
+        // concrete actor type).
+        template <typename TMethod, typename... TArgs>
+        decltype(auto) InvokeSession(TMethod&& method, TArgs&&... args) {
+            return IActor::InvokeOtherActor(Session->SessionActor(),
+                [&](auto&&) -> decltype(auto) {
+                    return std::invoke(std::forward<TMethod>(method), Session, std::forward<TArgs>(args)...);
+                });
+        }
 
 #define SESSION_EVENTS(HANDLER)                                \
     fFunc(TEvInterconnect::EvForward, HANDLER)                 \
@@ -454,7 +465,7 @@ namespace NActors {
         void ProcessPendingSessionEvents();
         void DropSessionEvent(STATEFN_SIG);
 
-        TInterconnectSessionTCP* Session = nullptr;
+        IInterconnectSession* Session = nullptr;
         TActorId SessionID;
 
         // virtual ids used during handshake to check if it is the connection
@@ -514,7 +525,7 @@ namespace NActors {
             // drop existing session if we have one
             if (Session) {
                 LOG_INFO_IC("ICP04", "terminating current session as we are negotiating a new one");
-                IActor::InvokeOtherActor(*Session, &TInterconnectSessionTCP::Terminate, TDisconnectReason::NewSession());
+                InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason::NewSession());
             }
 
             // ensure we have no current session

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -37,6 +37,7 @@
 #include "event_holder_pool.h"
 #include "channel_scheduler.h"
 #include "outgoing_stream.h"
+#include "interconnect_session_iface.h"
 
 #include <unordered_set>
 #include <unordered_map>
@@ -442,6 +443,7 @@ namespace NActors {
     class TInterconnectSessionTCP
        : public TActor<TInterconnectSessionTCP>
        , public TInterconnectLoggingBase
+       , public IInterconnectSession
     {
         enum {
             EvCheckCloseOnIdle = EventSpaceBegin(TEvents::ES_PRIVATE),
@@ -505,31 +507,38 @@ namespace NActors {
         TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy, TSessionParams params);
         ~TInterconnectSessionTCP();
 
-        void Init();
-        void CloseInputSession();
-        bool IsRdmaInUse();
-        bool HasRdmaState() const;
+        void Init() override;
+        void CloseInputSession() override;
+        bool IsRdmaInUse() override;
+        bool HasRdmaState() const override;
+        bool SupportsContinuation() const override { return true; }
 
         static TEvTerminate* NewEvTerminate(TDisconnectReason reason) {
             return new TEvTerminate(std::move(reason));
         }
 
-        TDuration GetPingRTT() const {
+        TDuration GetPingRTT() const override {
             return TDuration::MicroSeconds(ReceiveContext->PingRTT_us);
         }
 
-        i64 GetClockSkew() const {
+        i64 GetClockSkew() const override {
             return ReceiveContext->ClockSkew_us;
         }
 
-        std::optional<ui8> GetXDCFlags() const noexcept;
+        std::optional<ui8> GetXDCFlags() const noexcept override;
+
+        // IInterconnectSession bridge/accessors
+        IActor& SessionActor() noexcept override { return *this; }
+        const TSessionParams& GetParams() const override { return Params; }
+        const TIntrusivePtr<NInterconnect::TStreamSocket>& GetSocket() const override { return Socket; }
+        ui64 GetTotalOutputQueueSize() const override { return TotalOutputQueueSize; }
 
     private:
         friend class TInterconnectProxyTCP;
 
         void Handle(TEvTerminate::TPtr& ev);
         void HandlePoison();
-        void Terminate(TDisconnectReason reason);
+        void Terminate(TDisconnectReason reason) override;
         void PassAway() override;
 
         void Enqueue(STATEFN_SIG);
@@ -579,8 +588,8 @@ namespace NActors {
 
         void OnDisconnect(TEvSocketDisconnect::TPtr& ev);
 
-        THolder<TEvHandshakeAck> ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev);
-        void SetNewConnection(TEvHandshakeDone::TPtr& ev);
+        THolder<TEvHandshakeAck> ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) override;
+        void SetNewConnection(TEvHandshakeDone::TPtr& ev) override;
 
         TEvRam* RamInQueue = nullptr;
         ui64 RamStartedCycles = 0;
@@ -617,10 +626,10 @@ namespace NActors {
         void DropConfirmed(ui64 confirm);
         void ShutdownSocket(TDisconnectReason reason);
 
-        void StartHandshake();
+        void StartHandshake() override;
         void ReestablishConnection(TEvHandshakeDone::TPtr&& ev, bool startHandshakeOnSessionClose,
                 TDisconnectReason reason);
-        void ReestablishConnectionWithHandshake(TDisconnectReason reason);
+        void ReestablishConnectionWithHandshake(TDisconnectReason reason) override;
         void ReestablishConnectionExecute();
 
         TInterconnectProxyTCP* const Proxy;
@@ -780,7 +789,7 @@ namespace NActors {
         void HandleFlush();
         void ResetFlushLogic();
 
-        void GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev);
+        void GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev) override;
 
         TIntrusivePtr<TReceiveContext> ReceiveContext;
         TActorId ReceiverId;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -1,0 +1,144 @@
+#include "interconnect_tcp_session_v2.h"
+#include "interconnect_tcp_proxy.h"
+
+#include <util/stream/str.h>
+
+namespace NActors {
+
+    TInterconnectSessionTCPv2::TInterconnectSessionTCPv2(TInterconnectProxyTCP* const proxy, TSessionParams params)
+        : TActor(&TInterconnectSessionTCPv2::StateFunc)
+        , Proxy(proxy)
+        , Params(std::move(params))
+    {
+        // v2 does not support encryption
+        Y_ABORT_UNLESS(!Params.Encryption);
+        Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
+        Proxy->Metrics->SetConnected(0);
+    }
+
+    void TInterconnectSessionTCPv2::Init() {
+        SetPrefix(Sprintf("SessionV2 %s [node %" PRIu32 "]", SelfId().ToString().data(), Proxy->PeerNodeId));
+        LOG_INFO_IC_SESSION("ICS90", "v2 session created");
+        DirectSession = std::make_shared<TDirectSession>();
+    }
+
+    void TInterconnectSessionTCPv2::SetNewConnection(TEvHandshakeDone::TPtr& ev) {
+        // v2 establishes exactly one connection for its lifetime (no continuation)
+        Y_ABORT_UNLESS(!Socket, "TInterconnectSessionTCPv2 does not support connection continuation");
+
+        LOG_INFO_IC_SESSION("ICS91", "handshake done sender: %s self: %s peer: %s socket: %" PRIi64,
+            ev->Sender.ToString().data(), ev->Get()->Self.ToString().data(), ev->Get()->Peer.ToString().data(),
+            i64(*ev->Get()->Socket));
+
+        Socket = std::move(ev->Get()->Socket);
+        XdcSocket = std::move(ev->Get()->XdcSocket);
+
+        Proxy->Metrics->SetConnected(1);
+
+        // NOTE: data-plane setup (input session, poller registration, traffic generation) is stubbed.
+        // Subscribers receive the direct interface through TEvNodeConnected upon subscription.
+    }
+
+    void TInterconnectSessionTCPv2::Terminate(TDisconnectReason reason) {
+        LOG_INFO_IC_SESSION("ICS92", "v2 session terminated reason# %s", reason.ToString().data());
+
+        IActor::InvokeOtherActor(*Proxy, &TInterconnectProxyTCP::UnregisterSession, this);
+
+        // atomically disconnect the direct interface so racing user threads observe a clean shutdown
+        if (DirectSession) {
+            DirectSession->Shutdown();
+        }
+
+        if (Socket) {
+            Socket->Shutdown(SHUT_RDWR);
+        }
+        if (XdcSocket) {
+            XdcSocket->Shutdown(SHUT_RDWR);
+        }
+
+        for (const auto& [actorId, cookie] : Subscribers) {
+            Send(actorId, new TEvInterconnect::TEvNodeDisconnected(Proxy->PeerNodeId), 0, cookie);
+        }
+        Subscribers.clear();
+
+        Proxy->Metrics->SetConnected(0);
+
+        TActor::PassAway();
+    }
+
+    THolder<TEvHandshakeAck> TInterconnectSessionTCPv2::ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) {
+        Y_UNUSED(ev);
+        // v2 does not support continuation; the proxy is expected to reject such requests via
+        // SupportsContinuation(), so we should never get here.
+        Y_ABORT("TInterconnectSessionTCPv2 does not support handshake continuation");
+    }
+
+    void TInterconnectSessionTCPv2::StartHandshake() {
+        // no continuation -- lost connection means the session is gone
+        LOG_INFO_IC_SESSION("ICS93", "StartHandshake on v2 session -> terminating (no continuation)");
+        Terminate(TDisconnectReason::LostConnection());
+    }
+
+    void TInterconnectSessionTCPv2::ReestablishConnectionWithHandshake(TDisconnectReason reason) {
+        // no continuation -- lost connection means the session is gone
+        LOG_INFO_IC_SESSION("ICS94", "ReestablishConnectionWithHandshake on v2 session -> terminating (no continuation)");
+        Terminate(std::move(reason));
+    }
+
+    void TInterconnectSessionTCPv2::CloseInputSession() {
+        // no input session in the current stub
+    }
+
+    void TInterconnectSessionTCPv2::AddSubscriber(const TActorId& actorId, ui64 cookie) {
+        Subscribers[actorId] = cookie;
+    }
+
+    IEventBase* TInterconnectSessionTCPv2::MakeNodeConnectedEvent() const {
+        return new TEvInterconnect::TEvNodeConnected(Proxy->PeerNodeId, DirectSession);
+    }
+
+    void TInterconnectSessionTCPv2::Forward(STATEFN_SIG) {
+        Proxy->ValidateEvent(ev, "Forward");
+        if (ev->Flags & IEventHandle::FlagSubscribeOnSession) {
+            AddSubscriber(ev->Sender, ev->Cookie);
+            Send(ev->Sender, MakeNodeConnectedEvent(), 0, ev->Cookie);
+        }
+        // data-plane stub: the payload event is dropped for now
+        LOG_DEBUG_IC_SESSION("ICS95", "v2 stub dropping forwarded event to %s", ev->Recipient.ToString().data());
+    }
+
+    void TInterconnectSessionTCPv2::ForwardWithSubscribe(STATEFN_SIG) {
+        Proxy->ValidateEvent(ev, "ForwardWithSubscribe");
+        auto msg = ev->Release<TEvForwardSubscribeSession>();
+        Y_ABORT_UNLESS(msg->Event);
+        AddSubscriber(msg->Event->Sender, msg->Event->Cookie);
+        Send(msg->Event->Sender, MakeNodeConnectedEvent(), 0, msg->Event->Cookie);
+        // data-plane stub: the wrapped payload event is dropped for now
+    }
+
+    void TInterconnectSessionTCPv2::HandleSubscribe(STATEFN_SIG) {
+        LOG_DEBUG_IC_SESSION("ICS96", "subscribe for session state for %s", ev->Sender.ToString().data());
+        AddSubscriber(ev->Sender, ev->Cookie);
+        Send(ev->Sender, MakeNodeConnectedEvent(), 0, ev->Cookie);
+    }
+
+    void TInterconnectSessionTCPv2::HandleUnsubscribe(STATEFN_SIG) {
+        LOG_DEBUG_IC_SESSION("ICS97", "unsubscribe for session state for %s", ev->Sender.ToString().data());
+        Subscribers.erase(ev->Sender);
+    }
+
+    void TInterconnectSessionTCPv2::HandlePoison() {
+        Terminate(TDisconnectReason::UserRequest());
+    }
+
+    void TInterconnectSessionTCPv2::GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev) {
+        TStringStream str;
+        ev->Get()->Output(str);
+        str << "<div class=\"panel panel-info\">"
+               "<div class=\"panel-heading\">Session (v2)</div>"
+               "<div class=\"panel-body\">TInterconnectSessionTCPv2: data plane not yet implemented</div>"
+               "</div>";
+        TActivationContext::Send(new IEventHandle(ev->Recipient, ev->Sender, new NMon::TEvHttpInfoRes(str.Str())));
+    }
+
+}

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/interconnect.h>
+#include <ydb/library/actors/core/log.h>
+
+#include "interconnect_session_iface.h"
+#include "interconnect_direct_session.h"
+#include "logging/logging.h"
+
+#include <memory>
+#include <unordered_map>
+
+namespace NActors {
+
+    class TInterconnectProxyTCP;
+
+    // A new interconnect session actor. Unlike TInterconnectSessionTCP it:
+    //   * does not support session continuation over several consecutive TCP connections;
+    //   * does not support encryption;
+    //   * exposes a thread-safe direct send/receive interface (IDirectSession) to subscribers via
+    //     TEvInterconnect::TEvNodeConnected.
+    //
+    // NOTE: the data-plane operations (packetization, socket IO, input session, pinging, metrics, ...)
+    // are intentionally left as stubs in this first integration step.
+    class TInterconnectSessionTCPv2
+       : public TActor<TInterconnectSessionTCPv2>
+       , public TInterconnectLoggingBase
+       , public IInterconnectSession
+    {
+    public:
+        static constexpr EActivityType ActorActivityType() {
+            return EActivityType::INTERCONNECT_SESSION_TCP;
+        }
+
+        TInterconnectSessionTCPv2(TInterconnectProxyTCP* proxy, TSessionParams params);
+
+        // IInterconnectSession
+        IActor& SessionActor() noexcept override { return *this; }
+
+        void Init() override;
+        void SetNewConnection(TEvHandshakeDone::TPtr& ev) override;
+        void Terminate(TDisconnectReason reason) override;
+        THolder<TEvHandshakeAck> ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) override;
+        void StartHandshake() override;
+        void ReestablishConnectionWithHandshake(TDisconnectReason reason) override;
+        void CloseInputSession() override;
+        bool IsRdmaInUse() override { return false; }
+        bool HasRdmaState() const override { return false; }
+        bool SupportsContinuation() const override { return false; }
+
+        const TSessionParams& GetParams() const override { return Params; }
+        const TIntrusivePtr<NInterconnect::TStreamSocket>& GetSocket() const override { return Socket; }
+        ui64 GetTotalOutputQueueSize() const override { return 0; }
+        std::optional<ui8> GetXDCFlags() const override { return std::nullopt; }
+        TDuration GetPingRTT() const override { return TDuration::Zero(); }
+        i64 GetClockSkew() const override { return 0; }
+        void GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev) override;
+
+    private:
+        friend class TActor<TInterconnectSessionTCPv2>;
+
+        STATEFN(StateFunc) {
+            STRICT_STFUNC_BODY(
+                fFunc(TEvInterconnect::EvForward, Forward)
+                fFunc(TEvForwardSubscribeSession::EventType, ForwardWithSubscribe)
+                fFunc(TEvInterconnect::TEvConnectNode::EventType, HandleSubscribe)
+                fFunc(TEvents::TEvSubscribe::EventType, HandleSubscribe)
+                fFunc(TEvents::TEvUnsubscribe::EventType, HandleUnsubscribe)
+                cFunc(TEvents::TEvPoisonPill::EventType, HandlePoison)
+                cFunc(TEvInterconnect::EvForwardDelayed, IgnoreForwardDelayed)
+            )
+        }
+
+        void Forward(STATEFN_SIG);
+        void ForwardWithSubscribe(STATEFN_SIG);
+        void HandleSubscribe(STATEFN_SIG);
+        void HandleUnsubscribe(STATEFN_SIG);
+        void HandlePoison();
+        void IgnoreForwardDelayed() {}
+
+        void AddSubscriber(const TActorId& actorId, ui64 cookie);
+        IEventBase* MakeNodeConnectedEvent() const;
+
+        TInterconnectProxyTCP* const Proxy;
+        const TSessionParams Params;
+
+        TIntrusivePtr<NInterconnect::TStreamSocket> Socket;
+        TIntrusivePtr<NInterconnect::TStreamSocket> XdcSocket;
+
+        // thread-safe direct send/receive handle shared with users via TEvNodeConnected
+        std::shared_ptr<TDirectSession> DirectSession;
+
+        // subscribers awaiting connection state notifications (actor id -> cookie)
+        std::unordered_map<TActorId, ui64, TActorId::THash> Subscribers;
+    };
+
+}

--- a/ydb/library/actors/interconnect/types.h
+++ b/ydb/library/actors/interconnect/types.h
@@ -63,6 +63,7 @@ namespace NActors {
         bool UseRdma = {};
         bool ChecksumRdmaEvent = {};
         bool AllowDisablingPayloadChecksums = {};
+        bool UseSessionV2 = {};
         TString AuthCN;
         NActors::TScopeId PeerScopeId;
     };

--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -22,6 +22,7 @@ SRCS(
     interconnect_common.h
     interconnect_counters.cpp
     interconnect.h
+    interconnect_direct_session.h
     interconnect_handshake.cpp
     interconnect_handshake.h
     interconnect_metrics_aggregator.cpp
@@ -34,6 +35,7 @@ SRCS(
     interconnect_proxy_wrapper.cpp
     interconnect_proxy_wrapper.h
     interconnect_resolve.cpp
+    interconnect_session_iface.h
     interconnect_stream.cpp
     interconnect_stream.h
     interconnect_tcp_input_session.cpp
@@ -43,6 +45,8 @@ SRCS(
     interconnect_tcp_server.h
     interconnect_tcp_session.cpp
     interconnect_tcp_session.h
+    interconnect_tcp_session_v2.cpp
+    interconnect_tcp_session_v2.h
     interconnect_zc_processor.cpp
     interconnect_zc_processor.h
     load.cpp

--- a/ydb/library/actors/protos/interconnect.proto
+++ b/ydb/library/actors/protos/interconnect.proto
@@ -108,6 +108,7 @@ message THandshakeRequest {
     optional bool RequestXxhash = 24;
     optional bool RequestXdcShuffle = 25;
     optional bool RequestAllowDisablingPayloadChecksums = 28; // Can be requested per event. Affects XDC and RDMA payloads.
+    optional bool RequestSessionV2 = 29; // request TInterconnectSessionTCPv2 (no continuation, no encryption)
 
     optional bytes CompatibilityInfo = 22;
 
@@ -146,6 +147,7 @@ message THandshakeSuccess {
     optional bool UseXxhash = 16;
     optional bool UseXdcShuffle = 17;
     optional bool AllowDisablingPayloadChecksums = 21;
+    optional bool UseSessionV2 = 22; // negotiated TInterconnectSessionTCPv2 usage
 
     optional bytes CompatibilityInfo = 15;
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Introduce Interconnect TCP session v2 stub

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch introduces Interconnect TCP session v2 stub without any actual implementation.
