### PR TITLE
Remove support for plain password in alter user operations

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -1113,7 +1113,7 @@ message TLoginCreateUser {
     optional string User = 1;
     optional string Password = 2 [(Ydb.sensitive) = true];
     optional bool CanLogin = 3 [default = true];
-    optional bool IsHashedPassword = 4 [default = false, deprecated = true];
+    reserved 4; reserved "IsHashedPassword";
     optional string HashedPassword = 5 [(Ydb.sensitive) = true];
 }
 
@@ -1121,7 +1121,7 @@ message TLoginModifyUser {
     optional string User = 1;
     optional string Password = 2 [(Ydb.sensitive) = true];
     optional bool CanLogin = 3;
-    optional bool IsHashedPassword = 4 [default = false, deprecated = true];
+    reserved 4; reserved "IsHashedPassword";
     optional string HashedPassword = 5 [(Ydb.sensitive) = true];
 }
 

--- a/ydb/core/protos/flat_tx_scheme.proto
+++ b/ydb/core/protos/flat_tx_scheme.proto
@@ -157,7 +157,7 @@ message TEvLogin {
     }
 
     optional string User = 1;
-    optional string Password = 2 [deprecated = true, (Ydb.sensitive) = true];
+    reserved 2; reserved "Password";
     optional string ExternalAuth = 3;
     optional uint64 ExpiresAfterMs = 4;
     optional string PeerName = 5;  // IP address actually, same as TEvModifySchemeTransaction.PeerName

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -2428,15 +2428,36 @@ namespace Tests {
         UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::EResponseStatus::MSTATUS_OK);
     }
 
-    NKikimrScheme::TEvLoginResult TClient::Login(TTestActorRuntime& runtime, const TString& user, const TString& password) {
+    NKikimrScheme::TEvLoginResult TClient::Login(TTestActorRuntime& runtime,
+        const TString& user, NLoginProto::ESaslAuthMech::SaslAuthMech authMech,
+        NLoginProto::EHashType::HashType hashType, const TString& hash, const TString& authMessage)
+    {
         TActorId sender = runtime.AllocateEdgeActor();
         TAutoPtr<NSchemeShard::TEvSchemeShard::TEvLogin> evLogin(new NSchemeShard::TEvSchemeShard::TEvLogin());
         evLogin->Record.SetUser(user);
-        evLogin->Record.SetPassword(password);
+        auto& hashesToValidate = *evLogin->Record.MutableHashToValidate();
+        hashesToValidate.SetAuthMech(authMech);
+        hashesToValidate.SetHashType(hashType);
+        hashesToValidate.SetHash(hash);
+        hashesToValidate.SetAuthMessage(authMessage);
 
-        if (auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain(); user.EndsWith("@" + ldapDomain)) {
-            evLogin->Record.SetExternalAuth(ldapDomain);
-        }
+        const ui64 schemeRoot = GetPatchedSchemeRoot(SchemeRoot, Domain, SupportsRedirect);
+        ForwardToTablet(runtime, schemeRoot, sender, evLogin.Release());
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEvent<NSchemeShard::TEvSchemeShard::TEvLoginResult>(handle);
+        UNIT_ASSERT(event);
+        return event->Record;
+    }
+
+    NKikimrScheme::TEvLoginResult TClient::LoginExternal(TTestActorRuntime& runtime, const TString& user) {
+        // External (LDAP) authentication: the password is verified by LDAP, not by YDB, so it is passed through as is.
+        const auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain();
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        TAutoPtr<NSchemeShard::TEvSchemeShard::TEvLogin> evLogin(new NSchemeShard::TEvSchemeShard::TEvLogin());
+        evLogin->Record.SetUser(user);
+        evLogin->Record.SetExternalAuth(ldapDomain);
+
         const ui64 schemeRoot = GetPatchedSchemeRoot(SchemeRoot, Domain, SupportsRedirect);
         ForwardToTablet(runtime, schemeRoot, sender, evLogin.Release());
         TAutoPtr<IEventHandle> handle;

--- a/ydb/core/testlib/test_client.h
+++ b/ydb/core/testlib/test_client.h
@@ -700,7 +700,11 @@ namespace Tests {
         void TestAddGroupMembership(const TString& parent, const TString& group, const TString& member);
         NMsgBusProxy::EResponseStatus DeleteGroup(const TString& parent, const TString& group);
         void TestDeleteGroup(const TString& parent, const TString& group);
-        NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user, const TString& password);
+
+        NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime,
+            const TString& user, NLoginProto::ESaslAuthMech::SaslAuthMech authMech,
+            NLoginProto::EHashType::HashType hashType, const TString& hash, const TString& authMessage = "");
+        NKikimrScheme::TEvLoginResult LoginExternal(TTestActorRuntime& runtime, const TString& user);
 
         // ACL operations
         NMsgBusProxy::EResponseStatus ModifyOwner(const TString& parent, const TString& name, const TString& owner, const TString& userToken = "");

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4463,7 +4463,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TString fsSerializedSettings = std::get<11>(rec);
 
                 Y_ABORT_UNLESS(tableName.size() > 0);
-                
+
                 auto fillBackupSettings = [&](auto& tableInfo) {
                     tableInfo->BackupSettings.SetTableName(tableName);
                     tableInfo->BackupSettings.SetNeedToBill(needToBill);
@@ -4502,7 +4502,7 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         }
                     }
                 };
