### PR TITLE
schemeshard: action to move tablet to another storage pool

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -2465,6 +2465,7 @@ private:
 // request from Complete() — so success is reported only after the binding is durable.
 struct TSchemeShard::TTxMoveShardToStoragePool : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
     TEvPrivate::TEvMoveShardToStoragePool::TPtr Ev;
+    bool Persisted = false;
 
     TTxMoveShardToStoragePool(TSchemeShard* self, TEvPrivate::TEvMoveShardToStoragePool::TPtr& ev)
         : TBase(self)
@@ -2486,6 +2487,7 @@ struct TSchemeShard::TTxMoveShardToStoragePool : public NTabletFlatExecutor::TTr
         NIceDb::TNiceDb db(txc.DB);
         info->BindedChannels = Ev->Get()->NewBindings;
         Self->PersistChannelsBinding(db, shardIdx, info->BindedChannels);
+        Persisted = true;
 
         LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
             "TTxMoveShardToStoragePool: persisted new channel bindings for shard " << shardIdx);
@@ -2493,6 +2495,15 @@ struct TSchemeShard::TTxMoveShardToStoragePool : public NTabletFlatExecutor::TTr
     }
 
     void Complete(const TActorContext& ctx) override {
+        if (!Persisted) {
+            // Shard was deleted between the Hive ack and this transaction; Hive did apply the move
+            // but SchemeShard can no longer record it. Report partial success so the operator knows.
+            ctx.Send(Ev->Get()->HttpSender, new NMon::TEvRemoteBinaryInfoRes(
+                "HTTP/1.1 409 Conflict\r\nConnection: Close\r\n\r\n"
+                "Hive acknowledged the move but the shard was deleted before the bindings could be "
+                "persisted; the recorded bindings were not updated\r\n"));
+            return;
+        }
         // Binding durable now: answer with the Hive reply the actor captured.
         ctx.Send(Ev->Get()->HttpSender, new NMon::TEvRemoteJsonInfoRes(Ev->Get()->HiveReply));
     }

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -516,10 +516,13 @@ class TMonitoringMoveShardToStoragePool : public TActorBootstrapped<TMonitoringM
 private:
     NMon::TEvRemoteHttpInfo::TPtr Ev;
     TActorId SchemeShard;
-    TTabletId Hive;
+    TTabletId Hive;  // the Hive the request is currently addressed to; updated on a redirect
     TShardIdx ShardIdx;
     TChannelsBindings NewBindings;
-    THolder<TEvHive::TEvCreateTablet> CreateEv;
+    // Keep the request record so it can be re-sent to another Hive on INVALID_OWNER. The
+    // TEvCreateTablet event itself is consumed by each send, so it is rebuilt from this record.
+    NKikimrHive::TEvCreateTablet CreateRecord;
+    bool Redirected = false;
 
     TActorId PipeCache;
 
@@ -531,12 +534,18 @@ public:
         , Hive(hive)
         , ShardIdx(shardIdx)
         , NewBindings(std::move(newBindings))
-        , CreateEv(std::move(createEv))
+        , CreateRecord(createEv->Record)
     {}
+
+    void SendCreateTablet() {
+        auto ev = MakeHolder<TEvHive::TEvCreateTablet>();
+        ev->Record = CreateRecord;
+        Send(PipeCache, new TEvPipeCache::TEvForward(ev.Release(), ui64(Hive), /* subscribe */ true));
+    }
 
     void Bootstrap() {
         PipeCache = MakePipePerNodeCacheID(EPipePerNodeCache::Leader);
-        Send(PipeCache, new TEvPipeCache::TEvForward(CreateEv.Release(), ui64(Hive), /* subscribe */ true));
+        SendCreateTablet();
         Become(&TThis::StateWait);
     }
 
@@ -547,10 +556,52 @@ public:
         }
     }
 
