### PR TITLE
Fix create_issues_for_muted_tests false failures on closed PRs

### DIFF
--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -29,11 +29,7 @@ env:
 
 jobs:
   resolve-build-types:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'mute-unmute'))
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     outputs:
       base_branch: ${{ steps.resolve.outputs.base_branch }}
@@ -106,10 +102,9 @@ jobs:
     needs: resolve-build-types
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'mute-unmute'))
+      ((github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
+       github.event_name == 'workflow_dispatch')
     strategy:
       fail-fast: false
       matrix:
@@ -196,10 +191,9 @@ jobs:
     needs: [resolve-build-types, create-issues-for-muted-tests]
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.merged == true &&
-       contains(github.event.pull_request.labels.*.name, 'mute-unmute'))
+      ((github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
+       github.event_name == 'workflow_dispatch')
     steps:
       - name: Set environment variables for branches
         run: |

--- a/.github/workflows/create_issues_for_muted_tests.yml
+++ b/.github/workflows/create_issues_for_muted_tests.yml
@@ -25,10 +25,15 @@ on:
 
 env:
   GH_TOKEN: ${{ secrets.YDBOT_TOKEN }}
-  WORKFLOW_CHECKOUT_REF: ${{ github.ref_name }}
+  WORKFLOW_CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.pull_request.merge_commit_sha }}
 
 jobs:
   resolve-build-types:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'mute-unmute'))
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     outputs:
       base_branch: ${{ steps.resolve.outputs.base_branch }}
@@ -101,9 +106,10 @@ jobs:
     needs: resolve-build-types
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
-      ((github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
-       github.event_name == 'workflow_dispatch')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'mute-unmute'))
     strategy:
       fail-fast: false
       matrix:
@@ -190,9 +196,10 @@ jobs:
     needs: [resolve-build-types, create-issues-for-muted-tests]
     runs-on: [ self-hosted, auto-provisioned, build-preset-analytic-node]
     if: |
-      ((github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'mute-unmute')) ||
-       github.event_name == 'workflow_dispatch')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       contains(github.event.pull_request.labels.*.name, 'mute-unmute'))
     steps:
       - name: Set environment variables for branches
         run: |


### PR DESCRIPTION
## Summary

- Skip all jobs in `create_issues_for_muted_tests` unless the PR was actually merged with the `mute-unmute` label (or the workflow is dispatched manually).
- Checkout `merge_commit_sha` instead of the ephemeral `pull/N/merge` ref that GitHub deletes after close-without-merge.

This fixes false red checks like run [#29276682534](https://github.com/ydb-platform/ydb/actions/runs/29276682534), which was triggered by closing [#46376](https://github.com/ydb-platform/ydb/pull/46376) without merge and then failed on checkout of `46376/merge`.

## Test plan

- [ ] Close a PR to `main` without merge and without `mute-unmute` — workflow jobs should be skipped, no failed checkout.
- [ ] Merge a `mute-unmute` PR to `main` — workflow should run and checkout successfully.
- [ ] `workflow_dispatch` still works as before.


Made with [Cursor](https://cursor.com)