### PR TITLE
Set not null: CancelRequest in SchemeShard

### DIFF
--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -797,6 +797,7 @@ enum ETxTypes {
 
     TXTYPE_CREATE_SET_COLUMN_CONSTRAINT = 124             [(TxTypeOpts) = {Name: "TxCreateSetColumnConstraint"}];
     TXTYPE_GET_SET_COLUMN_CONSTRAINT = 125             [(TxTypeOpts) = {Name: "TxGetSetColumnConstraint"}];
+    TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT = 126             [(TxTypeOpts) = {Name: "TxCancelSetColumnConstraint"}];
 
     TXTYPE_TEST_SHARD_CONTROL = 126 [(TxTypeOpts) = {Name: "TxTestShardControl"}];
 

--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -797,10 +797,10 @@ enum ETxTypes {
 
     TXTYPE_CREATE_SET_COLUMN_CONSTRAINT = 124             [(TxTypeOpts) = {Name: "TxCreateSetColumnConstraint"}];
     TXTYPE_GET_SET_COLUMN_CONSTRAINT = 125             [(TxTypeOpts) = {Name: "TxGetSetColumnConstraint"}];
-    TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT = 126             [(TxTypeOpts) = {Name: "TxCancelSetColumnConstraint"}];
 
     TXTYPE_TEST_SHARD_CONTROL = 126 [(TxTypeOpts) = {Name: "TxTestShardControl"}];
 
     TXTYPE_LIST_SET_COLUMN_CONSTRAINT = 127             [(TxTypeOpts) = {Name: "TxListSetColumnConstraint"}];
     TXTYPE_FORGET_SET_COLUMN_CONSTRAINT = 128          [(TxTypeOpts) = {Name: "TxForgetSetColumnConstraint"}];
+    TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT = 129             [(TxTypeOpts) = {Name: "TxCancelSetColumnConstraint"}];
 }

--- a/ydb/core/protos/set_column_constraint.proto
+++ b/ydb/core/protos/set_column_constraint.proto
@@ -82,3 +82,14 @@ message TEvForgetResponse {
     optional Ydb.StatusIds.StatusCode Status = 2;
     repeated Ydb.Issue.IssueMessage Issues = 3;
 }
+
+message TEvCancelRequest {
+    optional string DatabaseName = 1;
+    optional uint64 OperationId = 2;
+}
+
+message TEvCancelResponse {
+    optional uint64 TxId = 1;
+    optional Ydb.StatusIds.StatusCode Status = 2;
+    repeated Ydb.Issue.IssueMessage Issues = 3;
+}

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -1025,7 +1025,7 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
     bool IsCloseToCompletion() {
         return OperationState == EOperationState::Done
             || OperationState == EOperationState::Unlocking
-            || OperationState == EOperationState::Finishing && UnlockNullWritesTxStatus == NKikimrScheme::StatusSuccess;
+            || OperationState == EOperationState::Finishing;
     }
 
     bool IsSetColumnConstraint() const override {

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -1015,6 +1015,8 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
     constexpr static ui32 MaxInProgressValidationShards = 10;
 
     bool ValidationFailed = false;  // true if any shard found NULL values
+    bool IsCancelled = false;
+    TString CancellationReason;
 
     bool IsDone() const override {
         return OperationState == EOperationState::Done;
@@ -1022,6 +1024,13 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
 
     bool IsSetColumnConstraint() const override {
         return true;
+    }
+
+    void MarkAsCancelled(TString&& reason) {
+        if (!IsCancelled) {
+            IsCancelled = true;
+            CancellationReason = std::move(reason);
+        }
     }
 };
 

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -1022,7 +1022,7 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
         return OperationState == EOperationState::Done;
     }
 
-    bool IsCloseToCompletion() {
+    bool IsCloseToCompletion() const {
         return OperationState == EOperationState::Done
             || OperationState == EOperationState::Unlocking
             || OperationState == EOperationState::Finishing;

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -1022,6 +1022,12 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
         return OperationState == EOperationState::Done;
     }
 
+    bool IsCloseToCompletion() {
+        return OperationState == EOperationState::Done
+            || OperationState == EOperationState::Unlocking
+            || OperationState == EOperationState::Finishing && UnlockNullWritesTxStatus == NKikimrScheme::StatusSuccess;
+    }
+
     bool IsSetColumnConstraint() const override {
         return true;
     }

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -5536,6 +5536,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     if (rowset.HaveValue<Schema::SetColumnConstraint::UserSID>()) {
                         operationInfo->UserSID = rowset.GetValue<Schema::SetColumnConstraint::UserSID>();
                     }
+                    operationInfo->IsCancelled = rowset.GetValueOrDefault<Schema::SetColumnConstraint::IsCancelled>(false);
+                    if (rowset.HaveValue<Schema::SetColumnConstraint::CancellationReason>()) {
+                        operationInfo->CancellationReason = rowset.GetValue<Schema::SetColumnConstraint::CancellationReason>();
+                    }
 
                     TTxId subStateTxId = rowset.GetValueOrDefault<Schema::SetColumnConstraint::SubStateTxId>(TTxId());
                     NKikimrScheme::EStatus subStateTxStatus = rowset.GetValueOrDefault<Schema::SetColumnConstraint::SubStateTxStatus>(NKikimrScheme::StatusSuccess);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5994,6 +5994,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvSetColumnConstraint::TEvGetRequest, Handle);
         HFuncTraced(TEvSetColumnConstraint::TEvListRequest, Handle);
         HFuncTraced(TEvSetColumnConstraint::TEvForgetRequest, Handle);
+        HFuncTraced(TEvSetColumnConstraint::TEvCancelRequest, Handle);
         HFuncTraced(TEvDataShard::TEvValidateRowConditionResponse, Handle);
         HFuncTraced(TEvIndexBuilder::TEvCreateRequest, Handle);
         HFuncTraced(TEvIndexBuilder::TEvGetRequest, Handle);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1941,6 +1941,7 @@ public:
         struct TTxGetSetColumnConstraint;
         struct TTxListSetColumnConstraint;
         struct TTxForgetSetColumnConstraint;
+        struct TTxCancelSetColumnConstraint;
     };
 
     NTabletFlatExecutor::ITransaction* CreateTxCreate(TEvIndexBuilder::TEvCreateRequest::TPtr& ev);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1994,12 +1994,14 @@ public:
     void Handle(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSetColumnConstraint::TEvListRequest::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx);
     NTabletFlatExecutor::ITransaction* CreateTxCreateSetColumnConstraint(TEvSetColumnConstraint::TEvCreateRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxGetSetColumnConstraint(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxListSetColumnConstraint(TEvSetColumnConstraint::TEvListRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxForgetSetColumnConstraint(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxSetColumnConstraintCancel(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxSetColumnConstraintProgress(TIndexBuildId id);
     NTabletFlatExecutor::ITransaction* CreateTxReplyAllocateSetColumnConstraint(TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxReplyModifySetColumnConstraint(TEvSchemeShard::TEvModifySchemeTransactionResult::TPtr& ev);
@@ -2028,6 +2030,7 @@ public:
     void PersistSetColumnConstraintUnlockTxStatus(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo);
     void PersistSetColumnConstraintUnlockTxDone(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo);
     void PersistSetColumnConstraintValidationFailedValue(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo);
+    void PersistSetColumnConstraintCancellation(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& operationInfo);
     void PersistSetColumnConstraintShardDone(NIceDb::TNiceDb& db, TIndexBuildId operationId, TShardIdx shardIdx, const TSetColumnConstraintOperationInfo& operationInfo);
     void PersistSetColumnConstraintForget(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info);
     void ForgetSetColumnConstraint(NIceDb::TNiceDb& db, const TSetColumnConstraintOperationInfo& info);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -2002,7 +2002,7 @@ public:
     NTabletFlatExecutor::ITransaction* CreateTxGetSetColumnConstraint(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxListSetColumnConstraint(TEvSetColumnConstraint::TEvListRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxForgetSetColumnConstraint(TEvSetColumnConstraint::TEvForgetRequest::TPtr& ev);
-    NTabletFlatExecutor::ITransaction* CreateTxSetColumnConstraintCancel(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev);
+    NTabletFlatExecutor::ITransaction* CreateTxCancelSetColumnConstraint(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxSetColumnConstraintProgress(TIndexBuildId id);
     NTabletFlatExecutor::ITransaction* CreateTxReplyAllocateSetColumnConstraint(TEvTxAllocatorClient::TEvAllocateResult::TPtr& ev);
     NTabletFlatExecutor::ITransaction* CreateTxReplyModifySetColumnConstraint(TEvSchemeShard::TEvModifySchemeTransactionResult::TPtr& ev);

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -2635,6 +2635,9 @@ struct Schema : NIceDb::Schema {
         struct StartTime :              Column<12, NScheme::NTypeIds::Uint64> {};
         struct EndTime :                Column<13, NScheme::NTypeIds::Uint64> {};
 
+        struct IsCancelled :            Column<14, NScheme::NTypeIds::Bool>   { static constexpr bool Default = false; };
+        struct CancellationReason :     Column<15, NScheme::NTypeIds::Utf8>   {};
+
         using TKey = TableKey<OperationId>;
         using TColumns = TableColumns<
             OperationId,
@@ -2649,7 +2652,9 @@ struct Schema : NIceDb::Schema {
             LockTxId,
             UserSID,
             StartTime,
-            EndTime
+            EndTime,
+            IsCancelled,
+            CancellationReason
         >;
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -280,7 +280,7 @@ void TSchemeShard::Handle(TEvSetColumnConstraint::TEvListRequest::TPtr& ev, cons
 }
 
 void TSchemeShard::Handle(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev, const TActorContext& ctx) {
-    Execute(CreateTxSetColumnConstraintCancel(ev), ctx);
+    Execute(CreateTxCancelSetColumnConstraint(ev), ctx);
 }
 
 void TSchemeShard::Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -213,6 +213,16 @@ void TSchemeShard::PersistSetColumnConstraintValidationFailedValue(
     );
 }
 
+void TSchemeShard::PersistSetColumnConstraintCancellation(
+    NIceDb::TNiceDb& db,
+    const TSetColumnConstraintOperationInfo& operationInfo)
+{
+    db.Table<Schema::SetColumnConstraint>().Key(ui64(operationInfo.Id)).Update(
+        NIceDb::TUpdate<Schema::SetColumnConstraint::IsCancelled>(operationInfo.IsCancelled),
+        NIceDb::TUpdate<Schema::SetColumnConstraint::CancellationReason>(operationInfo.CancellationReason)
+    );
+}
+
 void TSchemeShard::PersistSetColumnConstraintShardDone(
     NIceDb::TNiceDb& db,
     TIndexBuildId operationId,
@@ -267,6 +277,10 @@ void TSchemeShard::Handle(TEvSetColumnConstraint::TEvGetRequest::TPtr& ev, const
 
 void TSchemeShard::Handle(TEvSetColumnConstraint::TEvListRequest::TPtr& ev, const TActorContext& ctx) {
     Execute(CreateTxListSetColumnConstraint(ev), ctx);
+}
+
+void TSchemeShard::Handle(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxSetColumnConstraintCancel(ev), ctx);
 }
 
 void TSchemeShard::Handle(TEvDataShard::TEvValidateRowConditionResponse::TPtr& ev, const TActorContext& ctx) {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -30,6 +30,9 @@ std::vector<TString> DeserializeSetColumnConstraintColumnNames(const TString& se
 
 namespace {
 
+using EState = TSetColumnConstraintOperationInfo::EOperationState;
+using ProtoState = Ydb::Table::SetNotNullState;
+
 float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
     const ui64 total = operationInfo.ValidationShards.size();
     if (total == 0) {
@@ -37,6 +40,22 @@ float CalcSetColumnConstraintValidationProgress(const TSetColumnConstraintOperat
     }
     const ui64 done = operationInfo.DoneValidationShards.size();
     return static_cast<float>(done) / static_cast<float>(total) * 100.0f;
+}
+
+float CalcProgress(const TSetColumnConstraintOperationInfo& operationInfo) {
+    switch (operationInfo.OperationState) {
+    case EState::Invalid:
+    case EState::Locking:
+    case EState::LockingNullWrites:
+        return 0.0f;
+    case EState::Validating:
+        return CalcSetColumnConstraintValidationProgress(operationInfo);
+    case EState::Finishing:
+    case EState::Unlocking:
+        return 99.9f;
+    case EState::Done:
+        return 100.0f;
+    }
 }
 
 }
@@ -59,32 +78,33 @@ void FillSetColumnConstraint(
     }
 
     // Map internal state to proto state
-    using EState = TSetColumnConstraintOperationInfo::EOperationState;
-    using ProtoState = Ydb::Table::SetNotNullState;
-    switch (operationInfo.OperationState) {
-    case EState::Locking:
-    case EState::LockingNullWrites:
-        proto.SetState(ProtoState::STATE_PREPARING);
-        proto.SetProgress(0.0f);
-        break;
-    case EState::Validating:
-        proto.SetState(ProtoState::STATE_VALIDATING);
-        proto.SetProgress(CalcSetColumnConstraintValidationProgress(operationInfo));
-        break;
-    case EState::Finishing:
-    case EState::Unlocking:
-        proto.SetState(ProtoState::STATE_APPLYING);
-        proto.SetProgress(99.9f);
-        break;
-    case EState::Done:
-        proto.SetState(operationInfo.ValidationFailed
-            ? ProtoState::STATE_CANCELLED
-            : ProtoState::STATE_DONE);
-        proto.SetProgress(100.0f);
-        break;
-    case EState::Invalid:
-        proto.SetState(ProtoState::STATE_UNSPECIFIED);
-        break;
+    proto.SetProgress(CalcProgress(operationInfo));
+
+    if (operationInfo.IsCancelled) {
+        proto.SetState(ProtoState::STATE_CANCELLED);
+    } else {
+        switch (operationInfo.OperationState) {
+        case EState::Locking:
+        case EState::LockingNullWrites:
+            proto.SetState(ProtoState::STATE_PREPARING);
+            break;
+        case EState::Validating:
+            proto.SetState(ProtoState::STATE_VALIDATING);
+            break;
+        case EState::Finishing:
+        case EState::Unlocking:
+            proto.SetState(ProtoState::STATE_APPLYING);
+            break;
+        case EState::Done:
+            // There is no way when IsValidationFailed equals `true`,
+            // because IsValidationFailed is true exactly when IsCancelled is true.
+            // Therefore, there cannot be STATE_CANCELLED.
+            proto.SetState(ProtoState::STATE_DONE);
+            break;
+        case EState::Invalid:
+            proto.SetState(ProtoState::STATE_UNSPECIFIED);
+            break;
+        }
     }
 
     auto* settings = proto.MutableSettings();

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h
@@ -29,6 +29,8 @@ struct TEvSetColumnConstraint {
         EvListResponse,
         EvForgetRequest,
         EvForgetResponse,
+        EvCancelRequest,
+        EvCancelResponse,
 
         EvEnd
     };
@@ -103,6 +105,23 @@ struct TEvSetColumnConstraint {
         TEvForgetResponse() = default;
 
         explicit TEvForgetResponse(const ui64 txId) {
+            Record.SetTxId(txId);
+        }
+    };
+
+    struct TEvCancelRequest: public TEventPB<TEvCancelRequest, NKikimrSetColumnConstraint::TEvCancelRequest, EvCancelRequest> {
+        TEvCancelRequest() = default;
+
+        explicit TEvCancelRequest(const TString& dbName, ui64 operationId) {
+            Record.SetDatabaseName(dbName);
+            Record.SetOperationId(operationId);
+        }
+    };
+
+    struct TEvCancelResponse: public TEventPB<TEvCancelResponse, NKikimrSetColumnConstraint::TEvCancelResponse, EvCancelResponse> {
+        TEvCancelResponse() = default;
+
+        explicit TEvCancelResponse(const ui64 txId) {
             Record.SetTxId(txId);
         }
     };

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -38,6 +38,14 @@ public:
         }
 
         auto& operationInfo = *operationInfoPtr->get();
+        const TPathId subdomainPathId = database.GetPathIdForDomain();
+
+        if (operationInfo.DomainPathId != subdomainPathId) {
+            return Reply(
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> not found in database <" << record.GetDatabaseName() << ">"
+            );
+        }
 
         if (operationInfo.IsCloseToCompletion()) {
             return Reply(
@@ -70,7 +78,7 @@ public:
     void DoComplete(const TActorContext&) override {}
 };
 
-ITransaction* TSchemeShard::CreateTxSetColumnConstraintCancel(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev) {
+ITransaction* TSchemeShard::CreateTxCancelSetColumnConstraint(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev) {
     return new TIndexBuilder::TTxCancelSetColumnConstraint(this, ev);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -1,42 +1,23 @@
-#include "schemeshard_impl.h"
-#include "schemeshard_set_column_constraint.h"
-#include "schemeshard_path.h"
+#include <ydb/core/tx/schemeshard/index/build_index.h>
+#include <ydb/core/tx/schemeshard/index/build_index_helpers.h>
+#include <ydb/core/tx/schemeshard/index/build_index_tx_base.h>
+#include <ydb/core/tx/schemeshard/schemeshard_impl.h>
+#include <ydb/core/tx/schemeshard/schemeshard_set_column_constraint.h>
 
 namespace NKikimr {
 namespace NSchemeShard {
 
 using namespace NTabletFlatExecutor;
 
-struct TSchemeShard::TTxSetColumnConstraintCancel : public TSchemeShard::TIndexBuilder::TTxBase {
-private:
-    TEvSetColumnConstraint::TEvCancelRequest::TPtr Request;
-    THolder<TEvSetColumnConstraint::TEvCancelResponse> Response;
-
+struct TSchemeShard::TIndexBuilder::TTxCancelSetColumnConstraint : public TSchemeShard::TIndexBuilder::TTxSimple<TEvSetColumnConstraint::TEvCancelRequest, TEvSetColumnConstraint::TEvCancelResponse> {
 public:
-    explicit TTxSetColumnConstraintCancel(TSelf* self, TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev)
-        : TTxBase(self, TIndexBuildId(ev->Get()->Record.GetOperationId()), TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT)
-        , Request(ev)
+    explicit TTxCancelSetColumnConstraint(TSelf* self, TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev)
+        : TTxSimple(self, TIndexBuildId(ev->Get()->Record.GetOperationId()), ev, TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT)
     {}
-
-    bool Reply(Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, const TString& errorMessage = TString()) {
-        auto& record = Response->Record;
-        record.SetStatus(status);
-        if (errorMessage) {
-            AddIssue(record.MutableIssues(), errorMessage);
-        }
-
-        LOG_N("TTxSetColumnConstraintCancel: Reply"
-              << ", operationId: " << BuildId
-              << ", status: " << Ydb::StatusIds::StatusCode_Name(status)
-              << ", error: " << errorMessage);
-
-        Send(Request->Sender, std::move(Response), 0, Request->Cookie);
-        return true;
-    }
 
     bool DoExecute(TTransactionContext& txc, const TActorContext&) override {
         const auto& record = Request->Get()->Record;
-        LOG_I("TTxSetColumnConstraintCancel: DoExecute " << record.ShortDebugString());
+        LOG_D("TTxGetSetColumnConstraint::DoExecute " << record.ShortDebugString());
 
         Response = MakeHolder<TEvSetColumnConstraint::TEvCancelResponse>(record.GetOperationId());
 
@@ -77,28 +58,20 @@ public:
         operationInfo.MarkAsCancelled(TString("Cancelled by user request"));
         Self->PersistSetColumnConstraintCancellation(db, operationInfo);
 
-        // Trigger progress to handle the cancellation
+        // Note: The operation will continue through its natural stages:
+        // - TTxReplyValidateRowCondition ignores incoming validation messages due to IsCancelled flag
+        // - AlterMainTableUnlockNullWritesPropose will NOT set NOT NULL constraint due to IsCancelled check
+        // - The operation will complete naturally in Done state without setting the constraint
         Progress(BuildId);
 
         return Reply();
     }
 
     void DoComplete(const TActorContext&) override {}
-
-    void OnUnhandledException(TTransactionContext& /*txc*/, const TActorContext& /*ctx*/,
-        TIndexBuildInfo* /*operationInfo*/, const std::exception& exc) override
-    {
-        LOG_E("TTxSetColumnConstraintCancel: OnUnhandledException"
-            ", id# " << BuildId << ", exception: " << exc.what());
-    }
 };
 
 ITransaction* TSchemeShard::CreateTxSetColumnConstraintCancel(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev) {
-    return new TTxSetColumnConstraintCancel(this, ev);
-}
-
-void TSchemeShard::Handle(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev, const TActorContext& ctx) {
-    Execute(CreateTxSetColumnConstraintCancel(ev), ctx);
+    return new TIndexBuilder::TTxCancelSetColumnConstraint(this, ev);
 }
 
 } // NSchemeShard

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -17,7 +17,7 @@ public:
 
     bool DoExecute(TTransactionContext& txc, const TActorContext&) override {
         const auto& record = Request->Get()->Record;
-        LOG_D("TTxGetSetColumnConstraint::DoExecute " << record.ShortDebugString());
+        LOG_D("TTxCancelSetColumnConstraint::DoExecute " << record.ShortDebugString());
 
         Response = MakeHolder<TEvSetColumnConstraint::TEvCancelResponse>(record.GetOperationId());
 
@@ -39,10 +39,10 @@ public:
 
         auto& operationInfo = *operationInfoPtr->get();
 
-        if (operationInfo.IsDone()) {
+        if (operationInfo.IsCloseToCompletion()) {
             return Reply(
                 Ydb::StatusIds::PRECONDITION_FAILED,
-                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> has been finished already"
+                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> has already finished or is too close to completion to be cancelled"
             );
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -47,17 +47,17 @@ public:
             );
         }
 
-        if (operationInfo.IsCloseToCompletion()) {
-            return Reply(
-                Ydb::StatusIds::PRECONDITION_FAILED,
-                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> has already finished or is too close to completion to be cancelled"
-            );
-        }
-
         if (operationInfo.IsCancelled) {
             return Reply(
                 Ydb::StatusIds::PRECONDITION_FAILED,
                 TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> is already cancelled"
+            );
+        }
+
+        if (operationInfo.IsCloseToCompletion()) {
+            return Reply(
+                Ydb::StatusIds::PRECONDITION_FAILED,
+                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> has already finished or is too close to completion to be cancelled"
             );
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -1,0 +1,105 @@
+#include "schemeshard_impl.h"
+#include "schemeshard_set_column_constraint.h"
+#include "schemeshard_path.h"
+
+namespace NKikimr {
+namespace NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+struct TSchemeShard::TTxSetColumnConstraintCancel : public TSchemeShard::TIndexBuilder::TTxBase {
+private:
+    TEvSetColumnConstraint::TEvCancelRequest::TPtr Request;
+    THolder<TEvSetColumnConstraint::TEvCancelResponse> Response;
+
+public:
+    explicit TTxSetColumnConstraintCancel(TSelf* self, TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev)
+        : TTxBase(self, TIndexBuildId(ev->Get()->Record.GetOperationId()), TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT)
+        , Request(ev)
+    {}
+
+    bool Reply(Ydb::StatusIds::StatusCode status = Ydb::StatusIds::SUCCESS, const TString& errorMessage = TString()) {
+        auto& record = Response->Record;
+        record.SetStatus(status);
+        if (errorMessage) {
+            AddIssue(record.MutableIssues(), errorMessage);
+        }
+
+        LOG_N("TTxSetColumnConstraintCancel: Reply"
+              << ", operationId: " << BuildId
+              << ", status: " << Ydb::StatusIds::StatusCode_Name(status)
+              << ", error: " << errorMessage);
+
+        Send(Request->Sender, std::move(Response), 0, Request->Cookie);
+        return true;
+    }
+
+    bool DoExecute(TTransactionContext& txc, const TActorContext&) override {
+        const auto& record = Request->Get()->Record;
+        LOG_I("TTxSetColumnConstraintCancel: DoExecute " << record.ShortDebugString());
+
+        Response = MakeHolder<TEvSetColumnConstraint::TEvCancelResponse>(record.GetOperationId());
+
+        TPath database = TPath::Resolve(record.GetDatabaseName(), Self);
+        if (!database.IsResolved()) {
+            return Reply(
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "Database <" << record.GetDatabaseName() << "> not found"
+            );
+        }
+
+        auto* operationInfoPtr = Self->SetColumnConstraintOperations.FindPtr(BuildId);
+        if (!operationInfoPtr) {
+            return Reply(
+                Ydb::StatusIds::NOT_FOUND,
+                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> not found"
+            );
+        }
+
+        auto& operationInfo = *operationInfoPtr->get();
+
+        if (operationInfo.IsDone()) {
+            return Reply(
+                Ydb::StatusIds::PRECONDITION_FAILED,
+                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> has been finished already"
+            );
+        }
+
+        if (operationInfo.IsCancelled) {
+            return Reply(
+                Ydb::StatusIds::PRECONDITION_FAILED,
+                TStringBuilder() << "SetColumnConstraint operation with id <" << BuildId << "> is already cancelled"
+            );
+        }
+
+        // Mark operation as cancelled
+        NIceDb::TNiceDb db(txc.DB);
+        operationInfo.MarkAsCancelled(TString("Cancelled by user request"));
+        Self->PersistSetColumnConstraintCancellation(db, operationInfo);
+
+        // Trigger progress to handle the cancellation
+        Progress(BuildId);
+
+        return Reply();
+    }
+
+    void DoComplete(const TActorContext&) override {}
+
+    void OnUnhandledException(TTransactionContext& /*txc*/, const TActorContext& /*ctx*/,
+        TIndexBuildInfo* /*operationInfo*/, const std::exception& exc) override
+    {
+        LOG_E("TTxSetColumnConstraintCancel: OnUnhandledException"
+            ", id# " << BuildId << ", exception: " << exc.what());
+    }
+};
+
+ITransaction* TSchemeShard::CreateTxSetColumnConstraintCancel(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev) {
+    return new TTxSetColumnConstraintCancel(this, ev);
+}
+
+void TSchemeShard::Handle(TEvSetColumnConstraint::TEvCancelRequest::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxSetColumnConstraintCancel(ev), ctx);
+}
+
+} // NSchemeShard
+} // NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__get.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__get.cpp
@@ -55,6 +55,14 @@ public:
         auto* proto = respRecord.MutableSetColumnConstraint();
         FillSetColumnConstraint(*proto, operationInfo, Self);
 
+        // Add issue for cancelled operations
+        if (operationInfo.IsCancelled && !operationInfo.CancellationReason.empty()) {
+            auto* issue = respRecord.AddIssues();
+            issue->set_message(operationInfo.CancellationReason);
+            issue->set_issue_code(0);
+            issue->set_severity(NYql::TSeverityIds::S_ERROR);
+        }
+
         if (operationInfo.ValidationFailed && operationInfo.OperationState == TSetColumnConstraintOperationInfo::EOperationState::Done) {
             TPath tablePath = TPath::Init(operationInfo.TablePathId, Self);
             auto* issue = respRecord.AddIssues();

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -52,7 +52,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> AlterMainTableUnlockNullWrit
         col->SetName(TString(columnName));
         col->SetSetNotNullInProgress(false);
 
-        if (!operationInfo.ValidationFailed) {
+        if (!operationInfo.ValidationFailed && !operationInfo.IsCancelled) {
             col->SetNotNull(true);
         }
     }
@@ -352,6 +352,11 @@ public:
 
         auto& operationInfo = *operationInfoPtr->get();
 
+        if (operationInfo.IsCancelled) {
+            LOG_I("TTxReplyValidateRowCondition: operation is cancelled, ignoring message, id# " << BuildId);
+            return true;
+        }
+
         TShardIdx shardIdx;
         bool found = false;
         for (const auto& [idx, shardStatus] : operationInfo.ValidationShards) {
@@ -379,6 +384,7 @@ public:
         }
 
         auto oldValidationFailedValue = operationInfo.ValidationFailed;
+        TString cancellationReason;
 
         auto& shardStatus = operationInfo.ValidationShards.at(shardIdx);
         shardStatus.ValidateStatus = record.GetStatus();
@@ -398,6 +404,7 @@ public:
             if (!record.GetIsValid()) {
                 LOG_N("TTxReplyValidateRowCondition: validation failed on shard# " << shardIdx);
                 operationInfo.ValidationFailed = true;
+                cancellationReason = "Validation failed: found NULL values in column(s) being set to NOT NULL";
             }
 
             operationInfo.InProgressValidationShards.erase(shardIdx);
@@ -410,6 +417,7 @@ public:
                 << ", status# " << record.GetStatus());
 
             operationInfo.ValidationFailed = true;
+            cancellationReason = "Validation failed: internal error";
 
             operationInfo.InProgressValidationShards.erase(shardIdx);
             operationInfo.DoneValidationShards.insert(shardIdx);
@@ -423,8 +431,12 @@ public:
 
         {
             NIceDb::TNiceDb db(txc.DB);
+
             if (oldValidationFailedValue != operationInfo.ValidationFailed) {
                 Self->PersistSetColumnConstraintValidationFailedValue(db, operationInfo);
+
+                operationInfo.MarkAsCancelled(std::move(cancellationReason));
+                Self->PersistSetColumnConstraintCancellation(db, operationInfo);
             }
 
             Self->PersistSetColumnConstraintShardDone(db, BuildId, shardIdx, operationInfo);

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -633,12 +633,21 @@ public:
         : TTxBase(self, operationId, TXTYPE_CREATE_SET_COLUMN_CONSTRAINT)
     {}
 
-    bool DoExecute(TTransactionContext&, const TActorContext& /*ctx*/) override {
+    bool DoExecute(TTransactionContext& txc, const TActorContext& /*ctx*/) override {
         auto* operationInfoPtr = Self->SetColumnConstraintOperations.FindPtr(BuildId);
         Y_ENSURE(operationInfoPtr);
         auto& operationInfo = *operationInfoPtr->get();
 
-        LOG_D("TTxProgressSetColumnConstraint::DoExecute, id# " << BuildId << "; OperationState = " << ToString(operationInfo.OperationState));
+        LOG_D("TTxProgressSetColumnConstraint::DoExecute, id# " << BuildId
+            << "; OperationState = " << ToString(operationInfo.OperationState)
+            << "; IsCancelled = " << operationInfo.IsCancelled);
+
+        // Note on cancellation:
+        // When IsCancelled is set in early stages (Locking/LockingNullWrites/Validating),
+        // we immediately skip to Finishing to release locks without setting the constraint.
+        // - Finishing: AlterMainTableUnlockNullWritesPropose does NOT set NOT NULL (checked via !IsCancelled)
+        // - Unlocking: releases locks normally
+        // - Done: operation completes without setting the constraint
 
         switch (operationInfo.OperationState) {
             case TSetColumnConstraintOperationInfo::EOperationState::Invalid: {
@@ -646,6 +655,15 @@ public:
                 break;
             }
             case TSetColumnConstraintOperationInfo::EOperationState::Locking: {
+                // If cancelled, skip to Finishing to release locks without setting constraint
+                if (operationInfo.IsCancelled) {
+                    LOG_I("TTxProgressSetColumnConstraint: operation cancelled in Locking, jumping to Finishing, id# " << BuildId);
+                    NIceDb::TNiceDb db(txc.DB);
+                    ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
+                    Progress(BuildId);
+                    break;
+                }
+
                 if (operationInfo.LockTxId == InvalidTxId) {
                     AllocateTxId(BuildId);
                 } else if (operationInfo.LockTxStatus == NKikimrScheme::StatusSuccess) {
@@ -660,6 +678,15 @@ public:
                 break;
             }
             case TSetColumnConstraintOperationInfo::EOperationState::LockingNullWrites: {
+                // If cancelled, skip to Finishing to release locks without setting constraint
+                if (operationInfo.IsCancelled) {
+                    LOG_I("TTxProgressSetColumnConstraint: operation cancelled in LockingNullWrites, jumping to Finishing, id# " << BuildId);
+                    NIceDb::TNiceDb db(txc.DB);
+                    ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
+                    Progress(BuildId);
+                    break;
+                }
+
                 if (operationInfo.LockNullWritesTxId == InvalidTxId) {
                     AllocateTxId(BuildId);
                 } else if (operationInfo.LockNullWritesTxStatus == NKikimrScheme::StatusSuccess) {
@@ -674,6 +701,15 @@ public:
                 break;
             }
             case TSetColumnConstraintOperationInfo::EOperationState::Validating: {
+                // If cancelled, skip to Finishing to release locks without setting constraint
+                if (operationInfo.IsCancelled) {
+                    LOG_I("TTxProgressSetColumnConstraint: operation cancelled in Validating, jumping to Finishing, id# " << BuildId);
+                    NIceDb::TNiceDb db(txc.DB);
+                    ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
+                    Progress(BuildId);
+                    break;
+                }
+
                 if (DriveToSendMessageToPartOfShards(operationInfo)) {
                     ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
                     Progress(BuildId);

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -655,15 +655,6 @@ public:
                 break;
             }
             case TSetColumnConstraintOperationInfo::EOperationState::Locking: {
-                // If cancelled, skip to Finishing to release locks without setting constraint
-                if (operationInfo.IsCancelled) {
-                    LOG_I("TTxProgressSetColumnConstraint: operation cancelled in Locking, jumping to Finishing, id# " << BuildId);
-                    NIceDb::TNiceDb db(txc.DB);
-                    ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
-                    Progress(BuildId);
-                    break;
-                }
-
                 if (operationInfo.LockTxId == InvalidTxId) {
                     AllocateTxId(BuildId);
                 } else if (operationInfo.LockTxStatus == NKikimrScheme::StatusSuccess) {
@@ -809,3 +800,4 @@ ITransaction* TSchemeShard::CreateTxReplyValidateRowCondition(
 
 } // namespace NSchemeShard
 } // namespace NKikimr
+

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -642,13 +642,6 @@ public:
             << "; OperationState = " << ToString(operationInfo.OperationState)
             << "; IsCancelled = " << operationInfo.IsCancelled);
 
-        // Note on cancellation:
-        // When IsCancelled is set in early stages (Locking/LockingNullWrites/Validating),
-        // we immediately skip to Finishing to release locks without setting the constraint.
-        // - Finishing: AlterMainTableUnlockNullWritesPropose does NOT set NOT NULL (checked via !IsCancelled)
-        // - Unlocking: releases locks normally
-        // - Done: operation completes without setting the constraint
-
         switch (operationInfo.OperationState) {
             case TSetColumnConstraintOperationInfo::EOperationState::Invalid: {
                 Y_UNREACHABLE();

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -3625,6 +3625,23 @@ namespace NSchemeShardUT_Private {
         return TestForgetSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, txId, dbName, operationId, expectedStatus);
     }
 
+    NKikimrSetColumnConstraint::TEvCancelResponse TestCancelSetColumnConstraint(
+        TTestActorRuntime& runtime,
+        ui64 schemeShard,
+        const TString& dbName,
+        ui64 operationId)
+    {
+        auto request = MakeHolder<TEvSetColumnConstraint::TEvCancelRequest>(dbName, operationId);
+        
+        auto sender = runtime.AllocateEdgeActor();
+        ForwardToTablet(runtime, schemeShard, sender, request.Release());
+
+        TAutoPtr<IEventHandle> handle;
+        auto* event = runtime.GrabEdgeEvent<TEvSetColumnConstraint::TEvCancelResponse>(handle);
+        UNIT_ASSERT(event);
+        return event->Record;
+    }
+
     void TestCheckColumnsNotNull(
         TTestActorRuntime& runtime,
         const TString& tablePath,

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -817,5 +817,6 @@ namespace NSchemeShardUT_Private {
             Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
     NKikimrSetColumnConstraint::TEvForgetResponse TestForgetSetColumnConstraint(TTestActorRuntime& runtime, ui64 txId, const TString& dbName, ui64 operationId,
             Ydb::StatusIds::StatusCode expectedStatus = Ydb::StatusIds::SUCCESS);
+    NKikimrSetColumnConstraint::TEvCancelResponse TestCancelSetColumnConstraint(TTestActorRuntime& runtime, ui64 schemeShard, const TString& dbName, ui64 operationId);
     void TestCheckColumnsNotNull(TTestActorRuntime& runtime, const TString& tablePath, const std::map<TString, bool>& expectedColumnNotNullStates);
 } //NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1895,7 +1895,7 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             cancelResponse.ShortDebugString());
     }
 
-    Y_UNIT_TEST(CancelFinishedOperation) {
+    Y_UNIT_TEST(CancelAtFinishingUnlockingOrDoneStages) {
         TTestBasicRuntime runtime;
         runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
@@ -1904,48 +1904,122 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
 
         ui64 txId = 100;
         TString root = "/MyRoot";
-        TString tablePath = root + "/Table";
 
-        TestCreateTable(runtime, ++txId, root, R"(
-              Name: "Table"
-              Columns { Name: "key"   Type: "Uint32" }
-              Columns { Name: "value" Type: "Utf8"   }
-              KeyColumnNames: ["key"]
-        )");
-        env.TestWaitNotification(runtime, txId);
+        struct TStageTest {
+            TString StageName;
+            std::function<THolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>>(TTestActorRuntime&)> CreateBlocker;
+        };
 
-        ui64 setConstraintTxId = ++txId;
-        auto response = TestSetColumnConstraint(
-            runtime, setConstraintTxId,
-            TTestTxConfig::SchemeShard,
-            root,
-            tablePath,
-            {"value"});
+        TVector<TStageTest> stages = {
+            {
+                "Finishing",
+                [](TTestActorRuntime& runtime) {
+                    return MakeHolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>>(runtime, [](const auto& ev) {
+                        if (ev->Get()->Record.TransactionSize() > 0) {
+                            const auto& tx = ev->Get()->Record.GetTransaction(0);
+                            if (tx.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable &&
+                                tx.HasAlterTable() && tx.GetAlterTable().ColumnsSize() > 0) {
+                                for (const auto& col : tx.GetAlterTable().GetColumns()) {
+                                    if (col.HasSetNotNullInProgress() && !col.GetSetNotNullInProgress()) {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                        return false;
+                    });
+                }
+            },
+            {
+                "Unlocking",
+                [](TTestActorRuntime& runtime) {
+                    return MakeHolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>>(runtime, [](const auto& ev) {
+                        if (ev->Get()->Record.TransactionSize() > 0) {
+                            const auto& tx = ev->Get()->Record.GetTransaction(0);
+                            return tx.GetOperationType() == NKikimrSchemeOp::ESchemeOpDropLock;
+                        }
+                        return false;
+                    });
+                }
+            },
+            {
+                "Done",
+                nullptr  // No blocker needed, operation will complete fully
+            }
+        };
 
-        UNIT_ASSERT_VALUES_EQUAL_C(
-            response.GetStatus(),
-            Ydb::StatusIds::SUCCESS,
-            response.ShortDebugString());
+        for (size_t i = 0; i < stages.size(); ++i) {
+            const auto& stage = stages[i];
+            Cerr << "=== Testing cancel rejection at stage: " << stage.StageName << " ===" << Endl;
 
-        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+            // Create a new table for this stage
+            TString tableName = TStringBuilder() << "Table_" << stage.StageName;
+            TString tablePath = root + "/" + tableName;
 
-        TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+            TestCreateTable(runtime, ++txId, root, TStringBuilder() << R"(
+                  Name: ")" << tableName << R"("
+                  Columns { Name: "key"   Type: "Uint32" }
+                  Columns { Name: "value" Type: "Utf8"   }
+                  KeyColumnNames: ["key"]
+            )");
+            env.TestWaitNotification(runtime, txId);
 
-        auto cancelResponse = TestCancelSetColumnConstraint(
-            runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+            THolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>> blocker;
+            if (stage.CreateBlocker) {
+                blocker = stage.CreateBlocker(runtime);
+            }
 
-        UNIT_ASSERT_VALUES_EQUAL_C(
-            cancelResponse.GetStatus(),
-            Ydb::StatusIds::PRECONDITION_FAILED,
-            cancelResponse.ShortDebugString());
-        UNIT_ASSERT_VALUES_EQUAL_C(
-            cancelResponse.GetIssues().size(),
-            1,
-            cancelResponse.ShortDebugString());
-        UNIT_ASSERT_STRING_CONTAINS_C(
-            cancelResponse.GetIssues(0).message(),
-            "finished",
-            cancelResponse.ShortDebugString());
+            ui64 setConstraintTxId = ++txId;
+            AsyncSetColumnConstraint(
+                runtime, setConstraintTxId,
+                TTestTxConfig::SchemeShard,
+                root,
+                tablePath,
+                {"value"});
+
+            if (blocker) {
+                runtime.WaitFor("block event at " + stage.StageName, [&]{ return blocker->size() > 0; });
+
+                // Try to cancel while at this stage - should be rejected
+                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    cancelResponse.GetStatus(),
+                    Ydb::StatusIds::PRECONDITION_FAILED,
+                    "Cancel should be rejected at stage: " + stage.StageName);
+                UNIT_ASSERT_C(
+                    cancelResponse.GetIssues().size() > 0,
+                    "Expected error message for cancel at " + stage.StageName);
+                UNIT_ASSERT_STRING_CONTAINS_C(
+                    cancelResponse.GetIssues(0).message(),
+                    "finished",
+                    cancelResponse.ShortDebugString());
+
+                blocker->Stop().Unblock();
+            } else {
+                env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    cancelResponse.GetStatus(),
+                    Ydb::StatusIds::PRECONDITION_FAILED,
+                    "Cancel should be rejected at stage: " + stage.StageName);
+                UNIT_ASSERT_C(
+                    cancelResponse.GetIssues().size() > 0,
+                    "Expected error message for cancel at " + stage.StageName);
+                UNIT_ASSERT_STRING_CONTAINS_C(
+                    cancelResponse.GetIssues(0).message(),
+                    "finished",
+                    cancelResponse.ShortDebugString());
+            }
+
+            if (blocker) {
+                env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+            }
+
+            TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+
+            Cerr << "=== Cancel correctly rejected at stage: " << stage.StageName << " ===" << Endl;
+        }
     }
 
     Y_UNIT_TEST(CancelAlreadyCanceledOperation) {

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1845,6 +1845,165 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT(forgetResponse.IssuesSize() > 0);
     }
 
+    Y_UNIT_TEST(CancelGetListForgetIntegration) {
+        // ========================================
+        // Preparing
+
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // ========================================
+        // Create operation and cancel it
+
+        TBlockEvents<TEvDataShard::TEvValidateRowConditionRequest> blocker(runtime);
+
+        ui64 setConstraintTxId = ++txId;
+        AsyncSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        runtime.WaitFor("block validation", [&]{ return blocker.size() > 0; });
+
+        blocker.Stop();
+
+        auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            cancelResponse.ShortDebugString());
+
+        blocker.Unblock();
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        // ========================================
+        // Check schema
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", false}});
+
+        // ========================================
+        // List
+
+        auto listResponse = TestListSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            listResponse.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            listResponse.ShortDebugString());
+        UNIT_ASSERT_C(
+            listResponse.GetEntries().size() >= 1,
+            "Expected at least one operation in list");
+
+        bool foundOperation = false;
+        for (const auto& entry : listResponse.GetEntries()) {
+            if (entry.GetId() == setConstraintTxId) {
+                foundOperation = true;
+
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    entry.GetId(),
+                    setConstraintTxId,
+                    "TxId mismatch in list response");
+
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    static_cast<int>(entry.GetState()),
+                    static_cast<int>(Ydb::Table::SetNotNullState::STATE_CANCELLED),
+                    TStringBuilder() << "Expected STATE_CANCELLED, got: " << Ydb::Table::SetNotNullState_State_Name(entry.GetState()));
+
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    entry.GetSettings().GetNotNullColumns().size(),
+                    1,
+                    "Expected one column in settings");
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    entry.GetSettings().GetNotNullColumns().Get(0),
+                    "value",
+                    "Column name mismatch");
+
+                break;
+            }
+        }
+
+        UNIT_ASSERT_C(foundOperation, "Operation not found in list response");
+
+        // ========================================
+        // Get
+
+        // Get full response to check issues
+        auto sender = runtime.AllocateEdgeActor();
+        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender,
+            new TEvSetColumnConstraint::TEvGetRequest(root, setConstraintTxId));
+
+        TAutoPtr<IEventHandle> handle;
+        auto* getEvent = runtime.GrabEdgeEvent<TEvSetColumnConstraint::TEvGetResponse>(handle);
+        UNIT_ASSERT(getEvent);
+        
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            getEvent->Record.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            getEvent->Record.ShortDebugString());
+
+        const auto& getResponse = getEvent->Record.GetSetColumnConstraint();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            static_cast<int>(getResponse.GetState()),
+            static_cast<int>(Ydb::Table::SetNotNullState::STATE_CANCELLED),
+            TStringBuilder() << "Expected STATE_CANCELLED in Get, got: " << Ydb::Table::SetNotNullState_State_Name(getResponse.GetState()));
+
+        UNIT_ASSERT_C(
+            getEvent->Record.IssuesSize() > 0,
+            "Expected issues with error message in cancelled operation");
+        UNIT_ASSERT_STRING_CONTAINS(
+            getEvent->Record.GetIssues(0).message(),
+            "Cancelled by user request");
+        
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            getEvent->Record.GetIssues(0).message(),
+            "Cancelled",
+            "Error message should mention cancellation");
+
+        UNIT_ASSERT_C(
+            getResponse.HasSettings(),
+            "Expected settings in Get response");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            getResponse.GetSettings().GetNotNullColumns().size(),
+            1,
+            "Expected one column in Get settings");
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            getResponse.GetSettings().GetNotNullColumns().Get(0),
+            "value",
+            "Column name mismatch in Get");
+
+        // ========================================
+        // Forget
+
+        auto forgetResponse = TestForgetSetColumnConstraint(
+            runtime, ++txId, root, setConstraintTxId, Ydb::StatusIds::SUCCESS);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            forgetResponse.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            forgetResponse.ShortDebugString());
+
+        DoGetRequest(setConstraintTxId, runtime, root, Ydb::StatusIds::NOT_FOUND);
+    }
+
     Y_UNIT_TEST(CancelNonExistentOperation) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
@@ -2225,3 +2384,4 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         }
     }
 } // Y_UNIT_TEST_SUITE(SetNotNullTest)
+

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1087,8 +1087,8 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             Ydb::Table::SetNotNullState::STATE_PREPARING,
             Ydb::Table::SetNotNullState::STATE_PREPARING,
             Ydb::Table::SetNotNullState::STATE_VALIDATING,
-            Ydb::Table::SetNotNullState::STATE_APPLYING,
-            Ydb::Table::SetNotNullState::STATE_APPLYING,
+            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_CANCELLED : Ydb::Table::SetNotNullState::STATE_APPLYING),
+            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_CANCELLED : Ydb::Table::SetNotNullState::STATE_APPLYING),
             (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_CANCELLED : Ydb::Table::SetNotNullState::STATE_DONE)
         };
 

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/grpc_services/local_rpc/local_rpc.h>
 #include <ydb/library/testlib/helpers.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -1844,7 +1845,193 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT(forgetResponse.IssuesSize() > 0);
     }
 
-    Y_UNIT_TEST(CancelAtDifferentStages) {
+    Y_UNIT_TEST(CancelNonExistentOperation) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TString root = "/MyRoot";
+
+        auto cancelResponse = TestCancelSetColumnConstraint(
+            runtime, TTestTxConfig::SchemeShard, root, 999999);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetStatus(),
+            Ydb::StatusIds::NOT_FOUND,
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetIssues().size(),
+            1,
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            cancelResponse.GetIssues(0).message(),
+            "not found",
+            cancelResponse.ShortDebugString());
+    }
+
+    Y_UNIT_TEST(CancelOperationInNonExistentDatabase) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+
+        TString wrongRoot = "/NonExistentDB";
+
+        auto cancelResponse = TestCancelSetColumnConstraint(
+            runtime, TTestTxConfig::SchemeShard, wrongRoot, 100);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetStatus(),
+            Ydb::StatusIds::NOT_FOUND,
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetIssues().size(),
+            1,
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            cancelResponse.GetIssues(0).message(),
+            "Database",
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            cancelResponse.GetIssues(0).message(),
+            "not found",
+            cancelResponse.ShortDebugString());
+    }
+
+    Y_UNIT_TEST(CancelFinishedOperation) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        ui64 setConstraintTxId = ++txId;
+        auto response = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            response.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            response.ShortDebugString());
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", true}});
+
+        auto cancelResponse = TestCancelSetColumnConstraint(
+            runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetStatus(),
+            Ydb::StatusIds::PRECONDITION_FAILED,
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse.GetIssues().size(),
+            1,
+            cancelResponse.ShortDebugString());
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            cancelResponse.GetIssues(0).message(),
+            "finished",
+            cancelResponse.ShortDebugString());
+    }
+
+    Y_UNIT_TEST(CancelAlreadyCanceledOperation) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+
+        ui64 txId = 100;
+        TString root = "/MyRoot";
+        TString tablePath = root + "/Table";
+
+        TestCreateTable(runtime, ++txId, root, R"(
+              Name: "Table"
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        THolder<IEventHandle> delayedValidateRequest;
+        auto prevObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!delayedValidateRequest && ev->GetTypeRewrite() == TEvDataShard::TEvValidateRowConditionRequest::EventType) {
+                delayedValidateRequest.Reset(ev.Release());
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        ui64 setConstraintTxId = ++txId;
+        auto response = TestSetColumnConstraint(
+            runtime, setConstraintTxId,
+            TTestTxConfig::SchemeShard,
+            root,
+            tablePath,
+            {"value"});
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            response.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            response.ShortDebugString());
+
+        {
+            TDispatchOptions opts;
+            opts.FinalEvents.emplace_back([&delayedValidateRequest](IEventHandle&) -> bool {
+                return bool(delayedValidateRequest);
+            });
+            runtime.DispatchEvents(opts);
+        }
+
+        UNIT_ASSERT_C(delayedValidateRequest, "Failed to intercept TEvValidateRowConditionRequest");
+
+        auto cancelResponse1 = TestCancelSetColumnConstraint(
+            runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse1.GetStatus(),
+            Ydb::StatusIds::SUCCESS,
+            cancelResponse1.ShortDebugString());
+
+        auto cancelResponse2 = TestCancelSetColumnConstraint(
+            runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse2.GetStatus(),
+            Ydb::StatusIds::PRECONDITION_FAILED,
+            cancelResponse2.ShortDebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            cancelResponse2.GetIssues().size(),
+            1,
+            cancelResponse2.ShortDebugString());
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            cancelResponse2.GetIssues(0).message(),
+            "already cancelled",
+            cancelResponse2.ShortDebugString());
+
+        runtime.SetObserverFunc(prevObserver);
+        runtime.Send(delayedValidateRequest.Release(), 0, true);
+
+        env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+        TestCheckColumnsNotNull(runtime, tablePath, {{"value", false}});
+    }
+
+    Y_UNIT_TEST(CancelAtLockingStage) {
         TTestBasicRuntime runtime;
         runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
         runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
@@ -1852,143 +2039,115 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         TTestEnv env(runtime);
         TString root = "/MyRoot";
 
-        // Test cancellation at each stage of the operation
-        // Strategy: intercept the first event of the stage, cancel the operation, then let the event proceed
+        ui64 txId = 100;
+        TString tableName = "Table";
+        TString tablePath = root + "/" + tableName;
+
+        TestCreateTable(runtime, ++txId, root, TStringBuilder() << R"(
+              Name: ")" << tableName << R"("
+              Columns { Name: "key"   Type: "Uint32" }
+              Columns { Name: "value" Type: "Utf8"   }
+              KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
         struct TStageTest {
             TString StageName;
-            std::function<void(TTestActorRuntime&, ui64, const TString&, bool&)> SetupInterceptor;
+            std::function<THolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>>(TTestActorRuntime&)> CreateModifySchemeBlocker;
+            std::function<THolder<TBlockEvents<TEvDataShard::TEvValidateRowConditionRequest>>(TTestActorRuntime&)> CreateDataShardBlocker;
         };
 
         TVector<TStageTest> stages = {
             {
                 "Locking",
-                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
-                    ui32 modifySchemeCount = 0;
-                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
-                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
-                            if (++modifySchemeCount == 1) {
-                                cancelled = true;
-                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
-                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
-                                Cerr << "Cancelled at Locking stage" << Endl;
-                            }
+                [](TTestActorRuntime& runtime) {
+                    return MakeHolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>>(runtime, [](const auto& ev) {
+                        if (ev->Get()->Record.TransactionSize() > 0) {
+                            const auto& tx = ev->Get()->Record.GetTransaction(0);
+                            return tx.GetOperationType() == NKikimrSchemeOp::ESchemeOpCreateLock;
                         }
-                        return TTestActorRuntime::EEventAction::PROCESS;
+                        return false;
                     });
-                }
+                },
+                nullptr
             },
             {
-                "LockingNull Writes",
-                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
-                    ui32 modifySchemeCount = 0;
-                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
-                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
-                            if (++modifySchemeCount == 2) {
-                                cancelled = true;
-                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
-                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
-                                Cerr << "Cancelled at LockingNullWrites stage" << Endl;
+                "LockingNullWrites",
+                [](TTestActorRuntime& runtime) {
+                    return MakeHolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>>(runtime, [](const auto& ev) {
+                        if (ev->Get()->Record.TransactionSize() > 0) {
+                            const auto& tx = ev->Get()->Record.GetTransaction(0);
+                            if (tx.GetOperationType() == NKikimrSchemeOp::ESchemeOpAlterTable &&
+                                tx.HasAlterTable() && tx.GetAlterTable().ColumnsSize() > 0) {
+                                for (const auto& col : tx.GetAlterTable().GetColumns()) {
+                                    if (col.HasSetNotNullInProgress() && col.GetSetNotNullInProgress()) {
+                                        return true;
+                                    }
+                                }
                             }
                         }
-                        return TTestActorRuntime::EEventAction::PROCESS;
+                        return false;
                     });
-                }
+                },
+                nullptr
             },
             {
                 "Validating",
-                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
-                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
-                        if (!cancelled && ev->GetTypeRewrite() == TEvDataShard::TEvValidateRowConditionRequest::EventType) {
-                            cancelled = true;
-                            auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
-                            UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
-                            Cerr << "Cancelled at Validating stage" << Endl;
-                        }
-                        return TTestActorRuntime::EEventAction::PROCESS;
-                    });
-                }
-            },
-            {
-                "Finishing",
-                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
-                    ui32 modifySchemeCount = 0;
-                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
-                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
-                            if (++modifySchemeCount == 3) {
-                                cancelled = true;
-                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
-                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
-                                Cerr << "Cancelled at Finishing stage" << Endl;
-                            }
-                        }
-                        return TTestActorRuntime::EEventAction::PROCESS;
-                    });
-                }
-            },
-            {
-                "Unlocking",
-                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
-                    ui32 modifySchemeCount = 0;
-                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
-                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
-                            if (++modifySchemeCount == 4) {
-                                cancelled = true;
-                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
-                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
-                                Cerr << "Cancelled at Unlocking stage" << Endl;
-                            }
-                        }
-                        return TTestActorRuntime::EEventAction::PROCESS;
-                    });
+                nullptr,
+                [](TTestActorRuntime& runtime) {
+                    return MakeHolder<TBlockEvents<TEvDataShard::TEvValidateRowConditionRequest>>(runtime);
                 }
             }
         };
 
