### PR TITLE
Break circular dependency cs/columnshard_private_events.h <-> cs/**.

### DIFF
--- a/ydb/core/tx/columnshard/backup/async_jobs/import_downloader.cpp
+++ b/ydb/core/tx/columnshard/backup/async_jobs/import_downloader.cpp
@@ -2,7 +2,7 @@
 #include "import_downloader_counters.h"
 
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/datashard/datashard_impl.h>
 #include <ydb/core/tx/datashard/import_common.h>

--- a/ydb/core/tx/columnshard/backup/async_jobs/ut/ut_import_downloader.cpp
+++ b/ydb/core/tx/columnshard/backup/async_jobs/ut/ut_import_downloader.cpp
@@ -5,7 +5,7 @@
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/columnshard/backup/async_jobs/import_downloader.h>
 #include <ydb/core/tx/columnshard/backup/iscan/iscan.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/datashard/import_common.h>
 
 #include <ydb/apps/ydbd/export/export.h>

--- a/ydb/core/tx/columnshard/backup/async_jobs/ya.make
+++ b/ydb/core/tx/columnshard/backup/async_jobs/ya.make
@@ -12,7 +12,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
-    ydb/core/tx/columnshard/engines/protos  # stopgap: columnshard_private_events.h transitively requires engines/protos; direct columnshard dep would create a cycle
+    ydb/core/tx/columnshard/private_events
     ydb/library/actors/core
     ydb/library/signals
     ydb/core/tx/datashard

--- a/ydb/core/tx/columnshard/backup/import/import_actor.h
+++ b/ydb/core/tx/columnshard/backup/import/import_actor.h
@@ -7,8 +7,8 @@
 #include <ydb/core/tx/columnshard/backup/import/session.h>
 #include <ydb/core/tx/columnshard/bg_tasks/manager/actor.h>
 #include <ydb/core/tx/columnshard/blobs_action/abstract/storage.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 

--- a/ydb/core/tx/columnshard/backup/iscan/iscan.cpp
+++ b/ydb/core/tx/columnshard/backup/iscan/iscan.cpp
@@ -2,7 +2,7 @@
 
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 #include <ydb/core/protos/s3_settings.pb.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/datashard/backup_restore_traits.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/datashard/datashard_s3_upload.h>

--- a/ydb/core/tx/columnshard/backup/iscan/ut/ut_iscan.cpp
+++ b/ydb/core/tx/columnshard/backup/iscan/ut/ut_iscan.cpp
@@ -4,7 +4,7 @@
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/columnshard/backup/iscan/iscan.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/apps/ydbd/export/export.h>
 #include <ydb/library/testlib/s3_recipe_helper/s3_recipe_helper.h>

--- a/ydb/core/tx/columnshard/backup/iscan/ya.make
+++ b/ydb/core/tx/columnshard/backup/iscan/ya.make
@@ -6,7 +6,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/formats/arrow
-    ydb/core/tx/columnshard/engines/protos  # stopgap: columnshard_private_events.h transitively requires engines/protos; direct columnshard dep would create a cycle
+    ydb/core/tx/columnshard/private_events
     ydb/core/tx/datashard
     ydb/library/actors/core
     ydb/library/services

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc.cpp
@@ -2,7 +2,7 @@
 #include "storage.h"
 
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/log.h>
 

--- a/ydb/core/tx/columnshard/blobs_action/bs/gc_actor.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/bs/gc_actor.cpp
@@ -1,7 +1,7 @@
 #include "gc_actor.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NBlobOperations::NBlobStorage {
 

--- a/ydb/core/tx/columnshard/blobs_action/tier/gc.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/tier/gc.cpp
@@ -2,7 +2,7 @@
 
 #include <ydb/core/tx/columnshard/blobs_action/blob_manager_db.h>
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NBlobOperations::NTier {
 

--- a/ydb/core/tx/columnshard/blobs_action/tier/gc_actor.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/tier/gc_actor.cpp
@@ -1,6 +1,6 @@
 #include "gc_actor.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD_BLOBS_TIER
 

--- a/ydb/core/tx/columnshard/blobs_action/tier/gc_actor.h
+++ b/ydb/core/tx/columnshard/blobs_action/tier/gc_actor.h
@@ -4,7 +4,7 @@
 #include <ydb/core/base/blobstorage.h>
 #include <ydb/core/tx/columnshard/blob_cache.h>
 #include <ydb/core/tx/columnshard/blobs_action/abstract/gc_actor.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <library/cpp/retry/retry_policy.h>
 

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_gc_indexed.h
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_gc_indexed.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NColumnShard {
 class TTxGarbageCollectionFinished: public TTransactionBase<TColumnShard> {

--- a/ydb/core/tx/columnshard/blobs_action/transaction/tx_write_index.h
+++ b/ydb/core/tx/columnshard/blobs_action/transaction/tx_write_index.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NColumnShard {
 

--- a/ydb/core/tx/columnshard/column_fetching/cache_policy.cpp
+++ b/ydb/core/tx/columnshard/column_fetching/cache_policy.cpp
@@ -1,7 +1,7 @@
 #include "cache_policy.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/data_accessor/abstract/collector.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/general_cache/source/events.h>
 #include <ydb/core/tx/general_cache/usage/service.h>
 

--- a/ydb/core/tx/columnshard/columnshard__init.cpp
+++ b/ydb/core/tx/columnshard/columnshard__init.cpp
@@ -1,5 +1,4 @@
 #include "columnshard_impl.h"
-#include "columnshard_private_events.h"
 #include "columnshard_schema.h"
 
 #include "bg_tasks/adapter/adapter.h"
@@ -15,6 +14,7 @@
 #include <ydb/core/tablet/tablet_exception.h>
 #include <ydb/core/tx/columnshard/blobs_action/blob_manager_db.h>
 #include <ydb/core/tx/columnshard/operations/write.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/columnshard/transactions/locks_db.h>
 #include <ydb/core/tx/tiering/manager.h>
 
@@ -349,7 +349,7 @@ ITransaction* TColumnShard::CreateTxInitSchema() {
     return new TTxInitSchema(this);
 }
 
-void TColumnShard::Handle(TEvPrivate::TEvNormalizerResult::TPtr& ev, const TActorContext& ctx) {
+void TColumnShard::Handle(NOlap::TEvNormalizerResult::TPtr& ev, const TActorContext& ctx) {
     Execute(new TTxApplyNormalizer(this, ev->Get()->GetChanges()), ctx);
 }
 

--- a/ydb/core/tx/columnshard/columnshard__init.cpp
+++ b/ydb/core/tx/columnshard/columnshard__init.cpp
@@ -349,7 +349,7 @@ ITransaction* TColumnShard::CreateTxInitSchema() {
     return new TTxInitSchema(this);
 }
 
-void TColumnShard::Handle(NOlap::TEvNormalizerResult::TPtr& ev, const TActorContext& ctx) {
+void TColumnShard::Handle(TEvPrivate::TEvNormalizerResult::TPtr& ev, const TActorContext& ctx) {
     Execute(new TTxApplyNormalizer(this, ev->Get()->GetChanges()), ctx);
 }
 

--- a/ydb/core/tx/columnshard/columnshard__plan_step.cpp
+++ b/ydb/core/tx/columnshard/columnshard__plan_step.cpp
@@ -1,6 +1,7 @@
 #include "columnshard_impl.h"
-#include "columnshard_private_events.h"
 #include "columnshard_schema.h"
+
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <util/string/vector.h>
 

--- a/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
+++ b/ydb/core/tx/columnshard/columnshard__propose_transaction.cpp
@@ -1,6 +1,7 @@
 #include "columnshard_impl.h"
-#include "columnshard_private_events.h"
 #include "columnshard_schema.h"
+
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/struct_log/log_stack.h>
 #include <ydb/library/yql/dq/actors/compute/dq_compute_actor.h>

--- a/ydb/core/tx/columnshard/columnshard__write_index.cpp
+++ b/ydb/core/tx/columnshard/columnshard__write_index.cpp
@@ -1,10 +1,11 @@
 #include "columnshard_impl.h"
-#include "columnshard_private_events.h"
 
 #include "blobs_action/transaction/tx_draft.h"
 #include "blobs_action/transaction/tx_write_index.h"
 #include "engines/changes/abstract/abstract.h"
 #include "engines/writer/compacted_blob_constructor.h"
+
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/slide_limiter/usage/abstract.h>

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -814,7 +814,7 @@ private:
     virtual void DoOnRequestsFinished(
         NOlap::TDataAccessorsResult&& result, std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TResourcesGuard>&& guard) override {
         NActors::TActivationContext::Send(
-            TabletActorId, std::make_unique<TEvMetadataAccessorsInfo>(Processor, Generation,
+            TabletActorId, std::make_unique<TEvPrivate::TEvMetadataAccessorsInfo>(Processor, Generation,
                                NOlap::NResourceBroker::NSubscribe::TResourceContainer(std::move(result), std::move(guard))));
     }
 
@@ -1225,7 +1225,7 @@ void TColumnShard::RecheckForcedCompactions(const TActorContext& ctx) {
     }
 }
 
-void TColumnShard::Handle(TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& /*ctx*/) {
+void TColumnShard::Handle(TEvPrivate::TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& /*ctx*/) {
     AFL_VERIFY(ev->Get()->GetGeneration() == Generation())("ev", ev->Get()->GetGeneration())("tablet", Generation());
     ev->Get()->GetProcessor()->ApplyResult(
         ev->Get()->ExtractResult(), TablesManager.MutablePrimaryIndexAsVerified<NOlap::TColumnEngineForLogs>());
@@ -1671,7 +1671,7 @@ public:
     }
 };
 
-void TColumnShard::Handle(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& /*ctx*/) {
+void TColumnShard::Handle(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& /*ctx*/) {
     Execute(new TTxAskPortionChunks(this, ev->Get()->GetCallback(), std::move(ev->Get()->DetachPortions())));
 }
 
@@ -1867,8 +1867,8 @@ void TColumnShard::Enqueue(STFUNC_SIG) {
         "self_id", SelfId())("process", "Enqueue")("ev", ev->GetTypeName());
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvPrivate::TEvTieringModified, HandleInit);
-        HFunc(NOlap::TEvNormalizerResult, Handle);
-        HFunc(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors, Handle);
+        HFunc(TEvPrivate::TEvNormalizerResult, Handle);
+        HFunc(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable, Handle);
         HFunc(TEvColumnShard::TEvNotifyTxCompletion, Handle);

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -814,7 +814,7 @@ private:
     virtual void DoOnRequestsFinished(
         NOlap::TDataAccessorsResult&& result, std::shared_ptr<NOlap::NResourceBroker::NSubscribe::TResourcesGuard>&& guard) override {
         NActors::TActivationContext::Send(
-            TabletActorId, std::make_unique<TEvPrivate::TEvMetadataAccessorsInfo>(Processor, Generation,
+            TabletActorId, std::make_unique<TEvMetadataAccessorsInfo>(Processor, Generation,
                                NOlap::NResourceBroker::NSubscribe::TResourceContainer(std::move(result), std::move(guard))));
     }
 
@@ -1225,7 +1225,7 @@ void TColumnShard::RecheckForcedCompactions(const TActorContext& ctx) {
     }
 }
 
