### PR TITLE
Fix driver uaf

### DIFF
--- a/ydb/core/fq/libs/row_dispatcher/leader_election.cpp
+++ b/ydb/core/fq/libs/row_dispatcher/leader_election.cpp
@@ -89,6 +89,18 @@ struct TActorSystemPtrMixin {
     NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr ActorSystemPtr = std::make_shared<NKikimr::TDeferredActorLogBackend::TAtomicActorSystemPtr>(nullptr);
 };
 
+template <class TEvent>
+void SendToActorSystem(
+    const NKikimr::TDeferredActorLogBackend::TSharedAtomicActorSystemPtr& actorSystemPtr,
+    const TActorId& actorId,
+    TEvent* event)
+{
+    std::unique_ptr<TEvent> eventHolder(event);
+    if (auto* actorSystem = actorSystemPtr->load(std::memory_order_acquire)) {
+        actorSystem->Send(actorId, eventHolder.release());
+    }
+}
+
 class TLeaderElection: public TActorBootstrapped<TLeaderElection>, public TActorSystemPtrMixin {
 
     enum class EState {
@@ -133,6 +145,7 @@ public:
         NYdb::TDriver driver,
         const TString& tenant,
         const ::NMonitoring::TDynamicCounterPtr& counters);
+    ~TLeaderElection() override;
 
     void Bootstrap();
     void PassAway() override;
@@ -171,6 +184,7 @@ private:
     void ProcessState();
     void ResetState();
     void SetTimeout();
+    void StopYdb();
     NYdb::TDriverConfig GetYdbDriverConfig() const;
 };
 
