### PR TITLE
nemesis: add model guard impl

### DIFF
--- a/ydb/tests/compatibility/streaming/test_streaming.py
+++ b/ydb/tests/compatibility/streaming/test_streaming.py
@@ -234,7 +234,9 @@ class TestStreamingRestartToAnotherVersion(StreamingTestBase, RestartToAnotherVe
 class TestStreamingRollingUpgradeAndDowngrade(StreamingTestBase, RollingUpgradeAndDowngradeFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
+        # setupt
         yield from self.setup_cluster()
+        # teardown
 
     @link_test_case("#27924")
     @pytest.mark.parametrize("external", [True, False])

--- a/ydb/tests/compatibility/streaming/test_streaming.py
+++ b/ydb/tests/compatibility/streaming/test_streaming.py
@@ -234,9 +234,7 @@ class TestStreamingRestartToAnotherVersion(StreamingTestBase, RestartToAnotherVe
 class TestStreamingRollingUpgradeAndDowngrade(StreamingTestBase, RollingUpgradeAndDowngradeFixture):
     @pytest.fixture(autouse=True, scope="function")
     def setup(self):
-        # setupt
         yield from self.setup_cluster()
-        # teardown
 
     @link_test_case("#27924")
     @pytest.mark.parametrize("external", [True, False])

--- a/ydb/tests/library/nemesis/safety_warden.py
+++ b/ydb/tests/library/nemesis/safety_warden.py
@@ -450,9 +450,9 @@ class UnifiedAgentSanitizerSafetyWarden(SafetyWarden):
     Safety warden that checks for sanitizer errors (ASan/LSan/TSan/MSan/UBSan)
     in unified_agent logs.
 
-    Uses unified_agent to search kikimr-start logs for the canonical sanitizer
-    error pattern ``ERROR: <Word>Sanitizer:`` (e.g. ``ERROR: LeakSanitizer:``,
-    ``ERROR: AddressSanitizer:``).
+    Uses unified_agent to search kikimr-start logs for sanitizer report headers
+    ``ERROR:`` / ``WARNING: <Word>Sanitizer:`` (e.g. ``ERROR: LeakSanitizer:``,
+    ``WARNING: ThreadSanitizer:`` — TSan data races are WARNING by default).
 
     Each violation in the returned list is a full sanitizer report block,
     spanning from the leading ``=====`` separator line through the trailing
@@ -474,7 +474,7 @@ class UnifiedAgentSanitizerSafetyWarden(SafetyWarden):
 
     def list_of_safety_violations(self):
         """
-        Check unified_agent logs for sanitizer error blocks.
+        Check unified_agent logs for sanitizer error/warning blocks.
 
         Returns:
             List of violation strings, empty if no violations found.
@@ -491,13 +491,13 @@ class UnifiedAgentSanitizerSafetyWarden(SafetyWarden):
 
         # AWK program: collect lines between the leading "=====...====="
         # separator and the trailing "SUMMARY:" line. Emit the block only if
-        # it contains an "ERROR: <Word>Sanitizer:" line. Blocks are separated
-        # by lines containing only "--" so we can split on them later.
+        # it contains an "ERROR|WARNING: <Word>Sanitizer:" line. Blocks are
+        # separated by lines containing only "--" so we can split on them later.
         awk_program = (
             'BEGIN { buf=""; in_block=0; has_err=0 } '
             '/^=+$/ { buf=$0 ORS; in_block=1; has_err=0; next } '
             'in_block { buf=buf $0 ORS } '
-            'in_block && /ERROR:[[:space:]]*[A-Za-z]+Sanitizer:/ { has_err=1 } '
+            'in_block && /(ERROR|WARNING):[[:space:]]*[A-Za-z]+Sanitizer:/ { has_err=1 } '
             'in_block && /^SUMMARY:/ { '
             'if (has_err) { printf "%s--%s", buf, ORS } '
             'buf=""; in_block=0; has_err=0 '

--- a/ydb/tests/library/stability/deploy.py
+++ b/ydb/tests/library/stability/deploy.py
@@ -467,6 +467,63 @@ class StressUtilDeployer:
             logging.error(f"Error calling {url}: {exc}")
             return False
 
+    def _fetch_nemesis_problems(self, nemesis_log: list[str]) -> dict:
+        """Fetch ``GET /api/problems`` — nemesis-side anomalies from the chaos phase.
+
+        These never show up in cluster checks: a fault that never recovered (its failure budget
+        stays held, so the cluster ran degraded and the scheduler did less chaos than asked), or a
+        degraded chaos inventory (synthesized node ids, no slot chaos).
+
+        Returns:
+            The parsed payload, or ``{}`` when the endpoint is unavailable (older orchestrator).
+        """
+        endpoint = self._get_orchestrator_endpoint()
+        url = f"{endpoint}/api/problems"
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                body = json.loads(resp.read().decode())
+            return body if isinstance(body, dict) else {}
+        except Exception as exc:
+            nemesis_log.append(f"Could not fetch nemesis problems from {url}: {exc}")
+            logging.warning(f"Could not fetch nemesis problems from {url}: {exc}")
+            return {}
+
+    def _report_nemesis_problems(self, nemesis_log: list[str]) -> int:
+        """Put nemesis-side problems into the log and the Allure report.
+
+        Informational: the chaos side misbehaving does not by itself fail the workload, but it has
+        to be visible when reading the report — a stuck fault explains both a degraded cluster and
+        a suspiciously calm chaos phase.
+
+        Returns:
+            Number of reported problems.
+        """
+        payload = self._fetch_nemesis_problems(nemesis_log)
+        if not payload:
+            return 0
+
+        problems = payload.get("problems") or []
+        if not problems:
+            nemesis_log.append("Nemesis problems: none")
+            return 0
+
+        by_kind = payload.get("by_kind") or {}
+        summary = ", ".join(f"{kind}={count}" for kind, count in sorted(by_kind.items()))
+        nemesis_log.append(f"Nemesis problems: {len(problems)} ({summary})")
+        for problem in problems:
+            nemesis_log.append(
+                f"  [{problem.get('kind')}] x{problem.get('count', 1)} {problem.get('summary')}"
+            )
+        logging.warning(f"Nemesis reported {len(problems)} problem(s): {summary}")
+
+        allure.attach(
+            json.dumps(payload, indent=2, ensure_ascii=False),
+            f"Nemesis Problems ({len(problems)})",
+            attachment_type=allure.attachment_type.JSON,
+        )
+        return len(problems)
+
     # ------------------------------------------------------------------
     # Nemesis install (subprocess)
     # ------------------------------------------------------------------
@@ -648,6 +705,8 @@ class StressUtilDeployer:
                 nemesis_log.append("Nemesis chaos disabled successfully")
             else:
                 nemesis_log.append("Failed to disable nemesis chaos schedules")
+            # After the scheduler stopped: report what misbehaved during the chaos phase.
+            self._report_nemesis_problems(nemesis_log)
         else:
             nemesis_log.append(
                 "Nemesis services not installed, nothing to disable"
@@ -739,7 +798,8 @@ class StressUtilDeployer:
         """Manage nemesis chaos via the orchestrator HTTP API.
 
         * **enable** — install → health-poll → ``POST /api/scheduler/start``
-        * **disable** — ``POST /api/scheduler/stop``
+        * **disable** — ``POST /api/scheduler/stop`` → ``GET /api/problems``, whose stuck faults
+          and inventory degradation are attached to the Allure report
 
         Args:
             enable_nemesis: True to enable chaos, False to disable

--- a/ydb/tests/library/stability/deploy.py
+++ b/ydb/tests/library/stability/deploy.py
@@ -459,12 +459,12 @@ class StressUtilDeployer:
                     )
                     logging.info(f"Nemesis schedules response: {body}")
                     return True
-                nemesis_log.append(f"Unexpected schedule response: {body}")
-                logging.warning(f"Unexpected /api/schedule/all response: {body}")
+                nemesis_log.append(f"Unexpected scheduler response: {body}")
+                logging.warning(f"Unexpected {url} response: {body}")
                 return False
         except Exception as exc:
-            nemesis_log.append(f"Failed to {action.lower()} schedules: {exc}")
-            logging.error(f"Error calling /api/schedule/all: {exc}")
+            nemesis_log.append(f"Failed to {action.lower()} scheduler: {exc}")
+            logging.error(f"Error calling {url}: {exc}")
             return False
 
     # ------------------------------------------------------------------

--- a/ydb/tests/library/stability/deploy.py
+++ b/ydb/tests/library/stability/deploy.py
@@ -428,7 +428,7 @@ class StressUtilDeployer:
     def _set_schedules_enabled(
         self, enabled: bool, nemesis_log: list[str]
     ) -> bool:
-        """Start or stop the weighted nemesis scheduler via the orchestrator API.
+        """Start or stop the nemesis scheduler via the orchestrator API.
 
         ``POST /api/scheduler/start`` (empty profile → catalog defaults) or
         ``POST /api/scheduler/stop``.
@@ -441,7 +441,7 @@ class StressUtilDeployer:
         payload = json.dumps({}).encode()
 
         action = "Enabling" if enabled else "Disabling"
-        nemesis_log.append(f"{action} weighted nemesis scheduler via {url}")
+        nemesis_log.append(f"{action} nemesis scheduler via {url}")
         logging.info(f"{action} nemesis scheduler: POST {url}")
 
         try:

--- a/ydb/tests/library/stability/deploy.py
+++ b/ydb/tests/library/stability/deploy.py
@@ -428,18 +428,21 @@ class StressUtilDeployer:
     def _set_schedules_enabled(
         self, enabled: bool, nemesis_log: list[str]
     ) -> bool:
-        """Call ``POST /api/schedule/all`` to enable or disable all nemesis schedules.
+        """Start or stop the weighted nemesis scheduler via the orchestrator API.
+
+        ``POST /api/scheduler/start`` (empty profile → catalog defaults) or
+        ``POST /api/scheduler/stop``.
 
         Returns:
             ``True`` on success, ``False`` on failure.
         """
         endpoint = self._get_orchestrator_endpoint()
-        url = f"{endpoint}/api/schedule/all"
-        payload = json.dumps({"enabled": enabled}).encode()
+        url = f"{endpoint}/api/scheduler/{'start' if enabled else 'stop'}"
+        payload = json.dumps({}).encode()
 
         action = "Enabling" if enabled else "Disabling"
-        nemesis_log.append(f"{action} all nemesis schedules via {url}")
-        logging.info(f"{action} nemesis schedules: POST {url}")
+        nemesis_log.append(f"{action} weighted nemesis scheduler via {url}")
+        logging.info(f"{action} nemesis scheduler: POST {url}")
 
         try:
             req = urllib.request.Request(
@@ -733,10 +736,10 @@ class StressUtilDeployer:
         operation_context: str = None,
         existing_log: list = None,
     ):
-        """Manage nemesis chaos schedules via the orchestrator HTTP API.
+        """Manage nemesis chaos via the orchestrator HTTP API.
 
-        * **enable** — install → health-poll → ``POST /api/schedule/all``
-        * **disable** — ``POST /api/schedule/all {"enabled": false}``
+        * **enable** — install → health-poll → ``POST /api/scheduler/start``
+        * **disable** — ``POST /api/scheduler/stop``
 
         Args:
             enable_nemesis: True to enable chaos, False to disable

--- a/ydb/tests/library/stability/deploy.py
+++ b/ydb/tests/library/stability/deploy.py
@@ -468,14 +468,10 @@ class StressUtilDeployer:
             return False
 
     def _fetch_nemesis_problems(self, nemesis_log: list[str]) -> dict:
-        """Fetch ``GET /api/problems`` — nemesis-side anomalies from the chaos phase.
-
-        These never show up in cluster checks: a fault that never recovered (its failure budget
-        stays held, so the cluster ran degraded and the scheduler did less chaos than asked), or a
-        degraded chaos inventory (synthesized node ids, no slot chaos).
+        """``GET /api/problems``: chaos-side anomalies cluster checks cannot see.
 
         Returns:
-            The parsed payload, or ``{}`` when the endpoint is unavailable (older orchestrator).
+            The parsed payload, or ``{}`` when the endpoint is unavailable.
         """
         endpoint = self._get_orchestrator_endpoint()
         url = f"{endpoint}/api/problems"
@@ -490,11 +486,8 @@ class StressUtilDeployer:
             return {}
 
     def _report_nemesis_problems(self, nemesis_log: list[str]) -> int:
-        """Put nemesis-side problems into the log and the Allure report.
-
-        Informational: the chaos side misbehaving does not by itself fail the workload, but it has
-        to be visible when reading the report — a stuck fault explains both a degraded cluster and
-        a suspiciously calm chaos phase.
+        """Log chaos-side problems and attach them to Allure. Informational: does not fail the
+        workload, but a stuck fault explains both a degraded cluster and a calm chaos phase.
 
         Returns:
             Number of reported problems.
@@ -705,7 +698,7 @@ class StressUtilDeployer:
                 nemesis_log.append("Nemesis chaos disabled successfully")
             else:
                 nemesis_log.append("Failed to disable nemesis chaos schedules")
-            # After the scheduler stopped: report what misbehaved during the chaos phase.
+            # After the scheduler stopped: report what misbehaved.
             self._report_nemesis_problems(nemesis_log)
         else:
             nemesis_log.append(

--- a/ydb/tests/library/stability/healthcheck/healthcheck_reporter.py
+++ b/ydb/tests/library/stability/healthcheck/healthcheck_reporter.py
@@ -14,6 +14,7 @@ from ydb.tests.library.stability.utils.utils import unpack_resource
 class HealthCheckReporter():
     # Hard cap for terminating in-flight healthcheck subprocesses on stop.
     _KILL_GRACE_SECONDS = 2
+    _OUTPUT_LOG_LIMIT = 2000
 
     def __init__(self, hosts: list[str], store_results: bool = False):
         self.stop = False
@@ -31,6 +32,30 @@ class HealthCheckReporter():
         self._active_procs: set[subprocess.Popen] = set()
         self._executor: ThreadPoolExecutor | None = None
         unpack_resource('ydb_cli', self.ydb_path)
+        self.__log_cli_version()
+
+    def __log_cli_version(self):
+        try:
+            proc = subprocess.run(
+                [self.ydb_path, 'version'],
+                text=True, capture_output=True, timeout=30,
+            )
+            logging.info(
+                "healthcheck cli: %s (rc=%s, version=%r, stderr=%r)",
+                self.ydb_path, proc.returncode,
+                self.__shorten(proc.stdout), self.__shorten(proc.stderr),
+            )
+        except Exception as e:
+            logging.warning("Failed to get %s version: %s", self.ydb_path, e)
+
+    @classmethod
+    def __shorten(cls, text):
+        if not text:
+            return ''
+        text = text.strip()
+        if len(text) <= cls._OUTPUT_LOG_LIMIT:
+            return text
+        return f'{text[:cls._OUTPUT_LOG_LIMIT]}...<truncated, {len(text)} chars total>'
 
     def start_healthchecks(self):
         self.stop = False
@@ -106,6 +131,7 @@ class HealthCheckReporter():
             '--format', 'json',
         ]
         proc = None
+        started_at = time.monotonic()
         try:
             proc = subprocess.Popen(
                 cmd,
@@ -118,19 +144,43 @@ class HealthCheckReporter():
                 self._active_procs.add(proc)
 
             try:
-                stdout, _ = proc.communicate(timeout=self.hc_request_timeout_seconds)
+                stdout, stderr = proc.communicate(timeout=self.hc_request_timeout_seconds)
             except subprocess.TimeoutExpired:
                 # Treat timeout the same as the previous subprocess.run(timeout=...) behaviour.
                 try:
                     os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                 except (ProcessLookupError, PermissionError, OSError):
                     pass
-                proc.communicate(timeout=1)
-                raise
+                stdout, stderr = proc.communicate(timeout=1)
+                logging.error(
+                    "Healthcheck for %s timed out after %ss. stdout: %r, stderr: %r",
+                    host, self.hc_request_timeout_seconds,
+                    self.__shorten(stdout), self.__shorten(stderr),
+                )
+                return host, {'self_check_result': 'HC_REQUEST_ERROR'}
 
             if proc.returncode != 0:
-                raise subprocess.CalledProcessError(proc.returncode, cmd)
-            return host, json.loads(stdout)
+                if self.stop:
+                    # We SIGTERM'd it ourselves in stop_healthchecks(); not a cluster problem.
+                    logging.debug("Healthcheck for %s killed on shutdown (rc=%s)", host, proc.returncode)
+                    return host, {'self_check_result': 'HC_REQUEST_ERROR'}
+                # The CLI reports the actual reason (transport error, auth, misuse, ...)
+                # on stderr; without it a bare exit code says nothing.
+                logging.error(
+                    "Healthcheck for %s failed: rc=%s after %.1fs, cmd=%s, stderr: %r, stdout: %r",
+                    host, proc.returncode, time.monotonic() - started_at, ' '.join(cmd),
+                    self.__shorten(stderr), self.__shorten(stdout),
+                )
+                return host, {'self_check_result': 'HC_REQUEST_ERROR'}
+
+            try:
+                return host, json.loads(stdout)
+            except json.JSONDecodeError as e:
+                logging.error(
+                    "Healthcheck for %s returned rc=0 but unparseable output (%s). stdout: %r, stderr: %r",
+                    host, e, self.__shorten(stdout), self.__shorten(stderr),
+                )
+                return host, {'self_check_result': 'HC_REQUEST_ERROR'}
         except Exception:
             logging.error(f"Unexpected error during healthcheck for {host}: {traceback.format_exc()}")
             return host, {'self_check_result': 'HC_REQUEST_ERROR'}
@@ -177,11 +227,12 @@ class HealthCheckReporter():
     def __publish_healthcheck_results(self, results):
         for host, host_result in results.items():
             target_url = f"http://{host}:3124/write"
+            self_check_result = host_result.get('self_check_result', 'UNSPECIFIED')
             host_metric = {
                 "labels": {
                     "sensor": "test_metric",
                     "name": 'ydb_healthcheck_status',
-                    "self_check_result": host_result['self_check_result'],
+                    "self_check_result": self_check_result,
                 },
                 "value": 1
             }

--- a/ydb/tests/library/stability/healthcheck/healthcheck_reporter.py
+++ b/ydb/tests/library/stability/healthcheck/healthcheck_reporter.py
@@ -7,8 +7,18 @@ import threading
 import time
 import traceback
 import requests
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError as FuturesTimeoutError
 from ydb.tests.library.stability.utils.utils import unpack_resource
+
+
+# The nemesis orchestrator pins the root logger at WARNING
+# (ydb/tests/stability/nemesis/__main__.py), so bare logging.info()/logging.debug()
+# calls from this module are dropped. Own logger at DEBUG + propagation to the root
+# handler (installed at NOTSET by basicConfig) makes those records visible, and names
+# them so healthcheck output is greppable.
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class HealthCheckReporter():
@@ -32,21 +42,20 @@ class HealthCheckReporter():
         self._active_procs: set[subprocess.Popen] = set()
         self._executor: ThreadPoolExecutor | None = None
         unpack_resource('ydb_cli', self.ydb_path)
-        self.__log_cli_version()
-
-    def __log_cli_version(self):
+        # Deliberately no `ydb_cli version` probe: that command leaves NeedToCheckForUpdate
+        # set, which can make the CLI reach out to StorageUrl over the network
+        # (ydb/apps/ydb/commands/ydb_root.cpp:91), and __init__ runs during app init on the
+        # first request. Size is enough to spot a stale/unexpected binary, and a CLI that
+        # cannot parse our arguments now reports that on stderr anyway.
         try:
-            proc = subprocess.run(
-                [self.ydb_path, 'version'],
-                text=True, capture_output=True, timeout=30,
-            )
-            logging.info(
-                "healthcheck cli: %s (rc=%s, version=%r, stderr=%r)",
-                self.ydb_path, proc.returncode,
-                self.__shorten(proc.stdout), self.__shorten(proc.stderr),
-            )
-        except Exception as e:
-            logging.warning("Failed to get %s version: %s", self.ydb_path, e)
+            cli_size = os.path.getsize(self.ydb_path)
+        except OSError as e:
+            cli_size = f'<unavailable: {e}>'
+        logger.info(
+            "healthcheck starting: cli=%s (%s bytes), hosts=%d, period=%ss, timeout=%ss",
+            self.ydb_path, cli_size, len(self.hosts),
+            self.hc_period_seconds, self.hc_request_timeout_seconds,
+        )
 
     @classmethod
     def __shorten(cls, text):
@@ -79,7 +88,7 @@ class HealthCheckReporter():
         if self.healthcheck_thread and self.healthcheck_thread.is_alive():
             self.healthcheck_thread.join(self._KILL_GRACE_SECONDS + 5)
             if self.healthcheck_thread.is_alive():
-                logging.warning("Healthcheck thread did not stop gracefully, it may be hanging in a blocking operation")
+                logger.warning("Healthcheck thread did not stop gracefully, it may be hanging in a blocking operation")
 
     def __terminate_active_procs(self):
         with self._active_procs_lock:
@@ -105,20 +114,44 @@ class HealthCheckReporter():
                 try:
                     proc.wait(timeout=1.0)
                 except subprocess.TimeoutExpired:
-                    logging.warning("ydb_cli_hc pid=%s did not exit after SIGKILL", proc.pid)
+                    logger.warning("ydb_cli_hc pid=%s did not exit after SIGKILL", proc.pid)
 
     def __execute_healthcheck_thr(self):
         while not self.stop:
             try:
+                tick_started_at = time.monotonic()
                 results = self.__execute_healthcheck()
                 if self.store_results:
                     self.last_results = results
                 self.__publish_healthcheck_results(results)
-            except Exception as e:
-                logging.error(f"Error in healthcheck thread: {e}")
+                self.__log_tick_summary(results, time.monotonic() - tick_started_at)
+            except Exception:
+                logger.error(f"Error in healthcheck thread: {traceback.format_exc()}")
             # Interruptible sleep: wakes up immediately on stop_healthchecks().
             if self._stop_event.wait(timeout=self.hc_period_seconds):
                 break
+
+    def __log_tick_summary(self, results, elapsed):
+        # Without this the happy path is completely silent, so a healthy cluster and a
+        # dead healthcheck thread look identical in the log.
+        if not results:
+            logger.info("healthcheck tick: no hosts checked in %.1fs", elapsed)
+            return
+        by_status = Counter(
+            result.get('self_check_result', 'UNSPECIFIED') for result in results.values()
+        )
+        not_good = sorted(
+            host for host, result in results.items()
+            if result.get('self_check_result', 'UNSPECIFIED') != 'GOOD'
+        )
+        summary = ', '.join(f'{status}={count}' for status, count in sorted(by_status.items()))
+        if not_good:
+            logger.info(
+                "healthcheck tick: %d hosts in %.1fs — %s; not GOOD: %s",
+                len(results), elapsed, summary, ', '.join(not_good),
+            )
+        else:
+            logger.info("healthcheck tick: %d hosts in %.1fs — %s", len(results), elapsed, summary)
 
     def __run_one_healthcheck(self, host):
         if self.stop:
@@ -152,7 +185,7 @@ class HealthCheckReporter():
                 except (ProcessLookupError, PermissionError, OSError):
                     pass
                 stdout, stderr = proc.communicate(timeout=1)
-                logging.error(
+                logger.error(
                     "Healthcheck for %s timed out after %ss. stdout: %r, stderr: %r",
                     host, self.hc_request_timeout_seconds,
                     self.__shorten(stdout), self.__shorten(stderr),
@@ -162,11 +195,11 @@ class HealthCheckReporter():
             if proc.returncode != 0:
                 if self.stop:
                     # We SIGTERM'd it ourselves in stop_healthchecks(); not a cluster problem.
-                    logging.debug("Healthcheck for %s killed on shutdown (rc=%s)", host, proc.returncode)
+                    logger.debug("Healthcheck for %s killed on shutdown (rc=%s)", host, proc.returncode)
                     return host, {'self_check_result': 'HC_REQUEST_ERROR'}
                 # The CLI reports the actual reason (transport error, auth, misuse, ...)
                 # on stderr; without it a bare exit code says nothing.
-                logging.error(
+                logger.error(
                     "Healthcheck for %s failed: rc=%s after %.1fs, cmd=%s, stderr: %r, stdout: %r",
                     host, proc.returncode, time.monotonic() - started_at, ' '.join(cmd),
                     self.__shorten(stderr), self.__shorten(stdout),
@@ -176,13 +209,13 @@ class HealthCheckReporter():
             try:
                 return host, json.loads(stdout)
             except json.JSONDecodeError as e:
-                logging.error(
+                logger.error(
                     "Healthcheck for %s returned rc=0 but unparseable output (%s). stdout: %r, stderr: %r",
                     host, e, self.__shorten(stdout), self.__shorten(stderr),
                 )
                 return host, {'self_check_result': 'HC_REQUEST_ERROR'}
         except Exception:
-            logging.error(f"Unexpected error during healthcheck for {host}: {traceback.format_exc()}")
+            logger.error(f"Unexpected error during healthcheck for {host}: {traceback.format_exc()}")
             return host, {'self_check_result': 'HC_REQUEST_ERROR'}
         finally:
             if proc is not None:
@@ -213,7 +246,7 @@ class HealthCheckReporter():
                     got_host, result = future.result()
                     results[got_host] = result
                 except Exception:
-                    logging.error(f"Failed to retrieve result for healthcheck on {host}: {traceback.format_exc()}")
+                    logger.error(f"Failed to retrieve result for healthcheck on {host}: {traceback.format_exc()}")
                     results[host] = {'self_check_result': 'HC_RESULT_ERROR'}
         except FuturesTimeoutError:
             # Any futures that did not finish within the overall timeout: mark as error and try to cancel.
@@ -243,4 +276,4 @@ class HealthCheckReporter():
             try:
                 requests.post(target_url, json=payload, headers=headers, timeout=(5, 5))
             except Exception as e:
-                logging.error(f"Failed to publish healthcheck results for {host}: {e}")
+                logger.error(f"Failed to publish healthcheck results for {host}: {e}")

--- a/ydb/tests/stability/nemesis/README.md
+++ b/ydb/tests/stability/nemesis/README.md
@@ -96,6 +96,41 @@ Nemesis supports several categories of fault injection:
 - **Datacenter** — stop all nodes in a datacenter (multi-DC clusters)
 - **Bridge pile** — stop all nodes in a bridge pile (bridge-enabled clusters)
 
+## Chaos targets and failure model
+
+Planning is entity-based (`ChaosTarget`), not host-only. Dispatch still goes to an agent host; the target says what to hit on that host (or cluster-wide for tablets).
+
+| `target_kind` | Meaning |
+|---|---|
+| `host` | whole machine (time skew; network isolation if enabled) |
+| `node` / `slot` / `disk` | YDB process / tenant slot / drive |
+| `tablet` | Hive / tablet API (usually `guard_mode=BYPASS`) |
+| `datacenter` / `pile` | topology fanout |
+
+**Flow (one active nemesis at a time):**
+
+```text
+ClusterInventory.entities(kind)
+  → FailureModelGuard.filter_safe(...)
+  → planner.scheduled_tick(candidates)
+  → dispatch (payload includes chaos_target)
+  → record_inject / record_extract
+```
+
+There is **no** dispatch-time `can_inject` veto. Safety is plan-time `filter_safe` plus post-dispatch accounting. Erasure rules come from `cluster.yaml` (`static_erasure`, `location.rack` / `data_center`): e.g. `block-4-2` ≤ 2 racks, `mirror-3-dc` = 1 full DC + 1 rack elsewhere.
+
+**Catalog fields** (in `cluster_entries.py`): `target_kind`, `impact_scope`, `guard_mode` (`FULL` / `PREFILTER_ONLY` / `BYPASS`), optional `auto_recovery_sec`, `supports_manual`.
+
+**Agent contract:** node/slot/disk runners require explicit ids in `chaos_target` (`node_id`, `slot_idx`, `ic_port`) — no hostname guessing.
+
+**UI / API:**
+
+- History shows the target (not only host)
+- Manual Run lists nodes/slots when `supports_manual` and `target_kind` need them; types with `supports_manual: false` (network, time skew, rolling restart, bridge pile) are schedule-only
+- `GET /api/inventory` — hosts/nodes/slots used for planning
+
+More detail: `CHAOS_TARGET_IMPLEMENTATION_PLAN.md`.
+
 ## Extending Nemesis
 
 ### Adding a New Fault Type
@@ -131,6 +166,10 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "runner": MyCustomNemesis(),
         "schedule": 300,  # default interval in seconds
         "ui_group": "MyGroup",  # must exist in NEMESIS_UI_GROUPS
+        "target_kind": TargetKind.NODE,  # what planners select
+        "impact_scope": ImpactScope.NODE,  # failure-model projection
+        "guard_mode": GuardMode.FULL,
+        # "supports_manual": False,  # if planner.manual() is unsupported
         # Optional: specify a custom planner
         # "planner_cls": MyCustomPlanner,
         # "planner_factory": lambda key: MyCustomPlanner(key),
@@ -162,7 +201,8 @@ __all__ = [
 
 ### Custom Planners
 
-By default, Nemesis uses `DefaultRandomHostPlanner` which injects faults on a random host per tick. For more complex behavior, create a custom planner.
+By default, Nemesis uses `DefaultRandomHostPlanner`, which picks one random **candidate**
+(`ChaosTarget` of the type's `target_kind`) per tick. For more complex behavior, create a custom planner.
 
 Then register it in `cluster_entries.py`:
 

--- a/ydb/tests/stability/nemesis/README.md
+++ b/ydb/tests/stability/nemesis/README.md
@@ -107,19 +107,38 @@ Planning is entity-based (`ChaosTarget`), not host-only. Dispatch still goes to 
 | `tablet` | Hive / tablet API (usually `guard_mode=BYPASS`) |
 | `datacenter` / `pile` | topology fanout |
 
-**Flow (one active nemesis at a time):**
+**Flow — boundary scheduler** (`boundary_scheduler.py`, what `deploy.py` starts and what drives scheduled chaos):
+
+```text
+tick: cap = rand(1..max_per_tick)
+  → menu of (type, target) that currently fits the budget   (guard.fits)
+  → pick uniformly, guard.reserve(footprint)                 (atomic)
+  → plan_inject → dispatch (payload includes chaos_target)
+  → RecoveryProbe releases the budget by fact
+       self    — healthcheck sees the host answer again (else: stuck, budget kept)
+       extract — hold auto_recovery_sec, then dispatch the extract
+  → stop(): drains still-held toggle faults through their extract
+```
+
+**Flow — legacy per-type schedule** (`schedule_loop.py`, still available via `/api/schedule/*`):
 
 ```text
 ClusterInventory.entities(kind)
   → FailureModelGuard.filter_safe(...)
   → planner.scheduled_tick(candidates)
-  → dispatch (payload includes chaos_target)
-  → record_inject / record_extract
+  → dispatch → record_inject / record_extract
 ```
 
-There is **no** dispatch-time `can_inject` veto. Safety is plan-time `filter_safe` plus post-dispatch accounting. Erasure rules come from `cluster.yaml` (`static_erasure`, `location.rack` / `data_center`): e.g. `block-4-2` ≤ 2 racks, `mirror-3-dc` = 1 full DC + 1 rack elsewhere.
+There is **no** dispatch-time `can_inject` veto. Safety is plan-time (`filter_safe` / `fits`) plus accounting after dispatch (`record_inject` / `reserve`).
 
-**Catalog fields** (in `cluster_entries.py`): `target_kind`, `impact_scope`, `guard_mode` (`FULL` / `PREFILTER_ONLY` / `BYPASS`), optional `auto_recovery_sec`, `supports_manual`.
+**Two independent budgets**, both from `cluster.yaml` (`static_erasure`, `location.rack` / `data_center`):
+
+- *Fail domains* — `block-4-2` ≤ 2 domains, `mirror-3-dc` = 1 full realm + 1 domain elsewhere, `none` = 0. A domain is keyed `"<data_center>/<rack>"`: rack labels are only unique inside a DC (`rack: '1'` in every DC is normal), so the realm is part of the key. Only static-node / disk / DC faults spend this budget.
+- *Slots* — killing a dynamic node does not reduce storage redundancy, so it draws from its own budget: ≤ 30% of the cluster's slots down at once (`total_slots × slot_fraction`, ≥1 on small clusters). Charged by `reserve` (boundary scheduler) and by `record_inject` (legacy loop, manual inject). The one place that ignores it is the `filter_safe` pre-check: a slot candidate carries no fail domain, so it is always admitted there — `reserve` is what actually refuses.
+
+**The failure model is mandatory.** An unusable `cluster.yaml` — missing, unparsable, unknown `static_erasure`, a host without `location.rack`, or (for `mirror-3-dc`) without `location.data_center` — raises `FailureModelConfigError` and the orchestrator refuses to start. There is no unguarded mode: chaos that ignores fault tolerance is worse than no chaos.
+
+**Catalog fields** (in `cluster_entries.py`): `target_kind`, `impact_scope`, `guard_mode` (`FULL` — filtered and accounted for; `BYPASS` — costs no budget, for tablet chaos), optional `recovery`, `auto_recovery_sec`, `supports_manual`.
 
 **Agent contract:** node/slot/disk runners require explicit ids in `chaos_target` (`node_id`, `slot_idx`, `ic_port`) — no hostname guessing.
 
@@ -127,9 +146,10 @@ There is **no** dispatch-time `can_inject` veto. Safety is plan-time `filter_saf
 
 - History shows the target (not only host)
 - Manual Run lists nodes/slots when `supports_manual` and `target_kind` need them; types with `supports_manual: false` (network, time skew, rolling restart, bridge pile) are schedule-only
-- `GET /api/inventory` — hosts/nodes/slots used for planning
-
-More detail: `CHAOS_TARGET_IMPLEMENTATION_PLAN.md`.
+- `GET /api/inventory` — hosts/nodes/slots used for planning (built once at startup)
+- `GET /api/scheduler`, `POST /api/scheduler/start|stop` — boundary scheduler state and profile (`enabled`, `base_interval`, `jitter`, `max_per_tick`; invalid values and unknown type names are rejected with 400)
+- `GET /api/problems` — nemesis-side problems: faults that never recovered (budget still held) and a degraded inventory (harness unavailable → synthesized node ids, no slot chaos). `ydb/tests/stability/tests` fetches this when disabling nemesis and attaches it to the Allure report
+- The UI's Nemesis Scheduler card shows run state, profile, both budgets, the recovery probe and the problem list; the per-type schedule toggles in the accordion belong to the legacy loop
 
 ## Extending Nemesis
 

--- a/ydb/tests/stability/nemesis/README.md
+++ b/ydb/tests/stability/nemesis/README.md
@@ -111,7 +111,7 @@ Planning is entity-based (`ChaosTarget`), not host-only. Dispatch still goes to 
 
 ```text
 tick: cap = rand(1..max_per_tick)
-  → menu of (type, target) that currently fits the budget   (guard.fits)
+  → menu of (type, target) that currently fits the budget   (guard.budget_view)
   → pick uniformly, guard.reserve(footprint)                 (atomic)
   → plan_inject → dispatch (payload includes chaos_target)
   → RecoveryProbe releases the budget by fact
@@ -138,7 +138,7 @@ There is **no** dispatch-time `can_inject` veto. Safety is plan-time (`filter_sa
 
 **The failure model is mandatory.** An unusable `cluster.yaml` — missing, unparsable, unknown `static_erasure`, a host without `location.rack`, or (for `mirror-3-dc`) without `location.data_center` — raises `FailureModelConfigError` and the orchestrator refuses to start. There is no unguarded mode: chaos that ignores fault tolerance is worse than no chaos.
 
-**Catalog fields** (in `cluster_entries.py`): `target_kind`, `impact_scope`, `guard_mode` (`FULL` — filtered and accounted for; `BYPASS` — costs no budget, for tablet chaos), optional `recovery`, `auto_recovery_sec`, `supports_manual`.
+**Catalog fields** (in `cluster_entries.py`): `target_kind`, `impact_scope`, `guard_mode` (`FULL` — filtered and accounted for; `BYPASS` — costs no budget, for tablet chaos), optional `recovery` (`extract` for faults that stay applied until extracted), `auto_recovery_sec`, `supports_manual`, `boundary_safe` (a custom planner must opt in before the boundary scheduler may drive it — otherwise it could inject something other than the reserved target).
 
 **Agent contract:** node/slot/disk runners require explicit ids in `chaos_target` (`node_id`, `slot_idx`, `ic_port`) — no hostname guessing.
 
@@ -146,8 +146,8 @@ There is **no** dispatch-time `can_inject` veto. Safety is plan-time (`filter_sa
 
 - History shows the target (not only host)
 - Manual Run lists nodes/slots when `supports_manual` and `target_kind` need them; types with `supports_manual: false` (network, time skew, rolling restart, bridge pile) are schedule-only
-- `GET /api/inventory` — hosts/nodes/slots used for planning (built once at startup)
-- `GET /api/scheduler`, `POST /api/scheduler/start|stop` — boundary scheduler state and profile (`enabled`, `base_interval`, `jitter`, `max_per_tick`; invalid values and unknown type names are rejected with 400)
+- `GET /api/inventory` — hosts/nodes/slots used for planning (built once, on the orchestrator's first request; the UI fetches it once, not on every poll)
+- `GET /api/scheduler`, `POST /api/scheduler/start|stop` — boundary scheduler state and profile (`enabled`, `base_interval`, `jitter`, `max_per_tick`). Rejected with 400: invalid values, unknown type names, and types whose planner keeps its own target state (`supports_boundary_scheduler`)
 - `GET /api/problems` — nemesis-side problems: faults that never recovered (budget still held) and a degraded inventory (harness unavailable → synthesized node ids, no slot chaos). `ydb/tests/stability/tests` fetches this when disabling nemesis and attaches it to the Allure report
 - The UI's Nemesis Scheduler card shows run state, profile, both budgets, the recovery probe and the problem list; the per-type schedule toggles in the accordion belong to the legacy loop
 

--- a/ydb/tests/stability/nemesis/__main__.py
+++ b/ydb/tests/stability/nemesis/__main__.py
@@ -283,7 +283,9 @@ def main():
         # Second Flask app + thread: no conflict as long as nemesis_mon_port != app_port.
         monitor.setup_page(settings.app_host, settings.nemesis_mon_port)
         # threaded=True is important for concurrent request handling
-        from ydb.tests.stability.nemesis.app import app
+        from ydb.tests.stability.nemesis.app import app, require_failure_model_or_die
+        # No usable cluster.yaml → no failure model → no chaos: exit instead of serving unguarded.
+        require_failure_model_or_die(app)
         app.run(
             host=settings.app_host,
             port=settings.app_port,

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -5,6 +5,11 @@ import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 from ydb.tests.stability.nemesis.internal.orchestrator.orchestrator_warden_checker import OrchestratorWardenChecker
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.schedule_loop import OrchestratorNemesisSchedule
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import ChaosOrchestratorStore
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    ClusterTopologyModel,
+    FailureModelGuard,
+)
+from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import cluster_yaml_path
 from ydb.tests.stability.nemesis.internal.orchestrator.install import get_hosts_from_yaml
 from ydb.tests.stability.nemesis.internal.config import AgentSettings
 from ydb.tests.stability.nemesis.internal.agent.agent_warden_checker import AgentWardenChecker
@@ -77,7 +82,18 @@ def initialize_app():
         orchestrator_router.healthcheck_reporter = HealthCheckReporter(loaded_hosts, store_results=True)
         orchestrator_router.healthcheck_reporter.start_healthchecks()
 
-        orchestrator_router.chaos_store = ChaosOrchestratorStore()
+        # Failure-model guard: fail open (guard=None) if topology/erasure cannot be parsed.
+        failure_guard = None
+        try:
+            topology = ClusterTopologyModel(cluster_yaml_path())
+            failure_guard = FailureModelGuard(topology)
+            logger.info("Failure model guard: %s", failure_guard.snapshot())
+        except Exception as e:
+            logger.warning("Failure model guard disabled (init failed): %s", e)
+            failure_guard = None
+        orchestrator_router.failure_guard = failure_guard
+
+        orchestrator_router.chaos_store = ChaosOrchestratorStore(failure_guard=failure_guard)
         orchestrator_router.orchestrator_warden_checker = OrchestratorWardenChecker(
             hosts=loaded_hosts,
             mon_port=orchestrator_router.mon_port,
@@ -89,6 +105,7 @@ def initialize_app():
             get_hosts=lambda: orchestrator_router.hosts,
             is_local_host=orchestrator_router.is_local_host,
             get_app_port=orchestrator_router.get_app_port,
+            failure_guard=failure_guard,
         )
 
     current_app.config["NEMESIS_INITIALIZED"] = True

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -9,6 +9,7 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model imp
     ClusterTopologyModel,
     FailureModelGuard,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import cluster_yaml_path
 from ydb.tests.stability.nemesis.internal.orchestrator.install import get_hosts_from_yaml
 from ydb.tests.stability.nemesis.internal.config import AgentSettings
@@ -82,18 +83,25 @@ def initialize_app():
         orchestrator_router.healthcheck_reporter = HealthCheckReporter(loaded_hosts, store_results=True)
         orchestrator_router.healthcheck_reporter.start_healthchecks()
 
-        # Failure-model guard: fail open (guard=None) if topology/erasure cannot be parsed.
+        # Failure-model guard + inventory: fail open if topology/erasure cannot be parsed.
         failure_guard = None
+        inventory = None
         try:
             topology = ClusterTopologyModel(cluster_yaml_path())
             failure_guard = FailureModelGuard(topology)
+            inventory = ClusterInventory(topology, agent_hosts=loaded_hosts)
             logger.info("Failure model guard: %s", failure_guard.snapshot())
         except Exception as e:
             logger.warning("Failure model guard disabled (init failed): %s", e)
             failure_guard = None
+            inventory = None
         orchestrator_router.failure_guard = failure_guard
+        orchestrator_router.cluster_inventory = inventory
 
-        orchestrator_router.chaos_store = ChaosOrchestratorStore(failure_guard=failure_guard)
+        orchestrator_router.chaos_store = ChaosOrchestratorStore(
+            failure_guard=failure_guard,
+            inventory=inventory,
+        )
         orchestrator_router.orchestrator_warden_checker = OrchestratorWardenChecker(
             hosts=loaded_hosts,
             mon_port=orchestrator_router.mon_port,

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -5,7 +5,7 @@ import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 from ydb.tests.stability.nemesis.internal.orchestrator.orchestrator_warden_checker import OrchestratorWardenChecker
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.schedule_loop import OrchestratorNemesisSchedule
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import ChaosOrchestratorStore
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import WeightedNemesisScheduler
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import BoundaryNemesisScheduler
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import (
     RecoveryProbe,
     healthcheck_recovery,
@@ -121,14 +121,14 @@ def initialize_app():
             failure_guard=failure_guard,
         )
 
-        # Weighted boundary-walking scheduler (started on demand via /api/scheduler/start).
+        # Boundary-walking scheduler (started on demand via /api/scheduler/start).
         # Needs the failure model + inventory; recovery is fact-based via the healthcheck probe.
         if failure_guard is not None and inventory is not None:
             probe = RecoveryProbe(
                 guard=failure_guard,
                 recovered=healthcheck_recovery(orchestrator_router.healthcheck_reporter),
             )
-            orchestrator_router.weighted_scheduler = WeightedNemesisScheduler(
+            orchestrator_router.nemesis_scheduler = BoundaryNemesisScheduler(
                 guard=failure_guard,
                 inventory=inventory,
                 plan_inject=orchestrator_router.chaos_store.plan_inject_target,
@@ -139,7 +139,7 @@ def initialize_app():
                 recovery_probe=probe,
             )
         else:
-            orchestrator_router.weighted_scheduler = None
+            orchestrator_router.nemesis_scheduler = None
 
     current_app.config["NEMESIS_INITIALIZED"] = True
 
@@ -153,8 +153,8 @@ def cleanup_app(exception=None):
         if rep:
             rep.stop_healthchecks()
 
-        if orchestrator_router.weighted_scheduler:
-            orchestrator_router.weighted_scheduler.stop()
+        if orchestrator_router.nemesis_scheduler:
+            orchestrator_router.nemesis_scheduler.stop()
 
         if orchestrator_router.nemesis_schedule:
             orchestrator_router.nemesis_schedule.shutdown_disable_all()

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -12,8 +12,10 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe im
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     ClusterTopologyModel,
+    FailureModelConfigError,
     FailureModelGuard,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_problems import ChaosProblemStore
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import cluster_yaml_path
 from ydb.tests.stability.nemesis.internal.orchestrator.install import get_hosts_from_yaml
@@ -88,20 +90,35 @@ def initialize_app():
         orchestrator_router.healthcheck_reporter = HealthCheckReporter(loaded_hosts, store_results=True)
         orchestrator_router.healthcheck_reporter.start_healthchecks()
 
-        # Failure-model guard + inventory: fail open if topology/erasure cannot be parsed.
-        failure_guard = None
-        inventory = None
-        try:
+        # Problems surfaced to the stability test report via GET /api/problems.
+        problems = ChaosProblemStore()
+        orchestrator_router.chaos_problems = problems
+
+        # Failure-model guard + inventory. The topology is normally validated at startup by
+        # require_failure_model_or_die(); parse it here too for embedded/test use, where an
+        # unusable config surfaces as a failed request instead of a dead process. Either way the
+        # guard is live once we get past this line — there is no unguarded mode.
+        topology = current_app.config.get("NEMESIS_TOPOLOGY")
+        if topology is None:
             topology = ClusterTopologyModel(cluster_yaml_path())
-            inventory = ClusterInventory(topology, agent_hosts=loaded_hosts)
-            failure_guard = FailureModelGuard(topology, total_slots=len(inventory.slots))
-            logger.info("Failure model guard: %s", failure_guard.snapshot())
-        except Exception as e:
-            logger.warning("Failure model guard disabled (init failed): %s", e)
-            failure_guard = None
-            inventory = None
+            current_app.config["NEMESIS_TOPOLOGY"] = topology
+        inventory = ClusterInventory(topology, agent_hosts=loaded_hosts)
+        failure_guard = FailureModelGuard(topology, total_slots=len(inventory.slots))
+        logger.info("Failure model guard: %s", failure_guard.snapshot())
         orchestrator_router.failure_guard = failure_guard
         orchestrator_router.cluster_inventory = inventory
+
+        # A synthesized inventory means node/slot targets are guesses (and slot chaos is off) —
+        # not fatal, but it must not stay invisible in the test report.
+        if inventory.degraded_reason:
+            problems.record_inventory_degraded(
+                inventory.degraded_reason,
+                {
+                    "hosts": len(inventory.hosts),
+                    "nodes": len(inventory.nodes),
+                    "slots": len(inventory.slots),
+                },
+            )
 
         orchestrator_router.chaos_store = ChaosOrchestratorStore(
             failure_guard=failure_guard,
@@ -122,24 +139,24 @@ def initialize_app():
         )
 
         # Boundary-walking scheduler (started on demand via /api/scheduler/start).
-        # Needs the failure model + inventory; recovery is fact-based via the healthcheck probe.
-        if failure_guard is not None and inventory is not None:
-            probe = RecoveryProbe(
-                guard=failure_guard,
-                recovered=healthcheck_recovery(orchestrator_router.healthcheck_reporter),
-            )
-            orchestrator_router.nemesis_scheduler = BoundaryNemesisScheduler(
-                guard=failure_guard,
-                inventory=inventory,
-                plan_inject=orchestrator_router.chaos_store.plan_inject_target,
-                plan_extract=orchestrator_router.chaos_store.plan_extract_target,
-                dispatch=lambda cmd: orchestrator_router.nemesis_schedule.dispatch_command(
-                    cmd, track_history=True
-                ),
-                recovery_probe=probe,
-            )
-        else:
-            orchestrator_router.nemesis_scheduler = None
+        # Recovery is fact-based via the healthcheck probe.
+        probe = RecoveryProbe(
+            guard=failure_guard,
+            recovered=healthcheck_recovery(orchestrator_router.healthcheck_reporter),
+            # A fault that never recovers holds its budget forever — report it instead of
+            # leaving it as one ERROR line in the orchestrator log.
+            on_stuck=problems.record_stuck_fault,
+        )
+        orchestrator_router.nemesis_scheduler = BoundaryNemesisScheduler(
+            guard=failure_guard,
+            inventory=inventory,
+            plan_inject=orchestrator_router.chaos_store.plan_inject_target,
+            plan_extract=orchestrator_router.chaos_store.plan_extract_target,
+            dispatch=lambda cmd: orchestrator_router.nemesis_schedule.dispatch_command(
+                cmd, track_history=True
+            ),
+            recovery_probe=probe,
+        )
 
     current_app.config["NEMESIS_INITIALIZED"] = True
 
@@ -158,6 +175,25 @@ def cleanup_app(exception=None):
 
         if orchestrator_router.nemesis_schedule:
             orchestrator_router.nemesis_schedule.shutdown_disable_all()
+
+
+def require_failure_model_or_die(flask_app) -> None:
+    """Parse ``cluster.yaml`` into a failure model before serving, or exit the process.
+
+    The guard is not an optional extra: chaos that ignores the cluster's fault tolerance destroys
+    data and turns every stability failure into noise. So an unusable topology kills the
+    orchestrator at startup — loud, with the reason — instead of degrading into unbounded chaos.
+
+    Called from the ``run`` entry point rather than from :func:`create_app` so that merely importing
+    this module stays free of side effects. Agents don't plan chaos and need no model.
+    """
+    if get_settings().nemesis_type == "agent":
+        return
+    try:
+        flask_app.config["NEMESIS_TOPOLOGY"] = ClusterTopologyModel(cluster_yaml_path())
+    except FailureModelConfigError as e:
+        logger.critical("Refusing to start the nemesis orchestrator: %s", e)
+        raise SystemExit(2) from e
 
 
 def create_app():

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -90,14 +90,12 @@ def initialize_app():
         orchestrator_router.healthcheck_reporter = HealthCheckReporter(loaded_hosts, store_results=True)
         orchestrator_router.healthcheck_reporter.start_healthchecks()
 
-        # Problems surfaced to the stability test report via GET /api/problems.
+        # Surfaced to the stability test report via GET /api/problems.
         problems = ChaosProblemStore()
         orchestrator_router.chaos_problems = problems
 
-        # Failure-model guard + inventory. The topology is normally validated at startup by
-        # require_failure_model_or_die(); parse it here too for embedded/test use, where an
-        # unusable config surfaces as a failed request instead of a dead process. Either way the
-        # guard is live once we get past this line — there is no unguarded mode.
+        # Normally validated at startup by require_failure_model_or_die(); parsed here too for
+        # embedded/test use. Either way the guard is live past this line.
         topology = current_app.config.get("NEMESIS_TOPOLOGY")
         if topology is None:
             topology = ClusterTopologyModel(cluster_yaml_path())
@@ -108,8 +106,7 @@ def initialize_app():
         orchestrator_router.failure_guard = failure_guard
         orchestrator_router.cluster_inventory = inventory
 
-        # A synthesized inventory means node/slot targets are guesses (and slot chaos is off) —
-        # not fatal, but it must not stay invisible in the test report.
+        # Synthesized targets are guesses and slot chaos is off — not fatal, but must be visible.
         if inventory.degraded_reason:
             problems.record_inventory_degraded(
                 inventory.degraded_reason,
@@ -138,14 +135,11 @@ def initialize_app():
             failure_guard=failure_guard,
         )
 
-        # Boundary-walking scheduler (started on demand via /api/scheduler/start).
-        # Recovery is fact-based via the healthcheck probe.
+        # Boundary scheduler, started on demand via /api/scheduler/start.
         probe = RecoveryProbe(
             guard=failure_guard,
             recovered=healthcheck_recovery(orchestrator_router.healthcheck_reporter),
-            # A fault that never recovers holds its budget forever — report it instead of
-            # leaving it as one ERROR line in the orchestrator log.
-            on_stuck=problems.record_stuck_fault,
+            on_stuck=problems.record_stuck_fault,  # a never-recovering fault holds budget forever
         )
         orchestrator_router.nemesis_scheduler = BoundaryNemesisScheduler(
             guard=failure_guard,
@@ -176,17 +170,14 @@ def cleanup_app(exception=None):
         if orchestrator_router.nemesis_schedule:
             orchestrator_router.nemesis_schedule.shutdown_disable_all()
 
+        # Both steps above dispatch extracts; locally-run ones would die with the interpreter.
+        agent_router.wait_for_local_processes()
+
 
 def require_failure_model_or_die(flask_app) -> None:
-    """Parse ``cluster.yaml`` into a failure model before serving, or exit the process.
-
-    The guard is not an optional extra: chaos that ignores the cluster's fault tolerance destroys
-    data and turns every stability failure into noise. So an unusable topology kills the
-    orchestrator at startup — loud, with the reason — instead of degrading into unbounded chaos.
-
-    Called from the ``run`` entry point rather than from :func:`create_app` so that merely importing
-    this module stays free of side effects. Agents don't plan chaos and need no model.
-    """
+    """Parse ``cluster.yaml`` before serving, or exit: chaos without a fault-tolerance ceiling is
+    worse than no chaos. Called from the ``run`` entry point so importing this module stays free of
+    side effects; agents plan nothing and need no model."""
     if get_settings().nemesis_type == "agent":
         return
     try:

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -93,8 +93,8 @@ def initialize_app():
         inventory = None
         try:
             topology = ClusterTopologyModel(cluster_yaml_path())
-            failure_guard = FailureModelGuard(topology)
             inventory = ClusterInventory(topology, agent_hosts=loaded_hosts)
+            failure_guard = FailureModelGuard(topology, total_slots=len(inventory.slots))
             logger.info("Failure model guard: %s", failure_guard.snapshot())
         except Exception as e:
             logger.warning("Failure model guard disabled (init failed): %s", e)

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -5,6 +5,11 @@ import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 from ydb.tests.stability.nemesis.internal.orchestrator.orchestrator_warden_checker import OrchestratorWardenChecker
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.schedule_loop import OrchestratorNemesisSchedule
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import ChaosOrchestratorStore
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import WeightedNemesisScheduler
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import (
+    RecoveryProbe,
+    healthcheck_recovery,
+)
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     ClusterTopologyModel,
     FailureModelGuard,
@@ -116,6 +121,25 @@ def initialize_app():
             failure_guard=failure_guard,
         )
 
+        # Weighted boundary-walking scheduler (started on demand via /api/scheduler/start).
+        # Needs the failure model + inventory; recovery is fact-based via the healthcheck probe.
+        if failure_guard is not None and inventory is not None:
+            probe = RecoveryProbe(
+                guard=failure_guard,
+                recovered=healthcheck_recovery(orchestrator_router.healthcheck_reporter),
+            )
+            orchestrator_router.weighted_scheduler = WeightedNemesisScheduler(
+                guard=failure_guard,
+                inventory=inventory,
+                plan_inject=orchestrator_router.chaos_store.plan_inject_target,
+                dispatch=lambda cmd: orchestrator_router.nemesis_schedule.dispatch_command(
+                    cmd, track_history=True
+                ),
+                recovery_probe=probe,
+            )
+        else:
+            orchestrator_router.weighted_scheduler = None
+
     current_app.config["NEMESIS_INITIALIZED"] = True
 
 
@@ -127,6 +151,9 @@ def cleanup_app(exception=None):
         rep = orchestrator_router.healthcheck_reporter
         if rep:
             rep.stop_healthchecks()
+
+        if orchestrator_router.weighted_scheduler:
+            orchestrator_router.weighted_scheduler.stop()
 
         if orchestrator_router.nemesis_schedule:
             orchestrator_router.nemesis_schedule.shutdown_disable_all()

--- a/ydb/tests/stability/nemesis/app.py
+++ b/ydb/tests/stability/nemesis/app.py
@@ -132,6 +132,7 @@ def initialize_app():
                 guard=failure_guard,
                 inventory=inventory,
                 plan_inject=orchestrator_router.chaos_store.plan_inject_target,
+                plan_extract=orchestrator_router.chaos_store.plan_extract_target,
                 dispatch=lambda cmd: orchestrator_router.nemesis_schedule.dispatch_command(
                     cmd, track_history=True
                 ),

--- a/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
@@ -21,6 +21,7 @@ from typing import Any, Type
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_entries import all_nemesis_type_entries
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.default_planner import DefaultRandomHostPlanner
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     DEFAULT_RECOVERY_SEC,
     GuardMode,
@@ -123,6 +124,15 @@ def impact_scope_for(nemesis_type: str) -> ImpactScope:
     return scope if isinstance(scope, ImpactScope) else ImpactScope.NODE
 
 
+def target_kind_for(nemesis_type: str) -> TargetKind:
+    """TargetKind for ``nemesis_type`` (defaults to HOST when unannotated)."""
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return TargetKind.HOST
+    kind = spec.get("target_kind")
+    return kind if isinstance(kind, TargetKind) else TargetKind.HOST
+
+
 def guard_mode_for(nemesis_type: str) -> GuardMode:
     """GuardMode for ``nemesis_type``.
 
@@ -159,6 +169,20 @@ def recovery_sec_for(nemesis_type: str) -> float | None:
         return DEFAULT_RECOVERY_SEC
 
 
+def supports_manual_for(nemesis_type: str) -> bool:
+    """Whether UI/API manual inject on a host/target is supported for this type.
+
+    Planners that keep cross-tick state (network isolation, rolling restart, DC/pile
+    fanout) return None from ``manual()`` → ``False`` here.
+    """
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return False
+    if "supports_manual" in spec:
+        return bool(spec["supports_manual"])
+    return True
+
+
 def nemesis_types_flat_for_api() -> list[dict[str, Any]]:
     """Rows for GET /api/process_types."""
     result: list[dict[str, Any]] = []
@@ -167,12 +191,15 @@ def nemesis_types_flat_for_api() -> list[dict[str, Any]]:
         description = (
             runner.nemesis_description if runner and hasattr(runner, "nemesis_description") else ""
         )
+        kind = definition.get("target_kind")
         result.append(
             {
                 "name": name,
                 "description": description,
                 "schedule": int(definition.get("schedule") or 60),
                 "params": list(definition.get("params") or []),
+                "target_kind": kind.value if hasattr(kind, "value") else "host",
+                "supports_manual": supports_manual_for(name),
             }
         )
     return result
@@ -193,12 +220,15 @@ def nemesis_types_grouped_for_api() -> dict[str, Any]:
         gid = definition.get("ui_group", "Other")
         if gid not in groups:
             groups[gid] = {"description": "", "nemesis": []}
+        kind = definition.get("target_kind")
         groups[gid]["nemesis"].append(
             {
                 "name": name,
                 "description": description,
                 "schedule": int(definition.get("schedule") or 60),
                 "params": list(definition.get("params") or []),
+                "target_kind": kind.value if hasattr(kind, "value") else "host",
+                "supports_manual": supports_manual_for(name),
             }
         )
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
@@ -21,6 +21,11 @@ from typing import Any, Type
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_entries import all_nemesis_type_entries
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.default_planner import DefaultRandomHostPlanner
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    DEFAULT_RECOVERY_SEC,
+    GuardMode,
+    ImpactScope,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +112,51 @@ def build_all_planners() -> dict[str, NemesisPlannerBase]:
 
 def get_all_nemesis_types() -> list[str]:
     return list(NEMESIS_TYPES.keys())
+
+
+def impact_scope_for(nemesis_type: str) -> ImpactScope:
+    """ImpactScope for ``nemesis_type`` (defaults to NODE when unannotated)."""
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return ImpactScope.UNKNOWN
+    scope = spec.get("impact_scope")
+    return scope if isinstance(scope, ImpactScope) else ImpactScope.NODE
+
+
+def guard_mode_for(nemesis_type: str) -> GuardMode:
+    """GuardMode for ``nemesis_type``.
+
+    Default when unannotated: FULL for stateless types (no ``planner_cls`` /
+    ``planner_factory`` -> DefaultRandomHostPlanner), else BYPASS.
+    """
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return GuardMode.BYPASS
+    mode = spec.get("guard_mode")
+    if isinstance(mode, GuardMode):
+        return mode
+    has_custom_planner = spec.get("planner_cls") is not None or spec.get("planner_factory") is not None
+    return GuardMode.BYPASS if has_custom_planner else GuardMode.FULL
+
+
+def recovery_sec_for(nemesis_type: str) -> float | None:
+    """Auto-recovery window (seconds) passed to ``record_inject`` as ``recovery_sec``.
+
+    Number -> impairment auto-expires after that many seconds; ``None`` -> held until an
+    explicit extract (toggle faults); unannotated -> :data:`DEFAULT_RECOVERY_SEC`.
+    """
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return DEFAULT_RECOVERY_SEC
+    if "auto_recovery_sec" not in spec:
+        return DEFAULT_RECOVERY_SEC
+    val = spec.get("auto_recovery_sec")
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return DEFAULT_RECOVERY_SEC
 
 
 def nemesis_types_flat_for_api() -> list[dict[str, Any]]:

--- a/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
@@ -169,6 +169,21 @@ def recovery_sec_for(nemesis_type: str) -> float | None:
         return DEFAULT_RECOVERY_SEC
 
 
+def recovery_mode_for(nemesis_type: str) -> str:
+    """How the weighted scheduler recovers this fault and frees its budget.
+
+    ``"self"`` (default) — the fault heals on its own (SIGKILL + systemd restart, stop/start
+    pulse); the recovery probe releases the lease once healthcheck sees the host answer again.
+    ``"extract"`` — a toggle fault (clock skew, broken disk, stopped node) that stays broken
+    until told otherwise; the probe holds the lease for ``auto_recovery_sec`` then dispatches an
+    explicit extract and releases.
+    """
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return "self"
+    return "extract" if spec.get("recovery") == "extract" else "self"
+
+
 def weight_for(nemesis_type: str) -> float:
     """Relative selection weight for the weighted scheduler (unannotated -> 1.0).
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
@@ -170,7 +170,7 @@ def recovery_sec_for(nemesis_type: str) -> float | None:
 
 
 def recovery_mode_for(nemesis_type: str) -> str:
-    """How the weighted scheduler recovers this fault and frees its budget.
+    """How the boundary scheduler recovers this fault and frees its budget.
 
     ``"self"`` (default) — the fault heals on its own (SIGKILL + systemd restart, stop/start
     pulse); the recovery probe releases the lease once healthcheck sees the host answer again.
@@ -182,20 +182,6 @@ def recovery_mode_for(nemesis_type: str) -> str:
     if spec is None:
         return "self"
     return "extract" if spec.get("recovery") == "extract" else "self"
-
-
-def weight_for(nemesis_type: str) -> float:
-    """Relative selection weight for the weighted scheduler (unannotated -> 1.0).
-
-    Higher = picked more often. ``<= 0`` mutes the type (never scheduled)."""
-    spec = NEMESIS_TYPES.get(nemesis_type)
-    if spec is None:
-        return 1.0
-    try:
-        w = float(spec.get("weight", 1.0))
-    except (TypeError, ValueError):
-        return 1.0
-    return w if w > 0 else 0.0
 
 
 def supports_manual_for(nemesis_type: str) -> bool:

--- a/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
@@ -169,6 +169,20 @@ def recovery_sec_for(nemesis_type: str) -> float | None:
         return DEFAULT_RECOVERY_SEC
 
 
+def weight_for(nemesis_type: str) -> float:
+    """Relative selection weight for the weighted scheduler (unannotated -> 1.0).
+
+    Higher = picked more often. ``<= 0`` mutes the type (never scheduled)."""
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return 1.0
+    try:
+        w = float(spec.get("weight", 1.0))
+    except (TypeError, ValueError):
+        return 1.0
+    return w if w > 0 else 0.0
+
+
 def supports_manual_for(nemesis_type: str) -> bool:
     """Whether UI/API manual inject on a host/target is supported for this type.
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/catalog.py
@@ -111,10 +111,6 @@ def build_all_planners() -> dict[str, NemesisPlannerBase]:
 # ---------------------------------------------------------------------------
 
 
-def get_all_nemesis_types() -> list[str]:
-    return list(NEMESIS_TYPES.keys())
-
-
 def impact_scope_for(nemesis_type: str) -> ImpactScope:
     """ImpactScope for ``nemesis_type`` (defaults to NODE when unannotated)."""
     spec = NEMESIS_TYPES.get(nemesis_type)
@@ -134,11 +130,7 @@ def target_kind_for(nemesis_type: str) -> TargetKind:
 
 
 def guard_mode_for(nemesis_type: str) -> GuardMode:
-    """GuardMode for ``nemesis_type``.
-
-    Default when unannotated: FULL for stateless types (no ``planner_cls`` /
-    ``planner_factory`` -> DefaultRandomHostPlanner), else BYPASS.
-    """
+    """GuardMode of the type; unannotated defaults to FULL, or BYPASS for custom-planner types."""
     spec = NEMESIS_TYPES.get(nemesis_type)
     if spec is None:
         return GuardMode.BYPASS
@@ -150,11 +142,7 @@ def guard_mode_for(nemesis_type: str) -> GuardMode:
 
 
 def recovery_sec_for(nemesis_type: str) -> float | None:
-    """Auto-recovery window (seconds) passed to ``record_inject`` as ``recovery_sec``.
-
-    Number -> impairment auto-expires after that many seconds; ``None`` -> held until an
-    explicit extract (toggle faults); unannotated -> :data:`DEFAULT_RECOVERY_SEC`.
-    """
+    """``auto_recovery_sec`` of the type: how long the fault is expected to last."""
     spec = NEMESIS_TYPES.get(nemesis_type)
     if spec is None:
         return DEFAULT_RECOVERY_SEC
@@ -170,26 +158,53 @@ def recovery_sec_for(nemesis_type: str) -> float | None:
 
 
 def recovery_mode_for(nemesis_type: str) -> str:
-    """How the boundary scheduler recovers this fault and frees its budget.
-
-    ``"self"`` (default) — the fault heals on its own (SIGKILL + systemd restart, stop/start
-    pulse); the recovery probe releases the lease once healthcheck sees the host answer again.
-    ``"extract"`` — a toggle fault (clock skew, broken disk, stopped node) that stays broken
-    until told otherwise; the probe holds the lease for ``auto_recovery_sec`` then dispatches an
-    explicit extract and releases.
-    """
+    """``"self"`` — heals on its own (SIGKILL + systemd restart); ``"extract"`` — stays applied
+    until the probe dispatches an extract (clock skew, broken disk, stopped node)."""
     spec = NEMESIS_TYPES.get(nemesis_type)
     if spec is None:
         return "self"
     return "extract" if spec.get("recovery") == "extract" else "self"
 
 
-def supports_manual_for(nemesis_type: str) -> bool:
-    """Whether UI/API manual inject on a host/target is supported for this type.
+def impairment_hold_sec_for(nemesis_type: str, *, paired_extract: bool) -> float | None:
+    """``recovery_sec`` for ``record_inject``.
 
-    Planners that keep cross-tick state (network isolation, rolling restart, DC/pile
-    fanout) return None from ``manual()`` → ``False`` here.
+    ``paired_extract=True`` (manual inject, followed by a manual extract): a toggle fault holds its
+    budget until that extract. ``False`` (legacy loop, where the *next inject* toggles the fault
+    back): held for the length of the pulse, i.e. until the type's next tick.
     """
+    if recovery_mode_for(nemesis_type) != "extract":
+        return recovery_sec_for(nemesis_type)
+    if paired_extract:
+        return None
+    spec = NEMESIS_TYPES.get(nemesis_type) or {}
+    interval = float(spec.get("schedule") or 60)
+    window = recovery_sec_for(nemesis_type)
+    return max(interval, window) if window is not None else interval
+
+
+def supports_boundary_scheduler(nemesis_type: str) -> bool:
+    """Whether the boundary scheduler may inject this type on the target it reserved.
+
+    Safe: a DATACENTER target (fanned out over exactly that DC), a toggle fault (dispatched directly,
+    bypassing planners), or the default planner (injects the candidate it is handed). A custom planner
+    must opt in with ``boundary_safe``: one that keeps its own targets would inject something the
+    guard never reserved. Never builds the planner to ask — constructors may talk to the cluster.
+    """
+    spec = NEMESIS_TYPES.get(nemesis_type)
+    if spec is None:
+        return False
+    if "boundary_safe" in spec:
+        return bool(spec["boundary_safe"])
+    if target_kind_for(nemesis_type) is TargetKind.DATACENTER:
+        return True
+    if recovery_mode_for(nemesis_type) == "extract":
+        return True
+    return spec.get("planner_cls") is None and spec.get("planner_factory") is None
+
+
+def supports_manual_for(nemesis_type: str) -> bool:
+    """Whether UI/API manual inject works: planners with cross-tick state return None instead."""
     spec = NEMESIS_TYPES.get(nemesis_type)
     if spec is None:
         return False

--- a/ydb/tests/stability/nemesis/internal/nemesis/chaos_dispatch.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/chaos_dispatch.py
@@ -6,40 +6,69 @@ import uuid
 from dataclasses import dataclass
 from typing import Any
 
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+
 
 @dataclass(frozen=True)
 class DispatchCommand:
     execution_id: str
     scenario_id: str
     nemesis_type: str
-    host: str
     action: str
+    target: ChaosTarget
     payload: dict[str, Any]
+
+    @property
+    def host(self) -> str:
+        """Agent address (backward-compatible alias)."""
+        return self.target.host
 
 
 def dispatch(
     nemesis_type: str,
-    host: str,
+    host_or_target: str | ChaosTarget,
     action: str,
     payload: dict[str, Any],
     *,
     scenario_id: str | None = None,
+    target: ChaosTarget | None = None,
 ) -> DispatchCommand:
+    """Build a dispatch command.
+
+    ``host_or_target`` may be a hostname (legacy) or a :class:`ChaosTarget`.
+    Explicit ``target=`` overrides when provided.
+    """
+    if target is not None:
+        chaos_target = target
+    elif isinstance(host_or_target, ChaosTarget):
+        chaos_target = host_or_target
+    else:
+        chaos_target = ChaosTarget.for_host(str(host_or_target))
     return DispatchCommand(
         execution_id=str(uuid.uuid4()),
         scenario_id=scenario_id or str(uuid.uuid4()),
         nemesis_type=nemesis_type,
-        host=host,
         action=action,
+        target=chaos_target,
         payload=payload,
     )
 
 
 def fanout(
     nemesis_type: str,
-    hosts: list[str],
+    hosts_or_targets: list[str] | list[ChaosTarget],
     action: str,
     payload: dict[str, Any],
 ) -> list[DispatchCommand]:
     sid = str(uuid.uuid4())
-    return [dispatch(nemesis_type, h, action, payload, scenario_id=sid) for h in hosts]
+    return [
+        dispatch(nemesis_type, item, action, payload, scenario_id=sid)
+        for item in hosts_or_targets
+    ]
+
+
+__all__ = [
+    "DispatchCommand",
+    "dispatch",
+    "fanout",
+]

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -63,6 +63,10 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.topology_fanout_p
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.rolling_restart_planner import (
     RollingRestartNemesisPlanner
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    GuardMode,
+    ImpactScope,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -137,11 +141,16 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 200,
         "ui_group": "NetworkNemesis",
         "planner_cls": NetworkNemesisPlanner,
+        "impact_scope": ImpactScope.NETWORK,
+        "guard_mode": GuardMode.PREFILTER_ONLY,
     }
     out["KillNodeNemesis"] = {
         "runner": KillNodeNemesis(),
         "schedule": 200,
         "ui_group": "NodeNemesis",
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.FULL,
+        "auto_recovery_sec": 20,
     }
     # out["DnsNemesis"] = {
     #     "runner": DnsNemesis(),
@@ -157,6 +166,8 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "planner_factory": lambda nemesis_type_key, params=None: RollingRestartNemesisPlanner(
             **(params or {})
         ),
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.PREFILTER_ONLY,
         "params": [
             {
                 "name": "nodes_per_step",
@@ -188,6 +199,8 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 400,
         "ui_group": "NetworkNemesis",
         "planner_cls": TimeSkewNemesisPlanner,
+        "impact_scope": ImpactScope.NETWORK,
+        "guard_mode": GuardMode.PREFILTER_ONLY,
     }
 
     # --- tablet kills -------------------------------------------------------
@@ -196,17 +209,23 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
             "runner": cls(),
             "schedule": sched,
             "ui_group": _TABLET_UI_GROUP,
+            "impact_scope": ImpactScope.NODE,
+            "guard_mode": GuardMode.FULL,
         }
 
     out["KickTabletsFromNodeNemesis"] = {
         "runner": ClusterKickTabletsFromNodeNemesis(),
         "schedule": 200,
         "ui_group": _TABLET_UI_GROUP,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.FULL,
     }
     out["ReBalanceTabletsNemesis"] = {
         "runner": ClusterReBalanceTabletsNemesis(),
         "schedule": 120,
         "ui_group": _TABLET_UI_GROUP,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.FULL,
     }
 
     # One scheduled type per tablet kind is enough (orchestrator picks hosts at random per tick).
@@ -215,23 +234,35 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
             "runner": ClusterChangeTabletGroupNemesis(tt, channels=()),
             "schedule": 120,
             "ui_group": _TABLET_UI_GROUP,
+            "impact_scope": ImpactScope.NODE,
+            "guard_mode": GuardMode.FULL,
         }
         out[f"BulkChangeTabletGroup_{tt.name}"] = {
             "runner": ClusterBulkChangeTabletGroupNemesis(tt, percent=None, channels=()),
             "schedule": 180,
             "ui_group": _TABLET_UI_GROUP,
+            "impact_scope": ImpactScope.NODE,
+            "guard_mode": GuardMode.FULL,
         }
 
     # --- daemon kills -------------------------------------------------------
+    # SIGKILL + no-op extract: systemd auto-restarts the daemon, so the guard releases the rack
+    # on a timer (auto_recovery_sec) covering restart + rejoin, not on an explicit extract.
     out["KillSlotDaemonNemesis"] = {
         "runner": ClusterKillSlotDaemonNemesis(),
         "schedule": 120,
         "ui_group": _UI_GROUP,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.FULL,
+        "auto_recovery_sec": 90,
     }
     out["KillNodeDaemonNemesis"] = {
         "runner": ClusterKillNodeDaemonNemesis(),
         "schedule": 180,
         "ui_group": _UI_GROUP,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.FULL,
+        "auto_recovery_sec": 90,
     }
 
     # --- serial kills -------------------------------------------------------
@@ -240,27 +271,33 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 300,
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_node_planner_factory,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.PREFILTER_ONLY,
     }
     out["SerialKillSlotsNemesis"] = {
         "runner": ClusterSerialKillSlotsNemesis(),
         "schedule": 300,
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_slot_planner_factory,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.PREFILTER_ONLY,
     }
 
     # --- disk / rolling / stop-start / suspend ------------------------------
-    for wire, cls, sched in (
-        ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400),
-        ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400),
-        # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120),
-        ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400),
-        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800),
+    for wire, cls, sched, scope in (
+        ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK),
+        ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400, ImpactScope.DISK),
+        # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE),
+        ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE),
+        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE),
     ):
         out[wire] = {
             "runner": cls(),
             "schedule": sched,
             "ui_group": _UI_GROUP,
             "planner_factory": _pinned_planner_factory,
+            "impact_scope": scope,
+            "guard_mode": GuardMode.PREFILTER_ONLY,
         }
 
     # --- host reboot --------------------------------------------------------
@@ -324,6 +361,8 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
                 "schedule": sched,
                 "ui_group": _BRIDGE_UI_GROUP,
                 "planner_factory": _bridge_pile_fanout_planner_factory,
+                "impact_scope": ImpactScope.PILE,
+                "guard_mode": GuardMode.BYPASS,
             }
 
     return extra

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -67,6 +67,7 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model imp
     GuardMode,
     ImpactScope,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import TargetKind
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -136,18 +137,21 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
 
     # --- core nemesis (network / node / time skew) --------------------------
-    out["NetworkNemesis"] = {
-        "runner": NetworkNemesis(),
-        "schedule": 200,
-        "ui_group": "NetworkNemesis",
-        "planner_cls": NetworkNemesisPlanner,
-        "impact_scope": ImpactScope.NETWORK,
-        "guard_mode": GuardMode.PREFILTER_ONLY,
-    }
+    # out["NetworkNemesis"] = {
+    #     "runner": NetworkNemesis(),
+    #     "schedule": 200,
+    #     "ui_group": "NetworkNemesis",
+    #     "planner_cls": NetworkNemesisPlanner,
+    #     "target_kind": TargetKind.HOST,
+    #     "impact_scope": ImpactScope.NODE,
+    #     "guard_mode": GuardMode.PREFILTER_ONLY,
+    #     "supports_manual": False,
+    # }
     out["KillNodeNemesis"] = {
         "runner": KillNodeNemesis(),
         "schedule": 200,
         "ui_group": "NodeNemesis",
+        "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 20,
@@ -166,8 +170,10 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "planner_factory": lambda nemesis_type_key, params=None: RollingRestartNemesisPlanner(
             **(params or {})
         ),
+        "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.PREFILTER_ONLY,
+        "supports_manual": False,
         "params": [
             {
                 "name": "nodes_per_step",
@@ -199,8 +205,10 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 400,
         "ui_group": "NetworkNemesis",
         "planner_cls": TimeSkewNemesisPlanner,
-        "impact_scope": ImpactScope.NETWORK,
+        "target_kind": TargetKind.HOST,
+        "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.PREFILTER_ONLY,
+        "supports_manual": False,
     }
 
     # --- tablet kills -------------------------------------------------------
@@ -209,14 +217,16 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
             "runner": cls(),
             "schedule": sched,
             "ui_group": _TABLET_UI_GROUP,
+            "target_kind": TargetKind.TABLET,
             "impact_scope": ImpactScope.NODE,
-            "guard_mode": GuardMode.FULL,
+            "guard_mode": GuardMode.BYPASS,
         }
 
     out["KickTabletsFromNodeNemesis"] = {
         "runner": ClusterKickTabletsFromNodeNemesis(),
         "schedule": 200,
         "ui_group": _TABLET_UI_GROUP,
+        "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
     }
@@ -224,8 +234,9 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "runner": ClusterReBalanceTabletsNemesis(),
         "schedule": 120,
         "ui_group": _TABLET_UI_GROUP,
+        "target_kind": TargetKind.TABLET,
         "impact_scope": ImpactScope.NODE,
-        "guard_mode": GuardMode.FULL,
+        "guard_mode": GuardMode.BYPASS,
     }
 
     # One scheduled type per tablet kind is enough (orchestrator picks hosts at random per tick).
@@ -234,15 +245,17 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
             "runner": ClusterChangeTabletGroupNemesis(tt, channels=()),
             "schedule": 120,
             "ui_group": _TABLET_UI_GROUP,
+            "target_kind": TargetKind.TABLET,
             "impact_scope": ImpactScope.NODE,
-            "guard_mode": GuardMode.FULL,
+            "guard_mode": GuardMode.BYPASS,
         }
         out[f"BulkChangeTabletGroup_{tt.name}"] = {
             "runner": ClusterBulkChangeTabletGroupNemesis(tt, percent=None, channels=()),
             "schedule": 180,
             "ui_group": _TABLET_UI_GROUP,
+            "target_kind": TargetKind.TABLET,
             "impact_scope": ImpactScope.NODE,
-            "guard_mode": GuardMode.FULL,
+            "guard_mode": GuardMode.BYPASS,
         }
 
     # --- daemon kills -------------------------------------------------------
@@ -252,6 +265,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "runner": ClusterKillSlotDaemonNemesis(),
         "schedule": 120,
         "ui_group": _UI_GROUP,
+        "target_kind": TargetKind.SLOT,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
@@ -260,6 +274,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "runner": ClusterKillNodeDaemonNemesis(),
         "schedule": 180,
         "ui_group": _UI_GROUP,
+        "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
@@ -271,6 +286,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 300,
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_node_planner_factory,
+        "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.PREFILTER_ONLY,
     }
@@ -279,23 +295,25 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 300,
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_slot_planner_factory,
+        "target_kind": TargetKind.SLOT,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.PREFILTER_ONLY,
     }
 
     # --- disk / rolling / stop-start / suspend ------------------------------
-    for wire, cls, sched, scope in (
-        ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK),
-        ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400, ImpactScope.DISK),
-        # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE),
-        ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE),
-        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE),
+    for wire, cls, sched, scope, tkind in (
+        ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK, TargetKind.DISK),
+        ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400, ImpactScope.DISK, TargetKind.DISK),
+        # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE, TargetKind.NODE),
+        ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE, TargetKind.NODE),
+        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE, TargetKind.NODE),
     ):
         out[wire] = {
             "runner": cls(),
             "schedule": sched,
             "ui_group": _UI_GROUP,
             "planner_factory": _pinned_planner_factory,
+            "target_kind": tkind,
             "impact_scope": scope,
             "guard_mode": GuardMode.PREFILTER_ONLY,
         }
@@ -361,8 +379,10 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
                 "schedule": sched,
                 "ui_group": _BRIDGE_UI_GROUP,
                 "planner_factory": _bridge_pile_fanout_planner_factory,
+                "target_kind": TargetKind.PILE,
                 "impact_scope": ImpactScope.PILE,
                 "guard_mode": GuardMode.BYPASS,
+                "supports_manual": False,
             }
 
     return extra

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -43,11 +43,11 @@ from ydb.tests.stability.nemesis.internal.nemesis.runners import (
     ClusterSuspendNodeNemesis,
     # ClusterHardRebootHostNemesis,
     KillNodeNemesis,
-    NetworkNemesis,
+    # NetworkNemesis,
     TimeSkewNemesis,
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.network_planner import (
-    NetworkNemesisPlanner,
+    # NetworkNemesisPlanner,
     TimeSkewNemesisPlanner,
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.pinned_first_host_planner import (

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -211,52 +211,52 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "supports_manual": False,
     }
 
-    # --- tablet kills -------------------------------------------------------
-    for wire, cls, sched in _KILL_TABLET_SPECS:
-        out[wire] = {
-            "runner": cls(),
-            "schedule": sched,
-            "ui_group": _TABLET_UI_GROUP,
-            "target_kind": TargetKind.TABLET,
-            "impact_scope": ImpactScope.NODE,
-            "guard_mode": GuardMode.BYPASS,
-        }
-
-    out["KickTabletsFromNodeNemesis"] = {
-        "runner": ClusterKickTabletsFromNodeNemesis(),
-        "schedule": 200,
-        "ui_group": _TABLET_UI_GROUP,
-        "target_kind": TargetKind.NODE,
-        "impact_scope": ImpactScope.NODE,
-        "guard_mode": GuardMode.FULL,
-    }
-    out["ReBalanceTabletsNemesis"] = {
-        "runner": ClusterReBalanceTabletsNemesis(),
-        "schedule": 120,
-        "ui_group": _TABLET_UI_GROUP,
-        "target_kind": TargetKind.TABLET,
-        "impact_scope": ImpactScope.NODE,
-        "guard_mode": GuardMode.BYPASS,
-    }
-
-    # One scheduled type per tablet kind is enough (orchestrator picks hosts at random per tick).
-    for tt in _CHANGE_TABLET_TYPES:
-        out[f"ChangeTabletGroup_{tt.name}"] = {
-            "runner": ClusterChangeTabletGroupNemesis(tt, channels=()),
-            "schedule": 120,
-            "ui_group": _TABLET_UI_GROUP,
-            "target_kind": TargetKind.TABLET,
-            "impact_scope": ImpactScope.NODE,
-            "guard_mode": GuardMode.BYPASS,
-        }
-        out[f"BulkChangeTabletGroup_{tt.name}"] = {
-            "runner": ClusterBulkChangeTabletGroupNemesis(tt, percent=None, channels=()),
-            "schedule": 180,
-            "ui_group": _TABLET_UI_GROUP,
-            "target_kind": TargetKind.TABLET,
-            "impact_scope": ImpactScope.NODE,
-            "guard_mode": GuardMode.BYPASS,
-        }
+    # --- tablet chaos (temporarily disabled: BYPASS / not in failure-model budget) ---
+    # for wire, cls, sched in _KILL_TABLET_SPECS:
+    #     out[wire] = {
+    #         "runner": cls(),
+    #         "schedule": sched,
+    #         "ui_group": _TABLET_UI_GROUP,
+    #         "target_kind": TargetKind.TABLET,
+    #         "impact_scope": ImpactScope.NODE,
+    #         "guard_mode": GuardMode.BYPASS,
+    #     }
+    #
+    # out["KickTabletsFromNodeNemesis"] = {
+    #     "runner": ClusterKickTabletsFromNodeNemesis(),
+    #     "schedule": 200,
+    #     "ui_group": _TABLET_UI_GROUP,
+    #     "target_kind": TargetKind.NODE,
+    #     "impact_scope": ImpactScope.NODE,
+    #     "guard_mode": GuardMode.FULL,
+    # }
+    # out["ReBalanceTabletsNemesis"] = {
+    #     "runner": ClusterReBalanceTabletsNemesis(),
+    #     "schedule": 120,
+    #     "ui_group": _TABLET_UI_GROUP,
+    #     "target_kind": TargetKind.TABLET,
+    #     "impact_scope": ImpactScope.NODE,
+    #     "guard_mode": GuardMode.BYPASS,
+    # }
+    #
+    # # One scheduled type per tablet kind is enough (orchestrator picks hosts at random per tick).
+    # for tt in _CHANGE_TABLET_TYPES:
+    #     out[f"ChangeTabletGroup_{tt.name}"] = {
+    #         "runner": ClusterChangeTabletGroupNemesis(tt, channels=()),
+    #         "schedule": 120,
+    #         "ui_group": _TABLET_UI_GROUP,
+    #         "target_kind": TargetKind.TABLET,
+    #         "impact_scope": ImpactScope.NODE,
+    #         "guard_mode": GuardMode.BYPASS,
+    #     }
+    #     out[f"BulkChangeTabletGroup_{tt.name}"] = {
+    #         "runner": ClusterBulkChangeTabletGroupNemesis(tt, percent=None, channels=()),
+    #         "schedule": 180,
+    #         "ui_group": _TABLET_UI_GROUP,
+    #         "target_kind": TargetKind.TABLET,
+    #         "impact_scope": ImpactScope.NODE,
+    #         "guard_mode": GuardMode.BYPASS,
+    #     }
 
     # --- daemon kills -------------------------------------------------------
     # SIGKILL + no-op extract: systemd auto-restarts the daemon, so the guard releases the rack

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -144,7 +144,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
     #     "planner_cls": NetworkNemesisPlanner,
     #     "target_kind": TargetKind.HOST,
     #     "impact_scope": ImpactScope.NODE,
-    #     "guard_mode": GuardMode.PREFILTER_ONLY,
+    #     "guard_mode": GuardMode.FULL,
     #     "supports_manual": False,
     # }
     out["KillNodeNemesis"] = {
@@ -174,7 +174,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         ),
         "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
-        "guard_mode": GuardMode.PREFILTER_ONLY,
+        "guard_mode": GuardMode.FULL,
         "supports_manual": False,
         "params": [
             {
@@ -209,7 +209,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "planner_cls": TimeSkewNemesisPlanner,
         "target_kind": TargetKind.HOST,
         "impact_scope": ImpactScope.NODE,
-        "guard_mode": GuardMode.PREFILTER_ONLY,
+        "guard_mode": GuardMode.FULL,
         "supports_manual": False,
         # Toggle fault: skew the clock, then the scheduler dispatches extract (re-enable ntp).
         "recovery": "extract",
@@ -294,7 +294,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "planner_factory": _serial_staggered_node_planner_factory,
         "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
-        "guard_mode": GuardMode.PREFILTER_ONLY,
+        "guard_mode": GuardMode.FULL,
     }
     out["SerialKillSlotsNemesis"] = {
         "runner": ClusterSerialKillSlotsNemesis(),
@@ -303,7 +303,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "planner_factory": _serial_staggered_slot_planner_factory,
         "target_kind": TargetKind.SLOT,
         "impact_scope": ImpactScope.SLOT,
-        "guard_mode": GuardMode.PREFILTER_ONLY,
+        "guard_mode": GuardMode.FULL,
     }
 
     # --- disk / rolling / stop-start / suspend ------------------------------
@@ -327,7 +327,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
             "planner_factory": _pinned_planner_factory,
             "target_kind": tkind,
             "impact_scope": scope,
-            "guard_mode": GuardMode.PREFILTER_ONLY,
+            "guard_mode": GuardMode.FULL,
             **extra,
         }
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -15,9 +15,9 @@ from typing import Any, Type
 
 from ydb.tests.library.common.types import TabletTypes
 from ydb.tests.stability.nemesis.internal.nemesis.runners import (
-    # ClusterBulkChangeTabletGroupNemesis,
-    # ClusterChangeTabletGroupNemesis,
-    # ClusterKickTabletsFromNodeNemesis,
+    ClusterBulkChangeTabletGroupNemesis,
+    ClusterChangeTabletGroupNemesis,
+    ClusterKickTabletsFromNodeNemesis,
     ClusterKillBlockstorePartitionNemesis,
     ClusterKillBlockstoreVolumeNemesis,
     ClusterKillBsControllerNemesis,
@@ -33,7 +33,7 @@ from ydb.tests.stability.nemesis.internal.nemesis.runners import (
     ClusterKillSlotDaemonNemesis,
     ClusterKillTenantSlotBrokerNemesis,
     ClusterKillTxAllocatorNemesis,
-    # ClusterReBalanceTabletsNemesis,
+    ClusterReBalanceTabletsNemesis,
     ClusterRollingRestartNemesis,
     ClusterSafelyBreakDiskNemesis,
     ClusterSafelyCleanupDisksNemesis,
@@ -157,7 +157,6 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         # SIGKILL + systemd restart + rejoin: 20s was well under real re-replication, so the
         # probe cried "stuck" too early (and the timer freed budget before the node was back).
         "auto_recovery_sec": 120,
-        "weight": 1.0,
     }
     # out["DnsNemesis"] = {
     #     "runner": DnsNemesis(),
@@ -215,55 +214,54 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         # Toggle fault: skew the clock, then the scheduler dispatches extract (re-enable ntp).
         "recovery": "extract",
         "auto_recovery_sec": 120,
-        "weight": 1.0,
     }
 
-    # --- tablet chaos (temporarily disabled: BYPASS / not in failure-model budget) ---
-    # for wire, cls, sched in _KILL_TABLET_SPECS:
-    #     out[wire] = {
-    #         "runner": cls(),
-    #         "schedule": sched,
-    #         "ui_group": _TABLET_UI_GROUP,
-    #         "target_kind": TargetKind.TABLET,
-    #         "impact_scope": ImpactScope.NODE,
-    #         "guard_mode": GuardMode.BYPASS,
-    #     }
-    #
-    # out["KickTabletsFromNodeNemesis"] = {
-    #     "runner": ClusterKickTabletsFromNodeNemesis(),
-    #     "schedule": 200,
-    #     "ui_group": _TABLET_UI_GROUP,
-    #     "target_kind": TargetKind.NODE,
-    #     "impact_scope": ImpactScope.NODE,
-    #     "guard_mode": GuardMode.FULL,
-    # }
-    # out["ReBalanceTabletsNemesis"] = {
-    #     "runner": ClusterReBalanceTabletsNemesis(),
-    #     "schedule": 120,
-    #     "ui_group": _TABLET_UI_GROUP,
-    #     "target_kind": TargetKind.TABLET,
-    #     "impact_scope": ImpactScope.NODE,
-    #     "guard_mode": GuardMode.BYPASS,
-    # }
-    #
-    # # One scheduled type per tablet kind is enough (orchestrator picks hosts at random per tick).
-    # for tt in _CHANGE_TABLET_TYPES:
-    #     out[f"ChangeTabletGroup_{tt.name}"] = {
-    #         "runner": ClusterChangeTabletGroupNemesis(tt, channels=()),
-    #         "schedule": 120,
-    #         "ui_group": _TABLET_UI_GROUP,
-    #         "target_kind": TargetKind.TABLET,
-    #         "impact_scope": ImpactScope.NODE,
-    #         "guard_mode": GuardMode.BYPASS,
-    #     }
-    #     out[f"BulkChangeTabletGroup_{tt.name}"] = {
-    #         "runner": ClusterBulkChangeTabletGroupNemesis(tt, percent=None, channels=()),
-    #         "schedule": 180,
-    #         "ui_group": _TABLET_UI_GROUP,
-    #         "target_kind": TargetKind.TABLET,
-    #         "impact_scope": ImpactScope.NODE,
-    #         "guard_mode": GuardMode.BYPASS,
-    #     }
+    # --- tablet chaos (BYPASS: not counted against the failure-model budget) ---
+    for wire, cls, sched in _KILL_TABLET_SPECS:
+        out[wire] = {
+            "runner": cls(),
+            "schedule": sched,
+            "ui_group": _TABLET_UI_GROUP,
+            "target_kind": TargetKind.TABLET,
+            "impact_scope": ImpactScope.NODE,
+            "guard_mode": GuardMode.BYPASS,
+        }
+
+    out["KickTabletsFromNodeNemesis"] = {
+        "runner": ClusterKickTabletsFromNodeNemesis(),
+        "schedule": 200,
+        "ui_group": _TABLET_UI_GROUP,
+        "target_kind": TargetKind.NODE,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.FULL,
+    }
+    out["ReBalanceTabletsNemesis"] = {
+        "runner": ClusterReBalanceTabletsNemesis(),
+        "schedule": 120,
+        "ui_group": _TABLET_UI_GROUP,
+        "target_kind": TargetKind.TABLET,
+        "impact_scope": ImpactScope.NODE,
+        "guard_mode": GuardMode.BYPASS,
+    }
+
+    # One scheduled type per tablet kind is enough (orchestrator picks hosts at random per tick).
+    for tt in _CHANGE_TABLET_TYPES:
+        out[f"ChangeTabletGroup_{tt.name}"] = {
+            "runner": ClusterChangeTabletGroupNemesis(tt, channels=()),
+            "schedule": 120,
+            "ui_group": _TABLET_UI_GROUP,
+            "target_kind": TargetKind.TABLET,
+            "impact_scope": ImpactScope.NODE,
+            "guard_mode": GuardMode.BYPASS,
+        }
+        out[f"BulkChangeTabletGroup_{tt.name}"] = {
+            "runner": ClusterBulkChangeTabletGroupNemesis(tt, percent=None, channels=()),
+            "schedule": 180,
+            "ui_group": _TABLET_UI_GROUP,
+            "target_kind": TargetKind.TABLET,
+            "impact_scope": ImpactScope.NODE,
+            "guard_mode": GuardMode.BYPASS,
+        }
 
     # --- daemon kills -------------------------------------------------------
     # SIGKILL + no-op extract: systemd auto-restarts the daemon, so the guard releases the rack
@@ -276,7 +274,6 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
-        "weight": 3.0,
     }
     out["KillNodeDaemonNemesis"] = {
         "runner": ClusterKillNodeDaemonNemesis(),
@@ -286,7 +283,6 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
-        "weight": 2.0,
     }
 
     # --- serial kills -------------------------------------------------------
@@ -311,16 +307,16 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
 
     # --- disk / rolling / stop-start / suspend ------------------------------
     # Toggle faults (``recovery: extract``): the pinned planner injects the scheduler-chosen
-    # target; the weighted scheduler holds the budget for ``auto_recovery_sec`` then dispatches
+    # target; the boundary scheduler holds the budget for ``auto_recovery_sec`` then dispatches
     # an extract so the agent-side actor restores its stored state.
     for wire, cls, sched, scope, tkind, extra in (
         ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK, TargetKind.DISK,
-         {"recovery": "extract", "auto_recovery_sec": 120, "weight": 0.5}),
+         {"recovery": "extract", "auto_recovery_sec": 120}),
         ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400, ImpactScope.DISK, TargetKind.DISK,
-         {"recovery": "extract", "auto_recovery_sec": 90, "weight": 0.4}),
+         {"recovery": "extract", "auto_recovery_sec": 90}),
         # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE, TargetKind.NODE, {}),
         ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE, TargetKind.NODE,
-         {"recovery": "extract", "auto_recovery_sec": 90, "weight": 2.0}),
+         {"recovery": "extract", "auto_recovery_sec": 90}),
         ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE, TargetKind.NODE, {}),
     ):
         out[wire] = {
@@ -360,7 +356,7 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
 
     if yaml_has_multi_datacenter(path):
         # StopNodes only (self-recovering stop/start pulse). Route/iptables/DNS variants stay off:
-        # they need explicit extract and don't fit the inject-only weighted-scheduler path.
+        # they need explicit extract and don't fit the inject-only boundary-scheduler path.
         from ydb.tests.stability.nemesis.internal.nemesis.runners import (
             ClusterDataCenterStopNodesNemesis,
         )
@@ -374,7 +370,6 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
             "impact_scope": ImpactScope.DATACENTER,
             "guard_mode": GuardMode.FULL,  # reserves the whole realm (mirror-3-dc sacrificial DC)
             "auto_recovery_sec": 240,
-            "weight": 0.3,  # heavy + rare relative to node kills
             "supports_manual": False,
         }
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -154,7 +154,10 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
-        "auto_recovery_sec": 20,
+        # SIGKILL + systemd restart + rejoin: 20s was well under real re-replication, so the
+        # probe cried "stuck" too early (and the timer freed budget before the node was back).
+        "auto_recovery_sec": 120,
+        "weight": 3.0,
     }
     # out["DnsNemesis"] = {
     #     "runner": DnsNemesis(),
@@ -269,6 +272,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
+        "weight": 2.0,
     }
     out["KillNodeDaemonNemesis"] = {
         "runner": ClusterKillNodeDaemonNemesis(),
@@ -278,6 +282,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
+        "weight": 2.0,
     }
 
     # --- serial kills -------------------------------------------------------
@@ -343,24 +348,24 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
     extra: dict[str, dict[str, Any]] = {}
 
     if yaml_has_multi_datacenter(path):
-        pass
-        # from ydb.tests.stability.nemesis.internal.nemesis.runners import (
-        #     ClusterDataCenterIptablesBlockPortsNemesis,
-        #     ClusterDataCenterRouteUnreachableNemesis,
-        #     ClusterDataCenterStopNodesNemesis,
-        # )
+        # StopNodes only (self-recovering stop/start pulse). Route/iptables/DNS variants stay off:
+        # they need explicit extract and don't fit the inject-only weighted-scheduler path.
+        from ydb.tests.stability.nemesis.internal.nemesis.runners import (
+            ClusterDataCenterStopNodesNemesis,
+        )
 
-        # for wire, cls, sched in (
-        #     ("DataCenterStopNodesNemesis", ClusterDataCenterStopNodesNemesis, 600),
-        #     ("DataCenterRouteUnreachableNemesis", ClusterDataCenterRouteUnreachableNemesis, 600),
-        #     ("DataCenterIptablesBlockPortsNemesis", ClusterDataCenterIptablesBlockPortsNemesis, 600),
-        # ):
-        #     extra[wire] = {
-        #         "runner": cls(),
-        #         "schedule": sched,
-        #         "ui_group": _DATACENTER_UI_GROUP,
-        #         "planner_factory": _dc_fanout_planner_factory,
-        #     }
+        extra["DataCenterStopNodesNemesis"] = {
+            "runner": ClusterDataCenterStopNodesNemesis(),
+            "schedule": 600,
+            "ui_group": _DATACENTER_UI_GROUP,
+            "planner_factory": _dc_fanout_planner_factory,
+            "target_kind": TargetKind.DATACENTER,
+            "impact_scope": ImpactScope.DATACENTER,
+            "guard_mode": GuardMode.FULL,  # reserves the whole realm (mirror-3-dc sacrificial DC)
+            "auto_recovery_sec": 240,
+            "weight": 0.3,  # heavy + rare relative to node kills
+            "supports_manual": False,
+        }
 
     if yaml_has_bridge_piles_section(path):
         from ydb.tests.stability.nemesis.internal.nemesis.runners import (

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -15,9 +15,9 @@ from typing import Any, Type
 
 from ydb.tests.library.common.types import TabletTypes
 from ydb.tests.stability.nemesis.internal.nemesis.runners import (
-    ClusterBulkChangeTabletGroupNemesis,
-    ClusterChangeTabletGroupNemesis,
-    ClusterKickTabletsFromNodeNemesis,
+    # ClusterBulkChangeTabletGroupNemesis,
+    # ClusterChangeTabletGroupNemesis,
+    # ClusterKickTabletsFromNodeNemesis,
     ClusterKillBlockstorePartitionNemesis,
     ClusterKillBlockstoreVolumeNemesis,
     ClusterKillBsControllerNemesis,
@@ -33,7 +33,7 @@ from ydb.tests.stability.nemesis.internal.nemesis.runners import (
     ClusterKillSlotDaemonNemesis,
     ClusterKillTenantSlotBrokerNemesis,
     ClusterKillTxAllocatorNemesis,
-    ClusterReBalanceTabletsNemesis,
+    # ClusterReBalanceTabletsNemesis,
     ClusterRollingRestartNemesis,
     ClusterSafelyBreakDiskNemesis,
     ClusterSafelyCleanupDisksNemesis,

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -157,7 +157,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         # SIGKILL + systemd restart + rejoin: 20s was well under real re-replication, so the
         # probe cried "stuck" too early (and the timer freed budget before the node was back).
         "auto_recovery_sec": 120,
-        "weight": 3.0,
+        "weight": 1.0,
     }
     # out["DnsNemesis"] = {
     #     "runner": DnsNemesis(),
@@ -212,6 +212,10 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.PREFILTER_ONLY,
         "supports_manual": False,
+        # Toggle fault: skew the clock, then the scheduler dispatches extract (re-enable ntp).
+        "recovery": "extract",
+        "auto_recovery_sec": 120,
+        "weight": 1.0,
     }
 
     # --- tablet chaos (temporarily disabled: BYPASS / not in failure-model budget) ---
@@ -272,7 +276,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
-        "weight": 2.0,
+        "weight": 3.0,
     }
     out["KillNodeDaemonNemesis"] = {
         "runner": ClusterKillNodeDaemonNemesis(),
@@ -306,12 +310,18 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
     }
 
     # --- disk / rolling / stop-start / suspend ------------------------------
-    for wire, cls, sched, scope, tkind in (
-        ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK, TargetKind.DISK),
-        ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400, ImpactScope.DISK, TargetKind.DISK),
-        # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE, TargetKind.NODE),
-        ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE, TargetKind.NODE),
-        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE, TargetKind.NODE),
+    # Toggle faults (``recovery: extract``): the pinned planner injects the scheduler-chosen
+    # target; the weighted scheduler holds the budget for ``auto_recovery_sec`` then dispatches
+    # an extract so the agent-side actor restores its stored state.
+    for wire, cls, sched, scope, tkind, extra in (
+        ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK, TargetKind.DISK,
+         {"recovery": "extract", "auto_recovery_sec": 120, "weight": 0.5}),
+        ("SafelyCleanupDisksNemesis", ClusterSafelyCleanupDisksNemesis, 400, ImpactScope.DISK, TargetKind.DISK,
+         {"recovery": "extract", "auto_recovery_sec": 90, "weight": 0.4}),
+        # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE, TargetKind.NODE, {}),
+        ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE, TargetKind.NODE,
+         {"recovery": "extract", "auto_recovery_sec": 90, "weight": 2.0}),
+        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE, TargetKind.NODE, {}),
     ):
         out[wire] = {
             "runner": cls(),
@@ -321,6 +331,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
             "target_kind": tkind,
             "impact_scope": scope,
             "guard_mode": GuardMode.PREFILTER_ONLY,
+            **extra,
         }
 
     # --- host reboot --------------------------------------------------------

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -264,14 +264,15 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         }
 
     # --- daemon kills -------------------------------------------------------
-    # SIGKILL + no-op extract: systemd auto-restarts the daemon, so the guard releases the rack
-    # on a timer (auto_recovery_sec) covering restart + rejoin, not on an explicit extract.
+    # SIGKILL + no-op extract: systemd auto-restarts the daemon, so the guard releases the slot
+    # on a timer (auto_recovery_sec) covering restart + rejoin, not on an explicit extract. A slot
+    # is a dynamic node — it draws from the separate 30% slot budget, not the erasure/rack budget.
     out["KillSlotDaemonNemesis"] = {
         "runner": ClusterKillSlotDaemonNemesis(),
         "schedule": 120,
         "ui_group": _UI_GROUP,
         "target_kind": TargetKind.SLOT,
-        "impact_scope": ImpactScope.NODE,
+        "impact_scope": ImpactScope.SLOT,
         "guard_mode": GuardMode.FULL,
         "auto_recovery_sec": 90,
     }
@@ -301,7 +302,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_slot_planner_factory,
         "target_kind": TargetKind.SLOT,
-        "impact_scope": ImpactScope.NODE,
+        "impact_scope": ImpactScope.SLOT,
         "guard_mode": GuardMode.PREFILTER_ONLY,
     }
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/cluster_entries.py
@@ -154,8 +154,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
-        # SIGKILL + systemd restart + rejoin: 20s was well under real re-replication, so the
-        # probe cried "stuck" too early (and the timer freed budget before the node was back).
+        # SIGKILL + systemd restart + rejoin; shorter windows cried "stuck" too early.
         "auto_recovery_sec": 120,
     }
     # out["DnsNemesis"] = {
@@ -264,9 +263,7 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         }
 
     # --- daemon kills -------------------------------------------------------
-    # SIGKILL + no-op extract: systemd auto-restarts the daemon, so the guard releases the slot
-    # on a timer (auto_recovery_sec) covering restart + rejoin, not on an explicit extract. A slot
-    # is a dynamic node — it draws from the separate 30% slot budget, not the erasure/rack budget.
+    # SIGKILL + systemd restart, so the budget is released on a timer, not by an extract.
     out["KillSlotDaemonNemesis"] = {
         "runner": ClusterKillSlotDaemonNemesis(),
         "schedule": 120,
@@ -292,6 +289,8 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 300,
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_node_planner_factory,
+        # Injects exactly the candidates it is handed, so the boundary scheduler may drive it.
+        "boundary_safe": True,
         "target_kind": TargetKind.NODE,
         "impact_scope": ImpactScope.NODE,
         "guard_mode": GuardMode.FULL,
@@ -301,15 +300,14 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         "schedule": 300,
         "ui_group": _UI_GROUP,
         "planner_factory": _serial_staggered_slot_planner_factory,
+        "boundary_safe": True,
         "target_kind": TargetKind.SLOT,
         "impact_scope": ImpactScope.SLOT,
         "guard_mode": GuardMode.FULL,
     }
 
     # --- disk / rolling / stop-start / suspend ------------------------------
-    # Toggle faults (``recovery: extract``): the pinned planner injects the scheduler-chosen
-    # target; the boundary scheduler holds the budget for ``auto_recovery_sec`` then dispatches
-    # an extract so the agent-side actor restores its stored state.
+    # Toggle faults: the scheduler holds the budget for ``auto_recovery_sec``, then extracts.
     for wire, cls, sched, scope, tkind, extra in (
         ("SafelyBreakDiskNemesis", ClusterSafelyBreakDiskNemesis, 400, ImpactScope.DISK, TargetKind.DISK,
          {"recovery": "extract", "auto_recovery_sec": 120}),
@@ -318,7 +316,9 @@ def all_nemesis_type_entries() -> dict[str, dict[str, Any]]:
         # ("RollingUpdateClusterNemesis", ClusterRollingUpdateNemesis, 120, ImpactScope.NODE, TargetKind.NODE, {}),
         ("StopStartNodeNemesis", ClusterStopStartNodeNemesis, 400, ImpactScope.NODE, TargetKind.NODE,
          {"recovery": "extract", "auto_recovery_sec": 90}),
-        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE, TargetKind.NODE, {}),
+        # SIGSTOP: the node never comes back on its own, so it needs an extract like the others.
+        ("SuspendNodeNemesis", ClusterSuspendNodeNemesis, 800, ImpactScope.NODE, TargetKind.NODE,
+         {"recovery": "extract", "auto_recovery_sec": 90}),
     ):
         out[wire] = {
             "runner": cls(),
@@ -356,8 +356,8 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
     extra: dict[str, dict[str, Any]] = {}
 
     if yaml_has_multi_datacenter(path):
-        # StopNodes only (self-recovering stop/start pulse). Route/iptables/DNS variants stay off:
-        # they need explicit extract and don't fit the inject-only boundary-scheduler path.
+        # StopNodes only: it is a self-recovering pulse. The route/iptables/DNS variants need an
+        # explicit extract and don't fit the inject-only path.
         from ydb.tests.stability.nemesis.internal.nemesis.runners import (
             ClusterDataCenterStopNodesNemesis,
         )
@@ -369,7 +369,7 @@ def _topology_conditional_entries() -> dict[str, dict[str, Any]]:
             "planner_factory": _dc_fanout_planner_factory,
             "target_kind": TargetKind.DATACENTER,
             "impact_scope": ImpactScope.DATACENTER,
-            "guard_mode": GuardMode.FULL,  # reserves the whole realm (mirror-3-dc sacrificial DC)
+            "guard_mode": GuardMode.FULL,  # reserves the whole realm
             "auto_recovery_sec": 240,
             "supports_manual": False,
         }

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/cluster_disk.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/cluster_disk.py
@@ -14,24 +14,29 @@ from ydb.core.protos.blobstorage_config_pb2 import TConfigResponse
 
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import require_external_cluster
 from ydb.tests.stability.nemesis.internal.nemesis.monitored_actor import MonitoredAgentActor
+from ydb.tests.stability.nemesis.internal.nemesis.runners.target_payload import target_from_payload
 
 
-def _resolve_node_id_and_node(cluster, host: str | None) -> Tuple[int | None, Any]:
+def _resolve_node_id_and_node(cluster, host: str | None, node_id: int | None = None) -> Tuple[int | None, Any]:
     """
-    Map orchestrator ``payload['host']`` (same as dispatch target) to harness ``(node_id, node)``.
-    Hostnames must match cluster.yaml ``host`` / ``name`` (short hostname fallback).
+    Map orchestrator target to harness ``(node_id, node)``.
+    Prefers explicit ``node_id``; else match ``host`` against cluster.yaml hosts.
     """
+    if node_id is not None:
+        node = cluster.nodes.get(node_id)
+        if node is not None:
+            return node_id, node
     if not host or not str(host).strip():
         return None, None
     h = str(host).strip()
-    for node_id, node in cluster.nodes.items():
+    for nid, node in cluster.nodes.items():
         if node.host == h:
-            return node_id, node
+            return nid, node
     h_short = h.split(".")[0]
-    for node_id, node in cluster.nodes.items():
+    for nid, node in cluster.nodes.items():
         nh = node.host.split(".")[0] if "." in node.host else node.host
         if nh == h_short:
-            return node_id, node
+            return nid, node
     return None, None
 
 
@@ -147,11 +152,15 @@ class ClusterSafelyCleanupDisksNemesis(MonitoredAgentActor):
         cluster = require_external_cluster()
         if not self._state_ready(cluster):
             return
-        node_id, node = _resolve_node_id_and_node(cluster, _host_from_payload(payload))
+        target = target_from_payload(payload)
+        node_id_hint = target.node_id if target is not None else None
+        host = (target.host if target is not None else None) or _host_from_payload(payload)
+        node_id, node = _resolve_node_id_and_node(cluster, host, node_id_hint)
         if node is None:
             self._logger.error(
-                "SafelyCleanupDisks: unknown host %r (not in cluster.yaml nodes)",
-                _host_from_payload(payload),
+                "SafelyCleanupDisks: unknown host %r / node_id %r (not in cluster.yaml nodes)",
+                host,
+                node_id_hint,
             )
             return
         self._logger.info("SafelyCleanupDisks on node_id=%s host=%s", node_id, node.host)
@@ -220,11 +229,15 @@ class ClusterSafelyBreakDiskNemesis(MonitoredAgentActor):
         cluster = require_external_cluster()
         if not self._state_ready(cluster):
             return
-        node_id, _node = _resolve_node_id_and_node(cluster, _host_from_payload(payload))
+        target = target_from_payload(payload)
+        node_id_hint = target.node_id if target is not None else None
+        host = (target.host if target is not None else None) or _host_from_payload(payload)
+        node_id, _node = _resolve_node_id_and_node(cluster, host, node_id_hint)
         if node_id is None:
             self._logger.error(
-                "SafelyBreakDisk: unknown host %r (not in cluster.yaml nodes)",
-                _host_from_payload(payload),
+                "SafelyBreakDisk: unknown host %r / node_id %r (not in cluster.yaml nodes)",
+                host,
+                node_id_hint,
             )
             return
         self.extract_fault(payload)

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/cluster_hive.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/cluster_hive.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
-import random
-
 from ydb.tests.library.clients.kikimr_http_client import HiveClient
 
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import require_external_cluster
 from ydb.tests.stability.nemesis.internal.nemesis.monitored_actor import MonitoredAgentActor
+from ydb.tests.stability.nemesis.internal.nemesis.runners.target_payload import target_from_payload
 
 
 class ClusterKickTabletsFromNodeNemesis(MonitoredAgentActor):
-    """block_node → kick_tablets_from_node → unblock_node on random cluster node."""
+    """block_node → kick_tablets_from_node → unblock_node on ChaosTarget.node_id."""
 
     def __init__(self) -> None:
         super().__init__(scope="tablets")
@@ -25,12 +24,16 @@ class ClusterKickTabletsFromNodeNemesis(MonitoredAgentActor):
         return self._hive
 
     def inject_fault(self, payload=None) -> None:
-        del payload
+        payload = payload if isinstance(payload, dict) else {}
         cluster = require_external_cluster()
-        nodes = list(cluster.nodes.values())
-        if not nodes:
+        target = target_from_payload(payload)
+        if target is None or target.node_id is None:
+            self._logger.error("KickTabletsFromNode: ChaosTarget.node_id is required")
             return
-        node = random.choice(nodes)
+        node = cluster.nodes.get(target.node_id)
+        if node is None:
+            self._logger.error("KickTabletsFromNode: unknown node_id=%s", target.node_id)
+            return
         try:
             h = self._hive_client()
             h.block_node(node.node_id)

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/cluster_node.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/cluster_node.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import require_external_cluster
 from ydb.tests.stability.nemesis.internal.nemesis.monitored_actor import MonitoredAgentActor
+from ydb.tests.stability.nemesis.internal.nemesis.runners.target_payload import target_from_payload
 
 
 # ---------------------------------------------------------------------------
@@ -126,29 +127,35 @@ def _local_switch_version() -> None:
     )
 
 
-def _resolve_local_node(cluster):
-    """Find the cluster node object whose host matches the local FQDN / hostname."""
-    import socket
+def _node_from_target(cluster, payload: dict):
+    """Resolve a cluster node from ChaosTarget / payload; no hostname guessing."""
+    target = target_from_payload(payload)
+    node_id = payload.get("node_id")
+    if node_id is None and target is not None:
+        node_id = target.node_id
+    if node_id is None:
+        return None, None
+    return node_id, cluster.nodes.get(node_id)
 
-    fqdn = socket.getfqdn()
-    hostname = socket.gethostname()
-    for node in cluster.nodes.values():
-        if node.host in (fqdn, hostname) or node.host.split(".")[0] == hostname.split(".")[0]:
-            return node
+
+def _slot_from_target(cluster, payload: dict):
+    """Resolve a cluster slot from ChaosTarget / payload; no hostname guessing."""
+    target = target_from_payload(payload)
+    slot_idx = payload.get("slot_idx")
+    if slot_idx is None and target is not None:
+        slot_idx = target.slot_idx
+    if slot_idx is None:
+        return None, None
+    return slot_idx, cluster.slots.get(slot_idx)
+
+
+def _ic_port_from_target(payload: dict) -> int | None:
+    target = target_from_payload(payload)
+    if target is not None and target.ic_port is not None:
+        return int(target.ic_port)
+    if payload.get("node_ic_port") is not None:
+        return int(payload["node_ic_port"])
     return None
-
-
-def _resolve_local_slots(cluster):
-    """Return list of slot objects whose host matches the local FQDN / hostname."""
-    import socket
-
-    fqdn = socket.getfqdn()
-    hostname = socket.gethostname()
-    result = []
-    for slot in cluster.slots.values():
-        if slot.host in (fqdn, hostname) or slot.host.split(".")[0] == hostname.split(".")[0]:
-            result.append(slot)
-    return result
 
 
 # ---------------------------------------------------------------------------
@@ -157,22 +164,20 @@ def _resolve_local_slots(cluster):
 
 
 class ClusterKillSlotDaemonNemesis(MonitoredAgentActor):
-    """Kill one random local slot daemon via subprocess."""
+    """Kill one slot daemon; requires ChaosTarget.slot_idx (or payload.slot_idx)."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
 
     def inject_fault(self, payload=None) -> None:
-        del payload
+        payload = payload if isinstance(payload, dict) else {}
         cluster = require_external_cluster()
-        local_slots = _resolve_local_slots(cluster)
-        if not local_slots:
-            self._logger.warning("No local slots to kill")
+        slot_idx, slot = _slot_from_target(cluster, payload)
+        if slot is None:
+            self._logger.error("KillSlotDaemon: missing/unknown slot_idx in ChaosTarget (got %r)", slot_idx)
             return
-        import random
-        slot = random.choice(local_slots)
         try:
-            self._logger.info("Killing local slot daemon ic_port=%d", slot.ic_port)
+            self._logger.info("Killing slot daemon slot_idx=%s ic_port=%d", slot_idx, slot.ic_port)
             _local_kill_daemon_and_process(int(slot.ic_port))
             self.on_success_inject_fault()
         except Exception as e:
@@ -185,20 +190,20 @@ class ClusterKillSlotDaemonNemesis(MonitoredAgentActor):
 
 
 class ClusterKillNodeDaemonNemesis(MonitoredAgentActor):
-    """Kill the local kikimr node daemon via subprocess."""
+    """Kill a kikimr node daemon; requires ChaosTarget.node_id (or payload.node_id)."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
 
     def inject_fault(self, payload=None) -> None:
-        del payload
+        payload = payload if isinstance(payload, dict) else {}
         cluster = require_external_cluster()
-        node = _resolve_local_node(cluster)
+        node_id, node = _node_from_target(cluster, payload)
         if node is None:
-            self._logger.warning("No local node found in cluster — cannot kill")
+            self._logger.error("KillNodeDaemon: missing/unknown node_id in ChaosTarget (got %r)", node_id)
             return
         try:
-            self._logger.info("Killing local node daemon ic_port=%d", node.ic_port)
+            self._logger.info("Killing node daemon node_id=%s ic_port=%d", node_id, node.ic_port)
             _local_kill_daemon_and_process(int(node.ic_port))
             self.on_success_inject_fault()
         except Exception as e:
@@ -211,7 +216,7 @@ class ClusterKillNodeDaemonNemesis(MonitoredAgentActor):
 
 
 class ClusterSerialKillNodeNemesis(MonitoredAgentActor):
-    """Kill the local node daemon; ``node_id`` + ``sleep_before`` come from the orchestrator payload."""
+    """Kill the node daemon; ``node_id`` + ``sleep_before`` come from the orchestrator payload."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
@@ -223,17 +228,12 @@ class ClusterSerialKillNodeNemesis(MonitoredAgentActor):
             self._logger.info("Serial kill node: sleep %.1fs before kill", delay)
             time.sleep(delay)
         cluster = require_external_cluster()
-        # Resolve the target node from payload or fall back to local node
-        node_id = payload.get("node_id")
-        if node_id is not None:
-            node = cluster.nodes.get(node_id)
-        else:
-            node = _resolve_local_node(cluster)
+        node_id, node = _node_from_target(cluster, payload)
         if node is None:
-            self._logger.error("Serial kill node: no daemon (node_id=%s)", node_id)
+            self._logger.error("Serial kill node: missing/unknown node_id (got %r)", node_id)
             return
         try:
-            self._logger.info("Serial kill node daemon ic_port=%d", node.ic_port)
+            self._logger.info("Serial kill node daemon node_id=%s ic_port=%d", node_id, node.ic_port)
             _local_kill_daemon_and_process(int(node.ic_port))
             self.on_success_inject_fault()
         except Exception as e:
@@ -246,7 +246,7 @@ class ClusterSerialKillNodeNemesis(MonitoredAgentActor):
 
 
 class ClusterSerialKillSlotsNemesis(MonitoredAgentActor):
-    """Kill the local slot daemon; ``slot_idx`` + ``sleep_before`` from orchestrator."""
+    """Kill the slot daemon; ``slot_idx`` + ``sleep_before`` from orchestrator."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
@@ -258,19 +258,12 @@ class ClusterSerialKillSlotsNemesis(MonitoredAgentActor):
             self._logger.info("Serial kill slot: sleep %.1fs before kill", delay)
             time.sleep(delay)
         cluster = require_external_cluster()
-        # Resolve the target slot from payload or fall back to a random local slot
-        slot_idx = payload.get("slot_idx")
-        if slot_idx is not None:
-            slot = cluster.slots.get(slot_idx)
-        else:
-            local_slots = _resolve_local_slots(cluster)
-            import random
-            slot = random.choice(local_slots) if local_slots else None
+        slot_idx, slot = _slot_from_target(cluster, payload)
         if slot is None:
-            self._logger.error("Serial kill slot: no daemon (slot_idx=%s)", slot_idx)
+            self._logger.error("Serial kill slot: missing/unknown slot_idx (got %r)", slot_idx)
             return
         try:
-            self._logger.info("Serial kill slot daemon ic_port=%d", slot.ic_port)
+            self._logger.info("Serial kill slot daemon slot_idx=%s ic_port=%d", slot_idx, slot.ic_port)
             _local_kill_daemon_and_process(int(slot.ic_port))
             self.on_success_inject_fault()
         except Exception as e:
@@ -283,7 +276,7 @@ class ClusterSerialKillSlotsNemesis(MonitoredAgentActor):
 
 
 class ClusterStopStartNodeNemesis(MonitoredAgentActor):
-    """Stop the local node process; next inject starts it again (>=8 nodes)."""
+    """Stop the node process; next inject starts it again (>=8 nodes). Requires node_id."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
@@ -304,25 +297,25 @@ class ClusterStopStartNodeNemesis(MonitoredAgentActor):
             self.on_success_extract_fault()
 
     def inject_fault(self, payload=None) -> None:
-        del payload
+        payload = payload if isinstance(payload, dict) else {}
         cluster = require_external_cluster()
         if len(cluster.nodes) < 8:
             self._logger.info("Stop/start prohibited (< 8 nodes)")
             return
         if self._try_start_stopped():
             return
-        node = _resolve_local_node(cluster)
+        node_id, node = _node_from_target(cluster, payload)
         if node is None:
-            self._logger.warning("No local node found in cluster — cannot stop")
+            self._logger.error("StopStartNode: missing/unknown node_id in ChaosTarget (got %r)", node_id)
             return
         self._stopped_node = node
-        self._logger.info("Stopping local node ic_port=%d", node.ic_port)
+        self._logger.info("Stopping node_id=%s ic_port=%d", node_id, node.ic_port)
         _local_stop_kikimr(node)
         self.on_success_inject_fault()
 
 
 class ClusterSuspendNodeNemesis(MonitoredAgentActor):
-    """SIGSTOP / SIGCONT on local node or slot (>=8 nodes)."""
+    """SIGSTOP / SIGCONT on a node/slot process (>=8 nodes). Requires ic_port or node/slot id."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
@@ -343,26 +336,30 @@ class ClusterSuspendNodeNemesis(MonitoredAgentActor):
             self.on_success_extract_fault()
 
     def inject_fault(self, payload=None) -> None:
-        del payload
+        payload = payload if isinstance(payload, dict) else {}
         cluster = require_external_cluster()
         if len(cluster.nodes) < 8:
             self._logger.info("Suspend prohibited (< 8 nodes)")
             return
         if self._try_cont():
             return
-        import random
-        local_node = _resolve_local_node(cluster)
-        local_slots = _resolve_local_slots(cluster)
-        pool = []
-        if local_node is not None:
-            pool.append(local_node)
-        pool.extend(local_slots)
-        if not pool:
-            self._logger.warning("No local processes to suspend")
+
+        ic_port = _ic_port_from_target(payload)
+        if ic_port is None:
+            _, node = _node_from_target(cluster, payload)
+            if node is not None:
+                ic_port = int(node.ic_port)
+        if ic_port is None:
+            _, slot = _slot_from_target(cluster, payload)
+            if slot is not None:
+                ic_port = int(slot.ic_port)
+        if ic_port is None:
+            self._logger.error(
+                "SuspendNode: ChaosTarget must include ic_port, node_id, or slot_idx"
+            )
             return
-        target = random.choice(pool)
-        self._suspended_ic_port = int(target.ic_port)
-        self._logger.info("SIGSTOP local process ic_port=%d", self._suspended_ic_port)
+        self._suspended_ic_port = ic_port
+        self._logger.info("SIGSTOP process ic_port=%d", self._suspended_ic_port)
         _local_send_signal(self._suspended_ic_port, signal.SIGSTOP)
         self.on_success_inject_fault()
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
@@ -6,10 +6,11 @@ import signal
 import subprocess
 
 from ydb.tests.stability.nemesis.internal.nemesis.monitored_actor import MonitoredAgentActor
+from ydb.tests.stability.nemesis.internal.nemesis.runners.target_payload import target_from_payload
 
 
 class KillNodeNemesis(MonitoredAgentActor):
-    """SIGKILL one local YDB ic-port process; extract is a monitoring noop."""
+    """SIGKILL one local YDB ic-port process; requires ChaosTarget.ic_port / node_ic_port."""
 
     def __init__(self) -> None:
         super().__init__(scope="node")
@@ -19,9 +20,22 @@ class KillNodeNemesis(MonitoredAgentActor):
         sig_name = payload.get("signal", "SIGKILL")
         sig = getattr(signal, sig_name, signal.SIGKILL)
         self._logger.info("=== INJECT_FAULT START: KillNodeNemesis ===")
+        target = target_from_payload(payload)
+        ic_port = None
+        if target is not None and target.ic_port is not None:
+            ic_port = int(target.ic_port)
+        elif payload.get("node_ic_port") is not None:
+            ic_port = int(payload["node_ic_port"])
+
+        if ic_port is None:
+            self._logger.error(
+                "KillNodeNemesis: ChaosTarget must include ic_port (or payload.node_ic_port)"
+            )
+            return
+
         cmd = (
-            "ps aux | grep '\\--ic-port' | grep -v grep | awk '{ print $2 }' | shuf -n 1 | xargs -r sudo kill -%d"
-            % (int(sig),)
+            "ps aux | grep '\\--ic-port %d' | grep -v grep | awk '{ print $2 }' | "
+            "xargs -r sudo kill -%d" % (ic_port, int(sig))
         )
         self._logger.info("Executing: %s", cmd)
         subprocess.check_call(cmd, shell=True)

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
@@ -38,7 +38,7 @@ class KillNodeNemesis(MonitoredAgentActor):
             "xargs -r sudo kill -%d" % (ic_port, int(sig))
         )
         self._logger.info("Executing: %s", cmd)
-        subprocess.check_call(cmd, shell=True)
+        subprocess.run(cmd, shell=True, check=False)
         self.on_success_inject_fault()
         self._logger.info("=== INJECT_FAULT SUCCESS: KillNodeNemesis ===")
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
@@ -28,17 +28,26 @@ class KillNodeNemesis(MonitoredAgentActor):
             ic_port = int(payload["node_ic_port"])
 
         if ic_port is None:
-            self._logger.error(
+            # Fail loudly: the orchestrator has already reserved failure budget for this fault,
+            # so a silent no-op would look like injected chaos that never happened.
+            raise ValueError(
                 "KillNodeNemesis: ChaosTarget must include ic_port (or payload.node_ic_port)"
             )
-            return
 
+        # Match the port exactly (not as a prefix of a longer one), and no `xargs -r`: an empty
+        # pid list must fail the command instead of reporting a successful kill of nothing.
         cmd = (
-            "ps aux | grep '\\--ic-port %d' | grep -v grep | awk '{ print $2 }' | "
-            "xargs -r sudo kill -%d" % (ic_port, int(sig))
+            "ps aux | grep -E -- '--ic-port %d($|[^0-9])' | grep -v grep | awk '{ print $2 }' | "
+            "xargs sudo kill -%d" % (ic_port, int(sig))
         )
         self._logger.info("Executing: %s", cmd)
-        subprocess.run(cmd, shell=True, check=False)
+        try:
+            subprocess.check_call(cmd, shell=True)
+        except subprocess.CalledProcessError as e:
+            self._logger.error(
+                "KillNodeNemesis: no process killed on ic_port=%d (rc=%s)", ic_port, e.returncode
+            )
+            raise
         self.on_success_inject_fault()
         self._logger.info("=== INJECT_FAULT SUCCESS: KillNodeNemesis ===")
 

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/node_local.py
@@ -28,14 +28,12 @@ class KillNodeNemesis(MonitoredAgentActor):
             ic_port = int(payload["node_ic_port"])
 
         if ic_port is None:
-            # Fail loudly: the orchestrator has already reserved failure budget for this fault,
-            # so a silent no-op would look like injected chaos that never happened.
+            # Loudly: the budget is already reserved, so a no-op would look like injected chaos.
             raise ValueError(
                 "KillNodeNemesis: ChaosTarget must include ic_port (or payload.node_ic_port)"
             )
 
-        # Match the port exactly (not as a prefix of a longer one), and no `xargs -r`: an empty
-        # pid list must fail the command instead of reporting a successful kill of nothing.
+        # Exact port match, and no `xargs -r`: an empty pid list must fail, not report success.
         cmd = (
             "ps aux | grep -E -- '--ic-port %d($|[^0-9])' | grep -v grep | awk '{ print $2 }' | "
             "xargs sudo kill -%d" % (ic_port, int(sig))

--- a/ydb/tests/stability/nemesis/internal/nemesis/runners/target_payload.py
+++ b/ydb/tests/stability/nemesis/internal/nemesis/runners/target_payload.py
@@ -1,0 +1,13 @@
+"""Helpers to read ChaosTarget from agent payload."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+
+
+def target_from_payload(payload: dict[str, Any] | None) -> ChaosTarget | None:
+    if not isinstance(payload, dict):
+        return None
+    return ChaosTarget.from_dict(payload.get("chaos_target"))

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
@@ -30,6 +30,7 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target impo
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     DEFAULT_RECOVERY_SEC,
     FailureModelGuard,
+    Footprint,
     GuardMode,
     ImpactScope,
 )
@@ -152,12 +153,12 @@ class BoundaryNemesisScheduler:
 
     def _menu(
         self, bypass_used: frozenset[tuple[str, str]] = frozenset()
-    ) -> list[tuple[str, ChaosTarget, frozenset[str]]]:
+    ) -> list[tuple[str, ChaosTarget, Footprint]]:
         with self._cfg_lock:
             enabled = list(self._enabled)
         impaired = self._guard.active_identities()
         can_extract = self._can_extract()
-        menu: list[tuple[str, ChaosTarget, frozenset[str]]] = []
+        menu: list[tuple[str, ChaosTarget, Footprint]] = []
         for nemesis_type in enabled:
             # A toggle fault with no way to auto-extract would stay broken forever — don't offer it.
             if self._recovery_mode_for(nemesis_type) == "extract" and not can_extract:
@@ -176,13 +177,13 @@ class BoundaryNemesisScheduler:
                     # regardless of what's impaired. Deduped per (type, target) — tablet types all
                     # share one control-host target, so this keeps each firing at most once a tick.
                     if (nemesis_type, key) not in bypass_used:
-                        menu.append((nemesis_type, target, frozenset()))
+                        menu.append((nemesis_type, target, Footprint()))
                     continue
                 if key in impaired:
                     continue
-                racks = self._guard.footprint_for(target, scope)
-                if self._guard.fits(racks):
-                    menu.append((nemesis_type, target, racks))
+                footprint = self._guard.footprint_for(target, scope)
+                if self._guard.fits(footprint):
+                    menu.append((nemesis_type, target, footprint))
         return menu
 
     def tick(self) -> int:
@@ -195,7 +196,7 @@ class BoundaryNemesisScheduler:
             menu = self._menu(frozenset(bypass_used))
             if not menu:
                 break
-            nemesis_type, target, racks = self._rng.choice(menu)
+            nemesis_type, target, footprint = self._rng.choice(menu)
             if self._mode_for(nemesis_type) is GuardMode.BYPASS:
                 # No budget to reserve and no probe to track — just fire and remember it fired.
                 for cmd in self._plan_inject(nemesis_type, target):
@@ -209,19 +210,21 @@ class BoundaryNemesisScheduler:
             # The probe releases the budget by fact, so hold it (recovery_sec=None):
             #   extract  — toggle fault; probe holds `recovery`s then dispatches the extract.
             #   self     — probe releases once healthcheck sees the host answer again.
-            # A disabled (fail-open) guard, empty footprint, or missing probe falls back to the
-            # reserve timer so self-recovering budget never sticks.
+            # A disabled (fail-open) guard, no rack footprint (slots/tablets), or missing probe
+            # falls back to the reserve timer so self-recovering budget never sticks. Slot kills
+            # take this timer path deliberately: host healthcheck can't observe an individual
+            # slot's restart, so the recovery window is the honest signal.
             by_extract = (
                 self._recovery_mode_for(nemesis_type) == "extract" and self._can_extract()
             )
             by_healthcheck = (
                 not by_extract
                 and self._recovery_probe is not None
-                and bool(racks)
+                and bool(footprint.racks)
                 and self._guard.enabled
             )
             lease = self._guard.reserve(
-                racks,
+                footprint,
                 recovery_sec=None if (by_extract or by_healthcheck) else recovery,
                 identity_key=target.identity_key(),
             )

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
@@ -6,8 +6,11 @@ then sleeps a randomized interval. Replaces the per-type schedule threads in ``s
 
 Budget is released by the :class:`RecoveryProbe`, per the type's :func:`recovery_mode_for`:
 self-recovering faults are released once healthcheck sees the host answer again; toggle faults
-are held for their ``auto_recovery_sec`` then actively extracted. Without a probe (or a disabled,
-fail-open guard) self-recovering faults fall back to the reserve timer so budget never sticks.
+are held for their ``auto_recovery_sec`` then actively extracted. Without a probe, self-recovering
+faults fall back to the reserve timer so budget never sticks.
+
+:meth:`BoundaryNemesisScheduler.stop` drains toggle faults that are still inside their hold
+window through their extract, so switching chaos off never leaves the cluster broken.
 """
 
 from __future__ import annotations
@@ -156,7 +159,10 @@ class BoundaryNemesisScheduler:
     ) -> list[tuple[str, ChaosTarget, Footprint]]:
         with self._cfg_lock:
             enabled = list(self._enabled)
-        impaired = self._guard.active_identities()
+        # One budget snapshot for the whole menu: every candidate is judged against the same state,
+        # and reserve() re-checks atomically before anything is injected.
+        view = self._guard.budget_view()
+        impaired = view.touched
         can_extract = self._can_extract()
         menu: list[tuple[str, ChaosTarget, Footprint]] = []
         for nemesis_type in enabled:
@@ -182,7 +188,7 @@ class BoundaryNemesisScheduler:
                 if key in impaired:
                     continue
                 footprint = self._guard.footprint_for(target, scope)
-                if self._guard.fits(footprint):
+                if view.fits(footprint):
                     menu.append((nemesis_type, target, footprint))
         return menu
 
@@ -210,10 +216,10 @@ class BoundaryNemesisScheduler:
             # The probe releases the budget by fact, so hold it (recovery_sec=None):
             #   extract  — toggle fault; probe holds `recovery`s then dispatches the extract.
             #   self     — probe releases once healthcheck sees the host answer again.
-            # A disabled (fail-open) guard, no rack footprint (slots/tablets), or missing probe
-            # falls back to the reserve timer so self-recovering budget never sticks. Slot kills
-            # take this timer path deliberately: host healthcheck can't observe an individual
-            # slot's restart, so the recovery window is the honest signal.
+            # No rack footprint (slots/tablets) or a missing probe falls back to the reserve timer
+            # so self-recovering budget never sticks. Slot kills take this timer path deliberately:
+            # host healthcheck can't observe an individual slot's restart, so the recovery window
+            # is the honest signal.
             by_extract = (
                 self._recovery_mode_for(nemesis_type) == "extract" and self._can_extract()
             )
@@ -221,7 +227,6 @@ class BoundaryNemesisScheduler:
                 not by_extract
                 and self._recovery_probe is not None
                 and bool(footprint.racks)
-                and self._guard.enabled
             )
             lease = self._guard.reserve(
                 footprint,
@@ -283,6 +288,17 @@ class BoundaryNemesisScheduler:
             t.join(timeout=2.0)
         if self._recovery_probe is not None:
             self._recovery_probe.stop()
+            # Toggle faults still inside their hold window must be extracted here: nothing else
+            # will, so stopping chaos would otherwise leave a node stopped / disk broken / clock
+            # skewed for the rest of the run. Runs after the probe thread is joined so it cannot
+            # extract the same lease concurrently.
+            try:
+                drained = self._recovery_probe.drain_extracts()
+            except Exception:
+                logger.exception("failed to drain pending extracts on stop")
+            else:
+                if drained:
+                    logger.info("scheduler stop: extracted %d in-flight toggle fault(s)", drained)
 
 
 __all__ = ["BoundaryNemesisScheduler", "default_enabled_types"]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
@@ -1,16 +1,12 @@
-"""Single-threaded nemesis scheduler.
+"""Single-threaded nemesis scheduler that walks the failure-model boundary.
 
-Walks the failure-model boundary: each tick breaks a random number of things (``cap``), picking
-each fault uniformly at random from whatever currently fits the budget, reserving it atomically,
-then sleeps a randomized interval. Replaces the per-type schedule threads in ``schedule_loop.py``.
+Each tick breaks a random number of things (``cap``), picking uniformly from whatever fits the
+budget, reserving atomically, then sleeps a randomized interval. Replaces the per-type threads in
+``schedule_loop.py``.
 
-Budget is released by the :class:`RecoveryProbe`, per the type's :func:`recovery_mode_for`:
-self-recovering faults are released once healthcheck sees the host answer again; toggle faults
-are held for their ``auto_recovery_sec`` then actively extracted. Without a probe, self-recovering
-faults fall back to the reserve timer so budget never sticks.
-
-:meth:`BoundaryNemesisScheduler.stop` drains toggle faults that are still inside their hold
-window through their extract, so switching chaos off never leaves the cluster broken.
+Budget is released by the :class:`RecoveryProbe`: self-recovering faults once healthcheck sees the
+host answer again, toggle faults after ``auto_recovery_sec`` via an extract. :meth:`stop` extracts
+whatever is still held, so switching chaos off never leaves the cluster broken.
 """
 
 from __future__ import annotations
@@ -26,6 +22,7 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     impact_scope_for,
     recovery_mode_for as catalog_recovery_mode_for,
     recovery_sec_for,
+    supports_boundary_scheduler,
     target_kind_for,
 )
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
@@ -40,11 +37,8 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model imp
 
 logger = logging.getLogger(__name__)
 
-# Curated stability chaos profile: datacenter stop, node kill, slot kill, node stop/start, disk
-# break/cleanup, clock skew, plus tablet chaos. Filtered to what the cluster actually registers
-# (e.g. the DC type only exists on multi-DC clusters). Toggle members are recovered via timed
-# extract. Tablet types are BYPASS (injected without spending the failure-model budget), except
-# KickTabletsFromNodeNemesis, which kills the node and so is counted like any other node fault.
+# Curated stability profile, filtered to what this cluster registers (the DC type needs multi-DC).
+# Tablet types are BYPASS; KickTabletsFromNode kills the node, so it is budgeted like a node fault.
 _STABILITY_PROFILE: tuple[str, ...] = (
     "DataCenterStopNodesNemesis",
     "KillNodeNemesis",
@@ -62,10 +56,17 @@ _STABILITY_PROFILE: tuple[str, ...] = (
     "KickTabletsFromNodeNemesis",
 )
 
+# A tick can be slow: every dispatch is an HTTP POST with its own timeout.
+DEFAULT_STOP_JOIN_SEC: float = 10.0
+# ``start()`` must not run on top of a thread a previous ``stop()`` gave up on.
+DEFAULT_RESTART_JOIN_SEC: float = 30.0
+
 
 def default_enabled_types() -> list[str]:
-    """The stability chaos profile, restricted to types registered for this cluster."""
-    return [t for t in _STABILITY_PROFILE if t in NEMESIS_TYPES]
+    """The stability chaos profile: registered for this cluster and usable by this scheduler."""
+    return [
+        t for t in _STABILITY_PROFILE if t in NEMESIS_TYPES and supports_boundary_scheduler(t)
+    ]
 
 
 class BoundaryNemesisScheduler:
@@ -89,6 +90,8 @@ class BoundaryNemesisScheduler:
         max_per_tick: int = 3,
         default_recovery_sec: float = DEFAULT_RECOVERY_SEC,
         rng: random.Random | None = None,
+        stop_join_sec: float = DEFAULT_STOP_JOIN_SEC,
+        restart_join_sec: float = DEFAULT_RESTART_JOIN_SEC,
     ) -> None:
         self._guard = guard
         self._inventory = inventory
@@ -110,6 +113,8 @@ class BoundaryNemesisScheduler:
         self._base_interval = float(base_interval)
         self._jitter = float(jitter)
         self._max_per_tick = max(1, int(max_per_tick))
+        self._stop_join_sec = float(stop_join_sec)
+        self._restart_join_sec = float(restart_join_sec)
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -159,8 +164,7 @@ class BoundaryNemesisScheduler:
     ) -> list[tuple[str, ChaosTarget, Footprint]]:
         with self._cfg_lock:
             enabled = list(self._enabled)
-        # One budget snapshot for the whole menu: every candidate is judged against the same state,
-        # and reserve() re-checks atomically before anything is injected.
+        # One snapshot for the whole menu; reserve() re-checks atomically before injecting.
         view = self._guard.budget_view()
         impaired = view.touched
         can_extract = self._can_extract()
@@ -179,9 +183,8 @@ class BoundaryNemesisScheduler:
                     continue
                 seen.add(key)
                 if bypass:
-                    # BYPASS: not counted against the failure budget, so it's offered every tick
-                    # regardless of what's impaired. Deduped per (type, target) — tablet types all
-                    # share one control-host target, so this keeps each firing at most once a tick.
+                    # Costs no budget, so it is always offered. Deduped per (type, target) because
+                    # tablet types share one control-host target.
                     if (nemesis_type, key) not in bypass_used:
                         menu.append((nemesis_type, target, Footprint()))
                     continue
@@ -204,7 +207,7 @@ class BoundaryNemesisScheduler:
                 break
             nemesis_type, target, footprint = self._rng.choice(menu)
             if self._mode_for(nemesis_type) is GuardMode.BYPASS:
-                # No budget to reserve and no probe to track — just fire and remember it fired.
+                # Nothing to reserve or track — fire and remember it fired.
                 for cmd in self._plan_inject(nemesis_type, target):
                     self._dispatch(cmd)
                 bypass_used.add((nemesis_type, target.identity_key()))
@@ -213,13 +216,9 @@ class BoundaryNemesisScheduler:
             recovery = self._recovery_sec_for(nemesis_type)
             if recovery is None:
                 recovery = self._default_recovery_sec
-            # The probe releases the budget by fact, so hold it (recovery_sec=None):
-            #   extract  — toggle fault; probe holds `recovery`s then dispatches the extract.
-            #   self     — probe releases once healthcheck sees the host answer again.
-            # No rack footprint (slots/tablets) or a missing probe falls back to the reserve timer
-            # so self-recovering budget never sticks. Slot kills take this timer path deliberately:
-            # host healthcheck can't observe an individual slot's restart, so the recovery window
-            # is the honest signal.
+            # Hold the budget (recovery_sec=None) when the probe will release it by fact: after a
+            # timed extract, or once healthcheck sees the host again. Slot kills have no fail domain
+            # and healthcheck cannot see a single slot restart, so they fall back to the timer.
             by_extract = (
                 self._recovery_mode_for(nemesis_type) == "extract" and self._can_extract()
             )
@@ -273,8 +272,22 @@ class BoundaryNemesisScheduler:
             self._stop.wait(self._sleep_seconds())
 
     def start(self) -> None:
-        if self._thread and self._thread.is_alive():
-            return
+        t = self._thread
+        if t is not None and t.is_alive():
+            if not self._stop.is_set():
+                return  # already running
+            # A previous stop() gave up on a slow tick. Returning here would report "started" while
+            # the stop flag kills the old thread and the probe stays down — no budget ever released.
+            logger.warning(
+                "start(): previous scheduler thread is still stopping; waiting up to %.0fs",
+                self._restart_join_sec,
+            )
+            t.join(timeout=self._restart_join_sec)
+            if t.is_alive():
+                raise RuntimeError(
+                    f"previous scheduler thread is still shutting down after "
+                    f"{self._restart_join_sec:.0f}s; not starting a second one"
+                )
         if self._recovery_probe is not None:
             self._recovery_probe.start()
         self._stop.clear()
@@ -285,13 +298,17 @@ class BoundaryNemesisScheduler:
         self._stop.set()
         t = self._thread
         if t and t.is_alive() and t is not threading.current_thread():
-            t.join(timeout=2.0)
+            t.join(timeout=self._stop_join_sec)
+            if t.is_alive():
+                logger.warning(
+                    "scheduler thread still inside a tick %.0fs after stop; stopping the probe "
+                    "anyway — start() will wait for it",
+                    self._stop_join_sec,
+                )
         if self._recovery_probe is not None:
             self._recovery_probe.stop()
-            # Toggle faults still inside their hold window must be extracted here: nothing else
-            # will, so stopping chaos would otherwise leave a node stopped / disk broken / clock
-            # skewed for the rest of the run. Runs after the probe thread is joined so it cannot
-            # extract the same lease concurrently.
+            # Nothing else extracts them, so stopping chaos would leave a node stopped / disk
+            # broken / clock skewed. After the join, so no lease is extracted twice.
             try:
                 drained = self._recovery_probe.drain_extracts()
             except Exception:

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/boundary_scheduler.py
@@ -1,8 +1,8 @@
-"""Single-threaded weighted nemesis scheduler.
+"""Single-threaded nemesis scheduler.
 
 Walks the failure-model boundary: each tick breaks a random number of things (``cap``), picking
-each fault by weight from whatever currently fits the budget, reserving it atomically, then sleeps
-a randomized interval. Replaces the per-type schedule threads in ``schedule_loop.py``.
+each fault uniformly at random from whatever currently fits the budget, reserving it atomically,
+then sleeps a randomized interval. Replaces the per-type schedule threads in ``schedule_loop.py``.
 
 Budget is released by the :class:`RecoveryProbe`, per the type's :func:`recovery_mode_for`:
 self-recovering faults are released once healthcheck sees the host answer again; toggle faults
@@ -19,25 +19,28 @@ from typing import Callable, Sequence
 
 from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     NEMESIS_TYPES,
+    guard_mode_for,
     impact_scope_for,
     recovery_mode_for as catalog_recovery_mode_for,
     recovery_sec_for,
     target_kind_for,
-    weight_for as catalog_weight_for,
 )
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     DEFAULT_RECOVERY_SEC,
     FailureModelGuard,
+    GuardMode,
     ImpactScope,
 )
 
 logger = logging.getLogger(__name__)
 
 # Curated stability chaos profile: datacenter stop, node kill, slot kill, node stop/start, disk
-# break/cleanup, clock skew. Filtered to what the cluster actually registers (e.g. the DC type
-# only exists on multi-DC clusters). Toggle members are recovered via timed extract.
+# break/cleanup, clock skew, plus tablet chaos. Filtered to what the cluster actually registers
+# (e.g. the DC type only exists on multi-DC clusters). Toggle members are recovered via timed
+# extract. Tablet types are BYPASS (injected without spending the failure-model budget), except
+# KickTabletsFromNodeNemesis, which kills the node and so is counted like any other node fault.
 _STABILITY_PROFILE: tuple[str, ...] = (
     "DataCenterStopNodesNemesis",
     "KillNodeNemesis",
@@ -46,6 +49,13 @@ _STABILITY_PROFILE: tuple[str, ...] = (
     "SafelyBreakDiskNemesis",
     "SafelyCleanupDisksNemesis",
     "TimeSkewNemesis",
+    "KillHiveNemesis",
+    "KillCoordinatorNemesis",
+    "KillSchemeShardNemesis",
+    "KillDataShardNemesis",
+    "KillPersQueueNemesis",
+    "ReBalanceTabletsNemesis",
+    "KickTabletsFromNodeNemesis",
 )
 
 
@@ -54,7 +64,7 @@ def default_enabled_types() -> list[str]:
     return [t for t in _STABILITY_PROFILE if t in NEMESIS_TYPES]
 
 
-class WeightedNemesisScheduler:
+class BoundaryNemesisScheduler:
     def __init__(
         self,
         *,
@@ -65,9 +75,9 @@ class WeightedNemesisScheduler:
         recovery_probe=None,
         plan_extract: Callable[[str, ChaosTarget], list[DispatchCommand]] | None = None,
         enabled_types: Sequence[str] | None = None,
-        weight_for: Callable[[str], float] | None = None,
         scope_for: Callable[[str], ImpactScope] = impact_scope_for,
         kind_for: Callable[[str], TargetKind] = target_kind_for,
+        mode_for: Callable[[str], GuardMode] = guard_mode_for,
         recovery_sec_for: Callable[[str], float | None] = recovery_sec_for,
         recovery_mode_for: Callable[[str], str] = catalog_recovery_mode_for,
         base_interval: float = 60.0,
@@ -82,9 +92,9 @@ class WeightedNemesisScheduler:
         self._plan_extract = plan_extract
         self._dispatch = dispatch
         self._recovery_probe = recovery_probe
-        self._weight_for = weight_for or catalog_weight_for
         self._scope_for = scope_for
         self._kind_for = kind_for
+        self._mode_for = mode_for
         self._recovery_sec_for = recovery_sec_for
         self._recovery_mode_for = recovery_mode_for
         self._default_recovery_sec = float(default_recovery_sec)
@@ -103,7 +113,6 @@ class WeightedNemesisScheduler:
         self,
         *,
         enabled: Sequence[str] | None = None,
-        weights: dict[str, float] | None = None,
         base_interval: float | None = None,
         jitter: float | None = None,
         max_per_tick: int | None = None,
@@ -117,9 +126,6 @@ class WeightedNemesisScheduler:
                 self._jitter = float(jitter)
             if max_per_tick is not None:
                 self._max_per_tick = max(1, int(max_per_tick))
-        if weights is not None:
-            wmap = {k: float(v) for k, v in weights.items()}
-            self._weight_for = lambda t: wmap.get(t, 1.0)
 
     def running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
@@ -144,56 +150,59 @@ class WeightedNemesisScheduler:
     def _can_extract(self) -> bool:
         return self._plan_extract is not None and self._recovery_probe is not None
 
-    def _menu(self) -> list[tuple[str, ChaosTarget, frozenset[str], float]]:
+    def _menu(
+        self, bypass_used: frozenset[tuple[str, str]] = frozenset()
+    ) -> list[tuple[str, ChaosTarget, frozenset[str]]]:
         with self._cfg_lock:
             enabled = list(self._enabled)
         impaired = self._guard.active_identities()
         can_extract = self._can_extract()
-        menu: list[tuple[str, ChaosTarget, frozenset[str], float]] = []
+        menu: list[tuple[str, ChaosTarget, frozenset[str]]] = []
         for nemesis_type in enabled:
-            weight = self._weight_for(nemesis_type)
-            if weight <= 0:
-                continue
             # A toggle fault with no way to auto-extract would stay broken forever — don't offer it.
             if self._recovery_mode_for(nemesis_type) == "extract" and not can_extract:
                 continue
+            bypass = self._mode_for(nemesis_type) is GuardMode.BYPASS
             scope = self._scope_for(nemesis_type)
             kind = self._kind_for(nemesis_type)
             seen: set[str] = set()  # collapse duplicate targets (e.g. one DC exposed per host)
             for target in self._inventory.entities(kind):
                 key = target.identity_key()
-                if key in impaired or key in seen:
+                if key in seen:
                     continue
                 seen.add(key)
+                if bypass:
+                    # BYPASS: not counted against the failure budget, so it's offered every tick
+                    # regardless of what's impaired. Deduped per (type, target) — tablet types all
+                    # share one control-host target, so this keeps each firing at most once a tick.
+                    if (nemesis_type, key) not in bypass_used:
+                        menu.append((nemesis_type, target, frozenset()))
+                    continue
+                if key in impaired:
+                    continue
                 racks = self._guard.footprint_for(target, scope)
                 if self._guard.fits(racks):
-                    menu.append((nemesis_type, target, racks, weight))
+                    menu.append((nemesis_type, target, racks))
         return menu
-
-    def _weighted_choice(
-        self, menu: list[tuple[str, ChaosTarget, frozenset[str], float]]
-    ) -> tuple[str, ChaosTarget, frozenset[str], float]:
-        total = sum(item[3] for item in menu)
-        if total <= 0:
-            return self._rng.choice(menu)
-        r = self._rng.random() * total
-        acc = 0.0
-        for item in menu:
-            acc += item[3]
-            if r <= acc:
-                return item
-        return menu[-1]
 
     def tick(self) -> int:
         """One scheduling tick: break up to a random ``cap`` faults. Returns how many were injected."""
         with self._cfg_lock:
             cap = self._rng.randint(1, self._max_per_tick)
         added = 0
+        bypass_used: set[tuple[str, str]] = set()
         while added < cap:
-            menu = self._menu()
+            menu = self._menu(frozenset(bypass_used))
             if not menu:
                 break
-            nemesis_type, target, racks, _weight = self._weighted_choice(menu)
+            nemesis_type, target, racks = self._rng.choice(menu)
+            if self._mode_for(nemesis_type) is GuardMode.BYPASS:
+                # No budget to reserve and no probe to track — just fire and remember it fired.
+                for cmd in self._plan_inject(nemesis_type, target):
+                    self._dispatch(cmd)
+                bypass_used.add((nemesis_type, target.identity_key()))
+                added += 1
+                continue
             recovery = self._recovery_sec_for(nemesis_type)
             if recovery is None:
                 recovery = self._default_recovery_sec
@@ -245,14 +254,14 @@ class WeightedNemesisScheduler:
 
     def _run(self) -> None:
         logger.info(
-            "WeightedNemesisScheduler started: %d type(s), base=%.1fs jitter=%.2f max_per_tick=%d",
+            "BoundaryNemesisScheduler started: %d type(s), base=%.1fs jitter=%.2f max_per_tick=%d",
             len(self._enabled), self._base_interval, self._jitter, self._max_per_tick,
         )
         while not self._stop.is_set():
             try:
                 self.tick()
             except Exception:
-                logger.exception("weighted scheduler tick raised")
+                logger.exception("boundary scheduler tick raised")
             self._stop.wait(self._sleep_seconds())
 
     def start(self) -> None:
@@ -273,4 +282,4 @@ class WeightedNemesisScheduler:
             self._recovery_probe.stop()
 
 
-__all__ = ["WeightedNemesisScheduler", "default_enabled_types"]
+__all__ = ["BoundaryNemesisScheduler", "default_enabled_types"]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_problems.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_problems.py
@@ -1,0 +1,170 @@
+"""Problem log for nemesis-side anomalies, exposed via ``GET /api/problems``.
+
+Some things go wrong on the chaos side rather than on the cluster side, and nothing in the
+stability test would notice them otherwise:
+
+* a fault that never recovered (``RecoveryProbe`` reports it stuck and keeps holding its budget,
+  so the cluster is running degraded and the scheduler is quietly doing less chaos);
+* a degraded inventory (the cluster harness was unavailable, so node/slot ids and ports are
+  synthesized guesses and slot chaos does not run at all).
+
+An unusable failure model is *not* in this list: the orchestrator refuses to start without one
+(see ``app._require_failure_model``), so there is no "chaos ran unguarded" case to report.
+
+Both are recorded here so ``ydb/tests/stability/tests`` can pull them at the end of a phase and
+attach them to its Allure report (see ``StressUtilDeployer._report_nemesis_problems``).
+
+Problems are latched: an entry stays in the list after the fault eventually recovers, because the
+report is read once, after the run. Repeats of the same problem update ``last_seen`` / ``count``
+instead of piling up.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+# Problem kinds (kept stable — the stability test report groups by them).
+KIND_STUCK_FAULT = "stuck_fault"
+KIND_INVENTORY_DEGRADED = "inventory_degraded"
+
+DEFAULT_LIMIT = 200
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass
+class ChaosProblem:
+    kind: str
+    summary: str
+    nemesis_type: str = ""
+    target: str = ""
+    host: str = ""
+    details: dict = field(default_factory=dict)
+    first_seen: str = field(default_factory=_now_iso)
+    last_seen: str = field(default_factory=_now_iso)
+    count: int = 1
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.kind, self.nemesis_type, self.target)
+
+    def to_dict(self) -> dict:
+        return {
+            "kind": self.kind,
+            "summary": self.summary,
+            "nemesis_type": self.nemesis_type,
+            "target": self.target,
+            "host": self.host,
+            "details": dict(self.details),
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "count": self.count,
+        }
+
+
+class ChaosProblemStore:
+    """Thread-safe, deduplicating, bounded list of :class:`ChaosProblem`."""
+
+    def __init__(self, limit: int = DEFAULT_LIMIT) -> None:
+        self._lock = threading.Lock()
+        self._problems: dict[tuple[str, str, str], ChaosProblem] = {}
+        self._limit = max(1, int(limit))
+        self._dropped = 0
+
+    def record(
+        self,
+        kind: str,
+        summary: str,
+        *,
+        nemesis_type: str = "",
+        target: str = "",
+        host: str = "",
+        details: dict | None = None,
+    ) -> None:
+        problem = ChaosProblem(
+            kind=kind,
+            summary=summary,
+            nemesis_type=nemesis_type,
+            target=target,
+            host=host,
+            details=dict(details or {}),
+        )
+        with self._lock:
+            existing = self._problems.get(problem.key)
+            if existing is not None:
+                existing.count += 1
+                existing.last_seen = problem.last_seen
+                existing.summary = summary
+                existing.details = problem.details
+                return
+            if len(self._problems) >= self._limit:
+                self._dropped += 1
+                return
+            self._problems[problem.key] = problem
+        logger.warning("chaos problem recorded [%s]: %s", kind, summary)
+
+    def record_stuck_fault(self, fault) -> None:
+        """``on_stuck`` callback for :class:`RecoveryProbe`."""
+        target = fault.target
+        self.record(
+            KIND_STUCK_FAULT,
+            (
+                f"{fault.nemesis_type} on {target.identity_key()} did not recover within "
+                f"{fault.timeout_sec:.0f}s (held {fault.held_sec:.0f}s); failure budget still held"
+            ),
+            nemesis_type=fault.nemesis_type,
+            target=target.identity_key(),
+            host=target.host,
+            details={
+                "held_sec": round(float(fault.held_sec), 1),
+                "timeout_sec": round(float(fault.timeout_sec), 1),
+                "lease_id": fault.lease_id,
+            },
+        )
+
+    def record_inventory_degraded(self, reason: str, details: dict | None = None) -> None:
+        self.record(
+            KIND_INVENTORY_DEGRADED,
+            (
+                f"chaos inventory is degraded ({reason}): node/slot ids and ports are synthesized, "
+                f"slot chaos does not run"
+            ),
+            details=details,
+        )
+
+    def snapshot(self) -> list[dict]:
+        with self._lock:
+            problems = sorted(self._problems.values(), key=lambda p: p.first_seen)
+            return [p.to_dict() for p in problems]
+
+    def counts_by_kind(self) -> dict[str, int]:
+        with self._lock:
+            out: dict[str, int] = {}
+            for p in self._problems.values():
+                out[p.kind] = out.get(p.kind, 0) + 1
+            return out
+
+    @property
+    def dropped(self) -> int:
+        with self._lock:
+            return self._dropped
+
+    def clear(self) -> None:
+        with self._lock:
+            self._problems.clear()
+            self._dropped = 0
+
+
+__all__ = [
+    "ChaosProblem",
+    "ChaosProblemStore",
+    "KIND_STUCK_FAULT",
+    "KIND_INVENTORY_DEGRADED",
+]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_problems.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_problems.py
@@ -1,22 +1,10 @@
-"""Problem log for nemesis-side anomalies, exposed via ``GET /api/problems``.
+"""Problem log for chaos-side anomalies, served by ``GET /api/problems``.
 
-Some things go wrong on the chaos side rather than on the cluster side, and nothing in the
-stability test would notice them otherwise:
+Things the cluster checks cannot see: a fault that never recovered (its budget is still held, so the
+scheduler is quietly doing less chaos) and a degraded inventory (synthesized node ids, no slot
+chaos). ``ydb/tests/stability/tests`` pulls this when disabling nemesis and attaches it to Allure.
 
-* a fault that never recovered (``RecoveryProbe`` reports it stuck and keeps holding its budget,
-  so the cluster is running degraded and the scheduler is quietly doing less chaos);
-* a degraded inventory (the cluster harness was unavailable, so node/slot ids and ports are
-  synthesized guesses and slot chaos does not run at all).
-
-An unusable failure model is *not* in this list: the orchestrator refuses to start without one
-(see ``app._require_failure_model``), so there is no "chaos ran unguarded" case to report.
-
-Both are recorded here so ``ydb/tests/stability/tests`` can pull them at the end of a phase and
-attach them to its Allure report (see ``StressUtilDeployer._report_nemesis_problems``).
-
-Problems are latched: an entry stays in the list after the fault eventually recovers, because the
-report is read once, after the run. Repeats of the same problem update ``last_seen`` / ``count``
-instead of piling up.
+Entries are latched (the report is read once, after the run) and deduplicated by kind + target.
 """
 
 from __future__ import annotations
@@ -28,7 +16,7 @@ from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
-# Problem kinds (kept stable — the stability test report groups by them).
+# Kinds are stable: the test report groups by them.
 KIND_STUCK_FAULT = "stuck_fault"
 KIND_INVENTORY_DEGRADED = "inventory_degraded"
 
@@ -111,7 +99,7 @@ class ChaosProblemStore:
         logger.warning("chaos problem recorded [%s]: %s", kind, summary)
 
     def record_stuck_fault(self, fault) -> None:
-        """``on_stuck`` callback for :class:`RecoveryProbe`."""
+        """``on_stuck`` callback for the recovery probe."""
         target = fault.target
         self.record(
             KIND_STUCK_FAULT,
@@ -155,11 +143,6 @@ class ChaosProblemStore:
     def dropped(self) -> int:
         with self._lock:
             return self._dropped
-
-    def clear(self) -> None:
-        with self._lock:
-            self._problems.clear()
-            self._dropped = 0
 
 
 __all__ = [

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -5,16 +5,26 @@ Create one instance per app and pass it to OrchestratorNemesisSchedule / wire fr
 
 from __future__ import annotations
 
+import logging
 import threading
-from ydb.tests.stability.nemesis.internal.nemesis.catalog import build_all_planners, build_planner
+from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
+    build_all_planners,
+    build_planner,
+    guard_mode_for,
+    impact_scope_for,
+)
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+
+logger = logging.getLogger(__name__)
 
 
 class ChaosOrchestratorStore:
-    def __init__(self) -> None:
+    def __init__(self, failure_guard: FailureModelGuard | None = None) -> None:
         self._lock = threading.Lock()
         self._planners: dict[str, NemesisPlannerBase] = build_all_planners()
+        self._failure_guard = failure_guard
 
     def rebuild_planner(self, nemesis_type: str, params: dict | None = None) -> bool:
         """Re-create a planner for ``nemesis_type`` with the supplied ``params``.
@@ -34,6 +44,20 @@ class ChaosOrchestratorStore:
         planner = self._planners.get(nemesis_type)
         if planner is None:
             return []
+        # Variant B (pre-filter): restrict the host list for FULL / PREFILTER_ONLY types.
+        if self._failure_guard is not None and self._failure_guard.enabled:
+            mode = guard_mode_for(nemesis_type)
+            if mode in (GuardMode.FULL, GuardMode.PREFILTER_ONLY):
+                scope = impact_scope_for(nemesis_type)
+                filtered = self._failure_guard.filter_safe_hosts(hosts, scope)
+                if len(filtered) != len(hosts):
+                    logger.info(
+                        "Failure model pre-filter: %s %d -> %d safe host(s)",
+                        nemesis_type,
+                        len(hosts),
+                        len(filtered),
+                    )
+                hosts = filtered
         return planner.scheduled_tick(hosts)
 
     def plan_disable_schedule(self, nemesis_type: str) -> list[DispatchCommand]:

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -7,13 +7,17 @@ from __future__ import annotations
 
 import logging
 import threading
+
 from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     build_all_planners,
     build_planner,
     guard_mode_for,
     impact_scope_for,
+    target_kind_for,
 )
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
 
@@ -21,10 +25,15 @@ logger = logging.getLogger(__name__)
 
 
 class ChaosOrchestratorStore:
-    def __init__(self, failure_guard: FailureModelGuard | None = None) -> None:
+    def __init__(
+        self,
+        failure_guard: FailureModelGuard | None = None,
+        inventory: ClusterInventory | None = None,
+    ) -> None:
         self._lock = threading.Lock()
         self._planners: dict[str, NemesisPlannerBase] = build_all_planners()
         self._failure_guard = failure_guard
+        self._inventory = inventory
 
     def rebuild_planner(self, nemesis_type: str, params: dict | None = None) -> bool:
         """Re-create a planner for ``nemesis_type`` with the supplied ``params``.
@@ -40,25 +49,44 @@ class ChaosOrchestratorStore:
             except Exception:
                 return False
 
-    def plan_scheduled_tick(self, nemesis_type: str, hosts: list[str]) -> list[DispatchCommand]:
+    def plan_scheduled_tick(
+        self,
+        nemesis_type: str,
+        hosts: list[str] | None = None,
+    ) -> list[DispatchCommand]:
         planner = self._planners.get(nemesis_type)
         if planner is None:
             return []
-        # Variant B (pre-filter): restrict the host list for FULL / PREFILTER_ONLY types.
-        if self._failure_guard is not None and self._failure_guard.enabled:
-            mode = guard_mode_for(nemesis_type)
-            if mode in (GuardMode.FULL, GuardMode.PREFILTER_ONLY):
-                scope = impact_scope_for(nemesis_type)
-                filtered = self._failure_guard.filter_safe_hosts(hosts, scope)
-                if len(filtered) != len(hosts):
-                    logger.info(
-                        "Failure model pre-filter: %s %d -> %d safe host(s)",
-                        nemesis_type,
-                        len(hosts),
-                        len(filtered),
-                    )
-                hosts = filtered
-        return planner.scheduled_tick(hosts)
+
+        kind = target_kind_for(nemesis_type)
+        if self._inventory is not None:
+            candidates = self._inventory.entities(kind)
+        else:
+            # Fallback: host-only candidates from the agent host list.
+            candidates = [ChaosTarget.for_host(h) for h in (hosts or [])]
+
+        mode = guard_mode_for(nemesis_type)
+        if (
+            self._failure_guard is not None
+            and self._failure_guard.enabled
+            and mode in (GuardMode.FULL, GuardMode.PREFILTER_ONLY)
+        ):
+            scope = impact_scope_for(nemesis_type)
+            filtered = self._failure_guard.filter_safe(candidates, scope)
+            if len(filtered) != len(candidates):
+                logger.info(
+                    "Failure model pre-filter: %s %d -> %d safe candidate(s) (kind=%s)",
+                    nemesis_type,
+                    len(candidates),
+                    len(filtered),
+                    kind.value,
+                )
+            candidates = filtered
+
+        if not candidates:
+            logger.info("No safe candidates for %s (kind=%s)", nemesis_type, kind.value)
+            return []
+        return planner.scheduled_tick(candidates)
 
     def plan_disable_schedule(self, nemesis_type: str) -> list[DispatchCommand]:
         planner = self._planners.get(nemesis_type)

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -111,7 +111,7 @@ class ChaosOrchestratorStore:
     def plan_inject_target(
         self, nemesis_type: str, target: ChaosTarget
     ) -> list[DispatchCommand]:
-        """Inject command(s) for one already-chosen ``target`` (weighted scheduler path).
+        """Inject command(s) for one already-chosen ``target`` (boundary scheduler path).
 
         The scheduler has already reserved the failure budget, so this skips the legacy
         ``filter_safe`` pre-filter. A DATACENTER target fans out to every host in the chosen
@@ -132,7 +132,7 @@ class ChaosOrchestratorStore:
     def plan_extract_target(
         self, nemesis_type: str, target: ChaosTarget
     ) -> list[DispatchCommand]:
-        """Extract command for one chosen ``target`` (weighted-scheduler toggle recovery).
+        """Extract command for one chosen ``target`` (boundary-scheduler toggle recovery).
 
         Bypasses the planner's cross-tick state — the scheduler owns which target is broken;
         the agent-side actor restores from its own stored state on extract."""

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -15,13 +15,32 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     impact_scope_for,
     target_kind_for,
 )
-from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, fanout
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
 
 logger = logging.getLogger(__name__)
+
+
+def datacenter_inject_fanout(
+    nemesis_type: str, target: ChaosTarget, inventory
+) -> list[DispatchCommand]:
+    """Inject the DC fault on every host of ``target``'s datacenter (one shared scenario).
+
+    The scheduler already chose and reserved this DC, so we fan out to exactly its hosts
+    rather than let the round-robin ``DataCenterFanoutPlanner`` pick a different one."""
+    dc = target.group_id
+    hosts = [
+        t.host for t in inventory.entities(TargetKind.DATACENTER) if t.group_id == dc
+    ] or [target.host]
+    return fanout(
+        nemesis_type,
+        [ChaosTarget.for_datacenter(h, dc) for h in hosts],
+        "inject",
+        {"datacenter": dc},
+    )
 
 
 class ChaosOrchestratorStore:
@@ -88,6 +107,23 @@ class ChaosOrchestratorStore:
             return []
         return planner.scheduled_tick(candidates)
 
+    def plan_inject_target(
+        self, nemesis_type: str, target: ChaosTarget
+    ) -> list[DispatchCommand]:
+        """Inject command(s) for one already-chosen ``target`` (weighted scheduler path).
+
+        The scheduler has already reserved the failure budget, so this skips the legacy
+        ``filter_safe`` pre-filter. A DATACENTER target fans out to every host in the chosen
+        DC (the round-robin fanout planner would pick its own DC, not this one); anything else
+        goes to its planner as a single-target tick.
+        """
+        if target.kind is TargetKind.DATACENTER and self._inventory is not None:
+            return datacenter_inject_fanout(nemesis_type, target, self._inventory)
+        planner = self._planners.get(nemesis_type)
+        if planner is None:
+            return []
+        return planner.scheduled_tick([target])
+
     def plan_disable_schedule(self, nemesis_type: str) -> list[DispatchCommand]:
         planner = self._planners.get(nemesis_type)
         if planner is None:
@@ -109,4 +145,5 @@ class ChaosOrchestratorStore:
 __all__ = [
     "ChaosOrchestratorStore",
     "DispatchCommand",
+    "datacenter_inject_fanout",
 ]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -85,12 +85,7 @@ class ChaosOrchestratorStore:
             # Fallback: host-only candidates from the agent host list.
             candidates = [ChaosTarget.for_host(h) for h in (hosts or [])]
 
-        mode = guard_mode_for(nemesis_type)
-        if (
-            self._failure_guard is not None
-            and self._failure_guard.enabled
-            and mode in (GuardMode.FULL, GuardMode.PREFILTER_ONLY)
-        ):
+        if self._failure_guard is not None and guard_mode_for(nemesis_type) is GuardMode.FULL:
             scope = impact_scope_for(nemesis_type)
             filtered = self._failure_guard.filter_safe(candidates, scope)
             if len(filtered) != len(candidates):

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -28,10 +28,8 @@ logger = logging.getLogger(__name__)
 def datacenter_inject_fanout(
     nemesis_type: str, target: ChaosTarget, inventory
 ) -> list[DispatchCommand]:
-    """Inject the DC fault on every host of ``target``'s datacenter (one shared scenario).
-
-    The scheduler already chose and reserved this DC, so we fan out to exactly its hosts
-    rather than let the round-robin ``DataCenterFanoutPlanner`` pick a different one."""
+    """Inject on every host of ``target``'s DC (one scenario) — the DC is already reserved, so the
+    round-robin ``DataCenterFanoutPlanner`` must not pick a different one."""
     dc = target.group_id
     hosts = [
         t.host for t in inventory.entities(TargetKind.DATACENTER) if t.group_id == dc
@@ -56,12 +54,7 @@ class ChaosOrchestratorStore:
         self._inventory = inventory
 
     def rebuild_planner(self, nemesis_type: str, params: dict | None = None) -> bool:
-        """Re-create a planner for ``nemesis_type`` with the supplied ``params``.
-
-        Used when the UI starts a scheduled run with custom parameters. Returns
-        ``True`` if the planner was rebuilt, ``False`` if the type is unknown
-        or planner construction failed.
-        """
+        """Re-create a planner with UI-supplied ``params``; False if that failed."""
         with self._lock:
             try:
                 self._planners[nemesis_type] = build_planner(nemesis_type, params)
@@ -106,14 +99,10 @@ class ChaosOrchestratorStore:
     def plan_inject_target(
         self, nemesis_type: str, target: ChaosTarget
     ) -> list[DispatchCommand]:
-        """Inject command(s) for one already-chosen ``target`` (boundary scheduler path).
+        """Inject on one already-reserved ``target`` (boundary scheduler path), so no pre-filter.
 
-        The scheduler has already reserved the failure budget, so this skips the legacy
-        ``filter_safe`` pre-filter. A DATACENTER target fans out to every host in the chosen
-        DC (the round-robin fanout planner would pick its own DC, not this one); toggle faults
-        (``recovery: extract``) are dispatched directly so a stateful planner's cross-tick
-        bookkeeping can't fight the scheduler; anything else goes to its planner's single-target
-        tick.
+        A DATACENTER target is fanned out over its DC; a toggle fault is dispatched directly, so a
+        planner's cross-tick state cannot fight the scheduler; anything else goes to its planner.
         """
         if target.kind is TargetKind.DATACENTER and self._inventory is not None:
             return datacenter_inject_fanout(nemesis_type, target, self._inventory)
@@ -127,10 +116,8 @@ class ChaosOrchestratorStore:
     def plan_extract_target(
         self, nemesis_type: str, target: ChaosTarget
     ) -> list[DispatchCommand]:
-        """Extract command for one chosen ``target`` (boundary-scheduler toggle recovery).
-
-        Bypasses the planner's cross-tick state — the scheduler owns which target is broken;
-        the agent-side actor restores from its own stored state on extract."""
+        """Extract one chosen ``target``: the scheduler owns what is broken, and the agent-side
+        actor restores from its own stored state."""
         return self._direct_commands(nemesis_type, target, "extract")
 
     def _direct_commands(

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_state.py
@@ -13,9 +13,10 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     build_planner,
     guard_mode_for,
     impact_scope_for,
+    recovery_mode_for,
     target_kind_for,
 )
-from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, fanout
+from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch, fanout
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
@@ -114,15 +115,36 @@ class ChaosOrchestratorStore:
 
         The scheduler has already reserved the failure budget, so this skips the legacy
         ``filter_safe`` pre-filter. A DATACENTER target fans out to every host in the chosen
-        DC (the round-robin fanout planner would pick its own DC, not this one); anything else
-        goes to its planner as a single-target tick.
+        DC (the round-robin fanout planner would pick its own DC, not this one); toggle faults
+        (``recovery: extract``) are dispatched directly so a stateful planner's cross-tick
+        bookkeeping can't fight the scheduler; anything else goes to its planner's single-target
+        tick.
         """
         if target.kind is TargetKind.DATACENTER and self._inventory is not None:
             return datacenter_inject_fanout(nemesis_type, target, self._inventory)
+        if recovery_mode_for(nemesis_type) == "extract":
+            return self._direct_commands(nemesis_type, target, "inject")
         planner = self._planners.get(nemesis_type)
         if planner is None:
             return []
         return planner.scheduled_tick([target])
+
+    def plan_extract_target(
+        self, nemesis_type: str, target: ChaosTarget
+    ) -> list[DispatchCommand]:
+        """Extract command for one chosen ``target`` (weighted-scheduler toggle recovery).
+
+        Bypasses the planner's cross-tick state — the scheduler owns which target is broken;
+        the agent-side actor restores from its own stored state on extract."""
+        return self._direct_commands(nemesis_type, target, "extract")
+
+    def _direct_commands(
+        self, nemesis_type: str, target: ChaosTarget, action: str
+    ) -> list[DispatchCommand]:
+        planner = self._planners.get(nemesis_type)
+        attr = "PAYLOAD_INJECT" if action == "inject" else "PAYLOAD_EXTRACT"
+        payload = dict(getattr(planner, attr, {}) or {}) if planner is not None else {}
+        return [dispatch(nemesis_type, target, action, payload)]
 
     def plan_disable_schedule(self, nemesis_type: str) -> list[DispatchCommand]:
         planner = self._planners.get(nemesis_type)
@@ -146,4 +168,5 @@ __all__ = [
     "ChaosOrchestratorStore",
     "DispatchCommand",
     "datacenter_inject_fanout",
+    "dispatch",
 ]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_target.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_target.py
@@ -1,0 +1,173 @@
+"""ChaosTarget: unified descriptor of what a chaos inject/extract acts on.
+
+Dispatch still goes to an agent ``host``; ``kind`` + ids say which entity on that host
+(or cluster-wide tablet) is the real target. See CHAOS_TARGET_IMPLEMENTATION_PLAN.md.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+class TargetKind(enum.Enum):
+    HOST = "host"
+    NODE = "node"
+    SLOT = "slot"
+    DISK = "disk"
+    TABLET = "tablet"
+    DATACENTER = "datacenter"
+    PILE = "pile"
+
+
+@dataclass(frozen=True)
+class ChaosTarget:
+    kind: TargetKind
+    host: str
+    node_id: int | None = None
+    ic_port: int | None = None
+    slot_idx: int | None = None
+    disk_path: str | None = None
+    tablet_id: int | None = None
+    group_id: str | None = None  # datacenter name or pile id
+
+    # -- factories ----------------------------------------------------------
+
+    @classmethod
+    def for_host(cls, host: str) -> "ChaosTarget":
+        return cls(kind=TargetKind.HOST, host=host)
+
+    @classmethod
+    def for_node(
+        cls,
+        host: str,
+        *,
+        node_id: int | None = None,
+        ic_port: int | None = None,
+    ) -> "ChaosTarget":
+        return cls(kind=TargetKind.NODE, host=host, node_id=node_id, ic_port=ic_port)
+
+    @classmethod
+    def for_slot(
+        cls,
+        host: str,
+        *,
+        slot_idx: int | None = None,
+        ic_port: int | None = None,
+        node_id: int | None = None,
+    ) -> "ChaosTarget":
+        return cls(
+            kind=TargetKind.SLOT,
+            host=host,
+            slot_idx=slot_idx,
+            ic_port=ic_port,
+            node_id=node_id,
+        )
+
+    @classmethod
+    def for_disk(
+        cls,
+        host: str,
+        *,
+        node_id: int | None = None,
+        disk_path: str | None = None,
+        ic_port: int | None = None,
+    ) -> "ChaosTarget":
+        return cls(
+            kind=TargetKind.DISK,
+            host=host,
+            node_id=node_id,
+            disk_path=disk_path,
+            ic_port=ic_port,
+        )
+
+    @classmethod
+    def for_tablet(cls, host: str, *, tablet_id: int | None = None) -> "ChaosTarget":
+        return cls(kind=TargetKind.TABLET, host=host, tablet_id=tablet_id)
+
+    @classmethod
+    def for_datacenter(cls, host: str, datacenter: str) -> "ChaosTarget":
+        return cls(kind=TargetKind.DATACENTER, host=host, group_id=datacenter)
+
+    @classmethod
+    def for_pile(cls, host: str, pile_id: str | int) -> "ChaosTarget":
+        return cls(kind=TargetKind.PILE, host=host, group_id=str(pile_id))
+
+    # -- identity / serde ---------------------------------------------------
+
+    def identity_key(self) -> str:
+        """Stable key for touched-set bookkeeping."""
+        if self.kind is TargetKind.NODE:
+            return f"node:{self.node_id if self.node_id is not None else self.ic_port}:{self.host}"
+        if self.kind is TargetKind.SLOT:
+            return f"slot:{self.slot_idx if self.slot_idx is not None else self.ic_port}:{self.host}"
+        if self.kind is TargetKind.DISK:
+            return f"disk:{self.node_id}:{self.disk_path or ''}:{self.host}"
+        if self.kind is TargetKind.TABLET:
+            return f"tablet:{self.tablet_id}" if self.tablet_id is not None else f"tablet:any@{self.host}"
+        if self.kind is TargetKind.DATACENTER:
+            return f"dc:{self.group_id}"
+        if self.kind is TargetKind.PILE:
+            return f"pile:{self.group_id}"
+        return f"host:{self.host}"
+
+    def to_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["kind"] = self.kind.value
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "ChaosTarget | None":
+        if not data or not isinstance(data, dict):
+            return None
+        host = data.get("host")
+        if not host:
+            return None
+        kind_raw = data.get("kind", TargetKind.HOST.value)
+        try:
+            kind = TargetKind(kind_raw) if not isinstance(kind_raw, TargetKind) else kind_raw
+        except ValueError:
+            kind = TargetKind.HOST
+        return cls(
+            kind=kind,
+            host=str(host),
+            node_id=_as_optional_int(data.get("node_id")),
+            ic_port=_as_optional_int(data.get("ic_port")),
+            slot_idx=_as_optional_int(data.get("slot_idx")),
+            disk_path=_as_optional_str(data.get("disk_path")),
+            tablet_id=_as_optional_int(data.get("tablet_id")),
+            group_id=_as_optional_str(data.get("group_id")),
+        )
+
+    @classmethod
+    def from_host_or_dict(cls, host: str | None = None, data: dict[str, Any] | None = None) -> "ChaosTarget":
+        """Build from explicit target dict, else synthesize HOST target from ``host``."""
+        t = cls.from_dict(data)
+        if t is not None:
+            return t
+        if host:
+            return cls.for_host(str(host))
+        raise ValueError("ChaosTarget requires host or target dict")
+
+
+def _as_optional_int(v: Any) -> int | None:
+    if v is None or v == "":
+        return None
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_optional_str(v: Any) -> str | None:
+    if v is None:
+        return None
+    s = str(v).strip()
+    return s or None
+
+
+__all__ = [
+    "TargetKind",
+    "ChaosTarget",
+]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_target.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/chaos_target.py
@@ -1,7 +1,7 @@
 """ChaosTarget: unified descriptor of what a chaos inject/extract acts on.
 
 Dispatch still goes to an agent ``host``; ``kind`` + ids say which entity on that host
-(or cluster-wide tablet) is the real target. See CHAOS_TARGET_IMPLEMENTATION_PLAN.md.
+(or cluster-wide tablet) is the real target.
 """
 
 from __future__ import annotations

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/cluster_inventory.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/cluster_inventory.py
@@ -1,0 +1,198 @@
+"""ClusterInventory: host/node/slot entities for chaos planning.
+
+Built from ``cluster.yaml`` topology plus optional ``ExternalKiKiMRCluster`` enrichment
+(node_id, ic_port, slots). Fail-open: if cluster harness is unavailable, host-only
+candidates are still produced.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import ClusterTopologyModel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NodeInfo:
+    node_id: int
+    host: str
+    ic_port: int | None
+    rack: str | None
+    datacenter: str | None
+    bridge_pile_id: int | None = None
+
+
+@dataclass(frozen=True)
+class SlotInfo:
+    slot_idx: int
+    host: str
+    ic_port: int | None
+    node_id: int | None
+    rack: str | None
+    datacenter: str | None
+    bridge_pile_id: int | None = None
+
+
+class ClusterInventory:
+    def __init__(
+        self,
+        topology: ClusterTopologyModel,
+        *,
+        agent_hosts: Iterable[str] | None = None,
+    ) -> None:
+        self._topology = topology
+        self._agent_hosts = [h for h in (agent_hosts or []) if h]
+        if not self._agent_hosts:
+            self._agent_hosts = list(topology.hosts.keys())
+        self.nodes: dict[int, NodeInfo] = {}
+        self.slots: dict[int, SlotInfo] = {}
+        self._load_from_harness()
+
+    # -- loading ------------------------------------------------------------
+
+    def _load_from_harness(self) -> None:
+        try:
+            from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import require_external_cluster
+
+            cluster = require_external_cluster()
+        except Exception as e:  # noqa: BLE001 - inventory must fail open
+            logger.warning("ClusterInventory: harness unavailable (%s); host-only candidates", e)
+            self._synthesize_nodes_from_hosts()
+            return
+
+        try:
+            for node_id, node in cluster.nodes.items():
+                host = str(node.host)
+                self.nodes[int(node_id)] = NodeInfo(
+                    node_id=int(node_id),
+                    host=host,
+                    ic_port=int(node.ic_port) if getattr(node, "ic_port", None) else None,
+                    rack=getattr(node, "rack", None) or self._topology.rack_of(host),
+                    datacenter=getattr(node, "datacenter", None) or self._topology.dc_of(host),
+                    bridge_pile_id=getattr(node, "bridge_pile_id", None),
+                )
+            for slot_idx, slot in cluster.slots.items():
+                host = str(slot.host)
+                self.slots[int(slot_idx)] = SlotInfo(
+                    slot_idx=int(slot_idx),
+                    host=host,
+                    ic_port=int(slot.ic_port) if getattr(slot, "ic_port", None) else None,
+                    node_id=int(slot.node_id) if getattr(slot, "node_id", None) is not None else None,
+                    rack=getattr(slot, "rack", None) or self._topology.rack_of(host),
+                    datacenter=getattr(slot, "datacenter", None) or self._topology.dc_of(host),
+                    bridge_pile_id=getattr(slot, "bridge_pile_id", None),
+                )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("ClusterInventory: failed to read nodes/slots (%s); host-only", e)
+            self.nodes.clear()
+            self.slots.clear()
+            self._synthesize_nodes_from_hosts()
+
+        if not self.nodes:
+            self._synthesize_nodes_from_hosts()
+
+        logger.info(
+            "ClusterInventory: %d host(s), %d node(s), %d slot(s)",
+            len(self._agent_hosts),
+            len(self.nodes),
+            len(self.slots),
+        )
+
+    def _synthesize_nodes_from_hosts(self) -> None:
+        """One synthetic node per agent host when harness has no node map."""
+        for i, host in enumerate(self._agent_hosts, start=1):
+            if any(n.host == host for n in self.nodes.values()):
+                continue
+            self.nodes[i] = NodeInfo(
+                node_id=i,
+                host=host,
+                ic_port=19001,
+                rack=self._topology.rack_of(host),
+                datacenter=self._topology.dc_of(host),
+            )
+
+    # -- lookups ------------------------------------------------------------
+
+    @property
+    def hosts(self) -> list[str]:
+        return list(self._agent_hosts)
+
+    def control_host(self) -> str | None:
+        """Pinned first host for cluster-API tablet chaos."""
+        return self._agent_hosts[0] if self._agent_hosts else None
+
+    def nodes_on_host(self, host: str) -> list[NodeInfo]:
+        return [n for n in self.nodes.values() if n.host == host]
+
+    def slots_on_host(self, host: str) -> list[SlotInfo]:
+        return [s for s in self.slots.values() if s.host == host]
+
+    def node_by_id(self, node_id: int) -> NodeInfo | None:
+        return self.nodes.get(node_id)
+
+    def slot_by_idx(self, slot_idx: int) -> SlotInfo | None:
+        return self.slots.get(slot_idx)
+
+    # -- candidate generation -----------------------------------------------
+
+    def entities(self, kind: TargetKind) -> list[ChaosTarget]:
+        if kind is TargetKind.HOST:
+            return [ChaosTarget.for_host(h) for h in self._agent_hosts]
+        if kind is TargetKind.NODE:
+            return [
+                ChaosTarget.for_node(n.host, node_id=n.node_id, ic_port=n.ic_port)
+                for n in self.nodes.values()
+                if n.host in self._agent_hosts or not self._agent_hosts
+            ]
+        if kind is TargetKind.SLOT:
+            return [
+                ChaosTarget.for_slot(
+                    s.host, slot_idx=s.slot_idx, ic_port=s.ic_port, node_id=s.node_id
+                )
+                for s in self.slots.values()
+                if s.host in self._agent_hosts or not self._agent_hosts
+            ]
+        if kind is TargetKind.DISK:
+            # Disk path chosen on agent; plan at node granularity.
+            return [
+                ChaosTarget.for_disk(n.host, node_id=n.node_id, ic_port=n.ic_port)
+                for n in self.nodes.values()
+                if n.host in self._agent_hosts or not self._agent_hosts
+            ]
+        if kind is TargetKind.TABLET:
+            h = self.control_host()
+            return [ChaosTarget.for_tablet(h)] if h else []
+        if kind is TargetKind.DATACENTER:
+            by_dc: dict[str, list[str]] = {}
+            for h in self._agent_hosts:
+                dc = self._topology.dc_of(h) or "__unknown__"
+                by_dc.setdefault(dc, []).append(h)
+            out: list[ChaosTarget] = []
+            for dc, hosts in by_dc.items():
+                for h in hosts:
+                    out.append(ChaosTarget.for_datacenter(h, dc))
+            return out
+        if kind is TargetKind.PILE:
+            by_pile: dict[str, list[str]] = {}
+            for n in self.nodes.values():
+                if n.bridge_pile_id is None:
+                    continue
+                by_pile.setdefault(str(n.bridge_pile_id), []).append(n.host)
+            out = []
+            for pile_id, hosts in by_pile.items():
+                for h in sorted(set(hosts)):
+                    out.append(ChaosTarget.for_pile(h, pile_id))
+            return out
+        return []
+
+
+__all__ = [
+    "NodeInfo",
+    "SlotInfo",
+    "ClusterInventory",
+]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/cluster_inventory.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/cluster_inventory.py
@@ -1,8 +1,7 @@
 """ClusterInventory: host/node/slot entities for chaos planning.
 
-Built from ``cluster.yaml`` topology plus optional ``ExternalKiKiMRCluster`` enrichment
-(node_id, ic_port, slots). Fail-open: if cluster harness is unavailable, host-only
-candidates are still produced.
+Built from the ``cluster.yaml`` topology plus ``ExternalKiKiMRCluster`` (node_id, ic_port, slots).
+If the harness is unavailable, nodes are synthesized and ``degraded_reason`` says so.
 """
 
 from __future__ import annotations
@@ -51,8 +50,7 @@ class ClusterInventory:
             self._agent_hosts = list(topology.hosts.keys())
         self.nodes: dict[int, NodeInfo] = {}
         self.slots: dict[int, SlotInfo] = {}
-        # Set when nodes had to be synthesized from the host list: node/slot ids and ports are then
-        # guesses and there are no slots at all. Reported through ``GET /api/problems``.
+        # Set when nodes had to be synthesized: ids and ports are guesses, and there are no slots.
         self.degraded_reason: str | None = None
         self._load_from_harness()
 
@@ -131,18 +129,6 @@ class ClusterInventory:
     def control_host(self) -> str | None:
         """Pinned first host for cluster-API tablet chaos."""
         return self._agent_hosts[0] if self._agent_hosts else None
-
-    def nodes_on_host(self, host: str) -> list[NodeInfo]:
-        return [n for n in self.nodes.values() if n.host == host]
-
-    def slots_on_host(self, host: str) -> list[SlotInfo]:
-        return [s for s in self.slots.values() if s.host == host]
-
-    def node_by_id(self, node_id: int) -> NodeInfo | None:
-        return self.nodes.get(node_id)
-
-    def slot_by_idx(self, slot_idx: int) -> SlotInfo | None:
-        return self.slots.get(slot_idx)
 
     # -- candidate generation -----------------------------------------------
 

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/cluster_inventory.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/cluster_inventory.py
@@ -51,6 +51,9 @@ class ClusterInventory:
             self._agent_hosts = list(topology.hosts.keys())
         self.nodes: dict[int, NodeInfo] = {}
         self.slots: dict[int, SlotInfo] = {}
+        # Set when nodes had to be synthesized from the host list: node/slot ids and ports are then
+        # guesses and there are no slots at all. Reported through ``GET /api/problems``.
+        self.degraded_reason: str | None = None
         self._load_from_harness()
 
     # -- loading ------------------------------------------------------------
@@ -62,6 +65,7 @@ class ClusterInventory:
             cluster = require_external_cluster()
         except Exception as e:  # noqa: BLE001 - inventory must fail open
             logger.warning("ClusterInventory: harness unavailable (%s); host-only candidates", e)
+            self.degraded_reason = f"cluster harness unavailable ({e})"
             self._synthesize_nodes_from_hosts()
             return
 
@@ -91,9 +95,11 @@ class ClusterInventory:
             logger.warning("ClusterInventory: failed to read nodes/slots (%s); host-only", e)
             self.nodes.clear()
             self.slots.clear()
+            self.degraded_reason = f"cannot read nodes/slots from the harness ({e})"
             self._synthesize_nodes_from_hosts()
 
         if not self.nodes:
+            self.degraded_reason = self.degraded_reason or "harness reported no nodes"
             self._synthesize_nodes_from_hosts()
 
         logger.info(

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/default_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/default_planner.py
@@ -1,16 +1,20 @@
-"""Fallback orchestrator planner: each scheduled tick picks one random cluster host for inject."""
+"""Fallback orchestrator planner: each scheduled tick picks one random candidate for inject."""
 
 from __future__ import annotations
 
 import random
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import (
+    NemesisPlannerBase,
+    normalize_candidates,
+)
 
 
 class DefaultRandomHostPlanner(NemesisPlannerBase):
     """
-    No cross-tick state: one random host per tick for inject.
+    No cross-tick state: one random candidate per tick for inject.
     Disable-schedule extract is empty; manual inject/extract still dispatch to the chosen host.
     """
 
@@ -21,10 +25,11 @@ class DefaultRandomHostPlanner(NemesisPlannerBase):
         super().__init__()
         self.nemesis_type = nemesis_type
 
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        if not hosts:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        targets = normalize_candidates(candidates)
+        if not targets:
             return []
-        target = random.choice(hosts)
+        target = random.choice(targets)
         return [dispatch(self.nemesis_type, target, "inject", self.PAYLOAD_INJECT)]
 
     def _drain_tracked_hosts(self) -> list[str]:

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -1,0 +1,354 @@
+"""Failure-model guard: constrain nemesis chaos to the cluster's declared fault tolerance.
+
+Parses ``cluster.yaml`` into a :class:`ClusterTopologyModel` and exposes a
+:class:`FailureModelGuard` that vetoes/filters chaos exceeding the tolerated
+simultaneous-failure budget (fail domain = rack, fail realm = datacenter):
+
+    mirror-3-dc : 1 realm fully + 1 domain in another realm
+    block-4-2   : any 2 domains
+    none        : 0
+
+Unrelated to the runner-side ``scope=`` metrics argument in ``monitored_actor.py``.
+
+Each recorded impairment carries an optional recovery deadline, so faults that recover
+without an explicit extract (systemd auto-restart after SIGKILL, self-healing rolling
+restart) release their budget on a timer instead of piling up forever. ``recovery_sec=None``
+holds an impairment until an explicit extract (toggle faults that stay down until next inject).
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class ImpactScope(enum.Enum):
+    """Topology level a nemesis affects (orchestrator-side annotation)."""
+
+    NODE = "node"
+    DISK = "disk"
+    NETWORK = "network"
+    RACK = "rack"
+    DATACENTER = "datacenter"
+    PILE = "pile"
+    UNKNOWN = "unknown"
+
+
+class GuardMode(enum.Enum):
+    """How the failure-model guard treats a nemesis type.
+
+    FULL           : pre-filter host list (B) AND post-veto + record impact (A).
+    PREFILTER_ONLY : pre-filter host list only; never vetoed / recorded at dispatch.
+    BYPASS         : guard does not touch this type at all.
+    """
+
+    FULL = "full"
+    PREFILTER_ONLY = "prefilter_only"
+    BYPASS = "bypass"
+
+
+# Scopes that collapse to "one fail domain = the host's rack".
+_HOST_LEVEL_SCOPES = frozenset(
+    {ImpactScope.NODE, ImpactScope.DISK, ImpactScope.NETWORK, ImpactScope.RACK}
+)
+
+# Fallback recovery window (seconds) when a nemesis type has no ``auto_recovery_sec`` annotation.
+# Conservatively longer than a systemd restart so a node stays "impaired" until it likely rejoined.
+DEFAULT_RECOVERY_SEC: float = 120.0
+
+
+@dataclass(frozen=True)
+class FailureTolerance:
+    """Max simultaneous failures allowed by an erasure mode.
+
+    ``max_realm_plus_domain`` (mirror-3-dc): one whole realm may be lost, plus this many
+    extra domains in *other* realms combined.
+    ``max_domains`` (block-4-2): total domains allowed regardless of realm.
+    """
+
+    erasure: str
+    kind: str  # "realm_plus_domain" | "domains" | "none" | "unknown"
+    max_extra_domains: int = 0
+    max_domains: int = 0
+
+    @classmethod
+    def from_erasure(cls, erasure: str) -> "FailureTolerance":
+        e = (erasure or "").strip().lower()
+        if e == "mirror-3-dc":
+            return cls(erasure=e, kind="realm_plus_domain", max_extra_domains=1)
+        if e == "block-4-2":
+            return cls(erasure=e, kind="domains", max_domains=2)
+        if e == "none":
+            return cls(erasure=e, kind="none")
+        return cls(erasure=e or "unknown", kind="unknown")
+
+    @property
+    def guards(self) -> bool:
+        """True if this tolerance can actually make veto decisions."""
+        return self.kind in ("realm_plus_domain", "domains", "none")
+
+
+@dataclass
+class HostTopology:
+    host: str
+    rack: str | None
+    datacenter: str | None
+
+
+class ClusterTopologyModel:
+    """Parses ``cluster.yaml``: erasure mode and host -> rack -> datacenter mapping.
+
+    Fails open (``guards`` is False) when the file is missing, unparsable, the erasure mode
+    is unknown, or hosts have no rack/datacenter — the guard then never vetoes anything.
+    """
+
+    def __init__(self, yaml_path: str | None) -> None:
+        self.yaml_path = yaml_path or ""
+        self.hosts: dict[str, HostTopology] = {}
+        self._rack_to_dc: dict[str, str | None] = {}
+        self.tolerance = FailureTolerance.from_erasure("")
+        self._parse()
+
+    # -- parsing ------------------------------------------------------------
+
+    def _parse(self) -> None:
+        doc = self._load_doc(self.yaml_path)
+        if not doc:
+            logger.warning("FailureModel: cluster.yaml not loaded (%r); guard disabled", self.yaml_path)
+            return
+        self.tolerance = FailureTolerance.from_erasure(doc.get("static_erasure", ""))
+
+        hosts = doc.get("hosts")
+        if not isinstance(hosts, list) or not hosts:
+            hosts = (doc.get("config") or {}).get("hosts", [])
+        if not isinstance(hosts, list):
+            hosts = []
+
+        for h in hosts:
+            if not isinstance(h, dict):
+                continue
+            name = h.get("name") or h.get("host")
+            if not name:
+                continue
+            loc = h.get("location") or {}
+            if not isinstance(loc, dict):
+                loc = {}
+            rack = loc.get("rack")
+            dc = loc.get("data_center")
+            rack = str(rack) if rack is not None else None
+            dc = str(dc) if dc is not None else None
+            self.hosts[name] = HostTopology(host=name, rack=rack, datacenter=dc)
+            if rack is not None:
+                self._rack_to_dc[rack] = dc
+
+    @staticmethod
+    def _load_doc(path: str) -> dict | None:
+        if not path or not Path(path).is_file():
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                doc = yaml.safe_load(f.read())
+        except Exception as e:  # noqa: BLE001 - fail open on any parse error
+            logger.warning("FailureModel: failed to parse %r: %s", path, e)
+            return None
+        return doc if isinstance(doc, dict) else None
+
+    # -- lookups ------------------------------------------------------------
+
+    @property
+    def guards(self) -> bool:
+        """True only if we have a usable erasure model and topology to reason about."""
+        return self.tolerance.guards and bool(self.hosts)
+
+    def rack_of(self, host: str) -> str | None:
+        t = self.hosts.get(host)
+        return t.rack if t else None
+
+    def dc_of(self, host: str) -> str | None:
+        t = self.hosts.get(host)
+        return t.datacenter if t else None
+
+    def racks_in_dc(self, dc: str | None) -> set[str]:
+        return {r for r, d in self._rack_to_dc.items() if d == dc}
+
+    def dc_of_rack(self, rack: str) -> str | None:
+        return self._rack_to_dc.get(rack)
+
+
+@dataclass
+class _Impairment:
+    """One recorded fault footprint. ``deadline`` is a ``time.monotonic()`` value; ``None`` = held
+    until an explicit extract."""
+
+    execution_id: str
+    racks: set[str]
+    deadline: float | None
+
+
+class FailureModelGuard:
+    """Tracks impaired fail domains (racks) and validates new chaos against the failure model.
+
+    Only ``FULL``-mode injects are recorded; ``PREFILTER_ONLY`` / ``BYPASS`` are not counted.
+    Each impairment carries a recovery deadline so auto-recovering faults release their budget
+    without an explicit extract; expired impairments are purged lazily on every read/write.
+    """
+
+    def __init__(self, topology: ClusterTopologyModel) -> None:
+        self._topology = topology
+        self._lock = threading.Lock()
+        self._impairments: list[_Impairment] = []
+
+    @property
+    def enabled(self) -> bool:
+        return self._topology.guards
+
+    # -- rack resolution ----------------------------------------------------
+
+    def _racks_for(self, host: str, scope: ImpactScope) -> set[str]:
+        """Fail domains (rack keys) touched by injecting ``scope`` on ``host``."""
+        if scope == ImpactScope.DATACENTER:
+            dc = self._topology.dc_of(host)
+            racks = self._topology.racks_in_dc(dc)
+            return set(racks) if racks else {self._synthetic_key(host)}
+        if scope in _HOST_LEVEL_SCOPES:
+            rack = self._topology.rack_of(host)
+            return {rack if rack is not None else self._synthetic_key(host)}
+        # PILE / UNKNOWN: fall back to the host's rack (best effort).
+        rack = self._topology.rack_of(host)
+        return {rack if rack is not None else self._synthetic_key(host)}
+
+    @staticmethod
+    def _synthetic_key(host: str) -> str:
+        return f"__host__:{host}"
+
+    # -- impairment bookkeeping (call under _lock) --------------------------
+
+    def _purge_expired(self, now: float) -> None:
+        self._impairments = [
+            imp for imp in self._impairments if imp.deadline is None or imp.deadline > now
+        ]
+
+    def _active_racks(self, now: float) -> set[str]:
+        self._purge_expired(now)
+        active: set[str] = set()
+        for imp in self._impairments:
+            active |= imp.racks
+        return active
+
+    # -- tolerance check ----------------------------------------------------
+
+    def _is_tolerable(self, impaired_racks: set[str]) -> bool:
+        tol = self._topology.tolerance
+        n = len(impaired_racks)
+        if tol.kind == "none":
+            return n == 0
+        if tol.kind == "domains":
+            return n <= tol.max_domains
+        if tol.kind == "realm_plus_domain":
+            # One realm may be lost entirely, plus max_extra_domains in other realms combined.
+            by_dc: dict[str | None, int] = {}
+            for rack in impaired_racks:
+                dc = self._topology.dc_of_rack(rack) if not rack.startswith("__host__:") else None
+                by_dc[dc] = by_dc.get(dc, 0) + 1
+            if not by_dc:
+                return True
+            sacrificial = max(by_dc.values())  # the realm we allow to fail fully
+            remaining = n - sacrificial
+            return remaining <= tol.max_extra_domains
+        # unknown -> fail open
+        return True
+
+    # -- public API ---------------------------------------------------------
+
+    def can_inject(self, host: str, scope: ImpactScope) -> bool:
+        if not self.enabled:
+            return True
+        now = time.monotonic()
+        with self._lock:
+            hypothetical = self._active_racks(now) | self._racks_for(host, scope)
+            return self._is_tolerable(hypothetical)
+
+    def filter_safe_hosts(self, hosts: Iterable[str], scope: ImpactScope) -> list[str]:
+        if not self.enabled:
+            return list(hosts)
+        now = time.monotonic()
+        safe: list[str] = []
+        with self._lock:
+            active = self._active_racks(now)
+            for host in hosts:
+                hypothetical = active | self._racks_for(host, scope)
+                if self._is_tolerable(hypothetical):
+                    safe.append(host)
+        return safe
+
+    def record_inject(
+        self,
+        execution_id: str,
+        host: str,
+        scope: ImpactScope,
+        recovery_sec: float | None = DEFAULT_RECOVERY_SEC,
+    ) -> None:
+        """Mark ``host``'s fail domain(s) impaired.
+
+        ``recovery_sec``: auto-release window; after it elapses the impairment is dropped even
+        without an extract. ``None`` holds it until an explicit extract (toggle faults).
+        """
+        if not self.enabled:
+            return
+        racks = self._racks_for(host, scope)
+        deadline = None if recovery_sec is None else time.monotonic() + float(recovery_sec)
+        with self._lock:
+            # Idempotent re-inject: replace any prior record for this execution.
+            self._impairments = [
+                imp for imp in self._impairments if imp.execution_id != execution_id
+            ]
+            self._impairments.append(
+                _Impairment(execution_id=execution_id, racks=racks, deadline=deadline)
+            )
+
+    def record_extract(self, execution_id: str, host: str, scope: ImpactScope) -> None:
+        """Release the impairment recorded for ``execution_id`` (early recovery)."""
+        if not self.enabled:
+            return
+        with self._lock:
+            before = len(self._impairments)
+            self._impairments = [
+                imp for imp in self._impairments if imp.execution_id != execution_id
+            ]
+            if len(self._impairments) == before:
+                # Untracked execution (e.g. after restart): best-effort drop by racks.
+                racks = self._racks_for(host, scope)
+                self._impairments = [
+                    imp for imp in self._impairments if not (imp.racks <= racks)
+                ]
+
+    def snapshot(self) -> dict:
+        now = time.monotonic()
+        with self._lock:
+            active = sorted(self._active_racks(now))
+            return {
+                "enabled": self.enabled,
+                "erasure": self._topology.tolerance.erasure,
+                "impaired_racks": active,
+                "tracked_executions": len(self._impairments),
+            }
+
+
+__all__ = [
+    "ImpactScope",
+    "GuardMode",
+    "FailureTolerance",
+    "HostTopology",
+    "ClusterTopologyModel",
+    "FailureModelGuard",
+    "DEFAULT_RECOVERY_SEC",
+]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -50,8 +50,8 @@ class ImpactScope(enum.Enum):
 class GuardMode(enum.Enum):
     """How the failure-model guard treats a nemesis type.
 
-    FULL           : pre-filter host list (B) AND post-veto + record impact (A).
-    PREFILTER_ONLY : pre-filter host list only; never vetoed / recorded at dispatch.
+    FULL           : pre-filter candidates AND record inject/extract impact after dispatch.
+    PREFILTER_ONLY : pre-filter candidates only; impact is not recorded at dispatch.
     BYPASS         : guard does not touch this type at all.
     """
 
@@ -294,9 +294,11 @@ class FailureModelGuard:
         candidates: Iterable[ChaosTarget],
         scope: ImpactScope,
     ) -> list[ChaosTarget]:
-        """Return candidates that would not exceed the failure budget given current impairments.
+        """Return a jointly safe subset of ``candidates`` under the failure budget.
 
-        Also drops already-touched identities (same ChaosTarget.identity_key).
+        Candidates are checked in order. Each admitted target's fail domains are added to
+        the running ``active`` set, so later candidates see earlier admissions (order-dependent).
+        Already-touched identities (``ChaosTarget.identity_key``) are skipped.
         When the guard is disabled, returns all candidates unchanged.
         """
         candidates = list(candidates)
@@ -315,8 +317,10 @@ class FailureModelGuard:
                     # e.g. TABLET — always safe for erasure budget
                     safe.append(target)
                     continue
-                if self._is_tolerable(active | racks):
+                hypothetical = active | racks
+                if self._is_tolerable(hypothetical):
                     safe.append(target)
+                    active = hypothetical
         return safe
 
     def filter_safe_hosts(self, hosts: Iterable[str], scope: ImpactScope) -> list[str]:
@@ -379,11 +383,12 @@ class FailureModelGuard:
                 imp for imp in self._impairments if imp.execution_id != execution_id
             ]
             if len(self._impairments) == before:
-                racks = self._racks_for_target(chaos_target, scope)
-                if racks:
-                    self._impairments = [
-                        imp for imp in self._impairments if not (imp.racks <= racks)
-                    ]
+                # Untracked execution (e.g. after restart): drop by identity, not by rack subset
+                # (same rack can hold unrelated impairments).
+                key = chaos_target.identity_key()
+                self._impairments = [
+                    imp for imp in self._impairments if imp.identity_key != key
+                ]
 
     def snapshot(self) -> dict:
         now = time.monotonic()

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -28,6 +28,11 @@ from typing import Iterable
 
 import yaml
 
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import (
+    ChaosTarget,
+    TargetKind,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +41,6 @@ class ImpactScope(enum.Enum):
 
     NODE = "node"
     DISK = "disk"
-    NETWORK = "network"
     RACK = "rack"
     DATACENTER = "datacenter"
     PILE = "pile"
@@ -58,7 +62,7 @@ class GuardMode(enum.Enum):
 
 # Scopes that collapse to "one fail domain = the host's rack".
 _HOST_LEVEL_SCOPES = frozenset(
-    {ImpactScope.NODE, ImpactScope.DISK, ImpactScope.NETWORK, ImpactScope.RACK}
+    {ImpactScope.NODE, ImpactScope.DISK, ImpactScope.RACK}
 )
 
 # Fallback recovery window (seconds) when a nemesis type has no ``auto_recovery_sec`` annotation.
@@ -191,15 +195,18 @@ class _Impairment:
 
     execution_id: str
     racks: set[str]
+    identity_key: str
     deadline: float | None
 
 
 class FailureModelGuard:
-    """Tracks impaired fail domains (racks) and validates new chaos against the failure model.
+    """Tracks impaired fail domains (racks) and filters candidates against the failure model.
 
-    Only ``FULL``-mode injects are recorded; ``PREFILTER_ONLY`` / ``BYPASS`` are not counted.
-    Each impairment carries a recovery deadline so auto-recovering faults release their budget
-    without an explicit extract; expired impairments are purged lazily on every read/write.
+    Safety is applied at plan time via :meth:`filter_safe` (no dispatch-time veto).
+    ``record_inject`` / ``record_extract`` update the touched set after dispatch.
+    Tablet targets contribute no fail-domain racks.
+
+    Assumes a single active nemesis in MVP (no allocate/reserve locks across types).
     """
 
     def __init__(self, topology: ClusterTopologyModel) -> None:
@@ -213,7 +220,7 @@ class FailureModelGuard:
 
     # -- rack resolution ----------------------------------------------------
 
-    def _racks_for(self, host: str, scope: ImpactScope) -> set[str]:
+    def _racks_for_host(self, host: str, scope: ImpactScope) -> set[str]:
         """Fail domains (rack keys) touched by injecting ``scope`` on ``host``."""
         if scope == ImpactScope.DATACENTER:
             dc = self._topology.dc_of(host)
@@ -225,6 +232,15 @@ class FailureModelGuard:
         # PILE / UNKNOWN: fall back to the host's rack (best effort).
         rack = self._topology.rack_of(host)
         return {rack if rack is not None else self._synthetic_key(host)}
+
+    def _racks_for_target(self, target: ChaosTarget, scope: ImpactScope) -> set[str]:
+        if target.kind is TargetKind.TABLET:
+            return set()
+        if target.kind is TargetKind.DATACENTER or scope == ImpactScope.DATACENTER:
+            dc = target.group_id or self._topology.dc_of(target.host)
+            racks = self._topology.racks_in_dc(dc)
+            return set(racks) if racks else {self._synthetic_key(target.host)}
+        return self._racks_for_host(target.host, scope)
 
     @staticmethod
     def _synthetic_key(host: str) -> str:
@@ -243,6 +259,10 @@ class FailureModelGuard:
         for imp in self._impairments:
             active |= imp.racks
         return active
+
+    def _touched_keys(self, now: float) -> set[str]:
+        self._purge_expired(now)
+        return {imp.identity_key for imp in self._impairments}
 
     # -- tolerance check ----------------------------------------------------
 
@@ -269,76 +289,112 @@ class FailureModelGuard:
 
     # -- public API ---------------------------------------------------------
 
-    def can_inject(self, host: str, scope: ImpactScope) -> bool:
-        if not self.enabled:
-            return True
-        now = time.monotonic()
-        with self._lock:
-            hypothetical = self._active_racks(now) | self._racks_for(host, scope)
-            return self._is_tolerable(hypothetical)
+    def filter_safe(
+        self,
+        candidates: Iterable[ChaosTarget],
+        scope: ImpactScope,
+    ) -> list[ChaosTarget]:
+        """Return candidates that would not exceed the failure budget given current impairments.
 
-    def filter_safe_hosts(self, hosts: Iterable[str], scope: ImpactScope) -> list[str]:
+        Also drops already-touched identities (same ChaosTarget.identity_key).
+        When the guard is disabled, returns all candidates unchanged.
+        """
+        candidates = list(candidates)
         if not self.enabled:
-            return list(hosts)
+            return candidates
         now = time.monotonic()
-        safe: list[str] = []
+        safe: list[ChaosTarget] = []
         with self._lock:
             active = self._active_racks(now)
-            for host in hosts:
-                hypothetical = active | self._racks_for(host, scope)
-                if self._is_tolerable(hypothetical):
-                    safe.append(host)
+            touched = self._touched_keys(now)
+            for target in candidates:
+                if target.identity_key() in touched:
+                    continue
+                racks = self._racks_for_target(target, scope)
+                if not racks:
+                    # e.g. TABLET — always safe for erasure budget
+                    safe.append(target)
+                    continue
+                if self._is_tolerable(active | racks):
+                    safe.append(target)
         return safe
+
+    def filter_safe_hosts(self, hosts: Iterable[str], scope: ImpactScope) -> list[str]:
+        """Legacy wrapper: host strings → HOST targets → filter → host strings."""
+        targets = self.filter_safe(
+            [ChaosTarget.for_host(h) for h in hosts],
+            scope,
+        )
+        return [t.host for t in targets]
 
     def record_inject(
         self,
         execution_id: str,
-        host: str,
+        target: ChaosTarget | str,
         scope: ImpactScope,
         recovery_sec: float | None = DEFAULT_RECOVERY_SEC,
     ) -> None:
-        """Mark ``host``'s fail domain(s) impaired.
+        """Mark ``target``'s fail domain(s) impaired after a successful plan/dispatch.
 
-        ``recovery_sec``: auto-release window; after it elapses the impairment is dropped even
-        without an extract. ``None`` holds it until an explicit extract (toggle faults).
+        ``recovery_sec``: auto-release window; ``None`` holds until an explicit extract.
+        ``target`` may be a hostname string (legacy) or :class:`ChaosTarget`.
         """
         if not self.enabled:
             return
-        racks = self._racks_for(host, scope)
+        chaos_target = (
+            target if isinstance(target, ChaosTarget) else ChaosTarget.for_host(str(target))
+        )
+        racks = self._racks_for_target(chaos_target, scope)
+        if not racks and chaos_target.kind is TargetKind.TABLET:
+            return
         deadline = None if recovery_sec is None else time.monotonic() + float(recovery_sec)
         with self._lock:
-            # Idempotent re-inject: replace any prior record for this execution.
             self._impairments = [
                 imp for imp in self._impairments if imp.execution_id != execution_id
             ]
             self._impairments.append(
-                _Impairment(execution_id=execution_id, racks=racks, deadline=deadline)
+                _Impairment(
+                    execution_id=execution_id,
+                    racks=racks,
+                    identity_key=chaos_target.identity_key(),
+                    deadline=deadline,
+                )
             )
 
-    def record_extract(self, execution_id: str, host: str, scope: ImpactScope) -> None:
+    def record_extract(
+        self,
+        execution_id: str,
+        target: ChaosTarget | str,
+        scope: ImpactScope,
+    ) -> None:
         """Release the impairment recorded for ``execution_id`` (early recovery)."""
         if not self.enabled:
             return
+        chaos_target = (
+            target if isinstance(target, ChaosTarget) else ChaosTarget.for_host(str(target))
+        )
         with self._lock:
             before = len(self._impairments)
             self._impairments = [
                 imp for imp in self._impairments if imp.execution_id != execution_id
             ]
             if len(self._impairments) == before:
-                # Untracked execution (e.g. after restart): best-effort drop by racks.
-                racks = self._racks_for(host, scope)
-                self._impairments = [
-                    imp for imp in self._impairments if not (imp.racks <= racks)
-                ]
+                racks = self._racks_for_target(chaos_target, scope)
+                if racks:
+                    self._impairments = [
+                        imp for imp in self._impairments if not (imp.racks <= racks)
+                    ]
 
     def snapshot(self) -> dict:
         now = time.monotonic()
         with self._lock:
             active = sorted(self._active_racks(now))
+            touched = sorted(self._touched_keys(now))
             return {
                 "enabled": self.enabled,
                 "erasure": self._topology.tolerance.erasure,
                 "impaired_racks": active,
+                "touched_targets": touched,
                 "tracked_executions": len(self._impairments),
             }
 

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -8,6 +8,10 @@ simultaneous-failure budget (fail domain = rack, fail realm = datacenter):
     block-4-2   : any 2 domains
     none        : 0
 
+Only static (storage) node loss touches this erasure budget. Dynamic-node (slot) kills draw
+from a separate, independent budget: up to a fraction (default 30%) of the cluster's slots may
+be down at once. A :class:`Footprint` carries both dimensions so one lease covers either.
+
 Unrelated to the runner-side ``scope=`` metrics argument in ``monitored_actor.py``.
 
 Each recorded impairment carries an optional recovery deadline, so faults that recover
@@ -41,6 +45,7 @@ class ImpactScope(enum.Enum):
     """Topology level a nemesis affects (orchestrator-side annotation)."""
 
     NODE = "node"
+    SLOT = "slot"
     DISK = "disk"
     RACK = "rack"
     DATACENTER = "datacenter"
@@ -61,7 +66,8 @@ class GuardMode(enum.Enum):
     BYPASS = "bypass"
 
 
-# Scopes that collapse to "one fail domain = the host's rack".
+# Scopes that collapse to "one fail domain = the host's rack" (static storage nodes).
+# SLOT is deliberately excluded: dynamic-node kills draw from the separate slot budget.
 _HOST_LEVEL_SCOPES = frozenset(
     {ImpactScope.NODE, ImpactScope.DISK, ImpactScope.RACK}
 )
@@ -70,8 +76,29 @@ _HOST_LEVEL_SCOPES = frozenset(
 # Conservatively longer than a systemd restart so a node stays "impaired" until it likely rejoined.
 DEFAULT_RECOVERY_SEC: float = 120.0
 
+# Fraction of the cluster's dynamic-node slots that may be down simultaneously (separate from the
+# erasure/rack budget). Killing a slot doesn't reduce storage redundancy, so it's cheap chaos.
+DEFAULT_SLOT_FRACTION: float = 0.3
+
 # Sentinel lease from ``reserve`` when the guard is disabled (fail-open); ``release`` ignores it.
 _DISABLED_LEASE = "__disabled__"
+
+
+@dataclass(frozen=True)
+class Footprint:
+    """What one fault consumes from the budget: fail-domain racks and/or dynamic-node slots.
+
+    Rack faults (static nodes, disks, datacenters) fill ``racks``; a slot (dynamic node) kill
+    fills ``slots`` and leaves ``racks`` empty; a tablet touches neither. The two dimensions are
+    checked independently by the guard.
+    """
+
+    racks: frozenset[str] = frozenset()
+    slots: int = 0
+
+    def __bool__(self) -> bool:
+        """True if this represents a real impairment (used to decide fact-based recovery)."""
+        return bool(self.racks) or self.slots > 0
 
 
 @dataclass(frozen=True)
@@ -201,22 +228,37 @@ class _Impairment:
     racks: set[str]
     identity_key: str
     deadline: float | None
+    slots: int = 0
 
 
 class FailureModelGuard:
-    """Tracks impaired fail domains (racks) and filters candidates against the failure model.
+    """Tracks impaired fail domains (racks) + dynamic-node slots against the failure model.
 
     Safety is applied at plan time via :meth:`filter_safe` (no dispatch-time veto).
     ``record_inject`` / ``record_extract`` update the touched set after dispatch.
-    Tablet targets contribute no fail-domain racks.
+    Tablet targets contribute nothing; slot (dynamic node) targets contribute no rack but
+    draw from a separate slot budget (``total_slots`` × ``slot_fraction``).
 
     Assumes a single active nemesis in MVP (no allocate/reserve locks across types).
     """
 
-    def __init__(self, topology: ClusterTopologyModel) -> None:
+    def __init__(
+        self,
+        topology: ClusterTopologyModel,
+        *,
+        total_slots: int = 0,
+        slot_fraction: float = DEFAULT_SLOT_FRACTION,
+    ) -> None:
         self._topology = topology
         self._lock = threading.Lock()
         self._impairments: list[_Impairment] = []
+        self._total_slots = max(0, int(total_slots))
+        self._slot_fraction = float(slot_fraction)
+        # ≥1 when the cluster has any slots so slot chaos still runs on small test clusters;
+        # 0 means no slots known -> the slot budget fails open (never blocks).
+        self._max_slots = (
+            max(1, int(self._total_slots * self._slot_fraction)) if self._total_slots > 0 else 0
+        )
 
     @property
     def enabled(self) -> bool:
@@ -237,8 +279,13 @@ class FailureModelGuard:
         rack = self._topology.rack_of(host)
         return {rack if rack is not None else self._synthetic_key(host)}
 
+    @staticmethod
+    def _is_slot(target: ChaosTarget, scope: ImpactScope) -> bool:
+        """A dynamic-node (slot) fault — draws from the slot budget, not a rack fail-domain."""
+        return scope is ImpactScope.SLOT or target.kind is TargetKind.SLOT
+
     def _racks_for_target(self, target: ChaosTarget, scope: ImpactScope) -> set[str]:
-        if target.kind is TargetKind.TABLET:
+        if target.kind is TargetKind.TABLET or self._is_slot(target, scope):
             return set()
         if target.kind is TargetKind.DATACENTER or scope == ImpactScope.DATACENTER:
             dc = target.group_id or self._topology.dc_of(target.host)
@@ -250,9 +297,15 @@ class FailureModelGuard:
     def _synthetic_key(host: str) -> str:
         return f"__host__:{host}"
 
-    def footprint_for(self, target: ChaosTarget, scope: ImpactScope) -> frozenset[str]:
-        """Fail-domain racks ``target`` consumes at ``scope`` (empty for tablets)."""
-        return frozenset(self._racks_for_target(target, scope))
+    def footprint_for(self, target: ChaosTarget, scope: ImpactScope) -> Footprint:
+        """What ``target`` consumes at ``scope``: fail-domain racks and/or one slot.
+
+        Empty for tablets; one slot (no rack) for dynamic-node kills; the host's rack(s)
+        otherwise (static node / disk / datacenter)."""
+        return Footprint(
+            racks=frozenset(self._racks_for_target(target, scope)),
+            slots=1 if self._is_slot(target, scope) else 0,
+        )
 
     # -- impairment bookkeeping (call under _lock) --------------------------
 
@@ -267,6 +320,16 @@ class FailureModelGuard:
         for imp in self._impairments:
             active |= imp.racks
         return active
+
+    def _active_slots(self, now: float) -> int:
+        self._purge_expired(now)
+        return sum(imp.slots for imp in self._impairments)
+
+    def _slots_ok(self, add_slots: int, now: float) -> bool:
+        """Whether ``add_slots`` more slots stay within the 30% cluster budget (fail-open at 0)."""
+        if add_slots <= 0 or self._max_slots <= 0:
+            return True
+        return self._active_slots(now) + add_slots <= self._max_slots
 
     def _touched_keys(self, now: float) -> set[str]:
         self._purge_expired(now)
@@ -341,39 +404,44 @@ class FailureModelGuard:
 
     # -- lease-based budget API ---------------------------------------------
 
-    def fits(self, racks: frozenset[str]) -> bool:
-        """True if adding ``racks`` keeps the budget within tolerance (read-only, fail-open)."""
+    def fits(self, footprint: Footprint) -> bool:
+        """True if adding ``footprint`` keeps both budgets within tolerance (read-only, fail-open)."""
         if not self.enabled:
             return True
         now = time.monotonic()
         with self._lock:
-            return self._is_tolerable(self._active_racks(now) | set(racks))
+            return self._is_tolerable(
+                self._active_racks(now) | set(footprint.racks)
+            ) and self._slots_ok(footprint.slots, now)
 
     def reserve(
         self,
-        racks: frozenset[str],
+        footprint: Footprint,
         recovery_sec: float | None = None,
         identity_key: str | None = None,
     ) -> str | None:
-        """Atomically claim ``racks`` under one lock; return a lease id, or None if it exceeds
-        the budget. ``recovery_sec`` auto-expires the lease after that many seconds; ``None``
-        holds it until :meth:`release`. ``identity_key`` records which target the lease covers so
-        it shows up in :meth:`active_identities` (schedulers skip already-impaired targets).
-        A disabled guard returns a sentinel lease (fail-open)."""
+        """Atomically claim ``footprint`` (racks and/or slots) under one lock; return a lease id,
+        or None if it exceeds either budget. ``recovery_sec`` auto-expires the lease after that
+        many seconds; ``None`` holds it until :meth:`release`. ``identity_key`` records which target
+        the lease covers so it shows up in :meth:`active_identities` (schedulers skip already-impaired
+        targets). A disabled guard returns a sentinel lease (fail-open)."""
         if not self.enabled:
             return _DISABLED_LEASE
         now = time.monotonic()
         deadline = None if recovery_sec is None else now + float(recovery_sec)
         with self._lock:
-            if not self._is_tolerable(self._active_racks(now) | set(racks)):
+            if not self._is_tolerable(self._active_racks(now) | set(footprint.racks)):
+                return None
+            if not self._slots_ok(footprint.slots, now):
                 return None
             lease_id = uuid.uuid4().hex
             self._impairments.append(
                 _Impairment(
                     execution_id=lease_id,
-                    racks=set(racks),
+                    racks=set(footprint.racks),
                     identity_key=identity_key or f"lease:{lease_id}",
                     deadline=deadline,
+                    slots=footprint.slots,
                 )
             )
             return lease_id
@@ -464,6 +532,8 @@ class FailureModelGuard:
                 "enabled": self.enabled,
                 "erasure": self._topology.tolerance.erasure,
                 "impaired_racks": active,
+                "impaired_slots": self._active_slots(now),
+                "max_slots": self._max_slots,
                 "touched_targets": touched,
                 "tracked_executions": len(self._impairments),
             }
@@ -472,9 +542,11 @@ class FailureModelGuard:
 __all__ = [
     "ImpactScope",
     "GuardMode",
+    "Footprint",
     "FailureTolerance",
     "HostTopology",
     "ClusterTopologyModel",
     "FailureModelGuard",
     "DEFAULT_RECOVERY_SEC",
+    "DEFAULT_SLOT_FRACTION",
 ]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -8,9 +8,30 @@ simultaneous-failure budget (fail domain = rack, fail realm = datacenter):
     block-4-2   : any 2 domains
     none        : 0
 
+A fail domain is identified by :func:`fail_domain_key` — ``"<data_center>/<rack>"`` — because
+rack labels are only unique *within* a datacenter (``rack: '1'`` in every DC is a normal YDB
+config). Keying by the bare rack label would collapse one rack per DC into a single domain and
+let the guard admit chaos in every realm at once.
+
 Only static (storage) node loss touches this erasure budget. Dynamic-node (slot) kills draw
 from a separate, independent budget: up to a fraction (default 30%) of the cluster's slots may
 be down at once. A :class:`Footprint` carries both dimensions so one lease covers either.
+
+**Where the slot budget applies.** It is enforced by the lease API only — :meth:`fits` and
+:meth:`reserve`, i.e. the boundary scheduler's path, which is what runs stability chaos. The
+plan-time helpers do *not* enforce it: :meth:`filter_safe` (legacy per-type schedule loop in
+``schedule_loop.py`` and the manual ``POST /api/hosts/process`` pre-check) only reasons about
+fail domains, and :meth:`record_inject` records a slot fault's identity without charging a slot.
+So slot chaos driven through the legacy schedule or manual injects is bounded by nothing but its
+own dedup, and mixing both paths under-counts ``impaired_slots``. Fine while the boundary
+scheduler owns scheduled chaos; revisit if the legacy loop is used for slot types again.
+
+**The failure model is a hard requirement, not best effort.** An unusable ``cluster.yaml``
+(missing, unparsable, unknown ``static_erasure``, hosts without ``location.rack``) raises
+:class:`FailureModelConfigError` from :class:`ClusterTopologyModel`, and the orchestrator refuses
+to start — see ``app.create_app``. Running chaos without a fault-tolerance ceiling is worse than
+not running it at all, so there is no "guard disabled" mode: once the app is up, every guard API
+enforces the budget.
 
 Unrelated to the runner-side ``scope=`` metrics argument in ``monitored_actor.py``.
 
@@ -41,6 +62,15 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target impo
 logger = logging.getLogger(__name__)
 
 
+class FailureModelConfigError(RuntimeError):
+    """``cluster.yaml`` cannot back a failure model — the orchestrator must not start.
+
+    Raised for a missing/unparsable file, an unsupported ``static_erasure``, or hosts without the
+    ``location`` data the guard needs. Never caught to keep chaos running: unbounded chaos would
+    silently exceed the cluster's fault tolerance and turn every stability failure into noise.
+    """
+
+
 class ImpactScope(enum.Enum):
     """Topology level a nemesis affects (orchestrator-side annotation)."""
 
@@ -56,21 +86,13 @@ class ImpactScope(enum.Enum):
 class GuardMode(enum.Enum):
     """How the failure-model guard treats a nemesis type.
 
-    FULL           : pre-filter candidates AND record inject/extract impact after dispatch.
-    PREFILTER_ONLY : pre-filter candidates only; impact is not recorded at dispatch.
-    BYPASS         : guard does not touch this type at all.
+    FULL   : pre-filter candidates and account for the impact (``reserve`` / ``record_inject``).
+    BYPASS : the type costs no budget (tablet chaos) — offered every tick, never reserved.
     """
 
     FULL = "full"
-    PREFILTER_ONLY = "prefilter_only"
     BYPASS = "bypass"
 
-
-# Scopes that collapse to "one fail domain = the host's rack" (static storage nodes).
-# SLOT is deliberately excluded: dynamic-node kills draw from the separate slot budget.
-_HOST_LEVEL_SCOPES = frozenset(
-    {ImpactScope.NODE, ImpactScope.DISK, ImpactScope.RACK}
-)
 
 # Fallback recovery window (seconds) when a nemesis type has no ``auto_recovery_sec`` annotation.
 # Conservatively longer than a systemd restart so a node stays "impaired" until it likely rejoined.
@@ -80,17 +102,30 @@ DEFAULT_RECOVERY_SEC: float = 120.0
 # erasure/rack budget). Killing a slot doesn't reduce storage redundancy, so it's cheap chaos.
 DEFAULT_SLOT_FRACTION: float = 0.3
 
-# Sentinel lease from ``reserve`` when the guard is disabled (fail-open); ``release`` ignores it.
-_DISABLED_LEASE = "__disabled__"
+# Datacenter placeholder in a fail-domain key for hosts whose ``location`` has no ``data_center``.
+_UNKNOWN_DC = "?"
+
+# Prefix of a fail-domain key synthesized for a host that is not in ``cluster.yaml``.
+_SYNTHETIC_DOMAIN_PREFIX = "__host__:"
+
+
+def fail_domain_key(datacenter: str | None, rack: str) -> str:
+    """Fail-domain identity: ``"<data_center>/<rack>"``.
+
+    Rack labels in ``cluster.yaml`` are only unique inside a datacenter, so the realm has to be
+    part of the key — otherwise rack ``1`` of every DC would be one domain and ``mirror-3-dc``
+    would tolerate losing all three realms at once.
+    """
+    return f"{datacenter or _UNKNOWN_DC}/{rack}"
 
 
 @dataclass(frozen=True)
 class Footprint:
-    """What one fault consumes from the budget: fail-domain racks and/or dynamic-node slots.
+    """What one fault consumes from the budget: fail domains and/or dynamic-node slots.
 
-    Rack faults (static nodes, disks, datacenters) fill ``racks``; a slot (dynamic node) kill
-    fills ``slots`` and leaves ``racks`` empty; a tablet touches neither. The two dimensions are
-    checked independently by the guard.
+    Rack faults (static nodes, disks, datacenters) fill ``racks`` with :func:`fail_domain_key`
+    keys (``"<dc>/<rack>"``); a slot (dynamic node) kill fills ``slots`` and leaves ``racks``
+    empty; a tablet touches neither. The two dimensions are checked independently by the guard.
     """
 
     racks: frozenset[str] = frozenset()
@@ -142,14 +177,20 @@ class HostTopology:
 class ClusterTopologyModel:
     """Parses ``cluster.yaml``: erasure mode and host -> rack -> datacenter mapping.
 
-    Fails open (``guards`` is False) when the file is missing, unparsable, the erasure mode
-    is unknown, or hosts have no rack/datacenter — the guard then never vetoes anything.
+    Raises :class:`FailureModelConfigError` for anything that would leave the guard unable to
+    decide — missing/unparsable file, unsupported ``static_erasure``, no hosts, a host without
+    ``location.rack``, or (for ``mirror-3-dc``) without ``location.data_center``. Construction
+    therefore either yields a usable model or takes the orchestrator down with it.
+
+    ``rack_of`` / ``dc_of`` return the raw ``location`` labels (inventory, UI); the guard reasons
+    in :func:`fail_domain_key` keys via ``domain_of`` / ``domains_in_dc`` / ``dc_of_domain``.
     """
 
     def __init__(self, yaml_path: str | None) -> None:
         self.yaml_path = yaml_path or ""
         self.hosts: dict[str, HostTopology] = {}
-        self._rack_to_dc: dict[str, str | None] = {}
+        # fail-domain key ("<dc>/<rack>") -> datacenter
+        self._domain_to_dc: dict[str, str | None] = {}
         self.tolerance = FailureTolerance.from_erasure("")
         self._parse()
 
@@ -157,54 +198,82 @@ class ClusterTopologyModel:
 
     def _parse(self) -> None:
         doc = self._load_doc(self.yaml_path)
-        if not doc:
-            logger.warning("FailureModel: cluster.yaml not loaded (%r); guard disabled", self.yaml_path)
-            return
         self.tolerance = FailureTolerance.from_erasure(doc.get("static_erasure", ""))
+        if not self.tolerance.guards:
+            raise FailureModelConfigError(
+                f"{self.yaml_path}: static_erasure={doc.get('static_erasure')!r} is not a mode the "
+                f"failure model understands (expected mirror-3-dc, block-4-2 or none)"
+            )
 
         hosts = doc.get("hosts")
         if not isinstance(hosts, list) or not hosts:
             hosts = (doc.get("config") or {}).get("hosts", [])
-        if not isinstance(hosts, list):
-            hosts = []
+        if not isinstance(hosts, list) or not hosts:
+            raise FailureModelConfigError(f"{self.yaml_path}: no 'hosts' list to build a topology from")
 
+        needs_realm = self.tolerance.kind == "realm_plus_domain"
         for h in hosts:
             if not isinstance(h, dict):
-                continue
+                raise FailureModelConfigError(f"{self.yaml_path}: host entry is not a mapping: {h!r}")
             name = h.get("name") or h.get("host")
             if not name:
-                continue
-            loc = h.get("location") or {}
+                raise FailureModelConfigError(f"{self.yaml_path}: host entry without name/host: {h!r}")
+            loc = h.get("location")
             if not isinstance(loc, dict):
-                loc = {}
+                raise FailureModelConfigError(f"{self.yaml_path}: host {name} has no 'location' mapping")
             rack = loc.get("rack")
             dc = loc.get("data_center")
-            rack = str(rack) if rack is not None else None
+            if rack is None:
+                raise FailureModelConfigError(
+                    f"{self.yaml_path}: host {name} has no location.rack — the fail domain of every "
+                    f"host must be known to bound chaos"
+                )
+            if needs_realm and dc is None:
+                raise FailureModelConfigError(
+                    f"{self.yaml_path}: host {name} has no location.data_center, required by "
+                    f"{self.tolerance.erasure} (one realm may be sacrificed, so realms must be known)"
+                )
+            rack = str(rack)
             dc = str(dc) if dc is not None else None
             self.hosts[name] = HostTopology(host=name, rack=rack, datacenter=dc)
-            if rack is not None:
-                self._rack_to_dc[rack] = dc
+            self._domain_to_dc[fail_domain_key(dc, rack)] = dc
+
+        logger.info(
+            "FailureModel: %s, %d host(s), %d fail domain(s) from %s",
+            self.tolerance.erasure, len(self.hosts), len(self._domain_to_dc), self.yaml_path,
+        )
 
     @staticmethod
-    def _load_doc(path: str) -> dict | None:
-        if not path or not Path(path).is_file():
-            return None
+    def _load_doc(path: str) -> dict:
+        if not path:
+            raise FailureModelConfigError(
+                "no cluster.yaml path (set YAML_CONFIG_LOCATION); the failure-model guard needs the "
+                "cluster topology to bound chaos"
+            )
+        if not Path(path).is_file():
+            raise FailureModelConfigError(f"cluster.yaml not found at {path!r}")
         try:
             with open(path, "r", encoding="utf-8") as f:
                 doc = yaml.safe_load(f.read())
-        except Exception as e:  # noqa: BLE001 - fail open on any parse error
-            logger.warning("FailureModel: failed to parse %r: %s", path, e)
-            return None
-        return doc if isinstance(doc, dict) else None
+        except Exception as e:
+            raise FailureModelConfigError(f"cannot parse {path!r}: {e}") from e
+        if not isinstance(doc, dict):
+            raise FailureModelConfigError(f"{path!r}: expected a YAML mapping, got {type(doc).__name__}")
+        return doc
 
     # -- lookups ------------------------------------------------------------
 
     @property
     def guards(self) -> bool:
-        """True only if we have a usable erasure model and topology to reason about."""
+        """Always True: an unusable config raises instead of degrading into a no-op guard.
+
+        Kept because the guard state is reported through ``snapshot()`` / the API, where "the guard
+        is live" is worth stating explicitly.
+        """
         return self.tolerance.guards and bool(self.hosts)
 
     def rack_of(self, host: str) -> str | None:
+        """Raw ``location.rack`` label (not a fail-domain key) — inventory / UI."""
         t = self.hosts.get(host)
         return t.rack if t else None
 
@@ -212,11 +281,56 @@ class ClusterTopologyModel:
         t = self.hosts.get(host)
         return t.datacenter if t else None
 
-    def racks_in_dc(self, dc: str | None) -> set[str]:
-        return {r for r, d in self._rack_to_dc.items() if d == dc}
+    def domain_of(self, host: str) -> str | None:
+        """Fail-domain key of ``host``, or None when the host has no rack in ``cluster.yaml``."""
+        t = self.hosts.get(host)
+        if t is None or t.rack is None:
+            return None
+        return fail_domain_key(t.datacenter, t.rack)
 
-    def dc_of_rack(self, rack: str) -> str | None:
-        return self._rack_to_dc.get(rack)
+    def domains_in_dc(self, dc: str | None) -> set[str]:
+        """Every fail-domain key of realm ``dc``."""
+        return {d for d, ddc in self._domain_to_dc.items() if ddc == dc}
+
+    def dc_of_domain(self, domain: str) -> str | None:
+        return self._domain_to_dc.get(domain)
+
+
+class BudgetView:
+    """Read-only snapshot of both budgets, for filtering many candidates at once.
+
+    :meth:`FailureModelGuard.budget_view` builds one under a single lock; the scheduler then tests
+    every (type, target) pair against it instead of locking per candidate. Each candidate is
+    checked against the same captured state — exactly what per-candidate
+    :meth:`FailureModelGuard.fits` calls did, minus the lock traffic.
+
+    A view is advisory and may be stale: :meth:`FailureModelGuard.reserve` re-checks atomically and
+    refuses the fault if the budget moved meanwhile.
+    """
+
+    __slots__ = ("impaired_racks", "impaired_slots", "touched", "_is_tolerable", "_max_slots")
+
+    def __init__(
+        self,
+        *,
+        impaired_racks: frozenset[str],
+        impaired_slots: int,
+        touched: frozenset[str],
+        is_tolerable,
+        max_slots: int,
+    ) -> None:
+        self.impaired_racks = impaired_racks
+        self.impaired_slots = impaired_slots
+        self.touched = touched
+        self._is_tolerable = is_tolerable
+        self._max_slots = max_slots
+
+    def fits(self, footprint: Footprint) -> bool:
+        if not self._is_tolerable(set(self.impaired_racks) | set(footprint.racks)):
+            return False
+        if footprint.slots <= 0 or self._max_slots <= 0:
+            return True
+        return self.impaired_slots + footprint.slots <= self._max_slots
 
 
 @dataclass
@@ -262,22 +376,25 @@ class FailureModelGuard:
 
     @property
     def enabled(self) -> bool:
+        """Always True — an unusable topology raises at construction (see the module docstring).
+
+        Reported through :meth:`snapshot` and ``/api/scheduler`` / ``/api/problems`` so a report
+        can state that chaos ran under a live guard.
+        """
         return self._topology.guards
 
     # -- rack resolution ----------------------------------------------------
 
     def _racks_for_host(self, host: str, scope: ImpactScope) -> set[str]:
-        """Fail domains (rack keys) touched by injecting ``scope`` on ``host``."""
+        """Fail domains (``<dc>/<rack>`` keys) touched by injecting ``scope`` on ``host``."""
         if scope == ImpactScope.DATACENTER:
             dc = self._topology.dc_of(host)
-            racks = self._topology.racks_in_dc(dc)
-            return set(racks) if racks else {self._synthetic_key(host)}
-        if scope in _HOST_LEVEL_SCOPES:
-            rack = self._topology.rack_of(host)
-            return {rack if rack is not None else self._synthetic_key(host)}
-        # PILE / UNKNOWN: fall back to the host's rack (best effort).
-        rack = self._topology.rack_of(host)
-        return {rack if rack is not None else self._synthetic_key(host)}
+            domains = self._topology.domains_in_dc(dc)
+            return set(domains) if domains else {self._synthetic_key(host)}
+        # NODE / DISK / RACK — and PILE / UNKNOWN as best effort — collapse to the host's own fail
+        # domain. SLOT never reaches here: ``_racks_for_target`` routes it to the slot budget.
+        domain = self._topology.domain_of(host)
+        return {domain if domain is not None else self._synthetic_key(host)}
 
     @staticmethod
     def _is_slot(target: ChaosTarget, scope: ImpactScope) -> bool:
@@ -289,13 +406,25 @@ class FailureModelGuard:
             return set()
         if target.kind is TargetKind.DATACENTER or scope == ImpactScope.DATACENTER:
             dc = target.group_id or self._topology.dc_of(target.host)
-            racks = self._topology.racks_in_dc(dc)
-            return set(racks) if racks else {self._synthetic_key(target.host)}
+            domains = self._topology.domains_in_dc(dc)
+            return set(domains) if domains else {self._synthetic_key(target.host)}
         return self._racks_for_host(target.host, scope)
 
-    @staticmethod
-    def _synthetic_key(host: str) -> str:
-        return f"__host__:{host}"
+    def _synthetic_key(self, host: str) -> str:
+        """Fail-domain key for a host ``cluster.yaml`` has no rack for (e.g. an agent host that is
+        not in the config at all).
+
+        Namespaced by realm like a real domain key, so unknown-rack hosts in different DCs are not
+        lumped into one sacrificial realm under ``mirror-3-dc``.
+        """
+        return f"{_SYNTHETIC_DOMAIN_PREFIX}{fail_domain_key(self._topology.dc_of(host), host)}"
+
+    def _realm_of_domain(self, domain: str) -> str | None:
+        """Realm (datacenter) of a fail-domain key, synthetic ones included."""
+        if domain.startswith(_SYNTHETIC_DOMAIN_PREFIX):
+            dc = domain[len(_SYNTHETIC_DOMAIN_PREFIX):].split("/", 1)[0]
+            return None if dc == _UNKNOWN_DC else dc
+        return self._topology.dc_of_domain(domain)
 
     def footprint_for(self, target: ChaosTarget, scope: ImpactScope) -> Footprint:
         """What ``target`` consumes at ``scope``: fail-domain racks and/or one slot.
@@ -347,15 +476,15 @@ class FailureModelGuard:
         if tol.kind == "realm_plus_domain":
             # One realm may be lost entirely, plus max_extra_domains in other realms combined.
             by_dc: dict[str | None, int] = {}
-            for rack in impaired_racks:
-                dc = self._topology.dc_of_rack(rack) if not rack.startswith("__host__:") else None
-                by_dc[dc] = by_dc.get(dc, 0) + 1
+            for domain in impaired_racks:
+                realm = self._realm_of_domain(domain)
+                by_dc[realm] = by_dc.get(realm, 0) + 1
             if not by_dc:
                 return True
             sacrificial = max(by_dc.values())  # the realm we allow to fail fully
             remaining = n - sacrificial
             return remaining <= tol.max_extra_domains
-        # unknown -> fail open
+        # Unreachable: an erasure mode the model doesn't understand never gets past parsing.
         return True
 
     # -- public API ---------------------------------------------------------
@@ -365,16 +494,18 @@ class FailureModelGuard:
         candidates: Iterable[ChaosTarget],
         scope: ImpactScope,
     ) -> list[ChaosTarget]:
-        """Return a jointly safe subset of ``candidates`` under the failure budget.
+        """Return a jointly safe subset of ``candidates`` under the fail-domain budget.
 
         Candidates are checked in order. Each admitted target's fail domains are added to
         the running ``active`` set, so later candidates see earlier admissions (order-dependent).
         Already-touched identities (``ChaosTarget.identity_key``) are skipped.
-        When the guard is disabled, returns all candidates unchanged.
+
+        Only the erasure/fail-domain dimension is checked here: slot candidates carry no fail
+        domain, so they are always admitted regardless of the slot budget. Use :meth:`fits` /
+        :meth:`reserve` (boundary scheduler) when the slot budget must hold — see the module
+        docstring.
         """
         candidates = list(candidates)
-        if not self.enabled:
-            return candidates
         now = time.monotonic()
         safe: list[ChaosTarget] = []
         with self._lock:
@@ -405,9 +536,7 @@ class FailureModelGuard:
     # -- lease-based budget API ---------------------------------------------
 
     def fits(self, footprint: Footprint) -> bool:
-        """True if adding ``footprint`` keeps both budgets within tolerance (read-only, fail-open)."""
-        if not self.enabled:
-            return True
+        """True if adding ``footprint`` keeps both budgets within tolerance (read-only)."""
         now = time.monotonic()
         with self._lock:
             return self._is_tolerable(
@@ -424,9 +553,10 @@ class FailureModelGuard:
         or None if it exceeds either budget. ``recovery_sec`` auto-expires the lease after that
         many seconds; ``None`` holds it until :meth:`release`. ``identity_key`` records which target
         the lease covers so it shows up in :meth:`active_identities` (schedulers skip already-impaired
-        targets). A disabled guard returns a sentinel lease (fail-open)."""
-        if not self.enabled:
-            return _DISABLED_LEASE
+        targets).
+
+        Every granted lease id is unique, so callers may key their own bookkeeping by it (the
+        recovery probe tracks pending extracts that way)."""
         now = time.monotonic()
         deadline = None if recovery_sec is None else now + float(recovery_sec)
         with self._lock:
@@ -447,15 +577,25 @@ class FailureModelGuard:
             return lease_id
 
     def active_identities(self) -> set[str]:
-        """Identity keys of every non-expired impairment (empty when disabled, fail-open)."""
-        if not self.enabled:
-            return set()
+        """Identity keys of every non-expired impairment."""
         now = time.monotonic()
         with self._lock:
             return self._touched_keys(now)
 
+    def budget_view(self) -> BudgetView:
+        """Snapshot both budgets and the touched identities under one lock (see :class:`BudgetView`)."""
+        now = time.monotonic()
+        with self._lock:
+            return BudgetView(
+                impaired_racks=frozenset(self._active_racks(now)),
+                impaired_slots=self._active_slots(now),
+                touched=frozenset(self._touched_keys(now)),
+                is_tolerable=self._is_tolerable,
+                max_slots=self._max_slots,
+            )
+
     def release(self, lease_id: str | None) -> bool:
-        if not self.enabled or not lease_id or lease_id == _DISABLED_LEASE:
+        if not lease_id:
             return False
         with self._lock:
             before = len(self._impairments)
@@ -475,14 +615,17 @@ class FailureModelGuard:
 
         ``recovery_sec``: auto-release window; ``None`` holds until an explicit extract.
         ``target`` may be a hostname string (legacy) or :class:`ChaosTarget`.
+
+        Charges both dimensions of the target's :meth:`footprint_for` — fail domains for static
+        faults, one slot for a dynamic-node kill. A footprint that consumes nothing (tablets) is
+        not recorded at all. Unlike :meth:`reserve` this never refuses: the fault was already
+        dispatched, so the budget is told the truth even when that truth exceeds it.
         """
-        if not self.enabled:
-            return
         chaos_target = (
             target if isinstance(target, ChaosTarget) else ChaosTarget.for_host(str(target))
         )
-        racks = self._racks_for_target(chaos_target, scope)
-        if not racks and chaos_target.kind is TargetKind.TABLET:
+        footprint = self.footprint_for(chaos_target, scope)
+        if not footprint:
             return
         deadline = None if recovery_sec is None else time.monotonic() + float(recovery_sec)
         with self._lock:
@@ -492,9 +635,10 @@ class FailureModelGuard:
             self._impairments.append(
                 _Impairment(
                     execution_id=execution_id,
-                    racks=racks,
+                    racks=set(footprint.racks),
                     identity_key=chaos_target.identity_key(),
                     deadline=deadline,
+                    slots=footprint.slots,
                 )
             )
 
@@ -505,8 +649,6 @@ class FailureModelGuard:
         scope: ImpactScope,
     ) -> None:
         """Release the impairment recorded for ``execution_id`` (early recovery)."""
-        if not self.enabled:
-            return
         chaos_target = (
             target if isinstance(target, ChaosTarget) else ChaosTarget.for_host(str(target))
         )
@@ -543,6 +685,9 @@ __all__ = [
     "ImpactScope",
     "GuardMode",
     "Footprint",
+    "BudgetView",
+    "FailureModelConfigError",
+    "fail_domain_key",
     "FailureTolerance",
     "HostTopology",
     "ClusterTopologyModel",

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -22,6 +22,7 @@ import enum
 import logging
 import threading
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -68,6 +69,9 @@ _HOST_LEVEL_SCOPES = frozenset(
 # Fallback recovery window (seconds) when a nemesis type has no ``auto_recovery_sec`` annotation.
 # Conservatively longer than a systemd restart so a node stays "impaired" until it likely rejoined.
 DEFAULT_RECOVERY_SEC: float = 120.0
+
+# Sentinel lease from ``reserve`` when the guard is disabled (fail-open); ``release`` ignores it.
+_DISABLED_LEASE = "__disabled__"
 
 
 @dataclass(frozen=True)
@@ -246,6 +250,10 @@ class FailureModelGuard:
     def _synthetic_key(host: str) -> str:
         return f"__host__:{host}"
 
+    def footprint_for(self, target: ChaosTarget, scope: ImpactScope) -> frozenset[str]:
+        """Fail-domain racks ``target`` consumes at ``scope`` (empty for tablets)."""
+        return frozenset(self._racks_for_target(target, scope))
+
     # -- impairment bookkeeping (call under _lock) --------------------------
 
     def _purge_expired(self, now: float) -> None:
@@ -330,6 +338,63 @@ class FailureModelGuard:
             scope,
         )
         return [t.host for t in targets]
+
+    # -- lease-based budget API ---------------------------------------------
+
+    def fits(self, racks: frozenset[str]) -> bool:
+        """True if adding ``racks`` keeps the budget within tolerance (read-only, fail-open)."""
+        if not self.enabled:
+            return True
+        now = time.monotonic()
+        with self._lock:
+            return self._is_tolerable(self._active_racks(now) | set(racks))
+
+    def reserve(
+        self,
+        racks: frozenset[str],
+        recovery_sec: float | None = None,
+        identity_key: str | None = None,
+    ) -> str | None:
+        """Atomically claim ``racks`` under one lock; return a lease id, or None if it exceeds
+        the budget. ``recovery_sec`` auto-expires the lease after that many seconds; ``None``
+        holds it until :meth:`release`. ``identity_key`` records which target the lease covers so
+        it shows up in :meth:`active_identities` (schedulers skip already-impaired targets).
+        A disabled guard returns a sentinel lease (fail-open)."""
+        if not self.enabled:
+            return _DISABLED_LEASE
+        now = time.monotonic()
+        deadline = None if recovery_sec is None else now + float(recovery_sec)
+        with self._lock:
+            if not self._is_tolerable(self._active_racks(now) | set(racks)):
+                return None
+            lease_id = uuid.uuid4().hex
+            self._impairments.append(
+                _Impairment(
+                    execution_id=lease_id,
+                    racks=set(racks),
+                    identity_key=identity_key or f"lease:{lease_id}",
+                    deadline=deadline,
+                )
+            )
+            return lease_id
+
+    def active_identities(self) -> set[str]:
+        """Identity keys of every non-expired impairment (empty when disabled, fail-open)."""
+        if not self.enabled:
+            return set()
+        now = time.monotonic()
+        with self._lock:
+            return self._touched_keys(now)
+
+    def release(self, lease_id: str | None) -> bool:
+        if not self.enabled or not lease_id or lease_id == _DISABLED_LEASE:
+            return False
+        with self._lock:
+            before = len(self._impairments)
+            self._impairments = [
+                imp for imp in self._impairments if imp.execution_id != lease_id
+            ]
+            return len(self._impairments) != before
 
     def record_inject(
         self,

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/failure_model.py
@@ -1,44 +1,19 @@
-"""Failure-model guard: constrain nemesis chaos to the cluster's declared fault tolerance.
+"""Failure-model guard: keep chaos within the cluster's declared fault tolerance.
 
-Parses ``cluster.yaml`` into a :class:`ClusterTopologyModel` and exposes a
-:class:`FailureModelGuard` that vetoes/filters chaos exceeding the tolerated
-simultaneous-failure budget (fail domain = rack, fail realm = datacenter):
+Budget per ``static_erasure`` from ``cluster.yaml``::
 
     mirror-3-dc : 1 realm fully + 1 domain in another realm
     block-4-2   : any 2 domains
     none        : 0
 
-A fail domain is identified by :func:`fail_domain_key` — ``"<data_center>/<rack>"`` — because
-rack labels are only unique *within* a datacenter (``rack: '1'`` in every DC is a normal YDB
-config). Keying by the bare rack label would collapse one rack per DC into a single domain and
-let the guard admit chaos in every realm at once.
+A fail domain is ``"<dc>/<rack>"`` (:func:`fail_domain_key`): rack labels repeat across DCs, so the
+realm must be part of the key. Slot (dynamic node) kills cost no redundancy and draw from a separate
+budget instead: ≤30% of the cluster's slots at once.
 
-Only static (storage) node loss touches this erasure budget. Dynamic-node (slot) kills draw
-from a separate, independent budget: up to a fraction (default 30%) of the cluster's slots may
-be down at once. A :class:`Footprint` carries both dimensions so one lease covers either.
-
-**Where the slot budget applies.** It is enforced by the lease API only — :meth:`fits` and
-:meth:`reserve`, i.e. the boundary scheduler's path, which is what runs stability chaos. The
-plan-time helpers do *not* enforce it: :meth:`filter_safe` (legacy per-type schedule loop in
-``schedule_loop.py`` and the manual ``POST /api/hosts/process`` pre-check) only reasons about
-fail domains, and :meth:`record_inject` records a slot fault's identity without charging a slot.
-So slot chaos driven through the legacy schedule or manual injects is bounded by nothing but its
-own dedup, and mixing both paths under-counts ``impaired_slots``. Fine while the boundary
-scheduler owns scheduled chaos; revisit if the legacy loop is used for slot types again.
-
-**The failure model is a hard requirement, not best effort.** An unusable ``cluster.yaml``
-(missing, unparsable, unknown ``static_erasure``, hosts without ``location.rack``) raises
-:class:`FailureModelConfigError` from :class:`ClusterTopologyModel`, and the orchestrator refuses
-to start — see ``app.create_app``. Running chaos without a fault-tolerance ceiling is worse than
-not running it at all, so there is no "guard disabled" mode: once the app is up, every guard API
-enforces the budget.
+An unusable config raises :class:`FailureModelConfigError` and the orchestrator refuses to start
+(``app.require_failure_model_or_die``) — there is no unguarded mode.
 
 Unrelated to the runner-side ``scope=`` metrics argument in ``monitored_actor.py``.
-
-Each recorded impairment carries an optional recovery deadline, so faults that recover
-without an explicit extract (systemd auto-restart after SIGKILL, self-healing rolling
-restart) release their budget on a timer instead of piling up forever. ``recovery_sec=None``
-holds an impairment until an explicit extract (toggle faults that stay down until next inject).
 """
 
 from __future__ import annotations
@@ -63,12 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 class FailureModelConfigError(RuntimeError):
-    """``cluster.yaml`` cannot back a failure model — the orchestrator must not start.
-
-    Raised for a missing/unparsable file, an unsupported ``static_erasure``, or hosts without the
-    ``location`` data the guard needs. Never caught to keep chaos running: unbounded chaos would
-    silently exceed the cluster's fault tolerance and turn every stability failure into noise.
-    """
+    """``cluster.yaml`` cannot back a failure model, so the orchestrator must not start."""
 
 
 class ImpactScope(enum.Enum):
@@ -77,56 +47,43 @@ class ImpactScope(enum.Enum):
     NODE = "node"
     SLOT = "slot"
     DISK = "disk"
-    RACK = "rack"
     DATACENTER = "datacenter"
     PILE = "pile"
     UNKNOWN = "unknown"
 
 
 class GuardMode(enum.Enum):
-    """How the failure-model guard treats a nemesis type.
-
-    FULL   : pre-filter candidates and account for the impact (``reserve`` / ``record_inject``).
-    BYPASS : the type costs no budget (tablet chaos) — offered every tick, never reserved.
-    """
+    """FULL: filtered and accounted for. BYPASS: costs no budget (tablet chaos)."""
 
     FULL = "full"
     BYPASS = "bypass"
 
 
-# Fallback recovery window (seconds) when a nemesis type has no ``auto_recovery_sec`` annotation.
-# Conservatively longer than a systemd restart so a node stays "impaired" until it likely rejoined.
+# Recovery window for types without ``auto_recovery_sec``: longer than a systemd restart + rejoin.
 DEFAULT_RECOVERY_SEC: float = 120.0
 
-# Fraction of the cluster's dynamic-node slots that may be down simultaneously (separate from the
-# erasure/rack budget). Killing a slot doesn't reduce storage redundancy, so it's cheap chaos.
+# Share of the cluster's slots allowed down at once.
 DEFAULT_SLOT_FRACTION: float = 0.3
 
-# Datacenter placeholder in a fail-domain key for hosts whose ``location`` has no ``data_center``.
-_UNKNOWN_DC = "?"
+_UNKNOWN_DC = "?"                      # host with no ``location.data_center``
+_SYNTHETIC_DOMAIN_PREFIX = "__host__:"  # host with no rack in ``cluster.yaml``
 
-# Prefix of a fail-domain key synthesized for a host that is not in ``cluster.yaml``.
-_SYNTHETIC_DOMAIN_PREFIX = "__host__:"
+
+def _slots_within_budget(active_slots: int, add_slots: int, max_slots: int) -> bool:
+    """Slot-budget rule, shared by the guard and :class:`BudgetView`. ``max_slots<=0`` never blocks."""
+    if add_slots <= 0 or max_slots <= 0:
+        return True
+    return active_slots + add_slots <= max_slots
 
 
 def fail_domain_key(datacenter: str | None, rack: str) -> str:
-    """Fail-domain identity: ``"<data_center>/<rack>"``.
-
-    Rack labels in ``cluster.yaml`` are only unique inside a datacenter, so the realm has to be
-    part of the key — otherwise rack ``1`` of every DC would be one domain and ``mirror-3-dc``
-    would tolerate losing all three realms at once.
-    """
+    """``"<dc>/<rack>"`` — rack labels are only unique inside a datacenter."""
     return f"{datacenter or _UNKNOWN_DC}/{rack}"
 
 
 @dataclass(frozen=True)
 class Footprint:
-    """What one fault consumes from the budget: fail domains and/or dynamic-node slots.
-
-    Rack faults (static nodes, disks, datacenters) fill ``racks`` with :func:`fail_domain_key`
-    keys (``"<dc>/<rack>"``); a slot (dynamic node) kill fills ``slots`` and leaves ``racks``
-    empty; a tablet touches neither. The two dimensions are checked independently by the guard.
-    """
+    """What one fault consumes: fail-domain keys and/or slots. A tablet fault consumes neither."""
 
     racks: frozenset[str] = frozenset()
     slots: int = 0
@@ -175,15 +132,10 @@ class HostTopology:
 
 
 class ClusterTopologyModel:
-    """Parses ``cluster.yaml``: erasure mode and host -> rack -> datacenter mapping.
+    """``cluster.yaml`` -> erasure mode + host/rack/datacenter map, or :class:`FailureModelConfigError`.
 
-    Raises :class:`FailureModelConfigError` for anything that would leave the guard unable to
-    decide — missing/unparsable file, unsupported ``static_erasure``, no hosts, a host without
-    ``location.rack``, or (for ``mirror-3-dc``) without ``location.data_center``. Construction
-    therefore either yields a usable model or takes the orchestrator down with it.
-
-    ``rack_of`` / ``dc_of`` return the raw ``location`` labels (inventory, UI); the guard reasons
-    in :func:`fail_domain_key` keys via ``domain_of`` / ``domains_in_dc`` / ``dc_of_domain``.
+    ``rack_of`` / ``dc_of`` give the raw ``location`` labels (inventory, UI); the guard reasons in
+    fail-domain keys via ``domain_of`` / ``domains_in_dc`` / ``dc_of_domain``.
     """
 
     def __init__(self, yaml_path: str | None) -> None:
@@ -265,15 +217,11 @@ class ClusterTopologyModel:
 
     @property
     def guards(self) -> bool:
-        """Always True: an unusable config raises instead of degrading into a no-op guard.
-
-        Kept because the guard state is reported through ``snapshot()`` / the API, where "the guard
-        is live" is worth stating explicitly.
-        """
+        """Always True (an unusable config raises); reported through ``snapshot()`` / the API."""
         return self.tolerance.guards and bool(self.hosts)
 
     def rack_of(self, host: str) -> str | None:
-        """Raw ``location.rack`` label (not a fail-domain key) — inventory / UI."""
+        """Raw ``location.rack`` label, not a fail-domain key."""
         t = self.hosts.get(host)
         return t.rack if t else None
 
@@ -282,14 +230,14 @@ class ClusterTopologyModel:
         return t.datacenter if t else None
 
     def domain_of(self, host: str) -> str | None:
-        """Fail-domain key of ``host``, or None when the host has no rack in ``cluster.yaml``."""
+        """Fail-domain key of ``host``, or None if it is not in ``cluster.yaml``."""
         t = self.hosts.get(host)
         if t is None or t.rack is None:
             return None
         return fail_domain_key(t.datacenter, t.rack)
 
     def domains_in_dc(self, dc: str | None) -> set[str]:
-        """Every fail-domain key of realm ``dc``."""
+        """Fail-domain keys of realm ``dc``."""
         return {d for d, ddc in self._domain_to_dc.items() if ddc == dc}
 
     def dc_of_domain(self, domain: str) -> str | None:
@@ -297,15 +245,9 @@ class ClusterTopologyModel:
 
 
 class BudgetView:
-    """Read-only snapshot of both budgets, for filtering many candidates at once.
+    """Read-only budget snapshot: one lock for a whole menu of candidates.
 
-    :meth:`FailureModelGuard.budget_view` builds one under a single lock; the scheduler then tests
-    every (type, target) pair against it instead of locking per candidate. Each candidate is
-    checked against the same captured state — exactly what per-candidate
-    :meth:`FailureModelGuard.fits` calls did, minus the lock traffic.
-
-    A view is advisory and may be stale: :meth:`FailureModelGuard.reserve` re-checks atomically and
-    refuses the fault if the budget moved meanwhile.
+    Advisory — :meth:`FailureModelGuard.reserve` re-checks atomically before anything is injected.
     """
 
     __slots__ = ("impaired_racks", "impaired_slots", "touched", "_is_tolerable", "_max_slots")
@@ -326,17 +268,14 @@ class BudgetView:
         self._max_slots = max_slots
 
     def fits(self, footprint: Footprint) -> bool:
-        if not self._is_tolerable(set(self.impaired_racks) | set(footprint.racks)):
-            return False
-        if footprint.slots <= 0 or self._max_slots <= 0:
-            return True
-        return self.impaired_slots + footprint.slots <= self._max_slots
+        return self._is_tolerable(
+            set(self.impaired_racks) | set(footprint.racks)
+        ) and _slots_within_budget(self.impaired_slots, footprint.slots, self._max_slots)
 
 
 @dataclass
 class _Impairment:
-    """One recorded fault footprint. ``deadline`` is a ``time.monotonic()`` value; ``None`` = held
-    until an explicit extract."""
+    """One recorded fault. ``deadline`` is ``time.monotonic()``; ``None`` = held until extracted."""
 
     execution_id: str
     racks: set[str]
@@ -346,14 +285,13 @@ class _Impairment:
 
 
 class FailureModelGuard:
-    """Tracks impaired fail domains (racks) + dynamic-node slots against the failure model.
+    """Tracks impaired fail domains + slots. No dispatch-time veto; two ways in:
 
-    Safety is applied at plan time via :meth:`filter_safe` (no dispatch-time veto).
-    ``record_inject`` / ``record_extract`` update the touched set after dispatch.
-    Tablet targets contribute nothing; slot (dynamic node) targets contribute no rack but
-    draw from a separate slot budget (``total_slots`` × ``slot_fraction``).
-
-    Assumes a single active nemesis in MVP (no allocate/reserve locks across types).
+    * lease API (boundary scheduler): :meth:`budget_view` to filter, :meth:`reserve` to claim
+      atomically (the only call that refuses), :meth:`release` on recovery;
+    * plan-then-record (legacy loop, manual inject): :meth:`filter_safe`, then
+      :meth:`record_inject` / :meth:`record_extract` — recording never refuses, the fault already
+      happened.
     """
 
     def __init__(
@@ -366,39 +304,30 @@ class FailureModelGuard:
         self._topology = topology
         self._lock = threading.Lock()
         self._impairments: list[_Impairment] = []
-        self._total_slots = max(0, int(total_slots))
-        self._slot_fraction = float(slot_fraction)
-        # ≥1 when the cluster has any slots so slot chaos still runs on small test clusters;
-        # 0 means no slots known -> the slot budget fails open (never blocks).
-        self._max_slots = (
-            max(1, int(self._total_slots * self._slot_fraction)) if self._total_slots > 0 else 0
-        )
+        slots = max(0, int(total_slots))
+        # ≥1 so slot chaos still runs on small clusters; 0 (slot count unknown) never blocks.
+        self._max_slots = max(1, int(slots * float(slot_fraction))) if slots else 0
 
     @property
     def enabled(self) -> bool:
-        """Always True — an unusable topology raises at construction (see the module docstring).
-
-        Reported through :meth:`snapshot` and ``/api/scheduler`` / ``/api/problems`` so a report
-        can state that chaos ran under a live guard.
-        """
+        """Always True — an unusable topology raises at construction. Reported in :meth:`snapshot`."""
         return self._topology.guards
 
     # -- rack resolution ----------------------------------------------------
 
     def _racks_for_host(self, host: str, scope: ImpactScope) -> set[str]:
-        """Fail domains (``<dc>/<rack>`` keys) touched by injecting ``scope`` on ``host``."""
+        """Fail domains touched by injecting ``scope`` on ``host``."""
         if scope == ImpactScope.DATACENTER:
             dc = self._topology.dc_of(host)
             domains = self._topology.domains_in_dc(dc)
             return set(domains) if domains else {self._synthetic_key(host)}
-        # NODE / DISK / RACK — and PILE / UNKNOWN as best effort — collapse to the host's own fail
-        # domain. SLOT never reaches here: ``_racks_for_target`` routes it to the slot budget.
+        # Everything else collapses to the host's own domain (SLOT is routed to the slot budget).
         domain = self._topology.domain_of(host)
         return {domain if domain is not None else self._synthetic_key(host)}
 
     @staticmethod
     def _is_slot(target: ChaosTarget, scope: ImpactScope) -> bool:
-        """A dynamic-node (slot) fault — draws from the slot budget, not a rack fail-domain."""
+        """A slot fault: draws from the slot budget, not from a fail domain."""
         return scope is ImpactScope.SLOT or target.kind is TargetKind.SLOT
 
     def _racks_for_target(self, target: ChaosTarget, scope: ImpactScope) -> set[str]:
@@ -411,26 +340,18 @@ class FailureModelGuard:
         return self._racks_for_host(target.host, scope)
 
     def _synthetic_key(self, host: str) -> str:
-        """Fail-domain key for a host ``cluster.yaml`` has no rack for (e.g. an agent host that is
-        not in the config at all).
-
-        Namespaced by realm like a real domain key, so unknown-rack hosts in different DCs are not
-        lumped into one sacrificial realm under ``mirror-3-dc``.
-        """
+        """Fail-domain key for a host with no rack in ``cluster.yaml``; still namespaced by realm."""
         return f"{_SYNTHETIC_DOMAIN_PREFIX}{fail_domain_key(self._topology.dc_of(host), host)}"
 
     def _realm_of_domain(self, domain: str) -> str | None:
-        """Realm (datacenter) of a fail-domain key, synthetic ones included."""
+        """Realm of a fail-domain key, synthetic ones included."""
         if domain.startswith(_SYNTHETIC_DOMAIN_PREFIX):
             dc = domain[len(_SYNTHETIC_DOMAIN_PREFIX):].split("/", 1)[0]
             return None if dc == _UNKNOWN_DC else dc
         return self._topology.dc_of_domain(domain)
 
     def footprint_for(self, target: ChaosTarget, scope: ImpactScope) -> Footprint:
-        """What ``target`` consumes at ``scope``: fail-domain racks and/or one slot.
-
-        Empty for tablets; one slot (no rack) for dynamic-node kills; the host's rack(s)
-        otherwise (static node / disk / datacenter)."""
+        """Empty for tablets, one slot for slot kills, the host's fail domain(s) otherwise."""
         return Footprint(
             racks=frozenset(self._racks_for_target(target, scope)),
             slots=1 if self._is_slot(target, scope) else 0,
@@ -455,10 +376,10 @@ class FailureModelGuard:
         return sum(imp.slots for imp in self._impairments)
 
     def _slots_ok(self, add_slots: int, now: float) -> bool:
-        """Whether ``add_slots`` more slots stay within the 30% cluster budget (fail-open at 0)."""
+        """Whether ``add_slots`` more slots stay within the budget."""
         if add_slots <= 0 or self._max_slots <= 0:
             return True
-        return self._active_slots(now) + add_slots <= self._max_slots
+        return _slots_within_budget(self._active_slots(now), add_slots, self._max_slots)
 
     def _touched_keys(self, now: float) -> set[str]:
         self._purge_expired(now)
@@ -474,7 +395,7 @@ class FailureModelGuard:
         if tol.kind == "domains":
             return n <= tol.max_domains
         if tol.kind == "realm_plus_domain":
-            # One realm may be lost entirely, plus max_extra_domains in other realms combined.
+            # One realm may be lost entirely, plus max_extra_domains elsewhere.
             by_dc: dict[str | None, int] = {}
             for domain in impaired_racks:
                 realm = self._realm_of_domain(domain)
@@ -484,8 +405,7 @@ class FailureModelGuard:
             sacrificial = max(by_dc.values())  # the realm we allow to fail fully
             remaining = n - sacrificial
             return remaining <= tol.max_extra_domains
-        # Unreachable: an erasure mode the model doesn't understand never gets past parsing.
-        return True
+        return True  # unreachable: unknown modes never get past parsing
 
     # -- public API ---------------------------------------------------------
 
@@ -494,16 +414,10 @@ class FailureModelGuard:
         candidates: Iterable[ChaosTarget],
         scope: ImpactScope,
     ) -> list[ChaosTarget]:
-        """Return a jointly safe subset of ``candidates`` under the fail-domain budget.
+        """Jointly safe subset of ``candidates``: each admission narrows the budget for the next.
 
-        Candidates are checked in order. Each admitted target's fail domains are added to
-        the running ``active`` set, so later candidates see earlier admissions (order-dependent).
-        Already-touched identities (``ChaosTarget.identity_key``) are skipped.
-
-        Only the erasure/fail-domain dimension is checked here: slot candidates carry no fail
-        domain, so they are always admitted regardless of the slot budget. Use :meth:`fits` /
-        :meth:`reserve` (boundary scheduler) when the slot budget must hold — see the module
-        docstring.
+        Skips already-impaired identities. Fail domains only — a slot candidate has none, so it is
+        always admitted here and :meth:`reserve` is what refuses it.
         """
         candidates = list(candidates)
         now = time.monotonic()
@@ -525,23 +439,7 @@ class FailureModelGuard:
                     active = hypothetical
         return safe
 
-    def filter_safe_hosts(self, hosts: Iterable[str], scope: ImpactScope) -> list[str]:
-        """Legacy wrapper: host strings → HOST targets → filter → host strings."""
-        targets = self.filter_safe(
-            [ChaosTarget.for_host(h) for h in hosts],
-            scope,
-        )
-        return [t.host for t in targets]
-
     # -- lease-based budget API ---------------------------------------------
-
-    def fits(self, footprint: Footprint) -> bool:
-        """True if adding ``footprint`` keeps both budgets within tolerance (read-only)."""
-        now = time.monotonic()
-        with self._lock:
-            return self._is_tolerable(
-                self._active_racks(now) | set(footprint.racks)
-            ) and self._slots_ok(footprint.slots, now)
 
     def reserve(
         self,
@@ -549,14 +447,11 @@ class FailureModelGuard:
         recovery_sec: float | None = None,
         identity_key: str | None = None,
     ) -> str | None:
-        """Atomically claim ``footprint`` (racks and/or slots) under one lock; return a lease id,
-        or None if it exceeds either budget. ``recovery_sec`` auto-expires the lease after that
-        many seconds; ``None`` holds it until :meth:`release`. ``identity_key`` records which target
-        the lease covers so it shows up in :meth:`active_identities` (schedulers skip already-impaired
-        targets).
+        """Claim ``footprint`` atomically; return a unique lease id, or None if it exceeds a budget.
 
-        Every granted lease id is unique, so callers may key their own bookkeeping by it (the
-        recovery probe tracks pending extracts that way)."""
+        ``recovery_sec`` auto-expires the lease; ``None`` holds it until :meth:`release`.
+        ``identity_key`` is reported by :meth:`budget_view` so schedulers skip impaired targets.
+        """
         now = time.monotonic()
         deadline = None if recovery_sec is None else now + float(recovery_sec)
         with self._lock:
@@ -576,14 +471,8 @@ class FailureModelGuard:
             )
             return lease_id
 
-    def active_identities(self) -> set[str]:
-        """Identity keys of every non-expired impairment."""
-        now = time.monotonic()
-        with self._lock:
-            return self._touched_keys(now)
-
     def budget_view(self) -> BudgetView:
-        """Snapshot both budgets and the touched identities under one lock (see :class:`BudgetView`)."""
+        """Snapshot both budgets and the impaired identities under one lock."""
         now = time.monotonic()
         with self._lock:
             return BudgetView(
@@ -611,15 +500,10 @@ class FailureModelGuard:
         scope: ImpactScope,
         recovery_sec: float | None = DEFAULT_RECOVERY_SEC,
     ) -> None:
-        """Mark ``target``'s fail domain(s) impaired after a successful plan/dispatch.
+        """Account for an already-dispatched fault; never refuses.
 
-        ``recovery_sec``: auto-release window; ``None`` holds until an explicit extract.
-        ``target`` may be a hostname string (legacy) or :class:`ChaosTarget`.
-
-        Charges both dimensions of the target's :meth:`footprint_for` — fail domains for static
-        faults, one slot for a dynamic-node kill. A footprint that consumes nothing (tablets) is
-        not recorded at all. Unlike :meth:`reserve` this never refuses: the fault was already
-        dispatched, so the budget is told the truth even when that truth exceeds it.
+        Charges both dimensions of :meth:`footprint_for` (nothing is recorded for tablets).
+        ``recovery_sec=None`` holds the impairment until an explicit extract.
         """
         chaos_target = (
             target if isinstance(target, ChaosTarget) else ChaosTarget.for_host(str(target))
@@ -658,8 +542,8 @@ class FailureModelGuard:
                 imp for imp in self._impairments if imp.execution_id != execution_id
             ]
             if len(self._impairments) == before:
-                # Untracked execution (e.g. after restart): drop by identity, not by rack subset
-                # (same rack can hold unrelated impairments).
+                # Untracked execution (e.g. after a restart): drop by identity, not by domain —
+                # one domain can hold unrelated impairments.
                 key = chaos_target.identity_key()
                 self._impairments = [
                     imp for imp in self._impairments if imp.identity_key != key
@@ -669,14 +553,12 @@ class FailureModelGuard:
         now = time.monotonic()
         with self._lock:
             active = sorted(self._active_racks(now))
-            touched = sorted(self._touched_keys(now))
             return {
                 "enabled": self.enabled,
                 "erasure": self._topology.tolerance.erasure,
                 "impaired_racks": active,
                 "impaired_slots": self._active_slots(now),
                 "max_slots": self._max_slots,
-                "touched_targets": touched,
                 "tracked_executions": len(self._impairments),
             }
 

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/nemesis_planner_base.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/nemesis_planner_base.py
@@ -4,9 +4,21 @@ from __future__ import annotations
 
 import threading
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import ClassVar, Sequence
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch, fanout
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+
+
+def normalize_candidates(candidates: Sequence[ChaosTarget | str]) -> list[ChaosTarget]:
+    """Accept ChaosTarget list or legacy hostname list."""
+    out: list[ChaosTarget] = []
+    for c in candidates:
+        if isinstance(c, ChaosTarget):
+            out.append(c)
+        else:
+            out.append(ChaosTarget.for_host(str(c)))
+    return out
 
 
 class NemesisPlannerBase(ABC):
@@ -23,8 +35,8 @@ class NemesisPlannerBase(ABC):
         self._lock = threading.Lock()
 
     @abstractmethod
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        """Next step for scheduled chaos (subclass-specific)."""
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        """Next step for scheduled chaos; ``candidates`` already filter_safe'd."""
 
     def extract_all_on_disable(self) -> list[DispatchCommand]:
         with self._lock:
@@ -40,14 +52,15 @@ class NemesisPlannerBase(ABC):
         """Called under lock: return all tracked hosts and clear tracking."""
 
     def manual(self, host: str, action: str) -> list[DispatchCommand] | None:
+        target = ChaosTarget.for_host(host)
         if action == "inject":
             with self._lock:
                 self._register_inject(host)
-            return [dispatch(self.nemesis_type, host, "inject", self.PAYLOAD_INJECT)]
+            return [dispatch(self.nemesis_type, target, "inject", self.PAYLOAD_INJECT)]
         if action == "extract":
             with self._lock:
                 self._register_extract(host)
-            return [dispatch(self.nemesis_type, host, "extract", self.PAYLOAD_EXTRACT)]
+            return [dispatch(self.nemesis_type, target, "extract", self.PAYLOAD_EXTRACT)]
         return None
 
     @abstractmethod

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/network_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/network_planner.py
@@ -6,7 +6,11 @@ import random
 from dataclasses import dataclass, field
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch, fanout
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import (
+    NemesisPlannerBase,
+    normalize_candidates,
+)
 
 # Payloads — keep in sync with NetworkNemesis actor (catalog)
 PAYLOAD_INJECT = {"op": "isolate_node"}
@@ -30,26 +34,27 @@ class NetworkNemesisPlanner(NemesisPlannerBase):
         self._state = _NetworkIsolationState(max_affected=max_affected)
         self.nemesis_type = "NetworkNemesis"
 
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        if not hosts:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        targets = normalize_candidates(candidates)
+        if not targets:
             return []
-        inject_target: str | None = None
-        extract_targets: list[str] | None = None
+        inject_target: ChaosTarget | None = None
+        extract_hosts: list[str] | None = None
         with self._lock:
             if len(self._state.isolated_hosts) >= self._state.max_affected:
-                extract_targets = list(self._state.isolated_hosts)
+                extract_hosts = list(self._state.isolated_hosts)
                 self._state.isolated_hosts.clear()
             else:
-                avail = [h for h in hosts if h not in self._state.isolated_hosts]
+                avail = [t for t in targets if t.host not in self._state.isolated_hosts]
                 if not avail:
                     return []
                 inject_target = random.choice(avail)
-                self._state.isolated_hosts.add(inject_target)
+                self._state.isolated_hosts.add(inject_target.host)
         if inject_target is not None:
             return [dispatch(self.nemesis_type, inject_target, "inject", self.PAYLOAD_INJECT)]
-        if not extract_targets:
+        if not extract_hosts:
             return []
-        return fanout(self.nemesis_type, extract_targets, "extract", self.PAYLOAD_EXTRACT)
+        return fanout(self.nemesis_type, extract_hosts, "extract", self.PAYLOAD_EXTRACT)
 
     def manual(self, host, action, payload=None):  # noqa: D401
         """Disabled: planner relies on cross-tick state (isolated_hosts) for correctness."""

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/pinned_first_host_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/pinned_first_host_planner.py
@@ -1,47 +1,49 @@
-"""Planner that always runs inject/extract on the first cluster host (YAML order).
+"""Planner that always runs inject/extract on the first candidate (inventory / YAML order).
 
-Stateful cluster nemeses keep Python state in one agent process; dispatching every
 tick to the same host matches single-actor harness behavior.
 """
 
 from __future__ import annotations
 
-from typing import ClassVar
-
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import (
+    NemesisPlannerBase,
+    normalize_candidates,
+)
 
 
 class PinnedFirstHostPlanner(NemesisPlannerBase):
-    """``scheduled_tick`` → ``hosts[0]``; disable schedule → extract to that host."""
+    """``scheduled_tick`` → ``candidates[0]``; disable schedule → extract to that host."""
 
-    PAYLOAD_INJECT: ClassVar[dict] = {}
-    PAYLOAD_EXTRACT: ClassVar[dict] = {}
+    PAYLOAD_INJECT: dict = {}
+    PAYLOAD_EXTRACT: dict = {}
 
-    def __init__(self, nemesis_type_key: str) -> None:
+    def __init__(self, nemesis_type: str) -> None:
         super().__init__()
-        self._nemesis_type_key = nemesis_type_key
+        self.nemesis_type = nemesis_type
         self._control_host: str | None = None
+        self._control_target: ChaosTarget | None = None
 
-    @property
-    def nemesis_type(self) -> str:  # type: ignore[override]
-        return self._nemesis_type_key
-
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        if not hosts:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        targets = normalize_candidates(candidates)
+        if not targets:
             return []
-        h = hosts[0]
+        t = targets[0]
         with self._lock:
-            self._control_host = h
-        return [dispatch(self._nemesis_type_key, h, "inject", self.PAYLOAD_INJECT)]
+            self._control_host = t.host
+            self._control_target = t
+        return [dispatch(self.nemesis_type, t, "inject", self.PAYLOAD_INJECT)]
 
     def _drain_tracked_hosts(self) -> list[str]:
         h = self._control_host
         self._control_host = None
+        self._control_target = None
         return [h] if h else []
 
     def _register_inject(self, host: str) -> None:
         self._control_host = host
+        self._control_target = ChaosTarget.for_host(host)
 
     def _register_extract(self, _host: str) -> None:
         # Manual extract uses the requested host from ``manual()``; pin stays for disable-schedule fanout.

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/pinned_first_host_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/pinned_first_host_planner.py
@@ -1,6 +1,7 @@
 """Planner that always runs inject/extract on the first candidate (inventory / YAML order).
 
-tick to the same host matches single-actor harness behavior.
+Stateful cluster nemeses keep their Python state in one agent process, so dispatching every tick
+to the same host matches single-actor harness behavior.
 """
 
 from __future__ import annotations

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/pinned_first_host_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/pinned_first_host_planner.py
@@ -1,7 +1,6 @@
 """Planner that always runs inject/extract on the first candidate (inventory / YAML order).
 
-Stateful cluster nemeses keep their Python state in one agent process, so dispatching every tick
-to the same host matches single-actor harness behavior.
+Stateful cluster nemeses keep their state in one agent process, so every tick goes to the same host.
 """
 
 from __future__ import annotations

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
@@ -54,6 +54,7 @@ class _Pending:
     timeout_sec: float
     min_hold_sec: float
     stuck_reported: bool = False
+    recover_action: Callable[[], None] | None = None
 
 
 def healthcheck_recovery(
@@ -103,7 +104,16 @@ class RecoveryProbe:
         target: ChaosTarget,
         nemesis_type: str,
         timeout_sec: float | None = None,
+        recover_action: Callable[[], None] | None = None,
     ) -> None:
+        """Track a reserved fault until its budget can be released.
+
+        ``recover_action`` distinguishes the two recovery classes:
+        - ``None`` (self-recovering): released once ``recovered(target)`` is true; a fault that
+          overshoots ``timeout_sec`` is reported stuck and keeps holding budget.
+        - callable (toggle): after holding for ``timeout_sec`` the probe runs the action
+          (dispatch an extract) and releases the budget — no healthcheck, never stuck.
+        """
         if not lease_id:
             return
         timeout = float(timeout_sec) if timeout_sec is not None else self._default_timeout_sec
@@ -115,6 +125,7 @@ class RecoveryProbe:
                 reserved_at=self._clock(),
                 timeout_sec=timeout,
                 min_hold_sec=min(self._min_hold_sec, timeout),
+                recover_action=recover_action,
             )
 
     def forget(self, lease_id: str) -> None:
@@ -130,6 +141,10 @@ class RecoveryProbe:
         for p in items:
             held = now - p.reserved_at
             if held < p.min_hold_sec:
+                continue
+            if p.recover_action is not None:
+                if held >= p.timeout_sec:
+                    self._auto_extract(p, held)
                 continue
             try:
                 is_recovered = self._recovered(p.target)
@@ -167,6 +182,20 @@ class RecoveryProbe:
                 except Exception:
                     logger.exception("on_stuck callback raised")
         return stuck
+
+    def _auto_extract(self, p: _Pending, held: float) -> None:
+        """Toggle fault held long enough: dispatch its extract and release the budget."""
+        try:
+            p.recover_action()
+        except Exception:
+            logger.exception("auto-extract action raised for %s", p.target.identity_key())
+        self._guard.release(p.lease_id)
+        with self._lock:
+            self._pending.pop(p.lease_id, None)
+        logger.info(
+            "auto-extracted: %s (%s) after %.0fs hold; budget released",
+            p.target.host, p.nemesis_type, held,
+        )
 
     def pending(self) -> list[_Pending]:
         with self._lock:

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
@@ -1,0 +1,212 @@
+"""Fact-based recovery for reserved failure budget.
+
+The weighted scheduler reserves budget per injected fault and holds it (``recovery_sec=None``)
+until the fault is observed to have recovered. :class:`RecoveryProbe` polls a ``recovered(target)``
+predicate and calls :meth:`FailureModelGuard.release` the moment a target is back — instead of
+guessing a fixed timer. If a fault does NOT recover within its timeout the probe does not silently
+release the budget (that would let the scheduler pile more chaos onto a cluster that is not
+healing); it keeps holding and raises a stuck-fault problem for the warden to surface.
+
+``recovered`` is injected so the criterion can be healthcheck-based (:func:`healthcheck_recovery`),
+warden-based, or anything else without coupling this module to a data source.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard
+
+logger = logging.getLogger(__name__)
+
+# Healthcheck self_check_result values that mean "this host's endpoint did not answer".
+_HC_ERROR_RESULTS = frozenset({"HC_REQUEST_ERROR", "HC_RESULT_ERROR"})
+
+# Wait at least this long before trusting a recovery signal, so a stale pre-fault healthcheck
+# result cannot be mistaken for "already recovered" right after injection.
+DEFAULT_MIN_HOLD_SEC: float = 30.0
+DEFAULT_RECOVERY_TIMEOUT_SEC: float = 300.0
+DEFAULT_POLL_INTERVAL_SEC: float = 15.0
+
+
+@dataclass(frozen=True)
+class StuckFault:
+    """A reserved fault that has not recovered within its timeout (budget still held)."""
+
+    lease_id: str
+    nemesis_type: str
+    target: ChaosTarget
+    held_sec: float
+    timeout_sec: float
+
+
+@dataclass
+class _Pending:
+    lease_id: str
+    target: ChaosTarget
+    nemesis_type: str
+    reserved_at: float
+    timeout_sec: float
+    min_hold_sec: float
+    stuck_reported: bool = False
+
+
+def healthcheck_recovery(
+    reporter, error_results: frozenset[str] = _HC_ERROR_RESULTS
+) -> Callable[[ChaosTarget], bool]:
+    """``recovered`` predicate: a target is recovered once its host's healthcheck endpoint answers
+    again (any non-error ``self_check_result``). ``reporter`` is anything exposing ``last_results``
+    (e.g. ``HealthCheckReporter``)."""
+
+    def recovered(target: ChaosTarget) -> bool:
+        results = getattr(reporter, "last_results", None) or {}
+        entry = results.get(target.host)
+        if not isinstance(entry, dict):
+            return False  # no data yet -> assume not recovered
+        return entry.get("self_check_result") not in error_results
+
+    return recovered
+
+
+class RecoveryProbe:
+    def __init__(
+        self,
+        *,
+        guard: FailureModelGuard,
+        recovered: Callable[[ChaosTarget], bool],
+        on_stuck: Callable[[StuckFault], None] | None = None,
+        poll_interval: float = DEFAULT_POLL_INTERVAL_SEC,
+        default_timeout_sec: float = DEFAULT_RECOVERY_TIMEOUT_SEC,
+        min_hold_sec: float = DEFAULT_MIN_HOLD_SEC,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._guard = guard
+        self._recovered = recovered
+        self._on_stuck = on_stuck
+        self._poll_interval = float(poll_interval)
+        self._default_timeout_sec = float(default_timeout_sec)
+        self._min_hold_sec = float(min_hold_sec)
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._pending: dict[str, _Pending] = {}
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def track(
+        self,
+        lease_id: str,
+        target: ChaosTarget,
+        nemesis_type: str,
+        timeout_sec: float | None = None,
+    ) -> None:
+        if not lease_id:
+            return
+        timeout = float(timeout_sec) if timeout_sec is not None else self._default_timeout_sec
+        with self._lock:
+            self._pending[lease_id] = _Pending(
+                lease_id=lease_id,
+                target=target,
+                nemesis_type=nemesis_type,
+                reserved_at=self._clock(),
+                timeout_sec=timeout,
+                min_hold_sec=min(self._min_hold_sec, timeout),
+            )
+
+    def forget(self, lease_id: str) -> None:
+        with self._lock:
+            self._pending.pop(lease_id, None)
+
+    def tick(self) -> list[StuckFault]:
+        """Poll every tracked fault once. Releases recovered ones; returns newly-stuck ones."""
+        now = self._clock()
+        with self._lock:
+            items = list(self._pending.values())
+        stuck: list[StuckFault] = []
+        for p in items:
+            held = now - p.reserved_at
+            if held < p.min_hold_sec:
+                continue
+            try:
+                is_recovered = self._recovered(p.target)
+            except Exception:
+                logger.exception("recovery check raised for %s", p.target.identity_key())
+                is_recovered = False
+            if is_recovered:
+                self._guard.release(p.lease_id)
+                with self._lock:
+                    self._pending.pop(p.lease_id, None)
+                logger.info(
+                    "recovered: %s (%s) after %.0fs; budget released",
+                    p.target.host, p.nemesis_type, held,
+                )
+                continue
+            if held > p.timeout_sec and not p.stuck_reported:
+                p.stuck_reported = True
+                logger.error(
+                    "fault did not recover within %.0fs; holding budget: %s (%s)",
+                    p.timeout_sec, p.target.host, p.nemesis_type,
+                )
+                stuck.append(
+                    StuckFault(
+                        lease_id=p.lease_id,
+                        nemesis_type=p.nemesis_type,
+                        target=p.target,
+                        held_sec=held,
+                        timeout_sec=p.timeout_sec,
+                    )
+                )
+        for info in stuck:
+            if self._on_stuck is not None:
+                try:
+                    self._on_stuck(info)
+                except Exception:
+                    logger.exception("on_stuck callback raised")
+        return stuck
+
+    def pending(self) -> list[_Pending]:
+        with self._lock:
+            return list(self._pending.values())
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "tracked": len(self._pending),
+                "stuck": sum(1 for p in self._pending.values() if p.stuck_reported),
+            }
+
+    # -- loop ---------------------------------------------------------------
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.tick()
+            except Exception:
+                logger.exception("recovery probe tick raised")
+            self._stop.wait(self._poll_interval)
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        t = self._thread
+        if t and t.is_alive() and t is not threading.current_thread():
+            t.join(timeout=2.0)
+
+
+__all__ = [
+    "RecoveryProbe",
+    "StuckFault",
+    "healthcheck_recovery",
+    "DEFAULT_MIN_HOLD_SEC",
+    "DEFAULT_RECOVERY_TIMEOUT_SEC",
+]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
@@ -1,14 +1,8 @@
 """Fact-based recovery for reserved failure budget.
 
-The boundary scheduler reserves budget per injected fault and holds it (``recovery_sec=None``)
-until the fault is observed to have recovered. :class:`RecoveryProbe` polls a ``recovered(target)``
-predicate and calls :meth:`FailureModelGuard.release` the moment a target is back — instead of
-guessing a fixed timer. If a fault does NOT recover within its timeout the probe does not silently
-release the budget (that would let the scheduler pile more chaos onto a cluster that is not
-healing); it keeps holding and raises a stuck-fault problem for the warden to surface.
-
-``recovered`` is injected so the criterion can be healthcheck-based (:func:`healthcheck_recovery`),
-warden-based, or anything else without coupling this module to a data source.
+Polls a ``recovered(target)`` predicate and releases the lease the moment a target is back, instead
+of guessing a timer. A fault that overshoots its timeout is *not* released — it is reported stuck and
+keeps holding the budget, so chaos does not pile onto a cluster that is not healing.
 """
 
 from __future__ import annotations
@@ -27,8 +21,7 @@ logger = logging.getLogger(__name__)
 # Healthcheck self_check_result values that mean "this host's endpoint did not answer".
 _HC_ERROR_RESULTS = frozenset({"HC_REQUEST_ERROR", "HC_RESULT_ERROR"})
 
-# Wait at least this long before trusting a recovery signal, so a stale pre-fault healthcheck
-# result cannot be mistaken for "already recovered" right after injection.
+# Ignore recovery signals for this long, so a stale pre-fault healthcheck isn't read as recovery.
 DEFAULT_MIN_HOLD_SEC: float = 30.0
 DEFAULT_RECOVERY_TIMEOUT_SEC: float = 300.0
 DEFAULT_POLL_INTERVAL_SEC: float = 15.0
@@ -60,9 +53,7 @@ class _Pending:
 def healthcheck_recovery(
     reporter, error_results: frozenset[str] = _HC_ERROR_RESULTS
 ) -> Callable[[ChaosTarget], bool]:
-    """``recovered`` predicate: a target is recovered once its host's healthcheck endpoint answers
-    again (any non-error ``self_check_result``). ``reporter`` is anything exposing ``last_results``
-    (e.g. ``HealthCheckReporter``)."""
+    """``recovered`` predicate: the host's healthcheck endpoint answers again."""
 
     def recovered(target: ChaosTarget) -> bool:
         results = getattr(reporter, "last_results", None) or {}
@@ -108,11 +99,8 @@ class RecoveryProbe:
     ) -> None:
         """Track a reserved fault until its budget can be released.
 
-        ``recover_action`` distinguishes the two recovery classes:
-        - ``None`` (self-recovering): released once ``recovered(target)`` is true; a fault that
-          overshoots ``timeout_sec`` is reported stuck and keeps holding budget.
-        - callable (toggle): after holding for ``timeout_sec`` the probe runs the action
-          (dispatch an extract) and releases the budget — no healthcheck, never stuck.
+        ``recover_action=None`` (self-recovering): released once ``recovered(target)``, reported
+        stuck past ``timeout_sec``. A callable (toggle): run after ``timeout_sec``, then released.
         """
         if not lease_id:
             return
@@ -127,10 +115,6 @@ class RecoveryProbe:
                 min_hold_sec=min(self._min_hold_sec, timeout),
                 recover_action=recover_action,
             )
-
-    def forget(self, lease_id: str) -> None:
-        with self._lock:
-            self._pending.pop(lease_id, None)
 
     def tick(self) -> list[StuckFault]:
         """Poll every tracked fault once. Releases recovered ones; returns newly-stuck ones."""
@@ -184,18 +168,11 @@ class RecoveryProbe:
         return stuck
 
     def drain_extracts(self) -> int:
-        """Extract every tracked toggle fault right now, regardless of its remaining hold window.
+        """Extract every tracked toggle fault now, whatever is left of its hold window.
 
-        Called when chaos is switched off (scheduler ``stop()`` / app teardown): a fault that is
-        still waiting out its hold — stopped node, broken disk, skewed clock — would otherwise
-        never be extracted, and the cluster would stay broken after nemesis was disabled. Nothing
-        else extracts them: the boundary scheduler dispatches toggle injects directly, so the
-        planners' ``extract_all_on_disable`` bookkeeping never saw them.
-
-        Self-recovering faults are left tracked: they heal on their own, and a probe that is
-        started again keeps polling them.
-
-        Returns the number of extracts dispatched.
+        Called when chaos is switched off: nothing else would extract them (the scheduler dispatches
+        toggle injects directly, so the planners never saw them). Self-recovering faults stay
+        tracked. Returns the number of extracts dispatched.
         """
         with self._lock:
             pending = [p for p in self._pending.values() if p.recover_action is not None]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
@@ -1,6 +1,6 @@
 """Fact-based recovery for reserved failure budget.
 
-The weighted scheduler reserves budget per injected fault and holds it (``recovery_sec=None``)
+The boundary scheduler reserves budget per injected fault and holds it (``recovery_sec=None``)
 until the fault is observed to have recovered. :class:`RecoveryProbe` polls a ``recovered(target)``
 predicate and calls :meth:`FailureModelGuard.release` the moment a target is back — instead of
 guessing a fixed timer. If a fault does NOT recover within its timeout the probe does not silently

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/recovery_probe.py
@@ -183,7 +183,31 @@ class RecoveryProbe:
                     logger.exception("on_stuck callback raised")
         return stuck
 
-    def _auto_extract(self, p: _Pending, held: float) -> None:
+    def drain_extracts(self) -> int:
+        """Extract every tracked toggle fault right now, regardless of its remaining hold window.
+
+        Called when chaos is switched off (scheduler ``stop()`` / app teardown): a fault that is
+        still waiting out its hold — stopped node, broken disk, skewed clock — would otherwise
+        never be extracted, and the cluster would stay broken after nemesis was disabled. Nothing
+        else extracts them: the boundary scheduler dispatches toggle injects directly, so the
+        planners' ``extract_all_on_disable`` bookkeeping never saw them.
+
+        Self-recovering faults are left tracked: they heal on their own, and a probe that is
+        started again keeps polling them.
+
+        Returns the number of extracts dispatched.
+        """
+        with self._lock:
+            pending = [p for p in self._pending.values() if p.recover_action is not None]
+        if not pending:
+            return 0
+        logger.info("draining %d pending extract(s) on shutdown", len(pending))
+        now = self._clock()
+        for p in pending:
+            self._auto_extract(p, now - p.reserved_at, reason="drained on shutdown")
+        return len(pending)
+
+    def _auto_extract(self, p: _Pending, held: float, reason: str = "hold elapsed") -> None:
         """Toggle fault held long enough: dispatch its extract and release the budget."""
         try:
             p.recover_action()
@@ -193,8 +217,8 @@ class RecoveryProbe:
         with self._lock:
             self._pending.pop(p.lease_id, None)
         logger.info(
-            "auto-extracted: %s (%s) after %.0fs hold; budget released",
-            p.target.host, p.nemesis_type, held,
+            "auto-extracted: %s (%s) after %.0fs hold (%s); budget released",
+            p.target.host, p.nemesis_type, held, reason,
         )
 
     def pending(self) -> list[_Pending]:

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/rolling_restart_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/rolling_restart_planner.py
@@ -48,6 +48,11 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
 
     def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
         safe = normalize_candidates(candidates)
+        # Empty candidates means the failure guard (or inventory) admitted nothing.
+        # Do not treat empty safe_hosts as "no filter" — that would bypass the guard.
+        if not safe:
+            logger.info("rolling restart tick: no safe candidates from guard/inventory")
+            return []
         safe_hosts = {t.host for t in safe}
         safe_ic_ports = {t.ic_port for t in safe if t.ic_port is not None}
 
@@ -71,8 +76,7 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
                     n for n in self._target_nodes
                     if n not in self._affected_nodes
                     and (
-                        not safe_hosts
-                        or n.host in safe_hosts
+                        n.host in safe_hosts
                         or (getattr(n, "ic_port", None) in safe_ic_ports)
                     )
                 ]

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/rolling_restart_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/rolling_restart_planner.py
@@ -6,7 +6,11 @@ import logging
 import random
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch, fanout
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import (
+    NemesisPlannerBase,
+    normalize_candidates,
+)
 from ydb.tests.olap.lib.ydb_cluster import YdbCluster
 
 logger = logging.getLogger(__name__)
@@ -25,7 +29,6 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
     of relying on the base class' constant ``PAYLOAD_INJECT``/``PAYLOAD_EXTRACT``.
     """
 
-    # Empty placeholders — actual payload is built per node in scheduled_tick / manual.
     PAYLOAD_INJECT: dict = {}
     PAYLOAD_EXTRACT: dict = {}
 
@@ -43,7 +46,11 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
         self._affected_nodes = set()
         self.nemesis_type = "ClusterRollingRestartNemesis"
 
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        safe = normalize_candidates(candidates)
+        safe_hosts = {t.host for t in safe}
+        safe_ic_ports = {t.ic_port for t in safe if t.ic_port is not None}
+
         if not self._target_nodes:
             return []
         inject_targets: list[YdbCluster.Node] = []
@@ -60,7 +67,15 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
                     len(self._target_nodes), extract_targets,
                 )
             else:
-                avail = [n for n in self._target_nodes if n not in self._affected_nodes]
+                avail = [
+                    n for n in self._target_nodes
+                    if n not in self._affected_nodes
+                    and (
+                        not safe_hosts
+                        or n.host in safe_hosts
+                        or (getattr(n, "ic_port", None) in safe_ic_ports)
+                    )
+                ]
                 avail_hosts = sorted({n.host for n in avail})
                 if not avail:
                     logger.info(
@@ -82,7 +97,7 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
             result = [
                 dispatch(
                     self.nemesis_type,
-                    node.host,
+                    ChaosTarget.for_node(node.host, ic_port=int(node.ic_port)),
                     "inject",
                     self._build_inject_payload(node),
                 )
@@ -109,12 +124,6 @@ class RollingRestartNemesisPlanner(NemesisPlannerBase):
 
     def _register_extract(self, host: str) -> None:
         pass
-
-    def _find_node_by_host(self, host: str) -> "YdbCluster.Node | None":
-        for node in self._target_nodes:
-            if node.host == host:
-                return node
-        return None
 
     def _drain_tracked_hosts(self) -> list[str]:
         targets = list({node.host for node in self._affected_nodes})

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
@@ -15,8 +15,14 @@ import requests
 
 from ydb.tests.stability.nemesis.routers.agent_router import create_process_helper
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
-from ydb.tests.stability.nemesis.internal.nemesis.catalog import NEMESIS_TYPES
+from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
+    NEMESIS_TYPES,
+    guard_mode_for,
+    impact_scope_for,
+    recovery_sec_for,
+)
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import ChaosOrchestratorStore
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -38,6 +44,7 @@ class OrchestratorNemesisSchedule:
         is_local_host: Callable[[str], bool],
         get_app_port: Callable[[], int],
         history_limit: int = HISTORY_LIMIT,
+        failure_guard: FailureModelGuard | None = None,
     ) -> None:
         self._lock = threading.RLock()
         self._tasks: dict[str, dict] = {}
@@ -47,6 +54,7 @@ class OrchestratorNemesisSchedule:
         self._get_hosts = get_hosts
         self._is_local_host = is_local_host
         self._get_app_port = get_app_port
+        self._failure_guard = failure_guard
 
     @property
     def lock(self) -> threading.RLock:
@@ -228,6 +236,33 @@ class OrchestratorNemesisSchedule:
         for cmd in cmds:
             self.dispatch_command(cmd, track_history=True)
 
+    def _dispatch_guarded(self, cmd: DispatchCommand) -> None:
+        """Post-filter safety net (Variant A) used only by scheduled ticks.
+
+        For FULL-mode types: veto injects that would violate the failure model, and record
+        inject/extract impact. PREFILTER_ONLY / BYPASS types dispatch as-is (no veto, no record).
+        """
+        guard = self._failure_guard
+        if guard is None or not guard.enabled or guard_mode_for(cmd.nemesis_type) is not GuardMode.FULL:
+            self.dispatch_command(cmd, track_history=True)
+            return
+
+        scope = impact_scope_for(cmd.nemesis_type)
+        if cmd.action == "extract":
+            self.dispatch_command(cmd, track_history=True)
+            guard.record_extract(cmd.execution_id, cmd.host, scope)
+            return
+
+        if not guard.can_inject(cmd.host, scope):
+            logger.warning(
+                "VETOED by failure model: %s (%s) on %s", cmd.nemesis_type, scope.value, cmd.host
+            )
+            return
+        self.dispatch_command(cmd, track_history=True)
+        guard.record_inject(
+            cmd.execution_id, cmd.host, scope, recovery_sec=recovery_sec_for(cmd.nemesis_type)
+        )
+
     def _run_planned_tick(self, process_type: str) -> None:
         hosts = self._get_hosts()
         cmds = self._chaos_store.plan_scheduled_tick(process_type, hosts)
@@ -237,7 +272,7 @@ class OrchestratorNemesisSchedule:
         logger.info("Running %d dispatch(es) for %s", len(cmds), process_type)
         with ThreadPoolExecutor(max_workers=min(len(cmds), 10)) as executor:
             futures = [
-                executor.submit(self.dispatch_command, cmd, track_history=True)
+                executor.submit(self._dispatch_guarded, cmd)
                 for cmd in cmds
             ]
             for future in as_completed(futures):

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
@@ -191,10 +191,12 @@ class OrchestratorNemesisSchedule:
         try:
             payload = dict(cmd.payload or {})
             payload["host"] = cmd.host
+            payload["chaos_target"] = cmd.target.to_dict()
             body = {
                 "type": cmd.nemesis_type,
                 "action": cmd.action,
                 "payload": payload,
+                "target": cmd.target.to_dict(),
             }
             if self._is_local_host(cmd.host):
                 create_process_helper(
@@ -202,7 +204,12 @@ class OrchestratorNemesisSchedule:
                     cmd.action,
                     payload=payload,
                 )
-                logger.debug("Started %s on local host (%s)", cmd.nemesis_type, cmd.action)
+                logger.debug(
+                    "Started %s on local host (%s) target=%s",
+                    cmd.nemesis_type,
+                    cmd.action,
+                    cmd.target.identity_key(),
+                )
             else:
                 port = self._get_app_port()
                 requests.post(
@@ -217,6 +224,7 @@ class OrchestratorNemesisSchedule:
                         "type": cmd.nemesis_type,
                         "action": cmd.action,
                         "host": cmd.host,
+                        "target": cmd.target.to_dict(),
                         "execution_id": cmd.execution_id,
                         "scenario_id": cmd.scenario_id,
                         "timestamp": datetime.utcnow().isoformat() + "Z",
@@ -234,34 +242,24 @@ class OrchestratorNemesisSchedule:
             return
         logger.info("Disable schedule: %d extract dispatch(es) for %s", len(cmds), process_type)
         for cmd in cmds:
-            self.dispatch_command(cmd, track_history=True)
+            self._dispatch_and_record(cmd)
 
-    def _dispatch_guarded(self, cmd: DispatchCommand) -> None:
-        """Post-filter safety net (Variant A) used only by scheduled ticks.
-
-        For FULL-mode types: veto injects that would violate the failure model, and record
-        inject/extract impact. PREFILTER_ONLY / BYPASS types dispatch as-is (no veto, no record).
-        """
+    def _dispatch_and_record(self, cmd: DispatchCommand) -> None:
+        """Dispatch a planned command and record FULL-mode impact (no veto)."""
+        self.dispatch_command(cmd, track_history=True)
         guard = self._failure_guard
         if guard is None or not guard.enabled or guard_mode_for(cmd.nemesis_type) is not GuardMode.FULL:
-            self.dispatch_command(cmd, track_history=True)
             return
-
         scope = impact_scope_for(cmd.nemesis_type)
         if cmd.action == "extract":
-            self.dispatch_command(cmd, track_history=True)
-            guard.record_extract(cmd.execution_id, cmd.host, scope)
-            return
-
-        if not guard.can_inject(cmd.host, scope):
-            logger.warning(
-                "VETOED by failure model: %s (%s) on %s", cmd.nemesis_type, scope.value, cmd.host
+            guard.record_extract(cmd.execution_id, cmd.target, scope)
+        elif cmd.action == "inject":
+            guard.record_inject(
+                cmd.execution_id,
+                cmd.target,
+                scope,
+                recovery_sec=recovery_sec_for(cmd.nemesis_type),
             )
-            return
-        self.dispatch_command(cmd, track_history=True)
-        guard.record_inject(
-            cmd.execution_id, cmd.host, scope, recovery_sec=recovery_sec_for(cmd.nemesis_type)
-        )
 
     def _run_planned_tick(self, process_type: str) -> None:
         hosts = self._get_hosts()
@@ -271,10 +269,7 @@ class OrchestratorNemesisSchedule:
             return
         logger.info("Running %d dispatch(es) for %s", len(cmds), process_type)
         with ThreadPoolExecutor(max_workers=min(len(cmds), 10)) as executor:
-            futures = [
-                executor.submit(self._dispatch_guarded, cmd)
-                for cmd in cmds
-            ]
+            futures = [executor.submit(self._dispatch_and_record, cmd) for cmd in cmds]
             for future in as_completed(futures):
                 try:
                     future.result()

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
@@ -19,7 +19,7 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     NEMESIS_TYPES,
     guard_mode_for,
     impact_scope_for,
-    recovery_sec_for,
+    impairment_hold_sec_for,
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import ChaosOrchestratorStore
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
@@ -245,7 +245,7 @@ class OrchestratorNemesisSchedule:
             self._dispatch_and_record(cmd)
 
     def _dispatch_and_record(self, cmd: DispatchCommand) -> None:
-        """Dispatch a planned command and record FULL-mode impact (no veto)."""
+        """Dispatch a planned command and account for its impact (no veto)."""
         self.dispatch_command(cmd, track_history=True)
         guard = self._failure_guard
         if guard is None or guard_mode_for(cmd.nemesis_type) is not GuardMode.FULL:
@@ -258,7 +258,8 @@ class OrchestratorNemesisSchedule:
                 cmd.execution_id,
                 cmd.target,
                 scope,
-                recovery_sec=recovery_sec_for(cmd.nemesis_type),
+                # This loop toggles a fault back with its next inject, not with an extract.
+                recovery_sec=impairment_hold_sec_for(cmd.nemesis_type, paired_extract=False),
             )
 
     def _run_planned_tick(self, process_type: str) -> None:

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/schedule_loop.py
@@ -248,7 +248,7 @@ class OrchestratorNemesisSchedule:
         """Dispatch a planned command and record FULL-mode impact (no veto)."""
         self.dispatch_command(cmd, track_history=True)
         guard = self._failure_guard
-        if guard is None or not guard.enabled or guard_mode_for(cmd.nemesis_type) is not GuardMode.FULL:
+        if guard is None or guard_mode_for(cmd.nemesis_type) is not GuardMode.FULL:
             return
         scope = impact_scope_for(cmd.nemesis_type)
         if cmd.action == "extract":

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/serial_staggered_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/serial_staggered_planner.py
@@ -1,14 +1,16 @@
-"""Serial-style inject: one tick fans out to several agents with increasing ``sleep_before`` in payload."""
+"""Serial-style inject: one tick dispatches to the owner host of a chosen node/slot."""
 
 from __future__ import annotations
 
 import random
-import uuid
 from typing import ClassVar
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch
-from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import require_external_cluster
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import (
+    NemesisPlannerBase,
+    normalize_candidates,
+)
 
 # Lower bound of tools ``schedule_between_kills`` (30, 60) for node serial nemeses.
 DEFAULT_SERIAL_STAGGER_SEC = 30.0
@@ -16,9 +18,11 @@ DEFAULT_SERIAL_STAGGER_SEC = 30.0
 
 class SerialStaggeredInjectPlanner(NemesisPlannerBase):
     """
-    Each ``scheduled_tick``: sample ``K`` distinct hosts (``K`` in 1..4, capped by ``len(hosts)``),
-    dispatch inject to each with ``payload["sleep_before"] = i * stagger_sec`` and the same
-    ``node_id`` / ``slot_idx`` so every agent kills the same daemon (staggered in time).
+    Each ``scheduled_tick``: pick one node/slot from ``candidates`` and dispatch inject
+    only to that entity's owner host (with optional sleep_before for stagger compatibility).
+
+    Previously fanned out the same node_id to K random hosts; that is incorrect for
+    ChaosTarget — only the owner agent can kill the daemon.
     """
 
     PAYLOAD_INJECT: ClassVar[dict] = {}
@@ -41,43 +45,30 @@ class SerialStaggeredInjectPlanner(NemesisPlannerBase):
     def nemesis_type(self) -> str:  # type: ignore[override]
         return self._nemesis_type_key
 
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        if not hosts:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        targets = normalize_candidates(candidates)
+        if not targets:
             return []
-        cluster = require_external_cluster()
-        if cluster is None:
-            return []
+
         if self._target_kind == "node":
-            ids = list(cluster.nodes.keys())
-            if not ids:
-                return []
-            target_key, target_val = "node_id", random.choice(ids)
+            pool = [t for t in targets if t.kind is TargetKind.NODE] or targets
         elif self._target_kind == "slot":
-            ids = list(cluster.slots.keys())
-            if not ids:
-                return []
-            target_key, target_val = "slot_idx", random.choice(ids)
+            pool = [t for t in targets if t.kind is TargetKind.SLOT] or targets
         else:
             return []
 
-        k = min(random.randint(1, 4), len(hosts))
-        chosen = random.sample(hosts, k)
+        chosen = random.choice(pool)
+        payload: dict = {"sleep_before": 0.0}
+        if chosen.node_id is not None:
+            payload["node_id"] = chosen.node_id
+        if chosen.slot_idx is not None:
+            payload["slot_idx"] = chosen.slot_idx
+        if chosen.ic_port is not None:
+            payload["node_ic_port"] = chosen.ic_port
+
         with self._lock:
-            self._last_hosts = list(chosen)
-        scenario_id = str(uuid.uuid4())
-        return [
-            dispatch(
-                self._nemesis_type_key,
-                h,
-                "inject",
-                {
-                    "sleep_before": float(i) * self._stagger_sec,
-                    target_key: target_val,
-                },
-                scenario_id=scenario_id,
-            )
-            for i, h in enumerate(chosen)
-        ]
+            self._last_hosts = [chosen.host]
+        return [dispatch(self._nemesis_type_key, chosen, "inject", payload)]
 
     def _drain_tracked_hosts(self) -> list[str]:
         out = list(self._last_hosts)

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/serial_staggered_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/serial_staggered_planner.py
@@ -1,8 +1,9 @@
-"""Serial-style inject: one tick dispatches to the owner host of a chosen node/slot."""
+"""Serial-style inject: one tick kills K node/slot entities in sequence, ``stagger_sec`` apart."""
 
 from __future__ import annotations
 
 import random
+import uuid
 from typing import ClassVar
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch
@@ -15,14 +16,19 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_b
 # Lower bound of tools ``schedule_between_kills`` (30, 60) for node serial nemeses.
 DEFAULT_SERIAL_STAGGER_SEC = 30.0
 
+# Upper bound on entities killed within one tick (matches the pre-ChaosTarget planner).
+MAX_ENTITIES_PER_TICK = 4
+
 
 class SerialStaggeredInjectPlanner(NemesisPlannerBase):
     """
-    Each ``scheduled_tick``: pick one node/slot from ``candidates`` and dispatch inject
-    only to that entity's owner host (with optional sleep_before for stagger compatibility).
+    Each ``scheduled_tick``: sample ``K`` distinct node/slot entities (``K`` in
+    1..:data:`MAX_ENTITIES_PER_TICK`, capped by the candidate count) and dispatch one inject per
+    entity **to that entity's own owner host**, with ``payload["sleep_before"] = i * stagger_sec``
+    so the agents kill their daemons one after another instead of all at once.
 
-    Previously fanned out the same node_id to K random hosts; that is incorrect for
-    ChaosTarget — only the owner agent can kill the daemon.
+    The pre-ChaosTarget version fanned the *same* ``node_id`` out to K random hosts, which only
+    worked while the agent resolved the target locally; only the owner agent can kill the daemon.
     """
 
     PAYLOAD_INJECT: ClassVar[dict] = {}
@@ -57,18 +63,33 @@ class SerialStaggeredInjectPlanner(NemesisPlannerBase):
         else:
             return []
 
-        chosen = random.choice(pool)
-        payload: dict = {"sleep_before": 0.0}
-        if chosen.node_id is not None:
-            payload["node_id"] = chosen.node_id
-        if chosen.slot_idx is not None:
-            payload["slot_idx"] = chosen.slot_idx
-        if chosen.ic_port is not None:
-            payload["node_ic_port"] = chosen.ic_port
-
+        k = min(random.randint(1, MAX_ENTITIES_PER_TICK), len(pool))
+        chosen = random.sample(pool, k)
+        scenario_id = str(uuid.uuid4())
+        commands = [
+            dispatch(
+                self._nemesis_type_key,
+                target,
+                "inject",
+                self._payload_for(target, sleep_before=float(i) * self._stagger_sec),
+                scenario_id=scenario_id,
+            )
+            for i, target in enumerate(chosen)
+        ]
         with self._lock:
-            self._last_hosts = [chosen.host]
-        return [dispatch(self._nemesis_type_key, chosen, "inject", payload)]
+            self._last_hosts = [t.host for t in chosen]
+        return commands
+
+    def _payload_for(self, target: ChaosTarget, *, sleep_before: float) -> dict:
+        """Ids the agent needs to find the daemon, plus how long it waits before killing it."""
+        payload: dict = {"sleep_before": sleep_before}
+        if target.node_id is not None:
+            payload["node_id"] = target.node_id
+        if target.slot_idx is not None:
+            payload["slot_idx"] = target.slot_idx
+        if target.ic_port is not None:
+            payload["node_ic_port"] = target.ic_port
+        return payload
 
     def _drain_tracked_hosts(self) -> list[str]:
         out = list(self._last_hosts)

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/serial_staggered_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/serial_staggered_planner.py
@@ -16,19 +16,14 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_b
 # Lower bound of tools ``schedule_between_kills`` (30, 60) for node serial nemeses.
 DEFAULT_SERIAL_STAGGER_SEC = 30.0
 
-# Upper bound on entities killed within one tick (matches the pre-ChaosTarget planner).
 MAX_ENTITIES_PER_TICK = 4
 
 
 class SerialStaggeredInjectPlanner(NemesisPlannerBase):
-    """
-    Each ``scheduled_tick``: sample ``K`` distinct node/slot entities (``K`` in
-    1..:data:`MAX_ENTITIES_PER_TICK`, capped by the candidate count) and dispatch one inject per
-    entity **to that entity's own owner host**, with ``payload["sleep_before"] = i * stagger_sec``
-    so the agents kill their daemons one after another instead of all at once.
+    """Kill ``K`` distinct node/slot entities per tick (``K`` up to :data:`MAX_ENTITIES_PER_TICK`).
 
-    The pre-ChaosTarget version fanned the *same* ``node_id`` out to K random hosts, which only
-    worked while the agent resolved the target locally; only the owner agent can kill the daemon.
+    One inject per entity, dispatched to that entity's own owner host, with
+    ``payload["sleep_before"] = i * stagger_sec`` so the kills are serial rather than simultaneous.
     """
 
     PAYLOAD_INJECT: ClassVar[dict] = {}
@@ -81,7 +76,7 @@ class SerialStaggeredInjectPlanner(NemesisPlannerBase):
         return commands
 
     def _payload_for(self, target: ChaosTarget, *, sleep_before: float) -> dict:
-        """Ids the agent needs to find the daemon, plus how long it waits before killing it."""
+        """Ids the agent needs to find the daemon, plus its wait before killing it."""
         payload: dict = {"sleep_before": sleep_before}
         if target.node_id is not None:
             payload["node_id"] = target.node_id

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/topology_fanout_planner.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/topology_fanout_planner.py
@@ -20,7 +20,11 @@ from typing import ClassVar
 
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand, dispatch
 from ydb.tests.stability.nemesis.internal.nemesis.cluster_context import require_external_cluster
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import NemesisPlannerBase
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.nemesis_planner_base import (
+    NemesisPlannerBase,
+    normalize_candidates,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -75,8 +79,10 @@ class DataCenterFanoutPlanner(NemesisPlannerBase):
 
     # -- planner interface --------------------------------------------------
 
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        if not hosts:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        targets = normalize_candidates(candidates)
+        host_set = {t.host for t in targets}
+        if not host_set:
             return []
         cluster = require_external_cluster()
         if cluster is None:
@@ -86,8 +92,7 @@ class DataCenterFanoutPlanner(NemesisPlannerBase):
             return []
         dc = next(self._dc_cycle_iter)
         dc_hosts = dc_map.get(dc, [])
-        # Only dispatch to hosts that are in the known agent host list
-        target_hosts = [h for h in dc_hosts if h in hosts]
+        target_hosts = [h for h in dc_hosts if h in host_set]
         if not target_hosts:
             return []
         with self._lock:
@@ -96,7 +101,7 @@ class DataCenterFanoutPlanner(NemesisPlannerBase):
         return [
             dispatch(
                 self._nemesis_type_key,
-                h,
+                ChaosTarget.for_datacenter(h, dc),
                 "inject",
                 {"datacenter": dc},
                 scenario_id=scenario_id,
@@ -162,8 +167,10 @@ class BridgePileFanoutPlanner(NemesisPlannerBase):
 
     # -- planner interface --------------------------------------------------
 
-    def scheduled_tick(self, hosts: list[str]) -> list[DispatchCommand]:
-        if not hosts:
+    def scheduled_tick(self, candidates: list[ChaosTarget]) -> list[DispatchCommand]:
+        targets = normalize_candidates(candidates)
+        host_set = {t.host for t in targets}
+        if not host_set:
             return []
         cluster = require_external_cluster()
         if cluster is None:
@@ -173,8 +180,7 @@ class BridgePileFanoutPlanner(NemesisPlannerBase):
             return []
         pile_id = random.choice(list(pile_map.keys()))
         pile_hosts = pile_map.get(pile_id, [])
-        # Only dispatch to hosts that are in the known agent host list
-        target_hosts = [h for h in pile_hosts if h in hosts]
+        target_hosts = [h for h in pile_hosts if h in host_set]
         if not target_hosts:
             return []
         with self._lock:
@@ -183,7 +189,7 @@ class BridgePileFanoutPlanner(NemesisPlannerBase):
         return [
             dispatch(
                 self._nemesis_type_key,
-                h,
+                ChaosTarget.for_pile(h, pile_id),
                 "inject",
                 {"bridge_pile_id": pile_id},
                 scenario_id=scenario_id,

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/weighted_scheduler.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/weighted_scheduler.py
@@ -4,8 +4,10 @@ Walks the failure-model boundary: each tick breaks a random number of things (``
 each fault by weight from whatever currently fits the budget, reserving it atomically, then sleeps
 a randomized interval. Replaces the per-type schedule threads in ``schedule_loop.py``.
 
-Recovery is timer-based here (the reserved budget auto-expires); Phase 2 swaps in real recovery
-probes that release leases by fact.
+Budget is released by the :class:`RecoveryProbe`, per the type's :func:`recovery_mode_for`:
+self-recovering faults are released once healthcheck sees the host answer again; toggle faults
+are held for their ``auto_recovery_sec`` then actively extracted. Without a probe (or a disabled,
+fail-open guard) self-recovering faults fall back to the reserve timer so budget never sticks.
 """
 
 from __future__ import annotations
@@ -17,8 +19,8 @@ from typing import Callable, Sequence
 
 from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     NEMESIS_TYPES,
-    guard_mode_for,
     impact_scope_for,
+    recovery_mode_for as catalog_recovery_mode_for,
     recovery_sec_for,
     target_kind_for,
     weight_for as catalog_weight_for,
@@ -28,16 +30,28 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target impo
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     DEFAULT_RECOVERY_SEC,
     FailureModelGuard,
-    GuardMode,
     ImpactScope,
 )
 
 logger = logging.getLogger(__name__)
 
+# Curated stability chaos profile: datacenter stop, node kill, slot kill, node stop/start, disk
+# break/cleanup, clock skew. Filtered to what the cluster actually registers (e.g. the DC type
+# only exists on multi-DC clusters). Toggle members are recovered via timed extract.
+_STABILITY_PROFILE: tuple[str, ...] = (
+    "DataCenterStopNodesNemesis",
+    "KillNodeNemesis",
+    "KillSlotDaemonNemesis",
+    "StopStartNodeNemesis",
+    "SafelyBreakDiskNemesis",
+    "SafelyCleanupDisksNemesis",
+    "TimeSkewNemesis",
+)
+
 
 def default_enabled_types() -> list[str]:
-    """FULL-mode types (stateless, one-target injection) — the natural fit for weighted picking."""
-    return [t for t in NEMESIS_TYPES if guard_mode_for(t) is GuardMode.FULL]
+    """The stability chaos profile, restricted to types registered for this cluster."""
+    return [t for t in _STABILITY_PROFILE if t in NEMESIS_TYPES]
 
 
 class WeightedNemesisScheduler:
@@ -49,11 +63,13 @@ class WeightedNemesisScheduler:
         plan_inject: Callable[[str, ChaosTarget], list[DispatchCommand]],
         dispatch: Callable[[DispatchCommand], None],
         recovery_probe=None,
+        plan_extract: Callable[[str, ChaosTarget], list[DispatchCommand]] | None = None,
         enabled_types: Sequence[str] | None = None,
         weight_for: Callable[[str], float] | None = None,
         scope_for: Callable[[str], ImpactScope] = impact_scope_for,
         kind_for: Callable[[str], TargetKind] = target_kind_for,
         recovery_sec_for: Callable[[str], float | None] = recovery_sec_for,
+        recovery_mode_for: Callable[[str], str] = catalog_recovery_mode_for,
         base_interval: float = 60.0,
         jitter: float = 0.5,
         max_per_tick: int = 3,
@@ -63,12 +79,14 @@ class WeightedNemesisScheduler:
         self._guard = guard
         self._inventory = inventory
         self._plan_inject = plan_inject
+        self._plan_extract = plan_extract
         self._dispatch = dispatch
         self._recovery_probe = recovery_probe
         self._weight_for = weight_for or catalog_weight_for
         self._scope_for = scope_for
         self._kind_for = kind_for
         self._recovery_sec_for = recovery_sec_for
+        self._recovery_mode_for = recovery_mode_for
         self._default_recovery_sec = float(default_recovery_sec)
         self._rng = rng or random.Random()
         self._cfg_lock = threading.Lock()
@@ -123,14 +141,21 @@ class WeightedNemesisScheduler:
 
     # -- tick ---------------------------------------------------------------
 
+    def _can_extract(self) -> bool:
+        return self._plan_extract is not None and self._recovery_probe is not None
+
     def _menu(self) -> list[tuple[str, ChaosTarget, frozenset[str], float]]:
         with self._cfg_lock:
             enabled = list(self._enabled)
         impaired = self._guard.active_identities()
+        can_extract = self._can_extract()
         menu: list[tuple[str, ChaosTarget, frozenset[str], float]] = []
         for nemesis_type in enabled:
             weight = self._weight_for(nemesis_type)
             if weight <= 0:
+                continue
+            # A toggle fault with no way to auto-extract would stay broken forever — don't offer it.
+            if self._recovery_mode_for(nemesis_type) == "extract" and not can_extract:
                 continue
             scope = self._scope_for(nemesis_type)
             kind = self._kind_for(nemesis_type)
@@ -172,23 +197,44 @@ class WeightedNemesisScheduler:
             recovery = self._recovery_sec_for(nemesis_type)
             if recovery is None:
                 recovery = self._default_recovery_sec
-            # With a recovery probe, hold the budget (recovery_sec=None) until the fault is
-            # observed recovered; the probe releases by fact. Tablets (empty footprint), a disabled
-            # (fail-open) guard, and the probe-less path fall back to the timer so budget never sticks.
-            use_probe = self._recovery_probe is not None and bool(racks) and self._guard.enabled
+            # The probe releases the budget by fact, so hold it (recovery_sec=None):
+            #   extract  — toggle fault; probe holds `recovery`s then dispatches the extract.
+            #   self     — probe releases once healthcheck sees the host answer again.
+            # A disabled (fail-open) guard, empty footprint, or missing probe falls back to the
+            # reserve timer so self-recovering budget never sticks.
+            by_extract = (
+                self._recovery_mode_for(nemesis_type) == "extract" and self._can_extract()
+            )
+            by_healthcheck = (
+                not by_extract
+                and self._recovery_probe is not None
+                and bool(racks)
+                and self._guard.enabled
+            )
             lease = self._guard.reserve(
                 racks,
-                recovery_sec=None if use_probe else recovery,
+                recovery_sec=None if (by_extract or by_healthcheck) else recovery,
                 identity_key=target.identity_key(),
             )
             if lease is None:
                 break
             for cmd in self._plan_inject(nemesis_type, target):
                 self._dispatch(cmd)
-            if use_probe:
+            if by_extract:
+                self._recovery_probe.track(
+                    lease, target, nemesis_type, timeout_sec=recovery,
+                    recover_action=self._extract_action(nemesis_type, target),
+                )
+            elif by_healthcheck:
                 self._recovery_probe.track(lease, target, nemesis_type, timeout_sec=recovery)
             added += 1
         return added
+
+    def _extract_action(self, nemesis_type: str, target: ChaosTarget) -> Callable[[], None]:
+        def _recover() -> None:
+            for cmd in self._plan_extract(nemesis_type, target):
+                self._dispatch(cmd)
+        return _recover
 
     # -- loop ---------------------------------------------------------------
 

--- a/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/weighted_scheduler.py
+++ b/ydb/tests/stability/nemesis/internal/orchestrator/nemesis/weighted_scheduler.py
@@ -1,0 +1,230 @@
+"""Single-threaded weighted nemesis scheduler.
+
+Walks the failure-model boundary: each tick breaks a random number of things (``cap``), picking
+each fault by weight from whatever currently fits the budget, reserving it atomically, then sleeps
+a randomized interval. Replaces the per-type schedule threads in ``schedule_loop.py``.
+
+Recovery is timer-based here (the reserved budget auto-expires); Phase 2 swaps in real recovery
+probes that release leases by fact.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import threading
+from typing import Callable, Sequence
+
+from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
+    NEMESIS_TYPES,
+    guard_mode_for,
+    impact_scope_for,
+    recovery_sec_for,
+    target_kind_for,
+    weight_for as catalog_weight_for,
+)
+from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import DispatchCommand
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    DEFAULT_RECOVERY_SEC,
+    FailureModelGuard,
+    GuardMode,
+    ImpactScope,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def default_enabled_types() -> list[str]:
+    """FULL-mode types (stateless, one-target injection) — the natural fit for weighted picking."""
+    return [t for t in NEMESIS_TYPES if guard_mode_for(t) is GuardMode.FULL]
+
+
+class WeightedNemesisScheduler:
+    def __init__(
+        self,
+        *,
+        guard: FailureModelGuard,
+        inventory,
+        plan_inject: Callable[[str, ChaosTarget], list[DispatchCommand]],
+        dispatch: Callable[[DispatchCommand], None],
+        recovery_probe=None,
+        enabled_types: Sequence[str] | None = None,
+        weight_for: Callable[[str], float] | None = None,
+        scope_for: Callable[[str], ImpactScope] = impact_scope_for,
+        kind_for: Callable[[str], TargetKind] = target_kind_for,
+        recovery_sec_for: Callable[[str], float | None] = recovery_sec_for,
+        base_interval: float = 60.0,
+        jitter: float = 0.5,
+        max_per_tick: int = 3,
+        default_recovery_sec: float = DEFAULT_RECOVERY_SEC,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._guard = guard
+        self._inventory = inventory
+        self._plan_inject = plan_inject
+        self._dispatch = dispatch
+        self._recovery_probe = recovery_probe
+        self._weight_for = weight_for or catalog_weight_for
+        self._scope_for = scope_for
+        self._kind_for = kind_for
+        self._recovery_sec_for = recovery_sec_for
+        self._default_recovery_sec = float(default_recovery_sec)
+        self._rng = rng or random.Random()
+        self._cfg_lock = threading.Lock()
+        self._enabled = (
+            list(enabled_types) if enabled_types is not None else default_enabled_types()
+        )
+        self._base_interval = float(base_interval)
+        self._jitter = float(jitter)
+        self._max_per_tick = max(1, int(max_per_tick))
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def set_profile(
+        self,
+        *,
+        enabled: Sequence[str] | None = None,
+        weights: dict[str, float] | None = None,
+        base_interval: float | None = None,
+        jitter: float | None = None,
+        max_per_tick: int | None = None,
+    ) -> None:
+        with self._cfg_lock:
+            if enabled is not None:
+                self._enabled = list(enabled)
+            if base_interval is not None:
+                self._base_interval = float(base_interval)
+            if jitter is not None:
+                self._jitter = float(jitter)
+            if max_per_tick is not None:
+                self._max_per_tick = max(1, int(max_per_tick))
+        if weights is not None:
+            wmap = {k: float(v) for k, v in weights.items()}
+            self._weight_for = lambda t: wmap.get(t, 1.0)
+
+    def running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def status(self) -> dict:
+        with self._cfg_lock:
+            enabled = list(self._enabled)
+            base, jitter, cap = self._base_interval, self._jitter, self._max_per_tick
+        out: dict = {
+            "running": self.running(),
+            "enabled_types": enabled,
+            "base_interval": base,
+            "jitter": jitter,
+            "max_per_tick": cap,
+        }
+        if self._recovery_probe is not None:
+            out["recovery_probe"] = self._recovery_probe.snapshot()
+        return out
+
+    # -- tick ---------------------------------------------------------------
+
+    def _menu(self) -> list[tuple[str, ChaosTarget, frozenset[str], float]]:
+        with self._cfg_lock:
+            enabled = list(self._enabled)
+        impaired = self._guard.active_identities()
+        menu: list[tuple[str, ChaosTarget, frozenset[str], float]] = []
+        for nemesis_type in enabled:
+            weight = self._weight_for(nemesis_type)
+            if weight <= 0:
+                continue
+            scope = self._scope_for(nemesis_type)
+            kind = self._kind_for(nemesis_type)
+            seen: set[str] = set()  # collapse duplicate targets (e.g. one DC exposed per host)
+            for target in self._inventory.entities(kind):
+                key = target.identity_key()
+                if key in impaired or key in seen:
+                    continue
+                seen.add(key)
+                racks = self._guard.footprint_for(target, scope)
+                if self._guard.fits(racks):
+                    menu.append((nemesis_type, target, racks, weight))
+        return menu
+
+    def _weighted_choice(
+        self, menu: list[tuple[str, ChaosTarget, frozenset[str], float]]
+    ) -> tuple[str, ChaosTarget, frozenset[str], float]:
+        total = sum(item[3] for item in menu)
+        if total <= 0:
+            return self._rng.choice(menu)
+        r = self._rng.random() * total
+        acc = 0.0
+        for item in menu:
+            acc += item[3]
+            if r <= acc:
+                return item
+        return menu[-1]
+
+    def tick(self) -> int:
+        """One scheduling tick: break up to a random ``cap`` faults. Returns how many were injected."""
+        with self._cfg_lock:
+            cap = self._rng.randint(1, self._max_per_tick)
+        added = 0
+        while added < cap:
+            menu = self._menu()
+            if not menu:
+                break
+            nemesis_type, target, racks, _weight = self._weighted_choice(menu)
+            recovery = self._recovery_sec_for(nemesis_type)
+            if recovery is None:
+                recovery = self._default_recovery_sec
+            # With a recovery probe, hold the budget (recovery_sec=None) until the fault is
+            # observed recovered; the probe releases by fact. Tablets (empty footprint), a disabled
+            # (fail-open) guard, and the probe-less path fall back to the timer so budget never sticks.
+            use_probe = self._recovery_probe is not None and bool(racks) and self._guard.enabled
+            lease = self._guard.reserve(
+                racks,
+                recovery_sec=None if use_probe else recovery,
+                identity_key=target.identity_key(),
+            )
+            if lease is None:
+                break
+            for cmd in self._plan_inject(nemesis_type, target):
+                self._dispatch(cmd)
+            if use_probe:
+                self._recovery_probe.track(lease, target, nemesis_type, timeout_sec=recovery)
+            added += 1
+        return added
+
+    # -- loop ---------------------------------------------------------------
+
+    def _sleep_seconds(self) -> float:
+        with self._cfg_lock:
+            base, jitter = self._base_interval, self._jitter
+        return max(0.5, base * (1.0 + self._rng.uniform(-jitter, jitter)))
+
+    def _run(self) -> None:
+        logger.info(
+            "WeightedNemesisScheduler started: %d type(s), base=%.1fs jitter=%.2f max_per_tick=%d",
+            len(self._enabled), self._base_interval, self._jitter, self._max_per_tick,
+        )
+        while not self._stop.is_set():
+            try:
+                self.tick()
+            except Exception:
+                logger.exception("weighted scheduler tick raised")
+            self._stop.wait(self._sleep_seconds())
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        if self._recovery_probe is not None:
+            self._recovery_probe.start()
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        t = self._thread
+        if t and t.is_alive() and t is not threading.current_thread():
+            t.join(timeout=2.0)
+        if self._recovery_probe is not None:
+            self._recovery_probe.stop()
+
+
+__all__ = ["WeightedNemesisScheduler", "default_enabled_types"]

--- a/ydb/tests/stability/nemesis/routers/agent_router.py
+++ b/ydb/tests/stability/nemesis/routers/agent_router.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from flask import Blueprint, request, jsonify
 
@@ -42,6 +43,32 @@ def create_process_helper(
         payload=payload,
     )
     return {"status": "started"}
+
+
+def wait_for_local_processes(timeout: float = 20.0, poll_interval: float = 0.2) -> int:
+    """Block until locally-started actions finish; return how many are still running.
+
+    Actions run in daemon threads, which the interpreter kills on shutdown — that would drop the
+    teardown extracts for targets on this host.
+    """
+    deadline = time.monotonic() + float(timeout)
+
+    def _running() -> int:
+        return sum(1 for row in manager.get_all() if row.get("status") == "running")
+
+    pending = _running()
+    if not pending:
+        return 0
+    logger.info("waiting up to %.0fs for %d local nemesis action(s) to finish", timeout, pending)
+    while time.monotonic() < deadline:
+        pending = _running()
+        if not pending:
+            return 0
+        time.sleep(poll_interval)
+    pending = _running()
+    if pending:
+        logger.warning("%d local nemesis action(s) still running after %.0fs", pending, timeout)
+    return pending
 
 
 def start_warden_checks_helper():

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -17,7 +17,10 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     nemesis_types_flat_for_api,
     nemesis_types_grouped_for_api,
     recovery_sec_for,
+    target_kind_for,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
 import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 
@@ -35,6 +38,7 @@ orchestrator_warden_checker: OrchestratorWardenChecker | None = None
 nemesis_schedule: OrchestratorNemesisSchedule | None = None
 chaos_store: ChaosOrchestratorStore | None = None
 failure_guard: FailureModelGuard | None = None
+cluster_inventory: ClusterInventory | None = None
 healthcheck_reporter: Any = None
 
 
@@ -123,16 +127,46 @@ def create_host_process():
     host = data.get("host")
     action = data.get("action", "inject")
     force = bool(data.get("force", False))
+    target_data = data.get("target")
 
     if not process_type:
         return jsonify({"status": "error", "message": "Missing type field"}), 400
-    if not host:
-        return jsonify({"status": "error", "message": "Missing host field"}), 400
+    if not host and not target_data:
+        return jsonify({"status": "error", "message": "Missing host or target field"}), 400
 
     if process_type not in NEMESIS_TYPES:
         return jsonify({"status": "error", "message": "Invalid process type"}), 400
-    if host not in hosts:
+
+    try:
+        chaos_target = ChaosTarget.from_host_or_dict(host, target_data)
+    except ValueError as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+
+    # Expand bare host → concrete entity via inventory when target_kind needs it.
+    if target_data is None and cluster_inventory is not None:
+        kind = target_kind_for(process_type)
+        if kind is not TargetKind.HOST:
+            matching = [t for t in cluster_inventory.entities(kind) if t.host == chaos_target.host]
+            if len(matching) == 1:
+                chaos_target = matching[0]
+            elif len(matching) > 1:
+                return jsonify(
+                    {
+                        "status": "error",
+                        "message": (
+                            f"Host {chaos_target.host} has {len(matching)} {kind.value} "
+                            f"entities; pass an explicit target (node_id / slot_idx / …)."
+                        ),
+                    }
+                ), 400
+            elif kind is TargetKind.TABLET:
+                control = cluster_inventory.control_host()
+                if control:
+                    chaos_target = ChaosTarget.for_tablet(control)
+
+    if chaos_target.host not in hosts:
         return jsonify({"status": "error", "message": "Invalid host"}), 400
+    host = chaos_target.host
 
     if nemesis_schedule.is_schedule_enabled(process_type):
         return jsonify(
@@ -143,13 +177,10 @@ def create_host_process():
         ), 400
 
     try:
-        if process_type not in NEMESIS_TYPES:
-            return jsonify(
-                {"status": "error", "message": "Only orchestrator-planned nemesis types are supported"}
-            ), 400
         if chaos_store is None:
             return jsonify({"status": "error", "message": "Chaos store not initialized"}), 500
-        # Failure-model veto for manual inject of FULL-mode types (override with force=True).
+        # Plan-time safety for FULL-mode manual inject (no dispatch veto).
+        # force=True skips the filter check.
         if (
             not force
             and action == "inject"
@@ -158,13 +189,16 @@ def create_host_process():
             and guard_mode_for(process_type) is GuardMode.FULL
         ):
             scope = impact_scope_for(process_type)
-            if not failure_guard.can_inject(host, scope):
+            safe = failure_guard.filter_safe([chaos_target], scope)
+            if not safe:
                 return jsonify(
                     {
                         "status": "error",
                         "message": (
-                            f"VETOED by failure model: injecting {process_type} on {host} "
-                            f"would exceed the cluster's fault tolerance. Retry with force=true to override."
+                            f"Rejected by failure model: injecting {process_type} on "
+                            f"{chaos_target.identity_key()} would exceed the cluster's fault "
+                            f"tolerance (kind={target_kind_for(process_type).value}). "
+                            f"Retry with force=true to override."
                         ),
                     }
                 ), 409
@@ -174,6 +208,18 @@ def create_host_process():
             return jsonify(
                 {"status": "error", "message": "Could not plan manual execution for this type/action"}
             ), 400
+        # Prefer the explicit ChaosTarget from the request on planned commands.
+        cmds = [
+            type(c)(
+                execution_id=c.execution_id,
+                scenario_id=c.scenario_id,
+                nemesis_type=c.nemesis_type,
+                action=c.action,
+                target=chaos_target,
+                payload=c.payload,
+            )
+            for c in cmds
+        ]
         record_scope = impact_scope_for(process_type) if failure_guard is not None else None
         for cmd in cmds:
             nemesis_schedule.dispatch_command(cmd, track_history=False)
@@ -183,11 +229,11 @@ def create_host_process():
                 and guard_mode_for(process_type) is GuardMode.FULL
             ):
                 if cmd.action == "extract":
-                    failure_guard.record_extract(cmd.execution_id, cmd.host, record_scope)
+                    failure_guard.record_extract(cmd.execution_id, cmd.target, record_scope)
                 elif cmd.action == "inject":
                     failure_guard.record_inject(
                         cmd.execution_id,
-                        cmd.host,
+                        cmd.target,
                         record_scope,
                         recovery_sec=recovery_sec_for(cmd.nemesis_type),
                     )
@@ -199,6 +245,7 @@ def create_host_process():
                         "execution_id": c.execution_id,
                         "scenario_id": c.scenario_id,
                         "host": c.host,
+                        "target": c.target.to_dict(),
                         "action": c.action,
                     }
                     for c in cmds
@@ -219,6 +266,47 @@ def get_process_types():
 def get_process_types_grouped():
     """Return process types grouped by category with descriptions (from catalog NEMESIS_UI_GROUPS)."""
     return jsonify(nemesis_types_grouped_for_api())
+
+
+@blueprint.route("/api/inventory", methods=["GET"])
+def get_cluster_inventory():
+    """Return host/node/slot inventory used for ChaosTarget planning."""
+    if cluster_inventory is None:
+        return jsonify(
+            {
+                "hosts": list(hosts),
+                "nodes": [],
+                "slots": [],
+            }
+        )
+    return jsonify(
+        {
+            "hosts": cluster_inventory.hosts,
+            "nodes": [
+                {
+                    "node_id": n.node_id,
+                    "host": n.host,
+                    "ic_port": n.ic_port,
+                    "rack": n.rack,
+                    "datacenter": n.datacenter,
+                    "bridge_pile_id": n.bridge_pile_id,
+                }
+                for n in cluster_inventory.nodes.values()
+            ],
+            "slots": [
+                {
+                    "slot_idx": s.slot_idx,
+                    "host": s.host,
+                    "ic_port": s.ic_port,
+                    "node_id": s.node_id,
+                    "rack": s.rack,
+                    "datacenter": s.datacenter,
+                    "bridge_pile_id": s.bridge_pile_id,
+                }
+                for s in cluster_inventory.slots.values()
+            ],
+        }
+    )
 
 
 @blueprint.route("/api/hosts/health", methods=["GET"])

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -168,6 +168,9 @@ def create_host_process():
         return jsonify({"status": "error", "message": "Invalid host"}), 400
     host = chaos_target.host
 
+    if nemesis_schedule is None:
+        return jsonify({"status": "error", "message": "Schedule not initialized"}), 500
+
     if nemesis_schedule.is_schedule_enabled(process_type):
         return jsonify(
             {

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -12,9 +12,13 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.schedule_loop imp
 from ydb.tests.stability.nemesis.internal.orchestrator.orchestrator_warden_checker import OrchestratorWardenChecker
 from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     NEMESIS_TYPES,
+    guard_mode_for,
+    impact_scope_for,
     nemesis_types_flat_for_api,
     nemesis_types_grouped_for_api,
+    recovery_sec_for,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
 import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 
 
@@ -30,6 +34,7 @@ mon_port = 8765  # Default monitoring port
 orchestrator_warden_checker: OrchestratorWardenChecker | None = None
 nemesis_schedule: OrchestratorNemesisSchedule | None = None
 chaos_store: ChaosOrchestratorStore | None = None
+failure_guard: FailureModelGuard | None = None
 healthcheck_reporter: Any = None
 
 
@@ -117,6 +122,7 @@ def create_host_process():
     process_type = data.get("type")
     host = data.get("host")
     action = data.get("action", "inject")
+    force = bool(data.get("force", False))
 
     if not process_type:
         return jsonify({"status": "error", "message": "Missing type field"}), 400
@@ -143,13 +149,48 @@ def create_host_process():
             ), 400
         if chaos_store is None:
             return jsonify({"status": "error", "message": "Chaos store not initialized"}), 500
+        # Failure-model veto for manual inject of FULL-mode types (override with force=True).
+        if (
+            not force
+            and action == "inject"
+            and failure_guard is not None
+            and failure_guard.enabled
+            and guard_mode_for(process_type) is GuardMode.FULL
+        ):
+            scope = impact_scope_for(process_type)
+            if not failure_guard.can_inject(host, scope):
+                return jsonify(
+                    {
+                        "status": "error",
+                        "message": (
+                            f"VETOED by failure model: injecting {process_type} on {host} "
+                            f"would exceed the cluster's fault tolerance. Retry with force=true to override."
+                        ),
+                    }
+                ), 409
+
         cmds = chaos_store.plan_manual(process_type, host, action)
         if not cmds:
             return jsonify(
                 {"status": "error", "message": "Could not plan manual execution for this type/action"}
             ), 400
+        record_scope = impact_scope_for(process_type) if failure_guard is not None else None
         for cmd in cmds:
             nemesis_schedule.dispatch_command(cmd, track_history=False)
+            if (
+                failure_guard is not None
+                and failure_guard.enabled
+                and guard_mode_for(process_type) is GuardMode.FULL
+            ):
+                if cmd.action == "extract":
+                    failure_guard.record_extract(cmd.execution_id, cmd.host, record_scope)
+                elif cmd.action == "inject":
+                    failure_guard.record_inject(
+                        cmd.execution_id,
+                        cmd.host,
+                        record_scope,
+                        recovery_sec=recovery_sec_for(cmd.nemesis_type),
+                    )
         return jsonify(
             {
                 "status": "ok",

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -19,10 +19,14 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     recovery_sec_for,
     target_kind_for,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_problems import ChaosProblemStore
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import BoundaryNemesisScheduler
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import (
+    BoundaryNemesisScheduler,
+    default_enabled_types,
+)
 import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 
 
@@ -41,6 +45,7 @@ nemesis_scheduler: BoundaryNemesisScheduler | None = None
 chaos_store: ChaosOrchestratorStore | None = None
 failure_guard: FailureModelGuard | None = None
 cluster_inventory: ClusterInventory | None = None
+chaos_problems: ChaosProblemStore | None = None
 healthcheck_reporter: Any = None
 
 
@@ -190,7 +195,6 @@ def create_host_process():
             not force
             and action == "inject"
             and failure_guard is not None
-            and failure_guard.enabled
             and guard_mode_for(process_type) is GuardMode.FULL
         ):
             scope = impact_scope_for(process_type)
@@ -228,11 +232,7 @@ def create_host_process():
         record_scope = impact_scope_for(process_type) if failure_guard is not None else None
         for cmd in cmds:
             nemesis_schedule.dispatch_command(cmd, track_history=False)
-            if (
-                failure_guard is not None
-                and failure_guard.enabled
-                and guard_mode_for(process_type) is GuardMode.FULL
-            ):
+            if failure_guard is not None and guard_mode_for(process_type) is GuardMode.FULL:
                 if cmd.action == "extract":
                     failure_guard.record_extract(cmd.execution_id, cmd.target, record_scope)
                 elif cmd.action == "inject":
@@ -437,13 +437,61 @@ def get_scheduler():
     return jsonify(_scheduler_state())
 
 
+def _validated_profile(data: dict) -> tuple[dict, str | None]:
+    """Parse/validate a scheduler profile from a request body.
+
+    Returns ``(profile, error)``. Anything malformed is rejected instead of silently degrading
+    the run: an unknown type name would just never be offered, and a bare string in ``enabled``
+    would be split into single-character "types".
+    """
+    profile: dict = {}
+
+    if "enabled" in data:
+        enabled = data["enabled"]
+        if isinstance(enabled, str) or not isinstance(enabled, (list, tuple)):
+            return {}, "'enabled' must be a list of nemesis type names"
+        names = [str(t) for t in enabled]
+        unknown = [t for t in names if t not in NEMESIS_TYPES]
+        if unknown:
+            return {}, (
+                f"unknown nemesis type(s): {', '.join(sorted(unknown))}. "
+                f"See GET /api/process_types; default profile: {', '.join(default_enabled_types())}"
+            )
+        profile["enabled"] = names
+
+    for key, lo, hi in (("base_interval", 0.5, 86400.0), ("jitter", 0.0, 1.0)):
+        if key in data:
+            try:
+                value = float(data[key])
+            except (TypeError, ValueError):
+                return {}, f"'{key}' must be a number"
+            if not lo <= value <= hi:
+                return {}, f"'{key}' must be between {lo} and {hi}"
+            profile[key] = value
+
+    if "max_per_tick" in data:
+        try:
+            cap = int(data["max_per_tick"])
+        except (TypeError, ValueError):
+            return {}, "'max_per_tick' must be an integer"
+        if not 1 <= cap <= 100:
+            return {}, "'max_per_tick' must be between 1 and 100"
+        profile["max_per_tick"] = cap
+
+    unknown_keys = sorted(set(data) - {"enabled", "base_interval", "jitter", "max_per_tick"})
+    if unknown_keys:
+        return {}, f"unknown profile field(s): {', '.join(unknown_keys)}"
+
+    return profile, None
+
+
 @blueprint.route("/api/scheduler/start", methods=["POST"])
 def start_scheduler():
     """Apply an optional profile and start the nemesis scheduler.
 
     Body (all optional): ``enabled`` (list of type names), ``base_interval`` (sec),
     ``jitter`` (0..1), ``max_per_tick`` (int). Omitted fields keep their current value;
-    on a fresh scheduler that means the catalog defaults.
+    on a fresh scheduler that means the catalog defaults. Invalid values are rejected with 400.
     """
     if nemesis_scheduler is None:
         return jsonify(
@@ -454,11 +502,9 @@ def start_scheduler():
     if not isinstance(data, dict):
         return jsonify({"status": "error", "message": "Body must be a JSON object"}), 400
 
-    profile = {
-        k: data[k]
-        for k in ("enabled", "base_interval", "jitter", "max_per_tick")
-        if k in data
-    }
+    profile, error = _validated_profile(data)
+    if error is not None:
+        return jsonify({"status": "error", "message": error}), 400
     try:
         if profile:
             nemesis_scheduler.set_profile(**profile)
@@ -475,6 +521,29 @@ def stop_scheduler():
         return jsonify({"status": "ok", "message": "Scheduler not initialized"})
     nemesis_scheduler.stop()
     return jsonify({"status": "ok", "scheduler": _scheduler_state()})
+
+
+@blueprint.route("/api/problems", methods=["GET"])
+def get_chaos_problems():
+    """Nemesis-side problems for the stability test report.
+
+    Faults that never recovered (their failure budget is still held, so the cluster stays degraded
+    and the scheduler quietly does less chaos) and a failure-model guard that failed open.
+    ``ydb/tests/stability/tests`` polls this when disabling nemesis and attaches it to Allure.
+    """
+    problems = chaos_problems.snapshot() if chaos_problems is not None else []
+    payload = {
+        "count": len(problems),
+        "by_kind": chaos_problems.counts_by_kind() if chaos_problems is not None else {},
+        "problems": problems,
+        "guard_enabled": bool(failure_guard is not None and failure_guard.enabled),
+        "scheduler_running": bool(nemesis_scheduler is not None and nemesis_scheduler.running()),
+    }
+    if failure_guard is not None:
+        payload["failure_budget"] = failure_guard.snapshot()
+    if chaos_problems is not None and chaos_problems.dropped:
+        payload["dropped"] = chaos_problems.dropped
+    return jsonify(payload)
 
 
 @blueprint.route("/api/healthcheck", methods=["GET"])

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -22,7 +22,7 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import WeightedNemesisScheduler
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import BoundaryNemesisScheduler
 import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 
 
@@ -37,7 +37,7 @@ hosts: list[str] = []
 mon_port = 8765  # Default monitoring port
 orchestrator_warden_checker: OrchestratorWardenChecker | None = None
 nemesis_schedule: OrchestratorNemesisSchedule | None = None
-weighted_scheduler: WeightedNemesisScheduler | None = None
+nemesis_scheduler: BoundaryNemesisScheduler | None = None
 chaos_store: ChaosOrchestratorStore | None = None
 failure_guard: FailureModelGuard | None = None
 cluster_inventory: ClusterInventory | None = None
@@ -422,10 +422,10 @@ def get_schedule_history():
 
 
 def _scheduler_state() -> dict:
-    """Weighted-scheduler status plus the current failure-budget snapshot."""
-    if weighted_scheduler is None:
+    """Scheduler status plus the current failure-budget snapshot."""
+    if nemesis_scheduler is None:
         return {"available": False}
-    state = {"available": True, **weighted_scheduler.status()}
+    state = {"available": True, **nemesis_scheduler.status()}
     if failure_guard is not None:
         state["failure_budget"] = failure_guard.snapshot()
     return state
@@ -433,21 +433,21 @@ def _scheduler_state() -> dict:
 
 @blueprint.route("/api/scheduler", methods=["GET"])
 def get_scheduler():
-    """Weighted nemesis scheduler status (running, profile, budget, recovery probe)."""
+    """Nemesis scheduler status (running, profile, budget, recovery probe)."""
     return jsonify(_scheduler_state())
 
 
 @blueprint.route("/api/scheduler/start", methods=["POST"])
 def start_scheduler():
-    """Apply an optional profile and start the weighted scheduler.
+    """Apply an optional profile and start the nemesis scheduler.
 
-    Body (all optional): ``enabled`` (list of type names), ``weights`` (name->float),
-    ``base_interval`` (sec), ``jitter`` (0..1), ``max_per_tick`` (int). Omitted fields keep
-    their current value; on a fresh scheduler that means the catalog defaults.
+    Body (all optional): ``enabled`` (list of type names), ``base_interval`` (sec),
+    ``jitter`` (0..1), ``max_per_tick`` (int). Omitted fields keep their current value;
+    on a fresh scheduler that means the catalog defaults.
     """
-    if weighted_scheduler is None:
+    if nemesis_scheduler is None:
         return jsonify(
-            {"status": "error", "message": "Weighted scheduler not initialized (failure model unavailable)"}
+            {"status": "error", "message": "Nemesis scheduler not initialized (failure model unavailable)"}
         ), 500
 
     data = request.get_json(silent=True) or {}
@@ -456,13 +456,13 @@ def start_scheduler():
 
     profile = {
         k: data[k]
-        for k in ("enabled", "weights", "base_interval", "jitter", "max_per_tick")
+        for k in ("enabled", "base_interval", "jitter", "max_per_tick")
         if k in data
     }
     try:
         if profile:
-            weighted_scheduler.set_profile(**profile)
-        weighted_scheduler.start()
+            nemesis_scheduler.set_profile(**profile)
+        nemesis_scheduler.start()
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 400
     return jsonify({"status": "ok", "scheduler": _scheduler_state()})
@@ -470,10 +470,10 @@ def start_scheduler():
 
 @blueprint.route("/api/scheduler/stop", methods=["POST"])
 def stop_scheduler():
-    """Stop the weighted scheduler (and its recovery probe)."""
-    if weighted_scheduler is None:
+    """Stop the nemesis scheduler (and its recovery probe)."""
+    if nemesis_scheduler is None:
         return jsonify({"status": "ok", "message": "Scheduler not initialized"})
-    weighted_scheduler.stop()
+    nemesis_scheduler.stop()
     return jsonify({"status": "ok", "scheduler": _scheduler_state()})
 
 

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -22,6 +22,7 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.cluster_inventory import ClusterInventory
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import FailureModelGuard, GuardMode
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import WeightedNemesisScheduler
 import ydb.tests.stability.nemesis.routers.agent_router as agent_router
 
 
@@ -36,6 +37,7 @@ hosts: list[str] = []
 mon_port = 8765  # Default monitoring port
 orchestrator_warden_checker: OrchestratorWardenChecker | None = None
 nemesis_schedule: OrchestratorNemesisSchedule | None = None
+weighted_scheduler: WeightedNemesisScheduler | None = None
 chaos_store: ChaosOrchestratorStore | None = None
 failure_guard: FailureModelGuard | None = None
 cluster_inventory: ClusterInventory | None = None
@@ -417,6 +419,62 @@ def get_schedule():
 def get_schedule_history():
     """Return last scheduled executions"""
     return jsonify(nemesis_schedule.recent_history(15))
+
+
+def _scheduler_state() -> dict:
+    """Weighted-scheduler status plus the current failure-budget snapshot."""
+    if weighted_scheduler is None:
+        return {"available": False}
+    state = {"available": True, **weighted_scheduler.status()}
+    if failure_guard is not None:
+        state["failure_budget"] = failure_guard.snapshot()
+    return state
+
+
+@blueprint.route("/api/scheduler", methods=["GET"])
+def get_scheduler():
+    """Weighted nemesis scheduler status (running, profile, budget, recovery probe)."""
+    return jsonify(_scheduler_state())
+
+
+@blueprint.route("/api/scheduler/start", methods=["POST"])
+def start_scheduler():
+    """Apply an optional profile and start the weighted scheduler.
+
+    Body (all optional): ``enabled`` (list of type names), ``weights`` (name->float),
+    ``base_interval`` (sec), ``jitter`` (0..1), ``max_per_tick`` (int). Omitted fields keep
+    their current value; on a fresh scheduler that means the catalog defaults.
+    """
+    if weighted_scheduler is None:
+        return jsonify(
+            {"status": "error", "message": "Weighted scheduler not initialized (failure model unavailable)"}
+        ), 500
+
+    data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({"status": "error", "message": "Body must be a JSON object"}), 400
+
+    profile = {
+        k: data[k]
+        for k in ("enabled", "weights", "base_interval", "jitter", "max_per_tick")
+        if k in data
+    }
+    try:
+        if profile:
+            weighted_scheduler.set_profile(**profile)
+        weighted_scheduler.start()
+    except Exception as e:
+        return jsonify({"status": "error", "message": str(e)}), 400
+    return jsonify({"status": "ok", "scheduler": _scheduler_state()})
+
+
+@blueprint.route("/api/scheduler/stop", methods=["POST"])
+def stop_scheduler():
+    """Stop the weighted scheduler (and its recovery probe)."""
+    if weighted_scheduler is None:
+        return jsonify({"status": "ok", "message": "Scheduler not initialized"})
+    weighted_scheduler.stop()
+    return jsonify({"status": "ok", "scheduler": _scheduler_state()})
 
 
 @blueprint.route("/api/healthcheck", methods=["GET"])

--- a/ydb/tests/stability/nemesis/routers/orchestrator_router.py
+++ b/ydb/tests/stability/nemesis/routers/orchestrator_router.py
@@ -14,9 +14,10 @@ from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     NEMESIS_TYPES,
     guard_mode_for,
     impact_scope_for,
+    impairment_hold_sec_for,
     nemesis_types_flat_for_api,
     nemesis_types_grouped_for_api,
-    recovery_sec_for,
+    supports_boundary_scheduler,
     target_kind_for,
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_problems import ChaosProblemStore
@@ -149,7 +150,7 @@ def create_host_process():
     except ValueError as e:
         return jsonify({"status": "error", "message": str(e)}), 400
 
-    # Expand bare host → concrete entity via inventory when target_kind needs it.
+    # Expand a bare host into a concrete entity when the type needs one.
     if target_data is None and cluster_inventory is not None:
         kind = target_kind_for(process_type)
         if kind is not TargetKind.HOST:
@@ -189,8 +190,7 @@ def create_host_process():
     try:
         if chaos_store is None:
             return jsonify({"status": "error", "message": "Chaos store not initialized"}), 500
-        # Plan-time safety for FULL-mode manual inject (no dispatch veto).
-        # force=True skips the filter check.
+        # Plan-time safety for a FULL-mode manual inject; force=true skips it.
         if (
             not force
             and action == "inject"
@@ -217,7 +217,7 @@ def create_host_process():
             return jsonify(
                 {"status": "error", "message": "Could not plan manual execution for this type/action"}
             ), 400
-        # Prefer the explicit ChaosTarget from the request on planned commands.
+        # Prefer the request's ChaosTarget over whatever the planner picked.
         cmds = [
             type(c)(
                 execution_id=c.execution_id,
@@ -240,7 +240,10 @@ def create_host_process():
                         cmd.execution_id,
                         cmd.target,
                         record_scope,
-                        recovery_sec=recovery_sec_for(cmd.nemesis_type),
+                        # Paired by the operator, so a toggle holds its budget until that extract.
+                        recovery_sec=impairment_hold_sec_for(
+                            cmd.nemesis_type, paired_extract=True
+                        ),
                     )
         return jsonify(
             {
@@ -275,7 +278,7 @@ def get_process_types_grouped():
 
 @blueprint.route("/api/inventory", methods=["GET"])
 def get_cluster_inventory():
-    """Return host/node/slot inventory used for ChaosTarget planning."""
+    """Host/node/slot inventory used for planning."""
     if cluster_inventory is None:
         return jsonify(
             {
@@ -422,7 +425,7 @@ def get_schedule_history():
 
 
 def _scheduler_state() -> dict:
-    """Scheduler status plus the current failure-budget snapshot."""
+    """Scheduler status plus the failure-budget snapshot."""
     if nemesis_scheduler is None:
         return {"available": False}
     state = {"available": True, **nemesis_scheduler.status()}
@@ -438,12 +441,9 @@ def get_scheduler():
 
 
 def _validated_profile(data: dict) -> tuple[dict, str | None]:
-    """Parse/validate a scheduler profile from a request body.
-
-    Returns ``(profile, error)``. Anything malformed is rejected instead of silently degrading
-    the run: an unknown type name would just never be offered, and a bare string in ``enabled``
-    would be split into single-character "types".
-    """
+    """``(profile, error)`` from a request body. Malformed input is rejected, not silently ignored:
+    an unknown type would simply never fire, and a bare string in ``enabled`` would be split into
+    single-character "types"."""
     profile: dict = {}
 
     if "enabled" in data:
@@ -456,6 +456,13 @@ def _validated_profile(data: dict) -> tuple[dict, str | None]:
             return {}, (
                 f"unknown nemesis type(s): {', '.join(sorted(unknown))}. "
                 f"See GET /api/process_types; default profile: {', '.join(default_enabled_types())}"
+            )
+        unsupported = [t for t in names if not supports_boundary_scheduler(t)]
+        if unsupported:
+            return {}, (
+                f"type(s) not usable by the boundary scheduler: {', '.join(sorted(unsupported))}. "
+                f"Their planners keep their own target state, so they would inject somewhere other "
+                f"than the target the guard reserved. Run them through the per-type schedule instead."
             )
         profile["enabled"] = names
 
@@ -487,15 +494,14 @@ def _validated_profile(data: dict) -> tuple[dict, str | None]:
 
 @blueprint.route("/api/scheduler/start", methods=["POST"])
 def start_scheduler():
-    """Apply an optional profile and start the nemesis scheduler.
+    """Apply an optional profile and start the scheduler.
 
-    Body (all optional): ``enabled`` (list of type names), ``base_interval`` (sec),
-    ``jitter`` (0..1), ``max_per_tick`` (int). Omitted fields keep their current value;
-    on a fresh scheduler that means the catalog defaults. Invalid values are rejected with 400.
+    Body (all optional): ``enabled``, ``base_interval``, ``jitter``, ``max_per_tick``. Omitted fields
+    keep their current value; invalid ones are rejected with 400.
     """
     if nemesis_scheduler is None:
         return jsonify(
-            {"status": "error", "message": "Nemesis scheduler not initialized (failure model unavailable)"}
+            {"status": "error", "message": "Nemesis scheduler not initialized (orchestrator startup did not complete)"}
         ), 500
 
     data = request.get_json(silent=True) or {}
@@ -525,12 +531,7 @@ def stop_scheduler():
 
 @blueprint.route("/api/problems", methods=["GET"])
 def get_chaos_problems():
-    """Nemesis-side problems for the stability test report.
-
-    Faults that never recovered (their failure budget is still held, so the cluster stays degraded
-    and the scheduler quietly does less chaos) and a failure-model guard that failed open.
-    ``ydb/tests/stability/tests`` polls this when disabling nemesis and attaches it to Allure.
-    """
+    """Chaos-side problems for the stability test report: stuck faults, degraded inventory."""
     problems = chaos_problems.snapshot() if chaos_problems is not None else []
     payload = {
         "count": len(problems),

--- a/ydb/tests/stability/nemesis/static/HostProcessItem.js
+++ b/ydb/tests/stability/nemesis/static/HostProcessItem.js
@@ -2,7 +2,15 @@ export default {
   props: {
     host: String,
     processes: Array,
-    isScheduled: Boolean
+    isScheduled: Boolean,
+    targetKind: {
+      type: String,
+      default: 'host'
+    },
+    entities: {
+      type: Array,
+      default: () => []
+    }
   },
   setup(props) {
     const { computed } = Vue
@@ -17,18 +25,34 @@ export default {
       return props.processes.slice(1)
     })
 
+    const showEntityButtons = computed(() => {
+      return ['node', 'slot', 'disk'].includes(props.targetKind) && props.entities.length > 0
+    })
+
+    function entityLabel(entity) {
+      if (props.targetKind === 'slot') {
+        const port = entity.ic_port != null ? ` ic=${entity.ic_port}` : ''
+        return `slot ${entity.slot_idx}${port}`
+      }
+      const port = entity.ic_port != null ? ` ic=${entity.ic_port}` : ''
+      return `node ${entity.node_id}${port}`
+    }
+
     return {
       latestProcess,
-      previousProcesses
+      previousProcesses,
+      showEntityButtons,
+      entityLabel
     }
   },
-  emits: ['run-process'],
+  emits: ['run-process', 'run-target'],
   template: `
     <details class="collapse collapse-arrow bg-base-200 mb-2">
       <summary class="collapse-title font-medium flex justify-between items-center pr-12">
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 flex-wrap">
           <span class="font-mono font-bold">{{ host }}</span>
-          <div class="tooltip tooltip-right" :data-tip="isScheduled ? 'Disable scheduling to run manually' : 'Run nemesis on this host'">
+          <span class="badge badge-ghost badge-xs">{{ targetKind }}</span>
+          <div v-if="!showEntityButtons" class="tooltip tooltip-right" :data-tip="isScheduled ? 'Disable scheduling to run manually' : 'Run nemesis on this host'">
             <button
               class="btn btn-xs z-10"
               :class="isScheduled ? 'btn-disabled' : 'btn-primary'"
@@ -38,6 +62,18 @@ export default {
               Run
             </button>
           </div>
+          <template v-else>
+            <button
+              v-for="entity in entities"
+              :key="entityLabel(entity)"
+              class="btn btn-xs z-10"
+              :class="isScheduled ? 'btn-disabled' : 'btn-primary'"
+              :disabled="isScheduled"
+              @click.stop="$emit('run-target', entity)"
+            >
+              Run {{ entityLabel(entity) }}
+            </button>
+          </template>
         </div>
         
         <div v-if="latestProcess" class="flex items-center gap-4">
@@ -58,7 +94,6 @@ export default {
       
       <div class="collapse-content">
         <div v-if="latestProcess" class="pt-4">
-          <!-- Latest Run Details -->
           <div class="mb-4">
             <h3 class="font-bold text-sm mb-2">Latest Run (#{{ latestProcess.id }})</h3>
             <div class="font-mono bg-base-300 p-2 rounded text-xs mb-2 break-all">
@@ -70,7 +105,6 @@ export default {
             </div>
           </div>
 
-          <!-- Previous Runs -->
           <div v-if="previousProcesses.length > 0">
             <div class="divider text-xs">Previous Runs</div>
             <div class="overflow-x-auto">

--- a/ydb/tests/stability/nemesis/static/NemesisGroupAccordion.js
+++ b/ydb/tests/stability/nemesis/static/NemesisGroupAccordion.js
@@ -11,7 +11,8 @@ export default {
     hosts: Object,
     processes: Object,
     scheduleStatus: Object, // Schedule status for all nemesis types
-    processTypes: Array // All process types with their configurations
+    processTypes: Array, // All process types with their configurations
+    inventory: Object
   },
   setup(props) {
     const { ref, computed } = Vue
@@ -101,6 +102,7 @@ export default {
           :processes="getProcessesByType(nemesis.name)"
           :schedule-status="scheduleStatus"
           :process-types="processTypes"
+          :inventory="inventory"
         ></process-type-group>
       </div>
     </div>

--- a/ydb/tests/stability/nemesis/static/ProcessTypeGroup.js
+++ b/ydb/tests/stability/nemesis/static/ProcessTypeGroup.js
@@ -10,7 +10,8 @@ export default {
     hosts: Object, // { hostName: hostData }
     processes: Object, // { hostName: [ProcessInfo] }
     scheduleStatus: Object, // Schedule status for all nemesis types
-    processTypes: Array // All process types with their configurations
+    processTypes: Array, // All process types with their configurations
+    inventory: Object // { hosts, nodes, slots }
   },
   setup(props) {
     const { ref, computed, reactive, watch } = Vue
@@ -31,6 +32,13 @@ export default {
       return props.processTypes.find(pt => pt.name === props.type) || {}
     })
 
+    const targetKind = computed(() => processTypeEntry.value.target_kind || 'host')
+
+    const supportsManual = computed(() => {
+      // Default true when field absent (older API); explicit false hides host/node Run UI.
+      return processTypeEntry.value.supports_manual !== false
+    })
+
     // Get default interval from process types
     const defaultInterval = computed(() => {
       return processTypeEntry.value.schedule || 60
@@ -42,6 +50,17 @@ export default {
     })
 
     const hasParams = computed(() => paramSchema.value.length > 0)
+
+    function entitiesForHost(host) {
+      const inv = props.inventory || {}
+      if (targetKind.value === 'slot') {
+        return (inv.slots || []).filter(s => s.host === host)
+      }
+      if (targetKind.value === 'node' || targetKind.value === 'disk') {
+        return (inv.nodes || []).filter(n => n.host === host)
+      }
+      return []
+    }
 
     const PARAMS_STORAGE_KEY = 'nemesis:last-run-params'
 
@@ -186,6 +205,24 @@ export default {
         })
     }
 
+    function runTarget(entity) {
+      const kind = targetKind.value
+      const target = {
+        kind: kind === 'disk' ? 'disk' : kind,
+        host: entity.host,
+        node_id: entity.node_id ?? null,
+        ic_port: entity.ic_port ?? null,
+        slot_idx: entity.slot_idx ?? null
+      }
+      axios.post('/api/hosts/process', { host: entity.host, type: props.type, target })
+        .then(() => {
+          console.log(`Started process ${props.type} target=`, target)
+        })
+        .catch(err => {
+          console.error(`Failed to start process ${props.type}`, err)
+        })
+    }
+
     function getProcessesByTypeAndHost(host) {
       const hostProcs = props.processes[host] || []
       return hostProcs
@@ -201,11 +238,15 @@ export default {
       hasParams,
       showParamsModal,
       paramValues,
+      targetKind,
+      supportsManual,
+      entitiesForHost,
       openRunModal,
       cancelRunModal,
       submitParamsModal,
       stopSchedule,
       runProcess,
+      runTarget,
       getProcessesByTypeAndHost
     }
   },
@@ -216,6 +257,7 @@ export default {
           <div class="flex-1">
             <div class="flex items-center gap-3">
               <h2 class="text-xl font-bold">{{ type }}</h2>
+              <span class="badge badge-outline badge-sm">{{ targetKind }}</span>
               
               <div class="flex items-center gap-2">
                 <label class="text-sm">Interval (sec):</label>
@@ -329,15 +371,21 @@ export default {
       </teleport>
 
       <div class="collapse-content">
-        <div class="pt-4">
+        <div v-if="supportsManual" class="pt-4">
           <host-process-item
             v-for="(hostData, host) in hosts"
             :key="host"
             :host="host"
             :processes="getProcessesByTypeAndHost(host)"
             :is-scheduled="isEnabled"
+            :target-kind="targetKind"
+            :entities="entitiesForHost(host)"
             @run-process="runProcess"
+            @run-target="runTarget"
           ></host-process-item>
+        </div>
+        <div v-else class="pt-4 text-sm text-base-content/60">
+          Manual host/node inject is not available for this nemesis (schedule only).
         </div>
       </div>
     </details>

--- a/ydb/tests/stability/nemesis/static/SchedulerCard.js
+++ b/ydb/tests/stability/nemesis/static/SchedulerCard.js
@@ -1,9 +1,7 @@
 /**
- * Boundary-walking scheduler: run state, failure-model budget, recovery probe and the
- * nemesis-side problem list (GET /api/scheduler + GET /api/problems).
- *
- * This is the thing that actually drives scheduled chaos — the per-type schedule toggles in the
- * accordion belong to the legacy per-type loop.
+ * Scheduler state, failure budget, recovery probe and problems
+ * (GET /api/scheduler + GET /api/problems). This drives scheduled chaos; the per-type toggles in
+ * the accordion belong to the legacy loop.
  */
 export default {
   props: {
@@ -101,7 +99,7 @@ export default {
         </div>
 
         <div v-if="!available" class="text-sm opacity-60 pt-2">
-          Scheduler not initialized (failure model unavailable).
+          Scheduler not initialized — orchestrator startup did not complete.
         </div>
 
         <div v-else class="space-y-3 pt-2">

--- a/ydb/tests/stability/nemesis/static/SchedulerCard.js
+++ b/ydb/tests/stability/nemesis/static/SchedulerCard.js
@@ -1,0 +1,201 @@
+/**
+ * Boundary-walking scheduler: run state, failure-model budget, recovery probe and the
+ * nemesis-side problem list (GET /api/scheduler + GET /api/problems).
+ *
+ * This is the thing that actually drives scheduled chaos — the per-type schedule toggles in the
+ * accordion belong to the legacy per-type loop.
+ */
+export default {
+  props: {
+    scheduler: Object, // GET /api/scheduler payload
+    problems: Object,  // GET /api/problems payload
+    isBusy: Boolean
+  },
+  emits: ['start', 'stop'],
+  setup(props, { emit }) {
+    const { computed, ref } = Vue
+
+    const showTypes = ref(false)
+    const showProblems = ref(true)
+
+    const available = computed(() => props.scheduler?.available === true)
+    const running = computed(() => props.scheduler?.running === true)
+
+    const state = computed(() => {
+      if (!available.value) return 'unavailable'
+      return running.value ? 'running' : 'stopped'
+    })
+
+    const stateBadgeClass = computed(() => {
+      switch (state.value) {
+        case 'running': return 'badge-success'
+        case 'stopped': return 'badge-ghost'
+        default: return 'badge-error'
+      }
+    })
+
+    const enabledTypes = computed(() => props.scheduler?.enabled_types || [])
+    const budget = computed(() => props.scheduler?.failure_budget || {})
+    const probe = computed(() => props.scheduler?.recovery_probe || null)
+
+    const intervalText = computed(() => {
+      const base = props.scheduler?.base_interval
+      const jitter = props.scheduler?.jitter
+      if (base == null) return '-'
+      if (!jitter) return `${base}s`
+      return `${base}s ±${Math.round(jitter * 100)}%`
+    })
+
+    const impairedDomains = computed(() => budget.value.impaired_racks || [])
+
+    const slotsText = computed(() => {
+      const used = budget.value.impaired_slots
+      const max = budget.value.max_slots
+      if (used == null) return '-'
+      return max ? `${used}/${max}` : `${used} (unbounded)`
+    })
+
+    const problemList = computed(() => props.problems?.problems || [])
+    const problemsByKind = computed(() => props.problems?.by_kind || {})
+
+    function problemBadgeClass(kind) {
+      return kind === 'stuck_fault' ? 'badge-error' : 'badge-warning'
+    }
+
+    return {
+      available,
+      running,
+      state,
+      stateBadgeClass,
+      enabledTypes,
+      budget,
+      probe,
+      intervalText,
+      impairedDomains,
+      slotsText,
+      problemList,
+      problemsByKind,
+      problemBadgeClass,
+      showTypes,
+      showProblems,
+      start: () => emit('start'),
+      stop: () => emit('stop')
+    }
+  },
+  template: `
+    <div class="card bg-base-100 shadow-md">
+      <div class="card-body p-4">
+        <div class="flex justify-between items-center">
+          <h2 class="card-title text-lg">
+            Nemesis Scheduler
+            <span class="badge" :class="stateBadgeClass">{{ state }}</span>
+          </h2>
+          <div class="flex gap-2">
+            <button class="btn btn-xs btn-primary" :disabled="!available || running || isBusy" @click="start">
+              Start
+            </button>
+            <button class="btn btn-xs" :disabled="!available || !running || isBusy" @click="stop">
+              Stop
+            </button>
+          </div>
+        </div>
+
+        <div v-if="!available" class="text-sm opacity-60 pt-2">
+          Scheduler not initialized (failure model unavailable).
+        </div>
+
+        <div v-else class="space-y-3 pt-2">
+          <!-- Profile -->
+          <div class="grid grid-cols-3 gap-2 text-xs">
+            <div>
+              <div class="opacity-60">Interval</div>
+              <div class="font-mono">{{ intervalText }}</div>
+            </div>
+            <div>
+              <div class="opacity-60">Max faults / tick</div>
+              <div class="font-mono">{{ scheduler.max_per_tick ?? '-' }}</div>
+            </div>
+            <div>
+              <div class="opacity-60">Types</div>
+              <div class="font-mono cursor-pointer link link-hover" @click="showTypes = !showTypes">
+                {{ enabledTypes.length }}
+              </div>
+            </div>
+          </div>
+          <div v-if="showTypes" class="flex flex-wrap gap-1">
+            <span v-for="t in enabledTypes" :key="t" class="badge badge-outline badge-xs font-mono">{{ t }}</span>
+            <span v-if="enabledTypes.length === 0" class="text-xs opacity-50">no types enabled</span>
+          </div>
+
+          <!-- Failure budget -->
+          <div>
+            <h3 class="font-bold text-sm mb-1 flex items-center gap-2">
+              Failure budget
+              <span class="badge badge-sm badge-ghost font-mono">{{ budget.erasure || 'unknown' }}</span>
+            </h3>
+            <div class="grid grid-cols-3 gap-2 text-xs">
+              <div>
+                <div class="opacity-60">Impaired domains</div>
+                <div class="font-mono">{{ impairedDomains.length }}</div>
+              </div>
+              <div>
+                <div class="opacity-60">Slots down</div>
+                <div class="font-mono">{{ slotsText }}</div>
+              </div>
+              <div>
+                <div class="opacity-60">Probe tracked / stuck</div>
+                <div class="font-mono" :class="probe && probe.stuck ? 'text-error' : ''">
+                  {{ probe ? probe.tracked : '-' }} / {{ probe ? probe.stuck : '-' }}
+                </div>
+              </div>
+            </div>
+            <div v-if="impairedDomains.length > 0" class="flex flex-wrap gap-1 pt-1">
+              <span v-for="d in impairedDomains" :key="d" class="badge badge-warning badge-xs font-mono">{{ d }}</span>
+            </div>
+          </div>
+
+          <!-- Problems -->
+          <div>
+            <h3 class="font-bold text-sm mb-1 flex items-center gap-2 cursor-pointer"
+                @click="showProblems = !showProblems">
+              Problems
+              <span class="badge badge-sm" :class="problemList.length ? 'badge-error' : 'badge-success'">
+                {{ problemList.length }}
+              </span>
+              <span v-for="(count, kind) in problemsByKind" :key="kind"
+                    class="badge badge-xs" :class="problemBadgeClass(kind)">
+                {{ kind }}: {{ count }}
+              </span>
+            </h3>
+            <div v-if="showProblems">
+              <div v-if="problemList.length === 0" class="text-xs opacity-50">
+                No stuck faults, guard is doing its job.
+              </div>
+              <div v-else class="overflow-x-auto">
+                <table class="table table-xs w-full">
+                  <thead>
+                    <tr>
+                      <th>Kind</th>
+                      <th>Target</th>
+                      <th>What happened</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(p, idx) in problemList" :key="idx">
+                      <td>
+                        <span class="badge badge-xs" :class="problemBadgeClass(p.kind)">{{ p.kind }}</span>
+                        <span v-if="p.count > 1" class="text-xs opacity-70">x{{ p.count }}</span>
+                      </td>
+                      <td class="font-mono text-xs break-all">{{ p.target || '-' }}</td>
+                      <td class="text-xs">{{ p.summary }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+}

--- a/ydb/tests/stability/nemesis/static/index.html
+++ b/ydb/tests/stability/nemesis/static/index.html
@@ -26,6 +26,7 @@
         :processes="processes"
         :schedule-status="scheduleStatus"
         :process-types="processTypes"
+        :inventory="inventory"
       ></nemesis-group-accordion>
     </div>
 
@@ -69,7 +70,7 @@
                 <tr>
                   <th>Type</th>
                   <th>Action</th>
-                  <th>Host</th>
+                  <th>Target</th>
                   <th>Time</th>
                 </tr>
               </thead>
@@ -81,7 +82,7 @@
                       {{ entry.action }}
                     </span>
                   </td>
-                  <td class="font-mono text-xs">{{ entry.host }}</td>
+                  <td class="font-mono text-xs">{{ formatTarget(entry) }}</td>
                   <td class="text-xs opacity-70">{{ new Date(entry.timestamp).toLocaleTimeString() }}</td>
                 </tr>
                 <tr v-if="scheduleHistory.length === 0">
@@ -124,6 +125,7 @@
       const scheduleStatus = ref({}) // Schedule status for all nemesis types
       const wardenResults = ref({}) // Warden check results per host
       const wardenLoading = ref(false)
+      const inventory = ref({ hosts: [], nodes: [], slots: [] })
 
       // Axios interceptor for global error handling
       axios.interceptors.response.use(
@@ -144,6 +146,36 @@
         }
       )
 
+      function formatTarget(entry) {
+        const t = entry && entry.target
+        if (!t) {
+          return entry.host || ''
+        }
+        const kind = t.kind || 'host'
+        if (kind === 'node') {
+          const id = t.node_id != null ? `node=${t.node_id}` : ''
+          const port = t.ic_port != null ? `ic=${t.ic_port}` : ''
+          return [kind, entry.host || t.host, id, port].filter(Boolean).join(' ')
+        }
+        if (kind === 'slot') {
+          const id = t.slot_idx != null ? `slot=${t.slot_idx}` : ''
+          const port = t.ic_port != null ? `ic=${t.ic_port}` : ''
+          return [kind, entry.host || t.host, id, port].filter(Boolean).join(' ')
+        }
+        if (kind === 'disk') {
+          const id = t.node_id != null ? `node=${t.node_id}` : ''
+          const path = t.disk_path ? t.disk_path : ''
+          return [kind, entry.host || t.host, id, path].filter(Boolean).join(' ')
+        }
+        if (kind === 'tablet') {
+          return t.tablet_id != null ? `tablet=${t.tablet_id}` : `tablet @${t.host || entry.host}`
+        }
+        if (kind === 'datacenter' || kind === 'pile') {
+          return `${kind}=${t.group_id || '?'} @${t.host || entry.host}`
+        }
+        return `${kind} ${t.host || entry.host || ''}`
+      }
+
       function get_hosts_health() {
         return axios
           .get('/api/hosts/health')
@@ -153,6 +185,16 @@
           })
           .catch(err => {
             hostsFetchError.value = err
+          })
+      }
+
+      function get_inventory() {
+        axios.get('/api/inventory')
+          .then(response => {
+            inventory.value = response.data
+          })
+          .catch(err => {
+            console.error('Failed to fetch inventory', err)
           })
       }
 
@@ -248,6 +290,7 @@
 
       // Initial load
       get_hosts_health()
+      get_inventory()
       get_process_types()
       get_grouped_process_types()
       get_all_processes()
@@ -259,6 +302,7 @@
       // Poll every 5 seconds
       setInterval(() => {
         get_hosts_health()
+        get_inventory()
         get_all_processes()
         get_healthcheck()
         get_schedule_history()
@@ -279,6 +323,8 @@
         scheduleStatus,
         wardenResults,
         wardenLoading,
+        inventory,
+        formatTarget,
         getProcessesByType,
         runWardenChecks
       }

--- a/ydb/tests/stability/nemesis/static/index.html
+++ b/ydb/tests/stability/nemesis/static/index.html
@@ -30,9 +30,18 @@
       ></nemesis-group-accordion>
     </div>
 
-    <!-- Right Column: Hosts Status, Warden Checks & Schedule History (5 cols) -->
+    <!-- Right Column: Scheduler, Hosts Status, Warden Checks & Schedule History (5 cols) -->
     <div class="col-span-5">
       <div class="sticky top-4 space-y-6">
+        <!-- Nemesis Scheduler (boundary-walking): state, failure budget, problems -->
+        <scheduler-card
+          :scheduler="scheduler"
+          :problems="problems"
+          :is-busy="schedulerBusy"
+          @start="startScheduler"
+          @stop="stopScheduler">
+        </scheduler-card>
+
         <!-- Hosts Status -->
         <div>
           <h2 class="text-xl font-bold mb-4">Hosts Status</h2>
@@ -102,6 +111,7 @@
   import ProcessTypeGroup from './ProcessTypeGroup.js'
   import WardenChecksCard from './WardenChecksCard.js'
   import NemesisGroupAccordion from './NemesisGroupAccordion.js'
+  import SchedulerCard from './SchedulerCard.js'
 
   const { createApp, ref, computed } = Vue
 
@@ -110,7 +120,8 @@
       HostStatusItem,
       ProcessTypeGroup,
       WardenChecksCard,
-      NemesisGroupAccordion
+      NemesisGroupAccordion,
+      SchedulerCard
     },
     setup() {
       const message = ref('Nemesis')
@@ -126,6 +137,9 @@
       const wardenResults = ref({}) // Warden check results per host
       const wardenLoading = ref(false)
       const inventory = ref({ hosts: [], nodes: [], slots: [] })
+      const scheduler = ref({ available: false })
+      const problems = ref({ count: 0, problems: [], by_kind: {} })
+      const schedulerBusy = ref(false)
 
       // Axios interceptor for global error handling
       axios.interceptors.response.use(
@@ -188,6 +202,7 @@
           })
       }
 
+      // Inventory is built once at orchestrator startup, so it is fetched once, not polled.
       function get_inventory() {
         axios.get('/api/inventory')
           .then(response => {
@@ -196,6 +211,51 @@
           .catch(err => {
             console.error('Failed to fetch inventory', err)
           })
+      }
+
+      function get_scheduler() {
+        return axios.get('/api/scheduler')
+          .then(response => {
+            scheduler.value = response.data
+          })
+          .catch(err => {
+            console.error('Failed to fetch scheduler state', err)
+          })
+      }
+
+      function get_problems() {
+        return axios.get('/api/problems')
+          .then(response => {
+            problems.value = response.data
+          })
+          .catch(err => {
+            console.error('Failed to fetch nemesis problems', err)
+          })
+      }
+
+      function post_scheduler(action) {
+        schedulerBusy.value = true
+        return axios.post(`/api/scheduler/${action}`, {})
+          .then(response => {
+            if (response.data && response.data.scheduler) {
+              scheduler.value = response.data.scheduler
+            }
+          })
+          .catch(err => {
+            console.error(`Failed to ${action} scheduler`, err)
+          })
+          .finally(() => {
+            schedulerBusy.value = false
+            get_problems()
+          })
+      }
+
+      function startScheduler() {
+        return post_scheduler('start')
+      }
+
+      function stopScheduler() {
+        return post_scheduler('stop')
       }
 
       function get_process_types() {
@@ -298,16 +358,19 @@
       get_schedule_history()
       get_schedule_status()
       get_warden_results()
+      get_scheduler()
+      get_problems()
 
-      // Poll every 5 seconds
+      // Poll every 5 seconds (inventory is static — fetched once above)
       setInterval(() => {
         get_hosts_health()
-        get_inventory()
         get_all_processes()
         get_healthcheck()
         get_schedule_history()
         get_schedule_status()
         get_warden_results()
+        get_scheduler()
+        get_problems()
       }, 5000)
 
       return {
@@ -324,6 +387,11 @@
         wardenResults,
         wardenLoading,
         inventory,
+        scheduler,
+        problems,
+        schedulerBusy,
+        startScheduler,
+        stopScheduler,
         formatTarget,
         getProcessesByType,
         runWardenChecks

--- a/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
@@ -1,4 +1,4 @@
-"""Unit tests for the single-threaded boundary-walking nemesis scheduler."""
+"""The boundary-walking scheduler: tick, recovery wiring, lifecycle."""
 
 from __future__ import annotations
 
@@ -10,12 +10,10 @@ from pathlib import Path
 import pytest
 import yaml
 
-from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
-    NEMESIS_TYPES,
-    guard_mode_for,
-    recovery_mode_for,
-)
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import dispatch as build_dispatch
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import (
+    BoundaryNemesisScheduler,
+)
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import (
     datacenter_inject_fanout,
 )
@@ -27,29 +25,19 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model imp
     GuardMode,
     ImpactScope,
 )
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import (
-    BoundaryNemesisScheduler,
-    _STABILITY_PROFILE,
-    default_enabled_types,
-)
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import RecoveryProbe
 
 
-def _write_topology(hosts: list[dict], erasure: str) -> str:
+def _guard(erasure: str, **kwargs) -> FailureModelGuard:
+    hosts = [
+        {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}} for i in (1, 2, 3, 4)
+    ]
     fd, path = tempfile.mkstemp(suffix=".yaml")
     os.close(fd)
     Path(path).write_text(
         yaml.safe_dump({"static_erasure": erasure, "hosts": hosts}), encoding="utf-8"
     )
-    return path
-
-
-def _guard(erasure: str) -> FailureModelGuard:
-    hosts = [
-        {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}}
-        for i in (1, 2, 3, 4)
-    ]
-    return FailureModelGuard(ClusterTopologyModel(_write_topology(hosts, erasure)))
+    return FailureModelGuard(ClusterTopologyModel(path), **kwargs)
 
 
 class FakeInventory:
@@ -61,7 +49,7 @@ class FakeInventory:
 
 
 class ScriptedRandom:
-    """Deterministic stand-in for random.Random with scripted return values."""
+    """Deterministic stand-in for random.Random: always the same cap and the first menu entry."""
 
     def __init__(self, *, randint: int = 1, uniform: float = 0.0) -> None:
         self._randint = randint
@@ -75,6 +63,26 @@ class ScriptedRandom:
 
     def choice(self, seq):
         return seq[0]
+
+
+class RecordingProbe:
+    def __init__(self) -> None:
+        self.tracked: list = []
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def drain_extracts(self) -> int:
+        return 0
+
+    def snapshot(self) -> dict:
+        return {"tracked": len(self.tracked)}
+
+    def track(self, lease_id, target, nemesis_type, timeout_sec=None, recover_action=None):
+        self.tracked.append((lease_id, target, nemesis_type, timeout_sec, recover_action))
 
 
 def _make_scheduler(guard, inventory, dispatched, **overrides):
@@ -99,396 +107,165 @@ def _nodes() -> list[ChaosTarget]:
 
 
 class TestTick:
-    def test_single_tick_respects_block42_ceiling(self):
+    def test_tick_stops_at_the_budget(self):
         guard = _guard("block-4-2")
         dispatched: list = []
         sched = _make_scheduler(
             guard, FakeInventory(_nodes()), dispatched,
             max_per_tick=5, rng=ScriptedRandom(randint=5),
         )
-        injected = sched.tick()
-        assert injected == 2, (
-            "a single tick must stop at the block-4-2 budget of 2 fail domains even with a "
-            f"cap of 5; injected={injected}, snapshot={guard.snapshot()}"
-        )
-        assert len(dispatched) == 2, f"exactly two commands must be dispatched; got {len(dispatched)}"
-        assert len({c.target.host for c in dispatched}) == 2, (
-            "the two injects must hit two distinct hosts (identity exclusion), not the same one; "
-            f"hosts={[c.target.host for c in dispatched]}"
-        )
-        assert len(guard.snapshot()["impaired_racks"]) == 2
+        assert sched.tick() == 2, "block-4-2 tolerates 2 domains, whatever the cap"
+        assert len({c.target.host for c in dispatched}) == 2, "and not twice the same host"
 
-    def test_cap_fills_while_the_budget_allows(self):
-        # mirror-3-dc over 4 racks in one DC: the whole DC may be sacrificed, so 3 injects fit.
-        guard = _guard("mirror-3-dc")
+    def test_tick_fills_the_cap_while_the_budget_allows(self):
+        # mirror-3-dc over 4 racks of one DC: the whole realm may be sacrificed.
         dispatched: list = []
         sched = _make_scheduler(
-            guard, FakeInventory(_nodes()), dispatched,
+            _guard("mirror-3-dc"), FakeInventory(_nodes()), dispatched,
             max_per_tick=3, rng=ScriptedRandom(randint=3),
         )
-        injected = sched.tick()
-        assert injected == 3, f"a cap of 3 must fill while the budget allows; got {injected}"
-        assert len(dispatched) == 3
+        assert sched.tick() == 3
 
-    def test_menu_offers_every_enabled_type_uniformly(self):
-        guard = _guard("block-4-2")
+    def test_menu_offers_every_enabled_type(self):
         sched = _make_scheduler(
-            guard, FakeInventory(_nodes()), [],
-            enabled_types=["A", "B"],
-            max_per_tick=1, rng=ScriptedRandom(randint=1),
+            _guard("block-4-2"), FakeInventory(_nodes()), [], enabled_types=["A", "B"]
         )
-        menu = sched._menu()
-        assert {item[0] for item in menu} == {"A", "B"}, (
-            f"every enabled type must be offered (no weights, no muting); got {[m[0] for m in menu]}"
+        assert {item[0] for item in sched._menu()} == {"A", "B"}, "no weights, no muting"
+
+    def test_slot_tick_caps_at_the_slot_budget(self):
+        guard = _guard("block-4-2", total_slots=10)  # max_slots = 3
+        dispatched: list = []
+        sched = _make_scheduler(
+            guard, FakeInventory([ChaosTarget.for_slot("h1", slot_idx=i) for i in range(5)]),
+            dispatched,
+            enabled_types=["KillSlot"],
+            scope_for=lambda t: ImpactScope.SLOT,
+            kind_for=lambda t: TargetKind.SLOT,
+            max_per_tick=5, rng=ScriptedRandom(randint=5),
         )
-        assert all(len(item) == 3 for item in menu), "menu entries are (type, target, racks) triples"
-
-
-class TestSleep:
-    def test_sleep_low_extreme(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
-                                base_interval=60.0, jitter=0.5, rng=ScriptedRandom(uniform=-0.5))
-        assert sched._sleep_seconds() == pytest.approx(30.0)
-
-    def test_sleep_high_extreme(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
-                                base_interval=60.0, jitter=0.5, rng=ScriptedRandom(uniform=0.5))
-        assert sched._sleep_seconds() == pytest.approx(90.0)
-
-    def test_sleep_has_floor(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
-                                base_interval=0.1, jitter=0.0, rng=ScriptedRandom(uniform=0.0))
-        assert sched._sleep_seconds() == pytest.approx(0.5), "sleep must never drop below the 0.5s floor"
+        assert sched.tick() == 3
+        assert guard.snapshot()["impaired_racks"] == [], "slots cost no fail domain"
 
 
 class TestProfile:
-    def test_set_profile_updates_enabled_and_bounds(self):
+    @pytest.mark.parametrize("uniform,expected", [(-0.5, 30.0), (0.5, 90.0)])
+    def test_sleep_applies_jitter(self, uniform, expected):
+        sched = _make_scheduler(
+            _guard("block-4-2"), FakeInventory([]), [],
+            base_interval=60.0, jitter=0.5, rng=ScriptedRandom(uniform=uniform),
+        )
+        assert sched._sleep_seconds() == pytest.approx(expected)
+
+    def test_set_profile_and_status(self):
         sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [])
         sched.set_profile(enabled=["X"], base_interval=10.0, jitter=0.25, max_per_tick=7)
-        assert sched._enabled == ["X"]
-        assert sched._base_interval == 10.0
-        assert sched._jitter == 0.25
-        assert sched._max_per_tick == 7
+        status = sched.status()
+        assert status["running"] is False
+        assert (status["enabled_types"], status["base_interval"], status["max_per_tick"]) == (
+            ["X"], 10.0, 7,
+        )
 
 
 class TestDatacenterFanout:
-    def test_dc_target_fans_out_to_every_host_in_the_chosen_dc(self):
-        dc_targets = [
-            ChaosTarget.for_datacenter("h1", "dc1"),
-            ChaosTarget.for_datacenter("h2", "dc1"),
-            ChaosTarget.for_datacenter("h3", "dc2"),
-        ]
+    def test_chosen_dc_fans_out_to_its_own_hosts(self):
         cmds = datacenter_inject_fanout(
             "DataCenterStopNodesNemesis",
             ChaosTarget.for_datacenter("h1", "dc1"),
-            FakeInventory(dc_targets),
+            FakeInventory([
+                ChaosTarget.for_datacenter("h1", "dc1"),
+                ChaosTarget.for_datacenter("h2", "dc1"),
+                ChaosTarget.for_datacenter("h3", "dc2"),
+            ]),
         )
-        assert {c.target.host for c in cmds} == {"h1", "h2"}, (
-            "a chosen DC must fan out to exactly that DC's hosts, not the round-robin planner's; "
-            f"got {[c.target.host for c in cmds]}"
-        )
-        assert all(c.action == "inject" and c.target.kind is TargetKind.DATACENTER for c in cmds)
-        assert all(c.nemesis_type == "DataCenterStopNodesNemesis" for c in cmds)
-        assert len({c.scenario_id for c in cmds}) == 1, "one fanout must share a single scenario id"
-
-
-class TestStatus:
-    def test_status_reports_running_and_profile(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [],
-                                base_interval=42.0, jitter=0.25, max_per_tick=4)
-        st = sched.status()
-        assert st["running"] is False, "a scheduler that never started must report running=False"
-        assert st["base_interval"] == 42.0
-        assert st["jitter"] == 0.25
-        assert st["max_per_tick"] == 4
-        assert st["enabled_types"] == ["KillNode"]
-        assert "recovery_probe" not in st, "no probe wired -> no recovery_probe key"
-
-    def test_status_includes_probe_snapshot_when_wired(self):
-        class FakeProbe:
-            def start(self):
-                pass
-
-            def stop(self):
-                pass
-
-            def snapshot(self):
-                return {"tracked": 0, "stuck": 0}
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [],
-                                recovery_probe=FakeProbe())
-        assert sched.status()["recovery_probe"] == {"tracked": 0, "stuck": 0}
-
-
-class RecordingProbe:
-    def __init__(self) -> None:
-        self.tracked: list = []
-
-    def start(self) -> None:
-        pass
-
-    def stop(self) -> None:
-        pass
-
-    def snapshot(self) -> dict:
-        return {"tracked": len(self.tracked)}
-
-    def track(self, lease_id, target, nemesis_type, timeout_sec=None, recover_action=None):
-        self.tracked.append((lease_id, target, nemesis_type, timeout_sec, recover_action))
+        assert {c.target.host for c in cmds} == {"h1", "h2"}, "not the round-robin planner's DC"
+        assert len({c.scenario_id for c in cmds}) == 1
 
 
 class TestToggleRecovery:
-    def _toggle_scheduler(self, guard, dispatched, probe, **overrides):
+    def _toggle_scheduler(self, guard, dispatched, probe, hold_sec=90.0):
         return _make_scheduler(
             guard, FakeInventory(_nodes()), dispatched,
             enabled_types=["Toggle"],
             recovery_mode_for=lambda t: "extract",
-            recovery_sec_for=lambda t: 90.0,
+            recovery_sec_for=lambda t: hold_sec,
             plan_extract=lambda ntype, target: [build_dispatch(ntype, target, "extract", {})],
             recovery_probe=probe,
             max_per_tick=1, rng=ScriptedRandom(randint=1),
-            **overrides,
         )
 
-    def test_toggle_tick_holds_budget_and_tracks_extract_action(self):
+    def test_toggle_holds_budget_and_tracks_its_extract(self):
         guard = _guard("block-4-2")
         dispatched: list = []
         probe = RecordingProbe()
-        sched = self._toggle_scheduler(guard, dispatched, probe)
+        assert self._toggle_scheduler(guard, dispatched, probe).tick() == 1
+        assert len(guard.snapshot()["impaired_racks"]) == 1, "held, not expiring on a timer"
 
-        assert sched.tick() == 1
-        injects = [c for c in dispatched if c.action == "inject"]
-        assert len(injects) == 1, f"exactly one inject must be dispatched; got {dispatched}"
-        assert len(guard.snapshot()["impaired_racks"]) == 1, (
-            "a toggle fault must hold the budget (recovery_sec=None), not expire on a timer"
-        )
-        assert len(probe.tracked) == 1
         lease, target, ntype, timeout, action = probe.tracked[0]
-        assert ntype == "Toggle" and timeout == 90.0
-        assert action is not None, "toggle faults must be tracked with a recover_action"
-
-        # Running the recover_action must dispatch an extract for the same target.
+        assert (ntype, timeout) == ("Toggle", 90.0) and action is not None
         action()
         extracts = [c for c in dispatched if c.action == "extract"]
-        assert len(extracts) == 1 and extracts[0].target.host == target.host, (
-            f"recover_action must extract the injected target; got {dispatched}"
-        )
+        assert len(extracts) == 1 and extracts[0].target.host == target.host
 
-    def test_toggle_type_muted_when_extract_not_wired(self):
-        guard = _guard("block-4-2")
-        # No plan_extract / no probe -> a toggle fault can never auto-extract, so it must never
-        # be offered (else it would stay broken forever).
+    def test_toggle_is_muted_when_nothing_can_extract(self):
+        # Without a probe / plan_extract it would stay broken forever, so it must not be offered.
         sched = _make_scheduler(
-            guard, FakeInventory(_nodes()), [],
-            enabled_types=["Toggle"],
-            recovery_mode_for=lambda t: "extract",
+            _guard("block-4-2"), FakeInventory(_nodes()), [],
+            enabled_types=["Toggle"], recovery_mode_for=lambda t: "extract",
         )
-        assert sched._menu() == [], "toggle types must be filtered out with no way to extract"
-        assert sched.tick() == 0
+        assert sched._menu() == [] and sched.tick() == 0
+
+    def test_stop_extracts_what_is_still_held(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        probe = RecoveryProbe(
+            guard=guard, recovered=lambda t: False, min_hold_sec=0.0, poll_interval=3600.0
+        )
+        sched = self._toggle_scheduler(guard, dispatched, probe, hold_sec=600.0)
+        assert sched.tick() == 1
+        assert [c.action for c in dispatched] == ["inject"]
+
+        sched.stop()
+        assert [c.action for c in dispatched] == ["inject", "extract"], "stop must not leave it applied"
+        assert guard.snapshot()["impaired_racks"] == [] and probe.pending() == []
 
 
 class TestBypass:
-    """BYPASS types (tablet chaos) inject without spending the failure-model budget."""
-
-    def _bypass_scheduler(self, guard, dispatched, targets, enabled, **overrides):
+    def _bypass_scheduler(self, guard, dispatched, enabled, **overrides):
         return _make_scheduler(
-            guard, FakeInventory(targets), dispatched,
+            guard, FakeInventory([ChaosTarget.for_tablet("h1")]), dispatched,
             enabled_types=enabled,
             kind_for=lambda t: TargetKind.TABLET,
             mode_for=lambda t: GuardMode.BYPASS,
             **overrides,
         )
 
-    def test_bypass_fires_even_when_budget_is_full(self):
+    def test_bypass_fires_with_the_budget_exhausted_and_reserves_nothing(self):
         guard = _guard("block-4-2")
-        # Reserve the whole block-4-2 budget so no budgeted fault could fit.
-        assert guard.reserve(Footprint(racks=frozenset({"r1"})), recovery_sec=None, identity_key="x1")
-        assert guard.reserve(Footprint(racks=frozenset({"r2"})), recovery_sec=None, identity_key="x2")
+        for rack in ("r1", "r2"):
+            guard.reserve(Footprint(racks=frozenset({rack})), recovery_sec=None, identity_key=rack)
         dispatched: list = []
         sched = self._bypass_scheduler(
-            guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive"],
-            max_per_tick=1, rng=ScriptedRandom(randint=1),
+            guard, dispatched, ["KillHive"], max_per_tick=1, rng=ScriptedRandom(randint=1)
         )
-        assert sched.tick() == 1, "a BYPASS fault must fire even with the failure budget exhausted"
-        assert len(dispatched) == 1
-        assert len(guard.snapshot()["impaired_racks"]) == 2, (
-            "BYPASS injection must not reserve any additional budget"
-        )
+        assert sched.tick() == 1 and len(dispatched) == 1
+        assert len(guard.snapshot()["impaired_racks"]) == 2, "no extra budget spent"
 
-    def test_multiple_bypass_types_share_one_target_in_a_tick(self):
-        guard = _guard("block-4-2")
+    def test_dedup_is_per_type_and_target(self):
+        # Tablet types share one control-host target: each fires once, all of them fire.
         dispatched: list = []
         sched = self._bypass_scheduler(
-            guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive", "ReBalance"],
-            max_per_tick=2, rng=ScriptedRandom(randint=2),
+            _guard("block-4-2"), dispatched, ["KillHive", "ReBalance"],
+            max_per_tick=3, rng=ScriptedRandom(randint=3),
         )
-        assert sched.tick() == 2, (
-            "two BYPASS types on one control-host target must both fire (dedup is per "
-            "(type, target), not per target)"
-        )
+        assert sched.tick() == 2
         assert {c.nemesis_type for c in dispatched} == {"KillHive", "ReBalance"}
-
-    def test_bypass_type_fires_at_most_once_per_tick(self):
-        guard = _guard("block-4-2")
-        dispatched: list = []
-        sched = self._bypass_scheduler(
-            guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive"],
-            max_per_tick=3, rng=ScriptedRandom(randint=3),
-        )
-        assert sched.tick() == 1, (
-            "one BYPASS type on one target fires once per tick even at a higher cap; the "
-            "(type, target) dedup empties the menu after the first inject"
-        )
-
-
-class TestSlotScheduling:
-    """Slot kills draw from the separate 30% slot budget, not the erasure/rack budget."""
-
-    def _slots(self, n: int) -> list[ChaosTarget]:
-        return [ChaosTarget.for_slot("h1", slot_idx=i) for i in range(n)]
-
-    def _slot_scheduler(self, guard, dispatched, targets, **overrides):
-        return _make_scheduler(
-            guard, FakeInventory(targets), dispatched,
-            enabled_types=["KillSlot"],
-            scope_for=lambda t: ImpactScope.SLOT,
-            kind_for=lambda t: TargetKind.SLOT,
-            mode_for=lambda t: GuardMode.FULL,
-            **overrides,
-        )
-
-    def test_tick_caps_slots_at_thirty_percent(self):
-        # 10 slots -> max_slots = floor(0.3*10) = 3, even with 5 candidates and a cap of 5.
-        guard = FailureModelGuard(
-            ClusterTopologyModel(_write_topology(
-                [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}], "block-4-2",
-            )),
-            total_slots=10,
-        )
-        dispatched: list = []
-        sched = self._slot_scheduler(
-            guard, dispatched, self._slots(5),
-            max_per_tick=5, rng=ScriptedRandom(randint=5),
-        )
-        injected = sched.tick()
-        assert injected == 3, (
-            f"a single tick must stop at the 30% slot budget (3 of 10); injected={injected}, "
-            f"snapshot={guard.snapshot()}"
-        )
-        assert guard.snapshot()["impaired_slots"] == 3
-        assert guard.snapshot()["impaired_racks"] == [], (
-            "slot kills must never consume an erasure/rack fail-domain"
-        )
-
-    def test_slot_kill_does_not_spend_rack_budget(self):
-        # A full slot budget must leave the block-4-2 rack budget completely untouched.
-        guard = FailureModelGuard(
-            ClusterTopologyModel(_write_topology(
-                [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}], "block-4-2",
-            )),
-            total_slots=3,  # max_slots = 1
-        )
-        dispatched: list = []
-        sched = self._slot_scheduler(
-            guard, dispatched, self._slots(3),
-            max_per_tick=3, rng=ScriptedRandom(randint=3),
-        )
-        assert sched.tick() == 1, "the slot budget of 1 caps a single slot kill per tick"
-        assert guard.fits(Footprint(racks=frozenset({"r1"}))), (
-            "a rack fault must still fit while the slot budget is exhausted (independent budgets)"
-        )
-
-
-class TestDefaultProfile:
-    def test_default_profile_is_curated_and_registered(self):
-        enabled = default_enabled_types()
-        assert enabled, "the default profile must not be empty"
-        assert set(enabled) <= set(_STABILITY_PROFILE)
-        assert all(t in NEMESIS_TYPES for t in enabled), (
-            "every profile entry must be a registered nemesis type"
-        )
-        for t in ("KillNodeNemesis", "KillSlotDaemonNemesis", "StopStartNodeNemesis",
-                  "SafelyBreakDiskNemesis", "TimeSkewNemesis"):
-            assert t in enabled, f"{t} must be in the default stability profile"
-
-    def test_tablet_chaos_is_in_profile_and_bypass(self):
-        enabled = default_enabled_types()
-        for t in ("KillHiveNemesis", "KillCoordinatorNemesis", "ReBalanceTabletsNemesis"):
-            assert t in enabled, f"tablet chaos type {t} must be in the default profile"
-            assert guard_mode_for(t) is GuardMode.BYPASS, f"{t} must be BYPASS (no budget spent)"
-        # Kicking tablets kills the node, so it stays budgeted like any other node fault.
-        assert "KickTabletsFromNodeNemesis" in enabled
-        assert guard_mode_for("KickTabletsFromNodeNemesis") is GuardMode.FULL
-
-    def test_toggle_members_are_extract_mode(self):
-        for t in ("StopStartNodeNemesis", "SafelyBreakDiskNemesis",
-                  "SafelyCleanupDisksNemesis", "TimeSkewNemesis"):
-            assert recovery_mode_for(t) == "extract", f"{t} must recover via extract"
-        for t in ("KillNodeNemesis", "KillSlotDaemonNemesis"):
-            assert recovery_mode_for(t) == "self", f"{t} is self-recovering"
-
-
-class TestStopDrainsToggleFaults:
-    """``stop()`` (deploy.py's "disable nemesis") must not leave toggle faults applied."""
-
-    def _toggle_scheduler_with_real_probe(self, guard, dispatched):
-        # poll_interval is huge and the probe is never started, so only stop() can extract.
-        probe = RecoveryProbe(
-            guard=guard,
-            recovered=lambda t: False,
-            min_hold_sec=0.0,
-            poll_interval=3600.0,
-        )
-        sched = _make_scheduler(
-            guard, FakeInventory(_nodes()), dispatched,
-            enabled_types=["Toggle"],
-            recovery_mode_for=lambda t: "extract",
-            recovery_sec_for=lambda t: 600.0,  # hold window far longer than the test
-            plan_extract=lambda ntype, target: [build_dispatch(ntype, target, "extract", {})],
-            recovery_probe=probe,
-            max_per_tick=1, rng=ScriptedRandom(randint=1),
-        )
-        return sched, probe
-
-    def test_stop_extracts_faults_still_inside_their_hold_window(self):
-        guard = _guard("block-4-2")
-        dispatched: list = []
-        sched, probe = self._toggle_scheduler_with_real_probe(guard, dispatched)
-
-        assert sched.tick() == 1
-        assert [c.action for c in dispatched] == ["inject"], (
-            f"the tick must only inject so far; got {[c.action for c in dispatched]}"
-        )
-        injected_target = dispatched[0].target
-
-        sched.stop()
-
-        assert [c.action for c in dispatched] == ["inject", "extract"], (
-            "stopping the scheduler must extract the toggle fault it left applied; "
-            f"got {[c.action for c in dispatched]}"
-        )
-        assert dispatched[-1].target.identity_key() == injected_target.identity_key(), (
-            "the extract must target exactly what was injected; "
-            f"injected={injected_target.identity_key()}, extracted={dispatched[-1].target.identity_key()}"
-        )
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"draining on stop must release the budget too; snapshot={guard.snapshot()}"
-        )
-        assert probe.pending() == [], "nothing may stay tracked after stop"
-
-    def test_stop_without_pending_faults_dispatches_nothing(self):
-        guard = _guard("block-4-2")
-        dispatched: list = []
-        sched, _probe = self._toggle_scheduler_with_real_probe(guard, dispatched)
-        sched.stop()
-        assert dispatched == [], "stop() on an idle scheduler must not dispatch anything"
 
 
 class TestLifecycle:
-    def test_start_then_stop_terminates_thread(self):
-        guard = _guard("block-4-2")
+    def test_start_then_stop_terminates_the_thread(self):
         dispatched: list = []
         sched = _make_scheduler(
-            guard, FakeInventory(_nodes()), dispatched,
+            _guard("block-4-2"), FakeInventory(_nodes()), dispatched,
             base_interval=1000.0, jitter=0.0, max_per_tick=2, rng=ScriptedRandom(randint=2),
         )
         sched.start()
@@ -496,7 +273,5 @@ class TestLifecycle:
         while not dispatched and time.monotonic() < deadline:
             time.sleep(0.01)
         sched.stop()
-        assert sched._thread is not None and not sched._thread.is_alive(), (
-            "stop() must join the daemon thread"
-        )
-        assert dispatched, "the scheduler thread must have run at least one tick before stopping"
+        assert dispatched, "the thread must have ticked"
+        assert sched._thread is not None and not sched._thread.is_alive()

--- a/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
@@ -32,6 +32,7 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_schedule
     _STABILITY_PROFILE,
     default_enabled_types,
 )
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import RecoveryProbe
 
 
 def _write_topology(hosts: list[dict], erasure: str) -> str:
@@ -117,16 +118,16 @@ class TestTick:
         )
         assert len(guard.snapshot()["impaired_racks"]) == 2
 
-    def test_disabled_guard_fills_cap(self):
-        guard = _guard("no-such-erasure")  # unknown -> guard disabled (fail-open)
-        assert not guard.enabled, "unknown erasure must leave the guard disabled"
+    def test_cap_fills_while_the_budget_allows(self):
+        # mirror-3-dc over 4 racks in one DC: the whole DC may be sacrificed, so 3 injects fit.
+        guard = _guard("mirror-3-dc")
         dispatched: list = []
         sched = _make_scheduler(
             guard, FakeInventory(_nodes()), dispatched,
             max_per_tick=3, rng=ScriptedRandom(randint=3),
         )
         injected = sched.tick()
-        assert injected == 3, f"a disabled guard must never block; cap of 3 must fill; got {injected}"
+        assert injected == 3, f"a cap of 3 must fill while the budget allows; got {injected}"
         assert len(dispatched) == 3
 
     def test_menu_offers_every_enabled_type_uniformly(self):
@@ -424,6 +425,62 @@ class TestDefaultProfile:
             assert recovery_mode_for(t) == "extract", f"{t} must recover via extract"
         for t in ("KillNodeNemesis", "KillSlotDaemonNemesis"):
             assert recovery_mode_for(t) == "self", f"{t} is self-recovering"
+
+
+class TestStopDrainsToggleFaults:
+    """``stop()`` (deploy.py's "disable nemesis") must not leave toggle faults applied."""
+
+    def _toggle_scheduler_with_real_probe(self, guard, dispatched):
+        # poll_interval is huge and the probe is never started, so only stop() can extract.
+        probe = RecoveryProbe(
+            guard=guard,
+            recovered=lambda t: False,
+            min_hold_sec=0.0,
+            poll_interval=3600.0,
+        )
+        sched = _make_scheduler(
+            guard, FakeInventory(_nodes()), dispatched,
+            enabled_types=["Toggle"],
+            recovery_mode_for=lambda t: "extract",
+            recovery_sec_for=lambda t: 600.0,  # hold window far longer than the test
+            plan_extract=lambda ntype, target: [build_dispatch(ntype, target, "extract", {})],
+            recovery_probe=probe,
+            max_per_tick=1, rng=ScriptedRandom(randint=1),
+        )
+        return sched, probe
+
+    def test_stop_extracts_faults_still_inside_their_hold_window(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched, probe = self._toggle_scheduler_with_real_probe(guard, dispatched)
+
+        assert sched.tick() == 1
+        assert [c.action for c in dispatched] == ["inject"], (
+            f"the tick must only inject so far; got {[c.action for c in dispatched]}"
+        )
+        injected_target = dispatched[0].target
+
+        sched.stop()
+
+        assert [c.action for c in dispatched] == ["inject", "extract"], (
+            "stopping the scheduler must extract the toggle fault it left applied; "
+            f"got {[c.action for c in dispatched]}"
+        )
+        assert dispatched[-1].target.identity_key() == injected_target.identity_key(), (
+            "the extract must target exactly what was injected; "
+            f"injected={injected_target.identity_key()}, extracted={dispatched[-1].target.identity_key()}"
+        )
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"draining on stop must release the budget too; snapshot={guard.snapshot()}"
+        )
+        assert probe.pending() == [], "nothing may stay tracked after stop"
+
+    def test_stop_without_pending_faults_dispatches_nothing(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched, _probe = self._toggle_scheduler_with_real_probe(guard, dispatched)
+        sched.stop()
+        assert dispatched == [], "stop() on an idle scheduler must not dispatch anything"
 
 
 class TestLifecycle:

--- a/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
@@ -23,6 +23,7 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target impo
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     ClusterTopologyModel,
     FailureModelGuard,
+    Footprint,
     GuardMode,
     ImpactScope,
 )
@@ -299,8 +300,8 @@ class TestBypass:
     def test_bypass_fires_even_when_budget_is_full(self):
         guard = _guard("block-4-2")
         # Reserve the whole block-4-2 budget so no budgeted fault could fit.
-        assert guard.reserve(frozenset({"r1"}), recovery_sec=None, identity_key="x1")
-        assert guard.reserve(frozenset({"r2"}), recovery_sec=None, identity_key="x2")
+        assert guard.reserve(Footprint(racks=frozenset({"r1"})), recovery_sec=None, identity_key="x1")
+        assert guard.reserve(Footprint(racks=frozenset({"r2"})), recovery_sec=None, identity_key="x2")
         dispatched: list = []
         sched = self._bypass_scheduler(
             guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive"],
@@ -335,6 +336,64 @@ class TestBypass:
         assert sched.tick() == 1, (
             "one BYPASS type on one target fires once per tick even at a higher cap; the "
             "(type, target) dedup empties the menu after the first inject"
+        )
+
+
+class TestSlotScheduling:
+    """Slot kills draw from the separate 30% slot budget, not the erasure/rack budget."""
+
+    def _slots(self, n: int) -> list[ChaosTarget]:
+        return [ChaosTarget.for_slot("h1", slot_idx=i) for i in range(n)]
+
+    def _slot_scheduler(self, guard, dispatched, targets, **overrides):
+        return _make_scheduler(
+            guard, FakeInventory(targets), dispatched,
+            enabled_types=["KillSlot"],
+            scope_for=lambda t: ImpactScope.SLOT,
+            kind_for=lambda t: TargetKind.SLOT,
+            mode_for=lambda t: GuardMode.FULL,
+            **overrides,
+        )
+
+    def test_tick_caps_slots_at_thirty_percent(self):
+        # 10 slots -> max_slots = floor(0.3*10) = 3, even with 5 candidates and a cap of 5.
+        guard = FailureModelGuard(
+            ClusterTopologyModel(_write_topology(
+                [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}], "block-4-2",
+            )),
+            total_slots=10,
+        )
+        dispatched: list = []
+        sched = self._slot_scheduler(
+            guard, dispatched, self._slots(5),
+            max_per_tick=5, rng=ScriptedRandom(randint=5),
+        )
+        injected = sched.tick()
+        assert injected == 3, (
+            f"a single tick must stop at the 30% slot budget (3 of 10); injected={injected}, "
+            f"snapshot={guard.snapshot()}"
+        )
+        assert guard.snapshot()["impaired_slots"] == 3
+        assert guard.snapshot()["impaired_racks"] == [], (
+            "slot kills must never consume an erasure/rack fail-domain"
+        )
+
+    def test_slot_kill_does_not_spend_rack_budget(self):
+        # A full slot budget must leave the block-4-2 rack budget completely untouched.
+        guard = FailureModelGuard(
+            ClusterTopologyModel(_write_topology(
+                [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}], "block-4-2",
+            )),
+            total_slots=3,  # max_slots = 1
+        )
+        dispatched: list = []
+        sched = self._slot_scheduler(
+            guard, dispatched, self._slots(3),
+            max_per_tick=3, rng=ScriptedRandom(randint=3),
+        )
+        assert sched.tick() == 1, "the slot budget of 1 caps a single slot kill per tick"
+        assert guard.fits(Footprint(racks=frozenset({"r1"}))), (
+            "a rack fault must still fit while the slot budget is exhausted (independent budgets)"
         )
 
 

--- a/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
+++ b/ydb/tests/stability/nemesis/ut/test_boundary_scheduler.py
@@ -1,4 +1,4 @@
-"""Unit tests for the single-threaded weighted nemesis scheduler."""
+"""Unit tests for the single-threaded boundary-walking nemesis scheduler."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ import yaml
 
 from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
     NEMESIS_TYPES,
+    guard_mode_for,
     recovery_mode_for,
-    weight_for as catalog_weight_for,
 )
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import dispatch as build_dispatch
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import (
@@ -23,10 +23,11 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target impo
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     ClusterTopologyModel,
     FailureModelGuard,
+    GuardMode,
     ImpactScope,
 )
-from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import (
-    WeightedNemesisScheduler,
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import (
+    BoundaryNemesisScheduler,
     _STABILITY_PROFILE,
     default_enabled_types,
 )
@@ -60,16 +61,12 @@ class FakeInventory:
 class ScriptedRandom:
     """Deterministic stand-in for random.Random with scripted return values."""
 
-    def __init__(self, *, randint: int = 1, randoms=None, uniform: float = 0.0) -> None:
+    def __init__(self, *, randint: int = 1, uniform: float = 0.0) -> None:
         self._randint = randint
-        self._randoms = list(randoms if randoms is not None else [])
         self._uniform = uniform
 
     def randint(self, a: int, b: int) -> int:
         return max(a, min(b, self._randint))
-
-    def random(self) -> float:
-        return self._randoms.pop(0) if self._randoms else 0.0
 
     def uniform(self, a: float, b: float) -> float:
         return self._uniform
@@ -87,11 +84,12 @@ def _make_scheduler(guard, inventory, dispatched, **overrides):
         enabled_types=["KillNode"],
         scope_for=lambda t: ImpactScope.NODE,
         kind_for=lambda t: TargetKind.NODE,
+        mode_for=lambda t: GuardMode.FULL,
         recovery_sec_for=lambda t: None,
         default_recovery_sec=300.0,
     )
     kwargs.update(overrides)
-    return WeightedNemesisScheduler(**kwargs)
+    return BoundaryNemesisScheduler(**kwargs)
 
 
 def _nodes() -> list[ChaosTarget]:
@@ -118,63 +116,30 @@ class TestTick:
         )
         assert len(guard.snapshot()["impaired_racks"]) == 2
 
-    def test_disabled_guard_fills_cap_with_distinct_targets(self):
+    def test_disabled_guard_fills_cap(self):
         guard = _guard("no-such-erasure")  # unknown -> guard disabled (fail-open)
         assert not guard.enabled, "unknown erasure must leave the guard disabled"
         dispatched: list = []
         sched = _make_scheduler(
             guard, FakeInventory(_nodes()), dispatched,
-            max_per_tick=3, rng=ScriptedRandom(randint=3, randoms=[0.0, 0.3, 0.6]),
+            max_per_tick=3, rng=ScriptedRandom(randint=3),
         )
         injected = sched.tick()
         assert injected == 3, f"a disabled guard must never block; cap of 3 must fill; got {injected}"
         assert len(dispatched) == 3
-        assert len({c.target.host for c in dispatched}) == 3, (
-            "with a walking rng the disabled scheduler should spread across distinct hosts; "
-            f"hosts={[c.target.host for c in dispatched]}"
-        )
 
-    def test_zero_weight_type_is_never_offered(self):
+    def test_menu_offers_every_enabled_type_uniformly(self):
         guard = _guard("block-4-2")
-        dispatched: list = []
         sched = _make_scheduler(
-            guard, FakeInventory(_nodes()), dispatched,
-            enabled_types=["Muted", "Active"],
-            weight_for=lambda t: 0.0 if t == "Muted" else 1.0,
+            guard, FakeInventory(_nodes()), [],
+            enabled_types=["A", "B"],
             max_per_tick=1, rng=ScriptedRandom(randint=1),
         )
         menu = sched._menu()
-        assert menu, "the weighted (Active) type must still produce a menu"
-        assert all(item[0] == "Active" for item in menu), (
-            f"a zero-weight type must never appear in the menu; got {[m[0] for m in menu]}"
+        assert {item[0] for item in menu} == {"A", "B"}, (
+            f"every enabled type must be offered (no weights, no muting); got {[m[0] for m in menu]}"
         )
-
-
-class TestWeightedChoice:
-    def _menu(self):
-        t = ChaosTarget.for_node("h1", node_id=1)
-        fs = frozenset({"r1"})
-        return [("A", t, fs, 1.0), ("B", t, fs, 3.0)]
-
-    def test_low_draw_picks_first_bucket(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
-                                rng=ScriptedRandom(randoms=[0.1]))
-        picked = sched._weighted_choice(self._menu())
-        assert picked[0] == "A", f"r=0.4 lands in A's [0,1] bucket; got {picked[0]}"
-
-    def test_high_draw_picks_weighted_bucket(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
-                                rng=ScriptedRandom(randoms=[0.5]))
-        picked = sched._weighted_choice(self._menu())
-        assert picked[0] == "B", f"r=2.0 lands in B's (1,4] bucket; got {picked[0]}"
-
-    def test_all_zero_weight_menu_falls_back_to_choice(self):
-        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
-                                rng=ScriptedRandom())
-        t = ChaosTarget.for_node("h1", node_id=1)
-        menu = [("A", t, frozenset({"r1"}), 0.0), ("B", t, frozenset({"r2"}), 0.0)]
-        picked = sched._weighted_choice(menu)
-        assert picked[0] == "A", "with zero total weight, choice() (first element) is used"
+        assert all(len(item) == 3 for item in menu), "menu entries are (type, target, racks) triples"
 
 
 class TestSleep:
@@ -195,20 +160,13 @@ class TestSleep:
 
 
 class TestProfile:
-    def test_set_profile_updates_weights_and_bounds(self):
+    def test_set_profile_updates_enabled_and_bounds(self):
         sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [])
-        sched.set_profile(enabled=["X"], weights={"X": 2.0}, base_interval=10.0,
-                          jitter=0.25, max_per_tick=7)
-        assert sched._weight_for("X") == 2.0
-        assert sched._weight_for("unlisted") == 1.0, "unlisted types default to weight 1.0"
+        sched.set_profile(enabled=["X"], base_interval=10.0, jitter=0.25, max_per_tick=7)
+        assert sched._enabled == ["X"]
         assert sched._base_interval == 10.0
+        assert sched._jitter == 0.25
         assert sched._max_per_tick == 7
-
-
-class TestCatalogWeights:
-    def test_weight_for_reads_registry_and_defaults(self):
-        assert catalog_weight_for("KillSlotDaemonNemesis") == 3.0, "annotated weight must be read from the registry"
-        assert catalog_weight_for("no-such-nemesis") == 1.0, "unknown types default to weight 1.0"
 
 
 class TestDatacenterFanout:
@@ -326,6 +284,60 @@ class TestToggleRecovery:
         assert sched.tick() == 0
 
 
+class TestBypass:
+    """BYPASS types (tablet chaos) inject without spending the failure-model budget."""
+
+    def _bypass_scheduler(self, guard, dispatched, targets, enabled, **overrides):
+        return _make_scheduler(
+            guard, FakeInventory(targets), dispatched,
+            enabled_types=enabled,
+            kind_for=lambda t: TargetKind.TABLET,
+            mode_for=lambda t: GuardMode.BYPASS,
+            **overrides,
+        )
+
+    def test_bypass_fires_even_when_budget_is_full(self):
+        guard = _guard("block-4-2")
+        # Reserve the whole block-4-2 budget so no budgeted fault could fit.
+        assert guard.reserve(frozenset({"r1"}), recovery_sec=None, identity_key="x1")
+        assert guard.reserve(frozenset({"r2"}), recovery_sec=None, identity_key="x2")
+        dispatched: list = []
+        sched = self._bypass_scheduler(
+            guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive"],
+            max_per_tick=1, rng=ScriptedRandom(randint=1),
+        )
+        assert sched.tick() == 1, "a BYPASS fault must fire even with the failure budget exhausted"
+        assert len(dispatched) == 1
+        assert len(guard.snapshot()["impaired_racks"]) == 2, (
+            "BYPASS injection must not reserve any additional budget"
+        )
+
+    def test_multiple_bypass_types_share_one_target_in_a_tick(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched = self._bypass_scheduler(
+            guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive", "ReBalance"],
+            max_per_tick=2, rng=ScriptedRandom(randint=2),
+        )
+        assert sched.tick() == 2, (
+            "two BYPASS types on one control-host target must both fire (dedup is per "
+            "(type, target), not per target)"
+        )
+        assert {c.nemesis_type for c in dispatched} == {"KillHive", "ReBalance"}
+
+    def test_bypass_type_fires_at_most_once_per_tick(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched = self._bypass_scheduler(
+            guard, dispatched, [ChaosTarget.for_tablet("h1")], ["KillHive"],
+            max_per_tick=3, rng=ScriptedRandom(randint=3),
+        )
+        assert sched.tick() == 1, (
+            "one BYPASS type on one target fires once per tick even at a higher cap; the "
+            "(type, target) dedup empties the menu after the first inject"
+        )
+
+
 class TestDefaultProfile:
     def test_default_profile_is_curated_and_registered(self):
         enabled = default_enabled_types()
@@ -337,6 +349,15 @@ class TestDefaultProfile:
         for t in ("KillNodeNemesis", "KillSlotDaemonNemesis", "StopStartNodeNemesis",
                   "SafelyBreakDiskNemesis", "TimeSkewNemesis"):
             assert t in enabled, f"{t} must be in the default stability profile"
+
+    def test_tablet_chaos_is_in_profile_and_bypass(self):
+        enabled = default_enabled_types()
+        for t in ("KillHiveNemesis", "KillCoordinatorNemesis", "ReBalanceTabletsNemesis"):
+            assert t in enabled, f"tablet chaos type {t} must be in the default profile"
+            assert guard_mode_for(t) is GuardMode.BYPASS, f"{t} must be BYPASS (no budget spent)"
+        # Kicking tablets kills the node, so it stays budgeted like any other node fault.
+        assert "KickTabletsFromNodeNemesis" in enabled
+        assert guard_mode_for("KickTabletsFromNodeNemesis") is GuardMode.FULL
 
     def test_toggle_members_are_extract_mode(self):
         for t in ("StopStartNodeNemesis", "SafelyBreakDiskNemesis",

--- a/ydb/tests/stability/nemesis/ut/test_catalog_annotations.py
+++ b/ydb/tests/stability/nemesis/ut/test_catalog_annotations.py
@@ -1,0 +1,87 @@
+"""Catalog annotations must match how the runners actually behave."""
+
+from __future__ import annotations
+
+import pytest
+
+from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
+    NEMESIS_TYPES,
+    impairment_hold_sec_for,
+    recovery_mode_for,
+    recovery_sec_for,
+    supports_boundary_scheduler,
+    target_kind_for,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import (
+    _STABILITY_PROFILE,
+    default_enabled_types,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import TargetKind
+
+# Faults that stay applied until something extracts them.
+TOGGLE_TYPES = (
+    "StopStartNodeNemesis",
+    "SuspendNodeNemesis",
+    "SafelyBreakDiskNemesis",
+    "SafelyCleanupDisksNemesis",
+    "TimeSkewNemesis",
+)
+
+
+@pytest.mark.parametrize("field", ["target_kind", "impact_scope", "guard_mode"])
+def test_every_type_annotates_the_guard_fields(field):
+    # Implicit defaults would silently exempt custom-planner types from the budget.
+    missing = sorted(name for name, spec in NEMESIS_TYPES.items() if field not in spec)
+    assert missing == [], missing
+
+
+@pytest.mark.parametrize("nemesis_type", TOGGLE_TYPES)
+def test_toggle_faults_recover_by_extract(nemesis_type):
+    # Annotated self-recovering, they would wait for a healthcheck that never arrives.
+    assert recovery_mode_for(nemesis_type) == "extract"
+    assert recovery_sec_for(nemesis_type) is not None, "needs a hold window before the extract"
+
+
+def test_kills_are_self_recovering():
+    assert recovery_mode_for("KillNodeNemesis") == "self"
+    assert recovery_mode_for("KillSlotDaemonNemesis") == "self"
+
+
+class TestImpairmentHold:
+    def test_paired_extract_holds_a_toggle_until_extracted(self):
+        assert impairment_hold_sec_for("StopStartNodeNemesis", paired_extract=True) is None
+
+    def test_unpaired_toggle_is_held_for_its_pulse(self):
+        # The legacy loop toggles the fault back with its next inject, so the hold covers the gap.
+        hold = impairment_hold_sec_for("StopStartNodeNemesis", paired_extract=False)
+        assert hold is not None and hold >= float(NEMESIS_TYPES["StopStartNodeNemesis"]["schedule"])
+
+    def test_self_recovering_types_ignore_pairing(self):
+        expected = recovery_sec_for("KillNodeNemesis")
+        assert impairment_hold_sec_for("KillNodeNemesis", paired_extract=True) == expected
+        assert impairment_hold_sec_for("KillNodeNemesis", paired_extract=False) == expected
+
+
+class TestBoundarySchedulerCompatibility:
+    def test_whole_default_profile_is_usable(self):
+        enabled = default_enabled_types()
+        assert enabled and set(enabled) == {t for t in _STABILITY_PROFILE if t in NEMESIS_TYPES}, (
+            "dropping a profile member would silently shrink chaos"
+        )
+
+    def test_custom_planners_must_opt_in(self):
+        # Fail closed: a planner with its own targets would inject what the guard never reserved.
+        assert supports_boundary_scheduler("ClusterRollingRestartNemesis") is False
+        assert supports_boundary_scheduler("NoSuchNemesis") is False
+        for name, spec in NEMESIS_TYPES.items():
+            custom = spec.get("planner_cls") is not None or spec.get("planner_factory") is not None
+            derived_safe = (
+                target_kind_for(name) is TargetKind.DATACENTER
+                or recovery_mode_for(name) == "extract"
+            )
+            if custom and not derived_safe and "boundary_safe" not in spec:
+                assert supports_boundary_scheduler(name) is False, name
+
+    def test_default_planner_and_opted_in_types_are_usable(self):
+        for name in ("KillNodeNemesis", "KillHiveNemesis", "SerialKillNodeNemesis"):
+            assert supports_boundary_scheduler(name) is True, name

--- a/ydb/tests/stability/nemesis/ut/test_chaos_problems.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_problems.py
@@ -1,0 +1,120 @@
+"""Unit tests for the nemesis problem log and the scheduler-profile validation.
+
+Both exist so that chaos-side trouble reaches the stability test report instead of a log line:
+``ChaosProblemStore`` collects it, ``GET /api/problems`` serves it, and a rejected profile keeps a
+typo from silently disabling all chaos.
+"""
+
+from __future__ import annotations
+
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_problems import (
+    KIND_INVENTORY_DEGRADED,
+    KIND_STUCK_FAULT,
+    ChaosProblemStore,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import StuckFault
+from ydb.tests.stability.nemesis.routers.orchestrator_router import _validated_profile
+
+
+def _stuck(host: str = "h1", nemesis_type: str = "StopStartNodeNemesis") -> StuckFault:
+    return StuckFault(
+        lease_id="lease-1",
+        nemesis_type=nemesis_type,
+        target=ChaosTarget.for_node(host, node_id=1),
+        held_sec=420.0,
+        timeout_sec=300.0,
+    )
+
+
+class TestChaosProblemStore:
+    def test_stuck_fault_is_recorded_with_target_and_numbers(self):
+        store = ChaosProblemStore()
+        store.record_stuck_fault(_stuck())
+        problems = store.snapshot()
+        assert len(problems) == 1, f"one stuck fault must produce one problem; got {problems}"
+        problem = problems[0]
+        assert problem["kind"] == KIND_STUCK_FAULT
+        assert problem["host"] == "h1" and problem["target"] == "node:1:h1", (
+            f"the problem must name the target that did not recover; got {problem}"
+        )
+        assert problem["details"]["held_sec"] == 420.0
+        assert problem["details"]["timeout_sec"] == 300.0
+        assert "did not recover" in problem["summary"], (
+            f"summary must be readable in a test report; got {problem['summary']!r}"
+        )
+
+    def test_repeated_problem_is_deduplicated_with_a_counter(self):
+        store = ChaosProblemStore()
+        for _ in range(3):
+            store.record_stuck_fault(_stuck())
+        problems = store.snapshot()
+        assert len(problems) == 1, "the same fault must not pile up as separate problems"
+        assert problems[0]["count"] == 3, f"repeats must bump count; got {problems[0]}"
+        assert problems[0]["last_seen"] >= problems[0]["first_seen"]
+
+    def test_distinct_targets_stay_separate(self):
+        store = ChaosProblemStore()
+        store.record_stuck_fault(_stuck(host="h1"))
+        store.record_stuck_fault(_stuck(host="h2"))
+        store.record_inventory_degraded("cluster harness unavailable")
+        assert store.counts_by_kind() == {KIND_STUCK_FAULT: 2, KIND_INVENTORY_DEGRADED: 1}, (
+            f"different targets/kinds must be separate problems; got {store.counts_by_kind()}"
+        )
+
+    def test_store_is_bounded(self):
+        store = ChaosProblemStore(limit=2)
+        for i in range(5):
+            store.record_stuck_fault(_stuck(host=f"h{i}"))
+        assert len(store.snapshot()) == 2, "the store must not grow without bound"
+        assert store.dropped == 3, f"dropped problems must be counted; got {store.dropped}"
+
+    def test_clear_resets(self):
+        store = ChaosProblemStore()
+        store.record_stuck_fault(_stuck())
+        store.clear()
+        assert store.snapshot() == [] and store.dropped == 0
+
+
+class TestSchedulerProfileValidation:
+    def test_empty_body_is_a_valid_no_op(self):
+        profile, error = _validated_profile({})
+        assert (profile, error) == ({}, None), "an empty body must keep the current profile"
+
+    def test_unknown_type_is_rejected(self):
+        profile, error = _validated_profile({"enabled": ["KillNodeNemesis", "NoSuchNemesis"]})
+        assert profile == {} and error is not None, "an unknown type must not be accepted"
+        assert "NoSuchNemesis" in error, f"the error must name the offender; got {error!r}"
+
+    def test_string_instead_of_list_is_rejected(self):
+        # list("KillNodeNemesis") would silently become 15 single-character "types".
+        profile, error = _validated_profile({"enabled": "KillNodeNemesis"})
+        assert profile == {} and error is not None, "a bare string must not be split into types"
+
+    def test_known_types_pass_through(self):
+        profile, error = _validated_profile({"enabled": ["KillNodeNemesis"]})
+        assert error is None and profile == {"enabled": ["KillNodeNemesis"]}
+
+    def test_numeric_bounds(self):
+        good, error = _validated_profile(
+            {"base_interval": 30, "jitter": 0.25, "max_per_tick": 4}
+        )
+        assert error is None
+        assert good == {"base_interval": 30.0, "jitter": 0.25, "max_per_tick": 4}
+
+        for body in (
+            {"jitter": 1.5},
+            {"jitter": "wide"},
+            {"base_interval": 0},
+            {"max_per_tick": 0},
+            {"max_per_tick": "many"},
+        ):
+            profile, error = _validated_profile(body)
+            assert profile == {} and error is not None, f"{body} must be rejected"
+
+    def test_unknown_field_is_rejected(self):
+        profile, error = _validated_profile({"max_pertick": 3})
+        assert profile == {} and error is not None, (
+            "a misspelled field must not be silently ignored"
+        )
+        assert "max_pertick" in error

--- a/ydb/tests/stability/nemesis/ut/test_chaos_problems.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_problems.py
@@ -1,9 +1,4 @@
-"""Unit tests for the nemesis problem log and the scheduler-profile validation.
-
-Both exist so that chaos-side trouble reaches the stability test report instead of a log line:
-``ChaosProblemStore`` collects it, ``GET /api/problems`` serves it, and a rejected profile keeps a
-typo from silently disabling all chaos.
-"""
+"""The chaos-side problem log behind ``GET /api/problems``."""
 
 from __future__ import annotations
 
@@ -14,107 +9,42 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_problems im
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import StuckFault
-from ydb.tests.stability.nemesis.routers.orchestrator_router import _validated_profile
 
 
-def _stuck(host: str = "h1", nemesis_type: str = "StopStartNodeNemesis") -> StuckFault:
+def _stuck(host: str = "h1") -> StuckFault:
     return StuckFault(
         lease_id="lease-1",
-        nemesis_type=nemesis_type,
+        nemesis_type="StopStartNodeNemesis",
         target=ChaosTarget.for_node(host, node_id=1),
         held_sec=420.0,
         timeout_sec=300.0,
     )
 
 
-class TestChaosProblemStore:
-    def test_stuck_fault_is_recorded_with_target_and_numbers(self):
-        store = ChaosProblemStore()
-        store.record_stuck_fault(_stuck())
-        problems = store.snapshot()
-        assert len(problems) == 1, f"one stuck fault must produce one problem; got {problems}"
-        problem = problems[0]
-        assert problem["kind"] == KIND_STUCK_FAULT
-        assert problem["host"] == "h1" and problem["target"] == "node:1:h1", (
-            f"the problem must name the target that did not recover; got {problem}"
-        )
-        assert problem["details"]["held_sec"] == 420.0
-        assert problem["details"]["timeout_sec"] == 300.0
-        assert "did not recover" in problem["summary"], (
-            f"summary must be readable in a test report; got {problem['summary']!r}"
-        )
-
-    def test_repeated_problem_is_deduplicated_with_a_counter(self):
-        store = ChaosProblemStore()
-        for _ in range(3):
-            store.record_stuck_fault(_stuck())
-        problems = store.snapshot()
-        assert len(problems) == 1, "the same fault must not pile up as separate problems"
-        assert problems[0]["count"] == 3, f"repeats must bump count; got {problems[0]}"
-        assert problems[0]["last_seen"] >= problems[0]["first_seen"]
-
-    def test_distinct_targets_stay_separate(self):
-        store = ChaosProblemStore()
-        store.record_stuck_fault(_stuck(host="h1"))
-        store.record_stuck_fault(_stuck(host="h2"))
-        store.record_inventory_degraded("cluster harness unavailable")
-        assert store.counts_by_kind() == {KIND_STUCK_FAULT: 2, KIND_INVENTORY_DEGRADED: 1}, (
-            f"different targets/kinds must be separate problems; got {store.counts_by_kind()}"
-        )
-
-    def test_store_is_bounded(self):
-        store = ChaosProblemStore(limit=2)
-        for i in range(5):
-            store.record_stuck_fault(_stuck(host=f"h{i}"))
-        assert len(store.snapshot()) == 2, "the store must not grow without bound"
-        assert store.dropped == 3, f"dropped problems must be counted; got {store.dropped}"
-
-    def test_clear_resets(self):
-        store = ChaosProblemStore()
-        store.record_stuck_fault(_stuck())
-        store.clear()
-        assert store.snapshot() == [] and store.dropped == 0
+def test_stuck_fault_names_its_target_and_numbers():
+    store = ChaosProblemStore()
+    store.record_stuck_fault(_stuck())
+    problem = store.snapshot()[0]
+    assert problem["kind"] == KIND_STUCK_FAULT
+    assert (problem["target"], problem["host"]) == ("node:1:h1", "h1")
+    assert problem["details"] == {"held_sec": 420.0, "timeout_sec": 300.0, "lease_id": "lease-1"}
+    assert "did not recover" in problem["summary"]
 
 
-class TestSchedulerProfileValidation:
-    def test_empty_body_is_a_valid_no_op(self):
-        profile, error = _validated_profile({})
-        assert (profile, error) == ({}, None), "an empty body must keep the current profile"
+def test_repeats_are_counted_and_distinct_problems_kept_apart():
+    store = ChaosProblemStore()
+    for _ in range(3):
+        store.record_stuck_fault(_stuck("h1"))
+    store.record_stuck_fault(_stuck("h2"))
+    store.record_inventory_degraded("cluster harness unavailable")
 
-    def test_unknown_type_is_rejected(self):
-        profile, error = _validated_profile({"enabled": ["KillNodeNemesis", "NoSuchNemesis"]})
-        assert profile == {} and error is not None, "an unknown type must not be accepted"
-        assert "NoSuchNemesis" in error, f"the error must name the offender; got {error!r}"
+    assert store.counts_by_kind() == {KIND_STUCK_FAULT: 2, KIND_INVENTORY_DEGRADED: 1}
+    by_host = {p["host"]: p for p in store.snapshot() if p["host"]}
+    assert by_host["h1"]["count"] == 3 and by_host["h2"]["count"] == 1
 
-    def test_string_instead_of_list_is_rejected(self):
-        # list("KillNodeNemesis") would silently become 15 single-character "types".
-        profile, error = _validated_profile({"enabled": "KillNodeNemesis"})
-        assert profile == {} and error is not None, "a bare string must not be split into types"
 
-    def test_known_types_pass_through(self):
-        profile, error = _validated_profile({"enabled": ["KillNodeNemesis"]})
-        assert error is None and profile == {"enabled": ["KillNodeNemesis"]}
-
-    def test_numeric_bounds(self):
-        good, error = _validated_profile(
-            {"base_interval": 30, "jitter": 0.25, "max_per_tick": 4}
-        )
-        assert error is None
-        assert good == {"base_interval": 30.0, "jitter": 0.25, "max_per_tick": 4}
-
-        for body in (
-            {"jitter": 1.5},
-            {"jitter": "wide"},
-            {"base_interval": 0},
-            {"max_per_tick": 0},
-            {"max_per_tick": "many"},
-        ):
-            profile, error = _validated_profile(body)
-            assert profile == {} and error is not None, f"{body} must be rejected"
-
-    def test_unknown_field_is_rejected(self):
-        profile, error = _validated_profile({"max_pertick": 3})
-        assert profile == {} and error is not None, (
-            "a misspelled field must not be silently ignored"
-        )
-        assert "max_pertick" in error
+def test_store_is_bounded():
+    store = ChaosProblemStore(limit=2)
+    for i in range(5):
+        store.record_stuck_fault(_stuck(f"h{i}"))
+    assert len(store.snapshot()) == 2 and store.dropped == 3

--- a/ydb/tests/stability/nemesis/ut/test_chaos_target.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_target.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -24,7 +25,8 @@ def _write_topology_yaml(hosts: list[dict], erasure: str = "block-4-2") -> str:
         "static_erasure": erasure,
         "hosts": hosts,
     }
-    _fd, path = tempfile.mkstemp(suffix=".yaml")
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    os.close(fd)
     Path(path).write_text(yaml.safe_dump(doc), encoding="utf-8")
     return path
 
@@ -79,10 +81,19 @@ class TestFailureModelGuard:
         c2 = ChaosTarget.for_node("h2", node_id=2)
         c3 = ChaosTarget.for_node("h3", node_id=3)
 
+        # Joint filter accumulates admitted racks: block-4-2 budget is 2, so only first two.
         safe = guard.filter_safe([c1, c2, c3], ImpactScope.NODE)
-        assert {t.host for t in safe} == {"h1", "h2", "h3"}, (
-            f"with empty impairments, block-4-2 must allow all candidates; got {[t.host for t in safe]}"
+        assert {t.host for t in safe} == {"h1", "h2"}, (
+            "with empty impairments, block-4-2 joint filter must admit at most 2 domains; "
+            f"got {[t.host for t in safe]}"
         )
+
+        # Individually, each candidate is still tolerable against empty active set.
+        for cand in (c1, c2, c3):
+            alone = guard.filter_safe([cand], ImpactScope.NODE)
+            assert alone == [cand], (
+                f"single candidate {cand.host} must be safe alone; got {[t.host for t in alone]}"
+            )
 
         guard.record_inject("e1", c1, ImpactScope.NODE, recovery_sec=None)
         guard.record_inject("e2", c2, ImpactScope.NODE, recovery_sec=None)
@@ -115,13 +126,19 @@ class TestFailureModelGuard:
         extra_ok = ChaosTarget.for_node("h3", node_id=3)  # dc2 / r3 — one extra domain
         extra_other = ChaosTarget.for_node("h5", node_id=5)  # dc3 / r5
 
-        # filter_safe checks each candidate independently against current impairments.
+        # Individually, either remaining realm's domain is still tolerable.
+        for cand in (extra_ok, extra_other):
+            alone = guard.filter_safe([cand], ImpactScope.NODE)
+            assert alone == [cand], (
+                f"with only dc1 lost, {cand.host} must be safe alone; "
+                f"snapshot={guard.snapshot()}, alone={[t.host for t in alone]}"
+            )
+
+        # Jointly, accumulate admits only the first extra domain.
         safe = guard.filter_safe([extra_ok, extra_other], ImpactScope.NODE)
-        safe_hosts = {t.host for t in safe}
-        assert safe_hosts == {"h3", "h5"}, (
-            "with only dc1 lost, mirror-3-dc must still allow one extra domain in *either* "
-            f"remaining realm (h3 or h5) individually; snapshot={guard.snapshot()}, "
-            f"safe={sorted(safe_hosts)}"
+        assert [t.host for t in safe] == ["h3"], (
+            "joint filter must not admit two extra domains after sacrificial realm; "
+            f"snapshot={guard.snapshot()}, safe={[t.host for t in safe]}"
         )
 
         guard.record_inject("e-extra", extra_ok, ImpactScope.NODE, recovery_sec=None)
@@ -129,6 +146,25 @@ class TestFailureModelGuard:
         assert safe_after == [], (
             "after dc1 + one domain in dc2, mirror-3-dc must reject a domain in a third realm "
             f"(h5/dc3); snapshot={guard.snapshot()}, safe_after={[t.host for t in safe_after]}"
+        )
+
+    def test_record_extract_fallback_matches_identity_not_rack(self, block42_topology):
+        """Untracked extract must not drop unrelated impairments that share a rack."""
+        guard = FailureModelGuard(block42_topology)
+        # Two different node identities on the same host/rack.
+        n1 = ChaosTarget.for_node("h1", node_id=1, ic_port=19001)
+        n2 = ChaosTarget.for_node("h1", node_id=2, ic_port=19002)
+        guard.record_inject("tracked", n1, ImpactScope.NODE, recovery_sec=None)
+        # Simulate extract for an untracked execution of n2 (e.g. after restart).
+        guard.record_extract("untracked-other", n2, ImpactScope.NODE)
+        snap = guard.snapshot()
+        assert "r1" in snap["impaired_racks"], (
+            "extract fallback by identity must leave n1 impairment intact; "
+            f"snapshot={snap}"
+        )
+        guard.record_extract("tracked", n1, ImpactScope.NODE)
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"tracked extract must release n1; snapshot={guard.snapshot()}"
         )
 
     def test_tablet_targets_do_not_consume_budget(self, block42_topology):

--- a/ydb/tests/stability/nemesis/ut/test_chaos_target.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_target.py
@@ -1,0 +1,184 @@
+"""Unit tests for ChaosTarget / FailureModelGuard / serial planner core paths."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    ClusterTopologyModel,
+    FailureModelGuard,
+    ImpactScope,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.serial_staggered_planner import (
+    SerialStaggeredInjectPlanner,
+)
+
+
+def _write_topology_yaml(hosts: list[dict], erasure: str = "block-4-2") -> str:
+    doc = {
+        "static_erasure": erasure,
+        "hosts": hosts,
+    }
+    _fd, path = tempfile.mkstemp(suffix=".yaml")
+    Path(path).write_text(yaml.safe_dump(doc), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def block42_topology():
+    hosts = [
+        {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
+        {"name": "h2", "location": {"rack": "r2", "data_center": "dc1"}},
+        {"name": "h3", "location": {"rack": "r3", "data_center": "dc1"}},
+        {"name": "h4", "location": {"rack": "r4", "data_center": "dc1"}},
+    ]
+    path = _write_topology_yaml(hosts, "block-4-2")
+    return ClusterTopologyModel(path)
+
+
+@pytest.fixture
+def mirror3dc_topology():
+    # 3 realms (DC), 2 fail domains (racks) each — classic mirror-3-dc layout.
+    hosts = [
+        {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
+        {"name": "h2", "location": {"rack": "r2", "data_center": "dc1"}},
+        {"name": "h3", "location": {"rack": "r3", "data_center": "dc2"}},
+        {"name": "h4", "location": {"rack": "r4", "data_center": "dc2"}},
+        {"name": "h5", "location": {"rack": "r5", "data_center": "dc3"}},
+        {"name": "h6", "location": {"rack": "r6", "data_center": "dc3"}},
+    ]
+    path = _write_topology_yaml(hosts, "mirror-3-dc")
+    return ClusterTopologyModel(path)
+
+
+class TestChaosTarget:
+    def test_serde_roundtrip(self):
+        t = ChaosTarget.for_node("host-a", node_id=3, ic_port=19001)
+        restored = ChaosTarget.from_dict(t.to_dict())
+        assert restored == t, (
+            f"ChaosTarget serde lost fields: original={t.to_dict()}, restored={restored.to_dict()}"
+        )
+        assert restored.identity_key() == t.identity_key(), (
+            f"identity_key mismatch after serde: {t.identity_key()!r} != {restored.identity_key()!r}"
+        )
+
+
+class TestFailureModelGuard:
+    def test_filter_safe_block42_allows_two_domains(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        assert guard.enabled, (
+            f"block-4-2 guard must be enabled; snapshot={guard.snapshot()}"
+        )
+
+        c1 = ChaosTarget.for_node("h1", node_id=1)
+        c2 = ChaosTarget.for_node("h2", node_id=2)
+        c3 = ChaosTarget.for_node("h3", node_id=3)
+
+        safe = guard.filter_safe([c1, c2, c3], ImpactScope.NODE)
+        assert {t.host for t in safe} == {"h1", "h2", "h3"}, (
+            f"with empty impairments, block-4-2 must allow all candidates; got {[t.host for t in safe]}"
+        )
+
+        guard.record_inject("e1", c1, ImpactScope.NODE, recovery_sec=None)
+        guard.record_inject("e2", c2, ImpactScope.NODE, recovery_sec=None)
+
+        # Already touched identities are dropped; a third rack exceeds block-4-2 budget (max 2).
+        safe_after = guard.filter_safe([c1, c2, c3], ImpactScope.NODE)
+        assert safe_after == [], (
+            "block-4-2 with 2 impaired racks must reject a third domain and already-touched "
+            f"targets; snapshot={guard.snapshot()}, safe_after={[t.host for t in safe_after]}"
+        )
+
+    def test_filter_safe_mirror3dc_one_realm_plus_one_domain(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
+        assert guard.enabled, (
+            f"mirror-3-dc guard must be enabled; erasure={mirror3dc_topology.tolerance.erasure!r}, "
+            f"snapshot={guard.snapshot()}"
+        )
+        assert mirror3dc_topology.tolerance.kind == "realm_plus_domain", (
+            f"expected realm_plus_domain tolerance for mirror-3-dc, got {mirror3dc_topology.tolerance!r}"
+        )
+
+        # Impair whole dc1 (both racks) — one sacrificial realm.
+        guard.record_inject(
+            "dc1-r1", ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE, recovery_sec=None
+        )
+        guard.record_inject(
+            "dc1-r2", ChaosTarget.for_node("h2", node_id=2), ImpactScope.NODE, recovery_sec=None
+        )
+
+        extra_ok = ChaosTarget.for_node("h3", node_id=3)  # dc2 / r3 — one extra domain
+        extra_other = ChaosTarget.for_node("h5", node_id=5)  # dc3 / r5
+
+        # filter_safe checks each candidate independently against current impairments.
+        safe = guard.filter_safe([extra_ok, extra_other], ImpactScope.NODE)
+        safe_hosts = {t.host for t in safe}
+        assert safe_hosts == {"h3", "h5"}, (
+            "with only dc1 lost, mirror-3-dc must still allow one extra domain in *either* "
+            f"remaining realm (h3 or h5) individually; snapshot={guard.snapshot()}, "
+            f"safe={sorted(safe_hosts)}"
+        )
+
+        guard.record_inject("e-extra", extra_ok, ImpactScope.NODE, recovery_sec=None)
+        safe_after = guard.filter_safe([extra_other], ImpactScope.NODE)
+        assert safe_after == [], (
+            "after dc1 + one domain in dc2, mirror-3-dc must reject a domain in a third realm "
+            f"(h5/dc3); snapshot={guard.snapshot()}, safe_after={[t.host for t in safe_after]}"
+        )
+
+    def test_tablet_targets_do_not_consume_budget(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        tablet = ChaosTarget.for_tablet("h1", tablet_id=42)
+        guard.record_inject("t1", tablet, ImpactScope.NODE, recovery_sec=None)
+        snap = guard.snapshot()
+        assert snap["impaired_racks"] == [], (
+            f"tablet inject must not impair racks; snapshot={snap}"
+        )
+        assert snap["tracked_executions"] == 0, (
+            f"tablet inject must not create impairment records; snapshot={snap}"
+        )
+
+    def test_extract_releases_budget(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        t = ChaosTarget.for_host("h1")
+        guard.record_inject("e1", t, ImpactScope.NODE, recovery_sec=None)
+        assert "r1" in guard.snapshot()["impaired_racks"], (
+            f"host inject on h1 must mark rack r1 impaired; snapshot={guard.snapshot()}"
+        )
+        guard.record_extract("e1", t, ImpactScope.NODE)
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"extract must release impaired racks; snapshot={guard.snapshot()}"
+        )
+
+
+class TestSerialStaggeredPlanner:
+    def test_dispatches_only_to_owner_host(self):
+        planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")
+        candidates = [
+            ChaosTarget.for_node("h1", node_id=1, ic_port=19001),
+            ChaosTarget.for_node("h2", node_id=2, ic_port=19001),
+        ]
+        cmds = planner.scheduled_tick(candidates)
+        assert len(cmds) == 1, (
+            f"serial planner must emit exactly one command for one chosen node; got {len(cmds)}"
+        )
+        cmd = cmds[0]
+        assert cmd.target.host in {"h1", "h2"}, (
+            f"chosen host must be from candidates; got {cmd.target.host!r}"
+        )
+        assert cmd.target.node_id in {1, 2}, (
+            f"chosen node_id must be from candidates; got {cmd.target.node_id!r}"
+        )
+        assert cmd.payload.get("node_id") == cmd.target.node_id, (
+            f"payload.node_id must match ChaosTarget.node_id; "
+            f"payload={cmd.payload}, target={cmd.target.to_dict()}"
+        )
+        assert cmd.host == cmd.target.host, (
+            f"dispatch host must be the owner of the chosen node, not a random host; "
+            f"host={cmd.host!r}, target.host={cmd.target.host!r}"
+        )

--- a/ydb/tests/stability/nemesis/ut/test_chaos_target.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_target.py
@@ -198,8 +198,8 @@ class TestFailureBudgetLease:
     def test_footprint_for_node_is_single_rack(self, block42_topology):
         guard = FailureModelGuard(block42_topology)
         fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        assert fp == frozenset({"r1"}), (
-            f"a node footprint must be exactly its host's rack; got {fp}"
+        assert fp.racks == frozenset({"r1"}) and fp.slots == 0, (
+            f"a node footprint must be exactly its host's rack, no slots; got {fp}"
         )
 
     def test_footprint_for_datacenter_covers_all_its_racks(self, mirror3dc_topology):
@@ -207,14 +207,14 @@ class TestFailureBudgetLease:
         fp = guard.footprint_for(
             ChaosTarget.for_datacenter("h1", "dc1"), ImpactScope.DATACENTER
         )
-        assert fp == frozenset({"r1", "r2"}), (
+        assert fp.racks == frozenset({"r1", "r2"}), (
             f"a datacenter footprint must cover every rack in the DC; got {fp}"
         )
 
     def test_tablet_footprint_consumes_no_budget(self, block42_topology):
         guard = FailureModelGuard(block42_topology)
         fp = guard.footprint_for(ChaosTarget.for_tablet("h1", tablet_id=7), ImpactScope.NODE)
-        assert fp == frozenset(), f"a tablet footprint must be empty; got {fp}"
+        assert not fp, f"a tablet footprint must be empty (no racks, no slots); got {fp}"
         lease = guard.reserve(fp)
         assert lease is not None, "reserving an empty footprint must always succeed"
         assert guard.snapshot()["impaired_racks"] == [], (
@@ -320,6 +320,75 @@ class TestFailureBudgetLease:
         assert guard.release("never-issued") is False, (
             "releasing an unknown lease id must be a no-op, not raise"
         )
+
+
+class TestSlotBudget:
+    """Slots (dynamic nodes) draw from a separate 30% budget, not the erasure/rack budget."""
+
+    def _slot_fp(self, guard):
+        return guard.footprint_for(
+            ChaosTarget.for_slot("h1", slot_idx=1), ImpactScope.SLOT
+        )
+
+    def test_slot_footprint_is_slot_not_rack(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=10)
+        fp = self._slot_fp(guard)
+        assert fp.slots == 1 and fp.racks == frozenset(), (
+            f"a slot kill must consume one slot and zero racks; got {fp}"
+        )
+
+    def test_slot_kind_target_never_touches_racks(self, block42_topology):
+        # Even annotated NODE scope, a SLOT-kind target must not eat a rack fail-domain.
+        guard = FailureModelGuard(block42_topology, total_slots=10)
+        fp = guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=1), ImpactScope.NODE)
+        assert fp.slots == 1 and fp.racks == frozenset(), (
+            f"a SLOT-kind target must draw from the slot budget regardless of scope; got {fp}"
+        )
+
+    def test_slot_budget_caps_at_thirty_percent(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=10)  # max = floor(0.3*10) = 3
+        assert guard.snapshot()["max_slots"] == 3
+        leases = [
+            guard.reserve(
+                guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=i), ImpactScope.SLOT),
+                identity_key=f"slot:{i}",
+            )
+            for i in range(3)
+        ]
+        assert all(leases), "the first 30% of slots must all reserve"
+        assert guard.snapshot()["impaired_slots"] == 3
+        overflow = guard.reserve(
+            guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=3), ImpactScope.SLOT),
+            identity_key="slot:3",
+        )
+        assert overflow is None, "a 4th slot must exceed the 30% budget"
+        assert guard.snapshot()["impaired_racks"] == [], (
+            "slot reservations must never impair a rack fail-domain"
+        )
+
+    def test_slot_and_rack_budgets_are_independent(self, block42_topology):
+        # Fill the slot budget, then a node (rack) fault must still fit — dimensions don't cross.
+        guard = FailureModelGuard(block42_topology, total_slots=3)  # max_slots = floor(0.9)->1
+        assert guard.snapshot()["max_slots"] == 1
+        slot = guard.reserve(self._slot_fp(guard), identity_key="slot:1")
+        assert slot is not None
+        assert guard.reserve(self._slot_fp(guard), identity_key="slot:2") is None, (
+            "the slot budget is full at 1, so a second slot must be rejected"
+        )
+        node_fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        assert guard.fits(node_fp) and guard.reserve(node_fp) is not None, (
+            "a rack fault must still fit while the slot budget is exhausted (independent budgets)"
+        )
+
+    def test_slot_budget_fails_open_when_no_slots_known(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=0)
+        assert guard.snapshot()["max_slots"] == 0
+        # With no slot total, the slot dimension never blocks (fail-open).
+        for i in range(5):
+            fp = guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=i), ImpactScope.SLOT)
+            assert guard.reserve(fp, identity_key=f"slot:{i}") is not None, (
+                "unknown slot total must fail open, never blocking slot chaos"
+            )
 
 
 class TestSerialStaggeredPlanner:

--- a/ydb/tests/stability/nemesis/ut/test_chaos_target.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_target.py
@@ -192,6 +192,136 @@ class TestFailureModelGuard:
         )
 
 
+class TestFailureBudgetLease:
+    """Per-candidate lease API (footprint_for / fits / reserve / release) for the new scheduler."""
+
+    def test_footprint_for_node_is_single_rack(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        assert fp == frozenset({"r1"}), (
+            f"a node footprint must be exactly its host's rack; got {fp}"
+        )
+
+    def test_footprint_for_datacenter_covers_all_its_racks(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
+        fp = guard.footprint_for(
+            ChaosTarget.for_datacenter("h1", "dc1"), ImpactScope.DATACENTER
+        )
+        assert fp == frozenset({"r1", "r2"}), (
+            f"a datacenter footprint must cover every rack in the DC; got {fp}"
+        )
+
+    def test_tablet_footprint_consumes_no_budget(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        fp = guard.footprint_for(ChaosTarget.for_tablet("h1", tablet_id=7), ImpactScope.NODE)
+        assert fp == frozenset(), f"a tablet footprint must be empty; got {fp}"
+        lease = guard.reserve(fp)
+        assert lease is not None, "reserving an empty footprint must always succeed"
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"reserving a tablet footprint must not impair any rack; snapshot={guard.snapshot()}"
+        )
+
+    def test_fits_is_read_only(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        assert guard.fits(fp) and guard.fits(fp), "fits must be repeatable and not consume budget"
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"fits must not mutate the impaired set; snapshot={guard.snapshot()}"
+        )
+        assert guard.reserve(fp) is not None, "budget untouched by fits, so reserve must still fit"
+
+    def test_reserve_release_block42_budget(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        fp1 = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        fp2 = guard.footprint_for(ChaosTarget.for_node("h2", node_id=2), ImpactScope.NODE)
+        fp3 = guard.footprint_for(ChaosTarget.for_node("h3", node_id=3), ImpactScope.NODE)
+
+        l1 = guard.reserve(fp1)
+        l2 = guard.reserve(fp2)
+        assert l1 and l2, "block-4-2 must admit two distinct fail domains"
+
+        assert guard.reserve(fp3) is None, (
+            "a third distinct domain must exceed the block-4-2 budget; "
+            f"snapshot={guard.snapshot()}"
+        )
+        assert not guard.fits(fp3), "fits must agree with reserve that a third domain does not fit"
+
+        assert guard.release(l2) is True, "releasing an active lease must report success"
+        l3 = guard.reserve(fp3)
+        assert l3 is not None, (
+            f"after releasing one domain a third must fit again; snapshot={guard.snapshot()}"
+        )
+
+    def test_reserve_is_atomic_never_exceeds_budget(self, block42_topology):
+        """Sequential reservations of every rack must stop exactly at the budget."""
+        guard = FailureModelGuard(block42_topology)
+        leases = []
+        for host, rack_node in (("h1", 1), ("h2", 2), ("h3", 3), ("h4", 4)):
+            fp = guard.footprint_for(
+                ChaosTarget.for_node(host, node_id=rack_node), ImpactScope.NODE
+            )
+            leases.append(guard.reserve(fp))
+        granted = [x for x in leases if x is not None]
+        assert len(granted) == 2, (
+            f"block-4-2 must grant exactly 2 leases across 4 distinct racks; granted={leases}"
+        )
+        assert len(guard.snapshot()["impaired_racks"]) == 2, (
+            f"impaired set must never exceed the budget; snapshot={guard.snapshot()}"
+        )
+
+    def test_datacenter_footprint_mirror3dc_sacrificial_realm(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
+        dc1 = guard.footprint_for(
+            ChaosTarget.for_datacenter("h1", "dc1"), ImpactScope.DATACENTER
+        )
+        node_dc2 = guard.footprint_for(ChaosTarget.for_node("h3", node_id=3), ImpactScope.NODE)
+        node_dc3 = guard.footprint_for(ChaosTarget.for_node("h5", node_id=5), ImpactScope.NODE)
+
+        ldc = guard.reserve(dc1)
+        assert ldc is not None, "a whole DC must fit as the sacrificial realm on an empty budget"
+
+        lextra = guard.reserve(node_dc2)
+        assert lextra is not None, (
+            f"one extra domain in another realm must fit after sacrificing dc1; "
+            f"snapshot={guard.snapshot()}"
+        )
+
+        assert guard.reserve(node_dc3) is None, (
+            "a domain in a third realm must be rejected (1 realm + 1 domain budget); "
+            f"snapshot={guard.snapshot()}"
+        )
+
+        assert guard.release(ldc) is True
+        lthird = guard.reserve(node_dc3)
+        assert lthird is not None, (
+            f"after releasing dc1, single domains in dc2 and dc3 must both fit; "
+            f"snapshot={guard.snapshot()}"
+        )
+
+    def test_reserve_records_identity_for_active_identities(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        target = ChaosTarget.for_node("h1", node_id=1)
+        fp = guard.footprint_for(target, ImpactScope.NODE)
+        assert guard.active_identities() == set(), "no reservations means no active identities"
+        lease = guard.reserve(fp, identity_key=target.identity_key())
+        assert lease is not None
+        assert target.identity_key() in guard.active_identities(), (
+            "a reserved target's identity must be reported so schedulers skip re-hitting it; "
+            f"active={guard.active_identities()}"
+        )
+        assert guard.release(lease) is True
+        assert target.identity_key() not in guard.active_identities(), (
+            "releasing the lease must drop its identity from the active set"
+        )
+
+    def test_release_of_disabled_or_unknown_lease_is_noop(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        assert guard.release(None) is False, "releasing a None lease must be a no-op"
+        assert guard.release("never-issued") is False, (
+            "releasing an unknown lease id must be a no-op, not raise"
+        )
+
+
 class TestSerialStaggeredPlanner:
     def test_dispatches_only_to_owner_host(self):
         planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")

--- a/ydb/tests/stability/nemesis/ut/test_chaos_target.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_target.py
@@ -1,4 +1,4 @@
-"""Unit tests for ChaosTarget / FailureModelGuard / serial planner core paths."""
+"""ChaosTarget, the failure-model guard and the serial planner."""
 
 from __future__ import annotations
 
@@ -24,685 +24,267 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.serial_staggered_
 )
 
 
-def _write_topology_yaml(hosts: list[dict], erasure: str = "block-4-2") -> str:
-    doc = {
-        "static_erasure": erasure,
-        "hosts": hosts,
-    }
+def _topology_yaml(hosts: list[dict], erasure: str = "block-4-2") -> str:
     fd, path = tempfile.mkstemp(suffix=".yaml")
     os.close(fd)
-    Path(path).write_text(yaml.safe_dump(doc), encoding="utf-8")
+    Path(path).write_text(
+        yaml.safe_dump({"static_erasure": erasure, "hosts": hosts}), encoding="utf-8"
+    )
     return path
+
+
+def _hosts(spec: list[tuple[str, str, str | None]]) -> list[dict]:
+    out = []
+    for name, rack, dc in spec:
+        location = {"rack": rack}
+        if dc is not None:
+            location["data_center"] = dc
+        out.append({"name": name, "location": location})
+    return out
 
 
 @pytest.fixture
 def block42_topology():
-    hosts = [
-        {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
-        {"name": "h2", "location": {"rack": "r2", "data_center": "dc1"}},
-        {"name": "h3", "location": {"rack": "r3", "data_center": "dc1"}},
-        {"name": "h4", "location": {"rack": "r4", "data_center": "dc1"}},
-    ]
-    path = _write_topology_yaml(hosts, "block-4-2")
-    return ClusterTopologyModel(path)
+    hosts = _hosts([(f"h{i}", f"r{i}", "dc1") for i in (1, 2, 3, 4)])
+    return ClusterTopologyModel(_topology_yaml(hosts, "block-4-2"))
 
 
 @pytest.fixture
 def mirror3dc_topology():
-    # 3 realms (DC), 2 fail domains (racks) each — classic mirror-3-dc layout.
-    hosts = [
-        {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
-        {"name": "h2", "location": {"rack": "r2", "data_center": "dc1"}},
-        {"name": "h3", "location": {"rack": "r3", "data_center": "dc2"}},
-        {"name": "h4", "location": {"rack": "r4", "data_center": "dc2"}},
-        {"name": "h5", "location": {"rack": "r5", "data_center": "dc3"}},
-        {"name": "h6", "location": {"rack": "r6", "data_center": "dc3"}},
-    ]
-    path = _write_topology_yaml(hosts, "mirror-3-dc")
-    return ClusterTopologyModel(path)
+    """3 realms × 2 domains, with rack labels repeating per DC — as real configs do."""
+    hosts = _hosts(
+        [(f"{dc}-{name}", rack, dc) for dc in ("dc1", "dc2", "dc3") for name, rack in (("a", "1"), ("b", "2"))]
+    )
+    return ClusterTopologyModel(_topology_yaml(hosts, "mirror-3-dc"))
 
 
-@pytest.fixture
-def per_dc_rack_labels_topology():
-    """mirror-3-dc where rack labels restart in every DC (``rack: '1'``, ``'2'`` per realm).
-
-    This is how real ``cluster.yaml`` files label racks, and it is the case that collapsed into a
-    single fail domain when the guard keyed impairments by the bare rack label.
-    """
-    hosts = [
-        {"name": f"{dc}-{name}", "location": {"rack": rack, "data_center": dc}}
-        for dc in ("dc1", "dc2", "dc3")
-        for name, rack in (("a", "1"), ("b", "2"))
-    ]
-    path = _write_topology_yaml(hosts, "mirror-3-dc")
-    return ClusterTopologyModel(path)
-
-
-class TestChaosTarget:
-    def test_serde_roundtrip(self):
-        t = ChaosTarget.for_node("host-a", node_id=3, ic_port=19001)
-        restored = ChaosTarget.from_dict(t.to_dict())
-        assert restored == t, (
-            f"ChaosTarget serde lost fields: original={t.to_dict()}, restored={restored.to_dict()}"
-        )
-        assert restored.identity_key() == t.identity_key(), (
-            f"identity_key mismatch after serde: {t.identity_key()!r} != {restored.identity_key()!r}"
-        )
-
-
-class TestFailureModelGuard:
-    def test_filter_safe_block42_allows_two_domains(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        assert guard.enabled, (
-            f"block-4-2 guard must be enabled; snapshot={guard.snapshot()}"
-        )
-
-        c1 = ChaosTarget.for_node("h1", node_id=1)
-        c2 = ChaosTarget.for_node("h2", node_id=2)
-        c3 = ChaosTarget.for_node("h3", node_id=3)
-
-        # Joint filter accumulates admitted racks: block-4-2 budget is 2, so only first two.
-        safe = guard.filter_safe([c1, c2, c3], ImpactScope.NODE)
-        assert {t.host for t in safe} == {"h1", "h2"}, (
-            "with empty impairments, block-4-2 joint filter must admit at most 2 domains; "
-            f"got {[t.host for t in safe]}"
-        )
-
-        # Individually, each candidate is still tolerable against empty active set.
-        for cand in (c1, c2, c3):
-            alone = guard.filter_safe([cand], ImpactScope.NODE)
-            assert alone == [cand], (
-                f"single candidate {cand.host} must be safe alone; got {[t.host for t in alone]}"
-            )
-
-        guard.record_inject("e1", c1, ImpactScope.NODE, recovery_sec=None)
-        guard.record_inject("e2", c2, ImpactScope.NODE, recovery_sec=None)
-
-        # Already touched identities are dropped; a third rack exceeds block-4-2 budget (max 2).
-        safe_after = guard.filter_safe([c1, c2, c3], ImpactScope.NODE)
-        assert safe_after == [], (
-            "block-4-2 with 2 impaired racks must reject a third domain and already-touched "
-            f"targets; snapshot={guard.snapshot()}, safe_after={[t.host for t in safe_after]}"
-        )
-
-    def test_filter_safe_mirror3dc_one_realm_plus_one_domain(self, mirror3dc_topology):
-        guard = FailureModelGuard(mirror3dc_topology)
-        assert guard.enabled, (
-            f"mirror-3-dc guard must be enabled; erasure={mirror3dc_topology.tolerance.erasure!r}, "
-            f"snapshot={guard.snapshot()}"
-        )
-        assert mirror3dc_topology.tolerance.kind == "realm_plus_domain", (
-            f"expected realm_plus_domain tolerance for mirror-3-dc, got {mirror3dc_topology.tolerance!r}"
-        )
-
-        # Impair whole dc1 (both racks) — one sacrificial realm.
-        guard.record_inject(
-            "dc1-r1", ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE, recovery_sec=None
-        )
-        guard.record_inject(
-            "dc1-r2", ChaosTarget.for_node("h2", node_id=2), ImpactScope.NODE, recovery_sec=None
-        )
-
-        extra_ok = ChaosTarget.for_node("h3", node_id=3)  # dc2 / r3 — one extra domain
-        extra_other = ChaosTarget.for_node("h5", node_id=5)  # dc3 / r5
-
-        # Individually, either remaining realm's domain is still tolerable.
-        for cand in (extra_ok, extra_other):
-            alone = guard.filter_safe([cand], ImpactScope.NODE)
-            assert alone == [cand], (
-                f"with only dc1 lost, {cand.host} must be safe alone; "
-                f"snapshot={guard.snapshot()}, alone={[t.host for t in alone]}"
-            )
-
-        # Jointly, accumulate admits only the first extra domain.
-        safe = guard.filter_safe([extra_ok, extra_other], ImpactScope.NODE)
-        assert [t.host for t in safe] == ["h3"], (
-            "joint filter must not admit two extra domains after sacrificial realm; "
-            f"snapshot={guard.snapshot()}, safe={[t.host for t in safe]}"
-        )
-
-        guard.record_inject("e-extra", extra_ok, ImpactScope.NODE, recovery_sec=None)
-        safe_after = guard.filter_safe([extra_other], ImpactScope.NODE)
-        assert safe_after == [], (
-            "after dc1 + one domain in dc2, mirror-3-dc must reject a domain in a third realm "
-            f"(h5/dc3); snapshot={guard.snapshot()}, safe_after={[t.host for t in safe_after]}"
-        )
-
-    def test_record_extract_fallback_matches_identity_not_rack(self, block42_topology):
-        """Untracked extract must not drop unrelated impairments that share a rack."""
-        guard = FailureModelGuard(block42_topology)
-        # Two different node identities on the same host/rack.
-        n1 = ChaosTarget.for_node("h1", node_id=1, ic_port=19001)
-        n2 = ChaosTarget.for_node("h1", node_id=2, ic_port=19002)
-        guard.record_inject("tracked", n1, ImpactScope.NODE, recovery_sec=None)
-        # Simulate extract for an untracked execution of n2 (e.g. after restart).
-        guard.record_extract("untracked-other", n2, ImpactScope.NODE)
-        snap = guard.snapshot()
-        assert "dc1/r1" in snap["impaired_racks"], (
-            "extract fallback by identity must leave n1 impairment intact; "
-            f"snapshot={snap}"
-        )
-        guard.record_extract("tracked", n1, ImpactScope.NODE)
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"tracked extract must release n1; snapshot={guard.snapshot()}"
-        )
-
-    def test_tablet_targets_do_not_consume_budget(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        tablet = ChaosTarget.for_tablet("h1", tablet_id=42)
-        guard.record_inject("t1", tablet, ImpactScope.NODE, recovery_sec=None)
-        snap = guard.snapshot()
-        assert snap["impaired_racks"] == [], (
-            f"tablet inject must not impair racks; snapshot={snap}"
-        )
-        assert snap["tracked_executions"] == 0, (
-            f"tablet inject must not create impairment records; snapshot={snap}"
-        )
-
-    def test_extract_releases_budget(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        t = ChaosTarget.for_host("h1")
-        guard.record_inject("e1", t, ImpactScope.NODE, recovery_sec=None)
-        assert "dc1/r1" in guard.snapshot()["impaired_racks"], (
-            f"host inject on h1 must mark fail domain dc1/r1 impaired; snapshot={guard.snapshot()}"
-        )
-        guard.record_extract("e1", t, ImpactScope.NODE)
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"extract must release impaired racks; snapshot={guard.snapshot()}"
-        )
-
-
-class TestFailureBudgetLease:
-    """Per-candidate lease API (footprint_for / fits / reserve / release) for the new scheduler."""
-
-    def test_footprint_for_node_is_single_rack(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        assert fp.racks == frozenset({"dc1/r1"}) and fp.slots == 0, (
-            f"a node footprint must be exactly its host's fail domain, no slots; got {fp}"
-        )
-
-    def test_footprint_for_datacenter_covers_all_its_racks(self, mirror3dc_topology):
-        guard = FailureModelGuard(mirror3dc_topology)
-        fp = guard.footprint_for(
-            ChaosTarget.for_datacenter("h1", "dc1"), ImpactScope.DATACENTER
-        )
-        assert fp.racks == frozenset({"dc1/r1", "dc1/r2"}), (
-            f"a datacenter footprint must cover every rack in the DC; got {fp}"
-        )
-
-    def test_tablet_footprint_consumes_no_budget(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        fp = guard.footprint_for(ChaosTarget.for_tablet("h1", tablet_id=7), ImpactScope.NODE)
-        assert not fp, f"a tablet footprint must be empty (no racks, no slots); got {fp}"
-        lease = guard.reserve(fp)
-        assert lease is not None, "reserving an empty footprint must always succeed"
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"reserving a tablet footprint must not impair any rack; snapshot={guard.snapshot()}"
-        )
-
-    def test_fits_is_read_only(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        assert guard.fits(fp) and guard.fits(fp), "fits must be repeatable and not consume budget"
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"fits must not mutate the impaired set; snapshot={guard.snapshot()}"
-        )
-        assert guard.reserve(fp) is not None, "budget untouched by fits, so reserve must still fit"
-
-    def test_reserve_release_block42_budget(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        fp1 = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        fp2 = guard.footprint_for(ChaosTarget.for_node("h2", node_id=2), ImpactScope.NODE)
-        fp3 = guard.footprint_for(ChaosTarget.for_node("h3", node_id=3), ImpactScope.NODE)
-
-        l1 = guard.reserve(fp1)
-        l2 = guard.reserve(fp2)
-        assert l1 and l2, "block-4-2 must admit two distinct fail domains"
-
-        assert guard.reserve(fp3) is None, (
-            "a third distinct domain must exceed the block-4-2 budget; "
-            f"snapshot={guard.snapshot()}"
-        )
-        assert not guard.fits(fp3), "fits must agree with reserve that a third domain does not fit"
-
-        assert guard.release(l2) is True, "releasing an active lease must report success"
-        l3 = guard.reserve(fp3)
-        assert l3 is not None, (
-            f"after releasing one domain a third must fit again; snapshot={guard.snapshot()}"
-        )
-
-    def test_reserve_is_atomic_never_exceeds_budget(self, block42_topology):
-        """Sequential reservations of every rack must stop exactly at the budget."""
-        guard = FailureModelGuard(block42_topology)
-        leases = []
-        for host, rack_node in (("h1", 1), ("h2", 2), ("h3", 3), ("h4", 4)):
-            fp = guard.footprint_for(
-                ChaosTarget.for_node(host, node_id=rack_node), ImpactScope.NODE
-            )
-            leases.append(guard.reserve(fp))
-        granted = [x for x in leases if x is not None]
-        assert len(granted) == 2, (
-            f"block-4-2 must grant exactly 2 leases across 4 distinct racks; granted={leases}"
-        )
-        assert len(guard.snapshot()["impaired_racks"]) == 2, (
-            f"impaired set must never exceed the budget; snapshot={guard.snapshot()}"
-        )
-
-    def test_datacenter_footprint_mirror3dc_sacrificial_realm(self, mirror3dc_topology):
-        guard = FailureModelGuard(mirror3dc_topology)
-        dc1 = guard.footprint_for(
-            ChaosTarget.for_datacenter("h1", "dc1"), ImpactScope.DATACENTER
-        )
-        node_dc2 = guard.footprint_for(ChaosTarget.for_node("h3", node_id=3), ImpactScope.NODE)
-        node_dc3 = guard.footprint_for(ChaosTarget.for_node("h5", node_id=5), ImpactScope.NODE)
-
-        ldc = guard.reserve(dc1)
-        assert ldc is not None, "a whole DC must fit as the sacrificial realm on an empty budget"
-
-        lextra = guard.reserve(node_dc2)
-        assert lextra is not None, (
-            f"one extra domain in another realm must fit after sacrificing dc1; "
-            f"snapshot={guard.snapshot()}"
-        )
-
-        assert guard.reserve(node_dc3) is None, (
-            "a domain in a third realm must be rejected (1 realm + 1 domain budget); "
-            f"snapshot={guard.snapshot()}"
-        )
-
-        assert guard.release(ldc) is True
-        lthird = guard.reserve(node_dc3)
-        assert lthird is not None, (
-            f"after releasing dc1, single domains in dc2 and dc3 must both fit; "
-            f"snapshot={guard.snapshot()}"
-        )
-
-    def test_reserve_records_identity_for_active_identities(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        target = ChaosTarget.for_node("h1", node_id=1)
-        fp = guard.footprint_for(target, ImpactScope.NODE)
-        assert guard.active_identities() == set(), "no reservations means no active identities"
-        lease = guard.reserve(fp, identity_key=target.identity_key())
-        assert lease is not None
-        assert target.identity_key() in guard.active_identities(), (
-            "a reserved target's identity must be reported so schedulers skip re-hitting it; "
-            f"active={guard.active_identities()}"
-        )
-        assert guard.release(lease) is True
-        assert target.identity_key() not in guard.active_identities(), (
-            "releasing the lease must drop its identity from the active set"
-        )
-
-    def test_release_of_disabled_or_unknown_lease_is_noop(self, block42_topology):
-        guard = FailureModelGuard(block42_topology)
-        assert guard.release(None) is False, "releasing a None lease must be a no-op"
-        assert guard.release("never-issued") is False, (
-            "releasing an unknown lease id must be a no-op, not raise"
-        )
-
-
-class TestSlotBudget:
-    """Slots (dynamic nodes) draw from a separate 30% budget, not the erasure/rack budget."""
-
-    def _slot_fp(self, guard):
-        return guard.footprint_for(
-            ChaosTarget.for_slot("h1", slot_idx=1), ImpactScope.SLOT
-        )
-
-    def test_slot_footprint_is_slot_not_rack(self, block42_topology):
-        guard = FailureModelGuard(block42_topology, total_slots=10)
-        fp = self._slot_fp(guard)
-        assert fp.slots == 1 and fp.racks == frozenset(), (
-            f"a slot kill must consume one slot and zero racks; got {fp}"
-        )
-
-    def test_slot_kind_target_never_touches_racks(self, block42_topology):
-        # Even annotated NODE scope, a SLOT-kind target must not eat a rack fail-domain.
-        guard = FailureModelGuard(block42_topology, total_slots=10)
-        fp = guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=1), ImpactScope.NODE)
-        assert fp.slots == 1 and fp.racks == frozenset(), (
-            f"a SLOT-kind target must draw from the slot budget regardless of scope; got {fp}"
-        )
-
-    def test_slot_budget_caps_at_thirty_percent(self, block42_topology):
-        guard = FailureModelGuard(block42_topology, total_slots=10)  # max = floor(0.3*10) = 3
-        assert guard.snapshot()["max_slots"] == 3
-        leases = [
-            guard.reserve(
-                guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=i), ImpactScope.SLOT),
-                identity_key=f"slot:{i}",
-            )
-            for i in range(3)
-        ]
-        assert all(leases), "the first 30% of slots must all reserve"
-        assert guard.snapshot()["impaired_slots"] == 3
-        overflow = guard.reserve(
-            guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=3), ImpactScope.SLOT),
-            identity_key="slot:3",
-        )
-        assert overflow is None, "a 4th slot must exceed the 30% budget"
-        assert guard.snapshot()["impaired_racks"] == [], (
-            "slot reservations must never impair a rack fail-domain"
-        )
-
-    def test_slot_and_rack_budgets_are_independent(self, block42_topology):
-        # Fill the slot budget, then a node (rack) fault must still fit — dimensions don't cross.
-        guard = FailureModelGuard(block42_topology, total_slots=3)  # max_slots = floor(0.9)->1
-        assert guard.snapshot()["max_slots"] == 1
-        slot = guard.reserve(self._slot_fp(guard), identity_key="slot:1")
-        assert slot is not None
-        assert guard.reserve(self._slot_fp(guard), identity_key="slot:2") is None, (
-            "the slot budget is full at 1, so a second slot must be rejected"
-        )
-        node_fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        assert guard.fits(node_fp) and guard.reserve(node_fp) is not None, (
-            "a rack fault must still fit while the slot budget is exhausted (independent budgets)"
-        )
-
-    def test_record_inject_charges_the_slot_budget(self, block42_topology):
-        # The legacy schedule loop and manual injects go through record_inject, not reserve —
-        # they must spend the same slot budget, otherwise the two paths disagree.
-        guard = FailureModelGuard(block42_topology, total_slots=10)  # max = 3
-        for i in range(3):
-            guard.record_inject(
-                f"exec{i}",
-                ChaosTarget.for_slot("h1", slot_idx=i),
-                ImpactScope.SLOT,
-                recovery_sec=None,
-            )
-        snap = guard.snapshot()
-        assert snap["impaired_slots"] == 3, f"slot injects must charge the slot budget; got {snap}"
-        assert snap["impaired_racks"] == [], "a slot kill still must not spend a fail domain"
-        assert not guard.fits(self._slot_fp(guard)), (
-            "with the slot budget spent by record_inject, a further slot must not fit"
-        )
-
-    def test_record_inject_of_a_tablet_records_nothing(self, block42_topology):
-        guard = FailureModelGuard(block42_topology, total_slots=10)
-        guard.record_inject(
-            "t1", ChaosTarget.for_tablet("h1", tablet_id=1), ImpactScope.NODE, recovery_sec=None
-        )
-        snap = guard.snapshot()
-        assert snap["tracked_executions"] == 0 and snap["impaired_slots"] == 0, (
-            f"a tablet fault consumes neither dimension; got {snap}"
-        )
-
-    def test_slot_budget_fails_open_when_no_slots_known(self, block42_topology):
-        guard = FailureModelGuard(block42_topology, total_slots=0)
-        assert guard.snapshot()["max_slots"] == 0
-        # With no slot total, the slot dimension never blocks (fail-open).
-        for i in range(5):
-            fp = guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=i), ImpactScope.SLOT)
-            assert guard.reserve(fp, identity_key=f"slot:{i}") is not None, (
-                "unknown slot total must fail open, never blocking slot chaos"
-            )
+def test_chaos_target_serde_roundtrip():
+    t = ChaosTarget.for_node("host-a", node_id=3, ic_port=19001)
+    restored = ChaosTarget.from_dict(t.to_dict())
+    assert restored == t and restored.identity_key() == t.identity_key()
 
 
 class TestFailureModelIsMandatory:
-    """An unusable cluster.yaml must raise, not degrade into a guard that permits everything.
+    """An unusable config raises instead of degrading into a guard that permits everything."""
 
-    ``app.create_app`` lets this exception kill the orchestrator: unbounded chaos destroys data and
-    turns every stability failure into noise, so no failure model means no nemesis.
-    """
-
-    def test_missing_path_raises(self):
-        for path in ("", None):
+    def test_missing_or_unusable_config(self, tmp_path):
+        bad_yaml = tmp_path / "bad.yaml"
+        bad_yaml.write_text("static_erasure: [unclosed\n", encoding="utf-8")
+        not_a_mapping = tmp_path / "list.yaml"
+        not_a_mapping.write_text("- a\n- b\n", encoding="utf-8")
+        cases = [
+            "",
+            "/nonexistent/cluster.yaml",
+            str(bad_yaml),
+            str(not_a_mapping),
+            _topology_yaml(_hosts([("h1", "r1", "dc1")]), "no-such-erasure"),
+            _topology_yaml([], "block-4-2"),
+            _topology_yaml([{"name": "h1"}], "block-4-2"),  # no location
+            _topology_yaml([{"name": "h1", "location": {"data_center": "dc1"}}], "block-4-2"),  # no rack
+        ]
+        for path in cases:
             with pytest.raises(FailureModelConfigError):
                 ClusterTopologyModel(path)
 
-    def test_missing_file_raises(self):
-        with pytest.raises(FailureModelConfigError, match="not found"):
-            ClusterTopologyModel("/nonexistent/cluster.yaml")
-
-    def test_unparsable_yaml_raises(self, tmp_path):
-        bad = tmp_path / "cluster.yaml"
-        bad.write_text("static_erasure: [unclosed\n", encoding="utf-8")
-        with pytest.raises(FailureModelConfigError, match="cannot parse"):
-            ClusterTopologyModel(str(bad))
-
-    def test_non_mapping_document_raises(self, tmp_path):
-        bad = tmp_path / "cluster.yaml"
-        bad.write_text("- just\n- a\n- list\n", encoding="utf-8")
-        with pytest.raises(FailureModelConfigError, match="YAML mapping"):
-            ClusterTopologyModel(str(bad))
-
-    def test_unknown_erasure_raises(self):
-        hosts = [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}]
-        with pytest.raises(FailureModelConfigError, match="static_erasure"):
-            ClusterTopologyModel(_write_topology_yaml(hosts, "no-such-erasure"))
-
-    def test_no_hosts_raises(self):
-        with pytest.raises(FailureModelConfigError, match="hosts"):
-            ClusterTopologyModel(_write_topology_yaml([], "block-4-2"))
-
-    def test_host_without_rack_raises(self):
-        hosts = [
-            {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
-            {"name": "h2", "location": {"data_center": "dc1"}},
-        ]
-        with pytest.raises(FailureModelConfigError, match="location.rack"):
-            ClusterTopologyModel(_write_topology_yaml(hosts, "block-4-2"))
-
-    def test_host_without_location_raises(self):
-        with pytest.raises(FailureModelConfigError, match="location"):
-            ClusterTopologyModel(_write_topology_yaml([{"name": "h1"}], "block-4-2"))
-
     def test_mirror3dc_requires_datacenter(self):
         # Realms may be sacrificed whole, so a host with an unknown realm is not decidable.
-        hosts = [{"name": f"h{i}", "location": {"rack": f"r{i}"}} for i in (1, 2, 3)]
         with pytest.raises(FailureModelConfigError, match="data_center"):
-            ClusterTopologyModel(_write_topology_yaml(hosts, "mirror-3-dc"))
+            ClusterTopologyModel(_topology_yaml(_hosts([("h1", "r1", None)]), "mirror-3-dc"))
 
-    def test_block42_without_datacenter_is_accepted(self):
-        # block-4-2 counts domains regardless of realm, so data_center is optional there.
-        hosts = [{"name": f"h{i}", "location": {"rack": f"r{i}"}} for i in (1, 2, 3)]
-        topology = ClusterTopologyModel(_write_topology_yaml(hosts, "block-4-2"))
-        assert topology.guards
-        assert topology.domain_of("h1") == fail_domain_key(None, "r1")
-
-    def test_erasure_none_parses_and_forbids_everything(self):
-        hosts = [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}]
-        guard = FailureModelGuard(ClusterTopologyModel(_write_topology_yaml(hosts, "none")))
-        assert guard.enabled, "static_erasure=none is a valid model (zero tolerance), not an error"
-        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        assert not guard.fits(fp) and guard.reserve(fp) is None, (
-            "with no redundancy the guard must refuse every fault that touches a fail domain"
+    def test_erasure_none_forbids_everything(self):
+        guard = FailureModelGuard(
+            ClusterTopologyModel(_topology_yaml(_hosts([("h1", "r1", "dc1")]), "none"))
         )
+        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        assert guard.reserve(fp) is None, "no redundancy means no fault is tolerable"
 
 
 class TestFailDomainKeying:
-    """Rack labels repeat per datacenter, so a fail domain must be keyed by (dc, rack).
+    """Rack labels repeat per datacenter, so a domain must be keyed by (dc, rack)."""
 
-    Keying by the bare rack label collapsed rack ``1`` of every DC into one domain, and the guard
-    then admitted a fault in every realm at once — exactly what the failure model forbids.
-    """
+    def test_same_rack_label_in_different_dcs_are_distinct(self, mirror3dc_topology):
+        assert mirror3dc_topology.domain_of("dc1-a") != mirror3dc_topology.domain_of("dc2-a")
+        assert mirror3dc_topology.domains_in_dc("dc1") == {
+            fail_domain_key("dc1", "1"),
+            fail_domain_key("dc1", "2"),
+        }
 
-    def test_key_is_namespaced_by_datacenter(self):
-        assert fail_domain_key("dc1", "1") != fail_domain_key("dc2", "1"), (
-            "rack '1' in two datacenters must be two distinct fail domains"
-        )
-        assert fail_domain_key(None, "1") == "?/1", (
-            f"a host without data_center must still get a stable key; got {fail_domain_key(None, '1')!r}"
-        )
-
-    def test_same_rack_label_per_dc_are_distinct_domains(self, per_dc_rack_labels_topology):
-        topology = per_dc_rack_labels_topology
-        assert topology.domain_of("dc1-a") != topology.domain_of("dc2-a"), (
-            "hosts in different DCs sharing rack label '1' must map to different fail domains; "
-            f"dc1-a={topology.domain_of('dc1-a')!r}, dc2-a={topology.domain_of('dc2-a')!r}"
-        )
-        for dc in ("dc1", "dc2", "dc3"):
-            assert topology.domains_in_dc(dc) == {
-                fail_domain_key(dc, "1"),
-                fail_domain_key(dc, "2"),
-            }, (
-                f"every realm must keep its own two domains; {dc} -> {topology.domains_in_dc(dc)}"
-            )
-
-    def test_mirror3dc_rejects_a_fault_in_a_third_realm(self, per_dc_rack_labels_topology):
-        guard = FailureModelGuard(per_dc_rack_labels_topology)
-        assert guard.enabled
-
-        leases = []
+    def test_mirror3dc_rejects_a_fault_in_a_third_realm(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
         for host in ("dc1-a", "dc2-a"):  # rack '1' in two different DCs
             target = ChaosTarget.for_node(host, node_id=1)
-            fp = guard.footprint_for(target, ImpactScope.NODE)
-            leases.append(guard.reserve(fp, identity_key=target.identity_key()))
-        assert all(leases), (
-            f"one domain per realm in two realms must fit mirror-3-dc; snapshot={guard.snapshot()}"
-        )
-        assert len(guard.snapshot()["impaired_racks"]) == 2, (
-            "the two same-labelled racks must be counted as two domains, not one; "
-            f"snapshot={guard.snapshot()}"
-        )
+            assert guard.reserve(
+                guard.footprint_for(target, ImpactScope.NODE), identity_key=target.identity_key()
+            ), "one domain per realm in two realms must fit"
+        assert len(guard.snapshot()["impaired_racks"]) == 2, "same-labelled racks are two domains"
 
-        third = ChaosTarget.for_node("dc3-a", node_id=1)  # rack '1' again, third realm
+        third = ChaosTarget.for_node("dc3-a", node_id=1)
         third_fp = guard.footprint_for(third, ImpactScope.NODE)
-        assert not guard.fits(third_fp), (
-            "mirror-3-dc tolerates 1 realm + 1 domain, so a third realm must not fit; "
-            f"snapshot={guard.snapshot()}"
-        )
-        assert guard.reserve(third_fp, identity_key=third.identity_key()) is None, (
-            f"reserve must refuse the third realm; snapshot={guard.snapshot()}"
-        )
-        assert guard.filter_safe([third], ImpactScope.NODE) == [], (
-            f"filter_safe must agree with reserve; snapshot={guard.snapshot()}"
-        )
+        assert guard.reserve(third_fp) is None, "1 realm + 1 domain leaves no room for a third realm"
+        assert guard.filter_safe([third], ImpactScope.NODE) == [], "filter_safe must agree"
 
-    def test_block42_counts_same_label_racks_separately(self):
-        # Two DCs × rack '1'/'2'; block-4-2 tolerates 2 domains total, whatever their labels.
-        hosts = [
-            {"name": f"{dc}-{rack}", "location": {"rack": rack, "data_center": dc}}
-            for dc in ("dc1", "dc2")
-            for rack in ("1", "2")
-        ]
-        guard = FailureModelGuard(ClusterTopologyModel(_write_topology_yaml(hosts, "block-4-2")))
-        granted = []
-        for host in ("dc1-1", "dc2-1", "dc1-2"):
-            target = ChaosTarget.for_node(host, node_id=1)
-            granted.append(
-                guard.reserve(
-                    guard.footprint_for(target, ImpactScope.NODE),
-                    identity_key=target.identity_key(),
-                )
-            )
-        assert [g is not None for g in granted] == [True, True, False], (
-            "rack '1' of dc1 and dc2 are two domains, so the third fault must exceed block-4-2; "
-            f"granted={granted}, snapshot={guard.snapshot()}"
-        )
-
-    def test_datacenter_footprint_covers_only_its_own_realm(self, per_dc_rack_labels_topology):
-        guard = FailureModelGuard(per_dc_rack_labels_topology)
+    def test_datacenter_footprint_covers_only_its_own_realm(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
         fp = guard.footprint_for(ChaosTarget.for_datacenter("dc1-a", "dc1"), ImpactScope.DATACENTER)
-        assert fp.racks == {fail_domain_key("dc1", "1"), fail_domain_key("dc1", "2")}, (
-            "a DC footprint must be that DC's own domains — not a synthetic single-host key, and "
-            f"not another realm's racks; got {set(fp.racks)}"
-        )
+        assert set(fp.racks) == {fail_domain_key("dc1", "1"), fail_domain_key("dc1", "2")}
 
-    def test_unknown_hosts_get_realm_aware_synthetic_domains(self, per_dc_rack_labels_topology):
-        # A host that cluster.yaml has no rack for (e.g. an agent outside the config) still gets a
-        # realm-namespaced key, so two such hosts are not merged into one sacrificial realm.
-        guard = FailureModelGuard(per_dc_rack_labels_topology)
+    def test_unknown_hosts_get_realm_aware_synthetic_domains(self, mirror3dc_topology):
+        # Hosts absent from cluster.yaml must not collapse into one sacrificial realm.
+        guard = FailureModelGuard(mirror3dc_topology)
         keys = {
-            host: set(
-                guard.footprint_for(ChaosTarget.for_host(host), ImpactScope.NODE).racks
-            ).pop()
+            host: set(guard.footprint_for(ChaosTarget.for_host(host), ImpactScope.NODE).racks).pop()
             for host in ("ghost-a", "ghost-b")
         }
-        assert keys["ghost-a"] != keys["ghost-b"], (
-            f"unknown hosts must not share a fail domain; got {keys}"
-        )
+        assert keys["ghost-a"] != keys["ghost-b"], keys
         assert all(k.startswith("__host__:") for k in keys.values()), keys
 
 
-class TestSyntheticDomainRealms:
-    """Hosts whose realm *is* known but whose rack is not must be attributed to that realm."""
+class TestFilterSafeAndRecording:
+    def test_filter_safe_block42_admits_two_domains(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        candidates = [ChaosTarget.for_node(f"h{i}", node_id=i) for i in (1, 2, 3)]
+        safe = guard.filter_safe(candidates, ImpactScope.NODE)
+        assert {t.host for t in safe} == {"h1", "h2"}, "the budget is 2 domains"
 
-    def test_mirror3dc_counts_unknown_rack_hosts_per_realm(self):
-        # h1/h2 are in cluster.yaml (dc1, dc2); the guard is asked about hosts it has topology for
-        # but through a scope that has no rack — the synthetic key must still carry the realm.
-        hosts = [
-            {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
-            {"name": "h2", "location": {"rack": "r2", "data_center": "dc2"}},
-            {"name": "h3", "location": {"rack": "r3", "data_center": "dc3"}},
+    def test_filter_safe_mirror3dc_one_realm_plus_one_domain(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
+        for i, host in enumerate(("dc1-a", "dc1-b"), start=1):  # sacrifice dc1 entirely
+            guard.record_inject(
+                f"dc1-{i}", ChaosTarget.for_node(host, node_id=i), ImpactScope.NODE, recovery_sec=None
+            )
+        extra = [ChaosTarget.for_node("dc2-a", node_id=3), ChaosTarget.for_node("dc3-a", node_id=5)]
+        safe = guard.filter_safe(extra, ImpactScope.NODE)
+        assert [t.host for t in safe] == ["dc2-a"], "only one extra domain fits after a lost realm"
+
+    def test_untracked_extract_drops_by_identity_not_by_domain(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        n1 = ChaosTarget.for_node("h1", node_id=1)
+        n2 = ChaosTarget.for_node("h1", node_id=2)  # same host, same domain
+        guard.record_inject("tracked", n1, ImpactScope.NODE, recovery_sec=None)
+        guard.record_extract("untracked-other", n2, ImpactScope.NODE)
+        assert "dc1/r1" in guard.snapshot()["impaired_racks"], "n1 must survive n2's extract"
+        guard.record_extract("tracked", n1, ImpactScope.NODE)
+        assert guard.snapshot()["impaired_racks"] == []
+
+    def test_tablet_faults_consume_nothing(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        tablet = ChaosTarget.for_tablet("h1", tablet_id=42)
+        assert not guard.footprint_for(tablet, ImpactScope.NODE)
+        guard.record_inject("t1", tablet, ImpactScope.NODE, recovery_sec=None)
+        assert guard.snapshot()["tracked_executions"] == 0
+
+
+class TestLeaseBudget:
+    def test_reserve_stops_exactly_at_the_budget(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        leases = [
+            guard.reserve(
+                guard.footprint_for(ChaosTarget.for_node(h, node_id=i), ImpactScope.NODE)
+            )
+            for i, h in enumerate(("h1", "h2", "h3", "h4"), start=1)
         ]
-        guard = FailureModelGuard(ClusterTopologyModel(_write_topology_yaml(hosts, "mirror-3-dc")))
-        domains = {
-            guard._synthetic_key("h1"),
-            guard._synthetic_key("h2"),
-        }
-        assert domains == {"__host__:dc1/h1", "__host__:dc2/h2"}, (
-            f"synthetic keys must be namespaced by realm; got {domains}"
+        assert [x is not None for x in leases] == [True, True, False, False]
+        assert len(guard.snapshot()["impaired_racks"]) == 2
+
+        assert guard.release(leases[1]) is True
+        assert guard.reserve(
+            guard.footprint_for(ChaosTarget.for_node("h3", node_id=3), ImpactScope.NODE)
+        ), "a released domain frees room"
+
+    def test_release_of_unknown_lease_is_a_noop(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        assert guard.release(None) is False and guard.release("never-issued") is False
+
+    def test_datacenter_lease_is_the_sacrificial_realm(self, mirror3dc_topology):
+        guard = FailureModelGuard(mirror3dc_topology)
+        dc1 = guard.footprint_for(ChaosTarget.for_datacenter("dc1-a", "dc1"), ImpactScope.DATACENTER)
+        assert guard.reserve(dc1), "a whole DC fits as the sacrificial realm"
+        assert guard.reserve(
+            guard.footprint_for(ChaosTarget.for_node("dc2-a", node_id=3), ImpactScope.NODE)
+        ), "plus one domain elsewhere"
+        assert guard.reserve(
+            guard.footprint_for(ChaosTarget.for_node("dc3-a", node_id=5), ImpactScope.NODE)
+        ) is None, "but not a second one"
+
+    def test_budget_view_reports_impaired_identities(self, block42_topology):
+        guard = FailureModelGuard(block42_topology)
+        target = ChaosTarget.for_node("h1", node_id=1)
+        lease = guard.reserve(
+            guard.footprint_for(target, ImpactScope.NODE), identity_key=target.identity_key()
         )
-        # One synthetic domain per realm in two realms is still 1 sacrificial realm + 1 domain.
-        assert guard._is_tolerable(domains), f"two realms must be tolerable; domains={domains}"
-        assert not guard._is_tolerable(domains | {guard._synthetic_key("h3")}), (
-            "a third realm must not be tolerable — the old un-namespaced key made all three look "
-            "like one realm"
-        )
+        assert target.identity_key() in guard.budget_view().touched
+        guard.release(lease)
+        assert target.identity_key() not in guard.budget_view().touched
+
+
+class TestSlotBudget:
+    """Slots draw from their own 30% budget, not from the erasure budget."""
+
+    def _slot_fp(self, guard, idx=1):
+        return guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=idx), ImpactScope.SLOT)
+
+    def test_slot_footprint_has_no_fail_domain(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=10)
+        # Even with a NODE scope, a SLOT-kind target draws from the slot budget.
+        fp = guard.footprint_for(ChaosTarget.for_slot("h1", slot_idx=1), ImpactScope.NODE)
+        assert fp.slots == 1 and fp.racks == frozenset()
+
+    def test_reserve_caps_slots_at_thirty_percent(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=10)  # max = 3
+        assert guard.snapshot()["max_slots"] == 3
+        assert all(guard.reserve(self._slot_fp(guard, i), identity_key=f"s{i}") for i in range(3))
+        assert guard.reserve(self._slot_fp(guard, 3), identity_key="s3") is None
+        assert guard.snapshot()["impaired_racks"] == [], "slots never spend a fail domain"
+
+    def test_record_inject_charges_the_slot_budget(self, block42_topology):
+        # The legacy loop and manual injects go through record_inject, not reserve.
+        guard = FailureModelGuard(block42_topology, total_slots=10)
+        for i in range(3):
+            guard.record_inject(
+                f"e{i}", ChaosTarget.for_slot("h1", slot_idx=i), ImpactScope.SLOT, recovery_sec=None
+            )
+        assert guard.snapshot()["impaired_slots"] == 3
+        assert not guard.budget_view().fits(self._slot_fp(guard, 9)), "budget spent"
+
+    def test_slot_and_domain_budgets_are_independent(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=3)  # max_slots = 1
+        assert guard.reserve(self._slot_fp(guard), identity_key="s1")
+        assert guard.reserve(self._slot_fp(guard, 2), identity_key="s2") is None
+        assert guard.reserve(
+            guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        ), "a domain fault still fits while the slot budget is full"
+
+    def test_unknown_slot_count_never_blocks(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=0)
+        assert all(guard.reserve(self._slot_fp(guard, i), identity_key=f"s{i}") for i in range(5))
 
 
 class TestSerialStaggeredPlanner:
     def _candidates(self, n: int = 4) -> list[ChaosTarget]:
         return [
-            ChaosTarget.for_node(f"h{i}", node_id=i, ic_port=19000 + i)
-            for i in range(1, n + 1)
+            ChaosTarget.for_node(f"h{i}", node_id=i, ic_port=19000 + i) for i in range(1, n + 1)
         ]
 
-    def test_dispatches_only_to_owner_hosts(self):
+    def test_dispatches_to_owner_hosts_with_their_own_ids(self):
         planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")
-        candidates = self._candidates()
-        by_node = {t.node_id: t for t in candidates}
+        by_node = {t.node_id: t for t in self._candidates()}
 
-        cmds = planner.scheduled_tick(candidates)
-        assert 1 <= len(cmds) <= MAX_ENTITIES_PER_TICK, (
-            f"a serial tick must kill between 1 and {MAX_ENTITIES_PER_TICK} entities; got {len(cmds)}"
-        )
-        assert len({c.target.identity_key() for c in cmds}) == len(cmds), (
-            f"entities must be sampled without repetition; got {[c.target.to_dict() for c in cmds]}"
-        )
+        cmds = planner.scheduled_tick(list(by_node.values()))
+        assert 1 <= len(cmds) <= MAX_ENTITIES_PER_TICK
+        assert len({c.target.identity_key() for c in cmds}) == len(cmds), "sampled without repeats"
         for cmd in cmds:
-            chosen = by_node.get(cmd.target.node_id)
-            assert chosen is not None, f"node_id must come from the candidates; got {cmd.target!r}"
-            assert cmd.host == chosen.host, (
-                f"dispatch must go to the owner of the chosen node, not a random host; "
-                f"host={cmd.host!r}, owner={chosen.host!r}"
-            )
-            assert cmd.payload.get("node_id") == cmd.target.node_id, (
-                f"payload.node_id must match ChaosTarget.node_id; payload={cmd.payload}"
-            )
-            assert cmd.payload.get("node_ic_port") == chosen.ic_port, (
-                f"payload must carry the entity's own ic_port; payload={cmd.payload}"
-            )
+            chosen = by_node[cmd.target.node_id]
+            assert cmd.host == chosen.host, "only the owner agent can kill the daemon"
+            assert cmd.payload["node_id"] == chosen.node_id
+            assert cmd.payload["node_ic_port"] == chosen.ic_port
 
-    def test_kills_are_staggered_in_time_within_one_scenario(self):
-        planner = SerialStaggeredInjectPlanner(
-            "SerialKillNodeNemesis", target_kind="node", stagger_sec=7.5
-        )
-        # Sample until a tick picks more than one entity, so the stagger is observable.
-        for _ in range(50):
-            cmds = planner.scheduled_tick(self._candidates())
-            if len(cmds) > 1:
-                break
-        assert len(cmds) > 1, "expected at least one multi-entity tick out of 50 samples"
-
-        delays = [c.payload["sleep_before"] for c in cmds]
-        assert delays == [7.5 * i for i in range(len(cmds))], (
-            f"the i-th kill must wait i * stagger_sec so kills are serial, not simultaneous; "
-            f"got {delays}"
-        )
-        assert len({c.scenario_id for c in cmds}) == 1, (
-            "one staggered tick is one scenario, so its commands must share a scenario id"
-        )
-
-    def test_default_stagger_is_used_when_not_overridden(self):
+    def test_kills_are_staggered_within_one_scenario(self):
         planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")
-        for _ in range(50):
+        for _ in range(50):  # sample until a tick picks more than one entity
             cmds = planner.scheduled_tick(self._candidates())
             if len(cmds) > 1:
                 break
-        assert len(cmds) > 1, "expected at least one multi-entity tick out of 50 samples"
-        assert cmds[1].payload["sleep_before"] == DEFAULT_SERIAL_STAGGER_SEC, (
-            f"the default stagger must be {DEFAULT_SERIAL_STAGGER_SEC}s; got {cmds[1].payload}"
-        )
+        assert len(cmds) > 1, "expected a multi-entity tick within 50 samples"
+        delays = [c.payload["sleep_before"] for c in cmds]
+        assert delays == [DEFAULT_SERIAL_STAGGER_SEC * i for i in range(len(cmds))], delays
+        assert len({c.scenario_id for c in cmds}) == 1, "one tick is one scenario"

--- a/ydb/tests/stability/nemesis/ut/test_chaos_target.py
+++ b/ydb/tests/stability/nemesis/ut/test_chaos_target.py
@@ -12,10 +12,14 @@ import yaml
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
     ClusterTopologyModel,
+    FailureModelConfigError,
     FailureModelGuard,
     ImpactScope,
+    fail_domain_key,
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.serial_staggered_planner import (
+    DEFAULT_SERIAL_STAGGER_SEC,
+    MAX_ENTITIES_PER_TICK,
     SerialStaggeredInjectPlanner,
 )
 
@@ -53,6 +57,22 @@ def mirror3dc_topology():
         {"name": "h4", "location": {"rack": "r4", "data_center": "dc2"}},
         {"name": "h5", "location": {"rack": "r5", "data_center": "dc3"}},
         {"name": "h6", "location": {"rack": "r6", "data_center": "dc3"}},
+    ]
+    path = _write_topology_yaml(hosts, "mirror-3-dc")
+    return ClusterTopologyModel(path)
+
+
+@pytest.fixture
+def per_dc_rack_labels_topology():
+    """mirror-3-dc where rack labels restart in every DC (``rack: '1'``, ``'2'`` per realm).
+
+    This is how real ``cluster.yaml`` files label racks, and it is the case that collapsed into a
+    single fail domain when the guard keyed impairments by the bare rack label.
+    """
+    hosts = [
+        {"name": f"{dc}-{name}", "location": {"rack": rack, "data_center": dc}}
+        for dc in ("dc1", "dc2", "dc3")
+        for name, rack in (("a", "1"), ("b", "2"))
     ]
     path = _write_topology_yaml(hosts, "mirror-3-dc")
     return ClusterTopologyModel(path)
@@ -158,7 +178,7 @@ class TestFailureModelGuard:
         # Simulate extract for an untracked execution of n2 (e.g. after restart).
         guard.record_extract("untracked-other", n2, ImpactScope.NODE)
         snap = guard.snapshot()
-        assert "r1" in snap["impaired_racks"], (
+        assert "dc1/r1" in snap["impaired_racks"], (
             "extract fallback by identity must leave n1 impairment intact; "
             f"snapshot={snap}"
         )
@@ -183,8 +203,8 @@ class TestFailureModelGuard:
         guard = FailureModelGuard(block42_topology)
         t = ChaosTarget.for_host("h1")
         guard.record_inject("e1", t, ImpactScope.NODE, recovery_sec=None)
-        assert "r1" in guard.snapshot()["impaired_racks"], (
-            f"host inject on h1 must mark rack r1 impaired; snapshot={guard.snapshot()}"
+        assert "dc1/r1" in guard.snapshot()["impaired_racks"], (
+            f"host inject on h1 must mark fail domain dc1/r1 impaired; snapshot={guard.snapshot()}"
         )
         guard.record_extract("e1", t, ImpactScope.NODE)
         assert guard.snapshot()["impaired_racks"] == [], (
@@ -198,8 +218,8 @@ class TestFailureBudgetLease:
     def test_footprint_for_node_is_single_rack(self, block42_topology):
         guard = FailureModelGuard(block42_topology)
         fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
-        assert fp.racks == frozenset({"r1"}) and fp.slots == 0, (
-            f"a node footprint must be exactly its host's rack, no slots; got {fp}"
+        assert fp.racks == frozenset({"dc1/r1"}) and fp.slots == 0, (
+            f"a node footprint must be exactly its host's fail domain, no slots; got {fp}"
         )
 
     def test_footprint_for_datacenter_covers_all_its_racks(self, mirror3dc_topology):
@@ -207,7 +227,7 @@ class TestFailureBudgetLease:
         fp = guard.footprint_for(
             ChaosTarget.for_datacenter("h1", "dc1"), ImpactScope.DATACENTER
         )
-        assert fp.racks == frozenset({"r1", "r2"}), (
+        assert fp.racks == frozenset({"dc1/r1", "dc1/r2"}), (
             f"a datacenter footprint must cover every rack in the DC; got {fp}"
         )
 
@@ -380,6 +400,34 @@ class TestSlotBudget:
             "a rack fault must still fit while the slot budget is exhausted (independent budgets)"
         )
 
+    def test_record_inject_charges_the_slot_budget(self, block42_topology):
+        # The legacy schedule loop and manual injects go through record_inject, not reserve —
+        # they must spend the same slot budget, otherwise the two paths disagree.
+        guard = FailureModelGuard(block42_topology, total_slots=10)  # max = 3
+        for i in range(3):
+            guard.record_inject(
+                f"exec{i}",
+                ChaosTarget.for_slot("h1", slot_idx=i),
+                ImpactScope.SLOT,
+                recovery_sec=None,
+            )
+        snap = guard.snapshot()
+        assert snap["impaired_slots"] == 3, f"slot injects must charge the slot budget; got {snap}"
+        assert snap["impaired_racks"] == [], "a slot kill still must not spend a fail domain"
+        assert not guard.fits(self._slot_fp(guard)), (
+            "with the slot budget spent by record_inject, a further slot must not fit"
+        )
+
+    def test_record_inject_of_a_tablet_records_nothing(self, block42_topology):
+        guard = FailureModelGuard(block42_topology, total_slots=10)
+        guard.record_inject(
+            "t1", ChaosTarget.for_tablet("h1", tablet_id=1), ImpactScope.NODE, recovery_sec=None
+        )
+        snap = guard.snapshot()
+        assert snap["tracked_executions"] == 0 and snap["impaired_slots"] == 0, (
+            f"a tablet fault consumes neither dimension; got {snap}"
+        )
+
     def test_slot_budget_fails_open_when_no_slots_known(self, block42_topology):
         guard = FailureModelGuard(block42_topology, total_slots=0)
         assert guard.snapshot()["max_slots"] == 0
@@ -391,29 +439,270 @@ class TestSlotBudget:
             )
 
 
-class TestSerialStaggeredPlanner:
-    def test_dispatches_only_to_owner_host(self):
-        planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")
-        candidates = [
-            ChaosTarget.for_node("h1", node_id=1, ic_port=19001),
-            ChaosTarget.for_node("h2", node_id=2, ic_port=19001),
+class TestFailureModelIsMandatory:
+    """An unusable cluster.yaml must raise, not degrade into a guard that permits everything.
+
+    ``app.create_app`` lets this exception kill the orchestrator: unbounded chaos destroys data and
+    turns every stability failure into noise, so no failure model means no nemesis.
+    """
+
+    def test_missing_path_raises(self):
+        for path in ("", None):
+            with pytest.raises(FailureModelConfigError):
+                ClusterTopologyModel(path)
+
+    def test_missing_file_raises(self):
+        with pytest.raises(FailureModelConfigError, match="not found"):
+            ClusterTopologyModel("/nonexistent/cluster.yaml")
+
+    def test_unparsable_yaml_raises(self, tmp_path):
+        bad = tmp_path / "cluster.yaml"
+        bad.write_text("static_erasure: [unclosed\n", encoding="utf-8")
+        with pytest.raises(FailureModelConfigError, match="cannot parse"):
+            ClusterTopologyModel(str(bad))
+
+    def test_non_mapping_document_raises(self, tmp_path):
+        bad = tmp_path / "cluster.yaml"
+        bad.write_text("- just\n- a\n- list\n", encoding="utf-8")
+        with pytest.raises(FailureModelConfigError, match="YAML mapping"):
+            ClusterTopologyModel(str(bad))
+
+    def test_unknown_erasure_raises(self):
+        hosts = [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}]
+        with pytest.raises(FailureModelConfigError, match="static_erasure"):
+            ClusterTopologyModel(_write_topology_yaml(hosts, "no-such-erasure"))
+
+    def test_no_hosts_raises(self):
+        with pytest.raises(FailureModelConfigError, match="hosts"):
+            ClusterTopologyModel(_write_topology_yaml([], "block-4-2"))
+
+    def test_host_without_rack_raises(self):
+        hosts = [
+            {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
+            {"name": "h2", "location": {"data_center": "dc1"}},
         ]
+        with pytest.raises(FailureModelConfigError, match="location.rack"):
+            ClusterTopologyModel(_write_topology_yaml(hosts, "block-4-2"))
+
+    def test_host_without_location_raises(self):
+        with pytest.raises(FailureModelConfigError, match="location"):
+            ClusterTopologyModel(_write_topology_yaml([{"name": "h1"}], "block-4-2"))
+
+    def test_mirror3dc_requires_datacenter(self):
+        # Realms may be sacrificed whole, so a host with an unknown realm is not decidable.
+        hosts = [{"name": f"h{i}", "location": {"rack": f"r{i}"}} for i in (1, 2, 3)]
+        with pytest.raises(FailureModelConfigError, match="data_center"):
+            ClusterTopologyModel(_write_topology_yaml(hosts, "mirror-3-dc"))
+
+    def test_block42_without_datacenter_is_accepted(self):
+        # block-4-2 counts domains regardless of realm, so data_center is optional there.
+        hosts = [{"name": f"h{i}", "location": {"rack": f"r{i}"}} for i in (1, 2, 3)]
+        topology = ClusterTopologyModel(_write_topology_yaml(hosts, "block-4-2"))
+        assert topology.guards
+        assert topology.domain_of("h1") == fail_domain_key(None, "r1")
+
+    def test_erasure_none_parses_and_forbids_everything(self):
+        hosts = [{"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}}]
+        guard = FailureModelGuard(ClusterTopologyModel(_write_topology_yaml(hosts, "none")))
+        assert guard.enabled, "static_erasure=none is a valid model (zero tolerance), not an error"
+        fp = guard.footprint_for(ChaosTarget.for_node("h1", node_id=1), ImpactScope.NODE)
+        assert not guard.fits(fp) and guard.reserve(fp) is None, (
+            "with no redundancy the guard must refuse every fault that touches a fail domain"
+        )
+
+
+class TestFailDomainKeying:
+    """Rack labels repeat per datacenter, so a fail domain must be keyed by (dc, rack).
+
+    Keying by the bare rack label collapsed rack ``1`` of every DC into one domain, and the guard
+    then admitted a fault in every realm at once — exactly what the failure model forbids.
+    """
+
+    def test_key_is_namespaced_by_datacenter(self):
+        assert fail_domain_key("dc1", "1") != fail_domain_key("dc2", "1"), (
+            "rack '1' in two datacenters must be two distinct fail domains"
+        )
+        assert fail_domain_key(None, "1") == "?/1", (
+            f"a host without data_center must still get a stable key; got {fail_domain_key(None, '1')!r}"
+        )
+
+    def test_same_rack_label_per_dc_are_distinct_domains(self, per_dc_rack_labels_topology):
+        topology = per_dc_rack_labels_topology
+        assert topology.domain_of("dc1-a") != topology.domain_of("dc2-a"), (
+            "hosts in different DCs sharing rack label '1' must map to different fail domains; "
+            f"dc1-a={topology.domain_of('dc1-a')!r}, dc2-a={topology.domain_of('dc2-a')!r}"
+        )
+        for dc in ("dc1", "dc2", "dc3"):
+            assert topology.domains_in_dc(dc) == {
+                fail_domain_key(dc, "1"),
+                fail_domain_key(dc, "2"),
+            }, (
+                f"every realm must keep its own two domains; {dc} -> {topology.domains_in_dc(dc)}"
+            )
+
+    def test_mirror3dc_rejects_a_fault_in_a_third_realm(self, per_dc_rack_labels_topology):
+        guard = FailureModelGuard(per_dc_rack_labels_topology)
+        assert guard.enabled
+
+        leases = []
+        for host in ("dc1-a", "dc2-a"):  # rack '1' in two different DCs
+            target = ChaosTarget.for_node(host, node_id=1)
+            fp = guard.footprint_for(target, ImpactScope.NODE)
+            leases.append(guard.reserve(fp, identity_key=target.identity_key()))
+        assert all(leases), (
+            f"one domain per realm in two realms must fit mirror-3-dc; snapshot={guard.snapshot()}"
+        )
+        assert len(guard.snapshot()["impaired_racks"]) == 2, (
+            "the two same-labelled racks must be counted as two domains, not one; "
+            f"snapshot={guard.snapshot()}"
+        )
+
+        third = ChaosTarget.for_node("dc3-a", node_id=1)  # rack '1' again, third realm
+        third_fp = guard.footprint_for(third, ImpactScope.NODE)
+        assert not guard.fits(third_fp), (
+            "mirror-3-dc tolerates 1 realm + 1 domain, so a third realm must not fit; "
+            f"snapshot={guard.snapshot()}"
+        )
+        assert guard.reserve(third_fp, identity_key=third.identity_key()) is None, (
+            f"reserve must refuse the third realm; snapshot={guard.snapshot()}"
+        )
+        assert guard.filter_safe([third], ImpactScope.NODE) == [], (
+            f"filter_safe must agree with reserve; snapshot={guard.snapshot()}"
+        )
+
+    def test_block42_counts_same_label_racks_separately(self):
+        # Two DCs × rack '1'/'2'; block-4-2 tolerates 2 domains total, whatever their labels.
+        hosts = [
+            {"name": f"{dc}-{rack}", "location": {"rack": rack, "data_center": dc}}
+            for dc in ("dc1", "dc2")
+            for rack in ("1", "2")
+        ]
+        guard = FailureModelGuard(ClusterTopologyModel(_write_topology_yaml(hosts, "block-4-2")))
+        granted = []
+        for host in ("dc1-1", "dc2-1", "dc1-2"):
+            target = ChaosTarget.for_node(host, node_id=1)
+            granted.append(
+                guard.reserve(
+                    guard.footprint_for(target, ImpactScope.NODE),
+                    identity_key=target.identity_key(),
+                )
+            )
+        assert [g is not None for g in granted] == [True, True, False], (
+            "rack '1' of dc1 and dc2 are two domains, so the third fault must exceed block-4-2; "
+            f"granted={granted}, snapshot={guard.snapshot()}"
+        )
+
+    def test_datacenter_footprint_covers_only_its_own_realm(self, per_dc_rack_labels_topology):
+        guard = FailureModelGuard(per_dc_rack_labels_topology)
+        fp = guard.footprint_for(ChaosTarget.for_datacenter("dc1-a", "dc1"), ImpactScope.DATACENTER)
+        assert fp.racks == {fail_domain_key("dc1", "1"), fail_domain_key("dc1", "2")}, (
+            "a DC footprint must be that DC's own domains — not a synthetic single-host key, and "
+            f"not another realm's racks; got {set(fp.racks)}"
+        )
+
+    def test_unknown_hosts_get_realm_aware_synthetic_domains(self, per_dc_rack_labels_topology):
+        # A host that cluster.yaml has no rack for (e.g. an agent outside the config) still gets a
+        # realm-namespaced key, so two such hosts are not merged into one sacrificial realm.
+        guard = FailureModelGuard(per_dc_rack_labels_topology)
+        keys = {
+            host: set(
+                guard.footprint_for(ChaosTarget.for_host(host), ImpactScope.NODE).racks
+            ).pop()
+            for host in ("ghost-a", "ghost-b")
+        }
+        assert keys["ghost-a"] != keys["ghost-b"], (
+            f"unknown hosts must not share a fail domain; got {keys}"
+        )
+        assert all(k.startswith("__host__:") for k in keys.values()), keys
+
+
+class TestSyntheticDomainRealms:
+    """Hosts whose realm *is* known but whose rack is not must be attributed to that realm."""
+
+    def test_mirror3dc_counts_unknown_rack_hosts_per_realm(self):
+        # h1/h2 are in cluster.yaml (dc1, dc2); the guard is asked about hosts it has topology for
+        # but through a scope that has no rack — the synthetic key must still carry the realm.
+        hosts = [
+            {"name": "h1", "location": {"rack": "r1", "data_center": "dc1"}},
+            {"name": "h2", "location": {"rack": "r2", "data_center": "dc2"}},
+            {"name": "h3", "location": {"rack": "r3", "data_center": "dc3"}},
+        ]
+        guard = FailureModelGuard(ClusterTopologyModel(_write_topology_yaml(hosts, "mirror-3-dc")))
+        domains = {
+            guard._synthetic_key("h1"),
+            guard._synthetic_key("h2"),
+        }
+        assert domains == {"__host__:dc1/h1", "__host__:dc2/h2"}, (
+            f"synthetic keys must be namespaced by realm; got {domains}"
+        )
+        # One synthetic domain per realm in two realms is still 1 sacrificial realm + 1 domain.
+        assert guard._is_tolerable(domains), f"two realms must be tolerable; domains={domains}"
+        assert not guard._is_tolerable(domains | {guard._synthetic_key("h3")}), (
+            "a third realm must not be tolerable — the old un-namespaced key made all three look "
+            "like one realm"
+        )
+
+
+class TestSerialStaggeredPlanner:
+    def _candidates(self, n: int = 4) -> list[ChaosTarget]:
+        return [
+            ChaosTarget.for_node(f"h{i}", node_id=i, ic_port=19000 + i)
+            for i in range(1, n + 1)
+        ]
+
+    def test_dispatches_only_to_owner_hosts(self):
+        planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")
+        candidates = self._candidates()
+        by_node = {t.node_id: t for t in candidates}
+
         cmds = planner.scheduled_tick(candidates)
-        assert len(cmds) == 1, (
-            f"serial planner must emit exactly one command for one chosen node; got {len(cmds)}"
+        assert 1 <= len(cmds) <= MAX_ENTITIES_PER_TICK, (
+            f"a serial tick must kill between 1 and {MAX_ENTITIES_PER_TICK} entities; got {len(cmds)}"
         )
-        cmd = cmds[0]
-        assert cmd.target.host in {"h1", "h2"}, (
-            f"chosen host must be from candidates; got {cmd.target.host!r}"
+        assert len({c.target.identity_key() for c in cmds}) == len(cmds), (
+            f"entities must be sampled without repetition; got {[c.target.to_dict() for c in cmds]}"
         )
-        assert cmd.target.node_id in {1, 2}, (
-            f"chosen node_id must be from candidates; got {cmd.target.node_id!r}"
+        for cmd in cmds:
+            chosen = by_node.get(cmd.target.node_id)
+            assert chosen is not None, f"node_id must come from the candidates; got {cmd.target!r}"
+            assert cmd.host == chosen.host, (
+                f"dispatch must go to the owner of the chosen node, not a random host; "
+                f"host={cmd.host!r}, owner={chosen.host!r}"
+            )
+            assert cmd.payload.get("node_id") == cmd.target.node_id, (
+                f"payload.node_id must match ChaosTarget.node_id; payload={cmd.payload}"
+            )
+            assert cmd.payload.get("node_ic_port") == chosen.ic_port, (
+                f"payload must carry the entity's own ic_port; payload={cmd.payload}"
+            )
+
+    def test_kills_are_staggered_in_time_within_one_scenario(self):
+        planner = SerialStaggeredInjectPlanner(
+            "SerialKillNodeNemesis", target_kind="node", stagger_sec=7.5
         )
-        assert cmd.payload.get("node_id") == cmd.target.node_id, (
-            f"payload.node_id must match ChaosTarget.node_id; "
-            f"payload={cmd.payload}, target={cmd.target.to_dict()}"
+        # Sample until a tick picks more than one entity, so the stagger is observable.
+        for _ in range(50):
+            cmds = planner.scheduled_tick(self._candidates())
+            if len(cmds) > 1:
+                break
+        assert len(cmds) > 1, "expected at least one multi-entity tick out of 50 samples"
+
+        delays = [c.payload["sleep_before"] for c in cmds]
+        assert delays == [7.5 * i for i in range(len(cmds))], (
+            f"the i-th kill must wait i * stagger_sec so kills are serial, not simultaneous; "
+            f"got {delays}"
         )
-        assert cmd.host == cmd.target.host, (
-            f"dispatch host must be the owner of the chosen node, not a random host; "
-            f"host={cmd.host!r}, target.host={cmd.target.host!r}"
+        assert len({c.scenario_id for c in cmds}) == 1, (
+            "one staggered tick is one scenario, so its commands must share a scenario id"
+        )
+
+    def test_default_stagger_is_used_when_not_overridden(self):
+        planner = SerialStaggeredInjectPlanner("SerialKillNodeNemesis", target_kind="node")
+        for _ in range(50):
+            cmds = planner.scheduled_tick(self._candidates())
+            if len(cmds) > 1:
+                break
+        assert len(cmds) > 1, "expected at least one multi-entity tick out of 50 samples"
+        assert cmds[1].payload["sleep_before"] == DEFAULT_SERIAL_STAGGER_SEC, (
+            f"the default stagger must be {DEFAULT_SERIAL_STAGGER_SEC}s; got {cmds[1].payload}"
         )

--- a/ydb/tests/stability/nemesis/ut/test_guard_invariants.py
+++ b/ydb/tests/stability/nemesis/ut/test_guard_invariants.py
@@ -1,0 +1,184 @@
+"""Whole-loop properties: the budget must never be exceeded, and restart must keep chaos running."""
+
+from __future__ import annotations
+
+import os
+import random
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import dispatch as build_dispatch
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.boundary_scheduler import (
+    BoundaryNemesisScheduler,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    ClusterTopologyModel,
+    FailureModelGuard,
+    GuardMode,
+    ImpactScope,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import RecoveryProbe
+
+# 3 realms × 3 racks with labels repeating per DC; 2 nodes and 6 slots worth of targets per host.
+HOSTS = [
+    {"name": f"{dc}-r{r}", "location": {"rack": str(r), "data_center": dc}}
+    for dc in ("dc1", "dc2", "dc3")
+    for r in (1, 2, 3)
+]
+NODES = [ChaosTarget.for_node(h["name"], node_id=i + 1) for i, h in enumerate(HOSTS)]
+SLOTS = [
+    ChaosTarget.for_slot(h["name"], slot_idx=i * 10 + s)
+    for i, h in enumerate(HOSTS)
+    for s in range(6)
+]
+DCS = [ChaosTarget.for_datacenter(h["name"], h["location"]["data_center"]) for h in HOSTS]
+TABLETS = [ChaosTarget.for_tablet(HOSTS[0]["name"])]
+
+# type -> (kind, scope, guard mode, recovery mode, recovery window)
+TYPES = {
+    "KillNode": (TargetKind.NODE, ImpactScope.NODE, GuardMode.FULL, "self", 120.0),
+    "KillSlot": (TargetKind.SLOT, ImpactScope.SLOT, GuardMode.FULL, "self", 90.0),
+    "StopStart": (TargetKind.NODE, ImpactScope.NODE, GuardMode.FULL, "extract", 90.0),
+    "DCStop": (TargetKind.DATACENTER, ImpactScope.DATACENTER, GuardMode.FULL, "self", 240.0),
+    "KillHive": (TargetKind.TABLET, ImpactScope.NODE, GuardMode.BYPASS, "self", 60.0),
+}
+BY_KIND = {
+    TargetKind.NODE: NODES,
+    TargetKind.SLOT: SLOTS,
+    TargetKind.DATACENTER: DCS,
+    TargetKind.TABLET: TABLETS,
+}
+
+
+class Inventory:
+    def entities(self, kind):
+        return list(BY_KIND.get(kind, []))
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture(scope="module")
+def topology():
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    os.close(fd)
+    Path(path).write_text(
+        yaml.safe_dump({"static_erasure": "mirror-3-dc", "hosts": HOSTS}), encoding="utf-8"
+    )
+    return ClusterTopologyModel(path)
+
+
+def _scheduler(guard, inventory, dispatched, probe, rng, **overrides):
+    kwargs = dict(
+        guard=guard,
+        inventory=inventory,
+        plan_inject=lambda n, t: [build_dispatch(n, t, "inject", {})],
+        plan_extract=lambda n, t: [build_dispatch(n, t, "extract", {})],
+        dispatch=dispatched.append,
+        recovery_probe=probe,
+        enabled_types=list(TYPES),
+        scope_for=lambda n: TYPES[n][1],
+        kind_for=lambda n: TYPES[n][0],
+        mode_for=lambda n: TYPES[n][2],
+        recovery_sec_for=lambda n: TYPES[n][4],
+        recovery_mode_for=lambda n: TYPES[n][3],
+        max_per_tick=6,
+        rng=rng,
+    )
+    kwargs.update(overrides)
+    return BoundaryNemesisScheduler(**kwargs)
+
+
+def _assert_within_budget(guard, where: str) -> None:
+    snap = guard.snapshot()
+    domains = set(snap["impaired_racks"])
+    assert guard._is_tolerable(domains), f"{where}: erasure budget exceeded: {sorted(domains)}"
+    assert snap["impaired_slots"] <= snap["max_slots"], f"{where}: slot budget exceeded: {snap}"
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_budget_is_never_exceeded_across_many_ticks(topology, seed):
+    rng = random.Random(seed)
+    guard = FailureModelGuard(topology, total_slots=len(SLOTS))
+    clock, recovered, dispatched = Clock(), set(), []
+    probe = RecoveryProbe(
+        guard=guard, recovered=lambda t: t.host in recovered, min_hold_sec=0.0, clock=clock
+    )
+    sched = _scheduler(guard, Inventory(), dispatched, probe, rng)
+
+    injected = 0
+    for i in range(200):
+        injected += sched.tick()
+        _assert_within_budget(guard, f"tick {i}")
+        clock.t += rng.uniform(5, 60)
+        recovered.clear()
+        recovered.update(h["name"] for h in HOSTS if rng.random() < 0.35)
+        probe.tick()
+        _assert_within_budget(guard, f"probe {i}")
+
+    assert injected > 100, f"the simulation must actually inject chaos; got {injected}"
+
+    toggles = [c for c in dispatched if c.action == "inject" and c.nemesis_type == "StopStart"]
+    probe.drain_extracts()
+    extracts = [c for c in dispatched if c.action == "extract"]
+    assert len(extracts) == len(toggles), "every toggle inject must end in exactly one extract"
+
+
+class ProbeStub:
+    def __init__(self) -> None:
+        self.starts = 0
+
+    def start(self) -> None:
+        self.starts += 1
+
+    def stop(self) -> None:
+        pass
+
+    def drain_extracts(self) -> int:
+        return 0
+
+    def snapshot(self) -> dict:
+        return {"tracked": 0, "stuck": 0}
+
+    def track(self, *args, **kwargs) -> None:
+        pass
+
+
+def test_restart_after_a_slow_stop(topology):
+    """A start() on top of a thread still winding down used to be a silent no-op: the API said
+    "ok" while the stop flag killed the old thread and the probe stayed down."""
+    probe = ProbeStub()
+    sched = _scheduler(
+        FailureModelGuard(topology, total_slots=len(SLOTS)),
+        Inventory(),
+        [],
+        probe,
+        random.Random(0),
+        dispatch=lambda cmd: time.sleep(3.0),
+        enabled_types=["KillNode"],
+        base_interval=1000.0,
+        jitter=0.0,
+        max_per_tick=1,
+        stop_join_sec=0.5,      # stop() gives up while the tick is still dispatching
+        restart_join_sec=10.0,  # start() waits the dying thread out
+    )
+
+    sched.start()
+    time.sleep(0.4)  # a tick is in flight, blocked in dispatch
+    sched.stop()
+    assert sched.running(), "precondition: stop() gave up on the slow tick"
+
+    sched.start()
+    assert sched.running() and not sched._stop.is_set(), "must run again, with the flag cleared"
+    assert probe.starts == 2, "the recovery probe must be running again"
+    sched.stop()

--- a/ydb/tests/stability/nemesis/ut/test_orchestrator_api.py
+++ b/ydb/tests/stability/nemesis/ut/test_orchestrator_api.py
@@ -1,0 +1,141 @@
+"""Orchestrator endpoints this scheduler needs, through a Flask test client."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from flask import Flask
+
+import ydb.tests.stability.nemesis.routers.orchestrator_router as router
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_problems import ChaosProblemStore
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    ClusterTopologyModel,
+    FailureModelGuard,
+    ImpactScope,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import StuckFault
+
+
+class FakeScheduler:
+    def __init__(self) -> None:
+        self.profiles: list[dict] = []
+        self.started = 0
+        self._running = False
+
+    def running(self) -> bool:
+        return self._running
+
+    def status(self) -> dict:
+        return {"running": self._running, "enabled_types": ["KillNodeNemesis"], "max_per_tick": 3}
+
+    def set_profile(self, **kwargs) -> None:
+        self.profiles.append(kwargs)
+
+    def start(self) -> None:
+        self.started += 1
+        self._running = True
+
+    def stop(self) -> None:
+        self._running = False
+
+
+@pytest.fixture
+def client():
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    os.close(fd)
+    Path(path).write_text(
+        yaml.safe_dump({
+            "static_erasure": "block-4-2",
+            "hosts": [
+                {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}}
+                for i in (1, 2, 3)
+            ],
+        }),
+        encoding="utf-8",
+    )
+    app = Flask(__name__)
+    app.register_blueprint(router.blueprint)
+
+    router.hosts = ["h1", "h2", "h3"]
+    router.chaos_problems = ChaosProblemStore()
+    router.failure_guard = FailureModelGuard(ClusterTopologyModel(path), total_slots=10)
+    router.nemesis_scheduler = FakeScheduler()
+    router.cluster_inventory = None
+    with app.test_client() as c:
+        yield c
+
+
+def test_problems_reports_stuck_faults_and_the_budget(client):
+    body = client.get("/api/problems").get_json()
+    assert body["count"] == 0 and body["guard_enabled"] is True and "failure_budget" in body
+
+    router.chaos_problems.record_stuck_fault(
+        StuckFault(
+            lease_id="l1",
+            nemesis_type="StopStartNodeNemesis",
+            target=ChaosTarget.for_node("h1", node_id=1),
+            held_sec=400.0,
+            timeout_sec=300.0,
+        )
+    )
+    target = ChaosTarget.for_node("h1", node_id=1)
+    router.failure_guard.reserve(
+        router.failure_guard.footprint_for(target, ImpactScope.NODE),
+        identity_key=target.identity_key(),
+    )
+
+    body = client.get("/api/problems").get_json()
+    assert body["by_kind"] == {"stuck_fault": 1}
+    assert body["problems"][0]["target"] == "node:1:h1"
+    assert body["failure_budget"]["impaired_racks"] == ["dc1/r1"]
+
+
+def test_scheduler_start_and_stop(client):
+    body = client.post("/api/scheduler/start", json={}).get_json()
+    assert body["status"] == "ok" and body["scheduler"]["running"] is True
+    assert router.nemesis_scheduler.profiles == [], "an empty body keeps the current profile"
+
+    body = client.post("/api/scheduler/stop", json={}).get_json()
+    assert body["status"] == "ok" and body["scheduler"]["running"] is False
+
+
+def test_scheduler_start_applies_a_valid_profile(client):
+    resp = client.post(
+        "/api/scheduler/start",
+        json={"enabled": ["KillNodeNemesis"], "base_interval": 30, "max_per_tick": 2},
+    )
+    assert resp.status_code == 200, resp.data
+    assert router.nemesis_scheduler.profiles == [
+        {"enabled": ["KillNodeNemesis"], "base_interval": 30.0, "max_per_tick": 2}
+    ]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"enabled": "KillNodeNemesis"},                 # a bare string would split into letters
+        {"enabled": ["NoSuchNemesis"]},
+        {"enabled": ["ClusterRollingRestartNemesis"]},   # planner keeps its own targets
+        {"jitter": 3},
+        {"max_per_tick": 0},
+        {"base_intervall": 30},                         # a typo must not be ignored
+    ],
+)
+def test_scheduler_start_rejects_bad_profiles(client, body):
+    resp = client.post("/api/scheduler/start", json=body)
+    assert resp.status_code == 400, resp.data
+    assert resp.get_json()["message"]
+    assert router.nemesis_scheduler.started == 0, "a rejected profile must not start chaos"
+
+
+def test_endpoints_survive_missing_wiring(client):
+    router.chaos_problems = None
+    assert client.get("/api/problems").get_json()["problems"] == []
+    router.nemesis_scheduler = None
+    assert client.post("/api/scheduler/start", json={}).status_code == 500
+    assert client.get("/api/scheduler").get_json() == {"available": False}

--- a/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
+++ b/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
@@ -66,13 +66,13 @@ class TestRecoveryProbe:
         )
         target, lease = _reserve(guard, "h1", 1)
         probe.track(lease, target, "KillNode", timeout_sec=300.0)
-        assert guard.snapshot()["impaired_racks"] == ["r1"]
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"]
 
         # Still within min-hold: recovery signal must be ignored.
         recovered_hosts.add("h1")
         clock.advance(10.0)
         assert probe.tick() == []
-        assert guard.snapshot()["impaired_racks"] == ["r1"], "must not release before min-hold"
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], "must not release before min-hold"
 
         # Past min-hold and recovered -> budget released.
         clock.advance(40.0)
@@ -106,7 +106,7 @@ class TestRecoveryProbe:
             f"a fault past its timeout must be reported stuck; got {stuck}"
         )
         assert len(stuck_seen) == 1, "on_stuck must fire exactly once"
-        assert guard.snapshot()["impaired_racks"] == ["r1"], (
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], (
             "a stuck fault must KEEP holding budget, never silently release"
         )
 
@@ -114,7 +114,7 @@ class TestRecoveryProbe:
         clock.advance(60.0)
         assert probe.tick() == []
         assert len(stuck_seen) == 1, "stuck fault must not be re-reported every tick"
-        assert guard.snapshot()["impaired_racks"] == ["r1"]
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"]
 
     def test_forget_stops_tracking(self):
         guard = _guard()
@@ -145,12 +145,12 @@ class TestToggleAutoExtract:
             lease, target, "TimeSkewNemesis", timeout_sec=90.0,
             recover_action=lambda: extracted.append(target.host),
         )
-        assert guard.snapshot()["impaired_racks"] == ["r1"]
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"]
 
         clock.advance(60.0)  # past min-hold, before the hold window closes
         assert probe.tick() == []
         assert extracted == [], "must not extract before the hold elapses"
-        assert guard.snapshot()["impaired_racks"] == ["r1"], "budget held through the hold window"
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], "budget held through the hold window"
 
         clock.advance(40.0)  # now past the 90s hold
         assert probe.tick() == []
@@ -178,6 +178,68 @@ class TestToggleAutoExtract:
         assert probe.tick() == [], "a toggle fault is recovered by extract, never reported stuck"
         assert stuck_seen == []
         assert guard.snapshot()["impaired_racks"] == [], "released by extract, not held as stuck"
+
+
+class TestDrainExtracts:
+    """Switching chaos off must not leave toggle faults applied."""
+
+    def test_drain_extracts_pending_toggle_faults_before_their_hold_elapsed(self):
+        guard = _guard()
+        clock = FakeClock()
+        extracted: list[str] = []
+        probe = RecoveryProbe(
+            guard=guard, recovered=lambda t: False, min_hold_sec=30.0, clock=clock
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(
+            lease, target, "StopStartNodeNemesis", timeout_sec=600.0,
+            recover_action=lambda: extracted.append(target.host),
+        )
+        clock.advance(5.0)  # still deep inside the hold window
+        assert probe.tick() == [] and extracted == [], "nothing is due yet"
+
+        assert probe.drain_extracts() == 1, "the pending toggle fault must be drained"
+        assert extracted == ["h1"], (
+            "drain must dispatch the extract even though the hold window has not elapsed"
+        )
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"drained fault must release its budget; snapshot={guard.snapshot()}"
+        )
+        assert probe.pending() == [], "drained faults must stop being tracked"
+
+    def test_drain_keeps_self_recovering_faults_tracked(self):
+        guard = _guard()
+        clock = FakeClock()
+        probe = RecoveryProbe(
+            guard=guard, recovered=lambda t: False, min_hold_sec=0.0, clock=clock
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(lease, target, "KillNodeNemesis", timeout_sec=300.0)  # no recover_action
+
+        assert probe.drain_extracts() == 0, (
+            "a self-recovering fault has nothing to extract — it must not be drained"
+        )
+        assert [p.lease_id for p in probe.pending()] == [lease], (
+            "self-recovering faults stay tracked so a restarted probe keeps polling them"
+        )
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], (
+            "draining must not release a fault that is still down"
+        )
+
+    def test_drain_is_idempotent(self):
+        guard = _guard()
+        extracted: list[str] = []
+        probe = RecoveryProbe(
+            guard=guard, recovered=lambda t: False, min_hold_sec=0.0, clock=FakeClock()
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(
+            lease, target, "TimeSkewNemesis", timeout_sec=120.0,
+            recover_action=lambda: extracted.append(target.host),
+        )
+        assert probe.drain_extracts() == 1
+        assert probe.drain_extracts() == 0, "a second drain must not re-dispatch extracts"
+        assert extracted == ["h1"]
 
 
 class TestHealthcheckRecovery:

--- a/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
+++ b/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
@@ -129,6 +129,57 @@ class TestRecoveryProbe:
         assert probe.tick() == [], "a forgotten lease must not be polled or reported"
 
 
+class TestToggleAutoExtract:
+    def test_toggle_fault_extracts_then_releases_after_hold(self):
+        guard = _guard()
+        clock = FakeClock()
+        extracted: list[str] = []
+        probe = RecoveryProbe(
+            guard=guard,
+            recovered=lambda t: (_ for _ in ()).throw(AssertionError("healthcheck must not run")),
+            min_hold_sec=30.0,
+            clock=clock,
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(
+            lease, target, "TimeSkewNemesis", timeout_sec=90.0,
+            recover_action=lambda: extracted.append(target.host),
+        )
+        assert guard.snapshot()["impaired_racks"] == ["r1"]
+
+        clock.advance(60.0)  # past min-hold, before the hold window closes
+        assert probe.tick() == []
+        assert extracted == [], "must not extract before the hold elapses"
+        assert guard.snapshot()["impaired_racks"] == ["r1"], "budget held through the hold window"
+
+        clock.advance(40.0)  # now past the 90s hold
+        assert probe.tick() == []
+        assert extracted == ["h1"], "hold elapsed -> extract dispatched exactly once"
+        assert guard.snapshot()["impaired_racks"] == [], "extract must release the budget"
+        assert probe.pending() == []
+
+    def test_toggle_fault_never_reports_stuck(self):
+        guard = _guard()
+        clock = FakeClock()
+        stuck_seen: list[StuckFault] = []
+        probe = RecoveryProbe(
+            guard=guard,
+            recovered=lambda t: False,
+            on_stuck=stuck_seen.append,
+            min_hold_sec=0.0,
+            clock=clock,
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(
+            lease, target, "StopStartNodeNemesis", timeout_sec=50.0,
+            recover_action=lambda: None,
+        )
+        clock.advance(1000.0)  # far past the hold
+        assert probe.tick() == [], "a toggle fault is recovered by extract, never reported stuck"
+        assert stuck_seen == []
+        assert guard.snapshot()["impaired_racks"] == [], "released by extract, not held as stuck"
+
+
 class TestHealthcheckRecovery:
     def test_recovered_when_endpoint_answers(self):
         reporter = type("R", (), {"last_results": {}})()

--- a/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
+++ b/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
@@ -1,0 +1,147 @@
+"""Unit tests for fact-based recovery of reserved failure budget."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    ClusterTopologyModel,
+    FailureModelGuard,
+    ImpactScope,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe import (
+    RecoveryProbe,
+    StuckFault,
+    healthcheck_recovery,
+)
+
+
+def _guard() -> FailureModelGuard:
+    hosts = [
+        {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}}
+        for i in (1, 2, 3, 4)
+    ]
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    os.close(fd)
+    Path(path).write_text(
+        yaml.safe_dump({"static_erasure": "block-4-2", "hosts": hosts}), encoding="utf-8"
+    )
+    return FailureModelGuard(ClusterTopologyModel(path))
+
+
+class FakeClock:
+    def __init__(self, t: float = 0.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _reserve(guard, host, node_id):
+    target = ChaosTarget.for_node(host, node_id=node_id)
+    fp = guard.footprint_for(target, ImpactScope.NODE)
+    lease = guard.reserve(fp, recovery_sec=None, identity_key=target.identity_key())
+    return target, lease
+
+
+class TestRecoveryProbe:
+    def test_recovered_fault_releases_budget(self):
+        guard = _guard()
+        clock = FakeClock()
+        recovered_hosts = set()
+        probe = RecoveryProbe(
+            guard=guard,
+            recovered=lambda t: t.host in recovered_hosts,
+            min_hold_sec=30.0,
+            default_timeout_sec=300.0,
+            clock=clock,
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(lease, target, "KillNode", timeout_sec=300.0)
+        assert guard.snapshot()["impaired_racks"] == ["r1"]
+
+        # Still within min-hold: recovery signal must be ignored.
+        recovered_hosts.add("h1")
+        clock.advance(10.0)
+        assert probe.tick() == []
+        assert guard.snapshot()["impaired_racks"] == ["r1"], "must not release before min-hold"
+
+        # Past min-hold and recovered -> budget released.
+        clock.advance(40.0)
+        assert probe.tick() == []
+        assert guard.snapshot()["impaired_racks"] == [], (
+            f"recovered fault must release budget; snapshot={guard.snapshot()}"
+        )
+        assert probe.pending() == []
+
+    def test_stuck_fault_reports_once_and_holds_budget(self):
+        guard = _guard()
+        clock = FakeClock()
+        stuck_seen: list[StuckFault] = []
+        probe = RecoveryProbe(
+            guard=guard,
+            recovered=lambda t: False,  # never recovers
+            on_stuck=stuck_seen.append,
+            min_hold_sec=30.0,
+            default_timeout_sec=100.0,
+            clock=clock,
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(lease, target, "KillNode", timeout_sec=100.0)
+
+        clock.advance(50.0)  # past min-hold, before timeout
+        assert probe.tick() == [], "no stuck report before timeout"
+
+        clock.advance(60.0)  # now past 100s timeout
+        stuck = probe.tick()
+        assert len(stuck) == 1 and stuck[0].target.host == "h1", (
+            f"a fault past its timeout must be reported stuck; got {stuck}"
+        )
+        assert len(stuck_seen) == 1, "on_stuck must fire exactly once"
+        assert guard.snapshot()["impaired_racks"] == ["r1"], (
+            "a stuck fault must KEEP holding budget, never silently release"
+        )
+
+        # Subsequent ticks must not re-report the same stuck fault.
+        clock.advance(60.0)
+        assert probe.tick() == []
+        assert len(stuck_seen) == 1, "stuck fault must not be re-reported every tick"
+        assert guard.snapshot()["impaired_racks"] == ["r1"]
+
+    def test_forget_stops_tracking(self):
+        guard = _guard()
+        clock = FakeClock()
+        probe = RecoveryProbe(
+            guard=guard, recovered=lambda t: False, clock=clock, min_hold_sec=0.0
+        )
+        target, lease = _reserve(guard, "h1", 1)
+        probe.track(lease, target, "KillNode", timeout_sec=10.0)
+        probe.forget(lease)
+        clock.advance(1000.0)
+        assert probe.tick() == [], "a forgotten lease must not be polled or reported"
+
+
+class TestHealthcheckRecovery:
+    def test_recovered_when_endpoint_answers(self):
+        reporter = type("R", (), {"last_results": {}})()
+        recovered = healthcheck_recovery(reporter)
+        t = ChaosTarget.for_node("h1", node_id=1)
+
+        assert recovered(t) is False, "no healthcheck data yet must read as not-recovered"
+
+        reporter.last_results = {"h1": {"self_check_result": "HC_REQUEST_ERROR"}}
+        assert recovered(t) is False, "endpoint error means the host is still down"
+
+        reporter.last_results = {"h1": {"self_check_result": "GOOD"}}
+        assert recovered(t) is True, "endpoint answering GOOD means recovered"
+
+        reporter.last_results = {"h1": {"self_check_result": "DEGRADED"}}
+        assert recovered(t) is True, "a degraded-but-answering endpoint still counts as back"

--- a/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
+++ b/ydb/tests/stability/nemesis/ut/test_recovery_probe.py
@@ -1,4 +1,4 @@
-"""Unit tests for fact-based recovery of reserved failure budget."""
+"""Fact-based recovery of reserved failure budget."""
 
 from __future__ import annotations
 
@@ -23,8 +23,7 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.recovery_probe im
 
 def _guard() -> FailureModelGuard:
     hosts = [
-        {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}}
-        for i in (1, 2, 3, 4)
+        {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}} for i in (1, 2, 3, 4)
     ]
     fd, path = tempfile.mkstemp(suffix=".yaml")
     os.close(fd)
@@ -35,8 +34,8 @@ def _guard() -> FailureModelGuard:
 
 
 class FakeClock:
-    def __init__(self, t: float = 0.0) -> None:
-        self.t = t
+    def __init__(self) -> None:
+        self.t = 0.0
 
     def __call__(self) -> float:
         return self.t
@@ -45,216 +44,131 @@ class FakeClock:
         self.t += dt
 
 
-def _reserve(guard, host, node_id):
+def _reserve(guard, host="h1", node_id=1):
     target = ChaosTarget.for_node(host, node_id=node_id)
-    fp = guard.footprint_for(target, ImpactScope.NODE)
-    lease = guard.reserve(fp, recovery_sec=None, identity_key=target.identity_key())
+    lease = guard.reserve(
+        guard.footprint_for(target, ImpactScope.NODE),
+        recovery_sec=None,
+        identity_key=target.identity_key(),
+    )
     return target, lease
 
 
-class TestRecoveryProbe:
-    def test_recovered_fault_releases_budget(self):
-        guard = _guard()
-        clock = FakeClock()
-        recovered_hosts = set()
+class TestSelfRecovery:
+    def test_budget_is_released_once_the_target_is_back(self):
+        guard, clock, recovered = _guard(), FakeClock(), set()
         probe = RecoveryProbe(
-            guard=guard,
-            recovered=lambda t: t.host in recovered_hosts,
-            min_hold_sec=30.0,
-            default_timeout_sec=300.0,
-            clock=clock,
+            guard=guard, recovered=lambda t: t.host in recovered, min_hold_sec=30.0, clock=clock
         )
-        target, lease = _reserve(guard, "h1", 1)
+        target, lease = _reserve(guard)
         probe.track(lease, target, "KillNode", timeout_sec=300.0)
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"]
 
-        # Still within min-hold: recovery signal must be ignored.
-        recovered_hosts.add("h1")
+        recovered.add("h1")
         clock.advance(10.0)
-        assert probe.tick() == []
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], "must not release before min-hold"
+        probe.tick()
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], "min-hold ignores early signals"
 
-        # Past min-hold and recovered -> budget released.
         clock.advance(40.0)
-        assert probe.tick() == []
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"recovered fault must release budget; snapshot={guard.snapshot()}"
-        )
-        assert probe.pending() == []
+        probe.tick()
+        assert guard.snapshot()["impaired_racks"] == [] and probe.pending() == []
 
-    def test_stuck_fault_reports_once_and_holds_budget(self):
-        guard = _guard()
-        clock = FakeClock()
-        stuck_seen: list[StuckFault] = []
+    def test_a_stuck_fault_keeps_the_budget_and_is_reported_once(self):
+        guard, clock, seen = _guard(), FakeClock(), []
         probe = RecoveryProbe(
-            guard=guard,
-            recovered=lambda t: False,  # never recovers
-            on_stuck=stuck_seen.append,
-            min_hold_sec=30.0,
-            default_timeout_sec=100.0,
-            clock=clock,
+            guard=guard, recovered=lambda t: False, on_stuck=seen.append,
+            min_hold_sec=30.0, clock=clock,
         )
-        target, lease = _reserve(guard, "h1", 1)
+        target, lease = _reserve(guard)
         probe.track(lease, target, "KillNode", timeout_sec=100.0)
 
-        clock.advance(50.0)  # past min-hold, before timeout
-        assert probe.tick() == [], "no stuck report before timeout"
+        clock.advance(50.0)
+        assert probe.tick() == [], "not stuck before the timeout"
 
-        clock.advance(60.0)  # now past 100s timeout
-        stuck = probe.tick()
-        assert len(stuck) == 1 and stuck[0].target.host == "h1", (
-            f"a fault past its timeout must be reported stuck; got {stuck}"
-        )
-        assert len(stuck_seen) == 1, "on_stuck must fire exactly once"
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], (
-            "a stuck fault must KEEP holding budget, never silently release"
-        )
-
-        # Subsequent ticks must not re-report the same stuck fault.
         clock.advance(60.0)
-        assert probe.tick() == []
-        assert len(stuck_seen) == 1, "stuck fault must not be re-reported every tick"
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"]
+        stuck = probe.tick()
+        assert len(stuck) == 1 and stuck[0].target.host == "h1"
 
-    def test_forget_stops_tracking(self):
-        guard = _guard()
-        clock = FakeClock()
-        probe = RecoveryProbe(
-            guard=guard, recovered=lambda t: False, clock=clock, min_hold_sec=0.0
-        )
-        target, lease = _reserve(guard, "h1", 1)
-        probe.track(lease, target, "KillNode", timeout_sec=10.0)
-        probe.forget(lease)
-        clock.advance(1000.0)
-        assert probe.tick() == [], "a forgotten lease must not be polled or reported"
+        clock.advance(60.0)
+        assert probe.tick() == [] and len(seen) == 1, "reported once, not every tick"
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], "never silently released"
 
 
-class TestToggleAutoExtract:
-    def test_toggle_fault_extracts_then_releases_after_hold(self):
-        guard = _guard()
-        clock = FakeClock()
-        extracted: list[str] = []
+class TestToggleRecovery:
+    def test_extract_runs_after_the_hold_and_releases(self):
+        guard, clock, extracted = _guard(), FakeClock(), []
         probe = RecoveryProbe(
             guard=guard,
             recovered=lambda t: (_ for _ in ()).throw(AssertionError("healthcheck must not run")),
             min_hold_sec=30.0,
             clock=clock,
         )
-        target, lease = _reserve(guard, "h1", 1)
+        target, lease = _reserve(guard)
         probe.track(
             lease, target, "TimeSkewNemesis", timeout_sec=90.0,
             recover_action=lambda: extracted.append(target.host),
         )
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"]
 
-        clock.advance(60.0)  # past min-hold, before the hold window closes
-        assert probe.tick() == []
-        assert extracted == [], "must not extract before the hold elapses"
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], "budget held through the hold window"
+        clock.advance(60.0)
+        probe.tick()
+        assert extracted == [] and guard.snapshot()["impaired_racks"] == ["dc1/r1"]
 
-        clock.advance(40.0)  # now past the 90s hold
-        assert probe.tick() == []
-        assert extracted == ["h1"], "hold elapsed -> extract dispatched exactly once"
-        assert guard.snapshot()["impaired_racks"] == [], "extract must release the budget"
-        assert probe.pending() == []
+        clock.advance(40.0)
+        probe.tick()
+        assert extracted == ["h1"] and guard.snapshot()["impaired_racks"] == []
 
-    def test_toggle_fault_never_reports_stuck(self):
-        guard = _guard()
-        clock = FakeClock()
-        stuck_seen: list[StuckFault] = []
+    def test_toggle_faults_are_never_reported_stuck(self):
+        guard, clock, seen = _guard(), FakeClock(), []
         probe = RecoveryProbe(
-            guard=guard,
-            recovered=lambda t: False,
-            on_stuck=stuck_seen.append,
-            min_hold_sec=0.0,
-            clock=clock,
+            guard=guard, recovered=lambda t: False, on_stuck=seen.append,
+            min_hold_sec=0.0, clock=clock,
         )
-        target, lease = _reserve(guard, "h1", 1)
-        probe.track(
-            lease, target, "StopStartNodeNemesis", timeout_sec=50.0,
-            recover_action=lambda: None,
-        )
-        clock.advance(1000.0)  # far past the hold
-        assert probe.tick() == [], "a toggle fault is recovered by extract, never reported stuck"
-        assert stuck_seen == []
-        assert guard.snapshot()["impaired_racks"] == [], "released by extract, not held as stuck"
+        target, lease = _reserve(guard)
+        probe.track(lease, target, "StopStart", timeout_sec=50.0, recover_action=lambda: None)
+        clock.advance(1000.0)
+        assert probe.tick() == [] and seen == []
 
 
 class TestDrainExtracts:
-    """Switching chaos off must not leave toggle faults applied."""
-
-    def test_drain_extracts_pending_toggle_faults_before_their_hold_elapsed(self):
-        guard = _guard()
-        clock = FakeClock()
-        extracted: list[str] = []
+    def test_drain_extracts_toggles_early_and_leaves_the_rest_tracked(self):
+        guard, clock, extracted = _guard(), FakeClock(), []
         probe = RecoveryProbe(
             guard=guard, recovered=lambda t: False, min_hold_sec=30.0, clock=clock
         )
-        target, lease = _reserve(guard, "h1", 1)
+        toggle, toggle_lease = _reserve(guard, "h1", 1)
+        self_healing, self_lease = _reserve(guard, "h2", 2)
         probe.track(
-            lease, target, "StopStartNodeNemesis", timeout_sec=600.0,
-            recover_action=lambda: extracted.append(target.host),
+            toggle_lease, toggle, "StopStart", timeout_sec=600.0,
+            recover_action=lambda: extracted.append(toggle.host),
         )
-        clock.advance(5.0)  # still deep inside the hold window
-        assert probe.tick() == [] and extracted == [], "nothing is due yet"
+        probe.track(self_lease, self_healing, "KillNode", timeout_sec=300.0)
 
-        assert probe.drain_extracts() == 1, "the pending toggle fault must be drained"
-        assert extracted == ["h1"], (
-            "drain must dispatch the extract even though the hold window has not elapsed"
-        )
-        assert guard.snapshot()["impaired_racks"] == [], (
-            f"drained fault must release its budget; snapshot={guard.snapshot()}"
-        )
-        assert probe.pending() == [], "drained faults must stop being tracked"
+        assert probe.drain_extracts() == 1, "only the toggle has something to extract"
+        assert extracted == ["h1"], "dispatched even though the hold window is far from over"
+        assert [p.lease_id for p in probe.pending()] == [self_lease], "self-healing stays tracked"
+        assert guard.snapshot()["impaired_racks"] == ["dc1/r2"], "and keeps its budget"
 
-    def test_drain_keeps_self_recovering_faults_tracked(self):
-        guard = _guard()
-        clock = FakeClock()
-        probe = RecoveryProbe(
-            guard=guard, recovered=lambda t: False, min_hold_sec=0.0, clock=clock
-        )
-        target, lease = _reserve(guard, "h1", 1)
-        probe.track(lease, target, "KillNodeNemesis", timeout_sec=300.0)  # no recover_action
-
-        assert probe.drain_extracts() == 0, (
-            "a self-recovering fault has nothing to extract — it must not be drained"
-        )
-        assert [p.lease_id for p in probe.pending()] == [lease], (
-            "self-recovering faults stay tracked so a restarted probe keeps polling them"
-        )
-        assert guard.snapshot()["impaired_racks"] == ["dc1/r1"], (
-            "draining must not release a fault that is still down"
-        )
-
-    def test_drain_is_idempotent(self):
-        guard = _guard()
-        extracted: list[str] = []
-        probe = RecoveryProbe(
-            guard=guard, recovered=lambda t: False, min_hold_sec=0.0, clock=FakeClock()
-        )
-        target, lease = _reserve(guard, "h1", 1)
-        probe.track(
-            lease, target, "TimeSkewNemesis", timeout_sec=120.0,
-            recover_action=lambda: extracted.append(target.host),
-        )
-        assert probe.drain_extracts() == 1
-        assert probe.drain_extracts() == 0, "a second drain must not re-dispatch extracts"
-        assert extracted == ["h1"]
+        assert probe.drain_extracts() == 0 and extracted == ["h1"], "idempotent"
 
 
 class TestHealthcheckRecovery:
-    def test_recovered_when_endpoint_answers(self):
+    def test_recovered_when_the_endpoint_answers(self):
         reporter = type("R", (), {"last_results": {}})()
         recovered = healthcheck_recovery(reporter)
-        t = ChaosTarget.for_node("h1", node_id=1)
+        target = ChaosTarget.for_node("h1", node_id=1)
 
-        assert recovered(t) is False, "no healthcheck data yet must read as not-recovered"
-
+        assert recovered(target) is False, "no data yet is not recovery"
         reporter.last_results = {"h1": {"self_check_result": "HC_REQUEST_ERROR"}}
-        assert recovered(t) is False, "endpoint error means the host is still down"
-
-        reporter.last_results = {"h1": {"self_check_result": "GOOD"}}
-        assert recovered(t) is True, "endpoint answering GOOD means recovered"
-
+        assert recovered(target) is False
         reporter.last_results = {"h1": {"self_check_result": "DEGRADED"}}
-        assert recovered(t) is True, "a degraded-but-answering endpoint still counts as back"
+        assert recovered(target) is True, "degraded but answering counts as back"
+
+
+def test_stuck_fault_is_serializable_for_the_problem_log():
+    fault = StuckFault(
+        lease_id="l1",
+        nemesis_type="KillNode",
+        target=ChaosTarget.for_node("h1", node_id=1),
+        held_sec=400.0,
+        timeout_sec=300.0,
+    )
+    assert fault.target.identity_key() == "node:1:h1"

--- a/ydb/tests/stability/nemesis/ut/test_weighted_scheduler.py
+++ b/ydb/tests/stability/nemesis/ut/test_weighted_scheduler.py
@@ -10,7 +10,11 @@ from pathlib import Path
 import pytest
 import yaml
 
-from ydb.tests.stability.nemesis.internal.nemesis.catalog import weight_for as catalog_weight_for
+from ydb.tests.stability.nemesis.internal.nemesis.catalog import (
+    NEMESIS_TYPES,
+    recovery_mode_for,
+    weight_for as catalog_weight_for,
+)
 from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import dispatch as build_dispatch
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import (
     datacenter_inject_fanout,
@@ -23,6 +27,8 @@ from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model imp
 )
 from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import (
     WeightedNemesisScheduler,
+    _STABILITY_PROFILE,
+    default_enabled_types,
 )
 
 
@@ -201,7 +207,7 @@ class TestProfile:
 
 class TestCatalogWeights:
     def test_weight_for_reads_registry_and_defaults(self):
-        assert catalog_weight_for("KillNodeNemesis") == 3.0, "annotated weight must be read from the registry"
+        assert catalog_weight_for("KillSlotDaemonNemesis") == 3.0, "annotated weight must be read from the registry"
         assert catalog_weight_for("no-such-nemesis") == 1.0, "unknown types default to weight 1.0"
 
 
@@ -251,6 +257,93 @@ class TestStatus:
         sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [],
                                 recovery_probe=FakeProbe())
         assert sched.status()["recovery_probe"] == {"tracked": 0, "stuck": 0}
+
+
+class RecordingProbe:
+    def __init__(self) -> None:
+        self.tracked: list = []
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def snapshot(self) -> dict:
+        return {"tracked": len(self.tracked)}
+
+    def track(self, lease_id, target, nemesis_type, timeout_sec=None, recover_action=None):
+        self.tracked.append((lease_id, target, nemesis_type, timeout_sec, recover_action))
+
+
+class TestToggleRecovery:
+    def _toggle_scheduler(self, guard, dispatched, probe, **overrides):
+        return _make_scheduler(
+            guard, FakeInventory(_nodes()), dispatched,
+            enabled_types=["Toggle"],
+            recovery_mode_for=lambda t: "extract",
+            recovery_sec_for=lambda t: 90.0,
+            plan_extract=lambda ntype, target: [build_dispatch(ntype, target, "extract", {})],
+            recovery_probe=probe,
+            max_per_tick=1, rng=ScriptedRandom(randint=1),
+            **overrides,
+        )
+
+    def test_toggle_tick_holds_budget_and_tracks_extract_action(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        probe = RecordingProbe()
+        sched = self._toggle_scheduler(guard, dispatched, probe)
+
+        assert sched.tick() == 1
+        injects = [c for c in dispatched if c.action == "inject"]
+        assert len(injects) == 1, f"exactly one inject must be dispatched; got {dispatched}"
+        assert len(guard.snapshot()["impaired_racks"]) == 1, (
+            "a toggle fault must hold the budget (recovery_sec=None), not expire on a timer"
+        )
+        assert len(probe.tracked) == 1
+        lease, target, ntype, timeout, action = probe.tracked[0]
+        assert ntype == "Toggle" and timeout == 90.0
+        assert action is not None, "toggle faults must be tracked with a recover_action"
+
+        # Running the recover_action must dispatch an extract for the same target.
+        action()
+        extracts = [c for c in dispatched if c.action == "extract"]
+        assert len(extracts) == 1 and extracts[0].target.host == target.host, (
+            f"recover_action must extract the injected target; got {dispatched}"
+        )
+
+    def test_toggle_type_muted_when_extract_not_wired(self):
+        guard = _guard("block-4-2")
+        # No plan_extract / no probe -> a toggle fault can never auto-extract, so it must never
+        # be offered (else it would stay broken forever).
+        sched = _make_scheduler(
+            guard, FakeInventory(_nodes()), [],
+            enabled_types=["Toggle"],
+            recovery_mode_for=lambda t: "extract",
+        )
+        assert sched._menu() == [], "toggle types must be filtered out with no way to extract"
+        assert sched.tick() == 0
+
+
+class TestDefaultProfile:
+    def test_default_profile_is_curated_and_registered(self):
+        enabled = default_enabled_types()
+        assert enabled, "the default profile must not be empty"
+        assert set(enabled) <= set(_STABILITY_PROFILE)
+        assert all(t in NEMESIS_TYPES for t in enabled), (
+            "every profile entry must be a registered nemesis type"
+        )
+        for t in ("KillNodeNemesis", "KillSlotDaemonNemesis", "StopStartNodeNemesis",
+                  "SafelyBreakDiskNemesis", "TimeSkewNemesis"):
+            assert t in enabled, f"{t} must be in the default stability profile"
+
+    def test_toggle_members_are_extract_mode(self):
+        for t in ("StopStartNodeNemesis", "SafelyBreakDiskNemesis",
+                  "SafelyCleanupDisksNemesis", "TimeSkewNemesis"):
+            assert recovery_mode_for(t) == "extract", f"{t} must recover via extract"
+        for t in ("KillNodeNemesis", "KillSlotDaemonNemesis"):
+            assert recovery_mode_for(t) == "self", f"{t} is self-recovering"
 
 
 class TestLifecycle:

--- a/ydb/tests/stability/nemesis/ut/test_weighted_scheduler.py
+++ b/ydb/tests/stability/nemesis/ut/test_weighted_scheduler.py
@@ -1,0 +1,272 @@
+"""Unit tests for the single-threaded weighted nemesis scheduler."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ydb.tests.stability.nemesis.internal.nemesis.catalog import weight_for as catalog_weight_for
+from ydb.tests.stability.nemesis.internal.nemesis.chaos_dispatch import dispatch as build_dispatch
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_state import (
+    datacenter_inject_fanout,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.chaos_target import ChaosTarget, TargetKind
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.failure_model import (
+    ClusterTopologyModel,
+    FailureModelGuard,
+    ImpactScope,
+)
+from ydb.tests.stability.nemesis.internal.orchestrator.nemesis.weighted_scheduler import (
+    WeightedNemesisScheduler,
+)
+
+
+def _write_topology(hosts: list[dict], erasure: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".yaml")
+    os.close(fd)
+    Path(path).write_text(
+        yaml.safe_dump({"static_erasure": erasure, "hosts": hosts}), encoding="utf-8"
+    )
+    return path
+
+
+def _guard(erasure: str) -> FailureModelGuard:
+    hosts = [
+        {"name": f"h{i}", "location": {"rack": f"r{i}", "data_center": "dc1"}}
+        for i in (1, 2, 3, 4)
+    ]
+    return FailureModelGuard(ClusterTopologyModel(_write_topology(hosts, erasure)))
+
+
+class FakeInventory:
+    def __init__(self, targets: list[ChaosTarget]) -> None:
+        self._targets = list(targets)
+
+    def entities(self, kind: TargetKind) -> list[ChaosTarget]:
+        return list(self._targets)
+
+
+class ScriptedRandom:
+    """Deterministic stand-in for random.Random with scripted return values."""
+
+    def __init__(self, *, randint: int = 1, randoms=None, uniform: float = 0.0) -> None:
+        self._randint = randint
+        self._randoms = list(randoms if randoms is not None else [])
+        self._uniform = uniform
+
+    def randint(self, a: int, b: int) -> int:
+        return max(a, min(b, self._randint))
+
+    def random(self) -> float:
+        return self._randoms.pop(0) if self._randoms else 0.0
+
+    def uniform(self, a: float, b: float) -> float:
+        return self._uniform
+
+    def choice(self, seq):
+        return seq[0]
+
+
+def _make_scheduler(guard, inventory, dispatched, **overrides):
+    kwargs = dict(
+        guard=guard,
+        inventory=inventory,
+        plan_inject=lambda ntype, target: [build_dispatch(ntype, target, "inject", {})],
+        dispatch=lambda cmd: dispatched.append(cmd),
+        enabled_types=["KillNode"],
+        scope_for=lambda t: ImpactScope.NODE,
+        kind_for=lambda t: TargetKind.NODE,
+        recovery_sec_for=lambda t: None,
+        default_recovery_sec=300.0,
+    )
+    kwargs.update(overrides)
+    return WeightedNemesisScheduler(**kwargs)
+
+
+def _nodes() -> list[ChaosTarget]:
+    return [ChaosTarget.for_node(f"h{i}", node_id=i) for i in (1, 2, 3, 4)]
+
+
+class TestTick:
+    def test_single_tick_respects_block42_ceiling(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched = _make_scheduler(
+            guard, FakeInventory(_nodes()), dispatched,
+            max_per_tick=5, rng=ScriptedRandom(randint=5),
+        )
+        injected = sched.tick()
+        assert injected == 2, (
+            "a single tick must stop at the block-4-2 budget of 2 fail domains even with a "
+            f"cap of 5; injected={injected}, snapshot={guard.snapshot()}"
+        )
+        assert len(dispatched) == 2, f"exactly two commands must be dispatched; got {len(dispatched)}"
+        assert len({c.target.host for c in dispatched}) == 2, (
+            "the two injects must hit two distinct hosts (identity exclusion), not the same one; "
+            f"hosts={[c.target.host for c in dispatched]}"
+        )
+        assert len(guard.snapshot()["impaired_racks"]) == 2
+
+    def test_disabled_guard_fills_cap_with_distinct_targets(self):
+        guard = _guard("no-such-erasure")  # unknown -> guard disabled (fail-open)
+        assert not guard.enabled, "unknown erasure must leave the guard disabled"
+        dispatched: list = []
+        sched = _make_scheduler(
+            guard, FakeInventory(_nodes()), dispatched,
+            max_per_tick=3, rng=ScriptedRandom(randint=3, randoms=[0.0, 0.3, 0.6]),
+        )
+        injected = sched.tick()
+        assert injected == 3, f"a disabled guard must never block; cap of 3 must fill; got {injected}"
+        assert len(dispatched) == 3
+        assert len({c.target.host for c in dispatched}) == 3, (
+            "with a walking rng the disabled scheduler should spread across distinct hosts; "
+            f"hosts={[c.target.host for c in dispatched]}"
+        )
+
+    def test_zero_weight_type_is_never_offered(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched = _make_scheduler(
+            guard, FakeInventory(_nodes()), dispatched,
+            enabled_types=["Muted", "Active"],
+            weight_for=lambda t: 0.0 if t == "Muted" else 1.0,
+            max_per_tick=1, rng=ScriptedRandom(randint=1),
+        )
+        menu = sched._menu()
+        assert menu, "the weighted (Active) type must still produce a menu"
+        assert all(item[0] == "Active" for item in menu), (
+            f"a zero-weight type must never appear in the menu; got {[m[0] for m in menu]}"
+        )
+
+
+class TestWeightedChoice:
+    def _menu(self):
+        t = ChaosTarget.for_node("h1", node_id=1)
+        fs = frozenset({"r1"})
+        return [("A", t, fs, 1.0), ("B", t, fs, 3.0)]
+
+    def test_low_draw_picks_first_bucket(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
+                                rng=ScriptedRandom(randoms=[0.1]))
+        picked = sched._weighted_choice(self._menu())
+        assert picked[0] == "A", f"r=0.4 lands in A's [0,1] bucket; got {picked[0]}"
+
+    def test_high_draw_picks_weighted_bucket(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
+                                rng=ScriptedRandom(randoms=[0.5]))
+        picked = sched._weighted_choice(self._menu())
+        assert picked[0] == "B", f"r=2.0 lands in B's (1,4] bucket; got {picked[0]}"
+
+    def test_all_zero_weight_menu_falls_back_to_choice(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
+                                rng=ScriptedRandom())
+        t = ChaosTarget.for_node("h1", node_id=1)
+        menu = [("A", t, frozenset({"r1"}), 0.0), ("B", t, frozenset({"r2"}), 0.0)]
+        picked = sched._weighted_choice(menu)
+        assert picked[0] == "A", "with zero total weight, choice() (first element) is used"
+
+
+class TestSleep:
+    def test_sleep_low_extreme(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
+                                base_interval=60.0, jitter=0.5, rng=ScriptedRandom(uniform=-0.5))
+        assert sched._sleep_seconds() == pytest.approx(30.0)
+
+    def test_sleep_high_extreme(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
+                                base_interval=60.0, jitter=0.5, rng=ScriptedRandom(uniform=0.5))
+        assert sched._sleep_seconds() == pytest.approx(90.0)
+
+    def test_sleep_has_floor(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory([]), [],
+                                base_interval=0.1, jitter=0.0, rng=ScriptedRandom(uniform=0.0))
+        assert sched._sleep_seconds() == pytest.approx(0.5), "sleep must never drop below the 0.5s floor"
+
+
+class TestProfile:
+    def test_set_profile_updates_weights_and_bounds(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [])
+        sched.set_profile(enabled=["X"], weights={"X": 2.0}, base_interval=10.0,
+                          jitter=0.25, max_per_tick=7)
+        assert sched._weight_for("X") == 2.0
+        assert sched._weight_for("unlisted") == 1.0, "unlisted types default to weight 1.0"
+        assert sched._base_interval == 10.0
+        assert sched._max_per_tick == 7
+
+
+class TestCatalogWeights:
+    def test_weight_for_reads_registry_and_defaults(self):
+        assert catalog_weight_for("KillNodeNemesis") == 3.0, "annotated weight must be read from the registry"
+        assert catalog_weight_for("no-such-nemesis") == 1.0, "unknown types default to weight 1.0"
+
+
+class TestDatacenterFanout:
+    def test_dc_target_fans_out_to_every_host_in_the_chosen_dc(self):
+        dc_targets = [
+            ChaosTarget.for_datacenter("h1", "dc1"),
+            ChaosTarget.for_datacenter("h2", "dc1"),
+            ChaosTarget.for_datacenter("h3", "dc2"),
+        ]
+        cmds = datacenter_inject_fanout(
+            "DataCenterStopNodesNemesis",
+            ChaosTarget.for_datacenter("h1", "dc1"),
+            FakeInventory(dc_targets),
+        )
+        assert {c.target.host for c in cmds} == {"h1", "h2"}, (
+            "a chosen DC must fan out to exactly that DC's hosts, not the round-robin planner's; "
+            f"got {[c.target.host for c in cmds]}"
+        )
+        assert all(c.action == "inject" and c.target.kind is TargetKind.DATACENTER for c in cmds)
+        assert all(c.nemesis_type == "DataCenterStopNodesNemesis" for c in cmds)
+        assert len({c.scenario_id for c in cmds}) == 1, "one fanout must share a single scenario id"
+
+
+class TestStatus:
+    def test_status_reports_running_and_profile(self):
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [],
+                                base_interval=42.0, jitter=0.25, max_per_tick=4)
+        st = sched.status()
+        assert st["running"] is False, "a scheduler that never started must report running=False"
+        assert st["base_interval"] == 42.0
+        assert st["jitter"] == 0.25
+        assert st["max_per_tick"] == 4
+        assert st["enabled_types"] == ["KillNode"]
+        assert "recovery_probe" not in st, "no probe wired -> no recovery_probe key"
+
+    def test_status_includes_probe_snapshot_when_wired(self):
+        class FakeProbe:
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def snapshot(self):
+                return {"tracked": 0, "stuck": 0}
+        sched = _make_scheduler(_guard("block-4-2"), FakeInventory(_nodes()), [],
+                                recovery_probe=FakeProbe())
+        assert sched.status()["recovery_probe"] == {"tracked": 0, "stuck": 0}
+
+
+class TestLifecycle:
+    def test_start_then_stop_terminates_thread(self):
+        guard = _guard("block-4-2")
+        dispatched: list = []
+        sched = _make_scheduler(
+            guard, FakeInventory(_nodes()), dispatched,
+            base_interval=1000.0, jitter=0.0, max_per_tick=2, rng=ScriptedRandom(randint=2),
+        )
+        sched.start()
+        deadline = time.monotonic() + 2.0
+        while not dispatched and time.monotonic() < deadline:
+            time.sleep(0.01)
+        sched.stop()
+        assert sched._thread is not None and not sched._thread.is_alive(), (
+            "stop() must join the daemon thread"
+        )
+        assert dispatched, "the scheduler thread must have run at least one tick before stopping"

--- a/ydb/tests/stability/nemesis/ut/ya.make
+++ b/ydb/tests/stability/nemesis/ut/ya.make
@@ -1,0 +1,15 @@
+PY3TEST()
+
+SIZE(SMALL)
+
+TEST_SRCS(
+    test_chaos_target.py
+)
+
+PEERDIR(
+    ydb/tests/stability/nemesis
+    contrib/python/PyYAML
+    contrib/python/pytest
+)
+
+END()

--- a/ydb/tests/stability/nemesis/ut/ya.make
+++ b/ydb/tests/stability/nemesis/ut/ya.make
@@ -7,6 +7,9 @@ TEST_SRCS(
     test_boundary_scheduler.py
     test_recovery_probe.py
     test_chaos_problems.py
+    test_catalog_annotations.py
+    test_guard_invariants.py
+    test_orchestrator_api.py
 )
 
 PEERDIR(

--- a/ydb/tests/stability/nemesis/ut/ya.make
+++ b/ydb/tests/stability/nemesis/ut/ya.make
@@ -4,6 +4,8 @@ SIZE(SMALL)
 
 TEST_SRCS(
     test_chaos_target.py
+    test_weighted_scheduler.py
+    test_recovery_probe.py
 )
 
 PEERDIR(

--- a/ydb/tests/stability/nemesis/ut/ya.make
+++ b/ydb/tests/stability/nemesis/ut/ya.make
@@ -6,12 +6,14 @@ TEST_SRCS(
     test_chaos_target.py
     test_boundary_scheduler.py
     test_recovery_probe.py
+    test_chaos_problems.py
 )
 
 PEERDIR(
     ydb/tests/stability/nemesis
     contrib/python/PyYAML
     contrib/python/pytest
+    contrib/python/Flask
 )
 
 END()

--- a/ydb/tests/stability/nemesis/ut/ya.make
+++ b/ydb/tests/stability/nemesis/ut/ya.make
@@ -4,7 +4,7 @@ SIZE(SMALL)
 
 TEST_SRCS(
     test_chaos_target.py
-    test_weighted_scheduler.py
+    test_boundary_scheduler.py
     test_recovery_probe.py
 )
 

--- a/ydb/tests/stability/nemesis/ya.make
+++ b/ydb/tests/stability/nemesis/ya.make
@@ -40,6 +40,7 @@ PY_SRCS(
     internal/orchestrator/nemesis/topology_fanout_planner.py
     internal/orchestrator/nemesis/network_planner.py
     internal/orchestrator/nemesis/nemesis_planner_base.py
+    internal/orchestrator/nemesis/failure_model.py
     routers/agent_router.py
     routers/orchestrator_router.py
     app.py

--- a/ydb/tests/stability/nemesis/ya.make
+++ b/ydb/tests/stability/nemesis/ya.make
@@ -24,6 +24,7 @@ PY_SRCS(
     internal/nemesis/runners/datacenter.py
     internal/nemesis/runners/bridge_pile.py
     internal/nemesis/runners/yaml_gates.py
+    internal/nemesis/runners/target_payload.py
     internal/nemesis/chaos_dispatch.py
     internal/agent/agent_warden_checker.py
     internal/agent/nemesis/runner.py
@@ -41,6 +42,8 @@ PY_SRCS(
     internal/orchestrator/nemesis/network_planner.py
     internal/orchestrator/nemesis/nemesis_planner_base.py
     internal/orchestrator/nemesis/failure_model.py
+    internal/orchestrator/nemesis/chaos_target.py
+    internal/orchestrator/nemesis/cluster_inventory.py
     routers/agent_router.py
     routers/orchestrator_router.py
     app.py
@@ -60,3 +63,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/tests/stability/nemesis/ya.make
+++ b/ydb/tests/stability/nemesis/ya.make
@@ -36,6 +36,7 @@ PY_SRCS(
     internal/orchestrator/nemesis/boundary_scheduler.py
     internal/orchestrator/nemesis/recovery_probe.py
     internal/orchestrator/nemesis/chaos_state.py
+    internal/orchestrator/nemesis/chaos_problems.py
     internal/orchestrator/nemesis/default_planner.py
     internal/orchestrator/nemesis/pinned_first_host_planner.py
     internal/orchestrator/nemesis/serial_staggered_planner.py

--- a/ydb/tests/stability/nemesis/ya.make
+++ b/ydb/tests/stability/nemesis/ya.make
@@ -33,6 +33,8 @@ PY_SRCS(
     internal/orchestrator/unified_agent_verify_failed_aggregated.py
     internal/orchestrator/orchestrator_warden_checker.py
     internal/orchestrator/nemesis/schedule_loop.py
+    internal/orchestrator/nemesis/weighted_scheduler.py
+    internal/orchestrator/nemesis/recovery_probe.py
     internal/orchestrator/nemesis/chaos_state.py
     internal/orchestrator/nemesis/default_planner.py
     internal/orchestrator/nemesis/pinned_first_host_planner.py

--- a/ydb/tests/stability/nemesis/ya.make
+++ b/ydb/tests/stability/nemesis/ya.make
@@ -33,7 +33,7 @@ PY_SRCS(
     internal/orchestrator/unified_agent_verify_failed_aggregated.py
     internal/orchestrator/orchestrator_warden_checker.py
     internal/orchestrator/nemesis/schedule_loop.py
-    internal/orchestrator/nemesis/weighted_scheduler.py
+    internal/orchestrator/nemesis/boundary_scheduler.py
     internal/orchestrator/nemesis/recovery_probe.py
     internal/orchestrator/nemesis/chaos_state.py
     internal/orchestrator/nemesis/default_planner.py


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Немезисы в стабилити-тестах теперь не должны превысить fault-tolerance кластера.
Замена per-type потоков на одного планировщика.

## Failure-model guard
- `ClusterTopologyModel` парсит `cluster.yaml` (`static_erasure`, `location.rack`/`data_center`); `FailureModelGuard` держит бюджет одновременных отказов: `block-4-2` ≤ 2 стойки, `mirror-3-dc` = 1 ДЦ целиком + 1 стойка в другом, `none` = 0.
- Планирование по сущностям: `ChaosTarget` / `TargetKind` (host/node/slot/disk/tablet/datacenter/pile) + `ClusterInventory`.
- Безопасность в момент планирования (`filter_safe`) + учёт после диспатча (`reserve`/`release`)
- Ресурсы занятые хаосами возвращаются либо по таймеру, либо явным вызовом extract.

## Взвешенный планировщик
- Один поток «идёт по границе» модели: тик берёт случайный cap - кол-во шатаний в эту итерацию, набирает меню (тип, target) в рамках остатка бюджета, атомарно резервирует, инъектирует, спит рандомный интервал.
- `RecoveryProbe` освобождает бюджет по факту: **self** — по healthcheck (иначе stuck, держит бюджет); **extract** (для "stateful" шатанйи: stop/start, disk, TimeSkew) — держит окно и сам шлёт extract.
