### PR TITLE
LOG CRIT=>DEBUG

### DIFF
--- a/ydb/core/tx/columnshard/columnshard_subdomain_path_id.cpp
+++ b/ydb/core/tx/columnshard/columnshard_subdomain_path_id.cpp
@@ -112,7 +112,7 @@ void TColumnShard::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev
 
 void TColumnShard::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable::TPtr& ev, const TActorContext& ctx) {
     const auto* msg = ev->Get();
-    YDB_LOG_CRIT("",
+    YDB_LOG_DEBUG("",
         {"event", "scheme shard unavailable, will restart to try again"},
         {"pathId", msg->PathId});
     // This event may arrive while the tablet is still in StateInit, with init transactions


### PR DESCRIPTION
LOG CRIT=>DEBUG

```
2026-07-12T11:56:40.244448Z node 2 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.245982Z node 7 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.250071Z node 5 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.250457Z node 6 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.251457Z node 2 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.253666Z node 9 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.259940Z node 6 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.260023Z node 3 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.260847Z node 5 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.261261Z node 2 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.262236Z node 4 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.263729Z node 7 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.264515Z node 4 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.266108Z node 5 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.266145Z node 6 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.266863Z node 5 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.272438Z node 7 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.272475Z node 6 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.273004Z node 6 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.273884Z node 6 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
2026-07-12T11:56:40.274390Z node 5 :TX_COLUMNSHARD CRIT: columnshard_subdomain_path_id.cpp:117:  event=scheme shard unavailable, will restart to try again pathId=[OwnerId: 72075186224037897, LocalPathId: 1]
```