+    void SendError(ui32 httpCode, const TString& reason, const TString& details) {
+        // Nothing has been persisted, so the action stays retryable.
+        Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(TStringBuilder()
+            << "HTTP/1.1 " << httpCode << " " << reason << "\r\nConnection: Close\r\n\r\n"
+            << details << "\r\n"));
+    }
+
     void Handle(TEvHive::TEvCreateTabletReply::TPtr& ev) {
+        const auto& record = ev->Get()->Record;
+        const NKikimrProto::EReplyStatus status = record.GetStatus();
+
+        // The tablet lives on a different Hive: re-send the request there. Bindings are persisted
+        // only after the owning Hive acks with OK/ALREADY, so a redirect must not persist anything.
+        // A tablet is owned by exactly one Hive (the root Hive or a tenant Hive), so a correct Hive
+        // redirects at most once; a second INVALID_OWNER means something is wrong, so bail out.
+        if (status == NKikimrProto::INVALID_OWNER) {
+            const TTabletId redirectTo = TTabletId(record.GetForwardRequest().GetHiveTabletId());
+            if (!redirectTo || Redirected) {
+                SendError(502, "Bad Gateway", TStringBuilder()
+                    << "Hive redirected the request (INVALID_OWNER) but no valid target Hive was"
+                       " provided or it redirected more than once; nothing was changed");
+                PassAway();
+                return;
+            }
+            Redirected = true;
+            // Stop subscribing to the old Hive before addressing the new one.
+            Send(PipeCache, new TEvPipeCache::TEvUnlink(ui64(Hive)));
+            Hive = redirectTo;
+            SendCreateTablet();
+            return;  // keep waiting for the reply from the new Hive
+        }
+
+        // Any status other than OK/ALREADY means Hive did not apply the move (e.g. BLOCKED or
+        // ERROR). Report it and persist nothing, so the recorded bindings still name the old pool.
+        if (status != NKikimrProto::OK && status != NKikimrProto::ALREADY) {
+            SendError(409, "Conflict", TStringBuilder()
+                << "Hive rejected the move: status " << NKikimrProto::EReplyStatus_Name(status)
+                << ", error reason " << NKikimrHive::EErrorReason_Name(record.GetErrorReason())
+                << "; nothing was changed");
+            PassAway();
+            return;
+        }
+
         TString text;
         try {
-            NProtobufJson::Proto2Json(ev->Get()->Record, text, {
+            NProtobufJson::Proto2Json(record, text, {
                 .EnumMode = NProtobufJson::TProto2JsonConfig::EnumName,
                 .FieldNameMode = NProtobufJson::TProto2JsonConfig::FieldNameSnakeCaseDense,
                 .MapAsObject = true,
@@ -567,7 +618,11 @@ public:
         PassAway();
     }
 
-    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&) {
+    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
+        if (ev->Get()->TabletId != ui64(Hive)) {
+            // Stale problem from a Hive we already redirected away from; ignore.
+            return;
+        }
         // Hive not reached: nothing persisted, so the action is retryable.
         Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(TStringBuilder() << "HTTP/1.1 502 Bad Gateway\r\nConnection: Close\r\n\r\nHive tablet disconnected\r\n"));
         PassAway();
@@ -1641,7 +1696,11 @@ private:
 
         TStringBuilder options;
         for (const auto& pool : pools) {
-            options << std::format("<option value='{0}'>{0} ({1})</option>", pool.GetName(), pool.GetKind());
+            // Pool name/kind are not user-controlled, but escape them anyway as basic HTML hygiene
+            // so values with special characters render literally.
+            const TString name = EncodeHtmlPcdata(pool.GetName());
+            const TString kind = EncodeHtmlPcdata(pool.GetKind());
+            options << std::format("<option value='{0}'>{0} ({1})</option>", name, kind);
         }
 
         // Duplicate params in query string in addition to form-urlencoded body

--- a/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__monitoring.cpp
@@ -1,4 +1,5 @@
 #include "schemeshard_impl.h"
+#include "schemeshard__operation_common.h"
 
 #include <ydb/core/base/mon_auth.h>
 #include <ydb/core/tx/schemeshard/schemeshard__monitoring.h_serialized.h>  // for enum ESweepAlert support methods
@@ -130,6 +131,8 @@ struct TCgi {
     static const TParam Resume;
     static const TParam Cancel;
     static const TParam SweepAlert;
+    static const TParam StoragePool;
+    static const TParam ConfirmSamePool;
 
     struct TPages {
         static constexpr TStringBuf MainPage = "Main";
@@ -148,6 +151,7 @@ struct TCgi {
         static constexpr TStringBuf ForceDropUnsafe = "ForceDropUnsafe";
         static constexpr TStringBuf TablePartitionsFormatSwitch = "TablePartitionsFormatSwitch";
         static constexpr TStringBuf TablePartitionsFormatSweep = "TablePartitionsFormatSweep";
+        static constexpr TStringBuf MoveToStoragePool = "MoveToStoragePool";
     };
 };
 
@@ -176,6 +180,8 @@ const TCgi::TParam TCgi::Resume = TStringBuf("Resume");
 const TCgi::TParam TCgi::Cancel = TStringBuf("Cancel");
 const TCgi::TParam TCgi::SweepAlert = TStringBuf("sweepalert");
 const TCgi::TParam TCgi::Action = TStringBuf("Action");
+const TCgi::TParam TCgi::StoragePool = TStringBuf("StoragePool");
+const TCgi::TParam TCgi::ConfirmSamePool = TStringBuf("ConfirmSamePool");
 
 namespace {
 
@@ -492,6 +498,78 @@ public:
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&) {
         Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
             TStringBuilder() << "HTTP/1.1 502 Bad Gateway\r\nConnection: Close\r\n\r\nSchemeShard tablet disconnected\r\n"));
+        PassAway();
+    }
+
+    void PassAway() override {
+        if (PipeCache) {
+            Send(PipeCache, new TEvPipeCache::TEvUnlink(0));
+        }
+        TActorBootstrapped::PassAway();
+    }
+};
+
+// Moves a shard's channels to other storage pool: notify Hive first, then (only on ack) ask the
+// schemeshard to persist the new bindings via TEvMoveShardToStoragePool. Hive-first keeps a
+// failed move retryable — nothing is persisted, so the recorded bindings still name the old pool.
+class TMonitoringMoveShardToStoragePool : public TActorBootstrapped<TMonitoringMoveShardToStoragePool> {
+private:
+    NMon::TEvRemoteHttpInfo::TPtr Ev;
+    TActorId SchemeShard;
+    TTabletId Hive;
+    TShardIdx ShardIdx;
+    TChannelsBindings NewBindings;
+    THolder<TEvHive::TEvCreateTablet> CreateEv;
+
+    TActorId PipeCache;
+
+public:
+    TMonitoringMoveShardToStoragePool(NMon::TEvRemoteHttpInfo::TPtr&& ev, TActorId schemeShard, TTabletId hive,
+            TShardIdx shardIdx, TChannelsBindings newBindings, THolder<TEvHive::TEvCreateTablet> createEv)
+        : Ev(std::move(ev))
+        , SchemeShard(schemeShard)
+        , Hive(hive)
+        , ShardIdx(shardIdx)
+        , NewBindings(std::move(newBindings))
+        , CreateEv(std::move(createEv))
+    {}
+
+    void Bootstrap() {
+        PipeCache = MakePipePerNodeCacheID(EPipePerNodeCache::Leader);
+        Send(PipeCache, new TEvPipeCache::TEvForward(CreateEv.Release(), ui64(Hive), /* subscribe */ true));
+        Become(&TThis::StateWait);
+    }
+
+    STFUNC(StateWait) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvHive::TEvCreateTabletReply, Handle);
+            hFunc(TEvPipeCache::TEvDeliveryProblem, Handle);
+        }
+    }
+
+    void Handle(TEvHive::TEvCreateTabletReply::TPtr& ev) {
+        TString text;
+        try {
+            NProtobufJson::Proto2Json(ev->Get()->Record, text, {
+                .EnumMode = NProtobufJson::TProto2JsonConfig::EnumName,
+                .FieldNameMode = NProtobufJson::TProto2JsonConfig::FieldNameSnakeCaseDense,
+                .MapAsObject = true,
+            });
+        } catch (const std::exception& e) {
+            Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes("HTTP/1.1 500 Internal Error\r\nConnection: Close\r\n\r\nUnexpected failure to serialize the response\r\n"));
+            PassAway();
+            return;
+        }
+
+        // Hive acked; hand the sender and serialized reply to the schemeshard to persist the
+        // bindings. That tx answers the HTTP request, so success is reported only once durable.
+        Send(SchemeShard, new TEvPrivate::TEvMoveShardToStoragePool(ShardIdx, std::move(NewBindings), Ev->Sender, std::move(text)));
+        PassAway();
+    }
+
+    void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr&) {
+        // Hive not reached: nothing persisted, so the action is retryable.
+        Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(TStringBuilder() << "HTTP/1.1 502 Bad Gateway\r\nConnection: Close\r\n\r\nHive tablet disconnected\r\n"));
         PassAway();
     }
 
@@ -1508,7 +1586,102 @@ private:
                     ++channelId;
                 }
             }
+
+            ActionMoveToStoragePool(shard, str);
         }
