### PR TITLE
wm: add action reject

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
@@ -72,7 +72,7 @@ NMetadata::NModifications::TOperationParsingResult TResourcePoolClassifierManage
     }
 
     if (context.GetActivityType() == EActivityType::Create) {
-        if (!configJson.GetMap().contains("resource_pool")) {
+        if (!configJson.GetMap().contains("resource_pool") && !configJson.GetMap().contains("action")) {
             return TConclusionStatus::Fail("Missing required property resource_pool");
         }
 

--- a/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/resource_pool_classifier/manager.cpp
@@ -82,6 +82,13 @@ NMetadata::NModifications::TOperationParsingResult TResourcePoolClassifierManage
             return TConclusionStatus::Fail(TStringBuilder()<< "Symbol '" << *brokenAt << "' is not allowed in the resource pool classifier name '" << name << "'");
         }
     }
+
+    if (resourcePoolClassifierSettings.Action == EClassifierAction::Reject) {
+        if (configJson.GetMap().contains("resource_pool")) {
+            return TConclusionStatus::Fail("Property resource_pool must not be set when action='reject'");
+        }
+        configJson.InsertValue("resource_pool", DEFAULT_POOL_ID);
+    }
     if (auto error = resourcePoolClassifierSettings.Validate()) {
         return TConclusionStatus::Fail(TStringBuilder() << "Invalid resource pool classifier settings: " << *error);
     }

--- a/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
+++ b/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
@@ -1,6 +1,8 @@
 #include "kqp_query_classifier.h"
 #include "kqp_workload_service.h"
 
+#include <ydb/core/kqp/gateway/behaviour/resource_pool_classifier/object.h>
+
 namespace NKikimr::NKqp {
 
 inline constexpr char RESOLVER_IS_USER[] = "User request";
@@ -48,6 +50,10 @@ public:
                 return *PreClassifyResult = TPendingCompilation{.ResumeRank = rank};
             }
 
+            if (settings.Action == NResourcePool::EClassifierAction::Reject) {
+                return *PreClassifyResult = MakeRejectFromClassifier(value);
+            }
+
             if (TryResolve(settings, PreClassifyResult)) {
                 return *PreClassifyResult;
             }