-                
+
                 if (auto it = Self->Tables.find(pathId); it != Self->Tables.end()) {
                     fillBackupSettings(it->second);
                 } else if (Self->ColumnTables.contains(pathId)) {
@@ -4585,7 +4585,6 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 auto& sid = *securityState.AddSids();
                 sid.SetName(rowset.GetValue<Schema::LoginSids::SidName>());
                 sid.SetType(rowset.GetValue<Schema::LoginSids::SidType>());
-                sid.SetArgonHash(rowset.GetValue<Schema::LoginSids::SidHash>());
                 sid.SetPasswordHashes(rowset.GetValue<Schema::LoginSids::PasswordHashes>());
                 sid.SetCreatedAt(rowset.GetValueOrDefault<Schema::LoginSids::CreatedAt>());
                 sid.SetFailedLoginAttemptCount(rowset.GetValueOrDefault<Schema::LoginSids::FailedAttemptCount>());

--- a/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
@@ -58,10 +58,9 @@ struct TSchemeShard::TTxInitRoot : public TSchemeShard::TRwTxBase {
             } else {
                 auto& sid = Self->LoginProvider.Sids[defaultUser.GetName()];
                 db.Table<Schema::LoginSids>().Key(sid.Name).Update<Schema::LoginSids::SidType,
-                                                                   Schema::LoginSids::SidHash,
                                                                    Schema::LoginSids::PasswordHashes,
                                                                    Schema::LoginSids::CreatedAt>(
-                                                                    sid.Type, sid.ArgonHash, sid.PasswordHashes, ToMicroSeconds(sid.CreatedAt));
+                                                                    sid.Type, sid.PasswordHashes, ToMicroSeconds(sid.CreatedAt));
                 if (owner.empty()) {
                     owner = defaultUser.GetName();
                 }

--- a/ydb/core/tx/schemeshard/schemeshard__login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__login.cpp
@@ -46,8 +46,6 @@ struct TSchemeShard::TTxLogin : TSchemeShard::TRwTxBase {
             };
 
             request.HashToValidate = std::move(hashToValidate);
-        } else if (record.HasPassword()) { // for backward compatibility
-            request.Password = record.GetPassword();
         }
 
         return request;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -37,6 +37,11 @@ public:
                 case NKikimrSchemeOp::TAlterLogin::kCreateUser: {
                     const auto& createUser = alterLogin.GetCreateUser();
 
+                    if (!createUser.HasHashedPassword() || createUser.HasPassword()) {
+                        result->SetStatus(NKikimrScheme::StatusPreconditionFailed, "Plain password is no longer supported, use hashed password instead");
+                        break;
+                    }
+
                     NLogin::TLoginProvider::TCreateUserRequest request;
                     request.User = createUser.GetUser();
                     request.HashedPassword = createUser.GetHashedPassword();
@@ -71,6 +76,11 @@ public:
                 }
                 case NKikimrSchemeOp::TAlterLogin::kModifyUser: {
                     const auto& modifyUser = alterLogin.GetModifyUser();
+
+                    if (modifyUser.HasPassword()) {
+                        result->SetStatus(NKikimrScheme::StatusPreconditionFailed, "Plain password is no longer supported, use hashed password instead");
+                        break;
+                    }
 
                     NLogin::TLoginProvider::TModifyUserRequest request;
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -40,8 +40,6 @@ public:
                     NLogin::TLoginProvider::TCreateUserRequest request;
                     request.User = createUser.GetUser();
                     request.HashedPassword = createUser.GetHashedPassword();
-                    request.Password = createUser.GetPassword();
-                    request.IsHashedPassword = createUser.GetIsHashedPassword();
                     request.CanLogin = createUser.GetCanLogin();
 
                     auto response = context.SS->LoginProvider.CreateUser(request);
@@ -51,11 +49,10 @@ public:
                     } else {
                         auto& sid = context.SS->LoginProvider.Sids[createUser.GetUser()];
                         db.Table<Schema::LoginSids>().Key(sid.Name).Update<Schema::LoginSids::SidType,
-                                                                           Schema::LoginSids::SidHash,
                                                                            Schema::LoginSids::PasswordHashes,
                                                                            Schema::LoginSids::CreatedAt,
                                                                            Schema::LoginSids::IsEnabled>(
-                                                                            sid.Type, sid.ArgonHash, sid.PasswordHashes, ToMicroSeconds(sid.CreatedAt), sid.IsEnabled);
+                                                                            sid.Type, sid.PasswordHashes, ToMicroSeconds(sid.CreatedAt), sid.IsEnabled);
 
                         if (securityConfig.HasAllUsersGroup()) {
                             auto response = context.SS->LoginProvider.AddGroupMembership({
@@ -82,11 +79,6 @@ public:
                         request.HashedPassword = modifyUser.GetHashedPassword();
                     }
 
-                    if (modifyUser.HasPassword()) {
-                        request.Password = modifyUser.GetPassword();
-                        request.IsHashedPassword = modifyUser.GetIsHashedPassword();
-                    }
-
                     if (modifyUser.HasCanLogin()) {
                         request.CanLogin = modifyUser.GetCanLogin();
                     }
@@ -97,11 +89,10 @@ public:
                     } else {
                         auto& sid = context.SS->LoginProvider.Sids[modifyUser.GetUser()];
                         db.Table<Schema::LoginSids>().Key(sid.Name).Update<Schema::LoginSids::SidType,
-                                                                           Schema::LoginSids::SidHash,
                                                                            Schema::LoginSids::PasswordHashes,
                                                                            Schema::LoginSids::IsEnabled,
                                                                            Schema::LoginSids::FailedAttemptCount>(
-                                                                            sid.Type, sid.ArgonHash, sid.PasswordHashes, sid.IsEnabled, sid.FailedLoginAttemptCount);
+                                                                            sid.Type, sid.PasswordHashes, sid.IsEnabled, sid.FailedLoginAttemptCount);
                         result->SetStatus(NKikimrScheme::StatusSuccess);
 
                         AddIsUserAdmin(modifyUser.GetUser(), context.SS->LoginProvider, additionalParts);

--- a/ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp
@@ -104,9 +104,7 @@ struct TSchemeShard::TTxUserHashesMigration : public TTransactionBase<TSchemeSha
                     IsLoginProviderModified = true;
                 }
 
