### PR TITLE
Fix InferPDiskSlotCount misconfig for extra-small drives

### DIFF
--- a/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
+++ b/ydb/core/blobstorage/nodewarden/blobstorage_node_warden_ut.cpp
@@ -1070,7 +1070,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
 
         if (expectedRelativeError > 0) {
             UNIT_ASSERT_LE_C(abs(unitSizeRelativeError), expectedRelativeError,
-                TStringBuilder() << "abs(" << unitSizeRelativeError << ") < " << expectedRelativeError
+                TStringBuilder() << "abs(" << unitSizeRelativeError << ") <= " << expectedRelativeError
             );
         }
     }
@@ -1085,6 +1085,10 @@ Y_UNIT_TEST_SUITE(TBlobStorageWardenTest) {
         TestInferPDiskSlotCount(50000, 1000, 16, 13, 4u, 0.039);
         TestInferPDiskSlotCount(50000, 100, 16, 16, 32u, 0.024);
         TestInferPDiskSlotCount(18000, 200, 16, 11, 8u, 0.023);
+        TestInferPDiskSlotCount(200, 1000, 16, 1, 1u, 0.8);
+        TestInferPDiskSlotCount(999, 1000, 16, 1, 1u, 0.001);
+        TestInferPDiskSlotCount(1499, 1000, 16, 1, 1u, 0.499);
+        TestInferPDiskSlotCount(1500, 1000, 16, 2, 1u, 0.25);
 
         for (ui32 maxSlots = 1; maxSlots <= 24; maxSlots++) {
             for (ui64 i = 1; i <= 1024; i++) {

--- a/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
+++ b/ydb/core/blobstorage/nodewarden/node_warden_pdisk.cpp
@@ -30,7 +30,7 @@ namespace NKikimr::NStorage {
             slotSizeInUnits *= 2;
         }
 
-        pdiskConfig->ExpectedSlotCount = lround(slotCount/slotSizeInUnits);
+        pdiskConfig->ExpectedSlotCount = Max(1u, (ui32)lround(slotCount/slotSizeInUnits));
         pdiskConfig->SlotSizeInUnits = slotSizeInUnits;
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Fix InferPDiskSlotCount producing misconfig for drives smaller than `unit_size` https://github.com/ydb-platform/ydb/issues/46363

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Close #46363 