@@ -75,6 +81,10 @@ public:
 
             if (!MatchesDynamic(settings, preparedQuery)) {
                 continue;
+            }
+
+            if (settings.Action == NResourcePool::EClassifierAction::Reject) {
+                return *PostClassifyResult = MakeRejectFromClassifier(it->second);
             }
 
             if (TryResolve(settings, PostClassifyResult)) {
@@ -203,6 +213,16 @@ private:
     template<typename TStore>
     bool TryResolve(const NResourcePool::TClassifierSettings& classifier, TStore& store) {
         return TryResolve(classifier.ResourcePool, store, TStringBuilder() << "Classifier with rank: " << classifier.Rank);
+    }
+
+    static TReject MakeRejectFromClassifier(const TResourcePoolClassifierConfig& config) {
+        const auto& name = config.GetName();
+        const auto rank = config.GetRank();
+        return TReject{
+            .Code = Ydb::StatusIds::PRECONDITION_FAILED,
+            .Message = TStringBuilder() << "Request is rejected by classifier '" << name << "' (rank=" << rank << ")",
+            .Resolver = TStringBuilder() << "Classifier with rank: " << rank,
+        };
     }
 
     ///

--- a/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
+++ b/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
@@ -51,7 +51,8 @@ public:
             }
 
             if (settings.Action == NResourcePool::EClassifierAction::Reject) {
-                return *PreClassifyResult = MakeRejectFromClassifier(value);
+                PreClassifyResult = MakeRejectFromClassifier(value);
+                return *PreClassifyResult;
             }
 
             if (TryResolve(settings, PreClassifyResult)) {
@@ -84,7 +85,8 @@ public:
             }
 
             if (settings.Action == NResourcePool::EClassifierAction::Reject) {
-                return *PostClassifyResult = MakeRejectFromClassifier(it->second);
+                PostClassifyResult = MakeRejectFromClassifier(it->second);
+                return *PostClassifyResult;
             }
 
             if (TryResolve(settings, PostClassifyResult)) {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h
@@ -21,7 +21,8 @@ inline TResourcePoolClassifierConfig MakeClassifierConfig(
     const TString& database, const TString& name, i64 rank,
     const TString& resourcePool,
     std::optional<TString> memberName = std::nullopt,
-    std::optional<TString> hasAppName = std::nullopt)
+    std::optional<TString> hasAppName = std::nullopt,
+    std::optional<TString> action = std::nullopt)
 {
     NJson::TJsonValue json(NJson::JSON_MAP);
     json["resource_pool"] = resourcePool;
@@ -30,6 +31,9 @@ inline TResourcePoolClassifierConfig MakeClassifierConfig(
     }
     if (hasAppName) {
         json["has_app_name"] = *hasAppName;
+    }
+    if (action) {
+        json["action"] = *action;
     }
 
     TResourcePoolClassifierConfig config;
@@ -79,6 +83,7 @@ struct TClassifyTestCase {
     i64 Rank = 100;
     std::optional<TString> ClassifierMemberName;
     std::optional<TString> ClassifierHasAppName;
+    std::optional<TString> ClassifierAction;
 
     TString ContextAppName;
     TString ContextMemberName;
@@ -92,6 +97,7 @@ struct TClassifyTestCase {
         TString ResourcePool;
         std::optional<TString> MemberName;
         std::optional<TString> HasAppName;
+        std::optional<TString> Action;
     };
     std::vector<TExtraClassifier> ExtraClassifiers;
 
@@ -99,12 +105,12 @@ struct TClassifyTestCase {
         std::vector<TResourcePoolClassifierConfig> configs;
         configs.push_back(MakeClassifierConfig(
             TEST_DB, "c_main", Rank, ResourcePool,
-            ClassifierMemberName, ClassifierHasAppName));
+            ClassifierMemberName, ClassifierHasAppName, ClassifierAction));
 
         for (const auto& extra : ExtraClassifiers) {
             configs.push_back(MakeClassifierConfig(
                 TEST_DB, extra.Name, extra.Rank, extra.ResourcePool,
-                extra.MemberName, extra.HasAppName));
+                extra.MemberName, extra.HasAppName, extra.Action));
         }
 
         auto classifierSnap = MakeClassifierSnapshot(std::move(configs));