-                // persist password hashes in the new column 'PasswordHashes' to get rid of old column 'SidHash' in the next release
-                db.Table<Schema::LoginSids>().Key(sidName).Update<Schema::LoginSids::SidHash, Schema::LoginSids::PasswordHashes>(
-                                                                    sid.ArgonHash, sid.PasswordHashes);
+                db.Table<Schema::LoginSids>().Key(sidName).Update<Schema::LoginSids::PasswordHashes>(sid.PasswordHashes);
             }
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -1842,7 +1842,7 @@ struct Schema : NIceDb::Schema {
     struct LoginSids : Table<93> {
         struct SidName : Column<1, NScheme::NTypeIds::String> {};
         struct SidType : Column<2, NScheme::NTypeIds::Uint64> { using Type = NLoginProto::ESidType::SidType; };
-        struct SidHash : Column<3, NScheme::NTypeIds::String> {};
+        struct SidHash : Column<3, NScheme::NTypeIds::String> {}; // deprecated
         struct LastSuccessfulAttempt : Column<4, NScheme::NTypeIds::Timestamp> {};
         struct LastFailedAttempt : Column<5, NScheme::NTypeIds::Timestamp> {};
         struct FailedAttemptCount : Column<6, NScheme::NTypeIds::Uint32> {using Type = ui32; static constexpr Type Default = 0;};

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -20,10 +20,16 @@
 #include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/util/pb.h>
 
+#include <ydb/library/login/hashes_checker/hashes_checker.h>
+
 #include <yql/essentials/core/yql_type_annotation.h>
 #include <yql/essentials/public/issue/yql_issue_message.h>
 
+#include <library/cpp/json/json_writer.h>
+#include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <openssl/sha.h>
 
 #include <util/generic/maybe.h>
 #include <util/generic/ptr.h>
@@ -2559,21 +2565,44 @@ namespace NSchemeShardUT_Private {
         return TPathId(record.GetSchemeShardId(), record.GetSubDomainPathId());
     }
 
-    void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& password, const TVector<TExpectedResult>& expectedResults) {
-        auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
-        auto transaction = modifyTx->Record.AddTransaction();
-        transaction->SetWorkingDir(database);
-        transaction->SetOperationType(NKikimrSchemeOp::EOperationType::ESchemeOpAlterLogin);
+    TTestPasswordHashes MakeTestPasswordHashes(const TString& password) {
+        // Deterministically derive a new-format password hash from the plain password.
+        //
+        // We generate a SHA-256 (scram-sha-256) hash only: argon is a legacy format now.
+        // SchemeShard verifies a SASL PLAIN login by a plain string comparison of the supplied
+        // hash against the stored one, so we don't need a real scram computation here: we just build a
+        // pseudo hash of the required byte lengths that is a stable function of the password.
+        const auto& scram = NLogin::HashesRegistry.HashNamesMap.at("scram-sha-256");
 
-        auto createUser = transaction->MutableAlterLogin()->MutableCreateUser();
-        createUser->SetUser(user);
-        createUser->SetPassword(password);
+        const auto deriveBytes = [&password](const TString& tag, size_t size) {
+            TString result;
+            TString block = tag + password;
+            while (result.size() < size) {
+                unsigned char digest[SHA256_DIGEST_LENGTH];
+                SHA256(reinterpret_cast<const unsigned char*>(block.data()), block.size(), digest);
+                result.append(reinterpret_cast<const char*>(digest), sizeof(digest));
+                block.assign(reinterpret_cast<const char*>(digest), sizeof(digest));
+            }
 
-        AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
-        TestModificationResults(runtime, txId, expectedResults);
+            result.resize(size);
+            return result;
+        };
+
+        const TString saltB64 = Base64Encode(deriveBytes("salt:", scram.SaltSize));
+        const TString storedKeyB64 = Base64Encode(deriveBytes("stored:", scram.HashSize));
+        const TString serverKeyB64 = Base64Encode(deriveBytes("server:", scram.HashSize));
+
+        NJson::TJsonValue hashes;
+        hashes["scram-sha-256"] = ToString(scram.IterationsCount) + ":" + saltB64 + "$" + storedKeyB64 + ":" + serverKeyB64;
+        hashes["version"] = NLogin::HASHES_JSON_SCHEMA_VERSION;
+
+        return {
+            .HashedPassword = Base64Encode(NJson::WriteJson(hashes, false)),
+            .ScramServerKey = serverKeyB64,
+        };
     }
 
-    void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& hashedPassword, const TString& hashedPasswordOldFormat, const TVector<TExpectedResult>& expectedResults) {
+    void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& hashedPassword, const TVector<TExpectedResult>& expectedResults) {
         auto modifyTx = std::make_unique<TEvSchemeShard::TEvModifySchemeTransaction>(txId, TTestTxConfig::SchemeShard);
         auto transaction = modifyTx->Record.AddTransaction();
         transaction->SetWorkingDir(database);
@@ -2581,8 +2610,6 @@ namespace NSchemeShardUT_Private {
 
         auto createUser = transaction->MutableAlterLogin()->MutableCreateUser();
         createUser->SetUser(user);
-        createUser->SetIsHashedPassword(true);
-        createUser->SetPassword(hashedPasswordOldFormat);
         createUser->SetHashedPassword(hashedPassword);
 
         AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
@@ -2653,23 +2680,10 @@ namespace NSchemeShardUT_Private {
         TestModificationResults(runtime, txId, expectedResults);
     }
 
-    NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user, const TString& password) {
-        TActorId sender = runtime.AllocateEdgeActor();
-        auto evLogin = new TEvSchemeShard::TEvLogin();
-        evLogin->Record.SetUser(user);
-        evLogin->Record.SetPassword(password);
-
-        if (auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain(); user.EndsWith("@" + ldapDomain)) {
-            evLogin->Record.SetExternalAuth(ldapDomain);
-        }
-        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, evLogin);
-        TAutoPtr<IEventHandle> handle;
-        auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);
-        UNIT_ASSERT(event);
-        return event->Record;
-    }
-
-    NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user, NLoginProto::ESaslAuthMech::SaslAuthMech authMech, NLoginProto::EHashType::HashType hashType, const TString& hash, const TString& authMessage) {
+    NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime, const TString& user,
+        NLoginProto::ESaslAuthMech::SaslAuthMech authMech, NLoginProto::EHashType::HashType hashType,
+        const TString& hash, const TString& authMessage)
+    {
         TActorId sender = runtime.AllocateEdgeActor();
         auto evLogin = new TEvSchemeShard::TEvLogin();
         evLogin->Record.SetUser(user);
@@ -2679,6 +2693,21 @@ namespace NSchemeShardUT_Private {
         hashesToValidate.SetHash(hash);
         hashesToValidate.SetAuthMessage(authMessage);
 
+        ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, evLogin);
+        TAutoPtr<IEventHandle> handle;
+        auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);
+        UNIT_ASSERT(event);
+        return event->Record;
+    }
+
+    NKikimrScheme::TEvLoginResult LoginExternal(TTestActorRuntime& runtime, const TString& user) {
+        // External (LDAP) authentication: the password is verified by LDAP, not by YDB, so it is passed through as is.
+        const auto ldapDomain = runtime.GetAppData().AuthConfig.GetLdapAuthenticationDomain();
+
+        TActorId sender = runtime.AllocateEdgeActor();
+        auto evLogin = new TEvSchemeShard::TEvLogin();
+        evLogin->Record.SetUser(user);
+        evLogin->Record.SetExternalAuth(ldapDomain);
         ForwardToTablet(runtime, TTestTxConfig::SchemeShard, sender, evLogin);
         TAutoPtr<IEventHandle> handle;
         auto event = runtime.GrabEdgeEvent<TEvSchemeShard::TEvLoginResult>(handle);
@@ -2722,21 +2751,6 @@ namespace NSchemeShardUT_Private {
         ModifyUser(runtime, txId, database, [user, isEnabled](auto* alterUser) {
             alterUser->SetUser(std::move(user));
             alterUser->SetCanLogin(isEnabled);
-        });
-    }
-
-    void ChangePasswordUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& password) {
-        ModifyUser(runtime, txId, database, [user, password](auto* alterUser) {
-            alterUser->SetUser(std::move(user));
-            alterUser->SetPassword(std::move(password));
-        });
-    }
-
-    void ChangePasswordHashUser(TTestActorRuntime& runtime, ui64 txId, const TString& database, const TString& user, const TString& hash) {
-        ModifyUser(runtime, txId, database, [user, hash](auto* alterUser) {
-            alterUser->SetUser(std::move(user));
-            alterUser->SetPassword(std::move(hash));
-            alterUser->SetIsHashedPassword(true);
         });
     }
 

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -651,12 +651,15 @@ namespace NSchemeShardUT_Private {
         TTestActorRuntime& runtime, ui64 schemeShard, ui64 tabletId,
         NKikimrScheme::TEvFindTabletSubDomainPathIdResult::EStatus expected = NKikimrScheme::TEvFindTabletSubDomainPathIdResult::SUCCESS);
 
-    void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
-        const TString& user, const TString& password,
-        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+    struct TTestPasswordHashes {
+        TString HashedPassword;  // new-format hash (base64 JSON)
+        TString ScramServerKey;
+    };
+
+    TTestPasswordHashes MakeTestPasswordHashes(const TString& password);
 
     void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
-        const TString& user, const TString& hashedPassword, const TString& hashedPasswordOldFormat,
+        const TString& user, const TString& hashedPassword,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
     void CreateAlterLoginRemoveUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
