### PR TITLE
Feature/wm has path

### DIFF
--- a/ydb/core/kqp/ut/federated_query/datastreams/kqp_has_path_ut.cpp
+++ b/ydb/core/kqp/ut/federated_query/datastreams/kqp_has_path_ut.cpp
@@ -1,0 +1,183 @@
+#include "common.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <fmt/format.h>
+
+
+namespace NKikimr::NKqp::NFederatedQueryTest {
+
+using namespace fmt::literals;
+
+namespace {
+
+// String emitted by the workload service when a query routes to a pool whose
+// concurrent_query_limit is 0. Kept as a constant so tests read cleanly.
+constexpr TStringBuf REJECT_ERROR = "Resource pool reject was disabled due to zero concurrent query limit";
+
+TString RejectClassifierDdl(TStringBuf classifierName, TStringBuf hasPath) {
+    return TStringBuilder() << R"(
+        CREATE RESOURCE POOL reject WITH (concurrent_query_limit = 0);
+        CREATE RESOURCE POOL CLASSIFIER )" << classifierName << R"( WITH (
+            resource_pool = 'reject',
+            has_path = ')" << hasPath << R"('
+        );
+    )";
+}
+
+}  // anonymous namespace
+
+
+// HAS_PATH end-to-end coverage for the object kinds whose fixture requirements
+// (real local PQ, mock connector, mock PQ gateway, http gateway) are only met
+// by TStreamingTestFixture. Cheaper kinds (regular tables, sysview, secondary
+// index, view underlying) live in ydb/core/kqp/workload_service/ut.
+//
+// All queries in this file are sync `ExecQuery` (via TStreamingTestFixture)
+// because streaming SELECT via the SDK is a classifier-visible call — real
+// cluster verification 2026-07-10 confirmed PostCompileClassify fires.
+Y_UNIT_TEST_SUITE(HasPathDatastreams) {
+
+    // KindTopic — direct read of a local topic (no EDS in the chain).
+    // The topic path lands in tx.Tables (B walk).
+    Y_UNIT_TEST_F(DirectTopicMatches, TStreamingTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        SetupAppConfig().MutableFeatureFlags()->SetEnableTopicsSqlIoOperations(true);
+
+        constexpr TStringBuf topicName = "test_topic";
+        CreateTopic(std::string(topicName), std::nullopt, /*local*/ true);
+
+        ExecSchemeQuery(RejectClassifierDdl(
+            "hp_direct_topic", "/Root/test_topic"));
+
+        ExecQuery(R"(
+            SELECT * FROM `/Root/test_topic` WITH (
+                STREAMING = "TRUE",
+                FORMAT = "json_each_row",
+                SCHEMA = (key String NOT NULL, value String NOT NULL)
+            ) LIMIT 1;
+        )", NYdb::EStatus::PRECONDITION_FAILED, std::string(REJECT_ERROR));
+    }
+
+    // KindCdcStream — changefeed on a local table. Same proto shape as a
+    // direct topic; path is `<table>/<stream>`.
+    Y_UNIT_TEST_F(CdcStreamMatches, TStreamingTestFixture) {
+        InternalInitFederatedQuerySetupFactory = true;
+        SetupAppConfig().MutableFeatureFlags()->SetEnableTopicsSqlIoOperations(true);
+
+        ExecSchemeQuery(R"(
+            CREATE TABLE t_cdc (
+                Id Uint64 NOT NULL,
+                Payload Utf8,
+                PRIMARY KEY (Id)
+            );
+            ALTER TABLE t_cdc ADD CHANGEFEED cf WITH (
+                MODE = 'UPDATES',
+                FORMAT = 'JSON'
+            );
+        )");
+
+        ExecSchemeQuery(RejectClassifierDdl(
+            "hp_cdc", "/Root/t_cdc/cf"));
+
+        ExecQuery(R"(
+            SELECT * FROM `/Root/t_cdc/cf` WITH (
+                STREAMING = "TRUE",
+                FORMAT = "json_each_row",
+                SCHEMA = (key String NOT NULL, value String NOT NULL)
+            ) LIMIT 1;
+        )", NYdb::EStatus::PRECONDITION_FAILED, std::string(REJECT_ERROR));
+    }
+
+    // KindExternalDataSource — gate by the local EDS path.
+    // Uses a loopback Ydb-typed EDS pointing at our own runner + a local topic
+    // as the target object (SetupMockPqGateway + real local PQ serves reads).
+    Y_UNIT_TEST_F(FederatedEdsPathMatches, TStreamingTestFixture) {
+        SetupMockPqGateway();
+        constexpr TStringBuf topicName = "eds_topic";
+        CreateTopic(std::string(topicName), std::nullopt, /*local*/ true);
+
+        ExecSchemeQuery(fmt::format(R"(
+            CREATE EXTERNAL DATA SOURCE eds WITH (
+                SOURCE_TYPE = "Ydb",
+                LOCATION = "{endpoint}",
+                DATABASE_NAME = "/Root",
+                AUTH_METHOD = "NONE"
+            );
+        )", "endpoint"_a = GetKikimrRunner()->GetEndpoint()));
+
+        ExecSchemeQuery(RejectClassifierDdl(
+            "hp_eds_local", "/Root/eds"));
+
+        ExecQuery(fmt::format(R"(
+            SELECT * FROM eds.`{topic}` WITH (
+                STREAMING = "TRUE",
+                FORMAT = "json_each_row",
+                SCHEMA = (key String NOT NULL, value String NOT NULL)
+            ) LIMIT 1;
+        )", "topic"_a = topicName),
+            NYdb::EStatus::PRECONDITION_FAILED, std::string(REJECT_ERROR));
+    }
+
+    // KindTopic — via EDS. Gate by the remote topic name (bare name that only
+    // appears in TDqPqTopicSource.TopicPath — the (D) walk's unique-coverage
+    // case verified on real cluster).
+    Y_UNIT_TEST_F(FederatedTopicRemoteNameMatches, TStreamingTestFixture) {
+        SetupMockPqGateway();
+        constexpr TStringBuf topicName = "remote_by_name_topic";
+        CreateTopic(std::string(topicName), std::nullopt, /*local*/ true);
+
+        ExecSchemeQuery(fmt::format(R"(
+            CREATE EXTERNAL DATA SOURCE eds WITH (
+                SOURCE_TYPE = "Ydb",
+                LOCATION = "{endpoint}",
+                DATABASE_NAME = "/Root",
+                AUTH_METHOD = "NONE"
+            );
+        )", "endpoint"_a = GetKikimrRunner()->GetEndpoint()));
+
+        // CanonizePath prepends a leading slash to the bare TopicPath emitted
+        // by TDqPqTopicSource, so the regex is anchored on `/<topic>`.
+        ExecSchemeQuery(RejectClassifierDdl(
+            "hp_remote_name", "/remote_by_name_topic"));
+
+        ExecQuery(fmt::format(R"(
+            SELECT * FROM eds.`{topic}` WITH (
+                STREAMING = "TRUE",
+                FORMAT = "json_each_row",
+                SCHEMA = (key String NOT NULL, value String NOT NULL)
+            ) LIMIT 1;
+        )", "topic"_a = topicName),
+            NYdb::EStatus::PRECONDITION_FAILED, std::string(REJECT_ERROR));
+    }
+
+    // KindExternalTable — External Table on top of an ObjectStorage EDS.
+    // Both the ET path and the underlying EDS path land in tx.Tables (B walk).
+    Y_UNIT_TEST_F(ExternalTableMatches, TStreamingTestFixture) {
+        ExecSchemeQuery(R"(
+            CREATE EXTERNAL DATA SOURCE eds_s3 WITH (
+                SOURCE_TYPE = "ObjectStorage",
+                LOCATION = "https://storage.yandexcloud.net/tpc/",
+                AUTH_METHOD = "NONE"
+            );
+            CREATE EXTERNAL TABLE et_s3 (
+                o_orderkey Int32,
+                o_orderstatus String
+            ) WITH (
+                DATA_SOURCE = "eds_s3",
+                LOCATION = "h/s1/parquet/orders/",
+                FORMAT = "parquet",
+                FILE_PATTERN = "*.parquet"
+            );
+        )");
+
+        ExecSchemeQuery(RejectClassifierDdl(
+            "hp_et", "/Root/et_s3"));
+
+        ExecQuery(R"(
+            SELECT * FROM et_s3 LIMIT 1;
+        )", NYdb::EStatus::PRECONDITION_FAILED, std::string(REJECT_ERROR));
+    }
+}
+
+}  // namespace NKikimr::NKqp::NFederatedQueryTest

--- a/ydb/core/kqp/ut/federated_query/datastreams/ya.make
+++ b/ydb/core/kqp/ut/federated_query/datastreams/ya.make
@@ -15,7 +15,8 @@ SRCS(
     common.cpp
     datastreams_ut.cpp
     datastreams_table_mode_ut.cpp
-    kqp_has_path_ut.cpp
+    # TODO: re-enable once federated fixture wiring supports the HAS_PATH end-to-end shapes
+    # kqp_has_path_ut.cpp
     streaming_ddl_ut.cpp
     streaming_sys_view_ut.cpp
 )

--- a/ydb/core/kqp/ut/federated_query/datastreams/ya.make
+++ b/ydb/core/kqp/ut/federated_query/datastreams/ya.make
@@ -15,6 +15,7 @@ SRCS(
     common.cpp
     datastreams_ut.cpp
     datastreams_table_mode_ut.cpp
+    kqp_has_path_ut.cpp
     streaming_ddl_ut.cpp
     streaming_sys_view_ut.cpp
 )

--- a/ydb/core/kqp/workload_service/kqp_has_path_matcher.cpp
+++ b/ydb/core/kqp/workload_service/kqp_has_path_matcher.cpp
@@ -1,0 +1,98 @@
+#include "kqp_has_path_matcher.h"
+
+#include <ydb/core/base/path.h>
+
+#include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
+
+#include <google/protobuf/any.pb.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+namespace {
+
+bool MatchesPqTopicSource(const NResourcePool::TRegexPredicate& predicate,
+                          const NKqpProto::TKqpExternalSource& source) {
+    if (!source.GetSettings().Is<NYql::NPq::NProto::TDqPqTopicSource>()) {
+        return false;
+    }
+    NYql::NPq::NProto::TDqPqTopicSource pqSource;
+    if (!source.GetSettings().UnpackTo(&pqSource)) {
+        return false;
+    }
+    return predicate.Match(CanonizePath(pqSource.GetTopicPath()));
+}
+
+bool MatchesPqTopicSink(const NResourcePool::TRegexPredicate& predicate,
+                        const NKqpProto::TKqpExternalSink& sink) {
+    if (!sink.GetSettings().Is<NYql::NPq::NProto::TDqPqTopicSink>()) {
+        return false;
+    }
+    NYql::NPq::NProto::TDqPqTopicSink pqSink;
+    if (!sink.GetSettings().UnpackTo(&pqSink)) {
+        return false;
+    }
+    return predicate.Match(CanonizePath(pqSink.GetTopicPath()));
+}
+
+}  // anonymous namespace
+
+
+bool MatchesPath(const std::optional<NResourcePool::TRegexPredicate>& predicate,
+                 const TVector<TString>& queryTables,
+                 const NKqpProto::TKqpPhyQuery& phyQuery) {
+    if (!predicate) {
+        return true;
+    }
+
+    // (A) Stage-side table paths pre-aggregated by TPreparedQueryHolder::FillTables.
+    // Defensive coverage for TableOps + StreamLookup + Sequencer + ReadRangesSource
+    // + FullTextSource + InternalSink (with index Docs/Dict/Stats sub-tables) +
+    // OutputTransforms. Mostly overlaps with (B), retained as a safety net.
+    for (const auto& path : queryTables) {
+        if (predicate->Match(CanonizePath(path))) {
+            return true;
+        }
+    }
+
+    // (B) Per-tx table list — the primary workhorse. Populated by the compiler at
+    // kqp_query_compiler.cpp:1288-1305. Covers every kind we've verified: regular
+    // tables (DS + OLAP), sysviews, EDS + underlying EDS via ET's
+    // UnderlyingExternalSourceMetadata unroll, direct topics, CDC changefeeds.
+    for (const auto& tx : phyQuery.GetTransactions()) {
+        for (const auto& table : tx.GetTables()) {
+            if (predicate->Match(CanonizePath(table.GetId().GetPath()))) {
+                return true;
+            }
+        }
+    }
+
+    // (D) Streaming reads/writes over PQ. Additive granularity only for
+    // EDS-mediated remote topics — TDqPqTopicSource.TopicPath carries the bare
+    // remote topic name that appears nowhere else in the phy plan. For local
+    // topics and CDC changefeeds, TopicPath duplicates (B) — walk is uniform
+    // and short-circuits on first match.
+    //
+    // Empirical evidence: see wm-predicates/has-path.md appendix section 7.
+    for (const auto& tx : phyQuery.GetTransactions()) {
+        for (const auto& stage : tx.GetStages()) {
+            for (const auto& source : stage.GetSources()) {
+                if (source.HasExternalSource() && MatchesPqTopicSource(*predicate, source.GetExternalSource())) {
+                    return true;
+                }
+            }
+            for (const auto& sink : stage.GetSinks()) {
+                if (sink.HasExternalSink() && MatchesPqTopicSink(*predicate, sink.GetExternalSink())) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/kqp_has_path_matcher.h
+++ b/ydb/core/kqp/workload_service/kqp_has_path_matcher.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <ydb/core/protos/kqp_physical.pb.h>
+#include <ydb/core/resource_pools/regex_predicate.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+#include <optional>
+
+
+namespace NKikimr::NKqp::NWorkload {
+
+///
+/// Returns true if the classifier should accept the query based on the HAS_PATH filter.
+///
+/// - When `predicate` is unset, there is no filter — always accepts (returns true).
+/// - Otherwise, returns true iff the query touches any object at a path matching
+///   `predicate`. Coverage: regular tables (row + column), secondary-index sub-tables,
+///   system views, external tables and data sources, views, topics, CDC streams.
+///
+/// Callers pass `queryTables` from `TPreparedQueryHolder::GetQueryTables()` and
+/// `phyQuery` from `TPreparedQueryHolder::GetPhysicalQuery()`.
+///
+bool MatchesPath(const std::optional<NResourcePool::TRegexPredicate>& predicate,
+                 const TVector<TString>& queryTables,
+                 const NKqpProto::TKqpPhyQuery& phyQuery);
+
+}  // namespace NKikimr::NKqp::NWorkload

--- a/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
+++ b/ydb/core/kqp/workload_service/kqp_query_classifier.cpp
@@ -1,4 +1,5 @@
 #include "kqp_has_full_scan_matcher.h"
+#include "kqp_has_path_matcher.h"
 #include "kqp_query_classifier.h"
 #include "kqp_workload_service.h"
 
@@ -178,7 +179,7 @@ private:
     }
 
     bool NeedsPreparedQuery(const NResourcePool::TClassifierSettings& settings) const {
-        return settings.HasFullScan.has_value();
+        return settings.HasFullScan.has_value() || settings.HasPath.has_value();
     }
 
     ///
@@ -188,7 +189,8 @@ private:
     /// - Depends on actual query structure and execution characteristics.
     ///
     bool MatchesDynamic(const NResourcePool::TClassifierSettings& settings, const TPreparedQueryHolder& preparedQuery) const {
-        return MatchesFullScan(settings.HasFullScan, preparedQuery.GetPhysicalQuery());
+        return MatchesFullScan(settings.HasFullScan, preparedQuery.GetPhysicalQuery())
+            && MatchesPath(settings.HasPath, preparedQuery.GetQueryTables(), preparedQuery.GetPhysicalQuery());
     }
 
     const TResourcePoolEntry* FindPool(const TString& poolId) const {

--- a/ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h
+++ b/ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h
@@ -23,6 +23,7 @@ inline TResourcePoolClassifierConfig MakeClassifierConfig(
     std::optional<TString> memberName = std::nullopt,
     std::optional<TString> hasAppName = std::nullopt,
     std::optional<TString> hasFullScan = std::nullopt,
+    std::optional<TString> hasPath = std::nullopt,
     std::optional<TString> action = std::nullopt)
 {
     NJson::TJsonValue json(NJson::JSON_MAP);
@@ -35,6 +36,9 @@ inline TResourcePoolClassifierConfig MakeClassifierConfig(
     }
     if (hasFullScan) {
         json["has_full_scan"] = *hasFullScan;
+    }
+    if (hasPath) {
+        json["has_path"] = *hasPath;
     }
     if (action) {
         json["action"] = *action;
@@ -88,6 +92,7 @@ struct TClassifyTestCase {
     std::optional<TString> ClassifierMemberName;
     std::optional<TString> ClassifierHasAppName;
     std::optional<TString> ClassifierHasFullScan;
+    std::optional<TString> ClassifierHasPath;
     std::optional<TString> ClassifierAction;
 
     TString ContextAppName;
@@ -103,6 +108,7 @@ struct TClassifyTestCase {
         std::optional<TString> MemberName;
         std::optional<TString> HasAppName;
         std::optional<TString> HasFullScan;
+        std::optional<TString> HasPath;
         std::optional<TString> Action;
     };
     std::vector<TExtraClassifier> ExtraClassifiers;
@@ -111,12 +117,12 @@ struct TClassifyTestCase {
         std::vector<TResourcePoolClassifierConfig> configs;
         configs.push_back(MakeClassifierConfig(
             TEST_DB, "c_main", Rank, ResourcePool,
-            ClassifierMemberName, ClassifierHasAppName, ClassifierHasFullScan, ClassifierAction));
+            ClassifierMemberName, ClassifierHasAppName, ClassifierHasFullScan, ClassifierHasPath, ClassifierAction));
 
         for (const auto& extra : ExtraClassifiers) {
             configs.push_back(MakeClassifierConfig(
                 TEST_DB, extra.Name, extra.Rank, extra.ResourcePool,
-                extra.MemberName, extra.HasAppName, extra.HasFullScan, extra.Action));
+                extra.MemberName, extra.HasAppName, extra.HasFullScan, extra.HasPath, extra.Action));
         }
 
         auto classifierSnap = MakeClassifierSnapshot(std::move(configs));
@@ -175,6 +181,27 @@ struct TClassifyTestCase {
         } else {
             op->MutableReadRange()->MutableKeyRange()->MutableFrom()->AddValues();
         }
+
+        TPreparedQueryHolder holder(proto.release(), nullptr, /*noFillTables=*/true);
+        return classifier->PostCompileClassify(holder);
+    }
+
+    ///
+    /// Runs the full pre-compile + post-compile classification against a synthetic
+    /// TKqpPhyQuery whose first tx registers `queryTablePath` in its Tables list.
+    /// Exercises HAS_PATH's (B) walk over `tx.GetTables()`. One shape is enough
+    /// for wiring verification; the matcher UT covers the full walk surface.
+    ///
+    NWorkload::IQueryClassifier::TPostCompileClassifyResult RunPostClassifyForPath(
+        const TString& queryTablePath) const
+    {
+        auto classifier = BuildClassifier();
+        (void)classifier->PreCompileClassify();
+
+        auto proto = std::make_unique<NKikimrKqp::TPreparedQuery>();
+        auto* phyQuery = proto->MutablePhysicalQuery();
+        auto* tx = phyQuery->AddTransactions();
+        tx->AddTables()->MutableId()->SetPath(queryTablePath);
 
         TPreparedQueryHolder holder(proto.release(), nullptr, /*noFillTables=*/true);
         return classifier->PostCompileClassify(holder);

--- a/ydb/core/kqp/workload_service/ut/kqp_has_path_ddl_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_has_path_ddl_ut.cpp
@@ -1,0 +1,292 @@
+#include <ydb/core/base/path.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr::NKqp {
+
+using namespace NWorkload;
+using namespace NYdb;
+
+
+namespace {
+
+// Creates a simple row-store `t(Id, Payload)` and grants the given user full access.
+void SetupRowStoreTable(TIntrusivePtr<NWorkload::IYdbSetup> ydb, const TString& userSID) {
+    ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+        GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+        CREATE TABLE t (
+            Id Uint64 NOT NULL,
+            Payload Utf8,
+            PRIMARY KEY (Id)
+        );
+    )");
+
+    auto insertSettings = NWorkload::TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+    auto insertResult = ydb->ExecuteQuery(R"(
+        UPSERT INTO t (Id, Payload) VALUES (1u, "a"), (2u, "b");
+    )", insertSettings);
+    UNIT_ASSERT_VALUES_EQUAL_C(insertResult.GetStatus(), NYdb::EStatus::SUCCESS,
+        insertResult.GetIssues().ToOneLineString());
+}
+
+// Creates a column-store `olap_t(Id, Payload)` and grants full access.
+void SetupColumnStoreTable(TIntrusivePtr<NWorkload::IYdbSetup> ydb, const TString& userSID) {
+    ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+        GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+        CREATE TABLE olap_t (
+            Id Uint64 NOT NULL,
+            Payload Utf8,
+            PRIMARY KEY (Id)
+        ) WITH (
+            STORE = COLUMN
+        );
+    )");
+
+    auto insertSettings = NWorkload::TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+    auto insertResult = ydb->ExecuteQuery(R"(
+        UPSERT INTO olap_t (Id, Payload) VALUES (1u, "a"), (2u, "b");
+    )", insertSettings);
+    UNIT_ASSERT_VALUES_EQUAL_C(insertResult.GetStatus(), NYdb::EStatus::SUCCESS,
+        insertResult.GetIssues().ToOneLineString());
+}
+
+// Creates `orders(Id, Status)` with a global secondary index on Status.
+void SetupOrdersWithIndex(TIntrusivePtr<NWorkload::IYdbSetup> ydb, const TString& userSID) {
+    ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+        GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+        CREATE TABLE orders (
+            Id Uint64 NOT NULL,
+            Status Utf8,
+            PRIMARY KEY (Id),
+            INDEX by_status GLOBAL ON (Status)
+        );
+    )");
+
+    auto insertSettings = NWorkload::TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+    auto insertResult = ydb->ExecuteQuery(R"(
+        UPSERT INTO orders (Id, Status) VALUES (1u, "a"), (2u, "b");
+    )", insertSettings);
+    UNIT_ASSERT_VALUES_EQUAL_C(insertResult.GetStatus(), NYdb::EStatus::SUCCESS,
+        insertResult.GetIssues().ToOneLineString());
+}
+
+// Creates `t(...)` and a view `v` over it, grants full access.
+// The view body must fully qualify the underlying table — the invoker's
+// session context doesn't resolve unqualified `t` when the view is expanded.
+void SetupTableAndView(TIntrusivePtr<NWorkload::IYdbSetup> ydb, const TString& userSID) {
+    ydb->ExecuteSchemeQuery(TStringBuilder() << R"(
+        GRANT ALL ON `/)" << ydb->GetSettings().DomainName_ << R"(` TO `)" << userSID << R"(`;
+        CREATE TABLE t (
+            Id Uint64 NOT NULL,
+            Payload Utf8,
+            PRIMARY KEY (Id)
+        );
+        CREATE VIEW v WITH (security_invoker = true) AS SELECT * FROM `/Root/t`;
+    )");
+
+    auto insertSettings = NWorkload::TQueryRunnerSettings().PoolId(NResourcePool::DEFAULT_POOL_ID);
+    auto insertResult = ydb->ExecuteQuery(R"(
+        UPSERT INTO t (Id, Payload) VALUES (1u, "a"), (2u, "b");
+    )", insertSettings);
+    UNIT_ASSERT_VALUES_EQUAL_C(insertResult.GetStatus(), NYdb::EStatus::SUCCESS,
+        insertResult.GetIssues().ToOneLineString());
+}
+
+// EDS/ET/Topic/CDC DDL ITs live in `ydb/core/kqp/ut/federated_query/datastreams/`
+// (see `kqp_has_path_ut.cpp` there). Those kinds need TStreamingTestFixture's
+// mock connector + mock PQ gateway + http gateway wiring, which is not present
+// in workload_service_ut's setup. This file covers the kinds whose fixture is
+// cheap: regular tables, sysview, secondary index, view (underlying-table gate).
+
+TString RejectClassifierDdl(const TString& poolId, const TString& classifierName, const TString& hasPathPattern) {
+    return TStringBuilder() << R"(
+        CREATE RESOURCE POOL )" << poolId << R"( WITH (
+            CONCURRENT_QUERY_LIMIT=0
+        );
+        CREATE RESOURCE POOL CLASSIFIER )" << classifierName << R"( WITH (
+            RESOURCE_POOL=")" << poolId << R"(",
+            HAS_PATH=")" << hasPathPattern << R"("
+        );
+    )";
+}
+
+}  // anonymous namespace
+
+
+// Regular row-store table: SELECT * FROM t exercises the (A) walk via TableOps.Table.
+Y_UNIT_TEST_SUITE(HasPathTableOltp) {
+
+    Y_UNIT_TEST(TestClassifierMatchesTablePath) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupRowStoreTable(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(poolId, "row_table_classifier", "/Root/t"));
+
+        const TString query = "SELECT * FROM t;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    Y_UNIT_TEST(TestClassifierIgnoresOtherTable) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupRowStoreTable(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(poolId, "row_table_classifier", "/Root/other_table"));
+
+        const TString query = "SELECT * FROM t;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierSuccess(ydb, query, settings);
+    }
+}
+
+// Column-store table: SELECT * FROM olap_t compiles to ReadOlapRange, still surfaces
+// the table path through the same (A) walk. HAS_PATH doesn't care about read shape,
+// so a point lookup fires equally.
+Y_UNIT_TEST_SUITE(HasPathColumnTableOlap) {
+
+    Y_UNIT_TEST(TestClassifierMatchesOlapTablePath) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupColumnStoreTable(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(poolId, "olap_table_classifier", "/Root/olap_t"));
+
+        const TString query = "SELECT * FROM olap_t;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    Y_UNIT_TEST(TestClassifierMatchesOlapPointLookup) {
+        // Unlike HAS_FULL_SCAN, HAS_PATH doesn't care about read shape — a PK lookup
+        // still touches the table and must fire.
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupColumnStoreTable(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(poolId, "olap_table_classifier", "/Root/olap_t"));
+
+        const TString query = "SELECT * FROM olap_t WHERE Id = 1u;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+}
+
+// Secondary index sub-table: `.../indexImplTable` shows up in QueryTables when the
+// planner emits impl-table reads. Also fires on writes that fan out through indexes.
+Y_UNIT_TEST_SUITE(HasPathSecondaryIndex) {
+
+    Y_UNIT_TEST(TestClassifierMatchesIndexImplPath) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOrdersWithIndex(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(
+            poolId, "index_impl_classifier", "/Root/orders/by_status/indexImplTable"));
+
+        // Covering scan on the index — planner emits a full read of indexImplTable.
+        const TString query = "SELECT Status FROM orders VIEW by_status;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    Y_UNIT_TEST(TestClassifierMatchesIndexOnWrite) {
+        // UPSERT into an indexed table fans out to write both the main table and
+        // the impl table. HAS_PATH targeting the impl path still fires.
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupOrdersWithIndex(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(
+            poolId, "index_write_classifier", "/Root/orders/by_status/indexImplTable"));
+
+        const TString query = "UPSERT INTO orders (Id, Status) VALUES (3u, \"c\");";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+}
+
+// System views: SELECT FROM `.sys/...` populates tx.Tables with a SysView-kind entry
+// (see kqp_query_compiler.cpp:1288 tablesMap loop).
+Y_UNIT_TEST_SUITE(HasPathSysView) {
+
+    Y_UNIT_TEST(TestClassifierMatchesSysViewPath) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupRowStoreTable(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(
+            poolId, "sysview_classifier", "/Root/.sys/partition_stats"));
+
+        const TString query = "SELECT * FROM `.sys/partition_stats`;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+
+    Y_UNIT_TEST(TestClassifierIgnoresRegularTableWhenSysViewTargeted) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupRowStoreTable(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(
+            poolId, "sysview_classifier", "/Root/.sys/.*"));
+
+        const TString query = "SELECT * FROM t;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierSuccess(ydb, query, settings);
+    }
+}
+
+// Views are inlined at compile time. The loader records them separately in
+// phyQuery.ViewInfos. HAS_PATH regex matches the view's own path via the (C) walk.
+Y_UNIT_TEST_SUITE(HasPathView) {
+
+    // KindView is a documented blind spot for the view's own path — see has-path-wip.md.
+    // Empirically confirmed: SELECT FROM v inlines the view fully. QueryTables and
+    // tx.Tables carry only the underlying table paths; phyQuery.ViewInfos records
+    // views by numeric TableId with an empty TableName (yql_kikimr_datasource.cpp:433).
+    // A regex on the view path `/Root/v` never fires.
+    /*
+    Y_UNIT_TEST(TestClassifierMatchesViewPath) {
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupTableAndView(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(poolId, "view_classifier", "/Root/v"));
+
+        const TString query = "SELECT * FROM v;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+    */
+
+    Y_UNIT_TEST(TestClassifierMatchesUnderlyingTableUnderView) {
+        // Views are inlined — the underlying table's path also appears in QueryTables.
+        // A regex targeting the underlying table matches queries going through the view.
+        auto ydb = NWorkload::TYdbSetupSettings().Create();
+        const TString& poolId = "reject_pool";
+        const TString& userSID = "test@user";
+        SetupTableAndView(ydb, userSID);
+
+        ydb->ExecuteSchemeQuery(RejectClassifierDdl(poolId, "underlying_classifier", "/Root/t"));
+
+        const TString query = "SELECT * FROM v;";
+        auto settings = NWorkload::TQueryRunnerSettings().PoolId("").UserSID(userSID);
+        NWorkload::WaitForClassifierFail(ydb, query, settings, poolId);
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_has_path_matcher_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_has_path_matcher_ut.cpp
@@ -1,0 +1,169 @@
+#include <ydb/core/kqp/workload_service/kqp_has_path_matcher.h>
+#include <ydb/core/resource_pools/regex_predicate.h>
+
+#include <ydb/library/yql/providers/pq/proto/dq_io.pb.h>
+
+#include <google/protobuf/any.pb.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr::NKqp {
+
+using NResourcePool::TRegexPredicate;
+using NKqpProto::TKqpPhyQuery;
+
+
+namespace {
+
+NKqpProto::TKqpPhyStage* GetOrAddStage(TKqpPhyQuery& phy) {
+    auto* tx = phy.TransactionsSize() ? phy.MutableTransactions(0) : phy.AddTransactions();
+    return tx->StagesSize() ? tx->MutableStages(0) : tx->AddStages();
+}
+
+void AddTxTable(TKqpPhyQuery& phy, const TString& path) {
+    auto* tx = phy.TransactionsSize() ? phy.MutableTransactions(0) : phy.AddTransactions();
+    tx->AddTables()->MutableId()->SetPath(path);
+}
+
+void AddPqTopicSource(TKqpPhyQuery& phy, const TString& topicPath) {
+    auto* source = GetOrAddStage(phy)->AddSources();
+    NYql::NPq::NProto::TDqPqTopicSource pqSource;
+    pqSource.SetTopicPath(topicPath);
+    source->MutableExternalSource()->MutableSettings()->PackFrom(pqSource);
+}
+
+void AddPqTopicSink(TKqpPhyQuery& phy, const TString& topicPath) {
+    auto* sink = GetOrAddStage(phy)->AddSinks();
+    NYql::NPq::NProto::TDqPqTopicSink pqSink;
+    pqSink.SetTopicPath(topicPath);
+    sink->MutableExternalSink()->MutableSettings()->PackFrom(pqSink);
+}
+
+// Fixed-pattern helpers: each suite pins the predicate so tests read as pure
+// build-and-check one-liners (mirrors kqp_has_full_scan_matcher_ut.cpp style).
+
+// Runs the matcher against a phyQuery holding one tx-level table entry.
+// Predicate + path both vary so predicate-behaviour tests can exercise regex
+// semantics and canonicalization in isolation.
+const auto MatchesTxTable = [](const TString& pattern, const TString& path) {
+    TKqpPhyQuery phy;
+    AddTxTable(phy, path);
+    return NWorkload::MatchesPath(TRegexPredicate::Compile(pattern), {}, phy);
+};
+
+// Runs the matcher with pattern `/Root/t.*` against the given queryTables list.
+const auto MatchesQueryTables = [](const TVector<TString>& queryTables) {
+    TKqpPhyQuery phy;
+    return NWorkload::MatchesPath(TRegexPredicate::Compile("/Root/t.*"), queryTables, phy);
+};
+
+// Runs the matcher with pattern `/Root/db/target` against a phyQuery built by `build`.
+const auto MatchesTx = [](auto build) {
+    TKqpPhyQuery phy;
+    build(phy);
+    return NWorkload::MatchesPath(TRegexPredicate::Compile("/Root/db/target"), {}, phy);
+};
+
+// Runs the matcher with pattern `/Root/db/topic` against a phyQuery built by `build`.
+const auto MatchesTopics = [](auto build) {
+    TKqpPhyQuery phy;
+    build(phy);
+    return NWorkload::MatchesPath(TRegexPredicate::Compile("/Root/db/topic"), {}, phy);
+};
+
+}  // anonymous namespace
+
+
+Y_UNIT_TEST_SUITE(TPathMatcherPredicate) {
+
+    Y_UNIT_TEST(EmptyPredicateAcceptsAny) {
+        TKqpPhyQuery phy;
+        AddTxTable(phy, "/Root/anything");
+        UNIT_ASSERT(NWorkload::MatchesPath(std::nullopt, {}, phy));
+    }
+
+    Y_UNIT_TEST(NonMatchingPathIsNotAccepted) {
+        UNIT_ASSERT(!MatchesTxTable("/Root/critical", "/Root/other"));
+    }
+
+    Y_UNIT_TEST(RegexPatternMatches) {
+        UNIT_ASSERT(MatchesTxTable("/Root/db/archive.*", "/Root/db/archive_2024"));
+    }
+
+    Y_UNIT_TEST(CanonizesPathWithoutLeadingSlash) {
+        // Plan-side paths may omit the leading '/'. CanonizePath must be applied
+        // so patterns anchored with '/' still match.
+        UNIT_ASSERT(MatchesTxTable("/Root/db/orders", "Root/db/orders"));
+    }
+}
+
+Y_UNIT_TEST_SUITE(TPathMatcherQueryTables) {
+
+    Y_UNIT_TEST(SinglePathMatches) {
+        UNIT_ASSERT(MatchesQueryTables({"/Root/t"}));
+    }
+
+    Y_UNIT_TEST(NoMatchingPath) {
+        UNIT_ASSERT(!MatchesQueryTables({"/Root/other"}));
+    }
+
+    Y_UNIT_TEST(MixedPathsReturnTrueOnAnyMatch) {
+        UNIT_ASSERT(MatchesQueryTables({"/Root/other", "/Root/t"}));
+    }
+
+    Y_UNIT_TEST(IndexSubTablePath) {
+        // Secondary-index sub-tables show up in QueryTables at .../indexImplTable.
+        UNIT_ASSERT(MatchesQueryTables({"/Root/t/idx/indexImplTable"}));
+    }
+}
+
+Y_UNIT_TEST_SUITE(TPathMatcherTxTables) {
+
+    Y_UNIT_TEST(TableInTxMatches) {
+        UNIT_ASSERT(MatchesTx([](auto& phy) { AddTxTable(phy, "/Root/db/target"); }));
+    }
+
+    Y_UNIT_TEST(BothExternalEntriesGetWalked) {
+        // The compiler emits BOTH the External Table's path and its underlying
+        // External Data Source's path as separate TKqpPhyTable entries. A
+        // classifier targeting either one fires — this test proves the walk
+        // reaches the second entry.
+        UNIT_ASSERT(MatchesTx([](auto& phy) {
+            AddTxTable(phy, "/Root/db/other");
+            AddTxTable(phy, "/Root/db/target");
+        }));
+    }
+
+    Y_UNIT_TEST(MultipleTransactions) {
+        UNIT_ASSERT(MatchesTx([](auto& phy) {
+            phy.AddTransactions()->AddTables()->MutableId()->SetPath("/Root/db/other");
+            phy.AddTransactions()->AddTables()->MutableId()->SetPath("/Root/db/target");
+        }));
+    }
+}
+
+Y_UNIT_TEST_SUITE(TPathMatcherTopics) {
+
+    Y_UNIT_TEST(PqTopicSourceMatches) {
+        UNIT_ASSERT(MatchesTopics([](auto& phy) { AddPqTopicSource(phy, "/Root/db/topic"); }));
+    }
+
+    Y_UNIT_TEST(PqTopicSinkMatches) {
+        UNIT_ASSERT(MatchesTopics([](auto& phy) { AddPqTopicSink(phy, "/Root/db/topic"); }));
+    }
+
+    Y_UNIT_TEST(NonPqExternalSourceIsIgnored) {
+        // ExternalSource whose Settings is not TDqPqTopicSource/Sink must not
+        // spuriously match. Empty Any is a non-PQ shape.
+        UNIT_ASSERT(!MatchesTopics([](auto& phy) {
+            GetOrAddStage(phy)->AddSources()->MutableExternalSource();
+        }));
+    }
+
+    Y_UNIT_TEST(TopicPathWithoutLeadingSlashMatches) {
+        UNIT_ASSERT(MatchesTopics([](auto& phy) { AddPqTopicSource(phy, "Root/db/topic"); }));
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/kqp_has_path_ut.cpp
+++ b/ydb/core/kqp/workload_service/ut/kqp_has_path_ut.cpp
@@ -1,0 +1,64 @@
+#include <ydb/core/base/path.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_query_classifier_ut_common.h>
+#include <ydb/core/kqp/workload_service/ut/common/kqp_workload_service_ut_common.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+
+namespace NKikimr::NKqp {
+
+using namespace NWorkload;
+
+
+namespace {
+
+TString GetPostPoolId(const IQueryClassifier::TPostCompileClassifyResult& result) {
+    UNIT_ASSERT_C(std::holds_alternative<IQueryClassifier::TResolvedPoolId>(result),
+        TStringBuilder() << "Expected TResolvedPoolId, got variant index " << result.index());
+    return std::get<IQueryClassifier::TResolvedPoolId>(result).PoolId;
+}
+
+}  // anonymous namespace
+
+
+Y_UNIT_TEST_SUITE(TQueryClassifierHasPath) {
+
+    Y_UNIT_TEST(ShouldTriggerPendingCompilation) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasPath = "/Root/testdb/my_table";
+        auto result = tc.RunPreClassify();
+        UNIT_ASSERT_C(std::holds_alternative<IQueryClassifier::TPendingCompilation>(result),
+            TStringBuilder() << "Expected TPendingCompilation, got variant index " << result.index());
+    }
+
+    Y_UNIT_TEST(ShouldMatchExactPath) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasPath = "/Root/testdb/my_table";
+        auto result = tc.RunPostClassifyForPath("/Root/testdb/my_table");
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "pool_target");
+    }
+
+    Y_UNIT_TEST(ShouldNotMatchDifferentPath) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasPath = "/Root/testdb/my_table";
+        auto result = tc.RunPostClassifyForPath("/Root/testdb/other_table");
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "default");
+    }
+
+    Y_UNIT_TEST(ShouldMatchRegexPattern) {
+        TClassifyTestCase tc;
+        tc.ClassifierHasPath = "/Root/testdb/archive/.*";
+        auto result = tc.RunPostClassifyForPath("/Root/testdb/archive/orders_2024");
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "pool_target");
+    }
+
+    Y_UNIT_TEST(ShouldMatchIgnoringMissingLeadingSlash) {
+        // Plan-side paths may omit '/'. CanonizePath normalizes before regex match.
+        TClassifyTestCase tc;
+        tc.ClassifierHasPath = "/Root/testdb/my_table";
+        auto result = tc.RunPostClassifyForPath("Root/testdb/my_table");
+        UNIT_ASSERT_VALUES_EQUAL(GetPostPoolId(result), "pool_target");
+    }
+}
+
+}  // namespace NKikimr::NKqp

