### PR TITLE
Run dstool cluster balance using grpc only

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -23,6 +23,7 @@ import ydb.core.protos.grpc_pb2_grpc as kikimr_grpc
 import ydb.core.protos.msgbus_pb2 as kikimr_msgbus
 import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
 import ydb.core.protos.blobstorage_base3_pb2 as kikimr_bs3
+import ydb.core.protos.whiteboard_disk_states_pb2 as whiteboard_disk_states
 import ydb.core.protos.cms_pb2 as kikimr_cms
 import ydb.public.api.protos.draft.ydb_bridge_pb2 as ydb_bridge
 from ydb.public.api.grpc.draft import ydb_bridge_v1_pb2_grpc as bridge_grpc_server
@@ -1239,25 +1240,24 @@ def get_vslots_by_vdisk_ids(base_config, vdisk_ids):
     return res
 
 
+def vdisk_is_ok(vslot):
+    metrics = vslot.VDiskMetrics
+    return metrics.Replicated and metrics.State == whiteboard_disk_states.EVDiskState.OK
+
+
 def filter_healthy_groups(groups, base_config, vslot_map):
-    res = {
-        group.GroupId: len(group.VSlotId)
-        for group in base_config.Group
-        if group.GroupId in groups
-        if all(vslot.Status == 'READY' for vslot in vslots_of_group(group, vslot_map))
-    }
-    check_set = {
-        (*vslot_id, *attrgetter('GroupId', 'FailRealmIdx', 'FailDomainIdx', 'VDiskIdx')(vslot))
-        for vslot_id, vslot in vslot_map.items()
-        if vslot.GroupId in res
-    }
-    for vdisk_id, j in fetch_json_info('vdiskinfo', {node_id for node_id, _, _, _, _, _, _ in check_set}).items():
-        if j.get('Replicated') and j.get('VDiskState') == 'OK':
-            check_item = *vdisk_id, *itemgetter('GroupID', 'Ring', 'Domain', 'VDisk')(j['VDiskId'])
-            if check_item in check_set:
-                check_set.remove(check_item)
-                res[j['VDiskId']['GroupID']] -= 1
-    return {group_id for group_id, count in res.items() if not count}
+    healthy = set()
+    for group in base_config.Group:
+        if group.GroupId not in groups:
+            continue
+        vslots = list(vslots_of_group(group, vslot_map))
+        if not vslots:
+            continue
+        if not all(vslot.Status == 'READY' for vslot in vslots):
+            continue
+        if all(vdisk_is_ok(vslot) for vslot in vslots):
+            healthy.add(group.GroupId)
+    return healthy
 
 
 def add_host_access_options(parser):

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
@@ -11,7 +11,6 @@ success
 ===== grpc_calls =====
 
 ===== http_calls =====
-GET viewer/json/vdiskinfo?... (mocked)
 
 ===== mock_base_config =====
 
@@ -57,6 +56,8 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -71,6 +72,8 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
@@ -10,8 +10,6 @@ success
 
 ===== grpc_calls =====
 
-===== http_calls =====
-
 ===== mock_base_config =====
 
 TBaseConfig {
@@ -56,10 +54,10 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -72,10 +70,10 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
@@ -65,8 +65,6 @@ Request {
 }
 
 ===== http_calls =====
-GET viewer/json/vdiskinfo?... (mocked)
-GET viewer/json/vdiskinfo?... (mocked)
 
 ===== mock_base_config =====
 
@@ -112,6 +110,8 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -126,6 +126,8 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
@@ -64,8 +64,6 @@ Request {
   }
 }
 