--- a/ydb/core/kqp/workload_service/ut/kqp_action_reject_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_action_reject_ut.cpp
@@ -1,0 +1,151 @@
+#include <ydb/core/base/path.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr::NKqp {
+
+using namespace NWorkload;
+using namespace NYdb;
+
+namespace {
+
+const IQueryClassifier::TReject& AssertReject(const IQueryClassifier::TPreCompileClassifyResult& result) {
+    UNIT_ASSERT_C(std::holds_alternative<IQueryClassifier::TReject>(result),
+        TStringBuilder() << "Expected TReject, got variant index " << result.index());
+    return std::get<IQueryClassifier::TReject>(result);
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(TQueryClassifierActionReject) {
+
+    Y_UNIT_TEST(ShouldRejectWhenActionSet) {
+        TClassifyTestCase tc;
+        tc.ClassifierAction = "reject";
+
+        auto result = tc.RunPreClassify();
+        const auto& reject = AssertReject(result);
+        UNIT_ASSERT_EQUAL(reject.Code, Ydb::StatusIds::PRECONDITION_FAILED);
+        UNIT_ASSERT_STRING_CONTAINS(reject.Message, "Request is rejected by classifier 'c_main'");
+        UNIT_ASSERT_STRING_CONTAINS(reject.Message, "rank=100");
+    }
+
+    Y_UNIT_TEST(ShouldRejectEvenWithResourcePool) {
+        // action wins over resource_pool when both are specified
+        TClassifyTestCase tc;
+        tc.ResourcePool = "pool_target";
+        tc.ClassifierAction = "reject";
+
+        AssertReject(tc.RunPreClassify());
+    }
+
+    Y_UNIT_TEST(ShouldNotRejectWhenClassifierDoesNotMatch) {
+        TClassifyTestCase tc;
+        tc.ClassifierAction = "reject";
+        tc.ClassifierMemberName = "bob";
+        tc.ContextMemberName = "alice";
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPoolId(tc.RunPreClassify()), "default");
+    }
+}
+
+Y_UNIT_TEST_SUITE(ActionRejectDdl) {
+
+    Y_UNIT_TEST(TestActionRejectClassifier) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const TString& userSID = "test@user";
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+            CREATE RESOURCE POOL CLASSIFIER cl_reject WITH (
+                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
+                MEMBER_NAME=")" << userSID << R"(",
+                ACTION="reject",
+                RANK=100
+            );
+        )");
+
+        auto settings = TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier reject", [ydb, settings](TString& errorString) {
+            auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+            errorString = result.GetIssues().ToOneLineString();
+            return result.GetStatus() == NYdb::EStatus::PRECONDITION_FAILED
+                && errorString.Contains("Request is rejected by classifier 'cl_reject'")
+                && errorString.Contains("rank=100");
+        });
+    }
+
+    Y_UNIT_TEST(TestActionRejectCaseInsensitive) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const TString& userSID = "test@user";
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+            CREATE RESOURCE POOL CLASSIFIER cl_reject_ci WITH (
+                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
+                MEMBER_NAME=")" << userSID << R"(",
+                ACTION="REJECT",
+                RANK=100
+            );
+        )");
+
+        auto settings = TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier reject (case-insensitive action)", [ydb, settings](TString& errorString) {
+            auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+            errorString = result.GetIssues().ToOneLineString();
+            return result.GetStatus() == NYdb::EStatus::PRECONDITION_FAILED
+                && errorString.Contains("Request is rejected by classifier 'cl_reject_ci'");
+        });
+    }
+
+    Y_UNIT_TEST(TestActionRejectWithoutResourcePool) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const TString& userSID = "test@user";
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+            CREATE RESOURCE POOL CLASSIFIER cl_reject_no_pool WITH (
+                MEMBER_NAME=")" << userSID << R"(",
+                ACTION="reject",
+                RANK=100
+            );
+        )");
+
+        auto settings = TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier reject (no pool)", [ydb, settings](TString& errorString) {
+            auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+            errorString = result.GetIssues().ToOneLineString();
+            return result.GetStatus() == NYdb::EStatus::PRECONDITION_FAILED
+                && errorString.Contains("Request is rejected by classifier 'cl_reject_no_pool'");
+        });
+    }
+
+    Y_UNIT_TEST(TestClassifierMissingBothPoolAndAction) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        auto result = ydb->ExecuteQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL CLASSIFIER cl_incomplete WITH (
+                RANK=100
+            );
+        )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(), "Missing required property resource_pool");
+    }
+
+    Y_UNIT_TEST(TestActionRejectInvalidValue) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        auto result = ydb->ExecuteQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL CLASSIFIER cl_bad_action WITH (
+                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
+                ACTION="not_a_real_action"
+            );
+        )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), EStatus::SUCCESS);
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_action_reject_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_action_reject_ut.cpp
@@ -61,7 +61,6 @@ Y_UNIT_TEST_SUITE(ActionRejectDdl) {
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
             CREATE RESOURCE POOL CLASSIFIER cl_reject WITH (
-                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
                 MEMBER_NAME=")" << userSID << R"(",
                 ACTION="reject",
                 RANK=100
@@ -85,7 +84,6 @@ Y_UNIT_TEST_SUITE(ActionRejectDdl) {
         ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
             GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
             CREATE RESOURCE POOL CLASSIFIER cl_reject_ci WITH (
-                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
                 MEMBER_NAME=")" << userSID << R"(",
                 ACTION="REJECT",
                 RANK=100
@@ -145,6 +143,85 @@ Y_UNIT_TEST_SUITE(ActionRejectDdl) {
             );
         )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
         UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), EStatus::SUCCESS);
+    }
+
+    Y_UNIT_TEST(TestCreateActionRejectWithResourcePoolConflict) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        auto result = ydb->ExecuteQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL CLASSIFIER cl_reject_conflict WITH (
+                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
+                ACTION="reject",
+                RANK=100
+            );
+        )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(),
+            "Property resource_pool must not be set when action='reject'");
+    }
+
+    Y_UNIT_TEST(TestAlterActionRejectWithResourcePoolConflict) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const TString& userSID = "test@user";
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+            CREATE RESOURCE POOL CLASSIFIER cl_alter_conflict WITH (
+                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"(",
+                MEMBER_NAME=")" << userSID << R"(",
+                RANK=100
+            );
+        )");
+
+        auto result = ydb->ExecuteQuery(TStringBuilder() << R"(
+            ALTER RESOURCE POOL CLASSIFIER cl_alter_conflict SET (
+                ACTION="reject",
+                RESOURCE_POOL=")" << NResourcePool::DEFAULT_POOL_ID << R"("
+            );
+        )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_UNEQUAL(result.GetStatus(), EStatus::SUCCESS);
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToOneLineString(),
+            "Property resource_pool must not be set when action='reject'");
+    }
+
+    Y_UNIT_TEST(TestAlterSetActionRejectAlone) {
+        auto ydb = TYdbSetupSettings().Create();
+
+        const TString& userSID = "test@user";
+        const TString& poolId = "prior_pool";
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+            CREATE RESOURCE POOL )" << poolId << R"( WITH (
+                CONCURRENT_QUERY_LIMIT=10
+            );
+            CREATE RESOURCE POOL CLASSIFIER cl_alter_to_reject WITH (
+                RESOURCE_POOL=")" << poolId << R"(",
+                MEMBER_NAME=")" << userSID << R"(",
+                RANK=100
+            );
+            ALTER RESOURCE POOL CLASSIFIER cl_alter_to_reject SET (
+                ACTION="reject"
+            );
+        )");
+
+        auto settings = TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier reject (via alter)", [ydb, settings](TString& errorString) {
+            auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+            errorString = result.GetIssues().ToOneLineString();
+            return result.GetStatus() == NYdb::EStatus::PRECONDITION_FAILED
+                && errorString.Contains("Request is rejected by classifier 'cl_alter_to_reject'");
+        });
+
+        // Verify the ALTER also reset resource_pool to "default" in the stored config.
+        auto sysview = ydb->ExecuteQuery(R"(
+            SELECT ResourcePool, Action FROM `.sys/resource_pool_classifiers`
+            WHERE Name = "cl_alter_to_reject"
+        )", TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID));
+        UNIT_ASSERT_VALUES_EQUAL(sysview.GetStatus(), EStatus::SUCCESS);
+        NYdb::TResultSetParser row(sysview.GetResultSet(0));
+        UNIT_ASSERT(row.TryNextRow());
+        UNIT_ASSERT_VALUES_EQUAL(*row.ColumnParser("ResourcePool").GetOptionalUtf8(), NResourcePool::DEFAULT_POOL_ID);
+        UNIT_ASSERT_VALUES_EQUAL(*row.ColumnParser("Action").GetOptionalUtf8(), "reject");
     }
 }
 

