### PR TITLE
Implement IValueArrowCodec for translation between logical and physical representation

### DIFF
--- a/ydb/core/formats/arrow/accessor/common/json_value_view.cpp
+++ b/ydb/core/formats/arrow/accessor/common/json_value_view.cpp
@@ -1,8 +1,12 @@
 #include "json_value_view.h"
 
+#include <library/cpp/json/json_reader.h>
+#include <library/cpp/json/json_writer.h>
+
 #include <ydb/library/actors/core/log.h>
 
 #include <yql/essentials/types/binary_json/read.h>
+#include <yql/essentials/types/binary_json/write.h>
 
 #include <util/generic/ylimits.h>
 #include <util/string/cast.h>
@@ -11,6 +15,16 @@
 #include <limits>
 
 namespace NKikimr::NArrow::NAccessor {
+
+namespace {
+
+NBinaryJson::TBinaryJson JsonValueToBinaryJson(const NJson::TJsonValue& json) {
+    auto result = NBinaryJson::SerializeToBinaryJson(NJson::WriteJson(&json, false));
+    AFL_VERIFY(std::holds_alternative<NBinaryJson::TBinaryJson>(result));
+    return std::get<NBinaryJson::TBinaryJson>(std::move(result));
+}
+
+}   // namespace
 
 std::optional<TString> TJsonValueView::JsonNumberToString(double jsonNumber) {
     if (std::isnan(jsonNumber)) {
@@ -88,6 +102,34 @@ std::optional<TStringBuf> TJsonValueView::GetBinaryJsonBlobOptional() const {
         return std::nullopt;
     }
     return Bytes;
+}
+
+NJson::TJsonValue TJsonValueView::ToJsonValue() const {
+    switch (Kind) {
+        case EKind::BinaryJson: {
+            const auto text = NBinaryJson::SerializeToJson(Bytes);
+            NJson::TJsonValue result;
+            AFL_VERIFY(NJson::ReadJsonTree(text, &result));
+            return result;
+        }
+        case EKind::String:
+            return NJson::TJsonValue(Bytes);
+        case EKind::Number:
+            return NJson::TJsonValue(Number);
+        case EKind::Bool:
+            return NJson::TJsonValue(Bool);
+    }
+}
+
+NBinaryJson::TBinaryJson TJsonValueView::ToBinaryJson() const {
+    switch (Kind) {
+        case EKind::BinaryJson:
+            return NBinaryJson::TBinaryJson(Bytes.data(), Bytes.size());
+        case EKind::String:
+        case EKind::Number:
+        case EKind::Bool:
+            return JsonValueToBinaryJson(ToJsonValue());
+    }
 }
 
 std::optional<TStringBuf> TJsonValueView::ScalarFromBinaryJson() const {

--- a/ydb/core/formats/arrow/accessor/common/json_value_view.cpp
+++ b/ydb/core/formats/arrow/accessor/common/json_value_view.cpp
@@ -18,7 +18,7 @@ namespace NKikimr::NArrow::NAccessor {
 
 namespace {
 
-NBinaryJson::TBinaryJson JsonValueToBinaryJson(const NJson::TJsonValue& json) {
+NBinaryJson::TBinaryJson JsonValueToBinaryJsonVerified(const NJson::TJsonValue& json) {
     auto result = NBinaryJson::SerializeToBinaryJson(NJson::WriteJson(&json, false));
     AFL_VERIFY(std::holds_alternative<NBinaryJson::TBinaryJson>(result));
     return std::get<NBinaryJson::TBinaryJson>(std::move(result));
@@ -128,7 +128,7 @@ NBinaryJson::TBinaryJson TJsonValueView::ToBinaryJson() const {
         case EKind::String:
         case EKind::Number:
         case EKind::Bool:
-            return JsonValueToBinaryJson(ToJsonValue());
+            return JsonValueToBinaryJsonVerified(ToJsonValue());
     }
 }
 

--- a/ydb/core/formats/arrow/accessor/common/json_value_view.h
+++ b/ydb/core/formats/arrow/accessor/common/json_value_view.h
@@ -26,8 +26,6 @@ public:
     // Expected to be used only for containers, but no checks enforce that.
     std::optional<TStringBuf> GetBinaryJsonBlobOptional() const;
 
-    // Translate the value to a JSON value (for document reconstruction) or a BinaryJson blob. A native
-    // scalar is materialized; a BinaryJson blob is parsed/copied.
     NJson::TJsonValue ToJsonValue() const;
     NBinaryJson::TBinaryJson ToBinaryJson() const;
 private:

--- a/ydb/core/formats/arrow/accessor/common/json_value_view.h
+++ b/ydb/core/formats/arrow/accessor/common/json_value_view.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <library/cpp/json/writer/json_value.h>
+#include <yql/essentials/types/binary_json/format.h>
+
 #include <util/generic/string.h>
 
 #include <optional>
@@ -22,6 +25,11 @@ public:
     // So result will be different for a native scalar and the same scalar wrapped in BinaryJson.
     // Expected to be used only for containers, but no checks enforce that.
     std::optional<TStringBuf> GetBinaryJsonBlobOptional() const;
+
+    // Translate the value to a JSON value (for document reconstruction) or a BinaryJson blob. A native
+    // scalar is materialized; a BinaryJson blob is parsed/copied.
+    NJson::TJsonValue ToJsonValue() const;
+    NBinaryJson::TBinaryJson ToBinaryJson() const;
 private:
     static std::optional<TString> JsonNumberToString(double jsonNumber);
 

--- a/ydb/core/formats/arrow/accessor/common/ut/ut_json_value_view.cpp
+++ b/ydb/core/formats/arrow/accessor/common/ut/ut_json_value_view.cpp
@@ -74,18 +74,6 @@ Y_UNIT_TEST_SUITE(JsonValueView) {
         UNIT_ASSERT_VALUES_EQUAL(ScalarStr(TJsonValueView::OfBool(true)), BlobScalar("true"));
     }
 
-    // ToBinaryJson of a native scalar yields a blob that reads back to the same value.
-    Y_UNIT_TEST(ToBinaryJsonRoundTrip) {
-        const auto check = [](const TJsonValueView& native) {
-            const auto blob = native.ToBinaryJson();
-            UNIT_ASSERT_VALUES_EQUAL(ScalarStr(TJsonValueView::OfBinaryJson(TStringBuf(blob.data(), blob.size()))), ScalarStr(native));
-        };
-        check(TJsonValueView::OfString("hi"));
-        check(TJsonValueView::OfNumber(5.0));
-        check(TJsonValueView::OfNumber(2.5));
-        check(TJsonValueView::OfBool(true));
-    }
-
     Y_UNIT_TEST(ToJsonValue) {
         UNIT_ASSERT_VALUES_EQUAL(TJsonValueView::OfString("hi").ToJsonValue().GetString(), "hi");
         UNIT_ASSERT_VALUES_EQUAL(TJsonValueView::OfNumber(2.5).ToJsonValue().GetDouble(), 2.5);

--- a/ydb/core/formats/arrow/accessor/common/ut/ut_json_value_view.cpp
+++ b/ydb/core/formats/arrow/accessor/common/ut/ut_json_value_view.cpp
@@ -73,4 +73,25 @@ Y_UNIT_TEST_SUITE(JsonValueView) {
         UNIT_ASSERT_VALUES_EQUAL(ScalarStr(TJsonValueView::OfNumber(2.5)), BlobScalar("2.5"));
         UNIT_ASSERT_VALUES_EQUAL(ScalarStr(TJsonValueView::OfBool(true)), BlobScalar("true"));
     }
+
+    // ToBinaryJson of a native scalar yields a blob that reads back to the same value.
+    Y_UNIT_TEST(ToBinaryJsonRoundTrip) {
+        const auto check = [](const TJsonValueView& native) {
+            const auto blob = native.ToBinaryJson();
+            UNIT_ASSERT_VALUES_EQUAL(ScalarStr(TJsonValueView::OfBinaryJson(TStringBuf(blob.data(), blob.size()))), ScalarStr(native));
+        };
+        check(TJsonValueView::OfString("hi"));
+        check(TJsonValueView::OfNumber(5.0));
+        check(TJsonValueView::OfNumber(2.5));
+        check(TJsonValueView::OfBool(true));
+    }
+
+    Y_UNIT_TEST(ToJsonValue) {
+        UNIT_ASSERT_VALUES_EQUAL(TJsonValueView::OfString("hi").ToJsonValue().GetString(), "hi");
+        UNIT_ASSERT_VALUES_EQUAL(TJsonValueView::OfNumber(2.5).ToJsonValue().GetDouble(), 2.5);
+        UNIT_ASSERT(TJsonValueView::OfBool(true).ToJsonValue().GetBoolean());
+        const auto blob = ToBinaryJson(R"({"a":1})");
+        const auto json = TJsonValueView::OfBinaryJson(TStringBuf(blob.data(), blob.size())).ToJsonValue();
+        UNIT_ASSERT_VALUES_EQUAL(json["a"].GetInteger(), 1);
+    }
 }

--- a/ydb/core/formats/arrow/accessor/common/ya.make
+++ b/ydb/core/formats/arrow/accessor/common/ya.make
@@ -2,6 +2,7 @@ LIBRARY(library-formats-arrow-accessor-common)
 
 PEERDIR(
     contrib/libs/apache/arrow
+    library/cpp/json
     library/cpp/json/writer
     ydb/library/actors/core
     ydb/library/formats/arrow/protos

--- a/ydb/core/formats/arrow/accessor/plain/accessor.h
+++ b/ydb/core/formats/arrow/accessor/plain/accessor.h
@@ -70,41 +70,36 @@ public:
     {
     }
 
-    template <class TArrowDataType = arrow::StringType>
-    class TPlainBuilder {
+    class TPlainBuilderBase {
     private:
         std::unique_ptr<arrow::ArrayBuilder> Builder;
         std::optional<ui32> LastRecordIndex;
 
-    public:
-        TPlainBuilder(const ui32 reserveItems = 0, const ui32 reserveSize = 0) {
-            Builder = NArrow::MakeBuilder(arrow::TypeTraits<TArrowDataType>::type_singleton(), reserveItems, reserveSize);
+    protected:
+        arrow::ArrayBuilder& GetBuilder() {
+            return *Builder;
         }
 
-        void AddRecord(const ui32 recordIndex, const std::string_view value) {
-            AddValue(recordIndex, arrow::util::string_view(value.data(), value.size()));
-        }
-
-        template <class TValue>
-        void AddValue(const ui32 recordIndex, const TValue& value) {
+        template <class TAppender>
+        void AddAt(const ui32 recordIndex, const TAppender& append) {
             if (LastRecordIndex) {
                 AFL_VERIFY(*LastRecordIndex < recordIndex)("last", LastRecordIndex)("index", recordIndex);
                 TStatusValidator::Validate(Builder->AppendNulls(recordIndex - *LastRecordIndex - 1));
             } else {
                 TStatusValidator::Validate(Builder->AppendNulls(recordIndex));
             }
+            append(*Builder);
             LastRecordIndex = recordIndex;
-            AFL_VERIFY(NArrow::Append<TArrowDataType>(*Builder, value));
+        }
+
+    public:
+        TPlainBuilderBase(std::unique_ptr<arrow::ArrayBuilder> builder)
+            : Builder(std::move(builder)) {
+            AFL_VERIFY(!!Builder);
         }
 
         void AddNull(const ui32 recordIndex) {
-            if (LastRecordIndex) {
-                AFL_VERIFY(*LastRecordIndex < recordIndex)("last", LastRecordIndex)("index", recordIndex);
-                TStatusValidator::Validate(Builder->AppendNulls(recordIndex - *LastRecordIndex));
-            } else {
-                TStatusValidator::Validate(Builder->AppendNulls(recordIndex + 1));
-            }
-            LastRecordIndex = recordIndex;
+            AddAt(recordIndex, [](arrow::ArrayBuilder& builder) { TStatusValidator::Validate(builder.AppendNull()); });
         }
 
         std::shared_ptr<IChunkedArray> Finish(const ui32 recordsCount) {
@@ -115,6 +110,23 @@ public:
                 TStatusValidator::Validate(Builder->AppendNulls(recordsCount));
             }
             return std::make_shared<TTrivialArray>(NArrow::FinishBuilder(std::move(Builder)));
+        }
+    };
+
+    template <class TArrowDataType = arrow::StringType>
+    class TPlainBuilder: public TPlainBuilderBase {
+    public:
+        TPlainBuilder(const ui32 reserveItems = 0, const ui32 reserveSize = 0)
+            : TPlainBuilderBase(NArrow::MakeBuilder(arrow::TypeTraits<TArrowDataType>::type_singleton(), reserveItems, reserveSize)) {
+        }
+
+        void AddRecord(const ui32 recordIndex, const std::string_view value) {
+            AddValue(recordIndex, arrow::util::string_view(value.data(), value.size()));
+        }
+
+        template <class TValue>
+        void AddValue(const ui32 recordIndex, const TValue& value) {
+            AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AFL_VERIFY(NArrow::Append<TArrowDataType>(builder, value)); });
         }
     };
 

--- a/ydb/core/formats/arrow/accessor/sparsed/accessor.h
+++ b/ydb/core/formats/arrow/accessor/sparsed/accessor.h
@@ -253,38 +253,46 @@ public:
         return Record.GetRecords();
     }
 
-    template <class TDataType>
-    class TSparsedBuilder {
+    class TSparsedBuilderBase {
     private:
         std::unique_ptr<arrow::ArrayBuilder> IndexBuilder;
         std::unique_ptr<arrow::ArrayBuilder> ValueBuilder;
-        ui32 RecordsCount = 0;
+        const std::shared_ptr<arrow::DataType> ValueType;
         const std::shared_ptr<arrow::Scalar> DefaultValue;
         std::optional<ui32> LastRecordIndex;
 
-    public:
-        TSparsedBuilder(const std::shared_ptr<arrow::Scalar>& defaultValue, const ui32 reserveItems, const ui32 reserveData)
-            : DefaultValue(defaultValue)
-        {
-            IndexBuilder = NArrow::MakeBuilder(arrow::uint32(), reserveItems, 0);
-            ValueBuilder = NArrow::MakeBuilder(arrow::TypeTraits<TDataType>::type_singleton(), reserveItems, reserveData);
-        }
-
-        void AddRecord(const ui32 recordIndex, const std::string_view value) {
-            if (!!LastRecordIndex) {
-                AFL_VERIFY(*LastRecordIndex < recordIndex);
+        void AdvanceRecordIndex(const ui32 recordIndex) {
+            if (LastRecordIndex) {
+                AFL_VERIFY(*LastRecordIndex < recordIndex)("last", LastRecordIndex)("index", recordIndex);
             }
             LastRecordIndex = recordIndex;
+        }
+
+    protected:
+        arrow::ArrayBuilder& GetValueBuilder() {
+            return *ValueBuilder;
+        }
+
+        template <class TAppender>
+        void AddAt(const ui32 recordIndex, const TAppender& append) {
+            AdvanceRecordIndex(recordIndex);
             AFL_VERIFY(NArrow::Append<arrow::UInt32Type>(*IndexBuilder, recordIndex));
-            AFL_VERIFY(NArrow::Append<TDataType>(*ValueBuilder, arrow::util::string_view(value.data(), value.size())));
-            ++RecordsCount;
+            append(*ValueBuilder);
+        }
+
+    public:
+        TSparsedBuilderBase(std::unique_ptr<arrow::ArrayBuilder> valueBuilder, const std::shared_ptr<arrow::DataType>& valueType,
+            const std::shared_ptr<arrow::Scalar>& defaultValue, const ui32 reserveItems)
+            : IndexBuilder(NArrow::MakeBuilder(arrow::uint32(), reserveItems, 0))
+            , ValueBuilder(std::move(valueBuilder))
+            , ValueType(valueType)
+            , DefaultValue(defaultValue)
+        {
+            AFL_VERIFY(!!ValueBuilder);
         }
 
         void AddNull(const ui32 recordIndex) {
-            if (!!LastRecordIndex) {
-                AFL_VERIFY(*LastRecordIndex < recordIndex);
-            }
-            LastRecordIndex = recordIndex;
+            AdvanceRecordIndex(recordIndex);
             if (!!DefaultValue && DefaultValue->type->id() != arrow::null()->id()) {
                 AFL_VERIFY(NArrow::Append<arrow::UInt32Type>(*IndexBuilder, recordIndex));
                 TStatusValidator::Validate(ValueBuilder->AppendNull());
@@ -292,13 +300,24 @@ public:
         }
 
         std::shared_ptr<IChunkedArray> Finish(const ui32 recordsCount) {
-            TSparsedArray::TBuilder builder(DefaultValue, arrow::TypeTraits<TDataType>::type_singleton());
-            std::vector<std::unique_ptr<arrow::ArrayBuilder>> builders;
-            builders.emplace_back(std::move(IndexBuilder));
-            builders.emplace_back(std::move(ValueBuilder));
-            builder.AddChunk(recordsCount, arrow::RecordBatch::Make(TSparsedArray::BuildSchema(arrow::TypeTraits<TDataType>::type_singleton()),
-                                               RecordsCount, NArrow::Finish(std::move(builders))));
+            TBuilder builder(DefaultValue, ValueType);
+            builder.AddChunk(recordsCount, NArrow::FinishBuilder(std::move(IndexBuilder)), NArrow::FinishBuilder(std::move(ValueBuilder)));
             return builder.Finish();
+        }
+    };
+
+    template <class TDataType>
+    class TSparsedBuilder: public TSparsedBuilderBase {
+    public:
+        TSparsedBuilder(const std::shared_ptr<arrow::Scalar>& defaultValue, const ui32 reserveItems, const ui32 reserveData)
+            : TSparsedBuilderBase(NArrow::MakeBuilder(arrow::TypeTraits<TDataType>::type_singleton(), reserveItems, reserveData),
+                  arrow::TypeTraits<TDataType>::type_singleton(), defaultValue, reserveItems) {
+        }
+
+        void AddRecord(const ui32 recordIndex, const std::string_view value) {
+            AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) {
+                AFL_VERIFY(NArrow::Append<TDataType>(builder, arrow::util::string_view(value.data(), value.size())));
+            });
         }
     };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -85,7 +85,7 @@ public:
         }
 
         NArrow::NAccessor::TJsonValueView GetValue() const {
-            return ArrayElementToJsonValueView(*CurrentArrayData, GetLocalIndex(), ValueType);
+            return GetCodecForValueType(ValueType)->ReadValueView(*CurrentArrayData, GetLocalIndex());
         }
 
         bool HasValue() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -80,7 +80,7 @@ public:
         const arrow::Array& GetArray() const {
             return *CurrentArrayData;
         }
-        i64 GetLocalIndex() const {
+        ui32 GetLocalIndex() const {
             return ChunkAddress->GetAddress().GetLocalIndex(CurrentIndex);
         }
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.cpp
@@ -1,78 +1,40 @@
 #include "accessor.h"
 #include "columns_storage.h"
 #include "direct_builder.h"
+#include "encoding_builders.h"
 
 #include <util/string/escape.h>
 #include <ydb/core/formats/arrow/accessor/common/chunk_data.h>
 #include <ydb/core/formats/arrow/accessor/dictionary/constructor.h>
 #include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
 #include <ydb/core/formats/arrow/serializer/abstract.h>
 
 #include <contrib/libs/simdjson/include/simdjson.h>
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
-namespace {
-
-std::string_view MakeStoredBytesView(const NBinaryJson::TBinaryJson& rec, const EValueType valueType) {
-    if (valueType == EValueType::BinaryJson) {
-        return std::string_view(rec.Data(), rec.Size());
-    }
-    AFL_VERIFY(valueType == EValueType::String)("value_type", (ui32)valueType);
-    const auto scalar = ExtractStringScalar(rec);
-    return std::string_view(scalar.data(), scalar.size());
-}
-
-template <class TArrow, class TExtractor>
-std::shared_ptr<IChunkedArray> BuildTypedPlain(const std::deque<NBinaryJson::TBinaryJson>& values,
-    const std::vector<ui32>& recordIndexes, const ui32 recordsCount, const ui32 reserveData, const TExtractor& extract) {
-    TTrivialArray::TPlainBuilder<TArrow> builder(recordsCount, reserveData);
-    for (ui32 i = 0; i < recordIndexes.size(); ++i) {
-        builder.AddValue(recordIndexes[i], extract(values[i]));
-    }
-    return builder.Finish(recordsCount);
-}
-}   // namespace
-
 void TColumnElements::BuildSparsedAccessor(const ui32 recordsCount, const EValueType valueType) {
     AFL_VERIFY(!Accessor);
-    // Columns with non-binary encoding are not supported.
-    AFL_VERIFY(valueType == EValueType::BinaryJson || valueType == EValueType::String)("value_type", (ui32)valueType);
-    auto recordsBuilder = TSparsedArray::MakeBuilderBinary(RecordIndexes.size(), DataSize);
-    for (ui32 idx = 0; idx < RecordIndexes.size(); ++idx) {
-        recordsBuilder.AddRecord(RecordIndexes[idx], MakeStoredBytesView(Values[idx], valueType));
+    TEncodingSparsedBuilder builder(GetCodecForValueType(valueType), RecordIndexes.size(), DataSize);
+    for (ui32 i = 0; i < RecordIndexes.size(); ++i) {
+        builder.AddFromBinaryJson(RecordIndexes[i], Values[i]);
     }
-    Accessor = recordsBuilder.Finish(recordsCount);
+    Accessor = builder.Finish(recordsCount);
 }
 
 void TColumnElements::BuildPlainAccessor(const ui32 recordsCount, const EValueType valueType) {
     AFL_VERIFY(!Accessor);
-    switch (valueType) {
-        case EValueType::BinaryJson:
-        case EValueType::String:
-            Accessor = BuildTypedPlain<arrow::BinaryType>(Values, RecordIndexes, recordsCount, DataSize,
-                [valueType](const NBinaryJson::TBinaryJson& rec) {
-                    const auto sv = MakeStoredBytesView(rec, valueType);
-                    return arrow::util::string_view(sv.data(), sv.size());
-                });
-            break;
-        case EValueType::Double:
-            // No need to reserve by size for fixed-size arrays
-            Accessor = BuildTypedPlain<arrow::DoubleType>(Values, RecordIndexes, recordsCount, 0,
-                &ExtractDoubleScalar);
-            break;
-        case EValueType::Bool:
-            Accessor = BuildTypedPlain<arrow::BooleanType>(Values, RecordIndexes, recordsCount, 0,
-                &ExtractBoolScalar);
-            break;
+    TEncodingPlainBuilder builder(GetCodecForValueType(valueType), recordsCount, DataSize);
+    for (ui32 i = 0; i < RecordIndexes.size(); ++i) {
+        builder.AddFromBinaryJson(RecordIndexes[i], Values[i]);
     }
+    Accessor = builder.Finish(recordsCount);
 }
 
 void TColumnElements::BuildDictionaryAccessor(const ui32 recordsCount, const EValueType valueType) {
     BuildPlainAccessor(recordsCount, valueType);
-    const TChunkConstructionData cData(
-        recordsCount, nullptr, GetArrowTypeForValueType(valueType), NSerialization::TSerializerContainer::GetDefaultSerializer());
+    const TChunkConstructionData cData(recordsCount, nullptr, GetCodecForValueType(valueType)->GetArrowType(),
+        NSerialization::TSerializerContainer::GetDefaultSerializer());
     Accessor = NDictionary::TConstructor().Construct(Accessor, cData).DetachResult();
 }
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.h
@@ -192,10 +192,8 @@ public:
             if (separateColumns && settings.GetEnableNativeColumnsResolved()) {
                 valueType = DetectValueTypeForArray(i->GetValues());
             }
-            IChunkedArray::EType accessorType = IChunkedArray::EType::Array;
-            if (settings.IsSparsed(presentCount, recordsCount)) {
-                accessorType = IChunkedArray::EType::SparsedArray;
-            } else if (separateColumns && GetCodecForValueType(valueType)->CanBeDictionaryEncoded() &&
+            auto accessorType = settings.IsSparsed(presentCount, recordsCount) ? IChunkedArray::EType::SparsedArray : IChunkedArray::EType::Array;
+            if (separateColumns && CanBeDictionaryEncoded(valueType) &&
                        settings.IsDictionary(presentCount, enumerateValues)) {
                 accessorType = IChunkedArray::EType::Dictionary;
             }

--- a/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.h
@@ -195,7 +195,7 @@ public:
             IChunkedArray::EType accessorType = IChunkedArray::EType::Array;
             if (settings.IsSparsed(presentCount, recordsCount)) {
                 accessorType = IChunkedArray::EType::SparsedArray;
-            } else if (separateColumns && DictionaryApplicableForValueType(valueType) &&
+            } else if (separateColumns && GetCodecForValueType(valueType)->CanBeDictionaryEncoded() &&
                        settings.IsDictionary(presentCount, enumerateValues)) {
                 accessorType = IChunkedArray::EType::Dictionary;
             }

--- a/ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "types.h"
+
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
+#include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
+
+#include <ydb/library/actors/core/log.h>
+
+#include <yql/essentials/types/binary_json/format.h>
+
+// Subcolumn builders that either copy an arrow-native value or decode one from BinaryJson.
+namespace NKikimr::NArrow::NAccessor::NSubColumns {
+
+class TEncodingPlainBuilder: public TTrivialArray::TPlainBuilderBase {
+private:
+    std::shared_ptr<const IValueArrowCodec> Codec;
+
+public:
+    TEncodingPlainBuilder(const std::shared_ptr<const IValueArrowCodec>& codec, const ui32 reserveItems, const ui32 reserveData)
+        : TPlainBuilderBase(codec->MakeBuilder(reserveItems, reserveData))
+        , Codec(codec)
+    {
+    }
+
+    void AddFromBinaryJson(const ui32 recordIndex, const NBinaryJson::TBinaryJson& blob) {
+        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { Codec->AppendFromBinaryJson(builder, blob); });
+    }
+
+    void AddArrayElement(const ui32 recordIndex, const arrow::Array& array, const ui32 position) {
+        AFL_VERIFY(GetBuilder().type()->id() == array.type_id())("builder", GetBuilder().type()->ToString())("array", array.type()->ToString());
+        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AFL_VERIFY(NArrow::Append(builder, array, position)); });
+    }
+};
+
+class TEncodingSparsedBuilder: public TSparsedArray::TSparsedBuilderBase {
+private:
+    std::shared_ptr<const IValueArrowCodec> Codec;
+
+public:
+    TEncodingSparsedBuilder(const std::shared_ptr<const IValueArrowCodec>& codec, const ui32 reserveItems, const ui32 reserveData)
+        : TSparsedBuilderBase(codec->MakeBuilder(reserveItems, reserveData), codec->GetArrowType(), nullptr, reserveItems)
+        , Codec(codec)
+    {
+    }
+
+    void AddFromBinaryJson(const ui32 recordIndex, const NBinaryJson::TBinaryJson& blob) {
+        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { Codec->AppendFromBinaryJson(builder, blob); });
+    }
+
+    void AddArrayElement(const ui32 recordIndex, const arrow::Array& array, const ui32 position) {
+        AFL_VERIFY(GetValueBuilder().type()->id() == array.type_id())("builder", GetValueBuilder().type()->ToString())("array", array.type()->ToString());
+        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AFL_VERIFY(NArrow::Append(builder, array, position)); });
+    }
+};
+
+}   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/iterators.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/iterators.cpp
@@ -5,7 +5,7 @@ namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 NJson::TJsonValue TGeneralIterator::GetValue() const {
     AFL_VERIFY(IsValidFlag);
-    return ArrayElementToJsonValue(*CurrentArray, LocalIndex, ValueType);
+    return Codec->ReadValueView(*CurrentArray, LocalIndex).ToJsonValue();
 }
 
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/iterators.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/iterators.h
@@ -15,10 +15,10 @@ private:
     bool IsValidFlag = false;
     bool HasValueFlag = false;
     bool IsColumnKeyFlag = false;
-    EValueType ValueType = EValueType::BinaryJson;
-    // Current value as (array, local index); the reader interprets it per ValueType.
+    std::shared_ptr<const IValueArrowCodec> Codec;
+    // Current physical position as (array, local index)
     const arrow::Array* CurrentArray = nullptr;
-    i64 LocalIndex = 0;
+    ui32 LocalIndex = 0;
 
     void InitFromIterator(const TColumnsData::TIterator& iterator) {
         RecordIndex = iterator.GetCurrentRecordIndex();
@@ -72,12 +72,14 @@ public:
     TGeneralIterator(TColumnsData::TIterator&& iterator, const EValueType valueType, const std::optional<ui32> remappedKey = {})
         : Iterator(iterator)
         , RemappedKey(remappedKey)
-        , ValueType(valueType) {
+        , Codec(GetCodecForValueType(valueType)) {
         Initialize();
     }
+
     TGeneralIterator(TOthersData::TIterator&& iterator, const std::vector<ui32>& remapKeys = {})
         : Iterator(iterator)
-        , RemapKeys(remapKeys) {
+        , RemapKeys(remapKeys)
+        , Codec(GetCodecForValueType(EValueType::BinaryJson)) {
         Initialize();
     }
     bool IsColumnKey() const {
@@ -159,28 +161,23 @@ public:
     // Re-encode the current value to BinaryJson.
     NBinaryJson::TBinaryJson GetValueAsBinaryJson() const {
         AFL_VERIFY(IsValidFlag);
-        return ArrayElementToBinaryJson(*CurrentArray, LocalIndex, ValueType);
+        return Codec->ReadValueView(*CurrentArray, LocalIndex).ToBinaryJson();
     }
 
     EValueType GetValueType() const {
-        return ValueType;
+        return Codec->GetValueType();
     }
     const arrow::Array& GetArray() const {
         AFL_VERIFY(IsValidFlag);
         return *CurrentArray;
     }
-    i64 GetLocalIndex() const {
+    ui32 GetLocalIndex() const {
+        AFL_VERIFY(IsValidFlag);
         return LocalIndex;
     }
     ui32 GetValueSize() const {
         AFL_VERIFY(IsValidFlag);
-        return ArrayElementSize(*CurrentArray, LocalIndex, ValueType);
-    }
-    TStringBuf GetStorageView() const {
-        AFL_VERIFY(IsValidFlag);
-        AFL_VERIFY(ValueType == EValueType::String || ValueType == EValueType::BinaryJson)("value_type", (ui32)ValueType);
-        const auto view = static_cast<const arrow::BinaryArray&>(*CurrentArray).GetView(LocalIndex);
-        return TStringBuf(view.data(), view.size());
+        return Codec->GetElementSize(*CurrentArray, LocalIndex);
     }
 
     NJson::TJsonValue GetValue() const;

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -139,6 +139,7 @@ void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {
         return;
     }
 
+    const auto codec = GetCodecForValueType(ValueType);
     ChunkedArrayAccessor->VisitValues([&](std::shared_ptr<arrow::Array> arr) {
         AFL_VERIFY(arr);
         for (int64_t i = 0; i < arr->length(); ++i) {
@@ -147,7 +148,7 @@ void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {
                 continue;
             }
 
-            const auto value = ArrayElementToJsonValueView(*arr, i, ValueType);
+            const auto value = codec->ReadValueView(*arr, i);
             if (auto scalar = value.GetScalarOptional()) {
                 // A scalar has no sub-structure, so a remaining path cannot resolve against it.
                 visitor(RemainingPathPtr ? std::nullopt : scalar);

--- a/ydb/core/formats/arrow/accessor/sub_columns/others_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/others_storage.h
@@ -123,7 +123,7 @@ public:
             AFL_VERIFY(IsValid());
             return *Values;
         }
-        i64 GetLocalIndex() const {
+        ui32 GetLocalIndex() const {
             AFL_VERIFY(IsValid());
             return CurrentIndex;
         }

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -194,7 +194,7 @@ public:
     std::shared_ptr<arrow::Field> GetField(const ui32 index) const {
         AFL_VERIFY(index < DataNames->length());
         auto name = DataNames->GetView(index);
-        return std::make_shared<arrow::Field>(std::string(name.data(), name.size()), GetArrowTypeForValueType(GetValueType(index)));
+        return std::make_shared<arrow::Field>(std::string(name.data(), name.size()), GetCodecForValueType(GetValueType(index))->GetArrowType());
     }
 
     TRTStats GetRTStats(const ui32 index) const {
@@ -240,7 +240,6 @@ public:
         return result;
     }
 
-    bool IsSparsed(const ui32 columnIndex, const ui32 recordsCount, const TSettings& settings) const;
     TDictStats(const std::shared_ptr<arrow::RecordBatch>& original);
 };
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -3,22 +3,29 @@
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_binary.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_primitive.h>
 
-#include <library/cpp/json/json_reader.h>
-#include <library/cpp/json/json_writer.h>
-
 #include <ydb/library/actors/core/log.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
+#include <ydb/library/formats/arrow/switch/switch_type.h>
 
 #include <yql/essentials/types/binary_json/read.h>
-#include <yql/essentials/types/binary_json/write.h>
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 namespace {
 
-NBinaryJson::TBinaryJson ToBinaryJson(const NJson::TJsonValue& json) {
-    auto result = NBinaryJson::SerializeToBinaryJson(NJson::WriteJson(&json, false));
-    AFL_VERIFY(std::holds_alternative<NBinaryJson::TBinaryJson>(result));
-    return std::get<NBinaryJson::TBinaryJson>(std::move(result));
+TStringBuf ExtractStringScalar(const NBinaryJson::TBinaryJson& blob) {
+    auto reader = NBinaryJson::TBinaryJsonReader::Make(blob);
+    return reader->GetRootCursor().GetElement(0).GetString();
+}
+
+double ExtractDoubleScalar(const NBinaryJson::TBinaryJson& blob) {
+    auto reader = NBinaryJson::TBinaryJsonReader::Make(blob);
+    return reader->GetRootCursor().GetElement(0).GetNumber();
+}
+
+bool ExtractBoolScalar(const NBinaryJson::TBinaryJson& blob) {
+    auto reader = NBinaryJson::TBinaryJsonReader::Make(blob);
+    return reader->GetRootCursor().GetElement(0).GetType() == NBinaryJson::EEntryType::BoolTrue;
 }
 
 EValueType ValueTypeForItem(const NBinaryJson::TBinaryJson& blob) {
@@ -41,27 +48,105 @@ EValueType ValueTypeForItem(const NBinaryJson::TBinaryJson& blob) {
     }
 }
 
-}   // namespace
-
-std::shared_ptr<arrow::DataType> GetArrowTypeForValueType(const EValueType valueType) {
-    switch (valueType) {
-        case EValueType::BinaryJson:
-        case EValueType::String:
-            return arrow::binary();
-        case EValueType::Double:
-            return arrow::float64();
-        case EValueType::Bool:
-            return arrow::boolean();
-    }
+TStringBuf BinaryView(const arrow::Array& array, const i64 index) {
+    AFL_VERIFY(array.type()->id() == arrow::Type::BINARY);
+    const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
+    return TStringBuf(view.data(), view.size());
 }
 
-bool DictionaryApplicableForValueType(const EValueType valueType) {
+// BinaryJson and String share arrow::binary() storage; they differ only in what the bytes mean.
+class TBinaryBackedCodec: public IValueArrowCodec {
+public:
+    std::shared_ptr<arrow::DataType> GetArrowType() const override {
+        return arrow::binary();
+    }
+    bool CanBeDictionaryEncoded() const override {
+        return true;
+    }
+    ui32 GetElementSize(const arrow::Array& array, const i64 index) const override {
+        return BinaryView(array, index).size();
+    }
+    std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const override {
+        return NArrow::MakeBuilder(arrow::binary(), reserveItems, reserveData);
+    }
+};
+
+class TBinaryJsonCodec: public TBinaryBackedCodec {
+public:
+    EValueType GetValueType() const override {
+        return EValueType::BinaryJson;
+    }
+    TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const override {
+        return TJsonValueView::OfBinaryJson(BinaryView(array, index));
+    }
+    void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
+        AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(blob.data(), blob.size())));
+    }
+};
+
+class TStringCodec: public TBinaryBackedCodec {
+public:
+    EValueType GetValueType() const override {
+        return EValueType::String;
+    }
+    TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const override {
+        return TJsonValueView::OfString(BinaryView(array, index));
+    }
+    void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
+        const auto scalar = ExtractStringScalar(blob);
+        AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(scalar.data(), scalar.size())));
+    }
+};
+
+template <class TArrow, EValueType ValueType, auto ExtractScalar, auto MakeView>
+class TNativeScalarCodec: public IValueArrowCodec {
+private:
+    using TArray = typename arrow::TypeTraits<TArrow>::ArrayType;
+
+public:
+    EValueType GetValueType() const override {
+        return ValueType;
+    }
+    std::shared_ptr<arrow::DataType> GetArrowType() const override {
+        return arrow::TypeTraits<TArrow>::type_singleton();
+    }
+    bool CanBeDictionaryEncoded() const override {
+        return false;
+    }
+    ui32 GetElementSize(const arrow::Array& /*array*/, const i64 /*index*/) const override {
+        return sizeof(typename TArrow::c_type);
+    }
+    TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const override {
+        AFL_VERIFY(array.type()->id() == TArrow::type_id);
+        return MakeView(static_cast<const TArray&>(array).Value(index));
+    }
+    std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 /*reserveData*/) const override {
+        return NArrow::MakeBuilder(arrow::TypeTraits<TArrow>::type_singleton(), reserveItems, 0);
+    }
+    void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
+        AFL_VERIFY(NArrow::Append<TArrow>(builder, ExtractScalar(blob)));
+    }
+};
+
+using TDoubleCodec = TNativeScalarCodec<arrow::DoubleType, EValueType::Double, ExtractDoubleScalar, TJsonValueView::OfNumber>;
+using TBoolCodec = TNativeScalarCodec<arrow::BooleanType, EValueType::Bool, ExtractBoolScalar, TJsonValueView::OfBool>;
+
+}   // namespace
+
+std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType) {
+    static const std::shared_ptr<const IValueArrowCodec> binaryJson = std::make_shared<TBinaryJsonCodec>();
+    static const std::shared_ptr<const IValueArrowCodec> string = std::make_shared<TStringCodec>();
+    static const std::shared_ptr<const IValueArrowCodec> doubleValue = std::make_shared<TDoubleCodec>();
+    static const std::shared_ptr<const IValueArrowCodec> boolValue = std::make_shared<TBoolCodec>();
     switch (valueType) {
         case EValueType::BinaryJson:
+            return binaryJson;
         case EValueType::String:
-            return true;
-        default:
-            return false;
+            return string;
+        case EValueType::Double:
+            return doubleValue;
+        case EValueType::Bool:
+            return boolValue;
     }
 }
 
@@ -81,84 +166,6 @@ EValueType DetectValueTypeForArray(const std::deque<NBinaryJson::TBinaryJson>& v
         }
     }
     return common.value_or(EValueType::BinaryJson);
-}
-
-TStringBuf ExtractStringScalar(const NBinaryJson::TBinaryJson& blob) {
-    auto reader = NBinaryJson::TBinaryJsonReader::Make(blob);
-    return reader->GetRootCursor().GetElement(0).GetString();
-}
-
-double ExtractDoubleScalar(const NBinaryJson::TBinaryJson& blob) {
-    auto reader = NBinaryJson::TBinaryJsonReader::Make(blob);
-    return reader->GetRootCursor().GetElement(0).GetNumber();
-}
-
-bool ExtractBoolScalar(const NBinaryJson::TBinaryJson& blob) {
-    auto reader = NBinaryJson::TBinaryJsonReader::Make(blob);
-    return reader->GetRootCursor().GetElement(0).GetType() == NBinaryJson::EEntryType::BoolTrue;
-}
-
-NJson::TJsonValue ArrayElementToJsonValue(const arrow::Array& array, const i64 index, const EValueType valueType) {
-    switch (valueType) {
-        case EValueType::String: {
-            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
-            return NJson::TJsonValue(TStringBuf(view.data(), view.size()));
-        }
-        case EValueType::Double:
-            return NJson::TJsonValue(static_cast<const arrow::DoubleArray&>(array).Value(index));
-        case EValueType::Bool:
-            return NJson::TJsonValue(static_cast<const arrow::BooleanArray&>(array).Value(index));
-        case EValueType::BinaryJson: {
-            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
-            const auto text = NBinaryJson::SerializeToJson(TStringBuf(view.data(), view.size()));
-            NJson::TJsonValue result;
-            AFL_VERIFY(NJson::ReadJsonTree(text, &result));
-            return result;
-        }
-    }
-}
-
-NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, const i64 index, const EValueType valueType) {
-    switch (valueType) {
-        case EValueType::BinaryJson: {
-            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
-            return NBinaryJson::TBinaryJson(view.data(), view.size());
-        }
-        case EValueType::String:
-        case EValueType::Double:
-        case EValueType::Bool:
-            return ToBinaryJson(ArrayElementToJsonValue(array, index, valueType));
-    }
-}
-
-TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType) {
-    switch (valueType) {
-        case EValueType::String: {
-            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
-            return TJsonValueView::OfString(TStringBuf(view.data(), view.size()));
-        }
-        case EValueType::Double:
-            return TJsonValueView::OfNumber(static_cast<const arrow::DoubleArray&>(array).Value(index));
-        case EValueType::Bool:
-            return TJsonValueView::OfBool(static_cast<const arrow::BooleanArray&>(array).Value(index));
-        case EValueType::BinaryJson: {
-            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
-            return TJsonValueView::OfBinaryJson(TStringBuf(view.data(), view.size()));
-        }
-    }
-}
-
-ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType) {
-    switch (valueType) {
-        case EValueType::BinaryJson:
-        case EValueType::String:
-            return static_cast<const arrow::BinaryArray&>(array).GetView(index).size();
-        case EValueType::Double:
-            return sizeof(double);
-        case EValueType::Bool:
-            // actually only 1 bit in arrow representation, not 1 byte, but let's not overcomplicate things
-            return 1;
-    }
 }
 
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -60,9 +60,6 @@ public:
     std::shared_ptr<arrow::DataType> GetArrowType() const override {
         return arrow::binary();
     }
-    bool CanBeDictionaryEncoded() const override {
-        return true;
-    }
     ui32 GetElementSize(const arrow::Array& array, const i64 index) const override {
         return BinaryView(array, index).size();
     }
@@ -110,9 +107,6 @@ public:
     std::shared_ptr<arrow::DataType> GetArrowType() const override {
         return arrow::TypeTraits<TArrow>::type_singleton();
     }
-    bool CanBeDictionaryEncoded() const override {
-        return false;
-    }
     ui32 GetElementSize(const arrow::Array& /*array*/, const i64 /*index*/) const override {
         return sizeof(typename TArrow::c_type);
     }
@@ -132,6 +126,10 @@ using TDoubleCodec = TNativeScalarCodec<arrow::DoubleType, EValueType::Double, E
 using TBoolCodec = TNativeScalarCodec<arrow::BooleanType, EValueType::Bool, ExtractBoolScalar, TJsonValueView::OfBool>;
 
 }   // namespace