@@ -190,6 +204,10 @@ TLeaderElection::TLeaderElection(
     , ParentId(parentId)
     , CoordinatorId(coordinatorId)
     , Metrics(counters) {
+}
+
+TLeaderElection::~TLeaderElection() {
+    StopYdb();
 }
 
 ERetryErrorClass RetryFunc(const NYdb::TStatus& status) {
@@ -224,7 +242,7 @@ TYdbSdkRetryPolicy::TPtr MakeSchemaRetryPolicy() {
 void TLeaderElection::Bootstrap() {
     Become(&TLeaderElection::StateFunc);
     Y_ABORT_UNLESS(!ActorSystemPtr->load(std::memory_order_relaxed), "Double ActorSystemPtr init");
-    ActorSystemPtr->store(TActivationContext::ActorSystem(), std::memory_order_relaxed);
+    ActorSystemPtr->store(TActivationContext::ActorSystem(), std::memory_order_release);
 
     LogPrefix = "TLeaderElection " + SelfId().ToString() + " ";
     LOG_ROW_DISPATCHER_DEBUG("Successfully bootstrapped, local coordinator id " << CoordinatorId.ToString()
@@ -292,8 +310,8 @@ void TLeaderElection::ResetState() {
 void TLeaderElection::CreateSemaphore() {
     Session->CreateSemaphore(SemaphoreName, 1 /* limit */)
         .Subscribe(
-        [actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()](const NYdb::NCoordination::TAsyncResult<void>& future) {
-            actorSystem->Send(actorId, new TEvPrivate::TEvCreateSemaphoreResult(future));
+        [actorId = this->SelfId(), actorSystemPtr = ActorSystemPtr](const NYdb::NCoordination::TAsyncResult<void>& future) {
+            SendToActorSystem(actorSystemPtr, actorId, new TEvPrivate::TEvCreateSemaphoreResult(future));
         }); 
 }
 
@@ -314,8 +332,8 @@ void TLeaderElection::AcquireSemaphore() {
         SemaphoreName,
         NYdb::NCoordination::TAcquireSemaphoreSettings().Count(1).Data(strActorId))
         .Subscribe(
-            [actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()](const NYdb::NCoordination::TAsyncResult<bool>& future) {
-                actorSystem->Send(actorId, new TEvPrivate::TEvAcquireSemaphoreResult(future));
+            [actorId = this->SelfId(), actorSystemPtr = ActorSystemPtr](const NYdb::NCoordination::TAsyncResult<bool>& future) {
+                SendToActorSystem(actorSystemPtr, actorId, new TEvPrivate::TEvAcquireSemaphoreResult(future));
             });
 }
 
@@ -327,11 +345,11 @@ void TLeaderElection::StartSession() {
             CoordinationNodePath, 
             NYdb::NCoordination::TSessionSettings()
                 .Timeout(CoordinationSessionTimeout)
-                .OnStopped([actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()]() {
-                    actorSystem->Send(actorId, new TEvPrivate::TEvSessionStopped());
+                .OnStopped([actorId = this->SelfId(), actorSystemPtr = ActorSystemPtr]() {
+                    SendToActorSystem(actorSystemPtr, actorId, new TEvPrivate::TEvSessionStopped());
                 }))
-        .Subscribe([actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()](const NYdb::NCoordination::TAsyncSessionResult& future) {
-                actorSystem->Send(actorId, new TEvPrivate::TEvCreateSessionResult(future));
+        .Subscribe([actorId = this->SelfId(), actorSystemPtr = ActorSystemPtr](const NYdb::NCoordination::TAsyncSessionResult& future) {
+                SendToActorSystem(actorSystemPtr, actorId, new TEvPrivate::TEvCreateSessionResult(future));
             });
 }
 
@@ -388,10 +406,20 @@ void TLeaderElection::Handle(TEvPrivate::TEvAcquireSemaphoreResult::TPtr& ev) {
 
 void TLeaderElection::PassAway() {
     LOG_ROW_DISPATCHER_DEBUG("PassAway");
+    StopYdb();
+    TActorBootstrapped::PassAway();
+}
+
+void TLeaderElection::StopYdb() {
+    ActorSystemPtr->store(nullptr, std::memory_order_release);
+    // Close coordination session while the driver can still cancel/finish its
+    // requests; callbacks are drained by Driver->Stop(true) and dropped above.
+    Session.Clear();
+    YdbConnection.Reset();
     if (Driver) {
         Driver->Stop(true);
+        Driver.reset();
     }
-    TActorBootstrapped::PassAway();
 }
 
 void TLeaderElection::Handle(TEvPrivate::TEvSessionStopped::TPtr&) {
@@ -428,12 +456,12 @@ void TLeaderElection::DescribeSemaphore() {
             .WatchData()
             .WatchOwners()
             .IncludeOwners()
-            .OnChanged([actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()](bool /* isChanged */) {
-                actorSystem->Send(actorId, new TEvPrivate::TEvOnChangedResult());
+            .OnChanged([actorId = this->SelfId(), actorSystemPtr = ActorSystemPtr](bool /* isChanged */) {
+                SendToActorSystem(actorSystemPtr, actorId, new TEvPrivate::TEvOnChangedResult());
             }))
         .Subscribe(
-            [actorId = this->SelfId(), actorSystem = TActivationContext::ActorSystem()](const NYdb::NCoordination::TAsyncDescribeSemaphoreResult& future) {
-                actorSystem->Send(actorId, new TEvPrivate::TEvDescribeSemaphoreResult(future));
+            [actorId = this->SelfId(), actorSystemPtr = ActorSystemPtr](const NYdb::NCoordination::TAsyncDescribeSemaphoreResult& future) {
+                SendToActorSystem(actorSystemPtr, actorId, new TEvPrivate::TEvDescribeSemaphoreResult(future));
             });
 }
 

--- a/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
+++ b/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
@@ -177,11 +177,11 @@ class TSessionContext : public TThrRefBase {
 
 public:
     TSessionContext(
-            TGRpcConnectionsImpl* connections,
+            std::shared_ptr<TGRpcConnectionsImpl> connections,
             TDbDriverStatePtr dbState,
             const std::string& path,
             const TSessionSettings& settings)
-        : Connections_(connections)
+        : Connections_(std::move(connections))
         , DbDriverState_(dbState)
         , Path_(path)
         , Settings_(settings)
@@ -197,8 +197,8 @@ public:
         return result;
     }
 
-    void Start(IQueueClientContextProvider* provider) {
-        auto context = provider->CreateContext();
+    void Start() {
+        auto context = Connections_->CreateContext();
         if (!context) {
             auto status = MakeStatus(EStatus::CLIENT_CANCELLED, "Client is stopped");
             auto promise = std::move(SessionPromise);
@@ -1730,7 +1730,7 @@ private:
     }
 
 private:
-    TGRpcConnectionsImpl* const Connections_;
+    std::shared_ptr<TGRpcConnectionsImpl> Connections_;
     TDbDriverStatePtr DbDriverState_;
     const std::string Path_;
     const TSessionSettings Settings_;
@@ -1850,14 +1850,14 @@ public:
         const TSessionSettings& settings)
     {
         auto session = MakeIntrusive<TSessionContext>(
-            Connections_.get(),
+            Connections_,
             DbDriverState_,
             path,
             settings);
 
         auto result = session->TakeStartResult();
 
-        session->Start(Connections_.get());
+        session->Start();
 
         return result;
     }

--- a/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
+++ b/ydb/public/sdk/cpp/src/client/coordination/coordination.cpp
@@ -333,11 +333,16 @@ private:
     struct TDescribeSemaphoreOp : public TSimpleOp {
         const std::string Name;
         TDescribeSemaphoreSettings Settings;
+        NYdbGrpc::TQueueClientCallbackGuardFactory CallbackGuardFactory;
         TPromise<TDescribeSemaphoreResult> Promise = NewPromise<TDescribeSemaphoreResult>();
 
-        TDescribeSemaphoreOp(const std::string& name, const TDescribeSemaphoreSettings& settings)
+        TDescribeSemaphoreOp(
+                const std::string& name,
+                const TDescribeSemaphoreSettings& settings,
+                NYdbGrpc::TQueueClientCallbackGuardFactory callbackGuardFactory)
             : Name(name)
             , Settings(settings)
+            , CallbackGuardFactory(std::move(callbackGuardFactory))
         {}
 
         void FillRequest(TRequest& req, uint64_t reqId) const override {
@@ -356,7 +361,9 @@ private:
             } else if (Settings.OnChanged_) {
                 std::function<void(bool)> callback;
                 callback.swap(Settings.OnChanged_);
-                callback(false);
+                NYdbGrpc::RunQueueClientCallback(CallbackGuardFactory, [&] {
+                    callback(false);
+                });
             }
         }
     };
@@ -527,7 +534,10 @@ private:
         if (IsClosed()) {
             return MakeClosedResult<TSemaphoreDescription>();
         }
-        auto op = std::make_unique<TDescribeSemaphoreOp>(name, settings);
+        auto op = std::make_unique<TDescribeSemaphoreOp>(
+            name,
+            settings,
+            Connections_->GetCallbackGuardFactory());
         auto future = op->Promise.GetFuture();
         if (IsWriteAllowed()) {
             DoSendSimpleOp(std::move(op));
@@ -856,6 +866,13 @@ private:
     }
 
 private:
+    template<class TCallback>
+    void RunUserCallback(TCallback&& callback) {
+        NYdbGrpc::RunQueueClientCallback(
+            Connections_->GetCallbackGuardFactory(),
+            std::forward<TCallback>(callback));
+    }
+
     void OnProcessorStatus(TStatus status) {
         std::shared_ptr<IQueueClientContext> context;
         TDbDriverStatePtr dbDriverState;
@@ -1023,10 +1040,14 @@ private:
 
         if (stopped) {
             if (notifyExpired && Settings_.OnStateChanged_) {
-                Settings_.OnStateChanged_(ESessionState::EXPIRED);
+                RunUserCallback([this] {
+                    Settings_.OnStateChanged_(ESessionState::EXPIRED);
+                });
             }
             if (Settings_.OnStopped_) {
-                Settings_.OnStopped_();
+                RunUserCallback([this] {
+                    Settings_.OnStopped_();
+                });
             }
             return;
         }
@@ -1228,7 +1249,9 @@ private:
         }
 
         if (detached && Settings_.OnStateChanged_) {
-            Settings_.OnStateChanged_(ESessionState::DETACHED);
+            RunUserCallback([this] {
+                Settings_.OnStateChanged_(ESessionState::DETACHED);
+            });
         }
 
         if (sessionStartTimeoutContext) {
@@ -1442,9 +1465,13 @@ private:
                     }
                 }
                 if (expired && Settings_.OnStateChanged_) {
-                    Settings_.OnStateChanged_(ESessionState::EXPIRED);
+                    RunUserCallback([this] {
+                        Settings_.OnStateChanged_(ESessionState::EXPIRED);
+                    });
                 } else if (detached && Settings_.OnStateChanged_) {
-                    Settings_.OnStateChanged_(ESessionState::DETACHED);
+                    RunUserCallback([this] {
+                        Settings_.OnStateChanged_(ESessionState::DETACHED);
+                    });
                 }
                 return false;
             }
@@ -1475,7 +1502,9 @@ private:
                     }
                 }
                 if (Settings_.OnStateChanged_) {
-                    Settings_.OnStateChanged_(ESessionState::ATTACHED);
+                    RunUserCallback([this] {
+                        Settings_.OnStateChanged_(ESessionState::ATTACHED);
+                    });
                 }
                 if (replyPromise.Initialized()) {
                     // If there are no listeners session destructor will be immediately called outside of the lock
@@ -1518,7 +1547,9 @@ private:
                     Y_ABORT_UNLESS(SessionState != ESessionState::ATTACHED);
                 }
                 if (expired && Settings_.OnStateChanged_) {
-                    Settings_.OnStateChanged_(ESessionState::EXPIRED);
+                    RunUserCallback([this] {
+                        Settings_.OnStateChanged_(ESessionState::EXPIRED);
+                    });
                 }
                 return false;
             }
@@ -1555,7 +1586,9 @@ private:
                     supersededPromise.SetValue(TResult<bool>(std::move(status), false));
                 }
                 if (acceptedCallback) {
-                    acceptedCallback();
+                    RunUserCallback([callback = std::move(acceptedCallback)] {
+                        callback();
+                    });
                 }
                 return true;
             }
@@ -1636,7 +1669,9 @@ private:
                     }
                 }
                 if (callback) {
-                    callback(triggered);
+                    RunUserCallback([callback = std::move(callback), triggered] {
+                        callback(triggered);
+                    });
                 }
                 return true;
             }

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -366,7 +366,7 @@ TDriver::TDriver(const TDriverConfig& config) {
 }
 
 void TDriver::Stop(bool wait) {
-    if (TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback()) {
+    if (TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() || IsGRpcCompletionThread()) {
         auto impl = Impl_;
         impl->StopFromCallback(std::move(impl), wait);
         return;

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -366,13 +366,10 @@ TDriver::TDriver(const TDriverConfig& config) {
 }
 
 void TDriver::Stop(bool wait) {
-    if (TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() || IsGRpcCompletionThread()) {
-        auto impl = Impl_;
-        impl->StopFromCallback(std::move(impl), wait);
-        return;
-    }
-
-    Impl_->Stop(wait);
+    auto impl = Impl_;
+    TGRpcConnectionsImpl::DeferOrRunNow(impl->StopState_, [impl, wait]() mutable {
+        impl->Stop(wait);
+    });
 }
 
 TDriverConfig TDriver::GetConfig() const {

--- a/ydb/public/sdk/cpp/src/client/driver/driver.cpp
+++ b/ydb/public/sdk/cpp/src/client/driver/driver.cpp
@@ -362,21 +362,16 @@ TDriver::TDriver(const TDriverConfig& config) {
         ythrow yexception() << "Invalid config object";
     }
 
-    Impl_ = std::shared_ptr<TGRpcConnectionsImpl>(new TGRpcConnectionsImpl(config.Impl_), [] (TGRpcConnectionsImpl* impl) {
-        auto destroyImpl = [impl] {
-            impl->Stop(true);
-            delete impl;
-        };
-
-        if (IsGRpcCompletionThread()) {
-            std::thread(std::move(destroyImpl)).detach();
-        } else {
-            destroyImpl();
-        }
-    });
+    Impl_.reset(new TGRpcConnectionsImpl(config.Impl_), TGRpcConnectionsDeleter());
 }
 
 void TDriver::Stop(bool wait) {
+    if (TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback()) {
+        auto impl = Impl_;
+        impl->StopFromCallback(std::move(impl), wait);
+        return;
+    }
+
     Impl_->Stop(wait);
 }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -17,6 +17,13 @@ namespace {
 
         url.assign(to, Quote(to, TStringBuf(url), safe));
     }
+
+    NThreading::TFuture<void> MakeReadyFuture() {
+        auto promise = NThreading::NewPromise<void>();
+        auto future = promise.GetFuture();
+        promise.SetValue();
+        return future;
+    }
 }
 
 namespace NYdb::inline Dev {
@@ -286,7 +293,8 @@ void TDbDriverState::PostToResponseQueue(TPostTaskCb&& f) {
 }
 
 NThreading::TFuture<void> TDbDriverStateTracker::SendNotification(
-    TDbDriverState::ENotifyType type
+    TDbDriverState::ENotifyType type,
+    TNotificationCbRunner cbRunner
 ) {
     std::vector<std::weak_ptr<TDbDriverState>> states;
     {
@@ -303,7 +311,7 @@ NThreading::TFuture<void> TDbDriverStateTracker::SendNotification(
             std::lock_guard lock(strong->NotifyCbsLock);
             for (auto& cb : strong->NotifyCbs[static_cast<size_t>(type)]) {
                 if (cb) {
-                    auto future = cb();
+                    auto future = cbRunner ? cbRunner(cb) : cb();
                     if (!future.HasException()) {
                         results.push_back(future);
                     }
@@ -311,6 +319,9 @@ NThreading::TFuture<void> TDbDriverStateTracker::SendNotification(
                 }
             }
         }
+    }
+    if (results.empty()) {
+        return MakeReadyFuture();
     }
     return NThreading::WaitExceptionOrAll(results);
 }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.cpp
@@ -18,12 +18,6 @@ namespace {
         url.assign(to, Quote(to, TStringBuf(url), safe));
     }
 
-    NThreading::TFuture<void> MakeReadyFuture() {
-        auto promise = NThreading::NewPromise<void>();
-        auto future = promise.GetFuture();
-        promise.SetValue();
-        return future;
-    }
 }
 
 namespace NYdb::inline Dev {
@@ -321,7 +315,7 @@ NThreading::TFuture<void> TDbDriverStateTracker::SendNotification(
         }
     }
     if (results.empty()) {
-        return MakeReadyFuture();
+        return NThreading::MakeFuture();
     }
     return NThreading::WaitExceptionOrAll(results);
 }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/db_driver_state/state.h
@@ -98,6 +98,8 @@ class TDbDriverStateTracker {
     };
 public:
     TDbDriverStateTracker(IInternalClient* client);
+    using TNotificationCbRunner = std::function<NThreading::TFuture<void>(TDbDriverState::TCb& cb)>;
+
     TDbDriverState::TPtr GetDriverState(
         const std::string& database,
         const std::string& discoveryEndpoint,
@@ -106,7 +108,8 @@ public:
         std::shared_ptr<ICredentialsProviderFactory> credentialsProviderFactory
     );
     NThreading::TFuture<void> SendNotification(
-        TDbDriverState::ENotifyType type);
+        TDbDriverState::ENotifyType type,
+        TNotificationCbRunner cbRunner = {});
     void SetMetricRegistry(::NMonitoring::TMetricRegistry *sensorsRegistry);
 private:
     IInternalClient* DiscoveryClient_;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.h
@@ -30,6 +30,15 @@ using TResponseCb = std::function<void(TResponse*, TPlainStatus status)>;
 using TDeferredOperationCb = std::function<void(Ydb::Operations::Operation*, TPlainStatus status)>;
 using TDelayedCb = std::function<void(bool ok)>;
 
+inline TPlainStatus MakeClientStoppedStatus() {
+    return TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped");
+}
+
+class TQueueResponse : public IObjectInQueue {
+public:
+    virtual void Cancel() = 0;
+};
+
 template<typename TCb>
 class TGenericCbHolder {
 protected:
@@ -119,7 +128,7 @@ private:
 template<typename TResponse>
 class TGRpcErrorResponse
     : public TGenericCbHolder<TResponseCb<TResponse>>
-    , public IObjectInQueue
+    , public TQueueResponse
 {
 public:
     TGRpcErrorResponse(
@@ -147,6 +156,12 @@ public:
         delete this;
     }
 
+    void Cancel() override {
+        this->Context_.reset();
+        this->UserResponseCb_(nullptr, MakeClientStoppedStatus());
+        delete this;
+    }
+
 private:
     NYdbGrpc::TGrpcStatus GRpcStatus_;
     std::string Endpoint_;
@@ -155,7 +170,7 @@ private:
 template<typename TResponse>
 class TResult
     : public TGenericCbHolder<TResponseCb<TResponse>>
-    , public IObjectInQueue
+    , public TQueueResponse
 {
 public:
     TResult(
@@ -175,6 +190,12 @@ public:
     void Process(void*) override {
         this->Context_.reset();
         this->UserResponseCb_(&Response_, TPlainStatus{GRpcStatus_, Endpoint_, std::move(Metadata_)});
+        delete this;
+    }
+
+    void Cancel() override {
+        this->Context_.reset();
+        this->UserResponseCb_(nullptr, MakeClientStoppedStatus());
         delete this;
     }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.h
@@ -14,6 +14,8 @@
 
 #include <grpcpp/alarm.h>
 
+#include <memory>
+
 namespace NYdb::inline Dev {
 
 using NYdbGrpc::IQueueClientContext;
@@ -135,6 +137,7 @@ public:
             status.Issues.AddIssue(NYdb::NIssue::TIssue(msg));
         }
 
+        this->Context_.reset();
         this->UserResponseCb_(nullptr, status);
         delete this;
     }
@@ -165,6 +168,7 @@ public:
         , Metadata_(std::move(metadata)) {}
 
     void Process(void*) override {
+        this->Context_.reset();
         this->UserResponseCb_(&Response_, TPlainStatus{GRpcStatus_, Endpoint_, std::move(Metadata_)});
         delete this;
     }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/actions.h
@@ -89,11 +89,16 @@ private:
             LocalContext_.reset();
         }
 
-        if (ok) {
-            OnAlarm();
-        } else {
-            OnError();
-        }
+        auto guardFactory = this->Context_
+            ? this->Context_->GetCallbackGuardFactory()
+            : NYdbGrpc::TQueueClientCallbackGuardFactory();
+        NYdbGrpc::RunQueueClientCallback(guardFactory, [&] {
+            if (ok) {
+                OnAlarm();
+            } else {
+                OnError();
+            }
+        });
 
         return false;
     }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -4,7 +4,6 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/exceptions/exceptions.h>
 #include <ydb/public/sdk/cpp/src/client/impl/observability/constants.h>
 
-#include <future>
 #include <string>
 #include <thread>
 #include <utility>
@@ -14,23 +13,31 @@ namespace NYdb::inline Dev {
 
 namespace {
     thread_local ui32 SdkResponseCallbackDepth = 0;
-    thread_local std::shared_ptr<std::promise<void>> SdkResponseCallbackDonePromise;
-    thread_local std::shared_future<void> SdkResponseCallbackDone;
 
     template<class TCallback>
-    void RunAfterCurrentSdkCallback(TCallback&& callback) {
-        auto callbackDone = SdkResponseCallbackDone;
-
+    void RunAfterCurrentSdkCallback(std::shared_ptr<TDriverStopState> stopState, TCallback&& callback) {
+        // A fresh detached thread that runs to completion and exits: deferring onto a single
+        // long-lived worker instead was tried and regressed (a permanently-blocked worker
+        // faults at process teardown). Teardown-from-callback is rare, so on-demand is fine.
         try {
-            std::thread([callback = std::forward<TCallback>(callback), callbackDone = std::move(callbackDone)]() mutable {
-                if (callbackDone.valid()) {
-                    callbackDone.wait();
+            std::thread([stopState = std::move(stopState), callback = std::forward<TCallback>(callback)]() mutable {
+                // Wait until every in-flight SDK callback (including the one that scheduled
+                // us) has returned before touching the driver, so we never free it or join
+                // its threads from under a live callback frame.
+                if (stopState) {
+                    stopState->WaitCallbacksDrained();
                 }
                 callback();
             }).detach();
         } catch (...) {
             Y_ABORT("Failed to defer YDB driver action from SDK callback thread");
         }
+    }
+
+    TQueueClientCallbackGuardFactory MakeSdkCallbackGuardFactory(std::shared_ptr<TDriverStopState> stopState) {
+        return [stopState = std::move(stopState)] {
+            return std::make_unique<TSdkCallbackGuard>(stopState);
+        };
     }
 
     class TSdkQueueClientContext final : public NYdbGrpc::IQueueClientContext {
@@ -52,10 +59,7 @@ namespace {
         }
 
         TQueueClientCallbackGuardFactory GetCallbackGuardFactory() override {
-            auto stopState = StopState_;
-            return [stopState = std::move(stopState)] {
-                return std::make_unique<TSdkCallbackGuard>(stopState);
-            };
+            return MakeSdkCallbackGuardFactory(StopState_);
         }
 
         grpc::CompletionQueue* CompletionQueue() override {
@@ -97,14 +101,6 @@ void TDriverStopState::LeaveCallback() noexcept {
     }
 }
 
-void TDriverStopState::StartStopping() noexcept {
-    Stopping_.store(true, std::memory_order_release);
-}
-
-bool TDriverStopState::IsStopping() const noexcept {
-    return Stopping_.load(std::memory_order_acquire);
-}
-
 void TDriverStopState::WaitCallbacksDrained() {
     std::unique_lock lock(Mutex_);
     Drained_.wait(lock, [this] {
@@ -124,9 +120,8 @@ TSdkCallbackGuard::TSdkCallbackGuard(std::shared_ptr<TDriverStopState> stopState
     : StopState_(std::move(stopState))
 {
     Entered_ = !StopState_ || StopState_->TryEnterCallback();
-    if (Entered_ && ++SdkResponseCallbackDepth == 1) {
-        SdkResponseCallbackDonePromise = std::make_shared<std::promise<void>>();
-        SdkResponseCallbackDone = SdkResponseCallbackDonePromise->get_future().share();
+    if (Entered_) {
+        ++SdkResponseCallbackDepth;
     }
 }
 
@@ -135,11 +130,7 @@ TSdkCallbackGuard::~TSdkCallbackGuard() {
         return;
     }
 
-    if (--SdkResponseCallbackDepth == 0) {
-        SdkResponseCallbackDonePromise->set_value();
-        SdkResponseCallbackDonePromise.reset();
-        SdkResponseCallbackDone = {};
-    }
+    --SdkResponseCallbackDepth;
 
     if (StopState_) {
         StopState_->LeaveCallback();
@@ -390,12 +381,13 @@ bool TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() noexcept {
     return SdkResponseCallbackDepth != 0;
 }
 
-void TGRpcConnectionsImpl::StopFromCallback(std::shared_ptr<TGRpcConnectionsImpl> self, bool wait) {
-    // Waiting on an SDK callback thread may deadlock the response path needed to finish stop.
-    RunAfterCurrentSdkCallback(
-        [self = std::move(self), wait]() mutable {
-            self->Stop(wait);
-        });
+void TGRpcConnectionsImpl::DeferOrRunNow(std::shared_ptr<TDriverStopState> stopState, std::function<void()> action) {
+    if (!IsCurrentThreadInSdkCallback() && !NYdbGrpc::IsGRpcCompletionThread()) {
+        action();
+        return;
+    }
+
+    RunAfterCurrentSdkCallback(std::move(stopState), std::move(action));
 }
 
 void TGRpcConnectionsDeleter::operator()(TGRpcConnectionsImpl* connections) const noexcept {
@@ -403,27 +395,18 @@ void TGRpcConnectionsDeleter::operator()(TGRpcConnectionsImpl* connections) cons
         return;
     }
 
-    if (!TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() && !NYdbGrpc::IsGRpcCompletionThread()) {
+    TGRpcConnectionsImpl::DeferOrRunNow(connections->StopState_, [connections] {
         delete connections;
-        return;
-    }
-
-    RunAfterCurrentSdkCallback(
-        [connections] {
-            delete connections;
-        });
+    });
 }
 
 void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration period) {
     std::shared_ptr<IQueueClientContext> context;
     if (!TryCreateContext(context)) {
         NYdb::NIssue::TIssues issues;
-        TSdkCallbackGuard guard(StopState_);
-        if (guard.IsEntered()) {
-            cb(std::move(issues), EStatus::CLIENT_INTERNAL_ERROR);
-        } else {
-            cb(std::move(issues), EStatus::CLIENT_CANCELLED);
-        }
+        RunGuarded(StopState_,
+            [&] { cb(std::move(issues), EStatus::CLIENT_INTERNAL_ERROR); },
+            [&] { cb(std::move(issues), EStatus::CLIENT_CANCELLED); });
     } else {
         auto action = MakeIntrusive<TPeriodicAction>(
             std::move(cb),
@@ -437,12 +420,9 @@ void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration
 void TGRpcConnectionsImpl::PostToResponseQueue(std::function<void()>&& f) {
     auto stopState = StopState_;
     ResponseQueue_->Post([f = std::move(f), stopState = std::move(stopState)]() mutable {
-        TSdkCallbackGuard guard(stopState);
-        if (!guard.IsEntered()) {
-            return;
-        }
-        auto callback = std::move(f);
-        callback();
+        RunGuarded(stopState,
+            [&] { auto callback = std::move(f); callback(); },
+            [] {});
     });
 }
 
@@ -531,10 +511,7 @@ IQueueClientContextPtr TGRpcConnectionsImpl::CreateContext() {
 }
 
 TQueueClientCallbackGuardFactory TGRpcConnectionsImpl::GetCallbackGuardFactory() {
-    auto stopState = StopState_;
-    return [stopState = std::move(stopState)] {
-        return std::make_unique<TSdkCallbackGuard>(stopState);
-    };
+    return MakeSdkCallbackGuardFactory(StopState_);
 }
 
 bool TGRpcConnectionsImpl::TryCreateContext(IQueueClientContextPtr& context) {
@@ -553,7 +530,6 @@ void TGRpcConnectionsImpl::WaitIdle() {
 }
 
 void TGRpcConnectionsImpl::Stop(bool wait) {
-    StopState_->StartStopping();
     auto stopState = StopState_;
     StateTracker_.SendNotification(
         TDbDriverState::ENotifyType::STOP,
@@ -720,16 +696,15 @@ const TLog& TGRpcConnectionsImpl::GetLog() const {
 void TGRpcConnectionsImpl::EnqueueResponse(IObjectInQueue* action) {
     auto stopState = StopState_;
     ResponseQueue_->Post([action, stopState = std::move(stopState)]() {
-        TSdkCallbackGuard guard(stopState);
-        if (!guard.IsEntered()) {
-            if (auto* response = dynamic_cast<TQueueResponse*>(action)) {
-                response->Cancel();
-            } else {
-                delete action;
-            }
-            return;
-        }
-        action->Process(nullptr);
+        RunGuarded(stopState,
+            [&] { action->Process(nullptr); },
+            [&] {
+                if (auto* response = dynamic_cast<TQueueResponse*>(action)) {
+                    response->Cancel();
+                } else {
+                    delete action;
+                }
+            });
     });
 }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -32,21 +32,122 @@ namespace {
             Y_ABORT("Failed to defer YDB driver action from SDK callback thread");
         }
     }
+
+    class TSdkQueueClientContext final : public NYdbGrpc::IQueueClientContext {
+    public:
+        TSdkQueueClientContext(IQueueClientContextPtr underlying, std::shared_ptr<TDriverStopState> stopState)
+            : Underlying_(std::move(underlying))
+            , StopState_(std::move(stopState))
+        {
+            Y_ABORT_UNLESS(Underlying_);
+            Y_ABORT_UNLESS(StopState_);
+        }
+
+        IQueueClientContextPtr CreateContext() override {
+            auto child = Underlying_->CreateContext();
+            if (!child) {
+                return nullptr;
+            }
+            return std::make_shared<TSdkQueueClientContext>(std::move(child), StopState_);
+        }
+
+        TQueueClientCallbackGuardFactory GetCallbackGuardFactory() override {
+            auto stopState = StopState_;
+            return [stopState = std::move(stopState)] {
+                return std::make_unique<TSdkCallbackGuard>(stopState);
+            };
+        }
+
+        grpc::CompletionQueue* CompletionQueue() override {
+            return Underlying_->CompletionQueue();
+        }
+
+        bool IsCancelled() const override {
+            return Underlying_->IsCancelled();
+        }
+
+        bool Cancel() override {
+            return Underlying_->Cancel();
+        }
+
+        void SubscribeCancel(std::function<void()> callback) override {
+            Underlying_->SubscribeCancel(std::move(callback));
+        }
+
+    private:
+        IQueueClientContextPtr Underlying_;
+        std::shared_ptr<TDriverStopState> StopState_;
+    };
 }
 
-TSdkCallbackGuard::TSdkCallbackGuard() {
-    if (++SdkResponseCallbackDepth == 1) {
+bool TDriverStopState::TryEnterCallback() noexcept {
+    std::unique_lock lock(Mutex_);
+    if (Stopped_) {
+        return false;
+    }
+    ++InFlightCallbacks_;
+    return true;
+}
+
+void TDriverStopState::LeaveCallback() noexcept {
+    std::unique_lock lock(Mutex_);
+    Y_ABORT_UNLESS(InFlightCallbacks_ > 0);
+    if (--InFlightCallbacks_ == 0) {
+        Drained_.notify_all();
+    }
+}
+
+void TDriverStopState::StartStopping() noexcept {
+    Stopping_.store(true, std::memory_order_release);
+}
+
+bool TDriverStopState::IsStopping() const noexcept {
+    return Stopping_.load(std::memory_order_acquire);
+}
+
+void TDriverStopState::WaitCallbacksDrained() {
+    std::unique_lock lock(Mutex_);
+    Drained_.wait(lock, [this] {
+        return InFlightCallbacks_ == 0;
+    });
+}
+
+void TDriverStopState::MarkStopped() noexcept {
+    std::unique_lock lock(Mutex_);
+    Stopped_ = true;
+    if (InFlightCallbacks_ == 0) {
+        Drained_.notify_all();
+    }
+}
+
+TSdkCallbackGuard::TSdkCallbackGuard(std::shared_ptr<TDriverStopState> stopState)
+    : StopState_(std::move(stopState))
+{
+    Entered_ = !StopState_ || StopState_->TryEnterCallback();
+    if (Entered_ && ++SdkResponseCallbackDepth == 1) {
         SdkResponseCallbackDonePromise = std::make_shared<std::promise<void>>();
         SdkResponseCallbackDone = SdkResponseCallbackDonePromise->get_future().share();
     }
 }
 
 TSdkCallbackGuard::~TSdkCallbackGuard() {
+    if (!Entered_) {
+        return;
+    }
+
     if (--SdkResponseCallbackDepth == 0) {
         SdkResponseCallbackDonePromise->set_value();
         SdkResponseCallbackDonePromise.reset();
         SdkResponseCallbackDone = {};
     }
+
+    if (StopState_) {
+        StopState_->LeaveCallback();
+    }
+}
+
+bool TSdkCallbackGuard::IsEntered() const noexcept {
+    return Entered_;
 }
 
 bool IsTokenCorrect(const std::string& in) {
@@ -106,9 +207,12 @@ protected:
     TScheduledObject() { }
 
     void Start(TDuration timeout, IQueueClientContextProvider* provider) {
+        CallbackGuardFactory = provider->GetCallbackGuardFactory();
         auto context = provider->CreateContext();
         if (!context) {
-            Derived()->OnComplete(false);
+            NYdbGrpc::RunQueueClientCallback(CallbackGuardFactory, [&] {
+                Derived()->OnComplete(false);
+            });
             return;
         }
 
@@ -135,13 +239,16 @@ private:
             Context.reset();
         }
 
-        Derived()->OnComplete(ok);
+        NYdbGrpc::RunQueueClientCallback(CallbackGuardFactory, [&] {
+            Derived()->OnComplete(ok);
+        });
     }
 
 private:
     std::mutex Mutex;
     IQueueClientContextPtr Context;
     grpc::Alarm Alarm;
+    TQueueClientCallbackGuardFactory CallbackGuardFactory;
 
 private:
     using TFixedEvent = NYdbGrpc::TQueueClientFixedEvent<TSelf>;
@@ -164,7 +271,6 @@ public:
     }
 
     void OnComplete(bool ok) {
-        TSdkCallbackGuard guard;
         auto callback = std::move(Callback);
         callback(ok);
     }
@@ -201,6 +307,7 @@ private:
 TGRpcConnectionsImpl::TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> params)
     : MetricRegistryPtr_(nullptr)
     , ClientThreadsNum_(params->GetClientThreadsNum())
+    , StopState_(std::make_shared<TDriverStopState>())
     , DefaultDiscoveryEndpoint_(params->GetEndpoint())
     , SslCredentials_(params->GetSslCredentials())
     , DefaultDatabase_(params->GetDatabase())
@@ -269,8 +376,8 @@ TGRpcConnectionsImpl::TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> p
 }
 
 TGRpcConnectionsImpl::~TGRpcConnectionsImpl() {
-    GRpcClientLow_.Stop(true);
-    ResponseQueue_->Stop();
+    Stop(true);
+    StopState_->MarkStopped();
 }
 
 bool TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() noexcept {
@@ -290,7 +397,7 @@ void TGRpcConnectionsDeleter::operator()(TGRpcConnectionsImpl* connections) cons
         return;
     }
 
-    if (!TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback()) {
+    if (!TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() && !NYdbGrpc::IsGRpcCompletionThread()) {
         delete connections;
         return;
     }
@@ -305,7 +412,10 @@ void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration
     std::shared_ptr<IQueueClientContext> context;
     if (!TryCreateContext(context)) {
         NYdb::NIssue::TIssues issues;
-        cb(std::move(issues), EStatus::CLIENT_INTERNAL_ERROR);
+        TSdkCallbackGuard guard(StopState_);
+        if (guard.IsEntered()) {
+            cb(std::move(issues), EStatus::CLIENT_INTERNAL_ERROR);
+        }
     } else {
         auto action = MakeIntrusive<TPeriodicAction>(
             std::move(cb),
@@ -317,8 +427,12 @@ void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration
 }
 
 void TGRpcConnectionsImpl::PostToResponseQueue(std::function<void()>&& f) {
-    ResponseQueue_->Post([f = std::move(f)]() mutable {
-        TSdkCallbackGuard guard;
+    auto stopState = StopState_;
+    ResponseQueue_->Post([f = std::move(f), stopState = std::move(stopState)]() mutable {
+        TSdkCallbackGuard guard(stopState);
+        if (!guard.IsEntered()) {
+            return;
+        }
         auto callback = std::move(f);
         callback();
     });
@@ -364,7 +478,7 @@ NThreading::TFuture<bool> TGRpcConnectionsImpl::ScheduleFuture(
 {
     IQueueClientContextProvider* provider = context.get();
     if (!provider) {
-        provider = &GRpcClientLow_;
+        provider = this;
     }
 
     return MakeIntrusive<TScheduledFuture>()
@@ -378,7 +492,7 @@ void TGRpcConnectionsImpl::ScheduleCallback(
 {
     IQueueClientContextProvider* provider = context.get();
     if (!provider) {
-        provider = &GRpcClientLow_;
+        provider = this;
     }
 
     return MakeIntrusive<TScheduledCallback>(std::move(callback))
@@ -401,7 +515,18 @@ TDbDriverStatePtr TGRpcConnectionsImpl::GetDriverState(
 }
 
 IQueueClientContextPtr TGRpcConnectionsImpl::CreateContext() {
-    return GRpcClientLow_.CreateContext();
+    auto context = GRpcClientLow_.CreateContext();
+    if (!context) {
+        return nullptr;
+    }
+    return std::make_shared<TSdkQueueClientContext>(std::move(context), StopState_);
+}
+
+TQueueClientCallbackGuardFactory TGRpcConnectionsImpl::GetCallbackGuardFactory() {
+    auto stopState = StopState_;
+    return [stopState = std::move(stopState)] {
+        return std::make_unique<TSdkCallbackGuard>(stopState);
+    };
 }
 
 bool TGRpcConnectionsImpl::TryCreateContext(IQueueClientContextPtr& context) {
@@ -420,8 +545,26 @@ void TGRpcConnectionsImpl::WaitIdle() {
 }
 
 void TGRpcConnectionsImpl::Stop(bool wait) {
-    StateTracker_.SendNotification(TDbDriverState::ENotifyType::STOP).Wait();
+    StopState_->StartStopping();
+    auto stopState = StopState_;
+    StateTracker_.SendNotification(
+        TDbDriverState::ENotifyType::STOP,
+        [stopState = std::move(stopState)](TDbDriverState::TCb& cb) {
+            TSdkCallbackGuard guard(stopState);
+            if (guard.IsEntered()) {
+                return cb();
+            }
+
+            auto promise = NThreading::NewPromise<void>();
+            auto future = promise.GetFuture();
+            promise.SetValue();
+            return future;
+        }).Wait();
     GRpcClientLow_.Stop(wait);
+    if (wait) {
+        StopResponseQueue();
+        StopState_->WaitCallbacksDrained();
+    }
 }
 
 void TGRpcConnectionsImpl::SetGrpcKeepAlive(NYdbGrpc::TGRpcClientConfig& config, const TDeadline::Duration& timeout, bool permitWithoutCalls) {
@@ -475,9 +618,14 @@ TAsyncListEndpointsResult TGRpcConnectionsImpl::GetEndpoints(TDbDriverStatePtr d
 
     std::weak_ptr<TDbDriverState> weakState = dbState;
 
-    return promise.GetFuture().Apply([this, weakState](NThreading::TFuture<TListEndpointsResult> future){
+    auto stopState = StopState_;
+    return promise.GetFuture().Apply([this, weakState, stopState = std::move(stopState)](NThreading::TFuture<TListEndpointsResult> future){
         auto strong = weakState.lock();
         auto result = future.ExtractValue();
+        TSdkCallbackGuard guard(stopState);
+        if (!guard.IsEntered()) {
+            return NThreading::MakeFuture<TListEndpointsResult>(std::move(result));
+        }
         if (strong && result.DiscoveryStatus.IsTransportError()) {
             strong->StatCollector.IncDiscoveryFailDueTransportError();
         }
@@ -565,9 +713,20 @@ const TLog& TGRpcConnectionsImpl::GetLog() const {
 }
 
 void TGRpcConnectionsImpl::EnqueueResponse(IObjectInQueue* action) {
-    ResponseQueue_->Post([action]() {
-        TSdkCallbackGuard guard;
+    auto stopState = StopState_;
+    ResponseQueue_->Post([action, stopState = std::move(stopState)]() {
+        TSdkCallbackGuard guard(stopState);
+        if (!guard.IsEntered()) {
+            delete action;
+            return;
+        }
         action->Process(nullptr);
+    });
+}
+
+void TGRpcConnectionsImpl::StopResponseQueue() {
+    std::call_once(ResponseQueueStopOnce_, [this] {
+        ResponseQueue_->Stop();
     });
 }
 

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -203,6 +203,16 @@ class TScheduledObject : public TThrRefBase {
         return static_cast<TDerived*>(this);
     }
 
+    void Complete(bool ok) {
+        bool entered = true;
+        std::unique_ptr<NYdbGrpc::IQueueClientCallbackGuard> guard;
+        if (CallbackGuardFactory) {
+            guard = CallbackGuardFactory();
+            entered = !guard || guard->IsEntered();
+        }
+        Derived()->OnComplete(entered ? ok : false);
+    }
+
 protected:
     TScheduledObject() { }
 
@@ -210,9 +220,7 @@ protected:
         CallbackGuardFactory = provider->GetCallbackGuardFactory();
         auto context = provider->CreateContext();
         if (!context) {
-            NYdbGrpc::RunQueueClientCallback(CallbackGuardFactory, [&] {
-                Derived()->OnComplete(false);
-            });
+            Complete(false);
             return;
         }
 
@@ -239,9 +247,7 @@ private:
             Context.reset();
         }
 
-        NYdbGrpc::RunQueueClientCallback(CallbackGuardFactory, [&] {
-            Derived()->OnComplete(ok);
-        });
+        Complete(ok);
     }
 
 private:
@@ -415,6 +421,8 @@ void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration
         TSdkCallbackGuard guard(StopState_);
         if (guard.IsEntered()) {
             cb(std::move(issues), EStatus::CLIENT_INTERNAL_ERROR);
+        } else {
+            cb(std::move(issues), EStatus::CLIENT_CANCELLED);
         }
     } else {
         auto action = MakeIntrusive<TPeriodicAction>(
@@ -555,10 +563,7 @@ void TGRpcConnectionsImpl::Stop(bool wait) {
                 return cb();
             }
 
-            auto promise = NThreading::NewPromise<void>();
-            auto future = promise.GetFuture();
-            promise.SetValue();
-            return future;
+            return NThreading::MakeFuture();
         }).Wait();
     GRpcClientLow_.Stop(wait);
     if (wait) {
@@ -717,7 +722,11 @@ void TGRpcConnectionsImpl::EnqueueResponse(IObjectInQueue* action) {
     ResponseQueue_->Post([action, stopState = std::move(stopState)]() {
         TSdkCallbackGuard guard(stopState);
         if (!guard.IsEntered()) {
-            delete action;
+            if (auto* response = dynamic_cast<TQueueResponse*>(action)) {
+                response->Cancel();
+            } else {
+                delete action;
+            }
             return;
         }
         action->Process(nullptr);

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -4,10 +4,50 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/exceptions/exceptions.h>
 #include <ydb/public/sdk/cpp/src/client/impl/observability/constants.h>
 
+#include <future>
 #include <string>
+#include <thread>
+#include <utility>
 
 
 namespace NYdb::inline Dev {
+
+namespace {
+    thread_local ui32 SdkResponseCallbackDepth = 0;
+    thread_local std::shared_ptr<std::promise<void>> SdkResponseCallbackDonePromise;
+    thread_local std::shared_future<void> SdkResponseCallbackDone;
+
+    template<class TCallback>
+    void RunAfterCurrentSdkCallback(TCallback&& callback) {
+        auto callbackDone = SdkResponseCallbackDone;
+
+        try {
+            std::thread([callback = std::forward<TCallback>(callback), callbackDone = std::move(callbackDone)]() mutable {
+                if (callbackDone.valid()) {
+                    callbackDone.wait();
+                }
+                callback();
+            }).detach();
+        } catch (...) {
+            Y_ABORT("Failed to defer YDB driver action from SDK callback thread");
+        }
+    }
+}
+
+TSdkCallbackGuard::TSdkCallbackGuard() {
+    if (++SdkResponseCallbackDepth == 1) {
+        SdkResponseCallbackDonePromise = std::make_shared<std::promise<void>>();
+        SdkResponseCallbackDone = SdkResponseCallbackDonePromise->get_future().share();
+    }
+}
+
+TSdkCallbackGuard::~TSdkCallbackGuard() {
+    if (--SdkResponseCallbackDepth == 0) {
+        SdkResponseCallbackDonePromise->set_value();
+        SdkResponseCallbackDonePromise.reset();
+        SdkResponseCallbackDone = {};
+    }
+}
 
 bool IsTokenCorrect(const std::string& in) {
     for (char c : in) {
@@ -124,8 +164,9 @@ public:
     }
 
     void OnComplete(bool ok) {
-        Callback(ok);
-        Callback = { };
+        TSdkCallbackGuard guard;
+        auto callback = std::move(Callback);
+        callback(ok);
     }
 
 private:
@@ -232,6 +273,34 @@ TGRpcConnectionsImpl::~TGRpcConnectionsImpl() {
     ResponseQueue_->Stop();
 }
 
+bool TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback() noexcept {
+    return SdkResponseCallbackDepth != 0;
+}
+
+void TGRpcConnectionsImpl::StopFromCallback(std::shared_ptr<TGRpcConnectionsImpl> self, bool wait) {
+    // Waiting on an SDK callback thread may deadlock the response path needed to finish stop.
+    RunAfterCurrentSdkCallback(
+        [self = std::move(self), wait]() mutable {
+            self->Stop(wait);
+        });
+}
+
+void TGRpcConnectionsDeleter::operator()(TGRpcConnectionsImpl* connections) const noexcept {
+    if (!connections) {
+        return;
+    }
+
+    if (!TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback()) {
+        delete connections;
+        return;
+    }
+
+    RunAfterCurrentSdkCallback(
+        [connections] {
+            delete connections;
+        });
+}
+
 void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration period) {
     std::shared_ptr<IQueueClientContext> context;
     if (!TryCreateContext(context)) {
@@ -248,7 +317,11 @@ void TGRpcConnectionsImpl::AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration
 }
 
 void TGRpcConnectionsImpl::PostToResponseQueue(std::function<void()>&& f) {
-    ResponseQueue_->Post(std::move(f));
+    ResponseQueue_->Post([f = std::move(f)]() mutable {
+        TSdkCallbackGuard guard;
+        auto callback = std::move(f);
+        callback();
+    });
 }
 
 void TGRpcConnectionsImpl::ScheduleDelayedTask(TSimpleCb&& fn, TDeadline deadline) {
@@ -493,6 +566,7 @@ const TLog& TGRpcConnectionsImpl::GetLog() const {
 
 void TGRpcConnectionsImpl::EnqueueResponse(IObjectInQueue* action) {
     ResponseQueue_->Post([action]() {
+        TSdkCallbackGuard guard;
         action->Process(nullptr);
     });
 }

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -50,14 +50,10 @@ public:
     bool TryEnterCallback() noexcept;
     void LeaveCallback() noexcept;
 
-    void StartStopping() noexcept;
-    bool IsStopping() const noexcept;
-
     void WaitCallbacksDrained();
     void MarkStopped() noexcept;
 
 private:
-    std::atomic<bool> Stopping_{false};
     std::mutex Mutex_;
     std::condition_variable Drained_;
     ui64 InFlightCallbacks_ = 0;
@@ -76,6 +72,19 @@ private:
     bool Entered_ = false;
 };
 
+// Runs onEntered() while the driver is not stopping, otherwise onStopped().
+// The single choke point behind every SDK-level guarded callback: it decides
+// run-vs-substitute and keeps the in-flight-callback drain counter correct.
+template<class TOnEntered, class TOnStopped>
+void RunGuarded(const std::shared_ptr<TDriverStopState>& stopState, TOnEntered&& onEntered, TOnStopped&& onStopped) {
+    TSdkCallbackGuard guard(stopState);
+    if (guard.IsEntered()) {
+        std::forward<TOnEntered>(onEntered)();
+    } else {
+        std::forward<TOnStopped>(onStopped)();
+    }
+}
+
 std::string GetAuthInfo(TDbDriverStatePtr p);
 std::string CreateSDKBuildInfo();
 
@@ -85,14 +94,18 @@ class TGRpcConnectionsImpl
 {
     friend class TDeferredAction;
     friend class TDriver;
+    friend struct TGRpcConnectionsDeleter;
 public:
     TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> params);
     ~TGRpcConnectionsImpl();
 
     static bool IsCurrentThreadInSdkCallback() noexcept;
 
-private:
-    void StopFromCallback(std::shared_ptr<TGRpcConnectionsImpl> self, bool wait);
+    // Runs action() now if the caller is on a normal thread, otherwise defers it to a
+    // fresh thread that first waits for all in-flight callbacks to drain. Used for
+    // Stop()/delete triggered from within a callback, where running inline would
+    // deadlock (self-join) or free the driver under a live callback frame.
+    static void DeferOrRunNow(std::shared_ptr<TDriverStopState> stopState, std::function<void()> action);
 
 public:
     void AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration period) override;
@@ -208,12 +221,9 @@ public:
         TPlainStatus status,
         const std::shared_ptr<TDriverStopState>& stopState)
     {
-        TSdkCallbackGuard guard(stopState);
-        if (guard.IsEntered()) {
-            callback(response, std::move(status));
-        } else {
-            callback(nullptr, MakeClientStoppedStatus());
-        }
+        RunGuarded(stopState,
+            [&] { callback(response, std::move(status)); },
+            [&] { callback(nullptr, MakeClientStoppedStatus()); });
     }
 
     template<typename TCallback, typename TProcessor>
@@ -223,12 +233,9 @@ public:
         TProcessor processor,
         const std::shared_ptr<TDriverStopState>& stopState)
     {
-        TSdkCallbackGuard guard(stopState);
-        if (guard.IsEntered()) {
-            callback(std::move(status), std::move(processor));
-        } else {
-            callback(MakeClientStoppedStatus(), nullptr);
-        }
+        RunGuarded(stopState,
+            [&] { callback(std::move(status), std::move(processor)); },
+            [&] { callback(MakeClientStoppedStatus(), nullptr); });
     }
 
     template<typename TService, typename TCallback>
@@ -239,12 +246,9 @@ public:
         TEndpointKey endpoint,
         const std::shared_ptr<TDriverStopState>& stopState)
     {
-        TSdkCallbackGuard guard(stopState);
-        if (guard.IsEntered()) {
-            callback(std::move(status), std::move(serviceConnection), std::move(endpoint));
-        } else {
-            callback(MakeClientStoppedStatus(), std::unique_ptr<TServiceConnection<TService>>{nullptr}, TEndpointKey{});
-        }
+        RunGuarded(stopState,
+            [&] { callback(std::move(status), std::move(serviceConnection), std::move(endpoint)); },
+            [&] { callback(MakeClientStoppedStatus(), std::unique_ptr<TServiceConnection<TService>>{nullptr}, TEndpointKey{}); });
     }
 
     template<typename TRequest>
@@ -593,12 +597,9 @@ public:
                             };
                             processor->AddFinishedCallback(std::move(finishedCallback));
                             TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                            TSdkCallbackGuard guard(stopState);
-                            if (guard.IsEntered()) {
-                                responseCb(std::move(status), std::move(processor));
-                            } else {
-                                responseCb(MakeClientStoppedStatus(), nullptr);
-                            }
+                            RunGuarded(stopState,
+                                [&] { responseCb(std::move(status), std::move(processor)); },
+                                [&] { responseCb(MakeClientStoppedStatus(), nullptr); });
                         } else {
                             dbState->StatCollector.IncReqFailDueTransportError();
                             dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
@@ -606,12 +607,9 @@ public:
                                 dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                             }
                             TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                            TSdkCallbackGuard guard(stopState);
-                            if (guard.IsEntered()) {
-                                responseCb(std::move(status), nullptr);
-                            } else {
-                                responseCb(MakeClientStoppedStatus(), nullptr);
-                            }
+                            RunGuarded(stopState,
+                                [&] { responseCb(std::move(status), nullptr); },
+                                [&] { responseCb(MakeClientStoppedStatus(), nullptr); });
                         }
                     };
 
@@ -687,12 +685,9 @@ public:
                                 };
                                 processor->AddFinishedCallback(std::move(finishedCallback));
                                 TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                                TSdkCallbackGuard guard(stopState);
-                                if (guard.IsEntered()) {
-                                    connectedCallback(std::move(status), std::move(processor));
-                                } else {
-                                    connectedCallback(MakeClientStoppedStatus(), nullptr);
-                                }
+                                RunGuarded(stopState,
+                                    [&] { connectedCallback(std::move(status), std::move(processor)); },
+                                    [&] { connectedCallback(MakeClientStoppedStatus(), nullptr); });
                             } else {
                                 dbState->StatCollector.IncReqFailDueTransportError();
                                 dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
@@ -700,12 +695,9 @@ public:
                                     dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                                 }
                                 TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                                TSdkCallbackGuard guard(stopState);
-                                if (guard.IsEntered()) {
-                                    connectedCallback(std::move(status), nullptr);
-                                } else {
-                                    connectedCallback(MakeClientStoppedStatus(), nullptr);
-                                }
+                                RunGuarded(stopState,
+                                    [&] { connectedCallback(std::move(status), nullptr); },
+                                    [&] { connectedCallback(MakeClientStoppedStatus(), nullptr); });
                             }
                         };
 
@@ -825,26 +817,25 @@ private:
                 asyncResult.first.Subscribe([this, callback = std::move(callback), needUpdateChannels, dbState, preferredEndpoint, endpointPolicy, stopState = std::move(stopState)]
                     (const NThreading::TFuture<TEndpointUpdateResult>& future) mutable {
                     --QueuedRequests_;
-                    TSdkCallbackGuard guard(stopState);
-                    if (!guard.IsEntered()) {
-                        callback(MakeClientStoppedStatus(), TConnection{nullptr}, TEndpointKey{});
-                        return;
-                    }
-                    const auto& updateResult = future.GetValue();
-                    if (needUpdateChannels) {
+                    RunGuarded(stopState,
+                        [&] {
+                            const auto& updateResult = future.GetValue();
+                            if (needUpdateChannels) {
 #ifndef YDB_GRPC_BYPASS_CHANNEL_POOL
-                        DeleteChannels(updateResult.Removed);
+                                DeleteChannels(updateResult.Removed);
 #endif
-                    }
-                    auto discoveryStatus = updateResult.DiscoveryStatus;
-                    if (discoveryStatus.Status == EStatus::SUCCESS) {
-                        WithServiceConnection<TService>(std::move(callback), dbState, preferredEndpoint, endpointPolicy);
-                    } else {
-                        callback(
-                            TPlainStatus(discoveryStatus.Status, std::move(discoveryStatus.Issues)),
-                            TConnection{nullptr},
-                            TEndpointKey{});
-                    }
+                            }
+                            auto discoveryStatus = updateResult.DiscoveryStatus;
+                            if (discoveryStatus.Status == EStatus::SUCCESS) {
+                                WithServiceConnection<TService>(std::move(callback), dbState, preferredEndpoint, endpointPolicy);
+                            } else {
+                                callback(
+                                    TPlainStatus(discoveryStatus.Status, std::move(discoveryStatus.Issues)),
+                                    TConnection{nullptr},
+                                    TEndpointKey{});
+                            }
+                        },
+                        [&] { callback(MakeClientStoppedStatus(), TConnection{nullptr}, TEndpointKey{}); });
                 });
             }
             return;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -15,6 +15,9 @@
 
 #include <ydb/public/sdk/cpp/src/library/issue/yql_issue_message.h>
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 #include <optional>
 
 namespace NYdb::inline Dev {
@@ -34,16 +37,43 @@ constexpr TDeadline::Duration GET_ENDPOINTS_TIMEOUT = std::chrono::seconds(10); 
 using NYdbGrpc::TCallMeta;
 using NYdbGrpc::IQueueClientContextPtr;
 using NYdbGrpc::IQueueClientContextProvider;
+using NYdbGrpc::IQueueClientCallbackGuard;
+using NYdbGrpc::TQueueClientCallbackGuardFactory;
 
 class ICredentialsProvider;
 
 // Deferred callbacks
 using TDeferredResultCb = std::function<void(google::protobuf::Any*, TPlainStatus status)>;
 
-class TSdkCallbackGuard {
+class TDriverStopState {
 public:
-    TSdkCallbackGuard();
+    bool TryEnterCallback() noexcept;
+    void LeaveCallback() noexcept;
+
+    void StartStopping() noexcept;
+    bool IsStopping() const noexcept;
+
+    void WaitCallbacksDrained();
+    void MarkStopped() noexcept;
+
+private:
+    std::atomic<bool> Stopping_{false};
+    std::mutex Mutex_;
+    std::condition_variable Drained_;
+    ui64 InFlightCallbacks_ = 0;
+    bool Stopped_ = false;
+};
+
+class TSdkCallbackGuard final : public IQueueClientCallbackGuard {
+public:
+    explicit TSdkCallbackGuard(std::shared_ptr<TDriverStopState> stopState = {});
     ~TSdkCallbackGuard();
+
+    bool IsEntered() const noexcept override;
+
+private:
+    std::shared_ptr<TDriverStopState> StopState_;
+    bool Entered_ = false;
 };
 
 std::string GetAuthInfo(TDbDriverStatePtr p);
@@ -91,6 +121,7 @@ public:
         const std::optional<std::shared_ptr<ICredentialsProviderFactory>>& credentialsProviderFactory
     );
     IQueueClientContextPtr CreateContext() override;
+    TQueueClientCallbackGuardFactory GetCallbackGuardFactory() override;
     bool TryCreateContext(IQueueClientContextPtr& context);
     void WaitIdle();
     void Stop(bool wait = false);
@@ -230,13 +261,19 @@ public:
         Y_ABORT_UNLESS(dbState);
 
         if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
-            userResponseCb(nullptr, std::move(*tlsValidationStatus));
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                userResponseCb(nullptr, std::move(*tlsValidationStatus));
+            }
             return;
         }
 
         if (!TryCreateContext(context)) {
             TPlainStatus status(EStatus::CLIENT_CANCELLED, "Client is stopped");
-            userResponseCb(nullptr, TPlainStatus{status.Status, std::move(status.Issues)});
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                userResponseCb(nullptr, TPlainStatus{status.Status, std::move(status.Issues)});
+            }
             return;
         }
 
@@ -258,15 +295,17 @@ public:
         WithServiceConnection<TService>(
             [this, requestWrapper = std::move(requestWrapper), userResponseCb = std::move(userResponseCb), rpc, 
              requestSettings, context = std::move(context), dbState]
-            (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable -> void {
-                if (!status.Ok()) {
-                    context.reset();
-                    TSdkCallbackGuard guard;
-                    userResponseCb(
-                        nullptr,
-                        std::move(status));
-                    return;
-                }
+	            (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable -> void {
+	                if (!status.Ok()) {
+	                    context.reset();
+	                    TSdkCallbackGuard guard(StopState_);
+	                    if (guard.IsEntered()) {
+	                        userResponseCb(
+	                            nullptr,
+	                            std::move(status));
+	                    }
+	                    return;
+	                }
 
                 Y_ABORT_UNLESS(serviceConnection != nullptr);
 
@@ -274,15 +313,17 @@ public:
 
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
-                } catch (const TYdbException& e) {
-                    context.reset();
-                    TSdkCallbackGuard guard;
-                    userResponseCb(
-                        nullptr,
-                        TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what())
-                    );
-                    return;
-                }
+	                } catch (const TYdbException& e) {
+	                    context.reset();
+	                    TSdkCallbackGuard guard(StopState_);
+	                    if (guard.IsEntered()) {
+	                        userResponseCb(
+	                            nullptr,
+	                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what())
+	                        );
+	                    }
+	                    return;
+	                }
 
                 dbState->StatCollector.IncGRpcInFlight();
                 dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
@@ -351,7 +392,10 @@ public:
     {
         if (!TryCreateContext(context)) {
             TPlainStatus status(EStatus::CLIENT_CANCELLED, "Client is stopped");
-            userResponseCb(nullptr, status);
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                userResponseCb(nullptr, status);
+            }
             return;
         }
 
@@ -472,43 +516,53 @@ public:
         using TProcessor = typename NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TPtr;
 
         if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
-            responseCb(std::move(*tlsValidationStatus), nullptr);
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                responseCb(std::move(*tlsValidationStatus), nullptr);
+            }
             return;
         }
 
         if (!TryCreateContext(context)) {
-            responseCb(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                responseCb(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
+            }
             return;
         }
 
         WithServiceConnection<TService>(
-            [this, request, responseCb = std::move(responseCb), rpc, requestSettings, context = std::move(context), dbState](TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
-                if (!status.Ok()) {
-                    context.reset();
-                    TSdkCallbackGuard guard;
-                    responseCb(std::move(status), nullptr);
-                    return;
-                }
+	            [this, request, responseCb = std::move(responseCb), rpc, requestSettings, context = std::move(context), dbState](TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
+	                if (!status.Ok()) {
+	                    context.reset();
+	                    TSdkCallbackGuard guard(StopState_);
+	                    if (guard.IsEntered()) {
+	                        responseCb(std::move(status), nullptr);
+	                    }
+	                    return;
+	                }
 
                 Y_ABORT_UNLESS(serviceConnection != nullptr);
 
                 TCallMeta meta;
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
-                } catch (const TYdbException& e) {
-                    context.reset();
-                    TSdkCallbackGuard guard;
-                    responseCb(
-                        TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
-                        nullptr
-                    );
-                    return;
-                }
+	                } catch (const TYdbException& e) {
+	                    context.reset();
+	                    TSdkCallbackGuard guard(StopState_);
+	                    if (guard.IsEntered()) {
+	                        responseCb(
+	                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
+	                            nullptr
+	                        );
+	                    }
+	                    return;
+	                }
 
                 dbState->StatCollector.IncGRpcInFlight();
                 dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
 
-                auto lowCallback = [responseCb = std::move(responseCb), dbState, endpoint]
+	                auto lowCallback = [responseCb = std::move(responseCb), dbState, endpoint, stopState = StopState_]
                     (TGrpcStatus grpcStatus, TProcessor processor) mutable {
                         dbState->StatCollector.DecGRpcInFlight();
                         dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
@@ -520,21 +574,25 @@ public:
                                     dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                                 }
                             };
-                            processor->AddFinishedCallback(std::move(finishedCallback));
-                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                            TSdkCallbackGuard guard;
-                            responseCb(std::move(status), std::move(processor));
-                        } else {
+	                            processor->AddFinishedCallback(std::move(finishedCallback));
+	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+		                            TSdkCallbackGuard guard(stopState);
+	                            if (guard.IsEntered()) {
+	                                responseCb(std::move(status), std::move(processor));
+	                            }
+	                        } else {
                             dbState->StatCollector.IncReqFailDueTransportError();
                             dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
                             if (grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
                                 dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
-                            }
-                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                            TSdkCallbackGuard guard;
-                            responseCb(std::move(status), nullptr);
-                        }
-                    };
+	                            }
+	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+		                            TSdkCallbackGuard guard(stopState);
+	                            if (guard.IsEntered()) {
+	                                responseCb(std::move(status), nullptr);
+	                            }
+	                        }
+	                    };
 
                 serviceConnection->template DoStreamRequest<TRequest, TResponse>(
                     request,
@@ -558,44 +616,54 @@ public:
         using TProcessor = typename NYdbGrpc::IStreamRequestReadWriteProcessor<TRequest, TResponse>::TPtr;
 
         if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
-            connectedCallback(std::move(*tlsValidationStatus), nullptr);
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                connectedCallback(std::move(*tlsValidationStatus), nullptr);
+            }
             return;
         }
 
         if (!TryCreateContext(context)) {
-            connectedCallback(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
+            TSdkCallbackGuard guard(StopState_);
+            if (guard.IsEntered()) {
+                connectedCallback(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
+            }
             return;
         }
 
         WithServiceConnection<TService>(
             [this, connectedCallback = std::move(connectedCallback), rpc, requestSettings, context = std::move(context), dbState]
-            (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
-                if (!status.Ok()) {
-                    context.reset();
-                    TSdkCallbackGuard guard;
-                    connectedCallback(std::move(status), nullptr);
-                    return;
-                }
+	            (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
+	                if (!status.Ok()) {
+	                    context.reset();
+	                    TSdkCallbackGuard guard(StopState_);
+	                    if (guard.IsEntered()) {
+	                        connectedCallback(std::move(status), nullptr);
+	                    }
+	                    return;
+	                }
 
                 Y_ABORT_UNLESS(serviceConnection != nullptr);
 
                 TCallMeta meta;
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
-                } catch (const TYdbException& e) {
-                    context.reset();
-                    TSdkCallbackGuard guard;
-                    connectedCallback(
-                        TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
-                        nullptr
-                    );
-                    return;
-                }
+	                } catch (const TYdbException& e) {
+	                    context.reset();
+	                    TSdkCallbackGuard guard(StopState_);
+	                    if (guard.IsEntered()) {
+	                        connectedCallback(
+	                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
+	                            nullptr
+	                        );
+	                    }
+	                    return;
+	                }
 
                 dbState->StatCollector.IncGRpcInFlight();
                 dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
 
-                auto lowCallback = [connectedCallback = std::move(connectedCallback), dbState, endpoint]
+	                auto lowCallback = [connectedCallback = std::move(connectedCallback), dbState, endpoint, stopState = StopState_]
                     (TGrpcStatus grpcStatus, TProcessor processor) {
                         dbState->StatCollector.DecGRpcInFlight();
                         dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
@@ -607,21 +675,25 @@ public:
                                     dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                                 }
                             };
-                            processor->AddFinishedCallback(std::move(finishedCallback));
-                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                            TSdkCallbackGuard guard;
-                            connectedCallback(std::move(status), std::move(processor));
-                        } else {
+	                            processor->AddFinishedCallback(std::move(finishedCallback));
+	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+		                            TSdkCallbackGuard guard(stopState);
+	                            if (guard.IsEntered()) {
+	                                connectedCallback(std::move(status), std::move(processor));
+	                            }
+	                        } else {
                             dbState->StatCollector.IncReqFailDueTransportError();
                             dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
                             if (grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
                                 dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
-                            }
-                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-                            TSdkCallbackGuard guard;
-                            connectedCallback(std::move(status), nullptr);
-                        }
-                    };
+	                            }
+	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+		                            TSdkCallbackGuard guard(stopState);
+	                            if (guard.IsEntered()) {
+	                                connectedCallback(std::move(status), nullptr);
+	                            }
+	                        }
+	                    };
 
                 serviceConnection->template DoStreamRequest<TRequest, TResponse>(
                     std::move(lowCallback),
@@ -677,18 +749,21 @@ private:
         TConnection serviceConnection;
         TEndpointKey endpoint;
         std::tie(serviceConnection, endpoint) = GetServiceConnection<TService>(dbState, preferredEndpoint, endpointPolicy);
-        if (!serviceConnection) {
-            if (dbState->DiscoveryMode == EDiscoveryMode::Off) {
-                TStringStream errString;
-                errString << "No endpoint for database " << dbState->Database;
-                errString << ", cluster endpoint " << dbState->DiscoveryEndpoint;
-                dbState->StatCollector.IncReqFailNoEndpoint();
-                callback(
-                    TPlainStatus(EStatus::UNAVAILABLE, errString.Str()),
-                    TConnection{nullptr},
-                    TEndpointKey{ });
+	        if (!serviceConnection) {
+	            if (dbState->DiscoveryMode == EDiscoveryMode::Off) {
+	                TStringStream errString;
+	                errString << "No endpoint for database " << dbState->Database;
+	                errString << ", cluster endpoint " << dbState->DiscoveryEndpoint;
+	                dbState->StatCollector.IncReqFailNoEndpoint();
+	                TSdkCallbackGuard guard(StopState_);
+	                if (guard.IsEntered()) {
+	                    callback(
+	                        TPlainStatus(EStatus::UNAVAILABLE, errString.Str()),
+	                        TConnection{nullptr},
+	                        TEndpointKey{ });
+	                }
 
-            } else if (dbState->DiscoveryMode == EDiscoveryMode::Sync) {
+	            } else if (dbState->DiscoveryMode == EDiscoveryMode::Sync) {
                 TStringStream errString;
                 errString << "Endpoint list is empty for database " << dbState->Database;
                 errString << ", cluster endpoint " << dbState->DiscoveryEndpoint;
@@ -705,61 +780,76 @@ private:
                 } else {
                     errString <<".";
                     discoveryStatus.Issues.AddIssues({NYdb::NIssue::TIssue(errString.Str())});
-                }
-                dbState->StatCollector.IncReqFailNoEndpoint();
-                callback(
-                    discoveryStatus,
-                    TConnection{nullptr},
-                    TEndpointKey{ });
-            } else {
+	                }
+	                dbState->StatCollector.IncReqFailNoEndpoint();
+	                TSdkCallbackGuard guard(StopState_);
+	                if (guard.IsEntered()) {
+	                    callback(
+	                        discoveryStatus,
+	                        TConnection{nullptr},
+	                        TEndpointKey{ });
+	                }
+	            } else {
                 int64_t newVal;
                 int64_t val;
                 do {
                     val = QueuedRequests_.load();
-                    if (val >= MaxQueuedRequests_) {
-                        dbState->StatCollector.IncReqFailQueueOverflow();
-                        callback(
-                            TPlainStatus(EStatus::CLIENT_LIMITS_REACHED, "Requests queue limit reached"),
-                            TConnection{nullptr},
-                            TEndpointKey{ });
-                        return;
-                    }
+	                    if (val >= MaxQueuedRequests_) {
+	                        dbState->StatCollector.IncReqFailQueueOverflow();
+	                        TSdkCallbackGuard guard(StopState_);
+	                        if (guard.IsEntered()) {
+	                            callback(
+	                                TPlainStatus(EStatus::CLIENT_LIMITS_REACHED, "Requests queue limit reached"),
+	                                TConnection{nullptr},
+	                                TEndpointKey{ });
+	                        }
+	                        return;
+	                    }
                     newVal = val + 1;
                 } while (!QueuedRequests_.compare_exchange_weak(val, newVal));
 
                 // UpdateAsync guarantee one update in progress for state
-                auto asyncResult = dbState->EndpointPool.UpdateAsync();
-                const bool needUpdateChannels = asyncResult.second;
-                asyncResult.first.Subscribe([this, callback = std::move(callback), needUpdateChannels, dbState, preferredEndpoint, endpointPolicy]
-                    (const NThreading::TFuture<TEndpointUpdateResult>& future) mutable {
-                    --QueuedRequests_;
-                    const auto& updateResult = future.GetValue();
+	                auto asyncResult = dbState->EndpointPool.UpdateAsync();
+	                const bool needUpdateChannels = asyncResult.second;
+	                auto stopState = StopState_;
+	                asyncResult.first.Subscribe([this, callback = std::move(callback), needUpdateChannels, dbState, preferredEndpoint, endpointPolicy, stopState = std::move(stopState)]
+	                    (const NThreading::TFuture<TEndpointUpdateResult>& future) mutable {
+	                    TSdkCallbackGuard guard(stopState);
+	                    if (!guard.IsEntered()) {
+	                        return;
+	                    }
+	                    --QueuedRequests_;
+	                    const auto& updateResult = future.GetValue();
                     if (needUpdateChannels) {
 #ifndef YDB_GRPC_BYPASS_CHANNEL_POOL
                         DeleteChannels(updateResult.Removed);
 #endif
                     }
                     auto discoveryStatus = updateResult.DiscoveryStatus;
-                    if (discoveryStatus.Status == EStatus::SUCCESS) {
-                        WithServiceConnection<TService>(std::move(callback), dbState, preferredEndpoint, endpointPolicy);
-                    } else {
-                        callback(
-                            TPlainStatus(discoveryStatus.Status, std::move(discoveryStatus.Issues)),
-                            TConnection{nullptr},
-                            TEndpointKey{ });
-                    }
-                });
-            }
-            return;
-        }
+	                    if (discoveryStatus.Status == EStatus::SUCCESS) {
+	                        WithServiceConnection<TService>(std::move(callback), dbState, preferredEndpoint, endpointPolicy);
+	                    } else {
+	                        callback(
+	                            TPlainStatus(discoveryStatus.Status, std::move(discoveryStatus.Issues)),
+	                            TConnection{nullptr},
+	                            TEndpointKey{ });
+	                    }
+	                });
+	            }
+	            return;
+	        }
 
-        callback(
-            TPlainStatus{ },
-            std::move(serviceConnection),
-            std::move(endpoint));
-    }
+	        TSdkCallbackGuard guard(StopState_);
+	        if (guard.IsEntered()) {
+	            callback(
+	                TPlainStatus{ },
+	                std::move(serviceConnection),
+	                std::move(endpoint));
+	        }
+	    }
 
     void EnqueueResponse(IObjectInQueue* action);
+    void StopResponseQueue();
 
 private:
     TCallMeta MakeCallMeta(const TRpcRequestSettings& requestSettings, const TDbDriverStatePtr& dbState) const;
@@ -769,6 +859,8 @@ private:
 
     const std::size_t ClientThreadsNum_;
     std::shared_ptr<IExecutor> ResponseQueue_;
+    std::once_flag ResponseQueueStopOnce_;
+    std::shared_ptr<TDriverStopState> StopState_;
 
     const std::string DefaultDiscoveryEndpoint_;
     const TSslCredentials SslCredentials_;

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -201,6 +201,52 @@ public:
             TRequest,
             TResponse>::TAsyncRequest;
 
+    template<typename TResponse>
+    void RunResponseCallback(
+        TResponseCb<TResponse>& callback,
+        TResponse* response,
+        TPlainStatus status,
+        const std::shared_ptr<TDriverStopState>& stopState)
+    {
+        TSdkCallbackGuard guard(stopState);
+        if (guard.IsEntered()) {
+            callback(response, std::move(status));
+        } else {
+            callback(nullptr, MakeClientStoppedStatus());
+        }
+    }
+
+    template<typename TCallback, typename TProcessor>
+    void RunStreamCallback(
+        TCallback& callback,
+        TPlainStatus status,
+        TProcessor processor,
+        const std::shared_ptr<TDriverStopState>& stopState)
+    {
+        TSdkCallbackGuard guard(stopState);
+        if (guard.IsEntered()) {
+            callback(std::move(status), std::move(processor));
+        } else {
+            callback(MakeClientStoppedStatus(), nullptr);
+        }
+    }
+
+    template<typename TService, typename TCallback>
+    void RunServiceConnectionCallback(
+        TCallback& callback,
+        TPlainStatus status,
+        std::unique_ptr<TServiceConnection<TService>> serviceConnection,
+        TEndpointKey endpoint,
+        const std::shared_ptr<TDriverStopState>& stopState)
+    {
+        TSdkCallbackGuard guard(stopState);
+        if (guard.IsEntered()) {
+            callback(std::move(status), std::move(serviceConnection), std::move(endpoint));
+        } else {
+            callback(MakeClientStoppedStatus(), std::unique_ptr<TServiceConnection<TService>>{nullptr}, TEndpointKey{});
+        }
+    }
+
     template<typename TRequest>
     class TRequestWrapper {
     public:
@@ -261,19 +307,12 @@ public:
         Y_ABORT_UNLESS(dbState);
 
         if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                userResponseCb(nullptr, std::move(*tlsValidationStatus));
-            }
+            RunResponseCallback<TResponse>(userResponseCb, nullptr, std::move(*tlsValidationStatus), StopState_);
             return;
         }
 
         if (!TryCreateContext(context)) {
-            TPlainStatus status(EStatus::CLIENT_CANCELLED, "Client is stopped");
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                userResponseCb(nullptr, TPlainStatus{status.Status, std::move(status.Issues)});
-            }
+            RunResponseCallback<TResponse>(userResponseCb, nullptr, MakeClientStoppedStatus(), StopState_);
             return;
         }
 
@@ -295,87 +334,80 @@ public:
         WithServiceConnection<TService>(
             [this, requestWrapper = std::move(requestWrapper), userResponseCb = std::move(userResponseCb), rpc, 
              requestSettings, context = std::move(context), dbState]
-	            (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable -> void {
-	                if (!status.Ok()) {
-	                    context.reset();
-	                    TSdkCallbackGuard guard(StopState_);
-	                    if (guard.IsEntered()) {
-	                        userResponseCb(
-	                            nullptr,
-	                            std::move(status));
-	                    }
-	                    return;
-	                }
+                (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable -> void {
+                    if (!status.Ok()) {
+                        context.reset();
+                        RunResponseCallback<TResponse>(userResponseCb, nullptr, std::move(status), StopState_);
+                        return;
+                    }
 
-                Y_ABORT_UNLESS(serviceConnection != nullptr);
+                    Y_ABORT_UNLESS(serviceConnection != nullptr);
 
-                TCallMeta meta;
+                    TCallMeta meta;
 
-                try {
-                    meta = MakeCallMeta(requestSettings, dbState);
-	                } catch (const TYdbException& e) {
-	                    context.reset();
-	                    TSdkCallbackGuard guard(StopState_);
-	                    if (guard.IsEntered()) {
-	                        userResponseCb(
-	                            nullptr,
-	                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what())
-	                        );
-	                    }
-	                    return;
-	                }
+                    try {
+                        meta = MakeCallMeta(requestSettings, dbState);
+                    } catch (const TYdbException& e) {
+                        context.reset();
+                        RunResponseCallback<TResponse>(
+                            userResponseCb,
+                            nullptr,
+                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
+                            StopState_);
+                        return;
+                    }
 
-                dbState->StatCollector.IncGRpcInFlight();
-                dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
+                    dbState->StatCollector.IncGRpcInFlight();
+                    dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
 
-                NYdbGrpc::TAdvancedResponseCallback<TResponse> responseCbLow =
-                    [this, context, userResponseCb = std::move(userResponseCb), endpoint, dbState]
-                    (const grpc::ClientContext& ctx, TGrpcStatus&& grpcStatus, TResponse&& response) mutable -> void {
-                        dbState->StatCollector.DecGRpcInFlight();
-                        dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
+                    NYdbGrpc::TAdvancedResponseCallback<TResponse> responseCbLow =
+                        [this, context, userResponseCb = std::move(userResponseCb), endpoint, dbState]
+                        (const grpc::ClientContext& ctx, TGrpcStatus&& grpcStatus, TResponse&& response) mutable -> void {
+                            dbState->StatCollector.DecGRpcInFlight();
+                            dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
 
-                        if (NYdbGrpc::IsGRpcStatusGood(grpcStatus)) {
-                            std::multimap<std::string, std::string> metadata;
+                            if (NYdbGrpc::IsGRpcStatusGood(grpcStatus)) {
+                                std::multimap<std::string, std::string> metadata;
 
-                            for (const auto& [name, value] : ctx.GetServerInitialMetadata()) {
-                                metadata.emplace(
-                                    std::string(name.begin(), name.end()),
-                                    std::string(value.begin(), value.end()));
+                                for (const auto& [name, value] : ctx.GetServerInitialMetadata()) {
+                                    metadata.emplace(
+                                        std::string(name.begin(), name.end()),
+                                        std::string(value.begin(), value.end()));
+                                }
+                                for (const auto& [name, value] : ctx.GetServerTrailingMetadata()) {
+                                    metadata.emplace(
+                                        std::string(name.begin(), name.end()),
+                                        std::string(value.begin(), value.end()));
+                                }
+
+                                auto resp = new TResult<TResponse>(
+                                    std::move(response),
+                                    std::move(grpcStatus),
+                                    std::move(userResponseCb),
+                                    this,
+                                    std::move(context),
+                                    endpoint.GetEndpoint(),
+                                    std::move(metadata));
+
+                                EnqueueResponse(resp);
+                            } else {
+                                dbState->StatCollector.IncReqFailDueTransportError();
+                                dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
+
+                                auto resp = new TGRpcErrorResponse<TResponse>(
+                                    std::move(grpcStatus),
+                                    std::move(userResponseCb),
+                                    this,
+                                    std::move(context),
+                                    endpoint.GetEndpoint());
+
+                                dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
+
+                                EnqueueResponse(resp);
                             }
-                            for (const auto& [name, value] : ctx.GetServerTrailingMetadata()) {
-                                metadata.emplace(
-                                    std::string(name.begin(), name.end()),
-                                    std::string(value.begin(), value.end()));
-                            }
+                        };
 
-                            auto resp = new TResult<TResponse>(
-                                std::move(response),
-                                std::move(grpcStatus),
-                                std::move(userResponseCb),
-                                this,
-                                std::move(context),
-                                endpoint.GetEndpoint(),
-                                std::move(metadata));
-
-                            EnqueueResponse(resp);
-                        } else {
-                            dbState->StatCollector.IncReqFailDueTransportError();
-                            dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
-
-                            auto resp = new TGRpcErrorResponse<TResponse>(
-                                std::move(grpcStatus),
-                                std::move(userResponseCb),
-                                this,
-                                std::move(context),
-                                endpoint.GetEndpoint());
-
-                            dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
-
-                            EnqueueResponse(resp);
-                        }
-                    };
-
-                requestWrapper.DoRequest(serviceConnection, std::move(responseCbLow), rpc, meta, context.get());
+                    requestWrapper.DoRequest(serviceConnection, std::move(responseCbLow), rpc, meta, context.get());
             }, dbState, requestSettings.PreferredEndpoint, requestSettings.EndpointPolicy);
     }
 
@@ -391,11 +423,7 @@ public:
         std::shared_ptr<IQueueClientContext> context = nullptr)
     {
         if (!TryCreateContext(context)) {
-            TPlainStatus status(EStatus::CLIENT_CANCELLED, "Client is stopped");
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                userResponseCb(nullptr, status);
-            }
+            userResponseCb(nullptr, MakeClientStoppedStatus());
             return;
         }
 
@@ -516,53 +544,42 @@ public:
         using TProcessor = typename NYdbGrpc::IStreamRequestReadProcessor<TResponse>::TPtr;
 
         if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                responseCb(std::move(*tlsValidationStatus), nullptr);
-            }
+            RunStreamCallback(responseCb, std::move(*tlsValidationStatus), nullptr, StopState_);
             return;
         }
 
         if (!TryCreateContext(context)) {
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                responseCb(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
-            }
+            RunStreamCallback(responseCb, MakeClientStoppedStatus(), nullptr, StopState_);
             return;
         }
 
         WithServiceConnection<TService>(
-	            [this, request, responseCb = std::move(responseCb), rpc, requestSettings, context = std::move(context), dbState](TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
-	                if (!status.Ok()) {
-	                    context.reset();
-	                    TSdkCallbackGuard guard(StopState_);
-	                    if (guard.IsEntered()) {
-	                        responseCb(std::move(status), nullptr);
-	                    }
-	                    return;
-	                }
+            [this, request, responseCb = std::move(responseCb), rpc, requestSettings, context = std::move(context), dbState](TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
+                if (!status.Ok()) {
+                    context.reset();
+                    RunStreamCallback(responseCb, std::move(status), nullptr, StopState_);
+                    return;
+                }
 
                 Y_ABORT_UNLESS(serviceConnection != nullptr);
 
                 TCallMeta meta;
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
-	                } catch (const TYdbException& e) {
-	                    context.reset();
-	                    TSdkCallbackGuard guard(StopState_);
-	                    if (guard.IsEntered()) {
-	                        responseCb(
-	                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
-	                            nullptr
-	                        );
-	                    }
-	                    return;
-	                }
+                } catch (const TYdbException& e) {
+                    context.reset();
+                    RunStreamCallback(
+                        responseCb,
+                        TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
+                        nullptr,
+                        StopState_);
+                    return;
+                }
 
                 dbState->StatCollector.IncGRpcInFlight();
                 dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
 
-	                auto lowCallback = [responseCb = std::move(responseCb), dbState, endpoint, stopState = StopState_]
+                auto lowCallback = [responseCb = std::move(responseCb), dbState, endpoint, stopState = StopState_]
                     (TGrpcStatus grpcStatus, TProcessor processor) mutable {
                         dbState->StatCollector.DecGRpcInFlight();
                         dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
@@ -574,25 +591,29 @@ public:
                                     dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                                 }
                             };
-	                            processor->AddFinishedCallback(std::move(finishedCallback));
-	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-		                            TSdkCallbackGuard guard(stopState);
-	                            if (guard.IsEntered()) {
-	                                responseCb(std::move(status), std::move(processor));
-	                            }
-	                        } else {
+                            processor->AddFinishedCallback(std::move(finishedCallback));
+                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                            TSdkCallbackGuard guard(stopState);
+                            if (guard.IsEntered()) {
+                                responseCb(std::move(status), std::move(processor));
+                            } else {
+                                responseCb(MakeClientStoppedStatus(), nullptr);
+                            }
+                        } else {
                             dbState->StatCollector.IncReqFailDueTransportError();
                             dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
                             if (grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
                                 dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
-	                            }
-	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-		                            TSdkCallbackGuard guard(stopState);
-	                            if (guard.IsEntered()) {
-	                                responseCb(std::move(status), nullptr);
-	                            }
-	                        }
-	                    };
+                            }
+                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                            TSdkCallbackGuard guard(stopState);
+                            if (guard.IsEntered()) {
+                                responseCb(std::move(status), nullptr);
+                            } else {
+                                responseCb(MakeClientStoppedStatus(), nullptr);
+                            }
+                        }
+                    };
 
                 serviceConnection->template DoStreamRequest<TRequest, TResponse>(
                     request,
@@ -616,90 +637,83 @@ public:
         using TProcessor = typename NYdbGrpc::IStreamRequestReadWriteProcessor<TRequest, TResponse>::TPtr;
 
         if (auto tlsValidationStatus = ValidateClientTlsCredentials(dbState)) {
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                connectedCallback(std::move(*tlsValidationStatus), nullptr);
-            }
+            RunStreamCallback(connectedCallback, std::move(*tlsValidationStatus), nullptr, StopState_);
             return;
         }
 
         if (!TryCreateContext(context)) {
-            TSdkCallbackGuard guard(StopState_);
-            if (guard.IsEntered()) {
-                connectedCallback(TPlainStatus(EStatus::CLIENT_CANCELLED, "Client is stopped"), nullptr);
-            }
+            RunStreamCallback(connectedCallback, MakeClientStoppedStatus(), nullptr, StopState_);
             return;
         }
 
         WithServiceConnection<TService>(
             [this, connectedCallback = std::move(connectedCallback), rpc, requestSettings, context = std::move(context), dbState]
-	            (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
-	                if (!status.Ok()) {
-	                    context.reset();
-	                    TSdkCallbackGuard guard(StopState_);
-	                    if (guard.IsEntered()) {
-	                        connectedCallback(std::move(status), nullptr);
-	                    }
-	                    return;
-	                }
+                (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
+                    if (!status.Ok()) {
+                        context.reset();
+                        RunStreamCallback(connectedCallback, std::move(status), nullptr, StopState_);
+                        return;
+                    }
 
-                Y_ABORT_UNLESS(serviceConnection != nullptr);
+                    Y_ABORT_UNLESS(serviceConnection != nullptr);
 
-                TCallMeta meta;
-                try {
-                    meta = MakeCallMeta(requestSettings, dbState);
-	                } catch (const TYdbException& e) {
-	                    context.reset();
-	                    TSdkCallbackGuard guard(StopState_);
-	                    if (guard.IsEntered()) {
-	                        connectedCallback(
-	                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
-	                            nullptr
-	                        );
-	                    }
-	                    return;
-	                }
+                    TCallMeta meta;
+                    try {
+                        meta = MakeCallMeta(requestSettings, dbState);
+                    } catch (const TYdbException& e) {
+                        context.reset();
+                        RunStreamCallback(
+                            connectedCallback,
+                            TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
+                            nullptr,
+                            StopState_);
+                        return;
+                    }
 
-                dbState->StatCollector.IncGRpcInFlight();
-                dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
+                    dbState->StatCollector.IncGRpcInFlight();
+                    dbState->StatCollector.IncGRpcInFlightByHost(endpoint.GetEndpoint());
 
-	                auto lowCallback = [connectedCallback = std::move(connectedCallback), dbState, endpoint, stopState = StopState_]
-                    (TGrpcStatus grpcStatus, TProcessor processor) {
-                        dbState->StatCollector.DecGRpcInFlight();
-                        dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
+                    auto lowCallback = [connectedCallback = std::move(connectedCallback), dbState, endpoint, stopState = StopState_]
+                        (TGrpcStatus grpcStatus, TProcessor processor) {
+                            dbState->StatCollector.DecGRpcInFlight();
+                            dbState->StatCollector.DecGRpcInFlightByHost(endpoint.GetEndpoint());
 
-                        if (grpcStatus.Ok()) {
-                            Y_ABORT_UNLESS(processor);
-                            auto finishedCallback = [dbState, endpoint] (TGrpcStatus grpcStatus) {
-                                if (!grpcStatus.Ok() && grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
+                            if (grpcStatus.Ok()) {
+                                Y_ABORT_UNLESS(processor);
+                                auto finishedCallback = [dbState, endpoint] (TGrpcStatus grpcStatus) {
+                                    if (!grpcStatus.Ok() && grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
+                                        dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
+                                    }
+                                };
+                                processor->AddFinishedCallback(std::move(finishedCallback));
+                                TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                                TSdkCallbackGuard guard(stopState);
+                                if (guard.IsEntered()) {
+                                    connectedCallback(std::move(status), std::move(processor));
+                                } else {
+                                    connectedCallback(MakeClientStoppedStatus(), nullptr);
+                                }
+                            } else {
+                                dbState->StatCollector.IncReqFailDueTransportError();
+                                dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
+                                if (grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
                                     dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                                 }
-                            };
-	                            processor->AddFinishedCallback(std::move(finishedCallback));
-	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-		                            TSdkCallbackGuard guard(stopState);
-	                            if (guard.IsEntered()) {
-	                                connectedCallback(std::move(status), std::move(processor));
-	                            }
-	                        } else {
-                            dbState->StatCollector.IncReqFailDueTransportError();
-                            dbState->StatCollector.IncTransportErrorsByHost(endpoint.GetEndpoint());
-                            if (grpcStatus.GRpcStatusCode != grpc::StatusCode::CANCELLED) {
-                                dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
-	                            }
-	                            TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
-		                            TSdkCallbackGuard guard(stopState);
-	                            if (guard.IsEntered()) {
-	                                connectedCallback(std::move(status), nullptr);
-	                            }
-	                        }
-	                    };
+                                TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                                TSdkCallbackGuard guard(stopState);
+                                if (guard.IsEntered()) {
+                                    connectedCallback(std::move(status), nullptr);
+                                } else {
+                                    connectedCallback(MakeClientStoppedStatus(), nullptr);
+                                }
+                            }
+                        };
 
-                serviceConnection->template DoStreamRequest<TRequest, TResponse>(
-                    std::move(lowCallback),
-                    std::move(rpc),
-                    std::move(meta),
-                    context.get());
+                    serviceConnection->template DoStreamRequest<TRequest, TResponse>(
+                        std::move(lowCallback),
+                        std::move(rpc),
+                        std::move(meta),
+                        context.get());
             }, dbState, requestSettings.PreferredEndpoint, requestSettings.EndpointPolicy);
     }
 
@@ -749,21 +763,19 @@ private:
         TConnection serviceConnection;
         TEndpointKey endpoint;
         std::tie(serviceConnection, endpoint) = GetServiceConnection<TService>(dbState, preferredEndpoint, endpointPolicy);
-	        if (!serviceConnection) {
-	            if (dbState->DiscoveryMode == EDiscoveryMode::Off) {
-	                TStringStream errString;
-	                errString << "No endpoint for database " << dbState->Database;
-	                errString << ", cluster endpoint " << dbState->DiscoveryEndpoint;
-	                dbState->StatCollector.IncReqFailNoEndpoint();
-	                TSdkCallbackGuard guard(StopState_);
-	                if (guard.IsEntered()) {
-	                    callback(
-	                        TPlainStatus(EStatus::UNAVAILABLE, errString.Str()),
-	                        TConnection{nullptr},
-	                        TEndpointKey{ });
-	                }
-
-	            } else if (dbState->DiscoveryMode == EDiscoveryMode::Sync) {
+        if (!serviceConnection) {
+            if (dbState->DiscoveryMode == EDiscoveryMode::Off) {
+                TStringStream errString;
+                errString << "No endpoint for database " << dbState->Database;
+                errString << ", cluster endpoint " << dbState->DiscoveryEndpoint;
+                dbState->StatCollector.IncReqFailNoEndpoint();
+                RunServiceConnectionCallback<TService>(
+                    callback,
+                    TPlainStatus(EStatus::UNAVAILABLE, errString.Str()),
+                    TConnection{nullptr},
+                    TEndpointKey{},
+                    StopState_);
+            } else if (dbState->DiscoveryMode == EDiscoveryMode::Sync) {
                 TStringStream errString;
                 errString << "Endpoint list is empty for database " << dbState->Database;
                 errString << ", cluster endpoint " << dbState->DiscoveryEndpoint;
@@ -778,75 +790,73 @@ private:
                     errString << " while last discovery returned success status. Unable to continue processing.";
                     discoveryStatus = TPlainStatus(EStatus::UNAVAILABLE, errString.Str());
                 } else {
-                    errString <<".";
+                    errString << ".";
                     discoveryStatus.Issues.AddIssues({NYdb::NIssue::TIssue(errString.Str())});
-	                }
-	                dbState->StatCollector.IncReqFailNoEndpoint();
-	                TSdkCallbackGuard guard(StopState_);
-	                if (guard.IsEntered()) {
-	                    callback(
-	                        discoveryStatus,
-	                        TConnection{nullptr},
-	                        TEndpointKey{ });
-	                }
-	            } else {
+                }
+                dbState->StatCollector.IncReqFailNoEndpoint();
+                RunServiceConnectionCallback<TService>(
+                    callback,
+                    std::move(discoveryStatus),
+                    TConnection{nullptr},
+                    TEndpointKey{},
+                    StopState_);
+            } else {
                 int64_t newVal;
                 int64_t val;
                 do {
                     val = QueuedRequests_.load();
-	                    if (val >= MaxQueuedRequests_) {
-	                        dbState->StatCollector.IncReqFailQueueOverflow();
-	                        TSdkCallbackGuard guard(StopState_);
-	                        if (guard.IsEntered()) {
-	                            callback(
-	                                TPlainStatus(EStatus::CLIENT_LIMITS_REACHED, "Requests queue limit reached"),
-	                                TConnection{nullptr},
-	                                TEndpointKey{ });
-	                        }
-	                        return;
-	                    }
+                    if (val >= MaxQueuedRequests_) {
+                        dbState->StatCollector.IncReqFailQueueOverflow();
+                        RunServiceConnectionCallback<TService>(
+                            callback,
+                            TPlainStatus(EStatus::CLIENT_LIMITS_REACHED, "Requests queue limit reached"),
+                            TConnection{nullptr},
+                            TEndpointKey{},
+                            StopState_);
+                        return;
+                    }
                     newVal = val + 1;
                 } while (!QueuedRequests_.compare_exchange_weak(val, newVal));
 
-                // UpdateAsync guarantee one update in progress for state
-	                auto asyncResult = dbState->EndpointPool.UpdateAsync();
-	                const bool needUpdateChannels = asyncResult.second;
-	                auto stopState = StopState_;
-	                asyncResult.first.Subscribe([this, callback = std::move(callback), needUpdateChannels, dbState, preferredEndpoint, endpointPolicy, stopState = std::move(stopState)]
-	                    (const NThreading::TFuture<TEndpointUpdateResult>& future) mutable {
-	                    TSdkCallbackGuard guard(stopState);
-	                    if (!guard.IsEntered()) {
-	                        return;
-	                    }
-	                    --QueuedRequests_;
-	                    const auto& updateResult = future.GetValue();
+                // UpdateAsync guarantees one update in progress for state.
+                auto asyncResult = dbState->EndpointPool.UpdateAsync();
+                const bool needUpdateChannels = asyncResult.second;
+                auto stopState = StopState_;
+                asyncResult.first.Subscribe([this, callback = std::move(callback), needUpdateChannels, dbState, preferredEndpoint, endpointPolicy, stopState = std::move(stopState)]
+                    (const NThreading::TFuture<TEndpointUpdateResult>& future) mutable {
+                    --QueuedRequests_;
+                    TSdkCallbackGuard guard(stopState);
+                    if (!guard.IsEntered()) {
+                        callback(MakeClientStoppedStatus(), TConnection{nullptr}, TEndpointKey{});
+                        return;
+                    }
+                    const auto& updateResult = future.GetValue();
                     if (needUpdateChannels) {
 #ifndef YDB_GRPC_BYPASS_CHANNEL_POOL
                         DeleteChannels(updateResult.Removed);
 #endif
                     }
                     auto discoveryStatus = updateResult.DiscoveryStatus;
-	                    if (discoveryStatus.Status == EStatus::SUCCESS) {
-	                        WithServiceConnection<TService>(std::move(callback), dbState, preferredEndpoint, endpointPolicy);
-	                    } else {
-	                        callback(
-	                            TPlainStatus(discoveryStatus.Status, std::move(discoveryStatus.Issues)),
-	                            TConnection{nullptr},
-	                            TEndpointKey{ });
-	                    }
-	                });
-	            }
-	            return;
-	        }
+                    if (discoveryStatus.Status == EStatus::SUCCESS) {
+                        WithServiceConnection<TService>(std::move(callback), dbState, preferredEndpoint, endpointPolicy);
+                    } else {
+                        callback(
+                            TPlainStatus(discoveryStatus.Status, std::move(discoveryStatus.Issues)),
+                            TConnection{nullptr},
+                            TEndpointKey{});
+                    }
+                });
+            }
+            return;
+        }
 
-	        TSdkCallbackGuard guard(StopState_);
-	        if (guard.IsEntered()) {
-	            callback(
-	                TPlainStatus{ },
-	                std::move(serviceConnection),
-	                std::move(endpoint));
-	        }
-	    }
+        RunServiceConnectionCallback<TService>(
+            callback,
+            TPlainStatus{},
+            std::move(serviceConnection),
+            std::move(endpoint),
+            StopState_);
+    }
 
     void EnqueueResponse(IObjectInQueue* action);
     void StopResponseQueue();

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.h
@@ -40,6 +40,12 @@ class ICredentialsProvider;
 // Deferred callbacks
 using TDeferredResultCb = std::function<void(google::protobuf::Any*, TPlainStatus status)>;
 
+class TSdkCallbackGuard {
+public:
+    TSdkCallbackGuard();
+    ~TSdkCallbackGuard();
+};
+
 std::string GetAuthInfo(TDbDriverStatePtr p);
 std::string CreateSDKBuildInfo();
 
@@ -53,6 +59,12 @@ public:
     TGRpcConnectionsImpl(std::shared_ptr<IConnectionsParams> params);
     ~TGRpcConnectionsImpl();
 
+    static bool IsCurrentThreadInSdkCallback() noexcept;
+
+private:
+    void StopFromCallback(std::shared_ptr<TGRpcConnectionsImpl> self, bool wait);
+
+public:
     void AddPeriodicTask(TPeriodicCb&& cb, TDeadline::Duration period) override;
     void PostToResponseQueue(std::function<void()>&& f) override;
 
@@ -248,6 +260,8 @@ public:
              requestSettings, context = std::move(context), dbState]
             (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable -> void {
                 if (!status.Ok()) {
+                    context.reset();
+                    TSdkCallbackGuard guard;
                     userResponseCb(
                         nullptr,
                         std::move(status));
@@ -261,6 +275,8 @@ public:
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
                 } catch (const TYdbException& e) {
+                    context.reset();
+                    TSdkCallbackGuard guard;
                     userResponseCb(
                         nullptr,
                         TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what())
@@ -360,10 +376,12 @@ public:
                 } else {
                     NYdb::NIssue::TIssues opIssues;
                     NYdb::NIssue::IssuesFromMessage(operation->issues(), opIssues);
+                    context.reset();
                     userResponseCb(operation, TPlainStatus{static_cast<EStatus>(operation->status()), std::move(opIssues),
                         status.Endpoint, std::move(status.Metadata)});
                 }
             } else {
+                context.reset();
                 userResponseCb(nullptr, status);
             }
         };
@@ -466,6 +484,8 @@ public:
         WithServiceConnection<TService>(
             [this, request, responseCb = std::move(responseCb), rpc, requestSettings, context = std::move(context), dbState](TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
                 if (!status.Ok()) {
+                    context.reset();
+                    TSdkCallbackGuard guard;
                     responseCb(std::move(status), nullptr);
                     return;
                 }
@@ -476,6 +496,8 @@ public:
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
                 } catch (const TYdbException& e) {
+                    context.reset();
+                    TSdkCallbackGuard guard;
                     responseCb(
                         TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
                         nullptr
@@ -500,6 +522,7 @@ public:
                             };
                             processor->AddFinishedCallback(std::move(finishedCallback));
                             TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                            TSdkCallbackGuard guard;
                             responseCb(std::move(status), std::move(processor));
                         } else {
                             dbState->StatCollector.IncReqFailDueTransportError();
@@ -508,6 +531,7 @@ public:
                                 dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                             }
                             TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                            TSdkCallbackGuard guard;
                             responseCb(std::move(status), nullptr);
                         }
                     };
@@ -547,6 +571,8 @@ public:
             [this, connectedCallback = std::move(connectedCallback), rpc, requestSettings, context = std::move(context), dbState]
             (TPlainStatus status, TConnection serviceConnection, TEndpointKey endpoint) mutable {
                 if (!status.Ok()) {
+                    context.reset();
+                    TSdkCallbackGuard guard;
                     connectedCallback(std::move(status), nullptr);
                     return;
                 }
@@ -557,6 +583,8 @@ public:
                 try {
                     meta = MakeCallMeta(requestSettings, dbState);
                 } catch (const TYdbException& e) {
+                    context.reset();
+                    TSdkCallbackGuard guard;
                     connectedCallback(
                         TPlainStatus(dynamic_cast<const TAuthenticationError*>(&e) ? EStatus::CLIENT_UNAUTHENTICATED : EStatus::UNAVAILABLE, e.what()),
                         nullptr
@@ -581,6 +609,7 @@ public:
                             };
                             processor->AddFinishedCallback(std::move(finishedCallback));
                             TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                            TSdkCallbackGuard guard;
                             connectedCallback(std::move(status), std::move(processor));
                         } else {
                             dbState->StatCollector.IncReqFailDueTransportError();
@@ -589,6 +618,7 @@ public:
                                 dbState->EndpointPool.BanEndpoint(endpoint.GetEndpoint());
                             }
                             TPlainStatus status(std::move(grpcStatus), endpoint.GetEndpoint(), {});
+                            TSdkCallbackGuard guard;
                             connectedCallback(std::move(status), nullptr);
                         }
                     };
@@ -783,6 +813,10 @@ private:
     // Must be the last member (first called destructor)
     NYdbGrpc::TGRpcClientLow GRpcClientLow_;
     TLog Log;
+};
+
+struct TGRpcConnectionsDeleter {
+    void operator()(TGRpcConnectionsImpl* connections) const noexcept;
 };
 
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
@@ -73,7 +73,11 @@ std::shared_ptr<NObservability::TRequestSpan> TTableClient::TImpl::CreateRetryAt
 
 TTableClient::TImpl::~TImpl() {
     if (Connections_->GetDrainOnDtors()) {
-        Drain().Wait(DRAIN_TIMEOUT);
+        const bool closeRemote = !TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback();
+        auto drainFuture = Drain(closeRemote);
+        if (closeRemote) {
+            drainFuture.Wait(DRAIN_TIMEOUT);
+        }
     }
 }
 
@@ -96,7 +100,7 @@ void TTableClient::TImpl::InitStopper() {
     DbDriverState_->AddCb(std::move(cb), TDbDriverState::ENotifyType::STOP);
 }
 
-NThreading::TFuture<void> TTableClient::TImpl::Drain() {
+NThreading::TFuture<void> TTableClient::TImpl::Drain(bool closeRemote) {
     std::vector<std::unique_ptr<TKqpSessionCommon>> sessions;
     // No realocations under lock
     sessions.reserve(Settings_.SessionPoolSettings_.MaxActiveSessions_);
@@ -108,7 +112,10 @@ NThreading::TFuture<void> TTableClient::TImpl::Drain() {
     std::vector<TAsyncStatus> closeResults;
     for (auto& s : sessions) {
         if (!s->GetId().empty()) {
-            closeResults.push_back(CloseInternal(s.get()));
+            if (closeRemote) {
+                closeResults.push_back(CloseInternal(s.get()));
+            }
+            DbDriverState_->StatCollector.DecSessionsOnHost(s->GetEndpoint());
         }
     }
     sessions.clear();
@@ -1150,8 +1157,11 @@ void TTableClient::TImpl::DeleteSession(TKqpSessionCommon* sessionImpl) {
         SessionPool_.DecrementActiveCounter();
     }
 
+    const bool closeRemote = !TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback();
     if (!sessionImpl->GetId().empty()) {
-        CloseInternal(sessionImpl);
+        if (closeRemote) {
+            CloseInternal(sessionImpl);
+        }
         DbDriverState_->StatCollector.DecSessionsOnHost(sessionImpl->GetEndpoint());
     }
 

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
@@ -11,6 +11,14 @@ using namespace NThreading;
 
 const TKeepAliveSettings TTableClient::TImpl::KeepAliveSettings = TKeepAliveSettings().ClientTimeout(KEEP_ALIVE_CLIENT_TIMEOUT);
 
+namespace {
+    NThreading::TFuture<void> MakeReadyFuture() {
+        auto promise = NThreading::NewPromise<void>();
+        auto future = promise.GetFuture();
+        promise.SetValue();
+        return future;
+    }
+}
 
 TDuration GetMinTimeToTouch(const TSessionPoolSettings& settings) {
     return Min(settings.CloseIdleThreshold_, settings.KeepAliveIdleThreshold_);
@@ -90,9 +98,7 @@ void TTableClient::TImpl::InitStopper() {
     auto cb = [weak]() mutable {
         auto strong = weak.lock();
         if (!strong) {
-            auto promise = NThreading::NewPromise<void>();
-            promise.SetException("no more client");
-            return promise.GetFuture();
+            return MakeReadyFuture();
         }
         return strong->Drain();
     };
@@ -119,6 +125,9 @@ NThreading::TFuture<void> TTableClient::TImpl::Drain(bool closeRemote) {
         }
     }
     sessions.clear();
+    if (closeResults.empty()) {
+        return MakeReadyFuture();
+    }
     return NThreading::WaitExceptionOrAll(closeResults);
 }
 

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
@@ -21,7 +21,6 @@
 
 #include <library/cpp/threading/future/core/coroutine_traits.h>
 
-
 namespace NYdb::inline Dev {
 namespace NTable {
 
@@ -45,7 +44,7 @@ public:
 
     bool LinkObjToEndpoint(const TEndpointKey& endpoint, TEndpointObj* obj, const void* tag);
     void InitStopper();
-    NThreading::TFuture<void> Drain();
+    NThreading::TFuture<void> Drain(bool closeRemote = true);
     NThreading::TFuture<void> Stop();
     void ScheduleTaskUnsafe(std::function<void()>&& fn, TDeadline::Duration timeout);
     void StartPeriodicSessionPoolTask();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/direct_reader.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/direct_reader.cpp
@@ -588,7 +588,8 @@ void TDirectReadSession::OnReadDone(NYdbGrpc::TGrpcStatus&& grpcStatus, size_t c
                 cbContext = SelfContext, partitionSessionId = partitionSessionId.value()
             ]() {
                 callbacks->OnDirectReadDone(messages);
-            }
+            },
+            ClientContext->GetCallbackGuardFactory()
         );
     }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -150,7 +150,9 @@ public:
     // TODO(qyryq) Extract a separate TDeferredDirectReadActions class?
     void DeferReadFromProcessor(const typename IDirectReadProcessor::TPtr& processor, TDirectReadServerMessage* dst, typename IDirectReadProcessor::TReadCallback callback);
     void DeferScheduleCallback(TDuration delay, std::function<void(bool)> callback, TSingleClusterReadSessionContextPtr);
-    void DeferCallback(std::function<void()> callback);
+    void DeferCallback(
+        std::function<void()> callback,
+        NYdbGrpc::TQueueClientCallbackGuardFactory callbackGuardFactory = {});
 
     void DeferReadFromProcessor(const typename IProcessor<UseMigrationProtocol>::TPtr& processor, TServerMessage<UseMigrationProtocol>* dst, typename IProcessor<UseMigrationProtocol>::TReadCallback callback);
     void DeferStartExecutorTask(const typename IExecutor::TPtr& executor, typename IExecutor::TFunction&& task);
@@ -202,7 +204,12 @@ private:
         };
 
         std::optional<TScheduledCallback> ScheduledCallback;
-        std::optional<std::function<void()>> Callback;
+        struct TCallback {
+            std::function<void()> Callback;
+            NYdbGrpc::TQueueClientCallbackGuardFactory CallbackGuardFactory;
+        };
+
+        std::optional<TCallback> Callback;
     } DirectReadActions;
 
     // Executor tasks.

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -3657,9 +3657,15 @@ void TDeferredActions<UseMigrationProtocol>::DeferScheduleCallback(TDuration del
 }
 
 template<bool UseMigrationProtocol>
-void TDeferredActions<UseMigrationProtocol>::DeferCallback(std::function<void()> callback) {
+void TDeferredActions<UseMigrationProtocol>::DeferCallback(
+    std::function<void()> callback,
+    NYdbGrpc::TQueueClientCallbackGuardFactory callbackGuardFactory)
+{
     Y_ASSERT(!DirectReadActions.Callback);
-    DirectReadActions.Callback = std::move(callback);
+    DirectReadActions.Callback = typename TDirectReadDeferredActions::TCallback{
+        std::move(callback),
+        std::move(callbackGuardFactory)
+    };
 }
 
 template<bool UseMigrationProtocol>
@@ -3789,7 +3795,9 @@ template<bool UseMigrationProtocol>
 void TDeferredActions<UseMigrationProtocol>::DirectReadCallback() {
     auto& callback = DirectReadActions.Callback;
     if (callback) {
-        (*callback)();
+        NYdbGrpc::RunQueueClientCallback(callback->CallbackGuardFactory, [&] {
+            callback->Callback();
+        });
     }
 }
 

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
@@ -14,6 +14,8 @@
 
 #include <deque>
 #include <condition_variable>
+#include <functional>
+#include <memory>
 #include <typeinfo>
 #include <variant>
 #include <vector>
@@ -93,13 +95,47 @@ private:
 class IQueueClientContext;
 using IQueueClientContextPtr = std::shared_ptr<IQueueClientContext>;
 
+class IQueueClientCallbackGuard {
+public:
+    virtual ~IQueueClientCallbackGuard() = default;
+    virtual bool IsEntered() const noexcept = 0;
+};
+
+class TNoopQueueClientCallbackGuard final : public IQueueClientCallbackGuard {
+public:
+    bool IsEntered() const noexcept override {
+        return true;
+    }
+};
+
+using TQueueClientCallbackGuardFactory = std::function<std::unique_ptr<IQueueClientCallbackGuard>()>;
+
 // Provider of IQueueClientContext instances
 class IQueueClientContextProvider {
 public:
     virtual ~IQueueClientContextProvider() = default;
 
     virtual IQueueClientContextPtr CreateContext() = 0;
+
+    virtual TQueueClientCallbackGuardFactory GetCallbackGuardFactory() {
+        return [] {
+            return std::make_unique<TNoopQueueClientCallbackGuard>();
+        };
+    }
 };
+
+template<class F>
+void RunQueueClientCallback(const TQueueClientCallbackGuardFactory& guardFactory, F&& f) {
+    std::unique_ptr<IQueueClientCallbackGuard> guard;
+    if (guardFactory) {
+        guard = guardFactory();
+    } else {
+        guard = std::make_unique<TNoopQueueClientCallbackGuard>();
+    }
+    if (guard->IsEntered()) {
+        f();
+    }
+}
 
 // Activity context for a low-level client
 class IQueueClientContext : public IQueueClientContextProvider {
@@ -232,7 +268,9 @@ public:
 
     ~TSimpleRequestProcessor() {
         if (!Replied_ && Callback_) {
-            Callback_(TGrpcStatus::Internal("request left unhandled"), std::move(Reply_));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                Callback_(TGrpcStatus::Internal("request left unhandled"), std::move(Reply_));
+            });
             Callback_ = nullptr; // free resources as early as possible
         }
     }
@@ -249,7 +287,9 @@ public:
             status = TGrpcStatus::Internal("Unexpected error");
         }
         Replied_ = true;
-        Callback_(std::move(status), std::move(Reply_));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            Callback_(std::move(status), std::move(Reply_));
+        });
         Callback_ = nullptr; // free resources as early as possible
         return false;
     }