-void TColumnShard::Handle(TEvPrivate::TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& /*ctx*/) {
+void TColumnShard::Handle(TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& /*ctx*/) {
     AFL_VERIFY(ev->Get()->GetGeneration() == Generation())("ev", ev->Get()->GetGeneration())("tablet", Generation());
     ev->Get()->GetProcessor()->ApplyResult(
         ev->Get()->ExtractResult(), TablesManager.MutablePrimaryIndexAsVerified<NOlap::TColumnEngineForLogs>());
@@ -1671,7 +1671,7 @@ public:
     }
 };
 
-void TColumnShard::Handle(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& /*ctx*/) {
+void TColumnShard::Handle(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& /*ctx*/) {
     Execute(new TTxAskPortionChunks(this, ev->Get()->GetCallback(), std::move(ev->Get()->DetachPortions())));
 }
 
@@ -1867,8 +1867,8 @@ void TColumnShard::Enqueue(STFUNC_SIG) {
         "self_id", SelfId())("process", "Enqueue")("ev", ev->GetTypeName());
     switch (ev->GetTypeRewrite()) {
         HFunc(TEvPrivate::TEvTieringModified, HandleInit);
-        HFunc(TEvPrivate::TEvNormalizerResult, Handle);
-        HFunc(TEvPrivate::TEvAskTabletDataAccessors, Handle);
+        HFunc(NOlap::TEvNormalizerResult, Handle);
+        HFunc(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable, Handle);
         HFunc(TEvColumnShard::TEvNotifyTxCompletion, Handle);

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -177,7 +177,8 @@ using ITransaction = NTabletFlatExecutor::ITransaction;
 template <typename T>
 using TTransactionBase = NTabletFlatExecutor::TTransactionBase<T>;
 
-class TEvMetadataAccessorsInfo: public NActors::TEventLocal<TEvMetadataAccessorsInfo, TEvPrivate::EvMetadataAccessorsInfo> {
+class TEvPrivate::TEvMetadataAccessorsInfo
+    : public NActors::TEventLocal<TEvPrivate::TEvMetadataAccessorsInfo, TEvPrivate::EvMetadataAccessorsInfo> {
 private:
     const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor> Processor;
     const ui64 Generation;
@@ -314,7 +315,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(TEvMediatorTimecast::TEvNotifyPlanStep::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvWriteBlobsResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvStartCompaction::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvPrivate::TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& ctx);
 
     void Handle(NPrivateEvents::NWrite::TEvWritePortionResult::TPtr& ev, const TActorContext& ctx);
 
@@ -331,7 +332,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(TEvPrivate::TEvWriteDraft::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvGarbageCollectionFinished::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvTieringModified::TPtr& ev, const TActorContext&);
-    void Handle(NOlap::TEvNormalizerResult::TPtr& ev, const TActorContext&);
+    void Handle(TEvPrivate::TEvNormalizerResult::TPtr& ev, const TActorContext&);
 
     void Handle(NStat::TEvStatistics::TEvAnalyzeShard::TPtr& ev, const TActorContext& ctx);
     void Handle(NStat::TEvStatistics::TEvStatisticsRequest::TPtr& ev, const TActorContext& ctx);
@@ -353,7 +354,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(NOlap::NDataSharing::NEvents::TEvFinishedFromSource::TPtr& ev, const TActorContext& ctx);
     void Handle(NOlap::NDataSharing::NEvents::TEvAckFinishToSource::TPtr& ev, const TActorContext& ctx);
     void Handle(NOlap::NDataSharing::NEvents::TEvAckFinishFromInitiator::TPtr& ev, const TActorContext& ctx);
-    void Handle(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& ctx);
+    void Handle(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& ctx);
     void Handle(NColumnShard::TEvPrivate::TEvAskColumnData::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable::TPtr& ev, const TActorContext& ctx);
@@ -491,7 +492,7 @@ protected:
             HFunc(TEvTxProcessing::TEvPlanStep, Handle);
             HFunc(TEvPrivate::TEvWriteBlobsResult, Handle);
             HFunc(TEvPrivate::TEvStartCompaction, Handle);
-            HFunc(TEvMetadataAccessorsInfo, Handle);
+            HFunc(TEvPrivate::TEvMetadataAccessorsInfo, Handle);
             HFunc(NPrivateEvents::NWrite::TEvWritePortionResult, Handle);
 
             HFunc(TEvMediatorTimecast::TEvRegisterTabletResult, Handle);
@@ -528,7 +529,7 @@ protected:
             HFunc(NOlap::NDataSharing::NEvents::TEvFinishedFromSource, Handle);
             HFunc(NOlap::NDataSharing::NEvents::TEvAckFinishToSource, Handle);
             HFunc(NOlap::NDataSharing::NEvents::TEvAckFinishFromInitiator, Handle);
-            HFunc(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors, Handle);
+            HFunc(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors, Handle);
             HFunc(NColumnShard::TEvPrivate::TEvAskColumnData, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable, Handle);

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "background_controller.h"
 #include "columnshard.h"
-#include "columnshard_private_events.h"
 #include "columnshard_subdomain_path_id.h"
 #include "counters.h"
 #include "defs.h"
@@ -13,6 +12,7 @@
 #include "common/path_id.h"
 #include "counters/columnshard.h"
 #include "counters/counters_manager.h"
+#include "data_accessor/abstract/events.h"
 #include "data_sharing/destination/events/control.h"
 #include "data_sharing/destination/events/transfer.h"
 #include "data_sharing/manager/sessions.h"
@@ -21,8 +21,10 @@
 #include "data_sharing/source/events/control.h"
 #include "data_sharing/source/events/transfer.h"
 #include "normalizer/abstract/abstract.h"
+#include "normalizer/abstract/events.h"
 #include "operations/events.h"
 #include "operations/manager.h"
+#include "resource_subscriber/container.h"
 #include "resource_subscriber/counters.h"
 #include "resource_subscriber/task.h"
 #include "subscriber/abstract/manager/manager.h"
@@ -39,6 +41,7 @@
 #include <ydb/core/tx/columnshard/column_fetching/manager.h>
 #include <ydb/core/tx/columnshard/overload_manager/overload_manager_events.h>
 #include <ydb/core/tx/columnshard/overload_manager/overload_manager_service.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/data_events/events.h>
 #include <ydb/core/tx/locks/locks.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
@@ -174,6 +177,37 @@ using ITransaction = NTabletFlatExecutor::ITransaction;
 template <typename T>
 using TTransactionBase = NTabletFlatExecutor::TTransactionBase<T>;
 
+class TEvMetadataAccessorsInfo: public NActors::TEventLocal<TEvMetadataAccessorsInfo, TEvPrivate::EvMetadataAccessorsInfo> {
+private:
+    const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor> Processor;
+    const ui64 Generation;
+    std::optional<NOlap::NResourceBroker::NSubscribe::TResourceContainer<NOlap::TDataAccessorsResult>> Result;
+
+public:
+    const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor>& GetProcessor() const {
+        return Processor;
+    }
+
+    ui64 GetGeneration() const {
+        return Generation;
+    }
+
+    NOlap::NResourceBroker::NSubscribe::TResourceContainer<NOlap::TDataAccessorsResult> ExtractResult() {
+        AFL_VERIFY(Result);
+        auto result = std::move(*Result);
+        Result.reset();
+        return result;
+    }
+
+    TEvMetadataAccessorsInfo(const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor>& processor, const ui64 gen,
+        NOlap::NResourceBroker::NSubscribe::TResourceContainer<NOlap::TDataAccessorsResult>&& result)
+        : Processor(processor)
+        , Generation(gen)
+        , Result(std::move(result))
+    {
+    }
+};
+
 class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTabletExecutedFlat {
     friend class TEvWriteCommitSyncTransactionOperator;
     friend class TEvWriteCommitSecondaryTransactionOperator;
@@ -280,7 +314,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(TEvMediatorTimecast::TEvNotifyPlanStep::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvWriteBlobsResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvStartCompaction::TPtr& ev, const TActorContext& ctx);
-    void Handle(TEvPrivate::TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvMetadataAccessorsInfo::TPtr& ev, const TActorContext& ctx);
 
     void Handle(NPrivateEvents::NWrite::TEvWritePortionResult::TPtr& ev, const TActorContext& ctx);
 
@@ -297,7 +331,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(TEvPrivate::TEvWriteDraft::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvGarbageCollectionFinished::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvPrivate::TEvTieringModified::TPtr& ev, const TActorContext&);
-    void Handle(TEvPrivate::TEvNormalizerResult::TPtr& ev, const TActorContext&);
+    void Handle(NOlap::TEvNormalizerResult::TPtr& ev, const TActorContext&);
 
     void Handle(NStat::TEvStatistics::TEvAnalyzeShard::TPtr& ev, const TActorContext& ctx);
     void Handle(NStat::TEvStatistics::TEvStatisticsRequest::TPtr& ev, const TActorContext& ctx);
@@ -319,7 +353,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(NOlap::NDataSharing::NEvents::TEvFinishedFromSource::TPtr& ev, const TActorContext& ctx);
     void Handle(NOlap::NDataSharing::NEvents::TEvAckFinishToSource::TPtr& ev, const TActorContext& ctx);
     void Handle(NOlap::NDataSharing::NEvents::TEvAckFinishFromInitiator::TPtr& ev, const TActorContext& ctx);
-    void Handle(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& ctx);
+    void Handle(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors::TPtr& ev, const TActorContext& ctx);
     void Handle(NColumnShard::TEvPrivate::TEvAskColumnData::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable::TPtr& ev, const TActorContext& ctx);
@@ -457,7 +491,7 @@ protected:
             HFunc(TEvTxProcessing::TEvPlanStep, Handle);
             HFunc(TEvPrivate::TEvWriteBlobsResult, Handle);
             HFunc(TEvPrivate::TEvStartCompaction, Handle);
-            HFunc(TEvPrivate::TEvMetadataAccessorsInfo, Handle);
+            HFunc(TEvMetadataAccessorsInfo, Handle);
             HFunc(NPrivateEvents::NWrite::TEvWritePortionResult, Handle);
 
             HFunc(TEvMediatorTimecast::TEvRegisterTabletResult, Handle);
@@ -494,7 +528,7 @@ protected:
             HFunc(NOlap::NDataSharing::NEvents::TEvFinishedFromSource, Handle);
             HFunc(NOlap::NDataSharing::NEvents::TEvAckFinishToSource, Handle);
             HFunc(NOlap::NDataSharing::NEvents::TEvAckFinishFromInitiator, Handle);
-            HFunc(NColumnShard::TEvPrivate::TEvAskTabletDataAccessors, Handle);
+            HFunc(NOlap::NDataAccessorControl::TEvAskTabletDataAccessors, Handle);
             HFunc(NColumnShard::TEvPrivate::TEvAskColumnData, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
             HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable, Handle);

--- a/ydb/core/tx/columnshard/columnshard_private_events.cpp
+++ b/ydb/core/tx/columnshard/columnshard_private_events.cpp
@@ -1,3 +1,0 @@
-#include "columnshard_private_events.h"
-
-namespace NKikimr::NColumnShard {}

--- a/ydb/core/tx/columnshard/data_accessor/abstract/events.h
+++ b/ydb/core/tx/columnshard/data_accessor/abstract/events.h
@@ -6,21 +6,21 @@
 
 #include <ydb/library/actors/core/event_local.h>
 
-namespace NKikimr::NOlap::NDataAccessorControl {
+namespace NKikimr::NColumnShard {
 
-class TEvAskTabletDataAccessors
-    : public NActors::TEventLocal<TEvAskTabletDataAccessors, NColumnShard::TEvPrivate::EEv::EvAskTabletDataAccessors> {
+class TEvPrivate::TEvAskTabletDataAccessors
+    : public NActors::TEventLocal<TEvPrivate::TEvAskTabletDataAccessors, TEvPrivate::EEv::EvAskTabletDataAccessors> {
 private:
-    using TPortions = THashMap<TInternalPathId, TPortionsByConsumer>;
+    using TPortions = THashMap<TInternalPathId, NOlap::NDataAccessorControl::TPortionsByConsumer>;
     YDB_ACCESSOR_DEF(TPortions, Portions);
-    YDB_READONLY_DEF(std::shared_ptr<IAccessorCallback>, Callback);
+    YDB_READONLY_DEF(std::shared_ptr<NOlap::NDataAccessorControl::IAccessorCallback>, Callback);
 
 public:
-    explicit TEvAskTabletDataAccessors(TPortions&& portions, const std::shared_ptr<IAccessorCallback>& callback)
+    explicit TEvAskTabletDataAccessors(TPortions&& portions, const std::shared_ptr<NOlap::NDataAccessorControl::IAccessorCallback>& callback)
         : Portions(std::move(portions))
         , Callback(callback)
     {
     }
 };
 
-}   // namespace NKikimr::NOlap::NDataAccessorControl
+}   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/data_accessor/abstract/events.h
+++ b/ydb/core/tx/columnshard/data_accessor/abstract/events.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "collector.h"
+
+#include <ydb/core/tx/columnshard/private_events/events.h>
+
+#include <ydb/library/actors/core/event_local.h>
+
+namespace NKikimr::NOlap::NDataAccessorControl {
+
+class TEvAskTabletDataAccessors
+    : public NActors::TEventLocal<TEvAskTabletDataAccessors, NColumnShard::TEvPrivate::EEv::EvAskTabletDataAccessors> {
+private:
+    using TPortions = THashMap<TInternalPathId, TPortionsByConsumer>;
+    YDB_ACCESSOR_DEF(TPortions, Portions);
+    YDB_READONLY_DEF(std::shared_ptr<IAccessorCallback>, Callback);
+
+public:
+    explicit TEvAskTabletDataAccessors(TPortions&& portions, const std::shared_ptr<IAccessorCallback>& callback)
+        : Portions(std::move(portions))
+        , Callback(callback)
+    {
+    }
+};
+
+}   // namespace NKikimr::NOlap::NDataAccessorControl

--- a/ydb/core/tx/columnshard/data_accessor/abstract/ya.make
+++ b/ydb/core/tx/columnshard/data_accessor/abstract/ya.make
@@ -9,6 +9,7 @@ SRCS(
 PEERDIR(
     ydb/core/tx/columnshard/engines/portions
     ydb/core/tx/columnshard/engines/reader/tracing
+    ydb/core/tx/columnshard/private_events
     ydb/core/protos
 )
 

--- a/ydb/core/tx/columnshard/data_accessor/cache_policy/policy.cpp
+++ b/ydb/core/tx/columnshard/data_accessor/cache_policy/policy.cpp
@@ -87,7 +87,7 @@ TPortionsMetadataCachePolicy::BuildObjectsProcessor(const NActors::TActorId& ser
             }
             for (auto&& i : requests) {
                 NActors::TActivationContext::Send(
-                    i.first, std::make_unique<NOlap::NDataAccessorControl::TEvAskTabletDataAccessors>(i.second.ExtractRequest(),
+                    i.first, std::make_unique<NColumnShard::TEvPrivate::TEvAskTabletDataAccessors>(i.second.ExtractRequest(),
                                  std::make_shared<TAccessorsCallback>(i.first, selfPtr, i.second.ExtractRequestedAddresses())), 0, cookie);
             }
         }

--- a/ydb/core/tx/columnshard/data_accessor/cache_policy/policy.cpp
+++ b/ydb/core/tx/columnshard/data_accessor/cache_policy/policy.cpp
@@ -1,7 +1,7 @@
 #include "policy.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/data_accessor/abstract/collector.h>
+#include <ydb/core/tx/columnshard/data_accessor/abstract/events.h>
 #include <ydb/core/tx/general_cache/source/events.h>
 #include <ydb/core/tx/general_cache/usage/service.h>
 
@@ -87,7 +87,7 @@ TPortionsMetadataCachePolicy::BuildObjectsProcessor(const NActors::TActorId& ser
             }
             for (auto&& i : requests) {
                 NActors::TActivationContext::Send(
-                    i.first, std::make_unique<NColumnShard::TEvPrivate::TEvAskTabletDataAccessors>(i.second.ExtractRequest(),
+                    i.first, std::make_unique<NOlap::NDataAccessorControl::TEvAskTabletDataAccessors>(i.second.ExtractRequest(),
                                  std::make_shared<TAccessorsCallback>(i.first, selfPtr, i.second.ExtractRequestedAddresses())), 0, cookie);
             }
         }

--- a/ydb/core/tx/columnshard/diagnostics/scan_diagnostics_actor.h
+++ b/ydb/core/tx/columnshard/diagnostics/scan_diagnostics_actor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/events.h>

--- a/ydb/core/tx/columnshard/diagnostics/ya.make
+++ b/ydb/core/tx/columnshard/diagnostics/ya.make
@@ -9,7 +9,7 @@ PEERDIR(
     contrib/libs/opentelemetry-proto
     ydb/core/base/generated
     ydb/core/control/lib/generated
-    ydb/core/tx/columnshard/engines/protos  # stopgap: columnshard_private_events.h transitively requires engines/protos; direct columnshard dep would create a cycle
+    ydb/core/tx/columnshard/private_events
     ydb/library/aclib/protos
     ydb/library/actors/core
     yql/essentials/public/issue/protos

--- a/ydb/core/tx/columnshard/engines/changes/ttl.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/ttl.cpp
@@ -2,11 +2,11 @@
 
 #include <ydb/core/tx/columnshard/blobs_action/blob_manager_db.h>
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
 #include <ydb/core/tx/columnshard/engines/column_engine_logs.h>
 #include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
 #include <ydb/core/tx/columnshard/engines/portions/read_with_blobs.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/engines/reader/abstract/read_context.h
+++ b/ydb/core/tx/columnshard/engines/reader/abstract/read_context.h
@@ -98,8 +98,8 @@ public:
 
     void AbortWithError(const TString& errorMessage) {
         if (AbortionFlag->Inc() == 1) {
-            NActors::TActivationContext::Send(ScanActorId,
-                std::make_unique<NReader::TEvTaskProcessedResult>(TConclusionStatus::Fail(errorMessage), Counters.GetAbortsGuard()));
+            NActors::TActivationContext::Send(ScanActorId, std::make_unique<NColumnShard::TEvPrivate::TEvTaskProcessedResult>(
+                                                               TConclusionStatus::Fail(errorMessage), Counters.GetAbortsGuard()));
         }
     }
 

--- a/ydb/core/tx/columnshard/engines/reader/abstract/read_context.h
+++ b/ydb/core/tx/columnshard/engines/reader/abstract/read_context.h
@@ -4,10 +4,10 @@
 #include <ydb/core/protos/tx_datashard.pb.h>
 #include <ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.h>
 #include <ydb/core/tx/columnshard/column_fetching/manager.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/counters/duplicate_filtering.h>
 #include <ydb/core/tx/columnshard/counters/scan.h>
 #include <ydb/core/tx/columnshard/data_accessor/manager.h>
+#include <ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h>
 #include <ydb/core/tx/columnshard/engines/reader/common/result.h>
 #include <ydb/core/tx/columnshard/resource_subscriber/task.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
@@ -98,8 +98,8 @@ public:
 
     void AbortWithError(const TString& errorMessage) {
         if (AbortionFlag->Inc() == 1) {
-            NActors::TActivationContext::Send(ScanActorId, std::make_unique<NColumnShard::TEvPrivate::TEvTaskProcessedResult>(
-                                                               TConclusionStatus::Fail(errorMessage), Counters.GetAbortsGuard()));
+            NActors::TActivationContext::Send(ScanActorId,
+                std::make_unique<NReader::TEvTaskProcessedResult>(TConclusionStatus::Fail(errorMessage), Counters.GetAbortsGuard()));
         }
     }
 

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -119,7 +119,7 @@ void TColumnShardScan::Bootstrap(const TActorContext& ctx) {
     }
 }
 
-void TColumnShardScan::HandleScan(NColumnShard::TEvPrivate::TEvTaskProcessedResult::TPtr& ev) {
+void TColumnShardScan::HandleScan(NReader::TEvTaskProcessedResult::TPtr& ev) {
     TDuration delta = TDuration::Zero();
     if (ChunksLimiter.HasMore()) {
         delta = TInstant::Now() - StartWaitTime;

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -119,7 +119,7 @@ void TColumnShardScan::Bootstrap(const TActorContext& ctx) {
     }
 }
 
-void TColumnShardScan::HandleScan(NReader::TEvTaskProcessedResult::TPtr& ev) {
+void TColumnShardScan::HandleScan(NColumnShard::TEvPrivate::TEvTaskProcessedResult::TPtr& ev) {
     TDuration delta = TDuration::Zero();
     if (ChunksLimiter.HasMore()) {
         delta = TInstant::Now() - StartWaitTime;

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.h
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.h
@@ -3,11 +3,12 @@
 #include <ydb/core/kqp/compute_actor/kqp_compute_events.h>
 #include <ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.h>
 #include <ydb/core/tx/columnshard/column_fetching/manager.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/counters/scan.h>
 #include <ydb/core/tx/columnshard/engines/reader/abstract/abstract.h>
 #include <ydb/core/tx/columnshard/engines/reader/abstract/read_context.h>
 #include <ydb/core/tx/columnshard/engines/reader/abstract/read_metadata.h>
+#include <ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor_composite/usage/config.h>
 #include <ydb/core/tx/tracing/usage/tracing.h>
 
@@ -61,13 +62,13 @@ private:
             hFunc(NActors::TEvents::TEvPoison, HandleScan);
             hFunc(TEvents::TEvUndelivered, HandleScan);
             hFunc(TEvents::TEvWakeup, HandleScan);
-            hFunc(NColumnShard::TEvPrivate::TEvTaskProcessedResult, HandleScan);
+            hFunc(NReader::TEvTaskProcessedResult, HandleScan);
             default:
                 AFL_VERIFY(false)("unexpected_event", ev->GetTypeName());
         }
     }
 
-    void HandleScan(NColumnShard::TEvPrivate::TEvTaskProcessedResult::TPtr& ev);
+    void HandleScan(NReader::TEvTaskProcessedResult::TPtr& ev);
 
     void HandleScan(NKqp::TEvKqpCompute::TEvScanDataAck::TPtr& ev);
 

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.h
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.h
@@ -62,13 +62,13 @@ private:
             hFunc(NActors::TEvents::TEvPoison, HandleScan);
             hFunc(TEvents::TEvUndelivered, HandleScan);
             hFunc(TEvents::TEvWakeup, HandleScan);
-            hFunc(NReader::TEvTaskProcessedResult, HandleScan);
+            hFunc(NColumnShard::TEvPrivate::TEvTaskProcessedResult, HandleScan);
             default:
                 AFL_VERIFY(false)("unexpected_event", ev->GetTypeName());
         }
     }
 
-    void HandleScan(NReader::TEvTaskProcessedResult::TPtr& ev);
+    void HandleScan(NColumnShard::TEvPrivate::TEvTaskProcessedResult::TPtr& ev);
 
     void HandleScan(NKqp::TEvKqpCompute::TEvScanDataAck::TPtr& ev);
 

--- a/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.cpp
@@ -1,7 +1,5 @@
 #include "conveyor_task.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
-
 #include <ydb/library/actors/core/actor.h>
 
 namespace NKikimr::NOlap::NReader {
@@ -10,17 +8,17 @@ void IDataTasksProcessor::ITask::DoExecute(const std::shared_ptr<NConveyor::ITas
     auto result = DoExecuteImpl();
     if (result.IsFail()) {
         NActors::TActivationContext::AsActorContext().Send(
-            OwnerId, new NColumnShard::TEvPrivate::TEvTaskProcessedResult(result, std::move(Guard), GetSourceId()));
+            OwnerId, new NReader::TEvTaskProcessedResult(result, std::move(Guard), GetSourceId()));
     } else if (*result) {
-        NActors::TActivationContext::AsActorContext().Send(OwnerId,
-            new NColumnShard::TEvPrivate::TEvTaskProcessedResult(static_pointer_cast<IDataTasksProcessor::ITask>(taskPtr), std::move(Guard),
-                GetSourceId(), GetBlobBytes(), GetRawBytes(), GetFilteredRows(), GetTotalRows(), GetTotalReservedBytes()));
+        NActors::TActivationContext::AsActorContext().Send(
+            OwnerId, new NReader::TEvTaskProcessedResult(static_pointer_cast<IDataTasksProcessor::ITask>(taskPtr), std::move(Guard),
+                         GetSourceId(), GetBlobBytes(), GetRawBytes(), GetFilteredRows(), GetTotalRows(), GetTotalReservedBytes()));
     }
 }
 
 void IDataTasksProcessor::ITask::DoOnCannotExecute(const TString& reason) {
     NActors::TActivationContext::AsActorContext().Send(
-        OwnerId, new NColumnShard::TEvPrivate::TEvTaskProcessedResult(TConclusionStatus::Fail(reason), std::move(Guard)));
+        OwnerId, new NReader::TEvTaskProcessedResult(TConclusionStatus::Fail(reason), std::move(Guard)));
 }
 
 }   // namespace NKikimr::NOlap::NReader

--- a/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.cpp
@@ -8,17 +8,17 @@ void IDataTasksProcessor::ITask::DoExecute(const std::shared_ptr<NConveyor::ITas
     auto result = DoExecuteImpl();
     if (result.IsFail()) {
         NActors::TActivationContext::AsActorContext().Send(
-            OwnerId, new NReader::TEvTaskProcessedResult(result, std::move(Guard), GetSourceId()));
+            OwnerId, new NColumnShard::TEvPrivate::TEvTaskProcessedResult(result, std::move(Guard), GetSourceId()));
     } else if (*result) {
-        NActors::TActivationContext::AsActorContext().Send(
-            OwnerId, new NReader::TEvTaskProcessedResult(static_pointer_cast<IDataTasksProcessor::ITask>(taskPtr), std::move(Guard),
-                         GetSourceId(), GetBlobBytes(), GetRawBytes(), GetFilteredRows(), GetTotalRows(), GetTotalReservedBytes()));
+        NActors::TActivationContext::AsActorContext().Send(OwnerId,
+            new NColumnShard::TEvPrivate::TEvTaskProcessedResult(static_pointer_cast<IDataTasksProcessor::ITask>(taskPtr), std::move(Guard),
+                GetSourceId(), GetBlobBytes(), GetRawBytes(), GetFilteredRows(), GetTotalRows(), GetTotalReservedBytes()));
     }
 }
 
 void IDataTasksProcessor::ITask::DoOnCannotExecute(const TString& reason) {
     NActors::TActivationContext::AsActorContext().Send(
-        OwnerId, new NReader::TEvTaskProcessedResult(TConclusionStatus::Fail(reason), std::move(Guard)));
+        OwnerId, new NColumnShard::TEvPrivate::TEvTaskProcessedResult(TConclusionStatus::Fail(reason), std::move(Guard)));
 }
 
 }   // namespace NKikimr::NOlap::NReader

--- a/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h
+++ b/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <ydb/core/tx/columnshard/counters/scan.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
 
 #include <ydb/library/accessor/accessor.h>
+#include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/conclusion/result.h>
 
 namespace NKikimr::NOlap::NReader {
@@ -74,6 +76,60 @@ public:
         {
         }
     };
+};
+
+class TEvTaskProcessedResult: public NActors::TEventLocal<TEvTaskProcessedResult, NColumnShard::TEvPrivate::EEv::EvTaskProcessedResult> {
+private:
+    TConclusion<std::shared_ptr<IApplyAction>> Result;
+    NColumnShard::TCounterGuard ScanCounter;
+    ui64 SourceId = 0;
+    ui64 BlobBytes = 0;
+    ui64 RawBytes = 0;
+    ui32 FilteredRows = 0;
+    ui32 TotalRows = 0;
+    ui64 TotalReservedBytes = 0;
+
+public:
+    TConclusion<std::shared_ptr<IApplyAction>>& MutableResult() {
+        return Result;
+    }
+
+    ui64 GetSourceId() const {
+        return SourceId;
+    }
+
+    ui64 GetBlobBytes() const {
+        return BlobBytes;
+    }
+
+    ui64 GetRawBytes() const {
+        return RawBytes;
+    }
+
+    ui32 GetFilteredRows() const {
+        return FilteredRows;
+    }
+
+    ui32 GetTotalRows() const {
+        return TotalRows;
+    }
+
+    ui64 GetTotalReservedBytes() const {
+        return TotalReservedBytes;
+    }
+
+    TEvTaskProcessedResult(TConclusion<std::shared_ptr<IApplyAction>>&& result, NColumnShard::TCounterGuard&& scanCounters, ui64 sourceId = 0,
+        ui64 blobBytes = 0, ui64 rawBytes = 0, ui32 filteredRows = 0, ui32 totalRows = 0, ui64 totalReservedBytes = 0)
+        : Result(std::move(result))
+        , ScanCounter(std::move(scanCounters))
+        , SourceId(sourceId)
+        , BlobBytes(blobBytes)
+        , RawBytes(rawBytes)
+        , FilteredRows(filteredRows)
+        , TotalRows(totalRows)
+        , TotalReservedBytes(totalReservedBytes)
+    {
+    }
 };
 
 }   // namespace NKikimr::NOlap::NReader

--- a/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h
+++ b/ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h
@@ -78,10 +78,15 @@ public:
     };
 };
 