-        ui64 txId = 100;
+        for (const auto& stage : stages) {
+            Cerr << "=== Testing cancel at stage: " << stage.StageName << " ===" << Endl;
 
-        for (const auto& stageTest : stages) {
-            Cerr << "=== Testing cancellation at stage: " << stageTest.StageName << " ===" << Endl;
+            THolder<TBlockEvents<TEvSchemeShard::TEvModifySchemeTransaction>> modifySchemeBlocker;
+            THolder<TBlockEvents<TEvDataShard::TEvValidateRowConditionRequest>> dataShardBlocker;
 
-            TString tableName = TStringBuilder() << "Table_" << stageTest.StageName;
-            TString tablePath = root + "/" + tableName;
-
-            TestCreateTable(runtime, ++txId, root, TStringBuilder() << R"(
-                  Name: ")" << tableName << R"("
-                  Columns { Name: "key"   Type: "Uint32" }
-                  Columns { Name: "value" Type: "Utf8"   }
-                  KeyColumnNames: ["key"]
-            )");
-            env.TestWaitNotification(runtime, txId);
+            if (stage.CreateModifySchemeBlocker) {
+                modifySchemeBlocker = stage.CreateModifySchemeBlocker(runtime);
+            }
+            if (stage.CreateDataShardBlocker) {
+                dataShardBlocker = stage.CreateDataShardBlocker(runtime);
+            }
 
             ui64 setConstraintTxId = ++txId;
-            bool cancelled = false;
-            
-            // Setup interceptor before starting the operation
-            stageTest.SetupInterceptor(runtime, setConstraintTxId, root, cancelled);
-
-            auto response = TestSetColumnConstraint(
+            AsyncSetColumnConstraint(
                 runtime, setConstraintTxId,
                 TTestTxConfig::SchemeShard,
                 root,
                 tablePath,
                 {"value"});
 
+            if (modifySchemeBlocker) {
+                runtime.WaitFor("block event at " + stage.StageName, [&]{ return modifySchemeBlocker->size() > 0; });
+                modifySchemeBlocker->Stop();
+            }
+            if (dataShardBlocker) {
+                runtime.WaitFor("block event at " + stage.StageName, [&]{ return dataShardBlocker->size() > 0; });
+                dataShardBlocker->Stop();
+            }
+
+            auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
             UNIT_ASSERT_VALUES_EQUAL_C(
-                response.GetStatus(),
+                cancelResponse.GetStatus(),
                 Ydb::StatusIds::SUCCESS,
-                TStringBuilder() << "Stage: " << stageTest.StageName << ", " << response.ShortDebugString());
+                "Failed to cancel at stage: " + stage.StageName);
+
+            if (modifySchemeBlocker) {
+                modifySchemeBlocker->Unblock();
+            }
+            if (dataShardBlocker) {
+                dataShardBlocker->Unblock();
+            }
 
             env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
 
-            UNIT_ASSERT_C(cancelled, TStringBuilder() << "Operation was not cancelled at stage: " << stageTest.StageName);
-
-            runtime.SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
-
             TestCheckColumnsNotNull(runtime, tablePath, {{"value", false}});
 
-            Cerr << "=== Stage " << stageTest.StageName << " test passed ===" << Endl << Endl;
+            Cerr << "=== Successfully cancelled at stage: " << stage.StageName << " ===" << Endl;
         }
-
-        Cerr << "=== All stages tested successfully ===" << Endl;
     }
 } // Y_UNIT_TEST_SUITE(SetNotNullTest)

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1843,4 +1843,152 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
         UNIT_ASSERT_VALUES_EQUAL(forgetResponse.GetStatus(), Ydb::StatusIds::NOT_FOUND);
         UNIT_ASSERT(forgetResponse.IssuesSize() > 0);
     }