@@ -265,10 +305,13 @@ private:
     }
 
     void Start(TStub& stub, TAsyncRequest asyncRequest, const TRequest& request, IQueueClientContextProvider* provider) {
+        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
         auto context = provider->CreateContext();
         if (!context) {
             Replied_ = true;
-            Callback_(TGrpcStatus(grpc::StatusCode::CANCELLED, "Client is shutting down"), std::move(Reply_));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                Callback_(TGrpcStatus(grpc::StatusCode::CANCELLED, "Client is shutting down"), std::move(Reply_));
+            });
             Callback_ = nullptr;
             return;
         }
@@ -291,6 +334,7 @@ private:
     TResponse Reply_;
     std::mutex Mutex_;
     TAsyncReaderPtr Reader_;
+    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
 
     bool Replied_ = false;
 };
@@ -312,7 +356,9 @@ public:
 
     ~TAdvancedRequestProcessor() {
         if (!Replied_ && Callback_) {
-            Callback_(Context, TGrpcStatus::Internal("request left unhandled"), std::move(Reply_));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                Callback_(Context, TGrpcStatus::Internal("request left unhandled"), std::move(Reply_));
+            });
             Callback_ = nullptr; // free resources as early as possible
         }
     }
@@ -329,7 +375,9 @@ public:
             status = TGrpcStatus::Internal("Unexpected error");
         }
         Replied_ = true;
