### PR TITLE
Report per node mem stats iff EnableChannelMemoryTracking ff set

### DIFF
--- a/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
+++ b/ydb/core/kqp/node_service/kqp_query_control_plane.cpp
@@ -425,7 +425,7 @@ public:
 
         if (StatsMode == NYql::NDqProto::DQ_STATS_MODE_NONE) {
             StatsMode = runtimeSettings.GetStatsMode();
-            if (StatsMode == NYql::NDqProto::DQ_STATS_MODE_PROFILE) {
+            if (EnableChannelMemoryTracking && StatsMode == NYql::NDqProto::DQ_STATS_MODE_PROFILE) {
                 StatsReportPeriod = reportStatsSettings.MinInterval;
 
                 auto channelCounters = Counters_->GetChannelCounters();


### PR DESCRIPTION
Report per node mem stats iff EnableChannelMemoryTracking ff set
To avoid compatibility problems with older versions on rolling upgrade