### PR TITLE
wm: full scan predicate

### DIFF
--- a/ydb/core/kqp/workload_service/kqp_has_full_scan_matcher.cpp
+++ b/ydb/core/kqp/workload_service/kqp_has_full_scan_matcher.cpp
@@ -1,0 +1,81 @@
+#include "kqp_has_full_scan_matcher.h"
+
+#include <ydb/core/base/path.h>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+namespace {
+
+// Full-scan detection is purely a "no key filter" check. LIMIT is intentionally
+// ignored: `WHERE filter LIMIT N` with a zero-selectivity filter scans the whole
+// table at runtime, so treating LIMIT as an escape hatch would leak real full
+// scans past the classifier.
+bool IsFullScanTableOp(const NKqpProto::TKqpPhyTableOperation& op) {
+    if (op.HasReadRange()) {
+        // Row-store ReadRange: full scan iff both key bounds are empty.
+        const auto& range = op.GetReadRange().GetKeyRange();
+        return range.GetFrom().ValuesSize() == 0 && range.GetTo().ValuesSize() == 0;
+    }
+    if (op.HasReadRanges()) {
+        // Multi-range ReadRanges: full scan iff KeyRanges param name is empty.
+        return op.GetReadRanges().GetKeyRanges().GetParamName().empty();
+    }
+    if (op.HasReadOlapRange()) {
+        // OLAP ReadRanges: same rule — empty param name means "no key filter".
+        return op.GetReadOlapRange().GetKeyRanges().GetParamName().empty();
+    }
+    return false;
+}
+
+bool IsFullScanSource(const NKqpProto::TKqpReadRangesSource& source) {
+    if (source.HasKeyRange()) {
+        const auto& range = source.GetKeyRange();
+        return range.GetFrom().ValuesSize() == 0 && range.GetTo().ValuesSize() == 0;
+    }
+    if (source.HasRanges()) {
+        return source.GetRanges().GetParamName().empty();
+    }
+    // Neither KeyRange nor Ranges set — no filter, so full scan.
+    return true;
+}
+
+}  // anonymous namespace
+
+
+bool MatchesFullScan(const std::optional<NResourcePool::TRegexPredicate>& predicate,
+                   const NKqpProto::TKqpPhyQuery& phyQuery) {
+    if (!predicate) {
+        return true;
+    }
+
+    for (const auto& tx : phyQuery.GetTransactions()) {
+        for (const auto& stage : tx.GetStages()) {
+            for (const auto& op : stage.GetTableOps()) {
+                if (!predicate->Match(CanonizePath(op.GetTable().GetPath()))) {
+                    continue;
+                }
+                if (IsFullScanTableOp(op)) {
+                    return true;
+                }
+            }
+
+            for (const auto& source : stage.GetSources()) {
+                if (!source.HasReadRangesSource()) {
+                    continue;
+                }
+                const auto& rs = source.GetReadRangesSource();
+                if (!predicate->Match(CanonizePath(rs.GetTable().GetPath()))) {
+                    continue;
+                }
+                if (IsFullScanSource(rs)) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/kqp_has_full_scan_matcher.h
+++ b/ydb/core/kqp/workload_service/kqp_has_full_scan_matcher.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ydb/core/protos/kqp_physical.pb.h>
+#include <ydb/core/resource_pools/regex_predicate.h>
+
+#include <optional>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+///
+/// Returns true if the classifier should accept the query based on the HAS_FULL_SCAN filter.
+///
+/// - When `predicate` is unset, there is no filter — always accepts (returns true).
+/// - Otherwise, returns true iff at least one operation in `phyQuery`
+///   performs a full scan on a table whose path matches `predicate`.
+///
+bool MatchesFullScan(const std::optional<NResourcePool::TRegexPredicate>& predicate,
+                   const NKqpProto::TKqpPhyQuery& phyQuery);
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
+++ b/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
@@ -1,3 +1,4 @@
+#include "kqp_has_full_scan_matcher.h"
 #include "kqp_query_classifier.h"
 #include "kqp_workload_service.h"
 
@@ -47,7 +48,8 @@ public:
             }
 
             if (NeedsPreparedQuery(settings)) {
-                return *PreClassifyResult = TPendingCompilation{.ResumeRank = rank};
+                PreClassifyResult = TPendingCompilation{.ResumeRank = rank};
+                return *PreClassifyResult;
             }
 
             if (settings.Action == NResourcePool::EClassifierAction::Reject) {
@@ -175,8 +177,8 @@ private:
         return true;
     }
 
-    bool NeedsPreparedQuery(const NResourcePool::TClassifierSettings&) const {
-        return false;
+    bool NeedsPreparedQuery(const NResourcePool::TClassifierSettings& settings) const {
+        return settings.HasFullScan.has_value();
     }
 
     ///
@@ -185,10 +187,8 @@ private:
     /// - Involves SQL analysis, plan building, or computations.
     /// - Depends on actual query structure and execution characteristics.
     ///
-    /// Currently returns true (no dynamic filtering applied).
-    ///
-    bool MatchesDynamic(const NResourcePool::TClassifierSettings&, const TPreparedQueryHolder&) const {
-        return true;
+    bool MatchesDynamic(const NResourcePool::TClassifierSettings& settings, const TPreparedQueryHolder& preparedQuery) const {
+        return MatchesFullScan(settings.HasFullScan, preparedQuery.GetPhysicalQuery());
     }
 
     const TResourcePoolEntry* FindPool(const TString& poolId) const {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h
@@ -22,6 +22,7 @@ inline TResourcePoolClassifierConfig MakeClassifierConfig(
     const TString& resourcePool,
     std::optional<TString> memberName = std::nullopt,
     std::optional<TString> hasAppName = std::nullopt,
+    std::optional<TString> hasFullScan = std::nullopt,
     std::optional<TString> action = std::nullopt)
 {
     NJson::TJsonValue json(NJson::JSON_MAP);
@@ -31,6 +32,9 @@ inline TResourcePoolClassifierConfig MakeClassifierConfig(
     }
     if (hasAppName) {
         json["has_app_name"] = *hasAppName;
+    }
+    if (hasFullScan) {
+        json["has_full_scan"] = *hasFullScan;
     }
     if (action) {
         json["action"] = *action;
@@ -83,6 +87,7 @@ struct TClassifyTestCase {
     i64 Rank = 100;
     std::optional<TString> ClassifierMemberName;
     std::optional<TString> ClassifierHasAppName;
+    std::optional<TString> ClassifierHasFullScan;
     std::optional<TString> ClassifierAction;
 
     TString ContextAppName;
@@ -97,6 +102,7 @@ struct TClassifyTestCase {
         TString ResourcePool;
         std::optional<TString> MemberName;
         std::optional<TString> HasAppName;
+        std::optional<TString> HasFullScan;
         std::optional<TString> Action;
     };
     std::vector<TExtraClassifier> ExtraClassifiers;
@@ -105,12 +111,12 @@ struct TClassifyTestCase {
         std::vector<TResourcePoolClassifierConfig> configs;
         configs.push_back(MakeClassifierConfig(
             TEST_DB, "c_main", Rank, ResourcePool,
-            ClassifierMemberName, ClassifierHasAppName, ClassifierAction));
+            ClassifierMemberName, ClassifierHasAppName, ClassifierHasFullScan, ClassifierAction));
 
         for (const auto& extra : ExtraClassifiers) {
             configs.push_back(MakeClassifierConfig(
                 TEST_DB, extra.Name, extra.Rank, extra.ResourcePool,
-                extra.MemberName, extra.HasAppName, extra.Action));
+                extra.MemberName, extra.HasAppName, extra.HasFullScan, extra.Action));
         }
 
         auto classifierSnap = MakeClassifierSnapshot(std::move(configs));
@@ -144,6 +150,34 @@ struct TClassifyTestCase {
     NWorkload::IQueryClassifier::TPreCompileClassifyResult RunPreClassify() const {
         auto classifier = BuildClassifier();
         return classifier->PreCompileClassify();
+    }
+
+    ///
+    /// Runs the full pre-compile + post-compile classification against a synthetic
+    /// TKqpPhyQuery holding one table op on `queryTablePath` that either performs
+    /// a full scan (`isFullScan=true`) or a bounded read.
+    ///
+    NWorkload::IQueryClassifier::TPostCompileClassifyResult RunPostClassify(
+        const TString& queryTablePath, bool isFullScan) const
+    {
+        auto classifier = BuildClassifier();
+        (void)classifier->PreCompileClassify();
+
+        auto proto = std::make_unique<NKikimrKqp::TPreparedQuery>();
+        auto* phyQuery = proto->MutablePhysicalQuery();
+        auto* tx = phyQuery->AddTransactions();
+        auto* stage = tx->AddStages();
+        auto* op = stage->AddTableOps();
+        op->MutableTable()->SetPath(queryTablePath);
+
+        if (isFullScan) {
+            op->MutableReadRange()->MutableKeyRange();
+        } else {
+            op->MutableReadRange()->MutableKeyRange()->MutableFrom()->AddValues();
+        }
+
+        TPreparedQueryHolder holder(proto.release(), nullptr, /*noFillTables=*/true);
+        return classifier->PostCompileClassify(holder);
     }
 };
 

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.cpp
@@ -884,22 +884,30 @@ void IYdbSetup::WaitFor(TDuration timeout, TString description, std::function<bo
 
 //// Classifier helpers
 
-void WaitForClassifierFail(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings, const TString& poolId) {
-    ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier fail", [ydb, settings, poolId](TString& errorString) {
-        auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+void WaitForClassifierFail(TIntrusivePtr<IYdbSetup> ydb, const TString& query, const TQueryRunnerSettings& settings, const TString& poolId) {
+    ydb->WaitFor(TDuration::Seconds(10), "Resource pool classifier fail", [ydb, query, settings, poolId](TString& errorString) {
+        auto result = ydb->ExecuteQuery(query, settings);
 
         errorString = result.GetIssues().ToOneLineString();
         return result.GetStatus() == NYdb::EStatus::PRECONDITION_FAILED && errorString.Contains(TStringBuilder() << "Resource pool " << poolId << " was disabled due to zero concurrent query limit");
     });
 }
 
-void WaitForClassifierSuccess(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings) {
-    ydb->WaitFor(TDuration::Seconds(30), "Resource pool classifier success", [ydb, settings](TString& errorString) {
-        auto result = ydb->ExecuteQuery(TSampleQueries::TSelect42::Query, settings);
+void WaitForClassifierFail(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings, const TString& poolId) {
+    WaitForClassifierFail(ydb, TSampleQueries::TSelect42::Query, settings, poolId);
+}
+
+void WaitForClassifierSuccess(TIntrusivePtr<IYdbSetup> ydb, const TString& query, const TQueryRunnerSettings& settings) {
+    ydb->WaitFor(TDuration::Seconds(30), "Resource pool classifier success", [ydb, query, settings](TString& errorString) {
+        auto result = ydb->ExecuteQuery(query, settings);
 
         errorString = result.GetIssues().ToOneLineString();
         return result.GetStatus() == NYdb::EStatus::SUCCESS;
     });
+}
+
+void WaitForClassifierSuccess(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings) {
+    WaitForClassifierSuccess(ydb, TSampleQueries::TSelect42::Query, settings);
 }
 
 //// TSampleQueriess

--- a/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h
@@ -161,7 +161,9 @@ public:
 // Common classifier helpers
 
 void WaitForClassifierFail(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings, const TString& poolId);
+void WaitForClassifierFail(TIntrusivePtr<IYdbSetup> ydb, const TString& query, const TQueryRunnerSettings& settings, const TString& poolId);
 void WaitForClassifierSuccess(TIntrusivePtr<IYdbSetup> ydb, const TQueryRunnerSettings& settings);
+void WaitForClassifierSuccess(TIntrusivePtr<IYdbSetup> ydb, const TString& query, const TQueryRunnerSettings& settings);
 
 // Test queries
 

--- a/ydb/core/kqp/workload_service/ut/kqp_has_full_scan_matcher_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_has_full_scan_matcher_ut.cpp
@@ -1,0 +1,164 @@
+#include <ydb/core/kqp/workload_service/kqp_has_full_scan_matcher.h>
+#include <ydb/core/resource_pools/regex_predicate.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr::NKqp {
+
+using NResourcePool::TRegexPredicate;
+using NKqpProto::TKqpPhyQuery;
+using NKqpProto::TKqpPhyTableOperation;
+using NKqpProto::TKqpReadRangesSource;
+
+
+namespace {
+
+TKqpPhyTableOperation* AddOp(TKqpPhyQuery& phy, const TString& path) {
+    auto* tx = phy.TransactionsSize() ? phy.MutableTransactions(0) : phy.AddTransactions();
+    auto* stage = tx->StagesSize() ? tx->MutableStages(0) : tx->AddStages();
+    auto* op = stage->AddTableOps();
+    op->MutableTable()->SetPath(path);
+    return op;
+}
+
+TKqpReadRangesSource* AddSource(TKqpPhyQuery& phy, const TString& path) {
+    auto* tx = phy.TransactionsSize() ? phy.MutableTransactions(0) : phy.AddTransactions();
+    auto* stage = tx->StagesSize() ? tx->MutableStages(0) : tx->AddStages();
+    auto* source = stage->AddSources();
+    auto* rs = source->MutableReadRangesSource();
+    rs->MutableTable()->SetPath(path);
+    return rs;
+}
+
+// Build a phyQuery on /Root/t via `builder` (AddOp or AddSource), let `configure`
+// tweak the resulting op/source, and return the matcher verdict against /Root/t.
+const auto Matches = [](auto builder, auto configure) {
+    TKqpPhyQuery phy;
+    configure(builder(phy, TString("/Root/t")));
+    return NWorkload::MatchesFullScan(TRegexPredicate::Compile("/Root/t"), phy);
+};
+
+const auto AssertHasFullScan       = [](auto c) { UNIT_ASSERT( Matches(AddOp,     c)); };
+const auto AssertNoFullScan        = [](auto c) { UNIT_ASSERT(!Matches(AddOp,     c)); };
+const auto AssertHasFullScanSource = [](auto c) { UNIT_ASSERT( Matches(AddSource, c)); };
+const auto AssertNoFullScanSource  = [](auto c) { UNIT_ASSERT(!Matches(AddSource, c)); };
+
+}  // anonymous namespace
+
+
+Y_UNIT_TEST_SUITE(TFullScanMatcherPredicate) {
+
+    Y_UNIT_TEST(EmptyPredicateAcceptsAny) {
+        TKqpPhyQuery phy;
+        UNIT_ASSERT(NWorkload::MatchesFullScan(std::nullopt, phy));
+    }
+
+    Y_UNIT_TEST(NonMatchingPathIsIgnored) {
+        auto pred = TRegexPredicate::Compile("/Root/critical");
+        TKqpPhyQuery phy;
+        AddOp(phy, "/Root/other")->MutableReadRange()->MutableKeyRange();
+        UNIT_ASSERT(!NWorkload::MatchesFullScan(pred, phy));
+    }
+
+    Y_UNIT_TEST(RegexPatternMatches) {
+        auto pred = TRegexPredicate::Compile("/Root/db/orders_archive.*");
+        TKqpPhyQuery phy;
+        AddOp(phy, "/Root/db/orders_archive_2024")->MutableReadRange()->MutableKeyRange();
+        UNIT_ASSERT(NWorkload::MatchesFullScan(pred, phy));
+    }
+
+    Y_UNIT_TEST(MixedOpsReturnTrueOnAnyMatch) {
+        auto pred = TRegexPredicate::Compile("/Root/t");
+        TKqpPhyQuery phy;
+        AddOp(phy, "/Root/other")->MutableReadRange()->MutableKeyRange();
+        AddOp(phy, "/Root/t")->MutableReadRange()->MutableKeyRange();
+        UNIT_ASSERT(NWorkload::MatchesFullScan(pred, phy));
+    }
+}
+
+Y_UNIT_TEST_SUITE(TFullScanMatcherOps) {
+
+    Y_UNIT_TEST(ReadRangeEmptyBoundsIsFullScan) {
+        AssertHasFullScan([](auto* op) { op->MutableReadRange()->MutableKeyRange(); });
+    }
+
+    Y_UNIT_TEST(ReadRangeWithBoundsIsNotFullScan) {
+        AssertNoFullScan([](auto* op) {
+            op->MutableReadRange()->MutableKeyRange()->MutableFrom()->AddValues();
+        });
+    }
+
+    Y_UNIT_TEST(ReadRangesEmptyParamNameIsFullScan) {
+        // ParamName defaults to "" — matches the documented "full scan" convention.
+        AssertHasFullScan([](auto* op) { op->MutableReadRanges()->MutableKeyRanges(); });
+    }
+
+    Y_UNIT_TEST(ReadRangesWithParamNameIsNotFullScan) {
+        AssertNoFullScan([](auto* op) {
+            op->MutableReadRanges()->MutableKeyRanges()->SetParamName("keys");
+        });
+    }
+
+    Y_UNIT_TEST(ReadOlapRangeEmptyParamNameIsFullScan) {
+        AssertHasFullScan([](auto* op) { op->MutableReadOlapRange()->MutableKeyRanges(); });
+    }
+}
+
+Y_UNIT_TEST_SUITE(TFullScanMatcherSources) {
+
+    Y_UNIT_TEST(SourceEmptyKeyRangeIsFullScan) {
+        AssertHasFullScanSource([](auto* rs) { rs->MutableKeyRange(); });
+    }
+
+    Y_UNIT_TEST(SourceBoundedKeyRangeIsNotFullScan) {
+        AssertNoFullScanSource([](auto* rs) {
+            rs->MutableKeyRange()->MutableFrom()->AddValues();
+        });
+    }
+
+    Y_UNIT_TEST(SourceRangesEmptyParamNameIsFullScan) {
+        AssertHasFullScanSource([](auto* rs) { rs->MutableRanges(); });
+    }
+
+    Y_UNIT_TEST(SourceRangesWithParamNameIsNotFullScan) {
+        AssertNoFullScanSource([](auto* rs) { rs->MutableRanges()->SetParamName("keys"); });
+    }
+
+    Y_UNIT_TEST(SourceWithoutRangesOrKeyRangeIsFullScan) {
+        // neither KeyRange nor Ranges set
+        AssertHasFullScanSource([](auto*) {});
+    }
+}
+
+// LIMIT is intentionally ignored: a `WHERE filter LIMIT N` with a zero-selectivity
+// filter scans the whole table at runtime, so we do not let LIMIT bypass the classifier.
+Y_UNIT_TEST_SUITE(TFullScanMatcherLimit) {
+
+    Y_UNIT_TEST(ReadRangeWithLimitIsFullScan) {
+        AssertHasFullScan([](auto* op) {
+            op->MutableReadRange()->MutableKeyRange();
+            op->MutableReadRange()->MutableItemsLimit();
+        });
+    }
+
+    Y_UNIT_TEST(ReadRangesWithLimitIsFullScan) {
+        AssertHasFullScan([](auto* op) {
+            op->MutableReadRanges()->MutableKeyRanges();
+            op->MutableReadRanges()->MutableItemsLimit();
+        });
+    }
+
+    Y_UNIT_TEST(ReadOlapRangeWithLimitIsFullScan) {
+        AssertHasFullScan([](auto* op) {
+            op->MutableReadOlapRange()->MutableKeyRanges();
+            op->MutableReadOlapRange()->MutableItemsLimit();
+        });
+    }
+
+    Y_UNIT_TEST(SourceWithLimitIsFullScan) {
+        AssertHasFullScanSource([](auto* rs) { rs->MutableItemsLimit(); });
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_has_full_scan_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_has_full_scan_ut.cpp
@@ -1,0 +1,272 @@
+#include <ydb/core/base/path.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr::NKqp {
+
+using namespace NWorkload;
+using namespace NYdb;
+
+
+namespace {
+
+TString GetPostPoolId(const IQueryClassifier::TPostCompileClassifyResult& result) {
+    UNIT_ASSERT_C(std::holds_alternative<IQueryClassifier::TResolvedPoolId>(result),
+        TStringBuilder() << "Expected TResolvedPoolId, got variant index " << result.index());
+    return std::get<IQueryClassifier::TResolvedPoolId>(result).PoolId;
+}
+
+}  // anonymous namespace
+
+
+Y_UNIT_TEST_SUITE(TQueryClassifierHasFullScan) {
+
+    Y_UNIT_TEST(ShouldTriggerPendingCompilation) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasFullScan = "/Root/testdb/my_table";
+        auto result = tc.RunPreClassify();
+        UNIT_ASSERT_C(std::holds_alternative<IQueryClassifier::TPendingCompilation>(result),
+            TStringBuilder() << "Expected TPendingCompilation, got variant index " << result.index());
+    }
+
+    Y_UNIT_TEST(ShouldMatchFullScan) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasFullScan = "/Root/testdb/my_table";
+        auto result = tc.RunPostClassify("/Root/testdb/my_table", /*isFullScan=*/true);
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "pool_target");
+    }
+
+    Y_UNIT_TEST(ShouldNotMatchPartialScan) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasFullScan = "/Root/testdb/my_table";
+        auto result = tc.RunPostClassify("/Root/testdb/my_table", /*isFullScan=*/false);
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "default");
+    }
+
+    Y_UNIT_TEST(ShouldNotMatchFullScanOnDifferentTable) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasFullScan = "/Root/testdb/my_table";
+        auto result = tc.RunPostClassify("/Root/testdb/other_table", /*isFullScan=*/true);
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "default");
+    }
+
+    Y_UNIT_TEST(ShouldMatchRegexPattern) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasFullScan = "/Root/testdb/orders_.*";
+        auto result = tc.RunPostClassify("/Root/testdb/orders_2024", /*isFullScan=*/true);
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "pool_target");
+    }
+}
+
+namespace {
+
+// Creates `orders(Id, Status)` with a global secondary index on Status,
+// grants the given user full access, and inserts a couple of rows so the planner
+// doesn't take an empty-table shortcut.
+void SetupOrdersWithIndex(TIntrusivePtr<NWorkload::IYdbSetup> ydb, const TString& userSID) {
+    ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+        GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+        CREATE TABLE orders (
+            Id Uint64 NOT NULL,
+            Status Utf8,
+            PRIMARY KEY (Id),
+            INDEX by_status GLOBAL ON (Status)
+        );
+    )");
+
+    auto insertSettings = NWorkload::TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+    auto insertResult = ydb->ExecuteQuery(R"(
+        UPSERT INTO orders (Id, Status) VALUES
+            (1u, "a"),
+            (2u, "b");
+    )", insertSettings);
+    UNIT_ASSERT_VALUES_EQUAL_C(insertResult.GetStatus(), NYdb::EStatus::SUCCESS,
+        insertResult.GetIssues().ToOneLineString());
+}
+
+// Creates a column-store (OLAP) table `olap_events(Id, Payload)` with a HAS_FULL_SCAN
+// classifier targeting it, and inserts a couple of rows. The classifier's target pool
+// has CONCURRENT_QUERY_LIMIT=0 so any match rejects with PRECONDITION_FAILED.
+void SetupOlapEventsAndClassifier(
+    TIntrusivePtr<NWorkload::IYdbSetup> ydb, const TString& userSID, const TString& poolId)
+{
+    ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+        GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+        CREATE TABLE olap_events (
+            Id Uint64 NOT NULL,
+            Payload Utf8,
+            PRIMARY KEY (Id)
+        ) WITH (
+            STORE = COLUMN
+        );
+        CREATE RESOURCE POOL )" << poolId << R"( WITH (
+            CONCURRENT_QUERY_LIMIT=0
+        );
+        CREATE RESOURCE POOL CLASSIFIER olap_classifier WITH (
+            RESOURCE_POOL=")" << poolId << R"(",
+            HAS_FULL_SCAN="/Root/olap_events"
+        );
+    )");
+
+    auto insertSettings = NWorkload::TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+    auto insertResult = ydb->ExecuteQuery(R"(
+        UPSERT INTO olap_events (Id, Payload) VALUES (1u, "a"), (2u, "b");
+    )", insertSettings);
+    UNIT_ASSERT_VALUES_EQUAL_C(insertResult.GetStatus(), NYdb::EStatus::SUCCESS,
+        insertResult.GetIssues().ToOneLineString());
+}
+
+}  // anonymous namespace
+
+
+Y_UNIT_TEST_SUITE(HasFullScanSecondaryIndexOltpDdl) {
+
+    // Covering read on the secondary index: reads impl table only (Status is the indexed column),
+    // main table is not accessed. A classifier targeting only `/Root/orders` (not the impl path)
+    // must NOT fire — the impl full scan happens on a path outside the classifier's regex.
+    Y_UNIT_TEST(TestClassifierOnMainTableIgnoresIndexScan) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOrdersWithIndex(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL )" << poolId << R"( WITH (
+                CONCURRENT_QUERY_LIMIT=0
+            );
+            CREATE RESOURCE POOL CLASSIFIER main_only WITH (
+                RESOURCE_POOL=")" << poolId << R"(",
+                HAS_FULL_SCAN="/Root/orders"
+            );
+        )");
+
+        const TString query = "SELECT * FROM orders VIEW by_status;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierSuccess(ydb, query, settings);
+    }
+
+    // Same query, but the classifier targets the index impl table path directly.
+    // The impl full scan matches — classifier must fire and reject the query.
+    //
+    // Covering scan: reading only `Status` (an indexed column) forces the planner to
+    // scan the impl table without falling back to the main table.
+    // `SELECT * FROM orders VIEW by_status` (no predicate) would trigger the planner
+    // warning "Given predicate is not suitable for used index" and fall back to a main-table scan.
+    Y_UNIT_TEST(TestClassifierOnIndexImplTableDetectsFullScan) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOrdersWithIndex(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL )" << poolId << R"( WITH (
+                CONCURRENT_QUERY_LIMIT=0
+            );
+            CREATE RESOURCE POOL CLASSIFIER impl_only WITH (
+                RESOURCE_POOL=")" << poolId << R"(",
+                HAS_FULL_SCAN="/Root/orders/by_status/indexImplTable"
+            );
+        )");
+
+        const TString query = "SELECT * FROM orders VIEW by_status;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+}
+
+Y_UNIT_TEST_SUITE(HasFullScanIgnoresLimitDdl) {
+
+    // LIMIT does not bypass full-scan detection. `SELECT * FROM orders LIMIT 1` still has an
+    // unbounded ReadRange on /Root/orders — the classifier fires and rejects into the target pool.
+    Y_UNIT_TEST(TestLimitDoesNotBypassClassifier) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOrdersWithIndex(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+            CREATE RESOURCE POOL )" << poolId << R"( WITH (
+                CONCURRENT_QUERY_LIMIT=0
+            );
+            CREATE RESOURCE POOL CLASSIFIER main_only WITH (
+                RESOURCE_POOL=")" << poolId << R"(",
+                HAS_FULL_SCAN="/Root/orders"
+            );
+        )");
+
+        const TString query = "SELECT * FROM orders LIMIT 1;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    // Same LIMIT semantic applied to OLAP: `ReadOlapRange` with an unbounded param name and
+    // HasItemsLimit() set still counts as a full scan.
+    Y_UNIT_TEST(TestLimitDoesNotBypassClassifierOnOlapTable) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOlapEventsAndClassifier(ydb, userSID, poolId);
+
+        const TString query = "SELECT * FROM olap_events LIMIT 1;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    // Zero-selectivity filter behind a LIMIT: at runtime the executor scans the whole table
+    // looking for a non-existent value. The residual predicate lives in `OlapProgram` (opaque
+    // to the matcher) while `KeyRanges.ParamName` stays empty and `HasItemsLimit()` is set —
+    // exactly the runtime full-scan the LIMIT rule used to miss. OLAP is used because there is
+    // no secondary index to route the filter through, so the plan shape is unambiguous.
+    Y_UNIT_TEST(TestFilterWithLimitDoesNotBypassClassifierOnOlapTable) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOlapEventsAndClassifier(ydb, userSID, poolId);
+
+        const TString query = "SELECT * FROM olap_events WHERE Payload = 'nonexistent' LIMIT 1;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+}
+
+Y_UNIT_TEST_SUITE(HasFullScanOlapDdl) {
+
+    // Column-store (OLAP) tables emit `TKqpPhyOpReadOlapRanges` (TableOps branch) instead of
+    // row-store's `ReadRange`/`ReadRangesSource`. This test proves the matcher's OLAP branch
+    // is invoked end-to-end by the real planner, complementing the ReadOlapRange matcher UT.
+    Y_UNIT_TEST(TestClassifierDetectsFullScanOnOlapTable) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOlapEventsAndClassifier(ydb, userSID, poolId);
+
+        const TString query = "SELECT * FROM olap_events;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    // PK point lookup on OLAP compiles to a parametrized ReadOlapRange with a non-empty
+    // KeyRanges.ParamName. Matcher must not flag it — proves the OLAP negative branch e2e.
+    Y_UNIT_TEST(TestClassifierIgnoresPkPointLookupOnOlapTable) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOlapEventsAndClassifier(ydb, userSID, poolId);
+
+        const TString query = "SELECT * FROM olap_events WHERE Id = 1u;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierSuccess(ydb, query, settings);
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/ya.make
+++ b/ydb/core/kqp/workload_service/ut/ya.make
@@ -12,6 +12,8 @@ ENDIF()
 SRCS(
     kqp_action_reject_ut.cpp
     kqp_has_app_name_ut.cpp
+    kqp_has_full_scan_matcher_ut.cpp
+    kqp_has_full_scan_ut.cpp
     kqp_member_name_ut.cpp
     kqp_query_classifier_match_ut.cpp
     kqp_query_classifier_ut.cpp

--- a/ydb/core/kqp/workload_service/ya.make
+++ b/ydb/core/kqp/workload_service/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    kqp_has_full_scan_matcher.cpp
     kqp_query_classifier.cpp
     kqp_workload_service.cpp
 )

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
@@ -82,6 +82,7 @@ std::unordered_map<TString, TClassifierSettings::TProperty> TClassifierSettings:
         {"resource_pool", &ResourcePool},
         {"member_name", &MemberName},
         {"has_app_name", &HasAppName},
+        {"has_full_scan", &HasFullScan},
         {"action", &Action}
     };
     return properties;

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.h
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.h
@@ -44,6 +44,7 @@ struct TClassifierSettings : public TSettingsBase {
     TString ResourcePool = DEFAULT_POOL_ID;
     std::optional<TString> MemberName;
     std::optional<TRegexPredicate> HasAppName;
+    std::optional<TRegexPredicate> HasFullScan;
     std::optional<EClassifierAction> Action;
 };
 

--- a/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
@@ -44,6 +44,10 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         std::visit(TClassifierSettings::TParser{"ydb-ui|ydb-cli"}, propertiesMap["has_app_name"]);
         UNIT_ASSERT(settings.HasAppName.has_value());
         UNIT_ASSERT_VALUES_EQUAL(settings.HasAppName->Pattern, "ydb-ui|ydb-cli");
+
+        std::visit(TClassifierSettings::TParser{"/Root/db/orders_.*"}, propertiesMap["has_full_scan"]);
+        UNIT_ASSERT(settings.HasFullScan.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(settings.HasFullScan->Pattern, "/Root/db/orders_.*");
     }
 
     Y_UNIT_TEST(RegexPredicateInvalidPattern) {
@@ -51,6 +55,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         auto propertiesMap = settings.GetPropertiesMap();
 
         UNIT_ASSERT_EXCEPTION(std::visit(TClassifierSettings::TParser{"[invalid"}, propertiesMap["has_app_name"]), yexception);
+        UNIT_ASSERT_EXCEPTION(std::visit(TClassifierSettings::TParser{"[invalid"}, propertiesMap["has_full_scan"]), yexception);
     }
 
     Y_UNIT_TEST(SettingsExtracting) {
@@ -72,9 +77,11 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
 
         // Parse then extract — must round-trip the original pattern
         std::visit(TClassifierSettings::TParser{"ydb-.*"}, propertiesMap["has_app_name"]);
+        std::visit(TClassifierSettings::TParser{"/Root/db/orders_.*"}, propertiesMap["has_full_scan"]);
 
         TClassifierSettings::TExtractor extractor;
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_app_name"]), "ydb-.*");
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_full_scan"]), "/Root/db/orders_.*");
     }
 
     Y_UNIT_TEST(RegexPredicateExtractingEmpty) {
@@ -84,6 +91,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         // Not set — should extract as empty string
         TClassifierSettings::TExtractor extractor;
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_app_name"]), "");
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_full_scan"]), "");
     }
 
     Y_UNIT_TEST(ActionParsing) {

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -777,6 +777,7 @@ struct Schema : NIceDb::Schema {
         struct ResourcePool : Column<5, NScheme::NTypeIds::Utf8> {};
         struct HasAppName   : Column<6, NScheme::NTypeIds::Utf8> {};
         struct Action       : Column<7, NScheme::NTypeIds::Utf8> {};
+        struct HasFullScan  : Column<8, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<Name>;
         using TColumns = TableColumns<
@@ -785,7 +786,8 @@ struct Schema : NIceDb::Schema {
             MemberName,
             ResourcePool,
             HasAppName,
-            Action>;
+            Action,
+            HasFullScan>;
     };
 
     struct ShowCreate : Table<21> {

--- a/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
+++ b/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
@@ -107,6 +107,10 @@ private:
                     const auto& action = config.GetConfigJson()["action"].GetString();
                     return TCell(action.data(), action.size());
                 }});
+                insert({TSchema::HasFullScan::ColumnId, [] (const NKqp::TResourcePoolClassifierConfig& config) {
+                    const auto& hasFullScan = config.GetConfigJson()["has_full_scan"].GetString();
+                    return TCell(hasFullScan.data(), hasFullScan.size());
+                }});
             }
         };
         static TExtractorsMap extractors;

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -1019,6 +1019,10 @@
       {
         "name": "HasAppName",
         "type": "Utf8?"
+      },
+      {
+        "name": "HasFullScan",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -1001,6 +1001,10 @@
         "type": "Utf8?"
       },
       {
+        "name": "HasFullScan",
+        "type": "Utf8?"
+      },
+      {
         "name": "Name",
         "type": "Utf8?"
       },
@@ -1018,10 +1022,6 @@
       },
       {
         "name": "HasAppName",
-        "type": "Utf8?"
-      },
-      {
-        "name": "HasFullScan",
         "type": "Utf8?"
       }
     ],

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -577,6 +577,10 @@
         "type": "Utf8?"
       },
       {
+        "name": "HasFullScan",
+        "type": "Utf8?"
+      },
+      {
         "name": "Name",
         "type": "Utf8?"
       },