-        Callback_(Context, std::move(status), std::move(Reply_));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            Callback_(Context, std::move(status), std::move(Reply_));
+        });
         Callback_ = nullptr; // free resources as early as possible
         return false;
     }
@@ -345,10 +393,13 @@ private:
     }
 
     void Start(TStub& stub, TAsyncRequest asyncRequest, const TRequest& request, IQueueClientContextProvider* provider) {
+        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
         auto context = provider->CreateContext();
         if (!context) {
             Replied_ = true;
-            Callback_(Context, TGrpcStatus(grpc::StatusCode::CANCELLED, "Client is shutting down"), std::move(Reply_));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                Callback_(Context, TGrpcStatus(grpc::StatusCode::CANCELLED, "Client is shutting down"), std::move(Reply_));
+            });
             Callback_ = nullptr;
             return;
         }
@@ -371,6 +422,7 @@ private:
     TResponse Reply_;
     std::mutex Mutex_;
     TAsyncReaderPtr Reader_;
+    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
 
     bool Replied_ = false;
 };
@@ -585,7 +637,9 @@ public:
             }
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void Read(TResponse* message, TReadCallback callback) override {
@@ -613,7 +667,9 @@ public:
             status = TGrpcStatus(grpc::StatusCode::OUT_OF_RANGE, "Read EOF");
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void Finish(TReadCallback callback) override {
@@ -638,7 +694,9 @@ public:
             }
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void AddFinishedCallback(TReadCallback callback) override {
@@ -662,16 +720,21 @@ public:
             }
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
 private:
     void Start(TStub& stub, const TRequest& request, TAsyncRequest asyncRequest, IQueueClientContextProvider* provider) {
+        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
         auto context = provider->CreateContext();
         if (!context) {
             auto callback = std::move(Callback);
             TGrpcStatus status(grpc::StatusCode::CANCELLED, "Client is shutting down");
-            callback(std::move(status), nullptr);
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                callback(std::move(status), nullptr);
+            });
             return;
         }
 
