### PR TITLE
Add canonical Topic/Kafka transaction wire with legacy dual-write.

### DIFF
--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -27,6 +27,7 @@
 #include <ydb/core/tx/tx.h>
 #include <ydb/core/tx/sequenceproxy/public/events.h>
 #include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/public/write_id.h>
 #include <ydb/library/aclib/user_context.h>
 #include <ydb/library/actors/core/actorsystem.h>
 #include <ydb/library/actors/core/interconnect.h>
@@ -4552,12 +4553,12 @@ public:
         if (TxManager->GetTopicOperations().HasWriteId()) {
             writeId = TxManager->GetTopicOperations().GetWriteId();
         }
-        bool kafkaTransaction = TxManager->GetTopicOperations().HasKafkaOperations();
+        const auto& topicOps = TxManager->GetTopicOperations();
+        const bool kafkaTransaction = topicOps.HasKafkaOperations();
 
         THashSet<ui64> topicTabletPeers;
         bool omitPeerTopicTablets = false;
         if (!isImmediateCommit) {
-            const auto& topicOps = TxManager->GetTopicOperations();
             omitPeerTopicTablets = topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange();
             if (omitPeerTopicTablets) {
                 for (ui64 id : topicOps.GetReceivingTabletIds()) {
@@ -4575,14 +4576,9 @@ public:
             FillTopicsCommit(isImmediateCommit, transaction, TxManager, tabletId, omitPeerTopicTablets, topicTabletPeers);
 
             if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
-                auto* w = transaction.MutableWriteId();
-                w->SetNodeId(SelfId().NodeId());
-                w->SetKeyId(*writeId);
+                NPQ::SetWriteId(transaction, NPQ::TWriteId{SelfId().NodeId(), *writeId});
             } else if (t.hasWrite && kafkaTransaction) {
-                auto* w = transaction.MutableWriteId();
-                w->SetKafkaTransaction(true);
-                w->MutableKafkaProducerInstanceId()->SetId(TxManager->GetTopicOperations().GetKafkaProducerInstanceId().Id);
-                w->MutableKafkaProducerInstanceId()->SetEpoch(TxManager->GetTopicOperations().GetKafkaProducerInstanceId().Epoch);
+                NPQ::SetWriteId(transaction, NPQ::TWriteId{topicOps.GetKafkaProducerInstanceId()});
             }
             transaction.SetImmediate(isImmediateCommit);
 

--- a/ydb/core/kqp/runtime/ya.make
+++ b/ydb/core/kqp/runtime/ya.make
@@ -57,6 +57,7 @@ PEERDIR(
     ydb/core/kqp/common/buffer
     ydb/core/mon
     ydb/core/persqueue/events
+    ydb/core/persqueue/public
     ydb/core/protos
     ydb/core/scheme
     ydb/core/tx/scheme_board

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/path.h>
 #include <ydb/core/protos/kqp.pb.h>
+#include <ydb/core/persqueue/public/pqdata_transaction_compat.h>
 #include <ydb/core/persqueue/public/utils.h>
 #include <ydb/core/kafka_proxy/kafka_producer_instance_id.h>
 #include <ydb/library/actors/core/log.h>
@@ -234,19 +235,22 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, 
         NKikimrPQ::TPartitionOperation* o = t.tx.MutableOperations()->Add();
         o->SetPath(*Topic_);
         o->SetPartitionId(*Partition_);
-        o->SetConsumer(consumer);
         if (operations.IsKafkaApiOperation()) {
-            o->SetCommitOffsetsEnd(operations.GetKafkaCommitOffset());
-            o->SetKafkaTransaction(true);
+            auto* kafkaRead = o->MutableRead()->MutableKafka();
+            kafkaRead->SetConsumer(consumer);
+            kafkaRead->SetCommitOffsetsEnd(operations.GetKafkaCommitOffset());
         } else {
             auto [begin, end] = operations.GetOffsetsCommitRange();
-            o->SetCommitOffsetsBegin(begin);
-            o->SetCommitOffsetsEnd(end);
-            o->SetKillReadSession(operations.GetKillReadSession());
-            o->SetForceCommit(operations.GetForceCommit());
-            o->SetOnlyCheckCommitedToFinish(operations.GetOnlyCheckCommitedToFinish());
-            o->SetReadSessionId(operations.GetReadSessionId());
+            auto* topicRead = o->MutableRead()->MutableTopic();
+            topicRead->SetConsumer(consumer);
+            topicRead->SetCommitOffsetsBegin(begin);
+            topicRead->SetCommitOffsetsEnd(end);
+            topicRead->SetForceCommit(operations.GetForceCommit());
+            topicRead->SetKillReadSession(operations.GetKillReadSession());
+            topicRead->SetOnlyCheckCommitedToFinish(operations.GetOnlyCheckCommitedToFinish());
+            topicRead->SetReadSessionId(operations.GetReadSessionId());
         }
+        NPQ::DowngradeToLegacy(*o);
     }
 
     if (HasWriteOperations_) {
@@ -254,14 +258,16 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, 
         o->SetPartitionId(*Partition_);
         o->SetPath(*Topic_);
 
+        auto* write = o->MutableWrite();
+        write->SetSkipConflictCheck(skipConflictCheck);
         if (KafkaProducerInstanceId_.Defined()) { // kafka transaction
-            o->SetKafkaTransaction(true);
-            o->MutableKafkaProducerInstanceId()->SetId(KafkaProducerInstanceId_->Id);
-            o->MutableKafkaProducerInstanceId()->SetEpoch(KafkaProducerInstanceId_->Epoch);
+            auto* producerId = write->MutableKafka()->MutableKafkaProducerInstanceId();
+            producerId->SetId(KafkaProducerInstanceId_->Id);
+            producerId->SetEpoch(KafkaProducerInstanceId_->Epoch);
         } else if (SupportivePartition_.Defined()) {
-            o->SetSupportivePartition(*SupportivePartition_);
+            write->MutableTopic()->SetSupportivePartition(*SupportivePartition_);
         }
-        o->SetSkipConflictCheck(skipConflictCheck);
+        NPQ::DowngradeToLegacy(*o);
         t.hasWrite = true;
     }
 }

--- a/ydb/core/kqp/topics/ya.make
+++ b/ydb/core/kqp/topics/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/base
+    ydb/core/persqueue/public
     ydb/core/tx/scheme_cache
 )
 

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -1,5 +1,9 @@
 #include <ydb/core/kqp/topics/kqp_topics.h>
+#include <ydb/core/kafka_proxy/kafka_producer_instance_id.h>
+#include <ydb/core/protos/kqp.pb.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/yexception.h>
 
 namespace NKikimr::NKqp {
 
@@ -42,7 +46,14 @@ static
 void AssertReadOperation(const NTopic::TTopicOperationTransactions& txs,
                          const ui64 tabletId,
                          const size_t opsCount,
-                         const size_t opIndex)
+                         const size_t opIndex,
+                         const TString& consumer,
+                         ui64 begin,
+                         ui64 end,
+                         bool forceCommit,
+                         bool killReadSession,
+                         bool onlyCheckCommitedToFinish,
+                         const TString& readSessionId)
 {
     UNIT_ASSERT(txs.contains(tabletId));
     const auto& t = txs.at(tabletId);
@@ -50,6 +61,50 @@ void AssertReadOperation(const NTopic::TTopicOperationTransactions& txs,
     UNIT_ASSERT_LT(opIndex, opsCount);
     const auto& readOp = t.tx.GetOperations(opIndex);
     UNIT_ASSERT(not readOp.HasSkipConflictCheck());
+
+    UNIT_ASSERT(readOp.HasRead());
+    UNIT_ASSERT(readOp.GetRead().HasTopic());
+    const auto& topicRead = readOp.GetRead().GetTopic();
+    UNIT_ASSERT_EQUAL(topicRead.GetConsumer(), consumer);
+    UNIT_ASSERT_EQUAL(topicRead.GetCommitOffsetsBegin(), begin);
+    UNIT_ASSERT_EQUAL(topicRead.GetCommitOffsetsEnd(), end);
+    UNIT_ASSERT_EQUAL(topicRead.GetForceCommit(), forceCommit);
+    UNIT_ASSERT_EQUAL(topicRead.GetKillReadSession(), killReadSession);
+    UNIT_ASSERT_EQUAL(topicRead.GetOnlyCheckCommitedToFinish(), onlyCheckCommitedToFinish);
+    UNIT_ASSERT_EQUAL(topicRead.GetReadSessionId(), readSessionId);
+
+    UNIT_ASSERT_EQUAL(readOp.GetConsumer(), consumer);
+    UNIT_ASSERT_EQUAL(readOp.GetCommitOffsetsBegin(), begin);
+    UNIT_ASSERT_EQUAL(readOp.GetCommitOffsetsEnd(), end);
+    UNIT_ASSERT_EQUAL(readOp.GetForceCommit(), forceCommit);
+    UNIT_ASSERT_EQUAL(readOp.GetKillReadSession(), killReadSession);
+    UNIT_ASSERT_EQUAL(readOp.GetOnlyCheckCommitedToFinish(), onlyCheckCommitedToFinish);
+    UNIT_ASSERT_EQUAL(readOp.GetReadSessionId(), readSessionId);
+}
+
+static
+void AssertKafkaReadOperation(const NTopic::TTopicOperationTransactions& txs,
+                                const ui64 tabletId,
+                                const size_t opsCount,
+                                const size_t opIndex,
+                                const TString& consumer,
+                                ui64 commitOffsetEnd)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), opsCount);
+    UNIT_ASSERT_LT(opIndex, opsCount);
+    const auto& readOp = t.tx.GetOperations(opIndex);
+
+    UNIT_ASSERT(readOp.HasRead());
+    UNIT_ASSERT(readOp.GetRead().HasKafka());
+    const auto& kafkaRead = readOp.GetRead().GetKafka();
+    UNIT_ASSERT_EQUAL(kafkaRead.GetConsumer(), consumer);
+    UNIT_ASSERT_EQUAL(kafkaRead.GetCommitOffsetsEnd(), commitOffsetEnd);
+
+    UNIT_ASSERT(readOp.GetKafkaTransaction());
+    UNIT_ASSERT_EQUAL(readOp.GetConsumer(), consumer);
+    UNIT_ASSERT_EQUAL(readOp.GetCommitOffsetsEnd(), commitOffsetEnd);
 }
 
 static
