### PR TITLE
schemeshard: fix path refcount loss on reboot during CDC stream rotation

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__clean_pathes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__clean_pathes.cpp
@@ -131,7 +131,13 @@ struct TSchemeShard::TTxCleanDroppedPaths : public TTransactionBase<TSchemeShard
             TPathId pathId = *--itCandidate;
             Self->CleanDroppedPathsCandidates.erase(itCandidate);
             TPathElement::TPtr path = Self->PathsById.at(pathId);
-            if (path->DbRefCount == 0 && path->Dropped()) {
+            if (path->DbRefCount == 0 && path->AllChildrenCount > 0) {
+                // fail fast: a restart recomputes the counters and heals the drift
+                Y_FAIL_S("TTxCleanDroppedPaths: dropped path with children, DbRefCount is miscounted"
+                    << ", PathId# " << pathId
+                    << ", AllChildrenCount# " << path->AllChildrenCount
+                    << ", at schemeshard: " << Self->TabletID());
+            } else if (path->DbRefCount == 0 && path->Dropped()) {
                 LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                     "TTxCleanDroppedPaths: PersistRemovePath for PathId# " << pathId
                     << ", at schemeshard: "<< Self->TabletID());

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -3941,14 +3941,6 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     if (!srcPath->Dropped()) {
                         srcPath->PathState = TPathElement::EPathState::EPathStateCopying;
                     }
-                    srcPath->DbRefCount++;
-                }
-
-                if (txState.TxType == TTxState::TxCopySequence && txState.SourcePathId) {
-                    Y_ABORT_UNLESS(Self->PathsById.contains(txState.SourcePathId));
-                    TPathElement::TPtr srcPath = Self->PathsById.at(txState.SourcePathId);
-                    Y_VERIFY_S(srcPath, "Null path element, pathId: " << txState.SourcePathId);
-                    srcPath->DbRefCount++;
                 }
 
                 if (txState.TxType == TTxState::TxMoveTable || txState.TxType == TTxState::TxMoveTableIndex || txState.TxType == TTxState::TxMoveSequence || txState.TxType == TTxState::TxMoveLocalIndex) {
@@ -3960,7 +3952,16 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                     if (!srcPath->Dropped()) {
                         srcPath->PathState = TPathElement::EPathState::EPathStateMoving;
                     }
-                    srcPath->DbRefCount++;
+                }
+
+                if (txState.SourcePathId) {
+                    auto srcPathIt = Self->PathsById.find(txState.SourcePathId);
+                    Y_VERIFY_S(srcPathIt != Self->PathsById.end(), "Source path element not found for in-flight tx"
+                        << ", txId: " << operationId.GetTxId()
+                        << ", TxType: " << TTxState::TypeName(txState.TxType)
+                        << ", pathId: " << txState.SourcePathId);
+                    Y_VERIFY_S(srcPathIt->second, "Null path element, pathId: " << txState.SourcePathId);
+                    srcPathIt->second->DbRefCount++;
                 }
 
                 if (txState.TxType == TTxState::TxCreateSubDomain) {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_continuous_backup.cpp
@@ -38,7 +38,10 @@ TVector<ISubOperation::TPtr> CreateDropContinuousBackup(TOperationId opId, const
         }
     }
 
-    TVector<ISubOperation::TPtr> result;
+    NKikimrSchemeOp::TDropCdcStream dropCdcStreamOp;
+    dropCdcStreamOp.SetTableName(tableName);
+    TVector<TPath> streamPaths;
+
     for (auto& [child, _] : tablePath.Base()->GetChildren()) {
         if (child.EndsWith("_continuousBackupImpl")) {
             const auto checksResult = NCdc::DoDropStreamPathChecks(opId, workingDirPath, tableName, child);
@@ -57,13 +60,14 @@ TVector<ISubOperation::TPtr> CreateDropContinuousBackup(TOperationId opId, const
                 return {reject};
             }
 
-            NKikimrSchemeOp::TDropCdcStream dropCdcStreamOp;
-            dropCdcStreamOp.SetTableName(tableName);
             dropCdcStreamOp.AddStreamName(child);
-
-            TVector<TPath> streamPaths = {streamPath};
-            NCdc::DoDropStream(result, dropCdcStreamOp, opId, workingDirPath, tablePath, streamPaths, InvalidTxId, context);
+            streamPaths.push_back(streamPath);
         }
+    }
+
+    TVector<ISubOperation::TPtr> result;
+    if (!streamPaths.empty()) {
+        NCdc::DoDropStream(result, dropCdcStreamOp, opId, workingDirPath, tablePath, streamPaths, InvalidTxId, context);
     }
 
     return result;

--- a/ydb/core/tx/schemeshard/schemeshard_backup_incremental__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_backup_incremental__progress.cpp
@@ -124,7 +124,11 @@ public:
         const auto& shardInfo = Self->ShardInfos.at(shardIdx);
         Y_ABORT_UNLESS(shardInfo.TabletType == ETabletType::PersQueue);
 
