### PR TITLE
Revert: restore rebuild_docs on translation PRs (#46336)

### DIFF
--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -97,9 +97,9 @@ jobs:
               owner,
               repo,
               issue_number: translationPr.number,
-              labels: ['ok-to-test'],
+              labels: ['rebuild_docs', 'ok-to-test'],
             });
 
             core.info(
-              `Added ok-to-test to translation PR #${translationPr.number}`
+              `Added rebuild_docs and ok-to-test to translation PR #${translationPr.number}`
             );

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -59,8 +59,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
-              labels: ['ok-to-test'],
+              labels: ['ok-to-test', 'rebuild_docs'],
             });
             core.info(
-              `Added ok-to-test to translation PR #${prNumber}`
+              `Added ok-to-test and rebuild_docs to translation PR #${prNumber}`
             );


### PR DESCRIPTION
## Summary
Reverts #46336. Restores automatic `rebuild_docs` + `ok-to-test` labels on translation PRs after `doc_translate` / `doc_verify`.

## Why
`ok-to-test` is required for `checks_integrated` (merge gate on `main`). The #46336 experiment is rolled back to return to the previous CI behavior.

## Test plan
- [ ] Merge this revert
- [ ] `doc_translate` / `doc_verify` again add both labels to translation PR

Made with [Cursor](https://cursor.com)