### PR TITLE
Compaction preserves native column values. If input portions have different types, they will be reencoded as BinaryJson.

### DIFF
--- a/ydb/core/formats/arrow/accessor/sub_columns/iterators.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/iterators.h
@@ -156,11 +156,31 @@ public:
         return KeyIndex;
     }
 
-    // The ordered iterator (compaction's reader) expects BinaryJson. BinaryJson columns pass their
-    // bytes through directly; native columns are re-encoded into an owned buffer.
-    NBinaryJson::TBinaryJson GetValueAsBinaryJson() {
+    // Re-encode the current value to BinaryJson.
+    NBinaryJson::TBinaryJson GetValueAsBinaryJson() const {
         AFL_VERIFY(IsValidFlag);
         return ArrayElementToBinaryJson(*CurrentArray, LocalIndex, ValueType);
+    }
+
+    EValueType GetValueType() const {
+        return ValueType;
+    }
+    const arrow::Array& GetArray() const {
+        AFL_VERIFY(IsValidFlag);
+        return *CurrentArray;
+    }
+    i64 GetLocalIndex() const {
+        return LocalIndex;
+    }
+    ui32 GetValueSize() const {
+        AFL_VERIFY(IsValidFlag);
+        return ArrayElementSize(*CurrentArray, LocalIndex, ValueType);
+    }
+    TStringBuf GetStorageView() const {
+        AFL_VERIFY(IsValidFlag);
+        AFL_VERIFY(ValueType == EValueType::String || ValueType == EValueType::BinaryJson)("value_type", (ui32)ValueType);
+        const auto view = static_cast<const arrow::BinaryArray&>(*CurrentArray).GetView(LocalIndex);
+        return TStringBuf(view.data(), view.size());
     }
 
     NJson::TJsonValue GetValue() const;
@@ -334,7 +354,7 @@ public:
             while (SortedIterators.size() && SortedIterators.front()->GetRecordIndex() == recordIndex) {
                 std::pop_heap(SortedIterators.begin(), SortedIterators.end(), TIteratorsComparator());
                 auto& itColumn = *SortedIterators.back();
-                kvActor(Addresses[itColumn.GetKeyIndex()].GetOriginalIndex(), itColumn.GetValueAsBinaryJson(), itColumn.IsColumnKey());
+                kvActor(Addresses[itColumn.GetKeyIndex()].GetOriginalIndex(), itColumn, itColumn.IsColumnKey());
                 if (!itColumn.Next()) {
                     SortedIterators.pop_back();
                 } else {

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -139,6 +139,7 @@ ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueTy
         case EValueType::Double:
             return sizeof(double);
         case EValueType::Bool:
+            // actually only 1 bit in arrow representation, not 1 byte, but let's not overcomplicate things
             return 1;
     }
 }

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -131,4 +131,16 @@ NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, con
     }
 }
 
+ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType) {
+    switch (valueType) {
+        case EValueType::BinaryJson:
+        case EValueType::String:
+            return static_cast<const arrow::BinaryArray&>(array).GetView(index).size();
+        case EValueType::Double:
+            return sizeof(double);
+        case EValueType::Bool:
+            return 1;
+    }
+}
+
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.h
@@ -44,4 +44,6 @@ bool ExtractBoolScalar(const NBinaryJson::TBinaryJson& blob);
 NJson::TJsonValue ArrayElementToJsonValue(const arrow::Array& array, const i64 index, const EValueType valueType);
 NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, const i64 index, const EValueType valueType);
 
+ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType);
+
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_native_scalars.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_native_scalars.cpp
@@ -188,23 +188,4 @@ Y_UNIT_TEST_SUITE(SubColumnsNativeScalars) {
         UNIT_ASSERT_VALUES_EQUAL_C(CountValueType(arr, EValueType::String), 1, arr->DebugJson().GetStringRobust());
         UNIT_ASSERT_VALUES_EQUAL(PrintBinaryJsons(arr->GetChunkedArray()), PrintBinaryJsons(BuildSubColumns(docs, OffSettings())->GetChunkedArray()));
     }
