### PR TITLE
[Console, YAML Config, YDB CLI] Fixes from AI review

### DIFF
--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -175,9 +175,9 @@ public:
     void UpdateCandidateStartupConfig(TEvConsole::TEvConfigSubscriptionNotification::TPtr &ev);
 
     struct TParsedOpaqueConfig {
-        // Raw JSON section text used for cheap equality between updates.
+        // Raw YAML section text used for cheap equality between updates.
         // !empty() (empty strings aka "section present but empty" treated as absent config and not stored)
-        TString RawJson;
+        TString RawYaml;
         // May be null in the cache (parser produced nothing), but null
         // never placed into an outgoing event — see PopulateWithOpaqueConfigs.
         std::shared_ptr<const ::google::protobuf::Message> Parsed;
@@ -1167,53 +1167,66 @@ catch (...) {
 THashMap<ui32, TConfigsDispatcher::TParsedOpaqueConfig> TConfigsDispatcher::ParseOpaqueConfigs() const
 {
     THashMap<ui32, TParsedOpaqueConfig> result;
-    if (!YamlConfigEnabled || OpaqueConfigParsers.empty() || ResolvedJsonConfig.empty()) {
+    if (!YamlConfigEnabled || OpaqueConfigParsers.empty() || ResolvedYamlConfig.empty()) {
         return result;
     }
-    // The opaque carrier proto is empty by design — its content lives in the
-    // resolved YAML. Pull each kind's section out and pass it to the end-node
-    // parser that owns the real schema.
-    NJson::TJsonValue resolved;
-    if (!NJson::ReadJsonTree(ResolvedJsonConfig, &resolved)) {
-        return result;
-    }
-    const NJson::TJsonValue* configSection = &resolved;
-    if (const NJson::TJsonValue* c = nullptr; resolved.GetValuePointer("config", &c)) {
-        configSection = c;
-    }
-    const auto* desc = NKikimrConfig::TAppConfig::descriptor();
-    for (const auto& [kind, parser] : OpaqueConfigParsers) {
-        const auto* field = desc->FindFieldByNumber(kind);
-        if (!field) {
-            continue;
+
+    try {
+        // The opaque carrier proto is empty by design — its content lives in the
+        // resolved YAML. Pull each kind's section out and pass it to the end-node
+        // parser that owns the real schema.
+
+        NFyaml::TDocument yamlDoc = NFyaml::TDocument::Parse(ResolvedYamlConfig);
+
+        // ResolvedYamlConfig is the emitted 'config:' sub-tree (see
+        // NYamlConfig::Resolve) — its root IS the config content.
+        auto configSection = yamlDoc.Root();
+        if (configSection.Empty() || configSection.Type() != NFyaml::ENodeType::Mapping) {
+            return result;
         }
-        TString name = field->name();
-        NProtobufJson::ToSnakeCaseDense(&name);
-        const NJson::TJsonValue* section = nullptr;
-        if (!configSection->GetValuePointer(name, &section)) {
-            continue;   // section absent — no config
+
+        auto configMap = configSection.Map();
+        const auto* desc = NKikimrConfig::TAppConfig::descriptor();
+
+        for (const auto& [kind, parser] : OpaqueConfigParsers) {
+
+            const auto* field = desc->FindFieldByNumber(kind);
+            if (!field) {
+                continue;
+            }
+
+            TString name = field->name();
+            NProtobufJson::ToSnakeCaseDense(&name);
+            if (!configMap.Has(name)) {
+                continue;   // section absent — no config
+            }
+
+            TStringStream sectionStream;
+            sectionStream << configMap.at(name);
+            TString sectionYaml = sectionStream.Str();
+
+            TParsedOpaqueConfig entry;
+            entry.RawYaml = std::move(sectionYaml);
+            try {
+                entry.Parsed = parser(entry.RawYaml);
+                result.emplace(kind, std::move(entry));
+            }
+            catch (const std::exception& e) {
+                YDB_LOG_ERROR("Error parsing opaque config",
+                    {"kind", kind},
+                    {"name", name},
+                    {"error", e.what()});
+            }
+            catch (...) {
+                YDB_LOG_ERROR("Error parsing opaque config",
+                    {"kind", kind},
+                    {"name", name},
+                    {"error", "unknown exception"});
+            }
         }
-        TParsedOpaqueConfig entry;
-        entry.RawJson = NJson::WriteJson(section, /*formatOutput=*/ false);
-        if (entry.RawJson.empty()) {
-            continue;   // empty section — treated as "no config"
-        }
-        try {
-            entry.Parsed = parser(entry.RawJson);
-        }
-        catch (const std::exception& e) {
-            YDB_LOG_ERROR("Error parsing opaque config",
-                {"kind", kind},
-                {"name", name},
-                {"error", e.what()});
-        }
-        catch (...) {
-            YDB_LOG_ERROR("Error parsing opaque config",
-                {"kind", kind},
-                {"name", name},
-                {"error", "unknown exception"});
-        }
-        result.emplace(kind, std::move(entry));
+    } catch (const std::exception& e) {
+        YDB_LOG_ERROR("Error parsing resolved YAML config",
+            {"error", e.what()});
     }
     return result;
 }
@@ -1304,7 +1317,7 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
         auto newOpaqueConfigs = ParseOpaqueConfigs();
         for (const auto& [kind, parsed] : newOpaqueConfigs) {
             auto it = CurrentOpaqueConfigs.find(kind);
-            if (it == CurrentOpaqueConfigs.end() || it->second.RawJson != parsed.RawJson) {
+            if (it == CurrentOpaqueConfigs.end() || it->second.RawYaml != parsed.RawYaml) {
                 // config was added or changed
                 affectedOpaqueKinds.insert(kind);
             }
@@ -1327,6 +1340,7 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
             Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
                 if (affectedOpaqueKinds.contains(kind)) {
                     hasAffectedKinds = true;
+                    break;
                 }
             }
             if (!isYamlChanged && !yamlConfigTurnedOff && CurrentStateFunc() != &TThis::StateInit) {
@@ -1341,6 +1355,7 @@ void TConfigsDispatcher::Handle(TEvConsole::TEvConfigSubscriptionNotification::T
             Y_FOR_EACH_BIT(kind, FilterKinds(kinds)) {
                 if (affectedKinds.contains(kind)) {
                     hasAffectedKinds = true;
+                    break;
                 }
             }
             // we try resend all configs if yaml config was turned off

--- a/ydb/core/cms/console/console__alter_tenant.cpp
+++ b/ydb/core/cms/console/console__alter_tenant.cpp
@@ -289,14 +289,14 @@ public:
 
             if (key.size() > NSchemeShard::TUserAttributesLimits::MaxNameLen) {
                 return Error(Ydb::StatusIds::BAD_REQUEST,
-                    Sprintf("Key '%s' is too long, max: " PRIu32 ", actual: " PRIu32,
+                    Sprintf("Key '%s' is too long, max: " PRIu32 ", actual: %zu",
                         key.data(), NSchemeShard::TUserAttributesLimits::MaxNameLen, key.size()),
                     ctx);
             }
 
             if (value.size() > NSchemeShard::TUserAttributesLimits::MaxValueLen) {
                 return Error(Ydb::StatusIds::BAD_REQUEST,
-                    Sprintf("Value for key '%s' is too long, max: " PRIu32 ", actual: " PRIu32,
+                    Sprintf("Value for key '%s' is too long, max: " PRIu32 ", actual: %zu",
                         key.data(), NSchemeShard::TUserAttributesLimits::MaxValueLen, value.size()),
                     ctx);
             }
@@ -308,12 +308,34 @@ public:
             attrNames.insert(key);
         }
 
-        THashMap<TString, ui64> attributeMap;
+        THashMap<TString, ui64> existingAttributesIndexes;
+        THashMap<TString, TString> allAttributes;
         for (ui64 i = 0 ; i < Tenant->Attributes.UserAttributesSize(); i++) {
-            bool res = attributeMap.emplace(Tenant->Attributes.GetUserAttributes(i).GetKey(), i).second;
+            const auto& attr = Tenant->Attributes.GetUserAttributes(i);
+            bool res = existingAttributesIndexes.emplace(attr.GetKey(), i).second;
             if (!res)
                 return Error(Ydb::StatusIds::INTERNAL_ERROR,
                              "Unexpected duplicate attribute found in CMS local db", ctx);
+            allAttributes[attr.GetKey()] = attr.GetValue();
+        }
+
+        // Check new total attributes size
+        for (const auto& [key, value] : rec.alter_attributes()) {
+            allAttributes[key] = value;
+        }
+        ui64 totalBytes = 0;
+        for (const auto& [key, value] : allAttributes) {
+            if (value.empty()) {
+                continue;
+            }
+            totalBytes += key.size();
+            totalBytes += value.size();
+        }
+        if (totalBytes > NSchemeShard::TUserAttributesLimits::MaxBytes) {
+            return Error(Ydb::StatusIds::BAD_REQUEST,
+                Sprintf("Total attributes size is too big: %" PRIu64 " bytes (maximum allowed is %" PRIu32 " bytes)",
+                    totalBytes, NSchemeShard::TUserAttributesLimits::MaxBytes),
+                ctx);
         }
 
         // Apply computational units changes.
@@ -378,6 +400,8 @@ public:
             Self->DbUpdateTenantAlterIdempotencyKey(Tenant, Tenant->AlterIdempotencyKey, txc, ctx);
         }
 
+        // Apply attributes changes.
+
         // Attributes with empty values are kept forever as tombstones
         // to self-heal divergence with subdomain if subdomain AlterUserAttributes
         // request didn't reach SchemeShard (due to Console restart
@@ -385,8 +409,8 @@ public:
         // but before sending request into subdomain, etc)
         if (!rec.alter_attributes().empty()) {
             for (const auto& [key, value] : rec.alter_attributes()) {
-                const auto it = attributeMap.find(key);
-                if (it != attributeMap.end()) {
+                const auto it = existingAttributesIndexes.find(key);
+                if (it != existingAttributesIndexes.end()) {
                     if (value) {
                         Tenant->Attributes.MutableUserAttributes(it->second)->SetValue(value);
                     } else {

--- a/ydb/core/grpc_services/rpc_config.cpp
+++ b/ydb/core/grpc_services/rpc_config.cpp
@@ -55,7 +55,7 @@ bool ConvertGetConfigToFetchConfigResult(
     if (identityCount < configCount) {
         TStringBuilder descr;
         descr << (configCount - identityCount)
-              << " extra 'config' field with no corresponding 'identity' field";
+              << " extra 'config' field(s) with no corresponding 'identity' field(s)";
         error = descr;
         return false;
     }
@@ -122,7 +122,7 @@ bool ConvertGetConfigToFetchConfigResult(
                 // TYPE_NOT_SET is rejected with error by pre-validation above
                 break;
             default:
-                // Any other value comes from a newer Console is skipped with a warning
+                // Any other value that comes from a newer Console is skipped with a warning
                 // so we don't fail on forward-compatible additions
                 ALOG_NOTICE(NKikimrServices::GRPC_SERVER,
                     "Convert Ydb::DynamicConfig::ConfigIdentity to Ydb::Config::FetchConfigResult: "

--- a/ydb/library/yaml_config/public/yaml_config.cpp
+++ b/ydb/library/yaml_config/public/yaml_config.cpp
@@ -279,7 +279,7 @@ void Inherit(NFyaml::TMapping& toMap, const NFyaml::TMapping& fromMap) {
                 toMap.Append(it->Key().Copy().Ref(), it->Value().Copy().Ref());
             }
         } else {
-            toMap.Append(it->Key().Copy().Ref(),  it->Value().Copy().Ref());
+            toMap.Append(it->Key().Copy().Ref(), it->Value().Copy().Ref());
         }
     }
 }
@@ -493,9 +493,11 @@ void RestoreNodesTags(NFyaml::TNodeRef rootNode, const TElementsTags& tags) {
         }
 
         // Restore tag
-        auto tag = tags.find(node.Path());
-        if (tag != tags.end()) {
-            node.SetTag(tag->second);
+        {
+            auto tag = tags.find(node.Path());
+            if (tag != tags.end()) {
+                node.SetTag(tag->second);
+            }
         }
 
         // Go deep
@@ -1521,6 +1523,25 @@ void ResolveDatabaseConfig(NFyaml::TDocument& doc, const TSet<TNamedLabel>& labe
         return;
     }
 
+    auto removeSelectorsAndAllowedLabels =
+        [&]() {
+            if (hasSelectors) {
+                if (auto pair = rootMap.pair_at_opt("selector_config"); pair) {
+                    rootMap.Remove(pair);
+                }
+            }
+            if (hasAllowedLabels) {
+                if (auto pair = rootMap.pair_at_opt("allowed_labels"); pair) {
+                    rootMap.Remove(pair);
+                }
+            }
+        };
+
+    if (!rootMap.Has("config")) {
+        // No config section - just remove selectors and allowed_labels
+        removeSelectorsAndAllowedLabels();
+        return;
+    }
     auto configNode = rootMap.at("config");
 
     // Save existing nodes tags to restore them later
@@ -1534,16 +1555,7 @@ void ResolveDatabaseConfig(NFyaml::TDocument& doc, const TSet<TNamedLabel>& labe
     RemoveTags(doc);
 
     // Remove selectors and allowed_labels
-    if (hasSelectors) {
-        if (auto pair = rootMap.pair_at_opt("selector_config"); pair) {
-            rootMap.Remove(pair);
-        }
-    }
-    if (hasAllowedLabels) {
-        if (auto pair = rootMap.pair_at_opt("allowed_labels"); pair) {
-            rootMap.Remove(pair);
-        }
-    }
+    removeSelectorsAndAllowedLabels();
 
     // Restore existed nodes tags
     RestoreNodesTags(configNode, savedTags);

--- a/ydb/library/yaml_config/public/yaml_config_impl.h
+++ b/ydb/library/yaml_config/public/yaml_config_impl.h
@@ -61,6 +61,7 @@ TIncompatibilityRules ParseIncompatibilityRules(const NFyaml::TNodeRef& root);
  *
  *  - existing 'config' nodes tags are preserved (if any) at all nested levels
  *  - tags (if any) of added nodes at any nested level are propagated from selectors into 'config'
+ *  - input document anchors/aliases are resolved even when there are no selectors to apply
  */
 void ApplySelectors(NFyaml::TDocument& doc, const TSet<TNamedLabel>& labels);
 

--- a/ydb/library/yaml_config/yaml_config_helpers.h
+++ b/ydb/library/yaml_config/yaml_config_helpers.h
@@ -51,8 +51,8 @@ ui64 GetConfigHash(const TString& config);
 // @param allowUnknownFields - silently ignore unknown fields (for specified Proto)
 //
 // @return
-//  nullptr - on empty imput YAML
-//  parsed Proto message - on successfull parsing
+//  nullptr - on empty input YAML
+//  parsed Proto message - on successful parsing
 //
 // @throw
 //  std::exception - on underlying parser errors / unknown fields present (without allowUnknownFields)

--- a/ydb/public/lib/ydb_cli/commands/ydb_database_attribute.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_database_attribute.cpp
@@ -71,7 +71,7 @@ void TCommandDatabaseAttributeSet::Parse(TConfig& config) {
 
         if (value.empty()) {
             throw TMisuseException()
-                << "Bad attribure '" + attr + "'. Attribute value cannot be empty";
+                << "Bad attribute '" + attr + "'. Attribute value cannot be empty";
         }
 
         Attributes[items.at(0)] = value;


### PR DESCRIPTION
### Changelog entry

...

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Fixes from AI review for PRs:
- #41434
- #44420
- #46142
- #43238

### Detailed

* #41434

  * Minor | Medium: cluster field not populated for database config entries in cross-proto conversion — ydb/core/grpc_services/rpc_config.cpp:113-119

    no fix, `cluster` field is not applicable for dababase config
  * Nit | High: Singular "field" in error message regardless of count — ydb/core/grpc_services/rpc_config.cpp:57-58

    fixed
  * Nit | High: Missing "that" in comment grammar — ydb/core/grpc_services/rpc_config.cpp:125

    fixed
    
* #44420

  Critical issues

  * Critical | High: Sprintf format string mismatch -- PRIu32 format specifiers used with size_t (64-bit) arguments (key.size(), value.size()), causing undefined behavior on 64-bit platforms. Could produce garbage error messages or crash. -- ydb/core/cms/console/console__alter_tenant.cpp:289-296

    fixed

  Other findings

  * Major | High: StringSplitter(attr).Split('=') splits on every = in the input. Attribute values containing = (e.g., base64-encoded strings) are incorrectly rejected. Use .Limit(2) or manual find('='). -- ydb/public/lib/ydb_cli/commands/ydb_database_attribute.cpp:63

    no fix, values with '=' are not allowed as for existing SchemeShard attributes at `ydb/core/driver_lib/cli_base/cli_cmds_db.cpp::TClientCommandSchemaUserAttributeSet::Parse()`, `if (items.size() != 2)` check exists

  * Minor | Medium: ResolveDatabaseConfig saves/restores YAML tags by node path. After ApplySelectors mutates the document, newly added nodes could theoretically get incorrect tags if their paths collide with previously tagged nodes from removed sections. Unlikely in practice but fragile by design. -- ydb/library/yaml_config/public/yaml_config.cpp:1424-1455

    no fix, tags are preserved strictly by path by design, possible colliding lists elements internal tags are explicitly ignored at PR #46142 

  * Minor | Medium: ApplySelectors calls doc.Resolve() unconditionally, permanently mutating the input document's anchors/aliases even when no selectors match. The public API contract should document this side effect. -- ydb/library/yaml_config/public/yaml_config.cpp:379

    fixed, comment added

  * Minor | Medium: Attribute validation does not enforce TUserAttributesLimits::MaxBytes (total 10 KB limit for all attributes). Many individually valid attributes could exceed the total budget, causing Console-SchemeShard state divergence. -- ydb/core/cms/console/console__alter_tenant.cpp:280-306

    fixed

  * Minor | Medium: Validation of selector description field: selectorMap.at("description").Scalar() would throw with a confusing error if description is absent from a selector entry. -- ydb/core/cms/console/console_configs_manager.cpp:262

    no fix, matches the existing behavior in the original `Resolve` function

  * Minor | High: Renaming user-attribute to attribute (with user-attribute as alias) in cli_cmds_db.cpp is a potentially breaking change for existing scripts referencing the primary command name. Consider changelog entry. -- ydb/core/driver_lib/cli_base/cli_cmds_db.cpp:1292

    no fix, aligned with the YDB CLI team, the alias for backward compatibility is kept

  * Minor | Low: FillTenantStatus filters tombstone attributes via HasValue() (proto2 semantics). If any code path uses SetValue("") instead of ClearValue() for deletion, empty-value attributes would leak to the API. Currently correct, but fragile. -- ydb/core/cms/console/console_tenants_manager.cpp:2485

    no fix, aligned with existing `ydb/core/tx/schemeshard/user_attributes.h::TUserAttributes::ApplyPatch()` SchemeShard implementation, empty values representation is controlled by YDB CLI code

  * Nit | High: Typo "attribure" in error message, should be "attribute". -- ydb/public/lib/ydb_cli/commands/ydb_database_attribute.cpp:74

    fixed

  * Nit | High: Accidental double space before it->Value() in Inherit function. -- ydb/library/yaml_config/public/yaml_config.cpp:281

    fixed

  * Nit | Medium: IsDatabaseConfigSelectorsAllowed is public but only used internally by ValidateDatabaseConfig. Consider making it private. -- ydb/core/cms/console/console_configs_manager.h:99

    no fix, aligned with other similar TConfigsManager methods
    
* #46142

  * Major | Medium: rootMap.at("config") called without checking if config key exists -- will throw if a document has allowed_labels or selector_config but no config section. The old code iterated the whole document and was safe against this. -- ydb/library/yaml_config/public/yaml_config.cpp:1524

    fixed

  * Nit | High: Variable shadowing -- inner tag at line 513 shadows outer tag at line 496 in RestoreNodesTags. Both are iterators into the same tags map, which could cause confusion during maintenance. -- ydb/library/yaml_config/public/yaml_config.cpp:513

    fixed

* #43238

  * Nit | High: Missing break after setting hasAffectedKinds = true in opaque kind check loop — ydb/core/cms/console/configs_dispatcher.cpp:1327

    fixed

  * Nit | Medium: Documentation typos in DefaultOpaqueConfigParser: "imput" → "input", "successfull" → "successful" — ydb/library/yaml_config/yaml_config_helpers.h:54-55

    fixed

  * Nit | Low: DefaultOpaqueConfigParser parameter opaqueYamlConfig is misleading — when called from the dispatcher, the input is JSON (serialized via NJson::WriteJson). JSON is valid YAML so this works, but parameter name + docstring saying "YAML document" could confuse future maintainers — ydb/library/yaml_config/yaml_config_helpers.h:50,68

    fixed - dispatcher now feeds real YAML into the opaque parser instead of JSON, aligning behavior with the documented contract of DefaultOpaqueConfigParser(). The prior JSON string was valid YAML and worked correctly; the change is purely for clarity and to match the parameter's declared intent. As a side benefit, the YAML round-trip via libfyaml preserves scalar tags/styles end-to-end, whereas the JSON detour flattened them through JSON's narrower type set before re-parsing.