-class TEvTaskProcessedResult: public NActors::TEventLocal<TEvTaskProcessedResult, NColumnShard::TEvPrivate::EEv::EvTaskProcessedResult> {
+}   // namespace NKikimr::NOlap::NReader
+
+namespace NKikimr::NColumnShard {
+
+class TEvPrivate::TEvTaskProcessedResult
+    : public NActors::TEventLocal<TEvPrivate::TEvTaskProcessedResult, TEvPrivate::EEv::EvTaskProcessedResult> {
 private:
-    TConclusion<std::shared_ptr<IApplyAction>> Result;
-    NColumnShard::TCounterGuard ScanCounter;
+    TConclusion<std::shared_ptr<NOlap::NReader::IApplyAction>> Result;
+    TCounterGuard ScanCounter;
     ui64 SourceId = 0;
     ui64 BlobBytes = 0;
     ui64 RawBytes = 0;
@@ -90,7 +95,7 @@ private:
     ui64 TotalReservedBytes = 0;
 
 public:
-    TConclusion<std::shared_ptr<IApplyAction>>& MutableResult() {
+    TConclusion<std::shared_ptr<NOlap::NReader::IApplyAction>>& MutableResult() {
         return Result;
     }
 
@@ -118,7 +123,7 @@ public:
         return TotalReservedBytes;
     }
 
-    TEvTaskProcessedResult(TConclusion<std::shared_ptr<IApplyAction>>&& result, NColumnShard::TCounterGuard&& scanCounters, ui64 sourceId = 0,
+    TEvTaskProcessedResult(TConclusion<std::shared_ptr<NOlap::NReader::IApplyAction>>&& result, TCounterGuard&& scanCounters, ui64 sourceId = 0,
         ui64 blobBytes = 0, ui64 rawBytes = 0, ui32 filteredRows = 0, ui32 totalRows = 0, ui64 totalReservedBytes = 0)
         : Result(std::move(result))
         , ScanCounter(std::move(scanCounters))
@@ -132,4 +137,4 @@ public:
     }
 };
 
-}   // namespace NKikimr::NOlap::NReader
+}   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/engines/reader/common/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/common/ya.make
@@ -14,7 +14,10 @@ PEERDIR(
     ydb/core/tx/program
     ydb/core/tx/columnshard/engines/protos  # stopgap: columnshard_private_events.h transitively requires engines/protos; direct columnshard dep would create a cycle
     ydb/core/formats/arrow/reader
+    ydb/core/tx/columnshard/engines/portions
+    ydb/core/tx/columnshard/private_events
     ydb/core/tx/limiter/grouped_memory/usage
+    ydb/library/actors/core
 )
 
 GENERATE_ENUM_SERIALIZATION(description.h)

