### PR TITLE
Tie EnableIdmPermissionsManagement flag to system owner enforcement

### DIFF
--- a/ydb/core/base/auth.cpp
+++ b/ydb/core/base/auth.cpp
@@ -90,9 +90,26 @@ bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::
     return userToken->IsExist(databaseOwner);
 }
 
-void SetSystemOwnerIfNeeded(NKikimrScheme::TEvModifySchemeTransaction& record, const TAppData* appData) {
-    if (appData->AlwaysSetSystemOwner && record.GetOwner() != BUILTIN_ACL_METADATA) {
-        record.SetOwner(BUILTIN_ACL_BASIC_OWNER);
+TString ChooseAppropriateOwner(const NKikimrScheme::TEvModifySchemeTransaction& record,
+    const TAppData* appData, const std::optional<NACLib::TUserToken>& userToken)
+{
+    const bool alwaysSetSystemOwner = appData->AlwaysSetSystemOwner
+        || appData->FeatureFlags.GetEnableIdmPermissionsManagement();
+
+    if (!alwaysSetSystemOwner) {
+        if (userToken) {
+            return userToken->GetUserSID();
+        } else {
+            return record.GetOwner();
+        }
+    } else {
+        if ((userToken && userToken->GetUserSID() == BUILTIN_ACL_METADATA)
+            || record.GetOwner() == BUILTIN_ACL_METADATA)
+        {
+            return BUILTIN_ACL_METADATA;
+        } else {
+            return BUILTIN_ACL_BASIC_OWNER;
+        }
     }
 }
 

--- a/ydb/core/base/auth.h
+++ b/ydb/core/base/auth.h
@@ -24,9 +24,13 @@ bool IsStrictDatabaseOnlyToken(const TAppData* appData, const TString& userToken
 // Check token against database owner
 bool IsDatabaseAdministrator(const NACLib::TUserToken* userToken, const NACLib::TSID& databaseOwner);
 
-// When the AlwaysSetSystemOwner setting is enabled, forces the owner of a scheme
-// modification record to the system basic owner, unless the record is already owned
-// by the system metadata user (objects created by the system itself keep their owner).
-void SetSystemOwnerIfNeeded(NKikimrScheme::TEvModifySchemeTransaction& record, const TAppData* appData);
+// Computes the owner that should be set for a scheme modification record.
+// If neither the AlwaysSetSystemOwner setting nor the EnableIdmPermissionsManagement
+// feature flag is enabled, the owner is the acting user (from userToken, if given)
+// or, if no user token is given, the owner already present in the record.
+// Otherwise the owner is forced to the system basic owner,
+// unless objects created by the system itself.
+TString ChooseAppropriateOwner(const NKikimrScheme::TEvModifySchemeTransaction& record,
+    const TAppData* appData, const std::optional<NACLib::TUserToken>& userToken = std::nullopt);
 
 } // namespace NKikimr

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -346,4 +346,5 @@ message TFeatureFlags {
     optional bool EnableDataShardDirectPartImport = 299 [default = false];
     // For test purposes only, may cause persistent system failure if enabled
     optional bool BsControllerRestartBeforeCompatibilityInfoUpdate = 300 [default = false];
+    optional bool EnableIdmPermissionsManagement = 301 [default = false];
 }

--- a/ydb/core/tx/schemeshard/index/build_index__progress.cpp
+++ b/ydb/core/tx/schemeshard/index/build_index__progress.cpp
@@ -251,7 +251,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateIndexPropose(
 {
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.InitiateTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
-    SetSystemOwnerIfNeeded(propose->Record, AppData());
+    propose->Record.SetOwner(ChooseAppropriateOwner(propose->Record, AppData()));
 
     NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
     modifyScheme.SetInternal(true);
@@ -309,7 +309,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateBuildPropose(
 
     auto propose = MakeHolder<TEvSchemeShard::TEvModifySchemeTransaction>(ui64(buildInfo.ApplyTxId), ss->TabletID());
     propose->Record.SetFailOnExist(true);
-    SetSystemOwnerIfNeeded(propose->Record, AppData());
+    propose->Record.SetOwner(ChooseAppropriateOwner(propose->Record, AppData()));
 
     NKikimrSchemeOp::TModifyScheme& modifyScheme = *propose->Record.AddTransaction();
     modifyScheme.SetInternal(true);

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -103,7 +103,7 @@ bool TSchemeShard::ProcessOperationParts(
     TOperationContext& context)
 {
     auto selfId = SelfTabletId();
-    const TString owner = record.HasOwner() ? record.GetOwner() : BUILTIN_ACL_ROOT;
+    const TString owner = record.GetOwner().empty() ? BUILTIN_ACL_ROOT : record.GetOwner();
 
     if (parts.size() > 1) {
         // allow altering impl index tables as part of consistent operation

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -250,12 +250,13 @@ public:
             * By default, secrets should not inherit permissions from their parent object, except for the DescribeSchema grant.
             * This is done to prevent users from accidentally granting permissions to such sensitive objects.
             *
-            * When the flag is not set explicitly, the default depends on the AlwaysSetSystemOwner setting:
-            * with it enabled, permissions are inherited by default (inherit_permissions = true).
+            * When the flag is not set explicitly, the default depends on the AlwaysSetSystemOwner setting
+            * (or EnableIdmPermissionsManagement flag): with it enabled, permissions are inherited
+            * by default (inherit_permissions = true).
             */
             const bool inheritPermissions = createSecretProto.HasInheritPermissions()
                 ? createSecretProto.GetInheritPermissions()
-                : AppData()->AlwaysSetSystemOwner;
+                : AppData()->AlwaysSetSystemOwner || AppData()->FeatureFlags.GetEnableIdmPermissionsManagement();
 
             if (!inheritPermissions) {
                 secretPath->ACL = InterruptInheritanceExceptDescribe(dstPath.GetEffectiveACL());

--- a/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import__create.cpp
@@ -704,7 +704,7 @@ private:
             return false;
         }
 
-        if (AppData()->AlwaysSetSystemOwner) {
+        if (AppData()->AlwaysSetSystemOwner || AppData()->FeatureFlags.GetEnableIdmPermissionsManagement()) {
             op.SetNewOwner(BUILTIN_ACL_METADATA);
         }
 
@@ -760,7 +760,7 @@ private:
         }
         FillOwner(record, item.Permissions);
 
-        SetSystemOwnerIfNeeded(record, AppData());
+        record.SetOwner(ChooseAppropriateOwner(record, AppData()));
 
         if (TString error; !FillACL(modifyScheme, item.Permissions, error)) {
             NIceDb::TNiceDb db(txc.DB);

--- a/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_import_flow_proposals.cpp
@@ -108,7 +108,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> CreateTablePropose(
     }
     FillOwner(record, item.Permissions);
 
-    SetSystemOwnerIfNeeded(record, AppData());
+    record.SetOwner(ChooseAppropriateOwner(record, AppData()));
 
     if (!FillACL(modifyScheme, item.Permissions, error)) {
         return nullptr;

--- a/ydb/core/tx/schemeshard/schemeshard_xxport__helpers.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_xxport__helpers.cpp
@@ -30,7 +30,7 @@ THolder<TEvSchemeShard::TEvModifySchemeTransaction> MakeModifySchemeTransactionI
         record.SetUserSID(*xxportInfo.UserSID);
     }
 
-    SetSystemOwnerIfNeeded(record, AppData());
+    record.SetOwner(ChooseAppropriateOwner(record, AppData()));
 
     return propose;
 }

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -121,11 +121,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
     THolder<TEvSchemeShardPropose> MakePropose(ui64 schemeshardIdToRequest) {
         auto request = MakeHolder<TEvSchemeShardPropose>(TxId, schemeshardIdToRequest);
 
-        if (UserToken) {
-            request->Record.SetOwner(UserToken->GetUserSID());
-        }
-
-        SetSystemOwnerIfNeeded(request->Record, AppData());
+        request->Record.SetOwner(ChooseAppropriateOwner(request->Record, AppData(), UserToken));
 
         request->Record.SetPeerName(GetRequestProto().GetPeerName());
         if (GetRequestEv().HasModifyScheme()) {
@@ -1293,6 +1289,20 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         return msg;
     }
 
+    // If the missing access includes GrantAccessRights and permissions are managed via IDM,
+    // the message returned to the user points the user to use IDM instead.
+    TString MakeAccessDeniedError(const TActorContext& ctx, const TVector<TString>& path, ui32 neededAccess) {
+        const TString msg = MakeAccessDeniedError(ctx, path, TStringBuilder()
+            << "with access " << NACLib::AccessRightsToString(neededAccess)
+        );
+
+        if ((neededAccess & NACLib::EAccessRights::GrantAccessRights) && AppData()->FeatureFlags.GetEnableIdmPermissionsManagement()) {
+            return "All access rights are managed via roles in IDM, please use IDM to change them";
+        } else {
+            return msg;
+        }
+    }
+
     void InterpretResolveError(const NSchemeCache::TSchemeCacheNavigate* navigate, const TActorContext &ctx) {
         for (const auto& entry: navigate->ResultSet) {
             switch (entry.Status) {
@@ -1527,9 +1537,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             }
 
             if (!entry.SecurityObject->CheckAccess(access, *UserToken)) {
-                const auto errString = MakeAccessDeniedError(ctx, entry.Path, TStringBuilder()
-                    << "with access " << NACLib::AccessRightsToString(access)
-                );
+                const auto errString = MakeAccessDeniedError(ctx, entry.Path, access);
                 auto issue = MakeIssue(NKikimrIssues::TIssuesIds::ACCESS_DENIED, errString);
                 ReportStatus(TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::AccessDenied, nullptr, &issue, ctx);
                 return false;


### PR DESCRIPTION
- `ChooseAppropriateOwner` (formerly `SetSystemOwnerIfNeeded`) now also forces the system basic owner when the `EnableIdmPermissionsManagement` feature flag is enabled, treating it as equivalent to `AlwaysSetSystemOwner`.
- Access-denied error messages for missing `GrantAccessRights` on `ModifyACL` operations now state that ACL/permissions are managed via IDM roles when `EnableIdmPermissionsManagement` is enabled, directing users to use IDM instead of direct GRANT.
- Updated documentation comment for `ChooseAppropriateOwner` in `auth.h` to reflect the new signature and combined flag behavior.