### PR TITLE
sdk: Fix TDriver shutdown race in table session close

### DIFF
--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -347,8 +347,10 @@ void TGRpcConnectionsImpl::WaitIdle() {
 }
 
 void TGRpcConnectionsImpl::Stop(bool wait) {
-    StateTracker_.SendNotification(TDbDriverState::ENotifyType::STOP).Wait();
-    GRpcClientLow_.Stop(wait);
+    std::call_once(StopOnce_, [this, wait]() {
+        StateTracker_.SendNotification(TDbDriverState::ENotifyType::STOP).Wait();
+        GRpcClientLow_.Stop(wait);
+    });
 }
 
 void TGRpcConnectionsImpl::SetGrpcKeepAlive(NYdbGrpc::TGRpcClientConfig& config, const TDeadline::Duration& timeout, bool permitWithoutCalls) {

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -780,6 +780,8 @@ private:
 
     const std::size_t NetworkThreadsNum_;
     bool UsePerChannelTcpConnection_;
+    mutable std::once_flag StopOnce_;
+
     // Must be the last member (first called destructor)
     NYdbGrpc::TGRpcClientLow GRpcClientLow_;
     TLog Log;

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
@@ -112,6 +112,14 @@ NThreading::TFuture<void> TTableClient::TImpl::Drain() {
         }
     }
     sessions.clear();
+    {
+        std::lock_guard lock(InflightClosesMutex_);
+        closeResults.insert(
+            closeResults.end(),
+            std::make_move_iterator(InflightCloses_.begin()),
+            std::make_move_iterator(InflightCloses_.end()));
+        InflightCloses_.clear();
+    }
     return NThreading::WaitExceptionOrAll(closeResults);
 }
 
@@ -1107,11 +1115,12 @@ TAsyncStatus TTableClient::TImpl::CloseInternal(const TKqpSessionCommon* session
     static const auto internalCloseSessionSettings = TCloseSessionSettings()
             .ClientTimeout(TDuration::Seconds(2));
 
-    auto driver = Connections_;
+    // Keep connections alive until DeleteSession completes. Do not release the
+    // last shared_ptr from this callback: that can destroy TGRpcConnectionsImpl
+    // while Stop() is still running on another thread.
+    auto connections = Connections_;
     return Close(sessionImpl, internalCloseSessionSettings)
-        .Apply([driver{std::move(driver)}](TAsyncStatus status) mutable
-        {
-            driver.reset();
+        .Apply([connections = std::move(connections)](TAsyncStatus status) {
             return status;
         });
 }
@@ -1151,7 +1160,11 @@ void TTableClient::TImpl::DeleteSession(TKqpSessionCommon* sessionImpl) {
     }
 
     if (!sessionImpl->GetId().empty()) {
-        CloseInternal(sessionImpl);
+        auto closeFuture = CloseInternal(sessionImpl);
+        {
+            std::lock_guard lock(InflightClosesMutex_);
+            InflightCloses_.push_back(std::move(closeFuture));
+        }
         DbDriverState_->StatCollector.DecSessionsOnHost(sessionImpl->GetEndpoint());
     }
 

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
@@ -21,6 +21,9 @@
 
 #include <library/cpp/threading/future/core/coroutine_traits.h>
 
+#include <mutex>
+#include <vector>
+
 
 namespace NYdb::inline Dev {
 namespace NTable {
@@ -344,6 +347,8 @@ private:
     NSdkStats::TStatCollector::TClientOperationStatCollector OperationStatCollector_;
     NSessionPool::TSessionPool SessionPool_;
     TRequestMigrator RequestMigrator_;
+    std::mutex InflightClosesMutex_;
+    std::vector<TAsyncStatus> InflightCloses_;
     static const TKeepAliveSettings KeepAliveSettings;
 
     std::shared_ptr<NObservability::TRequestObservation> MakeObservation(const std::string& operationName) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make TGRpcConnectionsImpl::Stop() idempotent via std::call_once to prevent concurrent teardown when the last shared_ptr is released from an async DeleteSession callback.

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Track in-flight session closes started from DeleteSession and wait for them in Drain(), so standalone session destructors cannot outlive table client shutdown and release the driver while Stop() is still running.

This fixes heap-use-after-free in TableTest under ASAN when multiple tests run in parallel.

Example of the issue:

https://github.com/ydb-platform/ydb/pull/45806#issuecomment-4912443737

AddressSanitizer: heap-use-after-free in thread ydb-public-sdk-* on test shutdown.

```
WaitExceptionOrAll()
  ← TDbDriverStateTracker::SendNotification()     [state.cpp:315]
  ← TGRpcConnectionsImpl::Stop()                  [grpc_connections.cpp:350]
  ← TDriver destructor                              [driver.cpp:367]
```

Concurrent thread:

```
DeleteSession callback
  ← TTableClient::TImpl::CloseInternal()          [table_client.cpp:1114]
  ← shared_ptr<TGRpcConnectionsImpl>::reset()     → dropping connections
```