### PR TITLE
Integrate deferred publication into KQP QUERY_ACTION_TOPIC

### DIFF
--- a/ydb/core/kqp/common/events/query.h
+++ b/ydb/core/kqp/common/events/query.h
@@ -135,6 +135,14 @@ public:
         return Record.GetRequest().HasKafkaApiOperations();
     }
 
+    bool HasDeferredPublication() const {
+        return Record.GetRequest().HasDeferredPublication();
+    }
+
+    const ::NKikimrKqp::TTopicDeferredPublicationRequest& GetDeferredPublication() const {
+        return Record.GetRequest().GetDeferredPublication();
+    }
+
     bool GetKeepSession() const {
         return RequestCtx ? QuerySettings.KeepSession : Record.GetRequest().GetKeepSession();
     }

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -4580,7 +4580,10 @@ public:
                 NKikimrPQ::TWriteId proto;
                 auto* deferred = proto.MutableDeferredPublicationApi();
                 deferred->SetIntPublicationId(topicOps.GetDeferredPublicationIntId());
-                deferred->SetExtPublicationId(topicOps.GetDeferredPublicationExtId());
+                const auto& extPublicationId = topicOps.GetDeferredPublicationExtId();
+                if (!extPublicationId.empty()) {
+                    deferred->SetExtPublicationId(extPublicationId);
+                }
                 NPQ::SetWriteId(transaction, NPQ::TWriteId{std::move(proto)});
             } else if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
                 NPQ::SetWriteId(transaction, NPQ::TWriteId{SelfId().NodeId(), *writeId});

--- a/ydb/core/kqp/runtime/kqp_write_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_write_actor.cpp
@@ -4555,6 +4555,7 @@ public:
         }
         const auto& topicOps = TxManager->GetTopicOperations();
         const bool kafkaTransaction = topicOps.HasKafkaOperations();
+        const bool deferredPublication = topicOps.HasDeferredPublicationOperations();
 
         THashSet<ui64> topicTabletPeers;
         bool omitPeerTopicTablets = false;
@@ -4575,7 +4576,13 @@ public:
 
             FillTopicsCommit(isImmediateCommit, transaction, TxManager, tabletId, omitPeerTopicTablets, topicTabletPeers);
 