@@ -719,7 +782,9 @@ private:
             GetInitialMetadata(initialMetadata);
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void OnStartDone(bool ok) {
@@ -737,7 +802,9 @@ private:
             Callback = nullptr;
         }
 
-        callback({ }, typename TBase::TPtr(this));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback({ }, typename TBase::TPtr(this));
+        });
     }
 
     void OnFinished(bool ok) {
@@ -782,14 +849,18 @@ private:
 
         for (auto& finishedCallback : finishedCallbacks) {
             auto statusCopy = status;
-            finishedCallback(std::move(statusCopy));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                finishedCallback(std::move(statusCopy));
+            });
         }
 
         if (startCallback) {
             if (status.Ok()) {
                 status = TGrpcStatus(grpc::StatusCode::UNKNOWN, "Unknown stream failure");
             }
-            startCallback(std::move(status), nullptr);
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                startCallback(std::move(status), nullptr);
+            });
         } else if (readCallback) {
             if (status.Ok()) {
                 status = TGrpcStatus(grpc::StatusCode::OUT_OF_RANGE, "Read EOF");
@@ -799,14 +870,19 @@ private:
                         std::string(value.begin(), value.end()));
                 }
             }
-            readCallback(std::move(status));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                readCallback(std::move(status));
+            });
         } else if (finishCallback) {
-            finishCallback(std::move(status));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                finishCallback(std::move(status));
+            });
         }
     }
 
     TReaderCallback Callback;
     TAsyncReaderPtr Stream;
