### PR TITLE
Add cpu_topology library windows/non-l3 support

### DIFF
--- a/ydb/library/actors/util/cpu_topology.cpp
+++ b/ydb/library/actors/util/cpu_topology.cpp
@@ -365,6 +365,16 @@ void BuildDerivedGroups(TCpuTopology& topology) {
     SortGroups(topology.Packages);
 
     topology.PlacementGroups = topology.L3CacheGroups;
+    TCpuMask placementCpus;
+    for (const auto& group : topology.PlacementGroups) {
+        placementCpus = placementCpus | group.Cpus;
+    }
+
+    TCpuMask remainingCpus = topology.AllCpus - placementCpus;
+    if (!remainingCpus.IsEmpty()) {
+        topology.PlacementGroups.push_back(TCpuTopologyGroup{UnknownCpuTopologyId, std::move(remainingCpus)});
+    }
+
     ui32 placementGroupId = 0;
     for (auto& group : topology.PlacementGroups) {
         group.Id = placementGroupId++;
@@ -407,6 +417,7 @@ std::expected<TCpuTopology, TString> BuildFlatCpuTopology(TCpuId cpuCount) {
         result.Cpus.push_back(std::move(cpu));
     }
 
+    result.AllCpus = allCpus;
     result.NumaNodes.push_back(TCpuTopologyGroup{0, allCpus});
     BuildDerivedGroups(result);
     return result;
@@ -455,6 +466,9 @@ std::expected<TCpuTopology, TString> ParseSysfsCpuTopology(const TFsPath& root) 
     result.Cpus = std::move(*cpus);
     if (result.Cpus.empty()) {
         return std::unexpected("no CPU topology data found under " + CpuRootPath(root).GetPath());
+    }
+    for (const auto& cpu : result.Cpus) {
+        result.AllCpus.Set(cpu.CpuId);
     }
 
     auto numaNodes = ParseNumaNodes(root);

--- a/ydb/library/actors/util/cpu_topology.cpp
+++ b/ydb/library/actors/util/cpu_topology.cpp
@@ -8,9 +8,11 @@
 #include <util/string/cast.h>
 #include <util/string/strip.h>
 #include <util/system/error.h>
+#include <util/system/info.h>
 
 #include <algorithm>
 #include <cctype>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -369,6 +371,48 @@ void BuildDerivedGroups(TCpuTopology& topology) {
     }
 }
 
+#if defined(_win_)
+std::expected<TCpuTopology, TString> BuildFlatCpuTopology(TCpuId cpuCount) {
+    if (cpuCount == 0) {
+        return std::unexpected("no CPU topology data found: CPU count is zero");
+    }
+
+    TCpuMask allCpus;
+    for (TCpuId cpuId = 0; cpuId < cpuCount; ++cpuId) {
+        allCpus.Set(cpuId);
+    }
+
+    TCpuTopology result;
+    result.Cpus.reserve(cpuCount);
+    for (TCpuId cpuId = 0; cpuId < cpuCount; ++cpuId) {
+        TLogicalCpuInfo cpu;
+        cpu.CpuId = cpuId;
+        cpu.Online = true;
+
+        cpu.CoreId = cpuId;
+        cpu.CoreCpus.Set(cpuId);
+        cpu.ThreadSiblings.Set(cpuId);
+
+        cpu.ClusterId = 0;
+        cpu.ClusterCpus = allCpus;
+        cpu.L3CacheId = 0;
+        cpu.L3CacheCpus = allCpus;
+        cpu.DieId = 0;
+        cpu.DieCpus = allCpus;
+        cpu.PackageId = 0;
+        cpu.PackageCpus = allCpus;
+        cpu.NumaNodeId = 0;
+        cpu.NumaNodeCpus = allCpus;
+
+        result.Cpus.push_back(std::move(cpu));
+    }
+
+    result.NumaNodes.push_back(TCpuTopologyGroup{0, allCpus});
+    BuildDerivedGroups(result);
+    return result;
+}
+#endif
+
 } // namespace
 
 std::expected<TCpuMask, TString> TSchedCpuAffinityBackend::GetAffinity(size_t pid) const {
@@ -430,4 +474,16 @@ std::expected<TCpuTopology, TString> ParseSysfsCpuTopology(const TFsPath& root) 
 
     BuildDerivedGroups(result);
     return result;
+}
+
+std::expected<TCpuTopology, TString> ParseCpuTopology() {
+#if defined(_win_)
+    const size_t cpuCount = NSystemInfo::CachedNumberOfCpus();
+    if (cpuCount > std::numeric_limits<TCpuId>::max()) {
+        return std::unexpected("CPU count is too large: " + ToString(cpuCount));
+    }
+    return BuildFlatCpuTopology(static_cast<TCpuId>(cpuCount));
+#else
+    return ParseSysfsCpuTopology(TFsPath("/sys/devices/system"));
+#endif
 }