--- a/ydb/core/tx/columnshard/engines/reader/common/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/common/ya.make
@@ -12,7 +12,6 @@ SRCS(
 
 PEERDIR(
     ydb/core/tx/program
-    ydb/core/tx/columnshard/engines/protos  # stopgap: columnshard_private_events.h transitively requires engines/protos; direct columnshard dep would create a cycle
     ydb/core/formats/arrow/reader
     ydb/core/tx/columnshard/engines/portions
     ydb/core/tx/columnshard/private_events

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/common/accessors_ordering.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/common/accessors_ordering.cpp
@@ -84,9 +84,8 @@ private:
     }
 
     virtual void DoOnRequestsFinished(TDataAccessorsResult&& result) override {
-        NActors::TActivationContext::AsActorContext().Send(
-            ScanActorId, new NColumnShard::TEvPrivate::TEvTaskProcessedResult(
-                             std::make_shared<TApplySourceResult>(std::move(result), StartTime), std::move(Guard)));
+        NActors::TActivationContext::AsActorContext().Send(ScanActorId,
+            new NReader::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(std::move(result), StartTime), std::move(Guard)));
     }
 
 public:

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/common/accessors_ordering.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/common/accessors_ordering.cpp
@@ -84,8 +84,9 @@ private:
     }
 
     virtual void DoOnRequestsFinished(TDataAccessorsResult&& result) override {
-        NActors::TActivationContext::AsActorContext().Send(ScanActorId,
-            new NReader::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(std::move(result), StartTime), std::move(Guard)));
+        NActors::TActivationContext::AsActorContext().Send(
+            ScanActorId, new NColumnShard::TEvPrivate::TEvTaskProcessedResult(
+                             std::make_shared<TApplySourceResult>(std::move(result), StartTime), std::move(Guard)));
     }
 
 public:

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.cpp
@@ -25,7 +25,7 @@ bool TBlobsFetcherTask::DoOnError(const TString& storageId, const TBlobRange& ra
         {"statusCode", status.GetStatus()},
         {"storageId", storageId});
     NActors::TActorContext::AsActorContext().Send(Context->GetCommonContext()->GetScanActorId(),
-        std::make_unique<NReader::TEvTaskProcessedResult>(
+        std::make_unique<NColumnShard::TEvPrivate::TEvTaskProcessedResult>(
             TConclusionStatus::Fail(TStringBuilder{} << "Error reading blob range for data: " << range.ToString()
                                                      << ", error: " << status.GetErrorMessage()
                                                      << ", status: " << NKikimrProto::EReplyStatus_Name(status.GetStatus())), std::move(Guard)));

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.cpp
@@ -1,7 +1,6 @@
 #include "constructor.h"
 
 #include <ydb/core/tx/columnshard/blobs_reader/actor.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 
@@ -26,7 +25,7 @@ bool TBlobsFetcherTask::DoOnError(const TString& storageId, const TBlobRange& ra
         {"statusCode", status.GetStatus()},
         {"storageId", storageId});
     NActors::TActorContext::AsActorContext().Send(Context->GetCommonContext()->GetScanActorId(),
-        std::make_unique<NColumnShard::TEvPrivate::TEvTaskProcessedResult>(
+        std::make_unique<NReader::TEvTaskProcessedResult>(
             TConclusionStatus::Fail(TStringBuilder{} << "Error reading blob range for data: " << range.ToString()
                                                      << ", error: " << status.GetErrorMessage()
                                                      << ", status: " << NKikimrProto::EReplyStatus_Name(status.GetStatus())), std::move(Guard)));

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.h
@@ -107,7 +107,7 @@ private:
             {"statusCode", status.GetStatus()},
             {"storageId", storageId});
         NActors::TActorContext::AsActorContext().Send(Source->GetContext()->GetCommonContext()->GetScanActorId(),
-            std::make_unique<NReader::TEvTaskProcessedResult>(
+            std::make_unique<NColumnShard::TEvPrivate::TEvTaskProcessedResult>(
                 TConclusionStatus::Fail(
                     TStringBuilder{} << "Error reading blob range for columns: " << range.ToString() << ", error: " << status.GetErrorMessage()
                                      << ", status: " << NKikimrProto::EReplyStatus_Name(status.GetStatus())), std::move(Guard)));

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/constructor.h
@@ -9,6 +9,7 @@
 #include <ydb/core/tx/columnshard/engines/portions/column_record.h>
 #include <ydb/core/tx/columnshard/engines/reader/abstract/read_context.h>
 #include <ydb/core/tx/columnshard/engines/reader/abstract/read_metadata.h>
+#include <ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h>
 #include <ydb/core/tx/columnshard/engines/scheme/indexes/abstract/collection.h>
 
 namespace NKikimr::NOlap::NReader::NCommon {
@@ -106,7 +107,7 @@ private:
             {"statusCode", status.GetStatus()},
             {"storageId", storageId});
         NActors::TActorContext::AsActorContext().Send(Source->GetContext()->GetCommonContext()->GetScanActorId(),
-            std::make_unique<NColumnShard::TEvPrivate::TEvTaskProcessedResult>(
+            std::make_unique<NReader::TEvTaskProcessedResult>(
                 TConclusionStatus::Fail(
                     TStringBuilder{} << "Error reading blob range for columns: " << range.ToString() << ", error: " << status.GetErrorMessage()
                                      << ", status: " << NKikimrProto::EReplyStatus_Name(status.GetStatus())), std::move(Guard)));

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/events.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/events.h
@@ -3,7 +3,7 @@
 #include "common.h"
 
 #include <ydb/core/formats/arrow/filter/filter.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/conclusion/result.h>

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/private_events.h
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/private_events.h
@@ -3,8 +3,8 @@
 #include "context.h"
 
 #include <ydb/core/tx/columnshard/column_fetching/cache_policy.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/common.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NReader::NSimple::NDuplicateFiltering::NPrivate {
 

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
@@ -4,6 +4,7 @@
 
 #include <ydb/core/tx/columnshard/engines/filter.h>
 #include <ydb/core/tx/columnshard/engines/portions/written.h>
+#include <ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h>
 #include <ydb/core/tx/columnshard/engines/reader/simple_reader/duplicates/events.h>
 #include <ydb/core/tx/columnshard/engines/reader/tracing/data_source_probes.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
@@ -399,7 +400,7 @@ TConclusion<bool> TBuildResultStep::DoExecuteInplace(
     ReportTracing(source, step, TMonotonic::Now() - startExecution);
     const ui64 blobBytes = source->GetTotalBytesRead();
     NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-        new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+        new NReader::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
             source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
             sSource->GetUsedRawBytes(), recordsCount, source->GetRecordsCount(), source->GetReservedMemory()));
     return false;
@@ -453,7 +454,7 @@ TConclusion<bool> TPrepareResultStep::DoExecuteInplace(
         context->GetCommonContext()->GetCounters().OnSourceFinished(source->GetRecordsCount(), sSource->GetUsedRawBytes(), 0);
         const ui64 blobBytes = source->GetTotalBytesRead();
         NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-            new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+            new TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
                 source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
                 sSource->GetUsedRawBytes(), 0, source->GetRecordsCount(), source->GetReservedMemory()));
         return false;

--- a/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/simple_reader/iterator/fetching.cpp
@@ -400,7 +400,7 @@ TConclusion<bool> TBuildResultStep::DoExecuteInplace(
     ReportTracing(source, step, TMonotonic::Now() - startExecution);
     const ui64 blobBytes = source->GetTotalBytesRead();
     NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-        new NReader::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+        new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
             source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
             sSource->GetUsedRawBytes(), recordsCount, source->GetRecordsCount(), source->GetReservedMemory()));
     return false;