+    }
+
+    void ActionMoveToStoragePool(const TShardInfo& shard, TStringStream& str) const {
+        if (shard.TabletID == InvalidTabletId) {
+            return;
+        }
+        // A shard with no channel bindings can't be rebound to a new pool. On a tenant
+        // schemeshard this is expected for the tenant's system tablets: their storage pool
+        // bindings are kept only on the root schemeshard, so point the operator there. On
+        // the root schemeshard itself empty bindings are anomalous, so say so plainly
+        // rather than blaming a tenant that isn't involved.
+        if (shard.BindedChannels.empty()) {
+            if (Self->IsDomainSchemeShard) {
+                str << R"(
+                    <div class='container col-md-12'>
+                        <p>This is the <b>root schemeshard</b>, and this shard has no channel bindings
+                        recorded &mdash; that is unexpected. The tablet cannot be moved to another storage
+                        pool without bindings; investigate the shard's state before moving it.</p>
+                    </div>
+                )";
+                return;
+            }
+            const TStringBuf appPath = TabletDevUiAppPath();
+            const TString rootShardUrl = TStringBuilder() << appPath
+                << "?" << TCgi::TabletID.AsCgiParam(ui64(Self->ParentDomainId.OwnerId))
+                << "&" << TCgi::Page.AsCgiParam(TCgi::TPages::ShardInfoByTabletId)
+                << "&" << TCgi::ShardID.AsCgiParam(ui64(shard.TabletID))
+            ;
+            str << std::format(R"(
+                <div class='container col-md-12'>
+                    <p>This is a <b>tenant schemeshard</b>, and this shard has no channel bindings here:
+                    it is a tenant system tablet whose storage pool bindings are kept only on the root
+                    schemeshard. Move it to another storage pool from the
+                    <a href='{0}'>shard-info page on the root schemeshard</a>.</p>
+                </div>
+            )",
+                /* {0} */ rootShardUrl
+            );
+            return;
+        }
+        const TPathId subdomainPathId = Self->ResolvePathIdForDomain(shard.PathId);
+        auto itSubDomain = Self->SubDomains.find(subdomainPathId);
+        if (itSubDomain == Self->SubDomains.end()) {
+            return;
+        }
+        const auto& pools = itSubDomain->second->EffectiveStoragePools();
+        if (pools.empty()) {
+            return;
+        }
+
+        TStringBuilder options;
+        for (const auto& pool : pools) {
+            options << std::format("<option value='{0}'>{0} ({1})</option>", pool.GetName(), pool.GetKind());
+        }
+
+        // Duplicate params in query string in addition to form-urlencoded body
+        // to give user clear knowledge what parameters were.
+        // Params in the body are the actually used ones, query parameters will be ignored
+        // (see ydb/core/tablet/tablet_monitoring_proxy.cpp, TTabletMonitoringProxyActor::Handle(NMon::TEvHttpInfo::TPtr))
+        const TStringBuf appPath = TabletDevUiAppPath();
+        const TString actionUrl = TStringBuilder() << appPath << "?" << TCgi::TabletID.AsCgiParam(Self->TabletID())
+            << "&" << TCgi::Action.AsCgiParam(TCgi::TActions::MoveToStoragePool)
+            << "&" << TCgi::ShardID.AsCgiParam(shard.TabletID)
+        ;
+
+        str << std::format(R"(
+                <div class='container col-md-12'>
+                    <form method='POST' class='form-horizontal col-md-12' action='{0}'>
+                        <input type='hidden' id='TabletID' name='{1}' value='{2}' />
+                        <input type='hidden' id='Action' name='{3}' value='{4}' />
+                        <input type='hidden' id='ShardID' name='{5}' value='{6}' />
+                        <div class='form-group col-md-12'>
+                            <label for='{7}'>Target storage pool:</label>
+                            <select id='{7}' name='{7}'>{8}</select>
+                            <input class='btn btn-primary btn-lg' type='submit' value='Move tablet to storage pool' />
+                        </div>
+                        <div class='form-group col-md-12'>
+                            <label><input type='checkbox' name='{9}' value='1' /> Move even if already on this pool (re-notify Hive)</label>
+                        </div>
+                    </form>
+                </div>
+            )",
+            /* {0} */ actionUrl,
+            /* {1} */ TCgi::TabletID.Name,
+            /* {2} */ Self->TabletID(),
+            /* {3} */ TCgi::Action.Name,
+            /* {4} */ TCgi::TActions::MoveToStoragePool,
+            /* {5} */ TCgi::ShardID.Name,
+            /* {6} */ ui64(shard.TabletID),
+            /* {7} */ TCgi::StoragePool.Name,
+            /* {8} */ TString(options),
+            /* {9} */ TCgi::ConfirmSamePool.Name
+        );
     }
 
     TString LinkToPathInfo(TPathId pathId) const {
@@ -1943,12 +2116,19 @@ private:
 private:
     void SendBadRequest(const TString& details, const TActorContext& ctx) {
         ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
-            TStringBuilder() << "HTTP/1.1 400 Bad Request\r\nConnection: Close\r\n\r\n" << details << "\r\n"));
+            TStringBuilder() << "HTTP/1.1 400 Bad Request\r\nConnection: Close\r\n\r\n" << details << "\r\n"
+        ));
     }
 
     void SendRedirect(const TString& location, const TActorContext& ctx) {
         ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
             TStringBuilder() << "HTTP/1.1 303 See Other\r\nLocation: " << location << "\r\n\r\n"
+        ));
+    }
+
+    void SendOk(const TString& details, const TActorContext& ctx) {
+        ctx.Send(Ev->Sender, new NMon::TEvRemoteBinaryInfoRes(
+            TStringBuilder() << "HTTP/1.1 200 OK\r\nConnection: Close\r\n\r\n" << details << "\r\n"
         ));
     }
 
@@ -2008,6 +2188,115 @@ private:
             }
 
             ctx.Register(new TMonitoringForceDropUnsafe(std::move(Ev), Self->TabletID(), path.PathString()));
+
+        } else if (action == TCgi::TActions::MoveToStoragePool) {
+            const TTabletId tabletId = TTabletId(TryParseTabletId(params.Get(TCgi::ShardID)));
+            const TShardIdx shardIdx = Self->GetShardIdx(tabletId);
+            if (!shardIdx) {
+                SendBadRequest("Cannot find the specified shard", ctx);
+                return;
+            }
+            auto* info = Self->ShardInfos.FindPtr(shardIdx);
+            if (!info) {
+                SendBadRequest("Cannot find the specified shard info", ctx);
+                return;
+            }
+            if (info->TabletID == InvalidTabletId) {
+                SendBadRequest("Shard has no running tablet to move", ctx);
+                return;
+            }
+            // Reject if the shard is owned by an in-flight schema operation. CurrentTxId
+            // is set when an op starts but not reset on completion, so a bare
+            // CurrentTxId != InvalidTxId check would wrongly block long-idle shards;
+            // keying on the op being still active also lets idle system tablets be moved.
+            if (info->CurrentTxId != InvalidTxId && Self->Operations.contains(info->CurrentTxId)) {
+                SendBadRequest(
+                    TStringBuilder() << "Shard is busy with an in-flight operation " << info->CurrentTxId,
+                    ctx
+                );
+                return;
+            }
+            // A shard with no channel bindings can't be rebound: rebinding from empty
+            // would just persist and ship empty bindings to Hive. On a tenant schemeshard
+            // this is the expected shape of the tenant's system tablets (their bindings
+            // live only on the root schemeshard); on the root schemeshard it is anomalous.
+            if (info->BindedChannels.empty()) {
+                SendBadRequest(
+                    Self->IsDomainSchemeShard
+                        ? "Shard has no channel bindings; this is unexpected on the root schemeshard. "
+                          "Cannot move a tablet without bindings."
+                        : "Shard has no channel bindings on this tenant schemeshard; it is a tenant system "
+                          "tablet whose storage pool bindings are kept only on the root schemeshard. "
+                          "Move it from the root schemeshard instead.",
+                    ctx
+                );
+                return;
+            }
+
+            const TPathId subdomainPathId = Self->ResolvePathIdForDomain(info->PathId);
+            auto itSubDomain = Self->SubDomains.find(subdomainPathId);
+            if (itSubDomain == Self->SubDomains.end()) {
+                SendBadRequest(TStringBuilder() << "Cannot resolve subdomain for path " << info->PathId, ctx);
+                return;
+            }
+            const auto& pools = itSubDomain->second->EffectiveStoragePools();
+
+            const TString targetPoolName = params.Get(TCgi::StoragePool);
+            if (!targetPoolName) {
+                SendBadRequest("StoragePool parameter is required", ctx);
+                return;
+            }
+            const TStoragePool* targetPool = nullptr;
+            for (const auto& pool : pools) {
+                if (pool.GetName() == targetPoolName) {
+                    targetPool = &pool;
+                    break;
+                }
+            }
+            if (!targetPool) {
+                SendBadRequest(
+                    TStringBuilder() << "Storage pool '" << targetPoolName << "' is not registered for the shard's subdomain",
+                    ctx
+                );
+                return;
+            }
+
+            // Already on the target pool: normally a completed move (bindings are recorded only
+            // after a Hive ack), so no-op. The confirmation box forces a re-notify anyway (e.g. to
+            // reconcile a Hive that lost the assignment).
+            const bool alreadyOnTargetPool = AllOf(info->BindedChannels, [&](const auto& bind) {
+                return bind.GetStoragePoolName() == targetPool->GetName();
+            });
+            const bool confirmSamePool = params.Get(TCgi::ConfirmSamePool) == "1";
+            if (alreadyOnTargetPool && !confirmSamePool) {
+                SendOk(
+                    TStringBuilder() << "Shard is already on storage pool '" << targetPoolName
+                        << "', nothing to do. Tick the confirmation box to re-notify Hive anyway.",
+                    ctx
+                );
+                return;
+            }
+
+            // No persist here: compute new bindings and pre-build the Hive event. Persist runs only
+            // after Hive acks (in the actor's flow), keeping a failed move retryable.
+            TChannelsBindings newBindings = info->BindedChannels;
+            for (auto& bind : newBindings) {
+                bind.SetStoragePoolName(targetPool->GetName());
+                bind.SetStoragePoolKind(targetPool->GetKind());
+            }
+
+            TPathElement::TPtr path = Self->PathsById.at(info->PathId);
+            // CreateEvCreateTablet copies the current (old-pool) bindings; override with the new ones.
+            THolder<TEvHive::TEvCreateTablet> createEv = CreateEvCreateTablet(path, shardIdx, Self);
+            createEv->Record.ClearBindedChannels();
+            for (const auto& bind : newBindings) {
+                *createEv->Record.AddBindedChannels() = bind;
+            }
+            const TTabletId hive = Self->ResolveHive(shardIdx);
+
+            ctx.Register(new TMonitoringMoveShardToStoragePool(
+                std::move(Ev), Self->SelfId(), hive, shardIdx, std::move(newBindings), std::move(createEv)
+            ));
 
         } else if (action == TCgi::TActions::TablePartitionsFormatSwitch) {
             const bool switchEnabled = AppData()->FeatureFlags.GetEnableTablePartitionsFormatShardIdx();
@@ -2112,6 +2401,51 @@ private:
         }
     }
 };