+    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
     using TFixedEvent = TQueueClientFixedEvent<TSelf>;
     std::mutex Mutex;
     TFixedEvent OnReadDoneTag = { this, &TSelf::OnReadDone };
@@ -888,7 +964,9 @@ public:
         }
 
         if (!status.Ok() && callback) {
-            callback(std::move(status));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                callback(std::move(status));
+            });
         }
     }
 
@@ -918,7 +996,9 @@ public:
             }
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void Read(TResponse* message, TReadCallback callback) override {
@@ -946,7 +1026,9 @@ public:
             status = TGrpcStatus(grpc::StatusCode::OUT_OF_RANGE, "Read EOF");
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void Finish(TReadCallback callback) override {
@@ -976,7 +1058,9 @@ public:
             }
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void AddFinishedCallback(TReadCallback callback) override {
@@ -1000,18 +1084,23 @@ public:
             }
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
 private:
     template<typename> friend class TServiceConnection;
 
     void Start(TStub& stub, TAsyncRequest asyncRequest, IQueueClientContextProvider* provider) {
+        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
         auto context = provider->CreateContext();
         if (!context) {
             auto callback = std::move(ConnectedCallback);
             TGrpcStatus status(grpc::StatusCode::CANCELLED, "Client is shutting down");
-            callback(std::move(status), nullptr);
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                callback(std::move(status), nullptr);
+            });
             return;
         }
 