+
+    Y_UNIT_TEST(CancelAtDifferentStages) {
+        TTestBasicRuntime runtime;
+        runtime.SetLogPriority(NKikimrServices::FLAT_TX_SCHEMESHARD, NActors::NLog::PRI_TRACE);
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NActors::NLog::PRI_TRACE);
+
+        TTestEnv env(runtime);
+        TString root = "/MyRoot";
+
+        // Test cancellation at each stage of the operation
+        // Strategy: intercept the first event of the stage, cancel the operation, then let the event proceed
+        struct TStageTest {
+            TString StageName;
+            std::function<void(TTestActorRuntime&, ui64, const TString&, bool&)> SetupInterceptor;
+        };
+
+        TVector<TStageTest> stages = {
+            {
+                "Locking",
+                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
+                    ui32 modifySchemeCount = 0;
+                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
+                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
+                            if (++modifySchemeCount == 1) {
+                                cancelled = true;
+                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+                                Cerr << "Cancelled at Locking stage" << Endl;
+                            }
+                        }
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    });
+                }
+            },
+            {
+                "LockingNull Writes",
+                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
+                    ui32 modifySchemeCount = 0;
+                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
+                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
+                            if (++modifySchemeCount == 2) {
+                                cancelled = true;
+                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+                                Cerr << "Cancelled at LockingNullWrites stage" << Endl;
+                            }
+                        }
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    });
+                }
+            },
+            {
+                "Validating",
+                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
+                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
+                        if (!cancelled && ev->GetTypeRewrite() == TEvDataShard::TEvValidateRowConditionRequest::EventType) {
+                            cancelled = true;
+                            auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                            UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+                            Cerr << "Cancelled at Validating stage" << Endl;
+                        }
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    });
+                }
+            },
+            {
+                "Finishing",
+                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
+                    ui32 modifySchemeCount = 0;
+                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
+                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
+                            if (++modifySchemeCount == 3) {
+                                cancelled = true;
+                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+                                Cerr << "Cancelled at Finishing stage" << Endl;
+                            }
+                        }
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    });
+                }
+            },
+            {
+                "Unlocking",
+                [](TTestActorRuntime& runtime, ui64 setConstraintTxId, const TString& root, bool& cancelled) {
+                    ui32 modifySchemeCount = 0;
+                    runtime.SetObserverFunc([&, setConstraintTxId, root](TAutoPtr<IEventHandle>& ev) {
+                        if (!cancelled && ev->GetTypeRewrite() == TEvSchemeShard::TEvModifySchemeTransaction::EventType) {
+                            if (++modifySchemeCount == 4) {
+                                cancelled = true;
+                                auto cancelResponse = TestCancelSetColumnConstraint(runtime, TTestTxConfig::SchemeShard, root, setConstraintTxId);
+                                UNIT_ASSERT_VALUES_EQUAL(cancelResponse.GetStatus(), Ydb::StatusIds::SUCCESS);
+                                Cerr << "Cancelled at Unlocking stage" << Endl;
+                            }
+                        }
+                        return TTestActorRuntime::EEventAction::PROCESS;
+                    });
+                }
+            }
+        };
+
+        ui64 txId = 100;
+
+        for (const auto& stageTest : stages) {
+            Cerr << "=== Testing cancellation at stage: " << stageTest.StageName << " ===" << Endl;
+
+            TString tableName = TStringBuilder() << "Table_" << stageTest.StageName;
+            TString tablePath = root + "/" + tableName;
+
+            TestCreateTable(runtime, ++txId, root, TStringBuilder() << R"(
+                  Name: ")" << tableName << R"("
+                  Columns { Name: "key"   Type: "Uint32" }
+                  Columns { Name: "value" Type: "Utf8"   }
+                  KeyColumnNames: ["key"]
+            )");
+            env.TestWaitNotification(runtime, txId);
+
+            ui64 setConstraintTxId = ++txId;
+            bool cancelled = false;
+            
+            // Setup interceptor before starting the operation
+            stageTest.SetupInterceptor(runtime, setConstraintTxId, root, cancelled);
+
+            auto response = TestSetColumnConstraint(
+                runtime, setConstraintTxId,
+                TTestTxConfig::SchemeShard,
+                root,
+                tablePath,
+                {"value"});
+
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                response.GetStatus(),
+                Ydb::StatusIds::SUCCESS,
+                TStringBuilder() << "Stage: " << stageTest.StageName << ", " << response.ShortDebugString());
+
+            env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
+
+            UNIT_ASSERT_C(cancelled, TStringBuilder() << "Operation was not cancelled at stage: " << stageTest.StageName);
+
+            runtime.SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
+
+            TestCheckColumnsNotNull(runtime, tablePath, {{"value", false}});
+
+            Cerr << "=== Stage " << stageTest.StageName << " test passed ===" << Endl << Endl;
+        }
+
+        Cerr << "=== All stages tested successfully ===" << Endl;
+    }
 } // Y_UNIT_TEST_SUITE(SetNotNullTest)

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -314,6 +314,7 @@ SRCS(
     schemeshard_self_pinger.h
     schemeshard_set_column_constraint.cpp
     schemeshard_set_column_constraint.h
+    schemeshard_set_column_constraint__cancel.cpp
     schemeshard_set_column_constraint__create.cpp
     schemeshard_set_column_constraint__forget.cpp
     schemeshard_set_column_constraint__get.cpp

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -10390,6 +10390,16 @@
                 "ColumnId": 13,
                 "ColumnName": "EndTime",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 14,
+                "ColumnName": "IsCancelled",
+                "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 15,
+                "ColumnName": "CancellationReason",
+                "ColumnType": "Utf8"
             }
         ],
         "ColumnsDropped": [],
@@ -10408,7 +10418,9 @@
                     10,
                     11,
                     12,
-                    13
+                    13,
+                    14,
+                    15
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

As part of the SET NOT NULL implementation, a basic pull request was created (https://github.com/ydb-platform/ydb/pull/36152). It left a large number of gaps. This pull request addresses one of them.

Each long-running operation should primarily be implemented using five types of requests:

1. Create  
2. Get  
3. Cancel  
4. Forget  
5. List  

See [here](https://ydb.tech/docs/en/reference/ydb-cli/operation-list?version=main).

This pull request implements the `Cancel` request for the new operation at the `SchemeShard` level.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

It will be added on grpc_level and sdk levels later.
