### PR TITLE
Disable metering by default and enable after successful auth to avoid metering in case of auth timeouts

### DIFF
--- a/ydb/core/http_proxy/ut/ymq_ut.cpp
+++ b/ydb/core/http_proxy/ut/ymq_ut.cpp
@@ -3704,8 +3704,7 @@ Y_UNIT_TEST_SUITE(TestYmqHttpProxy) {
         DisableAuthorization();
 
         // Send an XML API CreateQueue request without authorization header.
-        // This triggers the XML API auth path (TCloudAuthRequestProxy) which calls
-        // Callback_->OnIamAuthError(), setting SkipMetering on the response.
+        // This triggers the XML API auth path (TCloudAuthRequestProxy) setting SkipMetering on the response due to auth non-successful.
         // Auth failures are reported with HTTP code 400 and an IncompleteSignature error.
         auto json2 = CreateQueueXml({{"QueueName", "XmlAuthFailQueue"}}, 400);
         UNIT_ASSERT_STRING_CONTAINS(GetByPath<TString>(json2, "__type"), "IncompleteSignature");

--- a/ydb/core/http_proxy/ymq.cpp
+++ b/ydb/core/http_proxy/ymq.cpp
@@ -314,8 +314,8 @@ namespace NKikimr::NHttpProxy {
                     HttpContext.FolderId = FolderId = ev->Get()->FolderId;
                     HttpContext.CloudId = CloudId = ev->Get()->CloudId;
                     UserSid = ev->Get()->Sid;
-                    SendGrpcRequestNoDriver(ctx);
                     IamAuthenticated = true;
+                    SendGrpcRequestNoDriver(ctx);
                 } else {
                     YDB_LOG_DEBUG_CTX(ctx, "Got cloud auth response",
                         {"logPrefix", LogPrefix()},
@@ -323,7 +323,6 @@ namespace NKikimr::NHttpProxy {
                         {"errorCode", ev->Get()->Error->ErrorCode},
                         {"message", ev->Get()->Error->Message});
 
-                    IamAuthenticated = false;
                     ReplyWithError(
                         ctx,
                         ev->Get()->Error->HttpStatusCode,

--- a/ydb/core/http_proxy/ymq.cpp
+++ b/ydb/core/http_proxy/ymq.cpp
@@ -195,7 +195,7 @@ namespace NKikimr::NHttpProxy {
             }
 
             void DoMetering(const THttpResponseData& data, THolder<THashMap<TString, TString>>&& queueTags, const TActorContext& ctx) {
-                if (IamAuthFailed_) {
+                if (!IamAuthenticated) {
                     YDB_LOG_DEBUG_CTX(ctx, "Skip metering event due to IAM auth failure");
                     return;
                 }
@@ -315,13 +315,15 @@ namespace NKikimr::NHttpProxy {
                     HttpContext.CloudId = CloudId = ev->Get()->CloudId;
                     UserSid = ev->Get()->Sid;
                     SendGrpcRequestNoDriver(ctx);
+                    IamAuthenticated = true;
                 } else {
                     YDB_LOG_DEBUG_CTX(ctx, "Got cloud auth response",
                         {"logPrefix", LogPrefix()},
                         {"httpStatusCode", ev->Get()->Error->HttpStatusCode},
                         {"errorCode", ev->Get()->Error->ErrorCode},
                         {"message", ev->Get()->Error->Message});
-                    IamAuthFailed_ = true;
+
+                    IamAuthenticated = false;
                     ReplyWithError(
                         ctx,
                         ev->Get()->Error->HttpStatusCode,
@@ -421,7 +423,7 @@ namespace NKikimr::NHttpProxy {
             TRetryCounter RetryCounter;
             TActorId AuthActor;
             bool InputCountersReported = false;
-            bool IamAuthFailed_ = false;
+            bool IamAuthenticated = false;
             TString FolderId;
             TString CloudId;
             TString ResourceId;

--- a/ydb/core/ymq/actor/actor.h
+++ b/ydb/core/ymq/actor/actor.h
@@ -11,7 +11,7 @@ public:
     virtual ~IReplyCallback() = default;
 
     virtual void DoSendReply(const NKikimrClient::TSqsResponse& resp) = 0;
-    virtual void OnIamAuthError() {}
+    virtual void OnIamAuthSuccess() {}
 };
 
 class IPingReplyCallback {

--- a/ydb/core/ymq/actor/auth_multi_factory.cpp
+++ b/ydb/core/ymq/actor/auth_multi_factory.cpp
@@ -545,12 +545,12 @@ void TCloudAuthRequestProxy::DoReply() {
 void TCloudAuthRequestProxy::SetError(const TErrorClass& errorClass, const TString& message) {
     auto* error = MakeMutableError();
     ::NKikimr::NSQS::MakeError(error, errorClass, Sprintf("%s Request id to report: %s.", message.c_str(), RequestId_.c_str()));
-    if (Callback_) {
-        Callback_->OnIamAuthError();
-    }
 }
 
 void TCloudAuthRequestProxy::OnSuccessfulAuth() {
+    if (Callback_) {
+        Callback_->OnIamAuthSuccess();
+    }
 #define SQS_REQUEST_CASE(action) \
     ProposeStaticCreds(*RequestHolder_->Y_CAT(Mutable, action)());
 

--- a/ydb/core/ymq/http/http.cpp
+++ b/ydb/core/ymq/http/http.cpp
@@ -77,7 +77,7 @@ public:
         response.FolderId = resp.GetFolderId();
         response.IsFifo = resp.GetIsFifo();
         response.ResourceId = resp.GetResourceId();
-        response.SkipMetering = IamAuthFailed_;
+        response.SkipMetering = !IamAuthSuccess_;
         for (const auto& tag : resp.GetQueueTags()) {
             response.QueueTags[tag.GetKey()] = tag.GetValue();
         }
@@ -85,8 +85,8 @@ public:
         Request_->SendResponse(response);
     }
 
-    void OnIamAuthError() override {
-        IamAuthFailed_ = true;
+    void OnIamAuthSuccess() override {
+        IamAuthSuccess_ = true;
     }
 
 private:
@@ -107,7 +107,7 @@ private:
 private:
     THttpRequest* const Request_;
     const TSqsRequest RequestParams_;
-    bool IamAuthFailed_ = false;
+    bool IamAuthSuccess_ = false;
 };
 
 class TPingHttpCallback : public IPingReplyCallback {


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

В случае ошибок, произошедших до окончания авторизации (в Bootstrap или таймаут), митеренг всё ещё отправлялся. 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Поправка к https://github.com/ydb-platform/ydb/pull/44632
