### PR TITLE
Restore dispatch-only rebuild_docs workflow (#43222)

### DIFF
--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -60,74 +60,8 @@ jobs:
             const hasDocs = files.some((f) => f.filename.startsWith('ydb/docs/'));
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
 
-      - name: Checkout PR head
+      - name: Dispatch docs build
         if: steps.docs-changes.outputs.has_docs == 'true'
-        uses: actions/checkout@v5
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-
-      - name: Get commit SHA
-        id: sha
-        if: steps.docs-changes.outputs.has_docs == 'true'
-        run: echo "value=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-      # Branches listed below keep the old logic (use-ya-opensource: false).
-      # All other branches use the new logic (use-ya-opensource: true).
-      # This workflow only runs on pull_request_target, so the relevant branch
-      # is the pull request base ref.
-      - name: Determine ya-opensource flag
-        id: ya
-        if: steps.docs-changes.outputs.has_docs == 'true'
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const legacyBranches = [
-              'stable-25-1',
-              'stable-25-2',
-              'stable-25-2-1',
-              'stable-25-3',
-              'stable-25-3-1',
-              'stable-25-4',
-              'stable-25-4-1',
-              'stable-26-1',
-              'stable-26-1-1',
-              'stable-26-2',
-              'stable-26-2-1',
-            ];
-            const baseRef = context.payload.pull_request.base.ref;
-            core.setOutput('use', legacyBranches.includes(baseRef) ? 'false' : 'true');
-
-
-      - name: Build
-        if: steps.docs-changes.outputs.has_docs == 'true'
-        uses: diplodoc-platform/docs-build-action@v3
-        with:
-          revision: "pr-${{ github.event.pull_request.number }}-${{ steps.sha.outputs.value }}"
-          src-root: "./ydb/docs"
-          cli-version: "4.59.12"
-          use-ya-opensource: ${{ steps.ya.outputs.use }}
-
-      - name: Fail on documentation build issues
-        if: steps.docs-changes.outputs.has_docs == 'true'
-        run: |
-          set -euo pipefail
-          if [[ ! -f build-html.log ]]; then
-            echo "::error::Documentation build log (build-html.log) not found"
-            exit 1
-          fi
-          issue_count=$(grep -cE '^(ERR|WARN)' build-html.log || true)
-          if [[ "$issue_count" -gt 0 ]]; then
-            echo "::error::Documentation build has ${issue_count} error(s)/warning(s)"
-            grep -E '^(ERR|WARN)' build-html.log | sort -u | head -20
-            if [[ "$issue_count" -gt 20 ]]; then
-              echo "... and $((issue_count - 20)) more (see PR comment for full log)"
-            fi
-            exit 1
-          fi
-          echo "No documentation build warnings or errors"
-
-      - name: Remove rebuild_docs label
-        if: always()
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -60,7 +60,14 @@ jobs:
             const hasDocs = files.some((f) => f.filename.startsWith('ydb/docs/'));
             core.setOutput('has_docs', hasDocs ? 'true' : 'false');
 
-      - name: Dispatch docs build
+      - name: Checkout PR head
+        if: steps.docs-changes.outputs.has_docs == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+
+      - name: Get commit SHA
+        id: sha
         if: steps.docs-changes.outputs.has_docs == 'true'
         run: echo "value=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows:
       - Build documentation
-      - Rebuild documentation
     types:
       - completed
 


### PR DESCRIPTION
## Summary
- `docs_build_rebuild.yaml`: dispatch-only again — remove label, check docs diff, `workflow_dispatch` → `docs_build.yaml`
- Drop leftover inline `docs-build-action` / checkout / sha steps (broken since #43222 security split)
- `docs_preview.yaml`: listen to **Build documentation** only (rebuild no longer produces artifacts)

## Context
PR #43222 moved the real YFM build into `docs_build.yaml` (`pull_request` / `workflow_dispatch`, read-only). `docs_build_rebuild.yaml` was meant to be a privileged trigger only, but the inline build steps were never removed → `ENOENT …/ydb/docs` on translation PRs ([#45157](https://github.com/ydb-platform/ydb/pull/45157)).

## Test plan
- [ ] Add `rebuild_docs` to a docs PR → **Rebuild documentation** check is green quickly
- [ ] **Build documentation** starts via dispatch and runs full YFM build
- [ ] Preview comment appears from `docs_preview` after **Build documentation** completes