@@ -454,7 +454,7 @@ TConclusion<bool> TPrepareResultStep::DoExecuteInplace(
         context->GetCommonContext()->GetCounters().OnSourceFinished(source->GetRecordsCount(), sSource->GetUsedRawBytes(), 0);
         const ui64 blobBytes = source->GetTotalBytesRead();
         NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-            new TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+            new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
                 source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
                 sSource->GetUsedRawBytes(), 0, source->GetRecordsCount(), source->GetReservedMemory()));
         return false;

--- a/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/transaction/tx_scan.cpp
@@ -1,11 +1,11 @@
 #include "tx_scan.h"
 
 #include <ydb/core/formats/arrow/arrow_batch_builder.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/engines/reader/actor/actor.h>
 #include <ydb/core/tx/columnshard/engines/reader/common/scan_memory_limiter.h>
 #include <ydb/core/tx/columnshard/engines/reader/plain_reader/constructor/constructor.h>
 #include <ydb/core/tx/columnshard/engines/reader/tracing/probes.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/columnshard/transactions/locks/read_start.h>
 
 #include <ydb/library/actors/struct_log/log_stack.h>

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/events.h
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/events.h
@@ -3,7 +3,7 @@
 #include "common.h"
 
 #include <ydb/core/formats/arrow/filter/filter.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/conclusion/result.h>

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/private_events.h
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/private_events.h
@@ -4,8 +4,8 @@
 #include "filters.h"
 
 #include <ydb/core/tx/columnshard/column_fetching/cache_policy.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/common.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NReader::NTrivial::NDuplicateFiltering::NPrivate {
 

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/fetching.cpp
@@ -4,6 +4,7 @@
 
 #include <ydb/core/tx/columnshard/engines/filter.h>
 #include <ydb/core/tx/columnshard/engines/portions/written.h>
+#include <ydb/core/tx/columnshard/engines/reader/common/conveyor_task.h>
 #include <ydb/core/tx/columnshard/engines/reader/tracing/data_source_probes.h>
 #include <ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/events.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
@@ -399,7 +400,7 @@ TConclusion<bool> TBuildResultStep::DoExecuteInplace(
     ReportTracing(source, step, TMonotonic::Now() - startExecution);
     const ui64 blobBytes = source->GetTotalBytesRead();
     NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-        new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+        new NReader::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
             source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
             sSource->GetUsedRawBytes(), recordsCount, source->GetRecordsCount(), source->GetReservedMemory()));
     return false;
@@ -453,7 +454,7 @@ TConclusion<bool> TPrepareResultStep::DoExecuteInplace(
         context->GetCommonContext()->GetCounters().OnSourceFinished(source->GetRecordsCount(), sSource->GetUsedRawBytes(), 0);
         const ui64 blobBytes = source->GetTotalBytesRead();
         NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-            new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+            new TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
                 source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
                 sSource->GetUsedRawBytes(), 0, source->GetRecordsCount(), source->GetReservedMemory()));
         return false;

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/iterator/fetching.cpp
@@ -400,7 +400,7 @@ TConclusion<bool> TBuildResultStep::DoExecuteInplace(
     ReportTracing(source, step, TMonotonic::Now() - startExecution);
     const ui64 blobBytes = source->GetTotalBytesRead();
     NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-        new NReader::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+        new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
             source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
             sSource->GetUsedRawBytes(), recordsCount, source->GetRecordsCount(), source->GetReservedMemory()));
     return false;