+
+bool CanBeDictionaryEncoded(EValueType valueType) {
+    return valueType == EValueType::BinaryJson || valueType == EValueType::String;
+}
 
 std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType) {
     static const std::shared_ptr<const IValueArrowCodec> binaryJson = std::make_shared<TBinaryJsonCodec>();

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.h
@@ -24,8 +24,8 @@ public:
     virtual bool CanBeDictionaryEncoded() const = 0;
 
     // Read path - wrap the physical element `index` as a logical value view (a native scalar for
-    // Double/Bool/String, or a BinaryJson blob for BinaryJson). The view aliases `array`, which must
-    // outlive it; all logical conversions (scalar projection, ToJsonValue, ToBinaryJson) live on the view.
+    // Double/Bool/String, or a BinaryJson blob for BinaryJson).
+    // The view aliases `array`, which must outlive it.
     virtual TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const = 0;
     // Approximate size of element `index` for accounting: variable for binary values, fixed for scalar types.
     virtual ui32 GetElementSize(const arrow::Array& array, const i64 index) const = 0;

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.h
@@ -5,43 +5,42 @@
 #include <deque>
 
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/array_base.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_base.h>
 #include <ydb/core/formats/arrow/accessor/common/json_value_view.h>
 
 #include <library/cpp/json/writer/json_value.h>
 
 #include <yql/essentials/types/binary_json/format.h>
 
-// Type conversions between BinaryJson, dedicated scalar types and arrow storage types.
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
-std::shared_ptr<arrow::DataType> GetArrowTypeForValueType(const EValueType valueType);
+// Conversion between physical arrow storage and logical JsonValue/BinaryJson in-program representation
+class IValueArrowCodec {
+public:
+    virtual ~IValueArrowCodec() = default;
 
+    virtual EValueType GetValueType() const = 0;
+    virtual std::shared_ptr<arrow::DataType> GetArrowType() const = 0;
+    virtual bool CanBeDictionaryEncoded() const = 0;
 
-// Dictionary encoding only enabled for the binary-backed types (BinaryJson blobs and raw strings).
-// Integral types would trade fixed-size position in array for fixed-size dictionary ref.
-// May still be good for compression, but requires further experiments.
-bool DictionaryApplicableForValueType(const EValueType valueType);
+    // Read path - wrap the physical element `index` as a logical value view (a native scalar for
+    // Double/Bool/String, or a BinaryJson blob for BinaryJson). The view aliases `array`, which must
+    // outlive it; all logical conversions (scalar projection, ToJsonValue, ToBinaryJson) live on the view.
+    virtual TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const = 0;
+    // Approximate size of element `index` for accounting: variable for binary values, fixed for scalar types.
+    virtual ui32 GetElementSize(const arrow::Array& array, const i64 index) const = 0;
+
+    // Write path - initialize builder and write values to it.
+    // reserveData makes sense only for variable-length types (BinaryJson and string).
+    virtual std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const = 0;
+    virtual void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const = 0;
+};
+
+std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType);
 
 // Element type to represent result of merging arrays with arg types
 EValueType MergeValueTypes(const std::optional<EValueType>& acc, const EValueType next);
 
 EValueType DetectValueTypeForArray(const std::deque<NBinaryJson::TBinaryJson>& values);
