### PR TITLE
[NBS] Removed unnecessary invariant check when outdated flush response arrived

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.cpp
@@ -585,12 +585,17 @@ void TBlocksDirtyMap::FlushFinished(
     const TVector<ui64>& flushFailed)
 {
     if (DisabledHosts.Get(route.DestinationHostIndex)) {
+        // No processing is required, all inflight operations have been updated
+        // when transition to disabled state occurs.
         return;
     }
 
     for (ui64 lsn: flushOk) {
         auto item = Inflight.GetValue(lsn);
-        Y_ABORT_UNLESS(item);
+        if (!item) {
+            // The item was deleted when the host was disabled.
+            continue;
+        }
         auto& inflight = item->Value;
 
         inflight.ConfirmFlush(route.DestinationHostIndex);
@@ -598,7 +603,10 @@ void TBlocksDirtyMap::FlushFinished(
 
     for (ui64 lsn: flushFailed) {
         auto item = Inflight.GetValue(lsn);
-        Y_ABORT_UNLESS(item);
+        if (!item) {
+            // The item was deleted when the host was disabled.
+            continue;
+        }
         auto& inflight = item->Value;
 
         inflight.FlushFailed(route.DestinationHostIndex);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map_ut.cpp
@@ -2034,6 +2034,59 @@ Y_UNIT_TEST_SUITE(TDirtyMapTest)
             40960,
             dirtyMap.GetPBufferCounters(THostIndex{2}).TotalBytesCount);
     }
+
+    Y_UNIT_TEST(ShouldIgnoreOutdatedFlushResponseAfterInflightRemoved)
+    {
+        const auto vchunkConfig = MakeTestVChunkConfig();
+        TBlocksDirtyMap dirtyMap(
+            vchunkConfig,
+            DefaultBlockSize,
+            DefaultVChunkSize / DefaultBlockSize);
+
+        const THostMask requested = MakePrimaryHosts();
+        const THostMask confirmed = MakePrimaryHosts();
+
+        // Complete a full write -> flush -> erase lifecycle so the inflight
+        // item for lsn 123 is removed from the map.
+        dirtyMap.RegisterInflightWrite(123, TBlockRange64::WithLength(10, 10));
+        dirtyMap.WriteFinished(
+            123,
+            TBlockRange64::WithLength(10, 10),
+            requested,
+            confirmed);
+
+        auto flushHint = dirtyMap.MakeFlushHint(1);
+        UNIT_ASSERT_EQUAL(false, flushHint.Empty());
+        for (const auto& [route, hint]: flushHint.GetAllHints()) {
+            dirtyMap.FlushFinished(route, MakeLsnVector(hint.Segments), {});
+        }
+
+        auto eraseHints = dirtyMap.MakeEraseHint(1);
+        UNIT_ASSERT_EQUAL(false, eraseHints.Empty());
+        for (const auto& [host, hint]: eraseHints.GetAllHints()) {
+            dirtyMap.EraseFinished(host, MakeLsnVector(hint.Segments), {});
+        }
+
+        // The inflight item is gone.
+        UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
+
+        // An outdated flush response for the already-removed inflight item must
+        // be ignored gracefully. Previously this tripped a Y_ABORT_UNLESS(item)
+        // invariant check. Exercise both the flushOk and flushFailed branches
+        // on still-enabled destination hosts.
+        dirtyMap.FlushFinished(
+            THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 0},
+            {123},
+            {});
+        dirtyMap.FlushFinished(
+            THostRoute{.SourceHostIndex = 1, .DestinationHostIndex = 1},
+            {},
+            {123});
+
+        // Nothing should have changed and no new flush hints appear.
+        UNIT_ASSERT_VALUES_EQUAL(0, dirtyMap.GetInflightCount());
+        UNIT_ASSERT_EQUAL(true, dirtyMap.MakeFlushHint(1).Empty());
+    }
 }
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
@@ -289,8 +289,9 @@ bool TVChunkConfig::IsValid() const
 TString TVChunkConfig::DebugPrint() const
 {
     TStringBuilder result;
-    result << "[" << VChunkIndex << "] PBuffer{" << PBufferHosts.DebugPrint()
-           << "} DDisk{" << DDiskHosts.DebugPrint() << "} Enabled{";
+    result << "[" << DBGIndex << "/" << VChunkIndex << "] PBuffer{"
+           << PBufferHosts.DebugPrint() << "} DDisk{" << DDiskHosts.DebugPrint()
+           << "} Enabled{";
     for (THostIndex hostIndex = 0; hostIndex < PBufferHosts.HostCount();
          ++hostIndex)
     {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -641,12 +641,12 @@ void TPartitionActor::HandleUpdateVChunkConfig(
 {
     auto& cfg = ev->Get()->VChunkConfig;
 
-    LOG_DEBUG_S(
+    LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
-        LogTitle.GetWithTime().c_str()
-            << " Handle UpdateVChunkConfig, vChunkIndex: "
-            << cfg.GetVChunkIndex());
+        "%s Handle UpdateVChunkConfig %s",
+        LogTitle.GetWithTime().c_str(),
+        cfg.DebugPrint().c_str());
 
     ExecuteTx(ctx, CreateTx<TUpdateVChunkConfig>(std::move(cfg)));
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -220,7 +220,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should stay the same since new config is not persisted yet.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
             "DDisk{Primary;Primary;Primary;None;None} "
             "Enabled{+++++}",
@@ -245,7 +245,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
             "DDisk{Primary;Primary;Primary;None;None} "
             "Enabled{-++++}",
@@ -283,7 +283,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
             "DDisk{Primary;Primary;Primary;None;None} "
             "Enabled{+++++}",
@@ -442,7 +442,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should stay the same since new config is not persisted yet.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{Primary;Primary;Primary;HandOff;HandOff} "
             "DDisk{Primary;Primary;Primary;None;None} "
             "Enabled{+++++}",
@@ -468,7 +468,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
             "DDisk{None;Primary;Primary;Primary;None} "
             "Enabled{-+++[0]+}",
@@ -507,7 +507,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
             "DDisk{None;Primary;Primary;Primary;None} "
             "Enabled{++++[0]+}",
@@ -541,7 +541,7 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Config should be updated.
         UNIT_ASSERT_VALUES_EQUAL(
-            "[100] "
+            "[0/100] "
             "PBuffer{HandOff;Primary;Primary;Primary;HandOff} "
             "DDisk{None;Primary;Primary;Primary;None} "
             "Enabled{+++++}",


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1 Removed unnecessary invariant check when outdated flush response arrived
2 print DBG index in logs
3 print vchunk config persist in logs

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
