### PR TITLE
NBS-7457: monitoring page Local DB tab

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -4,6 +4,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_stat.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/oracle.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
 
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
@@ -19,6 +20,7 @@ enum class EMonPage
 {
     Overview,
     Dbg,
+    LocalDb,
 };
 
 struct TTabletInfo
@@ -53,6 +55,17 @@ struct TDbgSnapshot
     TVector<THostSnapshot> Hosts;
 };
 
+// Persisted tablet state (local DB). Protos are pre-dumped to text; an absent
+// value means the row was never persisted.
+struct TLocalDbContents
+{
+    std::optional<TString> VolumeConfig;
+    std::optional<TString> DirectBlockGroupsConnections;
+    std::optional<TString> AddHostInProgress;
+    // Persisted per-vchunk overrides.
+    TVector<TVChunkConfig> VChunkConfigs;
+};
+
 struct TMonPageData
 {
     EMonPage Page = EMonPage::Overview;
@@ -64,6 +77,8 @@ struct TMonPageData
     TVector<TDbgSnapshot> Dbgs;
     // DBG detail index (absent => list view).
     std::optional<ui32> SelectedDbg;
+    // Local DB tab.
+    std::optional<TLocalDbContents> LocalDb;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -31,6 +31,8 @@ const char* PageParam(EMonPage page)
             return "overview";
         case EMonPage::Dbg:
             return "dbg";
+        case EMonPage::LocalDb:
+            return "localdb";
     }
     return "overview";
 }
@@ -42,6 +44,8 @@ const char* PageTitle(EMonPage page)
             return "Overview";
         case EMonPage::Dbg:
             return "DBGs";
+        case EMonPage::LocalDb:
+            return "Local DB";
     }
     return "";
 }