--- a/ydb/core/kqp/workload_service/ut/ya.make
+++ b/ydb/core/kqp/workload_service/ut/ya.make
@@ -10,6 +10,7 @@ ELSE()
 ENDIF()
 
 SRCS(
+    kqp_action_reject_ut.cpp
     kqp_has_app_name_ut.cpp
     kqp_member_name_ut.cpp
     kqp_query_classifier_match_ut.cpp

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
@@ -1,5 +1,6 @@
 #include "resource_pool_classifier_settings.h"
 
+#include <util/generic/serialized_enum.h>
 #include <util/string/builder.h>
 #include <util/string/cast.h>
 
@@ -38,12 +39,11 @@ void TClassifierSettings::TParser::operator()(std::optional<EClassifierAction>* 
         setting->reset();
         return;
     }
-    const auto lowered = to_lower(Value);
-    if (lowered == "reject") {
-        *setting = EClassifierAction::Reject;
-        return;
+    EClassifierAction parsed;
+    if (!TryFromString(to_lower(Value), parsed)) {
+        throw yexception() << "Invalid action '" << Value << "', supported values: " << GetEnumAllNames<EClassifierAction>();
     }
-    throw yexception() << "Invalid action '" << Value << "', supported values: 'reject'";
+    *setting = parsed;
 }
 
 //// TClassifierSettings::TExtractor
@@ -71,11 +71,7 @@ TString TClassifierSettings::TExtractor::operator()(std::optional<EClassifierAct
     if (!*setting) {
         return TString{};
     }
-    switch (**setting) {
-        case EClassifierAction::Reject:
-            return "reject";
-    }
-    return TString{};
+    return ToString(**setting);
 }
 
 //// TClassifierSettings

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
@@ -1,6 +1,7 @@
 #include "resource_pool_classifier_settings.h"
 
 #include <util/string/builder.h>
+#include <util/string/cast.h>
 
 #include <ydb/library/aclib/aclib.h>
 
@@ -32,6 +33,19 @@ void TClassifierSettings::TParser::operator()(std::optional<TRegexPredicate>* se
     }
 }
 