+
+// Persists a shard's new channel bindings once Hive has acked the move, then answers the HTTP
+// request from Complete() — so success is reported only after the binding is durable.
+struct TSchemeShard::TTxMoveShardToStoragePool : public NTabletFlatExecutor::TTransactionBase<TSchemeShard> {
+    TEvPrivate::TEvMoveShardToStoragePool::TPtr Ev;
+
+    TTxMoveShardToStoragePool(TSchemeShard* self, TEvPrivate::TEvMoveShardToStoragePool::TPtr& ev)
+        : TBase(self)
+        , Ev(ev)
+    {}
+
+    TTxType GetTxType() const override { return TXTYPE_MONITORING; }
+
+    bool Execute(NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& ctx) override {
+        const TShardIdx shardIdx = Ev->Get()->ShardIdx;
+        auto* info = Self->ShardInfos.FindPtr(shardIdx);
+        if (!info) {
+            // Shard deleted between Hive ack and persist; nothing to record.
+            LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                "TTxMoveShardToStoragePool: shard " << shardIdx << " no longer exists, skipping persist");
+            return true;
+        }
+
+        NIceDb::TNiceDb db(txc.DB);
+        info->BindedChannels = Ev->Get()->NewBindings;
+        Self->PersistChannelsBinding(db, shardIdx, info->BindedChannels);
+
+        LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+            "TTxMoveShardToStoragePool: persisted new channel bindings for shard " << shardIdx);
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        // Binding durable now: answer with the Hive reply the actor captured.
+        ctx.Send(Ev->Get()->HttpSender, new NMon::TEvRemoteJsonInfoRes(Ev->Get()->HiveReply));
+    }
+};
+
+NTabletFlatExecutor::ITransaction* TSchemeShard::CreateTxMoveShardToStoragePool(TEvPrivate::TEvMoveShardToStoragePool::TPtr& ev) {
+    return new TTxMoveShardToStoragePool(this, ev);
+}
+
+void TSchemeShard::Handle(TEvPrivate::TEvMoveShardToStoragePool::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxMoveShardToStoragePool(ev), ctx);
+}
 
 bool TSchemeShard::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev, const TActorContext &ctx) {
     if (!Executor() || !Executor()->GetStats().IsActive)

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -398,7 +398,7 @@ public:
     void SendCreateTabletEvent(const TPathId& pathId, TShardIdx shardIdx, TOperationContext& context) {
         auto path = context.SS->PathsById.at(pathId);
 
-        auto ev = CreateEvCreateTablet(path, shardIdx, context);
+        auto ev = CreateEvCreateTablet(path, shardIdx, context.SS);
         auto rootHiveId = context.SS->GetGlobalHive();
 
         LOG_D(DebugHint() << "Send CreateTablet event to Hive: " << rootHiveId << " msg:  "<< ev->Record.DebugString());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.cpp
@@ -17,16 +17,16 @@
 namespace NKikimr {
 namespace NSchemeShard {
 
-THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr targetPath, TShardIdx shardIdx, TOperationContext& context)
+THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr targetPath, TShardIdx shardIdx, TSchemeShard* ss)
 {
-    auto tablePartitionConfig = context.SS->GetTablePartitionConfigWithAlterData(targetPath->PathId);
-    const auto& shard = context.SS->ShardInfos[shardIdx];
+    auto tablePartitionConfig = ss->GetTablePartitionConfigWithAlterData(targetPath->PathId);
+    const auto& shard = ss->ShardInfos[shardIdx];
 
     if (shard.TabletType == ETabletType::BlockStorePartition ||
         shard.TabletType == ETabletType::BlockStorePartition2 ||
         shard.TabletType == ETabletType::BlockStorePartitionDirect)
     {
-        auto it = context.SS->BlockStoreVolumes.FindPtr(targetPath->PathId);
+        auto it = ss->BlockStoreVolumes.FindPtr(targetPath->PathId);
         Y_ABORT_UNLESS(it, "Missing BlockStoreVolume while creating BlockStorePartition tablet");
         auto volume = *it;
         /*const auto* volumeConfig = &volume->VolumeConfig;
@@ -37,20 +37,20 @@ THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr target
 
     THolder<TEvHive::TEvCreateTablet> ev = MakeHolder<TEvHive::TEvCreateTablet>(ui64(shardIdx.GetOwnerId()), ui64(shardIdx.GetLocalId()), shard.TabletType, shard.BindedChannels);
 
-    TPathId domainId = context.SS->ResolvePathIdForDomain(targetPath);
+    TPathId domainId = ss->ResolvePathIdForDomain(targetPath);
 
-    TPathElement::TPtr domainEl = context.SS->PathsById.at(domainId);
+    TPathElement::TPtr domainEl = ss->PathsById.at(domainId);
     auto objectDomain = ev->Record.MutableObjectDomain();
     if (domainEl->IsRoot()) {
-        objectDomain->SetSchemeShard(context.SS->ParentDomainId.OwnerId);
-        objectDomain->SetPathId(context.SS->ParentDomainId.LocalPathId);
+        objectDomain->SetSchemeShard(ss->ParentDomainId.OwnerId);
+        objectDomain->SetPathId(ss->ParentDomainId.LocalPathId);
     } else {
         objectDomain->SetSchemeShard(domainId.OwnerId);
         objectDomain->SetPathId(domainId.LocalPathId);
     }
 
-    Y_ABORT_UNLESS(context.SS->SubDomains.contains(domainId));
-    TSubDomainInfo::TPtr subDomain = context.SS->SubDomains.at(domainId);
+    Y_ABORT_UNLESS(ss->SubDomains.contains(domainId));
+    TSubDomainInfo::TPtr subDomain = ss->SubDomains.at(domainId);
 
     TPathId resourcesDomainId;
     if (subDomain->GetResourcesDomainId()) {
@@ -226,7 +226,7 @@ bool TCreateParts::HandleReply(TEvHive::TEvCreateTabletReply::TPtr& ev, TOperati
         context.OnComplete.UnbindMsgFromPipe(OperationId, hive, shardIdx);
 
         auto path = context.SS->PathsById.at(txState.TargetPathId);
-        auto request = CreateEvCreateTablet(path, shardIdx, context);
+        auto request = CreateEvCreateTablet(path, shardIdx, context.SS);
 
         LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                     DebugHint() << " CreateRequest"
@@ -351,7 +351,7 @@ bool TCreateParts::ProgressState(TOperationContext& context) {
             context.OnComplete.BindMsgToPipe(OperationId, context.SS->GetGlobalHive(), shard.Idx, ev.Release());
         } else {
             auto path = context.SS->PathsById.at(txState->TargetPathId);
-            auto ev = CreateEvCreateTablet(path, shard.Idx, context);
+            auto ev = CreateEvCreateTablet(path, shard.Idx, context.SS);
 
             auto hiveToRequest = context.SS->ResolveHive(shard.Idx);
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.h
@@ -66,7 +66,7 @@ NKikimrSchemeOp::TModifyScheme MoveTableTask(NKikimr::NSchemeShard::TPath& src, 
 NKikimrSchemeOp::TModifyScheme MoveTableIndexTask(NKikimr::NSchemeShard::TPath& src, NKikimr::NSchemeShard::TPath& dst);
 NKikimrSchemeOp::TModifyScheme MoveLocalIndexTask(const TString& tablePath, const TString& srcIndexPath, const TString& dstIndexName);
 
-THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr targetPath, TShardIdx shardIdx, TOperationContext& context);
+THolder<TEvHive::TEvCreateTablet> CreateEvCreateTablet(TPathElement::TPtr targetPath, TShardIdx shardIdx, TSchemeShard* ss);
 
 void AbortUnsafeDropOperation(const TOperationId& operationId, const TTxId& txId, TOperationContext& context);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -5901,6 +5901,7 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         HFuncTraced(TEvPrivate::TEvCleanDroppedPaths, Handle);
         HFuncTraced(TEvPrivate::TEvCleanDroppedSubDomains, Handle);
         HFuncTraced(TEvPrivate::TEvSubscribeToShardDeletion, Handle);
+        HFuncTraced(TEvPrivate::TEvMoveShardToStoragePool, Handle);
 
         // Test-only notification
         IgnoreFunc(TEvPrivate::TEvTestNotifySubdomainCleanup);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1053,6 +1053,10 @@ public:
     struct TTxMonitoring;
     //OnRenderAppHtmlPage
 
+    struct TTxMoveShardToStoragePool;
+    NTabletFlatExecutor::ITransaction* CreateTxMoveShardToStoragePool(TEvPrivate::TEvMoveShardToStoragePool::TPtr& ev);
+    void Handle(TEvPrivate::TEvMoveShardToStoragePool::TPtr& ev, const TActorContext& ctx);
+
     struct TTxInit;
     NTabletFlatExecutor::ITransaction* CreateTxInit();
 

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "schemeshard_identificators.h"
 
+#include <ydb/core/base/storage_pools.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
@@ -57,6 +58,7 @@ namespace TEvPrivate {
         EvProgressTablePartitionsFormatSweep,
         EvFullBackupItemDone,
         EvProgressForcedCompaction,
+        EvMoveShardToStoragePool,
         EvEnd
     };
 
@@ -404,6 +406,24 @@ namespace TEvPrivate {
 
     struct TEvProgressForcedCompaction : TEventLocal<TEvProgressForcedCompaction, EvProgressForcedCompaction> {
         TEvProgressForcedCompaction()
+        {}
+    };
+
+    // Sent by the DevUI move-shard actor once Hive acks, to persist the shard's new channel
+    // bindings in a dedicated tx. That tx also answers the HTTP request (from Complete()), so
+    // success is reported only after the binding is durable. HttpSender: the request's sender;
+    // HiveReply: the already-serialized Hive response to hand back.
+    struct TEvMoveShardToStoragePool : public TEventLocal<TEvMoveShardToStoragePool, EvMoveShardToStoragePool> {
+        TShardIdx ShardIdx;
+        TChannelsBindings NewBindings;
+        TActorId HttpSender;
+        TString HiveReply;
+
+        TEvMoveShardToStoragePool(const TShardIdx& shardIdx, TChannelsBindings newBindings, const TActorId& httpSender, TString hiveReply)
+            : ShardIdx(shardIdx)
+            , NewBindings(std::move(newBindings))
+            , HttpSender(httpSender)
+            , HiveReply(std::move(hiveReply))
         {}
     };
 

--- a/ydb/core/tx/schemeshard/ut_base/ut_move_tablet_to_storage_pool.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_move_tablet_to_storage_pool.cpp
@@ -1,0 +1,294 @@
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/mon_helpers.h>
+
+using namespace NKikimr;
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+namespace {
+
+// GET the DevUI shard-info-by-tablet-id page HTML.
+TString GetShardInfoHtml(TTestActorRuntime& runtime, ui64 schemeShard, ui64 tabletId) {
+    const TString query = TStringBuilder()
+        << "/app?TabletID=" << schemeShard
+        << "&Page=ShardInfoByTabletId"
+        << "&ShardID=" << tabletId
+    ;
+    return SendSchemeShardMonRequest(runtime, schemeShard, query, HTTP_METHOD_GET).Body;
+}
+
+// Extract the BindedChannels table region of the shard-info page, isolating it from
+// the MoveToStoragePool form (whose <select> lists every pool name).
+TString GetBindedChannelsRegion(const TString& html) {
+    TStringBuf text = html;
+    TStringBuf region;
+    if (!text.TrySplit("BindedChannels for shard idx", region, text)) {
+        return {};
+    }
+    text.TrySplit("</table>", region, text);
+    return TString(region);
+}
+
+}  // namespace
+
+Y_UNIT_TEST_SUITE(TSchemeShardMoveTabletToStoragePool) {
+
+    Y_UNIT_TEST_FLAGS(MoveToStoragePool, AlterDatabaseCreateHiveFirst, ExternalHive) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+        TestAlterExtSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf(R"(
+                    Name: "USER_0"
+                    ExternalSchemeShard: true
+                    PlanResolution: 50
+                    Coordinators: 1
+                    Mediators: 1
+                    TimeCastBucketsPerMediator: 2
+                    StoragePools {
+                        Name: "pool-1"
+                        Kind: "pool-kind-1"
+                    }
+                    StoragePools {
+                        Name: "pool-2"
+                        Kind: "pool-kind-2"
+                    }
+
+                    ExternalHive: %s
+                )",
+                ToString(ExternalHive).c_str()
+            )
+        );
+        env.TestWaitNotification(runtime, {txId, txId - 1});
+
+        ui64 tenantSchemeShard = 0;
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0"),
+            NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
+        });
+        UNIT_ASSERT(tenantSchemeShard != 0 && tenantSchemeShard != (ui64)-1);
+
+        // Create a table in the subdomain so its datashard binds to a storage pool.
+        TestCreateTable(runtime, tenantSchemeShard, ++txId, "/MyRoot/USER_0",
+            R"(
+                Name: "table"
+                Columns { Name: "key"   Type: "Uint64" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+            )"
+        );
+        env.TestWaitNotification(runtime, txId, tenantSchemeShard);
+
+        auto tableDesc = DescribePath(runtime, tenantSchemeShard, "/MyRoot/USER_0/table", true);
+        const auto& partitions = tableDesc.GetPathDescription().GetTablePartitions();
+        UNIT_ASSERT_VALUES_EQUAL(partitions.size(), 1);
+        const ui64 datashardId = partitions.Get(0).GetDatashardId();
+
+        // Move the datashard's storage to pool-2.
+        {
+            auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, datashardId, "pool-2");
+            UNIT_ASSERT_C(r.IsJson(), "Expected JSON success reply, got: " << r.Body);
+            UNIT_ASSERT_C(r.Body.Contains("OK"), "Expected Hive reply status OK, got: " << r.Body);
+        }
+
+        // The SchemeShard-side binding now points every channel at pool-2.
+        {
+            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, tenantSchemeShard, datashardId));
+            UNIT_ASSERT_C(region.Contains("pool-2"), region);
+            UNIT_ASSERT_C(!region.Contains("pool-1"), region);
+        }
+
+        // The binding is persisted: it survives a SchemeShard reboot.
+        RebootTablet(runtime, tenantSchemeShard, runtime.AllocateEdgeActor());
+        {
+            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, tenantSchemeShard, datashardId));
+            UNIT_ASSERT_C(region.Contains("pool-2"), region);
+            UNIT_ASSERT_C(!region.Contains("pool-1"), region);
+        }
+
+        // Moving to the pool the shard is already on is a no-op (no Hive round-trip).
+        {
+            auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, datashardId, "pool-2");
+            UNIT_ASSERT_C(!r.IsJson(), "Expected plain no-op reply, got JSON: " << r.Body);
+            UNIT_ASSERT_C(r.Body.Contains("already"), r.Body);
+        }
+
+        // ...unless the confirmation flag is set: then Hive is re-notified even for the same pool.
+        {
+            auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, datashardId, "pool-2", /* confirmSamePool */ true);
+            UNIT_ASSERT_C(r.IsJson(), "Expected JSON success reply, got: " << r.Body);
+            UNIT_ASSERT_C(r.Body.Contains("OK"), "Expected Hive reply status OK, got: " << r.Body);
+        }
+
+        // Negative: moving to a pool not registered for the subdomain is rejected.
+        {
+            auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, datashardId, "no-such-pool");
+            UNIT_ASSERT_C(!r.IsJson(), "Expected error reply, got JSON: " << r.Body);
+            UNIT_ASSERT_C(r.Body.Contains("not registered"), r.Body);
+        }
+
+        // Negative: unknown shard/tablet id is rejected.
+        {
+            auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, 0, "pool-2");
+            UNIT_ASSERT_C(!r.IsJson(), "Expected error reply, got JSON: " << r.Body);
+            UNIT_ASSERT_C(r.Body.Contains("Cannot find"), r.Body);
+        }
+    }
+
+    // A tenant's system tablet (e.g. schemeshard itself or a hive) is registered on the tenant
+    // schemeshard with no channel bindings: those live only on the root schemeshard.
+    // The move must be refused there and the operator pointed at the root schemeshard.
+    Y_UNIT_TEST_FLAGS(SystemTabletOnTenantSchemeShard, AlterDatabaseCreateHiveFirst, ExternalHive) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+        TestAlterExtSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf(R"(
+                    Name: "USER_0"
+                    ExternalSchemeShard: true
+                    PlanResolution: 50
+                    Coordinators: 1
+                    Mediators: 1
+                    TimeCastBucketsPerMediator: 2
+                    StoragePools {
+                        Name: "pool-1"
+                        Kind: "pool-kind-1"
+                    }
+                    StoragePools {
+                        Name: "pool-2"
+                        Kind: "pool-kind-2"
+                    }
+
+                    ExternalHive: %s
+                )",
+                ToString(ExternalHive).c_str()
+            )
+        );
+        env.TestWaitNotification(runtime, {txId, txId - 1});
+
+        ui64 tenantSchemeShard = 0;
+        auto subdomainDesc = DescribePath(runtime, "/MyRoot/USER_0");
+        TestDescribeResult(subdomainDesc, {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0"),
+            NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
+        });
+        UNIT_ASSERT(tenantSchemeShard != 0 && tenantSchemeShard != (ui64)-1);
+
+        //NOTE: Right after extsubdomain creation system tablets aren't even registered
+        // properly. They would be, but only after tenant schemeshard reboot.
+
+        // Before reboot.
+        {
+            // The tenant schemeshard doesn't even know about itself as a shard.
+            // Both ShardInfo page and MoveToStoragePool action returns error.
+            {
+                const TString html = GetShardInfoHtml(runtime, tenantSchemeShard, tenantSchemeShard);
+                UNIT_ASSERT_C(html.Contains("No shard info for shard ID"), html);
+            }
+            {
+                auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, tenantSchemeShard, "pool-2");
+                UNIT_ASSERT_C(!r.IsJson(), "Expected error reply, got JSON: " << r.Body);
+                UNIT_ASSERT_C(r.Body.Contains("Cannot find the specified shard"), r.Body);
+            }
+        }
+
+        RebootTablet(runtime, tenantSchemeShard, runtime.AllocateEdgeActor());
+
+        // After reboot.
+        {
+            // The tenant schemeshard offers no move form for the schemeshard (will be the same for any system tablet).
+            // It explains the shard is a tenant system tablet and links to the root schemeshard's shard-info page.
+            {
+                const TString html = GetShardInfoHtml(runtime, tenantSchemeShard, tenantSchemeShard);
+                UNIT_ASSERT_C(html.Contains("tenant schemeshard"), html);
+                UNIT_ASSERT_C(html.Contains(TStringBuilder() << "TabletID=" << ui64(TTestTxConfig::SchemeShard)), html);
+                UNIT_ASSERT_C(!html.Contains("Move tablet to storage pool"), html);
+            }
+
+            // POST is refused with a message pointing at the root schemeshard.
+            {
+                auto r = PostMoveToStoragePoolAction(runtime, tenantSchemeShard, tenantSchemeShard, "pool-2");
+                UNIT_ASSERT_C(!r.IsJson(), "Expected error reply, got JSON: " << r.Body);
+                UNIT_ASSERT_C(r.Body.Contains("no channel bindings"), r.Body);
+                UNIT_ASSERT_C(r.Body.Contains("root schemeshard"), r.Body);
+            }
+        }
+    }
+
+    // Root schemeshard can move a tenant's system tablet (e.g. the tenant schemeshard itself)
+    // to another storage pool because root maintains the channel bindings for all shards,
+    // including tenant system tablets.
+    Y_UNIT_TEST_FLAGS(MoveTenantSchemeShard, AlterDatabaseCreateHiveFirst, ExternalHive) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableAlterDatabaseCreateHiveFirst(AlterDatabaseCreateHiveFirst));
+        ui64 txId = 100;
+
+        TestCreateExtSubDomain(runtime, ++txId, "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+        TestAlterExtSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf(R"(
+                    Name: "USER_0"
+                    ExternalSchemeShard: true
+                    PlanResolution: 50
+                    Coordinators: 1
+                    Mediators: 1
+                    TimeCastBucketsPerMediator: 2
+                    StoragePools {
+                        Name: "pool-1"
+                        Kind: "pool-kind-1"
+                    }
+                    StoragePools {
+                        Name: "pool-2"
+                        Kind: "pool-kind-2"
+                    }
+
+                    ExternalHive: %s
+                )",
+                ToString(ExternalHive).c_str()
+            )
+        );
+        env.TestWaitNotification(runtime, {txId, txId - 1});
+
+        ui64 tenantSchemaShard = 0;
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0"),
+            NLs::ExtractTenantSchemeshard(&tenantSchemaShard),
+        });
+        UNIT_ASSERT(tenantSchemaShard != 0 && tenantSchemaShard != (ui64)-1);
+
+        // Root schemeshard shows pool-1 for all channels of the tenant schemeshard.
+        {
+            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, TTestTxConfig::SchemeShard, tenantSchemaShard));
+            UNIT_ASSERT_C(region.Contains("pool-1"), region);
+            UNIT_ASSERT_C(!region.Contains("pool-2"), region);
+        }
+
+        // From root schemeshard: move the tenant schemeshard to pool-2.
+        // Root has bindings for the tenant SS, so the move succeeds.
+        {
+            auto r = PostMoveToStoragePoolAction(runtime, TTestTxConfig::SchemeShard, tenantSchemaShard, "pool-2");
+            UNIT_ASSERT_C(r.IsJson(), "Expected JSON success reply, got: " << r.Body);
+            UNIT_ASSERT_C(r.Body.Contains("OK"), "Expected Hive reply status OK, got: " << r.Body);
+        }
+
+        // Root schemeshard now shows pool-2 for all channels of the tenant schemeshard.
+        {
+            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, TTestTxConfig::SchemeShard, tenantSchemaShard));
+            UNIT_ASSERT_C(!region.Contains("pool-1"), region);
+            UNIT_ASSERT_C(region.Contains("pool-2"), region);
+        }
+    }
+
+}