@@ -677,8 +680,7 @@ namespace NSchemeShardUT_Private {
         const TString& member, const TString& group,
         const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
 
-    NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime,
-        const TString& user, const TString& password);
+    NKikimrScheme::TEvLoginResult LoginExternal(TTestActorRuntime& runtime, const TString& user);
 
     NKikimrScheme::TEvLoginResult Login(TTestActorRuntime& runtime,
         const TString& user, NLoginProto::ESaslAuthMech::SaslAuthMech authMech,
@@ -696,12 +698,6 @@ namespace NSchemeShardUT_Private {
 
     void ChangeIsEnabledUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, bool isEnabled);
-
-    void ChangePasswordUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
-        const TString& user, const TString& password);
-
-    void ChangePasswordHashUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
-        const TString& user, const TString& hash);
 
     // Mimics data query to a single table with multiple partitions
     class TFakeDataReq {

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -25,21 +25,6 @@ namespace NSchemeShardUT_Private {
 
 TCertStorage CertStorage;
 
-void SetPasswordCheckerParameters(TTestActorRuntime &runtime, ui64 schemeShard, const NLogin::TPasswordComplexity::TInitializer& initializer) {
-    auto request = MakeHolder<NConsole::TEvConsole::TEvConfigNotificationRequest>();
-
-    ::NKikimrProto::TPasswordComplexity passwordComplexity;
-    passwordComplexity.SetMinLength(initializer.MinLength);
-    passwordComplexity.SetMinLowerCaseCount(initializer.MinLowerCaseCount);
-    passwordComplexity.SetMinUpperCaseCount(initializer.MinUpperCaseCount);
-    passwordComplexity.SetMinNumbersCount(initializer.MinNumbersCount);
-    passwordComplexity.SetMinSpecialCharsCount(initializer.MinSpecialCharsCount);
-    passwordComplexity.SetSpecialChars(initializer.SpecialChars);
-    passwordComplexity.SetCanContainUsername(initializer.CanContainUsername);
-    *request->Record.MutableConfig()->MutableAuthConfig()->MutablePasswordComplexity() = passwordComplexity;
-    SetConfig(runtime, schemeShard, std::move(request));
-}
-
 struct TAccountLockoutInitializer {
     size_t AttemptThreshold = 4;
     TString AttemptResetDuration = "1h";
@@ -91,7 +76,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
 
         {
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -99,7 +85,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         }
 
         // public keys are filled after the first login
-        auto resultLogin = Login(runtime, "user1", "password1");
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         {
@@ -126,13 +113,6 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         }
 
         {
-            TString hashOldFormat = R"(
-                {
-                    "hash": "ZO37rNB37kP9hzmKRGfwc4aYrboDt4OBDsF1TBn5oLw=",
-                    "salt": "HTkpQjtVJgBoA0CZu+i3zg==",
-                    "type": "argon2id"
-                }
-            )";
             TString hashes = R"(
                 {
                     "version": 1,
@@ -141,17 +121,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
                 }
             )";
 
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", Base64Encode(hashes), hashOldFormat);
+            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", Base64Encode(hashes));
         }
 
         {
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 1});
-        }
-
-        {
-            auto resultLogin = Login(runtime, "user1", "password1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         }
 
         {
@@ -181,16 +156,20 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableStrictAclCheck(StrictAclCheck));
         ui64 txId = 100;
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
-        auto resultLogin = Login(runtime, "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        const auto user2Hashes = MakeTestPasswordHashes("password2");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", user2Hashes.HashedPassword);
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         CreateAlterLoginRemoveUser(runtime, ++txId, "/MyRoot", "user1");
 
         // check user has been removed:
         {
-            auto resultLogin = Login(runtime, "user1", "password1");
+            auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                user1Hashes.ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user 'user1'");
         }
     }
@@ -222,9 +201,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableStrictAclCheck(StrictAclCheck));
         ui64 txId = 100;
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
-        auto resultLogin = Login(runtime, "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        const auto user2Hashes = MakeTestPasswordHashes("password2");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", user2Hashes.HashedPassword);
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         AsyncMkDir(runtime, ++txId, "/MyRoot", "Dir1/DirSub1");
@@ -258,7 +240,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),{
                 NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1"),
                 NLs::HasNoRight("+U:group"), NLs::HasEffectiveRight("+U:group")});
-            auto resultLogin = Login(runtime, "user1", "password1");
+            auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                user1Hashes.ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user 'user1'");
         }
     }
@@ -267,9 +250,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableStrictAclCheck(StrictAclCheck));
         ui64 txId = 100;
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
-        auto resultLogin = Login(runtime, "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        const auto user2Hashes = MakeTestPasswordHashes("password2");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", user2Hashes.HashedPassword);
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         AsyncMkDir(runtime, ++txId, "/MyRoot", "Dir1/DirSub1");
@@ -291,7 +277,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             {
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                     {NLs::HasOwner("user1")});
-                auto resultLogin = Login(runtime, "user1", "password1");
+                auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                    user1Hashes.ScramServerKey);
                 UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "");
             }
         }
@@ -304,7 +291,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         {
             TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                 {NLs::HasOwner("user2")});
-            auto resultLogin = Login(runtime, "user1", "password1");
+            auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                user1Hashes.ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user 'user1'");
         }
     }
@@ -313,9 +301,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableStrictAclCheck(StrictAclCheck));
         ui64 txId = 100;
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
-        auto resultLogin = Login(runtime, "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        const auto user2Hashes = MakeTestPasswordHashes("password2");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", user2Hashes.HashedPassword);
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         AsyncMkDir(runtime, ++txId, "/MyRoot", "Dir1/DirSub1");
@@ -344,7 +335,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
                     {NLs::HasRight("+U:user1"), NLs::HasEffectiveRight("+U:user1")});
                 TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                     {NLs::HasNoRight("+U:user1"), NLs::HasEffectiveRight("+U:user1")});
-                auto resultLogin = Login(runtime, "user1", "password1");
+                auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                    user1Hashes.ScramServerKey);
                 UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "");
             }
         }
@@ -368,7 +360,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1")});
             TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1/DirSub1"),
                 {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1")});
-            auto resultLogin = Login(runtime, "user1", "password1");
+            auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                user1Hashes.ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.GetError(), "Cannot find user 'user1'");
         }
     }
@@ -378,7 +371,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         TTestEnv env(runtime, TTestEnvOptions().EnableStrictAclCheck(StrictAclCheck));
         ui64 txId = 100;
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
         CreateAlterLoginCreateGroup(runtime, ++txId, "/MyRoot", "group1");
         AlterLoginAddGroupMembership(runtime, ++txId, "/MyRoot", "user1", "group1");
         TestDescribeResult(DescribePath(runtime, "/MyRoot"),
@@ -491,7 +485,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
     Y_UNIT_TEST(TestExternalLogin) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
-        auto resultLogin = Login(runtime, "user1@ldap", "password1");
+        auto resultLogin = LoginExternal(runtime, "user1@ldap");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
         CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 0});
@@ -501,7 +495,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
     Y_UNIT_TEST(TestExternalLoginWithIncorrectLdapDomain) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);
-        auto resultLogin = Login(runtime, "ldapuser@ldap.domain", "password1");
+        auto resultLogin = Login(runtime, "ldapuser@ldap.domain", NLoginProto::ESaslAuthMech::Plain,
+            NLoginProto::EHashType::ScramSha256, MakeTestPasswordHashes("password1").ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'ldapuser@ldap.domain'");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -527,7 +522,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             TestModificationResults(runtime, txId, {{NKikimrScheme::StatusPreconditionFailed, "Owner SID user1 not found in database `/MyRoot`"}});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
 
         TestDescribeResult(DescribePath(runtime, "/MyRoot/Dir1"),
             {NLs::HasNoRight("+U:user1"), NLs::HasNoEffectiveRight("+U:user1"), NLs::HasOwner("root@builtin")});
@@ -575,8 +571,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1", {{NKikimrScheme::StatusPreconditionFailed}});
-        auto resultLogin = Login(runtime, "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword, {{NKikimrScheme::StatusPreconditionFailed}});
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Login authentication is disabled");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
 
@@ -598,7 +596,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         }
 
         CreateAlterLoginCreateGroup(runtime, ++txId, "/MyRoot", "group1");
-        auto resultLogin = Login(runtime, "group1", "password1");
+        auto resultLogin = Login(runtime, "group1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes("password1").ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "group1 is a group");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
 
@@ -618,7 +617,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        auto resultLogin = Login(runtime, "user1", "password1");
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes("password1").ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user1'");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");
 
@@ -639,14 +639,18 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "123");
-        auto resultLogin1 = Login(runtime, "user1", "123");
+        const auto user1Hashes = MakeTestPasswordHashes("123");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
+        auto resultLogin1 = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin1.error(), "");
         ChangeIsEnabledUser(runtime, ++txId, "/MyRoot", "user1", false);
