### PR TITLE
Fix: сравнение ydbd size после unified PR-check

### DIFF
--- a/.github/scripts/get_main_build_size.py
+++ b/.github/scripts/get_main_build_size.py
@@ -54,7 +54,10 @@ def get_build_size(time_of_current_commit):
                 }
             else:
                 print(
-                    f"Error: Cant get binary size in db with params: github_event_name='push', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'",
+                    f"Error: Can't get binary size in db with params: "
+                    f"github_event_name='push', github_ref_name='{branch}', "
+                    f"build_preset='{build_preset}', "
+                    f"git_commit_time <= DateTime::FromSeconds({time_of_current_commit})",
                     file=sys.stderr
                 )
                 return 0

--- a/.github/scripts/get_main_build_size.py
+++ b/.github/scripts/get_main_build_size.py
@@ -26,7 +26,7 @@ def get_build_size(time_of_current_commit):
             select git_commit_time,github_sha,size_bytes,size_stripped_bytes,build_preset
             from binary_size 
             where 
-            github_workflow like "Postcommit%" and 
+            github_event_name = "push" and 
             github_ref_name="{branch}" and 
             build_preset="{build_preset}" and
             git_commit_time <= DateTime::FromSeconds({time_of_current_commit})
@@ -54,7 +54,7 @@ def get_build_size(time_of_current_commit):
                 }
             else:
                 print(
-                    f"Error: Cant get binary size in db with params: github_workflow like 'Postcommit%', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'",
+                    f"Error: Cant get binary size in db with params: github_event_name='push', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'",
                     file=sys.stderr
                 )
                 return 0


### PR DESCRIPTION
Fixes #46120

## Проблема

После #45533 baseline для ydbd size застрял на старых postcommit-записях. На PR показывались ложные алерты (+13–19 MiB), хотя diff косметический ([#46029](https://github.com/ydb-platform/ydb/pull/46029) сравнивался с `main` от 6 июля, а не свежим push).

## Причина

Postcommit push пишет в `binary_size` с `github_workflow=PR-check`, а baseline искал `Postcommit%`.

## Fix

В `get_main_build_size.py` baseline берём по `github_event_name=push` на target branch — postcommit попадает, PR merge preview нет.

## Результат
<img width="720" height="444" alt="image" src="https://github.com/user-attachments/assets/be88a983-0f5e-4cd0-8865-265a22629ea8" />

https://github.com/ydb-platform/ydb/pull/46317#issuecomment-4957062999

