### PR TITLE
CI smoke: validate ydbd size baseline fix (#46314)

### DIFF
--- a/.github/scripts/get_main_build_size.py
+++ b/.github/scripts/get_main_build_size.py
@@ -26,7 +26,7 @@ def get_build_size(time_of_current_commit):
             select git_commit_time,github_sha,size_bytes,size_stripped_bytes,build_preset
             from binary_size 
             where 
-            github_workflow like "Postcommit%" and 
+            github_event_name = "push" and 
             github_ref_name="{branch}" and 
             build_preset="{build_preset}" and
             git_commit_time <= DateTime::FromSeconds({time_of_current_commit})
@@ -54,7 +54,7 @@ def get_build_size(time_of_current_commit):
                 }
             else:
                 print(
-                    f"Error: Cant get binary size in db with params: github_workflow like 'Postcommit%', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'",
+                    f"Error: Cant get binary size in db with params: github_event_name='push', github_ref_name='{branch}', build_preset='{build_preset}, git_commit_time <= DateTime::FromSeconds({time_of_current_commit})'",
                     file=sys.stderr
                 )
                 return 0

--- a/ydb/core/mind/bscontroller/load_everything.cpp
+++ b/ydb/core/mind/bscontroller/load_everything.cpp
@@ -13,6 +13,7 @@ namespace NBsController {
 
 class TBlobStorageController::TTxLoadEverything : public TTransactionBase<TBlobStorageController> {
 public:
+    // Load all BSC state on startup (see also decommission race fix in #46029).
     TTxLoadEverything(TBlobStorageController *controller)
         : TBase(controller)
     {}


### PR DESCRIPTION
Test PR for [#46314](https://github.com/ydb-platform/ydb/pull/46314) — do not merge as-is.

## Purpose

Trigger PR-check + ydbd build to verify ydbd size comparison uses a recent `main` push baseline (not stale `Postcommit%` row).

## Changes

- Includes fix from `fix-ydbd-size-compare` (`get_main_build_size.py`: baseline by `github_event_name=push`)
- Cosmetic comment in `load_everything.cpp` only (recompile smoke)

## What to check

- [ ] PR-check completes
- [ ] ydbd size comment shows recent `main:` SHA (not days-old commit like `8cd9e45`)
- [ ] No false red alert on +10+ MiB for a one-line comment change

After validation, close this PR and merge #46314 only.


Made with [Cursor](https://cursor.com)