@@ -594,10 +598,6 @@
       },
       {
         "name": "HasAppName",
-        "type": "Utf8?"
-      },
-      {
-        "name": "HasFullScan",
         "type": "Utf8?"
       }
     ],

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -595,6 +595,10 @@
       {
         "name": "HasAppName",
         "type": "Utf8?"
+      },
+      {
+        "name": "HasFullScan",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [


### PR DESCRIPTION
### Changelog entry

Add `HAS_FULL_SCAN` regex predicate on workload manager resource pool classifiers to match queries whose plan reads a matching table with no key filter

### Changelog category

* New feature

### Description for reviewers

Summary:
- Introduce `HasFullScan` (`std::optional<TRegexPredicate>`) on `TClassifierSettings` and expose it as `HAS_FULL_SCAN` in the classifier DDL.
- New matcher `MatchesFullScan(predicate, phyQuery)`. Fires iff at least one read op targets a table whose path matches the regex **and** has no key filter (empty bounds / empty `ParamName`).
- `LIMIT` is deliberately not consulted — `SELECT * FROM t LIMIT N` still classifies as a full scan when the underlying read is unbounded.
- Dynamic wiring: `NeedsPreparedQuery` returns true when `HasFullScan` is set.
- Path canonicalization: `CanonizePath` is applied to every plan-side path before regex match (phy paths may omit the leading `/`).
- Sysview: new `HasFullScan` column (id 7) on `resource_pool_classifiers`, plumbed through the extractor and reflected in root/tenant canondata.

Tests:
- Matcher UT split into 4 suites: `TFullScanMatcherPredicate`, `TFullScanMatcherOps`, `TFullScanMatcherSources` , `TFullScanMatcherLimit` (pins that `HasItemsLimit()` does not bypass detection).
- Classifier IT : `TQueryClassifierHasFullScan`; DDL suites `HasFullScanSecondaryIndexOltpDdl`, `HasFullScanIgnoresLimitDdl`, `HasFullScanOlapDdl`.
- Settings UT: parse/extract round-trip for `has_full_scan`.

Examples:

```sql
-- Reject unbounded scans on a specific table
CREATE RESOURCE POOL CLASSIFIER reject_orders_scan WITH (
    RANK=100,
    RESOURCE_POOL="reject",
    HAS_FULL_SCAN='/Root/db/orders'
);

-- Route full scans on any archive table to an isolated pool
CREATE RESOURCE POOL CLASSIFIER archive_scans WITH (
    RANK=200,
    RESOURCE_POOL="pool_archive",
    HAS_FULL_SCAN='/Root/db/orders_archive.*'
);
```