-
-    // Current compaction always restores BinaryJson, may be dropped once that is fixed
-    Y_UNIT_TEST(OrderedIteratorNormalizesNativeToBinaryJson) {
-        auto arr = BuildSubColumns({ R"({"s":"x","n":3.5,"b":true})" }, NativeSettings(0));
-        auto it = arr->BuildOrderedIterator();
-        std::vector<TString> jsons;
-        it->ReadRecord(
-            0, [](ui32) {},
-            [&](ui32, const NBinaryJson::TBinaryJson& json, bool) {
-                UNIT_ASSERT_C(NBinaryJson::IsValidBinaryJson(TStringBuf(json.data(), json.size())), "ordered value is not BinaryJson");
-                jsons.push_back(TString(NBinaryJson::SerializeToJson(json)));
-            },
-            []() {});
-        std::sort(jsons.begin(), jsons.end());
-        UNIT_ASSERT_VALUES_EQUAL(jsons.size(), 3u);
-        UNIT_ASSERT_VALUES_EQUAL(jsons[0], "\"x\"");
-        UNIT_ASSERT_VALUES_EQUAL(jsons[1], "3.5");
-        UNIT_ASSERT_VALUES_EQUAL(jsons[2], "true");
-    }
 };

--- a/ydb/core/kqp/ut/olap/types/json_ut.cpp
+++ b/ydb/core/kqp/ut/olap/types/json_ut.cpp
@@ -1588,6 +1588,7 @@ constexpr const char* CreateColumnTableDdl = R"(CREATE TABLE `/Root/ColumnTable`
 
 // STOP_COMPACTION + create the JsonDocument table + pin the SIMPLE scan reader, then turn Col2 into a
 // SUB_COLUMNS column that separates every key (OTHERS_ALLOWED_FRACTION=0) with native scalar storage on.
