### PR TITLE
fix the mute by gracefully closing in table client

### DIFF
--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
@@ -81,9 +81,9 @@ std::shared_ptr<NObservability::TRequestSpan> TTableClient::TImpl::CreateRetryAt
 
 TTableClient::TImpl::~TImpl() {
     if (Connections_->GetDrainOnDtors()) {
-        const bool closeRemote = !TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback();
-        auto drainFuture = Drain(closeRemote);
-        if (closeRemote) {
+        const bool waitForDrain = !TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback();
+        auto drainFuture = Drain();
+        if (waitForDrain) {
             drainFuture.Wait(DRAIN_TIMEOUT);
         }
     }
@@ -106,7 +106,7 @@ void TTableClient::TImpl::InitStopper() {
     DbDriverState_->AddCb(std::move(cb), TDbDriverState::ENotifyType::STOP);
 }
 
-NThreading::TFuture<void> TTableClient::TImpl::Drain(bool closeRemote) {
+NThreading::TFuture<void> TTableClient::TImpl::Drain() {
     std::vector<std::unique_ptr<TKqpSessionCommon>> sessions;
     // No realocations under lock
     sessions.reserve(Settings_.SessionPoolSettings_.MaxActiveSessions_);
@@ -118,9 +118,7 @@ NThreading::TFuture<void> TTableClient::TImpl::Drain(bool closeRemote) {
     std::vector<TAsyncStatus> closeResults;
     for (auto& s : sessions) {
         if (!s->GetId().empty()) {
-            if (closeRemote) {
-                closeResults.push_back(CloseInternal(s.get()));
-            }
+            closeResults.push_back(CloseInternal(s.get()));
             DbDriverState_->StatCollector.DecSessionsOnHost(s->GetEndpoint());
         }
     }
@@ -1166,11 +1164,8 @@ void TTableClient::TImpl::DeleteSession(TKqpSessionCommon* sessionImpl) {
         SessionPool_.DecrementActiveCounter();
     }
 
-    const bool closeRemote = !TGRpcConnectionsImpl::IsCurrentThreadInSdkCallback();
     if (!sessionImpl->GetId().empty()) {
-        if (closeRemote) {
-            CloseInternal(sessionImpl);
-        }
+        CloseInternal(sessionImpl);
         DbDriverState_->StatCollector.DecSessionsOnHost(sessionImpl->GetEndpoint());
     }
 

--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.h
@@ -44,7 +44,7 @@ public:
 
     bool LinkObjToEndpoint(const TEndpointKey& endpoint, TEndpointObj* obj, const void* tag);
     void InitStopper();
-    NThreading::TFuture<void> Drain(bool closeRemote = true);
+    NThreading::TFuture<void> Drain();
     NThreading::TFuture<void> Stop();
     void ScheduleTaskUnsafe(std::function<void()>&& fn, TDeadline::Duration timeout);
     void StartPeriodicSessionPoolTask();

--- a/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/table/table_ut.cpp
@@ -443,6 +443,7 @@ TEST(TableTest, DropLastOwnersFromResponseCallbackDoesNotDeadlock) {
     ASSERT_TRUE(WaitUntil([&] {
         return connections.expired();
     }));
+    ASSERT_EQ(tableService.DeleteSessionRequests.load(), 2u);
 }
 
 TEST(TableTest, DriverStopFromResponseCallbackThenDropOwnersDoesNotDeadlock) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

PR #45962 made table-client destruction inside SDK callbacks skip remote DeleteSession calls to avoid blocking. This occasionally left  pooled sessions alive when the callback held the last client reference.
The fix always starts asynchronous session cleanup, while still avoiding waits inside callbacks. Driver shutdown remains unchanged.
