### PR TITLE
LOG CRIT=>DEBUG

### DIFF
--- a/ydb/core/kqp/workload_service/kqp_workload_service.cpp
+++ b/ydb/core/kqp/workload_service/kqp_workload_service.cpp
@@ -466,7 +466,7 @@ private:
         if (ev->Get()->Success) {
             LOG_D("Cleanup completed, tables exists: " << ev->Get()->TablesExists);
         } else {
-            LOG_C("Failed to cleanup tables, issues: " << ev->Get()->Issues.ToOneLineString());
+            LOG_D("Failed to cleanup tables, issues: " << ev->Get()->Issues.ToOneLineString());
         }
 
         TablesCreationStatus = ETablesCreationStatus::NotStarted;


### PR DESCRIPTION
LOG CRIT=>DEBUG

```
2026-07-12T11:56:40.241313Z node 7 :KQP_WORKLOAD_SERVICE CRIT: kqp_workload_service.cpp:469: [WorkloadService] [Service] Failed to cleanup tables, issues: [ { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry LookupError for table .metadata/workload_manager/delayed_requests } { <main>: Error: Retry limit exceeded for table .metadata/workload_manager/delayed_requests, LookupError } { <main>: Error: Retry limit exceeded for table .metadata/workload_manager/running_requests, LookupError } ]
```