-        Y_ABORT_UNLESS(Self->Topics.contains(shardInfo.PathId));
+        if (!Self->Topics.contains(shardInfo.PathId)) {
+            LOG_E("Topic with pathId# " << shardInfo.PathId
+                << " not found, likely dropped concurrently, ignoring offload status");
+            return;
+        }
         const auto& topic = Self->Topics.at(shardInfo.PathId);
 
         if (!topic->Partitions.contains(partitionId)) {

--- a/ydb/core/tx/schemeshard/ut_continuous_backup/ut_continuous_backup.cpp
+++ b/ydb/core/tx/schemeshard/ut_continuous_backup/ut_continuous_backup.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/metering/metering.h>
+#include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/tx/schemeshard/schemeshard_billing_helpers.h>
 #include <ydb/core/tx/schemeshard/schemeshard_impl.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
@@ -148,5 +149,63 @@ Y_UNIT_TEST_SUITE(TContinuousBackupTests) {
             NLs::IsTable,
             NLs::CheckColumns("IncrBackupImpl", {"key", "value", "__ydb_incrBackupImpl_changeMetadata"}, {}, {"key"}),
         });
+    }
+
+    Y_UNIT_TEST(DropAfterTakeIncrementalBackup) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableProtoSourceIdInfo(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Keep the offload status away so the orphan cleaner does not drop the
+        // rotated-out stream on its own: DropContinuousBackup must handle both
+        // streams by itself.
+        runtime.SetObserverFunc([](TAutoPtr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvPersQueue::TEvOffloadStatus::EventType) {
+                return TTestActorRuntime::EEventAction::DROP;
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        TestAlterContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            TakeIncrementalBackup {
+                DstPath: "IncrBackupImpl"
+                DstStreamPath: "1_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {NLs::PathExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl"), {NLs::PathExist});
+
+        // Both the rotated-out and the current stream exist; the drop must
+        // compose a single coordinated operation covering all of them —
+        // a separate drop per stream would reject itself (the second
+        // DropCdcStreamAtTable part sees the table under operation).
+        TestDropContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl"), {NLs::PathNotExist});
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl/streamImpl"), {NLs::PathNotExist});
     }
 } // TCdcStreamWithInitialScanTests

--- a/ydb/core/tx/schemeshard/ut_continuous_backup_reboots/ut_continuous_backup_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_continuous_backup_reboots/ut_continuous_backup_reboots.cpp
@@ -1,4 +1,7 @@
+#include <ydb/core/base/hive.h>
 #include <ydb/core/metering/metering.h>
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/schemeshard_billing_helpers.h>
 #include <ydb/core/tx/schemeshard/schemeshard_impl.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
@@ -287,6 +290,137 @@ Y_UNIT_TEST_SUITE(TContinuousBackupWithRebootsTests) {
                     NLs::CheckColumns("IncrBackupImpl3", {"key", "value", "__ydb_incrBackupImpl_changeMetadata"}, {}, {"key"}),
                 });
             }