+// tiling++ compaction to enforce merging of portions.
 TString NativeTableSetup() {
     TStringBuilder script;
     script << R"(
@@ -1595,6 +1596,9 @@ TString NativeTableSetup() {
         ------
         SCHEMA:
         )" << CreateColumnTableDdl << R"(
+        ------
+        SCHEMA:
+        ALTER OBJECT `/Root/ColumnTable` (TYPE TABLE) SET (ACTION=UPSERT_OPTIONS, `COMPACTION_PLANNER.CLASS_NAME`=`tiling++`)
         ------
         SCHEMA:
         ALTER OBJECT `/Root/ColumnTable` (TYPE TABLE) SET (ACTION=UPSERT_OPTIONS, `SCAN_READER_POLICY_NAME`=`SIMPLE`)
@@ -1675,6 +1679,40 @@ Y_UNIT_TEST_SUITE(KqpOlapJsonNativeScalars) {
         READ: SELECT * FROM `/Root/ColumnTable` ORDER BY Col1;
         EXPECTED: [[1u;["{\"b\":true,\"n\":1.5,\"s\":\"x\"}"]];[2u;["{\"b\":false,\"n\":2.5,\"s\":\"yy\"}"]]]
         )";
+        Variator::ToExecutor(Variator::SingleScript(script)).Execute();
+    }
+
+    Y_UNIT_TEST(Compaction) {
+        const TString script = TStringBuilder() << NativeTableSetup() << R"(
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES (1u, JsonDocument('{"n" : 1.5}')), (2u, JsonDocument('{"n" : 2.5}'))
+        ------
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES (3u, JsonDocument('{"n" : 3.5}')), (4u, JsonDocument('{"n" : 1.5}'))
+        ------
+        ONE_COMPACTION
+        ------
+        READ: SELECT * FROM `/Root/ColumnTable` ORDER BY Col1;
+        EXPECTED: [[1u;["{\"n\":1.5}"]];[2u;["{\"n\":2.5}"]];[3u;["{\"n\":3.5}"]];[4u;["{\"n\":1.5}"]]]
+        ------
+        )" << NativeValueTypeCheck(EValueType::Double);
+        Variator::ToExecutor(Variator::SingleScript(script)).Execute();
+    }
+
+    Y_UNIT_TEST(CompactionDivergentTypesFallback) {
+        const TString script = TStringBuilder() << NativeTableSetup() << R"(
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES (1u, JsonDocument('{"n" : 1.5}')), (2u, JsonDocument('{"n" : 2.5}'))
+        ------
+        DATA:
+        REPLACE INTO `/Root/ColumnTable` (Col1, Col2) VALUES (3u, JsonDocument('{"n" : "a"}')), (4u, JsonDocument('{"n" : "b"}'))
+        ------
+        ONE_COMPACTION
+        ------
+        READ: SELECT * FROM `/Root/ColumnTable` ORDER BY Col1;
+        EXPECTED: [[1u;["{\"n\":1.5}"]];[2u;["{\"n\":2.5}"]];[3u;["{\"n\":\"a\"}"]];[4u;["{\"n\":\"b\"}"]]]
+        ------
+        )" << NativeValueTypeCheck(EValueType::BinaryJson);
         Variator::ToExecutor(Variator::SingleScript(script)).Execute();
     }
 }

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
@@ -12,7 +12,10 @@
 namespace NKikimr::NOlap::NCompaction::NSubColumns {
 
 std::shared_ptr<NArrow::NAccessor::IChunkedArray> TMergedBuilder::MaybeDictionaryEncode(
-    const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& accessor, const ui32 filledRecordsCount) const {
+    const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& accessor, const ui32 filledRecordsCount, const EValueType valueType) const {
+    if (!NArrow::NAccessor::NSubColumns::DictionaryApplicableForValueType(valueType)) {
+        return accessor;
+    }
     const auto enumerateNotNull = [&accessor](const auto& consumer) {
         auto chunked = accessor->GetChunkedArray();
         for (int c = 0; c < chunked->num_chunks(); ++c) {
@@ -60,11 +63,11 @@ void TMergedBuilder::FlushData() {
     TDictStats::TBuilder statsBuilder;
     for (ui32 idx = 0; idx < ColumnBuilders.size(); ++idx) {
         if (ColumnBuilders[idx].GetFilledRecordsCount()) {
+            const auto valueType = ResultColumnStats.GetValueType(idx);
             auto accessor = ColumnBuilders[idx].Finish(RecordIndex);
-            accessor = MaybeDictionaryEncode(accessor, ColumnBuilders[idx].GetFilledRecordsCount());
-            // For now compaction reencodes all columns into BinaryJson
+            accessor = MaybeDictionaryEncode(accessor, ColumnBuilders[idx].GetFilledRecordsCount(), valueType);
             statsBuilder.Add(ResultColumnStats.GetColumnName(idx), ColumnBuilders[idx].GetFilledRecordsCount(),
-                ColumnBuilders[idx].GetFilledRecordsSize(), accessor->GetType(), NArrow::NAccessor::NSubColumns::EValueType::BinaryJson);
+                ColumnBuilders[idx].GetFilledRecordsSize(), accessor->GetType(), valueType);
             arrays.emplace_back(std::move(accessor));
         }
     }
@@ -78,12 +81,16 @@ void TMergedBuilder::FlushData() {
 void TMergedBuilder::Initialize() {
     ColumnBuilders.clear();
     for (ui32 i = 0; i < ResultColumnStats.GetColumnsCount(); ++i) {
+        const auto valueType = ResultColumnStats.GetValueType(i);
         switch (ResultColumnStats.GetAccessorType(i)) {
             case NArrow::NAccessor::IChunkedArray::EType::Array:
-                ColumnBuilders.emplace_back(TPlainBuilder(0, 0));
+                ColumnBuilders.emplace_back(
+                    TPlainRuntimeBuilder(NArrow::NAccessor::NSubColumns::GetArrowTypeForValueType(valueType)), valueType);
                 break;
             case NArrow::NAccessor::IChunkedArray::EType::SparsedArray:
-                ColumnBuilders.emplace_back(TSparsedBuilder(nullptr, 0, 0));
+                // Native scalars are never sparsed, so a sparsed column is always binary-backed.
+                AFL_VERIFY(valueType == EValueType::BinaryJson || valueType == EValueType::String)("value_type", (ui32)valueType);
+                ColumnBuilders.emplace_back(TSparsedBuilder(nullptr, 0, 0), valueType);
                 break;
             case NArrow::NAccessor::IChunkedArray::EType::Undefined:
             case NArrow::NAccessor::IChunkedArray::EType::SerializedChunkedArray:

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.h
@@ -95,7 +95,8 @@ private:
         {
         }
 
-        void AddRecord(const ui32 recordIndex, const TGeneralIterator& it) {
+        // Returns the number of value bytes actually stored, since a re-encoded value's stored size differs from its size in the source.
+        ui32 AddRecord(const ui32 recordIndex, const TGeneralIterator& it) {
             const bool passthrough = it.GetValueType() == TargetValueType;
 
             struct TVisitor {
@@ -103,29 +104,34 @@ private:
                 const TGeneralIterator& It;
                 const bool Passthrough;
 
-                void operator()(TSparsedBuilder& builder) const {
+                ui32 operator()(TSparsedBuilder& builder) const {
                     // Sparsed columns are always binary-backed, so the passthrough value is its storage bytes.
                     if (Passthrough) {
                         builder.AddRecord(RecordIndex, It.GetStorageView());
+                        return It.GetValueSize();
                     } else {
                         const auto bj = It.GetValueAsBinaryJson();
                         builder.AddRecord(RecordIndex, TStringBuf(bj.data(), bj.size()));
+                        return bj.size();
                     }
                 }
 
-                void operator()(TPlainRuntimeBuilder& builder) const {
+                ui32 operator()(TPlainRuntimeBuilder& builder) const {
                     if (Passthrough) {
                         builder.AddNativeValue(RecordIndex, It.GetArray(), It.GetLocalIndex());
+                        return It.GetValueSize();
                     } else {
                         const auto bj = It.GetValueAsBinaryJson();
                         builder.AddBinaryValue(RecordIndex, TStringBuf(bj.data(), bj.size()));
+                        return bj.size();
                     }
                 }
             };
 
-            std::visit(TVisitor{ recordIndex, it, passthrough }, Builder);
+            const ui32 storedSize = std::visit(TVisitor{ recordIndex, it, passthrough }, Builder);
             ++FilledRecordsCount;
-            FilledRecordsSize += it.GetValueSize();
+            FilledRecordsSize += storedSize;
+            return storedSize;
         }
 
         std::shared_ptr<NArrow::NAccessor::IChunkedArray> Finish(const ui32 recordsCount) {
@@ -164,15 +170,17 @@ public:
 
     void FinishRecord();
 
-    void AddColumnKV(const ui32 commonKeyIndex, const TGeneralIterator& iter) {
+    ui32 AddColumnKV(const ui32 commonKeyIndex, const TGeneralIterator& iter) {
         AFL_VERIFY(commonKeyIndex < ColumnBuilders.size());
-        ColumnBuilders[commonKeyIndex].AddRecord(RecordIndex, iter);
-        SumValuesSize += iter.GetValueSize();
+        const ui32 storedSize = ColumnBuilders[commonKeyIndex].AddRecord(RecordIndex, iter);
+        SumValuesSize += storedSize;
+        return storedSize;
     }
 
-    void AddOtherKV(const ui32 commonKeyIndex, const std::string_view value) {
+    ui32 AddOtherKV(const ui32 commonKeyIndex, const std::string_view value) {
         OthersBuilder->Add(RecordIndex, commonKeyIndex, value);
         SumValuesSize += value.size();
+        return value.size();
     }
 };
 

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.h
@@ -13,12 +13,13 @@ namespace NKikimr::NOlap::NCompaction::NSubColumns {
 class TMergedBuilder {
 private:
     using TSparsedBuilder = NArrow::NAccessor::TSparsedArray::TSparsedBuilder<arrow::BinaryType>;
-    using TPlainBuilder = NArrow::NAccessor::TTrivialArray::TPlainBuilder<arrow::BinaryType>;
     using TColumnsData = NArrow::NAccessor::NSubColumns::TColumnsData;
     using TOthersData = NArrow::NAccessor::NSubColumns::TOthersData;
     using TSettings = NArrow::NAccessor::NSubColumns::TSettings;
     using TDictStats = NArrow::NAccessor::NSubColumns::TDictStats;
     using TSubColumnsArray = NArrow::NAccessor::TSubColumnsArray;
+    using TGeneralIterator = NArrow::NAccessor::NSubColumns::TGeneralIterator;
+    using EValueType = NArrow::NAccessor::NSubColumns::EValueType;
 
     const TDictStats ResultColumnStats;
     const TChunkMergeContext& Context;
@@ -28,71 +29,109 @@ private:
     const TSettings Settings;
     const TRemapColumns& Remapper;
 
+    // A plain array builder whose element type is chosen at construction type.
+    // Commonality with TPlainBuilder to be refactored.
+    class TPlainRuntimeBuilder {
+    private:
+        std::unique_ptr<arrow::ArrayBuilder> Builder;
+        std::optional<ui32> LastRecordIndex;
+
+        void AppendGapNulls(const ui32 recordIndex) {
+            if (LastRecordIndex) {
+                AFL_VERIFY(*LastRecordIndex < recordIndex)("last", LastRecordIndex)("index", recordIndex);
+                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordIndex - *LastRecordIndex - 1));
+            } else {
+                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordIndex));
+            }
+            LastRecordIndex = recordIndex;
+        }
+
+    public:
+        TPlainRuntimeBuilder(const std::shared_ptr<arrow::DataType>& type)
+            : Builder(NArrow::MakeBuilder(type))
+        {
+        }
+
+        void AddNativeValue(const ui32 recordIndex, const arrow::Array& array, const i64 position) {
+            AFL_VERIFY(Builder->type()->id() == array.type_id())("builder", Builder->type()->ToString())("array", array.type()->ToString());
+            AppendGapNulls(recordIndex);
+            AFL_VERIFY(NArrow::Append(*Builder, array, position));
+        }
+
+        void AddBinaryValue(const ui32 recordIndex, const TStringBuf value) {
+            AFL_VERIFY(Builder->type()->id() == arrow::Type::BINARY)("type", Builder->type()->ToString());
+            AppendGapNulls(recordIndex);
+            AFL_VERIFY(NArrow::Append<arrow::BinaryType>(*Builder, arrow::util::string_view(value.data(), value.size())));
+        }
+
+        std::shared_ptr<NArrow::NAccessor::IChunkedArray> Finish(const ui32 recordsCount) {
+            if (LastRecordIndex) {
+                AFL_VERIFY(*LastRecordIndex < recordsCount)("last", LastRecordIndex)("count", recordsCount);
+                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordsCount - *LastRecordIndex - 1));
+            } else {
+                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordsCount));
+            }
+            return std::make_shared<NArrow::NAccessor::TTrivialArray>(NArrow::FinishBuilder(std::move(Builder)));
+        }
+    };
+
     class TGeneralAccessorBuilder {
     private:
-        std::variant<TSparsedBuilder, TPlainBuilder> Builder;
+        std::variant<TSparsedBuilder, TPlainRuntimeBuilder> Builder;
+        const EValueType TargetValueType;
         YDB_READONLY(ui32, FilledRecordsCount, 0);
         YDB_READONLY(ui64, FilledRecordsSize, 0);
 
     public:
-        TGeneralAccessorBuilder(TSparsedBuilder&& builder)
+        TGeneralAccessorBuilder(TSparsedBuilder&& builder, const EValueType targetValueType)
             : Builder(std::move(builder))
+            , TargetValueType(targetValueType)
         {
         }
 
-        TGeneralAccessorBuilder(TPlainBuilder&& builder)
+        TGeneralAccessorBuilder(TPlainRuntimeBuilder&& builder, const EValueType targetValueType)
             : Builder(std::move(builder))
+            , TargetValueType(targetValueType)
         {
         }
 
-        void AddRecord(const ui32 recordIndex, const std::string_view value) {
+        void AddRecord(const ui32 recordIndex, const TGeneralIterator& it) {
+            const bool passthrough = it.GetValueType() == TargetValueType;
+
             struct TVisitor {
-            private:
                 const ui32 RecordIndex;
-                const std::string_view Value;
+                const TGeneralIterator& It;
+                const bool Passthrough;
 
-            public:
                 void operator()(TSparsedBuilder& builder) const {
-                    builder.AddRecord(RecordIndex, Value);
+                    // Sparsed columns are always binary-backed, so the passthrough value is its storage bytes.
+                    if (Passthrough) {
+                        builder.AddRecord(RecordIndex, It.GetStorageView());
+                    } else {
+                        const auto bj = It.GetValueAsBinaryJson();
+                        builder.AddRecord(RecordIndex, TStringBuf(bj.data(), bj.size()));
+                    }
                 }
 
-                void operator()(TPlainBuilder& builder) const {
-                    builder.AddRecord(RecordIndex, Value);
-                }
-
-                TVisitor(const ui32 recordIndex, const std::string_view value)
-                    : RecordIndex(recordIndex)
-                    , Value(value)
-                {
+                void operator()(TPlainRuntimeBuilder& builder) const {
+                    if (Passthrough) {
+                        builder.AddNativeValue(RecordIndex, It.GetArray(), It.GetLocalIndex());
+                    } else {
+                        const auto bj = It.GetValueAsBinaryJson();
+                        builder.AddBinaryValue(RecordIndex, TStringBuf(bj.data(), bj.size()));
+                    }
                 }
             };
 
-            std::visit(TVisitor(recordIndex, value), Builder);
+            std::visit(TVisitor{ recordIndex, it, passthrough }, Builder);
             ++FilledRecordsCount;
-            FilledRecordsSize += value.size();
+            FilledRecordsSize += it.GetValueSize();
         }
 
         std::shared_ptr<NArrow::NAccessor::IChunkedArray> Finish(const ui32 recordsCount) {
-            struct TVisitor {
-            private:
-                const ui32 RecordsCount;
-
-            public:
-                std::shared_ptr<NArrow::NAccessor::IChunkedArray> operator()(TSparsedBuilder& builder) const {
-                    return builder.Finish(RecordsCount);
-                }
-
-                std::shared_ptr<NArrow::NAccessor::IChunkedArray> operator()(TPlainBuilder& builder) const {
-                    return builder.Finish(RecordsCount);
-                }
-
-                TVisitor(const ui32 recordsCount)
-                    : RecordsCount(recordsCount)
-                {
-                }
-            };
-
-            return std::visit(TVisitor(recordsCount), Builder);
+            return std::visit([recordsCount](auto& builder) {
+                return builder.Finish(recordsCount);
+            }, Builder);
         }
     };
 
@@ -104,7 +143,7 @@ private:
     void Initialize();
 
     std::shared_ptr<NArrow::NAccessor::IChunkedArray> MaybeDictionaryEncode(
-        const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& accessor, const ui32 filledRecordsCount) const;
+        const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& accessor, const ui32 filledRecordsCount, const EValueType valueType) const;
 
 public:
     TMergedBuilder(const NArrow::NAccessor::NSubColumns::TDictStats& columnStats, const TChunkMergeContext& context, const TSettings& settings,
@@ -125,10 +164,10 @@ public:
 
     void FinishRecord();
 
-    void AddColumnKV(const ui32 commonKeyIndex, const std::string_view value) {
+    void AddColumnKV(const ui32 commonKeyIndex, const TGeneralIterator& iter) {
         AFL_VERIFY(commonKeyIndex < ColumnBuilders.size());
-        ColumnBuilders[commonKeyIndex].AddRecord(RecordIndex, value);
-        SumValuesSize += value.size();
+        ColumnBuilders[commonKeyIndex].AddRecord(RecordIndex, iter);
+        SumValuesSize += iter.GetValueSize();
     }
 
     void AddOtherKV(const ui32 commonKeyIndex, const std::string_view value) {

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
@@ -50,15 +50,15 @@ TColumnPortionResult TSubColumnsMerger::DoExecute(const TChunkMergeContext& cont
         const auto startRecord = [&](const ui32 /*sourceRecordIndex*/) {
             builder.StartRecord();
         };
-        const auto addKV = [&](const ui32 sourceKeyIndex, const NBinaryJson::TBinaryJson& value, const bool isColumnKey) {
+        const auto addKV = [&](const ui32 sourceKeyIndex, const NArrow::NAccessor::NSubColumns::TGeneralIterator& iter, const bool isColumnKey) {
             auto commonKeyInfo = RemapKeyIndex.RemapIndex(sourceIdx, sourceKeyIndex, isColumnKey);
-            TStringBuf valueBuf(value.data(), value.size());
             if (commonKeyInfo.GetIsColumnKey()) {
-                builder.AddColumnKV(commonKeyInfo.GetCommonKeyIndex(), valueBuf);
-                columnStats.Add(value.size());
+                builder.AddColumnKV(commonKeyInfo.GetCommonKeyIndex(), iter);
+                columnStats.Add(iter.GetValueSize());
             } else {
-                builder.AddOtherKV(commonKeyInfo.GetCommonKeyIndex(), valueBuf);
-                otherStats.Add(value.size());
+                const auto bj = iter.GetValueAsBinaryJson();
+                builder.AddOtherKV(commonKeyInfo.GetCommonKeyIndex(), TStringBuf(bj.data(), bj.size()));
+                otherStats.Add(bj.size());
             }
         };
         const auto finishRecord = [&]() {

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/logic.cpp
@@ -53,12 +53,10 @@ TColumnPortionResult TSubColumnsMerger::DoExecute(const TChunkMergeContext& cont
         const auto addKV = [&](const ui32 sourceKeyIndex, const NArrow::NAccessor::NSubColumns::TGeneralIterator& iter, const bool isColumnKey) {
             auto commonKeyInfo = RemapKeyIndex.RemapIndex(sourceIdx, sourceKeyIndex, isColumnKey);
             if (commonKeyInfo.GetIsColumnKey()) {
-                builder.AddColumnKV(commonKeyInfo.GetCommonKeyIndex(), iter);
-                columnStats.Add(iter.GetValueSize());
+                columnStats.Add(builder.AddColumnKV(commonKeyInfo.GetCommonKeyIndex(), iter));
             } else {
                 const auto bj = iter.GetValueAsBinaryJson();
-                builder.AddOtherKV(commonKeyInfo.GetCommonKeyIndex(), TStringBuf(bj.data(), bj.size()));
-                otherStats.Add(bj.size());
+                otherStats.Add(builder.AddOtherKV(commonKeyInfo.GetCommonKeyIndex(), TStringBuf(bj.data(), bj.size())));
             }
         };
         const auto finishRecord = [&]() {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

