### PR TITLE
Add build info to crash/VERIFY backtrace output

### DIFF
--- a/ydb/core/base/backtrace.cpp
+++ b/ydb/core/base/backtrace.cpp
@@ -1,5 +1,8 @@
 #include "backtrace.h"
 
+#include <library/cpp/svnversion/svnversion.h>
+
+#include <util/stream/output.h>
 #include <util/system/backtrace.h>
 
 #if defined(__linux__) || defined(__APPLE__)
@@ -8,6 +11,23 @@
 #endif
 
 namespace NKikimr {
+
+namespace {
+
+void WriteBuildInfo(IOutputStream* out) {
+    const char* commit = GetProgramCommitId();
+    const char* dirty = GetVCSDirty();
+    const char* release = GetReleaseVersion();
+
+    *out << "build: commit " << (commit && *commit ? commit : "unknown")
+         << (dirty && *dirty ? " (dirty)" : " (clean)");
+    if (release && *release) {
+        *out << ", release " << release;
+    }
+    *out << Endl;
+}
+
+} // namespace
 
 #if defined(__linux__) || defined(__APPLE__)
 
@@ -36,16 +56,30 @@ void FormatBacktraceDwarf(IOutputStream* out, void* const* backtrace, size_t bac
     }
 }
 
+void FormatBacktraceWithBuildInfo(IOutputStream* out, void* const* backtrace, size_t backtraceSize) {
+    WriteBuildInfo(out);
+    FormatBacktraceDwarf(out, backtrace, backtraceSize);
+}
+
 }
 
 void EnableYDBBacktraceFormat() {
-    SetFormatBackTraceFn(FormatBacktraceDwarf);
+    SetFormatBackTraceFn(FormatBacktraceWithBuildInfo);
 }
 
 #else
 
+namespace {
+
+void FormatBacktraceWithBuildInfo(IOutputStream* out, void* const* backtrace, size_t backtraceSize) {
+    WriteBuildInfo(out);
+    FormatBackTrace(out, backtrace, backtraceSize);
+}
+
+}
+
 void EnableYDBBacktraceFormat() {
-    SetFormatBackTraceFn(FormatBackTrace);
+    SetFormatBackTraceFn(FormatBacktraceWithBuildInfo);
 }
 
 #endif

--- a/ydb/core/base/ut_backtrace/helper/main.cpp
+++ b/ydb/core/base/ut_backtrace/helper/main.cpp
@@ -1,0 +1,9 @@
+#include <ydb/core/base/backtrace.h>
+
+#include <util/system/yassert.h>
+
+int main() {
+    NKikimr::EnableYDBBacktraceFormat();
+    Y_ABORT("intentional abort for backtrace build-info test");
+    return 0;
+}

--- a/ydb/core/base/ut_backtrace/helper/ya.make
+++ b/ydb/core/base/ut_backtrace/helper/ya.make
@@ -1,0 +1,11 @@
+PROGRAM()
+
+SRCS(
+    main.cpp
+)
+
+PEERDIR(
+    ydb/core/base
+)
+
+END()

--- a/ydb/core/base/ut_backtrace/test.py
+++ b/ydb/core/base/ut_backtrace/test.py
@@ -1,0 +1,11 @@
+import yatest.common
+
+
+def test_crash_reports_build_info():
+    binary = yatest.common.binary_path("ydb/core/base/ut_backtrace/helper/helper")
+
+    res = yatest.common.execute([binary], check_exit_code=False)
+    stderr = res.std_err.decode("utf-8", errors="replace")
+
+    assert "build: commit " in stderr, stderr
+    assert ("(dirty)" in stderr) or ("(clean)" in stderr), stderr

--- a/ydb/core/base/ut_backtrace/ya.make
+++ b/ydb/core/base/ut_backtrace/ya.make
@@ -1,0 +1,15 @@
+PY3TEST()
+
+TEST_SRCS(
+    test.py
+)
+
+DEPENDS(
+    ydb/core/base/ut_backtrace/helper
+)
+
+END()
+
+RECURSE(
+    helper
+)

--- a/ydb/core/base/ya.make
+++ b/ydb/core/base/ya.make
@@ -107,6 +107,7 @@ PEERDIR(
     library/cpp/lwtrace
     library/cpp/lwtrace/mon
     library/cpp/random_provider
+    library/cpp/svnversion
     library/cpp/time_provider
     ydb/core/audit/audit_config
     ydb/core/base/generated
@@ -151,6 +152,7 @@ IF (NOT OPENSOURCE OR OPENSOURCE_PROJECT == "ydb")
 RECURSE_FOR_TESTS(
     ut
     ut_auth
+    ut_backtrace
     ut_board_subscriber
 )
 ENDIF()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->



### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Prepend a build identification line (commit sha + dirty/clean + release version if any) to the YDB backtrace formatter, so crash/VERIFY output makes it clear which binary crashed. Wired through the existing `EnableYDBBacktraceFormat()` hook; `util/system` is untouched. Adds a py3 test that crashes a helper and asserts the line is emitted.