-        auto resultLogin2 = Login(runtime, "user1", "123");
+        auto resultLogin2 = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin2.error(), "User user1 login denied: account is blocked");
         ChangeIsEnabledUser(runtime, ++txId, "/MyRoot", "user1", true);
-        auto resultLogin3 = Login(runtime, "user1", "123");
+        auto resultLogin3 = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin3.error(), "");
     }
 
@@ -667,10 +671,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "123");
+        const auto user1Hashes = MakeTestPasswordHashes("123");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
 
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold(); attempt++) {
-            auto resultLogin = Login(runtime, "user1", "wrongpassword");
+            auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes("wrongpassword").ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
 
@@ -679,225 +685,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // User is blocked for 3 seconds
         Sleep(TDuration::Seconds(4));
 
-        auto resultLogin = Login(runtime, "user1", "123");
+        auto resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "User user1 login denied: account is blocked");
-    }
-
-    Y_UNIT_TEST(ChangeAcceptablePasswordParameters) {
-        TTestBasicRuntime runtime;
-        TTestEnv env(runtime);
-        ui64 txId = 100;
-
-        {
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            Cerr << describe.DebugString() << Endl;
-            CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
-        }
-
-        // Password parameters:
-        //  min length 0
-        //  optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        // required: cannot contain username
-
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "Pass_word1");
-            auto resultLogin = Login(runtime, "user1", "Pass_word1");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 1});
-            CheckToken(resultLogin.token(), describe, "user1");
-        }
-
-        // Accept password without lower case symbols
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "PASSWORDU2");
-            auto resultLogin = Login(runtime, "user2", "PASSWORDU2");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 2});
-            CheckToken(resultLogin.token(), describe, "user2");
-        }
-
-        // Password parameters:
-        //  min length 0
-        //  optional: upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: lower case = 3, cannot contain username
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 3});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASSWORDU3", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 lower case character"}});
-            auto resultLogin = Login(runtime, "user3", "PASSWORDU3");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user3'");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 2});
-        }
-
-        // Add lower case symbols to password
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user3", "PASswORDu3");
-            auto resultLogin = Login(runtime, "user3", "PASswORDu3");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 3});
-            CheckToken(resultLogin.token(), describe, "user3");
-        }
-
-        // Accept password without upper case symbols
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user4", "passwordu4");
-            auto resultLogin = Login(runtime, "user4", "passwordu4");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 4});
-            CheckToken(resultLogin.token(), describe, "user4");
-        }
-
-        // Password parameters:
-        //  min length 0
-        //  optional: lower case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: upper case = 3, cannot contain username
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLowerCaseCount = 0, .MinUpperCaseCount = 3});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "passwordu5", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 upper case character"}});
-            auto resultLogin = Login(runtime, "user5", "passwordu5");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user5'");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 4});
-        }
-
-        // Add 3 upper case symbols to password
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user5", "PASswORDu5");
-            auto resultLogin = Login(runtime, "user5", "PASswORDu5");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 5});
-            CheckToken(resultLogin.token(), describe, "user5");
-        }
-
-        // Accept short password
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinUpperCaseCount = 0});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user6", "passwu6");
-            auto resultLogin = Login(runtime, "user6", "passwu6");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 6});
-            CheckToken(resultLogin.token(), describe, "user6");
-        }
-
-        // Password parameters:
-        //  min length 8
-        //  optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: cannot contain username
-        // Too short password
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 8});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwu7", {{NKikimrScheme::StatusPreconditionFailed, "Password is too short"}});
-            auto resultLogin = Login(runtime, "user7", "passwu7");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user7'");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 6});
-        }
-
-        // Password has correct length
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user7", "passwordu7");
-            auto resultLogin = Login(runtime, "user7", "passwordu7");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 7});
-            CheckToken(resultLogin.token(), describe, "user7");
-        }
-
-        // Accept password without numbers
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinLength = 0});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user8", "passWorDueitgh");
-            auto resultLogin = Login(runtime, "user8", "passWorDueitgh");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 8});
-            CheckToken(resultLogin.token(), describe, "user8");
-        }
-
-        // Password parameters:
-        //  min length 0
-        //  optional: lower case, upper case,special symbols from list !@#$%^&*()_+{}|<>?=
-        //  required: numbers = 3, cannot contain username
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 3});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "passwordunine", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 number"}});
-            auto resultLogin = Login(runtime, "user9", "passwordunine");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user9'");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 8});
-        }
-
-        // Password with numbers
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user9", "pas1swo5rdu9");
-            auto resultLogin = Login(runtime, "user9", "pas1swo5rdu9");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 9});
-            CheckToken(resultLogin.token(), describe, "user9");
-        }
-
-        // Accept password without special symbols
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinNumbersCount = 0});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user10", "passWorDu10");
-            auto resultLogin = Login(runtime, "user10", "passWorDu10");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 10});
-            CheckToken(resultLogin.token(), describe, "user10");
-        }
-
-        // Password parameters:
-        //  min length 0
-        //  optional: lower case, upper case, numbers
-        //  required: special symbols from list !@#$%^&*()_+{}|<>?= , cannot contain username
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.MinSpecialCharsCount = 3});
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11", {{NKikimrScheme::StatusPreconditionFailed, "Incorrect password format: should contain at least 3 special character"}});
-            auto resultLogin = Login(runtime, "user11", "passwordu11");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user11'");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 10});
-        }
-
-        // Password with special symbols
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user11", "passwordu11*&%#");
-            auto resultLogin = Login(runtime, "user11", "passwordu11*&%#");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 11});
-            CheckToken(resultLogin.token(), describe, "user11");
-        }
-
-        // Password parameters:
-        //  min length 0
-        //  optional: lower case, upper case, numbers
-        //  required: special symbols from list *# , cannot contain username
-        {
-            SetPasswordCheckerParameters(runtime, TTestTxConfig::SchemeShard, {.SpecialChars = "*#"}); // Only 2 special symbols are valid
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*&%#", {{NKikimrScheme::StatusPreconditionFailed, "Password contains unacceptable characters"}});
-            auto resultLogin = Login(runtime, "user12", "passwordu12*&%#");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Cannot find user 'user12'");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 11});
-        }
-
-        {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user12", "passwordu12*#");
-            auto resultLogin = Login(runtime, "user12", "passwordu12*#");
-            UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
-            auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
-            CheckSecurityState(describe, {.PublicKeysSize = 1, .SidsSize = 12});
-            CheckToken(resultLogin.token(), describe, "user12");
-        }
     }
 
     Y_UNIT_TEST(AccountLockoutAndAutomaticallyUnlock) {
@@ -917,17 +707,21 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
         NKikimrScheme::TEvLoginResult resultLogin;
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold(); attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
-        resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold());
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold()).ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
 
         // Also do not accept correct password