@@ -57,7 +112,8 @@ void AssertWriteOperation(const NTopic::TTopicOperationTransactions& txs,
                           const ui64 tabletId,
                           const size_t opsCount,
                           const size_t opIndex,
-                          const bool skipConflictCheck)
+                          const bool skipConflictCheck,
+                          TMaybe<ui32> supportivePartition = Nothing())
 {
     UNIT_ASSERT(txs.contains(tabletId));
     const auto& t = txs.at(tabletId);
@@ -67,6 +123,46 @@ void AssertWriteOperation(const NTopic::TTopicOperationTransactions& txs,
     const auto& writeOp = t.tx.GetOperations(opIndex);
     UNIT_ASSERT(writeOp.HasSkipConflictCheck());
     UNIT_ASSERT_EQUAL(writeOp.GetSkipConflictCheck(), skipConflictCheck);
+
+    UNIT_ASSERT(writeOp.HasWrite());
+    UNIT_ASSERT_EQUAL(writeOp.GetWrite().GetSkipConflictCheck(), skipConflictCheck);
+
+    if (supportivePartition.Defined()) {
+        UNIT_ASSERT_EQUAL(writeOp.GetSupportivePartition(), *supportivePartition);
+        UNIT_ASSERT(writeOp.GetWrite().HasTopic());
+        UNIT_ASSERT_EQUAL(writeOp.GetWrite().GetTopic().GetSupportivePartition(), *supportivePartition);
+    }
+}
+
+static
+void AssertKafkaWriteOperation(const NTopic::TTopicOperationTransactions& txs,
+                                 const ui64 tabletId,
+                                 const size_t opsCount,
+                                 const size_t opIndex,
+                                 const bool skipConflictCheck,
+                                 const NKafka::TProducerInstanceId& producerInstanceId)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT(t.hasWrite);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), opsCount);
+    UNIT_ASSERT_LT(opIndex, opsCount);
+    const auto& writeOp = t.tx.GetOperations(opIndex);
+    UNIT_ASSERT(writeOp.HasSkipConflictCheck());
+    UNIT_ASSERT_EQUAL(writeOp.GetSkipConflictCheck(), skipConflictCheck);
+
+    UNIT_ASSERT(writeOp.HasWrite());
+    UNIT_ASSERT_EQUAL(writeOp.GetWrite().GetSkipConflictCheck(), skipConflictCheck);
+    UNIT_ASSERT(writeOp.GetWrite().HasKafka());
+
+    UNIT_ASSERT(writeOp.GetKafkaTransaction());
+    const auto& legacyProducerId = writeOp.GetKafkaProducerInstanceId();
+    UNIT_ASSERT_EQUAL(legacyProducerId.GetId(), producerInstanceId.Id);
+    UNIT_ASSERT_EQUAL(legacyProducerId.GetEpoch(), producerInstanceId.Epoch);
+
+    const auto& canonicalProducerId = writeOp.GetWrite().GetKafka().GetKafkaProducerInstanceId();
+    UNIT_ASSERT_EQUAL(canonicalProducerId.GetId(), producerInstanceId.Id);
+    UNIT_ASSERT_EQUAL(canonicalProducerId.GetEpoch(), producerInstanceId.Epoch);
 }
 
 Y_UNIT_TEST(OnlyReadOperations) {
@@ -93,7 +189,7 @@ Y_UNIT_TEST(OnlyReadOperations) {
     topicOps.BuildTopicTxs(txs);
     UNIT_ASSERT_EQUAL(txs.size(), 1);
 
-    AssertReadOperation(txs, TABLETID, 1, 0);
+    AssertReadOperation(txs, TABLETID, 1, 0, "consumer", 100, 105, false, false, false, "read-session");
 }
 
 static
@@ -134,8 +230,8 @@ void TestReadWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     topicOps.BuildTopicTxs(txs);
     UNIT_ASSERT_EQUAL(txs.size(), 2);
 
-    AssertReadOperation(txs, TABLETID_A, 1, 0);
-    AssertWriteOperation(txs, TABLETID_B, 1, 0, shouldSkip);
+    AssertReadOperation(txs, TABLETID_A, 1, 0, "consumer", 100, 105, false, false, false, "read-session");
+    AssertWriteOperation(txs, TABLETID_B, 1, 0, shouldSkip, 100'001u);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
@@ -186,7 +282,7 @@ void TestOnlyWriteOperations(bool skipConflictCheck, bool trackProducerId) {
     topicOps.BuildTopicTxs(txs);
     UNIT_ASSERT_EQUAL(txs.size(), 1);
 
-    AssertWriteOperation(txs, TABLETID, 1, 0, shouldSkip);
+    AssertWriteOperation(txs, TABLETID, 1, 0, shouldSkip, 100'001u);
 }
 
 Y_UNIT_TEST(OnlyWriteOperations_NoSkipConflictCheck_NoTrackProducerId) {
@@ -235,8 +331,8 @@ void TestReadWriteOperationsOnePartition(bool skipConflictCheck, bool trackProdu
     topicOps.BuildTopicTxs(txs);
     UNIT_ASSERT_EQUAL(txs.size(), 1);
 
-    AssertReadOperation(txs, TABLETID, 2, 0);
-    AssertWriteOperation(txs, TABLETID, 2, 1, shouldSkip);
+    AssertReadOperation(txs, TABLETID, 2, 0, "consumer", 100, 105, false, false, false, "read-session");
+    AssertWriteOperation(txs, TABLETID, 2, 1, shouldSkip, 100'001u);
 }
 
 Y_UNIT_TEST(ReadWriteOperations_OnePartition_NoSkipConflictCheck_NoTrackProducerId) {
@@ -316,6 +412,41 @@ Y_UNIT_TEST(ShouldOmitPeerTopicPredicateExchange_FalseWhenTrackProducerId) {
     topicOps.SetTabletId(TOPIC, 1, 200);
 
     UNIT_ASSERT(!topicOps.ShouldOmitPeerTopicTabletsForPredicateExchange());
+}
+
+Y_UNIT_TEST(KafkaReadOperation_DualWrite) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+    const TString CONSUMER = "kafka-consumer";
+    const ui64 OFFSET = 42;
+
+    NTopic::TTopicOperations topicOps;
+    topicOps.AddKafkaApiReadOperation(TOPIC, PARTITION, CONSUMER, OFFSET);
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+    AssertKafkaReadOperation(txs, TABLETID, 1, 0, CONSUMER, OFFSET);
+}
+
+Y_UNIT_TEST(KafkaWriteOperation_DualWrite) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+    const NKafka::TProducerInstanceId PRODUCER_ID{7, 3};
+
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(false);
+    topicOps.SetTrackProducerId(false);
+    topicOps.AddKafkaApiWriteOperation(TOPIC, PARTITION, PRODUCER_ID);
+    topicOps.SetTabletId(TOPIC, PARTITION, TABLETID);
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+    AssertKafkaWriteOperation(txs, TABLETID, 1, 0, false, PRODUCER_ID);
 }
 
 }

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -2656,7 +2656,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
         // This branch happens when previous Kafka transaction has committed and we receive write for next one
         // after PQ has deleted supportive partition and before it has deleted writeId from TxWrites (tx has not transaitioned to DELETED state)
         PQ_LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.%01");
-        KafkaNextTransactionRequests[writeId.KafkaProducerInstanceId].push_back(event);
+        KafkaNextTransactionRequests[writeId.GetKafkaProducerInstanceId()].push_back(event);
         return;
     } else if (TxWrites.contains(writeId) && TxWrites.at(writeId).Partitions.contains(originalPartitionId)) {
         //
@@ -2677,7 +2677,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
             // This branch happens when previous Kafka transaction has committed and we receive write for next one
             // before PQ has deleted supportive partition for previous transaction
             PQ_LOG_D("GetOwnership request for the next Kafka transaction while previous is being deleted. Saving it till the complete delete of the previous tx.%02");
-            KafkaNextTransactionRequests[writeId.KafkaProducerInstanceId].push_back(event);
+            KafkaNextTransactionRequests[writeId.GetKafkaProducerInstanceId()].push_back(event);
             return;
         }
 
@@ -2695,10 +2695,10 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
     } else {
         if (!req.GetNeedSupportivePartition()) {
             // missing supportivce partition in kafka transaction means that we already committed and deleted transaction for current producerId + producerEpoch
-            NPersQueue::NErrorCode::EErrorCode errorCode = writeId.KafkaApiTransaction ?
+            NPersQueue::NErrorCode::EErrorCode errorCode = writeId.IsKafkaApiTransaction() ?
                 NPersQueue::NErrorCode::KAFKA_TRANSACTION_MISSING_SUPPORTIVE_PARTITION :
                 NPersQueue::NErrorCode::PRECONDITION_FAILED;
-            TString error = writeId.KafkaApiTransaction ?
+            TString error = writeId.IsKafkaApiTransaction() ?
                 "Kafka transaction and there is no supportive partition for current producerId and producerEpoch. It means GetOwnership request was not called from TPartitionWriter" :
                 "lost messages";
 
@@ -2741,7 +2741,7 @@ void TPersQueue::HandleEventForSupportivePartition(const ui64 responseCookie,
             SubscribeWriteId(writeId, ctx);
         }
 
-        if (writeId.KafkaApiTransaction) {
+        if (writeId.IsKafkaApiTransaction()) {
             writeInfo.KafkaTransaction = true;
             writeInfo.CreatedAt = TAppData::TimeProvider->Now();
         }
@@ -3216,7 +3216,7 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
 
     for (auto& pair : TxWrites) {
         if (txnExpired(pair.second)) {
-            PQ_LOG_D("Transaction for Kafka producer " << pair.first.KafkaProducerInstanceId << " is expired");
+            PQ_LOG_D("Transaction for Kafka producer " << pair.first.GetKafkaProducerInstanceId() << " is expired");
             BeginDeletePartitions(pair.first, pair.second);
         }
     }
@@ -3224,7 +3224,7 @@ void TPersQueue::ScheduleDeleteExpiredKafkaTransactions() {
 
 void TPersQueue::TryContinueKafkaWrites(const TMaybe<TWriteId> writeId, const TActorContext& ctx) {
     if (writeId.Defined() && writeId->IsKafkaApiTransaction()) {
-        auto it = KafkaNextTransactionRequests.find(writeId->KafkaProducerInstanceId);
+        auto it = KafkaNextTransactionRequests.find(writeId->GetKafkaProducerInstanceId());
         if (it != KafkaNextTransactionRequests.end()) {
             for (auto& request : it->second) {
                 Handle(request, ctx);
@@ -3704,16 +3704,16 @@ void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
                                   const TActorContext& ctx)
 {
     PQ_LOG_TX_D("send TEvSubscribeLock for WriteId " << writeId);
-    ctx.Send(NLongTxService::MakeLongTxServiceID(writeId.NodeId),
-             new NLongTxService::TEvLongTxService::TEvSubscribeLock(writeId.KeyId, writeId.NodeId));
+    ctx.Send(NLongTxService::MakeLongTxServiceID(writeId.GetNodeId()),
+             new NLongTxService::TEvLongTxService::TEvSubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
 }
 
 void TPersQueue::UnsubscribeWriteId(const TWriteId& writeId,
                                     const TActorContext& ctx)
 {
     PQ_LOG_TX_D("send TEvUnsubscribeLock for WriteId " << writeId);
-    ctx.Send(NLongTxService::MakeLongTxServiceID(writeId.NodeId),
-             new NLongTxService::TEvLongTxService::TEvUnsubscribeLock(writeId.KeyId, writeId.NodeId));
+    ctx.Send(NLongTxService::MakeLongTxServiceID(writeId.GetNodeId()),
+             new NLongTxService::TEvLongTxService::TEvUnsubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
 }
 
 void TPersQueue::CreateSupportivePartitionActors(const TActorContext& ctx)

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3703,6 +3703,7 @@ bool TPersQueue::CanProcessTxWrites() const
 void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
                                   const TActorContext& ctx)
 {
+    PQ_ENSURE(writeId.IsTopicApiTransaction());
     PQ_LOG_TX_D("send TEvSubscribeLock for WriteId " << writeId);
     ctx.Send(NLongTxService::MakeLongTxServiceID(writeId.GetNodeId()),
              new NLongTxService::TEvLongTxService::TEvSubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));
@@ -3711,6 +3712,7 @@ void TPersQueue::SubscribeWriteId(const TWriteId& writeId,
 void TPersQueue::UnsubscribeWriteId(const TWriteId& writeId,
                                     const TActorContext& ctx)
 {
+    PQ_ENSURE(writeId.IsTopicApiTransaction());
     PQ_LOG_TX_D("send TEvUnsubscribeLock for WriteId " << writeId);
     ctx.Send(NLongTxService::MakeLongTxServiceID(writeId.GetNodeId()),
              new NLongTxService::TEvLongTxService::TEvUnsubscribeLock(writeId.GetKeyId(), writeId.GetNodeId()));

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -47,10 +47,26 @@ bool HasLegacy(const NKikimrPQ::TWriteId& writeId)
         || writeId.HasNodeId() || writeId.HasKeyId();
 }
 
+void ClearLegacyPartitionOpFields(NKikimrPQ::TPartitionOperation& op)
+{
+    op.ClearCommitOffsetsBegin();
+    op.ClearCommitOffsetsEnd();
+    op.ClearConsumer();
+    op.ClearSupportivePartition();
+    op.ClearForceCommit();
+    op.ClearKillReadSession();
+    op.ClearOnlyCheckCommitedToFinish();
+    op.ClearReadSessionId();
+    op.SetKafkaTransaction(false);
+    op.ClearKafkaProducerInstanceId();
+    op.ClearSkipConflictCheck();
+}
+
 void DowngradeTopicReadToLegacy(
     const NKikimrPQ::TPartitionOperation::TReadOp::TTopicApi& topicRead,
     NKikimrPQ::TPartitionOperation& op)
 {
+    ClearLegacyPartitionOpFields(op);
     op.SetConsumer(topicRead.GetConsumer());
     op.SetCommitOffsetsBegin(topicRead.GetCommitOffsetsBegin());
     op.SetCommitOffsetsEnd(topicRead.GetCommitOffsetsEnd());
@@ -65,6 +81,7 @@ void DowngradeKafkaReadToLegacy(
     const NKikimrPQ::TPartitionOperation::TReadOp::TKafkaApi& kafkaRead,
     NKikimrPQ::TPartitionOperation& op)
 {
+    ClearLegacyPartitionOpFields(op);
     op.SetConsumer(kafkaRead.GetConsumer());
     op.SetCommitOffsetsEnd(kafkaRead.GetCommitOffsetsEnd());
     op.SetKafkaTransaction(true);
@@ -74,6 +91,7 @@ void DowngradeTopicWriteToLegacy(
     const NKikimrPQ::TPartitionOperation::TWriteOp& write,
     NKikimrPQ::TPartitionOperation& op)
 {
+    ClearLegacyPartitionOpFields(op);
     op.SetSkipConflictCheck(write.GetSkipConflictCheck());
     if (write.GetTopic().HasSupportivePartition()) {
         op.SetSupportivePartition(write.GetTopic().GetSupportivePartition());
@@ -85,6 +103,7 @@ void DowngradeKafkaWriteToLegacy(
     const NKikimrPQ::TPartitionOperation::TWriteOp& write,
     NKikimrPQ::TPartitionOperation& op)
 {
+    ClearLegacyPartitionOpFields(op);
     op.SetSkipConflictCheck(write.GetSkipConflictCheck());
     op.SetKafkaTransaction(true);
     CopyKafkaProducerInstanceId(

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -1,0 +1,253 @@
+#include "pqdata_transaction_compat.h"
+
+namespace NKikimr::NPQ {
+
+namespace {
+
+void CopyKafkaProducerInstanceId(
+    const NKikimrPQ::TKafkaProducerInstanceId& src,
+    NKikimrPQ::TKafkaProducerInstanceId* dst)
+{
+    dst->SetId(src.GetId());
+    dst->SetEpoch(src.GetEpoch());
+}
+
+void UpgradeTopicApiFromLegacy(NKikimrPQ::TWriteId& writeId)
+{
+    auto* topicApi = writeId.MutableTopicApi();
+    topicApi->SetNodeId(writeId.GetNodeId());
+    topicApi->SetKeyId(writeId.GetKeyId());
+}
+
+void UpgradeKafkaApiFromLegacy(NKikimrPQ::TWriteId& writeId)
+{
+    auto* kafkaApi = writeId.MutableKafkaApi();
+    CopyKafkaProducerInstanceId(writeId.GetKafkaProducerInstanceId(), kafkaApi->MutableKafkaProducerInstanceId());
+}
+
+void DowngradeTopicApiToLegacy(const NKikimrPQ::TWriteId::TTopicApi& topicApi, NKikimrPQ::TWriteId& writeId)
+{
+    writeId.SetKafkaTransaction(false);
+    writeId.SetNodeId(topicApi.GetNodeId());
+    writeId.SetKeyId(topicApi.GetKeyId());
+}
+
+void DowngradeKafkaApiToLegacy(const NKikimrPQ::TWriteId::TKafkaApi& kafkaApi, NKikimrPQ::TWriteId& writeId)
+{
+    writeId.SetKafkaTransaction(true);
+    CopyKafkaProducerInstanceId(kafkaApi.GetKafkaProducerInstanceId(), writeId.MutableKafkaProducerInstanceId());
+}
+
+bool HasLegacy(const NKikimrPQ::TWriteId& writeId)
+{
+    return writeId.GetKafkaTransaction() || writeId.HasKafkaProducerInstanceId()
+        || writeId.HasNodeId() || writeId.HasKeyId();
+}
+
+void DowngradeTopicReadToLegacy(
+    const NKikimrPQ::TPartitionOperation::TReadOp::TTopicApi& topicRead,
+    NKikimrPQ::TPartitionOperation& op)
+{
+    op.SetConsumer(topicRead.GetConsumer());
+    op.SetCommitOffsetsBegin(topicRead.GetCommitOffsetsBegin());
+    op.SetCommitOffsetsEnd(topicRead.GetCommitOffsetsEnd());
+    op.SetForceCommit(topicRead.GetForceCommit());
+    op.SetKillReadSession(topicRead.GetKillReadSession());
+    op.SetOnlyCheckCommitedToFinish(topicRead.GetOnlyCheckCommitedToFinish());
+    op.SetReadSessionId(topicRead.GetReadSessionId());
+    op.SetKafkaTransaction(false);
+}
+
+void DowngradeKafkaReadToLegacy(
+    const NKikimrPQ::TPartitionOperation::TReadOp::TKafkaApi& kafkaRead,
+    NKikimrPQ::TPartitionOperation& op)
+{
+    op.SetConsumer(kafkaRead.GetConsumer());
+    op.SetCommitOffsetsEnd(kafkaRead.GetCommitOffsetsEnd());
+    op.SetKafkaTransaction(true);
+}
+
+void DowngradeTopicWriteToLegacy(
+    const NKikimrPQ::TPartitionOperation::TWriteOp& write,
+    NKikimrPQ::TPartitionOperation& op)
+{
+    op.SetSkipConflictCheck(write.GetSkipConflictCheck());
+    if (write.GetTopic().HasSupportivePartition()) {
+        op.SetSupportivePartition(write.GetTopic().GetSupportivePartition());
+    }
+    op.SetKafkaTransaction(false);
+}
+
+void DowngradeKafkaWriteToLegacy(
+    const NKikimrPQ::TPartitionOperation::TWriteOp& write,
+    NKikimrPQ::TPartitionOperation& op)
+{
+    op.SetSkipConflictCheck(write.GetSkipConflictCheck());
+    op.SetKafkaTransaction(true);
+    CopyKafkaProducerInstanceId(
+        write.GetKafka().GetKafkaProducerInstanceId(),
+        op.MutableKafkaProducerInstanceId());
+}
+
+bool HasLegacyPartitionOp(const NKikimrPQ::TPartitionOperation& op)
+{
+    return op.HasConsumer() || op.HasCommitOffsetsBegin() || op.HasCommitOffsetsEnd()
+        || op.HasForceCommit() || op.HasKillReadSession() || op.HasOnlyCheckCommitedToFinish()
+        || op.HasReadSessionId() || op.GetKafkaTransaction()
+        || op.HasKafkaProducerInstanceId() || op.HasSupportivePartition() || op.HasSkipConflictCheck();
+}
+
+void UpgradeTopicReadFromLegacy(NKikimrPQ::TPartitionOperation& op)
+{
+    auto* topicRead = op.MutableRead()->MutableTopic();
+    topicRead->SetConsumer(op.GetConsumer());
+    topicRead->SetCommitOffsetsBegin(op.GetCommitOffsetsBegin());
+    topicRead->SetCommitOffsetsEnd(op.GetCommitOffsetsEnd());
+    topicRead->SetForceCommit(op.GetForceCommit());
+    topicRead->SetKillReadSession(op.GetKillReadSession());
+    topicRead->SetOnlyCheckCommitedToFinish(op.GetOnlyCheckCommitedToFinish());
+    topicRead->SetReadSessionId(op.GetReadSessionId());
+}
+
+void UpgradeKafkaReadFromLegacy(NKikimrPQ::TPartitionOperation& op)
+{
+    auto* kafkaRead = op.MutableRead()->MutableKafka();
+    kafkaRead->SetConsumer(op.GetConsumer());
+    kafkaRead->SetCommitOffsetsEnd(op.GetCommitOffsetsEnd());
+}
+
+void UpgradeTopicWriteFromLegacy(NKikimrPQ::TPartitionOperation& op)
+{
+    auto* write = op.MutableWrite();
+    write->SetSkipConflictCheck(op.GetSkipConflictCheck());
+    if (op.HasSupportivePartition()) {
+        write->MutableTopic()->SetSupportivePartition(op.GetSupportivePartition());
+    }
+}
+
+void UpgradeKafkaWriteFromLegacy(NKikimrPQ::TPartitionOperation& op)
+{
+    auto* write = op.MutableWrite();
+    write->SetSkipConflictCheck(op.GetSkipConflictCheck());
+    CopyKafkaProducerInstanceId(
+        op.GetKafkaProducerInstanceId(),
+        write->MutableKafka()->MutableKafkaProducerInstanceId());
+}
+
+} // namespace
+
+bool HasCanonical(const NKikimrPQ::TWriteId& writeId)
+{
+    return writeId.Id_case() != NKikimrPQ::TWriteId::ID_NOT_SET;
+}
+
+void UpgradeFromLegacy(NKikimrPQ::TWriteId& writeId)
+{
+    if (HasCanonical(writeId) || !HasLegacy(writeId)) {
+        return;
+    }
+
+    if (writeId.GetKafkaTransaction()) {
+        UpgradeKafkaApiFromLegacy(writeId);
+    } else {
+        UpgradeTopicApiFromLegacy(writeId);
+    }
+}
+
+void DowngradeToLegacy(NKikimrPQ::TWriteId& writeId)
+{
+    if (!HasCanonical(writeId)) {
+        return;
+    }
+
+    switch (writeId.Id_case()) {
+        case NKikimrPQ::TWriteId::kTopicApi:
+            DowngradeTopicApiToLegacy(writeId.GetTopicApi(), writeId);
+            break;
+        case NKikimrPQ::TWriteId::kKafkaApi:
+            DowngradeKafkaApiToLegacy(writeId.GetKafkaApi(), writeId);
+            break;
+        case NKikimrPQ::TWriteId::ID_NOT_SET:
+            break;
+    }
+}
+
+void EnsureCanonical(NKikimrPQ::TWriteId& writeId)
+{
+    UpgradeFromLegacy(writeId);
+}
+
+bool HasCanonical(const NKikimrPQ::TPartitionOperation& op)
+{
+    return op.Op_case() != NKikimrPQ::TPartitionOperation::OP_NOT_SET;
+}
+
+void DowngradeToLegacy(NKikimrPQ::TPartitionOperation& op)
+{
+    if (!HasCanonical(op)) {
+        return;
+    }
+
+    switch (op.Op_case()) {
+        case NKikimrPQ::TPartitionOperation::kRead:
+            switch (op.GetRead().Api_case()) {
+                case NKikimrPQ::TPartitionOperation::TReadOp::kTopic:
+                    DowngradeTopicReadToLegacy(op.GetRead().GetTopic(), op);
+                    break;
+                case NKikimrPQ::TPartitionOperation::TReadOp::kKafka:
+                    DowngradeKafkaReadToLegacy(op.GetRead().GetKafka(), op);
+                    break;
+                case NKikimrPQ::TPartitionOperation::TReadOp::API_NOT_SET:
+                    break;
+            }
+            break;
+        case NKikimrPQ::TPartitionOperation::kWrite:
+            switch (op.GetWrite().Api_case()) {
+                case NKikimrPQ::TPartitionOperation::TWriteOp::kTopic:
+                    DowngradeTopicWriteToLegacy(op.GetWrite(), op);
+                    break;
+                case NKikimrPQ::TPartitionOperation::TWriteOp::kKafka:
+                    DowngradeKafkaWriteToLegacy(op.GetWrite(), op);
+                    break;
+                case NKikimrPQ::TPartitionOperation::TWriteOp::API_NOT_SET:
+                    if (op.GetWrite().HasSkipConflictCheck()) {
+                        op.SetSkipConflictCheck(op.GetWrite().GetSkipConflictCheck());
+                    }
+                    break;
+            }
+            break;
+        case NKikimrPQ::TPartitionOperation::OP_NOT_SET:
+            break;
+    }
+}
+
+void UpgradeFromLegacy(NKikimrPQ::TPartitionOperation& op)
+{
+    if (HasCanonical(op) || !HasLegacyPartitionOp(op)) {
+        return;
+    }
+
+    if (op.GetKafkaTransaction() && op.HasKafkaProducerInstanceId()) {
+        UpgradeKafkaWriteFromLegacy(op);
+        return;
+    }
+
+    if (op.GetKafkaTransaction() && op.HasConsumer()) {
+        UpgradeKafkaReadFromLegacy(op);
+        return;
+    }
+
+    if (op.HasConsumer()) {
+        UpgradeTopicReadFromLegacy(op);
+        return;
+    }
+
+    UpgradeTopicWriteFromLegacy(op);
+}
+
+void EnsureCanonical(NKikimrPQ::TPartitionOperation& op)
+{
+    UpgradeFromLegacy(op);
+}
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -27,6 +27,7 @@ void UpgradeKafkaApiFromLegacy(NKikimrPQ::TWriteId& writeId)
 
 void DowngradeTopicApiToLegacy(const NKikimrPQ::TWriteId::TTopicApi& topicApi, NKikimrPQ::TWriteId& writeId)
 {
+    writeId.ClearKafkaProducerInstanceId();
     writeId.SetKafkaTransaction(false);
     writeId.SetNodeId(topicApi.GetNodeId());
     writeId.SetKeyId(topicApi.GetKeyId());
@@ -34,6 +35,8 @@ void DowngradeTopicApiToLegacy(const NKikimrPQ::TWriteId::TTopicApi& topicApi, N
 
 void DowngradeKafkaApiToLegacy(const NKikimrPQ::TWriteId::TKafkaApi& kafkaApi, NKikimrPQ::TWriteId& writeId)
 {
+    writeId.ClearNodeId();
+    writeId.ClearKeyId();
     writeId.SetKafkaTransaction(true);
     CopyKafkaProducerInstanceId(kafkaApi.GetKafkaProducerInstanceId(), writeId.MutableKafkaProducerInstanceId());
 }

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -232,6 +232,7 @@ void DowngradeToLegacy(NKikimrPQ::TPartitionOperation& op)
                     DowngradeKafkaWriteToLegacy(op.GetWrite(), op);
                     break;
                 case NKikimrPQ::TPartitionOperation::TWriteOp::API_NOT_SET:
+                    ClearLegacyPartitionOpFields(op);
                     if (op.GetWrite().HasSkipConflictCheck()) {
                         op.SetSkipConflictCheck(op.GetWrite().GetSkipConflictCheck());
                     }

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.h
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <ydb/core/protos/pqdata_transaction.pb.h>
+
+namespace NKikimr::NPQ {
+
+bool HasCanonical(const NKikimrPQ::TWriteId& writeId);
+void UpgradeFromLegacy(NKikimrPQ::TWriteId& writeId);
+void DowngradeToLegacy(NKikimrPQ::TWriteId& writeId);
+void EnsureCanonical(NKikimrPQ::TWriteId& writeId);
+
+bool HasCanonical(const NKikimrPQ::TPartitionOperation& op);
+void UpgradeFromLegacy(NKikimrPQ::TPartitionOperation& op);
+void DowngradeToLegacy(NKikimrPQ::TPartitionOperation& op);
+void EnsureCanonical(NKikimrPQ::TPartitionOperation& op);
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/public/write_id.cpp
+++ b/ydb/core/persqueue/public/write_id.cpp
@@ -4,6 +4,7 @@
 
 #include <util/digest/multi.h>
 #include <util/stream/output.h>
+#include <util/system/yassert.h>
 
 namespace NKikimr::NPQ {
 
@@ -46,6 +47,8 @@ int CompareWriteIdProto(const NKikimrPQ::TWriteId& lhs, const NKikimrPQ::TWriteI
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             return 0;
     }
+    Y_UNREACHABLE();
+    return 0;
 }
 
 } // namespace
@@ -103,6 +106,8 @@ size_t TWriteId::GetHash() const
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             return 0;
     }
+    Y_UNREACHABLE();
+    return 0;
 }
 
 void TWriteId::ToStream(IOutputStream& s) const

--- a/ydb/core/persqueue/public/write_id.cpp
+++ b/ydb/core/persqueue/public/write_id.cpp
@@ -1,40 +1,122 @@
 #include "write_id.h"
 
-#include <util/stream/output.h>
+#include "pqdata_transaction_compat.h"
 
-#include <tuple>
+#include <util/digest/multi.h>
+#include <util/stream/output.h>
 
 namespace NKikimr::NPQ {
 
-TWriteId::TWriteId(ui64 nodeId, ui64 keyId) :
-    KafkaApiTransaction(false),
-    NodeId(nodeId),
-    KeyId(keyId)
+namespace {
+
+int CompareScalars(auto lhs, auto rhs)
 {
+    if (lhs < rhs) {
+        return -1;
+    }
+    if (rhs < lhs) {
+        return 1;
+    }
+    return 0;
 }
 
-TWriteId::TWriteId(NKafka::TProducerInstanceId kafkaProducerInstanceId) :
-    KafkaApiTransaction(true),
-    KafkaProducerInstanceId(kafkaProducerInstanceId)
+int CompareWriteIdProto(const NKikimrPQ::TWriteId& lhs, const NKikimrPQ::TWriteId& rhs)
 {
+    if (lhs.Id_case() != rhs.Id_case()) {
+        return CompareScalars(lhs.Id_case(), rhs.Id_case());
+    }
+
+    switch (lhs.Id_case()) {
+        case NKikimrPQ::TWriteId::kTopicApi: {
+            const auto& l = lhs.GetTopicApi();
+            const auto& r = rhs.GetTopicApi();
+            if (auto cmp = CompareScalars(l.GetNodeId(), r.GetNodeId()); cmp != 0) {
+                return cmp;
+            }
+            return CompareScalars(l.GetKeyId(), r.GetKeyId());
+        }
+        case NKikimrPQ::TWriteId::kKafkaApi: {
+            const auto& l = lhs.GetKafkaApi().GetKafkaProducerInstanceId();
+            const auto& r = rhs.GetKafkaApi().GetKafkaProducerInstanceId();
+            if (auto cmp = CompareScalars(l.GetId(), r.GetId()); cmp != 0) {
+                return cmp;
+            }
+            return CompareScalars(l.GetEpoch(), r.GetEpoch());
+        }
+        case NKikimrPQ::TWriteId::ID_NOT_SET:
+            return 0;
+    }
+}
+
+} // namespace
+
+void TWriteId::SyncKafkaProducerInstanceIdFromProto()
+{
+    if (IsKafkaApiTransaction()) {
+        const auto& producerInstanceId = Proto.GetKafkaApi().GetKafkaProducerInstanceId();
+        KafkaProducerInstanceId = {producerInstanceId.GetId(), producerInstanceId.GetEpoch()};
+    } else {
+        KafkaProducerInstanceId = {};
+    }
+}
+
+TWriteId::TWriteId(ui64 nodeId, ui64 keyId)
+{
+    auto* topicApi = Proto.MutableTopicApi();
+    topicApi->SetNodeId(nodeId);
+    topicApi->SetKeyId(keyId);
+}
+
+TWriteId::TWriteId(NKafka::TProducerInstanceId kafkaProducerInstanceId)
+    : KafkaProducerInstanceId(kafkaProducerInstanceId)
+{
+    auto* kafkaApi = Proto.MutableKafkaApi();
+    auto* producerInstanceId = kafkaApi->MutableKafkaProducerInstanceId();
+    producerInstanceId->SetId(kafkaProducerInstanceId.Id);
+    producerInstanceId->SetEpoch(kafkaProducerInstanceId.Epoch);
+}
+
+TWriteId::TWriteId(NKikimrPQ::TWriteId proto)
+    : Proto(std::move(proto))
+{
+    EnsureCanonical(Proto);
+    SyncKafkaProducerInstanceIdFromProto();
 }
 
 bool TWriteId::operator==(const TWriteId& rhs) const
 {
-    return std::make_tuple(NodeId, KeyId) == std::make_tuple(rhs.NodeId, rhs.KeyId);
+    return CompareWriteIdProto(Proto, rhs.Proto) == 0;
 }
 
 bool TWriteId::operator<(const TWriteId& rhs) const
 {
-    return std::make_tuple(NodeId, KeyId) < std::make_tuple(rhs.NodeId, rhs.KeyId);
+    return CompareWriteIdProto(Proto, rhs.Proto) < 0;
+}
+
+size_t TWriteId::GetHash() const
+{
+    switch (Proto.Id_case()) {
+        case NKikimrPQ::TWriteId::kTopicApi:
+            return MultiHash(Proto.GetTopicApi().GetNodeId(), Proto.GetTopicApi().GetKeyId());
+        case NKikimrPQ::TWriteId::kKafkaApi:
+            return MultiHash(KafkaProducerInstanceId.Id, KafkaProducerInstanceId.Epoch);
+        case NKikimrPQ::TWriteId::ID_NOT_SET:
+            return 0;
+    }
 }
 
 void TWriteId::ToStream(IOutputStream& s) const
 {
-    if (KafkaApiTransaction) {
-        s << "KafkaTransactionWriteId{" << KafkaProducerInstanceId.Id << ", " << KafkaProducerInstanceId.Epoch << '}';
-    } else {
-        s << '{' << NodeId << ", " << KeyId << '}';
+    switch (Proto.Id_case()) {
+        case NKikimrPQ::TWriteId::kKafkaApi:
+            s << "KafkaTransactionWriteId{" << KafkaProducerInstanceId.Id << ", " << KafkaProducerInstanceId.Epoch << '}';
+            break;
+        case NKikimrPQ::TWriteId::kTopicApi:
+            s << '{' << GetNodeId() << ", " << GetKeyId() << '}';
+            break;
+        case NKikimrPQ::TWriteId::ID_NOT_SET:
+            s << "{}";
+            break;
     }
 }
 
@@ -47,29 +129,15 @@ TString TWriteId::ToString() const {
 template <class T>
 TWriteId GetWriteIdImpl(const T& m)
 {
-    const auto& writeId = m.GetWriteId();
-    if (writeId.GetKafkaTransaction()) {
-        const auto& kafkaProducerInstanceId = writeId.GetKafkaProducerInstanceId();
-        return TWriteId{NKafka::TProducerInstanceId{kafkaProducerInstanceId.GetId(), kafkaProducerInstanceId.GetEpoch()}};
-    } else {
-        return {writeId.GetNodeId(), writeId.GetKeyId()};
-    }
+    return TWriteId(m.GetWriteId());
 }
 
 template <class T>
 void SetWriteIdImpl(T& m, const TWriteId& writeId)
 {
     auto* w = m.MutableWriteId();
-    if (writeId.KafkaApiTransaction) {
-        w->SetKafkaTransaction(true);
-        auto* kafkaProducerInstanceId = w->MutableKafkaProducerInstanceId();
-        kafkaProducerInstanceId->SetId(writeId.KafkaProducerInstanceId.Id);
-        kafkaProducerInstanceId->SetEpoch(writeId.KafkaProducerInstanceId.Epoch);
-    } else {
-        w->SetKafkaTransaction(false);
-        w->SetNodeId(writeId.NodeId);
-        w->SetKeyId(writeId.KeyId);
-    }
+    *w = writeId.GetProto();
+    DowngradeToLegacy(*w);
 }
 
 TWriteId GetWriteId(const NKikimrPQ::TTransaction& m)
@@ -114,12 +182,28 @@ void SetWriteId(NKikimrClient::TPersQueuePartitionRequest& m, const NKikimr::NPQ
 
 TWriteId GetWriteId(const NKikimrKqp::TTopicOperationsResponse& m)
 {
-    return GetWriteIdImpl(m);
+    const auto& writeId = m.GetWriteId();
+    if (writeId.GetKafkaTransaction()) {
+        const auto& kafkaProducerInstanceId = writeId.GetKafkaProducerInstanceId();
+        return TWriteId{NKafka::TProducerInstanceId{kafkaProducerInstanceId.GetId(), kafkaProducerInstanceId.GetEpoch()}};
+    }
+    return {writeId.GetNodeId(), writeId.GetKeyId()};
 }
 
 void SetWriteId(NKikimrKqp::TTopicOperationsResponse& m, const TWriteId& writeId)
 {
-    SetWriteIdImpl(m, writeId);
+    auto* w = m.MutableWriteId();
+    if (writeId.IsKafkaApiTransaction()) {
+        const auto& producerInstanceId = writeId.GetKafkaProducerInstanceId();
+        w->SetKafkaTransaction(true);
+        auto* kafkaProducerInstanceId = w->MutableKafkaProducerInstanceId();
+        kafkaProducerInstanceId->SetId(producerInstanceId.Id);
+        kafkaProducerInstanceId->SetEpoch(producerInstanceId.Epoch);
+    } else if (writeId.IsTopicApiTransaction()) {
+        w->SetKafkaTransaction(false);
+        w->SetNodeId(writeId.GetNodeId());
+        w->SetKeyId(writeId.GetKeyId());
+    }
 }
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/public/write_id.h
+++ b/ydb/core/persqueue/public/write_id.h
@@ -44,16 +44,19 @@ struct TWriteId {
         return Proto.Id_case() == NKikimrPQ::TWriteId::kKafkaApi;
     }
 
+    // Precondition: IsTopicApiTransaction(). Otherwise returns default proto values (0).
     ui64 GetNodeId() const
     {
         return Proto.GetTopicApi().GetNodeId();
     }
 
+    // Precondition: IsTopicApiTransaction(). Otherwise returns default proto values (0).
     ui64 GetKeyId() const
     {
         return Proto.GetTopicApi().GetKeyId();
     }
 
+    // Precondition: IsKafkaApiTransaction(). Otherwise returns empty/default producer id.
     const NKafka::TProducerInstanceId& GetKafkaProducerInstanceId() const
     {
         return KafkaProducerInstanceId;

--- a/ydb/core/persqueue/public/write_id.h
+++ b/ydb/core/persqueue/public/write_id.h
@@ -6,7 +6,6 @@
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <ydb/core/protos/pqdata_transaction.pb.h>
 
-#include <util/digest/multi.h>
 #include <util/stream/fwd.h>
 #include <util/system/types.h>
 
@@ -25,6 +24,7 @@ struct TWriteId {
     TWriteId() = default;
     TWriteId(ui64 nodeId, ui64 keyId);
     explicit TWriteId(NKafka::TProducerInstanceId kafkaProducerInstanceId);
+    explicit TWriteId(NKikimrPQ::TWriteId proto);
 
     bool operator==(const TWriteId& rhs) const;
     bool operator<(const TWriteId& rhs) const;
@@ -32,29 +32,44 @@ struct TWriteId {
     void ToStream(IOutputStream& s) const;
     TString ToString() const;
 
-    size_t GetHash() const
-    {
-        return KafkaApiTransaction ?
-            MultiHash(KafkaProducerInstanceId.Id, KafkaProducerInstanceId.Epoch)
-            : MultiHash(NodeId, KeyId);
-    }
+    size_t GetHash() const;
 
     bool IsTopicApiTransaction() const
     {
-        return !KafkaApiTransaction;
+        return Proto.Id_case() == NKikimrPQ::TWriteId::kTopicApi;
     }
 
     bool IsKafkaApiTransaction() const
     {
-        return KafkaApiTransaction;
+        return Proto.Id_case() == NKikimrPQ::TWriteId::kKafkaApi;
     }
 
-    bool KafkaApiTransaction = false;
-    // these fields are used to identify topic api transaction
-    ui64 NodeId = 0;
-    ui64 KeyId = 0;
-    // Identifies kafka api transaction
+    ui64 GetNodeId() const
+    {
+        return Proto.GetTopicApi().GetNodeId();
+    }
+
+    ui64 GetKeyId() const
+    {
+        return Proto.GetTopicApi().GetKeyId();
+    }
+
+    const NKafka::TProducerInstanceId& GetKafkaProducerInstanceId() const
+    {
+        return KafkaProducerInstanceId;
+    }
+
+    const NKikimrPQ::TWriteId& GetProto() const
+    {
+        return Proto;
+    }
+
+private:
+    NKikimrPQ::TWriteId Proto;
+    // Denormalized Kafka id; matches Proto KafkaApi branch when IsKafkaApiTransaction().
     NKafka::TProducerInstanceId KafkaProducerInstanceId;
+
+    void SyncKafkaProducerInstanceIdFromProto();
 };
 
 TWriteId GetWriteId(const NKikimrPQ::TTransaction& m);

--- a/ydb/core/persqueue/public/ya.make
+++ b/ydb/core/persqueue/public/ya.make
@@ -5,6 +5,7 @@ SRCS(
     inflight_limiter.cpp
     pq_database.cpp
     pq_rl_helpers.cpp
+    pqdata_transaction_compat.cpp
     utils.cpp
     write_id.cpp
 )

--- a/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
+++ b/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
@@ -1,0 +1,166 @@
+#include <ydb/core/persqueue/public/pqdata_transaction_compat.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NPQ {
+namespace {
+
+void AssertTopicReadDualWrite(const NKikimrPQ::TPartitionOperation& op)
+{
+    UNIT_ASSERT(op.HasRead());
+    UNIT_ASSERT(op.GetRead().HasTopic());
+    const auto& topicRead = op.GetRead().GetTopic();
+
+    UNIT_ASSERT_EQUAL(op.GetConsumer(), topicRead.GetConsumer());
+    UNIT_ASSERT_EQUAL(op.GetCommitOffsetsBegin(), topicRead.GetCommitOffsetsBegin());
+    UNIT_ASSERT_EQUAL(op.GetCommitOffsetsEnd(), topicRead.GetCommitOffsetsEnd());
+    UNIT_ASSERT_EQUAL(op.GetForceCommit(), topicRead.GetForceCommit());
+    UNIT_ASSERT_EQUAL(op.GetKillReadSession(), topicRead.GetKillReadSession());
+    UNIT_ASSERT_EQUAL(op.GetOnlyCheckCommitedToFinish(), topicRead.GetOnlyCheckCommitedToFinish());
+    UNIT_ASSERT_EQUAL(op.GetReadSessionId(), topicRead.GetReadSessionId());
+    UNIT_ASSERT(!op.GetKafkaTransaction());
+}
+
+void AssertKafkaReadDualWrite(const NKikimrPQ::TPartitionOperation& op)
+{
+    UNIT_ASSERT(op.HasRead());
+    UNIT_ASSERT(op.GetRead().HasKafka());
+    const auto& kafkaRead = op.GetRead().GetKafka();
+
+    UNIT_ASSERT(op.GetKafkaTransaction());
+    UNIT_ASSERT_EQUAL(op.GetConsumer(), kafkaRead.GetConsumer());
+    UNIT_ASSERT_EQUAL(op.GetCommitOffsetsEnd(), kafkaRead.GetCommitOffsetsEnd());
+}
+
+void AssertTopicWriteDualWrite(const NKikimrPQ::TPartitionOperation& op, bool skipConflictCheck, TMaybe<ui32> supportivePartition)
+{
+    UNIT_ASSERT(op.HasWrite());
+    UNIT_ASSERT_EQUAL(op.GetSkipConflictCheck(), skipConflictCheck);
+    UNIT_ASSERT_EQUAL(op.GetWrite().GetSkipConflictCheck(), skipConflictCheck);
+
+    if (supportivePartition.Defined()) {
+        UNIT_ASSERT(op.GetWrite().HasTopic());
+        UNIT_ASSERT_EQUAL(op.GetSupportivePartition(), *supportivePartition);
+        UNIT_ASSERT_EQUAL(op.GetWrite().GetTopic().GetSupportivePartition(), *supportivePartition);
+    }
+    UNIT_ASSERT(!op.GetKafkaTransaction());
+}
+
+void AssertKafkaWriteDualWrite(const NKikimrPQ::TPartitionOperation& op, bool skipConflictCheck, i64 id, i32 epoch)
+{
+    UNIT_ASSERT(op.HasWrite());
+    UNIT_ASSERT_EQUAL(op.GetSkipConflictCheck(), skipConflictCheck);
+    UNIT_ASSERT_EQUAL(op.GetWrite().GetSkipConflictCheck(), skipConflictCheck);
+    UNIT_ASSERT(op.GetWrite().HasKafka());
+    UNIT_ASSERT(op.GetKafkaTransaction());
+
+    const auto& legacyProducerId = op.GetKafkaProducerInstanceId();
+    UNIT_ASSERT_EQUAL(legacyProducerId.GetId(), id);
+    UNIT_ASSERT_EQUAL(legacyProducerId.GetEpoch(), epoch);
+
+    const auto& canonicalProducerId = op.GetWrite().GetKafka().GetKafkaProducerInstanceId();
+    UNIT_ASSERT_EQUAL(canonicalProducerId.GetId(), id);
+    UNIT_ASSERT_EQUAL(canonicalProducerId.GetEpoch(), epoch);
+}
+
+Y_UNIT_TEST_SUITE(TPartitionOperationCompat) {
+
+Y_UNIT_TEST(DowngradeToLegacyTopicRead) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(3);
+
+    auto* topicRead = op.MutableRead()->MutableTopic();
+    topicRead->SetConsumer("consumer");
+    topicRead->SetCommitOffsetsBegin(10);
+    topicRead->SetCommitOffsetsEnd(20);
+    topicRead->SetForceCommit(true);
+    topicRead->SetKillReadSession(true);
+    topicRead->SetOnlyCheckCommitedToFinish(true);
+    topicRead->SetReadSessionId("session");
+
+    DowngradeToLegacy(op);
+    AssertTopicReadDualWrite(op);
+}
+
+Y_UNIT_TEST(DowngradeToLegacyKafkaRead) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(1);
+
+    auto* kafkaRead = op.MutableRead()->MutableKafka();
+    kafkaRead->SetConsumer("consumer");
+    kafkaRead->SetCommitOffsetsEnd(42);
+
+    DowngradeToLegacy(op);
+    AssertKafkaReadDualWrite(op);
+}
+
+Y_UNIT_TEST(DowngradeToLegacyTopicWrite) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(2);
+
+    auto* write = op.MutableWrite();
+    write->SetSkipConflictCheck(true);
+    write->MutableTopic()->SetSupportivePartition(100'001);
+
+    DowngradeToLegacy(op);
+    AssertTopicWriteDualWrite(op, true, 100'001u);
+}
+
+Y_UNIT_TEST(DowngradeToLegacyKafkaWrite) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(0);
+
+    auto* producerId = op.MutableWrite()->MutableKafka()->MutableKafkaProducerInstanceId();
+    producerId->SetId(7);
+    producerId->SetEpoch(3);
+    op.MutableWrite()->SetSkipConflictCheck(false);
+
+    DowngradeToLegacy(op);
+    AssertKafkaWriteDualWrite(op, false, 7, 3);
+}
+
+Y_UNIT_TEST(UpgradeFromLegacyTopicReadRoundTrip) {
+    NKikimrPQ::TPartitionOperation legacy;
+    legacy.SetPath("topic");
+    legacy.SetPartitionId(4);
+    legacy.SetConsumer("consumer");
+    legacy.SetCommitOffsetsBegin(1);
+    legacy.SetCommitOffsetsEnd(2);
+    legacy.SetForceCommit(true);
+    legacy.SetKillReadSession(false);
+    legacy.SetOnlyCheckCommitedToFinish(true);
+    legacy.SetReadSessionId("session");
+
+    UpgradeFromLegacy(legacy);
+    UNIT_ASSERT(HasCanonical(legacy));
+    AssertTopicReadDualWrite(legacy);
+
+    DowngradeToLegacy(legacy);
+    AssertTopicReadDualWrite(legacy);
+}
+
+Y_UNIT_TEST(UpgradeFromLegacyKafkaWriteRoundTrip) {
+    NKikimrPQ::TPartitionOperation legacy;
+    legacy.SetPath("topic");
+    legacy.SetPartitionId(0);
+    legacy.SetKafkaTransaction(true);
+    legacy.SetSkipConflictCheck(true);
+    legacy.MutableKafkaProducerInstanceId()->SetId(11);
+    legacy.MutableKafkaProducerInstanceId()->SetEpoch(12);
+
+    UpgradeFromLegacy(legacy);
+    UNIT_ASSERT(HasCanonical(legacy));
+    AssertKafkaWriteDualWrite(legacy, true, 11, 12);
+
+    DowngradeToLegacy(legacy);
+    AssertKafkaWriteDualWrite(legacy, true, 11, 12);
+}
+
+} // Y_UNIT_TEST_SUITE(TPartitionOperationCompat)
+
+} // namespace
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
+++ b/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
@@ -5,6 +5,13 @@
 namespace NKikimr::NPQ {
 namespace {
 
+bool IsWriteTxOperation(const NKikimrPQ::TPartitionOperation& operation)
+{
+    const bool isRead = operation.HasCommitOffsetsBegin()
+        || (operation.GetKafkaTransaction() && operation.HasCommitOffsetsEnd());
+    return !isRead;
+}
+
 void AssertTopicReadDualWrite(const NKikimrPQ::TPartitionOperation& op)
 {
     UNIT_ASSERT(op.HasRead());
@@ -30,6 +37,9 @@ void AssertKafkaReadDualWrite(const NKikimrPQ::TPartitionOperation& op)
     UNIT_ASSERT(op.GetKafkaTransaction());
     UNIT_ASSERT_EQUAL(op.GetConsumer(), kafkaRead.GetConsumer());
     UNIT_ASSERT_EQUAL(op.GetCommitOffsetsEnd(), kafkaRead.GetCommitOffsetsEnd());
+    UNIT_ASSERT(!op.HasCommitOffsetsBegin());
+    UNIT_ASSERT(!op.HasSupportivePartition());
+    UNIT_ASSERT(!op.HasKafkaProducerInstanceId());
 }
 
 void AssertTopicWriteDualWrite(const NKikimrPQ::TPartitionOperation& op, bool skipConflictCheck, TMaybe<ui32> supportivePartition)
@@ -42,6 +52,8 @@ void AssertTopicWriteDualWrite(const NKikimrPQ::TPartitionOperation& op, bool sk
         UNIT_ASSERT(op.GetWrite().HasTopic());
         UNIT_ASSERT_EQUAL(op.GetSupportivePartition(), *supportivePartition);
         UNIT_ASSERT_EQUAL(op.GetWrite().GetTopic().GetSupportivePartition(), *supportivePartition);
+    } else {
+        UNIT_ASSERT(!op.HasSupportivePartition());
     }
     UNIT_ASSERT(!op.GetKafkaTransaction());
 }
@@ -158,6 +170,45 @@ Y_UNIT_TEST(UpgradeFromLegacyKafkaWriteRoundTrip) {
 
     DowngradeToLegacy(legacy);
     AssertKafkaWriteDualWrite(legacy, true, 11, 12);
+}
+
+Y_UNIT_TEST(DowngradeToLegacyKafkaWriteClearsTopicReadLegacy) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(1);
+    op.SetConsumer("consumer");
+    op.SetCommitOffsetsBegin(10);
+    op.SetCommitOffsetsEnd(20);
+    UpgradeFromLegacy(op);
+
+    op.ClearOp();
+    auto* write = op.MutableWrite()->MutableKafka();
+    write->MutableKafkaProducerInstanceId()->SetId(7);
+    write->MutableKafkaProducerInstanceId()->SetEpoch(3);
+    op.MutableWrite()->SetSkipConflictCheck(false);
+
+    DowngradeToLegacy(op);
+
+    AssertKafkaWriteDualWrite(op, false, 7, 3);
+    UNIT_ASSERT(!op.HasCommitOffsetsBegin());
+    UNIT_ASSERT(IsWriteTxOperation(op));
+}
+
+Y_UNIT_TEST(DowngradeToLegacyTopicWriteClearsSupportivePartition) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(2);
+    op.SetSupportivePartition(100'001);
+    op.SetSkipConflictCheck(true);
+    UpgradeFromLegacy(op);
+
+    op.ClearOp();
+    op.MutableWrite()->SetSkipConflictCheck(false);
+    op.MutableWrite()->MutableTopic();
+
+    DowngradeToLegacy(op);
+
+    AssertTopicWriteDualWrite(op, false, Nothing());
 }
 
 } // Y_UNIT_TEST_SUITE(TPartitionOperationCompat)

--- a/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
+++ b/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
@@ -211,6 +211,31 @@ Y_UNIT_TEST(DowngradeToLegacyTopicWriteClearsSupportivePartition) {
     AssertTopicWriteDualWrite(op, false, Nothing());
 }
 
+Y_UNIT_TEST(DowngradeToLegacyWriteApiNotSetClearsLegacy) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(1);
+    op.SetConsumer("consumer");
+    op.SetCommitOffsetsBegin(10);
+    op.SetCommitOffsetsEnd(20);
+    UpgradeFromLegacy(op);
+
+    op.ClearOp();
+    op.MutableWrite()->SetSkipConflictCheck(true);
+
+    DowngradeToLegacy(op);
+
+    UNIT_ASSERT(op.HasWrite());
+    UNIT_ASSERT(op.GetSkipConflictCheck());
+    UNIT_ASSERT_EQUAL(op.GetWrite().GetSkipConflictCheck(), true);
+    UNIT_ASSERT(!op.HasCommitOffsetsBegin());
+    UNIT_ASSERT(!op.HasConsumer());
+    UNIT_ASSERT(!op.HasKafkaProducerInstanceId());
+    UNIT_ASSERT(!op.HasSupportivePartition());
+    UNIT_ASSERT(!op.GetKafkaTransaction());
+    UNIT_ASSERT(IsWriteTxOperation(op));
+}
+
 } // Y_UNIT_TEST_SUITE(TPartitionOperationCompat)
 
 } // namespace

--- a/ydb/core/persqueue/ut/write_id_ut.cpp
+++ b/ydb/core/persqueue/ut/write_id_ut.cpp
@@ -1,0 +1,149 @@
+#include <ydb/core/kafka_proxy/kafka_producer_instance_id.h>
+#include <ydb/core/persqueue/public/pqdata_transaction_compat.h>
+#include <ydb/core/persqueue/public/write_id.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/hash.h>
+
+namespace NKikimr::NPQ {
+namespace {
+
+NKikimrPQ::TWriteId MakeLegacyTopicWriteId(ui64 nodeId, ui64 keyId)
+{
+    NKikimrPQ::TWriteId writeId;
+    writeId.SetNodeId(nodeId);
+    writeId.SetKeyId(keyId);
+    return writeId;
+}
+
+NKikimrPQ::TWriteId MakeLegacyKafkaWriteId(i64 id, i32 epoch)
+{
+    NKikimrPQ::TWriteId writeId;
+    writeId.SetKafkaTransaction(true);
+    writeId.MutableKafkaProducerInstanceId()->SetId(id);
+    writeId.MutableKafkaProducerInstanceId()->SetEpoch(epoch);
+    return writeId;
+}
+
+Y_UNIT_TEST_SUITE(TWriteIdCompat) {
+
+Y_UNIT_TEST(UpgradeFromLegacyTopic) {
+    auto writeId = MakeLegacyTopicWriteId(10, 20);
+    UNIT_ASSERT(!HasCanonical(writeId));
+
+    UpgradeFromLegacy(writeId);
+
+    UNIT_ASSERT(HasCanonical(writeId));
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetTopicApi().GetNodeId(), 10u);
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetTopicApi().GetKeyId(), 20u);
+}
+
+Y_UNIT_TEST(UpgradeFromLegacyKafka) {
+    auto writeId = MakeLegacyKafkaWriteId(42, 3);
+    UNIT_ASSERT(!HasCanonical(writeId));
+
+    UpgradeFromLegacy(writeId);
+
+    UNIT_ASSERT(HasCanonical(writeId));
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetKafkaApi().GetKafkaProducerInstanceId().GetId(), 42);
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetKafkaApi().GetKafkaProducerInstanceId().GetEpoch(), 3);
+}
+
+Y_UNIT_TEST(DowngradeToLegacyKeepsCanonical) {
+    TWriteId writeId(1, 2);
+    auto proto = writeId.GetProto();
+
+    DowngradeToLegacy(proto);
+
+    UNIT_ASSERT(HasCanonical(proto));
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetNodeId(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetKeyId(), 2u);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetTopicApi().GetNodeId(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetTopicApi().GetKeyId(), 2u);
+}
+
+Y_UNIT_TEST(SetWriteIdWritesCanonicalAndLegacy) {
+    TWriteId writeId(NKafka::TProducerInstanceId{7, 8});
+    NKikimrPQ::TDataTransaction tx;
+    SetWriteId(tx, writeId);
+
+    const auto& proto = tx.GetWriteId();
+    UNIT_ASSERT(HasCanonical(proto));
+    UNIT_ASSERT(proto.GetKafkaTransaction());
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetKafkaProducerInstanceId().GetId(), 7);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetKafkaProducerInstanceId().GetEpoch(), 8);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetKafkaApi().GetKafkaProducerInstanceId().GetId(), 7);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetKafkaApi().GetKafkaProducerInstanceId().GetEpoch(), 8);
+}
+
+Y_UNIT_TEST(GetWriteIdRoundTripFromLegacyProto) {
+    NKikimrPQ::TDataTransaction tx;
+    *tx.MutableWriteId() = MakeLegacyTopicWriteId(3, 4);
+
+    const TWriteId writeId = GetWriteId(tx);
+
+    UNIT_ASSERT(writeId.IsTopicApiTransaction());
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetNodeId(), 3u);
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetKeyId(), 4u);
+}
+
+Y_UNIT_TEST(SetWriteIdRoundTrip) {
+    const TWriteId original(5, 6);
+    NKikimrPQ::TTransaction tx;
+    SetWriteId(tx, original);
+
+    UNIT_ASSERT_VALUES_EQUAL(GetWriteId(tx), original);
+}
+
+Y_UNIT_TEST(ProtoSerializeDeserializeRoundTrip) {
+    const TWriteId original(NKafka::TProducerInstanceId{11, 12});
+    NKikimrPQ::TWriteId proto = original.GetProto();
+    const TString bytes = proto.SerializeAsString();
+
+    NKikimrPQ::TWriteId parsed;
+    UNIT_ASSERT(parsed.ParseFromString(bytes));
+
+    UNIT_ASSERT_VALUES_EQUAL(TWriteId(std::move(parsed)), original);
+}
+
+} // Y_UNIT_TEST_SUITE(TWriteIdCompat)
+
+Y_UNIT_TEST_SUITE(TWriteIdEquality) {
+
+Y_UNIT_TEST(KafkaWriteIdsAreDistinct) {
+    const TWriteId first(NKafka::TProducerInstanceId{1, 0});
+    const TWriteId second(NKafka::TProducerInstanceId{2, 0});
+
+    UNIT_ASSERT(first != second);
+    UNIT_ASSERT_VALUES_UNEQUAL(first.GetHash(), second.GetHash());
+}
+
+Y_UNIT_TEST(HashMapStoresDistinctKafkaWriteIds) {
+    const TWriteId first(NKafka::TProducerInstanceId{1, 0});
+    const TWriteId second(NKafka::TProducerInstanceId{2, 0});
+
+    THashMap<TWriteId, ui32> txWrites;
+    txWrites[first] = 1;
+    txWrites[second] = 2;
+
+    UNIT_ASSERT_VALUES_EQUAL(txWrites.size(), 2u);
+    UNIT_ASSERT(txWrites.contains(first));
+    UNIT_ASSERT(txWrites.contains(second));
+}
+
+Y_UNIT_TEST(HashMatchesEquality) {
+    const TWriteId left(9, 10);
+    const TWriteId right(9, 10);
+    const TWriteId other(9, 11);
+
+    UNIT_ASSERT_VALUES_EQUAL(left, right);
+    UNIT_ASSERT_VALUES_EQUAL(left.GetHash(), right.GetHash());
+    UNIT_ASSERT(left != other);
+    UNIT_ASSERT_VALUES_UNEQUAL(left.GetHash(), other.GetHash());
+}
+
+} // Y_UNIT_TEST_SUITE(TWriteIdEquality)
+
+} // namespace
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/write_id_ut.cpp
+++ b/ydb/core/persqueue/ut/write_id_ut.cpp
@@ -63,6 +63,39 @@ Y_UNIT_TEST(DowngradeToLegacyKeepsCanonical) {
     UNIT_ASSERT_VALUES_EQUAL(proto.GetTopicApi().GetKeyId(), 2u);
 }
 
+Y_UNIT_TEST(DowngradeToLegacyTopicClearsKafkaLegacy) {
+    auto writeId = MakeLegacyKafkaWriteId(7, 8);
+    UpgradeFromLegacy(writeId);
+    writeId.ClearId();
+    auto* topicApi = writeId.MutableTopicApi();
+    topicApi->SetNodeId(1);
+    topicApi->SetKeyId(2);
+
+    DowngradeToLegacy(writeId);
+
+    UNIT_ASSERT(!writeId.GetKafkaTransaction());
+    UNIT_ASSERT(!writeId.HasKafkaProducerInstanceId());
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetNodeId(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetKeyId(), 2u);
+}
+
+Y_UNIT_TEST(DowngradeToLegacyKafkaClearsTopicLegacy) {
+    auto writeId = MakeLegacyTopicWriteId(10, 20);
+    UpgradeFromLegacy(writeId);
+    writeId.ClearId();
+    auto* producerId = writeId.MutableKafkaApi()->MutableKafkaProducerInstanceId();
+    producerId->SetId(7);
+    producerId->SetEpoch(8);
+
+    DowngradeToLegacy(writeId);
+
+    UNIT_ASSERT(writeId.GetKafkaTransaction());
+    UNIT_ASSERT(!writeId.HasNodeId());
+    UNIT_ASSERT(!writeId.HasKeyId());
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetKafkaProducerInstanceId().GetId(), 7);
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetKafkaProducerInstanceId().GetEpoch(), 8);
+}
+
 Y_UNIT_TEST(SetWriteIdWritesCanonicalAndLegacy) {
     TWriteId writeId(NKafka::TProducerInstanceId{7, 8});
     NKikimrPQ::TDataTransaction tx;

--- a/ydb/core/persqueue/ut/ya.make
+++ b/ydb/core/persqueue/ut/ya.make
@@ -51,6 +51,8 @@ SRCS(
     partition_scale_manager_graph_cmp_ut.cpp
     utils_ut.cpp
     events_ut.cpp
+    write_id_ut.cpp
+    pqdata_transaction_compat_ut.cpp
 )
 
 RESOURCE(

--- a/ydb/core/protos/pqdata_transaction.proto
+++ b/ydb/core/protos/pqdata_transaction.proto
@@ -10,6 +10,7 @@ message TKafkaProducerInstanceId {
 };
 
 message TPartitionOperation {
+    // Legacy flat representation (wire/KV backward compatibility). Prefer oneof Op for new code.
     optional uint32 PartitionId = 1;
     optional uint64 CommitOffsetsBegin = 2;
     optional uint64 CommitOffsetsEnd = 3;
@@ -23,13 +24,72 @@ message TPartitionOperation {
     optional bool KafkaTransaction = 11 [default = false];
     optional TKafkaProducerInstanceId KafkaProducerInstanceId = 12;
     optional bool SkipConflictCheck = 13;
+
+    message TReadOp {
+        message TTopicApi {
+            optional string Consumer = 1;
+            optional uint64 CommitOffsetsBegin = 2;
+            optional uint64 CommitOffsetsEnd = 3;
+            optional bool ForceCommit = 4;
+            optional bool KillReadSession = 5;
+            optional bool OnlyCheckCommitedToFinish = 6;
+            optional string ReadSessionId = 7;
+        };
+
+        message TKafkaApi {
+            optional string Consumer = 1;
+            optional uint64 CommitOffsetsEnd = 2;
+        };
+
+        oneof Api {
+            TTopicApi Topic = 1;
+            TKafkaApi Kafka = 2;
+        };
+    };
+
+    message TWriteOp {
+        optional bool SkipConflictCheck = 4;
+
+        message TTopicApi {
+            optional uint32 SupportivePartition = 1;
+        };
+
+        message TKafkaApi {
+            optional TKafkaProducerInstanceId KafkaProducerInstanceId = 1;
+        };
+
+        oneof Api {
+            TTopicApi Topic = 1;
+            TKafkaApi Kafka = 2;
+        };
+    };
+
+    oneof Op {
+        TReadOp Read = 14;
+        TWriteOp Write = 15;
+    }
 };
 
 message TWriteId {
+    // Legacy flat representation (wire/KV backward compatibility). Prefer oneof Id for new code.
     optional uint64 NodeId = 1;
     optional fixed64 KeyId = 2;
     optional bool KafkaTransaction = 3 [default = false];
     optional TKafkaProducerInstanceId KafkaProducerInstanceId = 4;
+
+    message TTopicApi {
+        optional uint64 NodeId = 1;
+        optional fixed64 KeyId = 2;
+    };
+
+    message TKafkaApi {
+        optional TKafkaProducerInstanceId KafkaProducerInstanceId = 1;
+    };
+
+    oneof Id {
+        TTopicApi TopicApi = 5;
+        TKafkaApi KafkaApi = 6;
+    }
 };
 
 message TDataTransaction {

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/txusage_fixture.cpp
@@ -1174,7 +1174,7 @@ void TFixture::SendLongTxLockStatus(const NActors::TActorId& actorId,
                                     NKikimrLongTxService::TEvLockStatus::EStatus status)
 {
     auto event =
-        std::make_unique<NKikimr::NLongTxService::TEvLongTxService::TEvLockStatus>(writeId.KeyId, writeId.NodeId,
+        std::make_unique<NKikimr::NLongTxService::TEvLongTxService::TEvLockStatus>(writeId.GetKeyId(), writeId.GetNodeId(),
                                                                                    status);
     auto& runtime = Setup->GetRuntime();
     runtime.SendToPipe(tabletId, actorId, event.release());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR introduces a canonical wire representation for Topic/Kafka transactional metadata (write id + partition operations) while preserving backward compatibility via legacy field dual-write, and refactors server-side code to use the new canonical form.

Proto oneof for TWriteId and TPartitionOperation, compat helpers, TWriteId refactor, and KQP dual-write in BuildTopicTxs.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