--- a/ydb/core/tx/schemeshard/ut_base/ut_move_tablet_to_storage_pool.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_move_tablet_to_storage_pool.cpp
@@ -270,7 +270,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTabletToStoragePool) {
 
         // Root schemeshard shows pool-1 for all channels of the tenant schemeshard.
         {
-            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, TTestTxConfig::SchemeShard, tenantSchemaShard));
+            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, TTestTxConfig::SchemeShard, tenantSchemeShard));
             UNIT_ASSERT_C(region.Contains("pool-1"), region);
             UNIT_ASSERT_C(!region.Contains("pool-2"), region);
         }
@@ -278,14 +278,14 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTabletToStoragePool) {
         // From root schemeshard: move the tenant schemeshard to pool-2.
         // Root has bindings for the tenant SS, so the move succeeds.
         {
-            auto r = PostMoveToStoragePoolAction(runtime, TTestTxConfig::SchemeShard, tenantSchemaShard, "pool-2");
+            auto r = PostMoveToStoragePoolAction(runtime, TTestTxConfig::SchemeShard, tenantSchemeShard, "pool-2");
             UNIT_ASSERT_C(r.IsJson(), "Expected JSON success reply, got: " << r.Body);
             UNIT_ASSERT_C(r.Body.Contains("OK"), "Expected Hive reply status OK, got: " << r.Body);
         }
 
         // Root schemeshard now shows pool-2 for all channels of the tenant schemeshard.
         {
-            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, TTestTxConfig::SchemeShard, tenantSchemaShard));
+            const TString region = GetBindedChannelsRegion(GetShardInfoHtml(runtime, TTestTxConfig::SchemeShard, tenantSchemeShard));
             UNIT_ASSERT_C(!region.Contains("pool-1"), region);
             UNIT_ASSERT_C(region.Contains("pool-2"), region);
         }