--- a/ydb/library/actors/util/cpu_topology.h
+++ b/ydb/library/actors/util/cpu_topology.h
@@ -59,6 +59,7 @@ struct TLogicalCpuInfo {
 struct TCpuTopology {
     // Source CPU information
     TVector<TLogicalCpuInfo> Cpus;
+    TCpuMask AllCpus;
 
     // Derived groupings
     TVector<TCpuTopologyGroup> Clusters;
@@ -67,7 +68,8 @@ struct TCpuTopology {
     TVector<TCpuTopologyGroup> Packages;
     TVector<TCpuTopologyGroup> NumaNodes;
 
-    // PlacementGroups are shared L3 cache boundaries.
+    // PlacementGroups use shared L3 cache boundaries when available.
+    // CPUs without L3 cache data are collected into one extra group.
     // Id is assigned by the parser after sorting (matches index)
     TVector<TCpuTopologyGroup> PlacementGroups;
 

--- a/ydb/library/actors/util/cpu_topology.h
+++ b/ydb/library/actors/util/cpu_topology.h
@@ -74,4 +74,5 @@ struct TCpuTopology {
     const TLogicalCpuInfo* FindCpu(TCpuId cpuId) const;
 };
 
-std::expected<TCpuTopology, TString> ParseSysfsCpuTopology(const TFsPath& root = TFsPath("/sys/devices/system"));
+std::expected<TCpuTopology, TString> ParseSysfsCpuTopology(const TFsPath& root);
+std::expected<TCpuTopology, TString> ParseCpuTopology();

--- a/ydb/library/actors/util/cpu_topology_ut.cpp
+++ b/ydb/library/actors/util/cpu_topology_ut.cpp
@@ -165,6 +165,7 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         auto topology = ParseSysfsCpuTopology(tempDir.Name());
         UNIT_ASSERT_C(topology.has_value(), topology.error());
         UNIT_ASSERT_VALUES_EQUAL(topology->Cpus.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(topology->AllCpus), "0");
 
         const TLogicalCpuInfo& cpu = topology->Cpus[0];
         UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(cpu.CoreCpus), "0,4");
@@ -195,6 +196,7 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
 
         auto topology = ParseSysfsCpuTopology(tempDir.Name());
         UNIT_ASSERT_C(topology.has_value(), topology.error());
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(topology->AllCpus), "0-1");
 
         UNIT_ASSERT_VALUES_EQUAL(topology->Dies.size(), 2);
         AssertGroup(topology->Dies, 0, 0, "0");
@@ -209,6 +211,7 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         const TCpuTopology topology = LoadSnapshot("amd-epyc-9654");
 
         UNIT_ASSERT_VALUES_EQUAL(topology.Cpus.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(topology.AllCpus), "0,104,192");
         UNIT_ASSERT_VALUES_EQUAL(topology.NumaNodes.size(), 2);
         AssertGroup(topology.NumaNodes, 0, 0, "0-95,192-287");
         AssertGroup(topology.NumaNodes, 1, 1, "96-191,288-383");
@@ -279,6 +282,7 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         const TCpuTopology topology = LoadSnapshot("intel-xeon-gold-6230");
 
         UNIT_ASSERT_VALUES_EQUAL(topology.Cpus.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(topology.AllCpus), "0,20,40");
         UNIT_ASSERT_VALUES_EQUAL(topology.NumaNodes.size(), 2);
         AssertGroup(topology.NumaNodes, 0, 0, "0-19,40-59");
         AssertGroup(topology.NumaNodes, 1, 1, "20-39,60-79");
@@ -344,10 +348,11 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         AssertGroup(topology.PlacementGroups, 1, 1, "20-39,60-79");
     }
 