+        });
+    }
+
+    // Regression test for issue #33764: "Parent path not found" on SchemeShard init.
+    //
+    // TSchemeShard::CreateTx increments DbRefCount of both TargetPathId and
+    // SourcePathId, and RemoveTx unconditionally decrements both. But TTxInit
+    // restores the SourcePathId reference only for a whitelist of tx types
+    // (CopyTable/CopySequence/Move*), which does not include TxRotateCdcStream
+    // and TxRotateCdcStreamAtTable — both of which hold SourcePathId = the old
+    // continuous backup stream.
+    //
+    // A reboot while the rotation is in flight therefore makes the subsequent
+    // RemoveTx steal two references from the old stream path — including the +1
+    // held by its streamImpl child row. When the old stream is later dropped
+    // (as the continuous backup cleaner does after offload), its DbRefCount
+    // reaches zero while the child's Paths row still exists, TTxCleanDroppedPaths
+    // erases the parent's row, and the next TTxInit fails:
+    //   MakePathElement(): requirement Self->PathsById.contains(parentPathId) failed
+    Y_UNIT_TEST(RebootMidRotationOrphansStreamImplPathRow) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableProtoSourceIdInfo(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        // Freeze the rotation before it can be planned: the multi-part
+        // AlterContinuousBackup operation cannot propose to the coordinator
+        // until every part finishes ConfigureParts, so suppressing the first
+        // datashard propose keeps TxRotateCdcStream/TxRotateCdcStreamAtTable
+        // in flight (persisted in TxInFlightV2).
+        TVector<THolder<IEventHandle>> suppressedProposes;
+        auto prevObserver = SetSuppressObserver(runtime, suppressedProposes,
+            TEvDataShard::TEvProposeTransaction::EventType);
+
+        AsyncAlterContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            TakeIncrementalBackup {
+                DstPath: "IncrBackupImpl"
+                DstStreamPath: "1_continuousBackupImpl"
+            }
+        )");
+        const ui64 rotateTxId = txId;
+        TestModificationResult(runtime, rotateTxId, NKikimrScheme::StatusAccepted);
+
+        WaitForSuppressed(runtime, suppressedProposes, 1, prevObserver);
+
+        // Reboot while the rotation is in flight: TTxInit restores both rotate
+        // tx states without re-incrementing the old stream's DbRefCount.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        // The restarted SchemeShard re-sends the suppressed propose and the
+        // rotation completes; RemoveTx now over-decrements the old stream's
+        // DbRefCount by two.
+        env.TestWaitNotification(runtime, rotateTxId);
+
+        // Keep PQ shards alive so the streamImpl child rows cannot be cleaned
+        // (the child's Paths row must outlive the parent's for the corruption
+        // to be observable at init), and delay TTxCleanDroppedPaths so the
+        // premature cleanup does not race the drop operation itself — without
+        // the delay it fires mid-operation and reproduces the precursor crash
+        //   DoDoneTransactions(): requirement ss->PathsById.contains(pathId)
+        // from the same issue instead of the init crash.
+        TVector<THolder<IEventHandle>> suppressedCleanups;
+        runtime.SetObserverFunc([&suppressedCleanups](TAutoPtr<IEventHandle>& ev) {
+            switch (ev->GetTypeRewrite()) {
+                case TEvHive::TEvDeleteTablet::EventType:
+                    return TTestActorRuntime::EEventAction::DROP;
+                // The still-alive PQ tablet reports the (empty) offload after
+                // its Topics entry is erased by the drop; keep it away from
+                // OnOffloadStatus, it is not part of this scenario.
+                case TEvPersQueue::TEvOffloadStatus::EventType:
+                    return TTestActorRuntime::EEventAction::DROP;
+                case TEvPrivate::TEvCleanDroppedPaths::EventType:
+                    suppressedCleanups.push_back(std::move(ev));
+                    return TTestActorRuntime::EEventAction::DROP;
+                default:
+                    return TTestActorRuntime::EEventAction::PROCESS;
+            }
+        });
+
+        // Drop the old stream exactly like the continuous backup cleaner does
+        // after the offload completes: an internal ESchemeOpDropCdcStream for
+        // the rotated-out stream only.
+        AsyncSend(runtime, TTestTxConfig::SchemeShard,
+            InternalTransaction(DropCdcStreamRequest(++txId, "/MyRoot", R"(
+                TableName: "Table"
+                StreamName: "0_continuousBackupImpl"
+            )")));
+        TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
+        env.TestWaitNotification(runtime, txId);
+
+        // Now let TTxCleanDroppedPaths run: with the stolen references the old
+        // stream's Paths row is erased while its streamImpl child row remains.
+        for (auto& ev : suppressedCleanups) {
+            runtime.Send(ev.Release());
+        }
+        env.SimulateSleep(runtime, TDuration::Seconds(1));
+
+        // With correct refcounting this reboot succeeds; with the bug TTxInit
+        // crashes with "Parent path not found" (schemeshard__init.cpp,
+        // MakePathElement), the exact fingerprint of issue #33764.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist,
+            NLs::IsTable,
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {
+            NLs::PathNotExist,
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl"), {
+            NLs::PathExist,
+            NLs::StreamState(NKikimrSchemeOp::ECdcStreamStateReady),
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/1_continuousBackupImpl/streamImpl"), {
+            NLs::PathExist,
         });
     }
 } // TContinuousBackupWithRebootsTests


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes #33764.

`TTxInit` restored the `SourcePathId` `DbRefCount` reference only for a whitelist of tx types, while `RemoveTx` decrements it unconditionally. A reboot during continuous backup CDC stream rotation (`TxRotateCdcStream`/`TxRotateCdcStreamAtTable` both source the old stream) made the post-reboot `RemoveTx` steal the references protecting the old stream's `Paths` row — including the one held by its `streamImpl` child row — so `TTxCleanDroppedPaths` erased the parent row while the child row remained, and the next `TTxInit` failed with `Parent path not found`.

Also:
- `TTxCleanDroppedPaths`: fail fast on a dropped path that still has children — the crash is self-healing (a restart recomputes the counters from the intact rows), while the row deletion would orphan the children and permanently brick the tablet
- `OnOffloadStatus`: tolerate a concurrently dropped topic (async tablet deletion makes this a legal race)
- `DropContinuousBackup`: single coordinated drop for all continuous backup streams (a drop per stream self-rejected when both the rotated-out and the current stream exist)

Regression tests reproduce the full crash chain deterministically (reboot mid-rotation → drop old stream → reboot).

Recovery mode for already-corrupted databases is split out into a follow-up PR (`SchemeShardControls.TolerateOrphanedPaths`).