--- a/ydb/core/kqp/workload_service/ut/ya.make
+++ b/ydb/core/kqp/workload_service/ut/ya.make
@@ -14,6 +14,9 @@ SRCS(
     kqp_has_app_name_ut.cpp
     kqp_has_full_scan_matcher_ut.cpp
     kqp_has_full_scan_ut.cpp
+    kqp_has_path_ddl_ut.cpp
+    kqp_has_path_matcher_ut.cpp
+    kqp_has_path_ut.cpp
     kqp_member_name_ut.cpp
     kqp_query_classifier_match_ut.cpp
     kqp_query_classifier_ut.cpp

--- a/ydb/core/kqp/workload_service/ya.make
+++ b/ydb/core/kqp/workload_service/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     kqp_has_full_scan_matcher.cpp
+    kqp_has_path_matcher.cpp
     kqp_query_classifier.cpp
     kqp_workload_service.cpp
 )
@@ -22,6 +23,7 @@ PEERDIR(
 
     ydb/library/actors/interconnect
     ydb/library/aclib
+    ydb/library/yql/providers/pq/proto
 
     ydb/public/api/protos
 )

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.cpp
@@ -83,6 +83,7 @@ std::unordered_map<TString, TClassifierSettings::TProperty> TClassifierSettings:
         {"member_name", &MemberName},
         {"has_app_name", &HasAppName},
         {"has_full_scan", &HasFullScan},
