### PR TITLE
Add root llms.txt index for main documentation

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,13 +1,15 @@
 # YDB
 
 > Open source distributed SQL database with strong consistency, ACID transactions, and horizontal scalability.
+>
+> This index points to documentation built from the `main` branch. On ydb.tech, URLs without `?version=main` redirect to the default stable release (currently v26.1).
 
 ## Documentation indexes (main)
 
-- [English documentation index](https://ydb.tech/docs/en/llms.txt)
-- [Russian documentation index](https://ydb.tech/docs/ru/llms.txt)
+- [English documentation index](https://ydb.tech/docs/en/llms.txt?version=main)
+- [Russian documentation index](https://ydb.tech/docs/ru/llms.txt?version=main)
 
 ## Full documentation (main)
 
-- [English full documentation](https://ydb.tech/docs/en/llms-full.txt)
-- [Russian full documentation](https://ydb.tech/docs/ru/llms-full.txt)
+- [English full documentation](https://ydb.tech/docs/en/llms-full.txt?version=main)
+- [Russian full documentation](https://ydb.tech/docs/ru/llms-full.txt?version=main)

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,13 @@
+# YDB
+
+> Open source distributed SQL database with strong consistency, ACID transactions, and horizontal scalability.
+
+## Documentation indexes (main)
+
+- [English documentation index](https://ydb.tech/docs/en/llms.txt)
+- [Russian documentation index](https://ydb.tech/docs/ru/llms.txt)
+
+## Full documentation (main)
+
+- [English full documentation](https://ydb.tech/docs/en/llms-full.txt)
+- [Russian full documentation](https://ydb.tech/docs/ru/llms-full.txt)


### PR DESCRIPTION
## Summary

- Add `llms.txt` at the repository root as an entry point for AI tools and crawlers.
- The file links to generated Diplodoc indexes for the **`main`** documentation branch only.
- All links use `?version=main`, because bare `/docs/{lang}/` URLs on ydb.tech redirect to the default stable release (currently `v26.1`).

Target URLs:
- `https://ydb.tech/docs/en/llms.txt?version=main`
- `https://ydb.tech/docs/ru/llms.txt?version=main`
- `https://ydb.tech/docs/en/llms-full.txt?version=main`
- `https://ydb.tech/docs/ru/llms-full.txt?version=main`

Version-specific links (stable branches) will be added to this file later.

## Test plan

- [ ] Verify `https://ydb.tech/llms.txt` returns the root index after deployment
- [ ] After the website team exposes generated docs indexes, verify all four `?version=main` URLs return 200
- [ ] Verify bare `/docs/en/llms.txt` without `?version=main` is **not** used as the main-branch entry point