-
-// Convert json blob to its contained scalar.
-// Fail on verify if blob is not of specified type.
-TStringBuf ExtractStringScalar(const NBinaryJson::TBinaryJson& blob);
-double ExtractDoubleScalar(const NBinaryJson::TBinaryJson& blob);
-bool ExtractBoolScalar(const NBinaryJson::TBinaryJson& blob);
-
-// Read element `index` of a materialized native column array (interpreted per valueType) as a JSON
-// value (document reconstruction) or a BinaryJson blob. The array's physical arrow type must match valueType.
-NJson::TJsonValue ArrayElementToJsonValue(const arrow::Array& array, const i64 index, const EValueType valueType);
-NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, const i64 index, const EValueType valueType);
-
-// Wrap element `index` as a logical value view: a native scalar for Double/Bool/String, or a BinaryJson
-// blob for BinaryJson. The returned view aliases `array`, which must outlive it.
-TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType);
-
-ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType);
 
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.h
@@ -21,7 +21,6 @@ public:
 
     virtual EValueType GetValueType() const = 0;
     virtual std::shared_ptr<arrow::DataType> GetArrowType() const = 0;
-    virtual bool CanBeDictionaryEncoded() const = 0;
 
     // Read path - wrap the physical element `index` as a logical value view (a native scalar for
     // Double/Bool/String, or a BinaryJson blob for BinaryJson).
