### PR TITLE
[ydb/library/fyamlcpp] Fix double-free memory on double SetTag() for node

### DIFF
--- a/ydb/library/fyamlcpp/fyamlcpp.cpp
+++ b/ydb/library/fyamlcpp/fyamlcpp.cpp
@@ -989,7 +989,7 @@ std::optional<TString> TNodeOpsBase::Tag(fy_node* node) const {
 void TNodeOpsBase::SetTag(fy_node* node, const TString& tag) {
     ENSURE_NODE_NOT_EMPTY(node);
     auto* str = new TString(std::move(tag));
-    auto* data = new TUserDataHolder(UserData(node), str);
+    auto* data = new TUserDataHolder(str);
     SetUserData(node, data);
     RethrowOnError(fy_node_set_tag(node, str->c_str(), str->length()), node);
 }
@@ -1008,7 +1008,7 @@ bool TNodeOpsBase::HasAnchor(fy_node* node) const {
 
 void TNodeOpsBase::SetAnchor(fy_node* node, const TString& anchor) {
     auto* str = new TString(anchor);
-    auto* data = new TUserDataHolder(UserData(node), str);
+    auto* data = new TUserDataHolder(str);
     SetUserData(node, data);
     RethrowOnError(fy_node_set_anchor(node, str->c_str(), str->length()), node);
 }

--- a/ydb/library/fyamlcpp/fyamlcpp.h
+++ b/ydb/library/fyamlcpp/fyamlcpp.h
@@ -120,13 +120,11 @@ public:
 template <class T>
 class TUserDataHolder : public IBasicUserData {
 public:
-    TUserDataHolder(IBasicUserData* next, T* data)
-        : Next_(next)
-        , Data_(data)
+    TUserDataHolder(T* data)
+        : Data_(data)
     {}
 
 private:
-    std::unique_ptr<IBasicUserData> Next_ = nullptr;
     std::unique_ptr<T> Data_ = nullptr;
 };
 

--- a/ydb/library/fyamlcpp/fyamlcpp_ut.cpp
+++ b/ydb/library/fyamlcpp/fyamlcpp_ut.cpp
@@ -548,4 +548,24 @@ c: bar
         }
     }
 
+    Y_UNIT_TEST(SetTag) {
+        const char *yaml = R"(
+test:
+  field_1: 1
+  field_2: 2
+)";
+
+        auto doc = NFyaml::TDocument::Parse(yaml);
+
+        auto node = doc.Root().Map().at("test");
+
+        UNIT_ASSERT(node);
+
+        for (int i = 0; i < 10; i++) {
+            auto tag = TString("!tag") + ToString(i);
+            node.SetTag(tag);
+
+            UNIT_ASSERT_VALUES_EQUAL(node.Tag(), tag);
+        }
+    }
 }


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

## Bug

Calling `NFyaml::TNodeRef::SetTag()` twice on the same node causes double-free memory.

## Root cause

1. `SetTag()` reads `UserData(node)` -> gets `data1`
2. `SetTag()` creates `TUserDataHolder data2{Next_=data1, ...}`
3. `SetTag()` calls `SetUserData(node, data2)` -> `fy_node_set_meta(node, data2)` -> destroys `data1` via `TDocument::DestroyUserData()`, registered as `fy_node_meta_clear_fn` in `TDocument::TDocument()` -> `TDocument::RegisterUserDataCleanup()` -> `fy_document_register_meta()` (document-registred `fy_node_meta_clear_fn` function is used to clear metadata for all documents nodes - see `fy_node_clear_meta()`).
4. `data2->Next_` == `data1` is now dangling
5. Later `data1` destroyed via `~unique_ptr(Next_)` -> double-free `data1`

Same with `NFyaml::TNodeRef::SetAnchor()`.

## Solution

Remove `TUserDataHolder::Next_` field as it has no usage (chaining of sequentially assigned attributes / anchors is not used anywhere and not available via public interface) and just stores unused data and duplicates memory releasing functionality, causing this bug.

## Tests

New unit-test `FYamlCpp::SetTag()` added:
- crashed before fix
- passed after fix
