### PR TITLE
EXT-2337 Fix CPU problem when subscribing to kesus quoter resource

### DIFF
--- a/ydb/core/kesus/tablet/quoter_resource_tree.cpp
+++ b/ydb/core/kesus/tablet/quoter_resource_tree.cpp
@@ -1437,7 +1437,7 @@ void TQuoterResources::DisconnectSession(const NActors::TActorId& pipeServerId) 
         Y_ABORT_UNLESS(sessionIter != Sessions.end());
         TQuoterSession* session = sessionIter->second.Get();
         session->GetResource()->OnSessionDisconnected(sessionClientId);
-        session->CloseSession(Ydb::StatusIds::SESSION_EXPIRED, "Disconected.");
+        session->CloseSession(Ydb::StatusIds::SESSION_EXPIRED, "Disconnected.");
         Sessions.erase(sessionIter);
     }
     PipeServerIdToSession.erase(outerIt);

--- a/ydb/core/kesus/tablet/quoter_resource_tree.cpp
+++ b/ydb/core/kesus/tablet/quoter_resource_tree.cpp
@@ -1412,35 +1412,35 @@ void TQuoterResources::FillCounters(NKikimrKesus::TEvGetQuoterResourceCountersRe
 
 void TQuoterResources::SetPipeServerId(TQuoterSessionId sessionId, const NActors::TActorId& prevId, const NActors::TActorId& id) {
     if (prevId) {
-        auto [prevIt, prevItEnd] = PipeServerIdToSession.equal_range(prevId);
-        for (; prevIt != prevItEnd; ++prevIt) {
-            if (prevIt->second.second == sessionId.second) { // compare resource id
-                PipeServerIdToSession.erase(prevIt);
-                break;
+        auto outerIt = PipeServerIdToSession.find(prevId);
+        if (outerIt != PipeServerIdToSession.end()) {
+            outerIt->second.erase(sessionId);
+            if (outerIt->second.empty()) {
+                PipeServerIdToSession.erase(outerIt);
             }
         }
     }
     if (id) {
-        PipeServerIdToSession.emplace(id, sessionId);
+        PipeServerIdToSession[id].insert(sessionId);
     }
 }
 
 void TQuoterResources::DisconnectSession(const NActors::TActorId& pipeServerId) {
-    auto [pipeToSessionItBegin, pipeToSessionItEnd] = PipeServerIdToSession.equal_range(pipeServerId);
-    for (auto pipeToSessionIt = pipeToSessionItBegin; pipeToSessionIt != pipeToSessionItEnd; ++pipeToSessionIt) {
-        const TQuoterSessionId sessionId = pipeToSessionIt->second;
+    auto outerIt = PipeServerIdToSession.find(pipeServerId);
+    if (outerIt == PipeServerIdToSession.end()) {
+        return;
+    }
+    for (const TQuoterSessionId& sessionId : outerIt->second) {
         const NActors::TActorId sessionClientId = sessionId.first;
 
-        {
-            const auto sessionIter = Sessions.find(sessionId);
-            Y_ABORT_UNLESS(sessionIter != Sessions.end());
-            TQuoterSession* session = sessionIter->second.Get();
-            session->GetResource()->OnSessionDisconnected(sessionClientId);
-            session->CloseSession(Ydb::StatusIds::SESSION_EXPIRED, "Disconected.");
-            Sessions.erase(sessionIter);
-        }
+        const auto sessionIter = Sessions.find(sessionId);
+        Y_ABORT_UNLESS(sessionIter != Sessions.end());
+        TQuoterSession* session = sessionIter->second.Get();
+        session->GetResource()->OnSessionDisconnected(sessionClientId);
+        session->CloseSession(Ydb::StatusIds::SESSION_EXPIRED, "Disconected.");
+        Sessions.erase(sessionIter);
     }
-    PipeServerIdToSession.erase(pipeToSessionItBegin, pipeToSessionItEnd);
+    PipeServerIdToSession.erase(outerIt);
 }
 
 void TQuoterResources::SetQuoterPath(const TString& quoterPath) {

--- a/ydb/core/kesus/tablet/quoter_resource_tree.h
+++ b/ydb/core/kesus/tablet/quoter_resource_tree.h
@@ -10,7 +10,6 @@
 
 #include <util/datetime/base.h>
 #include <util/generic/hash.h>
-#include <util/generic/hash_multi_map.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/ptr.h>
 #include <util/generic/string.h>
@@ -440,7 +439,7 @@ private:
     THashMap<ui64, THolder<TQuoterResourceTree>> ResourcesById;
     THashMap<TString, TQuoterResourceTree*> ResourcesByPath;
     THashMap<TQuoterSessionId, THolder<TQuoterSession>> Sessions;
-    THashMultiMap<NActors::TActorId, TQuoterSessionId> PipeServerIdToSession;
+    THashMap<NActors::TActorId, THashSet<TQuoterSessionId>> PipeServerIdToSession;
 
     TCounters Counters;
 };

--- a/ydb/core/kesus/tablet/quoter_runtime.cpp
+++ b/ydb/core/kesus/tablet/quoter_runtime.cpp
@@ -124,7 +124,9 @@ void TKesusTablet::Handle(TEvKesus::TEvSubscribeOnResources::TPtr& ev) {
             TQuoterSession* session = QuoterResources.GetOrCreateSession(clientId, clientVersion, resourceTree);
             session->SetResourceSink(sink);
             const NActors::TActorId prevPipeServerId = session->SetPipeServerId(pipeServerId);
-            QuoterResources.SetPipeServerId(TQuoterSessionId(clientId, resourceTree->GetResourceId()), prevPipeServerId, pipeServerId);
+            if (prevPipeServerId != pipeServerId) {
+                QuoterResources.SetPipeServerId(TQuoterSessionId(clientId, resourceTree->GetResourceId()), prevPipeServerId, pipeServerId);
+            }
             session->UpdateConsumptionState(resource.GetStartConsuming(), resource.GetInitialAmount(), queue, now);
 
             result->MutableError()->SetStatus(Ydb::StatusIds::SUCCESS);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Here we iterate over all resources inside one quoter proxy session: https://github.com/ydb-platform/ydb/blob/87dbaabebf9b75170b08645b4c2e8431f54c489b/ydb/core/kesus/tablet/quoter_resource_tree.cpp#L1415 

So, they are all resources used by one YDB node in this Kesus. It can be a significant amount.

As for the next stage, I want to support safe deletion of these session objects. It will be made in the next PR
