### PR TITLE
Fix initialization of EnablePDiskHighHDDInFlight in PDisk config

### DIFF
--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -44,9 +44,8 @@ namespace NKikimr::NStorage {
         const ui64 inMemoryForTestsBufferBytes = pdisk.GetInMemoryForTestsBufferBytes();
         Y_VERIFY_S(!inMemoryForTestsBufferBytes, "InMemory PDisk is deprecated, use SectorMap instead");
 
-        TIntrusivePtr<TPDiskConfig> pdiskConfig = new TPDiskConfig(path, pdiskGuid, pdiskID, pdiskCategory);
+        TIntrusivePtr<TPDiskConfig> pdiskConfig = new TPDiskConfig(path, pdiskGuid, pdiskID, pdiskCategory, &Cfg->FeatureFlags);
         pdiskConfig->StartOwnerRound = NextLocalPDiskInitOwnerRound();
-        pdiskConfig->FeatureFlags = Cfg->FeatureFlags;
         if (pdisk.HasManagementStage()) {
             pdiskConfig->SerialManagementStage = pdisk.GetManagementStage();
         }

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -193,7 +193,7 @@ struct TPDiskConfig : public TThrRefBase {
     {}
 
     TPDiskConfig(TString path, ui64 pDiskGuid, ui32 pdiskId, ui64 pDiskCategory,
-            NKikimrConfig::TFeatureFlags* featureFlags = nullptr)
+            const NKikimrConfig::TFeatureFlags* featureFlags = nullptr)
         : Path(path)
         , PDiskGuid(pDiskGuid)
         , PDiskId(pdiskId)

--- a/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
+++ b/ydb/core/blobstorage/pdisk/blobstorage_pdisk_config.h
@@ -192,12 +192,16 @@ struct TPDiskConfig : public TThrRefBase {
         : TPDiskConfig({}, pDiskGuid, pdiskId, pDiskCategory)
     {}
 
-    TPDiskConfig(TString path, ui64 pDiskGuid, ui32 pdiskId, ui64 pDiskCategory)
+    TPDiskConfig(TString path, ui64 pDiskGuid, ui32 pdiskId, ui64 pDiskCategory,
+            NKikimrConfig::TFeatureFlags* featureFlags = nullptr)
         : Path(path)
         , PDiskGuid(pDiskGuid)
         , PDiskId(pdiskId)
         , PDiskCategory(pDiskCategory)
     {
+        if (featureFlags) {
+            FeatureFlags = *featureFlags;
+        }
         Initialize();
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fill FeatureFlags in PDiskConfig before the Initialize()
This change is intended to make value of EnablePDiskHighHDDInFlight available on initialization of TPDiskConfig, where it is required to calculate operations inflight 

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)