### PR TITLE
Fix docs preview; stop auto rebuild_docs on translation PRs

### DIFF
--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -97,9 +97,9 @@ jobs:
               owner,
               repo,
               issue_number: translationPr.number,
-              labels: ['rebuild_docs', 'ok-to-test'],
+              labels: ['ok-to-test'],
             });
 
             core.info(
-              `Added rebuild_docs and ok-to-test to translation PR #${translationPr.number}`
+              `Added ok-to-test to translation PR #${translationPr.number}`
             );

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -59,8 +59,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              labels: ['ok-to-test', 'rebuild_docs'],
+              labels: ['ok-to-test'],
             });
             core.info(
-              `Added ok-to-test and rebuild_docs to translation PR #${prNumber}`
+              `Added ok-to-test to translation PR #${prNumber}`
             );


### PR DESCRIPTION
## Summary
- `docs_preview.yaml`: listen only to **Build documentation**; run preview only when that workflow succeeded.
- `ydbdoc-review.yml` / `ydbdoc-verify.yml`: stop adding `rebuild_docs` to translation PRs (docs build already runs on `pull_request`); keep `ok-to-test`.

## Why
Preview was triggered by skipped/failed **Rebuild documentation** runs without `inputs` artifacts → `no artifacts found`, no comment. Successful **Build documentation** runs were ignored in the noise.

## Test plan
- [ ] Translation PR commit → **Build documentation** success → preview comment with link
- [ ] `rebase-user-branch` label on PR still runs **Rebase user branch** (unchanged)
- [ ] `ok-to-test` on translation PR still runs **PR-check**