### PR TITLE
Columnshard clang style doesn't touch YDB_LOG context macro usages

### DIFF
--- a/ydb/core/tx/columnshard/.clang-format
+++ b/ydb/core/tx/columnshard/.clang-format
@@ -87,6 +87,10 @@ WhitespaceSensitiveMacros:
   - YDB_LOG_DEBUG
   - YDB_LOG_DEBUG_FAIL
   - YDB_LOG_TRACE
+  - YDB_LOG_CREATE_CONTEXT
+  - YDB_LOG_CREATE_CONTEXT_COMP
+  - YDB_LOG_UPDATE_CONTEXT
+  - YDB_LOG_REMOVE_CONTEXT
 IncludeCategories:
   - Regex:           '^"[0-9,a-z,A-Z,_]*\.h"'
     Priority:        0


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Стиль форматирования не затрагивает то, как оформляются макросы логирования