-            if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
+            if (t.hasWrite && deferredPublication) {
+                NKikimrPQ::TWriteId proto;
+                auto* deferred = proto.MutableDeferredPublicationApi();
+                deferred->SetIntPublicationId(topicOps.GetDeferredPublicationIntId());
+                deferred->SetExtPublicationId(topicOps.GetDeferredPublicationExtId());
+                NPQ::SetWriteId(transaction, NPQ::TWriteId{std::move(proto)});
+            } else if (t.hasWrite && writeId.Defined() && !kafkaTransaction) {
                 NPQ::SetWriteId(transaction, NPQ::TWriteId{SelfId().NodeId(), *writeId});
             } else if (t.hasWrite && kafkaTransaction) {
                 NPQ::SetWriteId(transaction, NPQ::TWriteId{topicOps.GetKafkaProducerInstanceId()});

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -469,8 +469,7 @@ void TKqpQueryState::FillDeferredPublicationOperations() {
     YQL_ENSURE(HasDeferredPublication());
 
     const auto& request = GetDeferredPublicationFromRequest();
-    YQL_ENSURE(request.HasOp());
-    YQL_ENSURE(request.HasIntPublicationId());
+    NTopic::ValidateDeferredPublicationRequest(request);
 
     TopicOperations = NTopic::TTopicOperations();
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -465,6 +465,31 @@ bool TKqpQueryState::PrepareNextStatementPart() {
     return true;
 }
 
+void TKqpQueryState::FillDeferredPublicationOperations() {
+    YQL_ENSURE(HasDeferredPublication());
+
+    const auto& request = GetDeferredPublicationFromRequest();
+    YQL_ENSURE(request.HasOp());
+    YQL_ENSURE(request.HasIntPublicationId());
+
+    TopicOperations = NTopic::TTopicOperations();
+
+    for (const auto& destination : request.GetDestinations()) {
+        YQL_ENSURE(destination.HasPath());
+        YQL_ENSURE(destination.HasPartitionId());
+        YQL_ENSURE(destination.HasTabletId());
+
+        auto path = CanonizePath(NPersQueue::GetFullTopicPath(GetDatabase(), destination.GetPath()));
+        TopicOperations.AddDeferredPublicationOperation(
+            path,
+            destination.GetPartitionId(),
+            destination.GetTabletId(),
+            request.GetOp(),
+            request.GetIntPublicationId(),
+            request.GetExtPublicationId());
+    }
+}
+
 void TKqpQueryState::FillTopicOperations() {
     YQL_ENSURE(HasTopicOperations() || HasKafkaApiOperations());
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -472,6 +472,8 @@ void TKqpQueryState::FillDeferredPublicationOperations() {
     NTopic::ValidateDeferredPublicationRequest(request);
 
     TopicOperations = NTopic::TTopicOperations();
+    // Same default as Kafka in FillTopicOperations: conflict check stays enabled on wire.
+    TopicOperations.SetTrackProducerId(true);
 
     for (const auto& destination : request.GetDestinations()) {
         YQL_ENSURE(destination.HasPath());

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -476,10 +476,6 @@ void TKqpQueryState::FillDeferredPublicationOperations() {
     TopicOperations.SetTrackProducerId(true);
 
     for (const auto& destination : request.GetDestinations()) {
-        YQL_ENSURE(destination.HasPath());
-        YQL_ENSURE(destination.HasPartitionId());
-        YQL_ENSURE(destination.HasTabletId());
-
         auto path = CanonizePath(NPersQueue::GetFullTopicPath(GetDatabase(), destination.GetPath()));
         TopicOperations.AddDeferredPublicationOperation(
             path,

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -307,6 +307,10 @@ public:
         return RequestEv->HasKafkaApiOperations();
     }
 
+    bool HasDeferredPublication() const {
+        return RequestEv->HasDeferredPublication();
+    }
+
     bool GetQueryKeepInCache() const {
         return RequestEv->GetQueryKeepInCache();
     }
@@ -429,6 +433,10 @@ public:
 
     const ::NKikimrKqp::TKafkaApiOperationsRequest& GetKafkaApiOperationsFromRequest() const {
         return RequestEv->GetKafkaApiOperations();
+    }
+
+    const ::NKikimrKqp::TTopicDeferredPublicationRequest& GetDeferredPublicationFromRequest() const {
+        return RequestEv->GetDeferredPublication();
     }
 
     bool NeedPersistentSnapshot() const {
@@ -694,6 +702,7 @@ public:
 
     //// Topic ops ////
     void FillTopicOperations();
+    void FillDeferredPublicationOperations();
     bool TryMergeTopicOffsets(const NTopic::TTopicOperations &operations, TString& message);
     std::unique_ptr<NSchemeCache::TSchemeCacheNavigate> BuildSchemeCacheNavigate();
     bool IsAccessDenied(const NSchemeCache::TSchemeCacheNavigate& response, TString& message);

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -719,16 +719,6 @@ public:
     }
 
     bool AreAllTheTopicsAndPartitionsKnown() const {
-        if (QueryState->HasDeferredPublication()) {
-            const auto& request = QueryState->GetDeferredPublicationFromRequest();
-            for (const auto& destination : request.GetDestinations()) {
-                if (!destination.HasTabletId()) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
         if (QueryState->HasTopicOperations()) {
             const NKikimrKqp::TTopicOperationsRequest& operations = QueryState->GetTopicOperationsFromRequest();
 

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -719,6 +719,16 @@ public:
     }
 
     bool AreAllTheTopicsAndPartitionsKnown() const {
+        if (QueryState->HasDeferredPublication()) {
+            const auto& request = QueryState->GetDeferredPublicationFromRequest();
+            for (const auto& destination : request.GetDestinations()) {
+                if (!destination.HasTabletId()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         if (QueryState->HasTopicOperations()) {
             const NKikimrKqp::TTopicOperationsRequest& operations = QueryState->GetTopicOperationsFromRequest();
 
@@ -771,7 +781,11 @@ public:
             return;
         }
 
-        QueryState->FillTopicOperations();
+        if (QueryState->HasDeferredPublication()) {
+            QueryState->FillDeferredPublicationOperations();
+        } else {
+            QueryState->FillTopicOperations();
+        }
 
         if (!AreAllTheTopicsAndPartitionsKnown()) {
             auto navigate = QueryState->BuildSchemeCacheNavigate();
@@ -785,7 +799,8 @@ public:
             ythrow TRequestFail(Ydb::StatusIds::BAD_REQUEST) << message;
         }
 
-        if (HasTopicWriteOperations() && !HasTopicApiWriteOperations() && !HasKafkaApiWriteOperations()) {
+        if (HasTopicWriteOperations() && !HasTopicApiWriteOperations() && !HasKafkaApiWriteOperations()
+            && !HasDeferredPublicationOperations()) {
             Become(&TKqpSessionActor::ExecuteState);
             Send(MakeTxProxyID(), new TEvTxUserProxy::TEvAllocateTxId, 0, QueryState->QueryId);
             return;
@@ -3919,7 +3934,8 @@ private:
 
         QueryState->TxCtx->TopicOperations.CacheSchemeCacheNavigate(response->ResultSet);
 
-        if (HasTopicWriteOperations() && !HasTopicApiWriteOperations() && !HasKafkaApiWriteOperations()) {
+        if (HasTopicWriteOperations() && !HasTopicApiWriteOperations() && !HasKafkaApiWriteOperations()
+            && !HasDeferredPublicationOperations()) {
             Send(MakeTxProxyID(), new TEvTxUserProxy::TEvAllocateTxId, 0, QueryState->QueryId);
             return;
         }
@@ -3950,6 +3966,10 @@ private:
 
     bool HasTopicApiWriteOperations() const {
         return QueryState->TxCtx->TopicOperations.HasWriteId();
+    }
+
+    bool HasDeferredPublicationOperations() const {
+        return QueryState->TxCtx->TopicOperations.HasDeferredPublicationOperations();
     }
 
     ui64 GetTopicWriteId() const {

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -328,6 +328,7 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, 
         auto* write = o->MutableWrite();
         write->SetSkipConflictCheck(skipConflictCheck);
         write->MutableDeferredPublication()->SetOp(MapDeferredPublicationOp(*DeferredPublicationOp_));
+        NPQ::DowngradeToLegacy(*o);
         t.hasWrite = true;
     } else if (HasWriteOperations_) {
         NKikimrPQ::TPartitionOperation* o = t.tx.MutableOperations()->Add();
@@ -494,7 +495,7 @@ NKafka::TProducerInstanceId TTopicOperations::GetKafkaProducerInstanceId() const
 
 ui64 TTopicOperations::GetDeferredPublicationIntId() const
 {
-    Y_ENSURE(HasDeferredPublicationOperations_);
+    Y_ENSURE(HasDeferredPublicationOperations());
     Y_ENSURE(DeferredPublicationIntId_.Defined());
 
     return *DeferredPublicationIntId_;
@@ -502,7 +503,7 @@ ui64 TTopicOperations::GetDeferredPublicationIntId() const
 
 const TString& TTopicOperations::GetDeferredPublicationExtId() const
 {
-    Y_ENSURE(HasDeferredPublicationOperations_);
+    Y_ENSURE(HasDeferredPublicationOperations());
     Y_ENSURE(DeferredPublicationExtId_.Defined());
 
     return *DeferredPublicationExtId_;

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -838,4 +838,11 @@ bool TTopicOperations::ShouldOmitPeerTopicTabletsForPredicateExchange() const
     return CalcSkipConflictCheck() && !HasReadOperations();
 }
 
+void ValidateDeferredPublicationRequest(const NKikimrKqp::TTopicDeferredPublicationRequest& request)
+{
+    Y_ENSURE(request.HasOp());
+    Y_ENSURE(request.HasIntPublicationId());
+    Y_ENSURE(!request.GetDestinations().empty(), "DeferredPublication request must have at least one destination");
+}
+
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -133,6 +133,18 @@ static bool HasTopicKafkaOperations(const TTopicOperations& ops)
         || (ops.HasWriteOperations() && !ops.HasDeferredPublicationOperations());
 }
 
+static void EnsureNoDeferredPublicationOperations(const TTopicOperations& ops)
+{
+    Y_ENSURE(!ops.HasDeferredPublicationOperations(),
+        "Topic/Kafka operations cannot be mixed with DeferredPublication");
+}
+
+static void EnsureNoTopicKafkaOperations(const TTopicOperations& ops)
+{
+    Y_ENSURE(!HasTopicKafkaOperations(ops),
+        "DeferredPublication cannot be mixed with Topic/Kafka operations");
+}
+
 //
 // TConsumerOperations
 //
@@ -587,6 +599,7 @@ void TTopicOperations::AddOperation(const TString& topic,
                                     const TString& readSessionId
                                     )
 {
+    EnsureNoDeferredPublicationOperations(*this);
     TTopicPartition key{topic, partition};
     Operations_[key].AddOperation(topic,
                                   partition,
@@ -602,6 +615,7 @@ void TTopicOperations::AddOperation(const TString& topic,
 void TTopicOperations::AddOperation(const TString& topic, ui32 partition,
                                     TMaybe<ui32> supportivePartition)
 {
+    EnsureNoDeferredPublicationOperations(*this);
     TTopicPartition key{topic, partition};
     Operations_[key].AddOperation(topic, partition, supportivePartition);
     HasWriteOperations_ = true;
@@ -609,6 +623,7 @@ void TTopicOperations::AddOperation(const TString& topic, ui32 partition,
 
 void TTopicOperations::AddKafkaApiWriteOperation(const TString& topic, ui32 partition, const NKafka::TProducerInstanceId& producerInstanceId)
 {
+    EnsureNoDeferredPublicationOperations(*this);
     Y_ENSURE(!KafkaProducerInstanceId_ || *KafkaProducerInstanceId_ == producerInstanceId);
 
     if (KafkaProducerInstanceId_.Empty()) {
@@ -623,6 +638,7 @@ void TTopicOperations::AddKafkaApiWriteOperation(const TString& topic, ui32 part
 
 void TTopicOperations::AddKafkaApiReadOperation(const TString& topic, ui32 partition, const TString& consumerName, ui64 offset)
 {
+    EnsureNoDeferredPublicationOperations(*this);
     TTopicPartition key{topic, partition};
     Operations_[key].AddKafkaApiReadOperation(topic, partition, consumerName, offset);
     HasReadOperations_ = true;
@@ -637,6 +653,7 @@ void TTopicOperations::AddDeferredPublicationOperation(
     ui64 intPublicationId,
     const TString& extPublicationId)
 {
+    EnsureNoTopicKafkaOperations(*this);
     UpdateDeferredPublicationIntId(DeferredPublicationIntId_, intPublicationId);
     UpdateDeferredPublicationExtId(DeferredPublicationExtId_, extPublicationId);
 

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -77,7 +77,10 @@ static void UpdateDeferredPublicationIntId(TMaybe<ui64>& lhs, const TMaybe<ui64>
 
 static void UpdateDeferredPublicationExtId(TMaybe<TString>& lhs, const TString& rhs)
 {
-    if (lhs.Empty()) {
+    if (rhs.empty()) {
+        return;
+    }
+    if (lhs.Empty() || lhs->empty()) {
         lhs = rhs;
         return;
     }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -562,9 +562,8 @@ ui64 TTopicOperations::GetDeferredPublicationIntId() const
 const TString& TTopicOperations::GetDeferredPublicationExtId() const
 {
     Y_ENSURE(HasDeferredPublicationOperations());
-    Y_ENSURE(DeferredPublicationExtId_.Defined());
-
-    return *DeferredPublicationExtId_;
+    static const TString emptyExtPublicationId;
+    return DeferredPublicationExtId_.GetOrElse(emptyExtPublicationId);
 }
 
 bool TTopicOperations::TabletHasReadOperations(ui64 tabletId) const

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -320,6 +320,8 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, 
         NPQ::DowngradeToLegacy(*o);
     }
 
+    // One partition operation is either deferred publication or a Topic/Kafka write,
+    // not both. Mixing different APIs in one distributed transaction is not supported.
     if (DeferredPublicationOp_.Defined()) {
         NKikimrPQ::TPartitionOperation* o = t.tx.MutableOperations()->Add();
         o->SetPartitionId(*Partition_);
@@ -747,6 +749,9 @@ void TTopicOperations::BuildTopicTxs(TTopicOperationTransactions& txs)
 
 void TTopicOperations::Merge(const TTopicOperations& rhs)
 {
+    // Merging accumulates operations from the same API within one transaction
+    // (e.g. multiple Topic offset commits). Mixing Topic, Kafka, and DeferredPublication
+    // APIs in one transaction is not supported.
     for (auto& [key, value] : rhs.Operations_) {
         Operations_[key].Merge(value);
     }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -884,6 +884,12 @@ void ValidateDeferredPublicationRequest(const NKikimrKqp::TTopicDeferredPublicat
         "DeferredPublication request must specify Publish or Cancel");
     Y_ENSURE(request.HasIntPublicationId());
     Y_ENSURE(!request.GetDestinations().empty(), "DeferredPublication request must have at least one destination");
+
+    for (const auto& destination : request.GetDestinations()) {
+        Y_ENSURE(destination.HasPath(), "DeferredPublication destination must have Path");
+        Y_ENSURE(destination.HasPartitionId(), "DeferredPublication destination must have PartitionId");
+        Y_ENSURE(destination.HasTabletId(), "DeferredPublication destination must have TabletId");
+    }
 }
 
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -37,6 +37,55 @@ static void UpdateKafkaProducerInstanceId(TMaybe<NKafka::TProducerInstanceId>& l
     }
 }
 
+template <class T>
+static void UpdateMatchingMaybe(TMaybe<T>& lhs, const TMaybe<T>& rhs)
+{
+    if (rhs.Empty()) {
+        return;
+    }
+    if (lhs.Empty()) {
+        lhs = rhs;
+        return;
+    }
+    Y_ENSURE(*lhs == *rhs);
+}
+
+template <class T>
+static void UpdateMatchingMaybe(TMaybe<T>& lhs, const T& rhs)
+{
+    UpdateMatchingMaybe(lhs, TMaybe<T>{rhs});
+}
+
+static void UpdateDeferredPublicationOp(
+    TMaybe<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>& lhs,
+    const TMaybe<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>& rhs)
+{
+    UpdateMatchingMaybe(lhs, rhs);
+}
+
+static void UpdateDeferredPublicationIntId(TMaybe<ui64>& lhs, const TMaybe<ui64>& rhs)
+{
+    UpdateMatchingMaybe(lhs, rhs);
+}
+
+static void UpdateDeferredPublicationExtId(TMaybe<TString>& lhs, const TMaybe<TString>& rhs)
+{
+    UpdateMatchingMaybe(lhs, rhs);
+}
+
+static NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::EOp MapDeferredPublicationOp(
+    NKikimrKqp::TTopicDeferredPublicationRequest::EOp op)
+{
+    switch (op) {
+        case NKikimrKqp::TTopicDeferredPublicationRequest::Publish:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Publish;
+        case NKikimrKqp::TTopicDeferredPublicationRequest::Cancel:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Cancel;
+        default:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Unspecified;
+    }
+}
+
 //
 // TConsumerOperations
 //
@@ -224,6 +273,24 @@ void TTopicPartitionOperations::AddKafkaApiReadOperation(const TString& topic, u
     Operations_[consumerName].AddKafkaApiOffsetCommit(consumerName, offset);
 }
 
+void TTopicPartitionOperations::AddDeferredPublicationOperation(
+    const TString& topic,
+    ui32 partition,
+    ui64 tabletId,
+    NKikimrKqp::TTopicDeferredPublicationRequest::EOp op)
+{
+    Y_ENSURE(Topic_.Empty() || Topic_ == topic);
+    Y_ENSURE(Partition_.Empty() || Partition_ == partition);
+
+    if (Topic_.Empty()) {
+        Topic_ = topic;
+        Partition_ = partition;
+    }
+
+    SetTabletId(tabletId);
+    UpdateDeferredPublicationOp(DeferredPublicationOp_, op);
+}
+
 void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, bool skipConflictCheck)
 {
     Y_ENSURE(TabletId_.Defined());
@@ -253,7 +320,16 @@ void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, 
         NPQ::DowngradeToLegacy(*o);
     }
 
-    if (HasWriteOperations_) {
+    if (DeferredPublicationOp_.Defined()) {
+        NKikimrPQ::TPartitionOperation* o = t.tx.MutableOperations()->Add();
+        o->SetPartitionId(*Partition_);
+        o->SetPath(*Topic_);
+
+        auto* write = o->MutableWrite();
+        write->SetSkipConflictCheck(skipConflictCheck);
+        write->MutableDeferredPublication()->SetOp(MapDeferredPublicationOp(*DeferredPublicationOp_));
+        t.hasWrite = true;
+    } else if (HasWriteOperations_) {
         NKikimrPQ::TPartitionOperation* o = t.tx.MutableOperations()->Add();
         o->SetPartitionId(*Partition_);
         o->SetPath(*Topic_);
@@ -293,6 +369,12 @@ void TTopicPartitionOperations::Merge(const TTopicPartitionOperations& rhs)
     }
 
     HasWriteOperations_ |= rhs.HasWriteOperations_;
+    UpdateDeferredPublicationOp(DeferredPublicationOp_, rhs.DeferredPublicationOp_);
+}
+
+bool TTopicPartitionOperations::HasDeferredPublicationOperations() const
+{
+    return DeferredPublicationOp_.Defined();
 }
 
 ui64 TTopicPartitionOperations::GetTabletId() const
@@ -364,7 +446,7 @@ bool TTopicOperations::IsValid() const
 
 bool TTopicOperations::HasOperations() const
 {
-    return HasReadOperations() || HasWriteOperations();
+    return HasReadOperations() || HasWriteOperations() || HasDeferredPublicationOperations();
 }
 
 bool TTopicOperations::HasReadOperations() const
@@ -380,6 +462,11 @@ bool TTopicOperations::HasWriteOperations() const
 bool TTopicOperations::HasKafkaOperations() const
 {
     return HasKafkaOperations_;
+}
+
+bool TTopicOperations::HasDeferredPublicationOperations() const
+{
+    return DeferredPublicationIntId_.Defined();
 }
 
 bool TTopicOperations::HasWriteId() const
@@ -403,6 +490,22 @@ NKafka::TProducerInstanceId TTopicOperations::GetKafkaProducerInstanceId() const
     Y_ENSURE(KafkaProducerInstanceId_.Defined());
 
     return *KafkaProducerInstanceId_;
+}
+
+ui64 TTopicOperations::GetDeferredPublicationIntId() const
+{
+    Y_ENSURE(HasDeferredPublicationOperations_);
+    Y_ENSURE(DeferredPublicationIntId_.Defined());
+
+    return *DeferredPublicationIntId_;
+}
+
+const TString& TTopicOperations::GetDeferredPublicationExtId() const
+{
+    Y_ENSURE(HasDeferredPublicationOperations_);
+    Y_ENSURE(DeferredPublicationExtId_.Defined());
+
+    return *DeferredPublicationExtId_;
 }
 
 bool TTopicOperations::TabletHasReadOperations(ui64 tabletId) const
@@ -466,6 +569,22 @@ void TTopicOperations::AddKafkaApiReadOperation(const TString& topic, ui32 parti
     Operations_[key].AddKafkaApiReadOperation(topic, partition, consumerName, offset);
     HasReadOperations_ = true;
     HasKafkaOperations_ = true;
+}
+
+void TTopicOperations::AddDeferredPublicationOperation(
+    const TString& topic,
+    ui32 partition,
+    ui64 tabletId,
+    NKikimrKqp::TTopicDeferredPublicationRequest::EOp op,
+    ui64 intPublicationId,
+    const TString& extPublicationId)
+{
+    UpdateDeferredPublicationIntId(DeferredPublicationIntId_, intPublicationId);
+    UpdateDeferredPublicationExtId(DeferredPublicationExtId_, extPublicationId);
+
+    TTopicPartition key{topic, partition};
+    Operations_[key].AddDeferredPublicationOperation(topic, partition, tabletId, op);
+    HasWriteOperations_ = true;
 }
 
 void TTopicOperations::FillSchemeCacheNavigate(NSchemeCache::TSchemeCacheNavigate& navigate,
@@ -636,6 +755,9 @@ void TTopicOperations::Merge(const TTopicOperations& rhs)
     HasWriteOperations_ |= rhs.HasWriteOperations_;
     HasKafkaOperations_ |= rhs.HasKafkaOperations_;
 
+    UpdateDeferredPublicationIntId(DeferredPublicationIntId_, rhs.DeferredPublicationIntId_);
+    UpdateDeferredPublicationExtId(DeferredPublicationExtId_, rhs.DeferredPublicationExtId_);
+
     MergeSkipConflictCheck(rhs.SkipConflictCheck_);
     MergeTrackProducerId(rhs.TrackProducerId_);
 }
@@ -654,7 +776,8 @@ TSet<ui64> TTopicOperations::GetSendingTabletIds() const
     TSet<ui64> ids;
     for (auto& [_, operations] : Operations_) {
         if (!operations.HasReadOperations() &&
-            operations.HasWriteOperations() && CalcSkipConflictCheck()) {
+            operations.HasWriteOperations() && CalcSkipConflictCheck() &&
+            !operations.HasDeferredPublicationOperations()) {
             continue;
         }
 

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -81,9 +81,33 @@ static NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::EOp Ma
             return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Publish;
         case NKikimrKqp::TTopicDeferredPublicationRequest::Cancel:
             return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Cancel;
+        case NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified:
         default:
             return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Unspecified;
     }
+}
+
+static void EnsureNoDeferredPublicationOperations(const TTopicPartitionOperations& ops)
+{
+    Y_ENSURE(!ops.HasDeferredPublicationOperations(),
+        "Topic/Kafka operations cannot be mixed with DeferredPublication");
+}
+
+static void EnsureNoTopicKafkaOperations(const TTopicPartitionOperations& ops)
+{
+    Y_ENSURE(!ops.HasReadOperations() && !ops.HasWriteOperations(),
+        "DeferredPublication cannot be mixed with Topic/Kafka operations");
+}
+
+static void EnsurePartitionOperationsNotMixed(const TTopicPartitionOperations& ops)
+{
+    Y_ENSURE(!(ops.HasDeferredPublicationOperations() && (ops.HasReadOperations() || ops.HasWriteOperations())),
+        "DeferredPublication cannot be mixed with Topic/Kafka operations");
+}
+
+static bool HasTopicKafkaOperations(const TTopicOperations& ops)
+{
+    return ops.HasReadOperations() || ops.HasWriteOperations() || ops.HasKafkaOperations();
 }
 
 //
@@ -220,6 +244,7 @@ void TTopicPartitionOperations::AddOperation(const TString& topic,
                                              bool onlyCheckCommitedToFinish,
                                              const TString& readSessionId)
 {
+    EnsureNoDeferredPublicationOperations(*this);
     Y_ENSURE(Topic_.Empty() || Topic_ == topic);
     Y_ENSURE(Partition_.Empty() || Partition_ == partition);
 
@@ -234,6 +259,7 @@ void TTopicPartitionOperations::AddOperation(const TString& topic,
 void TTopicPartitionOperations::AddOperation(const TString& topic, ui32 partition,
                                              TMaybe<ui32> supportivePartition)
 {
+    EnsureNoDeferredPublicationOperations(*this);
     Y_ENSURE(Topic_.Empty() || Topic_ == topic);
     Y_ENSURE(Partition_.Empty() || Partition_ == partition);
 
@@ -248,6 +274,7 @@ void TTopicPartitionOperations::AddOperation(const TString& topic, ui32 partitio
 }
 
 void TTopicPartitionOperations::AddKafkaApiWriteOperation(const TString& topic, ui32 partition, const NKafka::TProducerInstanceId& producerInstanceId) {
+    EnsureNoDeferredPublicationOperations(*this);
     Y_ENSURE(Topic_.Empty() || Topic_ == topic);
     Y_ENSURE(Partition_.Empty() || Partition_ == partition);
 
@@ -262,6 +289,7 @@ void TTopicPartitionOperations::AddKafkaApiWriteOperation(const TString& topic, 
 }
 
 void TTopicPartitionOperations::AddKafkaApiReadOperation(const TString& topic, ui32 partition, const TString& consumerName, ui64 offset) {
+    EnsureNoDeferredPublicationOperations(*this);
     Y_ENSURE(Topic_.Empty() || Topic_ == topic);
     Y_ENSURE(Partition_.Empty() || Partition_ == partition);
 
@@ -279,6 +307,9 @@ void TTopicPartitionOperations::AddDeferredPublicationOperation(
     ui64 tabletId,
     NKikimrKqp::TTopicDeferredPublicationRequest::EOp op)
 {
+    EnsureNoTopicKafkaOperations(*this);
+    Y_ENSURE(op != NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified,
+        "DeferredPublication operation must be Publish or Cancel");
     Y_ENSURE(Topic_.Empty() || Topic_ == topic);
     Y_ENSURE(Partition_.Empty() || Partition_ == partition);
 
@@ -293,6 +324,7 @@ void TTopicPartitionOperations::AddDeferredPublicationOperation(
 
 void TTopicPartitionOperations::BuildTopicTxs(TTopicOperationTransactions& txs, bool skipConflictCheck)
 {
+    EnsurePartitionOperationsNotMixed(*this);
     Y_ENSURE(TabletId_.Defined());
     Y_ENSURE(Partition_.Defined());
 
@@ -373,6 +405,7 @@ void TTopicPartitionOperations::Merge(const TTopicPartitionOperations& rhs)
 
     HasWriteOperations_ |= rhs.HasWriteOperations_;
     UpdateDeferredPublicationOp(DeferredPublicationOp_, rhs.DeferredPublicationOp_);
+    EnsurePartitionOperationsNotMixed(*this);
 }
 
 bool TTopicPartitionOperations::HasDeferredPublicationOperations() const
@@ -752,6 +785,11 @@ void TTopicOperations::Merge(const TTopicOperations& rhs)
     // Merging accumulates operations from the same API within one transaction
     // (e.g. multiple Topic offset commits). Mixing Topic, Kafka, and DeferredPublication
     // APIs in one transaction is not supported.
+    Y_ENSURE(!(HasDeferredPublicationOperations() && HasTopicKafkaOperations(rhs)),
+        "DeferredPublication cannot be merged with Topic/Kafka operations");
+    Y_ENSURE(!(rhs.HasDeferredPublicationOperations() && HasTopicKafkaOperations(*this)),
+        "Topic/Kafka operations cannot be merged with DeferredPublication");
+
     for (auto& [key, value] : rhs.Operations_) {
         Operations_[key].Merge(value);
     }
@@ -841,6 +879,8 @@ bool TTopicOperations::ShouldOmitPeerTopicTabletsForPredicateExchange() const
 void ValidateDeferredPublicationRequest(const NKikimrKqp::TTopicDeferredPublicationRequest& request)
 {
     Y_ENSURE(request.HasOp());
+    Y_ENSURE(request.GetOp() != NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified,
+        "DeferredPublication request must specify Publish or Cancel");
     Y_ENSURE(request.HasIntPublicationId());
     Y_ENSURE(!request.GetDestinations().empty(), "DeferredPublication request must have at least one destination");
 }

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -901,7 +901,9 @@ bool TTopicOperations::ShouldOmitPeerTopicTabletsForPredicateExchange() const
 void ValidateDeferredPublicationRequest(const NKikimrKqp::TTopicDeferredPublicationRequest& request)
 {
     Y_ENSURE(request.HasOp(), "DeferredPublication request must have Op");
-    Y_ENSURE(request.GetOp() != NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified,
+    const auto op = request.GetOp();
+    Y_ENSURE(op == NKikimrKqp::TTopicDeferredPublicationRequest::Publish
+            || op == NKikimrKqp::TTopicDeferredPublicationRequest::Cancel,
         "DeferredPublication request must specify Publish or Cancel");
     Y_ENSURE(request.HasIntPublicationId(), "DeferredPublication request must have IntPublicationId");
     Y_ENSURE(!request.GetDestinations().empty(), "DeferredPublication request must have at least one destination");

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -879,10 +879,10 @@ bool TTopicOperations::ShouldOmitPeerTopicTabletsForPredicateExchange() const
 
 void ValidateDeferredPublicationRequest(const NKikimrKqp::TTopicDeferredPublicationRequest& request)
 {
-    Y_ENSURE(request.HasOp());
+    Y_ENSURE(request.HasOp(), "DeferredPublication request must have Op");
     Y_ENSURE(request.GetOp() != NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified,
         "DeferredPublication request must specify Publish or Cancel");
-    Y_ENSURE(request.HasIntPublicationId());
+    Y_ENSURE(request.HasIntPublicationId(), "DeferredPublication request must have IntPublicationId");
     Y_ENSURE(!request.GetDestinations().empty(), "DeferredPublication request must have at least one destination");
 
     for (const auto& destination : request.GetDestinations()) {

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -37,40 +37,59 @@ static void UpdateKafkaProducerInstanceId(TMaybe<NKafka::TProducerInstanceId>& l
     }
 }
 
-template <class T>
-static void UpdateMatchingMaybe(TMaybe<T>& lhs, const TMaybe<T>& rhs)
+static void UpdateDeferredPublicationOp(
+    TMaybe<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>& lhs,
+    NKikimrKqp::TTopicDeferredPublicationRequest::EOp rhs)
 {
-    if (rhs.Empty()) {
-        return;
-    }
     if (lhs.Empty()) {
         lhs = rhs;
         return;
     }
-    Y_ENSURE(*lhs == *rhs);
-}
-
-template <class T>
-static void UpdateMatchingMaybe(TMaybe<T>& lhs, const T& rhs)
-{
-    UpdateMatchingMaybe(lhs, TMaybe<T>{rhs});
+    Y_ENSURE(*lhs == rhs, "DeferredPublication merge requires matching Op");
 }
 
 static void UpdateDeferredPublicationOp(
     TMaybe<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>& lhs,
     const TMaybe<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>& rhs)
 {
-    UpdateMatchingMaybe(lhs, rhs);
+    if (rhs.Empty()) {
+        return;
+    }
+    UpdateDeferredPublicationOp(lhs, *rhs);
+}
+
+static void UpdateDeferredPublicationIntId(TMaybe<ui64>& lhs, ui64 rhs)
+{
+    if (lhs.Empty()) {
+        lhs = rhs;
+        return;
+    }
+    Y_ENSURE(*lhs == rhs, "DeferredPublication merge requires matching IntPublicationId");
 }
 
 static void UpdateDeferredPublicationIntId(TMaybe<ui64>& lhs, const TMaybe<ui64>& rhs)
 {
-    UpdateMatchingMaybe(lhs, rhs);
+    if (rhs.Empty()) {
+        return;
+    }
+    UpdateDeferredPublicationIntId(lhs, *rhs);
+}
+
+static void UpdateDeferredPublicationExtId(TMaybe<TString>& lhs, const TString& rhs)
+{
+    if (lhs.Empty()) {
+        lhs = rhs;
+        return;
+    }
+    Y_ENSURE(*lhs == rhs, "DeferredPublication merge requires matching ExtPublicationId");
 }
 
 static void UpdateDeferredPublicationExtId(TMaybe<TString>& lhs, const TMaybe<TString>& rhs)
 {
-    UpdateMatchingMaybe(lhs, rhs);
+    if (rhs.Empty()) {
+        return;
+    }
+    UpdateDeferredPublicationExtId(lhs, *rhs);
 }
 
 static NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::EOp MapDeferredPublicationOp(

--- a/ydb/core/kqp/topics/kqp_topics.cpp
+++ b/ydb/core/kqp/topics/kqp_topics.cpp
@@ -107,7 +107,8 @@ static void EnsurePartitionOperationsNotMixed(const TTopicPartitionOperations& o
 
 static bool HasTopicKafkaOperations(const TTopicOperations& ops)
 {
-    return ops.HasReadOperations() || ops.HasWriteOperations() || ops.HasKafkaOperations();
+    return ops.HasReadOperations() || ops.HasKafkaOperations()
+        || (ops.HasWriteOperations() && !ops.HasDeferredPublicationOperations());
 }
 
 //

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -96,6 +96,11 @@ public:
 
     void AddKafkaApiReadOperation(const TString& topic, ui32 partition, const TString& consumerName, ui64 offset);
 
+    void AddDeferredPublicationOperation(const TString& topic,
+                                         ui32 partition,
+                                         ui64 tabletId,
+                                         NKikimrKqp::TTopicDeferredPublicationRequest::EOp op);
+
     void BuildTopicTxs(TTopicOperationTransactions &txs, bool skipConflictCheck);
 
     void Merge(const TTopicPartitionOperations& rhs);
@@ -108,12 +113,14 @@ public:
 
     bool HasReadOperations() const;
     bool HasWriteOperations() const;
+    bool HasDeferredPublicationOperations() const;
 
 private:
     TMaybe<TString> Topic_;
     TMaybe<ui32> Partition_;
     THashMap<TString, TConsumerOperations> Operations_;
     bool HasWriteOperations_ = false;
+    TMaybe<NKikimrKqp::TTopicDeferredPublicationRequest::EOp> DeferredPublicationOp_;
     TMaybe<ui64> TabletId_;
     TMaybe<ui32> SupportivePartition_;
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
@@ -140,10 +147,13 @@ public:
     bool HasReadOperations() const;
     bool HasWriteOperations() const;
     bool HasKafkaOperations() const;
+    bool HasDeferredPublicationOperations() const;
     bool HasWriteId() const;
     ui64 GetWriteId() const;
     void SetWriteId(NLongTxService::TLockHandle handle);
     NKafka::TProducerInstanceId GetKafkaProducerInstanceId() const;
+    ui64 GetDeferredPublicationIntId() const;
+    const TString& GetDeferredPublicationExtId() const;
 
     bool TabletHasReadOperations(ui64 tabletId) const;
 
@@ -160,6 +170,13 @@ public:
     void AddKafkaApiWriteOperation(const TString& topic, ui32 partition, const NKafka::TProducerInstanceId& producerInstanceId);
 
     void AddKafkaApiReadOperation(const TString& topic, ui32 partition, const TString& consumerName, ui64 offset);
+
+    void AddDeferredPublicationOperation(const TString& topic,
+                                         ui32 partition,
+                                         ui64 tabletId,
+                                         NKikimrKqp::TTopicDeferredPublicationRequest::EOp op,
+                                         ui64 intPublicationId,
+                                         const TString& extPublicationId);
 
     void FillSchemeCacheNavigate(NSchemeCache::TSchemeCacheNavigate& navigate,
                                  TMaybe<TString> consumer);
@@ -208,6 +225,8 @@ private:
     TMaybe<TString> Consumer_;
     NLongTxService::TLockHandle WriteId_;
     TMaybe<NKafka::TProducerInstanceId> KafkaProducerInstanceId_;
+    TMaybe<ui64> DeferredPublicationIntId_;
+    TMaybe<TString> DeferredPublicationExtId_;
 
     THashMap<TString, NSchemeCache::TSchemeCacheNavigate::TEntry> CachedNavigateResult_;
     bool SkipConflictCheck_ = true;

--- a/ydb/core/kqp/topics/kqp_topics.h
+++ b/ydb/core/kqp/topics/kqp_topics.h
@@ -233,4 +233,6 @@ private:
     bool TrackProducerId_ = false;
 };
 
+void ValidateDeferredPublicationRequest(const NKikimrKqp::TTopicDeferredPublicationRequest& request);
+
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -678,18 +678,6 @@ Y_UNIT_TEST(DeferredPublication_ValidateRejectsUnspecifiedOp) {
     UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
 }
 
-Y_UNIT_TEST(DeferredPublication_ValidateRejectsUnknownOp) {
-    NKikimrKqp::TTopicDeferredPublicationRequest request;
-    request.SetOp(static_cast<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>(100));
-    request.SetIntPublicationId(1);
-    auto* destination = request.AddDestinations();
-    destination->SetPath("topic");
-    destination->SetPartitionId(0);
-    destination->SetTabletId(1);
-
-    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
-}
-
 Y_UNIT_TEST(DeferredPublication_ValidateRejectsEmptyDestinations) {
     NKikimrKqp::TTopicDeferredPublicationRequest request;
     request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Publish);

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -590,6 +590,28 @@ Y_UNIT_TEST(DeferredPublication_MergeKeepsPublicationId) {
     UNIT_ASSERT_VALUES_EQUAL(lhs.GetSize(), 2u);
 }
 
+Y_UNIT_TEST(DeferredPublication_MergeAllowsMissingExtPublicationId) {
+    NTopic::TTopicOperations lhs;
+    lhs.AddDeferredPublicationOperation("topic_A", 0, 100,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "");
+
+    NTopic::TTopicOperations rhs;
+    AddDeferredPublicationOperation(rhs, "topic_B", 1, 200,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11");
+
+    lhs.Merge(rhs);
+
+    UNIT_ASSERT_VALUES_EQUAL(lhs.GetDeferredPublicationIntId(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL(lhs.GetDeferredPublicationExtId(), "ext-11");
+
+    NTopic::TTopicOperations followUp;
+    followUp.AddDeferredPublicationOperation("topic_C", 2, 300,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "");
+
+    lhs.Merge(followUp);
+    UNIT_ASSERT_VALUES_EQUAL(lhs.GetDeferredPublicationExtId(), "ext-11");
+}
+
 Y_UNIT_TEST(DeferredPublication_MergeConflictsOnDifferentPublicationId) {
     NTopic::TTopicOperations lhs;
     AddDeferredPublicationOperation(lhs, "topic_A", 0, 100,

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -522,6 +522,15 @@ Y_UNIT_TEST(DeferredPublication_Publish_SingleDestination) {
         NKikimrKqp::TTopicDeferredPublicationRequest::Publish, false);
 }
 
+Y_UNIT_TEST(DeferredPublication_GetExtIdReturnsEmptyWhenOmitted) {
+    NTopic::TTopicOperations topicOps;
+    topicOps.AddDeferredPublicationOperation("topic", 0, 1'000'000,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 42, "");
+
+    UNIT_ASSERT(topicOps.HasDeferredPublicationOperations());
+    UNIT_ASSERT_VALUES_EQUAL(topicOps.GetDeferredPublicationExtId(), "");
+}
+
 Y_UNIT_TEST(DeferredPublication_Cancel_MultipleDestinations) {
     const TString TOPIC_A = "topic_A";
     const TString TOPIC_B = "topic_B";

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -449,6 +449,161 @@ Y_UNIT_TEST(KafkaWriteOperation_DualWrite) {
     AssertKafkaWriteOperation(txs, TABLETID, 1, 0, false, PRODUCER_ID);
 }
 
+static
+void AddDeferredPublicationOperation(NTopic::TTopicOperations& ops,
+                                     const TString& topic,
+                                     ui32 partition,
+                                     ui64 tabletId,
+                                     NKikimrKqp::TTopicDeferredPublicationRequest::EOp op,
+                                     ui64 intPublicationId,
+                                     const TString& extPublicationId)
+{
+    ops.SetTrackProducerId(true);
+    ops.AddDeferredPublicationOperation(topic, partition, tabletId, op, intPublicationId, extPublicationId);
+}
+
+static
+NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::EOp ExpectedDeferredPublicationOp(
+    NKikimrKqp::TTopicDeferredPublicationRequest::EOp op)
+{
+    switch (op) {
+        case NKikimrKqp::TTopicDeferredPublicationRequest::Publish:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Publish;
+        case NKikimrKqp::TTopicDeferredPublicationRequest::Cancel:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Cancel;
+        default:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Unspecified;
+    }
+}
+
+static
+void AssertDeferredPublicationOperation(const NTopic::TTopicOperationTransactions& txs,
+                                        ui64 tabletId,
+                                        const TString& topic,
+                                        ui32 partition,
+                                        NKikimrKqp::TTopicDeferredPublicationRequest::EOp op,
+                                        bool skipConflictCheck)
+{
+    UNIT_ASSERT(txs.contains(tabletId));
+    const auto& t = txs.at(tabletId);
+    UNIT_ASSERT(t.hasWrite);
+    UNIT_ASSERT_EQUAL(t.tx.OperationsSize(), 1);
+
+    const auto& writeOp = t.tx.GetOperations(0);
+    UNIT_ASSERT_EQUAL(writeOp.GetPath(), topic);
+    UNIT_ASSERT_EQUAL(writeOp.GetPartitionId(), partition);
+    UNIT_ASSERT(writeOp.HasWrite());
+    UNIT_ASSERT(writeOp.GetWrite().HasDeferredPublication());
+    UNIT_ASSERT_EQUAL(writeOp.GetWrite().GetDeferredPublication().GetOp(), ExpectedDeferredPublicationOp(op));
+    UNIT_ASSERT_EQUAL(writeOp.GetWrite().GetSkipConflictCheck(), skipConflictCheck);
+}
+
+Y_UNIT_TEST(DeferredPublication_Publish_SingleDestination) {
+    const TString TOPIC = "topic";
+    const ui32 PARTITION = 0;
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+    AddDeferredPublicationOperation(topicOps, TOPIC, PARTITION, TABLETID,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 42, "ext-42");
+
+    UNIT_ASSERT(topicOps.HasDeferredPublicationOperations());
+    UNIT_ASSERT(topicOps.HasWriteOperations());
+    UNIT_ASSERT(!topicOps.HasWriteId());
+    UNIT_ASSERT_VALUES_EQUAL(topicOps.GetDeferredPublicationIntId(), 42u);
+    UNIT_ASSERT_VALUES_EQUAL(topicOps.GetDeferredPublicationExtId(), "ext-42");
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 1);
+    AssertDeferredPublicationOperation(txs, TABLETID, TOPIC, PARTITION,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, false);
+}
+
+Y_UNIT_TEST(DeferredPublication_Cancel_MultipleDestinations) {
+    const TString TOPIC_A = "topic_A";
+    const TString TOPIC_B = "topic_B";
+    const ui64 TABLETID_A = 1'000'000;
+    const ui64 TABLETID_B = 2'000'000;
+
+    NTopic::TTopicOperations topicOps;
+    AddDeferredPublicationOperation(topicOps, TOPIC_A, 0, TABLETID_A,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Cancel, 7, "ext-7");
+    AddDeferredPublicationOperation(topicOps, TOPIC_B, 1, TABLETID_B,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Cancel, 7, "ext-7");
+
+    const auto recvTabletIds = topicOps.GetReceivingTabletIds();
+    UNIT_ASSERT_EQUAL(recvTabletIds.size(), 2);
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(recvTabletIds.contains(TABLETID_B));
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 2);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_A));
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID_B));
+
+    NTopic::TTopicOperationTransactions txs;
+    topicOps.BuildTopicTxs(txs);
+    UNIT_ASSERT_EQUAL(txs.size(), 2);
+    AssertDeferredPublicationOperation(txs, TABLETID_A, TOPIC_A, 0,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Cancel, false);
+    AssertDeferredPublicationOperation(txs, TABLETID_B, TOPIC_B, 1,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Cancel, false);
+}
+
+Y_UNIT_TEST(DeferredPublication_GetSendingTabletIds_IncludesWriteOnlyTablet) {
+    const TString TOPIC = "topic";
+    const ui64 TABLETID = 1'000'000;
+
+    NTopic::TTopicOperations topicOps;
+    topicOps.SetSkipConflictCheck(true);
+    topicOps.SetTrackProducerId(false);
+
+    AddDeferredPublicationOperation(topicOps, TOPIC, 0, TABLETID,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 1, "ext");
+
+    const auto sendTabletIds = topicOps.GetSendingTabletIds();
+    UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);
+    UNIT_ASSERT(sendTabletIds.contains(TABLETID));
+}
+
+Y_UNIT_TEST(DeferredPublication_MergeKeepsPublicationId) {
+    NTopic::TTopicOperations lhs;
+    AddDeferredPublicationOperation(lhs, "topic_A", 0, 100,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11");
+
+    NTopic::TTopicOperations rhs;
+    AddDeferredPublicationOperation(rhs, "topic_B", 1, 200,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11");
+
+    lhs.Merge(rhs);
+
+    UNIT_ASSERT(lhs.HasDeferredPublicationOperations());
+    UNIT_ASSERT_VALUES_EQUAL(lhs.GetDeferredPublicationIntId(), 11u);
+    UNIT_ASSERT_VALUES_EQUAL(lhs.GetDeferredPublicationExtId(), "ext-11");
+    UNIT_ASSERT_VALUES_EQUAL(lhs.GetSize(), 2u);
+}
+
+Y_UNIT_TEST(DeferredPublication_MergeConflictsOnDifferentPublicationId) {
+    NTopic::TTopicOperations lhs;
+    AddDeferredPublicationOperation(lhs, "topic_A", 0, 100,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11");
+
+    NTopic::TTopicOperations rhs;
+    AddDeferredPublicationOperation(rhs, "topic_B", 1, 200,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 22, "ext-22");
+
+    UNIT_ASSERT_EXCEPTION(lhs.Merge(rhs), yexception);
+}
+
+Y_UNIT_TEST(DeferredPublication_ValidateRejectsEmptyDestinations) {
+    NKikimrKqp::TTopicDeferredPublicationRequest request;
+    request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Publish);
+    request.SetIntPublicationId(1);
+
+    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
+}
+
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -561,8 +561,10 @@ Y_UNIT_TEST(DeferredPublication_GetSendingTabletIds_IncludesWriteOnlyTablet) {
     topicOps.SetSkipConflictCheck(true);
     topicOps.SetTrackProducerId(false);
 
-    AddDeferredPublicationOperation(topicOps, TOPIC, 0, TABLETID,
+    topicOps.AddDeferredPublicationOperation(TOPIC, 0, TABLETID,
         NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 1, "ext");
+
+    UNIT_ASSERT(topicOps.CalcSkipConflictCheck());
 
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -556,15 +556,17 @@ Y_UNIT_TEST(DeferredPublication_Cancel_MultipleDestinations) {
 Y_UNIT_TEST(DeferredPublication_GetSendingTabletIds_IncludesWriteOnlyTablet) {
     const TString TOPIC = "topic";
     const ui64 TABLETID = 1'000'000;
+    const bool skipConflictCheck = true;
+    const bool trackProducerId = false;
 
     NTopic::TTopicOperations topicOps;
-    topicOps.SetSkipConflictCheck(true);
-    topicOps.SetTrackProducerId(false);
+    topicOps.SetSkipConflictCheck(skipConflictCheck);
+    topicOps.SetTrackProducerId(trackProducerId);
 
     topicOps.AddDeferredPublicationOperation(TOPIC, 0, TABLETID,
         NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 1, "ext");
 
-    UNIT_ASSERT(topicOps.CalcSkipConflictCheck());
+    UNIT_ASSERT(ShouldSkipConflictCheck(skipConflictCheck, trackProducerId));
 
     const auto sendTabletIds = topicOps.GetSendingTabletIds();
     UNIT_ASSERT_EQUAL(sendTabletIds.size(), 1);

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -657,6 +657,18 @@ Y_UNIT_TEST(DeferredPublication_ValidateRejectsUnspecifiedOp) {
     UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
 }
 
+Y_UNIT_TEST(DeferredPublication_ValidateRejectsUnknownOp) {
+    NKikimrKqp::TTopicDeferredPublicationRequest request;
+    request.SetOp(static_cast<NKikimrKqp::TTopicDeferredPublicationRequest::EOp>(100));
+    request.SetIntPublicationId(1);
+    auto* destination = request.AddDestinations();
+    destination->SetPath("topic");
+    destination->SetPartitionId(0);
+    destination->SetTabletId(1);
+
+    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
+}
+
 Y_UNIT_TEST(DeferredPublication_ValidateRejectsEmptyDestinations) {
     NKikimrKqp::TTopicDeferredPublicationRequest request;
     request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Publish);

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -471,6 +471,8 @@ NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::EOp ExpectedD
             return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Publish;
         case NKikimrKqp::TTopicDeferredPublicationRequest::Cancel:
             return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Cancel;
+        case NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified:
+            return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Unspecified;
         default:
             return NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Unspecified;
     }
@@ -594,6 +596,30 @@ Y_UNIT_TEST(DeferredPublication_MergeConflictsOnDifferentPublicationId) {
         NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 22, "ext-22");
 
     UNIT_ASSERT_EXCEPTION(lhs.Merge(rhs), yexception);
+}
+
+Y_UNIT_TEST(DeferredPublication_MergeRejectsTopicWrite) {
+    NTopic::TTopicOperations lhs;
+    AddDeferredPublicationOperation(lhs, "topic_A", 0, 100,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11");
+
+    NTopic::TTopicOperations rhs;
+    AddWriteOperation(rhs, "topic_B", 1, 100'001);
+    rhs.SetTabletId("topic_B", 1, 200);
+
+    UNIT_ASSERT_EXCEPTION(lhs.Merge(rhs), yexception);
+}
+
+Y_UNIT_TEST(DeferredPublication_ValidateRejectsUnspecifiedOp) {
+    NKikimrKqp::TTopicDeferredPublicationRequest request;
+    request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified);
+    request.SetIntPublicationId(1);
+    auto* destination = request.AddDestinations();
+    destination->SetPath("topic");
+    destination->SetPartitionId(0);
+    destination->SetTabletId(1);
+
+    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
 }
 
 Y_UNIT_TEST(DeferredPublication_ValidateRejectsEmptyDestinations) {

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -630,6 +630,39 @@ Y_UNIT_TEST(DeferredPublication_ValidateRejectsEmptyDestinations) {
     UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
 }
 
+Y_UNIT_TEST(DeferredPublication_ValidateRejectsDestinationWithoutPath) {
+    NKikimrKqp::TTopicDeferredPublicationRequest request;
+    request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Publish);
+    request.SetIntPublicationId(1);
+    auto* destination = request.AddDestinations();
+    destination->SetPartitionId(0);
+    destination->SetTabletId(1);
+
+    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
+}
+
+Y_UNIT_TEST(DeferredPublication_ValidateRejectsDestinationWithoutPartitionId) {
+    NKikimrKqp::TTopicDeferredPublicationRequest request;
+    request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Publish);
+    request.SetIntPublicationId(1);
+    auto* destination = request.AddDestinations();
+    destination->SetPath("topic");
+    destination->SetTabletId(1);
+
+    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
+}
+
+Y_UNIT_TEST(DeferredPublication_ValidateRejectsDestinationWithoutTabletId) {
+    NKikimrKqp::TTopicDeferredPublicationRequest request;
+    request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Publish);
+    request.SetIntPublicationId(1);
+    auto* destination = request.AddDestinations();
+    destination->SetPath("topic");
+    destination->SetPartitionId(0);
+
+    UNIT_ASSERT_EXCEPTION(NTopic::ValidateDeferredPublicationRequest(request), yexception);
+}
+
 }
 
 }

--- a/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
+++ b/ydb/core/kqp/ut/topics/kqp_topics_ut.cpp
@@ -645,6 +645,27 @@ Y_UNIT_TEST(DeferredPublication_MergeRejectsTopicWrite) {
     UNIT_ASSERT_EXCEPTION(lhs.Merge(rhs), yexception);
 }
 
+Y_UNIT_TEST(DeferredPublication_AddRejectsTopicWriteAfterDeferred) {
+    NTopic::TTopicOperations topicOps;
+    AddDeferredPublicationOperation(topicOps, "topic_A", 0, 100,
+        NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11");
+
+    UNIT_ASSERT_EXCEPTION(
+        AddWriteOperation(topicOps, "topic_B", 1, 100'001),
+        yexception);
+}
+
+Y_UNIT_TEST(DeferredPublication_AddRejectsDeferredAfterTopicWrite) {
+    NTopic::TTopicOperations topicOps;
+    AddWriteOperation(topicOps, "topic_A", 0, 100'001);
+    topicOps.SetTabletId("topic_A", 0, 100);
+
+    UNIT_ASSERT_EXCEPTION(
+        AddDeferredPublicationOperation(topicOps, "topic_B", 1, 200,
+            NKikimrKqp::TTopicDeferredPublicationRequest::Publish, 11, "ext-11"),
+        yexception);
+}
+
 Y_UNIT_TEST(DeferredPublication_ValidateRejectsUnspecifiedOp) {
     NKikimrKqp::TTopicDeferredPublicationRequest request;
     request.SetOp(NKikimrKqp::TTopicDeferredPublicationRequest::Unspecified);

--- a/ydb/core/persqueue/pqtablet/common/event_helpers.h
+++ b/ydb/core/persqueue/pqtablet/common/event_helpers.h
@@ -33,6 +33,12 @@ bool IsWriteTxOperation(const NKikimrPQ::TPartitionOperation& operation)
     return !isRead;
 }
 
+inline
+bool IsDeferredPublicationTxOperation(const NKikimrPQ::TPartitionOperation& operation)
+{
+    return operation.HasWrite() && operation.GetWrite().HasDeferredPublication();
+}
+
 template <class C>
 bool AllExistingWritesSkipConflictCheck(const C& ops)
 {

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3401,6 +3401,28 @@ void TPersQueue::HandleDataTransaction(TAutoPtr<TEvPersQueue::TEvProposeTransact
         return;
     }
 
+    if (txBody.HasWriteId() && GetWriteId(txBody).IsDeferredPublicationApiTransaction()) {
+        PQ_LOG_TX_W("TxId " << event.GetTxId() << " deferred publication is not supported");
+        SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
+                                    event.GetTxId(),
+                                    NKikimrPQ::TError::BAD_REQUEST,
+                                    "deferred publication is not supported",
+                                    ctx);
+        return;
+    }
+
+    for (const auto& operation : txBody.GetOperations()) {
+        if (IsDeferredPublicationTxOperation(operation)) {
+            PQ_LOG_TX_W("TxId " << event.GetTxId() << " deferred publication is not supported");
+            SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),
+                                        event.GetTxId(),
+                                        NKikimrPQ::TError::BAD_REQUEST,
+                                        "deferred publication is not supported",
+                                        ctx);
+            return;
+        }
+    }
+
     if (!CheckTxWriteOperations(txBody)) {
         PQ_LOG_TX_W("TxId " << event.GetTxId() << " invalid WriteId " << txBody.GetWriteId());
         SendProposeTransactionAbort(ActorIdFromProto(event.GetSourceActor()),

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -112,11 +112,11 @@ void DowngradeKafkaWriteToLegacy(
 }
 
 void DowngradeDeferredPublicationWriteToLegacy(
-    const NKikimrPQ::TPartitionOperation::TWriteOp& write,
+    const NKikimrPQ::TPartitionOperation::TWriteOp& /*write*/,
     NKikimrPQ::TPartitionOperation& op)
 {
+    // Legacy wire has no deferred-publication representation; do not populate legacy write fields.
     ClearLegacyPartitionOpFields(op);
-    op.SetSkipConflictCheck(write.GetSkipConflictCheck());
 }
 
 bool HasLegacyPartitionOp(const NKikimrPQ::TPartitionOperation& op)

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -111,6 +111,14 @@ void DowngradeKafkaWriteToLegacy(
         op.MutableKafkaProducerInstanceId());
 }
 
+void DowngradeDeferredPublicationWriteToLegacy(
+    const NKikimrPQ::TPartitionOperation::TWriteOp& write,
+    NKikimrPQ::TPartitionOperation& op)
+{
+    ClearLegacyPartitionOpFields(op);
+    op.SetSkipConflictCheck(write.GetSkipConflictCheck());
+}
+
 bool HasLegacyPartitionOp(const NKikimrPQ::TPartitionOperation& op)
 {
     return op.HasConsumer() || op.HasCommitOffsetsBegin() || op.HasCommitOffsetsEnd()
@@ -233,6 +241,9 @@ void DowngradeToLegacy(NKikimrPQ::TPartitionOperation& op)
                     break;
                 case NKikimrPQ::TPartitionOperation::TWriteOp::kKafka:
                     DowngradeKafkaWriteToLegacy(op.GetWrite(), op);
+                    break;
+                case NKikimrPQ::TPartitionOperation::TWriteOp::kDeferredPublication:
+                    DowngradeDeferredPublicationWriteToLegacy(op.GetWrite(), op);
                     break;
                 case NKikimrPQ::TPartitionOperation::TWriteOp::API_NOT_SET:
                     ClearLegacyPartitionOpFields(op);

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -47,6 +47,14 @@ bool HasLegacy(const NKikimrPQ::TWriteId& writeId)
         || writeId.HasNodeId() || writeId.HasKeyId();
 }
 
+void ClearLegacyWriteIdFields(NKikimrPQ::TWriteId& writeId)
+{
+    writeId.ClearNodeId();
+    writeId.ClearKeyId();
+    writeId.SetKafkaTransaction(false);
+    writeId.ClearKafkaProducerInstanceId();
+}
+
 void ClearLegacyPartitionOpFields(NKikimrPQ::TPartitionOperation& op)
 {
     op.ClearCommitOffsetsBegin();
@@ -198,7 +206,7 @@ void DowngradeToLegacy(NKikimrPQ::TWriteId& writeId)
             DowngradeKafkaApiToLegacy(writeId.GetKafkaApi(), writeId);
             break;
         case NKikimrPQ::TWriteId::kDeferredPublicationApi:
-            // Legacy wire format has no deferred representation.
+            ClearLegacyWriteIdFields(writeId);
             break;
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             break;

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -189,6 +189,9 @@ void DowngradeToLegacy(NKikimrPQ::TWriteId& writeId)
         case NKikimrPQ::TWriteId::kKafkaApi:
             DowngradeKafkaApiToLegacy(writeId.GetKafkaApi(), writeId);
             break;
+        case NKikimrPQ::TWriteId::kDeferredPublicationApi:
+            // Legacy wire format has no deferred representation.
+            break;
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             break;
     }

--- a/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
+++ b/ydb/core/persqueue/public/pqdata_transaction_compat.cpp
@@ -120,11 +120,12 @@ void DowngradeKafkaWriteToLegacy(
 }
 
 void DowngradeDeferredPublicationWriteToLegacy(
-    const NKikimrPQ::TPartitionOperation::TWriteOp& /*write*/,
+    const NKikimrPQ::TPartitionOperation::TWriteOp& write,
     NKikimrPQ::TPartitionOperation& op)
 {
-    // Legacy wire has no deferred-publication representation; do not populate legacy write fields.
+    // Legacy wire has no deferred-publication API; keep only SkipConflictCheck in sync with canonical write.
     ClearLegacyPartitionOpFields(op);
+    op.SetSkipConflictCheck(write.GetSkipConflictCheck());
 }
 
 bool HasLegacyPartitionOp(const NKikimrPQ::TPartitionOperation& op)

--- a/ydb/core/persqueue/public/write_id.cpp
+++ b/ydb/core/persqueue/public/write_id.cpp
@@ -103,15 +103,16 @@ bool TWriteId::operator<(const TWriteId& rhs) const
 
 size_t TWriteId::GetHash() const
 {
+    const auto idCase = static_cast<size_t>(Proto.Id_case());
     switch (Proto.Id_case()) {
         case NKikimrPQ::TWriteId::kTopicApi:
-            return MultiHash(Proto.GetTopicApi().GetNodeId(), Proto.GetTopicApi().GetKeyId());
+            return MultiHash(idCase, Proto.GetTopicApi().GetNodeId(), Proto.GetTopicApi().GetKeyId());
         case NKikimrPQ::TWriteId::kKafkaApi:
-            return MultiHash(KafkaProducerInstanceId.Id, KafkaProducerInstanceId.Epoch);
+            return MultiHash(idCase, KafkaProducerInstanceId.Id, KafkaProducerInstanceId.Epoch);
         case NKikimrPQ::TWriteId::kDeferredPublicationApi:
-            return Proto.GetDeferredPublicationApi().GetIntPublicationId();
+            return MultiHash(idCase, Proto.GetDeferredPublicationApi().GetIntPublicationId());
         case NKikimrPQ::TWriteId::ID_NOT_SET:
-            return 0;
+            return MultiHash(idCase);
     }
     Y_UNREACHABLE();
     return 0;

--- a/ydb/core/persqueue/public/write_id.cpp
+++ b/ydb/core/persqueue/public/write_id.cpp
@@ -44,6 +44,14 @@ int CompareWriteIdProto(const NKikimrPQ::TWriteId& lhs, const NKikimrPQ::TWriteI
             }
             return CompareScalars(l.GetEpoch(), r.GetEpoch());
         }
+        case NKikimrPQ::TWriteId::kDeferredPublicationApi: {
+            const auto& l = lhs.GetDeferredPublicationApi();
+            const auto& r = rhs.GetDeferredPublicationApi();
+            if (auto cmp = CompareScalars(l.GetIntPublicationId(), r.GetIntPublicationId()); cmp != 0) {
+                return cmp;
+            }
+            return l.GetExtPublicationId().compare(r.GetExtPublicationId());
+        }
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             return 0;
     }
@@ -103,6 +111,10 @@ size_t TWriteId::GetHash() const
             return MultiHash(Proto.GetTopicApi().GetNodeId(), Proto.GetTopicApi().GetKeyId());
         case NKikimrPQ::TWriteId::kKafkaApi:
             return MultiHash(KafkaProducerInstanceId.Id, KafkaProducerInstanceId.Epoch);
+        case NKikimrPQ::TWriteId::kDeferredPublicationApi: {
+            const auto& deferredPublicationApi = Proto.GetDeferredPublicationApi();
+            return MultiHash(deferredPublicationApi.GetIntPublicationId(), deferredPublicationApi.GetExtPublicationId());
+        }
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             return 0;
     }
@@ -119,6 +131,12 @@ void TWriteId::ToStream(IOutputStream& s) const
         case NKikimrPQ::TWriteId::kTopicApi:
             s << '{' << GetNodeId() << ", " << GetKeyId() << '}';
             break;
+        case NKikimrPQ::TWriteId::kDeferredPublicationApi: {
+            const auto& deferredPublicationApi = Proto.GetDeferredPublicationApi();
+            s << "DeferredPublicationWriteId{" << deferredPublicationApi.GetIntPublicationId()
+                << ", " << deferredPublicationApi.GetExtPublicationId() << '}';
+            break;
+        }
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             s << "{}";
             break;

--- a/ydb/core/persqueue/public/write_id.cpp
+++ b/ydb/core/persqueue/public/write_id.cpp
@@ -47,10 +47,7 @@ int CompareWriteIdProto(const NKikimrPQ::TWriteId& lhs, const NKikimrPQ::TWriteI
         case NKikimrPQ::TWriteId::kDeferredPublicationApi: {
             const auto& l = lhs.GetDeferredPublicationApi();
             const auto& r = rhs.GetDeferredPublicationApi();
-            if (auto cmp = CompareScalars(l.GetIntPublicationId(), r.GetIntPublicationId()); cmp != 0) {
-                return cmp;
-            }
-            return l.GetExtPublicationId().compare(r.GetExtPublicationId());
+            return CompareScalars(l.GetIntPublicationId(), r.GetIntPublicationId());
         }
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             return 0;
@@ -111,10 +108,8 @@ size_t TWriteId::GetHash() const
             return MultiHash(Proto.GetTopicApi().GetNodeId(), Proto.GetTopicApi().GetKeyId());
         case NKikimrPQ::TWriteId::kKafkaApi:
             return MultiHash(KafkaProducerInstanceId.Id, KafkaProducerInstanceId.Epoch);
-        case NKikimrPQ::TWriteId::kDeferredPublicationApi: {
-            const auto& deferredPublicationApi = Proto.GetDeferredPublicationApi();
-            return MultiHash(deferredPublicationApi.GetIntPublicationId(), deferredPublicationApi.GetExtPublicationId());
-        }
+        case NKikimrPQ::TWriteId::kDeferredPublicationApi:
+            return Proto.GetDeferredPublicationApi().GetIntPublicationId();
         case NKikimrPQ::TWriteId::ID_NOT_SET:
             return 0;
     }

--- a/ydb/core/persqueue/public/write_id.h
+++ b/ydb/core/persqueue/public/write_id.h
@@ -44,6 +44,11 @@ struct TWriteId {
         return Proto.Id_case() == NKikimrPQ::TWriteId::kKafkaApi;
     }
 
+    bool IsDeferredPublicationApiTransaction() const
+    {
+        return Proto.Id_case() == NKikimrPQ::TWriteId::kDeferredPublicationApi;
+    }
+
     // Precondition: IsTopicApiTransaction(). Otherwise returns default proto values (0).
     ui64 GetNodeId() const
     {

--- a/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
+++ b/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
@@ -149,7 +149,9 @@ Y_UNIT_TEST(DowngradeToLegacyDeferredPublicationWriteClearsLegacy) {
 
     UNIT_ASSERT(op.HasWrite());
     UNIT_ASSERT(op.GetWrite().HasDeferredPublication());
-    UNIT_ASSERT(!op.HasSkipConflictCheck());
+    UNIT_ASSERT(op.HasSkipConflictCheck());
+    UNIT_ASSERT(op.GetSkipConflictCheck());
+    UNIT_ASSERT_EQUAL(op.GetSkipConflictCheck(), op.GetWrite().GetSkipConflictCheck());
     UNIT_ASSERT(!op.GetKafkaTransaction());
     UNIT_ASSERT(!op.HasConsumer());
     UNIT_ASSERT(!op.HasSupportivePartition());

--- a/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
+++ b/ydb/core/persqueue/ut/pqdata_transaction_compat_ut.cpp
@@ -135,6 +135,27 @@ Y_UNIT_TEST(DowngradeToLegacyKafkaWrite) {
     AssertKafkaWriteDualWrite(op, false, 7, 3);
 }
 
+Y_UNIT_TEST(DowngradeToLegacyDeferredPublicationWriteClearsLegacy) {
+    NKikimrPQ::TPartitionOperation op;
+    op.SetPath("topic");
+    op.SetPartitionId(0);
+
+    auto* write = op.MutableWrite();
+    write->SetSkipConflictCheck(true);
+    write->MutableDeferredPublication()->SetOp(
+        NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi::Publish);
+
+    DowngradeToLegacy(op);
+
+    UNIT_ASSERT(op.HasWrite());
+    UNIT_ASSERT(op.GetWrite().HasDeferredPublication());
+    UNIT_ASSERT(!op.HasSkipConflictCheck());
+    UNIT_ASSERT(!op.GetKafkaTransaction());
+    UNIT_ASSERT(!op.HasConsumer());
+    UNIT_ASSERT(!op.HasSupportivePartition());
+    UNIT_ASSERT(!op.HasKafkaProducerInstanceId());
+}
+
 Y_UNIT_TEST(UpgradeFromLegacyTopicReadRoundTrip) {
     NKikimrPQ::TPartitionOperation legacy;
     legacy.SetPath("topic");

--- a/ydb/core/persqueue/ut/write_id_ut.cpp
+++ b/ydb/core/persqueue/ut/write_id_ut.cpp
@@ -187,7 +187,10 @@ Y_UNIT_TEST(DowngradeToLegacyDeferredClearsStaleLegacyFields) {
     DowngradeToLegacy(writeId);
 
     UNIT_ASSERT(HasCanonical(writeId));
-    UNIT_ASSERT(!HasLegacy(writeId));
+    UNIT_ASSERT(!writeId.HasNodeId());
+    UNIT_ASSERT(!writeId.HasKeyId());
+    UNIT_ASSERT(!writeId.GetKafkaTransaction());
+    UNIT_ASSERT(!writeId.HasKafkaProducerInstanceId());
     UNIT_ASSERT_VALUES_EQUAL(writeId.GetDeferredPublicationApi().GetIntPublicationId(), 7u);
 }
 

--- a/ydb/core/persqueue/ut/write_id_ut.cpp
+++ b/ydb/core/persqueue/ut/write_id_ut.cpp
@@ -176,6 +176,21 @@ Y_UNIT_TEST(DowngradeToLegacyKeepsDeferredCanonical) {
     UNIT_ASSERT_VALUES_EQUAL(writeId.GetDeferredPublicationApi().GetExtPublicationId(), "ext-7");
 }
 
+Y_UNIT_TEST(DowngradeToLegacyDeferredClearsStaleLegacyFields) {
+    auto writeId = MakeDeferredWriteId(7, "ext-7");
+    writeId.SetNodeId(1);
+    writeId.SetKeyId(2);
+    writeId.SetKafkaTransaction(true);
+    writeId.MutableKafkaProducerInstanceId()->SetId(3);
+    writeId.MutableKafkaProducerInstanceId()->SetEpoch(4);
+
+    DowngradeToLegacy(writeId);
+
+    UNIT_ASSERT(HasCanonical(writeId));
+    UNIT_ASSERT(!HasLegacy(writeId));
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetDeferredPublicationApi().GetIntPublicationId(), 7u);
+}
+
 } // Y_UNIT_TEST_SUITE(TWriteIdCompat)
 
 Y_UNIT_TEST_SUITE(TWriteIdEquality) {

--- a/ydb/core/persqueue/ut/write_id_ut.cpp
+++ b/ydb/core/persqueue/ut/write_id_ut.cpp
@@ -26,6 +26,15 @@ NKikimrPQ::TWriteId MakeLegacyKafkaWriteId(i64 id, i32 epoch)
     return writeId;
 }
 
+NKikimrPQ::TWriteId MakeDeferredWriteId(ui64 intPublicationId, const TString& extPublicationId)
+{
+    NKikimrPQ::TWriteId writeId;
+    auto* deferred = writeId.MutableDeferredPublicationApi();
+    deferred->SetIntPublicationId(intPublicationId);
+    deferred->SetExtPublicationId(extPublicationId);
+    return writeId;
+}
+
 Y_UNIT_TEST_SUITE(TWriteIdCompat) {
 
 Y_UNIT_TEST(UpgradeFromLegacyTopic) {
@@ -140,6 +149,33 @@ Y_UNIT_TEST(ProtoSerializeDeserializeRoundTrip) {
     UNIT_ASSERT_VALUES_EQUAL(TWriteId(std::move(parsed)), original);
 }
 
+Y_UNIT_TEST(SetWriteIdDeferredRoundTrip) {
+    const TWriteId original(MakeDeferredWriteId(42, "ext-42"));
+    NKikimrPQ::TDataTransaction tx;
+    SetWriteId(tx, original);
+
+    const TWriteId restored = GetWriteId(tx);
+    UNIT_ASSERT(restored.IsDeferredPublicationApiTransaction());
+    UNIT_ASSERT_VALUES_EQUAL(restored, original);
+
+    const auto& proto = tx.GetWriteId();
+    UNIT_ASSERT(HasCanonical(proto));
+    UNIT_ASSERT(proto.HasDeferredPublicationApi());
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetDeferredPublicationApi().GetIntPublicationId(), 42u);
+    UNIT_ASSERT_VALUES_EQUAL(proto.GetDeferredPublicationApi().GetExtPublicationId(), "ext-42");
+}
+
+Y_UNIT_TEST(DowngradeToLegacyKeepsDeferredCanonical) {
+    auto writeId = MakeDeferredWriteId(7, "ext-7");
+    UNIT_ASSERT(HasCanonical(writeId));
+
+    DowngradeToLegacy(writeId);
+
+    UNIT_ASSERT(HasCanonical(writeId));
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetDeferredPublicationApi().GetIntPublicationId(), 7u);
+    UNIT_ASSERT_VALUES_EQUAL(writeId.GetDeferredPublicationApi().GetExtPublicationId(), "ext-7");
+}
+
 } // Y_UNIT_TEST_SUITE(TWriteIdCompat)
 
 Y_UNIT_TEST_SUITE(TWriteIdEquality) {
@@ -174,6 +210,14 @@ Y_UNIT_TEST(HashMatchesEquality) {
     UNIT_ASSERT_VALUES_EQUAL(left.GetHash(), right.GetHash());
     UNIT_ASSERT(left != other);
     UNIT_ASSERT_VALUES_UNEQUAL(left.GetHash(), other.GetHash());
+}
+
+Y_UNIT_TEST(DeferredWriteIdsAreDistinct) {
+    const TWriteId first(MakeDeferredWriteId(1, "ext-a"));
+    const TWriteId second(MakeDeferredWriteId(2, "ext-b"));
+
+    UNIT_ASSERT(first != second);
+    UNIT_ASSERT_VALUES_UNEQUAL(first.GetHash(), second.GetHash());
 }
 
 } // Y_UNIT_TEST_SUITE(TWriteIdEquality)

--- a/ydb/core/persqueue/ut/write_id_ut.cpp
+++ b/ydb/core/persqueue/ut/write_id_ut.cpp
@@ -220,6 +220,17 @@ Y_UNIT_TEST(DeferredWriteIdsAreDistinct) {
     UNIT_ASSERT_VALUES_UNEQUAL(first.GetHash(), second.GetHash());
 }
 
+Y_UNIT_TEST(DeferredWriteIdsIgnoreExtPublicationId) {
+    const TWriteId withExt(MakeDeferredWriteId(42, "ext-42"));
+    const TWriteId withoutExt(MakeDeferredWriteId(42, ""));
+    const TWriteId otherExt(MakeDeferredWriteId(42, "other-ext"));
+
+    UNIT_ASSERT_VALUES_EQUAL(withExt, withoutExt);
+    UNIT_ASSERT_VALUES_EQUAL(withExt, otherExt);
+    UNIT_ASSERT_VALUES_EQUAL(withExt.GetHash(), withoutExt.GetHash());
+    UNIT_ASSERT_VALUES_EQUAL(withExt.GetHash(), otherExt.GetHash());
+}
+
 } // Y_UNIT_TEST_SUITE(TWriteIdEquality)
 
 } // namespace

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -173,6 +173,8 @@ message TQueryRequest {
     reserved 19; // (deprecated) StatsMode
     optional NYql.NDqProto.EDqStatsMode StatsMode = 20; // deprecated
     optional Ydb.Table.QueryStatsCollection.Mode CollectStats = 21;
+    // QUERY_ACTION_TOPIC carries exactly one topic API per request: Topic, Kafka, or DeferredPublication.
+    // Breaking change: fields 22 and 37 were independent optionals; oneof keeps the last tag on wire if both are set.
     oneof TopicRequestOperations {
         TTopicOperationsRequest TopicOperations = 22;
         TKafkaApiOperationsRequest KafkaApiOperations = 37;

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -117,8 +117,9 @@ message TKafkaApiOperationsRequest {
 
 message TTopicDeferredPublicationRequest {
     enum EOp {
-        Publish = 0;
-        Cancel = 1;
+        Unspecified = 0;
+        Publish = 1;
+        Cancel = 2;
     }
 
     message TDestination {

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -115,6 +115,24 @@ message TKafkaApiOperationsRequest {
     }
 }
 
+message TTopicDeferredPublicationRequest {
+    enum EOp {
+        Publish = 0;
+        Cancel = 1;
+    }
+
+    message TDestination {
+        optional string Path = 1;
+        optional uint32 PartitionId = 2;
+        optional uint64 TabletId = 3;
+    }
+
+    optional EOp Op = 1;
+    optional uint64 IntPublicationId = 2;
+    optional string ExtPublicationId = 3;
+    repeated TDestination Destinations = 4;
+}
+
 message TTopicOperationsResponse {
     message TWriteId {
         message TKafkaProducerInstanceId {
@@ -154,7 +172,11 @@ message TQueryRequest {
     reserved 19; // (deprecated) StatsMode
     optional NYql.NDqProto.EDqStatsMode StatsMode = 20; // deprecated
     optional Ydb.Table.QueryStatsCollection.Mode CollectStats = 21;
-    optional TTopicOperationsRequest TopicOperations = 22;
+    oneof TopicRequestOperations {
+        TTopicOperationsRequest TopicOperations = 22;
+        TKafkaApiOperationsRequest KafkaApiOperations = 37;
+        TTopicDeferredPublicationRequest DeferredPublication = 42;
+    }
     optional bool UsePublicResponseDataFormat = 23;
     map<string, Ydb.TypedValue> YdbParameters = 24;
     optional bool IsInternalCall = 25;
@@ -169,7 +191,6 @@ message TQueryRequest {
     optional uint64 OutputChunkMaxSize = 34;
     optional string PoolId = 35;
     optional string DatabaseId = 36;
-    optional TKafkaApiOperationsRequest KafkaApiOperations = 37;
     optional Ydb.Query.SchemaInclusionMode SchemaInclusionMode = 38;
     optional Ydb.ResultSet.Format ResultSetFormat = 39;
     optional Ydb.Formats.ArrowFormatSettings ArrowFormatSettings = 40;

--- a/ydb/core/protos/pqdata_transaction.proto
+++ b/ydb/core/protos/pqdata_transaction.proto
@@ -58,9 +58,20 @@ message TPartitionOperation {
             optional TKafkaProducerInstanceId KafkaProducerInstanceId = 1;
         };
 
+        message TDeferredPublicationApi {
+            enum EOp {
+                Unspecified = 0;
+                Publish = 1;
+                Cancel = 2;
+            };
+
+            optional EOp Op = 1;
+        };
+
         oneof Api {
             TTopicApi Topic = 1;
             TKafkaApi Kafka = 2;
+            TDeferredPublicationApi DeferredPublication = 3;
         };
     };
 
@@ -86,9 +97,16 @@ message TWriteId {
         optional TKafkaProducerInstanceId KafkaProducerInstanceId = 1;
     };
 
+    message TDeferredPublicationApi {
+        optional uint64 IntPublicationId = 1;
+        // Informational copy from BeginPublication; not used to look up the registry on each write.
+        optional string ExtPublicationId = 2;
+    };
+
     oneof Id {
         TTopicApi TopicApi = 5;
         TKafkaApi KafkaApi = 6;
+        TDeferredPublicationApi DeferredPublicationApi = 7;
     }
 };
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

This PR introduces a new “deferred publication” topic-operation flow across KQP and PersQueue/PQ transaction wiring by extending protobuf APIs and teaching KQP’s topic operation builder and write actor to emit the new operation.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