@@ -1044,7 +1133,9 @@ private:
             ConnectedCallback = nullptr;
         }
 
-        callback({ }, typename TBase::TPtr(this));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback({ }, typename TBase::TPtr(this));
+        });
     }
 
     void OnReadDone(bool ok) {
@@ -1084,7 +1175,9 @@ private:
             GetInitialMetadata(initialMetadata);
         }
 
-        callback(std::move(status));
+        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            callback(std::move(status));
+        });
     }
 
     void OnWriteDone(bool ok) {
@@ -1123,7 +1216,9 @@ private:
         }
 
         if (okCallback) {
-            okCallback(TGrpcStatus());
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                okCallback(TGrpcStatus());
+            });
         }
     }
 
@@ -1174,20 +1269,26 @@ private:
                 if (writeStatus.Ok()) {
                     writeStatus = TGrpcStatus(grpc::StatusCode::CANCELLED, "Write request dropped");
                 }
-                item.Callback(std::move(writeStatus));
+                RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                    item.Callback(std::move(writeStatus));
+                });
             }
         }
 
         for (auto& finishedCallback : finishedCallbacks) {
             TGrpcStatus statusCopy = status;
-            finishedCallback(std::move(statusCopy));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                finishedCallback(std::move(statusCopy));
+            });
         }
 
         if (connectedCallback) {
             if (status.Ok()) {
                 status = TGrpcStatus(grpc::StatusCode::UNKNOWN, "Unknown stream failure");
             }
-            connectedCallback(std::move(status), nullptr);
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                connectedCallback(std::move(status), nullptr);
+            });
         } else if (readCallback) {
             if (status.Ok()) {
                 status = TGrpcStatus(grpc::StatusCode::OUT_OF_RANGE, "Read EOF");
@@ -1197,9 +1298,13 @@ private:
                         std::string(value.begin(), value.end()));
                 }
             }
-            readCallback(std::move(status));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                readCallback(std::move(status));
+            });
         } else if (finishCallback) {
-            finishCallback(std::move(status));
+            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                finishCallback(std::move(status));
+            });
         }
     }
 
@@ -1220,6 +1325,7 @@ private:
 private:
     std::mutex Mutex;
     TAsyncReaderWriterPtr Stream;
+    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
     TConnectedCallback ConnectedCallback;
     TReadCallback ReadCallback;
     TReadCallback FinishCallback;

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_client_low.h
@@ -246,9 +246,19 @@ protected:
 
     void GetInitialMetadata(std::unordered_multimap<std::string, std::string>* metadata);
 
+    void InitCallbackGuard(IQueueClientContextProvider* provider) {
+        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
+    }
+
+    template<class F>
+    void RunGuarded(F&& f) {
+        RunQueueClientCallback(CallbackGuardFactory_, std::forward<F>(f));
+    }
+
     grpc::Status Status;
     grpc::ClientContext Context;
     std::shared_ptr<IQueueClientContext> LocalContext;
+    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
 };
 
 template<typename TStub, typename TRequest, typename TResponse>
@@ -268,7 +278,7 @@ public:
 
     ~TSimpleRequestProcessor() {
         if (!Replied_ && Callback_) {
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 Callback_(TGrpcStatus::Internal("request left unhandled"), std::move(Reply_));
             });
             Callback_ = nullptr; // free resources as early as possible
@@ -287,7 +297,7 @@ public:
             status = TGrpcStatus::Internal("Unexpected error");
         }
         Replied_ = true;
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             Callback_(std::move(status), std::move(Reply_));
         });
         Callback_ = nullptr; // free resources as early as possible
@@ -305,11 +315,11 @@ private:
     }
 
     void Start(TStub& stub, TAsyncRequest asyncRequest, const TRequest& request, IQueueClientContextProvider* provider) {
-        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
+        InitCallbackGuard(provider);
         auto context = provider->CreateContext();
         if (!context) {
             Replied_ = true;
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 Callback_(TGrpcStatus(grpc::StatusCode::CANCELLED, "Client is shutting down"), std::move(Reply_));
             });
             Callback_ = nullptr;
@@ -334,7 +344,6 @@ private:
     TResponse Reply_;
     std::mutex Mutex_;
     TAsyncReaderPtr Reader_;
-    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
 
     bool Replied_ = false;
 };
@@ -356,7 +365,7 @@ public:
 
     ~TAdvancedRequestProcessor() {
         if (!Replied_ && Callback_) {
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 Callback_(Context, TGrpcStatus::Internal("request left unhandled"), std::move(Reply_));
             });
             Callback_ = nullptr; // free resources as early as possible
@@ -375,7 +384,7 @@ public:
             status = TGrpcStatus::Internal("Unexpected error");
         }
         Replied_ = true;
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             Callback_(Context, std::move(status), std::move(Reply_));
         });
         Callback_ = nullptr; // free resources as early as possible
@@ -393,11 +402,11 @@ private:
     }
 
     void Start(TStub& stub, TAsyncRequest asyncRequest, const TRequest& request, IQueueClientContextProvider* provider) {
-        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
+        InitCallbackGuard(provider);
         auto context = provider->CreateContext();
         if (!context) {
             Replied_ = true;
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 Callback_(Context, TGrpcStatus(grpc::StatusCode::CANCELLED, "Client is shutting down"), std::move(Reply_));
             });
             Callback_ = nullptr;
@@ -422,7 +431,6 @@ private:
     TResponse Reply_;
     std::mutex Mutex_;
     TAsyncReaderPtr Reader_;
-    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
 
     bool Replied_ = false;
 };
