### PR TITLE
docs: `disabled_authentication_paths` in `monitoring_config`

### DIFF
--- a/ydb/docs/en/core/reference/configuration/index.md
+++ b/ydb/docs/en/core/reference/configuration/index.md
@@ -17,7 +17,7 @@ The following top-level configuration sections are available, listed in alphabet
 || [{#T}](blob_storage_config.md) | No | Static cluster group configuration for system tablets ||
 || [{#T}](bridge_config.md) | No | Cluster piles for bridge mode ||
 || [{#T}](client_certificate_authorization.md) | No | Client certificate authentication ||
-|| [{#T}](cms_config.md) | No | Cluster Management System configuration ||
+|| || [{#T}](cms_config.md) | No | Cluster Management System configuration ||
 || [{#T}](domains_config.md) | No | Cluster domain configuration including Blob Storage and State Storage ||
 || [{#T}](feature_flags.md) | No | Feature flags to enable or disable specific {{ ydb-short-name }} features ||
 || [{#T}](healthcheck_config.md) | No | Health check service thresholds and timeout settings ||
@@ -27,6 +27,7 @@ The following top-level configuration sections are available, listed in alphabet
 || [{#T}](kafka.md) | No | [Kafka Proxy](../../reference/kafka-api/index.md) configuration ||
 || [{#T}](log_config.md) | No | Logging configuration and parameters ||
 || [{#T}](memory_controller_config.md) | No | Memory allocation and limits for database components ||
+|| [{#T}](monitoring_config.md) | No | Parameters for [YDB Monitoring](../embedded-ui/ydb-monitoring.md) ||
 || [{#T}](node_broker_config.md) | No | Stable node names configuration ||
 || [{#T}](query_service_config.md) | No | Federated query connector configuration ||
 || [{#T}](resource_broker_config.md) | No | Resource broker for controlling CPU and memory consumption ||

--- a/ydb/docs/en/core/reference/configuration/monitoring_config.md
+++ b/ydb/docs/en/core/reference/configuration/monitoring_config.md
@@ -1,0 +1,61 @@
+# monitoring_config
+
+The `monitoring_config` section of the {{ ydb-short-name }} configuration file defines parameters for [YDB Monitoring](../embedded-ui/ydb-monitoring.md). Below are the settings related to [authentication](../../security/authentication.md) on specific pages of the built-in monitoring.
+
+```yaml
+monitoring_config:
+  # authentication on /counters and /healthcheck pages
+  require_counters_authentication: false
+  require_healthcheck_authentication: false
+  # list of paths for which authentication is disabled
+  disabled_authentication_paths:
+    - /ver
+    - /trace
+```
+
+## Authentication on Monitoring Pages {#authentication}
+
+#|
+|| Parameter | Description ||
+|| `require_counters_authentication` | Mandatory [authentication](../../security/authentication.md) mode on `/counters` and `/counters/hosts` pages.
+
+Possible values:
+
+- `true` — access to `/counters` and `/counters/hosts` is allowed only with an [authentication token](../../concepts/glossary.md#auth-token); requests undergo authentication and permission checks.
+
+    The value `true` is only valid when mandatory [authentication](../../security/authentication.md) is enabled in the [security_config](./security_config.md) section of the {{ ydb-short-name }} configuration file.
+
+- `false` — requests to `/counters` and `/counters/hosts` can be made without an [authentication token](../../concepts/glossary.md#auth-token).
+
+Default value: `false`.
+    ||
+|| `require_healthcheck_authentication` | Additional [authentication](../../security/authentication.md) requirement for the `/healthcheck` endpoint on top of general cluster rules.
+
+Possible values:
+
+- `true` — any `/healthcheck` response, including the [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) (the `format=prometheus` parameter), is returned only when requested with an [authentication token](../../concepts/glossary.md#auth-token); requests undergo authentication and permission checks.
+
+    The value `true` is only valid when mandatory [authentication](../../security/authentication.md) is enabled in the [security_config](./security_config.md) section of the {{ ydb-short-name }} configuration file.
+
+- `false` — when mandatory authentication is enabled in the cluster, requests to `/healthcheck` without a token are still allowed if output in the [Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/) (`format=prometheus`) is requested. For other `/healthcheck` response formats, general rules apply (see the note below).
+
+Default value: `false`.
+
+{% note info %}
+
+If mandatory [authentication](../../security/authentication.md) is enabled in [security_config](./security_config.md), a token is required for `/healthcheck` responses in any format other than Prometheus, regardless of the `require_healthcheck_authentication` value.
+
+{% endnote %}
+
+||
+|| `disabled_authentication_paths` | A list of built-in monitoring paths for which mandatory [authentication](../../security/authentication.md) is disabled (even if the mandatory authentication mode `enforce_user_token_requirement` is enabled in [security_config](./security_config.md)).
+
+The following rules apply when matching paths:
+- The path must match exactly (for example, `/ver` or `/trace`).
+- Query parameters are stripped before matching (for example, a `/ver?foo=bar` request will successfully match `/ver`).
+- Subpaths are not matched automatically (for example, if authentication is disabled for `/ver`, authentication is still required for `/ver/subpath`).
+- Prefixes are not matched automatically (for example, `/prefix/ver` will still require authentication).
+
+Default value: empty list.
+||
+|#

--- a/ydb/docs/en/core/reference/configuration/toc_p.yaml
+++ b/ydb/docs/en/core/reference/configuration/toc_p.yaml
@@ -29,6 +29,8 @@ items:
   href: log_config.md
 - name: memory_controller_config
   href: memory_controller_config.md
+- name: monitoring_config
+  href: monitoring_config.md
 - name: node_broker_config
   href: node_broker_config.md
 - name: resource_broker_config

--- a/ydb/docs/ru/core/reference/configuration/monitoring_config.md
+++ b/ydb/docs/ru/core/reference/configuration/monitoring_config.md
@@ -7,6 +7,10 @@ monitoring_config:
   # аутентификация на страницах /counters и /healthcheck
   require_counters_authentication: false
   require_healthcheck_authentication: false
+  # список путей, для которых отключена аутентификация
+  disabled_authentication_paths:
+    - /ver
+    - /trace
 ```
 
 ## Аутентификация на страницах мониторинга {#authentication}
@@ -43,5 +47,15 @@ monitoring_config:
 
 {% endnote %}
 
+||
+|| `disabled_authentication_paths` | Список путей встроенного мониторинга, для которых отключается обязательная [аутентификация](../../security/authentication.md) (даже если в [security_config](./security_config.md) включен режим обязательной аутентификации `enforce_user_token_requirement`).
+
+При сопоставлении путей действуют следующие правила:
+- Путь должен совпадать ровно (например, `/ver` или `/trace`).
+- Параметры запроса (query parameters) отсекаются перед сопоставлением (например, запрос `/ver?foo=bar` успешно сопоставится с `/ver`).
+- Подпути не сопоставляются автоматически (например, если отключена аутентификация для `/ver`, то для `/ver/subpath` аутентификация по-прежнему будет требоваться).
+- Префиксы не сопоставляются автоматически (например, `/prefix/ver` по-прежнему потребует аутентификацию).
+
+Значение по умолчанию: пустой список.
 ||
 |#


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Documented the `disabled_authentication_paths` parameter in `monitoring_config`.

### Changelog category <!-- remove all except one -->

* Documentation (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR adds documentation for the new `disabled_authentication_paths` parameter in `monitoring_config`, which was introduced in https://github.com/ydb-platform/ydb/pull/45684.

The `disabled_authentication_paths` parameter allows specifying a list of built-in monitoring paths (e.g., `/ver`, `/trace`) for which mandatory authentication is bypassed, even if `enforce_user_token_requirement` is enabled in `security_config`.

Changes:
- Updated Russian documentation: `ydb/docs/ru/core/reference/configuration/monitoring_config.md`
- Created English documentation: `ydb/docs/en/core/reference/configuration/monitoring_config.md`
- Added `monitoring_config` to English table of contents (`toc_p.yaml`) and configuration index (`index.md`)