@@ -454,7 +454,7 @@ TConclusion<bool> TPrepareResultStep::DoExecuteInplace(
         context->GetCommonContext()->GetCounters().OnSourceFinished(source->GetRecordsCount(), sSource->GetUsedRawBytes(), 0);
         const ui64 blobBytes = source->GetTotalBytesRead();
         NActors::TActivationContext::AsActorContext().Send(context->GetCommonContext()->GetScanActorId(),
-            new TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
+            new NColumnShard::TEvPrivate::TEvTaskProcessedResult(std::make_shared<TApplySourceResult>(source, step),
                 source->GetContext()->GetCommonContext()->GetCounters().GetResultsForSourceGuard(), source->GetDeprecatedPortionId(), blobBytes,
                 sSource->GetUsedRawBytes(), 0, source->GetRecordsCount(), source->GetReservedMemory()));
         return false;

--- a/ydb/core/tx/columnshard/engines/writer/buffer/actor2.cpp
+++ b/ydb/core/tx/columnshard/engines/writer/buffer/actor2.cpp
@@ -1,7 +1,7 @@
 #include "actor2.h"
 
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 

--- a/ydb/core/tx/columnshard/engines/writer/buffer/events.h
+++ b/ydb/core/tx/columnshard/engines/writer/buffer/events.h
@@ -2,8 +2,8 @@
 
 #include <ydb/core/formats/arrow/process_columns.h>
 #include <ydb/core/formats/arrow/size_calcer.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/operations/common/context.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/data_events/write_data.h>
 
 #include <ydb/library/actors/core/event_local.h>

--- a/ydb/core/tx/columnshard/engines/writer/compacted_blob_constructor.h
+++ b/ydb/core/tx/columnshard/engines/writer/compacted_blob_constructor.h
@@ -5,7 +5,7 @@
 
 #include <ydb/core/tx/columnshard/blobs_action/abstract/action.h>
 #include <ydb/core/tx/columnshard/columnshard.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/engines/writer/indexed_blob_constructor.cpp
+++ b/ydb/core/tx/columnshard/engines/writer/indexed_blob_constructor.cpp
@@ -2,8 +2,8 @@
 
 #include <ydb/core/tx/columnshard/blob.h>
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/defs.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
 

--- a/ydb/core/tx/columnshard/export/actor/export_actor.h
+++ b/ydb/core/tx/columnshard/export/actor/export_actor.h
@@ -7,10 +7,10 @@
 #include <ydb/core/tx/columnshard/backup/iscan/iscan.h>
 #include <ydb/core/tx/columnshard/bg_tasks/manager/actor.h>
 #include <ydb/core/tx/columnshard/blobs_action/abstract/storage.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/export/common/identifier.h>
 #include <ydb/core/tx/columnshard/export/session/session.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/struct_log/log_stack.h>

--- a/ydb/core/tx/columnshard/export/actor/ut/ut_export_actor_lifecycle.cpp
+++ b/ydb/core/tx/columnshard/export/actor/ut/ut_export_actor_lifecycle.cpp
@@ -3,12 +3,12 @@
 #include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/tx/columnshard/bg_tasks/events/local.h>
 #include <ydb/core/tx/columnshard/columnshard.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/export/session/session.h>
 #include <ydb/core/tx/columnshard/export/session/task.h>
 #include <ydb/core/tx/columnshard/hooks/abstract/abstract.h>
 #include <ydb/core/tx/columnshard/hooks/testing/controller.h>
 #include <ydb/core/tx/columnshard/operations/write_data.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/columnshard/test_helper/columnshard_ut_common.h>
 #include <ydb/core/tx/columnshard/test_helper/controllers.h>
 #include <ydb/core/tx/datashard/datashard.h>

--- a/ydb/core/tx/columnshard/export/actor/ut/ya.make
+++ b/ydb/core/tx/columnshard/export/actor/ut/ya.make
@@ -23,6 +23,7 @@ PEERDIR(
     ydb/core/tx/columnshard/export/actor
     ydb/core/tx/columnshard/hooks/abstract
     ydb/core/tx/columnshard/hooks/testing
+    ydb/core/tx/columnshard/private_events
     ydb/core/tx/columnshard/test_helper
     ydb/library/testlib/s3_recipe_helper
     ydb/public/lib/yson_value

--- a/ydb/core/tx/columnshard/normalizer/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/normalizer/abstract/abstract.cpp
@@ -57,7 +57,8 @@ bool TNormalizationController::SwitchNormalizer() {
 }
 
 void TTrivialNormalizerTask::Start(const TNormalizationController& /* controller */, const TNormalizationContext& nCtx) {
-    TActorContext::AsActorContext().Send(nCtx.GetShardActor(), std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(Changes));
+    TActorContext::AsActorContext().Send(
+        nCtx.GetShardActor(), std::make_unique<NKikimr::NColumnShard::TEvPrivate::TEvNormalizerResult>(Changes));
 }
 
 void TNormalizationController::AddNormalizerEvent(NIceDb::TNiceDb& db, const TString& eventType, const TString& eventDescription) const {

--- a/ydb/core/tx/columnshard/normalizer/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/normalizer/abstract/abstract.cpp
@@ -1,8 +1,9 @@
 #include "abstract.h"
+#include "events.h"
 
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
 
@@ -56,7 +57,7 @@ bool TNormalizationController::SwitchNormalizer() {
 }
 
 void TTrivialNormalizerTask::Start(const TNormalizationController& /* controller */, const TNormalizationContext& nCtx) {
-    TActorContext::AsActorContext().Send(nCtx.GetShardActor(), std::make_unique<NColumnShard::TEvPrivate::TEvNormalizerResult>(Changes));
+    TActorContext::AsActorContext().Send(nCtx.GetShardActor(), std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(Changes));
 }
 
 void TNormalizationController::AddNormalizerEvent(NIceDb::TNiceDb& db, const TString& eventType, const TString& eventDescription) const {

--- a/ydb/core/tx/columnshard/normalizer/abstract/events.h
+++ b/ydb/core/tx/columnshard/normalizer/abstract/events.h
@@ -6,21 +6,21 @@
 
 #include <ydb/library/actors/core/event_local.h>
 
-namespace NKikimr::NOlap {
+namespace NKikimr::NColumnShard {
 
-class TEvNormalizerResult: public NActors::TEventLocal<TEvNormalizerResult, NColumnShard::TEvPrivate::EEv::EvNormalizerResult> {
-    INormalizerChanges::TPtr Changes;
+class TEvPrivate::TEvNormalizerResult: public NActors::TEventLocal<TEvPrivate::TEvNormalizerResult, TEvPrivate::EEv::EvNormalizerResult> {
+    NOlap::INormalizerChanges::TPtr Changes;
 
 public:
-    TEvNormalizerResult(INormalizerChanges::TPtr changes)
+    TEvNormalizerResult(NOlap::INormalizerChanges::TPtr changes)
         : Changes(changes)
     {
     }
 
-    INormalizerChanges::TPtr GetChanges() const {
+    NOlap::INormalizerChanges::TPtr GetChanges() const {
         Y_ABORT_UNLESS(!!Changes);
         return Changes;
     }
 };
 
-}   // namespace NKikimr::NOlap
+}   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/normalizer/abstract/events.h
+++ b/ydb/core/tx/columnshard/normalizer/abstract/events.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "abstract.h"
+
+#include <ydb/core/tx/columnshard/private_events/events.h>
+
+#include <ydb/library/actors/core/event_local.h>
+
+namespace NKikimr::NOlap {
+
+class TEvNormalizerResult: public NActors::TEventLocal<TEvNormalizerResult, NColumnShard::TEvPrivate::EEv::EvNormalizerResult> {
+    INormalizerChanges::TPtr Changes;
+
+public:
+    TEvNormalizerResult(INormalizerChanges::TPtr changes)
+        : Changes(changes)
+    {
+    }
+
+    INormalizerChanges::TPtr GetChanges() const {
+        Y_ABORT_UNLESS(!!Changes);
+        return Changes;
+    }
+};
+
+}   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/normalizer/abstract/ya.make
+++ b/ydb/core/tx/columnshard/normalizer/abstract/ya.make
@@ -9,6 +9,7 @@ GENERATE_ENUM_SERIALIZATION(abstract.h)
 PEERDIR(
     ydb/core/tablet_flat
     ydb/core/tx/columnshard/blobs_action/abstract
+    ydb/core/tx/columnshard/private_events
     ydb/core/tx/columnshard/resource_subscriber
 )
 

--- a/ydb/core/tx/columnshard/normalizer/granule/clean_granule.cpp
+++ b/ydb/core/tx/columnshard/normalizer/granule/clean_granule.cpp
@@ -1,6 +1,6 @@
 #include "clean_granule.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/normalizer/granule/normalizer.cpp
+++ b/ydb/core/tx/columnshard/normalizer/granule/normalizer.cpp
@@ -1,6 +1,6 @@
 #include "normalizer.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/normalizer/insert_table/broken_dedup.cpp
+++ b/ydb/core/tx/columnshard/normalizer/insert_table/broken_dedup.cpp
@@ -1,7 +1,7 @@
 #include "broken_dedup.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
 

--- a/ydb/core/tx/columnshard/normalizer/portion/broken_blobs.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/broken_blobs.cpp
@@ -116,7 +116,8 @@ protected:
         }
 
         auto changes = std::make_shared<TNormalizerResult>(std::move(BrokenPortions), Schemas);
-        TActorContext::AsActorContext().Send(NormContext.GetShardActor(), std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(changes));
+        TActorContext::AsActorContext().Send(
+            NormContext.GetShardActor(), std::make_unique<NKikimr::NColumnShard::TEvPrivate::TEvNormalizerResult>(changes));
     }
 
     virtual bool DoOnError(const TString& storageId, const TBlobRange& range, const IBlobsReadingAction::TErrorStatus& status) override {

--- a/ydb/core/tx/columnshard/normalizer/portion/broken_blobs.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/broken_blobs.cpp
@@ -5,6 +5,7 @@
 #include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
 #include <ydb/core/tx/columnshard/engines/portions/read_with_blobs.h>
 #include <ydb/core/tx/columnshard/engines/scheme/filtered_scheme.h>
+#include <ydb/core/tx/columnshard/normalizer/abstract/events.h>
 #include <ydb/core/tx/columnshard/tables_manager.h>
 
 #include <ydb/library/actors/struct_log/log_stack.h>
@@ -115,8 +116,7 @@ protected:
         }
 
         auto changes = std::make_shared<TNormalizerResult>(std::move(BrokenPortions), Schemas);
-        TActorContext::AsActorContext().Send(
-            NormContext.GetShardActor(), std::make_unique<NColumnShard::TEvPrivate::TEvNormalizerResult>(changes));
+        TActorContext::AsActorContext().Send(NormContext.GetShardActor(), std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(changes));
     }
 
     virtual bool DoOnError(const TString& storageId, const TBlobRange& range, const IBlobsReadingAction::TErrorStatus& status) override {

--- a/ydb/core/tx/columnshard/normalizer/portion/chunks.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/chunks.cpp
@@ -73,7 +73,8 @@ protected:
         }
 
         auto changes = std::make_shared<TChunksNormalizer::TNormalizerResult>(std::move(Chunks));
-        TActorContext::AsActorContext().Send(NormContext.GetShardActor(), std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(changes));
+        TActorContext::AsActorContext().Send(
+            NormContext.GetShardActor(), std::make_unique<NKikimr::NColumnShard::TEvPrivate::TEvNormalizerResult>(changes));
     }
 
 public:

--- a/ydb/core/tx/columnshard/normalizer/portion/chunks.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/chunks.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/tx/columnshard/data_accessor/manager.h>
 #include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
 #include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
+#include <ydb/core/tx/columnshard/normalizer/abstract/events.h>
 #include <ydb/core/tx/columnshard/tables_manager.h>
 
 namespace NKikimr::NOlap {
@@ -72,8 +73,7 @@ protected:
         }
 
         auto changes = std::make_shared<TChunksNormalizer::TNormalizerResult>(std::move(Chunks));
-        TActorContext::AsActorContext().Send(
-            NormContext.GetShardActor(), std::make_unique<NColumnShard::TEvPrivate::TEvNormalizerResult>(changes));
+        TActorContext::AsActorContext().Send(NormContext.GetShardActor(), std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(changes));
     }
 
 public:

--- a/ydb/core/tx/columnshard/normalizer/portion/clean.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean.cpp
@@ -64,8 +64,9 @@ public:
         for (auto&& blobId : Blobs) {
             removeAction->DeclareSelfRemove(blobId);
         }
-        TActorContext::AsActorContext().Send(nCtx.GetShardActor(),
-            std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(std::make_shared<TBlobsRemovingResult>(removeAction, std::move(Portions))));
+        TActorContext::AsActorContext().Send(
+            nCtx.GetShardActor(), std::make_unique<NKikimr::NColumnShard::TEvPrivate::TEvNormalizerResult>(
+                                      std::make_shared<TBlobsRemovingResult>(removeAction, std::move(Portions))));
     }
 };
 

--- a/ydb/core/tx/columnshard/normalizer/portion/clean.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
 #include <ydb/core/tx/columnshard/engines/portions/data_accessor.h>
 #include <ydb/core/tx/columnshard/engines/scheme/filtered_scheme.h>
+#include <ydb/core/tx/columnshard/normalizer/abstract/events.h>
 #include <ydb/core/tx/columnshard/tables_manager.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
@@ -63,9 +64,8 @@ public:
         for (auto&& blobId : Blobs) {
             removeAction->DeclareSelfRemove(blobId);
         }
