### PR TITLE
schemeshard: hoist copy-table grab out of per-partition loop, drop non-propose grabs

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_copy_table.cpp
@@ -83,6 +83,32 @@ public:
                  "CopyTable partition counts don't match");
         const ui64 dstSchemaVersion = NEW_TABLE_ALTER_VERSION;
 
+        TVector<TPathId> streamsToDrop;
+        TPath srcPath = TPath::Init(txState->SourcePathId, context.SS);
+        for (const auto& [name, id] : srcPath.Base()->GetChildren()) {
+            if (context.SS->PathsById.contains(id)) {
+                auto childPath = context.SS->PathsById.at(id);
+                if (childPath->IsCdcStream() &&
+                    childPath->PathState == TPathElement::EPathState::EPathStateDrop &&
+                    childPath->DropTxId == OperationId.GetTxId()) {
+                    streamsToDrop.push_back(id);
+                }
+            }
+        }
+
+        const bool hasDrop = !streamsToDrop.empty();
+        const bool hasCreate = (txState->CdcPathId != InvalidPathId);
+
+        ui64 coordVersion = 0;
+        if (hasDrop || hasCreate) {
+            auto srcTable = context.SS->Tables.at(txState->SourcePathId);
+            srcTable->InitAlterData(OperationId);
+            coordVersion = srcTable->AlterData->CoordinatedSchemaVersion.GetOrElse(srcTable->AlterVersion + 1);
+
+            NIceDb::TNiceDb db(context.GetDB());
+            context.SS->PersistAddAlterTable(db, txState->SourcePathId, srcTable->AlterData);
+        }
+
         for (ui32 i = 0; i < dstTableInfo->GetPartitions().size(); ++i) {
             TShardIdx srcShardIdx = srcTableInfo->GetPartitions()[i]->ShardIdx;
             TTabletId srcDatashardId = context.SS->ShardInfos[srcShardIdx].TabletID;
@@ -120,35 +146,9 @@ public:
             NKikimrTxDataShard::TFlatSchemeTransaction oldShardTx;
             context.SS->FillSeqNo(oldShardTx, seqNo);
 
-            TVector<TPathId> streamsToDrop;
-            TPath srcPath = TPath::Init(txState->SourcePathId, context.SS);
-            for (const auto& [name, id] : srcPath.Base()->GetChildren()) {
-                if (context.SS->PathsById.contains(id)) {
-                    auto childPath = context.SS->PathsById.at(id);
-                    if (childPath->IsCdcStream() &&
-                        childPath->PathState == TPathElement::EPathState::EPathStateDrop &&
-                        childPath->DropTxId == OperationId.GetTxId()) {
-                        streamsToDrop.push_back(id);
-                    }
-                }
-            }
-
-            bool hasDrop = !streamsToDrop.empty();
-            bool hasCreate = (txState->CdcPathId != InvalidPathId);
-
             if (hasDrop || hasCreate) {
                 auto& combined = *oldShardTx.MutableCreateIncrementalBackupSrc();
                 FillSrcSnapshot(txState, ui64(dstDatashardId), *combined.MutableSendSnapshot());
-
-                // Get coordinated version from source table's AlterData (shared across both drop and create)
-                // GrabTable is needed for proper rollback if operation fails
-                context.MemChanges.GrabTable(context.SS, txState->SourcePathId);
-                auto srcTable = context.SS->Tables.at(txState->SourcePathId);
-                srcTable->InitAlterData(OperationId);
-                ui64 coordVersion = srcTable->AlterData->CoordinatedSchemaVersion.GetOrElse(srcTable->AlterVersion + 1);
-
-                NIceDb::TNiceDb db(context.GetDB());
-                context.SS->PersistAddAlterTable(db, txState->SourcePathId, srcTable->AlterData);
 
                 if (hasDrop) {
                     auto& dropNotice = *combined.MutableDropCdcStreamNotice();
@@ -306,7 +306,6 @@ public:
             }
 
             if (hasCdcChanges && context.SS->Tables.contains(srcPathId)) {
-                context.MemChanges.GrabTable(context.SS, srcPathId);
                 auto srcTable = context.SS->Tables.at(srcPathId);
 
                 // Don't call InitAlterData() here - it was already called in ConfigureParts,
@@ -328,7 +327,6 @@ public:
                 if (parentPathId && context.SS->PathsById.contains(parentPathId)) {
                     auto parentPath = context.SS->PathsById.at(parentPathId);
                     if (parentPath->IsTableIndex() && context.SS->Indexes.contains(parentPathId)) {
-                        context.MemChanges.GrabIndex(context.SS, parentPathId);
                         auto index = context.SS->Indexes.at(parentPathId);
                         if (index->AlterVersion < srcTable->AlterVersion) {
                             index->AlterVersion = srcTable->AlterVersion;
@@ -352,7 +350,6 @@ public:
                         continue;
                     }
                     if (context.SS->Indexes.contains(childPathId)) {
-                        context.MemChanges.GrabIndex(context.SS, childPathId);
                         auto index = context.SS->Indexes.at(childPathId);
                         if (index->AlterVersion < srcTable->AlterVersion) {
                             index->AlterVersion = srcTable->AlterVersion;
@@ -371,7 +368,6 @@ public:
             context.OnComplete.PublishToSchemeBoard(OperationId, srcPathId);
 
             if (txState->CdcPathId != InvalidPathId && context.SS->CdcStreams.contains(txState->CdcPathId)) {
-                context.MemChanges.GrabCdcStream(context.SS, txState->CdcPathId);
                 auto stream = context.SS->CdcStreams.at(txState->CdcPathId);
                 if (stream->AlterData) {
                     stream->FinishAlter();
@@ -388,8 +384,6 @@ public:
                     if (streamPath->IsCdcStream() &&
                         streamPath->PathState == TPathElement::EPathState::EPathStateDrop &&
                         streamPath->DropTxId == OperationId.GetTxId()) {
-
-                        context.MemChanges.GrabCdcStream(context.SS, id);
 
                         context.SS->PersistRemoveCdcStream(db, id);
                         context.SS->CdcStreams.erase(id);

--- a/ydb/core/tx/schemeshard/ut_backup_collection/ut_backup_collection.cpp
+++ b/ydb/core/tx/schemeshard/ut_backup_collection/ut_backup_collection.cpp
@@ -1790,6 +1790,181 @@ Y_UNIT_TEST_SUITE(TBackupCollectionTests) {
             "CDC stream name should have X.509 timestamp format (YYYYMMDDHHMMSSZ_continuousBackupImpl)");
     }
 
+    // Multi-partition (P=4) full backup of an indexed table. A full backup decomposes into
+    // TCopyTable sub-ops with CDC streams armed on the source; TConfigureParts::ProgressState
+    // iterates over every source partition, and the incremental-backup block that previously
+    // deep-copied the source TTableInfo once per partition (O(P^2)) is now hoisted out of that
+    // loop. This exercises the hoisted path with P>1 -- SingleTableWithGlobalSyncIndex only
+    // covers a single-partition source.
+    Y_UNIT_TEST(FullBackupMultiShardTableWithIndex) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));
+        ui64 txId = 100;
+
+        SetupLogging(runtime);
+        PrepareDirs(runtime, env, txId);
+
+        TString collectionSettings = R"(
+            Name: ")" DEFAULT_NAME_1 R"("
+            ExplicitEntryList {
+                Entries {
+                    Type: ETypeTable
+                    Path: "/MyRoot/TableWithIndex"
+                }
+            }
+            Cluster: {}
+            IncrementalBackupConfig: {}
+        )";
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections/", collectionSettings);
+        env.TestWaitNotification(runtime, txId);
+
+        // Indexed table whose main table has 4 uniform partitions.
+        TestCreateIndexedTable(runtime, ++txId, "/MyRoot", R"(
+            TableDescription {
+                Name: "TableWithIndex"
+                Columns { Name: "key" Type: "Uint32" }
+                Columns { Name: "value" Type: "Utf8" }
+                KeyColumnNames: ["key"]
+                UniformPartitionsCount: 4
+            }
+            IndexDescription {
+                Name: "ValueIndex"
+                KeyColumnNames: ["value"]
+                Type: EIndexTypeGlobal
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/TableWithIndex", true), {
+            NLs::PathExist,
+            NLs::PartitionCount(4),
+        });
+
+        // Full backup: drives the multi-partition TCopyTable-with-CDC path (TConfigureParts loop).
+        TestBackupBackupCollection(runtime, ++txId, "/MyRoot",
+            R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+        env.TestWaitNotification(runtime, txId);
+
+        // Main table keeps its 4 partitions and gains a continuous-backup CDC stream.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/TableWithIndex", true), {
+            NLs::PathExist,
+            NLs::PartitionCount(4),
+        });
+
+        auto mainTableDesc = DescribePrivatePath(runtime, "/MyRoot/TableWithIndex", true, true);
+        UNIT_ASSERT(mainTableDesc.GetPathDescription().HasTable());
+        const auto& tableDesc = mainTableDesc.GetPathDescription().GetTable();
+        bool foundMainTableCdc = false;
+        for (size_t i = 0; i < tableDesc.CdcStreamsSize(); ++i) {
+            if (tableDesc.GetCdcStreams(i).GetName().EndsWith("_continuousBackupImpl")) {
+                foundMainTableCdc = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(foundMainTableCdc, "Main table should have a _continuousBackupImpl CDC stream after full backup");
+
+        // Index impl table also gets its continuous-backup stream (exercises the index copy sub-op).
+        auto indexDesc = DescribePrivatePath(runtime, "/MyRoot/TableWithIndex/ValueIndex", true, true);
+        UNIT_ASSERT(indexDesc.GetPathDescription().HasTableIndex());
+        UNIT_ASSERT_VALUES_EQUAL(indexDesc.GetPathDescription().ChildrenSize(), 1);
+        TString indexImplTableName = indexDesc.GetPathDescription().GetChildren(0).GetName();
+
+        auto indexImplTableDesc = DescribePrivatePath(runtime,
+            "/MyRoot/TableWithIndex/ValueIndex/" + indexImplTableName, true, true);
+        UNIT_ASSERT(indexImplTableDesc.GetPathDescription().HasTable());
+        const auto& indexTableDesc = indexImplTableDesc.GetPathDescription().GetTable();
+        bool foundIndexCdc = false;
+        for (size_t i = 0; i < indexTableDesc.CdcStreamsSize(); ++i) {
+            if (indexTableDesc.GetCdcStreams(i).GetName().EndsWith("_continuousBackupImpl")) {
+                foundIndexCdc = true;
+                break;
+            }
+        }
+        UNIT_ASSERT_C(foundIndexCdc, "Index impl table should have a _continuousBackupImpl CDC stream after full backup");
+    }
+
+    // Second full backup over a table that already carries a continuous-backup CDC stream. The
+    // backup op finds the prior "*_continuousBackupImpl" stream and arms DropSrcCdcStream for it,
+    // which drives the hasDrop branch of TCopyTable::TConfigureParts::ProgressState (and the
+    // stream-drop handling in TPropose::HandleReply) -- the branch the single-backup tests never
+    // reach. Confirms that path still works after the GrabTable/GrabIndex removals.
+    Y_UNIT_TEST(SecondFullBackupDropsPriorCdcStream) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));
+        ui64 txId = 100;
+
+        SetupLogging(runtime);
+        PrepareDirs(runtime, env, txId);
+
+        TString collectionSettings = R"(
+            Name: ")" DEFAULT_NAME_1 R"("
+            ExplicitEntryList {
+                Entries {
+                    Type: ETypeTable
+                    Path: "/MyRoot/Table"
+                }
+            }
+            Cluster: {}
+            IncrementalBackupConfig: {}
+        )";
+        TestCreateBackupCollection(runtime, ++txId, "/MyRoot/.backups/collections/", collectionSettings);
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint32" }
+            Columns { Name: "value" Type: "Utf8" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 2
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        auto cbStreamNames = [&]() -> TVector<TString> {
+            TVector<TString> out;
+            auto desc = DescribePrivatePath(runtime, "/MyRoot/Table", true, true);
+            const auto& t = desc.GetPathDescription().GetTable();
+            for (size_t i = 0; i < t.CdcStreamsSize(); ++i) {
+                const auto& s = t.GetCdcStreams(i);
+                if (s.GetName().EndsWith("_continuousBackupImpl")) {
+                    out.push_back(s.GetName());
+                }
+            }
+            return out;
+        };
+
+        // First full backup: creates continuous-backup stream S1.
+        TestBackupBackupCollection(runtime, ++txId, "/MyRoot",
+            R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+        env.TestWaitNotification(runtime, txId);
+
+        auto names1 = cbStreamNames();
+        Cerr << "streams after backup 1: " << JoinSeq(",", names1) << Endl;
+        UNIT_ASSERT_VALUES_EQUAL_C(names1.size(), 1u, "first backup should create exactly one continuous-backup stream");
+        const TString s1 = names1[0];
+
+        // Advance the clock so the second backup's timestamp-based stream name differs from S1;
+        // that makes S1 the "old" stream the op drops (arming hasDrop in the copy sub-op).
+        env.SimulateSleep(runtime, TDuration::Seconds(2));
+
+        // Second full backup: drops S1, creates S2.
+        TestBackupBackupCollection(runtime, ++txId, "/MyRoot",
+            R"(Name: ".backups/collections/)" DEFAULT_NAME_1 R"(")");
+        env.TestWaitNotification(runtime, txId);
+
+        auto names2 = cbStreamNames();
+        Cerr << "streams after backup 2: " << JoinSeq(",", names2) << Endl;
+        // A new stream (name != S1) must exist -> the rotate/create ran; and S1 must be gone
+        // (or being dropped) -> the drop branch (hasDrop) ran.
+        bool hasNew = false;
+        bool s1Survives = false;
+        for (const auto& n : names2) {
+            if (n != s1) hasNew = true;
+            if (n == s1) s1Survives = true;
+        }
+        UNIT_ASSERT_C(hasNew, "second backup must create a new continuous-backup stream (rotation)");
+        UNIT_ASSERT_C(!s1Survives, "second backup must drop the prior continuous-backup stream S1");
+    }
+
     Y_UNIT_TEST(SingleTableWithMultipleGlobalSyncIndexes) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableBackupService(true));

--- a/ydb/core/tx/schemeshard/ut_continuous_backup/ut_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/ut_continuous_backup/ut_continuous_backup.cpp
@@ -149,4 +149,71 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
             NLs::CheckColumns("IncrBackupImpl", {"key", "value", "__ydb_incrBackupImpl_changeMetadata"}, {}, {"key"}),
         });
     }