--- a/ydb/core/tx/schemeshard/ut_base/ut_move_tablet_to_storage_pool.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_move_tablet_to_storage_pool.cpp
@@ -260,13 +260,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardMoveTabletToStoragePool) {
         );
         env.TestWaitNotification(runtime, {txId, txId - 1});
 
-        ui64 tenantSchemaShard = 0;
+        ui64 tenantSchemeShard = 0;
         TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
             NLs::PathExist,
             NLs::IsExternalSubDomain("USER_0"),
-            NLs::ExtractTenantSchemeshard(&tenantSchemaShard),
+            NLs::ExtractTenantSchemeshard(&tenantSchemeShard),
         });
-        UNIT_ASSERT(tenantSchemaShard != 0 && tenantSchemaShard != (ui64)-1);
+        UNIT_ASSERT(tenantSchemeShard != 0 && tenantSchemeShard != (ui64)-1);
 
         // Root schemeshard shows pool-1 for all channels of the tenant schemeshard.
         {

--- a/ydb/core/tx/schemeshard/ut_base/ya.make
+++ b/ydb/core/tx/schemeshard/ut_base/ya.make
@@ -21,6 +21,7 @@ SRCS(
     ut_base.cpp
     ut_counters.cpp
     ut_info_types.cpp
+    ut_move_tablet_to_storage_pool.cpp
     ut_table_decimal_types.cpp
     ut_table_info.cpp
     ut_table_pg_types.cpp

--- a/ydb/core/tx/schemeshard/ut_helpers/mon_helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/mon_helpers.cpp
@@ -1,0 +1,68 @@
+#include "mon_helpers.h"
+
+#include <ydb/library/actors/core/mon.h>
+#include <ydb/library/actors/http/http.h>
+
+#include <util/string/builder.h>
+
+namespace NSchemeShardUT_Private {
+
+using namespace NKikimr;
+using namespace NActors;
+
+// Note on queries below: they omit the `TabletID` cgi param. The SchemeShard mon
+// handler never reads it (it uses Self->TabletID() for self-links), and the request
+// is delivered straight to the target tablet via SendToPipe rather than through the
+// tablet-monitoring HTTP proxy that would route by TabletID. So the param is inert here.
+TSchemeShardMonResponse SendSchemeShardMonRequest(TTestActorRuntime& runtime, ui64 schemeShard, const TString& query, HTTP_METHOD method) {
+    auto sender = runtime.AllocateEdgeActor();
+    runtime.SendToPipe(schemeShard, sender, new NMon::TEvRemoteHttpInfo(query, method), 0, {});
+
+    TAutoPtr<IEventHandle> handle;
+    auto [http, json, bin] = runtime.GrabEdgeEventsRethrow<NMon::TEvRemoteHttpInfoRes, NMon::TEvRemoteJsonInfoRes, NMon::TEvRemoteBinaryInfoRes>(handle);
+
+    if (http) {
+        return {TSchemeShardMonResponse::EKind::Http, http->Html};
+    }
+    if (json) {
+        return {TSchemeShardMonResponse::EKind::Json, json->Json};
+    }
+    return {TSchemeShardMonResponse::EKind::Binary, bin->Blob};
+}
+
+TString PostSwitchAction(TTestActorRuntime& runtime, ui64 schemeShard, TPathId pathId, TStringBuf format) {
+    const TString query = TStringBuilder()
+        << "/app?Action=TablePartitionsFormatSwitch"
+        << "&OwnerPathId=" << pathId.OwnerId
+        << "&LocalPathId=" << pathId.LocalPathId
+        << "&format=" << format
+    ;
+    return SendSchemeShardMonRequest(runtime, schemeShard, query, HTTP_METHOD_POST).Body;
+}
+
+TString PostSweepAction(TTestActorRuntime& runtime, ui64 schemeShard, const TString& params) {
+    const TString query = TStringBuilder()
+        << "/app?Action=TablePartitionsFormatSweep" << params;
+    auto reply = SendSchemeShardMonRequest(runtime, schemeShard, query, HTTP_METHOD_POST);
+
+    // The sweep action answers with a redirect; its `Location` is relative to the
+    // original query base, so follow it (prefixed with `/`) with a GET.
+    NHttp::THttpParser<NHttp::THttpResponse> parser(reply.Body);
+    NHttp::THeaders headers(parser.Headers);
+    const TString location = TStringBuilder() << "/" << headers.Get("Location");
+    return SendSchemeShardMonRequest(runtime, schemeShard, location, HTTP_METHOD_GET).Body;
+}
+
+TSchemeShardMonResponse PostMoveToStoragePoolAction(TTestActorRuntime& runtime, ui64 schemeShard, ui64 tabletId, const TString& storagePool, bool confirmSamePool) {
+    TStringBuilder query;
+    query << "/app?Action=MoveToStoragePool"
+        << "&ShardID=" << tabletId
+        << "&StoragePool=" << storagePool
+    ;
+    if (confirmSamePool) {
+        query << "&ConfirmSamePool=1";
+    }
+    return SendSchemeShardMonRequest(runtime, schemeShard, query, HTTP_METHOD_POST);
+}
+
+}  // namespace NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/mon_helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/mon_helpers.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <ydb/core/scheme/scheme_pathid.h>
+#include <ydb/core/testlib/actors/test_runtime.h>
+
+#include <library/cpp/http/fetch/httpheader.h>  // for HTTP_METHOD
+
+#include <util/generic/string.h>
+#include <util/generic/strbuf.h>
+
+namespace NSchemeShardUT_Private {
+
+using namespace NKikimr;
+
+// Reply to a SchemeShard DevUI monitoring request. The SchemeShard answers with one
+// of three event types depending on the request: an HTML page, a JSON action result,
+// or a plain-text/binary blob (errors, redirects).
+struct TSchemeShardMonResponse {
+    enum class EKind {
+        Http,    // TEvRemoteHttpInfoRes   — page HTML
+        Json,    // TEvRemoteJsonInfoRes   — action success payload
+        Binary,  // TEvRemoteBinaryInfoRes — errors, redirects, plain text
+    };
+
+    EKind Kind = EKind::Binary;
+    TString Body;
+
+    bool IsHttp() const { return Kind == EKind::Http; }
+    bool IsJson() const { return Kind == EKind::Json; }
+    bool IsBinary() const { return Kind == EKind::Binary; }
+};
+
+// Send a SchemeShard DevUI monitoring request (query is the full "/app?..." string)
+// to the given SchemeShard tablet and return whichever reply it produced.
+TSchemeShardMonResponse SendSchemeShardMonRequest(NActors::TTestActorRuntime& runtime, ui64 schemeShard, const TString& query, HTTP_METHOD method);
+
+// POST the TablePartitionsFormatSwitch admin action; returns the raw response body.
+TString PostSwitchAction(NActors::TTestActorRuntime& runtime, ui64 schemeShard, TPathId pathId, TStringBuf format);
+
+// POST the TablePartitionsFormatSweep admin action; the action replies with a redirect,
+// so this follows the Location with a GET and returns the resulting page HTML.
+TString PostSweepAction(NActors::TTestActorRuntime& runtime, ui64 schemeShard, const TString& params);
+
+// POST the MoveToStoragePool admin action for a shard's tablet; returns the reply
+// (JSON on success, plain text on error). Set confirmSamePool to force a Hive re-notify
+// even when the shard is already on the target pool.
+TSchemeShardMonResponse PostMoveToStoragePoolAction(NActors::TTestActorRuntime& runtime, ui64 schemeShard, ui64 tabletId, const TString& storagePool, bool confirmSamePool = false);
+
+}  // namespace NSchemeShardUT_Private

--- a/ydb/core/tx/schemeshard/ut_helpers/ya.make
+++ b/ydb/core/tx/schemeshard/ut_helpers/ya.make
@@ -24,6 +24,9 @@ PEERDIR(
     ydb/public/lib/deprecated/kicli
     ydb/public/sdk/cpp/src/client/driver
     ydb/public/sdk/cpp/src/client/table
+    ydb/library/actors/core
+    ydb/library/actors/http
+    library/cpp/http/fetch
 )
 
 SRCS(
@@ -34,6 +37,8 @@ SRCS(
     helpers_flags_n.h
     ls_checks.cpp
     ls_checks.h
+    mon_helpers.cpp
+    mon_helpers.h
     olap_helpers.cpp
     olap_helpers.h
     schemeshard_counters.cpp

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_split_merge.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/tablet_flat/util_fmt_cell.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/mon_helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
 #include <ydb/public/lib/value/value.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>  // for Y_UNIT_TEST_FLAGS_N
@@ -15,7 +16,6 @@ using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
 
 // defined in ut_table_partitions_format.cpp
-TString PostSwitchAction(TTestActorRuntime& runtime, ui64 schemeShard, TPathId pathId, TStringBuf format);
 TPathId GetPathId(TTestActorRuntime& runtime, const TString& path);
 
 namespace {

--- a/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
+++ b/ydb/core/tx/schemeshard/ut_split_merge/ut_table_partitions_format.cpp
@@ -1,28 +1,12 @@
 #include <ydb/core/protos/counters_schemeshard.pb.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers_flags_n.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/mon_helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
-#include <ydb/library/actors/core/mon.h>
-#include <ydb/library/actors/http/http.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
 using namespace NSchemeShardUT_Private;
-
-// Also used in ut_split_merge.cpp
-TString PostSwitchAction(TTestActorRuntime& runtime, ui64 schemeShard, TPathId pathId, TStringBuf format) {
-    auto sender = runtime.AllocateEdgeActor();
-    const TString query = TStringBuilder()
-    << "/app?Action=TablePartitionsFormatSwitch"
-    << "&OwnerPathId=" << pathId.OwnerId
-    << "&LocalPathId=" << pathId.LocalPathId
-    << "&format=" << format
-    ;
-    auto req = std::make_unique<NActors::NMon::TEvRemoteHttpInfo>(query, HTTP_METHOD_POST);
-    runtime.SendToPipe(schemeShard, sender, req.release(), 0, {});
-    auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteBinaryInfoRes>(sender);
-    return r->Get()->Blob;
-}
 
 TPathId GetPathId(TTestActorRuntime& runtime, const TString& path) {
     auto desc = DescribePath(runtime, path);
@@ -31,26 +15,6 @@ TPathId GetPathId(TTestActorRuntime& runtime, const TString& path) {
 }
 
 namespace {
-
-TString PostSweepAction(TTestActorRuntime& runtime, ui64 schemeShard, const TString& params) {
-    auto sender = runtime.AllocateEdgeActor();
-    TString redirectLocation;
-    {
-        const TString query = TStringBuilder() << "/app?TabletID=" << schemeShard << "&Action=TablePartitionsFormatSweep" << params;
-        runtime.SendToPipe(schemeShard, sender, new NActors::NMon::TEvRemoteHttpInfo(query, HTTP_METHOD_POST), 0, {});
-        auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteBinaryInfoRes>(sender);
-        NHttp::THttpParser<NHttp::THttpResponse> parser(r->Get()->Blob);
-        NHttp::THeaders headers(parser.Headers);
-        redirectLocation = headers.Get("Location");
-    }
-    // `Location` is relative to the original query base, needs adding `/` prefix.
-    {
-        const TString query = TStringBuilder() << "/" << redirectLocation;
-        runtime.SendToPipe(schemeShard, sender, new NActors::NMon::TEvRemoteHttpInfo(query, HTTP_METHOD_GET), 0, {});
-        auto r = runtime.GrabEdgeEventRethrow<NActors::NMon::TEvRemoteHttpInfoRes>(sender);
-        return r->Get()->Html;
-    }
-}
 
 // Get table partitions format counters by parsing AdminRequest mon page.
 // Sensitive to page markup changes.


### PR DESCRIPTION
New schemeshard admin action `MoveToStoragePool` moves a shard to another storage pool.

- Button on the shard-info page
- Target storage pool is picked from the database's storage pools
- Moving a shard is really a rebinding of all the tablet's channels to the target storage pool
- Done by sending `CreateTablet` with the updated channel bindings to the Hive
- New bindings are persisted on the Hive's ack (`CreateTabletResult`)
- Failure to get an ack leaves nothing persisted on the schemeshard side
- So the action can be retried
- `CreateTablet` is idempotent — sending it more than once does no harm
- Still, moving a shard to the storage pool it's already on is a no-op
- Unless the confirmation box (next to the button) is checked to force the send to the Hive

The action is universal — works for any subdomain's shard/tablet.
On a tenant schemeshard, a shard-info page can show empty channel bindings: those shards are the tenant's system tablets (their channel bindings live only on the root schemeshard). In that case there's no button (the move is rejected); the UI links to the root schemeshard page instead, with an explanation.