+void TClassifierSettings::TParser::operator()(std::optional<EClassifierAction>* setting) const {
+    if (Value.empty()) {
+        setting->reset();
+        return;
+    }
+    const auto lowered = to_lower(Value);
+    if (lowered == "reject") {
+        *setting = EClassifierAction::Reject;
+        return;
+    }
+    throw yexception() << "Invalid action '" << Value << "', supported values: 'reject'";
+}
+
 //// TClassifierSettings::TExtractor
 
 TString TClassifierSettings::TExtractor::operator()(i64* setting) const {
@@ -53,6 +67,17 @@ TString TClassifierSettings::TExtractor::operator()(std::optional<TRegexPredicat
     return TString{};
 }
 
+TString TClassifierSettings::TExtractor::operator()(std::optional<EClassifierAction>* setting) const {
+    if (!*setting) {
+        return TString{};
+    }
+    switch (**setting) {
+        case EClassifierAction::Reject:
+            return "reject";
+    }
+    return TString{};
+}
+
 //// TClassifierSettings
 
 std::unordered_map<TString, TClassifierSettings::TProperty> TClassifierSettings::GetPropertiesMap() {
@@ -60,7 +85,8 @@ std::unordered_map<TString, TClassifierSettings::TProperty> TClassifierSettings:
         {"rank", &Rank},
         {"resource_pool", &ResourcePool},
         {"member_name", &MemberName},
-        {"has_app_name", &HasAppName}
+        {"has_app_name", &HasAppName},
+        {"action", &Action}
     };
     return properties;
 }

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.h
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.h
@@ -11,15 +11,20 @@ namespace NKikimr::NResourcePool {
 inline constexpr i64 CLASSIFIER_RANK_OFFSET = 1000;
 inline constexpr i64 CLASSIFIER_COUNT_LIMIT = 1000;
 
+enum class EClassifierAction {
+    Reject,
+};
+
 struct TClassifierSettings : public TSettingsBase {
     using TBase = TSettingsBase;
-    using TProperty = std::variant<i64*, TString*, std::optional<TString>*, std::optional<TRegexPredicate>*>;
+    using TProperty = std::variant<i64*, TString*, std::optional<TString>*, std::optional<TRegexPredicate>*, std::optional<EClassifierAction>*>;
 
     struct TParser : public TBase::TParser {
         void operator()(i64* setting) const;
         void operator()(TString* setting) const;
         void operator()(std::optional<TString>* setting) const;
         void operator()(std::optional<TRegexPredicate>* setting) const;
+        void operator()(std::optional<EClassifierAction>* setting) const;
     };
 
     struct TExtractor : public TBase::TExtractor {
@@ -27,6 +32,7 @@ struct TClassifierSettings : public TSettingsBase {
         TString operator()(TString* setting) const;
         TString operator()(std::optional<TString>* setting) const;
         TString operator()(std::optional<TRegexPredicate>* setting) const;
+        TString operator()(std::optional<EClassifierAction>* setting) const;
     };
 
     bool operator==(const TClassifierSettings& other) const = delete;
@@ -38,6 +44,7 @@ struct TClassifierSettings : public TSettingsBase {
     TString ResourcePool = DEFAULT_POOL_ID;
     std::optional<TString> MemberName;
     std::optional<TRegexPredicate> HasAppName;
+    std::optional<EClassifierAction> Action;
 };
 
 }  // namespace NKikimr::NResourcePool

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.h
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.h
@@ -12,7 +12,7 @@ inline constexpr i64 CLASSIFIER_RANK_OFFSET = 1000;
 inline constexpr i64 CLASSIFIER_COUNT_LIMIT = 1000;
 
 enum class EClassifierAction {
-    Reject,
+    Reject /* "reject" */,
 };
 
 struct TClassifierSettings : public TSettingsBase {

--- a/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
@@ -86,6 +86,43 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_app_name"]), "");
     }
 
+    Y_UNIT_TEST(ActionParsing) {
+        TClassifierSettings settings;
+        auto propertiesMap = settings.GetPropertiesMap();
+
+        std::visit(TClassifierSettings::TParser{"reject"}, propertiesMap["action"]);
+        UNIT_ASSERT(settings.Action.has_value());
+        UNIT_ASSERT_EQUAL(*settings.Action, EClassifierAction::Reject);
+
+        // Case-insensitive
+        std::visit(TClassifierSettings::TParser{"REJECT"}, propertiesMap["action"]);
+        UNIT_ASSERT_EQUAL(*settings.Action, EClassifierAction::Reject);
+        std::visit(TClassifierSettings::TParser{"Reject"}, propertiesMap["action"]);
+        UNIT_ASSERT_EQUAL(*settings.Action, EClassifierAction::Reject);
+
+        // Empty resets to nullopt
+        std::visit(TClassifierSettings::TParser{""}, propertiesMap["action"]);
+        UNIT_ASSERT(!settings.Action.has_value());
+    }
+
+    Y_UNIT_TEST(ActionInvalid) {
+        TClassifierSettings settings;
+        auto propertiesMap = settings.GetPropertiesMap();
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(std::visit(TClassifierSettings::TParser{"allow"}, propertiesMap["action"]), yexception, "Invalid action 'allow'");
+    }
+
+    Y_UNIT_TEST(ActionExtracting) {
+        TClassifierSettings settings;
+        auto propertiesMap = settings.GetPropertiesMap();
+
+        TClassifierSettings::TExtractor extractor;
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["action"]), "");
+
+        settings.Action = EClassifierAction::Reject;
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["action"]), "reject");
+    }
+
     Y_UNIT_TEST(SettingsValidation) {
         TClassifierSettings settings;
         settings.MemberName = BUILTIN_ACL_METADATA;

--- a/ydb/core/resource_pools/ya.make
+++ b/ydb/core/resource_pools/ya.make
@@ -6,6 +6,8 @@ SRCS(
     resource_pool_settings.cpp
 )
 
+GENERATE_ENUM_SERIALIZATION(resource_pool_classifier_settings.h)
+
 PEERDIR(
     contrib/libs/protobuf
     library/cpp/regex/pcre

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -795,6 +795,7 @@ struct Schema : NIceDb::Schema {
         struct MemberName   : Column<4, NScheme::NTypeIds::Utf8> {};
         struct ResourcePool : Column<5, NScheme::NTypeIds::Utf8> {};
         struct HasAppName   : Column<6, NScheme::NTypeIds::Utf8> {};
+        struct Action       : Column<7, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<Name>;
         using TColumns = TableColumns<
@@ -802,7 +803,8 @@ struct Schema : NIceDb::Schema {
             Rank,
             MemberName,
             ResourcePool,
-            HasAppName>;
+            HasAppName,
+            Action>;
     };
 
     struct ShowCreate : Table<21> {

--- a/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
+++ b/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
@@ -103,6 +103,10 @@ private:
                     const auto& hasAppName = config.GetConfigJson()["has_app_name"].GetString();
                     return TCell(hasAppName.data(), hasAppName.size());
                 }});
+                insert({TSchema::Action::ColumnId, [] (const NKqp::TResourcePoolClassifierConfig& config) {
+                    const auto& action = config.GetConfigJson()["action"].GetString();
+                    return TCell(action.data(), action.size());
+                }});
             }
         };
         static TExtractorsMap extractors;

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -997,6 +997,10 @@
   "resource_pool_classifiers": {
     "columns": [
       {
+        "name": "Action",
+        "type": "Utf8?"
+      },
+      {
         "name": "Name",
         "type": "Utf8?"
       },
@@ -1014,10 +1018,6 @@
       },
       {
         "name": "HasAppName",
-        "type": "Utf8?"
-      },
-      {
-        "name": "Action",
         "type": "Utf8?"
       }
     ],

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -1015,6 +1015,10 @@
       {
         "name": "HasAppName",
         "type": "Utf8?"
+      },
+      {
+        "name": "Action",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -591,6 +591,10 @@
       {
         "name": "HasAppName",
         "type": "Utf8?"
+      },
+      {
+        "name": "Action",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -573,6 +573,10 @@
   "resource_pool_classifiers": {
     "columns": [
       {
+        "name": "Action",
+        "type": "Utf8?"
+      },
+      {
         "name": "Name",
         "type": "Utf8?"
       },
@@ -590,10 +594,6 @@
       },
       {
         "name": "HasAppName",
-        "type": "Utf8?"
-      },
-      {
-        "name": "Action",
         "type": "Utf8?"
       }
     ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add `ACTION="reject"` on workload manager resource pool classifiers to reject matched requests before pool routing

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Summary:
  - Introduce `EClassifierAction::Reject` in `ydb/core/resource_pools` and expose it as `ACTION` in the classifier DDL 
  - Wire reject into both `PreCompileClassify` and `PostCompileClassify`
  - `RESOURCE_POOL` becomes optional when `ACTION="reject"` is set (a reject-only classifier doesn't need a target pool). Classifiers with neither still fail at DDL with "Missing required property resource_pool".
  - Sysview: new `Action` column on `resource_pool_classifiers`, plumbed through the extractor and reflected in root/tenant canondata.

  Tests:
  - Unit: `TQueryClassifierActionReject` — reject on plain match, reject wins over `resource_pool`, no reject when classifier doesn't match.
  - IT: `ActionRejectDdl` — happy-path reject, case-insensitive `ACTION="REJECT"`, reject-only classifier without `RESOURCE_POOL`, DDL failure when both are absent, DDL failure on invalid action value.
  - Settings UT: parse/extract round-trip for the new enum value.

  Examples:

  ```sql
  -- Reject all requests from a member
  CREATE RESOURCE POOL CLASSIFIER reject_batch WITH (
      RANK=100,
      MEMBER_NAME="batch@user",
      ACTION="reject"
  );

  -- Reject requests from an app
  CREATE RESOURCE POOL CLASSIFIER reject_legacy_cli WITH (
      RANK=150,
      HAS_APP_NAME="ydb-cli-v0.*",
      ACTION="reject"
  );
```