-        TActorContext::AsActorContext().Send(
-            nCtx.GetShardActor(), std::make_unique<NColumnShard::TEvPrivate::TEvNormalizerResult>(
-                                      std::make_shared<TBlobsRemovingResult>(removeAction, std::move(Portions))));
+        TActorContext::AsActorContext().Send(nCtx.GetShardActor(),
+            std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(std::make_shared<TBlobsRemovingResult>(removeAction, std::move(Portions))));
     }
 };
 

--- a/ydb/core/tx/columnshard/normalizer/portion/clean_index_columns.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean_index_columns.h
@@ -3,8 +3,8 @@
 #include "clean_unused_tables_template.h"
 
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NCleanUnusedTables {
 using namespace NColumnShard;

--- a/ydb/core/tx/columnshard/normalizer/portion/clean_index_columns_v1.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean_index_columns_v1.h
@@ -3,8 +3,8 @@
 #include "clean_unused_tables_template.h"
 
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NCleanUnusedTables {
 using namespace NColumnShard;

--- a/ydb/core/tx/columnshard/normalizer/portion/clean_ttl_preset_setting_info.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean_ttl_preset_setting_info.h
@@ -2,8 +2,8 @@
 
 #include "clean_unused_tables_template.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NCleanUnusedTables {
 using namespace NColumnShard;

--- a/ydb/core/tx/columnshard/normalizer/portion/clean_ttl_preset_setting_version_info.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean_ttl_preset_setting_version_info.h
@@ -2,8 +2,8 @@
 
 #include "clean_unused_tables_template.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap::NCleanUnusedTables {
 using namespace NColumnShard;

--- a/ydb/core/tx/columnshard/normalizer/portion/clean_unused_tables_template.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/clean_unused_tables_template.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/normalizer/abstract/abstract.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <memory>
 #include <vector>

--- a/ydb/core/tx/columnshard/normalizer/portion/leaked_blobs.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/leaked_blobs.cpp
@@ -397,7 +397,7 @@ private:
         PrintFoundLeakedBlobsStats();
         PrintLeakedBlobIdsChunks();
         TActorContext::AsActorContext().Send(
-            CSActorId, std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(std::make_shared<TLeakedBlobsNormalizerChanges>(
+            CSActorId, std::make_unique<NKikimr::NColumnShard::TEvPrivate::TEvNormalizerResult>(std::make_shared<TLeakedBlobsNormalizerChanges>(
                            std::move(BSBlobIds), CSTabletId, TablePathId, TablePath, DsGroupSelector, LogLevel)));
         PassAway();
     }

--- a/ydb/core/tx/columnshard/normalizer/portion/leaked_blobs.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/leaked_blobs.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/tx/columnshard/data_accessor/manager.h>
 #include <ydb/core/tx/columnshard/engines/column_engine_logs.h>
 #include <ydb/core/tx/columnshard/engines/portions/constructor_accessor.h>
+#include <ydb/core/tx/columnshard/normalizer/abstract/events.h>
 #include <ydb/core/tx/columnshard/tables_manager.h>
 
 #include <ydb/library/actors/core/actor.h>
@@ -396,7 +397,7 @@ private:
         PrintFoundLeakedBlobsStats();
         PrintLeakedBlobIdsChunks();
         TActorContext::AsActorContext().Send(
-            CSActorId, std::make_unique<NColumnShard::TEvPrivate::TEvNormalizerResult>(std::make_shared<TLeakedBlobsNormalizerChanges>(
+            CSActorId, std::make_unique<NKikimr::NOlap::TEvNormalizerResult>(std::make_shared<TLeakedBlobsNormalizerChanges>(
                            std::move(BSBlobIds), CSTabletId, TablePathId, TablePath, DsGroupSelector, LogLevel)));
         PassAway();
     }

--- a/ydb/core/tx/columnshard/normalizer/portion/normalizer.h
+++ b/ydb/core/tx/columnshard/normalizer/portion/normalizer.h
@@ -2,10 +2,10 @@
 
 #include <ydb/core/tx/columnshard/blobs_action/counters/storage.h>
 #include <ydb/core/tx/columnshard/blobs_reader/task.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/defs.h>
 #include <ydb/core/tx/columnshard/engines/scheme/abstract_scheme.h>
 #include <ydb/core/tx/columnshard/normalizer/abstract/abstract.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
 #include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>

--- a/ydb/core/tx/columnshard/normalizer/portion/special_cleaner.cpp
+++ b/ydb/core/tx/columnshard/normalizer/portion/special_cleaner.cpp
@@ -1,6 +1,6 @@
 #include "special_cleaner.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
 

--- a/ydb/core/tx/columnshard/normalizer/tables/normalizer.cpp
+++ b/ydb/core/tx/columnshard/normalizer/tables/normalizer.cpp
@@ -1,6 +1,6 @@
 #include "normalizer.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/normalizer/tablet/broken_txs.cpp
+++ b/ydb/core/tx/columnshard/normalizer/tablet/broken_txs.cpp
@@ -1,7 +1,7 @@
 #include "broken_txs.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/columnshard_schema.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_COLUMNSHARD
 

--- a/ydb/core/tx/columnshard/normalizer/tablet/gc_counters.cpp
+++ b/ydb/core/tx/columnshard/normalizer/tablet/gc_counters.cpp
@@ -1,6 +1,6 @@
 #include "gc_counters.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/operations/batch_builder/builder.cpp
+++ b/ydb/core/tx/columnshard/operations/batch_builder/builder.cpp
@@ -2,10 +2,10 @@
 #include "merger.h"
 #include "restore.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/engines/writer/buffer/events.h>
 #include <ydb/core/tx/columnshard/engines/writer/indexed_blob_constructor.h>
 #include <ydb/core/tx/columnshard/operations/slice_builder/builder.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 #include <ydb/core/tx/data_events/common/modification_type.h>

--- a/ydb/core/tx/columnshard/operations/batch_builder/builder.h
+++ b/ydb/core/tx/columnshard/operations/batch_builder/builder.h
@@ -1,9 +1,9 @@
 #pragma once
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>
 #include <ydb/core/tx/columnshard/counters/columnshard.h>
 #include <ydb/core/tx/columnshard/engines/scheme/versions/abstract_scheme.h>
 #include <ydb/core/tx/columnshard/operations/common/context.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
 #include <ydb/core/tx/data_events/write_data.h>
 

--- a/ydb/core/tx/columnshard/operations/batch_builder/restore.cpp
+++ b/ydb/core/tx/columnshard/operations/batch_builder/restore.cpp
@@ -1,8 +1,8 @@
 #include "restore.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/engines/writer/buffer/events.h>
 #include <ydb/core/tx/columnshard/operations/slice_builder/builder.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 

--- a/ydb/core/tx/columnshard/operations/batch_builder/restore.h
+++ b/ydb/core/tx/columnshard/operations/batch_builder/restore.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "merger.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/data_reader/actor.h>
 #include <ydb/core/tx/columnshard/engines/scheme/versions/abstract_scheme.h>
 #include <ydb/core/tx/columnshard/operations/common/context.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NOlap {
 

--- a/ydb/core/tx/columnshard/operations/events.h
+++ b/ydb/core/tx/columnshard/operations/events.h
@@ -1,8 +1,8 @@
 #pragma once
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/common/blob.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/engines/portions/write_with_blobs.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <util/generic/hash.h>
 

--- a/ydb/core/tx/columnshard/operations/slice_builder/builder.cpp
+++ b/ydb/core/tx/columnshard/operations/slice_builder/builder.cpp
@@ -1,13 +1,13 @@
 #include "builder.h"
 
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/defs.h>
 #include <ydb/core/tx/columnshard/engines/portions/write_with_blobs.h>
 #include <ydb/core/tx/columnshard/engines/scheme/index_info.h>
 #include <ydb/core/tx/columnshard/engines/writer/buffer/events.h>
 #include <ydb/core/tx/columnshard/engines/writer/indexed_blob_constructor.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/struct_log/log_stack.h>
 

--- a/ydb/core/tx/columnshard/operations/slice_builder/builder.h
+++ b/ydb/core/tx/columnshard/operations/slice_builder/builder.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <ydb/core/formats/arrow/size_calcer.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/engines/scheme/versions/abstract_scheme.h>
 #include <ydb/core/tx/columnshard/operations/common/context.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
 #include <ydb/core/tx/data_events/write_data.h>
 

--- a/ydb/core/tx/columnshard/operations/slice_builder/pack_builder.cpp
+++ b/ydb/core/tx/columnshard/operations/slice_builder/pack_builder.cpp
@@ -3,12 +3,12 @@
 #include <ydb/core/formats/arrow/reader/merger.h>
 #include <ydb/core/formats/arrow/reader/result_builder.h>
 #include <ydb/core/tx/columnshard/columnshard_impl.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/defs.h>
 #include <ydb/core/tx/columnshard/engines/portions/write_with_blobs.h>
 #include <ydb/core/tx/columnshard/engines/scheme/index_info.h>
 #include <ydb/core/tx/columnshard/engines/writer/buffer/events.h>
 #include <ydb/core/tx/columnshard/engines/writer/indexed_blob_constructor.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/actors/struct_log/log_stack.h>
 

--- a/ydb/core/tx/columnshard/operations/slice_builder/pack_builder.h
+++ b/ydb/core/tx/columnshard/operations/slice_builder/pack_builder.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <ydb/core/formats/arrow/size_calcer.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/common/path_id.h>
 #include <ydb/core/tx/columnshard/engines/scheme/versions/abstract_scheme.h>
 #include <ydb/core/tx/columnshard/operations/common/context.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
 #include <ydb/core/tx/data_events/write_data.h>
 

--- a/ydb/core/tx/columnshard/overload_manager/overload_manager_events.h
+++ b/ydb/core/tx/columnshard/overload_manager/overload_manager_events.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <ydb/core/base/events.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/overload_manager/overload_manager_common_types.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 namespace NKikimr::NColumnShard::NOverload {
 

--- a/ydb/core/tx/columnshard/private_events/events.cpp
+++ b/ydb/core/tx/columnshard/private_events/events.cpp
@@ -1,0 +1,3 @@
+#include "events.h"
+
+namespace NKikimr::NColumnShard {}

--- a/ydb/core/tx/columnshard/private_events/events.h
+++ b/ydb/core/tx/columnshard/private_events/events.h
@@ -1,24 +1,18 @@
 #pragma once
 
-#include "defs.h"
-
-#include "blobs_action/abstract/gc.h"
-
 #include <ydb/core/formats/arrow/special_keys.h>
 #include <ydb/core/protos/counters_columnshard.pb.h>
+#include <ydb/core/tx/columnshard/blobs_action/abstract/gc.h>
 #include <ydb/core/tx/columnshard/counters/scan.h>
-#include <ydb/core/tx/columnshard/engines/column_engine.h>
+#include <ydb/core/tx/columnshard/defs.h>
+#include <ydb/core/tx/columnshard/engines/changes/abstract/abstract.h>
+#include <ydb/core/tx/columnshard/engines/portions/portion_info.h>
 #include <ydb/core/tx/columnshard/engines/writer/indexed_blob_constructor.h>
 #include <ydb/core/tx/columnshard/engines/writer/write_controller.h>
-#include <ydb/core/tx/columnshard/normalizer/abstract/abstract.h>
-#include <ydb/core/tx/columnshard/resource_subscriber/container.h>
 #include <ydb/core/tx/data_events/write_data.h>
+#include <ydb/core/tx/general_cache/source/abstract.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/abstract.h>
 #include <ydb/core/tx/priorities/usage/abstract.h>
-
-namespace NKikimr::NOlap::NReader {
-class IApplyAction;
-}
 
 namespace NKikimr::NOlap {
 class IBlobsWritingAction;
@@ -97,52 +91,6 @@ struct TEvPrivate {
 
     static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
 
-    class TEvMetadataAccessorsInfo: public NActors::TEventLocal<TEvMetadataAccessorsInfo, EvMetadataAccessorsInfo> {
-    private:
-        const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor> Processor;
-        const ui64 Generation;
-        std::optional<NOlap::NResourceBroker::NSubscribe::TResourceContainer<NOlap::TDataAccessorsResult>> Result;
-
-    public:
-        const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor>& GetProcessor() const {
-            return Processor;
-        }
-
-        ui64 GetGeneration() const {
-            return Generation;
-        }
-
-        NOlap::NResourceBroker::NSubscribe::TResourceContainer<NOlap::TDataAccessorsResult> ExtractResult() {
-            AFL_VERIFY(Result);
-            auto result = std::move(*Result);
-            Result.reset();
-            return result;
-        }
-
-        TEvMetadataAccessorsInfo(const std::shared_ptr<NOlap::IMetadataAccessorResultProcessor>& processor, const ui64 gen,
-            NOlap::NResourceBroker::NSubscribe::TResourceContainer<NOlap::TDataAccessorsResult>&& result)
-            : Processor(processor)
-            , Generation(gen)
-            , Result(std::move(result))
-        {
-        }
-    };
-
-    class TEvAskTabletDataAccessors
-        : public NActors::TEventLocal<TEvAskTabletDataAccessors, NColumnShard::TEvPrivate::EEv::EvAskTabletDataAccessors> {
-    private:
-        using TPortions = THashMap<TInternalPathId, NOlap::NDataAccessorControl::TPortionsByConsumer>;
-        YDB_ACCESSOR_DEF(TPortions, Portions);
-        YDB_READONLY_DEF(std::shared_ptr<NOlap::NDataAccessorControl::IAccessorCallback>, Callback);
-
-    public:
-        explicit TEvAskTabletDataAccessors(TPortions&& portions, const std::shared_ptr<NOlap::NDataAccessorControl::IAccessorCallback>& callback)
-            : Portions(std::move(portions))
-            , Callback(callback)
-        {
-        }
-    };
-
     class TEvAskColumnData: public NActors::TEventLocal<TEvAskColumnData, NColumnShard::TEvPrivate::EEv::EvAskColumnData> {
     public:
         class TPortionRequest {
@@ -200,60 +148,6 @@ struct TEvPrivate {
         }
     };
 
-    class TEvTaskProcessedResult: public NActors::TEventLocal<TEvTaskProcessedResult, EvTaskProcessedResult> {
-    private:
-        TConclusion<std::shared_ptr<NOlap::NReader::IApplyAction>> Result;
-        TCounterGuard ScanCounter;
-        ui64 SourceId = 0;
-        ui64 BlobBytes = 0;
-        ui64 RawBytes = 0;
-        ui32 FilteredRows = 0;
-        ui32 TotalRows = 0;
-        ui64 TotalReservedBytes = 0;
-
-    public:
-        TConclusion<std::shared_ptr<NOlap::NReader::IApplyAction>>& MutableResult() {
-            return Result;
-        }
-
-        ui64 GetSourceId() const {
-            return SourceId;
-        }
-
-        ui64 GetBlobBytes() const {
-            return BlobBytes;
-        }
-
-        ui64 GetRawBytes() const {
-            return RawBytes;
-        }
-
-        ui32 GetFilteredRows() const {
-            return FilteredRows;
-        }
-
-        ui32 GetTotalRows() const {
-            return TotalRows;
-        }
-
-        ui64 GetTotalReservedBytes() const {
-            return TotalReservedBytes;
-        }
-
-        TEvTaskProcessedResult(TConclusion<std::shared_ptr<NOlap::NReader::IApplyAction>>&& result, TCounterGuard&& scanCounters,
-            ui64 sourceId = 0, ui64 blobBytes = 0, ui64 rawBytes = 0, ui32 filteredRows = 0, ui32 totalRows = 0, ui64 totalReservedBytes = 0)
-            : Result(std::move(result))
-            , ScanCounter(std::move(scanCounters))
-            , SourceId(sourceId)
-            , BlobBytes(blobBytes)
-            , RawBytes(rawBytes)
-            , FilteredRows(filteredRows)
-            , TotalRows(totalRows)
-            , TotalReservedBytes(totalReservedBytes)
-        {
-        }
-    };
-
     struct TEvTieringModified: public TEventLocal<TEvTieringModified, EvTieringModified> {};
 
     struct TEvWriteDraft: public TEventLocal<TEvWriteDraft, EvWriteDraft> {
@@ -262,21 +156,6 @@ struct TEvPrivate {
         TEvWriteDraft(std::shared_ptr<IWriteController> controller)
             : WriteController(controller)
         {
-        }
-    };
-
-    class TEvNormalizerResult: public TEventLocal<TEvNormalizerResult, EvNormalizerResult> {
-        NOlap::INormalizerChanges::TPtr Changes;
-
-    public:
-        TEvNormalizerResult(NOlap::INormalizerChanges::TPtr changes)
-            : Changes(changes)
-        {
-        }
-
-        NOlap::INormalizerChanges::TPtr GetChanges() const {
-            Y_ABORT_UNLESS(!!Changes);
-            return Changes;
         }
     };
 

--- a/ydb/core/tx/columnshard/private_events/events.h
+++ b/ydb/core/tx/columnshard/private_events/events.h
@@ -91,6 +91,12 @@ struct TEvPrivate {
 
     static_assert(EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE), "expect EvEnd < EventSpaceEnd(TEvents::ES_PRIVATE)");
 
+    // Defined out-of-line in their owning modules because of dependencies (kept there to avoid pulling those modules' deps into private_events):
+    class TEvNormalizerResult;
+    class TEvAskTabletDataAccessors;
+    class TEvTaskProcessedResult;
+    class TEvMetadataAccessorsInfo;
+
     class TEvAskColumnData: public NActors::TEventLocal<TEvAskColumnData, NColumnShard::TEvPrivate::EEv::EvAskColumnData> {
     public:
         class TPortionRequest {

--- a/ydb/core/tx/columnshard/private_events/ya.make
+++ b/ydb/core/tx/columnshard/private_events/ya.make
@@ -1,0 +1,27 @@
+LIBRARY()
+
+SRCS(
+    events.cpp
+)
+
+PEERDIR(
+    ydb/core/base
+    ydb/core/control/lib
+    ydb/core/formats/arrow
+    ydb/core/protos
+    ydb/core/tx/columnshard/blobs_action/abstract
+    ydb/core/tx/columnshard/common
+    ydb/core/tx/columnshard/counters
+    ydb/core/tx/columnshard/engines/changes/abstract
+    ydb/core/tx/columnshard/engines/portions
+    ydb/core/tx/columnshard/engines/writer
+    ydb/core/tx/data_events
+    ydb/core/tx/general_cache/source
+    ydb/core/tx/limiter/grouped_memory/usage
+    ydb/core/tx/priorities/usage
+    ydb/library/actors/core
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/core/tx/columnshard/resource_subscriber/events.h
+++ b/ydb/core/tx/columnshard/resource_subscriber/events.h
@@ -2,7 +2,7 @@
 
 #include "task.h"
 
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/actors/core/event_local.h>

--- a/ydb/core/tx/columnshard/resource_subscriber/ya.make
+++ b/ydb/core/tx/columnshard/resource_subscriber/ya.make
@@ -10,7 +10,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/protos
-    ydb/core/tx/columnshard/engines/protos  # stopgap: columnshard_private_events.h transitively requires engines/protos; direct columnshard dep would create a cycle
+    ydb/core/tx/columnshard/private_events
     ydb/library/actors/core
     ydb/core/tablet_flat
 )

--- a/ydb/core/tx/columnshard/test_helper/shard_reader.h
+++ b/ydb/core/tx/columnshard/test_helper/shard_reader.h
@@ -3,8 +3,8 @@
 #include <ydb/core/kqp/compute_actor/kqp_compute_events.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/testlib/tablet_helpers.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
 #include <ydb/core/tx/columnshard/common/snapshot.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/datashard/datashard.h>
 
 #include <ydb/library/accessor/accessor.h>

--- a/ydb/core/tx/columnshard/write_actor.cpp
+++ b/ydb/core/tx/columnshard/write_actor.cpp
@@ -1,6 +1,6 @@
 #include "columnshard_impl.h"
-#include "columnshard_private_events.h"
 
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/util/backoff.h>
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>

--- a/ydb/core/tx/columnshard/ya.make
+++ b/ydb/core/tx/columnshard/ya.make
@@ -19,7 +19,6 @@ SRCS(
     columnshard__write.cpp
     columnshard__write_index.cpp
     columnshard_impl.cpp
-    columnshard_private_events.cpp
     columnshard_schema.cpp
     columnshard_subdomain_path_id.cpp
     columnshard_view.cpp
@@ -63,6 +62,7 @@ PEERDIR(
     ydb/core/tx/columnshard/normalizer
     ydb/core/tx/columnshard/operations
     ydb/core/tx/columnshard/overload_manager
+    ydb/core/tx/columnshard/private_events
     ydb/core/tx/columnshard/resource_subscriber
     ydb/core/tx/columnshard/splitter
     ydb/core/tx/columnshard/subscriber
@@ -98,6 +98,7 @@ END()
 
 RECURSE(
     engines
+    private_events
     splitter
     tools/visualize_portions
     tools/memory_tests

--- a/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
+++ b/ydb/core/tx/schemeshard/ut_export/ut_export.cpp
@@ -11,7 +11,7 @@
 #include <ydb/core/tablet_flat/shared_cache_events.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/testlib/audit_helpers/audit_helper.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/columnshard/test_helper/columnshard_ut_common.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_billing_helpers.h>

--- a/ydb/core/tx/schemeshard/ut_export/ya.make
+++ b/ydb/core/tx/schemeshard/ut_export/ya.make
@@ -24,6 +24,7 @@ IF (NOT OS_WINDOWS)
         ydb/core/tx
         ydb/core/tx/columnshard
         ydb/core/tx/columnshard/hooks/testing
+        ydb/core/tx/columnshard/private_events
         ydb/core/tx/columnshard/test_helper
         ydb/core/tx/schemeshard/ut_helpers
         ydb/core/util

--- a/ydb/core/tx/tiering/manager.cpp
+++ b/ydb/core/tx/tiering/manager.cpp
@@ -4,7 +4,6 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/services/scheme_secret/resolver.h>
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/tiering/fetcher.h>
 #include <ydb/core/tx/tiering/tier/identifier.h>
 

--- a/ydb/core/tx/tiering/manager.cpp
+++ b/ydb/core/tx/tiering/manager.cpp
@@ -4,7 +4,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/services/scheme_secret/resolver.h>
 #include <ydb/core/protos/config.pb.h>
-#include <ydb/core/tx/columnshard/columnshard_private_events.h>
+#include <ydb/core/tx/columnshard/private_events/events.h>
 #include <ydb/core/tx/tiering/fetcher.h>
 #include <ydb/core/tx/tiering/tier/identifier.h>
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

columnshard_private_events.h extracted to a separate directory.
Events that cause circular dependencies moved out into their targets.