@@ -35,6 +34,8 @@ public:
     virtual std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const = 0;
     virtual void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const = 0;
 };
+
+bool CanBeDictionaryEncoded(EValueType valueType);
 
 std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType);
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sparsed.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_sparsed.cpp
@@ -1,0 +1,64 @@
+#include <ydb/core/formats/arrow/accessor/sub_columns/direct_builder.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/types.h>
+
+#include <contrib/libs/apache/arrow/cpp/src/arrow/chunked_array.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <yql/essentials/types/binary_json/write.h>
+
+Y_UNIT_TEST_SUITE(SubColumnsSparsedBuilder) {
+    using namespace NKikimr;
+    using namespace NKikimr::NArrow;
+    using namespace NKikimr::NArrow::NAccessor;
+    using namespace NKikimr::NArrow::NAccessor::NSubColumns;
+
+    NBinaryJson::TBinaryJson ToBinaryJson(const TString& json) {
+        auto v = NBinaryJson::SerializeToBinaryJson(json);
+        auto* bj = std::get_if<NBinaryJson::TBinaryJson>(&v);
+        UNIT_ASSERT(bj);
+        return *bj;
+    }
+
+    std::shared_ptr<IChunkedArray> BuildColumn(
+        const std::vector<std::pair<ui32, TString>>& data, const ui32 recordsCount, const EValueType vt, const bool sparsed) {
+        TColumnElements col("k");
+        for (auto&& [idx, json] : data) {
+            col.AddData(ToBinaryJson(json), idx);
+        }
+        if (sparsed) {
+            col.BuildSparsedAccessor(recordsCount, vt);
+        } else {
+            col.BuildPlainAccessor(recordsCount, vt);
+        }
+        return col.GetAccessorVerified();
+    }
+
+    void CheckSparsedMatchesPlain(
+        const std::vector<std::pair<ui32, TString>>& data, const ui32 recordsCount, const EValueType vt) {
+        auto sparsed = BuildColumn(data, recordsCount, vt, true);
+        auto plain = BuildColumn(data, recordsCount, vt, false);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)sparsed->GetType(), (ui32)IChunkedArray::EType::SparsedArray);
+        UNIT_ASSERT_VALUES_EQUAL((ui32)plain->GetType(), (ui32)IChunkedArray::EType::Array);
+        UNIT_ASSERT_VALUES_EQUAL(sparsed->GetRecordsCount(), recordsCount);
+        UNIT_ASSERT_VALUES_EQUAL(plain->GetRecordsCount(), recordsCount);
+        auto sc = sparsed->GetChunkedArray();
+        auto pc = plain->GetChunkedArray();
+        UNIT_ASSERT_C(sc->Equals(pc), TStringBuilder() << "sparsed=" << sc->ToString() << " plain=" << pc->ToString());
+    }
+
+    Y_UNIT_TEST(StringMatchesPlain) {
+        CheckSparsedMatchesPlain({ { 1, R"("x")" }, { 4, R"("yy")" }, { 7, R"("zzz")" } }, 10, EValueType::String);
+    }
+
+    Y_UNIT_TEST(DoubleMatchesPlain) {
+        CheckSparsedMatchesPlain({ { 0, "3.5" }, { 2, "-2" }, { 9, "1000000" } }, 10, EValueType::Double);
+    }
+
+    Y_UNIT_TEST(BoolMatchesPlain) {
+        CheckSparsedMatchesPlain({ { 3, "true" }, { 5, "false" } }, 8, EValueType::Bool);
+    }
+
+    Y_UNIT_TEST(BinaryJsonMatchesPlain) {
+        CheckSparsedMatchesPlain({ { 1, R"([1,2])" }, { 2, R"({"a":1})" } }, 5, EValueType::BinaryJson);
+    }
+}

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ya.make
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ya.make
@@ -13,6 +13,7 @@ SRCS(
     ut_sub_columns.cpp
     ut_native_scalars.cpp
     ut_dictionary.cpp
+    ut_sparsed.cpp
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
@@ -13,7 +13,7 @@ namespace NKikimr::NOlap::NCompaction::NSubColumns {
 
 std::shared_ptr<NArrow::NAccessor::IChunkedArray> TMergedBuilder::MaybeDictionaryEncode(
     const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& accessor, const ui32 filledRecordsCount, const EValueType valueType) const {
-    if (!NArrow::NAccessor::NSubColumns::GetCodecForValueType(valueType)->CanBeDictionaryEncoded()) {
+    if (!NArrow::NAccessor::NSubColumns::CanBeDictionaryEncoded(valueType)) {
         return accessor;
     }
     const auto enumerateNotNull = [&accessor](const auto& consumer) {

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
@@ -13,7 +13,7 @@ namespace NKikimr::NOlap::NCompaction::NSubColumns {
 
 std::shared_ptr<NArrow::NAccessor::IChunkedArray> TMergedBuilder::MaybeDictionaryEncode(
     const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& accessor, const ui32 filledRecordsCount, const EValueType valueType) const {
-    if (!NArrow::NAccessor::NSubColumns::DictionaryApplicableForValueType(valueType)) {
+    if (!NArrow::NAccessor::NSubColumns::GetCodecForValueType(valueType)->CanBeDictionaryEncoded()) {
         return accessor;
     }
     const auto enumerateNotNull = [&accessor](const auto& consumer) {
@@ -85,12 +85,11 @@ void TMergedBuilder::Initialize() {
         switch (ResultColumnStats.GetAccessorType(i)) {
             case NArrow::NAccessor::IChunkedArray::EType::Array:
                 ColumnBuilders.emplace_back(
-                    TPlainRuntimeBuilder(NArrow::NAccessor::NSubColumns::GetArrowTypeForValueType(valueType)), valueType);
+                    TEncodingPlainBuilder(NArrow::NAccessor::NSubColumns::GetCodecForValueType(valueType), 0, 0), valueType);
                 break;
             case NArrow::NAccessor::IChunkedArray::EType::SparsedArray:
-                // Native scalars are never sparsed, so a sparsed column is always binary-backed.
-                AFL_VERIFY(valueType == EValueType::BinaryJson || valueType == EValueType::String)("value_type", (ui32)valueType);
-                ColumnBuilders.emplace_back(TSparsedBuilder(nullptr, 0, 0), valueType);
+                ColumnBuilders.emplace_back(
+                    TEncodingSparsedBuilder(NArrow::NAccessor::NSubColumns::GetCodecForValueType(valueType), 0, 0), valueType);
                 break;
             case NArrow::NAccessor::IChunkedArray::EType::Undefined:
             case NArrow::NAccessor::IChunkedArray::EType::SerializedChunkedArray:

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.h
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.h
@@ -1,9 +1,8 @@
 #pragma once
 #include "remap.h"
 
-#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
-#include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/accessor.h>
+#include <ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h>
 #include <ydb/core/formats/arrow/accessor/sub_columns/settings.h>
 #include <ydb/core/tx/columnshard/engines/changes/compaction/abstract/merger.h>
 #include <ydb/core/tx/columnshard/engines/storage/chunks/column.h>
@@ -12,7 +11,8 @@ namespace NKikimr::NOlap::NCompaction::NSubColumns {
 
 class TMergedBuilder {
 private:
-    using TSparsedBuilder = NArrow::NAccessor::TSparsedArray::TSparsedBuilder<arrow::BinaryType>;
+    using TEncodingSparsedBuilder = NArrow::NAccessor::NSubColumns::TEncodingSparsedBuilder;
+    using TEncodingPlainBuilder = NArrow::NAccessor::NSubColumns::TEncodingPlainBuilder;
     using TColumnsData = NArrow::NAccessor::NSubColumns::TColumnsData;
     using TOthersData = NArrow::NAccessor::NSubColumns::TOthersData;
     using TSettings = NArrow::NAccessor::NSubColumns::TSettings;
@@ -29,106 +29,39 @@ private:
     const TSettings Settings;
     const TRemapColumns& Remapper;
 
-    // A plain array builder whose element type is chosen at construction type.
-    // Commonality with TPlainBuilder to be refactored.
-    class TPlainRuntimeBuilder {
-    private:
-        std::unique_ptr<arrow::ArrayBuilder> Builder;
-        std::optional<ui32> LastRecordIndex;
-
-        void AppendGapNulls(const ui32 recordIndex) {
-            if (LastRecordIndex) {
-                AFL_VERIFY(*LastRecordIndex < recordIndex)("last", LastRecordIndex)("index", recordIndex);
-                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordIndex - *LastRecordIndex - 1));
-            } else {
-                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordIndex));
-            }
-            LastRecordIndex = recordIndex;
-        }
-
-    public:
-        TPlainRuntimeBuilder(const std::shared_ptr<arrow::DataType>& type)
-            : Builder(NArrow::MakeBuilder(type))
-        {
-        }
-
-        void AddNativeValue(const ui32 recordIndex, const arrow::Array& array, const i64 position) {
-            AFL_VERIFY(Builder->type()->id() == array.type_id())("builder", Builder->type()->ToString())("array", array.type()->ToString());
-            AppendGapNulls(recordIndex);
-            AFL_VERIFY(NArrow::Append(*Builder, array, position));
-        }
-
-        void AddBinaryValue(const ui32 recordIndex, const TStringBuf value) {
-            AFL_VERIFY(Builder->type()->id() == arrow::Type::BINARY)("type", Builder->type()->ToString());
-            AppendGapNulls(recordIndex);
-            AFL_VERIFY(NArrow::Append<arrow::BinaryType>(*Builder, arrow::util::string_view(value.data(), value.size())));
-        }
-
-        std::shared_ptr<NArrow::NAccessor::IChunkedArray> Finish(const ui32 recordsCount) {
-            if (LastRecordIndex) {
-                AFL_VERIFY(*LastRecordIndex < recordsCount)("last", LastRecordIndex)("count", recordsCount);
-                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordsCount - *LastRecordIndex - 1));
-            } else {
-                NArrow::TStatusValidator::Validate(Builder->AppendNulls(recordsCount));
-            }
-            return std::make_shared<NArrow::NAccessor::TTrivialArray>(NArrow::FinishBuilder(std::move(Builder)));
-        }
-    };
-
     class TGeneralAccessorBuilder {
     private:
-        std::variant<TSparsedBuilder, TPlainRuntimeBuilder> Builder;
+        std::variant<TEncodingSparsedBuilder, TEncodingPlainBuilder> Builder;
         const EValueType TargetValueType;
         YDB_READONLY(ui32, FilledRecordsCount, 0);
         YDB_READONLY(ui64, FilledRecordsSize, 0);
 
     public:
-        TGeneralAccessorBuilder(TSparsedBuilder&& builder, const EValueType targetValueType)
+        TGeneralAccessorBuilder(TEncodingSparsedBuilder&& builder, const EValueType targetValueType)
             : Builder(std::move(builder))
             , TargetValueType(targetValueType)
         {
         }
 
-        TGeneralAccessorBuilder(TPlainRuntimeBuilder&& builder, const EValueType targetValueType)
+        TGeneralAccessorBuilder(TEncodingPlainBuilder&& builder, const EValueType targetValueType)
             : Builder(std::move(builder))
             , TargetValueType(targetValueType)
         {
         }
 
-        // Returns the number of value bytes actually stored, since a re-encoded value's stored size differs from its size in the source.
+        // Returns the number of value bytes actually stored, since a re-encoded value's stored size differs from its
+        // size in the source. Both builders share the same interface, so one generic visitor covers both.
         ui32 AddRecord(const ui32 recordIndex, const TGeneralIterator& it) {
             const bool passthrough = it.GetValueType() == TargetValueType;
-
-            struct TVisitor {
-                const ui32 RecordIndex;
-                const TGeneralIterator& It;
-                const bool Passthrough;
-
-                ui32 operator()(TSparsedBuilder& builder) const {
-                    // Sparsed columns are always binary-backed, so the passthrough value is its storage bytes.
-                    if (Passthrough) {
-                        builder.AddRecord(RecordIndex, It.GetStorageView());
-                        return It.GetValueSize();
-                    } else {
-                        const auto bj = It.GetValueAsBinaryJson();
-                        builder.AddRecord(RecordIndex, TStringBuf(bj.data(), bj.size()));
-                        return bj.size();
-                    }
+            const ui32 storedSize = std::visit([&](auto& builder) -> ui32 {
+                if (passthrough) {
+                    builder.AddArrayElement(recordIndex, it.GetArray(), it.GetLocalIndex());
+                    return it.GetValueSize();
                 }
-
-                ui32 operator()(TPlainRuntimeBuilder& builder) const {
-                    if (Passthrough) {
-                        builder.AddNativeValue(RecordIndex, It.GetArray(), It.GetLocalIndex());
-                        return It.GetValueSize();
-                    } else {
-                        const auto bj = It.GetValueAsBinaryJson();
-                        builder.AddBinaryValue(RecordIndex, TStringBuf(bj.data(), bj.size()));
-                        return bj.size();
-                    }
-                }
-            };
-
-            const ui32 storedSize = std::visit(TVisitor{ recordIndex, it, passthrough }, Builder);
+                const auto bj = it.GetValueAsBinaryJson();
+                builder.AddFromBinaryJson(recordIndex, bj);
+                return bj.size();
+            }, Builder);
             ++FilledRecordsCount;
             FilledRecordsSize += storedSize;
             return storedSize;


### PR DESCRIPTION
IValueArrowCodec reads/writes json values into properly typed arrays.
TEncodingPlainBuilder/TEncodingSparsedBuilder with same interface are used for building and compacting subcolumns.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

