### PR TITLE
schemeshard: TolerateOrphanedPaths ICB control for emergency recovery

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -1622,6 +1622,11 @@ message TImmediateControlsConfig {
             MinValue: -1,
             MaxValue: 604800,
             DefaultValue: 86400 }];
+        optional uint64 TolerateOrphanedPaths = 19 [(ControlOptions) = {
+            Description: "Emergency recovery only: tolerate SchemeShard local database inconsistencies (orphaned paths, references to missing paths) instead of failing fast. Enable to boot and repair a broken SchemeShard, then disable again",
+            MinValue: 0,
+            MaxValue: 1,
+            DefaultValue: 0 }];
     }
 
     message TTCMallocControls {

--- a/ydb/core/tx/schemeshard/schemeshard__clean_pathes.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__clean_pathes.cpp
@@ -131,12 +131,19 @@ struct TSchemeShard::TTxCleanDroppedPaths : public TTransactionBase<TSchemeShard
             TPathId pathId = *--itCandidate;
             Self->CleanDroppedPathsCandidates.erase(itCandidate);
             TPathElement::TPtr path = Self->PathsById.at(pathId);
-            if (path->DbRefCount == 0 && path->AllChildrenCount > 0) {
+            if (path->DbRefCount == 0 && path->Dropped() && path->AllChildrenCount > 0) {
                 // fail fast: a restart recomputes the counters and heals the drift
-                Y_FAIL_S("TTxCleanDroppedPaths: dropped path with children, DbRefCount is miscounted"
+                Y_VERIFY_S(Self->TolerateOrphanedPaths,
+                    "TTxCleanDroppedPaths: dropped path with children, DbRefCount is miscounted"
                     << ", PathId# " << pathId
                     << ", AllChildrenCount# " << path->AllChildrenCount
                     << ", at schemeshard: " << Self->TabletID());
+                LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                    "TTxCleanDroppedPaths: skip dropped path with children, DbRefCount is miscounted"
+                    << ", PathId# " << pathId
+                    << ", AllChildrenCount# " << path->AllChildrenCount
+                    << ", at schemeshard: " << Self->TabletID());
+                ++SkippedCount;
             } else if (path->DbRefCount == 0 && path->Dropped()) {
                 LOG_DEBUG_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                     "TTxCleanDroppedPaths: PersistRemovePath for PathId# " << pathId

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1489,6 +1489,30 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             Y_DEBUG_ABORT_UNLESS(IsSorted(pathRows.begin(), pathRows.end()));
 
             for (auto& rec: pathRows) {
+                if (Self->TolerateOrphanedPaths) {
+                    const TPathId pathId = std::get<0>(rec);
+                    const TPathId parentPathId = std::get<1>(rec);
+                    if (pathId != Self->RootPathId() && !Self->PathsById.contains(parentPathId)) {
+                        LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                            "TTxInit: parent path row is missing from the local database"
+                                << ", synthesizing an in-memory dropped placeholder parent"
+                                << ", pathId: " << pathId
+                                << ", parentPathId: " << parentPathId);
+                        TPathElement::TPtr placeholder = new TPathElement(
+                            parentPathId, Self->RootPathId(), Self->RootPathId(),
+                            TStringBuilder() << "__orphan_placeholder_"
+                                << parentPathId.OwnerId << "_" << parentPathId.LocalPathId,
+                            TString());
+                        placeholder->PathType = TPathElement::EPathType::EPathTypeDir;
+                        placeholder->StepCreated = TStepId(1);
+                        placeholder->CreateTxId = TTxId(1);
+                        placeholder->SetDropped(TStepId(1), TTxId(1));
+                        placeholder->IsOrphanPlaceholder = true;
+                        Self->PathsById[parentPathId] = placeholder;
+                        Self->HasOrphanPlaceholders = true;
+                    }
+                }
+
                 TPathElement::TPtr path = MakePathElement(rec);
 
                 Y_ABORT_UNLESS(path->PathId != Self->RootPathId());
@@ -3890,6 +3914,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
         TVector<TOperationId> splitOpIds;
         TVector<TOperationId> forceDropOpIds;
         THashSet<TPathId> pathsUnderOperation;
+        // Orphaned in-flight txs skipped under TolerateOrphanedPaths: their
+        // rows are removed so recovery converges and the control can be
+        // disabled afterwards
+        THashSet<TOperationId> skippedOrphanTxs;
+        THashSet<TTxId> skippedOrphanTxIds;
+
         // Read in-flight txid
         {
             auto txInFlightRowset = db.Table<Schema::TxInFlightV2>().Range().Select();
@@ -3924,6 +3954,27 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                                                 txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::SourceLocalPathId>());
                 txState.NeedUpdateObject = txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::NeedUpdateObject>(false);
                 txState.NeedSyncHive = txInFlightRowset.GetValueOrDefault<Schema::TxInFlightV2::NeedSyncHive>(false);
+
+                if (Self->TolerateOrphanedPaths) {
+                    const bool orphanTarget = !Self->PathsById.contains(txState.TargetPathId);
+                    const bool orphanSource = bool(txState.SourcePathId) && !Self->PathsById.contains(txState.SourcePathId);
+                    if (orphanTarget || orphanSource) {
+                        LOG_ERROR_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                            "TTxInit for TxInFlight: " << (orphanTarget ? "target" : "source")
+                                << " path element not found, skipping tx restore and removing its rows"
+                                << ", txId: " << operationId.GetTxId()
+                                << ", partId: " << operationId.GetSubTxId()
+                                << ", TxType: " << TTxState::TypeName(txState.TxType)
+                                << ", pathId: " << (orphanTarget ? txState.TargetPathId : txState.SourcePathId));
+                        Self->PersistRemoveTx(db, operationId, txState);
+                        skippedOrphanTxs.insert(operationId);
+                        skippedOrphanTxIds.insert(operationId.GetTxId());
+                        Self->TxInFlight.erase(operationId);
+                        if (!txInFlightRowset.Next())
+                            return false;
+                        continue;
+                    }
+                }
 
                 if ((txState.TxType == TTxState::TxCopyTable || txState.TxType == TTxState::TxReadOnlyCopyColumnTable) && txState.SourcePathId) {
                     Y_ABORT_UNLESS(txState.SourcePathId);
@@ -4285,6 +4336,10 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 TTxState::ETxState operation = std::get<2>(rec);
 
                 TTxState* txState = Self->FindTx(operationId);
+                if (!txState && skippedOrphanTxs.contains(operationId)) {
+                    Self->PersistRemoveTxShard(db, operationId, shardIdx);
+                    continue;
+                }
                 Y_VERIFY_S(txState, "There's shard for unknown Operation"
                                << ", shardIdx: " << shardIdx
                                << ", txId: " << operationId.GetTxId());
@@ -4399,6 +4454,15 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             while (!txDependenciesRowset.EndOfSet()) {
                 auto txId = txDependenciesRowset.GetValue<Schema::TxDependencies::TxId>();
                 auto dependentTxId = txDependenciesRowset.GetValue<Schema::TxDependencies::DependentTxId>();
+
+                if ((!Self->Operations.contains(txId) && skippedOrphanTxIds.contains(txId))
+                    || (!Self->Operations.contains(dependentTxId) && skippedOrphanTxIds.contains(dependentTxId)))
+                {
+                    Self->PersistRemoveTxDependency(db, txId, dependentTxId);
+                    if (!txDependenciesRowset.Next())
+                        return false;
+                    continue;
+                }
 
                 Y_VERIFY_S(Self->Operations.contains(txId), "Parent operation is not found"
                                                             << ", parent txId " << txId

--- a/ydb/core/tx/schemeshard/schemeshard__init_populator.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init_populator.cpp
@@ -9,6 +9,22 @@ namespace NSchemeShard {
 
 using namespace NTabletFlatExecutor;
 
+static bool IsUnderOrphanPlaceholder(const TSchemeShard* self, TPathElement::TPtr path) {
+    for (TPathElement::TPtr cur = path; ; ) {
+        if (cur->IsOrphanPlaceholder) {
+            return true;
+        }
+        if (cur->PathId == self->RootPathId()) {
+            return false;
+        }
+        auto parentIt = self->PathsById.find(cur->ParentPathId);
+        if (parentIt == self->PathsById.end()) {
+            return false;
+        }
+        cur = parentIt->second;
+    }
+}
+
 struct TSchemeShard::TTxInitPopulator : public TTransactionBase<TSchemeShard> {
     using TDescription = NSchemeBoard::TTwoPartDescription;
 
@@ -43,6 +59,10 @@ struct TSchemeShard::TTxInitPopulator : public TTransactionBase<TSchemeShard> {
             }
 
             if (!Self->PathIsActive(pathId)) {
+                continue;
+            }
+
+            if (Self->HasOrphanPlaceholders && IsUnderOrphanPlaceholder(Self, pathEl)) {
                 continue;
             }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -706,6 +706,8 @@ TMessageSeqNo TSchemeShard::NextRound() {
 }
 
 void TSchemeShard::Clear() {
+    HasOrphanPlaceholders = false;
+
     PathsById.clear();
 
     Tables.clear();
@@ -2426,9 +2428,12 @@ void TSchemeShard::PersistRemovePath(NIceDb::TNiceDb& db, const TPathElement::TP
     Y_DEBUG_ABORT_UNLESS(itParent != PathsById.end());
     if (itParent != PathsById.end()) {
         itParent->second->RemoveChild(path->Name, path->PathId);
-        Y_ABORT_UNLESS(itParent->second->AllChildrenCount > 0);
-        --itParent->second->AllChildrenCount;
-        DecrementPathDbRefCount(path->ParentPathId, "remove path");
+        // placeholders are never attached to their parent and never counted
+        if (!path->IsOrphanPlaceholder) {
+            Y_ABORT_UNLESS(itParent->second->AllChildrenCount > 0);
+            --itParent->second->AllChildrenCount;
+            DecrementPathDbRefCount(path->ParentPathId, "remove path");
+        }
     }
 }
 
@@ -5534,6 +5539,7 @@ TSchemeShard::TSchemeShard(const TActorId &tablet, TTabletStorageInfo *info)
     , AllowServerlessStorageBilling(0, 0, 1)
     , DisablePublicationsOfDropping(0, 0, 1)
     , FillAllocatePQ(0, 0, 1)
+    , TolerateOrphanedPaths(0, 0, 1)
     , SplitSettings()
     , IsReadOnlyMode(false)
     , ParentDomainLink(this)
@@ -5742,6 +5748,7 @@ void TSchemeShard::OnActivateExecutor(const TActorContext &ctx) {
     TControlBoard::RegisterSharedControl(AllowConditionalEraseOperations, icb.SchemeShardControls.AllowConditionalEraseOperations);
     TControlBoard::RegisterSharedControl(DisablePublicationsOfDropping, icb.SchemeShardControls.DisablePublicationsOfDropping);
     TControlBoard::RegisterSharedControl(FillAllocatePQ, icb.SchemeShardControls.FillAllocatePQ);
+    TControlBoard::RegisterSharedControl(TolerateOrphanedPaths, icb.SchemeShardControls.TolerateOrphanedPaths);
 
     TControlBoard::RegisterSharedControl(MaxCommitRedoMB, icb.TabletControls.MaxCommitRedoMB);
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -238,6 +238,8 @@ public:
     TControlWrapper AllowServerlessStorageBilling;
     TControlWrapper DisablePublicationsOfDropping;
     TControlWrapper FillAllocatePQ;
+    TControlWrapper TolerateOrphanedPaths;
+    bool HasOrphanPlaceholders = false; // in-memory, set by TTxInit
 
     // Shared with NTabletFlatExecutor::TExecutor
     TControlWrapper MaxCommitRedoMB;

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.h
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.h
@@ -61,6 +61,8 @@ struct TPathElement : TSimpleRefCount<TPathElement> {
     TTxId DropTxId = InvalidTxId;
     TTxId LastTxId = InvalidTxId;
 
+    bool IsOrphanPlaceholder = false; // in-memory only, never persisted
+
     ui64 DirAlterVersion = 0;
     ui64 ACLVersion = 0;
 

--- a/ydb/core/tx/schemeshard/ut_continuous_backup_reboots/ut_continuous_backup_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_continuous_backup_reboots/ut_continuous_backup_reboots.cpp
@@ -423,4 +423,116 @@ Y_UNIT_TEST_SUITE(TContinuousBackupWithRebootsTests) {
             NLs::PathExist,
         });
     }
+
+    // Recovery path for local databases already corrupted by issue #33764:
+    // a Paths row exists whose parent's Paths row is missing. With the
+    // SchemeShardControls.TolerateOrphanedPaths ICB control enabled,
+    // TTxInit synthesizes an in-memory dropped placeholder parent (nothing is
+    // persisted) instead of failing to start, quarantining the orphaned
+    // subtree. Without the control such a database cannot boot at all.
+    Y_UNIT_TEST(SelfHealOrphanedPathRowViaIcb) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions().EnableProtoSourceIdInfo(true));
+        ui64 txId = 100;
+
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        TestCreateContinuousBackup(runtime, ++txId, "/MyRoot", R"(
+            TableName: "Table"
+            ContinuousBackupDescription {
+                StreamName: "0_continuousBackupImpl"
+            }
+        )");
+        env.TestWaitNotification(runtime, txId);
+
+        const auto streamDesc = DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl");
+        const ui64 streamOwnerId = streamDesc.GetPathOwnerId();
+        const ui64 streamLocalId = streamDesc.GetPathId();
+        const auto implDesc = DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl");
+        const ui64 implLocalId = implDesc.GetPathId();
+        TestDescribeResult(implDesc, {
+            NLs::PathExist,
+        });
+
+        // Corrupt the local database the way issue #33764 did: the stream's
+        // Paths and CdcStream rows are gone (in production removed by the
+        // completed drop + premature TTxCleanDroppedPaths), while the
+        // streamImpl child's Paths row remains.
+        NKikimrMiniKQL::TResult result;
+        TString err;
+        const auto status = LocalMiniKQL(runtime, TTestTxConfig::SchemeShard, Sprintf(R"(
+            (
+                (let pathKey '('('Id (Uint64 '%)" PRIu64 R"())))
+                (let streamKey '('('OwnerPathId (Uint64 '%)" PRIu64 R"()) '('LocalPathId (Uint64 '%)" PRIu64 R"())))
+                (return (AsList
+                    (EraseRow 'Paths pathKey)
+                    (EraseRow 'CdcStream streamKey)
+                ))
+            )
+        )", streamLocalId, streamOwnerId, streamLocalId), result, err);
+        UNIT_ASSERT_VALUES_EQUAL_C(status, NKikimrProto::EReplyStatus::OK, err);
+
+        TControlBoard::SetValue(1, runtime.GetAppData().Icb->SchemeShardControls.TolerateOrphanedPaths);
+
+        // Without the control this reboot would fail TTxInit with
+        // "Parent path not found"; with it the orphaned streamImpl is
+        // quarantined under a placeholder and the tablet boots.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist,
+            NLs::IsTable,
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl"), {
+            NLs::PathNotExist,
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table/0_continuousBackupImpl/streamImpl"), {
+            NLs::PathNotExist,
+        });
+
+        // The healed schemeshard remains fully operational.
+        TestCreateTable(runtime, ++txId, "/MyRoot", R"(
+            Name: "Table2"
+            Columns { Name: "key" Type: "Uint64" }
+            Columns { Name: "value" Type: "Uint64" }
+            KeyColumnNames: ["key"]
+        )");
+        env.TestWaitNotification(runtime, txId);
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table2"), {
+            NLs::PathExist,
+            NLs::IsTable,
+        });
+
+        // Placeholder synthesis is idempotent across further reboots.
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist,
+            NLs::IsTable,
+        });
+
+        // Remediation per the runbook: force-drop the quarantined subtree by
+        // path id and let the rows drain; the placeholder then evaporates on
+        // its own once its last child row is removed.
+        TestForceDropUnsafe(runtime, ++txId, implLocalId);
+        env.TestWaitNotification(runtime, txId);
+        env.SimulateSleep(runtime, TDuration::Seconds(5));
+
+        // The database is consistent again: it boots with the control off.
+        TControlBoard::SetValue(0, runtime.GetAppData().Icb->SchemeShardControls.TolerateOrphanedPaths);
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table"), {
+            NLs::PathExist,
+            NLs::IsTable,
+        });
+        TestDescribeResult(DescribePrivatePath(runtime, "/MyRoot/Table2"), {
+            NLs::PathExist,
+            NLs::IsTable,
+        });
+    }
 } // TContinuousBackupWithRebootsTests


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Follow-up to #46295, which prevents new #33764-style corruption and makes SchemeShard fail fast on local database inconsistencies. A database where the corruption already happened (parent `Paths` row deleted, child rows remaining) still cannot boot — the parent row is physically gone.

New `SchemeShardControls.TolerateOrphanedPaths` ICB control (default off, emergency recovery only). When enabled:
- `TTxInit` synthesizes an in-memory dropped placeholder parent for orphaned path rows (nothing is persisted; the quarantined subtree is excluded from scheme board population, unreachable by name, no name conflicts — a same-name recreation supersedes the stale scheme board entry by higher path id)
- `TTxInit` skips in-flight transactions whose target path row is missing and skips missing source path references
- `TTxCleanDroppedPaths` skips a dropped path that still has children instead of stopping the tablet

Recovery runbook: enable → restart the node → boot succeeds, `LOG_ERROR`s name the orphaned path ids → force-drop the orphaned subtrees by path id → wait for the rows to be cleaned (dropped orphans and the placeholder clean up automatically once their references drain) → disable. The control must stay enabled until the orphaned rows are physically removed.

Regression test corrupts the local database via MiniKQL exactly like the issue (parent row erased, `streamImpl` child row kept) and verifies boot + operability + reboot stability with the control enabled.