-===== http_calls =====
-
 ===== mock_base_config =====
 
 TBaseConfig {
@@ -110,10 +108,10 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -126,10 +124,10 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
@@ -37,8 +37,6 @@ Request {
 }
 
 ===== http_calls =====
-GET viewer/json/vdiskinfo?... (mocked)
-GET viewer/json/vdiskinfo?... (mocked)
 
 ===== mock_base_config =====
 
@@ -84,6 +82,8 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -98,6 +98,8 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -112,6 +114,8 @@ VSlot {
   GroupId: 2147483651
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -126,6 +130,8 @@ VSlot {
   GroupId: 2147483652
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -140,6 +146,8 @@ VSlot {
   GroupId: 2147483653
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -154,6 +162,8 @@ VSlot {
   GroupId: 2147483654
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -168,6 +178,8 @@ VSlot {
   GroupId: 2147483655
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -182,6 +194,8 @@ VSlot {
   GroupId: 2147483656
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
@@ -36,8 +36,6 @@ Request {
   }
 }
 
-===== http_calls =====
-
 ===== mock_base_config =====
 
 TBaseConfig {
@@ -82,10 +80,10 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -98,10 +96,10 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -114,10 +112,10 @@ VSlot {
   GroupId: 2147483651
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -130,10 +128,10 @@ VSlot {
   GroupId: 2147483652
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -146,10 +144,10 @@ VSlot {
   GroupId: 2147483653
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -162,10 +160,10 @@ VSlot {
   GroupId: 2147483654
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -178,10 +176,10 @@ VSlot {
   GroupId: 2147483655
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -194,10 +192,10 @@ VSlot {
   GroupId: 2147483656
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
@@ -36,8 +36,6 @@ Request {
   }
 }
 
-===== http_calls =====
-
 ===== mock_base_config =====
 
 TBaseConfig {
@@ -82,10 +80,10 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -98,10 +96,10 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -114,10 +112,10 @@ VSlot {
   GroupId: 2147483651
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -130,10 +128,10 @@ VSlot {
   GroupId: 2147483652
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -146,10 +144,10 @@ VSlot {
   GroupId: 2147483653
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -162,10 +160,10 @@ VSlot {
   GroupId: 2147483654
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -178,10 +176,10 @@ VSlot {
   GroupId: 2147483655
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -194,10 +192,10 @@ VSlot {
   GroupId: 2147483656
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }
@@ -210,10 +208,10 @@ VSlot {
   GroupId: 2147483657
   GroupGeneration: 1
   VDiskMetrics {
-    Replicated: true
-    State: OK
     AvailableSize: 0
     AllocatedSize: 0
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
@@ -37,8 +37,6 @@ Request {
 }
 
 ===== http_calls =====
-GET viewer/json/vdiskinfo?... (mocked)
-GET viewer/json/vdiskinfo?... (mocked)
 
 ===== mock_base_config =====
 
@@ -84,6 +82,8 @@ VSlot {
   GroupId: 2147483649
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -98,6 +98,8 @@ VSlot {
   GroupId: 2147483650
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -112,6 +114,8 @@ VSlot {
   GroupId: 2147483651
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -126,6 +130,8 @@ VSlot {
   GroupId: 2147483652
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -140,6 +146,8 @@ VSlot {
   GroupId: 2147483653
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -154,6 +162,8 @@ VSlot {
   GroupId: 2147483654
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -168,6 +178,8 @@ VSlot {
   GroupId: 2147483655
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -182,6 +194,8 @@ VSlot {
   GroupId: 2147483656
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }
@@ -196,6 +210,8 @@ VSlot {
   GroupId: 2147483657
   GroupGeneration: 1
   VDiskMetrics {
+    Replicated: true
+    State: OK
     AvailableSize: 0
     AllocatedSize: 0
   }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt
@@ -46,6 +46,8 @@ VSlot {
   VDiskMetrics {
     AvailableSize: 0
     AllocatedSize: 40000000000
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.0
@@ -46,6 +46,8 @@ VSlot {
   VDiskMetrics {
     AvailableSize: 360000000000
     AllocatedSize: 40000000000
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.1
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.1
@@ -46,6 +46,8 @@ VSlot {
   VDiskMetrics {
     AvailableSize: 360000000000
     AllocatedSize: 40000000000
+    State: OK
+    Replicated: true
   }
   Status: "READY"
 }

--- a/ydb/tests/functional/dstool/conftest.py
+++ b/ydb/tests/functional/dstool/conftest.py
@@ -1,6 +1,7 @@
 import ydb.core.protos.blobstorage_config_pb2 as kikimr_bsconfig
 import ydb.core.protos.blobstorage_base3_pb2 as kikimr_bsbase3
 import ydb.core.protos.msgbus_pb2 as kikimr_msgbus
+from ydb.core.protos.whiteboard_disk_states_pb2 import EVDiskState
 from ydb.tests.library.common.msgbus_types import MessageBusStatus
 
 # XXX: setting of pytest_plugins should work if specified directly in test modules
@@ -56,6 +57,9 @@ class BaseConfigBuilder:
         vslot.Status = status
         vslot.VDiskMetrics.AllocatedSize = allocated_size
         vslot.VDiskMetrics.AvailableSize = available_size
+        if status == 'READY':
+            vslot.VDiskMetrics.Replicated = True
+            vslot.VDiskMetrics.State = EVDiskState.OK
         return self
 
     def add_group(self, group_id, erasure_species='none',

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -524,7 +524,7 @@ class Test(TestBase):
                 pending_reassigns = {}
             fake_grpc_handler = FakeReassignGroupDiskHandler(pending_reassigns, base_config)
             return self._trace('--verbose', 'cluster', 'balance', '--storage-pool=test-pool', '--max-iterations=1', *args,
-                               with_grpc_calls=True, allow_http_fetch=True,
+                               with_grpc_calls=True,
                                mock_base_config=base_config,
                                fake_grpc_handler=fake_grpc_handler)
 
@@ -561,7 +561,7 @@ class Test(TestBase):
             fake_grpc_handler = FakeReassignGroupDiskHandler(pending_reassigns, base_config)
             return self._trace('--verbose', 'cluster', 'balance', '--only-from-overpopulated-pdisks',
                                '--storage-pool=test-pool', '--max-iterations=1',
-                               with_grpc_calls=True, allow_http_fetch=True,
+                               with_grpc_calls=True,
                                mock_base_config=base_config,
                                fake_grpc_handler=fake_grpc_handler)
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Currently `dstool cluster balance` uses a call to HTTP `/viewer/json/vdiskinfo` API, which cannot be used programmatically on external installations with authentication enabled.

This PR replaces the HTTP request with call to GRPC API QueryBaseConfig/VDiskMetrics, the latter being already used in the dstool code.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

Only dstool code has been updated, no server-side changes are required.