-    Y_UNIT_TEST(IntelMeteorLakeSnapshotUsesL3PlacementGroupWithCpuWithoutL3Cache) {
+    Y_UNIT_TEST(IntelMeteorLakeSnapshotUsesL3AndRemainingPlacementGroups) {
         const TCpuTopology topology = LoadSnapshot("intel-meteor-lake");
 
         UNIT_ASSERT_VALUES_EQUAL(topology.Cpus.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(topology.AllCpus), "0,10,20");
         UNIT_ASSERT_VALUES_EQUAL(topology.NumaNodes.size(), 1);
         AssertGroup(topology.NumaNodes, 0, 0, "0-21");
 
@@ -374,9 +379,10 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         AssertGroup(topology.Dies, 0, 0, "0-21");
         UNIT_ASSERT_VALUES_EQUAL(topology.L3CacheGroups.size(), 1);
         AssertGroup(topology.L3CacheGroups, 0, 0, "0-19");
-        UNIT_ASSERT_VALUES_EQUAL(topology.PlacementGroups.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(topology.PlacementGroups.size(), 2);
         AssertSequentialPlacementGroupIds(topology);
         AssertGroup(topology.PlacementGroups, 0, 0, "0-19");
+        AssertGroup(topology.PlacementGroups, 1, 1, "20");
     }
 
 #if defined(_win_)
@@ -390,6 +396,7 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         const TString expectedCpus = cpuCount == 1
             ? TString("0")
             : TString("0-") + ToString(cpuCount - 1);
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(topology->AllCpus), expectedCpus);
 
         UNIT_ASSERT_VALUES_EQUAL(topology->NumaNodes.size(), 1);
         AssertGroup(topology->NumaNodes, 0, 0, expectedCpus);

--- a/ydb/library/actors/util/cpu_topology_ut.cpp
+++ b/ydb/library/actors/util/cpu_topology_ut.cpp
@@ -8,6 +8,7 @@
 #include <util/stream/str.h>
 #include <util/stream/file.h>
 #include <util/string/cast.h>
+#include <util/system/info.h>
 
 #include <map>
 
@@ -377,5 +378,32 @@ Y_UNIT_TEST_SUITE(CpuTopology) {
         AssertSequentialPlacementGroupIds(topology);
         AssertGroup(topology.PlacementGroups, 0, 0, "0-19");
     }
+
+#if defined(_win_)
+    Y_UNIT_TEST(ParseCpuTopologyUsesSinglePlacementGroupOnWindows) {
+        auto topology = ParseCpuTopology();
+        UNIT_ASSERT_C(topology.has_value(), topology.error());
+
+        const TCpuId cpuCount = static_cast<TCpuId>(NSystemInfo::CachedNumberOfCpus());
+        UNIT_ASSERT_VALUES_EQUAL(topology->Cpus.size(), cpuCount);
+
+        const TString expectedCpus = cpuCount == 1
+            ? TString("0")
+            : TString("0-") + ToString(cpuCount - 1);
+
+        UNIT_ASSERT_VALUES_EQUAL(topology->NumaNodes.size(), 1);
+        AssertGroup(topology->NumaNodes, 0, 0, expectedCpus);
+        UNIT_ASSERT_VALUES_EQUAL(topology->L3CacheGroups.size(), 1);
+        AssertGroup(topology->L3CacheGroups, 0, 0, expectedCpus);
+        UNIT_ASSERT_VALUES_EQUAL(topology->PlacementGroups.size(), 1);
+        AssertGroup(topology->PlacementGroups, 0, 0, expectedCpus);
+
+        const TLogicalCpuInfo* cpu0 = topology->FindCpu(0);
+        UNIT_ASSERT(cpu0);
+        UNIT_ASSERT(cpu0->Online);
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(cpu0->CoreCpus), "0");
+        UNIT_ASSERT_VALUES_EQUAL(ToCpuListString(cpu0->L3CacheCpus), expectedCpus);
+    }
+#endif
 
 }


### PR DESCRIPTION
### Changelog entry 

* Add Windows support for cpu_topology library
* Add support for cores without L3 cache

### Changelog category 

* Improvement

### Description for reviewers

Previous: https://github.com/ydb-platform/ydb/pull/45733