@@ -637,7 +645,7 @@ public:
             }
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -667,7 +675,7 @@ public:
             status = TGrpcStatus(grpc::StatusCode::OUT_OF_RANGE, "Read EOF");
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -694,7 +702,7 @@ public:
             }
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -720,19 +728,19 @@ public:
             }
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
 
 private:
     void Start(TStub& stub, const TRequest& request, TAsyncRequest asyncRequest, IQueueClientContextProvider* provider) {
-        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
+        InitCallbackGuard(provider);
         auto context = provider->CreateContext();
         if (!context) {
             auto callback = std::move(Callback);
             TGrpcStatus status(grpc::StatusCode::CANCELLED, "Client is shutting down");
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 callback(std::move(status), nullptr);
             });
             return;
@@ -782,7 +790,7 @@ private:
             GetInitialMetadata(initialMetadata);
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -802,7 +810,7 @@ private:
             Callback = nullptr;
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback({ }, typename TBase::TPtr(this));
         });
     }
@@ -849,7 +857,7 @@ private:
 
         for (auto& finishedCallback : finishedCallbacks) {
             auto statusCopy = status;
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 finishedCallback(std::move(statusCopy));
             });
         }
@@ -858,7 +866,7 @@ private:
             if (status.Ok()) {
                 status = TGrpcStatus(grpc::StatusCode::UNKNOWN, "Unknown stream failure");
             }
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 startCallback(std::move(status), nullptr);
             });
         } else if (readCallback) {
@@ -870,11 +878,11 @@ private:
                         std::string(value.begin(), value.end()));
                 }
             }
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 readCallback(std::move(status));
             });
         } else if (finishCallback) {
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 finishCallback(std::move(status));
             });
         }
@@ -882,7 +890,6 @@ private:
 
     TReaderCallback Callback;
     TAsyncReaderPtr Stream;
-    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
     using TFixedEvent = TQueueClientFixedEvent<TSelf>;
     std::mutex Mutex;
     TFixedEvent OnReadDoneTag = { this, &TSelf::OnReadDone };
@@ -964,7 +971,7 @@ public:
         }
 
         if (!status.Ok() && callback) {
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 callback(std::move(status));
             });
         }
@@ -996,7 +1003,7 @@ public:
             }
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -1026,7 +1033,7 @@ public:
             status = TGrpcStatus(grpc::StatusCode::OUT_OF_RANGE, "Read EOF");
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -1058,7 +1065,7 @@ public:
             }
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -1084,7 +1091,7 @@ public:
             }
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -1093,12 +1100,12 @@ private:
     template<typename> friend class TServiceConnection;
 
     void Start(TStub& stub, TAsyncRequest asyncRequest, IQueueClientContextProvider* provider) {
-        CallbackGuardFactory_ = provider->GetCallbackGuardFactory();
+        InitCallbackGuard(provider);
         auto context = provider->CreateContext();
         if (!context) {
             auto callback = std::move(ConnectedCallback);
             TGrpcStatus status(grpc::StatusCode::CANCELLED, "Client is shutting down");
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 callback(std::move(status), nullptr);
             });
             return;
@@ -1133,7 +1140,7 @@ private:
             ConnectedCallback = nullptr;
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback({ }, typename TBase::TPtr(this));
         });
     }
@@ -1175,7 +1182,7 @@ private:
             GetInitialMetadata(initialMetadata);
         }
 
-        RunQueueClientCallback(CallbackGuardFactory_, [&] {
+        RunGuarded([&] {
             callback(std::move(status));
         });
     }
@@ -1216,7 +1223,7 @@ private:
         }
 
         if (okCallback) {
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 okCallback(TGrpcStatus());
             });
         }
@@ -1269,7 +1276,7 @@ private:
                 if (writeStatus.Ok()) {
                     writeStatus = TGrpcStatus(grpc::StatusCode::CANCELLED, "Write request dropped");
                 }
-                RunQueueClientCallback(CallbackGuardFactory_, [&] {
+                RunGuarded([&] {
                     item.Callback(std::move(writeStatus));
                 });
             }
@@ -1277,7 +1284,7 @@ private:
 
         for (auto& finishedCallback : finishedCallbacks) {
             TGrpcStatus statusCopy = status;
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 finishedCallback(std::move(statusCopy));
             });
         }
@@ -1286,7 +1293,7 @@ private:
             if (status.Ok()) {
                 status = TGrpcStatus(grpc::StatusCode::UNKNOWN, "Unknown stream failure");
             }
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 connectedCallback(std::move(status), nullptr);
             });
         } else if (readCallback) {
@@ -1298,11 +1305,11 @@ private:
                         std::string(value.begin(), value.end()));
                 }
             }
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 readCallback(std::move(status));
             });
         } else if (finishCallback) {
-            RunQueueClientCallback(CallbackGuardFactory_, [&] {
+            RunGuarded([&] {
                 finishCallback(std::move(status));
             });
         }
@@ -1325,7 +1332,6 @@ private:
 private:
     std::mutex Mutex;
     TAsyncReaderWriterPtr Stream;
-    TQueueClientCallbackGuardFactory CallbackGuardFactory_;
     TConnectedCallback ConnectedCallback;
     TReadCallback ReadCallback;
     TReadCallback FinishCallback;

--- a/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/coordination/coordination_ut.cpp
@@ -81,7 +81,10 @@ namespace {
             size_t pings_received = 0;
             while (stream->Read(&request)) {
                 std::cerr << "Session request: " << request.ShortDebugString() << std::endl;
-                Y_ABORT_UNLESS(request.has_ping(), "Only ping requests are supported");
+                if (request.has_session_stop()) {
+                    return grpc::Status::OK;
+                }
+                Y_ABORT_UNLESS(request.has_ping(), "Only ping and stop requests are supported");
                 if (++pings_received <= 2) {
                     // Only reply to the first 2 ping requests
                     Ydb::Coordination::SessionResponse response;
@@ -293,6 +296,51 @@ Y_UNIT_TEST_SUITE(Coordination) {
         auto res2 = session.Close().ExtractValueSync();
         std::cerr << "Close: " << ToString(res2.GetStatus()) << ": " << res2.GetIssues().ToString() << std::endl;
         UNIT_ASSERT_VALUES_EQUAL_C(res2.GetStatus(), EStatus::CLIENT_CANCELLED, res2.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(SessionDropsDriverFromStateCallback) {
+        TPortManager pm;
+
+        TMockCoordinationService coordinationService;
+        ui16 coordinationPort = pm.GetPort();
+        auto coordinationServer = StartGrpcServer(
+                TStringBuilder() << "0.0.0.0:" << coordinationPort,
+                coordinationService);
+
+        TMockDiscoveryService discoveryService;
+        {
+            auto& dbResult = discoveryService.MockResults["/Root/My/DB"];
+            auto* endpoint = dbResult.add_endpoints();
+            endpoint->set_address("localhost");
+            endpoint->set_port(coordinationPort);
+        }
+
+        ui16 discoveryPort = pm.GetPort();
+        auto discoveryServer = StartGrpcServer(
+                TStringBuilder() << "0.0.0.0:" << discoveryPort,
+                discoveryService);
+
+        auto config = TDriverConfig()
+            .SetEndpoint(TStringBuilder() << "localhost:" << discoveryPort)
+            .SetDatabase("/Root/My/DB");
+        std::optional<TDriver> driver(std::in_place, config);
+        std::optional<TClient> client(std::in_place, *driver);
+
+        auto droppedPromise = NThreading::NewPromise();
+        auto droppedFuture = droppedPromise.GetFuture();
+        auto settings = TSessionSettings()
+            .OnStateChanged([&](auto state) mutable {
+                if (state == ESessionState::ATTACHED) {
+                    client.reset();
+                    driver.reset();
+                    droppedPromise.SetValue();
+                }
+            })
+            .Timeout(TDuration::MilliSeconds(1000));
+
+        auto res = client->StartSession("/Some/Path", settings).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(res.GetStatus(), EStatus::SUCCESS, res.GetIssues().ToString());
+        UNIT_ASSERT(droppedFuture.Wait(TDuration::Seconds(10)));
     }
 
 }

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -13,6 +13,11 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
 using namespace NYdb;
 
 namespace {
@@ -59,6 +64,11 @@ namespace {
 
             //
 
+            if (CreateTableStarted) {
+                CreateTableStarted->set_value();
+                ContinueCreateTable.wait();
+            }
+
             auto op = response->mutable_operation();
 
             op->set_ready(true);
@@ -66,6 +76,24 @@ namespace {
 
             // Save the CreateTable request to allow the test to verify it
             LastCreateTableRequest = Ydb::Table::CreateTableRequest(*request);
+            return grpc::Status::OK;
+        }
+
+        virtual grpc::Status DeleteSession(
+            grpc::ServerContext* /* context */,
+            const Ydb::Table::DeleteSessionRequest* request,
+            Ydb::Table::DeleteSessionResponse* response
+        ) override {
+            std::cerr << "DeleteSession():" << std::endl
+                << request->DebugString()
+                << std::endl;
+
+            ++DeleteSessionRequests;
+
+            auto op = response->mutable_operation();
+            op->set_ready(true);
+            op->set_status(Ydb::StatusIds::SUCCESS);
+
             return grpc::Status::OK;
         }
 
@@ -92,6 +120,9 @@ namespace {
 
         std::optional<Ydb::Table::CreateTableRequest> LastCreateTableRequest;
         std::optional<Ydb::Table::AlterTableRequest> LastAlterTableRequest;
+        std::atomic_uint DeleteSessionRequests = 0;
+        std::promise<void>* CreateTableStarted = nullptr;
+        std::shared_future<void> ContinueCreateTable;
     };
 
     /**
@@ -110,6 +141,18 @@ namespace {
             .AddListeningPort(TString{address}, grpc::InsecureServerCredentials())
             .RegisterService(&service)
             .BuildAndStart();
+    }
+
+    template<class TPredicate>
+    bool WaitUntil(TPredicate&& predicate, std::chrono::milliseconds timeout = std::chrono::seconds(10)) {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (predicate()) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return predicate();
     }
 
     /**
@@ -159,6 +202,306 @@ namespace {
     }
 
 } // namespace <anonymous>
+
+TEST(TableTest, SessionHandleDestructionSendsDeleteSession) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    tableSession.reset();
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() == 1u;
+    }));
+
+    tableClient.reset();
+    driver.reset();
+}
+
+TEST(TableTest, ClientDestructorSendsDeleteSessionForPooledSessions) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    tableSession.reset();
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() == 1u;
+    }));
+    tableService.DeleteSessionRequests.store(0);
+
+    {
+        auto pooledSessionResult = tableClient->GetSession().ExtractValueSync();
+        ASSERT_TRUE(pooledSessionResult.IsSuccess());
+        auto pooledSession = pooledSessionResult.GetSession();
+    }
+
+    tableClient.reset();
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() == 1u;
+    }));
+
+    driver.reset();
+}
+
+TEST(TableTest, ExplicitStopClosesPooledSessions) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    tableSession.reset();
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() == 1u;
+    }));
+    tableService.DeleteSessionRequests.store(0);
+
+    {
+        auto pooledSessionResult = tableClient->GetSession().ExtractValueSync();
+        ASSERT_TRUE(pooledSessionResult.IsSuccess());
+        auto pooledSession = pooledSessionResult.GetSession();
+    }
+
+    ASSERT_EQ(tableService.DeleteSessionRequests.load(), 0u);
+
+    ASSERT_TRUE(tableClient->Stop().Wait(TDuration::Seconds(10)));
+    ASSERT_EQ(tableService.DeleteSessionRequests.load(), 1u);
+}
+
+TEST(TableTest, CheckedOutPooledSessionClosesRemotelyAfterExplicitStop) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    tableSession.reset();
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() == 1u;
+    }));
+    tableService.DeleteSessionRequests.store(0);
+
+    {
+        auto pooledSessionResult = tableClient->GetSession().ExtractValueSync();
+        ASSERT_TRUE(pooledSessionResult.IsSuccess());
+        auto pooledSession = pooledSessionResult.GetSession();
+
+        ASSERT_TRUE(tableClient->Stop().Wait(TDuration::Seconds(10)));
+        ASSERT_EQ(tableService.DeleteSessionRequests.load(), 0u);
+    }
+
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() == 1u;
+    }));
+}
+
+TEST(TableTest, DriverStopFromResponseCallbackRunsStopNotifications) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    {
+        auto pooledSessionResult = tableClient->GetSession().ExtractValueSync();
+        ASSERT_TRUE(pooledSessionResult.IsSuccess());
+        auto pooledSession = pooledSessionResult.GetSession();
+    }
+
+    std::promise<void> createTableStarted;
+    auto createTableStartedFuture = createTableStarted.get_future();
+    std::promise<void> continueCreateTable;
+    tableService.CreateTableStarted = &createTableStarted;
+    tableService.ContinueCreateTable = continueCreateTable.get_future().share();
+
+    std::promise<void> callbackDone;
+    auto callbackDoneFuture = callbackDone.get_future();
+    std::atomic_bool success = false;
+
+    auto requestFuture = tableSession->CreateTable(
+        "/Root/My/DB/driver_stop_from_callback",
+        NTable::TTableBuilder().Build()
+    );
+
+    ASSERT_EQ(createTableStartedFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+
+    requestFuture.Subscribe([&](const NThreading::TFuture<TStatus>& future) mutable {
+        success.store(future.GetValue().IsSuccess());
+        driver->Stop(true);
+        callbackDone.set_value();
+    });
+
+    continueCreateTable.set_value();
+
+    ASSERT_EQ(callbackDoneFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    ASSERT_TRUE(success.load());
+
+    ASSERT_TRUE(WaitUntil([&] {
+        return tableService.DeleteSessionRequests.load() >= 1u;
+    }));
+    ASSERT_TRUE(WaitUntil([&] {
+        auto stoppedSessionResult = tableClient->CreateSession().ExtractValueSync();
+        return stoppedSessionResult.GetStatus() == EStatus::CLIENT_CANCELLED;
+    }));
+}
+
+TEST(TableTest, DropLastOwnersFromResponseCallbackDoesNotDeadlock) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    std::weak_ptr<TGRpcConnectionsImpl> connections = CreateInternalInterface(*driver);
+
+    {
+        auto pooledSessionResult = tableClient->GetSession().ExtractValueSync();
+        ASSERT_TRUE(pooledSessionResult.IsSuccess());
+        auto pooledSession = pooledSessionResult.GetSession();
+    }
+
+    std::promise<void> createTableStarted;
+    auto createTableStartedFuture = createTableStarted.get_future();
+    std::promise<void> continueCreateTable;
+    tableService.CreateTableStarted = &createTableStarted;
+    tableService.ContinueCreateTable = continueCreateTable.get_future().share();
+
+    std::promise<void> callbackDone;
+    auto callbackDoneFuture = callbackDone.get_future();
+    std::atomic_bool success = false;
+
+    auto requestFuture = tableSession->CreateTable(
+        "/Root/My/DB/drop_owners",
+        NTable::TTableBuilder().Build()
+    );
+
+    ASSERT_EQ(createTableStartedFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+
+    requestFuture.Subscribe([&](const NThreading::TFuture<TStatus>& future) mutable {
+        success.store(future.GetValue().IsSuccess());
+        tableSession.reset();
+        tableClient.reset();
+        driver.reset();
+        callbackDone.set_value();
+    });
+
+    continueCreateTable.set_value();
+
+    ASSERT_EQ(callbackDoneFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    ASSERT_TRUE(success.load());
+    ASSERT_TRUE(WaitUntil([&] {
+        return connections.expired();
+    }));
+}
+
+TEST(TableTest, DriverStopFromResponseCallbackThenDropOwnersDoesNotDeadlock) {
+    TMockTableService tableService;
+    std::unique_ptr<grpc::Server> grpcServer;
+    std::unique_ptr<TDriver> driver;
+    std::unique_ptr<NTable::TTableClient> tableClient;
+    std::unique_ptr<NTable::TSession> tableSession;
+
+    StartServerWithTableService(
+        tableService,
+        grpcServer,
+        driver,
+        tableClient,
+        tableSession
+    );
+
+    std::weak_ptr<TGRpcConnectionsImpl> connections = CreateInternalInterface(*driver);
+
+    {
+        auto pooledSessionResult = tableClient->GetSession().ExtractValueSync();
+        ASSERT_TRUE(pooledSessionResult.IsSuccess());
+        auto pooledSession = pooledSessionResult.GetSession();
+    }
+
+    std::promise<void> createTableStarted;
+    auto createTableStartedFuture = createTableStarted.get_future();
+    std::promise<void> continueCreateTable;
+    tableService.CreateTableStarted = &createTableStarted;
+    tableService.ContinueCreateTable = continueCreateTable.get_future().share();
+
+    std::promise<void> callbackDone;
+    auto callbackDoneFuture = callbackDone.get_future();
+    std::atomic_bool success = false;
+
+    auto requestFuture = tableSession->CreateTable(
+        "/Root/My/DB/driver_stop_drop_owners",
+        NTable::TTableBuilder().Build()
+    );
+
+    ASSERT_EQ(createTableStartedFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+
+    requestFuture.Subscribe([&](const NThreading::TFuture<TStatus>& future) mutable {
+        success.store(future.GetValue().IsSuccess());
+        driver->Stop(true);
+        tableSession.reset();
+        tableClient.reset();
+        driver.reset();
+        callbackDone.set_value();
+    });
+
+    continueCreateTable.set_value();
+
+    ASSERT_EQ(callbackDoneFuture.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    ASSERT_TRUE(success.load());
+    ASSERT_TRUE(WaitUntil([&] {
+        return connections.expired();
+    }));
+}
 
 /**
  * Verify that the SDK creates the CREATE TABLE request correctly,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

This PR reworks YDB C++ SDK driver shutdown so all async callback paths participate in a shared driver stop state machine. Shutdown now stops response handling, fails queued/pending futures, drains completion work, and only then destroys the underlying driver/connection state.

It fixes ASAN-detected shutdown races where SDK callback threads could write into driver-owned state after the driver had already begun destruction. 

Driver shutdown flow:
1. TDriver::Stop() enters a shared driver stop state.
2. All registered SDK clients get STOP notification and drain/cancel their own pending work.
3. Low-level gRPC is stopped: no new contexts, existing contexts are cancelled, completion queues drain.
4. For wait=true, the SDK response queue is stopped.
5. Driver machinery destruction waits until all guarded SDK callbacks have exited.
6. After that the driver is marked fully stopped, so late callbacks are skipped instead of touching freed state.