### PR TITLE
NBS-7459: key PBuffer records by (generation, lsn)

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_algorithms.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_algorithms.cpp
@@ -5,6 +5,9 @@
 #include <util/generic/algorithm.h>
 #include <util/generic/set.h>
 
+#include <functional>
+#include <tuple>
+
 namespace NYdb::NBS::NBlockStore {
 
 namespace {
@@ -12,28 +15,26 @@ namespace {
 struct TBoundary
 {
     ui64 Offset{};
-    ui64 Key{};
+    TPBufferKey Key{};
     bool Open{};
 
-    bool operator<(const TBoundary& rhs) const;
+    bool operator<(const TBoundary& rhs) const
+    {
+        return std::make_tuple(Offset, Open, Key) <
+               std::make_tuple(rhs.Offset, rhs.Open, rhs.Key);
+    }
 };
-
-bool TBoundary::operator<(const TBoundary& rhs) const
-{
-    return std::make_tuple(Offset, Open, Key) <
-           std::make_tuple(rhs.Offset, rhs.Open, rhs.Key);
-}
 
 }   // namespace
 
 // Algorithm's short description:
-// - create vector with boundaries (also lsn and open/close sign) of source
+// - create vector with boundaries (also key and open/close sign) of source
 // ranges
 // - sort boundaries by offset
 // - iterate over boundaries and keep active keys for all current overlapping
 // ranges
-// - add range into the result on the end of the current range with an active
-// lsn
+// - add range into the result on the end of the current range with the
+// greatest key
 
 TVector<TWeightedRange> SplitOnNonOverlappingContinuousRanges(
     TBlockRange64 fullRange,
@@ -41,15 +42,16 @@ TVector<TWeightedRange> SplitOnNonOverlappingContinuousRanges(
 {
     TVector<TWeightedRange> result;
     if (overlappingRanges.empty()) {
-        result.push_back({.Key = 0, .Range = fullRange});
+        result.push_back({.Key = TPBufferKey{}, .Range = fullRange});
         return result;
     }
 
     // prepare boundaries
     TStackVec<TBoundary> boundaries;
-    boundaries.push_back({.Offset = fullRange.Start, .Key = 0, .Open = true});
     boundaries.push_back(
-        {.Offset = fullRange.End + 1, .Key = 0, .Open = false});
+        {.Offset = fullRange.Start, .Key = TPBufferKey{}, .Open = true});
+    boundaries.push_back(
+        {.Offset = fullRange.End + 1, .Key = TPBufferKey{}, .Open = false});
 
     for (const auto& item: overlappingRanges) {
         auto intersect = fullRange.Intersect(item.Range);
@@ -61,10 +63,10 @@ TVector<TWeightedRange> SplitOnNonOverlappingContinuousRanges(
     Sort(boundaries.begin(), boundaries.end());
 
     // main algorithm's part
-    TSet<ui64, std::greater<>> activeKeys;
+    TSet<TPBufferKey, std::greater<TPBufferKey>> activeKeys;
     activeKeys.insert(boundaries[0].Key);
     ui64 segmentStart = boundaries[0].Offset;
-    ui64 currentBestKey = *activeKeys.begin();
+    TPBufferKey currentBestKey = *activeKeys.begin();
 
     for (ui64 i = 1; i < boundaries.size(); ++i) {
         if (boundaries[i].Open) {
@@ -73,8 +75,9 @@ TVector<TWeightedRange> SplitOnNonOverlappingContinuousRanges(
             activeKeys.erase(boundaries[i].Key);
         }
 
-        ui64 newBestKey = activeKeys.empty() ? 0 : *activeKeys.begin();
-        bool isLast = activeKeys.empty();
+        const TPBufferKey newBestKey =
+            activeKeys.empty() ? TPBufferKey{} : *activeKeys.begin();
+        const bool isLast = activeKeys.empty();
         if (isLast) {
             Y_ABORT_IF(i != boundaries.size() - 1);
         }

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_algorithms.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_algorithms.h
@@ -1,16 +1,19 @@
 #pragma once
 
 #include "block_range.h"
-
-#include <util/system/types.h>
+#include "pbuffer_key.h"
 
 #include <span>
 
 namespace NYdb::NBS::NBlockStore {
 
+// A block range tagged with a PBuffer record id.
+// SplitOnNonOverlappingContinuousRanges keeps the greatest key on overlaps. A
+// default-constructed key marks a hole (no overlapping record; callers treat it
+// as DDisk).
 struct TWeightedRange
 {
-    ui64 Key{};
+    TPBufferKey Key{};
     TBlockRange64 Range;
 
     bool operator<(const TWeightedRange& other) const
@@ -19,10 +22,8 @@ struct TWeightedRange
     }
 };
 
-// The function splits overlapping ranges into non-overlapping ranges
-//   and returns their in a container.
-// Result is continuous range's sequence, where original 'holes' are
-//   fullfilled with ranges with a key == 0.
+// Splits overlapping ranges into a continuous sequence of non-overlapping
+// ranges covering fullRange. Holes are filled with a default-constructed key.
 TVector<TWeightedRange> SplitOnNonOverlappingContinuousRanges(
     TBlockRange64 fullRange,
     std::span<const TWeightedRange> overlappingRanges);

--- a/ydb/core/nbs/cloud/blockstore/libs/common/block_range_algorithms_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/block_range_algorithms_ut.cpp
@@ -2,17 +2,24 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/string/builder.h>
+
 #include <span>
 
 namespace NYdb::NBS::NBlockStore {
 
 namespace {
 
+[[nodiscard]] TPBufferKey Key(ui64 lsn)
+{
+    return {.Lsn = lsn};
+}
+
 [[nodiscard]] TString DebugPrintResult(const std::span<TWeightedRange> result)
 {
     TStringBuilder resultStr;
     for (const auto& item: result) {
-        resultStr << item.Key << item.Range.Print() << ";";
+        resultStr << item.Key.Print() << item.Range.Print() << ";";
     }
     return resultStr;
 }
@@ -28,132 +35,148 @@ Y_UNIT_TEST_SUITE(TSplitOnNonOverlappingContinuousRanges)
             TBlockRange64::MakeClosedInterval(0, 100),
             ranges);
 
-        UNIT_ASSERT_VALUES_EQUAL("0[0..100];", DebugPrintResult(result));
+        UNIT_ASSERT_VALUES_EQUAL("0:0[0..100];", DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(RangeWithEdgesOfRequest)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 19)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 19)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(10, 19),
             ranges);
 
-        UNIT_ASSERT_VALUES_EQUAL("100[10..19];", DebugPrintResult(result));
+        UNIT_ASSERT_VALUES_EQUAL("0:100[10..19];", DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(CutEdges)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 50)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(20, 60)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 50)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(20, 60)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(15, 55),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "100[15..19];"
-            "200[20..55];",
+            "0:100[15..19];"
+            "0:200[20..55];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(CutEdges2)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 50)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(20, 40)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 50)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(20, 40)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(15, 45),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "100[15..19];"
-            "200[20..40];"
-            "100[41..45];",
+            "0:100[15..19];"
+            "0:200[20..40];"
+            "0:100[41..45];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(TwoSequentialNonOverlappingRanges)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 19)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(30, 39)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 19)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(30, 39)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(0, 49),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "0[0..9];"
-            "100[10..19];"
-            "0[20..29];"
-            "200[30..39];"
-            "0[40..49];",
+            "0:0[0..9];"
+            "0:100[10..19];"
+            "0:0[20..29];"
+            "0:200[30..39];"
+            "0:0[40..49];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(TwoFullyOverlappingRanges)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 50)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(20, 30)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 50)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(20, 30)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(10, 50),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "100[10..19];"
-            "200[20..30];"
-            "100[31..50];",
+            "0:100[10..19];"
+            "0:200[20..30];"
+            "0:100[31..50];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(TwoPartiallyOverlappingRanges)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 30)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(25, 45)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 30)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(25, 45)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(10, 45),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "100[10..24];"
-            "200[25..45];",
+            "0:100[10..24];"
+            "0:200[25..45];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(ThreeOverlappingRanges)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 50)},
-            {.Key = 150, .Range = TBlockRange64::MakeClosedInterval(20, 40)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(30, 35)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 50)},
+            {.Key = Key(150),
+             .Range = TBlockRange64::MakeClosedInterval(20, 40)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(30, 35)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(10, 50),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "100[10..19];"
-            "150[20..29];"
-            "200[30..35];"
-            "150[36..40];"
-            "100[41..50];",
+            "0:100[10..19];"
+            "0:150[20..29];"
+            "0:200[30..35];"
+            "0:150[36..40];"
+            "0:100[41..50];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(RangeWithSameStart)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 109)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(10, 49)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 109)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(10, 49)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(0, 99),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "0[0..9];"
-            "200[10..49];"
-            "100[50..99];",
+            "0:0[0..9];"
+            "0:200[10..49];"
+            "0:100[50..99];",
             DebugPrintResult(result));
     }
 
@@ -163,7 +186,8 @@ Y_UNIT_TEST_SUITE(TSplitOnNonOverlappingContinuousRanges)
         const int keysCount = 100;
         for (ui64 i = 1; i <= keysCount; ++i) {
             ranges.push_back(
-                {.Key = i, .Range = TBlockRange64::MakeClosedInterval(i, i)});
+                {.Key = Key(i),
+                 .Range = TBlockRange64::MakeClosedInterval(i, i)});
         }
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(0, keysCount),
@@ -172,7 +196,7 @@ Y_UNIT_TEST_SUITE(TSplitOnNonOverlappingContinuousRanges)
         UNIT_ASSERT_VALUES_EQUAL(keysCount + 1, result.size());
 
         for (size_t i = 0; i < result.size(); ++i) {
-            UNIT_ASSERT_VALUES_EQUAL(i, result[i].Key);
+            UNIT_ASSERT_VALUES_EQUAL(i, result[i].Key.Lsn);
             UNIT_ASSERT_VALUES_EQUAL(i, result[i].Range.Start);
             UNIT_ASSERT_VALUES_EQUAL(i, result[i].Range.Start);
         }
@@ -181,61 +205,71 @@ Y_UNIT_TEST_SUITE(TSplitOnNonOverlappingContinuousRanges)
     Y_UNIT_TEST(StaircaseWithOverlappedRanges)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 30)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(25, 45)},
-            {.Key = 300, .Range = TBlockRange64::MakeClosedInterval(40, 60)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 30)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(25, 45)},
+            {.Key = Key(300),
+             .Range = TBlockRange64::MakeClosedInterval(40, 60)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(10, 60),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "100[10..24];"
-            "200[25..39];"
-            "300[40..60];",
+            "0:100[10..24];"
+            "0:200[25..39];"
+            "0:300[40..60];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(InsideOfBaseRange)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 15)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(25, 30)},
-            {.Key = 300, .Range = TBlockRange64::MakeClosedInterval(45, 50)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 15)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(25, 30)},
+            {.Key = Key(300),
+             .Range = TBlockRange64::MakeClosedInterval(45, 50)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(0, 60),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "0[0..9];"
-            "100[10..15];"
-            "0[16..24];"
-            "200[25..30];"
-            "0[31..44];"
-            "300[45..50];"
-            "0[51..60];",
+            "0:0[0..9];"
+            "0:100[10..15];"
+            "0:0[16..24];"
+            "0:200[25..30];"
+            "0:0[31..44];"
+            "0:300[45..50];"
+            "0:0[51..60];",
             DebugPrintResult(result));
     }
 
     Y_UNIT_TEST(FewBiggerKeysInsideOfOneSmaller)
     {
         TVector<TWeightedRange> ranges = {
-            {.Key = 100, .Range = TBlockRange64::MakeClosedInterval(10, 100)},
-            {.Key = 200, .Range = TBlockRange64::MakeClosedInterval(20, 25)},
-            {.Key = 300, .Range = TBlockRange64::MakeClosedInterval(40, 45)},
-            {.Key = 400, .Range = TBlockRange64::MakeClosedInterval(70, 75)}};
+            {.Key = Key(100),
+             .Range = TBlockRange64::MakeClosedInterval(10, 100)},
+            {.Key = Key(200),
+             .Range = TBlockRange64::MakeClosedInterval(20, 25)},
+            {.Key = Key(300),
+             .Range = TBlockRange64::MakeClosedInterval(40, 45)},
+            {.Key = Key(400),
+             .Range = TBlockRange64::MakeClosedInterval(70, 75)}};
         auto result = SplitOnNonOverlappingContinuousRanges(
             TBlockRange64::MakeClosedInterval(0, 100),
             ranges);
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "0[0..9];"
-            "100[10..19];"
-            "200[20..25];"
-            "100[26..39];"
-            "300[40..45];"
-            "100[46..69];"
-            "400[70..75];"
-            "100[76..100];",
+            "0:0[0..9];"
+            "0:100[10..19];"
+            "0:200[20..25];"
+            "0:100[26..39];"
+            "0:300[40..45];"
+            "0:100[46..69];"
+            "0:400[70..75];"
+            "0:100[76..100];",
             DebugPrintResult(result));
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.cpp
@@ -11,12 +11,6 @@ TString TPBufferKey::Print() const
     return TStringBuilder() << Generation << ":" << Lsn;
 }
 
-IOutputStream& operator<<(IOutputStream& out, const TPBufferKey& rhs)
-{
-    out << rhs.Print();
-    return out;
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 
 }   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.cpp
@@ -1,0 +1,22 @@
+#include "pbuffer_key.h"
+
+#include <util/string/builder.h>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString TPBufferKey::Print() const
+{
+    return TStringBuilder() << Generation << ":" << Lsn;
+}
+
+IOutputStream& operator<<(IOutputStream& out, const TPBufferKey& rhs)
+{
+    out << rhs.Print();
+    return out;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h
@@ -2,7 +2,6 @@
 
 #include <util/digest/multi.h>
 #include <util/generic/string.h>
-#include <util/stream/fwd.h>
 #include <util/system/types.h>
 
 #include <compare>
@@ -30,8 +29,6 @@ struct TPBufferKey
 
     [[nodiscard]] TString Print() const;
 };
-
-IOutputStream& operator<<(IOutputStream& out, const TPBufferKey& rhs);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <util/digest/multi.h>
+#include <util/generic/string.h>
+#include <util/stream/fwd.h>
+#include <util/system/types.h>
+
+#include <compare>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Identity of a persistent buffer record. A record is written under the tablet
+// generation that is current at write time and keeps it for life, so the
+// record is addressed by that generation plus the lsn issued within it. New
+// writes of a restarted tablet live in a fresh generation and can never
+// collide with records restored from previous generations, whatever lsns they
+// carry. The ordering is lexicographic with the generation first, which
+// matches real time across tablet restarts: every record of an older
+// generation precedes every record of a newer one.
+struct TPBufferKey
+{
+    ui32 Generation = 0;
+    ui64 Lsn = 0;
+
+    friend constexpr auto operator<=>(
+        const TPBufferKey&,
+        const TPBufferKey&) = default;
+
+    [[nodiscard]] TString Print() const;
+};
+
+IOutputStream& operator<<(IOutputStream& out, const TPBufferKey& rhs);
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore
+
+template <>
+struct THash<NYdb::NBS::NBlockStore::TPBufferKey>
+{
+    size_t operator()(
+        const NYdb::NBS::NBlockStore::TPBufferKey& pBufferKey) const
+    {
+        return MultiHash(pBufferKey.Generation, pBufferKey.Lsn);
+    }
+};

--- a/ydb/core/nbs/cloud/blockstore/libs/common/record_id.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/record_id.cpp
@@ -1,0 +1,22 @@
+#include "record_id.h"
+
+#include <util/string/builder.h>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString TRecordId::Print() const
+{
+    return TStringBuilder() << Generation << ":" << Lsn;
+}
+
+IOutputStream& operator<<(IOutputStream& out, const TRecordId& rhs)
+{
+    out << rhs.Print();
+    return out;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore

--- a/ydb/core/nbs/cloud/blockstore/libs/common/record_id.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/record_id.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <util/digest/multi.h>
+#include <util/generic/string.h>
+#include <util/stream/fwd.h>
+#include <util/system/types.h>
+
+#include <compare>
+
+namespace NYdb::NBS::NBlockStore {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Identity of a persistent buffer record. A record is written under the tablet
+// generation that is current at write time and keeps it for life, so the
+// record is addressed by that generation plus the lsn issued within it. New
+// writes of a restarted tablet live in a fresh generation and can never
+// collide with records restored from previous generations, whatever lsns they
+// carry. The ordering is lexicographic with the generation first, which
+// matches real time across tablet restarts: every record of an older
+// generation precedes every record of a newer one.
+struct TRecordId
+{
+    ui32 Generation = 0;
+    ui64 Lsn = 0;
+
+    friend constexpr auto operator<=>(
+        const TRecordId&,
+        const TRecordId&) = default;
+
+    [[nodiscard]] TString Print() const;
+};
+
+IOutputStream& operator<<(IOutputStream& out, const TRecordId& rhs);
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore
+
+template <>
+struct THash<NYdb::NBS::NBlockStore::TRecordId>
+{
+    size_t operator()(const NYdb::NBS::NBlockStore::TRecordId& recordId) const
+    {
+        return MultiHash(recordId.Generation, recordId.Lsn);
+    }
+};

--- a/ydb/core/nbs/cloud/blockstore/libs/common/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/ya.make
@@ -4,6 +4,7 @@ SRCS(
     block_range_algorithms.cpp
     block_range_map.cpp
     block_range.cpp
+    record_id.cpp
     thread_checker.cpp
 )
 

--- a/ydb/core/nbs/cloud/blockstore/libs/common/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/common/ya.make
@@ -6,6 +6,7 @@ SRCS(
     block_range_map.cpp
     block_range.cpp
     printable_params.cpp
+    pbuffer_key.cpp
     thread_checker.cpp
 )
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -89,12 +89,12 @@ void TBaseFixture::Init()
     DirectBlockGroup->ReadBlocksFromPBufferHandler = [&]   //
         (ui32 vChunkIndex,
          THostIndex hostIndex,
-         ui64 lsn,
+         TRecordId recordId,
          TBlockRange64 range,
          const TGuardedSgList& guardedSglist,
          const NWilson::TTraceId& traceId)
     {
-        Y_UNUSED(lsn);
+        Y_UNUSED(recordId);
         Y_UNUSED(traceId);
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(THostIndex{0}, hostIndex);
@@ -117,14 +117,14 @@ void TBaseFixture::Init()
     DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
         (ui32 vChunkIndex,
          THostIndex hostIndex,
-         ui64 lsn,
+         TRecordId recordId,
          TBlockRange64 range,
          const TGuardedSgList& guardedSglist,
          const NWilson::TTraceId& traceId)
     {
         Y_UNUSED(traceId);
         Y_UNUSED(hostIndex);
-        Y_UNUSED(lsn);
+        Y_UNUSED(recordId);
 
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -89,12 +89,12 @@ void TBaseFixture::Init()
     DirectBlockGroup->ReadBlocksFromPBufferHandler = [&]   //
         (ui32 vChunkIndex,
          THostIndex hostIndex,
-         ui64 lsn,
+         TPBufferKey pBufferKey,
          TBlockRange64 range,
          const TGuardedSgList& guardedSglist,
          const NWilson::TTraceId& traceId)
     {
-        Y_UNUSED(lsn);
+        Y_UNUSED(pBufferKey);
         Y_UNUSED(traceId);
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(THostIndex{0}, hostIndex);
@@ -117,14 +117,14 @@ void TBaseFixture::Init()
     DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
         (ui32 vChunkIndex,
          THostIndex hostIndex,
-         ui64 lsn,
+         TPBufferKey pBufferKey,
          TBlockRange64 range,
          const TGuardedSgList& guardedSglist,
          const NWilson::TTraceId& traceId)
     {
         Y_UNUSED(traceId);
         Y_UNUSED(hostIndex);
-        Y_UNUSED(lsn);
+        Y_UNUSED(pBufferKey);
 
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -4,6 +4,7 @@
 #include "vchunk.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/context.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/partition_direct_service_mock.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.h>
@@ -24,6 +25,12 @@ constexpr ui64 DefaultVChunkSize = RegionSize / DirectBlockGroupsCount;
 ////////////////////////////////////////////////////////////////////////////////
 
 TString GenerateRandomString(size_t size);
+
+// Makes a record id for tests, which run within a single tablet generation.
+constexpr TRecordId MakeId(ui64 lsn)
+{
+    return {.Generation = 1, .Lsn = lsn};
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "direct_block_group_mock.h"
-#include "dirty_map/pbuffer_key_test_helpers.h"
 #include "partition_direct_service_mock.h"
 #include "vchunk.h"
 
@@ -11,6 +10,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/service/trace_service_mock.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/model/disk_description.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/model/log_title.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/pbuffer_key_test_helpers.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "direct_block_group_mock.h"
+#include "dirty_map/pbuffer_key_test_helpers.h"
 #include "partition_direct_service_mock.h"
 #include "vchunk.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/context.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/storage_test.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/trace_service_mock.h>
@@ -28,12 +28,6 @@ constexpr ui64 DefaultVChunkSize = RegionSize / DirectBlockGroupsCount;
 ////////////////////////////////////////////////////////////////////////////////
 
 TString GenerateRandomString(size_t size);
-
-// Makes a PBuffer key for tests, which run within a single tablet generation.
-constexpr TPBufferKey MakeKey(ui64 lsn)
-{
-    return {.Generation = 1, .Lsn = lsn};
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -5,6 +5,7 @@
 #include "vchunk.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/context.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/storage_test.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/trace_service_mock.h>
@@ -27,6 +28,12 @@ constexpr ui64 DefaultVChunkSize = RegionSize / DirectBlockGroupsCount;
 ////////////////////////////////////////////////////////////////////////////////
 
 TString GenerateRandomString(size_t size);
+
+// Makes a PBuffer key for tests, which run within a single tablet generation.
+constexpr TPBufferKey MakeKey(ui64 lsn)
+{
+    return {.Generation = 1, .Lsn = lsn};
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<TWriteRequestBundle> MakeWriteBundle(
         NWilson::TTraceId(),
         MakeIntrusive<TCallContext>(),
         f.Range);
-    bundle->SetLsn(f.UserLsn);
+    bundle->SetPBufferKey(f.UserPBufferKey);
     return bundle;
 }
 
@@ -126,9 +126,11 @@ void InitFixture(TWriteRequestTestFixture& f)
 
     // Split the range so CreateReadRequestExecutor picks the multi-location
     // path when MakeReadHint is called for BM_ReadMultiple*.
-    f.DirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(20, 10));
+    f.DirtyMap->RegisterInflightWrite(
+        MakeKey(100),
+        TBlockRange64::WithLength(20, 10));
     f.DirtyMap->WriteFinished(
-        100,
+        MakeKey(100),
         TBlockRange64::WithLength(20, 10),
         f.VChunkConfig.GetDesiredPBuffers(),
         f.VChunkConfig.GetDesiredPBuffers());
@@ -257,7 +259,7 @@ static void BM_EraseRequestExecutorCreation(benchmark::State& state)
             previous.reset();
         }
         TEraseHint hint;
-        hint.Segments.push_back(TEraseSegment{.Generation = 1, .Lsn = 42});
+        hint.Segments.push_back(TEraseSegment{.PBufferKey = MakeKey(42)});
         state.ResumeTiming();
 
         auto executor = std::make_shared<TEraseRequestExecutor>(
@@ -291,7 +293,7 @@ static void BM_FlushRequestExecutorCreation(benchmark::State& state)
         }
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .PBufferKey = MakeKey(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         state.ResumeTiming();
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
@@ -355,21 +355,27 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // Mark DDisk#1 completely fresh.
         DirtyMap.MarkFresh(FreshDDisk, 0);
 
-        DirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        DirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         DirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),   // #0
             MakePrimariesMask(),
             MakePrimariesMask());
-        DirtyMap.RegisterInflightWrite(124, TBlockRange64::WithLength(250, 10));
+        DirtyMap.RegisterInflightWrite(
+            MakeId(124),
+            TBlockRange64::WithLength(250, 10));
         DirtyMap.WriteFinished(
-            124,
+            MakeId(124),
             TBlockRange64::WithLength(250, 10),   // #0 + #1
             MakePrimariesMask(),
             MakePrimariesMask());
-        DirtyMap.RegisterInflightWrite(125, TBlockRange64::WithLength(260, 10));
+        DirtyMap.RegisterInflightWrite(
+            MakeId(125),
+            TBlockRange64::WithLength(260, 10));
         DirtyMap.WriteFinished(
-            125,
+            MakeId(125),
             TBlockRange64::WithLength(260, 10),   // #1
             MakePrimariesMask(),
             MakePrimariesMask());
@@ -384,9 +390,9 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // range #0
         auto flushHints = DirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:125[260..269];"
-            "H0->H3:125[260..269];"
-            "H2->H2:125[260..269];",
+            "H0->H0:1:125[260..269];"
+            "H0->H3:1:125[260..269];"
+            "H2->H2:1:125[260..269];",
             flushHints.DebugPrint());
 
         // Read range #0 - OK.
@@ -407,10 +413,10 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // but contains #0
         flushHints = DirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H0->H3:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H0->H3:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHints.DebugPrint());
 
         // Read range #1 - OK.
@@ -430,10 +436,10 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // Flush hints should contains writes overlapped with range #1
         flushHints = DirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:124[250..259];"
-            "H0->H3:124[250..259];"
-            "H1->H1:124[250..259];"
-            "H2->H2:124[250..259];",
+            "H0->H0:1:124[250..259];"
+            "H0->H3:1:124[250..259];"
+            "H1->H1:1:124[250..259];"
+            "H2->H2:1:124[250..259];",
             flushHints.DebugPrint());
 
         // Read range #2 - OK.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ddisk_data_copier_ut.cpp
@@ -25,7 +25,7 @@ THostMask MakePrimariesMask()
 void FinishFlushes(TBlocksDirtyMap& dirtyMap, const TFlushHints& hints)
 {
     for (const auto& [route, flush]: hints.GetAllHints()) {
-        dirtyMap.FlushFinished(route, {MakeLsnVector(flush.Segments)}, {});
+        dirtyMap.FlushFinished(route, {MakePBufferKeys(flush.Segments)}, {});
     }
 }
 
@@ -688,25 +688,27 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // Mark DDisk#1 completely fresh.
         DirtyMap->UpdateWatermarkDebugOnly(FreshDDisk, 0);
 
-        DirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        DirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         DirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             overlapped_0,
             MakePrimariesMask(),
             MakePrimariesMask());
         DirtyMap->RegisterInflightWrite(
-            124,
+            MakeKey(124),
             TBlockRange64::WithLength(250, 10));
         DirtyMap->WriteFinished(
-            124,
+            MakeKey(124),
             overlapped_01,
             MakePrimariesMask(),
             MakePrimariesMask());
         DirtyMap->RegisterInflightWrite(
-            125,
+            MakeKey(125),
             TBlockRange64::WithLength(260, 10));
         DirtyMap->WriteFinished(
-            125,
+            MakeKey(125),
             overlapped_1,
             MakePrimariesMask(),
             MakePrimariesMask());
@@ -724,10 +726,10 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // range #0
         auto flushHints = DirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:125[260..269];"
-            "H0->H3:125[260..269];"
-            "H1->H1:125[260..269];"
-            "H2->H2:125[260..269];",
+            "H0->H0:1:125[260..269];"
+            "H0->H3:1:125[260..269];"
+            "H1->H1:1:125[260..269];"
+            "H2->H2:1:125[260..269];",
             flushHints.DebugPrint());
 
         // Read range #0 - OK.
@@ -759,10 +761,10 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // but contains #0
         flushHints = DirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H0->H3:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H0->H3:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHints.DebugPrint());
 
         // Read range #1 - OK.
@@ -785,10 +787,10 @@ Y_UNIT_TEST_SUITE(TDDiskDataCopierTest)
         // Flush hints should contains writes overlapped with range #1
         flushHints = DirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:124[250..259];"
-            "H0->H3:124[250..259];"
-            "H1->H1:124[250..259];"
-            "H2->H2:124[250..259];",
+            "H0->H0:1:124[250..259];"
+            "H0->H3:1:124[250..259];"
+            "H1->H1:1:124[250..259];"
+            "H2->H2:1:124[250..259];",
             flushHints.DebugPrint());
 
         // Read range #2 - OK.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -4,6 +4,7 @@
 
 #include "restore_request.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/public.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/public.h>
@@ -61,7 +62,7 @@ struct TDBGRestoreResponse
 {
     struct TRestoreMeta
     {
-        ui64 Lsn = 0;
+        TRecordId RecordId;
         TBlockRange64 Range;
         THostIndex HostIndex = InvalidHostIndex;
     };
@@ -73,7 +74,7 @@ struct TDBGRestoreResponse
 struct TListPBufferMeta
 {
     ui32 VChunkIndex = 0;
-    ui64 Lsn = 0;
+    TRecordId RecordId;
     TBlockRange64 Range;
 };
 
@@ -117,6 +118,11 @@ public:
 
     virtual TExecutorPtr GetExecutor() = 0;
 
+    // The tablet generation this DBG was created with. New records are
+    // minted under it; restored records keep the generation they were
+    // written in.
+    virtual ui32 GetTabletGeneration() const = 0;
+
     virtual IOraclePtr GetOracle() = 0;
 
     virtual void Schedule(TDuration delay, TCallback callback) = 0;
@@ -140,7 +146,7 @@ public:
     virtual NThreading::TFuture<TDBGReadBlocksResponse> ReadBlocksFromPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) = 0;
@@ -155,7 +161,7 @@ public:
     virtual NThreading::TFuture<TDBGWriteBlocksResponse> WriteBlocksToPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) = 0;
@@ -167,7 +173,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -192,13 +198,14 @@ public:
         const TEraseSegments& segments,
         const NWilson::TTraceId& traceId) = 0;
 
+    // The bound is an lsn within the current tablet generation; the PBuffer
+    // side additionally drops every record of the previous generations.
     virtual void BarrierEraseFromPBuffer(ui64 lsn) = 0;
 
-    // The lowest lsn that must be preserved across all vchunks of this
-    // DirectBlockGroup (records below it are safe to erase). Used to compute
-    // the tablet-wide cleanup watermark. Resolves on the executor thread.
-    // nullopt means nothing is inflight here.
-    virtual NThreading::TFuture<std::optional<ui64>>
+    // The lowest record id that must be preserved across all vchunks of this
+    // DirectBlockGroup. Used to compute the tablet-wide cleanup watermark.
+    // Resolves on the executor thread. nullopt means nothing is inflight here.
+    virtual NThreading::TFuture<std::optional<TRecordId>>
     GatherSafeBarrierForErase() = 0;
 
     // Get a list of all entries in PBuffers belonging to a given vChunkIndex.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -4,6 +4,7 @@
 
 #include "restore_request.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/public.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/public.h>
@@ -61,7 +62,7 @@ struct TDBGRestoreResponse
 {
     struct TRestoreMeta
     {
-        ui64 Lsn = 0;
+        TPBufferKey PBufferKey;
         TBlockRange64 Range;
         THostIndex HostIndex = InvalidHostIndex;
     };
@@ -73,7 +74,7 @@ struct TDBGRestoreResponse
 struct TListPBufferMeta
 {
     ui32 VChunkIndex = 0;
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
     TBlockRange64 Range;
 };
 
@@ -117,6 +118,11 @@ public:
 
     virtual TExecutorPtr GetExecutor() = 0;
 
+    // The tablet generation this DBG was created with. New records are
+    // minted under it; restored records keep the generation they were
+    // written in.
+    virtual ui32 GetTabletGeneration() const = 0;
+
     virtual IOraclePtr GetOracle() = 0;
 
     virtual void Schedule(TDuration delay, TCallback callback) = 0;
@@ -142,7 +148,7 @@ public:
     virtual NThreading::TFuture<TDBGReadBlocksResponse> ReadBlocksFromPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) = 0;
@@ -157,7 +163,7 @@ public:
     virtual NThreading::TFuture<TDBGWriteBlocksResponse> WriteBlocksToPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) = 0;
@@ -169,7 +175,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -194,13 +200,14 @@ public:
         const TEraseSegments& segments,
         const NWilson::TTraceId& traceId) = 0;
 
+    // The bound is an lsn within the current tablet generation; the PBuffer
+    // side additionally drops every record of the previous generations.
     virtual void BarrierEraseFromPBuffer(ui64 lsn) = 0;
 
-    // The lowest lsn that must be preserved across all vchunks of this
-    // DirectBlockGroup (records below it are safe to erase). Used to compute
-    // the tablet-wide cleanup watermark. Resolves on the executor thread.
-    // nullopt means nothing is inflight here.
-    virtual NThreading::TFuture<std::optional<ui64>>
+    // The lowest record id that must be preserved across all vchunks of this
+    // DirectBlockGroup. Used to compute the tablet-wide cleanup watermark.
+    // Resolves on the executor thread. nullopt means nothing is inflight here.
+    virtual NThreading::TFuture<std::optional<TPBufferKey>>
     GatherSafeBarrierForErase() = 0;
 
     // Get a list of all entries in PBuffers belonging to a given vChunkIndex.

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -43,13 +43,15 @@ TListPBufferResponse MakeListPBufferResponse(
     result.Error = TranslateError(response);
     result.Meta.reserve(response.GetRecords().size());
     for (const auto& segment: response.GetRecords()) {
-        ui64 lsn = segment.GetLsn();
+        TRecordId recordId{
+            .Generation = segment.GetGeneration(),
+            .Lsn = segment.GetLsn()};
         ui32 vChunkIndex = segment.GetSelector().GetVChunkIndex();
         auto range = TBlockRange64::WithLength(
             segment.GetSelector().GetOffsetInBytes() / DefaultBlockSize,
             segment.GetSelector().GetSize() / DefaultBlockSize);
         result.Meta.push_back(
-            {.VChunkIndex = vChunkIndex, .Lsn = lsn, .Range = range});
+            {.VChunkIndex = vChunkIndex, .RecordId = recordId, .Range = range});
     }
     return result;
 }
@@ -222,6 +224,11 @@ void TDirectBlockGroup::Register(TVChunkWeakPtr weakVChunk)
 TExecutorPtr TDirectBlockGroup::GetExecutor()
 {
     return Executor;
+}
+
+ui32 TDirectBlockGroup::GetTabletGeneration() const
+{
+    return TabletGeneration;
 }
 
 IOraclePtr TDirectBlockGroup::GetOracle()
@@ -403,7 +410,7 @@ NThreading::TFuture<TDBGReadBlocksResponse>
 TDirectBlockGroup::ReadBlocksFromPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
@@ -428,7 +435,7 @@ TDirectBlockGroup::ReadBlocksFromPBuffer(
             vChunkIndex,
             range.Start * DefaultBlockSize,
             range.Size() * DefaultBlockSize),
-        lsn,
+        recordId,
         NKikimr::NDDisk::TReadInstruction(true),
         guardedSglist,
         childSpan.get());
@@ -606,13 +613,15 @@ NThreading::TFuture<TDBGWriteBlocksResponse>
 TDirectBlockGroup::WriteBlocksToPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
 {
     // INVARIANT: PBuffer does NOT require a session/lock
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+    // New records are always minted under the current tablet generation.
+    Y_ABORT_UNLESS(recordId.Generation == TabletGeneration);
 
     using TEvWritePersistentBufferResultFuture = NThreading::TFuture<
         NKikimrBlobStorage::NDDisk::TEvWritePersistentBufferResult>;
@@ -631,7 +640,7 @@ TDirectBlockGroup::WriteBlocksToPBuffer(
             vChunkIndex,
             range.Start * DefaultBlockSize,
             range.Size() * DefaultBlockSize),
-        lsn,
+        recordId.Lsn,
         NKikimr::NDDisk::TWriteInstruction(0),
         guardedSglist,
         childSpan.get());
@@ -681,7 +690,7 @@ void TDirectBlockGroup::WriteBlocksToManyPBuffers(
     ui32 vChunkIndex,
     THostIndex coordinatorHostIndex,
     THostMask hostIndexes,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     TDuration replyTimeout,
     const TGuardedSgList& guardedSglist,
@@ -694,6 +703,8 @@ void TDirectBlockGroup::WriteBlocksToManyPBuffers(
     // INVARIANT: PBuffer does NOT require a session/lock
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
     Y_ABORT_UNLESS(hostIndexes.Count() > 0);
+    // New records are always minted under the current tablet generation.
+    Y_ABORT_UNLESS(recordId.Generation == TabletGeneration);
 
     const auto startAt = TMonotonic::Now();
 
@@ -772,7 +783,7 @@ void TDirectBlockGroup::WriteBlocksToManyPBuffers(
             vChunkIndex,
             range.Start * DefaultBlockSize,
             range.Size() * DefaultBlockSize),
-        lsn,
+        recordId.Lsn,
         NKikimr::NDDisk::TWriteInstruction(0),
         std::move(disksIds),
         replyTimeout,
@@ -890,7 +901,7 @@ NThreading::TFuture<TDBGFlushResponse> TDirectBlockGroup::SyncWithPBuffer(
         PBufferConnections[pbufferHostIndex].HostConnection,
         DDiskConnections[ddiskHostIndex].HostConnection,
         std::move(selectors),
-        TPBufferSegment::MakeLsnVector(segments),
+        TPBufferSegment::MakeRecordIds(segments),
         childSpan.get());
 
     future.Subscribe(
@@ -1007,7 +1018,7 @@ NThreading::TFuture<TDBGEraseResponse> TDirectBlockGroup::BatchEraseFromPBuffer(
 
     auto future = StorageTransport->BatchEraseFromPBuffer(
         PBufferConnections[hostIndex].HostConnection,
-        MakeLsnVector(segments),
+        MakeRecordIds(segments),
         childSpan.get());
 
     auto promise = NewPromise<TDBGEraseResponse>();
@@ -1141,10 +1152,10 @@ void TDirectBlockGroup::DoBarrierEraseFromPBuffer(
         });
 }
 
-NThreading::TFuture<std::optional<ui64>>
+NThreading::TFuture<std::optional<TRecordId>>
 TDirectBlockGroup::GatherSafeBarrierForErase()
 {
-    auto promise = NewPromise<std::optional<ui64>>();
+    auto promise = NewPromise<std::optional<TRecordId>>();
     auto future = promise.GetFuture();
 
     Executor->ExecuteSimple(
@@ -1156,15 +1167,15 @@ TDirectBlockGroup::GatherSafeBarrierForErase()
                 return;
             }
 
-            std::optional<ui64> safeBarrier;
+            std::optional<TRecordId> safeBarrier;
             for (const auto& weakVChunk: self->VChunks) {
                 auto vChunk = weakVChunk.lock();
                 if (!vChunk) {
                     continue;
                 }
-                const auto lsn = vChunk->GetSafeBarrierForErase();
-                if (lsn && (!safeBarrier || *lsn < *safeBarrier)) {
-                    safeBarrier = lsn;
+                const auto candidate = vChunk->GetSafeBarrierForErase();
+                if (candidate && (!safeBarrier || *candidate < *safeBarrier)) {
+                    safeBarrier = candidate;
                 }
             }
             promise.SetValue(safeBarrier);
@@ -1683,7 +1694,9 @@ void TDirectBlockGroup::OnPBuffersListed(
                 restoredPBuffer.Error = response.Error;
             }
             restoredPBuffer.Meta.push_back(
-                {.Lsn = meta.Lsn, .Range = meta.Range, .HostIndex = hostIndex});
+                {.RecordId = meta.RecordId,
+                 .Range = meta.Range,
+                 .HostIndex = hostIndex});
         }
     }
     RestoredPBuffersPromise.SetValue();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -73,13 +73,17 @@ TListPBufferResponse MakeListPBufferResponse(
     result.Error = TranslateError(response);
     result.Meta.reserve(response.GetRecords().size());
     for (const auto& segment: response.GetRecords()) {
-        ui64 lsn = segment.GetLsn();
+        TPBufferKey pBufferKey{
+            .Generation = segment.GetGeneration(),
+            .Lsn = segment.GetLsn()};
         ui32 vChunkIndex = segment.GetSelector().GetVChunkIndex();
         auto range = TBlockRange64::WithLength(
             segment.GetSelector().GetOffsetInBytes() / DefaultBlockSize,
             segment.GetSelector().GetSize() / DefaultBlockSize);
         result.Meta.push_back(
-            {.VChunkIndex = vChunkIndex, .Lsn = lsn, .Range = range});
+            {.VChunkIndex = vChunkIndex,
+             .PBufferKey = pBufferKey,
+             .Range = range});
     }
     return result;
 }
@@ -253,6 +257,11 @@ void TDirectBlockGroup::Register(TVChunkWeakPtr weakVChunk)
 TExecutorPtr TDirectBlockGroup::GetExecutor()
 {
     return Executor;
+}
+
+ui32 TDirectBlockGroup::GetTabletGeneration() const
+{
+    return TabletGeneration;
 }
 
 IOraclePtr TDirectBlockGroup::GetOracle()
@@ -433,7 +442,7 @@ NThreading::TFuture<TDBGReadBlocksResponse>
 TDirectBlockGroup::ReadBlocksFromPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
@@ -458,7 +467,7 @@ TDirectBlockGroup::ReadBlocksFromPBuffer(
             vChunkIndex,
             range.Start * DefaultBlockSize,
             range.Size() * DefaultBlockSize),
-        lsn,
+        pBufferKey,
         NKikimr::NDDisk::TReadInstruction(true),
         guardedSglist,
         childSpan.get());
@@ -634,13 +643,15 @@ NThreading::TFuture<TDBGWriteBlocksResponse>
 TDirectBlockGroup::WriteBlocksToPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
 {
     // INVARIANT: PBuffer does NOT require a session/lock
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+    // New records are always minted under the current tablet generation.
+    Y_ABORT_UNLESS(pBufferKey.Generation == TabletGeneration);
 
     using TEvWritePersistentBufferResultFuture = NThreading::TFuture<
         NKikimrBlobStorage::NDDisk::TEvWritePersistentBufferResult>;
@@ -659,7 +670,7 @@ TDirectBlockGroup::WriteBlocksToPBuffer(
             vChunkIndex,
             range.Start * DefaultBlockSize,
             range.Size() * DefaultBlockSize),
-        lsn,
+        pBufferKey.Lsn,
         NKikimr::NDDisk::TWriteInstruction(0),
         guardedSglist,
         childSpan.get());
@@ -709,7 +720,7 @@ void TDirectBlockGroup::WriteBlocksToManyPBuffers(
     ui32 vChunkIndex,
     THostIndex coordinatorHostIndex,
     THostMask hostIndexes,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     TDuration replyTimeout,
     const TGuardedSgList& guardedSglist,
@@ -722,6 +733,8 @@ void TDirectBlockGroup::WriteBlocksToManyPBuffers(
     // INVARIANT: PBuffer does NOT require a session/lock
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
     Y_ABORT_UNLESS(hostIndexes.Count() > 0);
+    // New records are always minted under the current tablet generation.
+    Y_ABORT_UNLESS(pBufferKey.Generation == TabletGeneration);
 
     const auto startAt = TMonotonic::Now();
 
@@ -799,7 +812,7 @@ void TDirectBlockGroup::WriteBlocksToManyPBuffers(
             vChunkIndex,
             range.Start * DefaultBlockSize,
             range.Size() * DefaultBlockSize),
-        lsn,
+        pBufferKey.Lsn,
         NKikimr::NDDisk::TWriteInstruction(0),
         std::move(disksIds),
         replyTimeout,
@@ -918,7 +931,7 @@ NThreading::TFuture<TDBGFlushResponse> TDirectBlockGroup::SyncWithPBuffer(
         PBufferConnections[pbufferHostIndex].HostConnection,
         DDiskConnections[ddiskHostIndex].HostConnection,
         std::move(selectors),
-        TPBufferSegment::MakeLsnVector(segments),
+        TPBufferSegment::MakePBufferKeys(segments),
         childSpan.get());
 
     future.Subscribe(
@@ -1037,7 +1050,7 @@ NThreading::TFuture<TDBGEraseResponse> TDirectBlockGroup::BatchEraseFromPBuffer(
 
     auto future = StorageTransport->BatchEraseFromPBuffer(
         PBufferConnections[hostIndex].HostConnection,
-        MakeLsnVector(segments),
+        MakePBufferKeys(segments),
         childSpan.get());
 
     auto promise = NewPromise<TDBGEraseResponse>();
@@ -1178,10 +1191,10 @@ void TDirectBlockGroup::DoBarrierEraseFromPBuffer(
         });
 }
 
-NThreading::TFuture<std::optional<ui64>>
+NThreading::TFuture<std::optional<TPBufferKey>>
 TDirectBlockGroup::GatherSafeBarrierForErase()
 {
-    auto promise = NewPromise<std::optional<ui64>>();
+    auto promise = NewPromise<std::optional<TPBufferKey>>();
     auto future = promise.GetFuture();
 
     Executor->ExecuteSimple(
@@ -1193,15 +1206,15 @@ TDirectBlockGroup::GatherSafeBarrierForErase()
                 return;
             }
 
-            std::optional<ui64> safeBarrier;
+            std::optional<TPBufferKey> safeBarrier;
             for (const auto& weakVChunk: self->VChunks) {
                 auto vChunk = weakVChunk.lock();
                 if (!vChunk) {
                     continue;
                 }
-                const auto lsn = vChunk->GetSafeBarrierForErase();
-                if (lsn && (!safeBarrier || *lsn < *safeBarrier)) {
-                    safeBarrier = lsn;
+                const auto candidate = vChunk->GetSafeBarrierForErase();
+                if (candidate && (!safeBarrier || *candidate < *safeBarrier)) {
+                    safeBarrier = candidate;
                 }
             }
             promise.SetValue(safeBarrier);
@@ -1772,7 +1785,9 @@ void TDirectBlockGroup::OnPBuffersListed(
                 restoredPBuffer.Error = response.Error;
             }
             restoredPBuffer.Meta.push_back(
-                {.Lsn = meta.Lsn, .Range = meta.Range, .HostIndex = hostIndex});
+                {.PBufferKey = meta.PBufferKey,
+                 .Range = meta.Range,
+                 .HostIndex = hostIndex});
         }
     }
     RestoredPBuffersPromise.SetValue();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -63,6 +63,8 @@ public:
 
     TExecutorPtr GetExecutor() override;
 
+    ui32 GetTabletGeneration() const override;
+
     IOraclePtr GetOracle() override;
 
     void Schedule(TDuration delay, TCallback callback) override;
@@ -83,7 +85,7 @@ public:
     NThreading::TFuture<TDBGReadBlocksResponse> ReadBlocksFromPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -98,7 +100,7 @@ public:
     NThreading::TFuture<TDBGWriteBlocksResponse> WriteBlocksToPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -107,7 +109,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -128,7 +130,7 @@ public:
 
     void BarrierEraseFromPBuffer(ui64 lsn) override;
 
-    NThreading::TFuture<std::optional<ui64>>
+    NThreading::TFuture<std::optional<TRecordId>>
     GatherSafeBarrierForErase() override;
 
     NThreading::TFuture<TDBGRestoreResponse> RestoreDBGPBuffers(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -65,6 +65,8 @@ public:
 
     TExecutorPtr GetExecutor() override;
 
+    ui32 GetTabletGeneration() const override;
+
     IOraclePtr GetOracle() override;
 
     void Schedule(TDuration delay, TCallback callback) override;
@@ -87,7 +89,7 @@ public:
     NThreading::TFuture<TDBGReadBlocksResponse> ReadBlocksFromPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -102,7 +104,7 @@ public:
     NThreading::TFuture<TDBGWriteBlocksResponse> WriteBlocksToPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -111,7 +113,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -132,7 +134,7 @@ public:
 
     void BarrierEraseFromPBuffer(ui64 lsn) override;
 
-    NThreading::TFuture<std::optional<ui64>>
+    NThreading::TFuture<std::optional<TPBufferKey>>
     GatherSafeBarrierForErase() override;
 
     NThreading::TFuture<TDBGRestoreResponse> RestoreDBGPBuffers(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -366,7 +366,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,   // VChunkIndex
                     2,   // Coordinator
                     hosts,
-                    100,   // lsn
+                    TRecordId{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,
@@ -425,8 +425,9 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             [&]
             {
                 TVector<TPBufferSegment> segments;
-                segments.push_back(
-                    TPBufferSegment(100, TBlockRange64::WithLength(0, 3)));
+                segments.push_back(TPBufferSegment(
+                    TRecordId{.Generation = 1, .Lsn = 100},
+                    TBlockRange64::WithLength(0, 3)));
 
                 return dbg->SyncWithPBuffer(
                     10,   // VChunkIndex
@@ -488,8 +489,9 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             [&]
             {
                 TVector<TPBufferSegment> segments;
-                segments.push_back(
-                    TPBufferSegment(100, TBlockRange64::WithLength(0, 3)));
+                segments.push_back(TPBufferSegment(
+                    TRecordId{.Generation = 1, .Lsn = 100},
+                    TBlockRange64::WithLength(0, 3)));
 
                 return dbg->SyncWithPBuffer(
                     10,   // VChunkIndex
@@ -571,7 +573,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,   // VChunkIndex
                     coordinatorHost,
                     hosts,
-                    100,   // lsn
+                    TRecordId{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,
@@ -651,7 +653,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,   // VChunkIndex
                     coordinatorHost,
                     hosts,
-                    100,   // lsn
+                    TRecordId{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,
@@ -867,8 +869,9 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             [&]
             {
                 TVector<TPBufferSegment> segments;
-                segments.push_back(
-                    TPBufferSegment(100, TBlockRange64::WithLength(0, 3)));
+                segments.push_back(TPBufferSegment(
+                    TRecordId{.Generation = 1, .Lsn = 100},
+                    TBlockRange64::WithLength(0, 3)));
 
                 return dbg->SyncWithPBuffer(
                     10,
@@ -1020,7 +1023,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,
                     2,
                     hosts,
-                    100,
+                    TRecordId{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -366,7 +366,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,   // VChunkIndex
                     2,   // Coordinator
                     hosts,
-                    100,   // lsn
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,
@@ -425,8 +425,9 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             [&]
             {
                 TVector<TPBufferSegment> segments;
-                segments.push_back(
-                    TPBufferSegment(100, TBlockRange64::WithLength(0, 3)));
+                segments.push_back(TPBufferSegment(
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
+                    TBlockRange64::WithLength(0, 3)));
 
                 return dbg->SyncWithPBuffer(
                     10,   // VChunkIndex
@@ -488,8 +489,9 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             [&]
             {
                 TVector<TPBufferSegment> segments;
-                segments.push_back(
-                    TPBufferSegment(100, TBlockRange64::WithLength(0, 3)));
+                segments.push_back(TPBufferSegment(
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
+                    TBlockRange64::WithLength(0, 3)));
 
                 return dbg->SyncWithPBuffer(
                     10,   // VChunkIndex
@@ -571,7 +573,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,   // VChunkIndex
                     coordinatorHost,
                     hosts,
-                    100,   // lsn
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,
@@ -651,7 +653,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,   // VChunkIndex
                     coordinatorHost,
                     hosts,
-                    100,   // lsn
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,
@@ -867,8 +869,9 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             [&]
             {
                 TVector<TPBufferSegment> segments;
-                segments.push_back(
-                    TPBufferSegment(100, TBlockRange64::WithLength(0, 3)));
+                segments.push_back(TPBufferSegment(
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
+                    TBlockRange64::WithLength(0, 3)));
 
                 return dbg->SyncWithPBuffer(
                     10,
@@ -1213,7 +1216,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                     0,
                     2,
                     hosts,
-                    100,
+                    TPBufferKey{.Generation = 1, .Lsn = 100},
                     TBlockRange64::WithLength(0, 3),
                     TDuration::Seconds(1),
                     guardedSglist,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -206,6 +206,12 @@ TExecutorPtr TDirectBlockGroupMock::GetExecutor()
     return Executor;
 }
 
+ui32 TDirectBlockGroupMock::GetTabletGeneration() const
+{
+    // Tests run within a single tablet generation.
+    return 1;
+}
+
 IOraclePtr TDirectBlockGroupMock::GetOracle()
 {
     return &Oracle;
@@ -254,7 +260,7 @@ NThreading::TFuture<TDBGReadBlocksResponse>
 TDirectBlockGroupMock::ReadBlocksFromPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
@@ -262,7 +268,7 @@ TDirectBlockGroupMock::ReadBlocksFromPBuffer(
     return ReadBlocksFromPBufferHandler(
         vChunkIndex,
         hostIndex,
-        lsn,
+        recordId,
         range,
         guardedSglist,
         traceId);
@@ -288,7 +294,7 @@ NThreading::TFuture<TDBGWriteBlocksResponse>
 TDirectBlockGroupMock::WriteBlocksToPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
@@ -296,7 +302,7 @@ TDirectBlockGroupMock::WriteBlocksToPBuffer(
     return WriteBlocksToPBufferHandler(
         vChunkIndex,
         hostIndex,
-        lsn,
+        recordId,
         range,
         guardedSglist,
         traceId);
@@ -306,7 +312,7 @@ void TDirectBlockGroupMock::WriteBlocksToManyPBuffers(
     ui32 vChunkIndex,
     THostIndex coordinatorHostIndex,
     THostMask hostIndexes,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     TDuration replyTimeout,
     const TGuardedSgList& guardedSglist,
@@ -317,7 +323,7 @@ void TDirectBlockGroupMock::WriteBlocksToManyPBuffers(
         vChunkIndex,
         coordinatorHostIndex,
         hostIndexes,
-        lsn,
+        recordId,
         range,
         replyTimeout,
         guardedSglist,
@@ -354,10 +360,10 @@ void TDirectBlockGroupMock::BarrierEraseFromPBuffer(ui64 lsn)
     Y_UNUSED(lsn);
 }
 
-NThreading::TFuture<std::optional<ui64>>
+NThreading::TFuture<std::optional<TRecordId>>
 TDirectBlockGroupMock::GatherSafeBarrierForErase()
 {
-    return NThreading::MakeFuture<std::optional<ui64>>(std::nullopt);
+    return NThreading::MakeFuture<std::optional<TRecordId>>(std::nullopt);
 }
 
 NThreading::TFuture<TDBGRestoreResponse>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -211,6 +211,12 @@ TExecutorPtr TDirectBlockGroupMock::GetExecutor()
     return Executor;
 }
 
+ui32 TDirectBlockGroupMock::GetTabletGeneration() const
+{
+    // Tests run within a single tablet generation.
+    return 1;
+}
+
 IOraclePtr TDirectBlockGroupMock::GetOracle()
 {
     return &Oracle;
@@ -261,7 +267,7 @@ NThreading::TFuture<TDBGReadBlocksResponse>
 TDirectBlockGroupMock::ReadBlocksFromPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
@@ -269,7 +275,7 @@ TDirectBlockGroupMock::ReadBlocksFromPBuffer(
     return ReadBlocksFromPBufferHandler(
         vChunkIndex,
         hostIndex,
-        lsn,
+        pBufferKey,
         range,
         guardedSglist,
         traceId);
@@ -295,7 +301,7 @@ NThreading::TFuture<TDBGWriteBlocksResponse>
 TDirectBlockGroupMock::WriteBlocksToPBuffer(
     ui32 vChunkIndex,
     THostIndex hostIndex,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     const TGuardedSgList& guardedSglist,
     const NWilson::TTraceId& traceId)
@@ -303,7 +309,7 @@ TDirectBlockGroupMock::WriteBlocksToPBuffer(
     return WriteBlocksToPBufferHandler(
         vChunkIndex,
         hostIndex,
-        lsn,
+        pBufferKey,
         range,
         guardedSglist,
         traceId);
@@ -313,7 +319,7 @@ void TDirectBlockGroupMock::WriteBlocksToManyPBuffers(
     ui32 vChunkIndex,
     THostIndex coordinatorHostIndex,
     THostMask hostIndexes,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     TDuration replyTimeout,
     const TGuardedSgList& guardedSglist,
@@ -324,7 +330,7 @@ void TDirectBlockGroupMock::WriteBlocksToManyPBuffers(
         vChunkIndex,
         coordinatorHostIndex,
         hostIndexes,
-        lsn,
+        pBufferKey,
         range,
         replyTimeout,
         guardedSglist,
@@ -361,10 +367,10 @@ void TDirectBlockGroupMock::BarrierEraseFromPBuffer(ui64 lsn)
     Y_UNUSED(lsn);
 }
 
-NThreading::TFuture<std::optional<ui64>>
+NThreading::TFuture<std::optional<TPBufferKey>>
 TDirectBlockGroupMock::GatherSafeBarrierForErase()
 {
-    return NThreading::MakeFuture<std::optional<ui64>>(std::nullopt);
+    return NThreading::MakeFuture<std::optional<TPBufferKey>>(std::nullopt);
 }
 
 NThreading::TFuture<TDBGRestoreResponse>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -87,7 +87,7 @@ public:
         std::function<NThreading::TFuture<TDBGReadBlocksResponse>(
             ui32 vChunkIndex,
             THostIndex hostIndex,
-            ui64 lsn,
+            TRecordId recordId,
             TBlockRange64 range,
             const TGuardedSgList& guardedSglist,
             const NWilson::TTraceId& traceId)>;
@@ -102,7 +102,7 @@ public:
         std::function<NThreading::TFuture<TDBGWriteBlocksResponse>(
             ui32 vChunkIndex,
             THostIndex hostIndex,
-            ui64 lsn,
+            TRecordId recordId,
             TBlockRange64 range,
             const TGuardedSgList& guardedSglist,
             const NWilson::TTraceId& traceId)>;
@@ -110,7 +110,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -166,6 +166,9 @@ public:
     void Register(TVChunkWeakPtr vChunk) override;
 
     TExecutorPtr GetExecutor() override;
+
+    ui32 GetTabletGeneration() const override;
+
     IOraclePtr GetOracle() override;
 
     void Schedule(TDuration delay, TCallback callback) override;
@@ -186,7 +189,7 @@ public:
     NThreading::TFuture<TDBGReadBlocksResponse> ReadBlocksFromPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -201,7 +204,7 @@ public:
     NThreading::TFuture<TDBGWriteBlocksResponse> WriteBlocksToPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -210,7 +213,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -231,7 +234,7 @@ public:
 
     void BarrierEraseFromPBuffer(ui64 lsn) override;
 
-    NThreading::TFuture<std::optional<ui64>>
+    NThreading::TFuture<std::optional<TRecordId>>
     GatherSafeBarrierForErase() override;
 
     NThreading::TFuture<TDBGRestoreResponse> RestoreDBGPBuffers(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -89,7 +89,7 @@ public:
         std::function<NThreading::TFuture<TDBGReadBlocksResponse>(
             ui32 vChunkIndex,
             THostIndex hostIndex,
-            ui64 lsn,
+            TPBufferKey pBufferKey,
             TBlockRange64 range,
             const TGuardedSgList& guardedSglist,
             const NWilson::TTraceId& traceId)>;
@@ -104,7 +104,7 @@ public:
         std::function<NThreading::TFuture<TDBGWriteBlocksResponse>(
             ui32 vChunkIndex,
             THostIndex hostIndex,
-            ui64 lsn,
+            TPBufferKey pBufferKey,
             TBlockRange64 range,
             const TGuardedSgList& guardedSglist,
             const NWilson::TTraceId& traceId)>;
@@ -112,7 +112,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -168,6 +168,9 @@ public:
     void Register(TVChunkWeakPtr vChunk) override;
 
     TExecutorPtr GetExecutor() override;
+
+    ui32 GetTabletGeneration() const override;
+
     IOraclePtr GetOracle() override;
 
     void Schedule(TDuration delay, TCallback callback) override;
@@ -190,7 +193,7 @@ public:
     NThreading::TFuture<TDBGReadBlocksResponse> ReadBlocksFromPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -205,7 +208,7 @@ public:
     NThreading::TFuture<TDBGWriteBlocksResponse> WriteBlocksToPBuffer(
         ui32 vChunkIndex,
         THostIndex hostIndex,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         const TGuardedSgList& guardedSglist,
         const NWilson::TTraceId& traceId) override;
@@ -214,7 +217,7 @@ public:
         ui32 vChunkIndex,
         THostIndex coordinatorHostIndex,
         THostMask hostIndexes,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         TDuration replyTimeout,
         const TGuardedSgList& guardedSglist,
@@ -235,7 +238,7 @@ public:
 
     void BarrierEraseFromPBuffer(ui64 lsn) override;
 
-    NThreading::TFuture<std::optional<ui64>>
+    NThreading::TFuture<std::optional<TPBufferKey>>
     GatherSafeBarrierForErase() override;
 
     NThreading::TFuture<TDBGRestoreResponse> RestoreDBGPBuffers(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -7,6 +7,7 @@
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
+#include <util/generic/algorithm.h>
 #include <util/generic/map.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
@@ -17,12 +18,12 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 namespace {
 template <typename T>
-TVector<ui64> DoMakeLsnVector(std::span<const T> segments)
+TVector<TRecordId> DoMakeRecordIds(std::span<const T> segments)
 {
-    TVector<ui64> result;
+    TVector<TRecordId> result;
     result.reserve(segments.size());
     for (const auto& segment: segments) {
-        result.push_back(segment.Lsn);
+        result.push_back(segment.RecordId);
     }
     return result;
 }
@@ -33,12 +34,12 @@ TVector<ui64> DoMakeLsnVector(std::span<const T> segments)
 
 TReadRangeHint::TReadRangeHint(
     THostMask hostMask,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 requestRelativeRange,
     TBlockRange64 vchunkRange,
     TRangeLock&& lock)
     : HostMask(hostMask)
-    , Lsn(lsn)
+    , RecordId(recordId)
     , RequestRelativeRange(requestRelativeRange)
     , VChunkRange(vchunkRange)
     , Lock(std::move(lock))
@@ -50,9 +51,15 @@ TReadRangeHint& TReadRangeHint::operator=(
 
 TString TReadRangeHint::DebugPrint() const
 {
-    return TStringBuilder()
-           << Lsn << "{" << HostMask.Print() << VChunkRange.Print()
+    TStringBuilder result;
+    if (RecordId.Lsn == 0) {
+        result << "0";
+    } else {
+        result << RecordId.Print();
+    }
+    result << "{" << HostMask.Print() << VChunkRange.Print()
            << RequestRelativeRange.Print() << "};";
+    return result;
 }
 
 TString TReadHint::DebugPrint() const
@@ -72,23 +79,18 @@ TString TReadHint::DebugPrint() const
 ////////////////////////////////////////////////////////////////////////////////
 
 // static
-TVector<ui64> TPBufferSegment::MakeLsnVector(
+TVector<TRecordId> TPBufferSegment::MakeRecordIds(
     std::span<const TPBufferSegment> segments)
 {
-    TVector<ui64> result;
-    result.reserve(segments.size());
-    for (const auto& segment: segments) {
-        result.push_back(segment.Lsn);
-    }
-    return result;
+    return DoMakeRecordIds(segments);
 }
 
 TString TPBufferSegment::DebugPrint(bool brief) const
 {
     if (brief) {
-        return ToString(Lsn);
+        return ToString(RecordId.Lsn);
     }
-    return TStringBuilder() << Lsn << Range.Print();
+    return TStringBuilder() << RecordId.Print() << Range.Print();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -112,13 +114,13 @@ TString TFlushHint::DebugPrint(bool brief) const
 void TFlushHints::AddHint(
     THostIndex source,
     THostIndex destination,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range)
 {
     Hints[THostRoute{
               .SourceHostIndex = source,
               .DestinationHostIndex = destination}]
-        .Segments.emplace_back(lsn, range);
+        .Segments.emplace_back(recordId, range);
 }
 
 bool TFlushHints::Empty() const
@@ -150,9 +152,9 @@ TString TFlushHints::DebugPrint() const
 TString TEraseSegment::DebugPrint(bool brief) const
 {
     if (brief) {
-        return ToString(Lsn);
+        return ToString(RecordId.Lsn);
     }
-    return TStringBuilder() << Generation << ":" << Lsn;
+    return RecordId.Print();
 }
 
 TString TEraseHint::DebugPrint(bool brief) const
@@ -169,11 +171,9 @@ TString TEraseHint::DebugPrint(bool brief) const
     return builder;
 }
 
-void TEraseHints::AddHint(THostIndex host, ui64 lsn)
+void TEraseHints::AddHint(THostIndex host, TRecordId recordId)
 {
-    Hints[host].Segments.emplace_back(
-        0,   // TODO(drbasic)
-        lsn);
+    Hints[host].Segments.emplace_back(recordId);
 }
 
 bool TEraseHints::Empty() const
@@ -336,7 +336,7 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
         DDiskStates[indx].SwitchOffline();
     }
 
-    TVector<ui64> erased;
+    TVector<TRecordId> erased;
     Inflight.Enumerate(
         [&](TInflightMap::TFindItem& item)
         {
@@ -349,30 +349,30 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
             return TInflightMap::EEnumerateContinuation::Continue;
         });
 
-    for (auto lsn: erased) {
-        Inflight.RemoveRange(lsn);
-        ReadyToErase.erase(lsn);
-        ReadyToFlush.erase(lsn);
+    for (auto recordId: erased) {
+        Inflight.RemoveRange(recordId);
+        ReadyToErase.erase(recordId);
+        ReadyToFlush.erase(recordId);
     }
 }
 
 void TBlocksDirtyMap::RestorePBuffer(
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     THostIndex host)
 {
     Y_ABORT_UNLESS(host < PBufferCounters.size());
 
-    if (auto item = Inflight.GetValue(lsn)) {
+    if (auto item = Inflight.GetValue(recordId)) {
         Y_ABORT_UNLESS(item->Range == range);
 
         auto& inflight = item->Value;
         inflight.RestorePBuffer(host);
     } else {
         Inflight.AddRange(
-            lsn,
+            recordId,
             range,
-            TInflightInfo(this, lsn, range.Size() * BlockSize, host));
+            TInflightInfo(this, recordId, range.Size() * BlockSize, host));
     }
 }
 
@@ -382,31 +382,56 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
 {
     TReadHint result;
     if (!Inflight.HasOverlaps(range)) {   // read from ddisk
-        result.RangeHints.push_back(MakeReadRangeHint({}, 0, range, 0));
+        result.RangeHints.push_back(MakeReadRangeHint({}, {}, range, 0));
         return result;
     }
 
+    struct TOverlappingRecord
+    {
+        TRecordId RecordId;
+        TBlockRange64 Range;
+        TReadSource ReadSource;
+    };
+
     bool shouldWaitQuorum = false;
-    TStackVec<TWeightedRange> ranges;
+    // The split helper weighs ranges with plain ui64 keys where the bigger key
+    // wins the overlap and 0 marks a hole. Collect the readable overlapping
+    // records, order them by record id (the lexicographic order matches real
+    // time across generations), and use dense 1-based positions as weights.
+    TStackVec<TOverlappingRecord> overlapping;
     Inflight.EnumerateOverlapping(
         range,
         [&](TInflightMap::TFindItem& item)
         {
-            const auto readMask = item.Value.ReadMask();
-            if (readMask.Empty()) {
+            const auto readSource = item.Value.ReadMask();
+            if (readSource.Empty()) {
                 shouldWaitQuorum = true;
                 result.WaitReady = item.Value.GetQuorumReadyFuture();
                 result.RangeHints.clear();
                 return TInflightMap::EEnumerateContinuation::Stop;
             }
 
-            if (!readMask.OnlyDDisk()) {
-                ranges.push_back({.Key = item.Key, .Range = item.Range});
+            if (!readSource.OnlyDDisk()) {
+                overlapping.push_back(
+                    {.RecordId = item.Key,
+                     .Range = item.Range,
+                     .ReadSource = readSource});
             }
             return TInflightMap::EEnumerateContinuation::Continue;
         });
     if (shouldWaitQuorum) {
         return result;
+    }
+
+    Sort(
+        overlapping,
+        [](const auto& lhs, const auto& rhs)
+        { return lhs.RecordId < rhs.RecordId; });
+
+    TStackVec<TWeightedRange> ranges;
+    ranges.reserve(overlapping.size());
+    for (size_t i = 0; i < overlapping.size(); ++i) {
+        ranges.push_back({.Key = i + 1, .Range = overlapping[i].Range});
     }
 
     auto nonOverlappingRanges =
@@ -415,24 +440,20 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
 
     ui64 offsetBlocks{};
     for (auto& nonOverlappingRange: nonOverlappingRanges) {
-        auto lsn = nonOverlappingRange.Key;
+        const ui64 weight = nonOverlappingRange.Key;
 
-        if (lsn == 0) {
+        if (weight == 0) {
             auto hint = MakeReadRangeHint(
                 {},
-                0,
+                {},
                 nonOverlappingRange.Range,
                 offsetBlocks);
             result.RangeHints.push_back(std::move(hint));
         } else {
-            auto item = Inflight.GetValue(lsn);
-            Y_ABORT_UNLESS(item);
-            const auto readMask = item->Value.ReadMask();
-            Y_DEBUG_ABORT_UNLESS(!readMask.Empty());
-
+            const auto& record = overlapping[weight - 1];
             auto hint = MakeReadRangeHint(
-                readMask.Mask,
-                lsn,
+                record.ReadSource.Mask,
+                record.RecordId,
                 nonOverlappingRange.Range,
                 offsetBlocks);
             result.RangeHints.push_back(std::move(hint));
@@ -458,17 +479,17 @@ TFlushHints TBlocksDirtyMap::MakeFlushHint(size_t batchSize)
         return result;
     }
 
-    TSet<ui64> readyToFlush;
+    TSet<TRecordId> readyToFlush;
     readyToFlush.swap(ReadyToFlush);
 
-    for (ui64 lsn: readyToFlush) {
-        auto item = Inflight.GetValue(lsn);
+    for (TRecordId recordId: readyToFlush) {
+        auto item = Inflight.GetValue(recordId);
         Y_ABORT_UNLESS(item);
         auto& val = item->Value;
 
         if (InflightDDiskReads.HasOverlaps(item->Range)) {
             // Can't flush to DDisk during reading from overlapped range.
-            ReadyToFlush.insert(lsn);
+            ReadyToFlush.insert(recordId);
             continue;
         }
 
@@ -496,11 +517,11 @@ TEraseHints TBlocksDirtyMap::MakeEraseHint(size_t batchSize)
         return result;
     }
 
-    TSet<ui64> readyToErase;
+    TSet<TRecordId> readyToErase;
     readyToErase.swap(ReadyToErase);
 
-    for (ui64 lsn: readyToErase) {
-        auto item = Inflight.GetValue(lsn);
+    for (TRecordId recordId: readyToErase) {
+        auto item = Inflight.GetValue(recordId);
         Y_ABORT_UNLESS(item);
 
         auto& val = item->Value;
@@ -534,36 +555,38 @@ TEraseHints TBlocksDirtyMap::MakeEraseBelatedHint()
     for (const auto& item: readyToEraseBelated) {
         auto hostMask = item.Hosts;
         for (auto host: hostMask) {
-            result.AddHint(host, item.Lsn);
+            result.AddHint(host, item.RecordId);
         }
     }
 
     return result;
 }
 
-void TBlocksDirtyMap::RegisterInflightWrite(ui64 lsn, TBlockRange64 range)
+void TBlocksDirtyMap::RegisterInflightWrite(
+    TRecordId recordId,
+    TBlockRange64 range)
 {
     const bool inserted = Inflight.AddRange(
-        lsn,
+        recordId,
         range,
-        TInflightInfo(this, lsn, range.Size() * BlockSize));
+        TInflightInfo(this, recordId, range.Size() * BlockSize));
     Y_ABORT_UNLESS(inserted);
 }
 
 void TBlocksDirtyMap::WriteFinished(
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     THostMask requested,
     THostMask confirmed)
 {
     // Every write is pre-registered as pending at generation time (see
     // RegisterInflightWrite), so the entry always exists here.
-    auto item = Inflight.GetValue(lsn);
+    auto item = Inflight.GetValue(recordId);
     Y_ABORT_UNLESS(item);
     Y_ABORT_UNLESS(item->Range == range);
 
     if (confirmed.Count() < QuorumDirectBlockGroupHostCount) {
-        const bool removed = Inflight.RemoveRange(lsn);
+        const bool removed = Inflight.RemoveRange(recordId);
         Y_ABORT_UNLESS(removed);
         return;
     }
@@ -573,8 +596,8 @@ void TBlocksDirtyMap::WriteFinished(
 
 void TBlocksDirtyMap::FlushFinished(
     THostRoute route,
-    const TVector<ui64>& flushOk,
-    const TVector<ui64>& flushFailed)
+    const TVector<TRecordId>& flushOk,
+    const TVector<TRecordId>& flushFailed)
 {
     if (DisabledHosts.Get(route.DestinationHostIndex)) {
         // No processing is required, all inflight operations have been updated
@@ -582,8 +605,8 @@ void TBlocksDirtyMap::FlushFinished(
         return;
     }
 
-    for (ui64 lsn: flushOk) {
-        auto item = Inflight.GetValue(lsn);
+    for (TRecordId recordId: flushOk) {
+        auto item = Inflight.GetValue(recordId);
         if (!item) {
             // The item was deleted when the host was disabled.
             continue;
@@ -593,8 +616,8 @@ void TBlocksDirtyMap::FlushFinished(
         inflight.ConfirmFlush(route.DestinationHostIndex);
     }
 
-    for (ui64 lsn: flushFailed) {
-        auto item = Inflight.GetValue(lsn);
+    for (TRecordId recordId: flushFailed) {
+        auto item = Inflight.GetValue(recordId);
         if (!item) {
             // The item was deleted when the host was disabled.
             continue;
@@ -607,11 +630,11 @@ void TBlocksDirtyMap::FlushFinished(
 
 void TBlocksDirtyMap::EraseFinished(
     THostIndex host,
-    const TVector<ui64>& eraseOk,
-    const TVector<ui64>& eraseFailed)
+    const TVector<TRecordId>& eraseOk,
+    const TVector<TRecordId>& eraseFailed)
 {
-    for (ui64 lsn: eraseOk) {
-        auto item = Inflight.GetValue(lsn);
+    for (TRecordId recordId: eraseOk) {
+        auto item = Inflight.GetValue(recordId);
         if (!item) {
             // The record already left the inflight map: deleted when the host
             // was disabled, or this is a belated ack (for example a duplicate
@@ -626,8 +649,8 @@ void TBlocksDirtyMap::EraseFinished(
         }
     }
 
-    for (ui64 lsn: eraseFailed) {
-        auto item = Inflight.GetValue(lsn);
+    for (TRecordId recordId: eraseFailed) {
+        auto item = Inflight.GetValue(recordId);
         if (!item) {
             // The record already left the inflight map: deleted when the host
             // was disabled, or this is a belated failure. Nothing to track
@@ -642,18 +665,18 @@ void TBlocksDirtyMap::EraseFinished(
 
 void TBlocksDirtyMap::UpdateBelatedEraseQueue(
     THostMask completedWrites,
-    ui64 lsn)
+    TRecordId recordId)
 {
-    const auto item = Inflight.GetValue(lsn);
-    const bool unknownLsn = item == std::nullopt;
+    const auto item = Inflight.GetValue(recordId);
+    const bool unknownRecord = item == std::nullopt;
     const bool erasingInProgress =
         item &&
         (item->Value.GetState() == TInflightInfo::EState::PBufferErasing ||
          item->Value.GetState() == TInflightInfo::EState::PBufferErased);
 
-    if (unknownLsn || erasingInProgress) {
+    if (unknownRecord || erasingInProgress) {
         ReadyToEraseBelated.emplace(
-            TInfoEraseBelated{.Lsn = lsn, .Hosts = completedWrites});
+            TInfoEraseBelated{.RecordId = recordId, .Hosts = completedWrites});
     }
 }
 
@@ -707,7 +730,7 @@ ui64 TBlocksDirtyMap::GetMinFlushPendingLsn() const
         return 0;
     }
     // TSet is ordered, so the first element is the minimum. O(1) access.
-    return *ReadyToFlush.begin();
+    return ReadyToFlush.begin()->Lsn;
 }
 
 ui64 TBlocksDirtyMap::GetMinErasePendingLsn() const
@@ -716,10 +739,10 @@ ui64 TBlocksDirtyMap::GetMinErasePendingLsn() const
         return 0;
     }
     // TSet is ordered, so the first element is the minimum. O(1) access.
-    return *ReadyToErase.begin();
+    return ReadyToErase.begin()->Lsn;
 }
 
-std::optional<ui64> TBlocksDirtyMap::GetSafeBarrierForErase() const
+std::optional<TRecordId> TBlocksDirtyMap::GetSafeBarrierForErase() const
 {
     return Inflight.GetMinKey();
 }
@@ -740,16 +763,16 @@ ui64 TBlocksDirtyMap::GetPBufferUsedSize(THostIndex host) const
     return PBufferCounters[host].CurrentBytesCount;
 }
 
-void TBlocksDirtyMap::LockPBuffer(ui64 lsn)
+void TBlocksDirtyMap::LockPBuffer(TRecordId recordId)
 {
-    auto item = Inflight.GetValue(lsn);
+    auto item = Inflight.GetValue(recordId);
     Y_ABORT_UNLESS(item.has_value());
     item->Value.LockPBuffer();
 }
 
-void TBlocksDirtyMap::UnlockPBuffer(ui64 lsn)
+void TBlocksDirtyMap::UnlockPBuffer(TRecordId recordId)
 {
-    auto item = Inflight.GetValue(lsn);
+    auto item = Inflight.GetValue(recordId);
     Y_ABORT_UNLESS(item.has_value());
     item->Value.UnlockPBuffer();
 }
@@ -783,38 +806,38 @@ void TBlocksDirtyMap::UnLockDDiskRange(TLockRangeHandle handle)
     InflightDDiskReads.RemoveRange(handle);
 }
 
-void TBlocksDirtyMap::Register(ui64 lsn, EQueueType queueType)
+void TBlocksDirtyMap::Register(TRecordId recordId, EQueueType queueType)
 {
     switch (queueType) {
         case IReadyQueue::EQueueType::Clone: {
-            ReadyToClone.insert(lsn);
+            ReadyToClone.insert(recordId);
 
-            ReadyToFlush.erase(lsn);
-            ReadyToErase.erase(lsn);
+            ReadyToFlush.erase(recordId);
+            ReadyToErase.erase(recordId);
             break;
         }
         case IReadyQueue::EQueueType::Flush: {
-            ReadyToFlush.insert(lsn);
+            ReadyToFlush.insert(recordId);
 
-            ReadyToClone.erase(lsn);
-            ReadyToErase.erase(lsn);
+            ReadyToClone.erase(recordId);
+            ReadyToErase.erase(recordId);
             break;
         }
         case IReadyQueue::EQueueType::Erase: {
-            ReadyToErase.insert(lsn);
+            ReadyToErase.insert(recordId);
 
-            ReadyToClone.erase(lsn);
-            ReadyToFlush.erase(lsn);
+            ReadyToClone.erase(recordId);
+            ReadyToFlush.erase(recordId);
             break;
         }
     }
 }
 
-void TBlocksDirtyMap::UnRegister(ui64 lsn)
+void TBlocksDirtyMap::UnRegister(TRecordId recordId)
 {
-    ReadyToErase.erase(lsn);
-    ReadyToClone.erase(lsn);
-    ReadyToFlush.erase(lsn);
+    ReadyToErase.erase(recordId);
+    ReadyToClone.erase(recordId);
+    ReadyToFlush.erase(recordId);
 }
 
 void TBlocksDirtyMap::DataToPBufferAdded(
@@ -886,7 +909,7 @@ TString TBlocksDirtyMap::DebugPrintPBuffers()
     Inflight.Enumerate(
         [&](TInflightMap::TFindItem& item)
         {
-            result << "  " << item.Key << item.Range.Print()
+            result << "  " << item.Key.Print() << item.Range.Print()
                    << item.Value.DebugPrint(now) << "\n";
             return TInflightMap::EEnumerateContinuation::Continue;
         });
@@ -939,8 +962,8 @@ TString TBlocksDirtyMap::DebugPrintDDiskState() const
 TString TBlocksDirtyMap::DebugPrintReadyToClone() const
 {
     TStringBuilder result;
-    for (auto lsn: ReadyToClone) {
-        result << ToString(lsn) << ";";
+    for (auto recordId: ReadyToClone) {
+        result << recordId.Print() << ";";
     }
     return result;
 }
@@ -948,8 +971,8 @@ TString TBlocksDirtyMap::DebugPrintReadyToClone() const
 TString TBlocksDirtyMap::DebugPrintReadyToFlush() const
 {
     TStringBuilder result;
-    for (auto lsn: ReadyToFlush) {
-        result << ToString(lsn) << ";";
+    for (auto recordId: ReadyToFlush) {
+        result << recordId.Print() << ";";
     }
     return result;
 }
@@ -957,8 +980,8 @@ TString TBlocksDirtyMap::DebugPrintReadyToFlush() const
 TString TBlocksDirtyMap::DebugPrintReadyToErase() const
 {
     TStringBuilder result;
-    for (auto lsn: ReadyToErase) {
-        result << ToString(lsn) << ";";
+    for (auto recordId: ReadyToErase) {
+        result << recordId.Print() << ";";
     }
     return result;
 }
@@ -991,13 +1014,13 @@ THostMask TBlocksDirtyMap::FilterLocations(
 
 TReadRangeHint TBlocksDirtyMap::MakeReadRangeHint(
     THostMask mask,
-    ui64 lsn,
+    TRecordId recordId,
     TBlockRange64 range,
     ui64 offsetBlocks)
 {
     if (mask.Empty()) {
         mask = FilterLocations(DesiredDDisks, range);
-    } else if (lsn == 0) {
+    } else if (recordId.Lsn == 0) {
         mask = mask.LogicalAnd(DesiredDDisks);
         mask = FilterLocations(mask, range);
     }
@@ -1012,10 +1035,11 @@ TReadRangeHint TBlocksDirtyMap::MakeReadRangeHint(
 
     return TReadRangeHint(
         mask,
-        lsn,
+        recordId,
         TBlockRange64::WithLength(offsetBlocks, range.Size()),
         range,
-        lsn == 0 ? TRangeLock(this, range, mask) : TRangeLock(this, lsn));
+        recordId.Lsn == 0 ? TRangeLock(this, range, mask)
+                          : TRangeLock(this, recordId));
 }
 
 bool TBlocksDirtyMap::TInfoEraseBelated::operator<(
@@ -1023,7 +1047,7 @@ bool TBlocksDirtyMap::TInfoEraseBelated::operator<(
 {
     auto makeTuple = [](const TInfoEraseBelated& info)
     {
-        return std::tie(info.Lsn, info.Hosts);
+        return std::tie(info.RecordId, info.Hosts);
     };
 
     return makeTuple(*this) < makeTuple(other);
@@ -1031,14 +1055,14 @@ bool TBlocksDirtyMap::TInfoEraseBelated::operator<(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<ui64> MakeLsnVector(std::span<const TPBufferSegment> segments)
+TVector<TRecordId> MakeRecordIds(std::span<const TPBufferSegment> segments)
 {
-    return DoMakeLsnVector<TPBufferSegment>(segments);
+    return DoMakeRecordIds(segments);
 }
 
-TVector<ui64> MakeLsnVector(std::span<const TEraseSegment> segments)
+TVector<TRecordId> MakeRecordIds(std::span<const TEraseSegment> segments)
 {
-    return DoMakeLsnVector<TEraseSegment>(segments);
+    return DoMakeRecordIds(segments);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -151,19 +151,10 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
         return result;
     }
 
-    struct TOverlappingRecord
-    {
-        TPBufferKey PBufferKey;
-        TBlockRange64 Range;
-        TReadSource ReadSource;
-    };
-
     bool shouldWaitQuorum = false;
-    // The split helper uses plain ui64 keys: the bigger key wins the overlap,
-    // 0 marks a hole. Collect the readable overlapping records, order them by
-    // record id (lexicographic order matches real time across generations),
-    // and use dense 1-based record indexes as those keys.
-    TStackVec<TOverlappingRecord> overlapping;
+    // Greatest TPBufferKey wins an overlap (lexicographic order matches real
+    // time). A default key is a hole and is read from DDisk.
+    TStackVec<TWeightedRange> ranges;
     Inflight.EnumerateOverlapping(
         range,
         [&](TInflightMap::TFindItem& item)
@@ -177,26 +168,12 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
             }
 
             if (!readSource.OnlyDDisk()) {
-                overlapping.push_back(
-                    {.PBufferKey = item.Key,
-                     .Range = item.Range,
-                     .ReadSource = readSource});
+                ranges.push_back({.Key = item.Key, .Range = item.Range});
             }
             return TInflightMap::EEnumerateContinuation::Continue;
         });
     if (shouldWaitQuorum) {
         return result;
-    }
-
-    Sort(
-        overlapping,
-        [](const auto& lhs, const auto& rhs)
-        { return lhs.PBufferKey < rhs.PBufferKey; });
-
-    TStackVec<TWeightedRange> ranges;
-    ranges.reserve(overlapping.size());
-    for (size_t i = 0; i < overlapping.size(); ++i) {
-        ranges.push_back({.Key = i + 1, .Range = overlapping[i].Range});
     }
 
     auto nonOverlappingRanges =
@@ -205,9 +182,7 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
 
     ui64 offsetBlocks{};
     for (auto& nonOverlappingRange: nonOverlappingRanges) {
-        const ui64 recordIndex = nonOverlappingRange.Key;
-
-        if (recordIndex == 0) {
+        if (nonOverlappingRange.Key == TPBufferKey{}) {
             auto hint = MakeReadRangeHint(
                 {},
                 {},
@@ -215,10 +190,14 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
                 offsetBlocks);
             result.RangeHints.push_back(std::move(hint));
         } else {
-            const auto& record = overlapping[recordIndex - 1];
+            auto item = Inflight.GetValue(nonOverlappingRange.Key);
+            Y_ABORT_UNLESS(item);
+            const auto readMask = item->Value.ReadMask();
+            Y_DEBUG_ABORT_UNLESS(!readMask.Empty());
+
             auto hint = MakeReadRangeHint(
-                record.ReadSource.Mask,
-                record.PBufferKey,
+                readMask.Mask,
+                nonOverlappingRange.Key,
                 nonOverlappingRange.Range,
                 offsetBlocks);
             result.RangeHints.push_back(std::move(hint));
@@ -811,7 +790,7 @@ TString TBlocksDirtyMap::DebugPrintPBuffers()
     Inflight.Enumerate(
         [&](TInflightMap::TFindItem& item)
         {
-            result << "  " << item.Key << item.Range.Print()
+            result << "  " << item.Key.Print() << item.Range.Print()
                    << item.Value.DebugPrint(now) << "\n";
             return TInflightMap::EEnumerateContinuation::Continue;
         });
@@ -865,7 +844,7 @@ TString TBlocksDirtyMap::DebugPrintReadyToClone() const
 {
     TStringBuilder result;
     for (auto pBufferKey: ReadyToClone) {
-        result << ToString(pBufferKey) << ";";
+        result << pBufferKey.Print() << ";";
     }
     return result;
 }
@@ -874,7 +853,7 @@ TString TBlocksDirtyMap::DebugPrintReadyToFlush() const
 {
     TStringBuilder result;
     for (auto pBufferKey: ReadyToFlush) {
-        result << ToString(pBufferKey) << ";";
+        result << pBufferKey.Print() << ";";
     }
     return result;
 }
@@ -883,7 +862,7 @@ TString TBlocksDirtyMap::DebugPrintReadyToErase() const
 {
     TStringBuilder result;
     for (auto pBufferKey: ReadyToErase) {
-        result << ToString(pBufferKey) << ";";
+        result << pBufferKey.Print() << ";";
     }
     return result;
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -8,6 +8,7 @@
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
+#include <util/generic/algorithm.h>
 #include <util/generic/map.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
@@ -94,7 +95,7 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
         }
     }
 
-    TVector<ui64> erased;
+    TVector<TPBufferKey> erased;
     Inflight.Enumerate(
         [&](TInflightMap::TFindItem& item)
         {
@@ -107,34 +108,34 @@ void TBlocksDirtyMap::UpdateConfig(const TVChunkConfig& vChunkConfig)
             return TInflightMap::EEnumerateContinuation::Continue;
         });
 
-    for (auto lsn: erased) {
-        Inflight.RemoveRange(lsn);
-        ReadyToErase.erase(lsn);
-        ReadyToFlush.erase(lsn);
+    for (auto pBufferKey: erased) {
+        Inflight.RemoveRange(pBufferKey);
+        ReadyToErase.erase(pBufferKey);
+        ReadyToFlush.erase(pBufferKey);
     }
 }
 
 void TBlocksDirtyMap::RestorePBuffer(
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     THostIndex host)
 {
     Y_ABORT_UNLESS(host < PBufferCounters.size());
 
-    if (auto item = Inflight.GetValue(lsn)) {
+    if (auto item = Inflight.GetValue(pBufferKey)) {
         Y_ABORT_UNLESS(item->Range == range);
 
         auto& inflight = item->Value;
         inflight.RestorePBuffer(host);
     } else {
         Inflight.AddRange(
-            lsn,
+            pBufferKey,
             range,
             TInflightInfo(
                 this,
                 DesiredDDisks,
                 DisabledHosts,
-                lsn,
+                pBufferKey,
                 range.Size() * BlockSize,
                 host));
     }
@@ -146,31 +147,56 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
 {
     TReadHint result;
     if (!Inflight.HasOverlaps(range)) {   // read from ddisk
-        result.RangeHints.push_back(MakeReadRangeHint({}, 0, range, 0));
+        result.RangeHints.push_back(MakeReadRangeHint({}, {}, range, 0));
         return result;
     }
 
+    struct TOverlappingRecord
+    {
+        TPBufferKey PBufferKey;
+        TBlockRange64 Range;
+        TReadSource ReadSource;
+    };
+
     bool shouldWaitQuorum = false;
-    TStackVec<TWeightedRange> ranges;
+    // The split helper uses plain ui64 keys: the bigger key wins the overlap,
+    // 0 marks a hole. Collect the readable overlapping records, order them by
+    // record id (lexicographic order matches real time across generations),
+    // and use dense 1-based record indexes as those keys.
+    TStackVec<TOverlappingRecord> overlapping;
     Inflight.EnumerateOverlapping(
         range,
         [&](TInflightMap::TFindItem& item)
         {
-            const auto readMask = item.Value.ReadMask();
-            if (readMask.Empty()) {
+            const auto readSource = item.Value.ReadMask();
+            if (readSource.Empty()) {
                 shouldWaitQuorum = true;
                 result.WaitReady = item.Value.GetQuorumReadyFuture();
                 result.RangeHints.clear();
                 return TInflightMap::EEnumerateContinuation::Stop;
             }
 
-            if (!readMask.OnlyDDisk()) {
-                ranges.push_back({.Key = item.Key, .Range = item.Range});
+            if (!readSource.OnlyDDisk()) {
+                overlapping.push_back(
+                    {.PBufferKey = item.Key,
+                     .Range = item.Range,
+                     .ReadSource = readSource});
             }
             return TInflightMap::EEnumerateContinuation::Continue;
         });
     if (shouldWaitQuorum) {
         return result;
+    }
+
+    Sort(
+        overlapping,
+        [](const auto& lhs, const auto& rhs)
+        { return lhs.PBufferKey < rhs.PBufferKey; });
+
+    TStackVec<TWeightedRange> ranges;
+    ranges.reserve(overlapping.size());
+    for (size_t i = 0; i < overlapping.size(); ++i) {
+        ranges.push_back({.Key = i + 1, .Range = overlapping[i].Range});
     }
 
     auto nonOverlappingRanges =
@@ -179,24 +205,20 @@ TReadHint TBlocksDirtyMap::MakeReadHint(TBlockRange64 range)
 
     ui64 offsetBlocks{};
     for (auto& nonOverlappingRange: nonOverlappingRanges) {
-        auto lsn = nonOverlappingRange.Key;
+        const ui64 recordIndex = nonOverlappingRange.Key;
 
-        if (lsn == 0) {
+        if (recordIndex == 0) {
             auto hint = MakeReadRangeHint(
                 {},
-                0,
+                {},
                 nonOverlappingRange.Range,
                 offsetBlocks);
             result.RangeHints.push_back(std::move(hint));
         } else {
-            auto item = Inflight.GetValue(lsn);
-            Y_ABORT_UNLESS(item);
-            const auto readMask = item->Value.ReadMask();
-            Y_DEBUG_ABORT_UNLESS(!readMask.Empty());
-
+            const auto& record = overlapping[recordIndex - 1];
             auto hint = MakeReadRangeHint(
-                readMask.Mask,
-                lsn,
+                record.ReadSource.Mask,
+                record.PBufferKey,
                 nonOverlappingRange.Range,
                 offsetBlocks);
             result.RangeHints.push_back(std::move(hint));
@@ -224,23 +246,23 @@ TFlushHints TBlocksDirtyMap::MakeFlushHint(size_t batchSize)
         return result;
     }
 
-    TSet<ui64> readyToFlush;
+    TSet<TPBufferKey> readyToFlush;
     readyToFlush.swap(ReadyToFlush);
 
-    for (ui64 lsn: readyToFlush) {
-        auto item = Inflight.GetValue(lsn);
+    for (TPBufferKey pBufferKey: readyToFlush) {
+        auto item = Inflight.GetValue(pBufferKey);
         Y_ABORT_UNLESS(item);
         auto& val = item->Value;
 
         if (InflightDDiskReads.HasOverlaps(item->Range)) {
             // Can't flush to DDisk during reading from overlapped range.
-            ReadyToFlush.insert(lsn);
+            ReadyToFlush.insert(pBufferKey);
             continue;
         }
 
         if (InflightDDiskSyncMap.HasOverlaps(item->Range)) {
             // Can't flush to DDisk during sync of overlapped range.
-            ReadyToFlush.insert(lsn);
+            ReadyToFlush.insert(pBufferKey);
             continue;
         }
 
@@ -263,17 +285,17 @@ TEraseHints TBlocksDirtyMap::MakeEraseHint(size_t batchSize)
         return result;
     }
 
-    TSet<ui64> readyToErase;
+    TSet<TPBufferKey> readyToErase;
     readyToErase.swap(ReadyToErase);
 
-    for (ui64 lsn: readyToErase) {
-        auto item = Inflight.GetValue(lsn);
+    for (TPBufferKey pBufferKey: readyToErase) {
+        auto item = Inflight.GetValue(pBufferKey);
         Y_ABORT_UNLESS(item);
 
         auto& val = item->Value;
 
         if (!CheckEraseAbility(item->Range, val)) {
-            ReadyToErase.insert(lsn);
+            ReadyToErase.insert(pBufferKey);
             continue;
         }
 
@@ -306,36 +328,38 @@ TEraseHints TBlocksDirtyMap::MakeEraseBelatedHint()
     for (const auto& item: readyToEraseBelated) {
         auto hostMask = item.Hosts;
         for (auto host: hostMask) {
-            result.AddHint(host, item.Lsn);
+            result.AddHint(host, item.PBufferKey);
         }
     }
 
     return result;
 }
 
-void TBlocksDirtyMap::RegisterInflightWrite(ui64 lsn, TBlockRange64 range)
+void TBlocksDirtyMap::RegisterInflightWrite(
+    TPBufferKey pBufferKey,
+    TBlockRange64 range)
 {
     const bool inserted = Inflight.AddRange(
-        lsn,
+        pBufferKey,
         range,
         TInflightInfo(
             this,
             DesiredDDisks,
             DisabledHosts,
-            lsn,
+            pBufferKey,
             range.Size() * BlockSize));
     Y_ABORT_UNLESS(inserted);
 }
 
 void TBlocksDirtyMap::WriteFinished(
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     THostMask requested,
     THostMask confirmed)
 {
     // Every write is pre-registered as pending at generation time (see
     // RegisterInflightWrite), so the entry always exists here.
-    auto item = Inflight.GetValue(lsn);
+    auto item = Inflight.GetValue(pBufferKey);
     Y_ABORT_UNLESS(item);
     Y_ABORT_UNLESS(item->Range == range);
 
@@ -346,7 +370,7 @@ void TBlocksDirtyMap::WriteFinished(
         // client with an error. The written PBuffers will be cleared through a
         // barrier garbage collection later. For now, we will forget about this
         // request as if it never existed.
-        const bool removed = Inflight.RemoveRange(lsn);
+        const bool removed = Inflight.RemoveRange(pBufferKey);
         Y_ABORT_UNLESS(removed);
         return;
     }
@@ -365,8 +389,8 @@ void TBlocksDirtyMap::WriteFinished(
 
 void TBlocksDirtyMap::FlushFinished(
     THostRoute route,
-    const TVector<ui64>& flushOk,
-    const TVector<ui64>& flushFailed)
+    const TVector<TPBufferKey>& flushOk,
+    const TVector<TPBufferKey>& flushFailed)
 {
     if (DisabledHosts.Get(route.DestinationHostIndex)) {
         // No processing is required, all inflight operations have been updated
@@ -374,8 +398,8 @@ void TBlocksDirtyMap::FlushFinished(
         return;
     }
 
-    for (ui64 lsn: flushOk) {
-        auto item = Inflight.GetValue(lsn);
+    for (TPBufferKey pBufferKey: flushOk) {
+        auto item = Inflight.GetValue(pBufferKey);
         if (!item) {
             // The item was deleted when the host was disabled.
             continue;
@@ -386,8 +410,8 @@ void TBlocksDirtyMap::FlushFinished(
         InflightFlushFinished(item->Range);
     }
 
-    for (ui64 lsn: flushFailed) {
-        auto item = Inflight.GetValue(lsn);
+    for (TPBufferKey pBufferKey: flushFailed) {
+        auto item = Inflight.GetValue(pBufferKey);
         if (!item) {
             // The item was deleted when the host was disabled.
             continue;
@@ -401,11 +425,11 @@ void TBlocksDirtyMap::FlushFinished(
 
 void TBlocksDirtyMap::EraseFinished(
     THostIndex host,
-    const TVector<ui64>& eraseOk,
-    const TVector<ui64>& eraseFailed)
+    const TVector<TPBufferKey>& eraseOk,
+    const TVector<TPBufferKey>& eraseFailed)
 {
-    for (ui64 lsn: eraseOk) {
-        auto item = Inflight.GetValue(lsn);
+    for (TPBufferKey pBufferKey: eraseOk) {
+        auto item = Inflight.GetValue(pBufferKey);
         if (!item) {
             // The record already left the inflight map: deleted when the host
             // was disabled, or this is a belated ack (for example a duplicate
@@ -420,8 +444,8 @@ void TBlocksDirtyMap::EraseFinished(
         }
     }
 
-    for (ui64 lsn: eraseFailed) {
-        auto item = Inflight.GetValue(lsn);
+    for (TPBufferKey pBufferKey: eraseFailed) {
+        auto item = Inflight.GetValue(pBufferKey);
         if (!item) {
             // The record already left the inflight map: deleted when the host
             // was disabled, or this is a belated failure. Nothing to track
@@ -436,9 +460,9 @@ void TBlocksDirtyMap::EraseFinished(
 
 void TBlocksDirtyMap::UpdateBelatedEraseQueue(
     THostMask completedWrites,
-    ui64 lsn)
+    TPBufferKey pBufferKey)
 {
-    const auto item = Inflight.GetValue(lsn);
+    const auto item = Inflight.GetValue(pBufferKey);
     const bool unknownLsn = item == std::nullopt;
     const bool erasingInProgress =
         item &&
@@ -446,8 +470,9 @@ void TBlocksDirtyMap::UpdateBelatedEraseQueue(
          item->Value.GetState() == TInflightInfo::EState::PBufferErased);
 
     if (unknownLsn || erasingInProgress) {
-        ReadyToEraseBelated.emplace(
-            TInfoEraseBelated{.Lsn = lsn, .Hosts = completedWrites});
+        ReadyToEraseBelated.emplace(TInfoEraseBelated{
+            .PBufferKey = pBufferKey,
+            .Hosts = completedWrites});
     }
 }
 
@@ -548,7 +573,7 @@ ui64 TBlocksDirtyMap::GetMinFlushPendingLsn() const
         return 0;
     }
     // TSet is ordered, so the first element is the minimum. O(1) access.
-    return *ReadyToFlush.begin();
+    return ReadyToFlush.begin()->Lsn;
 }
 
 ui64 TBlocksDirtyMap::GetMinErasePendingLsn() const
@@ -557,10 +582,10 @@ ui64 TBlocksDirtyMap::GetMinErasePendingLsn() const
         return 0;
     }
     // TSet is ordered, so the first element is the minimum. O(1) access.
-    return *ReadyToErase.begin();
+    return ReadyToErase.begin()->Lsn;
 }
 
-std::optional<ui64> TBlocksDirtyMap::GetSafeBarrierForErase() const
+std::optional<TPBufferKey> TBlocksDirtyMap::GetSafeBarrierForErase() const
 {
     return Inflight.GetMinKey();
 }
@@ -603,16 +628,16 @@ TCountAndSize TBlocksDirtyMap::GetBehindBlocks(THostIndex host) const
     return result;
 }
 
-void TBlocksDirtyMap::LockPBuffer(ui64 lsn)
+void TBlocksDirtyMap::LockPBuffer(TPBufferKey pBufferKey)
 {
-    auto item = Inflight.GetValue(lsn);
+    auto item = Inflight.GetValue(pBufferKey);
     Y_ABORT_UNLESS(item.has_value());
     item->Value.LockPBuffer();
 }
 
-void TBlocksDirtyMap::UnlockPBuffer(ui64 lsn)
+void TBlocksDirtyMap::UnlockPBuffer(TPBufferKey pBufferKey)
 {
-    auto item = Inflight.GetValue(lsn);
+    auto item = Inflight.GetValue(pBufferKey);
     Y_ABORT_UNLESS(item.has_value());
     item->Value.UnlockPBuffer();
 }
@@ -646,54 +671,54 @@ void TBlocksDirtyMap::UnLockDDiskRange(TLockRangeHandle handle)
     InflightDDiskReads.RemoveRange(handle);
 }
 
-void TBlocksDirtyMap::Register(ui64 lsn, EQueueType queueType)
+void TBlocksDirtyMap::Register(TPBufferKey pBufferKey, EQueueType queueType)
 {
     switch (queueType) {
         case IReadyQueue::EQueueType::Clone: {
-            ReadyToClone.insert(lsn);
+            ReadyToClone.insert(pBufferKey);
 
-            ReadyToFlush.erase(lsn);
-            ReadyToErase.erase(lsn);
+            ReadyToFlush.erase(pBufferKey);
+            ReadyToErase.erase(pBufferKey);
             break;
         }
         case IReadyQueue::EQueueType::Flush: {
-            ReadyToFlush.insert(lsn);
+            ReadyToFlush.insert(pBufferKey);
 
-            ReadyToClone.erase(lsn);
-            ReadyToErase.erase(lsn);
+            ReadyToClone.erase(pBufferKey);
+            ReadyToErase.erase(pBufferKey);
             break;
         }
         case IReadyQueue::EQueueType::Erase: {
-            ReadyToErase.insert(lsn);
+            ReadyToErase.insert(pBufferKey);
 
-            ReadyToClone.erase(lsn);
-            ReadyToFlush.erase(lsn);
+            ReadyToClone.erase(pBufferKey);
+            ReadyToFlush.erase(pBufferKey);
             break;
         }
     }
 }
 
-void TBlocksDirtyMap::UnRegister(ui64 lsn, EQueueType queueType)
+void TBlocksDirtyMap::UnRegister(TPBufferKey pBufferKey, EQueueType queueType)
 {
     switch (queueType) {
         case IReadyQueue::EQueueType::Clone: {
-            ReadyToClone.erase(lsn);
+            ReadyToClone.erase(pBufferKey);
             break;
         }
         case IReadyQueue::EQueueType::Flush: {
-            ReadyToFlush.erase(lsn);
+            ReadyToFlush.erase(pBufferKey);
             break;
         }
         case IReadyQueue::EQueueType::Erase: {
-            ReadyToErase.erase(lsn);
+            ReadyToErase.erase(pBufferKey);
             break;
         }
     }
 }
 
-void TBlocksDirtyMap::FlushCompleted(ui64 lsn, THostMask ddisks)
+void TBlocksDirtyMap::FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks)
 {
-    AddToAheadAndBehindOnFlushCompleted(lsn, ddisks);
+    AddToAheadAndBehindOnFlushCompleted(pBufferKey, ddisks);
 }
 
 void TBlocksDirtyMap::DataToPBufferAdded(
@@ -839,8 +864,8 @@ TString TBlocksDirtyMap::DebugPrintDDiskState() const
 TString TBlocksDirtyMap::DebugPrintReadyToClone() const
 {
     TStringBuilder result;
-    for (auto lsn: ReadyToClone) {
-        result << ToString(lsn) << ";";
+    for (auto pBufferKey: ReadyToClone) {
+        result << ToString(pBufferKey) << ";";
     }
     return result;
 }
@@ -848,8 +873,8 @@ TString TBlocksDirtyMap::DebugPrintReadyToClone() const
 TString TBlocksDirtyMap::DebugPrintReadyToFlush() const
 {
     TStringBuilder result;
-    for (auto lsn: ReadyToFlush) {
-        result << ToString(lsn) << ";";
+    for (auto pBufferKey: ReadyToFlush) {
+        result << ToString(pBufferKey) << ";";
     }
     return result;
 }
@@ -857,8 +882,8 @@ TString TBlocksDirtyMap::DebugPrintReadyToFlush() const
 TString TBlocksDirtyMap::DebugPrintReadyToErase() const
 {
     TStringBuilder result;
-    for (auto lsn: ReadyToErase) {
-        result << ToString(lsn) << ";";
+    for (auto pBufferKey: ReadyToErase) {
+        result << ToString(pBufferKey) << ";";
     }
     return result;
 }
@@ -946,13 +971,13 @@ THostMask TBlocksDirtyMap::FilterLocations(
 
 TReadRangeHint TBlocksDirtyMap::MakeReadRangeHint(
     THostMask mask,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range,
     ui64 offsetBlocks)
 {
     if (mask.Empty()) {
         mask = FilterLocations(DesiredDDisks, range);
-    } else if (lsn == 0) {
+    } else if (pBufferKey.Lsn == 0) {
         mask = mask.LogicalAnd(DesiredDDisks);
         mask = FilterLocations(mask, range);
     }
@@ -967,15 +992,15 @@ TReadRangeHint TBlocksDirtyMap::MakeReadRangeHint(
 
     return TReadRangeHint(
         mask,
-        lsn,
+        pBufferKey,
         TBlockRange64::WithLength(offsetBlocks, range.Size()),
         range,
-        lsn == 0 ? TRangeLock(weak_from_this(), range, mask)
-                 : TRangeLock(weak_from_this(), lsn));
+        pBufferKey.Lsn == 0 ? TRangeLock(weak_from_this(), range, mask)
+                            : TRangeLock(weak_from_this(), pBufferKey));
 }
 
 void TBlocksDirtyMap::AddToAheadAndBehindOnFlushCompleted(
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     THostMask ddisks)
 {
     // Check that one of the ddisks is lagging or aheading, in this case it
@@ -988,7 +1013,7 @@ void TBlocksDirtyMap::AddToAheadAndBehindOnFlushCompleted(
         return;
     }
 
-    auto inflight = Inflight.GetValue(lsn);
+    auto inflight = Inflight.GetValue(pBufferKey);
     Y_ABORT_UNLESS(inflight);
     const auto state = inflight->Value.GetState();
     Y_ABORT_UNLESS(
@@ -1083,7 +1108,7 @@ bool TBlocksDirtyMap::TInfoEraseBelated::operator<(
 {
     auto makeTuple = [](const TInfoEraseBelated& info)
     {
-        return std::tie(info.Lsn, info.Hosts);
+        return std::tie(info.PBufferKey, info.Hosts);
     };
 
     return makeTuple(*this) < makeTuple(other);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -4,6 +4,7 @@
 #include "range_locker.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range_map.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
 #include <library/cpp/threading/future/core/future.h>
@@ -25,7 +26,7 @@ struct TReadRangeHint
 {
     TReadRangeHint(
         THostMask hostMask,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 requestRelativeRange,
         TBlockRange64 vchunkRange,
         TRangeLock&& lock);
@@ -34,10 +35,11 @@ struct TReadRangeHint
     TReadRangeHint& operator=(TReadRangeHint&& other) noexcept;
 
     THostMask HostMask;
-    // 0 -> read from DDisk (HostMask is the DDisk hosts to choose from).
-    // >0 -> read from a PBuffer that holds the inflight write at this lsn
+    // RecordId.Lsn == 0 -> read from DDisk (HostMask is the DDisk hosts to
+    // choose from).
+    // RecordId.Lsn > 0 -> read from a PBuffer that holds this inflight record
     // (HostMask is the PBuffer hosts that confirmed the write).
-    ui64 Lsn = 0;
+    TRecordId RecordId;
 
     // Range relative to the request.
     TBlockRange64 RequestRelativeRange;
@@ -65,10 +67,10 @@ struct TReadHint
 
 struct TPBufferSegment
 {
-    ui64 Lsn = 0;
+    TRecordId RecordId;
     TBlockRange64 Range;
 
-    static TVector<ui64> MakeLsnVector(
+    static TVector<TRecordId> MakeRecordIds(
         std::span<const TPBufferSegment> segments);
 
     [[nodiscard]] TString DebugPrint(bool brief) const;
@@ -89,7 +91,7 @@ public:
     void AddHint(
         THostIndex source,
         THostIndex destination,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range);
 
     [[nodiscard]] bool Empty() const;
@@ -106,8 +108,7 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 struct TEraseSegment
 {
-    ui32 Generation = 0;
-    ui64 Lsn = 0;
+    TRecordId RecordId;
 
     [[nodiscard]] TString DebugPrint(bool brief) const;
 };
@@ -126,7 +127,7 @@ class TEraseHints
 public:
     using THints = TMap<THostIndex, TEraseHint>;
 
-    void AddHint(THostIndex host, ui64 lsn);
+    void AddHint(THostIndex host, TRecordId recordId);
 
     [[nodiscard]] bool Empty() const;
 
@@ -233,7 +234,8 @@ public:
     // Note. Fresh watermarks are not applying for exists DDisks.
     void UpdateConfig(const TVChunkConfig& vChunkConfig);
 
-    void RestorePBuffer(ui64 lsn, TBlockRange64 range, THostIndex host);
+    void
+    RestorePBuffer(TRecordId recordId, TBlockRange64 range, THostIndex host);
 
     // MakeReadHint can work with multiple locations and returns multiple
     // RangeHints
@@ -242,25 +244,26 @@ public:
     [[nodiscard]] TEraseHints MakeEraseHint(size_t batchSize);
     [[nodiscard]] TEraseHints MakeEraseBelatedHint();
 
-    // Registers a write as pending (lsn generated, data not in any PBuffer
-    // yet) so that the cleanup bound covers it from the moment of generation.
-    void RegisterInflightWrite(ui64 lsn, TBlockRange64 range);
+    // Registers a write as pending (the record id is issued, data not in any
+    // PBuffer yet) so that the cleanup bound covers it from the moment it is
+    // issued.
+    void RegisterInflightWrite(TRecordId recordId, TBlockRange64 range);
 
     void WriteFinished(
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         THostMask requested,
         THostMask confirmed);
     void FlushFinished(
         THostRoute route,
-        const TVector<ui64>& flushOk,
-        const TVector<ui64>& flushFailed);
+        const TVector<TRecordId>& flushOk,
+        const TVector<TRecordId>& flushFailed);
     void EraseFinished(
         THostIndex host,
-        const TVector<ui64>& eraseOk,
-        const TVector<ui64>& eraseFailed);
+        const TVector<TRecordId>& eraseOk,
+        const TVector<TRecordId>& eraseFailed);
 
-    void UpdateBelatedEraseQueue(THostMask completedWrites, ui64 lsn);
+    void UpdateBelatedEraseQueue(THostMask completedWrites, TRecordId recordId);
 
     // Sets a mark on the ddisk to which offset it contains data and can be read
     // from it.
@@ -280,22 +283,22 @@ public:
     [[nodiscard]] size_t GetEraseBelatedCount() const;
     [[nodiscard]] ui64 GetMinFlushPendingLsn() const;
     [[nodiscard]] ui64 GetMinErasePendingLsn() const;
-    [[nodiscard]] std::optional<ui64> GetSafeBarrierForErase() const;
+    [[nodiscard]] std::optional<TRecordId> GetSafeBarrierForErase() const;
     [[nodiscard]] const TPBufferCounters& GetPBufferCounters(
         THostIndex host) const;
     [[nodiscard]] ui64 GetPBufferUsedSize(THostIndex host) const;
 
     // ILockableRanges implementation
-    void LockPBuffer(ui64 lsn) override;
-    void UnlockPBuffer(ui64 lsn) override;
+    void LockPBuffer(TRecordId recordId) override;
+    void UnlockPBuffer(TRecordId recordId) override;
     TLockRangeHandle LockDDiskRange(
         TBlockRange64 range,
         THostMask mask) override;
     void UnLockDDiskRange(TLockRangeHandle handle) override;
 
     // IReadyQueue implementation
-    void Register(ui64 lsn, EQueueType queueType) override;
-    void UnRegister(ui64 lsn) override;
+    void Register(TRecordId recordId, EQueueType queueType) override;
+    void UnRegister(TRecordId recordId) override;
     void DataToPBufferAdded(
         THostIndex host,
         EPBufferCounter counter,
@@ -318,13 +321,13 @@ public:
     [[nodiscard]] TString DebugPrintReadyToErase() const;
 
 private:
-    using TInflightMap = TBlockRangeMap<ui64, TInflightInfo>;
+    using TInflightMap = TBlockRangeMap<TRecordId, TInflightInfo>;
     using TInflightDDiskReadsMap =
         TBlockRangeMap<ILockableRanges::TLockRangeHandle, THostMask>;
 
     struct TInfoEraseBelated
     {
-        ui64 Lsn{};
+        TRecordId RecordId;
         THostMask Hosts;
 
         bool operator<(const TInfoEraseBelated& other) const;
@@ -339,7 +342,7 @@ private:
     // Create single readRangeHint for specified parameters
     [[nodiscard]] TReadRangeHint MakeReadRangeHint(
         THostMask mask,
-        ui64 lsn,
+        TRecordId recordId,
         TBlockRange64 range,
         ui64 offsetBlocks);
 
@@ -354,15 +357,15 @@ private:
 
     // Ranges that need to be copied to other PBuffers in order to reach a
     // quorum.
-    THashSet<ui64> ReadyToClone;
+    THashSet<TRecordId> ReadyToClone;
 
     // Ranges that are written PBuffers with quorum and ready to be flushed to
-    // DDisk. Using TSet for O(1) min LSN access.
-    TSet<ui64> ReadyToFlush;
+    // DDisk. Using TSet for O(1) min record access.
+    TSet<TRecordId> ReadyToFlush;
 
     // Ranges that are fully transferred to DDisk and can be erased.
-    // Using TSet for O(1) min LSN access.
-    TSet<ui64> ReadyToErase;
+    // Using TSet for O(1) min record access.
+    TSet<TRecordId> ReadyToErase;
 
     TSet<TInfoEraseBelated> ReadyToEraseBelated;
 
@@ -379,8 +382,8 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<ui64> MakeLsnVector(std::span<const TPBufferSegment> segments);
-TVector<ui64> MakeLsnVector(std::span<const TEraseSegment> segments);
+TVector<TRecordId> MakeRecordIds(std::span<const TPBufferSegment> segments);
+TVector<TRecordId> MakeRecordIds(std::span<const TEraseSegment> segments);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h
@@ -67,7 +67,10 @@ public:
     // Note. Fresh watermarks are not applying for exists DDisks.
     void UpdateConfig(const TVChunkConfig& vChunkConfig);
 
-    void RestorePBuffer(ui64 lsn, TBlockRange64 range, THostIndex host);
+    void RestorePBuffer(
+        TPBufferKey pBufferKey,
+        TBlockRange64 range,
+        THostIndex host);
 
     // MakeReadHint can work with multiple locations and returns multiple
     // RangeHints
@@ -78,23 +81,25 @@ public:
 
     // Registers a write as pending (lsn generated, data not in any PBuffer
     // yet) so that the cleanup bound covers it from the moment of generation.
-    void RegisterInflightWrite(ui64 lsn, TBlockRange64 range);
+    void RegisterInflightWrite(TPBufferKey pBufferKey, TBlockRange64 range);
 
     void WriteFinished(
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         THostMask requested,
         THostMask confirmed);
     void FlushFinished(
         THostRoute route,
-        const TVector<ui64>& flushOk,
-        const TVector<ui64>& flushFailed);
+        const TVector<TPBufferKey>& flushOk,
+        const TVector<TPBufferKey>& flushFailed);
     void EraseFinished(
         THostIndex host,
-        const TVector<ui64>& eraseOk,
-        const TVector<ui64>& eraseFailed);
+        const TVector<TPBufferKey>& eraseOk,
+        const TVector<TPBufferKey>& eraseFailed);
 
-    void UpdateBelatedEraseQueue(THostMask completedWrites, ui64 lsn);
+    void UpdateBelatedEraseQueue(
+        THostMask completedWrites,
+        TPBufferKey pBufferKey);
 
     // Sets the mark up to which the disk can be read.
     void UpdateWatermarkDebugOnly(THostIndex host, ui64 bytesOffset);
@@ -118,7 +123,7 @@ public:
     [[nodiscard]] size_t GetEraseBelatedCount() const;
     [[nodiscard]] ui64 GetMinFlushPendingLsn() const;
     [[nodiscard]] ui64 GetMinErasePendingLsn() const;
-    [[nodiscard]] std::optional<ui64> GetSafeBarrierForErase() const;
+    [[nodiscard]] std::optional<TPBufferKey> GetSafeBarrierForErase() const;
     [[nodiscard]] const TPBufferCounters& GetPBufferCounters(
         THostIndex host) const;
     [[nodiscard]] TCountAndSize GetPBuffersUsage(THostIndex host) const;
@@ -126,17 +131,17 @@ public:
     [[nodiscard]] TCountAndSize GetBehindBlocks(THostIndex host) const;
 
     // ILockableRanges implementation
-    void LockPBuffer(ui64 lsn) override;
-    void UnlockPBuffer(ui64 lsn) override;
+    void LockPBuffer(TPBufferKey pBufferKey) override;
+    void UnlockPBuffer(TPBufferKey pBufferKey) override;
     TLockRangeHandle LockDDiskRange(
         TBlockRange64 range,
         THostMask mask) override;
     void UnLockDDiskRange(TLockRangeHandle handle) override;
 
     // IReadyQueue implementation
-    void Register(ui64 lsn, EQueueType queueType) override;
-    void UnRegister(ui64 lsn, EQueueType queueType) override;
-    void FlushCompleted(ui64 lsn, THostMask ddisks) override;
+    void Register(TPBufferKey pBufferKey, EQueueType queueType) override;
+    void UnRegister(TPBufferKey pBufferKey, EQueueType queueType) override;
+    void FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks) override;
     void DataToPBufferAdded(
         THostIndex host,
         EPBufferCounter counter,
@@ -172,13 +177,13 @@ public:
     [[nodiscard]] TString DebugPrintInflightSync();
 
 private:
-    using TInflightMap = TBlockRangeMap<ui64, TInflightInfo>;
+    using TInflightMap = TBlockRangeMap<TPBufferKey, TInflightInfo>;
     using TInflightDDiskReadsMap =
         TBlockRangeMap<ILockableRanges::TLockRangeHandle, THostMask>;
 
     struct TInfoEraseBelated
     {
-        ui64 Lsn{};
+        TPBufferKey PBufferKey;
         THostMask Hosts;
 
         bool operator<(const TInfoEraseBelated& other) const;
@@ -202,11 +207,13 @@ private:
     // Create single readRangeHint for specified parameters
     [[nodiscard]] TReadRangeHint MakeReadRangeHint(
         THostMask mask,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range,
         ui64 offsetBlocks);
 
-    void AddToAheadAndBehindOnFlushCompleted(ui64 lsn, THostMask ddisks);
+    void AddToAheadAndBehindOnFlushCompleted(
+        TPBufferKey pBufferKey,
+        THostMask ddisks);
 
     [[nodiscard]] bool HasInflightFlush(THostIndex host, TBlockRange64 range);
     void InflightFlushFinished(TBlockRange64 range);
@@ -226,15 +233,15 @@ private:
 
     // Ranges that need to be copied to other PBuffers in order to reach a
     // quorum.
-    THashSet<ui64> ReadyToClone;
+    THashSet<TPBufferKey> ReadyToClone;
 
     // Ranges that are written PBuffers with quorum and ready to be flushed to
     // DDisk. Using TSet for O(1) min LSN access.
-    TSet<ui64> ReadyToFlush;
+    TSet<TPBufferKey> ReadyToFlush;
 
     // Ranges that are fully transferred to DDisk and can be erased.
     // Using TSet for O(1) min LSN access.
-    TSet<ui64> ReadyToErase;
+    TSet<TPBufferKey> ReadyToErase;
 
     TSet<TInfoEraseBelated> ReadyToEraseBelated;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -1,5 +1,7 @@
 #include "dirty_map.h"
 
+#include "record_id_test_helpers.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
@@ -339,9 +341,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -351,7 +355,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2][10..19][0..9]};",
+            "1:123{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Disable host 0.
@@ -362,7 +366,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // WriteConfirmed mask is {0,1,2}; host 0 is disabled, so it is
         // excluded from the read mask.
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H1,H2][10..19][0..9]};",
+            "1:123{[H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Counters on primary PBuffers contain one record with 40960 bytes
@@ -388,16 +392,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(124, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(124),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            124,
+            MakeId(124),
             TBlockRange64::WithLength(10, 10),
             MakeHostMask(true, true, false, true, false),
             MakeHostMask(true, true, false, true, false));
@@ -406,7 +414,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "124{[H0,H1,H3][10..19][0..9]};",
+            "1:124{[H0,H1,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Disable host 0
@@ -415,7 +423,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         readHint = dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "124{[H1,H3][10..19][0..9]};",
+            "1:124{[H1,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
         readHint.RangeHints[0].Lock.Arm();
@@ -465,9 +473,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Flush commands should be generated after completing the required
         // number of write operations.
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -478,9 +488,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         flushHint = dirtyMap.MakeFlushHint(2);
         UNIT_ASSERT_EQUAL(true, flushHint.Empty());
 
-        dirtyMap.RegisterInflightWrite(124, TBlockRange64::WithLength(20, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(124),
+            TBlockRange64::WithLength(20, 10));
         dirtyMap.WriteFinished(
-            124,
+            MakeId(124),
             TBlockRange64::WithLength(20, 10),
             requested,
             confirmed);
@@ -490,9 +502,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         flushHint = dirtyMap.MakeFlushHint(2);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19],124[20..29];"
-            "H1->H1:123[10..19],124[20..29];"
-            "H2->H2:123[10..19],124[20..29];",
+            "H0->H0:1:123[10..19],1:124[20..29];"
+            "H1->H1:1:123[10..19],1:124[20..29];"
+            "H2->H2:1:123[10..19],1:124[20..29];",
             flushHint.DebugPrint());
         // Erase hints should be generated after completing flushing.
         auto eraseHints = dirtyMap.MakeEraseHint(2);
@@ -507,36 +519,36 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // After getting flushing errors, we should get flush hints again
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123, 124},
+            {MakeId(123), MakeId(124)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
-            {123, 124},
+            {MakeId(123), MakeId(124)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
             {},
-            {123, 124});
+            {MakeId(123), MakeId(124)});
 
         flushHint = dirtyMap.MakeFlushHint(2);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
         UNIT_ASSERT_VALUES_EQUAL(
-            "H2->H2:123[10..19],124[20..29];",
+            "H2->H2:1:123[10..19],1:124[20..29];",
             flushHint.DebugPrint());
 
         // Complete flushing to third ddisk
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123, 124},
+            {MakeId(123), MakeId(124)},
             {});
 
         // Erase hints should be generated after completing the required
         // number of write operations.
         eraseHints = dirtyMap.MakeEraseHint(2);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123,0:124;"
-            "H1:0:123,0:124;"
-            "H2:0:123,0:124;",
+            "H0:1:123,1:124;"
+            "H1:1:123,1:124;"
+            "H2:1:123,1:124;",
             eraseHints.DebugPrint());
 
         // After getting erase hints, we should not get it once again
@@ -546,18 +558,18 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         }
 
         // After getting erasing errors, we should get erase hints again
-        dirtyMap.EraseFinished(THostIndex{0}, {123, 124}, {});
-        dirtyMap.EraseFinished(THostIndex{1}, {123, 124}, {});
-        dirtyMap.EraseFinished(THostIndex{2}, {}, {123, 124});
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(123), MakeId(124)}, {});
+        dirtyMap.EraseFinished(THostIndex{1}, {MakeId(123), MakeId(124)}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {}, {MakeId(123), MakeId(124)});
 
         eraseHints = dirtyMap.MakeEraseHint(2);
-        UNIT_ASSERT_VALUES_EQUAL("H2:0:123,0:124;", eraseHints.DebugPrint());
+        UNIT_ASSERT_VALUES_EQUAL("H2:1:123,1:124;", eraseHints.DebugPrint());
 
         // Should still have two inflight items
         UNIT_ASSERT_VALUES_EQUAL(2, dirtyMap.GetInflightCount());
 
         // Complete erasing from third pbuffer
-        dirtyMap.EraseFinished(THostIndex{2}, {123, 124}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(123), MakeId(124)}, {});
         eraseHints = dirtyMap.MakeEraseHint(2);
         UNIT_ASSERT_EQUAL(true, eraseHints.Empty());
 
@@ -592,53 +604,53 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // A write counts towards the barrier from the moment it is registered
         // (pending), before any PBuffer acknowledges it.
-        dirtyMap.RegisterInflightWrite(123, range1);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.RegisterInflightWrite(MakeId(123), range1);
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // The barrier tracks the minimum inflight lsn.
-        dirtyMap.RegisterInflightWrite(124, range2);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.RegisterInflightWrite(MakeId(124), range2);
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // The lsn stays inflight through the written and flushed states, so the
         // barrier does not advance past a not-yet-erased write.
-        dirtyMap.WriteFinished(123, range1, requested, confirmed);
-        dirtyMap.WriteFinished(124, range2, requested, confirmed);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.WriteFinished(MakeId(123), range1, requested, confirmed);
+        dirtyMap.WriteFinished(MakeId(124), range2, requested, confirmed);
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         auto flushHint = dirtyMap.MakeFlushHint(2);
         UNIT_ASSERT(!flushHint.Empty());
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123, 124},
+            {MakeId(123), MakeId(124)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
-            {123, 124},
+            {MakeId(123), MakeId(124)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123, 124},
+            {MakeId(123), MakeId(124)},
             {});
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // Erasing lsn 123 from only a sub-quorum of hosts keeps it inflight, so
         // the barrier is still held at 123.
         auto eraseHint = dirtyMap.MakeEraseHint(2);
         UNIT_ASSERT(!eraseHint.Empty());
-        dirtyMap.EraseFinished(THostIndex{0}, {123}, {});
-        dirtyMap.EraseFinished(THostIndex{1}, {123}, {});
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(123)}, {});
+        dirtyMap.EraseFinished(THostIndex{1}, {MakeId(123)}, {});
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // Once 123 is erased everywhere it leaves the inflight map and the
         // barrier advances to 124.
-        dirtyMap.EraseFinished(THostIndex{2}, {123}, {});
-        UNIT_ASSERT_VALUES_EQUAL(124, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(123)}, {});
+        UNIT_ASSERT_VALUES_EQUAL(124, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // Erasing 124 everywhere drains the map -> no barrier.
-        dirtyMap.EraseFinished(THostIndex{0}, {124}, {});
-        dirtyMap.EraseFinished(THostIndex{1}, {124}, {});
-        dirtyMap.EraseFinished(THostIndex{2}, {124}, {});
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(124)}, {});
+        dirtyMap.EraseFinished(THostIndex{1}, {MakeId(124)}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(124)}, {});
         UNIT_ASSERT(!dirtyMap.GetSafeBarrierForErase().has_value());
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
     }
@@ -654,13 +666,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const auto range = TBlockRange64::WithLength(10, 10);
 
         // A registered (pending) write holds the barrier.
-        dirtyMap.RegisterInflightWrite(123, range);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.RegisterInflightWrite(MakeId(123), range);
+        UNIT_ASSERT_VALUES_EQUAL(123, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // A write that fails to reach a quorum of PBuffers drops its pending
         // entry and stops holding the barrier.
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             range,
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));   // 2 < quorum 3
@@ -682,27 +694,30 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         const auto range = TBlockRange64::WithLength(10, 10);
-        dirtyMap.RegisterInflightWrite(100, range);
-        dirtyMap
-            .WriteFinished(100, range, MakePrimaryHosts(), MakePrimaryHosts());
+        dirtyMap.RegisterInflightWrite(MakeId(100), range);
+        dirtyMap.WriteFinished(
+            MakeId(100),
+            range,
+            MakePrimaryHosts(),
+            MakePrimaryHosts());
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT(!flushHint.Empty());
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT(!eraseHints.Empty());
-        dirtyMap.EraseFinished(THostIndex{0}, {100}, {});
-        dirtyMap.EraseFinished(THostIndex{1}, {100}, {});
-        dirtyMap.EraseFinished(THostIndex{2}, {100}, {});
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(100)}, {});
+        dirtyMap.EraseFinished(THostIndex{1}, {MakeId(100)}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(100)}, {});
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
 
         // A late success and a late failure for the forgotten lsn: the
         // record is long gone, both must be no-ops.
-        dirtyMap.EraseFinished(THostIndex{2}, {100}, {});
-        dirtyMap.EraseFinished(THostIndex{2}, {}, {100});
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(100)}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {}, {MakeId(100)});
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
     }
 
@@ -719,23 +734,26 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         const auto range = TBlockRange64::WithLength(10, 10);
-        dirtyMap.RegisterInflightWrite(100, range);
-        dirtyMap
-            .WriteFinished(100, range, MakePrimaryHosts(), MakePrimaryHosts());
+        dirtyMap.RegisterInflightWrite(MakeId(100), range);
+        dirtyMap.WriteFinished(
+            MakeId(100),
+            range,
+            MakePrimaryHosts(),
+            MakePrimaryHosts());
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT(!flushHint.Empty());
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT(!eraseHints.Empty());
-        dirtyMap.EraseFinished(THostIndex{0}, {100}, {});
-        dirtyMap.EraseFinished(THostIndex{1}, {100}, {});
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(100)}, {});
+        dirtyMap.EraseFinished(THostIndex{1}, {MakeId(100)}, {});
         // The erase on host 2 does not complete in time: the request is
         // marked failed and re-queued.
-        dirtyMap.EraseFinished(THostIndex{2}, {}, {100});
+        dirtyMap.EraseFinished(THostIndex{2}, {}, {MakeId(100)});
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap.GetInflightCount());
 
         // The host gets disabled; the re-queued erase is confirmed on its
@@ -747,7 +765,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
 
         // The genuine response from the disabled host finally arrives.
-        dirtyMap.EraseFinished(THostIndex{2}, {100}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(100)}, {});
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
     }
 
@@ -776,37 +794,39 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(false, true, true, true, false);
         const THostMask confirmed = requested;
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H0:123[10..19];"   // Cross-node
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];"
-            "H3->H3:123[10..19];",
+            "H1->H0:1:123[10..19];"   // Cross-node
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];"
+            "H3->H3:1:123[10..19];",
             flushHint.DebugPrint());
 
         // Finish flushes
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         // Erase hints
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;"
-            "H3:0:123;",
+            "H1:1:123;"
+            "H2:1:123;"
+            "H3:1:123;",
             eraseHints.DebugPrint());
 
         // Finish erasing
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
     }
 
@@ -831,36 +851,38 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(false, true, true, true, false);
         const THostMask confirmed = requested;
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];"
-            "H3->H3:123[10..19];",
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];"
+            "H3->H3:1:123[10..19];",
             flushHint.DebugPrint());
 
         // Finish flushes
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         // Erase hints
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;"
-            "H3:0:123;",
+            "H1:1:123;"
+            "H2:1:123;"
+            "H3:1:123;",
             eraseHints.DebugPrint());
 
         // Finish erasing
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
     }
 
@@ -894,36 +916,38 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(false, false, true, true, true);
         const THostMask confirmed = requested;
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H2->H2:123[10..19];"
-            "H3->H3:123[10..19];"
-            "H4->H4:123[10..19];",
+            "H2->H2:1:123[10..19];"
+            "H3->H3:1:123[10..19];"
+            "H4->H4:1:123[10..19];",
             flushHint.DebugPrint());
 
         // Finish flushes
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         // Erase hints
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H2:0:123;"
-            "H3:0:123;"
-            "H4:0:123;",
+            "H2:1:123;"
+            "H3:1:123;"
+            "H4:1:123;",
             eraseHints.DebugPrint());
 
         // Finish erasing
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
     }
 
@@ -952,35 +976,37 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(true, true, true, false, false);
         const THostMask confirmed = requested;
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H1:123[10..19];"
-            "H1->H3:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H1->H1:1:123[10..19];"
+            "H1->H3:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
 
         // Finish flushes
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         // Erase hints
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;",
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
 
         // Finish erasing
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
 
         // Should remove inflight items
@@ -1006,33 +1032,39 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask confirmed = requested;
 
         // Range below write watermark. Should be flushed to 4 ddisks.
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
         // Range cross write watermark. Should be flushed to 4 ddisks.
-        dirtyMap.RegisterInflightWrite(124, TBlockRange64::WithLength(95, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(124),
+            TBlockRange64::WithLength(95, 10));
         dirtyMap.WriteFinished(
-            124,
+            MakeId(124),
             TBlockRange64::WithLength(95, 10),
             requested,
             confirmed);
         // Range over write watermark. Should be flushed to 3 ddisks.
-        dirtyMap.RegisterInflightWrite(125, TBlockRange64::WithLength(100, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(125),
+            TBlockRange64::WithLength(100, 10));
         dirtyMap.WriteFinished(
-            125,
+            MakeId(125),
             TBlockRange64::WithLength(100, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap.MakeFlushHint(3);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19],124[95..104],125[100..109];"
-            "H0->H3:123[10..19],124[95..104],125[100..109];"
-            "H1->H1:123[10..19],124[95..104],125[100..109];"
-            "H2->H2:123[10..19],124[95..104];",
+            "H0->H0:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H0->H3:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H1->H1:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H2->H2:1:123[10..19],1:124[95..104];",
             flushHint.DebugPrint());
     }
 
@@ -1053,32 +1085,38 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask confirmed = requested;
 
         // Range below write watermark. Should be flushed.
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
         // Range cross write watermark. Should be flushed.
-        dirtyMap.RegisterInflightWrite(124, TBlockRange64::WithLength(95, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(124),
+            TBlockRange64::WithLength(95, 10));
         dirtyMap.WriteFinished(
-            124,
+            MakeId(124),
             TBlockRange64::WithLength(95, 10),
             requested,
             confirmed);
         // Range over write watermark. Should be flushed only to healthy DDisks.
-        dirtyMap.RegisterInflightWrite(125, TBlockRange64::WithLength(100, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(125),
+            TBlockRange64::WithLength(100, 10));
         dirtyMap.WriteFinished(
-            125,
+            MakeId(125),
             TBlockRange64::WithLength(100, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap.MakeFlushHint(3);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19],124[95..104],125[100..109];"
-            "H1->H1:123[10..19],124[95..104],125[100..109];"
-            "H2->H2:123[10..19],124[95..104];",
+            "H0->H0:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H1->H1:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H2->H2:1:123[10..19],1:124[95..104];",
             flushHint.DebugPrint());
     }
 
@@ -1090,9 +1128,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1100,18 +1140,18 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
         for (const auto& [route, flush]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, {MakeLsnVector(flush.Segments)}, {});
+            dirtyMap.FlushFinished(route, {MakeRecordIds(flush.Segments)}, {});
         }
 
         // Lock pbuffer
-        dirtyMap.LockPBuffer(123);
+        dirtyMap.LockPBuffer(MakeId(123));
 
         // Erase hints should not be generated when PBuffer is locked.
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_EQUAL(true, eraseHints.Empty());
 
         // UnLock pbuffer
-        dirtyMap.UnlockPBuffer(123);
+        dirtyMap.UnlockPBuffer(MakeId(123));
 
         // Erase hints should be generated when PBuffer is unlocked.
         eraseHints = dirtyMap.MakeEraseHint(1);
@@ -1132,9 +1172,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.LockDDiskRange(TBlockRange64::WithLength(5, 10), mask);
 
         // User write to overlapped with locked range.
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1160,15 +1202,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{0});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
 
@@ -1177,9 +1219,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
     }
 
@@ -1193,19 +1235,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Block written to four PBuffers
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{0});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{3});
 
@@ -1214,15 +1256,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
 
         auto readHint =
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2,H3][10..19][0..9]};",
+            "1:123{[H0,H1,H2,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
         for (THostIndex h:
@@ -1246,15 +1288,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Block written to two primary PBuffers and one hand-off PBuffer
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{3});
 
@@ -1263,15 +1305,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H1->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
 
         auto readHint =
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H1,H2,H3][10..19][0..9]};",
+            "1:123{[H1,H2,H3][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1283,45 +1325,49 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(0, 100));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(0, 100));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(0, 100),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[0..99];"
-            "H1->H1:123[0..99];"
-            "H2->H2:123[0..99];",
+            "H0->H0:1:123[0..99];"
+            "H1->H1:1:123[0..99];"
+            "H2->H2:1:123[0..99];",
             flushHint.DebugPrint());
 
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123},
+            {MakeId(123)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
-            {123},
+            {MakeId(123)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123},
+            {MakeId(123)},
             {});
 
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123;"
-            "H1:0:123;"
-            "H2:0:123;",
+            "H0:1:123;"
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
 
-        dirtyMap.EraseFinished(THostIndex{0}, {123}, {});
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(123)}, {});
 
-        dirtyMap.RegisterInflightWrite(124, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(124),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            124,
+            MakeId(124),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1335,7 +1381,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(0, 100));
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "124{[H0,H1,H2][10..19][10..19]};"
+            "1:124{[H0,H1,H2][10..19][10..19]};"
             "0{[H0,H1,H2][20..99][20..99]};",
             readHint.DebugPrint());
     }
@@ -1349,7 +1395,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{0});
         auto readHint1 =
@@ -1358,7 +1404,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(false, readHint1.WaitReady.IsReady());
 
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         auto readHint2 =
@@ -1367,13 +1413,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(false, readHint2.WaitReady.IsReady());
 
         dirtyMap.RestorePBuffer(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
         auto readHint3 =
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2][10..19][0..9]};",
+            "1:123{[H0,H1,H2][10..19][0..9]};",
             readHint3.DebugPrint());
 
         UNIT_ASSERT_VALUES_EQUAL(true, readHint1.WaitReady.IsReady());
@@ -1388,16 +1434,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(30, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(30, 10));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(30, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1407,9 +1457,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(5, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "100{[H0,H1,H2][10..19][10..19]};"
+            "1:100{[H0,H1,H2][10..19][10..19]};"
             "0{[H0,H1,H2][20..29][20..29]};"
-            "200{[H0,H1,H2][30..39][30..39]};"
+            "1:200{[H0,H1,H2][30..39][30..39]};"
             "0{[H0,H1,H2][40..49][40..49]};",
             readHint.DebugPrint());
     }
@@ -1422,16 +1472,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 41));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(20, 11));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(20, 11));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(20, 11),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1441,14 +1495,16 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(3, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};"
-            "200{[H0,H1,H2][20..30][10..20]};"
-            "100{[H0,H1,H2][31..50][21..40]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};"
+            "1:200{[H0,H1,H2][20..30][10..20]};"
+            "1:100{[H0,H1,H2][31..50][21..40]};",
             readHint.DebugPrint());
 
-        dirtyMap.RegisterInflightWrite(300, TBlockRange64::WithLength(0, 50));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(300),
+            TBlockRange64::WithLength(0, 50));
         dirtyMap.WriteFinished(
-            300,
+            MakeId(300),
             TBlockRange64::WithLength(0, 50),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1456,7 +1512,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "300{[H0,H1,H2][5..44][0..39]};",
+            "1:300{[H0,H1,H2][5..44][0..39]};",
             readHint.DebugPrint());
     }
 
@@ -1468,16 +1524,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 21));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 21));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(25, 21));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(25, 21));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(25, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1487,8 +1547,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(2, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..24][0..14]};"
-            "200{[H0,H1,H2][25..45][15..35]};",
+            "1:100{[H0,H1,H2][10..24][0..14]};"
+            "1:200{[H0,H1,H2][25..45][15..35]};",
             readHint.DebugPrint());
     }
 
@@ -1500,23 +1560,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 41));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(150, TBlockRange64::WithLength(20, 21));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(150),
+            TBlockRange64::WithLength(20, 21));
         dirtyMap.WriteFinished(
-            150,
+            MakeId(150),
             TBlockRange64::WithLength(20, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(30, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(30, 6));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(30, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1526,11 +1592,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(5, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};"
-            "150{[H0,H1,H2][20..29][10..19]};"
-            "200{[H0,H1,H2][30..35][20..25]};"
-            "150{[H0,H1,H2][36..40][26..30]};"
-            "100{[H0,H1,H2][41..50][31..40]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};"
+            "1:150{[H0,H1,H2][20..29][10..19]};"
+            "1:200{[H0,H1,H2][30..35][20..25]};"
+            "1:150{[H0,H1,H2][36..40][26..30]};"
+            "1:100{[H0,H1,H2][41..50][31..40]};",
             readHint.DebugPrint());
     }
 
@@ -1542,9 +1608,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1554,7 +1622,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1566,16 +1634,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 100));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 100));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 100),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(10, 40));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(10, 40));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(10, 40),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1586,8 +1658,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(3, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "200{[H0,H1,H2][10..49][10..49]};"
-            "100{[H0,H1,H2][50..99][50..99]};",
+            "1:200{[H0,H1,H2][10..49][10..49]};"
+            "1:100{[H0,H1,H2][50..99][50..99]};",
             readHint.DebugPrint());
     }
 
@@ -1601,9 +1673,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         const int lsnsCount = 100;
         for (int i = 1; i <= lsnsCount; ++i) {
-            dirtyMap.RegisterInflightWrite(i, TBlockRange64::WithLength(i, 1));
+            dirtyMap.RegisterInflightWrite(
+                MakeId(i),
+                TBlockRange64::WithLength(i, 1));
             dirtyMap.WriteFinished(
-                i,
+                MakeId(i),
                 TBlockRange64::WithLength(i, 1),
                 MakePrimaryHosts(),
                 MakePrimaryHosts());
@@ -1615,7 +1689,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(lsnsCount + 1, readHint.RangeHints.size());
 
         for (size_t i = 0; i < readHint.RangeHints.size(); ++i) {
-            UNIT_ASSERT_VALUES_EQUAL(i, readHint.RangeHints[i].Lsn);
+            UNIT_ASSERT_VALUES_EQUAL(i, readHint.RangeHints[i].RecordId.Lsn);
             UNIT_ASSERT_VALUES_EQUAL(
                 i,
                 readHint.RangeHints[i].RequestRelativeRange.Start);
@@ -1637,23 +1711,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 21));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 21));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(25, 21));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(25, 21));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(25, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(300, TBlockRange64::WithLength(40, 21));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(300),
+            TBlockRange64::WithLength(40, 21));
         dirtyMap.WriteFinished(
-            300,
+            MakeId(300),
             TBlockRange64::WithLength(40, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1663,9 +1743,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(3, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..24][0..14]};"
-            "200{[H0,H1,H2][25..39][15..29]};"
-            "300{[H0,H1,H2][40..60][30..50]};",
+            "1:100{[H0,H1,H2][10..24][0..14]};"
+            "1:200{[H0,H1,H2][25..39][15..29]};"
+            "1:300{[H0,H1,H2][40..60][30..50]};",
             readHint.DebugPrint());
     }
 
@@ -1677,23 +1757,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 6));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(25, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(25, 6));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(25, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(300, TBlockRange64::WithLength(45, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(300),
+            TBlockRange64::WithLength(45, 6));
         dirtyMap.WriteFinished(
-            300,
+            MakeId(300),
             TBlockRange64::WithLength(45, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1703,11 +1789,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(7, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "100{[H0,H1,H2][10..15][10..15]};"
+            "1:100{[H0,H1,H2][10..15][10..15]};"
             "0{[H0,H1,H2][16..24][16..24]};"
-            "200{[H0,H1,H2][25..30][25..30]};"
+            "1:200{[H0,H1,H2][25..30][25..30]};"
             "0{[H0,H1,H2][31..44][31..44]};"
-            "300{[H0,H1,H2][45..50][45..50]};"
+            "1:300{[H0,H1,H2][45..50][45..50]};"
             "0{[H0,H1,H2][51..60][51..60]};",
             readHint.DebugPrint());
     }
@@ -1720,30 +1806,38 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 91));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 91));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 91),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(20, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(20, 6));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(20, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(300, TBlockRange64::WithLength(40, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(300),
+            TBlockRange64::WithLength(40, 6));
         dirtyMap.WriteFinished(
-            300,
+            MakeId(300),
             TBlockRange64::WithLength(40, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap.RegisterInflightWrite(400, TBlockRange64::WithLength(70, 6));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(400),
+            TBlockRange64::WithLength(70, 6));
         dirtyMap.WriteFinished(
-            400,
+            MakeId(400),
             TBlockRange64::WithLength(70, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1753,13 +1847,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(7, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};"
-            "200{[H0,H1,H2][20..25][10..15]};"
-            "100{[H0,H1,H2][26..39][16..29]};"
-            "300{[H0,H1,H2][40..45][30..35]};"
-            "100{[H0,H1,H2][46..69][36..59]};"
-            "400{[H0,H1,H2][70..75][60..65]};"
-            "100{[H0,H1,H2][76..100][66..90]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};"
+            "1:200{[H0,H1,H2][20..25][10..15]};"
+            "1:100{[H0,H1,H2][26..39][16..29]};"
+            "1:300{[H0,H1,H2][40..45][30..35]};"
+            "1:100{[H0,H1,H2][46..69][36..59]};"
+            "1:400{[H0,H1,H2][70..75][60..65]};"
+            "1:100{[H0,H1,H2][76..100][66..90]};",
             readHint.DebugPrint());
     }
 
@@ -1772,9 +1866,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         auto inflightCounterBeforeWrite = dirtyMap.GetInflightCount();
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 41));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));
@@ -1792,9 +1888,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "0{[H0,H1,H2][10..50][0..40]};",
             readHint.DebugPrint());
 
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(10, 41));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakeHostMask(true, true, true, false, false));
@@ -1802,7 +1900,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 41));
         UNIT_ASSERT_VALUES_EQUAL(1, readHint1.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "200{[H0,H1,H2][10..50][0..40]};",
+            "1:200{[H0,H1,H2][10..50][0..40]};",
             readHint1.DebugPrint());
     }
 
@@ -1815,7 +1913,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         // Register a pending write (no PBuffer acknowledgement yet).
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
 
         // A read during pending write should see DDisk data (Lsn=0),
         // not the unacknowledged PBuffer data.
@@ -1828,14 +1928,14 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Complete the write. Now reads should see PBuffer data.
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         readHint = dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2][10..19][0..9]};",
+            "1:123{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1848,15 +1948,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         // First write completes normally.
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         // Second write overlaps and is pending.
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(10, 10));
 
         // Actually, the pending write (Lsn=200) overlaps the completed one
         // (Lsn=100) — the latest Lsn wins, and since Lsn 200 is in
@@ -1864,19 +1968,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Complete the second write.
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         readHint = dirtyMap.MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "200{[H0,H1,H2][10..19][0..9]};",
+            "1:200{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1891,9 +1995,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -1901,7 +2007,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Flush all hosts.
         auto flushHint = dirtyMap.MakeFlushHint(1);
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         // Disable host 0 before erase.
@@ -1911,13 +2017,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Erase hints should only include enabled hosts.
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;",
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
 
         // Finish erasing on enabled hosts.
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
 
         // The disabled host's erase was auto-confirmed, so inflight should be
@@ -1937,28 +2043,32 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT(!dirtyMap.GetSafeBarrierForErase().has_value());
 
         // Pending write holds the barrier from the moment of registration.
-        dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
-        UNIT_ASSERT_VALUES_EQUAL(100, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(10, 10));
+        UNIT_ASSERT_VALUES_EQUAL(100, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // Second pending write — barrier stays at 100.
-        dirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(20, 10));
-        UNIT_ASSERT_VALUES_EQUAL(100, *dirtyMap.GetSafeBarrierForErase());
+        dirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(20, 10));
+        UNIT_ASSERT_VALUES_EQUAL(100, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // Completing write 100 with sub-quorum drops it.
         dirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));
-        UNIT_ASSERT_VALUES_EQUAL(200, *dirtyMap.GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(200, dirtyMap.GetSafeBarrierForErase()->Lsn);
 
         // Completing write 200 with quorum keeps it until erased.
         dirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(20, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(200, *dirtyMap.GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(200, dirtyMap.GetSafeBarrierForErase()->Lsn);
     }
 
     Y_UNIT_TEST(ShouldCleanupInflightWhenHostEvacuatedDuringFlush)
@@ -1972,9 +2082,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -1988,11 +2100,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Confirm flush on hosts 0 and 2 only (leave host 1 pending).
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123},
+            {MakeId(123)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123},
+            {MakeId(123)},
             {});
 
         // Host 1 bytes are still accounted.
@@ -2016,9 +2128,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(false, eraseHints.Empty());
 
         // Erase should only cover hosts that still have write data (0 and 2).
-        UNIT_ASSERT_VALUES_EQUAL("H0:0:123;H2:0:123;", eraseHints.DebugPrint());
+        UNIT_ASSERT_VALUES_EQUAL("H0:1:123;H2:1:123;", eraseHints.DebugPrint());
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
 
         // Inflight should be fully cleaned up.
@@ -2036,9 +2148,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2046,23 +2160,23 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Flush all hosts.
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         // Get erase hints and finish erase on hosts 0 and 2 only.
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123;"
-            "H1:0:123;"
-            "H2:0:123;",
+            "H0:1:123;"
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
-        dirtyMap.EraseFinished(THostIndex{0}, {123}, {});
-        dirtyMap.EraseFinished(THostIndex{2}, {123}, {});
+        dirtyMap.EraseFinished(THostIndex{0}, {MakeId(123)}, {});
+        dirtyMap.EraseFinished(THostIndex{2}, {MakeId(123)}, {});
 
         // Inflight item still present — host 1 erase pending.
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap.GetInflightCount());
@@ -2086,9 +2200,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2135,9 +2251,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Complete a full write -> flush -> erase lifecycle so the inflight
         // item for lsn 123 is removed from the map.
-        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.RegisterInflightWrite(
+            MakeId(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap.WriteFinished(
-            123,
+            MakeId(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2145,13 +2263,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto flushHint = dirtyMap.MakeFlushHint(1);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
         for (const auto& [route, hint]: flushHint.GetAllHints()) {
-            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+            dirtyMap.FlushFinished(route, MakeRecordIds(hint.Segments), {});
         }
 
         auto eraseHints = dirtyMap.MakeEraseHint(1);
         UNIT_ASSERT_EQUAL(false, eraseHints.Empty());
         for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+            dirtyMap.EraseFinished(host, MakeRecordIds(hint.Segments), {});
         }
 
         // The inflight item is gone.
@@ -2163,12 +2281,12 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // on still-enabled destination hosts.
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123},
+            {MakeId(123)},
             {});
         dirtyMap.FlushFinished(
             THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
             {},
-            {123});
+            {MakeId(123)});
 
         // Nothing should have changed and no new flush hints appear.
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -673,32 +673,32 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // (pending), before any PBuffer acknowledges it.
         dirtyMap->RegisterInflightWrite(MakeKey(123), range1);
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // The barrier tracks the minimum inflight lsn.
         dirtyMap->RegisterInflightWrite(MakeKey(124), range2);
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // The lsn stays inflight through the written and flushed states, so the
         // barrier does not advance past a not-yet-erased write.
         dirtyMap->WriteFinished(MakeKey(123), range1, requested, confirmed);
         dirtyMap->WriteFinished(MakeKey(124), range2, requested, confirmed);
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         auto flushHint = dirtyMap->MakeFlushHint(2);
         UNIT_ASSERT(!flushHint.Empty());
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
         FlushAll(flushHint, *dirtyMap);
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // Erasing lsn 123 from only a sub-quorum of hosts keeps it inflight, so
         // the barrier is still held at 123.
@@ -707,15 +707,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(123)}, {});
         dirtyMap->EraseFinished(THostIndex{1}, {MakeKey(123)}, {});
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // Once 123 is erased everywhere it leaves the inflight map and the
         // barrier advances to 124.
         dirtyMap->EraseFinished(THostIndex{2}, {MakeKey(123)}, {});
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(124),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(124).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // Erasing 124 everywhere drains the map -> no barrier.
         dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(124)}, {});
@@ -738,8 +738,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // A registered (pending) write holds the barrier.
         dirtyMap->RegisterInflightWrite(MakeKey(123), range);
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(123).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // A write that fails to reach a quorum of PBuffers drops its pending
         // entry and stops holding the barrier.
@@ -2070,16 +2070,16 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeKey(100),
             TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(100),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(100).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // Second pending write — barrier stays at 100.
         dirtyMap->RegisterInflightWrite(
             MakeKey(200),
             TBlockRange64::WithLength(20, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(100),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(100).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // Completing write 100 with sub-quorum drops it.
         dirtyMap->WriteFinished(
@@ -2088,8 +2088,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(200),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(200).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
 
         // Completing write 200 with quorum keeps it until erased.
         dirtyMap->WriteFinished(
@@ -2098,8 +2098,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakePrimaryHosts(),
             MakePrimaryHosts());
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(200),
-            *dirtyMap->GetSafeBarrierForErase());
+            MakeKey(200).Print(),
+            dirtyMap->GetSafeBarrierForErase()->Print());
     }
 
     Y_UNIT_TEST(ShouldCleanupInflightWhenHostEvacuatedDuringFlush)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -1,5 +1,7 @@
 #include "dirty_map.h"
 
+#include "pbuffer_key_test_helpers.h"
+
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_roles.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
@@ -54,14 +56,14 @@ THostMask MakeHostMask(bool b0, bool b1, bool b2, bool b3, bool b4)
 void FlushAll(const TFlushHints& flushHint, TBlocksDirtyMap& dirtyMap)
 {
     for (const auto& [route, hint]: flushHint.GetAllHints()) {
-        dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+        dirtyMap.FlushFinished(route, MakePBufferKeys(hint.Segments), {});
     }
 }
 
 void EraseAll(const TEraseHints& eraseHints, TBlocksDirtyMap& dirtyMap)
 {
     for (const auto& [host, hint]: eraseHints.GetAllHints()) {
-        dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+        dirtyMap.EraseFinished(host, MakePBufferKeys(hint.Segments), {});
     }
 }
 
@@ -394,19 +396,21 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         // After write, we should be able to get read hints (read from
-        // confirmed PBuffers — hosts {0,1,2}).
+        // confirmed PBuffers — hosts {0, 1, 2}).
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2][10..19][0..9]};",
+            "1:123{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Disable host 0.
@@ -414,10 +418,10 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         dirtyMap->UpdateConfig(vchunkConfig);
 
         readHint = dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
-        // WriteConfirmed mask is {0,1,2}; host 0 is disabled, so it is
+        // WriteConfirmed mask is {0, 1, 2}; host 0 is disabled, so it is
         // excluded from the read mask.
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H1,H2][10..19][0..9]};",
+            "1:123{[H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Counters on primary PBuffers contain one record with 40960 bytes
@@ -443,16 +447,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(124, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(124),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            124,
+            MakeKey(124),
             TBlockRange64::WithLength(10, 10),
             MakeHostMask(true, true, false, true, false),
             MakeHostMask(true, true, false, true, false));
@@ -461,7 +469,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "124{[H0,H1,H3][10..19][0..9]};",
+            "1:124{[H0,H1,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Disable host 0
@@ -470,7 +478,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         readHint = dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "124{[H1,H3][10..19][0..9]};",
+            "1:124{[H1,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
         readHint.RangeHints[0].Lock.Arm();
@@ -520,9 +528,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Flush commands should be generated after completing the required
         // number of write operations.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -533,9 +543,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         flushHint = dirtyMap->MakeFlushHint(2);
         UNIT_ASSERT_EQUAL(true, flushHint.Empty());
 
-        dirtyMap->RegisterInflightWrite(124, TBlockRange64::WithLength(20, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(124),
+            TBlockRange64::WithLength(20, 10));
         dirtyMap->WriteFinished(
-            124,
+            MakeKey(124),
             TBlockRange64::WithLength(20, 10),
             requested,
             confirmed);
@@ -545,9 +557,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         flushHint = dirtyMap->MakeFlushHint(2);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19],124[20..29];"
-            "H1->H1:123[10..19],124[20..29];"
-            "H2->H2:123[10..19],124[20..29];",
+            "H0->H0:1:123[10..19],1:124[20..29];"
+            "H1->H1:1:123[10..19],1:124[20..29];"
+            "H2->H2:1:123[10..19],1:124[20..29];",
             flushHint.DebugPrint());
         // Erase hints should be generated after completing flushing.
         auto eraseHints = dirtyMap->MakeEraseHint(2);
@@ -562,36 +574,36 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // After getting flushing errors, we should get flush hints again
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123, 124},
+            {MakeKey(123), MakeKey(124)},
             {});
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
-            {123, 124},
+            {MakeKey(123), MakeKey(124)},
             {});
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
             {},
-            {123, 124});
+            {MakeKey(123), MakeKey(124)});
 
         flushHint = dirtyMap->MakeFlushHint(2);
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
         UNIT_ASSERT_VALUES_EQUAL(
-            "H2->H2:123[10..19],124[20..29];",
+            "H2->H2:1:123[10..19],1:124[20..29];",
             flushHint.DebugPrint());
 
         // Complete flushing to third ddisk
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123, 124},
+            {MakeKey(123), MakeKey(124)},
             {});
 
         // Erase hints should be generated after completing the required
         // number of write operations.
         eraseHints = dirtyMap->MakeEraseHint(2);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123,0:124;"
-            "H1:0:123,0:124;"
-            "H2:0:123,0:124;",
+            "H0:1:123,1:124;"
+            "H1:1:123,1:124;"
+            "H2:1:123,1:124;",
             eraseHints.DebugPrint());
 
         // After getting erase hints, we should not get it once again
@@ -601,18 +613,30 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         }
 
         // After getting erasing errors, we should get erase hints again
-        dirtyMap->EraseFinished(THostIndex{0}, {123, 124}, {});
-        dirtyMap->EraseFinished(THostIndex{1}, {123, 124}, {});
-        dirtyMap->EraseFinished(THostIndex{2}, {}, {123, 124});
+        dirtyMap->EraseFinished(
+            THostIndex{0},
+            {MakeKey(123), MakeKey(124)},
+            {});
+        dirtyMap->EraseFinished(
+            THostIndex{1},
+            {MakeKey(123), MakeKey(124)},
+            {});
+        dirtyMap->EraseFinished(
+            THostIndex{2},
+            {},
+            {MakeKey(123), MakeKey(124)});
 
         eraseHints = dirtyMap->MakeEraseHint(2);
-        UNIT_ASSERT_VALUES_EQUAL("H2:0:123,0:124;", eraseHints.DebugPrint());
+        UNIT_ASSERT_VALUES_EQUAL("H2:1:123,1:124;", eraseHints.DebugPrint());
 
         // Should still have two inflight items
         UNIT_ASSERT_VALUES_EQUAL(2, dirtyMap->GetInflightCount());
 
         // Complete erasing from third pbuffer
-        dirtyMap->EraseFinished(THostIndex{2}, {123, 124}, {});
+        dirtyMap->EraseFinished(
+            THostIndex{2},
+            {MakeKey(123), MakeKey(124)},
+            {});
         eraseHints = dirtyMap->MakeEraseHint(2);
         UNIT_ASSERT_EQUAL(true, eraseHints.Empty());
 
@@ -647,42 +671,56 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // A write counts towards the barrier from the moment it is registered
         // (pending), before any PBuffer acknowledges it.
-        dirtyMap->RegisterInflightWrite(123, range1);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->RegisterInflightWrite(MakeKey(123), range1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // The barrier tracks the minimum inflight lsn.
-        dirtyMap->RegisterInflightWrite(124, range2);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->RegisterInflightWrite(MakeKey(124), range2);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // The lsn stays inflight through the written and flushed states, so the
         // barrier does not advance past a not-yet-erased write.
-        dirtyMap->WriteFinished(123, range1, requested, confirmed);
-        dirtyMap->WriteFinished(124, range2, requested, confirmed);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->WriteFinished(MakeKey(123), range1, requested, confirmed);
+        dirtyMap->WriteFinished(MakeKey(124), range2, requested, confirmed);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
 
         auto flushHint = dirtyMap->MakeFlushHint(2);
         UNIT_ASSERT(!flushHint.Empty());
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
         FlushAll(flushHint, *dirtyMap);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // Erasing lsn 123 from only a sub-quorum of hosts keeps it inflight, so
         // the barrier is still held at 123.
         auto eraseHint = dirtyMap->MakeEraseHint(2);
         UNIT_ASSERT(!eraseHint.Empty());
-        dirtyMap->EraseFinished(THostIndex{0}, {123}, {});
-        dirtyMap->EraseFinished(THostIndex{1}, {123}, {});
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(123)}, {});
+        dirtyMap->EraseFinished(THostIndex{1}, {MakeKey(123)}, {});
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // Once 123 is erased everywhere it leaves the inflight map and the
         // barrier advances to 124.
-        dirtyMap->EraseFinished(THostIndex{2}, {123}, {});
-        UNIT_ASSERT_VALUES_EQUAL(124, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->EraseFinished(THostIndex{2}, {MakeKey(123)}, {});
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(124),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // Erasing 124 everywhere drains the map -> no barrier.
-        dirtyMap->EraseFinished(THostIndex{0}, {124}, {});
-        dirtyMap->EraseFinished(THostIndex{1}, {124}, {});
-        dirtyMap->EraseFinished(THostIndex{2}, {124}, {});
+        dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(124)}, {});
+        dirtyMap->EraseFinished(THostIndex{1}, {MakeKey(124)}, {});
+        dirtyMap->EraseFinished(THostIndex{2}, {MakeKey(124)}, {});
         UNIT_ASSERT(!dirtyMap->GetSafeBarrierForErase().has_value());
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
     }
@@ -698,13 +736,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const auto range = TBlockRange64::WithLength(10, 10);
 
         // A registered (pending) write holds the barrier.
-        dirtyMap->RegisterInflightWrite(123, range);
-        UNIT_ASSERT_VALUES_EQUAL(123, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->RegisterInflightWrite(MakeKey(123), range);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // A write that fails to reach a quorum of PBuffers drops its pending
         // entry and stops holding the barrier.
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             range,
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));   // 2 < quorum 3
@@ -726,9 +766,12 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         const auto range = TBlockRange64::WithLength(10, 10);
-        dirtyMap->RegisterInflightWrite(100, range);
-        dirtyMap
-            ->WriteFinished(100, range, MakePrimaryHosts(), MakePrimaryHosts());
+        dirtyMap->RegisterInflightWrite(MakeKey(100), range);
+        dirtyMap->WriteFinished(
+            MakeKey(100),
+            range,
+            MakePrimaryHosts(),
+            MakePrimaryHosts());
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT(!flushHint.Empty());
@@ -741,8 +784,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // A late success and a late failure for the forgotten lsn: the
         // record is long gone, both must be no-ops.
-        dirtyMap->EraseFinished(THostIndex{2}, {100}, {});
-        dirtyMap->EraseFinished(THostIndex{2}, {}, {100});
+        dirtyMap->EraseFinished(THostIndex{2}, {MakeKey(100)}, {});
+        dirtyMap->EraseFinished(THostIndex{2}, {}, {MakeKey(100)});
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
     }
 
@@ -759,9 +802,12 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         const auto range = TBlockRange64::WithLength(10, 10);
-        dirtyMap->RegisterInflightWrite(100, range);
-        dirtyMap
-            ->WriteFinished(100, range, MakePrimaryHosts(), MakePrimaryHosts());
+        dirtyMap->RegisterInflightWrite(MakeKey(100), range);
+        dirtyMap->WriteFinished(
+            MakeKey(100),
+            range,
+            MakePrimaryHosts(),
+            MakePrimaryHosts());
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT(!flushHint.Empty());
@@ -769,11 +815,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT(!eraseHints.Empty());
-        dirtyMap->EraseFinished(THostIndex{0}, {100}, {});
-        dirtyMap->EraseFinished(THostIndex{1}, {100}, {});
+        dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(100)}, {});
+        dirtyMap->EraseFinished(THostIndex{1}, {MakeKey(100)}, {});
         // The erase on host 2 does not complete in time: the request is
         // marked failed and re-queued.
-        dirtyMap->EraseFinished(THostIndex{2}, {}, {100});
+        dirtyMap->EraseFinished(THostIndex{2}, {}, {MakeKey(100)});
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap->GetInflightCount());
 
         // The host gets disabled; the re-queued erase is confirmed on its
@@ -785,7 +831,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
 
         // The genuine response from the disabled host finally arrives.
-        dirtyMap->EraseFinished(THostIndex{2}, {100}, {});
+        dirtyMap->EraseFinished(THostIndex{2}, {MakeKey(100)}, {});
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
     }
 
@@ -814,28 +860,30 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(false, true, true, true, false);
         const THostMask confirmed = requested;
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H0:123[10..19];"   // Cross-node
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];"
-            "H3->H3:123[10..19];",
+            "H1->H0:1:123[10..19];"   // Cross-node
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];"
+            "H3->H3:1:123[10..19];",
             flushHint.DebugPrint());
         FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;"
-            "H3:0:123;",
+            "H1:1:123;"
+            "H2:1:123;"
+            "H3:1:123;",
             eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
     }
@@ -873,9 +921,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Write above the fresh watermark to all four DDisks.
         const THostMask requested = MakeHostMask(true, true, true, true, false);
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             requested);
@@ -919,28 +969,30 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(false, true, true, true, false);
         const THostMask confirmed = requested;
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H1:123[10..19];"
-            "H1->H4:123[10..19];"   // ???
-            "H2->H2:123[10..19];"
-            "H3->H3:123[10..19];",
+            "H1->H1:1:123[10..19];"
+            "H1->H4:1:123[10..19];"   // ???
+            "H2->H2:1:123[10..19];"
+            "H3->H3:1:123[10..19];",
             flushHint.DebugPrint());
         FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;"
-            "H3:0:123;",
+            "H1:1:123;"
+            "H2:1:123;"
+            "H3:1:123;",
             eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
     }
@@ -975,27 +1027,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(false, false, true, true, true);
         const THostMask confirmed = requested;
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H2->H2:123[10..19];"
-            "H3->H3:123[10..19];"
-            "H4->H4:123[10..19];",
+            "H2->H2:1:123[10..19];"
+            "H3->H3:1:123[10..19];"
+            "H4->H4:1:123[10..19];",
             flushHint.DebugPrint());
         FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H2:0:123;"
-            "H3:0:123;"
-            "H4:0:123;",
+            "H2:1:123;"
+            "H3:1:123;"
+            "H4:1:123;",
             eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
     }
@@ -1025,26 +1079,28 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             MakeHostMask(true, true, true, false, false);
         const THostMask confirmed = requested;
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H1:123[10..19];"
-            "H1->H3:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H1->H1:1:123[10..19];"
+            "H1->H3:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
         FlushAll(flushHint, *dirtyMap);
 
         // Erase hints
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;",
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
         // Should remove inflight items
@@ -1070,34 +1126,38 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask confirmed = requested;
 
         // Range below write watermark. Should be flushed to 3 enabled ddisks.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
         // Range cross write watermark. Should be flushed to 3 enabled ddisks.
-        dirtyMap->RegisterInflightWrite(124, TBlockRange64::WithLength(95, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(124),
+            TBlockRange64::WithLength(95, 10));
         dirtyMap->WriteFinished(
-            124,
+            MakeKey(124),
             TBlockRange64::WithLength(95, 10),
             requested,
             confirmed);
         // Range over write watermark. Should be flushed to 3 enabled ddisks.
         dirtyMap->RegisterInflightWrite(
-            125,
+            MakeKey(125),
             TBlockRange64::WithLength(100, 10));
         dirtyMap->WriteFinished(
-            125,
+            MakeKey(125),
             TBlockRange64::WithLength(100, 10),
             requested,
             confirmed);
 
         auto flushHint = dirtyMap->MakeFlushHint(3);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19],124[95..104],125[100..109];"
-            "H1->H1:123[10..19],124[95..104],125[100..109];"
-            "H3->H3:123[10..19],124[95..104],125[100..109];",
+            "H0->H0:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H1->H1:1:123[10..19],1:124[95..104],1:125[100..109];"
+            "H3->H3:1:123[10..19],1:124[95..104],1:125[100..109];",
             flushHint.DebugPrint());
     }
 
@@ -1109,9 +1169,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1121,14 +1183,14 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         FlushAll(flushHint, *dirtyMap);
 
         // Lock pbuffer
-        dirtyMap->LockPBuffer(123);
+        dirtyMap->LockPBuffer(MakeKey(123));
 
         // Erase hints should not be generated when PBuffer is locked.
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_EQUAL(true, eraseHints.Empty());
 
         // UnLock pbuffer
-        dirtyMap->UnlockPBuffer(123);
+        dirtyMap->UnlockPBuffer(MakeKey(123));
 
         // Erase hints should be generated when PBuffer is unlocked.
         eraseHints = dirtyMap->MakeEraseHint(1);
@@ -1149,9 +1211,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap->LockDDiskRange(TBlockRange64::WithLength(5, 10), mask);
 
         // User write to overlapped with locked range.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1177,15 +1241,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{0});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
 
@@ -1194,9 +1258,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
     }
 
@@ -1210,19 +1274,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Block written to four PBuffers
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{0});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{3});
 
@@ -1231,15 +1295,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
 
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2,H3][10..19][0..9]};",
+            "1:123{[H0,H1,H2,H3][10..19][0..9]};",
             readHint.DebugPrint());
 
         for (THostIndex h:
@@ -1263,15 +1327,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Block written to two primary PBuffers and one hand-off PBuffer
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{3});
 
@@ -1280,15 +1344,15 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_EQUAL(false, flushHint.Empty());
 
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H1->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
 
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H1,H2,H3][10..19][0..9]};",
+            "1:123{[H1,H2,H3][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1300,33 +1364,37 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(0, 100));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(0, 100));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(0, 100),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[0..99];"
-            "H1->H1:123[0..99];"
-            "H2->H2:123[0..99];",
+            "H0->H0:1:123[0..99];"
+            "H1->H1:1:123[0..99];"
+            "H2->H2:1:123[0..99];",
             flushHint.DebugPrint());
         FlushAll(flushHint, *dirtyMap);
 
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123;"
-            "H1:0:123;"
-            "H2:0:123;",
+            "H0:1:123;"
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
 
-        dirtyMap->EraseFinished(THostIndex{0}, {123}, {});
+        dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(123)}, {});
 
-        dirtyMap->RegisterInflightWrite(124, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(124),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            124,
+            MakeKey(124),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1340,7 +1408,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(0, 100));
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "124{[H0,H1,H2][10..19][10..19]};"
+            "1:124{[H0,H1,H2][10..19][10..19]};"
             "0{[H0,H1,H2][20..99][20..99]};",
             readHint.DebugPrint());
     }
@@ -1354,7 +1422,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{0});
         auto readHint1 =
@@ -1363,7 +1431,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(false, readHint1.WaitReady.IsReady());
 
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{1});
         auto readHint2 =
@@ -1372,13 +1440,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(false, readHint2.WaitReady.IsReady());
 
         dirtyMap->RestorePBuffer(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             THostIndex{2});
         auto readHint3 =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2][10..19][0..9]};",
+            "1:123{[H0,H1,H2][10..19][0..9]};",
             readHint3.DebugPrint());
 
         UNIT_ASSERT_VALUES_EQUAL(true, readHint1.WaitReady.IsReady());
@@ -1393,16 +1461,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(30, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(30, 10));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(30, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1413,9 +1485,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(5, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "100{[H0,H1,H2][10..19][10..19]};"
+            "1:100{[H0,H1,H2][10..19][10..19]};"
             "0{[H0,H1,H2][20..29][20..29]};"
-            "200{[H0,H1,H2][30..39][30..39]};"
+            "1:200{[H0,H1,H2][30..39][30..39]};"
             "0{[H0,H1,H2][40..49][40..49]};",
             readHint.DebugPrint());
     }
@@ -1428,16 +1500,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 41));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(20, 11));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(20, 11));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(20, 11),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1447,14 +1523,16 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(3, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};"
-            "200{[H0,H1,H2][20..30][10..20]};"
-            "100{[H0,H1,H2][31..50][21..40]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};"
+            "1:200{[H0,H1,H2][20..30][10..20]};"
+            "1:100{[H0,H1,H2][31..50][21..40]};",
             readHint.DebugPrint());
 
-        dirtyMap->RegisterInflightWrite(300, TBlockRange64::WithLength(0, 50));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(300),
+            TBlockRange64::WithLength(0, 50));
         dirtyMap->WriteFinished(
-            300,
+            MakeKey(300),
             TBlockRange64::WithLength(0, 50),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1462,7 +1540,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "300{[H0,H1,H2][5..44][0..39]};",
+            "1:300{[H0,H1,H2][5..44][0..39]};",
             readHint.DebugPrint());
     }
 
@@ -1474,16 +1552,20 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 21));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 21));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(25, 21));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(25, 21));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(25, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1493,8 +1575,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(2, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..24][0..14]};"
-            "200{[H0,H1,H2][25..45][15..35]};",
+            "1:100{[H0,H1,H2][10..24][0..14]};"
+            "1:200{[H0,H1,H2][25..45][15..35]};",
             readHint.DebugPrint());
     }
 
@@ -1506,23 +1588,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 41));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(150, TBlockRange64::WithLength(20, 21));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(150),
+            TBlockRange64::WithLength(20, 21));
         dirtyMap->WriteFinished(
-            150,
+            MakeKey(150),
             TBlockRange64::WithLength(20, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(30, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(30, 6));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(30, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1532,11 +1620,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(5, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};"
-            "150{[H0,H1,H2][20..29][10..19]};"
-            "200{[H0,H1,H2][30..35][20..25]};"
-            "150{[H0,H1,H2][36..40][26..30]};"
-            "100{[H0,H1,H2][41..50][31..40]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};"
+            "1:150{[H0,H1,H2][20..29][10..19]};"
+            "1:200{[H0,H1,H2][30..35][20..25]};"
+            "1:150{[H0,H1,H2][36..40][26..30]};"
+            "1:100{[H0,H1,H2][41..50][31..40]};",
             readHint.DebugPrint());
     }
 
@@ -1548,9 +1636,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1560,7 +1650,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(1, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1573,17 +1663,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         dirtyMap->RegisterInflightWrite(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 100));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 100),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(10, 40));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(10, 40));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(10, 40),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1594,8 +1686,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(3, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "200{[H0,H1,H2][10..49][10..49]};"
-            "100{[H0,H1,H2][50..99][50..99]};",
+            "1:200{[H0,H1,H2][10..49][10..49]};"
+            "1:100{[H0,H1,H2][50..99][50..99]};",
             readHint.DebugPrint());
     }
 
@@ -1609,9 +1701,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         const int lsnsCount = 100;
         for (int i = 1; i <= lsnsCount; ++i) {
-            dirtyMap->RegisterInflightWrite(i, TBlockRange64::WithLength(i, 1));
+            dirtyMap->RegisterInflightWrite(
+                MakeKey(i),
+                TBlockRange64::WithLength(i, 1));
             dirtyMap->WriteFinished(
-                i,
+                MakeKey(i),
                 TBlockRange64::WithLength(i, 1),
                 MakePrimaryHosts(),
                 MakePrimaryHosts());
@@ -1623,7 +1717,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(lsnsCount + 1, readHint.RangeHints.size());
 
         for (size_t i = 0; i < readHint.RangeHints.size(); ++i) {
-            UNIT_ASSERT_VALUES_EQUAL(i, readHint.RangeHints[i].Lsn);
+            UNIT_ASSERT_VALUES_EQUAL(i, readHint.RangeHints[i].PBufferKey.Lsn);
             UNIT_ASSERT_VALUES_EQUAL(
                 i,
                 readHint.RangeHints[i].RequestRelativeRange.Start);
@@ -1645,23 +1739,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 21));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 21));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(25, 21));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(25, 21));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(25, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(300, TBlockRange64::WithLength(40, 21));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(300),
+            TBlockRange64::WithLength(40, 21));
         dirtyMap->WriteFinished(
-            300,
+            MakeKey(300),
             TBlockRange64::WithLength(40, 21),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1671,9 +1771,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(3, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..24][0..14]};"
-            "200{[H0,H1,H2][25..39][15..29]};"
-            "300{[H0,H1,H2][40..60][30..50]};",
+            "1:100{[H0,H1,H2][10..24][0..14]};"
+            "1:200{[H0,H1,H2][25..39][15..29]};"
+            "1:300{[H0,H1,H2][40..60][30..50]};",
             readHint.DebugPrint());
     }
 
@@ -1685,23 +1785,29 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 6));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(25, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(25, 6));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(25, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(300, TBlockRange64::WithLength(45, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(300),
+            TBlockRange64::WithLength(45, 6));
         dirtyMap->WriteFinished(
-            300,
+            MakeKey(300),
             TBlockRange64::WithLength(45, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1712,11 +1818,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(7, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
             "0{[H0,H1,H2][0..9][0..9]};"
-            "100{[H0,H1,H2][10..15][10..15]};"
+            "1:100{[H0,H1,H2][10..15][10..15]};"
             "0{[H0,H1,H2][16..24][16..24]};"
-            "200{[H0,H1,H2][25..30][25..30]};"
+            "1:200{[H0,H1,H2][25..30][25..30]};"
             "0{[H0,H1,H2][31..44][31..44]};"
-            "300{[H0,H1,H2][45..50][45..50]};"
+            "1:300{[H0,H1,H2][45..50][45..50]};"
             "0{[H0,H1,H2][51..60][51..60]};",
             readHint.DebugPrint());
     }
@@ -1729,30 +1835,38 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 91));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 91));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 91),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(20, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(20, 6));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(20, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(300, TBlockRange64::WithLength(40, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(300),
+            TBlockRange64::WithLength(40, 6));
         dirtyMap->WriteFinished(
-            300,
+            MakeKey(300),
             TBlockRange64::WithLength(40, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
-        dirtyMap->RegisterInflightWrite(400, TBlockRange64::WithLength(70, 6));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(400),
+            TBlockRange64::WithLength(70, 6));
         dirtyMap->WriteFinished(
-            400,
+            MakeKey(400),
             TBlockRange64::WithLength(70, 6),
             MakePrimaryHosts(),
             MakePrimaryHosts());
@@ -1762,13 +1876,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         UNIT_ASSERT_VALUES_EQUAL(7, readHint.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};"
-            "200{[H0,H1,H2][20..25][10..15]};"
-            "100{[H0,H1,H2][26..39][16..29]};"
-            "300{[H0,H1,H2][40..45][30..35]};"
-            "100{[H0,H1,H2][46..69][36..59]};"
-            "400{[H0,H1,H2][70..75][60..65]};"
-            "100{[H0,H1,H2][76..100][66..90]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};"
+            "1:200{[H0,H1,H2][20..25][10..15]};"
+            "1:100{[H0,H1,H2][26..39][16..29]};"
+            "1:300{[H0,H1,H2][40..45][30..35]};"
+            "1:100{[H0,H1,H2][46..69][36..59]};"
+            "1:400{[H0,H1,H2][70..75][60..65]};"
+            "1:100{[H0,H1,H2][76..100][66..90]};",
             readHint.DebugPrint());
     }
 
@@ -1781,9 +1895,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         auto inflightCounterBeforeWrite = dirtyMap->GetInflightCount();
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 41));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));
@@ -1801,9 +1917,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             "0{[H0,H1,H2][10..50][0..40]};",
             readHint.DebugPrint());
 
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(10, 41));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(10, 41));
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(10, 41),
             MakePrimaryHosts(),
             MakeHostMask(true, true, true, false, false));
@@ -1811,7 +1929,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 41));
         UNIT_ASSERT_VALUES_EQUAL(1, readHint1.RangeHints.size());
         UNIT_ASSERT_VALUES_EQUAL(
-            "200{[H0,H1,H2][10..50][0..40]};",
+            "1:200{[H0,H1,H2][10..50][0..40]};",
             readHint1.DebugPrint());
     }
 
@@ -1824,7 +1942,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         // Register a pending write (no PBuffer acknowledgement yet).
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
 
         // A read during pending write should see DDisk data (Lsn=0),
         // not the unacknowledged PBuffer data.
@@ -1837,14 +1957,14 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Complete the write. Now reads should see PBuffer data.
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         readHint = dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H0,H1,H2][10..19][0..9]};",
+            "1:123{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1857,15 +1977,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         // First write completes normally.
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         // Second write overlaps and is pending.
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(10, 10));
 
         // Actually, the pending write (Lsn=200) overlaps the completed one
         // (Lsn=100) — the latest Lsn wins, and since Lsn 200 is in
@@ -1873,19 +1997,19 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "100{[H0,H1,H2][10..19][0..9]};",
+            "1:100{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // Complete the second write.
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
 
         readHint = dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "200{[H0,H1,H2][10..19][0..9]};",
+            "1:200{[H0,H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -1900,9 +2024,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -1918,8 +2044,8 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Erase hints should only include enabled hosts.
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H1:0:123;"
-            "H2:0:123;",
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
 
@@ -1940,28 +2066,40 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT(!dirtyMap->GetSafeBarrierForErase().has_value());
 
         // Pending write holds the barrier from the moment of registration.
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
-        UNIT_ASSERT_VALUES_EQUAL(100, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 10));
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(100),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // Second pending write — barrier stays at 100.
-        dirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(20, 10));
-        UNIT_ASSERT_VALUES_EQUAL(100, *dirtyMap->GetSafeBarrierForErase());
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(20, 10));
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(100),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // Completing write 100 with sub-quorum drops it.
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 10),
             MakePrimaryHosts(),
             MakeHostMask(true, true, false, false, false));
-        UNIT_ASSERT_VALUES_EQUAL(200, *dirtyMap->GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(200),
+            *dirtyMap->GetSafeBarrierForErase());
 
         // Completing write 200 with quorum keeps it until erased.
         dirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(20, 10),
             MakePrimaryHosts(),
             MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(200, *dirtyMap->GetSafeBarrierForErase());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(200),
+            *dirtyMap->GetSafeBarrierForErase());
     }
 
     Y_UNIT_TEST(ShouldCleanupInflightWhenHostEvacuatedDuringFlush)
@@ -1975,9 +2113,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -1991,11 +2131,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Confirm flush on hosts 0 and 2 only (leave host 1 pending).
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123},
+            {MakeKey(123)},
             {});
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 2, .DestinationHostIndex = 2},
-            {123},
+            {MakeKey(123)},
             {});
 
         // Host 1 bytes are still accounted.
@@ -2004,25 +2144,28 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap->GetPBufferCounters(THostIndex{1}).Current.Size);
 
         // Evacuate host 1 — this promotes host 3 as replacement.
-        // DDisk set changes from {0,1,2} to {0,2,3}, making host 1 "removed".
+        // DDisk set changes from {0, 1, 2} to {0, 2, 3}, making host 1
+        // "removed".
         vchunkConfig.EvacuateHost(1);
         dirtyMap->UpdateConfig(vchunkConfig);
 
         // Flush to promoted host requested.
         flushHint = dirtyMap->MakeFlushHint(1);
-        UNIT_ASSERT_VALUES_EQUAL("H0->H3:123[10..19];", flushHint.DebugPrint());
+        UNIT_ASSERT_VALUES_EQUAL(
+            "H0->H3:1:123[10..19];",
+            flushHint.DebugPrint());
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 3},
-            {123},
+            {MakeKey(123)},
             {});
 
-        // Flush should have completed (FlushDesired became {0,2} which equals
+        // Flush should have completed (FlushDesired became {0, 2} which equals
         // FlushConfirmed), erase should now be possible.
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(false, eraseHints.Empty());
 
         // Erase should only cover hosts that still have write data (0 and 2).
-        UNIT_ASSERT_VALUES_EQUAL("H0:0:123;H2:0:123;", eraseHints.DebugPrint());
+        UNIT_ASSERT_VALUES_EQUAL("H0:1:123;H2:1:123;", eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
         // Inflight should be fully cleaned up.
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
@@ -2039,9 +2182,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2049,21 +2194,21 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Flush all hosts.
         auto flushHint = dirtyMap->MakeFlushHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0->H0:123[10..19];"
-            "H1->H1:123[10..19];"
-            "H2->H2:123[10..19];",
+            "H0->H0:1:123[10..19];"
+            "H1->H1:1:123[10..19];"
+            "H2->H2:1:123[10..19];",
             flushHint.DebugPrint());
         FlushAll(flushHint, *dirtyMap);
 
         // Get erase hints and finish erase on hosts 0 and 2 only.
         auto eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123;"
-            "H1:0:123;"
-            "H2:0:123;",
+            "H0:1:123;"
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
-        dirtyMap->EraseFinished(THostIndex{0}, {123}, {});
-        dirtyMap->EraseFinished(THostIndex{2}, {123}, {});
+        dirtyMap->EraseFinished(THostIndex{0}, {MakeKey(123)}, {});
+        dirtyMap->EraseFinished(THostIndex{2}, {MakeKey(123)}, {});
 
         // Inflight item still present — host 1 erase pending.
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap->GetInflightCount());
@@ -2087,9 +2232,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         const THostMask requested = MakePrimaryHosts();
         const THostMask confirmed = MakePrimaryHosts();
 
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2100,7 +2247,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             UNIT_ASSERT_VALUES_EQUAL(40960, counters.Current.Size);
         }
 
-        // Evacuate host 2 — host 3 gets promoted; DDisk set becomes {0,1,3}.
+        // Evacuate host 2 — host 3 gets promoted; DDisk set becomes {0, 1, 3}.
         vchunkConfig.EvacuateHost(2);
         dirtyMap->UpdateConfig(vchunkConfig);
 
@@ -2134,9 +2281,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
 
         // Complete a full write -> flush -> erase lifecycle so the inflight
         // item for lsn 123 is removed from the map.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2157,12 +2306,12 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // on still-enabled destination hosts.
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
-            {123},
+            {MakeKey(123)},
             {});
         dirtyMap->FlushFinished(
             THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
             {},
-            {123});
+            {MakeKey(123)});
 
         // Nothing should have changed and no new flush hints appear.
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetInflightCount());
@@ -2182,11 +2331,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        const THostMask requested = MakePrimaryHosts();   // {0,1,2}
-        const THostMask confirmed = MakePrimaryHosts();   // {0,1,2}
+        const THostMask requested = MakePrimaryHosts();   // {0, 1, 2}
+        const THostMask confirmed = MakePrimaryHosts();   // {0, 1, 2}
 
         // Register a pending write across all three primary hosts.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap->GetInflightCount());
 
         // Host 0 is evacuated after the write is registered but before the
@@ -2201,7 +2352,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // The write response finally arrives, confirming all three hosts,
         // including the now-evacuated host 0.
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2226,7 +2377,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H1,H2][10..19][0..9]};",
+            "1:123{[H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
     }
 
@@ -2242,11 +2393,13 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultBlockSize,
             DefaultVChunkSize / DefaultBlockSize);
 
-        const THostMask requested = MakePrimaryHosts();   // {0,1,2}
-        const THostMask confirmed = MakePrimaryHosts();   // {0,1,2}
+        const THostMask requested = MakePrimaryHosts();   // {0, 1, 2}
+        const THostMask confirmed = MakePrimaryHosts();   // {0, 1, 2}
 
         // Register a pending write across all three primary hosts.
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(1, dirtyMap->GetInflightCount());
 
         // Host 0 is only temporarily disabled: it stays in the DDisk set, so
@@ -2258,7 +2411,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // The write response finally arrives, confirming all three hosts,
         // including the temporarily-disabled host 0.
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             confirmed);
@@ -2282,7 +2435,7 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         auto readHint =
             dirtyMap->MakeReadHint(TBlockRange64::WithLength(10, 10));
         UNIT_ASSERT_VALUES_EQUAL(
-            "123{[H1,H2][10..19][0..9]};",
+            "1:123{[H1,H2][10..19][0..9]};",
             readHint.DebugPrint());
 
         // No flush is generated while a desired DDisk is still disabled.
@@ -2484,9 +2637,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap->GetCurrentGeneration());
 
         const THostMask requested = MakeHostMask(true, true, true, true, false);
-        dirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 10),
             requested,
             requested);
@@ -2519,9 +2674,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             dirtyMap->DebugPrintBehind());
         eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:100;"
-            "H2:0:100;"
-            "H3:0:100;",
+            "H0:1:100;"
+            "H2:1:100;"
+            "H3:1:100;",
             eraseHints.DebugPrint());
     }
 
@@ -2543,9 +2698,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             DefaultVChunkSize / DefaultBlockSize);
 
         const THostMask requested = MakeHostMask(true, true, true, true, false);
-        source->RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+        source->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(10, 10));
         source->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(10, 10),
             requested,
             requested);
@@ -2629,9 +2786,11 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // the generation advances.
         const THostMask requested =
             MakeHostMask(true, true, true, false, false);
-        dirtyMap->RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap->RegisterInflightWrite(
+            MakeKey(123),
+            TBlockRange64::WithLength(10, 10));
         dirtyMap->WriteFinished(
-            123,
+            MakeKey(123),
             TBlockRange64::WithLength(10, 10),
             requested,
             requested);
@@ -2659,9 +2818,9 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
         // Can erase since red blocks persisted.
         eraseHints = dirtyMap->MakeEraseHint(1);
         UNIT_ASSERT_VALUES_EQUAL(
-            "H0:0:123;"
-            "H1:0:123;"
-            "H2:0:123;",
+            "H0:1:123;"
+            "H1:1:123;"
+            "H2:1:123;",
             eraseHints.DebugPrint());
         EraseAll(eraseHints, *dirtyMap);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/hints.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/hints.cpp
@@ -12,12 +12,12 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 namespace {
 
 template <typename T>
-TVector<ui64> DoMakeLsnVector(std::span<const T> segments)
+TVector<TPBufferKey> DoMakePBufferKeys(std::span<const T> segments)
 {
-    TVector<ui64> result;
+    TVector<TPBufferKey> result;
     result.reserve(segments.size());
     for (const auto& segment: segments) {
-        result.push_back(segment.Lsn);
+        result.push_back(segment.PBufferKey);
     }
     return result;
 }
@@ -28,12 +28,12 @@ TVector<ui64> DoMakeLsnVector(std::span<const T> segments)
 
 TReadRangeHint::TReadRangeHint(
     THostMask hostMask,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 requestRelativeRange,
     TBlockRange64 vchunkRange,
     TRangeLock&& lock)
     : HostMask(hostMask)
-    , Lsn(lsn)
+    , PBufferKey(pBufferKey)
     , RequestRelativeRange(requestRelativeRange)
     , VChunkRange(vchunkRange)
     , Lock(std::move(lock))
@@ -45,9 +45,15 @@ TReadRangeHint& TReadRangeHint::operator=(
 
 TString TReadRangeHint::DebugPrint() const
 {
-    return TStringBuilder()
-           << Lsn << "{" << HostMask.Print() << VChunkRange.Print()
+    TStringBuilder result;
+    if (PBufferKey.Lsn == 0) {
+        result << "0";
+    } else {
+        result << PBufferKey.Print();
+    }
+    result << "{" << HostMask.Print() << VChunkRange.Print()
            << RequestRelativeRange.Print() << "};";
+    return result;
 }
 
 TString TReadHint::DebugPrint() const
@@ -67,23 +73,18 @@ TString TReadHint::DebugPrint() const
 ////////////////////////////////////////////////////////////////////////////////
 
 // static
-TVector<ui64> TPBufferSegment::MakeLsnVector(
+TVector<TPBufferKey> TPBufferSegment::MakePBufferKeys(
     std::span<const TPBufferSegment> segments)
 {
-    TVector<ui64> result;
-    result.reserve(segments.size());
-    for (const auto& segment: segments) {
-        result.push_back(segment.Lsn);
-    }
-    return result;
+    return DoMakePBufferKeys(segments);
 }
 
 TString TPBufferSegment::DebugPrint(bool brief) const
 {
     if (brief) {
-        return ToString(Lsn);
+        return ToString(PBufferKey.Lsn);
     }
-    return TStringBuilder() << Lsn << Range.Print();
+    return TStringBuilder() << PBufferKey.Print() << Range.Print();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -107,13 +108,13 @@ TString TFlushHint::DebugPrint(bool brief) const
 void TFlushHints::AddHint(
     THostIndex source,
     THostIndex destination,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     TBlockRange64 range)
 {
     Hints[THostRoute{
               .SourceHostIndex = source,
               .DestinationHostIndex = destination}]
-        .Segments.emplace_back(lsn, range);
+        .Segments.emplace_back(pBufferKey, range);
 }
 
 bool TFlushHints::Empty() const
@@ -145,9 +146,9 @@ TString TFlushHints::DebugPrint() const
 TString TEraseSegment::DebugPrint(bool brief) const
 {
     if (brief) {
-        return ToString(Lsn);
+        return ToString(PBufferKey.Lsn);
     }
-    return TStringBuilder() << Generation << ":" << Lsn;
+    return PBufferKey.Print();
 }
 
 TString TEraseHint::DebugPrint(bool brief) const
@@ -164,11 +165,9 @@ TString TEraseHint::DebugPrint(bool brief) const
     return builder;
 }
 
-void TEraseHints::AddHint(THostIndex host, ui64 lsn)
+void TEraseHints::AddHint(THostIndex host, TPBufferKey pBufferKey)
 {
-    Hints[host].Segments.emplace_back(
-        0,   // TODO(drbasic)
-        lsn);
+    Hints[host].Segments.push_back(TEraseSegment{.PBufferKey = pBufferKey});
 }
 
 bool TEraseHints::Empty() const
@@ -197,14 +196,14 @@ TString TEraseHints::DebugPrint() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<ui64> MakeLsnVector(std::span<const TPBufferSegment> segments)
+TVector<TPBufferKey> MakePBufferKeys(std::span<const TPBufferSegment> segments)
 {
-    return DoMakeLsnVector<TPBufferSegment>(segments);
+    return DoMakePBufferKeys<TPBufferSegment>(segments);
 }
 
-TVector<ui64> MakeLsnVector(std::span<const TEraseSegment> segments)
+TVector<TPBufferKey> MakePBufferKeys(std::span<const TEraseSegment> segments)
 {
-    return DoMakeLsnVector<TEraseSegment>(segments);
+    return DoMakePBufferKeys<TEraseSegment>(segments);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/hints.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/hints.h
@@ -3,6 +3,7 @@
 #include "range_locker.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
@@ -22,7 +23,7 @@ struct TReadRangeHint
 {
     TReadRangeHint(
         THostMask hostMask,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 requestRelativeRange,
         TBlockRange64 vchunkRange,
         TRangeLock&& lock);
@@ -31,10 +32,11 @@ struct TReadRangeHint
     TReadRangeHint& operator=(TReadRangeHint&& other) noexcept;
 
     THostMask HostMask;
-    // 0 -> read from DDisk (HostMask is the DDisk hosts to choose from).
-    // >0 -> read from a PBuffer that holds the inflight write at this lsn
+    // PBufferKey.Lsn == 0 -> read from DDisk (HostMask is the DDisk hosts to
+    // choose from).
+    // PBufferKey.Lsn > 0 -> read from a PBuffer that holds this inflight record
     // (HostMask is the PBuffer hosts that confirmed the write).
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
 
     // Range relative to the request.
     TBlockRange64 RequestRelativeRange;
@@ -62,10 +64,10 @@ struct TReadHint
 
 struct TPBufferSegment
 {
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
     TBlockRange64 Range;
 
-    static TVector<ui64> MakeLsnVector(
+    static TVector<TPBufferKey> MakePBufferKeys(
         std::span<const TPBufferSegment> segments);
 
     [[nodiscard]] TString DebugPrint(bool brief) const;
@@ -86,7 +88,7 @@ public:
     void AddHint(
         THostIndex source,
         THostIndex destination,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         TBlockRange64 range);
 
     [[nodiscard]] bool Empty() const;
@@ -104,8 +106,7 @@ private:
 
 struct TEraseSegment
 {
-    ui32 Generation = 0;
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
 
     [[nodiscard]] TString DebugPrint(bool brief) const;
 };
@@ -124,7 +125,7 @@ class TEraseHints
 public:
     using THints = TMap<THostIndex, TEraseHint>;
 
-    void AddHint(THostIndex host, ui64 lsn);
+    void AddHint(THostIndex host, TPBufferKey pBufferKey);
 
     [[nodiscard]] bool Empty() const;
 
@@ -153,8 +154,8 @@ struct TSyncHint
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TVector<ui64> MakeLsnVector(std::span<const TPBufferSegment> segments);
-TVector<ui64> MakeLsnVector(std::span<const TEraseSegment> segments);
+TVector<TPBufferKey> MakePBufferKeys(std::span<const TPBufferSegment> segments);
+TVector<TPBufferKey> MakePBufferKeys(std::span<const TEraseSegment> segments);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -13,28 +13,28 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 TInflightInfo::TInflightInfo(
     IReadyQueue* readyQueues,
-    ui64 lsn,
+    TRecordId recordId,
     size_t byteCount,
     THostIndex host)
     : State(EState::PBufferIncompleteWrite)
     , ReadyQueue(readyQueues)
-    , Lsn(lsn)
+    , RecordId(recordId)
     , ByteCount(byteCount)
     , StartAt(TInstant::Now())
 {
     WriteRequested.Set(host);
     WriteConfirmed.Set(host);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Clone);
+    ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Clone);
     ApplyBytes(host, IReadyQueue::EPBufferCounter::Total, true);
 }
 
 TInflightInfo::TInflightInfo(
     IReadyQueue* readyQueue,
-    ui64 lsn,
+    TRecordId recordId,
     size_t byteCount)
     : State(EState::PBufferPendingWrite)
     , ReadyQueue(readyQueue)
-    , Lsn(lsn)
+    , RecordId(recordId)
     , ByteCount(byteCount)
     , StartAt(TInstant::Now())
 {
@@ -46,7 +46,7 @@ TInflightInfo::TInflightInfo(
 TInflightInfo::TInflightInfo(TInflightInfo&& other) noexcept
     : State(other.State)
     , ReadyQueue(other.ReadyQueue)
-    , Lsn(other.Lsn)
+    , RecordId(other.RecordId)
     , ByteCount(other.ByteCount)
     , StartAt(other.StartAt)
     , PBuffersLockCount(other.PBuffersLockCount)
@@ -94,7 +94,7 @@ void TInflightInfo::RestorePBuffer(THostIndex host)
         }
 
         SetState(EState::PBufferWritten);
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+        ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Flush);
     }
 }
 
@@ -111,7 +111,7 @@ void TInflightInfo::OnWritten(
     SetState(EState::PBufferWritten);
 
     ApplyBytes(WriteRequested, IReadyQueue::EPBufferCounter::Total, true);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+    ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Flush);
 }
 
 TInflightInfo::EState TInflightInfo::GetState() const
@@ -133,17 +133,17 @@ TReadSource TInflightInfo::ReadMask() const
         case EState::PBufferPendingWrite:
             // The write is not acknowledged yet, so it is invisible to reads:
             // read the pre-write data from DDisk (Lsn=0). Never blocks.
-            return {.Mask = THostMask::MakeAll(MaxHostCount), .Lsn = 0};
+            return {.Mask = THostMask::MakeAll(MaxHostCount), .RecordId = {}};
 
         case EState::PBufferIncompleteWrite:
             // Reading will be possible only after receiving a quorum.
-            return {.Mask = THostMask::MakeEmpty(), .Lsn = 0};
+            return {.Mask = THostMask::MakeEmpty(), .RecordId = {}};
 
         case EState::PBufferWritten:
         case EState::PBufferFlushing:
             // The data is written to PBuffer, but not transferred to DDisk.
-            // Will read from confirmed PBuffer at this inflight's Lsn.
-            return {.Mask = WriteConfirmed, .Lsn = Lsn};
+            // Will read from a confirmed PBuffer at this inflight's record id.
+            return {.Mask = WriteConfirmed, .RecordId = RecordId};
 
         case EState::PBufferFlushed:
         case EState::PBufferErasing:
@@ -151,7 +151,7 @@ TReadSource TInflightInfo::ReadMask() const
             // The data has already been transferred to DDisk.
             // Will read from DDisks. Lsn=0 marks a DDisk read.
             // Filter out non-desired or fresh later.
-            return {.Mask = THostMask::MakeAll(MaxHostCount), .Lsn = 0};
+            return {.Mask = THostMask::MakeAll(MaxHostCount), .RecordId = {}};
     }
 }
 
@@ -204,7 +204,7 @@ void TInflightInfo::ConfirmFlush(THostIndex host)
     }
 
     if (State == EState::PBufferFlushed && PBuffersLockCount == 0) {
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+        ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Erase);
     }
 }
 
@@ -215,7 +215,7 @@ void TInflightInfo::FlushFailed(THostIndex host)
     Y_ABORT_UNLESS(!FlushConfirmed.Get(host));
 
     FlushRequested.Reset(host);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+    ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Flush);
 }
 
 THostMask TInflightInfo::GetRequestedFlushes() const
@@ -260,7 +260,7 @@ void TInflightInfo::EraseFailed(THostIndex host)
     Y_ABORT_UNLESS(!EraseConfirmed.Get(host));
 
     EraseRequested.Reset(host);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+    ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Erase);
 }
 
 THostMask TInflightInfo::GetEraseNeeded() const
@@ -301,7 +301,7 @@ void TInflightInfo::RemoveHosts(THostMask removed)
 
     // Register for erase if flush is done and PBuffers are not locked.
     if (State == EState::PBufferFlushed && PBuffersLockCount == 0) {
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+        ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Erase);
     }
 
     // Check if erase became complete after removing hosts.
@@ -319,7 +319,7 @@ void TInflightInfo::LockPBuffer()
     ++PBuffersLockCount;
 
     if (PBuffersLockCount == 1) {
-        ReadyQueue->UnRegister(Lsn);
+        ReadyQueue->UnRegister(RecordId);
         ApplyBytes(WriteConfirmed, IReadyQueue::EPBufferCounter::Locked, true);
     }
 }
@@ -337,9 +337,9 @@ void TInflightInfo::UnlockPBuffer()
         ApplyBytes(WriteConfirmed, IReadyQueue::EPBufferCounter::Locked, false);
 
         if (State == EState::PBufferWritten) {
-            ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+            ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Flush);
         } else if (State == EState::PBufferFlushed) {
-            ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
+            ReadyQueue->Register(RecordId, IReadyQueue::EQueueType::Erase);
         }
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -15,12 +15,12 @@ TInflightInfo::TInflightInfo(
     IReadyQueue* readyQueues,
     THostMask desiredDDisks,
     THostMask disabled,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     size_t byteCount,
     THostIndex host)
     : State(EState::PBufferIncompleteWrite)
     , ReadyQueue(readyQueues)
-    , Lsn(lsn)
+    , PBufferKey(pBufferKey)
     , ByteCount(byteCount)
     , StartAt(TInstant::Now())
     , DesiredDDisks(desiredDDisks)
@@ -28,7 +28,7 @@ TInflightInfo::TInflightInfo(
 {
     WriteRequested.Set(host);
     WriteConfirmed.Set(host);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Clone);
+    ReadyQueue->Register(PBufferKey, IReadyQueue::EQueueType::Clone);
     ApplyBytes(host, IReadyQueue::EPBufferCounter::Total, true);
 }
 
@@ -36,11 +36,11 @@ TInflightInfo::TInflightInfo(
     IReadyQueue* readyQueue,
     THostMask desiredDDisks,
     THostMask disabled,
-    ui64 lsn,
+    TPBufferKey pBufferKey,
     size_t byteCount)
     : State(EState::PBufferPendingWrite)
     , ReadyQueue(readyQueue)
-    , Lsn(lsn)
+    , PBufferKey(pBufferKey)
     , ByteCount(byteCount)
     , StartAt(TInstant::Now())
     , DesiredDDisks(desiredDDisks)
@@ -54,7 +54,7 @@ TInflightInfo::TInflightInfo(
 TInflightInfo::TInflightInfo(TInflightInfo&& other) noexcept
     : State(other.State)
     , ReadyQueue(other.ReadyQueue)
-    , Lsn(other.Lsn)
+    , PBufferKey(other.PBufferKey)
     , ByteCount(other.ByteCount)
     , StartAt(other.StartAt)
     , PBuffersLockCount(other.PBuffersLockCount)
@@ -109,7 +109,7 @@ void TInflightInfo::RestorePBuffer(THostIndex host)
         }
 
         SetState(EState::PBufferWritten);
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+        ReadyQueue->Register(PBufferKey, IReadyQueue::EQueueType::Flush);
     }
 }
 
@@ -126,7 +126,7 @@ void TInflightInfo::OnWritten(
     SetState(EState::PBufferWritten);
 
     ApplyBytes(WriteRequested, IReadyQueue::EPBufferCounter::Total, true);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+    ReadyQueue->Register(PBufferKey, IReadyQueue::EQueueType::Flush);
 }
 
 TInflightInfo::EState TInflightInfo::GetState() const
@@ -148,17 +148,17 @@ TReadSource TInflightInfo::ReadMask() const
         case EState::PBufferPendingWrite:
             // The write is not acknowledged yet, so it is invisible to reads:
             // read the pre-write data from DDisk (Lsn=0). Never blocks.
-            return {.Mask = THostMask::MakeAll(MaxHostCount), .Lsn = 0};
+            return {.Mask = THostMask::MakeAll(MaxHostCount), .PBufferKey = {}};
 
         case EState::PBufferIncompleteWrite:
             // Reading will be possible only after receiving a quorum.
-            return {.Mask = THostMask::MakeEmpty(), .Lsn = 0};
+            return {.Mask = THostMask::MakeEmpty(), .PBufferKey = {}};
 
         case EState::PBufferWritten:
         case EState::PBufferFlushing:
             // The data is written to PBuffer, but not transferred to DDisk.
             // Will read from confirmed PBuffer at this inflight's Lsn.
-            return {.Mask = WriteConfirmed, .Lsn = Lsn};
+            return {.Mask = WriteConfirmed, .PBufferKey = PBufferKey};
 
         case EState::PBufferFlushed:
         case EState::PBufferErasing:
@@ -166,7 +166,7 @@ TReadSource TInflightInfo::ReadMask() const
             // The data has already been transferred to DDisk.
             // Will read from DDisks. Lsn=0 marks a DDisk read.
             // Filter out non-desired or fresh later.
-            return {.Mask = THostMask::MakeAll(MaxHostCount), .Lsn = 0};
+            return {.Mask = THostMask::MakeAll(MaxHostCount), .PBufferKey = {}};
     }
 }
 
@@ -226,7 +226,7 @@ void TInflightInfo::FlushFailed(THostIndex host)
     Y_ABORT_UNLESS(!FlushConfirmed.Get(host));
 
     FlushRequested.Reset(host);
-    ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+    ReadyQueue->Register(PBufferKey, IReadyQueue::EQueueType::Flush);
 }
 
 THostMask TInflightInfo::GetInflightFlushes() const
@@ -310,7 +310,9 @@ void TInflightInfo::UpdateHosts(
                 DesiredDDisks.Exclude(Disabled).Exclude(FlushRequested);
             if (!notRequestsFlushes.Empty()) {
                 // New desired added. Will flush to it.
-                ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Flush);
+                ReadyQueue->Register(
+                    PBufferKey,
+                    IReadyQueue::EQueueType::Flush);
             }
             MaybeAdvanceToFlushed();
             break;
@@ -344,7 +346,7 @@ void TInflightInfo::LockPBuffer()
 
     if (PBuffersLockCount == 1) {
         // When lsn locked for reading, we should not erase it.
-        ReadyQueue->UnRegister(Lsn, IReadyQueue::EQueueType::Erase);
+        ReadyQueue->UnRegister(PBufferKey, IReadyQueue::EQueueType::Erase);
         ApplyBytes(WriteConfirmed, IReadyQueue::EPBufferCounter::Locked, true);
     }
 }
@@ -485,8 +487,8 @@ void TInflightInfo::MaybeQueryErase()
         State == EState::PBufferFlushed || State == EState::PBufferErasing);
 
     if (!WriteRequested.Exclude(Disabled).Exclude(EraseRequested).Empty()) {
-        ReadyQueue->Register(Lsn, IReadyQueue::EQueueType::Erase);
-        ReadyQueue->FlushCompleted(Lsn, FlushConfirmed);
+        ReadyQueue->Register(PBufferKey, IReadyQueue::EQueueType::Erase);
+        ReadyQueue->FlushCompleted(PBufferKey, FlushConfirmed);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/disable_copy.h>
@@ -32,13 +33,13 @@ struct IReadyQueue
 
     virtual ~IReadyQueue() = default;
 
-    // Registers an Lsn ready for cloning, flushing, or erasing.
-    // An Lsn can only be registered in one queue. The new registration deletes
-    // the old one.
-    virtual void Register(ui64 lsn, EQueueType queueType) = 0;
+    // Registers a record ready for cloning, flushing, or erasing.
+    // A record can only be registered in one queue. The new registration
+    // deletes the old one.
+    virtual void Register(TRecordId recordId, EQueueType queueType) = 0;
 
-    // Removes all registrations from Lsn.
-    virtual void UnRegister(ui64 lsn) = 0;
+    // Removes all registrations of the record.
+    virtual void UnRegister(TRecordId recordId) = 0;
 
     // Notification about the change of byte counters in PBuffer
     virtual void DataToPBufferAdded(
@@ -57,10 +58,11 @@ struct IReadyQueue
 struct TReadSource
 {
     THostMask Mask;
-    // 0 -> read from DDisk (Mask is the set of DDisk hosts to read from).
-    // >0 -> read from a PBuffer that holds the inflight write at this lsn
+    // RecordId.Lsn == 0 -> read from DDisk (Mask is the set of DDisk hosts to
+    // read from).
+    // RecordId.Lsn > 0 -> read from a PBuffer that holds this inflight record
     // (Mask is the set of PBuffer hosts that confirmed the write).
-    ui64 Lsn = 0;
+    TRecordId RecordId;
 
     [[nodiscard]] bool Empty() const
     {
@@ -69,7 +71,7 @@ struct TReadSource
 
     [[nodiscard]] bool OnlyDDisk() const
     {
-        return Lsn == 0;
+        return RecordId.Lsn == 0;
     }
 };
 
@@ -78,7 +80,7 @@ class TInflightInfo: public TDisableCopy
 public:
     enum class EState
     {
-        // The lsn is generated but the write has not been acknowledged yet.
+        // The record id is issued but the write has not been acknowledged yet.
         // Tracked only to hold the cleanup watermark; invisible to reads (a
         // concurrent read sees the pre-write data on DDisk, as before).
         PBufferPendingWrite,
@@ -111,14 +113,18 @@ public:
 
     TInflightInfo(
         IReadyQueue* readyQueues,
-        ui64 lsn,
+        TRecordId recordId,
         size_t byteCount,
         THostIndex host);
 
-    // Pending write: lsn is generated but data is not in any PBuffer yet.
-    // ReadMask is empty (reads wait on the quorum future) and the write is not
-    // flushable. Call OnWritten once a quorum of PBuffers confirms the write.
-    TInflightInfo(IReadyQueue* readyQueue, ui64 lsn, size_t byteCount);
+    // Pending write: the record id is issued but data is not in any PBuffer
+    // yet. ReadMask is empty (reads wait on the quorum future) and the write is
+    // not flushable. Call OnWritten once a quorum of PBuffers confirms the
+    // write.
+    TInflightInfo(
+        IReadyQueue* readyQueue,
+        TRecordId recordId,
+        size_t byteCount);
 
     TInflightInfo(TInflightInfo&& other) noexcept;
 
@@ -185,7 +191,7 @@ private:
     EState State;
 
     IReadyQueue* ReadyQueue = nullptr;
-    ui64 Lsn = 0;
+    TRecordId RecordId;
     size_t ByteCount = 0;
     TInstant StartAt;
     size_t PBuffersLockCount = 0;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/disable_copy.h>
@@ -32,16 +33,16 @@ struct IReadyQueue
 
     virtual ~IReadyQueue() = default;
 
-    // Registers an Lsn ready for cloning, flushing, or erasing.
-    // An Lsn can only be registered in one queue. The new registration deletes
-    // the old one.
-    virtual void Register(ui64 lsn, EQueueType queueType) = 0;
+    // Registers a record ready for cloning, flushing, or erasing.
+    // A record can only be registered in one queue. The new registration
+    // deletes the old one.
+    virtual void Register(TPBufferKey pBufferKey, EQueueType queueType) = 0;
 
-    // Removes Lsn registration.
-    virtual void UnRegister(ui64 lsn, EQueueType queueType) = 0;
+    // Removes the record's registration from the given queue.
+    virtual void UnRegister(TPBufferKey pBufferKey, EQueueType queueType) = 0;
 
     // Notifies of flushes completion to DDisks.
-    virtual void FlushCompleted(ui64 lsn, THostMask ddisks) = 0;
+    virtual void FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks) = 0;
 
     // Notification about the change of byte counters in PBuffer
     virtual void DataToPBufferAdded(
@@ -60,10 +61,11 @@ struct IReadyQueue
 struct TReadSource
 {
     THostMask Mask;
-    // 0 -> read from DDisk (Mask is the set of DDisk hosts to read from).
-    // >0 -> read from a PBuffer that holds the inflight write at this lsn
+    // PBufferKey.Lsn == 0 -> read from DDisk (Mask is the set of DDisk hosts to
+    // read from).
+    // PBufferKey.Lsn > 0 -> read from a PBuffer that holds this inflight record
     // (Mask is the set of PBuffer hosts that confirmed the write).
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
 
     [[nodiscard]] bool Empty() const
     {
@@ -72,7 +74,7 @@ struct TReadSource
 
     [[nodiscard]] bool OnlyDDisk() const
     {
-        return Lsn == 0;
+        return PBufferKey.Lsn == 0;
     }
 };
 
@@ -117,7 +119,7 @@ public:
         IReadyQueue* readyQueues,
         THostMask desiredDDisks,
         THostMask disabled,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         size_t byteCount,
         THostIndex host);
 
@@ -128,7 +130,7 @@ public:
         IReadyQueue* readyQueue,
         THostMask desiredDDisks,
         THostMask disabled,
-        ui64 lsn,
+        TPBufferKey pBufferKey,
         size_t byteCount);
 
     TInflightInfo(TInflightInfo&& other) noexcept;
@@ -205,7 +207,7 @@ private:
     EState State;
 
     IReadyQueue* ReadyQueue = nullptr;
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
     size_t ByteCount = 0;
     TInstant StartAt;
     size_t PBuffersLockCount = 0;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -1,5 +1,7 @@
 #include "inflight_info.h"
 
+#include "record_id_test_helpers.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
@@ -10,7 +12,7 @@ namespace {
 
 struct TTestReadyQueue: public IReadyQueue
 {
-    void Register(ui64 lsn, EQueueType queueType) override
+    void Register(TRecordId lsn, EQueueType queueType) override
     {
         switch (queueType) {
             case IReadyQueue::EQueueType::Clone: {
@@ -37,7 +39,7 @@ struct TTestReadyQueue: public IReadyQueue
         }
     }
 
-    void UnRegister(ui64 lsn) override
+    void UnRegister(TRecordId lsn) override
     {
         ReadyToErase.erase(lsn);
         ReadyToClone.erase(lsn);
@@ -70,9 +72,9 @@ struct TTestReadyQueue: public IReadyQueue
         return PBufferCounters[host][EPBufferCounter::Locked];
     }
 
-    THashSet<ui64> ReadyToClone;
-    THashSet<ui64> ReadyToFlush;
-    THashSet<ui64> ReadyToErase;
+    THashSet<TRecordId> ReadyToClone;
+    THashSet<TRecordId> ReadyToFlush;
+    THashSet<TRecordId> ReadyToErase;
     TMap<THostIndex, TMap<EPBufferCounter, size_t>> PBufferCounters;
 };
 
@@ -90,23 +92,37 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldHandleRestore)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096, THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToClone.contains(123));
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeId(123),
+            4096,
+            THostIndex{0});
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToClone.contains(MakeId(123)));
 
         inflightInfo.RestorePBuffer(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToClone.contains(MakeId(123)));
 
         inflightInfo.RestorePBuffer(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToClone.contains(MakeId(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeId(123)));
     }
 
     Y_UNIT_TEST(ShouldHandleConfirmedWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeId(123)));
 
         // Start flushes
         UNIT_ASSERT_VALUES_EQUAL(
@@ -121,11 +137,17 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
         inflightInfo.ConfirmFlush(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
         inflightInfo.ConfirmFlush(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
 
         // Check erase requests
         inflightInfo.RequestErase(THostIndex{0});
@@ -147,9 +169,11 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldHandleLock)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeId(123)));
 
         // Start flushes
         auto l = inflightInfo.RequestFlush(THostIndex{0}, THostMask());
@@ -170,7 +194,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.empty());
 
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
 
         // Check erase requests
         inflightInfo.RequestErase(THostIndex{0});
@@ -192,7 +218,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldPutToReadyQueueOnFail)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Flush started
@@ -209,7 +235,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         // When a flush fails, the lsn must be queued for a flush again.
         readyQueue.ReadyToFlush.clear();
         inflightInfo.FlushFailed(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeId(123)));
 
         // Restart flush to host 0
         UNIT_ASSERT_VALUES_EQUAL(
@@ -218,11 +246,17 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
         inflightInfo.ConfirmFlush(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
         inflightInfo.ConfirmFlush(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
 
         // Erase started
         inflightInfo.RequestErase(THostIndex{0});
@@ -232,14 +266,20 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         // When a erase fails, the lsn must be queued for a erase again.
         readyQueue.ReadyToErase.clear();
         inflightInfo.EraseFailed(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
     }
 
     Y_UNIT_TEST(ShouldCountTotalBytesForRestore)
     {
         TTestReadyQueue readyQueue;
         {
-            TInflightInfo inflightInfo(&readyQueue, 123, 4096, THostIndex{0});
+            TInflightInfo inflightInfo(
+                &readyQueue,
+                MakeId(123),
+                4096,
+                THostIndex{0});
 
             inflightInfo.RestorePBuffer(THostIndex{1});
             inflightInfo.RestorePBuffer(THostIndex{2});
@@ -263,7 +303,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     {
         TTestReadyQueue readyQueue;
         {
-            TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+            TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
             inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
             UNIT_ASSERT_VALUES_EQUAL(
@@ -284,7 +324,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldTrackGetEraseNeeded)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Start and confirm flushes to all 3 hosts.
@@ -345,7 +385,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldReturnEraseNeededAfterEraseFailed)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Flush all hosts.
@@ -380,7 +420,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldReturnDDiskReadMaskForPendingWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
 
         // In PBufferPendingWrite state, ReadMask should return DDisk with all
         // hosts enabled (Lsn=0 means DDisk read).
@@ -401,13 +441,13 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         readSource = inflightInfo.ReadMask();
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.OnlyDDisk());
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
-        UNIT_ASSERT_VALUES_EQUAL(123, readSource.Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(123), readSource.RecordId);
     }
 
     Y_UNIT_TEST(ShouldQuorumReadyFutureForPendingWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
 
         auto future = inflightInfo.GetQuorumReadyFuture();
         UNIT_ASSERT_VALUES_EQUAL(false, future.IsReady());
@@ -424,7 +464,11 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldQuorumReadyFutureForIncompleteWrite)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096, THostIndex{0});
+        TInflightInfo inflightInfo(
+            &readyQueue,
+            MakeId(123),
+            4096,
+            THostIndex{0});
 
         auto future = inflightInfo.GetQuorumReadyFuture();
         UNIT_ASSERT_VALUES_EQUAL(false, future.IsReady());
@@ -441,7 +485,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     {
         TTestReadyQueue readyQueue;
         {
-            TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+            TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
 
             // Pending write should not account any bytes.
             UNIT_ASSERT_VALUES_EQUAL(
@@ -475,7 +519,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldRemoveHostsNoOpWhenNoOverlap)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Hosts 3 and 4 were never written to — RemoveHosts should be a no-op.
@@ -496,7 +540,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldRemoveHostsReleaseBytesInWrittenState)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // All 3 hosts have 4096 bytes in Total.
@@ -521,7 +565,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldRemoveHostsCompleteFlush)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Request flush for all 3 hosts.
@@ -537,7 +581,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushing,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
 
         // Remove host 2 — flush should now be complete.
         THostMask removed;
@@ -548,7 +594,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
         // Erase should be registered.
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
         // Host 2 bytes released.
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetTotalBytes(THostIndex{2}));
     }
@@ -556,7 +604,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldRemoveHostsCompleteErase)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Flush all hosts.
@@ -597,7 +645,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldRemoveHostsReleaseLockBytesWhenLocked)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Lock PBuffer — this should track locked bytes.
@@ -638,7 +686,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
     Y_UNIT_TEST(ShouldRemoveHostsNotRegisterEraseWhenLocked)
     {
         TTestReadyQueue readyQueue;
-        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        TInflightInfo inflightInfo(&readyQueue, MakeId(123), 4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Request and confirm flush for hosts 0 and 1.
@@ -664,11 +712,15 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
 
         // After unlock, erase should be registered.
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeId(123)));
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -562,7 +562,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         readSource = inflightInfo.ReadMask();
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.OnlyDDisk());
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(123), readSource.PBufferKey);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123).Print(),
+            readSource.PBufferKey.Print());
     }
 
     Y_UNIT_TEST(ShouldReturnEmptyReadMaskForIncompleteWrite)
@@ -595,7 +597,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         readSource = inflightInfo.ReadMask();
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.OnlyDDisk());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(123), readSource.PBufferKey);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(123).Print(),
+            readSource.PBufferKey.Print());
     }
 
     Y_UNIT_TEST(ShouldReadFromDDiskAfterFlushed)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -1,5 +1,7 @@
 #include "inflight_info.h"
 
+#include "pbuffer_key_test_helpers.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
@@ -10,54 +12,54 @@ namespace {
 
 struct TTestReadyQueue: public IReadyQueue
 {
-    void Register(ui64 lsn, EQueueType queueType) override
+    void Register(TPBufferKey pBufferKey, EQueueType queueType) override
     {
         switch (queueType) {
             case IReadyQueue::EQueueType::Clone: {
-                ReadyToClone.insert(lsn);
+                ReadyToClone.insert(pBufferKey);
 
-                ReadyToFlush.erase(lsn);
-                ReadyToErase.erase(lsn);
+                ReadyToFlush.erase(pBufferKey);
+                ReadyToErase.erase(pBufferKey);
                 break;
             }
             case IReadyQueue::EQueueType::Flush: {
-                ReadyToFlush.insert(lsn);
+                ReadyToFlush.insert(pBufferKey);
 
-                ReadyToClone.erase(lsn);
-                ReadyToErase.erase(lsn);
+                ReadyToClone.erase(pBufferKey);
+                ReadyToErase.erase(pBufferKey);
                 break;
             }
             case IReadyQueue::EQueueType::Erase: {
-                ReadyToErase.insert(lsn);
+                ReadyToErase.insert(pBufferKey);
 
-                ReadyToClone.erase(lsn);
-                ReadyToFlush.erase(lsn);
+                ReadyToClone.erase(pBufferKey);
+                ReadyToFlush.erase(pBufferKey);
                 break;
             }
         }
     }
 
-    void UnRegister(ui64 lsn, EQueueType queueType) override
+    void UnRegister(TPBufferKey pBufferKey, EQueueType queueType) override
     {
         switch (queueType) {
             case IReadyQueue::EQueueType::Clone: {
-                ReadyToClone.erase(lsn);
+                ReadyToClone.erase(pBufferKey);
                 break;
             }
             case IReadyQueue::EQueueType::Flush: {
-                ReadyToFlush.erase(lsn);
+                ReadyToFlush.erase(pBufferKey);
                 break;
             }
             case IReadyQueue::EQueueType::Erase: {
-                ReadyToErase.erase(lsn);
+                ReadyToErase.erase(pBufferKey);
                 break;
             }
         }
     }
 
-    void FlushCompleted(ui64 lsn, THostMask ddisks) override
+    void FlushCompleted(TPBufferKey pBufferKey, THostMask ddisks) override
     {
-        FlushCompletions[lsn] = ddisks;
+        FlushCompletions[pBufferKey] = ddisks;
     }
 
     void DataToPBufferAdded(
@@ -81,14 +83,14 @@ struct TTestReadyQueue: public IReadyQueue
         return PBufferCounters[host][EPBufferCounter::Total];
     }
 
-    bool HasFlushCompleted(ui64 lsn)
+    bool HasFlushCompleted(TPBufferKey pBufferKey)
     {
-        return FlushCompletions.contains(lsn);
+        return FlushCompletions.contains(pBufferKey);
     }
 
-    TString GetFlushCompletedMask(ui64 lsn)
+    TString GetFlushCompletedMask(TPBufferKey pBufferKey)
     {
-        auto it = FlushCompletions.find(lsn);
+        auto it = FlushCompletions.find(pBufferKey);
         return it == FlushCompletions.end() ? "" : it->second.Print();
     }
 
@@ -97,10 +99,10 @@ struct TTestReadyQueue: public IReadyQueue
         return PBufferCounters[host][EPBufferCounter::Locked];
     }
 
-    THashSet<ui64> ReadyToClone;
-    THashSet<ui64> ReadyToFlush;
-    THashSet<ui64> ReadyToErase;
-    THashMap<ui64, THostMask> FlushCompletions;
+    THashSet<TPBufferKey> ReadyToClone;
+    THashSet<TPBufferKey> ReadyToFlush;
+    THashSet<TPBufferKey> ReadyToErase;
+    THashMap<TPBufferKey, THostMask> FlushCompletions;
     TMap<THostIndex, TMap<EPBufferCounter, size_t>> PBufferCounters;
 };
 
@@ -156,26 +158,34 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096,
             THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToClone.contains(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferIncompleteWrite,
             inflightInfo.GetState());
 
         // Restoring a second PBuffer does not yet reach the quorum (3 hosts).
         inflightInfo.RestorePBuffer(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToClone.contains(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferIncompleteWrite,
             inflightInfo.GetState());
 
-        // Third PBuffer reaches the quorum: switches to Written and the lsn
-        // moves from the clone queue to the flush queue.
+        // Third PBuffer reaches the quorum: switches to Written and the
+        // pBufferKey moves from the clone queue to the flush queue.
         inflightInfo.RestorePBuffer(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToClone.contains(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferWritten,
             inflightInfo.GetState());
@@ -188,10 +198,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
 
         // Start flushes
         UNIT_ASSERT_VALUES_EQUAL(
@@ -206,11 +218,17 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         inflightInfo.ConfirmFlush(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         inflightInfo.ConfirmFlush(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Check erase requests
         inflightInfo.RequestErase(THostIndex{0});
@@ -236,10 +254,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
 
         // Start flushes
         Y_UNUSED(inflightInfo.RequestFlush(THostIndex{0}));
@@ -259,7 +279,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.empty());
 
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Check erase requests
         inflightInfo.RequestErase(THostIndex{0});
@@ -285,7 +307,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -300,10 +322,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             THostIndex{2},
             inflightInfo.RequestFlush(THostIndex{2}));
 
-        // When a flush fails, the lsn must be queued for a flush again.
+        // When a flush fails, the pBufferKey must be queued for a flush again.
         readyQueue.ReadyToFlush.clear();
         inflightInfo.FlushFailed(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
 
         // The failed host is no longer inflight.
         UNIT_ASSERT_VALUES_EQUAL(
@@ -317,21 +341,29 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
 
         // Confirm flushes
         inflightInfo.ConfirmFlush(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         inflightInfo.ConfirmFlush(THostIndex{1});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         inflightInfo.ConfirmFlush(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Erase started
         inflightInfo.RequestErase(THostIndex{0});
         inflightInfo.RequestErase(THostIndex{1});
         inflightInfo.RequestErase(THostIndex{2});
 
-        // When a erase fails, the lsn must be queued for a erase again.
+        // When a erase fails, the pBufferKey must be queued for a erase again.
         readyQueue.ReadyToErase.clear();
         inflightInfo.EraseFailed(THostIndex{0});
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Redo the failed erase so the destructor invariants hold.
         inflightInfo.RequestErase(THostIndex{0});
@@ -346,7 +378,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeMask({THostIndex{2}}),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -379,7 +411,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
                 &readyQueue,
                 MakeDDisks(),
                 THostMask::MakeEmpty(),
-                123,
+                MakeKey(123),
                 4096,
                 THostIndex{0});
 
@@ -409,7 +441,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
                 &readyQueue,
                 MakeDDisks(),
                 THostMask::MakeEmpty(),
-                123,
+                MakeKey(123),
                 4096);
             inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -435,7 +467,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -480,7 +512,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -508,7 +540,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
 
         // In PBufferPendingWrite state, ReadMask should return DDisk with all
@@ -530,7 +562,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         readSource = inflightInfo.ReadMask();
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.OnlyDDisk());
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
-        UNIT_ASSERT_VALUES_EQUAL(123, readSource.Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(123), readSource.PBufferKey);
     }
 
     Y_UNIT_TEST(ShouldReturnEmptyReadMaskForIncompleteWrite)
@@ -540,7 +572,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096,
             THostIndex{0});
 
@@ -563,7 +595,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         readSource = inflightInfo.ReadMask();
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.Empty());
         UNIT_ASSERT_VALUES_EQUAL(false, readSource.OnlyDDisk());
-        UNIT_ASSERT_VALUES_EQUAL(123, readSource.Lsn);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(123), readSource.PBufferKey);
     }
 
     Y_UNIT_TEST(ShouldReadFromDDiskAfterFlushed)
@@ -573,7 +605,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -599,7 +631,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
 
         auto future = inflightInfo.GetQuorumReadyFuture();
@@ -618,7 +650,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096,
             THostIndex{0});
 
@@ -641,7 +673,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
                 &readyQueue,
                 MakeDDisks(),
                 THostMask::MakeEmpty(),
-                123,
+                MakeKey(123),
                 4096);
 
             // Pending write should not account any bytes.
@@ -680,16 +712,20 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
         FlushAll(inflightInfo);
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Locking accounts locked bytes on all confirmed hosts and unregisters
-        // the lsn from the erase queue.
+        // the pBufferKey from the erase queue.
         inflightInfo.LockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
             readyQueue.GetLockedBytes(THostIndex{0}));
@@ -711,14 +747,18 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
             readyQueue.GetLockedBytes(THostIndex{0}));
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
 
         // Final unlock releases the locked bytes and re-registers the erase.
         inflightInfo.UnlockPBuffer();
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{0}));
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{1}));
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{2}));
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
     }
 
     Y_UNIT_TEST(ShouldRegisterEraseAfterUnlockInFlushedState)
@@ -728,7 +768,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -746,11 +786,15 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Unlocking in the flushed state registers the erase.
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         EraseAll(inflightInfo);
     }
@@ -766,7 +810,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -797,7 +841,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(4),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
 
@@ -813,7 +857,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushing,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Disable + remove host 3. Now DesiredDDisks\Disabled == FlushConfirmed
         // and the quorum holds, so the flush completes.
@@ -823,7 +869,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Erase all still-written hosts (host 3 excluded via Disabled).
         inflightInfo.RequestErase(THostIndex{0});
@@ -845,7 +893,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -873,8 +921,8 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             inflightInfo.GetState());
     }
 
-    // Adding a new desired DDisk while flushing must re-register the lsn for
-    // flushing so the new host gets its copy.
+    // Adding a new desired DDisk while flushing must re-register the pBufferKey
+    // for flushing so the new host gets its copy.
     Y_UNIT_TEST(ShouldUpdateHostsRegisterFlushWhenAddingDesired)
     {
         TTestReadyQueue readyQueue;
@@ -882,7 +930,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -911,16 +959,22 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
 
-        // Locking in the written state accounts locked bytes and keeps the lsn
-        // in the flush queue (only the erase queue is touched).
+        // Locking in the written state accounts locked bytes and keeps the
+        // pBufferKey in the flush queue (only the erase queue is touched).
         inflightInfo.LockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             4096,
             readyQueue.GetLockedBytes(THostIndex{0}));
@@ -928,8 +982,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         // Unlocking in the written state must not register an erase: erase is
         // only registered once the buffer is flushed.
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(0, readyQueue.GetLockedBytes(THostIndex{0}));
 
         // Finish flush + erase so the destructor invariants hold.
@@ -948,7 +1006,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
                 &readyQueue,
                 MakeDDisks(),
                 THostMask::MakeEmpty(),
-                123,
+                MakeKey(123),
                 4096);
             inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
             FlushAll(inflightInfo);
@@ -978,7 +1036,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
                 &readyQueue,
                 MakeDDisks(),
                 THostMask::MakeEmpty(),
-                123,
+                MakeKey(123),
                 4096);
             source.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
             UNIT_ASSERT_VALUES_EQUAL(
@@ -1013,21 +1071,25 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // No notification before the flush completes.
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
 
         FlushAll(inflightInfo);
 
         // After the flush reaches the quorum FlushCompleted fires with the full
         // set of confirmed DDisks.
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             "[H0,H1,H2]",
-            readyQueue.GetFlushCompletedMask(123));
+            readyQueue.GetFlushCompletedMask(MakeKey(123)));
 
         EraseAll(inflightInfo);
     }
@@ -1044,7 +1106,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(4),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(4), MakePrimaryHosts(4));
 
@@ -1057,7 +1119,9 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         inflightInfo.ConfirmFlush(THostIndex{0});
         inflightInfo.ConfirmFlush(THostIndex{1});
         inflightInfo.ConfirmFlush(THostIndex{2});
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
 
         // Disable + remove host 3. The quorum holds, the flush completes and
         // FlushCompleted reports only the confirmed hosts.
@@ -1067,10 +1131,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             "[H0,H1,H2]",
-            readyQueue.GetFlushCompletedMask(123));
+            readyQueue.GetFlushCompletedMask(MakeKey(123)));
 
         // Erase all still-written hosts (host 3 excluded via Disabled).
         inflightInfo.RequestErase(THostIndex{0});
@@ -1093,7 +1159,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
@@ -1111,14 +1177,18 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         UNIT_ASSERT_VALUES_EQUAL(
             TInflightInfo::EState::PBufferFlushed,
             inflightInfo.GetState());
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
 
         // Unlocking in the flushed state finally fires FlushCompleted.
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             "[H0,H1,H2]",
-            readyQueue.GetFlushCompletedMask(123));
+            readyQueue.GetFlushCompletedMask(MakeKey(123)));
 
         EraseAll(inflightInfo);
     }
@@ -1132,16 +1202,20 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         // Lock/unlock while still in the written state: no flush happened, so
         // no completion notification may fire.
         inflightInfo.LockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
 
         // Finish flush + erase so the destructor invariants hold.
         FlushAll(inflightInfo);
@@ -1157,12 +1231,14 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
         inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
 
         FlushAll(inflightInfo);
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
 
         // Request erase for host 0 and then fail it. Clearing the capture map
         // lets us observe the re-notification.
@@ -1171,10 +1247,12 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         inflightInfo.EraseFailed(THostIndex{0});
 
         // EraseFailed re-runs the erase-query path and notifies again.
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.HasFlushCompleted(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.HasFlushCompleted(MakeKey(123)));
         UNIT_ASSERT_VALUES_EQUAL(
             "[H0,H1,H2]",
-            readyQueue.GetFlushCompletedMask(123));
+            readyQueue.GetFlushCompletedMask(MakeKey(123)));
 
         EraseAll(inflightInfo);
     }
@@ -1190,26 +1268,38 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096,
             THostIndex{0});
         inflightInfo.RestorePBuffer(THostIndex{1});
         inflightInfo.RestorePBuffer(THostIndex{2});
 
         // Quorum reached: moved from clone to flush queue.
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToClone.contains(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToFlush.contains(MakeKey(123)));
 
         FlushAll(inflightInfo);
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         // Locking unregisters only the erase queue, nothing else.
         inflightInfo.LockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
-        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToClone.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
+        UNIT_ASSERT_VALUES_EQUAL(
+            false,
+            readyQueue.ReadyToClone.contains(MakeKey(123)));
 
         inflightInfo.UnlockPBuffer();
-        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(
+            true,
+            readyQueue.ReadyToErase.contains(MakeKey(123)));
 
         EraseAll(inflightInfo);
     }
@@ -1221,7 +1311,7 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
             &readyQueue,
             MakeDDisks(),
             THostMask::MakeEmpty(),
-            123,
+            MakeKey(123),
             4096);
 
         UNIT_ASSERT_VALUES_EQUAL(0u, inflightInfo.GetPersistGeneration());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/pbuffer_key_test_helpers.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/pbuffer_key_test_helpers.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Makes a PBuffer key for tests, which run within a single tablet generation.
+constexpr TPBufferKey MakeKey(ui64 lsn)
+{
+    return {.Generation = 1, .Lsn = lsn};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.cpp
@@ -6,7 +6,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 TRangeLock::TRangeLock(TRangeLock&& other) noexcept
     : LockableRanges(other.LockableRanges)
-    , Lsn(other.Lsn)
+    , RecordId(other.RecordId)
     , Range(other.Range)
     , Mask(other.Mask)
     , LockRange(other.LockRange)
@@ -24,7 +24,7 @@ TRangeLock::~TRangeLock()
 TRangeLock& TRangeLock::operator=(TRangeLock&& other) noexcept
 {
     LockableRanges = other.LockableRanges;
-    Lsn = other.Lsn;
+    RecordId = other.RecordId;
     Range = other.Range;
     Mask = other.Mask;
     LockRange = other.LockRange;
@@ -43,8 +43,8 @@ void TRangeLock::Arm()
 
     Armed = true;
 
-    if (Lsn) {
-        LockableRanges->LockPBuffer(Lsn);
+    if (RecordId.Lsn) {
+        LockableRanges->LockPBuffer(RecordId);
     } else {
         Y_ABORT_UNLESS(!Mask.Empty());
         LockRange = LockableRanges->LockDDiskRange(Range, Mask);
@@ -60,16 +60,16 @@ void TRangeLock::Disarm()
 
     Y_ABORT_UNLESS(LockableRanges);
 
-    if (Lsn) {
-        LockableRanges->UnlockPBuffer(Lsn);
+    if (RecordId.Lsn) {
+        LockableRanges->UnlockPBuffer(RecordId);
     } else {
         LockableRanges->UnLockDDiskRange(LockRange);
     }
 }
 
-TRangeLock::TRangeLock(ILockableRanges* lockableRanges, ui64 lsn)
+TRangeLock::TRangeLock(ILockableRanges* lockableRanges, TRecordId recordId)
     : LockableRanges(lockableRanges)
-    , Lsn(lsn)
+    , RecordId(recordId)
 {}
 
 TRangeLock::TRangeLock(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.cpp
@@ -6,7 +6,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 TRangeLock::TRangeLock(TRangeLock&& other) noexcept
     : LockableRanges(std::move(other.LockableRanges))
-    , Lsn(other.Lsn)
+    , PBufferKey(other.PBufferKey)
     , Range(other.Range)
     , Mask(other.Mask)
     , LockRange(other.LockRange)
@@ -25,7 +25,7 @@ TRangeLock& TRangeLock::operator=(TRangeLock&& other) noexcept
     Disarm();
 
     LockableRanges = std::move(other.LockableRanges);
-    Lsn = other.Lsn;
+    PBufferKey = other.PBufferKey;
     Range = other.Range;
     Mask = other.Mask;
     LockRange = other.LockRange;
@@ -43,8 +43,8 @@ void TRangeLock::Arm()
     Armed = true;
 
     if (auto lockableRanges = LockableRanges.lock()) {
-        if (Lsn) {
-            lockableRanges->LockPBuffer(Lsn);
+        if (PBufferKey.Lsn) {
+            lockableRanges->LockPBuffer(PBufferKey);
         } else {
             Y_ABORT_UNLESS(!Mask.Empty());
             LockRange = lockableRanges->LockDDiskRange(Range, Mask);
@@ -60,17 +60,19 @@ void TRangeLock::Disarm()
     Armed = false;
 
     if (auto lockableRanges = LockableRanges.lock()) {
-        if (Lsn) {
-            lockableRanges->UnlockPBuffer(Lsn);
+        if (PBufferKey.Lsn) {
+            lockableRanges->UnlockPBuffer(PBufferKey);
         } else {
             lockableRanges->UnLockDDiskRange(LockRange);
         }
     }
 }
 
-TRangeLock::TRangeLock(ILockableRangesWeakPtr lockableRanges, ui64 lsn)
+TRangeLock::TRangeLock(
+    ILockableRangesWeakPtr lockableRanges,
+    TPBufferKey pBufferKey)
     : LockableRanges(std::move(lockableRanges))
-    , Lsn(lsn)
+    , PBufferKey(pBufferKey)
 {}
 
 TRangeLock::TRangeLock(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/disable_copy.h>
@@ -17,8 +18,8 @@ struct ILockableRanges
 
     virtual ~ILockableRanges() = default;
 
-    virtual void LockPBuffer(ui64 lsn) = 0;
-    virtual void UnlockPBuffer(ui64 lsn) = 0;
+    virtual void LockPBuffer(TRecordId recordId) = 0;
+    virtual void UnlockPBuffer(TRecordId recordId) = 0;
     virtual TLockRangeHandle LockDDiskRange(
         TBlockRange64 range,
         THostMask mask) = 0;
@@ -43,8 +44,8 @@ private:
     friend class TRangeLockAccess;
     friend class TDDiskDataCopier;
 
-    // Lock PBuffer with given lsn.
-    TRangeLock(ILockableRanges* lockableRanges, ui64 lsn);
+    // Lock the PBuffer record with the given id.
+    TRangeLock(ILockableRanges* lockableRanges, TRecordId recordId);
 
     // Lock the range on the DDisks specified by the mask.
     TRangeLock(
@@ -53,7 +54,7 @@ private:
         THostMask mask);
 
     ILockableRanges* LockableRanges = nullptr;
-    ui64 Lsn = 0;
+    TRecordId RecordId;
     TBlockRange64 Range;
     THostMask Mask;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker.h
@@ -3,6 +3,7 @@
 #include "public.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_mask.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/disable_copy.h>
@@ -19,8 +20,8 @@ struct ILockableRanges
 
     virtual ~ILockableRanges() = default;
 
-    virtual void LockPBuffer(ui64 lsn) = 0;
-    virtual void UnlockPBuffer(ui64 lsn) = 0;
+    virtual void LockPBuffer(TPBufferKey pBufferKey) = 0;
+    virtual void UnlockPBuffer(TPBufferKey pBufferKey) = 0;
     virtual TLockRangeHandle LockDDiskRange(
         TBlockRange64 range,
         THostMask mask) = 0;
@@ -45,8 +46,8 @@ private:
     friend class TRangeLockAccess;
     friend class TDDiskDataCopier;
 
-    // Lock PBuffer with given lsn.
-    TRangeLock(ILockableRangesWeakPtr lockableRanges, ui64 lsn);
+    // Lock the PBuffer record with the given id.
+    TRangeLock(ILockableRangesWeakPtr lockableRanges, TPBufferKey pBufferKey);
 
     // Lock the range on the DDisks specified by the mask.
     TRangeLock(
@@ -55,7 +56,7 @@ private:
         THostMask mask);
 
     ILockableRangesWeakPtr LockableRanges;
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
     TBlockRange64 Range;
     THostMask Mask;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker_ut.cpp
@@ -1,5 +1,7 @@
 #include "range_locker.h"
 
+#include "record_id_test_helpers.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
@@ -9,9 +11,9 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 class TRangeLockAccess
 {
 public:
-    static TRangeLock Make(ILockableRanges* lockableRanges, ui64 lsn)
+    static TRangeLock Make(ILockableRanges* lockableRanges, TRecordId recordId)
     {
-        return TRangeLock(lockableRanges, lsn);
+        return TRangeLock(lockableRanges, recordId);
     }
 
     static TRangeLock
@@ -26,16 +28,16 @@ public:
 class TMockLockableRanges: public ILockableRanges
 {
 public:
-    void LockPBuffer(ui64 lsn) override
+    void LockPBuffer(TRecordId recordId) override
     {
-        ++LsnLocks[lsn];
+        ++LsnLocks[recordId];
     }
 
-    void UnlockPBuffer(ui64 lsn) override
+    void UnlockPBuffer(TRecordId recordId) override
     {
-        auto count = --LsnLocks[lsn];
+        auto count = --LsnLocks[recordId];
         if (count == 0) {
-            LsnLocks.erase(lsn);
+            LsnLocks.erase(recordId);
         }
     }
 
@@ -59,7 +61,7 @@ public:
         }
     }
 
-    TMap<ui64, size_t> LsnLocks;
+    TMap<TRecordId, size_t> LsnLocks;
     TMap<ui64, size_t> RangeLocks;
 
 private:
@@ -76,7 +78,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         THostMask mask = THostMask::MakeAll(3);
 
         {
-            TRangeLock lock1 = TRangeLockAccess::Make(&mock, 123);
+            TRangeLock lock1 = TRangeLockAccess::Make(&mock, MakeId(123));
             TRangeLock lock2 = TRangeLockAccess::Make(
                 &mock,
                 TBlockRange64::MakeOneBlock(100),
@@ -93,11 +95,11 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         TMockLockableRanges mock;
 
         {
-            TRangeLock lock = TRangeLockAccess::Make(&mock, 123);
+            TRangeLock lock = TRangeLockAccess::Make(&mock, MakeId(123));
 
             lock.Arm();
             UNIT_ASSERT_VALUES_EQUAL(1, mock.LsnLocks.size());
-            UNIT_ASSERT_VALUES_EQUAL(1, mock.LsnLocks[123]);
+            UNIT_ASSERT_VALUES_EQUAL(1, mock.LsnLocks[MakeId(123)]);
             UNIT_ASSERT_VALUES_EQUAL(0, mock.RangeLocks.size());
         }
         UNIT_ASSERT_VALUES_EQUAL(0, mock.LsnLocks.size());
@@ -130,7 +132,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         THostMask mask = THostMask::MakeAll(3);
 
         {
-            TRangeLock lock1 = TRangeLockAccess::Make(&mock, 456);
+            TRangeLock lock1 = TRangeLockAccess::Make(&mock, MakeId(456));
             TRangeLock lock2 = TRangeLockAccess::Make(
                 &mock,
                 TBlockRange64::MakeOneBlock(100),
@@ -157,7 +159,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         THostMask mask = THostMask::MakeAll(3);
 
         {
-            TRangeLock lock1 = TRangeLockAccess::Make(&mock, 456);
+            TRangeLock lock1 = TRangeLockAccess::Make(&mock, MakeId(456));
             TRangeLock lock2 = TRangeLockAccess::Make(
                 &mock,
                 TBlockRange64::MakeOneBlock(100),
@@ -168,8 +170,8 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
             UNIT_ASSERT_VALUES_EQUAL(1, mock.LsnLocks.size());
             UNIT_ASSERT_VALUES_EQUAL(1, mock.RangeLocks.size());
             {
-                TRangeLock lock3 = TRangeLockAccess::Make(&mock, 0);
-                TRangeLock lock4 = TRangeLockAccess::Make(&mock, 0);
+                TRangeLock lock3 = TRangeLockAccess::Make(&mock, MakeId(0));
+                TRangeLock lock4 = TRangeLockAccess::Make(&mock, MakeId(0));
                 lock3 = std::move(lock1);
                 lock4 = std::move(lock2);
             }
@@ -185,7 +187,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         TMockLockableRanges mock;
         THostMask mask = THostMask::MakeAll(3);
 
-        TRangeLock lock1 = TRangeLockAccess::Make(&mock, 456);
+        TRangeLock lock1 = TRangeLockAccess::Make(&mock, MakeId(456));
         TRangeLock lock2 = TRangeLockAccess::Make(
             &mock,
             TBlockRange64::MakeOneBlock(100),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/range_locker_ut.cpp
@@ -1,5 +1,7 @@
 #include "range_locker.h"
 
+#include "pbuffer_key_test_helpers.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <utility>
@@ -11,9 +13,11 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 class TRangeLockAccess
 {
 public:
-    static TRangeLock Make(ILockableRangesWeakPtr lockableRanges, ui64 lsn)
+    static TRangeLock Make(
+        ILockableRangesWeakPtr lockableRanges,
+        TPBufferKey pBufferKey)
     {
-        return TRangeLock(std::move(lockableRanges), lsn);
+        return TRangeLock(std::move(lockableRanges), pBufferKey);
     }
 
     static TRangeLock Make(
@@ -32,16 +36,16 @@ class TMockLockableRanges
     , public std::enable_shared_from_this<TMockLockableRanges>
 {
 public:
-    void LockPBuffer(ui64 lsn) override
+    void LockPBuffer(TPBufferKey pBufferKey) override
     {
-        ++LsnLocks[lsn];
+        ++LsnLocks[pBufferKey];
     }
 
-    void UnlockPBuffer(ui64 lsn) override
+    void UnlockPBuffer(TPBufferKey pBufferKey) override
     {
-        auto count = --LsnLocks[lsn];
+        auto count = --LsnLocks[pBufferKey];
         if (count == 0) {
-            LsnLocks.erase(lsn);
+            LsnLocks.erase(pBufferKey);
         }
     }
 
@@ -65,7 +69,7 @@ public:
         }
     }
 
-    TMap<ui64, size_t> LsnLocks;
+    TMap<TPBufferKey, size_t> LsnLocks;
     TMap<ui64, size_t> RangeLocks;
 
 private:
@@ -82,7 +86,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         THostMask mask = THostMask::MakeAll(3);
 
         {
-            TRangeLock lock1 = TRangeLockAccess::Make(mock, 123);
+            TRangeLock lock1 = TRangeLockAccess::Make(mock, MakeKey(123));
             TRangeLock lock2 = TRangeLockAccess::Make(
                 mock,
                 TBlockRange64::MakeOneBlock(100),
@@ -99,11 +103,11 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         auto mock = std::make_shared<TMockLockableRanges>();
 
         {
-            TRangeLock lock = TRangeLockAccess::Make(mock, 123);
+            TRangeLock lock = TRangeLockAccess::Make(mock, MakeKey(123));
 
             lock.Arm();
             UNIT_ASSERT_VALUES_EQUAL(1, mock->LsnLocks.size());
-            UNIT_ASSERT_VALUES_EQUAL(1, mock->LsnLocks[123]);
+            UNIT_ASSERT_VALUES_EQUAL(1, mock->LsnLocks[MakeKey(123)]);
             UNIT_ASSERT_VALUES_EQUAL(0, mock->RangeLocks.size());
         }
         UNIT_ASSERT_VALUES_EQUAL(0, mock->LsnLocks.size());
@@ -136,7 +140,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         THostMask mask = THostMask::MakeAll(3);
 
         {
-            TRangeLock lock1 = TRangeLockAccess::Make(mock, 456);
+            TRangeLock lock1 = TRangeLockAccess::Make(mock, MakeKey(456));
             TRangeLock lock2 = TRangeLockAccess::Make(
                 mock,
                 TBlockRange64::MakeOneBlock(100),
@@ -163,7 +167,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         THostMask mask = THostMask::MakeAll(3);
 
         {
-            TRangeLock lock1 = TRangeLockAccess::Make(mock, 456);
+            TRangeLock lock1 = TRangeLockAccess::Make(mock, MakeKey(456));
             TRangeLock lock2 = TRangeLockAccess::Make(
                 mock,
                 TBlockRange64::MakeOneBlock(100),
@@ -174,8 +178,8 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
             UNIT_ASSERT_VALUES_EQUAL(1, mock->LsnLocks.size());
             UNIT_ASSERT_VALUES_EQUAL(1, mock->RangeLocks.size());
             {
-                TRangeLock lock3 = TRangeLockAccess::Make(mock, 0);
-                TRangeLock lock4 = TRangeLockAccess::Make(mock, 0);
+                TRangeLock lock3 = TRangeLockAccess::Make(mock, MakeKey(0));
+                TRangeLock lock4 = TRangeLockAccess::Make(mock, MakeKey(0));
                 lock3 = std::move(lock1);
                 lock4 = std::move(lock2);
             }
@@ -191,7 +195,7 @@ Y_UNIT_TEST_SUITE(TRangeLockTest)
         auto mock = std::make_shared<TMockLockableRanges>();
         THostMask mask = THostMask::MakeAll(3);
 
-        TRangeLock lock1 = TRangeLockAccess::Make(mock, 456);
+        TRangeLock lock1 = TRangeLockAccess::Make(mock, MakeKey(456));
         TRangeLock lock2 = TRangeLockAccess::Make(
             mock,
             TBlockRange64::MakeOneBlock(100),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/record_id_test_helpers.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/record_id_test_helpers.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Makes a record id for tests, which run within a single tablet generation.
+constexpr TRecordId MakeId(ui64 lsn)
+{
+    return {.Generation = 1, .Lsn = lsn};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
@@ -87,16 +87,16 @@ void TEraseRequestExecutor::OnEraseResponse(const TDBGEraseResponse& response)
             LogTitle.GetWithTime().c_str(),
             FormatError(response.Error).c_str());
 
-        Reply({}, MakeLsnVector(Hint.Segments));
+        Reply({}, MakeRecordIds(Hint.Segments));
         return;
     }
 
-    Reply(MakeLsnVector(Hint.Segments), {});
+    Reply(MakeRecordIds(Hint.Segments), {});
 }
 
 void TEraseRequestExecutor::Reply(
-    TVector<ui64> eraseOk,
-    TVector<ui64> eraseFailed)
+    TVector<TRecordId> eraseOk,
+    TVector<TRecordId> eraseFailed)
 {
     Promise.TrySetValue(TResponse{
         .Host = Host,
@@ -139,7 +139,7 @@ void TEraseRequestExecutor::OnRequestTimeout()
         "%s OnRequestTimeout.",
         LogTitle.GetWithTime().c_str());
 
-    Reply({}, MakeLsnVector(Hint.Segments));
+    Reply({}, MakeRecordIds(Hint.Segments));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
@@ -91,16 +91,16 @@ void TEraseRequestExecutor::OnEraseResponse(const TDBGEraseResponse& response)
             LogTitle.GetWithTime().c_str(),
             FormatError(response.Error).Quote().c_str());
 
-        Reply({}, MakeLsnVector(Hint.Segments));
+        Reply({}, MakePBufferKeys(Hint.Segments));
         return;
     }
 
-    Reply(MakeLsnVector(Hint.Segments), {});
+    Reply(MakePBufferKeys(Hint.Segments), {});
 }
 
 void TEraseRequestExecutor::Reply(
-    TVector<ui64> eraseOk,
-    TVector<ui64> eraseFailed)
+    TVector<TPBufferKey> eraseOk,
+    TVector<TPBufferKey> eraseFailed)
 {
     Promise.TrySetValue(TResponse{
         .Host = Host,
@@ -143,7 +143,7 @@ void TEraseRequestExecutor::OnRequestTimeout()
         "%s OnRequestTimeout.",
         LogTitle.GetWithTime().c_str());
 
-    Reply({}, MakeLsnVector(Hint.Segments));
+    Reply({}, MakePBufferKeys(Hint.Segments));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.h
@@ -21,8 +21,8 @@ public:
     struct TResponse
     {
         THostIndex Host = InvalidHostIndex;
-        TVector<ui64> EraseOk;
-        TVector<ui64> EraseFailed;
+        TVector<TRecordId> EraseOk;
+        TVector<TRecordId> EraseFailed;
     };
 
     TEraseRequestExecutor(
@@ -45,7 +45,7 @@ public:
 private:
     void SendEraseRequest(THostIndex host);
     void OnEraseResponse(const TDBGEraseResponse& response);
-    void Reply(TVector<ui64> eraseOk, TVector<ui64> eraseFailed);
+    void Reply(TVector<TRecordId> eraseOk, TVector<TRecordId> eraseFailed);
 
     void ScheduleRequestTimeout();
     void OnRequestTimeout();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.h
@@ -21,8 +21,8 @@ public:
     struct TResponse
     {
         THostIndex Host = InvalidHostIndex;
-        TVector<ui64> EraseOk;
-        TVector<ui64> EraseFailed;
+        TVector<TPBufferKey> EraseOk;
+        TVector<TPBufferKey> EraseFailed;
     };
 
     TEraseRequestExecutor(
@@ -45,7 +45,7 @@ public:
 private:
     void SendEraseRequest(THostIndex host);
     void OnEraseResponse(const TDBGEraseResponse& response);
-    void Reply(TVector<ui64> eraseOk, TVector<ui64> eraseFailed);
+    void Reply(TVector<TPBufferKey> eraseOk, TVector<TPBufferKey> eraseFailed);
 
     void ScheduleRequestTimeout();
     void OnRequestTimeout();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request_ut.cpp
@@ -19,8 +19,8 @@ Y_UNIT_TEST_SUITE(TEraseRequestTest)
 
         THostIndex host = 1;
         TEraseHint hint;
-        hint.Segments.push_back(TEraseSegment{.Generation = 1, .Lsn = 42});
-        hint.Segments.push_back(TEraseSegment{.Generation = 1, .Lsn = 43});
+        hint.Segments.push_back(TEraseSegment{.RecordId = MakeId(42)});
+        hint.Segments.push_back(TEraseSegment{.RecordId = MakeId(43)});
 
         auto eraseRequest = std::make_shared<TEraseRequestExecutor>(
             Runtime->GetActorSystem(0),
@@ -42,8 +42,8 @@ Y_UNIT_TEST_SUITE(TEraseRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(2, response.EraseOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.EraseOk[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.EraseOk[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(42), response.EraseOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(43), response.EraseOk[1]);
         UNIT_ASSERT_VALUES_EQUAL(0, response.EraseFailed.size());
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request_ut.cpp
@@ -42,8 +42,12 @@ Y_UNIT_TEST_SUITE(TEraseRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(2, response.EraseOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.EraseOk[0]);
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.EraseOk[1]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(42).Print(),
+            response.EraseOk[0].Print());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(43).Print(),
+            response.EraseOk[1].Print());
         UNIT_ASSERT_VALUES_EQUAL(0, response.EraseFailed.size());
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request_ut.cpp
@@ -19,8 +19,8 @@ Y_UNIT_TEST_SUITE(TEraseRequestTest)
 
         THostIndex host = 1;
         TEraseHint hint;
-        hint.Segments.push_back(TEraseSegment{.Generation = 1, .Lsn = 42});
-        hint.Segments.push_back(TEraseSegment{.Generation = 1, .Lsn = 43});
+        hint.Segments.push_back(TEraseSegment{.PBufferKey = MakeKey(42)});
+        hint.Segments.push_back(TEraseSegment{.PBufferKey = MakeKey(43)});
 
         auto eraseRequest = std::make_shared<TEraseRequestExecutor>(
             Runtime->GetActorSystem(0),
@@ -42,8 +42,8 @@ Y_UNIT_TEST_SUITE(TEraseRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(2, response.EraseOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.EraseOk[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.EraseOk[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.EraseOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.EraseOk[1]);
         UNIT_ASSERT_VALUES_EQUAL(0, response.EraseFailed.size());
     }
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -476,8 +476,8 @@ void TFastPathService::MaybeTriggerPBufferCleanup(ui64 lsn)
 
 void TFastPathService::PBufferCleanup()
 {
-    // Pull the smallest inflight lsn from every DirectBlockGroup. Each group
-    // writes its own result slot; the last responder computes the global
+    // Pull the smallest inflight record id from every DirectBlockGroup. Each
+    // group writes its own result slot; the last responder computes the global
     // minimum (see FinishPBufferCleanup).
     const size_t dbgCount = DirectBlockGroups.size();
     CleanupGather.SafeBarriers.assign(dbgCount, std::nullopt);
@@ -486,7 +486,7 @@ void TFastPathService::PBufferCleanup()
     for (size_t i = 0; i < dbgCount; ++i) {
         DirectBlockGroups[i]->GatherSafeBarrierForErase().Subscribe(
             [weakSelf = weak_from_this(), i]   //
-            (const NThreading::TFuture<std::optional<ui64>>& f)
+            (const NThreading::TFuture<std::optional<TRecordId>>& f)
             {
                 if (auto self = weakSelf.lock()) {
                     self->OnGatherSafeBarrierForErase(i, f.GetValue());
@@ -497,7 +497,7 @@ void TFastPathService::PBufferCleanup()
 
 void TFastPathService::OnGatherSafeBarrierForErase(
     size_t dbgIndex,
-    std::optional<ui64> safeBarrier)
+    std::optional<TRecordId> safeBarrier)
 {
     CleanupGather.SafeBarriers[dbgIndex] = safeBarrier;
     if (CleanupGather.PendingResponses.fetch_sub(1) == 1) {
@@ -507,7 +507,7 @@ void TFastPathService::OnGatherSafeBarrierForErase(
 
 void TFastPathService::FinishPBufferCleanup()
 {
-    std::optional<ui64> globalMin;
+    std::optional<TRecordId> globalMin;
     for (const auto& safeBarrier: CleanupGather.SafeBarriers) {
         if (safeBarrier && (!globalMin || *safeBarrier < *globalMin)) {
             globalMin = safeBarrier;
@@ -516,15 +516,23 @@ void TFastPathService::FinishPBufferCleanup()
 
     CleanupGather.Active.store(false);
 
-    if (!globalMin || *globalMin == 0) {
-        // 0 is the blocking bound: some vchunk has not finished restoring its
-        // dirty map, so its records are not accounted for yet. Skip the tick.
+    if (!globalMin) {
+        return;
+    }
+    if (globalMin->Generation !=
+        DirectBlockGroups.front()->GetTabletGeneration())
+    {
+        // The barrier erase drops every record of the previous generations on
+        // the PBuffer side, regardless of the lsn bound. While such a record
+        // is still tracked here (or a vchunk has not finished restoring its
+        // dirty map and reports the zero record id), skip the tick and let
+        // those records drain through the regular flush and erase path.
         return;
     }
 
-    LastSafeBarrier.store(*globalMin);
+    LastSafeBarrier.store(globalMin->Lsn);
 
-    const ui64 cleanupBound = *globalMin - 1;
+    const ui64 cleanupBound = globalMin->Lsn - 1;
     for (const auto& dbg: DirectBlockGroups) {
         dbg->BarrierEraseFromPBuffer(cleanupBound);
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -563,8 +563,8 @@ void TFastPathService::MaybeTriggerPBufferCleanup(ui64 lsn)
 
 void TFastPathService::PBufferCleanup()
 {
-    // Pull the smallest inflight lsn from every DirectBlockGroup. Each group
-    // writes its own result slot; the last responder computes the global
+    // Pull the smallest inflight record id from every DirectBlockGroup. Each
+    // group writes its own result slot; the last responder computes the global
     // minimum (see FinishPBufferCleanup).
     const size_t dbgCount = DirectBlockGroups.size();
     CleanupGather.SafeBarriers.assign(dbgCount, std::nullopt);
@@ -573,7 +573,7 @@ void TFastPathService::PBufferCleanup()
     for (size_t i = 0; i < dbgCount; ++i) {
         DirectBlockGroups[i]->GatherSafeBarrierForErase().Subscribe(
             [weakSelf = weak_from_this(), i]   //
-            (const NThreading::TFuture<std::optional<ui64>>& f)
+            (const NThreading::TFuture<std::optional<TPBufferKey>>& f)
             {
                 if (auto self = weakSelf.lock()) {
                     self->OnGatherSafeBarrierForErase(i, f.GetValue());
@@ -584,7 +584,7 @@ void TFastPathService::PBufferCleanup()
 
 void TFastPathService::OnGatherSafeBarrierForErase(
     size_t dbgIndex,
-    std::optional<ui64> safeBarrier)
+    std::optional<TPBufferKey> safeBarrier)
 {
     CleanupGather.SafeBarriers[dbgIndex] = safeBarrier;
     if (CleanupGather.PendingResponses.fetch_sub(1) == 1) {
@@ -594,7 +594,7 @@ void TFastPathService::OnGatherSafeBarrierForErase(
 
 void TFastPathService::FinishPBufferCleanup()
 {
-    std::optional<ui64> globalMin;
+    std::optional<TPBufferKey> globalMin;
     for (const auto& safeBarrier: CleanupGather.SafeBarriers) {
         if (safeBarrier && (!globalMin || *safeBarrier < *globalMin)) {
             globalMin = safeBarrier;
@@ -603,15 +603,15 @@ void TFastPathService::FinishPBufferCleanup()
 
     CleanupGather.Active.store(false);
 
-    if (!globalMin || *globalMin == 0) {
-        // 0 is the blocking bound: some vchunk has not finished restoring its
-        // dirty map, so its records are not accounted for yet. Skip the tick.
+    // Lsn 0 is the blocking bound: some vchunk has not finished restoring its
+    // dirty map, so its records are not accounted for yet. Skip the tick.
+    if (!globalMin || globalMin->Lsn == 0) {
         return;
     }
 
-    LastSafeBarrier.store(*globalMin);
+    LastSafeBarrier.store(globalMin->Lsn);
 
-    const ui64 cleanupBound = *globalMin - 1;
+    const ui64 cleanupBound = globalMin->Lsn - 1;
     for (const auto& dbg: DirectBlockGroups) {
         dbg->BarrierEraseFromPBuffer(cleanupBound);
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -48,14 +48,15 @@ private:
     struct TPBufferCleanupGather
     {
         std::atomic<bool> Active{false};
-        TVector<std::optional<ui64>> SafeBarriers;
+        TVector<std::optional<TRecordId>> SafeBarriers;
         std::atomic<size_t> PendingResponses{0};
     };
 
     TPBufferCleanupGather CleanupGather;
 
-    // Result of the last finished cleanup round: the minimum safe barrier
-    // across all DBGs. 0 until the first round finishes.
+    // Result of the last finished cleanup round: the lsn of the minimum safe
+    // barrier across all DBGs (only current-generation barriers reach the
+    // store). 0 until the first round finishes.
     std::atomic<ui64> LastSafeBarrier{0};
 
 public:
@@ -139,7 +140,7 @@ private:
     void PBufferCleanup();
     void OnGatherSafeBarrierForErase(
         size_t dbgIndex,
-        std::optional<ui64> safeBarrier);
+        std::optional<TRecordId> safeBarrier);
     void FinishPBufferCleanup();
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -54,14 +54,14 @@ private:
     struct TPBufferCleanupGather
     {
         std::atomic<bool> Active{false};
-        TVector<std::optional<ui64>> SafeBarriers;
+        TVector<std::optional<TPBufferKey>> SafeBarriers;
         std::atomic<size_t> PendingResponses{0};
     };
 
     TPBufferCleanupGather CleanupGather;
 
-    // Result of the last finished cleanup round: the minimum safe barrier
-    // across all DBGs. 0 until the first round finishes.
+    // Result of the last finished cleanup round: the lsn of the minimum safe
+    // barrier across all DBGs. 0 until the first round finishes.
     std::atomic<ui64> LastSafeBarrier{0};
 
     TAdaptiveLock PBufferBarrierLock;
@@ -162,7 +162,7 @@ private:
     void PBufferCleanup();
     void OnGatherSafeBarrierForErase(
         size_t dbgIndex,
-        std::optional<ui64> safeBarrier);
+        std::optional<TPBufferKey> safeBarrier);
     void FinishPBufferCleanup();
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
@@ -112,23 +112,23 @@ void TFlushRequestExecutor::OnFlushResponse(const TDBGFlushResponse& response)
 {
     Y_ABORT_UNLESS(Hint.Segments.size() == response.Errors.size());
 
-    TVector<ui64> flushOk;
-    TVector<ui64> flushFailed;
+    TVector<TRecordId> flushOk;
+    TVector<TRecordId> flushFailed;
     flushOk.reserve(Hint.Segments.size());
     for (size_t i = 0; i < Hint.Segments.size(); ++i) {
         if (HasError(response.Errors[i])) {
             LOG_ERROR(
                 *ActorSystem,
                 NKikimrServices::NBS_PARTITION,
-                "%s Flush failed: %lu %s %s",
+                "%s Flush failed: %s %s %s",
                 LogTitle.GetWithTime().c_str(),
-                Hint.Segments[i].Lsn,
+                Hint.Segments[i].RecordId.Print().c_str(),
                 Hint.Segments[i].Range.Print().c_str(),
                 FormatError(response.Errors[i]).c_str());
 
-            flushFailed.push_back(Hint.Segments[i].Lsn);
+            flushFailed.push_back(Hint.Segments[i].RecordId);
         } else {
-            flushOk.push_back(Hint.Segments[i].Lsn);
+            flushOk.push_back(Hint.Segments[i].RecordId);
         }
     }
 
@@ -136,8 +136,8 @@ void TFlushRequestExecutor::OnFlushResponse(const TDBGFlushResponse& response)
 }
 
 void TFlushRequestExecutor::Reply(
-    TVector<ui64> flushOk,
-    TVector<ui64> flushFailed)
+    TVector<TRecordId> flushOk,
+    TVector<TRecordId> flushFailed)
 {
     Promise.TrySetValue(TResponse{
         .Route = Route,
@@ -180,7 +180,7 @@ void TFlushRequestExecutor::OnRequestTimeout()
         "%s OnRequestTimeout.",
         LogTitle.GetWithTime().c_str());
 
-    Reply({}, MakeLsnVector(Hint.Segments));
+    Reply({}, MakeRecordIds(Hint.Segments));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
@@ -119,23 +119,23 @@ void TFlushRequestExecutor::OnFlushResponse(const TDBGFlushResponse& response)
 {
     Y_ABORT_UNLESS(Hint.Segments.size() == response.Errors.size());
 
-    TVector<ui64> flushOk;
-    TVector<ui64> flushFailed;
+    TVector<TPBufferKey> flushOk;
+    TVector<TPBufferKey> flushFailed;
     flushOk.reserve(Hint.Segments.size());
     for (size_t i = 0; i < Hint.Segments.size(); ++i) {
         if (HasError(response.Errors[i])) {
             LOG_ERROR(
                 *ActorSystem,
                 NKikimrServices::NBS_PARTITION,
-                "%s Flush failed: %lu %s %s",
+                "%s Flush failed: %s %s %s",
                 LogTitle.GetWithTime().c_str(),
-                Hint.Segments[i].Lsn,
+                Hint.Segments[i].PBufferKey.Print().c_str(),
                 Hint.Segments[i].Range.Print().c_str(),
                 FormatError(response.Errors[i]).Quote().c_str());
 
-            flushFailed.push_back(Hint.Segments[i].Lsn);
+            flushFailed.push_back(Hint.Segments[i].PBufferKey);
         } else {
-            flushOk.push_back(Hint.Segments[i].Lsn);
+            flushOk.push_back(Hint.Segments[i].PBufferKey);
         }
     }
 
@@ -143,8 +143,8 @@ void TFlushRequestExecutor::OnFlushResponse(const TDBGFlushResponse& response)
 }
 
 void TFlushRequestExecutor::Reply(
-    TVector<ui64> flushOk,
-    TVector<ui64> flushFailed)
+    TVector<TPBufferKey> flushOk,
+    TVector<TPBufferKey> flushFailed)
 {
     Promise.TrySetValue(TResponse{
         .Route = Route,
@@ -187,7 +187,7 @@ void TFlushRequestExecutor::OnRequestTimeout()
         "%s OnRequestTimeout.",
         LogTitle.GetWithTime().c_str());
 
-    Reply({}, MakeLsnVector(Hint.Segments));
+    Reply({}, MakePBufferKeys(Hint.Segments));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.h
@@ -21,8 +21,8 @@ public:
     struct TResponse
     {
         THostRoute Route;
-        TVector<ui64> FlushOk;
-        TVector<ui64> FlushFailed;
+        TVector<TRecordId> FlushOk;
+        TVector<TRecordId> FlushFailed;
     };
 
     TFlushRequestExecutor(
@@ -46,7 +46,7 @@ private:
     void DoRun();
     void SendFlushRequest(THostIndex host);
     void OnFlushResponse(const TDBGFlushResponse& response);
-    void Reply(TVector<ui64> flushOk, TVector<ui64> flushFailed);
+    void Reply(TVector<TRecordId> flushOk, TVector<TRecordId> flushFailed);
 
     void ScheduleRequestTimeout();
     void OnRequestTimeout();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.h
@@ -21,8 +21,8 @@ public:
     struct TResponse
     {
         THostRoute Route;
-        TVector<ui64> FlushOk;
-        TVector<ui64> FlushFailed;
+        TVector<TPBufferKey> FlushOk;
+        TVector<TPBufferKey> FlushFailed;
     };
 
     TFlushRequestExecutor(
@@ -46,7 +46,7 @@ private:
     void DoRun();
     void SendFlushRequest(THostIndex host);
     void OnFlushResponse(const TDBGFlushResponse& response);
-    void Reply(TVector<ui64> flushOk, TVector<ui64> flushFailed);
+    void Reply(TVector<TPBufferKey> flushOk, TVector<TPBufferKey> flushFailed);
 
     void ScheduleRequestTimeout();
     void OnRequestTimeout();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request_ut.cpp
@@ -20,10 +20,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 0, .DestinationHostIndex = 0};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .RecordId = MakeId(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .RecordId = MakeId(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -48,8 +48,8 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushOk[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushOk[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(42), response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(43), response.FlushOk[1]);
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushFailed.size());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
@@ -61,10 +61,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .RecordId = MakeId(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .RecordId = MakeId(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -89,9 +89,9 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(42), response.FlushOk[0]);
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(43), response.FlushFailed[0]);
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -102,10 +102,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .RecordId = MakeId(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .RecordId = MakeId(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -131,8 +131,8 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushOk.size());
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushFailed[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushFailed[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(42), response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(43), response.FlushFailed[1]);
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -144,10 +144,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .RecordId = MakeId(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .RecordId = MakeId(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -176,8 +176,8 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushOk.size());
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushFailed[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushFailed[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(42), response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(43), response.FlushFailed[1]);
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -195,7 +195,7 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .RecordId = MakeId(42),
             .Range = TBlockRange64::WithLength(10, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -231,7 +231,7 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeId(42), response.FlushOk[0]);
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushFailed.size());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request_ut.cpp
@@ -48,8 +48,12 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushOk[0]);
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushOk[1]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(42).Print(),
+            response.FlushOk[0].Print());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(43).Print(),
+            response.FlushOk[1].Print());
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushFailed.size());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
@@ -89,9 +93,13 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(42).Print(),
+            response.FlushOk[0].Print());
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(43).Print(),
+            response.FlushFailed[0].Print());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -131,8 +139,12 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushOk.size());
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushFailed[0]);
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushFailed[1]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(42).Print(),
+            response.FlushFailed[0].Print());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(43).Print(),
+            response.FlushFailed[1].Print());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -176,8 +188,12 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushOk.size());
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushFailed[0]);
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushFailed[1]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(42).Print(),
+            response.FlushFailed[0].Print());
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(43).Print(),
+            response.FlushFailed[1].Print());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -231,7 +247,9 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(
+            MakeKey(42).Print(),
+            response.FlushOk[0].Print());
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushFailed.size());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request_ut.cpp
@@ -20,10 +20,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 0, .DestinationHostIndex = 0};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .PBufferKey = MakeKey(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .PBufferKey = MakeKey(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -48,8 +48,8 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushOk[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushOk[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushOk[1]);
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushFailed.size());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
@@ -61,10 +61,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .PBufferKey = MakeKey(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .PBufferKey = MakeKey(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -89,9 +89,9 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushOk[0]);
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushFailed[0]);
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -102,10 +102,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .PBufferKey = MakeKey(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .PBufferKey = MakeKey(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -131,8 +131,8 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushOk.size());
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushFailed[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushFailed[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushFailed[1]);
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -144,10 +144,10 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .PBufferKey = MakeKey(42),
             .Range = TBlockRange64::WithLength(10, 3)});
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 43,
+            .PBufferKey = MakeKey(43),
             .Range = TBlockRange64::WithLength(20, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -176,8 +176,8 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushOk.size());
         UNIT_ASSERT_VALUES_EQUAL(2, response.FlushFailed.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushFailed[0]);
-        UNIT_ASSERT_VALUES_EQUAL(43, response.FlushFailed[1]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushFailed[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(43), response.FlushFailed[1]);
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }
 
@@ -195,7 +195,7 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         THostRoute route{.SourceHostIndex = 1, .DestinationHostIndex = 2};
         TFlushHint hint;
         hint.Segments.push_back(TPBufferSegment{
-            .Lsn = 42,
+            .PBufferKey = MakeKey(42),
             .Range = TBlockRange64::WithLength(10, 3)});
 
         auto flushRequest = std::make_shared<TFlushRequestExecutor>(
@@ -231,7 +231,7 @@ Y_UNIT_TEST_SUITE(TFlushRequestTest)
         UNIT_ASSERT_VALUES_EQUAL(true, future.HasValue());
         const auto& response = future.GetValue();
         UNIT_ASSERT_VALUES_EQUAL(1, response.FlushOk.size());
-        UNIT_ASSERT_VALUES_EQUAL(42, response.FlushOk[0]);
+        UNIT_ASSERT_VALUES_EQUAL(MakeKey(42), response.FlushOk[0]);
         UNIT_ASSERT_VALUES_EQUAL(0, response.FlushFailed.size());
         UNIT_ASSERT_EQUAL_C(route, response.Route, response.Route.DebugPrint());
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
@@ -1,7 +1,7 @@
 #include "direct_block_group_test_fixture.h"
-#include "dirty_map/pbuffer_key_test_helpers.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/pbuffer_key_test_helpers.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/fake_direct_session.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/ic_storage_transport_test_adapter.h>
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ic_direct_storage_transport_ut.cpp
@@ -1,4 +1,5 @@
 #include "direct_block_group_test_fixture.h"
+#include "dirty_map/pbuffer_key_test_helpers.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib/fake_direct_session.h>
@@ -302,7 +303,7 @@ Y_UNIT_TEST_SUITE(TICDirectStorageTransportTest)
         auto readFuture = transport->ReadFromPBuffer(
             connection,
             NDDisk::TBlockSelector{1, 0, DefaultBlockSize},
-            /*lsn=*/42,
+            MakeKey(42),
             NDDisk::TReadInstruction(/*returnInRopePayload=*/true),
             MakeSgList(readBuf),
             nullptr);
@@ -510,7 +511,7 @@ Y_UNIT_TEST_SUITE(TICDirectStorageTransportTest)
         auto future = transportPtr->ReadFromPBuffer(
             connection,
             NDDisk::TBlockSelector{0, 0, DefaultBlockSize},
-            /*lsn=*/1,
+            MakeKey(1),
             NDDisk::TReadInstruction(/*returnInRopePayload=*/true),
             MakeSgList(readBuf),
             nullptr);
@@ -554,7 +555,7 @@ Y_UNIT_TEST_SUITE(TICDirectStorageTransportTest)
 
         auto batch = transport->BatchEraseFromPBuffer(
             pbConnection,
-            TVector<ui64>{1, 2, 3},
+            TVector<TPBufferKey>{MakeKey(1), MakeKey(2), MakeKey(3)},
             nullptr);
         WaitFuture(executor, batch, WaitTimeout);
         UNIT_ASSERT(
@@ -574,7 +575,7 @@ Y_UNIT_TEST_SUITE(TICDirectStorageTransportTest)
             pbConnection,
             ddConnection,
             TVector{NDDisk::TBlockSelector{0, 0, DefaultBlockSize}},
-            TVector<ui64>{1},
+            TVector<TPBufferKey>{MakeKey(1)},
             nullptr);
         WaitFuture(executor, sync, WaitTimeout);
         UNIT_ASSERT(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h>
@@ -74,7 +75,7 @@ struct TDbgSnapshot
 struct TVChunkSnapshot
 {
     TVChunkConfig VChunkConfig;
-    std::optional<ui64> SafeBarrier;
+    std::optional<TRecordId> SafeBarrier;
     TString DirtyMapDump;
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h>
@@ -75,7 +76,7 @@ struct TDbgSnapshot
 struct TVChunkSnapshot
 {
     TVChunkConfig VChunkConfig;
-    std::optional<ui64> SafeBarrier;
+    std::optional<TPBufferKey> SafeBarrier;
     TString DirtyMapDump;
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -573,7 +573,7 @@ void RenderVChunk(IOutputStream& str, const TMonPageData& data)
                     }
                     TABLED () {
                         if (vchunk.SafeBarrier) {
-                            str << *vchunk.SafeBarrier;
+                            str << vchunk.SafeBarrier->Print();
                         } else {
                             str << "-";
                         }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -652,7 +652,7 @@ void RenderVChunk(IOutputStream& str, const TMonPageData& data)
                     }
                     TABLED () {
                         if (vchunk.SafeBarrier) {
-                            str << *vchunk.SafeBarrier;
+                            str << vchunk.SafeBarrier->Print();
                         } else {
                             str << "-";
                         }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -208,7 +208,7 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
             .VChunk =
                 TVChunkSnapshot{
                     .VChunkConfig = config,
-                    .SafeBarrier = 100,
+                    .SafeBarrier = TRecordId{.Generation = 1, .Lsn = 100},
                     .DirtyMapDump = "DDiskStates: dump-text",
                 },
         };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -278,7 +278,7 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
             .VChunk =
                 TVChunkSnapshot{
                     .VChunkConfig = config,
-                    .SafeBarrier = 100,
+                    .SafeBarrier = TPBufferKey{.Generation = 1, .Lsn = 100},
                     .DirtyMapDump = "DDiskStates: dump-text",
                 },
         };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -1131,7 +1131,6 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         StopFastPathService(env, partition, edge);
     }
 
-#if 0   // Temporarily disabled until restore is working correctly
     Y_UNIT_TEST(ShouldRestorePartitionAfterRestart)
     {
         TEnvironmentSetup env{{
@@ -1222,7 +1221,6 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
                 expectedData);
         }
     }
-#endif
 
     // PBuffer cleanup: once the write LSN advances by PBufferCleanupLsnStep the
     // tablet barrier-erases PBuffer records up to the cleanup bound. Drive two

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -1258,7 +1258,6 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         StopFastPathService(env, partition, edge);
     }
 
-#if 0   // Temporarily disabled until restore is working correctly
     Y_UNIT_TEST(ShouldRestorePartitionAfterRestart)
     {
         TEnvironmentSetup env{{
@@ -1349,7 +1348,6 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
                 expectedData);
         }
     }
-#endif
 
     // PBuffer cleanup: once the write LSN advances by PBufferCleanupLsnStep the
     // tablet barrier-erases PBuffer records up to the cleanup bound. Drive two

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
@@ -37,7 +37,7 @@ TReadSingleLocationRequestExecutor::TReadSingleLocationRequestExecutor(
     , LogTitle(logTitle.GetChildWithTags(
           GetCycleCount(),
           {{"t", "Read"},
-           {"lsn", ToString(readHint.Lsn)},
+           {"recordId", readHint.RecordId.Print()},
            {"r", request->Headers.Range.Print()},
            {"vr", readHint.VChunkRange.Print()}}))
     , VChunkConfig(vChunkConfig)
@@ -111,7 +111,7 @@ void TReadSingleLocationRequestExecutor::StartReading()
     }
     Requested.Set(*host);
 
-    const bool fromDDisk = ReadHint.Lsn == 0;
+    const bool fromDDisk = ReadHint.RecordId.Lsn == 0;
 
     const size_t tryCount = Requested.Count();
     NActors::NLog::EPriority printPriority =
@@ -132,7 +132,7 @@ void TReadSingleLocationRequestExecutor::StartReading()
 
     ScheduleHedging(DirectBlockGroup->GetOracle()->GetReadHedgingDelay(
         *host,
-        ReadHint.Lsn == 0 ? EDataLocation::DDisk : EDataLocation::PBuffer));
+        fromDDisk ? EDataLocation::DDisk : EDataLocation::PBuffer));
 
     auto future = fromDDisk ? DirectBlockGroup->ReadBlocksFromDDisk(
                                   VChunkConfig.GetVChunkIndex(),
@@ -143,7 +143,7 @@ void TReadSingleLocationRequestExecutor::StartReading()
                             : DirectBlockGroup->ReadBlocksFromPBuffer(
                                   VChunkConfig.GetVChunkIndex(),
                                   *host,
-                                  ReadHint.Lsn,
+                                  ReadHint.RecordId,
                                   ReadHint.VChunkRange,
                                   Request->Sglist,
                                   TraceId);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_single_location.cpp
@@ -37,9 +37,9 @@ TReadSingleLocationRequestExecutor::TReadSingleLocationRequestExecutor(
     , LogTitle(logTitle.GetChildWithTags(
           GetCycleCount(),
           {{"t", "Read"},
-           {"lsn", readHint.Lsn},
-           {"r", request->Headers.Range},
-           {"vr", readHint.VChunkRange}}))
+           {"pBufferKey", readHint.PBufferKey.Print()},
+           {"r", request->Headers.Range.Print()},
+           {"vr", readHint.VChunkRange.Print()}}))
     , VChunkConfig(vChunkConfig)
     , DirectBlockGroup(std::move(directBlockGroup))
     , CallContext(std::move(callContext))
@@ -121,7 +121,7 @@ void TReadSingleLocationRequestExecutor::StartReading()
     }
     Requested.Set(*host);
 
-    const bool fromDDisk = ReadHint.Lsn == 0;
+    const bool fromDDisk = ReadHint.PBufferKey.Lsn == 0;
 
     const size_t tryCount = Requested.Count();
     NActors::NLog::EPriority printPriority =
@@ -142,7 +142,8 @@ void TReadSingleLocationRequestExecutor::StartReading()
 
     ScheduleHedging(DirectBlockGroup->GetOracle()->GetReadHedgingDelay(
         *host,
-        ReadHint.Lsn == 0 ? EDataLocation::DDisk : EDataLocation::PBuffer));
+        ReadHint.PBufferKey.Lsn == 0 ? EDataLocation::DDisk
+                                     : EDataLocation::PBuffer));
 
     auto future = fromDDisk ? DirectBlockGroup->ReadBlocksFromDDisk(
                                   VChunkConfig.GetVChunkIndex(),
@@ -153,7 +154,7 @@ void TReadSingleLocationRequestExecutor::StartReading()
                             : DirectBlockGroup->ReadBlocksFromPBuffer(
                                   VChunkConfig.GetVChunkIndex(),
                                   *host,
-                                  ReadHint.Lsn,
+                                  ReadHint.PBufferKey,
                                   ReadHint.VChunkRange,
                                   SgList,
                                   TraceId);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_ut.cpp
@@ -65,9 +65,11 @@ Y_UNIT_TEST_SUITE(TReadRequestTest)
                 .RequestId = 1,
                 .Range = range});
 
-        DirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(20, 10));
+        DirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(20, 10));
         DirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(20, 10),
             VChunkConfig.GetDesiredPBuffers(),
             VChunkConfig.GetDesiredPBuffers());
@@ -132,16 +134,20 @@ Y_UNIT_TEST_SUITE(TReadRequestTest)
     {
         Init();
 
-        DirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(20, 10));
+        DirtyMap.RegisterInflightWrite(
+            MakeId(100),
+            TBlockRange64::WithLength(20, 10));
         DirtyMap.WriteFinished(
-            100,
+            MakeId(100),
             TBlockRange64::WithLength(20, 10),
             VChunkConfig.GetDesiredPBuffers(),
             VChunkConfig.GetDesiredPBuffers());
 
-        DirtyMap.RegisterInflightWrite(200, TBlockRange64::WithLength(40, 10));
+        DirtyMap.RegisterInflightWrite(
+            MakeId(200),
+            TBlockRange64::WithLength(40, 10));
         DirtyMap.WriteFinished(
-            200,
+            MakeId(200),
             TBlockRange64::WithLength(40, 10),
             VChunkConfig.GetDesiredPBuffers(),
             VChunkConfig.GetDesiredPBuffers());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_ut.cpp
@@ -65,9 +65,11 @@ Y_UNIT_TEST_SUITE(TReadRequestTest)
                 .RequestId = 1,
                 .Range = range});
 
-        DirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(20, 10));
+        DirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(20, 10));
         DirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(20, 10),
             VChunkConfig.GetDesiredPBuffers(),
             VChunkConfig.GetDesiredPBuffers());
@@ -132,16 +134,20 @@ Y_UNIT_TEST_SUITE(TReadRequestTest)
     {
         Init();
 
-        DirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(20, 10));
+        DirtyMap->RegisterInflightWrite(
+            MakeKey(100),
+            TBlockRange64::WithLength(20, 10));
         DirtyMap->WriteFinished(
-            100,
+            MakeKey(100),
             TBlockRange64::WithLength(20, 10),
             VChunkConfig.GetDesiredPBuffers(),
             VChunkConfig.GetDesiredPBuffers());
 
-        DirtyMap->RegisterInflightWrite(200, TBlockRange64::WithLength(40, 10));
+        DirtyMap->RegisterInflightWrite(
+            MakeKey(200),
+            TBlockRange64::WithLength(40, 10));
         DirtyMap->WriteFinished(
-            200,
+            MakeKey(200),
             TBlockRange64::WithLength(40, 10),
             VChunkConfig.GetDesiredPBuffers(),
             VChunkConfig.GetDesiredPBuffers());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -273,7 +273,7 @@ ui64 TVChunk::GetPBufferUsedSize(THostIndex hostIndex) const
     return BlocksDirtyMap.GetPBufferUsedSize(hostIndex);
 }
 
-std::optional<ui64> TVChunk::GetSafeBarrierForErase() const
+std::optional<TRecordId> TVChunk::GetSafeBarrierForErase() const
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
@@ -282,7 +282,7 @@ std::optional<ui64> TVChunk::GetSafeBarrierForErase() const
         // PBuffers and are not inflight, so an empty dirty map does not mean
         // "no constraint". Report the blocking bound so the tablet-wide
         // cleanup skips its tick until every vchunk finishes restoring.
-        return 0;
+        return TRecordId{};
     }
 
     return BlocksDirtyMap.GetSafeBarrierForErase();
@@ -340,7 +340,7 @@ void TVChunk::OnWriteBlocksResponse(
             NWilson::EFlags::AUTO_END);
 
         BlocksDirtyMap.WriteFinished(
-            response.Lsn,
+            response.RecordId,
             bundle->GetVChunkRange(),
             response.RequestedWrites,
             response.CompletedWrites);
@@ -369,7 +369,9 @@ void TVChunk::OnBelatedWriteBlocksResponse(
         LogTitle.GetWithTime().c_str(),
         bundle->GetVChunkRange().Print().c_str());
 
-    BlocksDirtyMap.UpdateBelatedEraseQueue(completedWrites, bundle->GetLsn());
+    BlocksDirtyMap.UpdateBelatedEraseQueue(
+        completedWrites,
+        bundle->GetRecordId());
 
     DoErase(false, TBlocksDirtyMap::EEraseType::Belated);
     ScheduleCleaningUp();
@@ -382,7 +384,10 @@ void TVChunk::UpdateDirtyMap(const TDBGRestoreResponse& response)
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
     for (const auto& meta: response.Meta) {
-        BlocksDirtyMap.RestorePBuffer(meta.Lsn, meta.Range, meta.HostIndex);
+        BlocksDirtyMap.RestorePBuffer(
+            meta.RecordId,
+            meta.Range,
+            meta.HostIndex);
     }
     if (!DirtyMapReady.HasValue()) {
         DirtyMapReady.SetValue();
@@ -560,18 +565,21 @@ void TVChunk::DoWriteBlocksLocal(std::shared_ptr<TWriteRequestBundle> bundle)
 
     WaitForDirtyMapReady();
 
-    // Generate the lsn and register the write as inflight on the same executor
-    // thread, so the cleanup watermark covers it from the moment of generation.
-    const ui64 lsn = PartitionDirectService->GenerateLsn();
-    bundle->SetLsn(lsn);
-    BlocksDirtyMap.RegisterInflightWrite(lsn, bundle->GetVChunkRange());
+    // Mint the record id and register the write as inflight on the same
+    // executor thread, so the cleanup watermark covers it from the moment of
+    // minting.
+    const TRecordId recordId{
+        .Generation = DirectBlockGroup->GetTabletGeneration(),
+        .Lsn = PartitionDirectService->GenerateLsn()};
+    bundle->SetRecordId(recordId);
+    BlocksDirtyMap.RegisterInflightWrite(recordId, bundle->GetVChunkRange());
 
     LOG_DEBUG(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,
-        "%s DoWriteBlocksLocal: lsn %lu %s",
+        "%s DoWriteBlocksLocal: recordId %s %s",
         LogTitle.GetWithTime().c_str(),
-        lsn,
+        recordId.Print().c_str(),
         bundle->GetVChunkRange().Print().c_str());
 
     auto writeExecutor = CreateWriteRequestExecutor(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -318,7 +318,7 @@ TCountAndSize TVChunk::GetBehindBlocks(THostIndex hostIndex) const
     return BlocksDirtyMap->GetBehindBlocks(hostIndex);
 }
 
-std::optional<ui64> TVChunk::GetSafeBarrierForErase() const
+std::optional<TPBufferKey> TVChunk::GetSafeBarrierForErase() const
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
@@ -327,7 +327,7 @@ std::optional<ui64> TVChunk::GetSafeBarrierForErase() const
         // PBuffers and are not inflight, so an empty dirty map does not mean
         // "no constraint". Report the blocking bound so the tablet-wide
         // cleanup skips its tick until every vchunk finishes restoring.
-        return 0;
+        return TPBufferKey{};
     }
 
     return BlocksDirtyMap->GetSafeBarrierForErase();
@@ -390,7 +390,7 @@ void TVChunk::OnWriteBlocksResponse(
             NWilson::EFlags::AUTO_END);
 
         BlocksDirtyMap->WriteFinished(
-            response.Lsn,
+            response.PBufferKey,
             bundle->GetVChunkRange(),
             response.RequestedWrites,
             response.CompletedWrites);
@@ -419,7 +419,9 @@ void TVChunk::OnBelatedWriteBlocksResponse(
         LogTitle.GetWithTime().c_str(),
         bundle->GetVChunkRange().Print().c_str());
 
-    BlocksDirtyMap->UpdateBelatedEraseQueue(completedWrites, bundle->GetLsn());
+    BlocksDirtyMap->UpdateBelatedEraseQueue(
+        completedWrites,
+        bundle->GetPBufferKey());
 
     DoErase(false, TBlocksDirtyMap::EEraseType::Belated);
     DoPersistDirtyMap();
@@ -433,7 +435,10 @@ void TVChunk::UpdateDirtyMap(const TDBGRestoreResponse& response)
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
     for (const auto& meta: response.Meta) {
-        BlocksDirtyMap->RestorePBuffer(meta.Lsn, meta.Range, meta.HostIndex);
+        BlocksDirtyMap->RestorePBuffer(
+            meta.PBufferKey,
+            meta.Range,
+            meta.HostIndex);
     }
     if (!DirtyMapReady.HasValue()) {
         DirtyMapReady.SetValue();
@@ -633,18 +638,21 @@ void TVChunk::DoWriteBlocksLocal(std::shared_ptr<TWriteRequestBundle> bundle)
 
     WaitForDirtyMapReady();
 
-    // Generate the lsn and register the write as inflight on the same executor
-    // thread, so the cleanup watermark covers it from the moment of generation.
-    const ui64 lsn = PartitionDirectService->GenerateLsn();
-    bundle->SetLsn(lsn);
-    BlocksDirtyMap->RegisterInflightWrite(lsn, bundle->GetVChunkRange());
+    // Mint the record id and register the write as inflight on the same
+    // executor thread, so the cleanup watermark covers it from the moment of
+    // minting.
+    const TPBufferKey pBufferKey{
+        .Generation = DirectBlockGroup->GetTabletGeneration(),
+        .Lsn = PartitionDirectService->GenerateLsn()};
+    bundle->SetPBufferKey(pBufferKey);
+    BlocksDirtyMap->RegisterInflightWrite(pBufferKey, bundle->GetVChunkRange());
 
     LOG_DEBUG(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,
-        "%s DoWriteBlocksLocal: lsn %lu %s",
+        "%s DoWriteBlocksLocal: pBufferKey %s %s",
         LogTitle.GetWithTime().c_str(),
-        lsn,
+        pBufferKey.Print().c_str(),
         bundle->GetVChunkRange().Print().c_str());
 
     auto writeExecutor = CreateWriteRequestExecutor(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -69,11 +69,12 @@ public:
     [[nodiscard]] ui64 GetPBufferUsedSize(THostIndex hostIndex) const;
 
     // This vchunk's contribution to the tablet-wide cleanup watermark: the
-    // smallest lsn still held in PBuffers, or nullopt when nothing is inflight.
-    // Until the dirty map is restored it returns 0 (the blocking bound), so
-    // the cleanup cannot erase records that are not accounted for yet.
+    // smallest record id still held in PBuffers, or nullopt when nothing is
+    // inflight. Until the dirty map is restored it returns the zero record id
+    // (the blocking bound), so the cleanup cannot erase records that are not
+    // accounted for yet.
     // Must run on the executor thread.
-    [[nodiscard]] std::optional<ui64> GetSafeBarrierForErase() const;
+    [[nodiscard]] std::optional<TRecordId> GetSafeBarrierForErase() const;
 
     [[nodiscard]] TString DebugPrintDirtyMap();
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -76,11 +76,12 @@ public:
     [[nodiscard]] TCountAndSize GetBehindBlocks(THostIndex hostIndex) const;
 
     // This vchunk's contribution to the tablet-wide cleanup watermark: the
-    // smallest lsn still held in PBuffers, or nullopt when nothing is inflight.
-    // Until the dirty map is restored it returns 0 (the blocking bound), so
-    // the cleanup cannot erase records that are not accounted for yet.
+    // smallest record id still held in PBuffers, or nullopt when nothing is
+    // inflight. Until the dirty map is restored it returns the zero record id
+    // (the blocking bound), so the cleanup cannot erase records that are not
+    // accounted for yet.
     // Must run on the executor thread.
-    [[nodiscard]] std::optional<ui64> GetSafeBarrierForErase() const;
+    [[nodiscard]] std::optional<TPBufferKey> GetSafeBarrierForErase() const;
 
     [[nodiscard]] TString DebugPrintDirtyMap();
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -17,11 +17,11 @@ namespace {
 
 // GetSafeBarrierForErase asserts it runs on the vchunk's executor thread, so
 // hop onto the executor and bring the value back.
-std::optional<ui64> GetSafeBarrierOnExecutor(
+std::optional<TRecordId> GetSafeBarrierOnExecutor(
     const TExecutorPtr& executor,
     TVChunk& vchunk)
 {
-    auto promise = NThreading::NewPromise<std::optional<ui64>>();
+    auto promise = NThreading::NewPromise<std::optional<TRecordId>>();
     auto future = promise.GetFuture();
     executor->ExecuteSimple(
         [promise = std::move(promise), &vchunk]() mutable
@@ -162,14 +162,13 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         auto future =
             vchunk->WriteBlocksLocal(callContext, request, NWilson::TTraceId());
 
-        // GenerateLsn + RegisterInflightWrite happen as the write is
-        // dispatched, so the safe barrier is held at the generated lsn (123)
-        // right away.
+        // The record id is minted and registered as the write is dispatched,
+        // so the safe barrier is held at the minted record id right away.
         UNIT_ASSERT_VALUES_EQUAL(
             true,
             WaitWriteRequests(3, TDuration::Seconds(10)));
         UNIT_ASSERT_VALUES_EQUAL(
-            123,
+            MakeId(123),
             *GetSafeBarrierOnExecutor(
                 DirectBlockGroup->GetExecutor(),
                 *vchunk));
@@ -183,7 +182,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             result.Error.GetCode(),
             FormatError(result.Error));
         UNIT_ASSERT_VALUES_EQUAL(
-            123,
+            MakeId(123),
             *GetSafeBarrierOnExecutor(
                 DirectBlockGroup->GetExecutor(),
                 *vchunk));
@@ -196,8 +195,8 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
     // Reporting "no constraint" (nullopt) in that window is indistinguishable
     // from an idle vchunk, so FinishPBufferCleanup would skip it and a
     // tablet-wide barrier erase could wipe the very records the restore is
-    // about to return. An un-restored vchunk must report the blocking bound
-    // (0) instead; cleanup skips its tick on it.
+    // about to return. An un-restored vchunk must report the zero record id
+    // (the blocking bound) instead; cleanup skips its tick on it.
     Y_UNIT_TEST_F(
         ShouldConstrainCleanupBarrierUntilRestoreCompletes,
         TBaseFixture)
@@ -250,7 +249,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             barrierWhileRestoring.has_value(),
             "vchunk with a pending restore reported 'no constraint' to the "
             "cleanup barrier gather");
-        UNIT_ASSERT_VALUES_EQUAL(0, *barrierWhileRestoring);
+        UNIT_ASSERT_VALUES_EQUAL(TRecordId{}, *barrierWhileRestoring);
         UNIT_ASSERT(!barrierAfterRestore.has_value());
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -203,10 +203,9 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             true,
             WaitWriteRequests(3, TDuration::Seconds(10)));
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *GetSafeBarrierOnExecutor(
-                DirectBlockGroup->GetExecutor(),
-                *vchunk));
+            MakeKey(123).Print(),
+            GetSafeBarrierOnExecutor(DirectBlockGroup->GetExecutor(), *vchunk)
+                ->Print());
 
         // Acknowledging the PBuffer writes does not release the barrier: the
         // entry stays inflight until it is flushed and erased.
@@ -217,10 +216,9 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             result.Error.GetCode(),
             FormatError(result.Error));
         UNIT_ASSERT_VALUES_EQUAL(
-            MakeKey(123),
-            *GetSafeBarrierOnExecutor(
-                DirectBlockGroup->GetExecutor(),
-                *vchunk));
+            MakeKey(123).Print(),
+            GetSafeBarrierOnExecutor(DirectBlockGroup->GetExecutor(), *vchunk)
+                ->Print());
 
         vchunk->Stop().GetValue(TDuration::Seconds(10));
     }
@@ -287,7 +285,9 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             barrierWhileRestoring.has_value(),
             "vchunk with a pending restore reported 'no constraint' to the "
             "cleanup barrier gather");
-        UNIT_ASSERT_VALUES_EQUAL(TPBufferKey{}, *barrierWhileRestoring);
+        UNIT_ASSERT_VALUES_EQUAL(
+            TPBufferKey{}.Print(),
+            barrierWhileRestoring->Print());
         UNIT_ASSERT(!barrierAfterRestore.has_value());
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -19,11 +19,11 @@ namespace {
 
 // GetSafeBarrierForErase asserts it runs on the vchunk's executor thread, so
 // hop onto the executor and bring the value back.
-std::optional<ui64> GetSafeBarrierOnExecutor(
+std::optional<TPBufferKey> GetSafeBarrierOnExecutor(
     const TExecutorPtr& executor,
     TVChunk& vchunk)
 {
-    auto promise = NThreading::NewPromise<std::optional<ui64>>();
+    auto promise = NThreading::NewPromise<std::optional<TPBufferKey>>();
     auto future = promise.GetFuture();
     executor->ExecuteSimple(
         [promise = std::move(promise), &vchunk]() mutable
@@ -43,16 +43,18 @@ void MakeDirtyMapNeedPersist(TBlocksDirtyMap& dirtyMap)
     requested.Set(2);
     requested.Set(3);
 
-    dirtyMap.RegisterInflightWrite(100, TBlockRange64::WithLength(10, 10));
+    dirtyMap.RegisterInflightWrite(
+        MakeKey(100),
+        TBlockRange64::WithLength(10, 10));
     dirtyMap.WriteFinished(
-        100,
+        MakeKey(100),
         TBlockRange64::WithLength(10, 10),
         requested,
         requested);
 
     auto flushHint = dirtyMap.MakeFlushHint(1);
     for (const auto& [route, hint]: flushHint.GetAllHints()) {
-        dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+        dirtyMap.FlushFinished(route, MakePBufferKeys(hint.Segments), {});
     }
 }
 
@@ -195,14 +197,13 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
         auto future =
             vchunk->WriteBlocksLocal(callContext, request, NWilson::TTraceId());
 
-        // GenerateLsn + RegisterInflightWrite happen as the write is
-        // dispatched, so the safe barrier is held at the generated lsn (123)
-        // right away.
+        // The record id is minted and registered as the write is dispatched,
+        // so the safe barrier is held at the minted record id right away.
         UNIT_ASSERT_VALUES_EQUAL(
             true,
             WaitWriteRequests(3, TDuration::Seconds(10)));
         UNIT_ASSERT_VALUES_EQUAL(
-            123,
+            MakeKey(123),
             *GetSafeBarrierOnExecutor(
                 DirectBlockGroup->GetExecutor(),
                 *vchunk));
@@ -216,7 +217,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             result.Error.GetCode(),
             FormatError(result.Error));
         UNIT_ASSERT_VALUES_EQUAL(
-            123,
+            MakeKey(123),
             *GetSafeBarrierOnExecutor(
                 DirectBlockGroup->GetExecutor(),
                 *vchunk));
@@ -229,8 +230,8 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
     // Reporting "no constraint" (nullopt) in that window is indistinguishable
     // from an idle vchunk, so FinishPBufferCleanup would skip it and a
     // tablet-wide barrier erase could wipe the very records the restore is
-    // about to return. An un-restored vchunk must report the blocking bound
-    // (0) instead; cleanup skips its tick on it.
+    // about to return. An un-restored vchunk must report the zero record id
+    // (the blocking bound) instead; cleanup skips its tick on it.
     Y_UNIT_TEST_F(
         ShouldConstrainCleanupBarrierUntilRestoreCompletes,
         TBaseFixture)
@@ -286,7 +287,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             barrierWhileRestoring.has_value(),
             "vchunk with a pending restore reported 'no constraint' to the "
             "cleanup barrier gather");
-        UNIT_ASSERT_VALUES_EQUAL(0, *barrierWhileRestoring);
+        UNIT_ASSERT_VALUES_EQUAL(TPBufferKey{}, *barrierWhileRestoring);
         UNIT_ASSERT(!barrierAfterRestore.has_value());
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
@@ -36,7 +36,7 @@ TWriteRequestExecutor::TWriteRequestExecutor(
     , LogTitle(logTitle.GetChildWithTags(
           GetCycleCount(),
           {{"t", ToString(WriteMode)},
-           {"lsn", ToString(bundle->GetLsn())},
+           {"recordId", bundle->GetRecordId().Print()},
            {"r", bundle->GetRange().Print()},
            {"rv", bundle->GetVChunkRange().Print()}}))
     , VChunkConfig(vChunkConfig)
@@ -120,7 +120,7 @@ void TWriteRequestExecutor::SendIndirectWriteRequest(THostMask hosts)
         VChunkConfig.GetVChunkIndex(),
         coordinator,
         hosts,
-        Bundle->GetLsn(),
+        Bundle->GetRecordId(),
         Bundle->GetVChunkRange(),
         IndirectWriteReplyTimeout,
         Bundle->GetSgList(),
@@ -288,7 +288,7 @@ void TWriteRequestExecutor::SendDirectWriteRequest(THostIndex host)
     auto future = DirectBlockGroup->WriteBlocksToPBuffer(
         VChunkConfig.GetVChunkIndex(),
         host,
-        Bundle->GetLsn(),
+        Bundle->GetRecordId(),
         Bundle->GetVChunkRange(),
         Bundle->GetSgList(),
         span ? span->GetTraceId() : NWilson::TTraceId());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request.cpp
@@ -11,6 +11,8 @@
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>
 
+#include <util/string/cast.h>
+
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 namespace {
@@ -35,12 +37,10 @@ TWriteRequestExecutor::TWriteRequestExecutor(
     , WriteMode(directBlockGroup->GetOracle()->GetWriteMode())
     , LogTitle(logTitle.GetChildWithTags(
           GetCycleCount(),
-          {{"t",
-            WriteMode == EWriteMode::IndirectWrite ? "IndirectWrite"
-                                                   : "DirectWrite"},
-           {"lsn", bundle->GetLsn()},
-           {"r", bundle->GetRange()},
-           {"rv", bundle->GetVChunkRange()}}))
+          {{"t", ToString(WriteMode)},
+           {"pBufferKey", bundle->GetPBufferKey().Print()},
+           {"r", bundle->GetRange().Print()},
+           {"rv", bundle->GetVChunkRange().Print()}}))
     , VChunkConfig(vChunkConfig)
     , DirectBlockGroup(std::move(directBlockGroup))
     , Bundle(std::move(bundle))
@@ -122,7 +122,7 @@ void TWriteRequestExecutor::SendIndirectWriteRequest(THostMask hosts)
         VChunkConfig.GetVChunkIndex(),
         coordinator,
         hosts,
-        Bundle->GetLsn(),
+        Bundle->GetPBufferKey(),
         Bundle->GetVChunkRange(),
         IndirectWriteReplyTimeout,
         Bundle->GetSgList(),
@@ -290,7 +290,7 @@ void TWriteRequestExecutor::SendDirectWriteRequest(THostIndex host)
     auto future = DirectBlockGroup->WriteBlocksToPBuffer(
         VChunkConfig.GetVChunkIndex(),
         host,
-        Bundle->GetLsn(),
+        Bundle->GetPBufferKey(),
         Bundle->GetVChunkRange(),
         Bundle->GetSgList(),
         span ? span->GetTraceId() : NWilson::TTraceId());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.cpp
@@ -39,7 +39,7 @@ void TWriteRequestBundle::Reply(
             shared_from_this(),
             TWriteRequestResponse{
                 .Error = std::move(error),
-                .Lsn = Lsn,
+                .RecordId = RecordId,
                 .RequestedWrites = requestedWrites,
                 .CompletedWrites = completedWrites});
     } else {
@@ -84,14 +84,14 @@ TBlockRange64 TWriteRequestBundle::GetVChunkRange() const
     return VChunkRange;
 }
 
-void TWriteRequestBundle::SetLsn(ui64 lsn)
+void TWriteRequestBundle::SetRecordId(TRecordId recordId)
 {
-    Lsn = lsn;
+    RecordId = recordId;
 }
 
-ui64 TWriteRequestBundle::GetLsn() const
+TRecordId TWriteRequestBundle::GetRecordId() const
 {
-    return Lsn;
+    return RecordId;
 }
 
 TGuardedSgList& TWriteRequestBundle::GetSgList()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.cpp
@@ -51,7 +51,7 @@ void TWriteRequestBundle::Reply(
             shared_from_this(),
             TWriteRequestResponse{
                 .Error = std::move(error),
-                .Lsn = Lsn,
+                .PBufferKey = PBufferKey,
                 .RequestedWrites = requestedWrites,
                 .CompletedWrites = completedWrites});
     } else {
@@ -96,14 +96,14 @@ TBlockRange64 TWriteRequestBundle::GetVChunkRange() const
     return VChunkRange;
 }
 
-void TWriteRequestBundle::SetLsn(ui64 lsn)
+void TWriteRequestBundle::SetPBufferKey(TPBufferKey pBufferKey)
 {
-    Lsn = lsn;
+    PBufferKey = pBufferKey;
 }
 
-ui64 TWriteRequestBundle::GetLsn() const
+TPBufferKey TWriteRequestBundle::GetPBufferKey() const
 {
-    return Lsn;
+    return PBufferKey;
 }
 
 TGuardedSgList& TWriteRequestBundle::GetSgList()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/diagnostics/trace_helpers.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/public.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/request.h>
@@ -16,7 +17,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 struct TWriteRequestResponse
 {
     NProto::TError Error;
-    ui64 Lsn = 0;
+    TRecordId RecordId;
     // The PBuffer hosts where the attempt was made to write the data.
     THostMask RequestedWrites;
     // The PBuffer hosts where exactly the data was written and confirmed.
@@ -54,8 +55,8 @@ public:
     NWilson::TSpan& GetSpan();
     TBlockRange64 GetRange() const;
     TBlockRange64 GetVChunkRange() const;
-    void SetLsn(ui64 lsn);
-    ui64 GetLsn() const;
+    void SetRecordId(TRecordId recordId);
+    TRecordId GetRecordId() const;
     TGuardedSgList& GetSgList();
 
 private:
@@ -64,7 +65,7 @@ private:
     NWilson::TSpan Span;
     TCallContextPtr CallContext;
     TBlockRange64 VChunkRange;
-    ui64 Lsn = 0;
+    TRecordId RecordId;
 
     NThreading::TPromise<TWriteBlocksLocalResponse> Promise;
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_bundle.h
@@ -2,6 +2,7 @@
 
 #include "public.h"
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/diagnostics/trace_helpers.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/public.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/service/request.h>
@@ -16,7 +17,7 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 struct TWriteRequestResponse
 {
     NProto::TError Error;
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
     // The PBuffer hosts where the attempt was made to write the data.
     THostMask RequestedWrites;
     // The PBuffer hosts where exactly the data was written and confirmed.
@@ -54,8 +55,8 @@ public:
     NWilson::TSpan& GetSpan();
     TBlockRange64 GetRange() const;
     TBlockRange64 GetVChunkRange() const;
-    void SetLsn(ui64 lsn);
-    ui64 GetLsn() const;
+    void SetPBufferKey(TPBufferKey pBufferKey);
+    TPBufferKey GetPBufferKey() const;
     TGuardedSgList& GetSgList();
 
 private:
@@ -65,7 +66,7 @@ private:
     NWilson::TSpan Span;
     TCallContextPtr CallContext;
     TBlockRange64 VChunkRange;
-    ui64 Lsn = 0;
+    TPBufferKey PBufferKey;
 
     NThreading::TPromise<TWriteBlocksLocalResponse> Promise;
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.cpp
@@ -38,12 +38,12 @@ void TWriteRequestTestFixture::Init()
     DirectBlockGroup->WriteBlocksToPBufferHandler = [this]   //
         (ui32 vChunkIndex,
          ui8 hostIndex,
-         ui64 lsn,
+         TRecordId recordId,
          TBlockRange64 range,
          const TGuardedSgList& guardedSglist,
          const NWilson::TTraceId& traceId)
     {
-        Y_UNUSED(hostIndex, lsn, traceId, guardedSglist);
+        Y_UNUSED(hostIndex, recordId, traceId, guardedSglist);
 
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
@@ -60,7 +60,7 @@ void TWriteRequestTestFixture::Init()
             ui32 vChunkIndex,
             THostIndex coordinatorHostIndex,
             THostMask hostIndexes,
-            ui64 lsn,
+            TRecordId recordId,
             TBlockRange64 range,
             TDuration replyTimeout,
             const TGuardedSgList& guardedSglist,
@@ -71,7 +71,7 @@ void TWriteRequestTestFixture::Init()
             vChunkIndex,
             coordinatorHostIndex,
             hostIndexes,
-            lsn,
+            recordId,
             range,
             replyTimeout,
             guardedSglist,
@@ -142,7 +142,7 @@ TWriteRequestTestFixture::GetManyPBuffersHandlerWithImmediateOkResponse()
             ui32 vChunkIndex,
             THostIndex coordinatorHostIndex,
             THostMask hostIndexes,
-            ui64 lsn,
+            TRecordId recordId,
             TBlockRange64 range,
             TDuration replyTimeout,
             const TGuardedSgList& guardedSglist,
@@ -151,7 +151,7 @@ TWriteRequestTestFixture::GetManyPBuffersHandlerWithImmediateOkResponse()
     {
         Y_UNUSED(coordinatorHostIndex, replyTimeout, guardedSglist, traceId);
 
-        UNIT_ASSERT_VALUES_EQUAL(UserLsn, lsn);
+        UNIT_ASSERT_VALUES_EQUAL(UserRecordId, recordId);
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
@@ -188,7 +188,7 @@ TWriteRequestExecutorPtr TWriteRequestTestFixture::CreateRequestExecutor(
         NWilson::TTraceId(),
         MakeIntrusive<TCallContext>(),
         Range);
-    bundle->SetLsn(UserLsn);
+    bundle->SetRecordId(UserRecordId);
 
     WriteClient->Response.reset();
     DirectBlockGroup->Oracle.WriteMode = writeMode;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.cpp
@@ -151,7 +151,7 @@ TWriteRequestTestFixture::GetManyPBuffersHandlerWithImmediateOkResponse()
     {
         Y_UNUSED(coordinatorHostIndex, replyTimeout, guardedSglist, traceId);
 
-        UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey, pBufferKey);
+        UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey.Print(), pBufferKey.Print());
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.cpp
@@ -38,12 +38,12 @@ void TWriteRequestTestFixture::Init()
     DirectBlockGroup->WriteBlocksToPBufferHandler = [this]   //
         (ui32 vChunkIndex,
          ui8 hostIndex,
-         ui64 lsn,
+         TPBufferKey pBufferKey,
          TBlockRange64 range,
          const TGuardedSgList& guardedSglist,
          const NWilson::TTraceId& traceId)
     {
-        Y_UNUSED(hostIndex, lsn, traceId, guardedSglist);
+        Y_UNUSED(hostIndex, pBufferKey, traceId, guardedSglist);
 
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
@@ -60,7 +60,7 @@ void TWriteRequestTestFixture::Init()
             ui32 vChunkIndex,
             THostIndex coordinatorHostIndex,
             THostMask hostIndexes,
-            ui64 lsn,
+            TPBufferKey pBufferKey,
             TBlockRange64 range,
             TDuration replyTimeout,
             const TGuardedSgList& guardedSglist,
@@ -71,7 +71,7 @@ void TWriteRequestTestFixture::Init()
             vChunkIndex,
             coordinatorHostIndex,
             hostIndexes,
-            lsn,
+            pBufferKey,
             range,
             replyTimeout,
             guardedSglist,
@@ -142,7 +142,7 @@ TWriteRequestTestFixture::GetManyPBuffersHandlerWithImmediateOkResponse()
             ui32 vChunkIndex,
             THostIndex coordinatorHostIndex,
             THostMask hostIndexes,
-            ui64 lsn,
+            TPBufferKey pBufferKey,
             TBlockRange64 range,
             TDuration replyTimeout,
             const TGuardedSgList& guardedSglist,
@@ -151,7 +151,7 @@ TWriteRequestTestFixture::GetManyPBuffersHandlerWithImmediateOkResponse()
     {
         Y_UNUSED(coordinatorHostIndex, replyTimeout, guardedSglist, traceId);
 
-        UNIT_ASSERT_VALUES_EQUAL(UserLsn, lsn);
+        UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey, pBufferKey);
         UNIT_ASSERT_VALUES_EQUAL(VChunkConfig.GetVChunkIndex(), vChunkIndex);
         UNIT_ASSERT_VALUES_EQUAL(ExpectedRange, range);
 
@@ -188,7 +188,7 @@ TWriteRequestExecutorPtr TWriteRequestTestFixture::CreateRequestExecutor(
         NWilson::TTraceId(),
         MakeIntrusive<TCallContext>(),
         Range);
-    bundle->SetLsn(UserLsn);
+    bundle->SetPBufferKey(UserPBufferKey);
 
     WriteClient->Response.reset();
     DirectBlockGroup->Oracle.WriteMode = writeMode;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.h
@@ -25,7 +25,7 @@ struct TWriteClientMock: IWriteClient
 ////////////////////////////////////////////////////////////////////////////////
 struct TWriteRequestTestFixture: public TBaseFixture
 {
-    ui64 UserLsn = 123;
+    TRecordId UserRecordId{.Generation = 1, .Lsn = 123};
     TBlockRange64 Range = TBlockRange64::WithLength(10, 10);
     TDuration HedgeDelay = TDuration::MilliSeconds(1000);
     TDuration Timeout = TDuration::MilliSeconds(1000);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.h
@@ -25,7 +25,7 @@ struct TWriteClientMock: IWriteClient
 ////////////////////////////////////////////////////////////////////////////////
 struct TWriteRequestTestFixture: public TBaseFixture
 {
-    ui64 UserLsn = 123;
+    TPBufferKey UserPBufferKey{.Generation = 1, .Lsn = 123};
     TBlockRange64 Range = TBlockRange64::WithLength(10, 10);
     TDuration HedgeDelay = TDuration::MilliSeconds(1000);
     TDuration Timeout = TDuration::MilliSeconds(1000);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
@@ -108,7 +108,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
         DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
             (ui32 vChunkIndex,
              THostIndex hostIndex,
-             ui64 lsn,
+             TRecordId recordId,
              TBlockRange64 range,
              const TGuardedSgList& guardedSglist,
              const NWilson::TTraceId& traceId)
@@ -116,7 +116,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(traceId);
             Y_UNUSED(guardedSglist);
 
-            UNIT_ASSERT_C(UserLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(UserRecordId, recordId);
             UNIT_ASSERT_VALUES_EQUAL(
                 VChunkConfig.GetVChunkIndex(),
                 vChunkIndex);
@@ -171,7 +171,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
         DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
             (ui32 vChunkIndex,
              THostIndex hostIndex,
-             ui64 lsn,
+             TRecordId recordId,
              TBlockRange64 range,
              const TGuardedSgList& guardedSglist,
              const NWilson::TTraceId& traceId)
@@ -179,7 +179,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(traceId);
             Y_UNUSED(guardedSglist);
 
-            UNIT_ASSERT_C(UserLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(UserRecordId, recordId);
             UNIT_ASSERT_VALUES_EQUAL(
                 VChunkConfig.GetVChunkIndex(),
                 vChunkIndex);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
@@ -116,7 +116,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(traceId);
             Y_UNUSED(guardedSglist);
 
-            UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey, pBufferKey);
+            UNIT_ASSERT_VALUES_EQUAL(
+                UserPBufferKey.Print(),
+                pBufferKey.Print());
             UNIT_ASSERT_VALUES_EQUAL(
                 VChunkConfig.GetVChunkIndex(),
                 vChunkIndex);
@@ -179,7 +181,9 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(traceId);
             Y_UNUSED(guardedSglist);
 
-            UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey, pBufferKey);
+            UNIT_ASSERT_VALUES_EQUAL(
+                UserPBufferKey.Print(),
+                pBufferKey.Print());
             UNIT_ASSERT_VALUES_EQUAL(
                 VChunkConfig.GetVChunkIndex(),
                 vChunkIndex);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_ut.cpp
@@ -108,7 +108,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
         DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
             (ui32 vChunkIndex,
              THostIndex hostIndex,
-             ui64 lsn,
+             TPBufferKey pBufferKey,
              TBlockRange64 range,
              const TGuardedSgList& guardedSglist,
              const NWilson::TTraceId& traceId)
@@ -116,7 +116,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(traceId);
             Y_UNUSED(guardedSglist);
 
-            UNIT_ASSERT_C(UserLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey, pBufferKey);
             UNIT_ASSERT_VALUES_EQUAL(
                 VChunkConfig.GetVChunkIndex(),
                 vChunkIndex);
@@ -171,7 +171,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
         DirectBlockGroup->WriteBlocksToPBufferHandler = [&]   //
             (ui32 vChunkIndex,
              THostIndex hostIndex,
-             ui64 lsn,
+             TPBufferKey pBufferKey,
              TBlockRange64 range,
              const TGuardedSgList& guardedSglist,
              const NWilson::TTraceId& traceId)
@@ -179,7 +179,7 @@ Y_UNIT_TEST_SUITE(TWriteRequestTest)
             Y_UNUSED(traceId);
             Y_UNUSED(guardedSglist);
 
-            UNIT_ASSERT_C(UserLsn, lsn);
+            UNIT_ASSERT_VALUES_EQUAL(UserPBufferKey, pBufferKey);
             UNIT_ASSERT_VALUES_EQUAL(
                 VChunkConfig.GetVChunkIndex(),
                 vChunkIndex);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_direct_storage_transport.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_direct_storage_transport.cpp
@@ -518,7 +518,7 @@ TICDirectStorageTransport::WriteToDDisk(
 TFuture<IStorageTransport::TEvErasePersistentBufferResult>
 TICDirectStorageTransport::BatchEraseFromPBuffer(
     const THostConnection& connection,
-    TVector<ui64> lsns,
+    TVector<TPBufferKey> pBufferKeys,
     NWilson::TSpan* span)
 {
     Y_ABORT_UNLESS(connection.ConnectionType == EConnectionType::PBuffer);
@@ -527,14 +527,14 @@ TICDirectStorageTransport::BatchEraseFromPBuffer(
     if (!entry) {
         return TICStorageTransport::BatchEraseFromPBuffer(
             connection,
-            std::move(lsns),
+            std::move(pBufferKeys),
             span);
     }
 
     auto request = std::make_unique<NDDisk::TEvBatchErasePersistentBuffer>(
         connection.Credentials);
-    for (auto lsn: lsns) {
-        request->AddErase(lsn, connection.Credentials.Generation);
+    for (const auto& pBufferKey: pBufferKeys) {
+        request->AddErase(pBufferKey.Lsn, pBufferKey.Generation);
     }
 
     auto promise = NewPromise<TEvErasePersistentBufferResult>();
@@ -611,7 +611,7 @@ TFuture<IStorageTransport::TEvReadPersistentBufferResult>
 TICDirectStorageTransport::ReadFromPBuffer(
     const THostConnection& connection,
     const NDDisk::TBlockSelector& selector,
-    const ui64 lsn,
+    const TPBufferKey pBufferKey,
     const NDDisk::TReadInstruction instruction,
     const TGuardedSgList& data,
     NWilson::TSpan* span)
@@ -623,7 +623,7 @@ TICDirectStorageTransport::ReadFromPBuffer(
         return TICStorageTransport::ReadFromPBuffer(
             connection,
             selector,
-            lsn,
+            pBufferKey,
             instruction,
             data,
             span);
@@ -632,8 +632,8 @@ TICDirectStorageTransport::ReadFromPBuffer(
     auto request = std::make_unique<NDDisk::TEvReadPersistentBuffer>(
         connection.Credentials,
         selector,
-        lsn,
-        connection.Credentials.Generation,
+        pBufferKey.Lsn,
+        pBufferKey.Generation,
         instruction);
 
     auto promise = NewPromise<TEvReadPersistentBufferResult>();
@@ -717,7 +717,7 @@ TICDirectStorageTransport::SyncWithPBuffer(
     const THostConnection& pbufferConnection,
     const THostConnection& ddiskConnection,
     TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-    TVector<ui64> lsns,
+    TVector<TPBufferKey> pBufferKeys,
     NWilson::TSpan* span)
 {
     Y_ABORT_UNLESS(
@@ -731,7 +731,7 @@ TICDirectStorageTransport::SyncWithPBuffer(
             pbufferConnection,
             ddiskConnection,
             std::move(selectors),
-            std::move(lsns),
+            std::move(pBufferKeys),
             span);
     }
 
@@ -742,14 +742,14 @@ TICDirectStorageTransport::SyncWithPBuffer(
         pbufferConnection.DDiskId.PDiskId,
         pbufferConnection.DDiskId.DDiskSlotId);
 
-    Y_ABORT_UNLESS(selectors.size() == lsns.size());
+    Y_ABORT_UNLESS(selectors.size() == pBufferKeys.size());
     for (size_t i = 0; i < selectors.size(); ++i) {
         request->AddSegmentFromPB(
             pBufferId,
             *pbufferConnection.Credentials.DDiskInstanceGuid,
             selectors[i],
-            lsns[i],
-            ddiskConnection.Credentials.Generation);
+            pBufferKeys[i].Lsn,
+            pBufferKeys[i].Generation);
     }
 
     auto promise = NewPromise<TEvSyncResult>();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_direct_storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_direct_storage_transport.h
@@ -31,7 +31,7 @@ public:
     NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TPBufferKey pBufferKey,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) override;
@@ -73,12 +73,12 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BarrierEraseFromPBuffer(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
@@ -139,7 +139,7 @@ TICStorageTransport::WriteToDDisk(
 TFuture<NKikimrBlobStorage::NDDisk::TEvErasePersistentBufferResult>
 TICStorageTransport::BatchEraseFromPBuffer(
     const THostConnection& connection,
-    TVector<ui64> lsns,
+    TVector<TRecordId> recordIds,
     NWilson::TSpan* span)
 {
     Y_ABORT_UNLESS(connection.ConnectionType == EConnectionType::PBuffer);
@@ -148,7 +148,7 @@ TICStorageTransport::BatchEraseFromPBuffer(
         std::make_unique<TEvTransportPrivate::TEvBatchEraseFromPBuffer>(
             connection.GetServiceId(),
             connection.Credentials,
-            std::move(lsns),
+            std::move(recordIds),
             span ? span->GetTraceId() : NWilson::TTraceId());
 
     auto future = request->Promise.GetFuture();
@@ -190,7 +190,7 @@ TFuture<NKikimrBlobStorage::NDDisk::TEvReadPersistentBufferResult>
 TICStorageTransport::ReadFromPBuffer(
     const THostConnection& connection,
     const NDDisk::TBlockSelector& selector,
-    const ui64 lsn,
+    const TRecordId recordId,
     const NDDisk::TReadInstruction instruction,
     const TGuardedSgList& data,
     NWilson::TSpan* span)
@@ -201,7 +201,7 @@ TICStorageTransport::ReadFromPBuffer(
         connection.GetServiceId(),
         connection.Credentials,
         selector,
-        lsn,
+        recordId,
         instruction,
         data,
         span ? span->GetTraceId() : NWilson::TTraceId());
@@ -249,7 +249,7 @@ TICStorageTransport::SyncWithPBuffer(
     const THostConnection& pbufferConnection,
     const THostConnection& ddiskConnection,
     TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-    TVector<ui64> lsns,
+    TVector<TRecordId> recordIds,
     NWilson::TSpan* span)
 {
     Y_ABORT_UNLESS(
@@ -260,7 +260,7 @@ TICStorageTransport::SyncWithPBuffer(
         ddiskConnection.GetServiceId(),
         ddiskConnection.Credentials,
         std::move(selectors),
-        std::move(lsns),
+        std::move(recordIds),
         pbufferConnection.DDiskId,
         pbufferConnection.Credentials,
         span ? span->GetTraceId() : NWilson::TTraceId());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.cpp
@@ -146,7 +146,7 @@ TICStorageTransport::WriteToDDisk(
 TFuture<NKikimrBlobStorage::NDDisk::TEvErasePersistentBufferResult>
 TICStorageTransport::BatchEraseFromPBuffer(
     const THostConnection& connection,
-    TVector<ui64> lsns,
+    TVector<TPBufferKey> pBufferKeys,
     NWilson::TSpan* span)
 {
     Y_ABORT_UNLESS(connection.ConnectionType == EConnectionType::PBuffer);
@@ -155,7 +155,7 @@ TICStorageTransport::BatchEraseFromPBuffer(
         std::make_unique<TEvTransportPrivate::TEvBatchEraseFromPBuffer>(
             connection.GetServiceId(),
             connection.Credentials,
-            std::move(lsns),
+            std::move(pBufferKeys),
             span ? span->GetTraceId() : NWilson::TTraceId());
 
     auto future = request->Promise.GetFuture();
@@ -197,7 +197,7 @@ TFuture<NKikimrBlobStorage::NDDisk::TEvReadPersistentBufferResult>
 TICStorageTransport::ReadFromPBuffer(
     const THostConnection& connection,
     const NDDisk::TBlockSelector& selector,
-    const ui64 lsn,
+    const TPBufferKey pBufferKey,
     const NDDisk::TReadInstruction instruction,
     const TGuardedSgList& data,
     NWilson::TSpan* span)
@@ -208,7 +208,7 @@ TICStorageTransport::ReadFromPBuffer(
         connection.GetServiceId(),
         connection.Credentials,
         selector,
-        lsn,
+        pBufferKey,
         instruction,
         data,
         span ? span->GetTraceId() : NWilson::TTraceId());
@@ -256,7 +256,7 @@ TICStorageTransport::SyncWithPBuffer(
     const THostConnection& pbufferConnection,
     const THostConnection& ddiskConnection,
     TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-    TVector<ui64> lsns,
+    TVector<TPBufferKey> pBufferKeys,
     NWilson::TSpan* span)
 {
     Y_ABORT_UNLESS(
@@ -267,7 +267,7 @@ TICStorageTransport::SyncWithPBuffer(
         ddiskConnection.GetServiceId(),
         ddiskConnection.Credentials,
         std::move(selectors),
-        std::move(lsns),
+        std::move(pBufferKeys),
         pbufferConnection.DDiskId,
         pbufferConnection.Credentials,
         span ? span->GetTraceId() : NWilson::TTraceId());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
@@ -20,7 +20,7 @@ public:
     NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TRecordId recordId,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) override;
@@ -62,12 +62,12 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TRecordId> recordIds,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TRecordId> recordIds,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BarrierEraseFromPBuffer(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport.h
@@ -26,7 +26,7 @@ public:
     NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TPBufferKey pBufferKey,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) override;
@@ -68,12 +68,12 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BarrierEraseFromPBuffer(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
@@ -688,8 +688,8 @@ void TICStorageTransportActor::HandleBatchErasePersistentBuffer(
 
     auto request = std::make_unique<NDDisk::TEvBatchErasePersistentBuffer>(
         msg->Credentials);
-    for (auto lsn: msg->Lsns) {
-        request->AddErase(lsn, msg->Credentials.Generation);
+    for (const auto& recordId: msg->RecordIds) {
+        request->AddErase(recordId.Lsn, recordId.Generation);
     }
 
     ctx.Send(MakeHolder<IEventHandle>(
@@ -854,8 +854,8 @@ void TICStorageTransportActor::HandleReadPersistentBuffer(
     auto request = std::make_unique<NDDisk::TEvReadPersistentBuffer>(
         msg->Credentials,
         msg->Selector,
-        msg->Lsn,
-        msg->Credentials.Generation,
+        msg->RecordId.Lsn,
+        msg->RecordId.Generation,
         msg->Instruction);
 
     SendWithUndeliveryTracking(
@@ -1078,14 +1078,14 @@ void TICStorageTransportActor::HandleSyncWithPersistentBuffer(
         msg->PBufferId.PDiskId,
         msg->PBufferId.DDiskSlotId);
 
-    Y_ABORT_UNLESS(msg->Selectors.size() == msg->Lsns.size());
+    Y_ABORT_UNLESS(msg->Selectors.size() == msg->RecordIds.size());
     for (size_t i = 0; i < msg->Selectors.size(); ++i) {
         request->AddSegmentFromPB(
             pBufferId,
             *msg->PBufferCredentials.DDiskInstanceGuid,
             msg->Selectors[i],
-            msg->Lsns[i],
-            msg->Credentials.Generation);
+            msg->RecordIds[i].Lsn,
+            msg->RecordIds[i].Generation);
     }
 
     SendWithUndeliveryTracking(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
@@ -680,8 +680,8 @@ void TICStorageTransportActor::HandleBatchErasePersistentBuffer(
 
     auto request = std::make_unique<NDDisk::TEvBatchErasePersistentBuffer>(
         msg->Credentials);
-    for (auto lsn: msg->Lsns) {
-        request->AddErase(lsn, msg->Credentials.Generation);
+    for (const auto& pBufferKey: msg->PBufferKeys) {
+        request->AddErase(pBufferKey.Lsn, pBufferKey.Generation);
     }
 
     ctx.Send(MakeHolder<IEventHandle>(
@@ -847,8 +847,8 @@ void TICStorageTransportActor::HandleReadPersistentBuffer(
     auto request = std::make_unique<NDDisk::TEvReadPersistentBuffer>(
         msg->Credentials,
         msg->Selector,
-        msg->Lsn,
-        msg->Credentials.Generation,
+        msg->PBufferKey.Lsn,
+        msg->PBufferKey.Generation,
         msg->Instruction);
 
     SendWithUndeliveryTracking(
@@ -1073,14 +1073,14 @@ void TICStorageTransportActor::HandleSyncWithPersistentBuffer(
         msg->PBufferId.PDiskId,
         msg->PBufferId.DDiskSlotId);
 
-    Y_ABORT_UNLESS(msg->Selectors.size() == msg->Lsns.size());
+    Y_ABORT_UNLESS(msg->Selectors.size() == msg->PBufferKeys.size());
     for (size_t i = 0; i < msg->Selectors.size(); ++i) {
         request->AddSegmentFromPB(
             pBufferId,
             *msg->PBufferCredentials.DDiskInstanceGuid,
             msg->Selectors[i],
-            msg->Lsns[i],
-            msg->Credentials.Generation);
+            msg->PBufferKeys[i].Lsn,
+            msg->PBufferKeys[i].Generation);
     }
 
     SendWithUndeliveryTracking(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_events.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_events.h
@@ -114,7 +114,7 @@ struct TEvTransportPrivate
 
         const NActors::TActorId ServiceId;
         const NKikimr::NDDisk::TQueryCredentials Credentials;
-        const TVector<ui64> Lsns;
+        const TVector<TRecordId> RecordIds;
         NWilson::TTraceId TraceId;
         NThreading::TPromise<TResult> Promise =
             NThreading::NewPromise<TResult>();
@@ -122,11 +122,11 @@ struct TEvTransportPrivate
         TBatchEraseFromPBuffer(
             const NActors::TActorId serviceId,
             const NKikimr::NDDisk::TQueryCredentials& credentials,
-            TVector<ui64> lsns,
+            TVector<TRecordId> recordIds,
             NWilson::TTraceId traceId)
             : ServiceId(serviceId)
             , Credentials(credentials)
-            , Lsns(std::move(lsns))
+            , RecordIds(std::move(recordIds))
             , TraceId(std::move(traceId))
         {}
 
@@ -167,7 +167,7 @@ struct TEvTransportPrivate
         const NActors::TActorId ServiceId;
         const NKikimr::NDDisk::TQueryCredentials Credentials;
         const NKikimr::NDDisk::TBlockSelector Selector;
-        const ui64 Lsn;
+        const TRecordId RecordId;
         const NKikimr::NDDisk::TReadInstruction Instruction;
         TGuardedSgList Data;
         NWilson::TTraceId TraceId;
@@ -178,14 +178,14 @@ struct TEvTransportPrivate
             const NActors::TActorId serviceId,
             const NKikimr::NDDisk::TQueryCredentials& credentials,
             const NKikimr::NDDisk::TBlockSelector& selector,
-            const ui64 lsn,
+            const TRecordId recordId,
             const NKikimr::NDDisk::TReadInstruction instruction,
             const TGuardedSgList& data,
             NWilson::TTraceId traceId)
             : ServiceId(serviceId)
             , Credentials(credentials)
             , Selector(selector)
-            , Lsn(lsn)
+            , RecordId(recordId)
             , Instruction(instruction)
             , Data(data)
             , TraceId(std::move(traceId))
@@ -233,7 +233,7 @@ struct TEvTransportPrivate
         const NActors::TActorId ServiceId;
         const NKikimr::NDDisk::TQueryCredentials Credentials;
         const TVector<NKikimr::NDDisk::TBlockSelector> Selectors;
-        const TVector<ui64> Lsns;
+        const TVector<TRecordId> RecordIds;
         const NKikimr::NBsController::TDDiskId PBufferId;
         const NKikimr::NDDisk::TQueryCredentials PBufferCredentials;
         NWilson::TTraceId TraceId;
@@ -244,14 +244,14 @@ struct TEvTransportPrivate
             const NActors::TActorId serviceId,
             const NKikimr::NDDisk::TQueryCredentials& credentials,
             TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-            TVector<ui64> lsns,
+            TVector<TRecordId> recordIds,
             const NKikimr::NBsController::TDDiskId& pBufferId,
             const NKikimr::NDDisk::TQueryCredentials& pBufferCredentials,
             NWilson::TTraceId traceId)
             : ServiceId(serviceId)
             , Credentials(credentials)
             , Selectors(std::move(selectors))
-            , Lsns(std::move(lsns))
+            , RecordIds(std::move(recordIds))
             , PBufferId(pBufferId)
             , PBufferCredentials(pBufferCredentials)
             , TraceId(std::move(traceId))

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_events.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_events.h
@@ -114,7 +114,7 @@ struct TEvTransportPrivate
 
         const NActors::TActorId ServiceId;
         const NKikimr::NDDisk::TQueryCredentials Credentials;
-        const TVector<ui64> Lsns;
+        const TVector<TPBufferKey> PBufferKeys;
         NWilson::TTraceId TraceId;
         NThreading::TPromise<TResult> Promise =
             NThreading::NewPromise<TResult>();
@@ -122,11 +122,11 @@ struct TEvTransportPrivate
         TBatchEraseFromPBuffer(
             const NActors::TActorId serviceId,
             const NKikimr::NDDisk::TQueryCredentials& credentials,
-            TVector<ui64> lsns,
+            TVector<TPBufferKey> pBufferKeys,
             NWilson::TTraceId traceId)
             : ServiceId(serviceId)
             , Credentials(credentials)
-            , Lsns(std::move(lsns))
+            , PBufferKeys(std::move(pBufferKeys))
             , TraceId(std::move(traceId))
         {}
 
@@ -167,7 +167,7 @@ struct TEvTransportPrivate
         const NActors::TActorId ServiceId;
         const NKikimr::NDDisk::TQueryCredentials Credentials;
         const NKikimr::NDDisk::TBlockSelector Selector;
-        const ui64 Lsn;
+        const TPBufferKey PBufferKey;
         const NKikimr::NDDisk::TReadInstruction Instruction;
         TGuardedSgList Data;
         NWilson::TTraceId TraceId;
@@ -178,14 +178,14 @@ struct TEvTransportPrivate
             const NActors::TActorId serviceId,
             const NKikimr::NDDisk::TQueryCredentials& credentials,
             const NKikimr::NDDisk::TBlockSelector& selector,
-            const ui64 lsn,
+            const TPBufferKey pBufferKey,
             const NKikimr::NDDisk::TReadInstruction instruction,
             const TGuardedSgList& data,
             NWilson::TTraceId traceId)
             : ServiceId(serviceId)
             , Credentials(credentials)
             , Selector(selector)
-            , Lsn(lsn)
+            , PBufferKey(pBufferKey)
             , Instruction(instruction)
             , Data(data)
             , TraceId(std::move(traceId))
@@ -233,7 +233,7 @@ struct TEvTransportPrivate
         const NActors::TActorId ServiceId;
         const NKikimr::NDDisk::TQueryCredentials Credentials;
         const TVector<NKikimr::NDDisk::TBlockSelector> Selectors;
-        const TVector<ui64> Lsns;
+        const TVector<TPBufferKey> PBufferKeys;
         const NKikimr::NBsController::TDDiskId PBufferId;
         const NKikimr::NDDisk::TQueryCredentials PBufferCredentials;
         NWilson::TTraceId TraceId;
@@ -244,14 +244,14 @@ struct TEvTransportPrivate
             const NActors::TActorId serviceId,
             const NKikimr::NDDisk::TQueryCredentials& credentials,
             TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-            TVector<ui64> lsns,
+            TVector<TPBufferKey> pBufferKeys,
             const NKikimr::NBsController::TDDiskId& pBufferId,
             const NKikimr::NDDisk::TQueryCredentials& pBufferCredentials,
             NWilson::TTraceId traceId)
             : ServiceId(serviceId)
             , Credentials(credentials)
             , Selectors(std::move(selectors))
-            , Lsns(std::move(lsns))
+            , PBufferKeys(std::move(pBufferKeys))
             , PBufferId(pBufferId)
             , PBufferCredentials(pBufferCredentials)
             , TraceId(std::move(traceId))

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/record_id.h>
+
 #include <ydb/core/nbs/cloud/storage/core/libs/common/guarded_sglist.h>
 
 #include <ydb/core/blobstorage/ddisk/ddisk.h>
@@ -73,7 +75,7 @@ public:
     virtual NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TRecordId recordId,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) = 0;
@@ -118,13 +120,13 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TRecordId> recordIds,
         NWilson::TSpan* span) = 0;
 
     virtual NThreading::TFuture<TEvErasePersistentBufferResult>
     BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TRecordId> recordIds,
         NWilson::TSpan* span) = 0;
 
     virtual NThreading::TFuture<TEvErasePersistentBufferResult>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ydb/core/nbs/cloud/blockstore/libs/common/pbuffer_key.h>
+
 #include <ydb/core/nbs/cloud/storage/core/libs/common/guarded_sglist.h>
 
 #include <ydb/core/blobstorage/ddisk/ddisk.h>
@@ -75,7 +77,7 @@ public:
     virtual NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TPBufferKey pBufferKey,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) = 0;
@@ -120,13 +122,13 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) = 0;
 
     virtual NThreading::TFuture<TEvErasePersistentBufferResult>
     BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) = 0;
 
     virtual NThreading::TFuture<TEvErasePersistentBufferResult>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.cpp
@@ -135,12 +135,12 @@ NThreading::TFuture<TEvReadPersistentBufferResult>
 TStorageTransportMock::ReadFromPBuffer(
     const THostConnection& connection,
     const NKikimr::NDDisk::TBlockSelector& selector,
-    const ui64 lsn,
+    const TRecordId recordId,
     const NKikimr::NDDisk::TReadInstruction instruction,
     const TGuardedSgList& data,
     NWilson::TSpan* span)
 {
-    Y_UNUSED(connection, selector, lsn, instruction, data, span);
+    Y_UNUSED(connection, selector, recordId, instruction, data, span);
 
     TEvReadPersistentBufferResult result;
     result.SetStatus(ReadFromPBufferStatus);
@@ -256,10 +256,10 @@ NThreading::TFuture<TEvSyncResult> TStorageTransportMock::SyncWithPBuffer(
     const THostConnection& pbufferConnection,
     const THostConnection& ddiskConnection,
     TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-    TVector<ui64> lsns,
+    TVector<TRecordId> recordIds,
     NWilson::TSpan* span)
 {
-    Y_UNUSED(pbufferConnection, ddiskConnection, lsns, span);
+    Y_UNUSED(pbufferConnection, ddiskConnection, recordIds, span);
 
     TEvSyncResult result;
     result.SetStatus(SyncWithPBufferStatus);
@@ -274,10 +274,10 @@ NThreading::TFuture<TEvSyncResult> TStorageTransportMock::SyncWithPBuffer(
 NThreading::TFuture<TEvErasePersistentBufferResult>
 TStorageTransportMock::BatchEraseFromPBuffer(
     const THostConnection& connection,
-    TVector<ui64> lsns,
+    TVector<TRecordId> recordIds,
     NWilson::TSpan* span)
 {
-    Y_UNUSED(connection, lsns, span);
+    Y_UNUSED(connection, recordIds, span);
 
     Y_ABORT("BatchEraseFromPBuffer is not expected in this test");
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.cpp
@@ -135,12 +135,12 @@ NThreading::TFuture<TEvReadPersistentBufferResult>
 TStorageTransportMock::ReadFromPBuffer(
     const THostConnection& connection,
     const NKikimr::NDDisk::TBlockSelector& selector,
-    const ui64 lsn,
+    const TPBufferKey pBufferKey,
     const NKikimr::NDDisk::TReadInstruction instruction,
     const TGuardedSgList& data,
     NWilson::TSpan* span)
 {
-    Y_UNUSED(connection, selector, lsn, instruction, data, span);
+    Y_UNUSED(connection, selector, pBufferKey, instruction, data, span);
 
     TEvReadPersistentBufferResult result;
     result.SetStatus(ReadFromPBufferStatus);
@@ -256,10 +256,10 @@ NThreading::TFuture<TEvSyncResult> TStorageTransportMock::SyncWithPBuffer(
     const THostConnection& pbufferConnection,
     const THostConnection& ddiskConnection,
     TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-    TVector<ui64> lsns,
+    TVector<TPBufferKey> pBufferKeys,
     NWilson::TSpan* span)
 {
-    Y_UNUSED(pbufferConnection, ddiskConnection, lsns, span);
+    Y_UNUSED(pbufferConnection, ddiskConnection, pBufferKeys, span);
 
     TEvSyncResult result;
     result.SetStatus(SyncWithPBufferStatus);
@@ -274,10 +274,10 @@ NThreading::TFuture<TEvSyncResult> TStorageTransportMock::SyncWithPBuffer(
 NThreading::TFuture<TEvErasePersistentBufferResult>
 TStorageTransportMock::BatchEraseFromPBuffer(
     const THostConnection& connection,
-    TVector<ui64> lsns,
+    TVector<TPBufferKey> pBufferKeys,
     NWilson::TSpan* span)
 {
-    Y_UNUSED(connection, lsns, span);
+    Y_UNUSED(connection, pBufferKeys, span);
 
     Y_ABORT("BatchEraseFromPBuffer is not expected in this test");
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.h
@@ -109,7 +109,7 @@ public:
     NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TRecordId recordId,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) override;
@@ -151,12 +151,12 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TRecordId> recordIds,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TRecordId> recordIds,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BarrierEraseFromPBuffer(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/storage_transport_mock.h
@@ -110,7 +110,7 @@ public:
     NThreading::TFuture<TEvReadPersistentBufferResult> ReadFromPBuffer(
         const THostConnection& connection,
         const NKikimr::NDDisk::TBlockSelector& selector,
-        const ui64 lsn,
+        const TPBufferKey pBufferKey,
         const NKikimr::NDDisk::TReadInstruction instruction,
         const TGuardedSgList& data,
         NWilson::TSpan* span) override;
@@ -152,12 +152,12 @@ public:
         const THostConnection& pbufferConnection,
         const THostConnection& ddiskConnection,
         TVector<NKikimr::NDDisk::TBlockSelector> selectors,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BatchEraseFromPBuffer(
         const THostConnection& connection,
-        TVector<ui64> lsns,
+        TVector<TPBufferKey> pBufferKeys,
         NWilson::TSpan* span) override;
 
     NThreading::TFuture<TEvErasePersistentBufferResult> BarrierEraseFromPBuffer(


### PR DESCRIPTION
Identify PBuffer records by (generation, lsn) so they stay addressable after tablet restart.
___

job | err | IOPS main | IOPS PR | Δ IOPS | lat p99 main | lat p99 PR | Δ p99
-- | -- | -- | -- | -- | -- | -- | --
randread4k | 0 | 69.2k | 69.0k | −0.2% | 646 µs | 638 µs | −1.3%
randrw4k read | 0 | 27.2k | 27.6k | +1.1% | 1.31 ms | 927 µs | −29% (шум)
randrw4k write | 0 | 27.2k | 27.5k | +1.1% | 957 µs | 954 µs | −0.3%
randwrite4k | 0 | 44.3k | 44.9k | +1.5% | 1.18 ms | 1.07 ms | −9% (шум)
verify_sha1 | 0 | 2.9k | 3.0k | +3.5% | 20.3 ms | 20.9 ms | +3.0%