-} // TCdcStreamWithInitialScanTests
+
+    // Multi-partition (P=4) characterization of the TakeIncrementalBackup action, which rotates the
+    // continuous-backup CDC stream and creates the increment table. NB: this action does NOT go
+    // through TCopyTable, so it does not exercise the copy-table grab/hoist fix -- that path is
+    // driven by full backup of a backup collection and is covered in ut_backup_collection. This
+    // test just guards the take-incremental flow at multi-partition scale.
+    Y_UNIT_TEST(TakeIncrementalBackupMultiShard) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableProtoSourceIdInfo(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+            UniformPartitionsCount: 4
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true), {
+            NLs::PathExist,
+            NLs::IsTable,
+            NLs::PartitionCount(4),
+        });
+
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {
+            NLs::PathExist,
+            NLs::StreamState(NKikimrSchemeOp::ECdcStreamStateReady),
+        });
+
+        TestAlterContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            TakeIncrementalBackup {
+                DstPath: "IncrBackupImpl"
+                DstStreamPath: "1_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // The new incremental-backup stream must be ready across all shards...
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl"), {
+            NLs::PathExist,
+            NLs::StreamState(NKikimrSchemeOp::ECdcStreamStateReady),
+        });
+
+        // ...and the destination incremental-backup table must be created correctly.
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/IncrBackupImpl"), {
+            NLs::PathExist,
+            NLs::IsTable,
+            NLs::CheckColumns("IncrBackupImpl", {"key", "value", "__ydb_incrBackupImpl_changeMetadata"}, {}, {"key"}),
+        });
+
+        // The source table still has its original partitions after the copy.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/Table", true), {
+            NLs::PathExist,
+            NLs::PartitionCount(4),
+        });
+    }
+} // TContinuousBackupTests


### PR DESCRIPTION
### Changelog entry

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

`TCopyTable::TConfigureParts::ProgressState` deep-copied the source `TTableInfo` once per partition (O(P²)). That grab — and the sibling `GrabTable`/`GrabIndex` in `TPropose::HandleReply` — run in execute/plan-step transactions whose `MemChanges` is never `UnDo()`'d, so they were pure cost. Hoist the loop-invariant `AlterData` work out of the loop and drop the dead grabs. Adds multi-partition full-backup and CDC-stream-rotation tests.