@@ -114,6 +118,7 @@ void RenderMenu(
     static const EMonPage pages[] = {
         EMonPage::Overview,
         EMonPage::Dbg,
+        EMonPage::LocalDb,
     };
     str << "<div style='margin:0.5em 0 1em;'>";
     for (EMonPage page: pages) {
@@ -324,6 +329,65 @@ void RenderDbgDetail(
     }
 }
 
+void RenderProtoDump(
+    IOutputStream& str,
+    const char* name,
+    const std::optional<TString>& dump)
+{
+    if (!dump) {
+        str << "<div style='margin-bottom:0.5em;'>" << name << " (none)</div>";
+        return;
+    }
+    // display:list-item brings back the fold triangle that the page CSS
+    // hides; the pointer marks the line as clickable.
+    str << "<details style='margin-bottom:0.5em;'>"
+           "<summary style='display:list-item; cursor:pointer;'>"
+        << name << "</summary><pre>" << HtmlEscape(*dump) << "</pre></details>";
+}
+
+void RenderLocalDb(IOutputStream& str, const TLocalDbContents& db)
+{
+    HTML (str) {
+        TAG (TH3) {
+            str << "Local DB";
+        }
+        RenderProtoDump(str, "VolumeConfig", db.VolumeConfig);
+        RenderProtoDump(
+            str,
+            "DirectBlockGroupsConnections",
+            db.DirectBlockGroupsConnections);
+        RenderProtoDump(str, "AddHostInProgress", db.AddHostInProgress);
+        TAG (TH4) {
+            str << "VChunkConfigs (persisted overrides)";
+        }
+        TABLE_CLASS ("table table-condensed") {
+            TABLEHEAD () {
+                TABLER () {
+                    TABLEH () {
+                        str << "VChunkIndex";
+                    }
+                    TABLEH () {
+                        str << "Config";
+                    }
+                }
+            }
+            TABLEBODY () {
+                for (const auto& config: db.VChunkConfigs) {
+                    TABLER () {
+                        TABLED () {
+                            str << config.GetVChunkIndex();
+                        }
+                        TABLED () {
+                            str << "<pre>" << HtmlEscape(config.DebugPrint())
+                                << "</pre>";
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 void RenderDbg(IOutputStream& str, const TMonPageData& data)
 {
     if (!data.SelectedDbg) {
@@ -371,6 +435,11 @@ TString RenderMonPage(const TMonPageData& data)
             break;
         case EMonPage::Dbg:
             RenderDbg(str, data);
+            break;
+        case EMonPage::LocalDb:
+            if (data.LocalDb) {
+                RenderLocalDb(str, *data.LocalDb);
+            }
             break;
     }
     return str.Str();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -260,6 +260,25 @@ void RenderDbgDetail(
 {
     str << "<div style='margin-bottom:0.5em;'><a href='?TabletID="
         << tabletInfo.TabletId << "&page=dbg'>&larr; back to DBGs</a></div>";
+    // POST, not a link: link prefetching must not add hosts.
+    //
+    // The same parameters go into both the action URL and the hidden fields
+    // because the request has two readers, each looking at one place only:
+    // the mon proxy picks the target tablet from the POST body, while the
+    // tablet's Cgi() reads the URL query.
+    str << "<form method='post' action='?TabletID=" << tabletInfo.TabletId
+        << "&page=dbg&dbg=" << dbg.Index
+        << "&action=addhost' style='margin-bottom:0.5em;'>"
+           "<input type='hidden' name='TabletID' value='"
+        << tabletInfo.TabletId
+        << "'/>"
+           "<input type='hidden' name='page' value='dbg'/>"
+           "<input type='hidden' name='dbg' value='"
+        << dbg.Index
+        << "'/>"
+           "<input type='hidden' name='action' value='addhost'/>"
+           "<button type='submit' class='btn btn-default'>Add host</button>"
+           "</form>";
     HTML (str) {
         TAG (TH3) {
             str << "DBG #" << dbg.Index;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -58,6 +58,7 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
         UNIT_ASSERT_STRING_CONTAINS(html, "Overview");
         UNIT_ASSERT_STRING_CONTAINS(html, "page=overview");
         UNIT_ASSERT_STRING_CONTAINS(html, "page=dbg");
+        UNIT_ASSERT_STRING_CONTAINS(html, "page=localdb");
         UNIT_ASSERT_STRING_CONTAINS(html, "DirectBlockGroups");
         UNIT_ASSERT_STRING_CONTAINS(html, "VChunks (total)");
         UNIT_ASSERT_STRING_CONTAINS(html, "LSN counter");
@@ -128,6 +129,34 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
 
         const TString html = RenderMonPage(data);
         UNIT_ASSERT_STRING_CONTAINS(html, "not found");
+    }
+
+    Y_UNIT_TEST(LocalDbShowsPersistedState)
+    {
+        const TMonPageData data{
+            .Page = EMonPage::LocalDb,
+            .TabletInfo = {.TabletId = 42},
+            .LocalDb =
+                TLocalDbContents{
+                    .VolumeConfig = "DiskId: vol-1",
+                    .VChunkConfigs = {TVChunkConfig::MakeDefault(3, 5, 3)},
+                },
+        };
+
+        const TString html = RenderMonPage(data);
+        UNIT_ASSERT_STRING_CONTAINS(html, "Local DB");
+        // Long proto dumps are collapsed; the summary is styled to look
+        // clickable (fold triangle + pointer).
+        UNIT_ASSERT_STRING_CONTAINS(html, "<details");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "<summary style='display:list-item; cursor:pointer;");
+        UNIT_ASSERT_STRING_CONTAINS(html, "DiskId: vol-1");
+        // DirectBlockGroupsConnections / AddHostInProgress not persisted.
+        UNIT_ASSERT_STRING_CONTAINS(html, "(none)");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "VChunkConfigs (persisted overrides)");
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -100,6 +100,8 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
         UNIT_ASSERT_STRING_CONTAINS(html, "1 Online");
         UNIT_ASSERT_STRING_CONTAINS(html, "1 Sufferer");
         UNIT_ASSERT_STRING_CONTAINS(html, "Consecutive success");
+        // The add-host button lives on the detail page only.
+        UNIT_ASSERT(!html.Contains("action=addhost"));
     }
 
     Y_UNIT_TEST(DbgDetailShowsHostsTable)
@@ -117,6 +119,20 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
             html,
             "WriteToPBuffer");   // operation column
         UNIT_ASSERT_STRING_CONTAINS(html, "back to DBGs");
+        // The add-host form: POST with parameters both in the URL (read by
+        // the tablet) and as hidden fields (read by the mon proxy router).
+        UNIT_ASSERT_STRING_CONTAINS(html, "<form method='post'");
+        UNIT_ASSERT_STRING_CONTAINS(html, "page=dbg&dbg=1&action=addhost");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "<input type='hidden' name='TabletID' value='42'/>");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "<input type='hidden' name='dbg' value='1'/>");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "<input type='hidden' name='action' value='addhost'/>");
+        UNIT_ASSERT_STRING_CONTAINS(html, "Add host");
     }
 
     Y_UNIT_TEST(DbgDetailNotFound)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
@@ -4,11 +4,14 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.h>
 
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/core/mon.h>
+#include <ydb/library/services/services.pb.h>
 
 #include <library/cpp/cgiparam/cgiparam.h>
 
 #include <util/generic/algorithm.h>
+#include <util/string/builder.h>
 #include <util/string/cast.h>
 
 #include <numeric>
@@ -110,11 +113,48 @@ void TPartitionActor::HandleHttpInfo(
         return;
     }
 
+    const std::optional<size_t> selectedDbg = ParseSelectedDbg(cgi);
+
+    // The "Add host" button. POST only: link prefetching must not add hosts.
+    //
+    // The index is user input from the URL, but HandleAddHostToDBG treats an
+    // out-of-range index as a bug and aborts - so bounds-check it here. All
+    // other checks live there. The reply bounces back to the same DBG page.
+    if (page == EMonPage::Dbg && selectedDbg &&
+        cgi.Get("action") == "addhost" &&
+        ev->Get()->GetMethod() == HTTP_METHOD_POST)
+    {
+        const bool dbgExists =
+            *selectedDbg < FastPathService->GetDirectBlockGroups().size();
+        if (dbgExists) {
+            LOG_INFO(
+                ctx,
+                NKikimrServices::NBS_PARTITION,
+                "%s Mon page requested AddHost dbgId=%lu",
+                LogTitle.GetWithTime().c_str(),
+                *selectedDbg);
+
+            FastPathService->RequestAddHost(*selectedDbg);
+        }
+
+        TStringBuilder reply;
+        if (dbgExists) {
+            reply << "<p>Add host requested for DBG #" << *selectedDbg
+                  << ".</p>";
+        } else {
+            reply << "<p>DBG #" << *selectedDbg << " not found.</p>";
+        }
+        // Bounce straight back to the same DBG page.
+        reply << "<meta http-equiv='refresh' content='0; ?TabletID="
+              << TabletID() << "&page=dbg&dbg=" << *selectedDbg << "'/>";
+        ctx.Send(ev->Sender, new NMon::TEvRemoteHttpInfoRes(reply));
+        return;
+    }
+
     // DBG page: gather snapshots, then render + reply in the callback. Safe
     // off-thread - captures are taken here and RenderMonPage is pure.
     auto* actorSystem = TActivationContext::ActorSystem();
     const TActorId requester = ev->Sender;
-    const std::optional<size_t> selectedDbg = ParseSelectedDbg(cgi);
 
     FastPathService->GatherMonSnapshots(selectedDbg)
         .Subscribe(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
@@ -2,6 +2,7 @@
 #include "partition_direct_actor.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_database.h>
 
 #include <ydb/library/actors/core/mon.h>
 
@@ -10,11 +11,14 @@
 #include <util/generic/algorithm.h>
 #include <util/string/cast.h>
 
+#include <numeric>
 #include <optional>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 using namespace NActors;
+using namespace NKikimr;
+using namespace NKikimr::NTabletFlatExecutor;
 
 namespace {
 
@@ -22,8 +26,12 @@ namespace {
 
 EMonPage ParsePage(const TCgiParameters& cgi)
 {
-    if (cgi.Get("page") == "dbg") {
+    const TString& page = cgi.Get("page");
+    if (page == "dbg") {
         return EMonPage::Dbg;
+    }
+    if (page == "localdb") {
+        return EMonPage::LocalDb;
     }
     return EMonPage::Overview;
 }
@@ -35,6 +43,26 @@ std::optional<size_t> ParseSelectedDbg(const TCgiParameters& cgi)
         return dbgIndex;
     }
     return std::nullopt;
+}
+
+template <typename TProto>
+std::optional<TString> DumpProto(const TMaybe<TProto>& proto)
+{
+    if (!proto.Defined()) {
+        return std::nullopt;
+    }
+    return proto->DebugString();
+}
+
+TLocalDbContents MakeLocalDbContents(const TTxPartition::TMonitoring& args)
+{
+    return {
+        .VolumeConfig = DumpProto(args.VolumeConfig),
+        .DirectBlockGroupsConnections =
+            DumpProto(args.DirectBlockGroupsConnections),
+        .AddHostInProgress = DumpProto(args.AddHostInProgress),
+        .VChunkConfigs = args.VChunkConfigs,
+    };
 }
 
 }   // namespace
@@ -75,6 +103,13 @@ void TPartitionActor::HandleHttpInfo(
         return;
     }
 
+    // Local DB page: read the persisted state in a transaction;
+    // CompleteMonitoring renders and replies.
+    if (page == EMonPage::LocalDb) {
+        ExecuteTx(ctx, CreateTx<TMonitoring>(ev->Sender));
+        return;
+    }
+
     // DBG page: gather snapshots, then render + reply in the callback. Safe
     // off-thread - captures are taken here and RenderMonPage is pure.
     auto* actorSystem = TActivationContext::ActorSystem();
@@ -105,6 +140,55 @@ void TPartitionActor::HandleHttpInfo(
                     requester,
                     new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
             });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TPartitionActor::PrepareMonitoring(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxPartition::TMonitoring& args)
+{
+    Y_UNUSED(ctx);
+
+    TPartitionDatabase db(tx.DB);
+
+    std::initializer_list<bool> results = {
+        db.ReadVolumeConfig(args.VolumeConfig),
+        db.ReadDirectBlockGroupsConnections(args.DirectBlockGroupsConnections),
+        db.ReadAllVChunkConfigs(args.VChunkConfigs),
+        db.ReadAddHostInProgress(args.AddHostInProgress),
+    };
+
+    return std::accumulate(
+        results.begin(),
+        results.end(),
+        true,
+        std::logical_and<>());
+}
+
+void TPartitionActor::ExecuteMonitoring(
+    const TActorContext& ctx,
+    TTransactionContext& tx,
+    TTxPartition::TMonitoring& args)
+{
+    Y_UNUSED(ctx);
+    Y_UNUSED(tx);
+    Y_UNUSED(args);
+}
+
+void TPartitionActor::CompleteMonitoring(
+    const TActorContext& ctx,
+    TTxPartition::TMonitoring& args)
+{
+    TMonPageData data{
+        .Page = EMonPage::LocalDb,
+        .TabletInfo = MakeMonTabletInfo(),
+        .LocalDb = MakeLocalDbContents(args),
+    };
+    ctx.Send(
+        args.Requester,
+        new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -24,7 +24,8 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
     xxx(StorePartitionIds, __VA_ARGS__)             \
     xxx(UpdateVChunkConfig, __VA_ARGS__)            \
     xxx(StartAddHost, __VA_ARGS__)                  \
-    xxx(AddHostToDBG, __VA_ARGS__)
+    xxx(AddHostToDBG, __VA_ARGS__)                  \
+    xxx(Monitoring, __VA_ARGS__)
 
 // BLOCKSTORE_PARTITION_TRANSACTIONS
 
@@ -163,6 +164,32 @@ struct TTxPartition
 
         void Clear()
         {}
+    };
+
+    //
+    // Monitoring: read the local DB contents for the mon page.
+    //
+    struct TMonitoring
+    {
+        const NActors::TActorId Requester;
+
+        // Filled by Prepare.
+        TMaybe<NKikimrBlockStore::TVolumeConfig> VolumeConfig;
+        TMaybe<TDirectBlockGroupsConnections> DirectBlockGroupsConnections;
+        TMaybe<TAddHostInProgress> AddHostInProgress;
+        TVector<TVChunkConfig> VChunkConfigs;
+
+        explicit TMonitoring(NActors::TActorId requester)
+            : Requester(requester)
+        {}
+
+        void Clear()
+        {
+            VolumeConfig.Clear();
+            DirectBlockGroupsConnections.Clear();
+            AddHostInProgress.Clear();
+            VChunkConfigs.clear();
+        }
     };
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -508,8 +508,9 @@ void TPartitionActor::HandleAddHostToDBG(
         LogTitle.GetWithTime().c_str(),
         dbgId);
 
-    // TEvAddHostToDBG is only sent by a running FastPathService, so it (and the
-    // allocated DBGs) is alive by the time we handle the request.
+    // TEvAddHostToDBG is only sent via a running FastPathService (by a DBG or
+    // by the mon page button), so it (and the allocated DBGs) is alive by the
+    // time we handle the request.
     Y_ABORT_UNLESS(FastPathService);
 
     if (!ValidateAddHostToDBGRequest(ctx, dbgId)) {


### PR DESCRIPTION
Third tab of the partition_direct tablet mon page (after Overview #44380 and DBGs #44914): shows the tablet's persisted state.

- `VolumeConfig`, `DirectBlockGroupsConnections`, `AddHostInProgress` — proto dumps, `(none)` when never persisted;
- `VChunkConfigs (persisted overrides)` — per-vchunk config rows.

Data is read in a local-DB transaction (`Monitoring`): `Prepare` reads the same set as `PrepareLoadState`, `Complete` renders and replies to the requester carried in the tx args. Runtime pages keep using the future-based gather; no actor events / cookies involved.