-        resultLogin = Login(runtime, "user1", "password1");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
 
         {
@@ -938,9 +732,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // User is blocked for 3 seconds
         Sleep(TDuration::Seconds(4));
 
-        resultLogin = Login(runtime, "user1", "wrongpassword6");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes("wrongpassword6").ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
-        resultLogin = Login(runtime, "user1", "password1");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         {
@@ -967,10 +763,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
         NKikimrScheme::TEvLoginResult resultLogin;
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold() - 1; attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
 
@@ -984,10 +782,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
         // FailedAttemptCount should be reset
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold() - 1; attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold() + attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold() + attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
-        resultLogin = Login(runtime, "user1", "password1");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         {
@@ -1014,13 +814,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
         NKikimrScheme::TEvLoginResult resultLogin;
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold(); attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
-        resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold());
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold()).ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
 
         {
@@ -1032,7 +835,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         Sleep(TDuration::Seconds(4));
 
         // Unlock user after 3 seconds
-        resultLogin = Login(runtime, "user1", "password1");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
 
         {
@@ -1044,13 +848,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         size_t newAttemptThreshold = 6;
         SetAccountLockoutParameters(runtime, TTestTxConfig::SchemeShard, {.AttemptThreshold = newAttemptThreshold, .AttemptResetDuration = "7s"});
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", "password2");
+        const auto user2Hashes = MakeTestPasswordHashes("password2");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user2", user2Hashes.HashedPassword);
         // Now user2 have 6 attempts to login
         for (size_t attempt = 0; attempt < newAttemptThreshold; attempt++) {
-            resultLogin = Login(runtime, "user2", TStringBuilder() << "wrongpassword2" << attempt);
+            resultLogin = Login(runtime, "user2", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword2" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
-        resultLogin = Login(runtime, "user2", TStringBuilder() << "wrongpassword2" << newAttemptThreshold);
+        resultLogin = Login(runtime, "user2", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes(TStringBuilder() << "wrongpassword2" << newAttemptThreshold).ScramServerKey);
         // User is not permitted to log in after 6 attempts
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user2 login denied: too many failed password attempts");
 
@@ -1062,14 +869,16 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         // user2 is blocked for 7 seconds
         // After 4 seconds user2 must be locked out
         Sleep(TDuration::Seconds(4));
-        resultLogin = Login(runtime, "user2", "wrongpassword28");
+        resultLogin = Login(runtime, "user2", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes("wrongpassword28").ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user2 login denied: too many failed password attempts");
 
         // After 7 seconds user2 must be unlocked
         Sleep(TDuration::Seconds(8));
 
         // Unlock user after 7 sec
-        resultLogin = Login(runtime, "user2", "password2");
+        resultLogin = Login(runtime, "user2", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user2Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         {
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -1089,17 +898,21 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
         NKikimrScheme::TEvLoginResult resultLogin;
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold(); attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
-        resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold());
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold()).ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
 
         // Also do not accept correct password
-        resultLogin = Login(runtime, "user1", "password1");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
     }
 
@@ -1120,11 +933,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             CheckSecurityState(describe, {.PublicKeysSize = 0, .SidsSize = 0});
         }
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
         // Make 2 failed login attempts
         NKikimrScheme::TEvLoginResult resultLogin;
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold() / 2; attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
 
@@ -1133,10 +948,12 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
         // After reboot schemeshard user has only 2 attempts to successful login before lock out
         for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold() / 2; attempt++) {
-            resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << attempt);
+            resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         }
-        resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold());
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold()).ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
 
         {
@@ -1148,13 +965,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
         RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
 
         // After reboot schemeshard user1 must be locked out
-        resultLogin = Login(runtime, "user1", TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold());
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << accountLockoutConfig.GetAttemptThreshold()).ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), TStringBuilder() << "User user1 login denied: too many failed password attempts");
 
         // User1 must be unlocked in 1 second after reboot schemeshard
         Sleep(TDuration::Seconds(2));
 
-        resultLogin = Login(runtime, "user1", "password1");
+        resultLogin = Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         {
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -1182,16 +1001,19 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
         TString userName = "user1";
         TString userPassword = "password1";
+        const auto userHashes = MakeTestPasswordHashes(userPassword);
 
         auto blockUser = [&]() {
             for (size_t attempt = 0; attempt < accountLockoutConfig.GetAttemptThreshold(); attempt++) {
-                auto resultLogin = Login(runtime, userName, TStringBuilder() << "wrongpassword" << attempt);
+                auto resultLogin = Login(runtime, userName, NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                    MakeTestPasswordHashes(TStringBuilder() << "wrongpassword" << attempt).ScramServerKey);
                 UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
             }
         };
 
         auto loginUser = [&](TString error) {
-            auto resultLogin = Login(runtime, userName, userPassword);
+            auto resultLogin = Login(runtime, userName, NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+                userHashes.ScramServerKey);
             UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), error);
         };
 
@@ -1200,7 +1022,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
             RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
         };
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", userName, userPassword);
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", userName, userHashes.HashedPassword);
 
         blockUser();
         loginUser(TStringBuilder() << "User " << userName << " login denied: too many failed password attempts");
@@ -1230,13 +1052,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginFinalize) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", testUser, "password1");
+        const auto userHashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", testUser, userHashes.HashedPassword);
 
         const auto check = NLogin::TLoginProvider::TPasswordCheckResult{.Status =
             NLogin::TLoginProvider::TPasswordCheckResult::EStatus::SUCCESS};
         const auto request = NLogin::TLoginProvider::TLoginUserRequest({.User = testUser});
         // public keys are filled after the first login
-        UNIT_ASSERT_VALUES_EQUAL(Login(runtime, testUser, "wrong-password1").error(), "Invalid password");
+        UNIT_ASSERT_VALUES_EQUAL(Login(runtime, testUser, NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes("wrong-password1").ScramServerKey).error(), "Invalid password");
         const auto resultLogin = LoginFinalize(runtime, request, check, "", false);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -1249,7 +1073,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginFinalize) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
 
         NLogin::TLoginProvider::TPasswordCheckResult check;
         check.FillInvalidPassword();
@@ -1265,13 +1090,15 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginFinalize) {
         TTestEnv env(runtime);
         ui64 txId = 100;
 
-        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", "password1");
+        const auto user1Hashes = MakeTestPasswordHashes("password1");
+        CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
 
         NLogin::TLoginProvider::TPasswordCheckResult check;
         check.FillInvalidPassword();
         const auto request = NLogin::TLoginProvider::TLoginUserRequest({.User = "user1"});
         // public keys are filled after the first login
-        UNIT_ASSERT_VALUES_EQUAL(Login(runtime, "user1", "password1").error(), "");
+        UNIT_ASSERT_VALUES_EQUAL(Login(runtime, "user1", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            user1Hashes.ScramServerKey).error(), "");
         const auto resultLogin = LoginFinalize(runtime, request, check, "", false);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "Invalid password");
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.token(), "");

