### PR TITLE
Sesison interface refactoring. Pass session params via Init method, not ctor

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_session_iface.h
+++ b/ydb/library/actors/interconnect/interconnect_session_iface.h
@@ -21,7 +21,7 @@ namespace NActors {
         virtual IActor& SessionActor() noexcept = 0;
 
         // synchronous call surface used by the proxy (invoked via InvokeOtherActor within actor context)
-        virtual void Init() = 0;
+        virtual void Init(const TSessionParams& params) = 0;
         virtual void SetNewConnection(TEvHandshakeDone::TPtr& ev) = 0;
         virtual void Terminate(TDisconnectReason reason) = 0;
         virtual THolder<TEvHandshakeAck> ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) = 0;

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -401,12 +401,12 @@ namespace NActors {
             // Create new session actor.
             ++RdmaRetryWatchdogCookie;
             if (msg->Params.UseSessionV2) {
-                Session = new TInterconnectSessionTCPv2(this, msg->Params);
+                Session = new TInterconnectSessionTCPv2(this);
             } else {
-                Session = new TInterconnectSessionTCP(this, msg->Params);
+                Session = new TInterconnectSessionTCP(this);
             }
             SessionID = RegisterWithSameMailbox(&Session->SessionActor());
-            InvokeSession(&IInterconnectSession::Init);
+            InvokeSession(&IInterconnectSession::Init, msg->Params);
             SessionVirtualId = msg->Self;
             RemoteSessionVirtualId = msg->Peer;
             LOG_INFO_IC("ICP22", "created new session: %s", SessionID.ToString().data());

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -38,13 +38,12 @@ namespace NActors {
         return eventTypeName.empty() ? TStringBuf("manual") : TStringBuf(eventTypeName);
     }
 
-    TInterconnectSessionTCP::TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy, TSessionParams params)
+    TInterconnectSessionTCP::TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy)
         : TActor(&TInterconnectSessionTCP::StateFunc)
         , Created(TInstant::Now())
         , Proxy(proxy)
         , CloseOnIdleWatchdog(GetCloseOnIdleTimeout(), std::bind(&TThis::OnCloseOnIdleTimerHit, this))
         , LostConnectionWatchdog(GetLostConnectionTimeout(), std::bind(&TThis::OnLostConnectionTimerHit, this))
-        , Params(std::move(params))
         , KernelLivenessMode(Params.UseKernelLiveness)
         , TotalOutputQueueSize(0)
         , OutputStuckFlag(false)
@@ -52,8 +51,6 @@ namespace NActors {
         , OutputCounter(0ULL)
         , ZcProcessor(proxy->Common->Settings.SocketSendOptimization == ESocketSendOptimization::IC_MSG_ZEROCOPY)
     {
-        Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
-        Proxy->Metrics->SetConnected(0);
         PartUpdateTimestamp = GetCycleCountFast();
         ReceiveContext.Reset(new TReceiveContext);
     }
@@ -68,7 +65,10 @@ namespace NActors {
         }
     }
 
-    void TInterconnectSessionTCP::Init() {
+    void TInterconnectSessionTCP::Init(const TSessionParams& params) {
+        Params = params;
+        Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
+        Proxy->Metrics->SetConnected(0);
         auto destroyCallback = [as = TActivationContext::ActorSystem(), id = Proxy->Common->DestructorId](THolder<IEventBase> event) {
             as->Send(id, event.Release());
         };

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -504,10 +504,10 @@ namespace NActors {
         using TSubscriberHistory = std::unordered_map<TSubscriberHistoryKey, ui64, TSubscriberHistoryKeyHash>;
         static constexpr ui64 MaxSubscriberHistoryEntries = 1000;
 
-        TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy, TSessionParams params);
+        explicit TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy);
         ~TInterconnectSessionTCP();
 
-        void Init() override;
+        void Init(const TSessionParams& params) override;
         void CloseInputSession() override;
         bool IsRdmaInUse() override;
         bool HasRdmaState() const override;
@@ -681,7 +681,7 @@ namespace NActors {
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        const TSessionParams Params; // stable session template used for continuation handshakes
+        TSessionParams Params; // stable session template used for continuation handshakes
         // Runtime mode negotiated for the current socket; may differ from Params on reconnect.
         bool KernelLivenessMode = false;
         std::unique_ptr<TEventHolderPool> Pool;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -5,18 +5,17 @@
 
 namespace NActors {
 
-    TInterconnectSessionTCPv2::TInterconnectSessionTCPv2(TInterconnectProxyTCP* const proxy, TSessionParams params)
+    TInterconnectSessionTCPv2::TInterconnectSessionTCPv2(TInterconnectProxyTCP* const proxy)
         : TActor(&TInterconnectSessionTCPv2::StateFunc)
         , Proxy(proxy)
-        , Params(std::move(params))
-    {
+    { }
+
+    void TInterconnectSessionTCPv2::Init(const TSessionParams& params) {
+        Params = params;
         // v2 does not support encryption
         Y_ABORT_UNLESS(!Params.Encryption);
         Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
         Proxy->Metrics->SetConnected(0);
-    }
-
-    void TInterconnectSessionTCPv2::Init() {
         SetPrefix(Sprintf("SessionV2 %s [node %" PRIu32 "]", SelfId().ToString().data(), Proxy->PeerNodeId));
         LOG_INFO_IC_SESSION("ICS90", "v2 session created");
         DirectSession = std::make_shared<TDirectSession>();

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
@@ -35,12 +35,12 @@ namespace NActors {
             return EActivityType::INTERCONNECT_SESSION_TCP;
         }
 
-        TInterconnectSessionTCPv2(TInterconnectProxyTCP* proxy, TSessionParams params);
+        explicit TInterconnectSessionTCPv2(TInterconnectProxyTCP* proxy);
 
         // IInterconnectSession
         IActor& SessionActor() noexcept override { return *this; }
 
-        void Init() override;
+        void Init(const TSessionParams& params) override;
         void SetNewConnection(TEvHandshakeDone::TPtr& ev) override;
         void Terminate(TDisconnectReason reason) override;
         THolder<TEvHandshakeAck> ProcessHandshakeRequest(TEvHandshakeAsk::TPtr& ev) override;
@@ -85,7 +85,7 @@ namespace NActors {
         IEventBase* MakeNodeConnectedEvent() const;
 
         TInterconnectProxyTCP* const Proxy;
-        const TSessionParams Params;
+        TSessionParams Params;
 
         TIntrusivePtr<NInterconnect::TStreamSocket> Socket;
         TIntrusivePtr<NInterconnect::TStreamSocket> XdcSocket;


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

in case of rdma we need attach SRQ to session actor, not handshake. So we need to be able create session before TEvhandshakeDone event
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