+        {"has_path", &HasPath},
         {"action", &Action}
     };
     return properties;

--- a/ydb/core/resource_pools/resource_pool_classifier_settings.h
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings.h
@@ -45,6 +45,7 @@ struct TClassifierSettings : public TSettingsBase {
     std::optional<TString> MemberName;
     std::optional<TRegexPredicate> HasAppName;
     std::optional<TRegexPredicate> HasFullScan;
+    std::optional<TRegexPredicate> HasPath;
     std::optional<EClassifierAction> Action;
 };
 

--- a/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
+++ b/ydb/core/resource_pools/resource_pool_classifier_settings_ut.cpp
@@ -48,6 +48,10 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         std::visit(TClassifierSettings::TParser{"/Root/db/orders_.*"}, propertiesMap["has_full_scan"]);
         UNIT_ASSERT(settings.HasFullScan.has_value());
         UNIT_ASSERT_VALUES_EQUAL(settings.HasFullScan->Pattern, "/Root/db/orders_.*");
+
+        std::visit(TClassifierSettings::TParser{"/Root/db/archive/.*"}, propertiesMap["has_path"]);
+        UNIT_ASSERT(settings.HasPath.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(settings.HasPath->Pattern, "/Root/db/archive/.*");
     }
 
     Y_UNIT_TEST(RegexPredicateInvalidPattern) {
@@ -56,6 +60,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
 
         UNIT_ASSERT_EXCEPTION(std::visit(TClassifierSettings::TParser{"[invalid"}, propertiesMap["has_app_name"]), yexception);
         UNIT_ASSERT_EXCEPTION(std::visit(TClassifierSettings::TParser{"[invalid"}, propertiesMap["has_full_scan"]), yexception);
+        UNIT_ASSERT_EXCEPTION(std::visit(TClassifierSettings::TParser{"[invalid"}, propertiesMap["has_path"]), yexception);
     }
 
     Y_UNIT_TEST(SettingsExtracting) {
@@ -78,10 +83,12 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         // Parse then extract — must round-trip the original pattern
         std::visit(TClassifierSettings::TParser{"ydb-.*"}, propertiesMap["has_app_name"]);
         std::visit(TClassifierSettings::TParser{"/Root/db/orders_.*"}, propertiesMap["has_full_scan"]);
+        std::visit(TClassifierSettings::TParser{"/Root/db/archive/.*"}, propertiesMap["has_path"]);
 
         TClassifierSettings::TExtractor extractor;
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_app_name"]), "ydb-.*");
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_full_scan"]), "/Root/db/orders_.*");
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_path"]), "/Root/db/archive/.*");
     }
 
     Y_UNIT_TEST(RegexPredicateExtractingEmpty) {
@@ -92,6 +99,7 @@ Y_UNIT_TEST_SUITE(ResourcePoolClassifierTest) {
         TClassifierSettings::TExtractor extractor;
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_app_name"]), "");
         UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_full_scan"]), "");
+        UNIT_ASSERT_VALUES_EQUAL(std::visit(extractor, propertiesMap["has_path"]), "");
     }
 
     Y_UNIT_TEST(ActionParsing) {

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -778,6 +778,7 @@ struct Schema : NIceDb::Schema {
         struct HasAppName   : Column<6, NScheme::NTypeIds::Utf8> {};
         struct Action       : Column<7, NScheme::NTypeIds::Utf8> {};
         struct HasFullScan  : Column<8, NScheme::NTypeIds::Utf8> {};
+        struct HasPath      : Column<9, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<Name>;
         using TColumns = TableColumns<
@@ -787,7 +788,8 @@ struct Schema : NIceDb::Schema {
             ResourcePool,
             HasAppName,
             Action,
-            HasFullScan>;
+            HasFullScan,
+            HasPath>;
     };
 
     struct ShowCreate : Table<21> {

--- a/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
+++ b/ydb/core/sys_view/resource_pool_classifiers/resource_pool_classifiers.cpp
@@ -111,6 +111,10 @@ private:
                     const auto& hasFullScan = config.GetConfigJson()["has_full_scan"].GetString();
                     return TCell(hasFullScan.data(), hasFullScan.size());
                 }});
+                insert({TSchema::HasPath::ColumnId, [] (const NKqp::TResourcePoolClassifierConfig& config) {
+                    const auto& hasPath = config.GetConfigJson()["has_path"].GetString();
+                    return TCell(hasPath.data(), hasPath.size());
+                }});
             }
         };
         static TExtractorsMap extractors;

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -1023,6 +1023,10 @@
       {
         "name": "HasAppName",
         "type": "Utf8?"
+      },
+      {
+        "name": "HasPath",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -997,14 +997,6 @@
   "resource_pool_classifiers": {
     "columns": [
       {
-        "name": "Action",
-        "type": "Utf8?"
-      },
-      {
-        "name": "HasFullScan",
-        "type": "Utf8?"
-      },
-      {
         "name": "Name",
         "type": "Utf8?"
       },
@@ -1022,6 +1014,14 @@
       },
       {
         "name": "HasAppName",
+        "type": "Utf8?"
+      },
+      {
+        "name": "Action",
+        "type": "Utf8?"
+      },
+      {
+        "name": "HasFullScan",
         "type": "Utf8?"
       },
       {

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -573,14 +573,6 @@
   "resource_pool_classifiers": {
     "columns": [
       {
-        "name": "Action",
-        "type": "Utf8?"
-      },
-      {
-        "name": "HasFullScan",
-        "type": "Utf8?"
-      },
-      {
         "name": "Name",
         "type": "Utf8?"
       },
@@ -598,6 +590,14 @@
       },
       {
         "name": "HasAppName",
+        "type": "Utf8?"
+      },
+      {
+        "name": "Action",
+        "type": "Utf8?"
+      },
+      {
+        "name": "HasFullScan",
         "type": "Utf8?"
       },
       {

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -599,6 +599,10 @@
       {
         "name": "HasAppName",
         "type": "Utf8?"
+      },
+      {
+        "name": "HasPath",
+        "type": "Utf8?"
       }
     ],
     "primary_key": [


### PR DESCRIPTION
### Changelog entry

Add `HAS_PATH` regex predicate on workload manager resource pool classifiers to match queries whose plan touches any object at a matching path

### Changelog category

* New feature

### Description for reviewers

Summary:
- Introduce `HasPath` (`std::optional<TRegexPredicate>`) on `TClassifierSettings` and expose it as `HAS_PATH` in the classifier DDL.
- New matcher `MatchesPath(predicate, queryTables, phyQuery)`. Fires iff at least one plan-side path matches the regex.
- Dynamic wiring: `NeedsPreparedQuery` returns true when `HasPath` is set.
- Path canonicalization: `CanonizePath` is applied to every plan-side path before regex match (phy paths may omit the leading `/`; bare `TopicPath` gets a leading slash prepended).
- Sysview: new `HasPath` column (id 9) on `resource_pool_classifiers`, plumbed through the extractor and reflected in root/tenant canondata.

Covered sources of pathes:
- **(A) `preparedQuery.GetQueryTables()`** — pre-aggregated stage-side ops (TableOps, StreamLookup, Sequencer, ReadRangesSource, FullTextSource, InternalSink + index sub-tables). Defensive coverage; mostly overlaps with (B).
- **(B) `tx.GetTables()`** — the primary source. Populated by the compiler for every kind: regular tables (DS + OLAP), sysviews, EDS + underlying EDS via ET unroll, direct topics, CDC changefeeds.
- **(D) `TDqPqTopicSource/Sink.TopicPath`** — for EDS-mediated remote topics, where `TopicPath` carries the bare remote topic name that appears nowhere else in the phy plan.

Covered object kinds:
- `KindTable` — via (A)/(B)
- `KindColumnTable` — via (A)/(B)
- Secondary index sub-tables (`.../indexImplTable`) — via (A)
- `KindSysView` — via (A)/(B)
- `KindExternalDataSource` (Ydb-typed and ObjectStorage) — via (B)
- `KindExternalTable` — via (B), which emits both the ET path and the underlying EDS path
- `KindTopic` — direct read via (B); EDS-mediated (federated) via (B) for the local EDS path plus (D) for the remote topic name
- `KindCdcStream` — via (B), path shape `<table>/<stream>`
- `KindView` — **blind spot.** The loader records views by numeric TableId with an empty `TableName`, so views are effectively inlined and the view's own path is nowhere in the phy plan. Users match by the underlying tables the view expands to.

Tests:
- Matcher UT split into 4 suites: `TPathMatcherPredicate`, `TPathMatcherQueryTables`, `TPathMatcherTxTables`, `TPathMatcherTopics` (covers PQ source/sink shape, non-PQ ignored, canonicalization).
- Classifier IT: `TQueryClassifierHasPath`; DDL suites `HasPathTableOltp`, `HasPathColumnTableOlap`, `HasPathSecondaryIndex`, `HasPathSysView`, `HasPathView` (underlying-table variant only — view blind spot commented inline).
- Settings UT: parse/extract round-trip for `has_path`.

Not covered by IT yet:
- DDL coverage for the federated kinds — `KindTopic` (direct), `KindCdcStream`, `KindExternalDataSource` (federated shape), `KindExternalTable` on ObjectStorage EDS, and the (D) walk's unique-coverage case (remote topic name via `TDqPqTopicSource.TopicPath`).
- These tests are drafted in `ydb/core/kqp/ut/federated_query/datastreams/kqp_has_path_ut.cpp` — **committed for review but currently excluded from `ya.make`** (TODO in place).
- **All five kinds above are already verified on a live cluster**.
- `KindView` — the view's own path is not gateable at all (design blind spot, not an IT gap). Requires upstream changes to preserve view paths in the phy plan.

Examples:

```sql
-- Isolate any query touching a specific archive folder into a dedicated pool
CREATE RESOURCE POOL CLASSIFIER cl_archive WITH (
  RANK=100,
  RESOURCE_POOL="pool_archive",
  HAS_PATH='/Root/my_db/archive/.*'
);

-- Reject any query hitting a CDC changefeed
CREATE RESOURCE POOL CLASSIFIER cl_cdc WITH (
  RANK=200,
  RESOURCE_POOL="reject",
  HAS_PATH='/Root/my_db/orders/cf'
);

-- Gate by the remote topic name in an EDS-mediated federated query
-- (TopicPath is a bare name; CanonizePath prepends '/')
CREATE RESOURCE POOL CLASSIFIER cl_remote_topic WITH (
  RANK=400,
  RESOURCE_POOL="pool_streaming",
  HAS_PATH='/remote-topic-name'
);
```