--- a/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
+++ b/ydb/core/tx/schemeshard/ut_login_large/ut_login_large.cpp
@@ -37,9 +37,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginLargeTest) {
         runtime.SetDispatchedEventsLimit(100'000'000'000);
 
         for (auto userId : xrange(usersTotal)) {
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId), "password" + std::to_string(userId));
+            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user" + std::to_string(userId), MakeTestPasswordHashes("password" + std::to_string(userId)).HashedPassword);
         }
-        auto resultLogin = Login(runtime, "user0", "password0");
+        auto resultLogin = Login(runtime, "user0", NLoginProto::ESaslAuthMech::Plain, NLoginProto::EHashType::ScramSha256,
+            MakeTestPasswordHashes("password0").ScramServerKey);
         UNIT_ASSERT_VALUES_EQUAL(resultLogin.error(), "");
         
         {
@@ -84,7 +85,8 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginLargeTest) {
 
         {
             TLogStopwatch stopwatch(TStringBuilder() << "Created single user userx");
-            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "userx", "passwordX");
+            const auto userxHashes = MakeTestPasswordHashes("passwordX");
+            CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "userx", userxHashes.HashedPassword);
         }
 
         {

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -1737,6 +1737,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                     if (NLogin::IsOldFormatHash(targetUser.GetHashedPassword())) {
                         targetUser.SetHashedPassword(NLogin::ConvertOldFormatHash(targetUser.GetHashedPassword()));
                     }
+                    targetUser.ClearPassword();
                 } else {
                     RunPasswordHasher(ctx, targetUser.GetUser(), targetUser.GetPassword());
                     return;
@@ -1752,6 +1753,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
                     if (NLogin::IsOldFormatHash(targetUser.GetHashedPassword())) {
                         targetUser.SetHashedPassword(NLogin::ConvertOldFormatHash(targetUser.GetHashedPassword()));
                     }
+                    targetUser.ClearPassword();
                 } else if (targetUser.HasPassword()) {
                     RunPasswordHasher(ctx, targetUser.GetUser(), targetUser.GetPassword());
                     return;

--- a/ydb/core/tx/tx_proxy/schemereq_ut.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq_ut.cpp
@@ -219,38 +219,6 @@ TString LoginUser(TTestEnv& env, const TString& database, const TString& user, c
     return loginResult.token();
 }
 
-TString LoginUser2(TTestEnv& env, const TString& database, const TString& user, const TString& password) {
-    ui64 schemeshardId = 0;
-    auto runtime = env.GetTestServer().GetRuntime();
-    TActorId sender = runtime->AllocateEdgeActor();
-    {
-        TAutoPtr<NSchemeShard::TEvSchemeShard::TEvDescribeScheme> request(new NSchemeShard::TEvSchemeShard::TEvDescribeScheme());
-        request->Record.SetPath(database);
-        const ui64 rootSchemeshardId = Tests::ChangeStateStorage(Tests::SchemeRoot, env.GetSettings().Domain);
-        ForwardToTablet(*runtime, rootSchemeshardId, sender, request.Release(), 0);
-
-        TAutoPtr<IEventHandle> handle;
-        runtime->GrabEdgeEvent<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>(handle);
-        const auto& record = handle->Get<NSchemeShard::TEvSchemeShard::TEvDescribeSchemeResult>()->GetRecord();
-
-        schemeshardId = record.GetPathDescription().GetDomainDescription().GetProcessingParams().GetSchemeShard();
-    }
-    // schemeshardId could be equal to rootSchemeshardId if database is a root
-    {
-        auto evLogin = new NSchemeShard::TEvSchemeShard::TEvLogin();
-        evLogin->Record.SetUser(user);
-        evLogin->Record.SetPassword(password);
-
-        ForwardToTablet(*runtime, schemeshardId, sender, evLogin);
-
-        TAutoPtr<IEventHandle> handle;
-        auto event = runtime->GrabEdgeEvent<NSchemeShard::TEvSchemeShard::TEvLoginResult>(handle);
-
-        UNIT_ASSERT_C(event->Record.GetError().empty(), event->Record.GetError());
-        return event->Record.GetToken();
-    }
-}
-
 NYdb::NQuery::TQueryClient CreateQueryClient(const TTestEnv& env, const TString& token, const TString& database) {
     NYdb::NQuery::TClientSettings settings;
     settings.Database(database);

--- a/ydb/services/ydb/ydb_login_ut.cpp
+++ b/ydb/services/ydb/ydb_login_ut.cpp
@@ -48,11 +48,26 @@ public:
         return client.ExecuteQuery(sql, NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
     }
 
-    void CreateUser(TString user, TString password) {
-        TClient client(*(Server.ServerSettings));
-        client.SetSecurityToken(RootToken);
-        auto status = client.CreateUser("/Root", user, password);
-        UNIT_ASSERT_VALUES_EQUAL(status, NMsgBusProxy::MSTATUS_OK);
+    NYdb::NQuery::TExecuteQueryResult CreateUser(const TString& user, const TString& password, const TString& token = "") {
+        auto query = std::format("CREATE USER {0:} PASSWORD '{1:}'", std::string(user), std::string(password));
+        return ExecuteSql(token.empty() ? RootToken : token, TString(query));
+    }
+
+    NYdb::NQuery::TExecuteQueryResult CreateUserHash(const TString& user, const TString& hash, const TString& token = "") {
+        auto query = std::format("CREATE USER {0:} HASH '{1:}'", std::string(user), std::string(hash));
+        return ExecuteSql(token.empty() ? RootToken : token, TString(query));
+    }
+
+    NYdb::NQuery::TExecuteQueryResult AlterUserHash(const TString& user, const TString& hash, const TString& token = "") {
+        auto query = std::format("ALTER USER {0:} HASH '{1:}'", std::string(user), std::string(hash));
+        return ExecuteSql(token.empty() ? RootToken : token, TString(query));
+    }
+
+    void SetPasswordComplexity(const NKikimrProto::TPasswordComplexity& passwordComplexity) {
+        auto* runtime = Server.GetRuntime();
+        for (ui32 i = 0; i < runtime->GetNodeCount(); ++i) {
+            *runtime->GetAppData(i).AuthConfig.MutablePasswordComplexity() = passwordComplexity;
+        }
     }
 
     void ModifyACL(bool add, TString user, ui32 access) {
@@ -169,8 +184,7 @@ Y_UNIT_TEST_SUITE(TGRpcAuthentication) {
                 "scram-sha-256": "4096:s0QSrrFVkMTh3k2TTk860A==$LmCubRpIYV1zHMLucTtu7XjhB+PgWwH8ABCYGyVF1mo=:eUrie0C98tEFgygSOtom/fwPmgnMxeq53l7YTFfYncc="
             }
         )";
-        auto createUserQuery = std::format("CREATE USER {0:} HASH '{1:}'", std::string(User), std::string(Base64Encode(hash)));
-        auto result = loginConnection.ExecuteSql("root@builtin", TString(createUserQuery));
+        auto result = loginConnection.CreateUserHash(User, Base64Encode(hash));
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         auto factory = CreateLoginCredentialsProviderFactory({.User = User, .Password = "password1"});
@@ -183,8 +197,7 @@ Y_UNIT_TEST_SUITE(TGRpcAuthentication) {
                 "argon2id": "HTkpQjtVJgBoA0CZu+i3zg==$ZO37rNB37kP9hzmKRGfwc4aYrboDt4OBDsF1TBn5oLw="
             }
         )";
-        auto alterUserQuery = std::format("ALTER USER {0:} HASH '{1:}'", std::string(User), std::string(Base64Encode(hash)));
-        result = loginConnection.ExecuteSql("root@builtin", TString(alterUserQuery));
+        result = loginConnection.AlterUserHash(User, Base64Encode(hash));
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         factory = CreateLoginCredentialsProviderFactory({.User = User, .Password = "password1"});
@@ -219,8 +232,7 @@ Y_UNIT_TEST_SUITE(TGRpcAuthentication) {
                 "scram-sha-256": "4096:s0QSrrFVkMTh3k2TTk860A==$LmCubRpIYV1zHMLucTtu7XjhB+PgWwH8ABCYGyVF1mo=:eUrie0C98tEFgygSOtom/fwPmgnMxeq53l7YTFfYncc="
             }
         )";
-        auto alterUserQuery = std::format("ALTER USER {0:} HASH '{1:}'", std::string(User), std::string(Base64Encode(hash)));
-        auto result = loginConnection.ExecuteSql("root@builtin", TString(alterUserQuery));
+        auto result = loginConnection.AlterUserHash(User, Base64Encode(hash));
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         factory = CreateLoginCredentialsProviderFactory({.User = User, .Password = Password});
@@ -330,8 +342,10 @@ Y_UNIT_TEST_SUITE(TAuthenticationWithSqlExecution) {
 
         auto adminToken = loginConnection.GetToken(adminName, adminPassword);
 
-        auto query = std::format("CREATE USER {0:}; ALTER USER {0:} HASH '{1:}';", user, hash);
-        auto result = loginConnection.ExecuteSql(adminToken, TString(query));
+        auto createResult = loginConnection.CreateUser(TString(user), TString(password), adminToken);
+        UNIT_ASSERT_VALUES_EQUAL_C(createResult.GetStatus(), EStatus::SUCCESS, createResult.GetIssues().ToString());
+
+        auto result = loginConnection.AlterUserHash(TString(user), TString(hash), adminToken);
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
 
         loginConnection.ModifyACL(true, TString(user), NACLib::EAccessRights::ConnectDatabase);
@@ -420,6 +434,92 @@ Y_UNIT_TEST_SUITE(TModifyUser) {
         }
 
         loginConnection.Stop();
+    }
+}
+
+Y_UNIT_TEST_SUITE(TLoginPasswordComplexity) {
+
+    void CheckPasswordAccepted(TLoginClientConnection& conn, const TString& user, const TString& password) {
+        auto result = conn.CreateUser(user, password);
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        conn.GetToken(user, password);
+    }
+
+    void CheckPasswordRejected(TLoginClientConnection& conn, const TString& user, const TString& password,
+        const TString& expectedError)
+    {
+        auto result = conn.CreateUser(user, password);
+        UNIT_ASSERT_C(result.GetStatus() != EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(), expectedError, result.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(ChangeAcceptablePasswordParameters) {
+        TLoginClientConnection conn;
+
+        // Default complexity: min length 0
+        // optional: lower case, upper case, numbers, special symbols from list !@#$%^&*()_+{}|<>?=
+        // required: cannot contain username
+        {
+            CheckPasswordAccepted(conn, "user1", "Pass_word1");
+            CheckPasswordAccepted(conn, "user2", "PASSWORDU2");
+            CheckPasswordRejected(conn, "user3", "user3passwd", "Password must not contain user name");
+        }
+
+        // Require at least 3 lower case characters.
+        {
+            NKikimrProto::TPasswordComplexity complexity;
+            complexity.SetMinLowerCaseCount(3);
+            conn.SetPasswordComplexity(complexity);
+            CheckPasswordRejected(conn, "user4", "PASSWORDU4", "should contain at least 3 lower case character");
+            CheckPasswordAccepted(conn, "user4", "PASswORDu4");
+        }
+
+        // Require at least 3 upper case characters.
+        {
+            NKikimrProto::TPasswordComplexity complexity;
+            complexity.SetMinUpperCaseCount(3);
+            conn.SetPasswordComplexity(complexity);
+            CheckPasswordRejected(conn, "user5", "passwordu5", "should contain at least 3 upper case character");
+            CheckPasswordAccepted(conn, "user5", "PASswORDu5");
+        }
+
+        // Require a minimum length of 8.
+        {
+            NKikimrProto::TPasswordComplexity complexity;
+            complexity.SetMinLength(8);
+            conn.SetPasswordComplexity(complexity);
+            CheckPasswordRejected(conn, "user6", "passwu6", "Password is too short");
+            CheckPasswordAccepted(conn, "user6", "passwordu6");
+        }
+
+        // Require at least 3 numbers.
+        {
+            NKikimrProto::TPasswordComplexity complexity;
+            complexity.SetMinNumbersCount(3);
+            conn.SetPasswordComplexity(complexity);
+            CheckPasswordRejected(conn, "user7", "passworduseven", "should contain at least 3 number");
+            CheckPasswordAccepted(conn, "user7", "pas1swo5rdu7");
+        }
+
+        // Require at least 3 special characters (default set of special characters).
+        {
+            NKikimrProto::TPasswordComplexity complexity;
+            complexity.SetMinSpecialCharsCount(3);
+            conn.SetPasswordComplexity(complexity);
+            CheckPasswordRejected(conn, "user8", "passwordu8", "should contain at least 3 special character");
+            CheckPasswordAccepted(conn, "user8", "passwordu8*&%#");
+        }
+
+        // Restrict the set of acceptable special characters to "*#".
+        {
+            NKikimrProto::TPasswordComplexity complexity;
+            complexity.SetSpecialChars("*#");
+            conn.SetPasswordComplexity(complexity);
+            CheckPasswordRejected(conn, "user9", "passwordu9*&%#", "Password contains unacceptable characters");
+            CheckPasswordAccepted(conn, "user9", "passwordu9*#");
+        }
+
+        conn.Stop();
     }
 }
 


### PR DESCRIPTION
This PR removes the ability to pass plain (non-hashed) passwords through `CreateUser`/`ModifyUser` schemeshard operations and cleans up the related legacy Argon hash handling.

- **Forbid plain password in alter-user ops**: dropped the `IsHashedPassword` flag and plain `Password` handling from `TLoginCreateUser`/`TLoginModifyUser` requests; field 4 is now `reserved` in [`flat_scheme_op.proto`](ydb/core/protos/flat_scheme_op.proto:1116).
- **Drop legacy `SidHash`**: stopped reading/writing the old `SidHash` column, relying solely on the new `PasswordHashes` storage in [`schemeshard__init.cpp`](ydb/core/tx/schemeshard/schemeshard__init.cpp:4585), [`schemeshard__init_root.cpp`](ydb/core/tx/schemeshard/schemeshard__init_root.cpp:60) and [`schemeshard__user_hashes_migration.cpp`](ydb/core/tx/schemeshard/schemeshard__user_hashes_migration.cpp:104).
- **Refactor login/alter-user tests**: reworked SchemeShard `AlterUser`/`Login` unit tests and helpers for the new hashed-only API in [`ut_login.cpp`](ydb/core/tx/schemeshard/ut_login/ut_login.cpp:1) and [`ydb_login_ut.cpp`](ydb/services/ydb/ydb_login_ut.cpp:1).