### PR TITLE
Dispatch docs build after translation; ok-to-test only after doc_verify

### DIFF
--- a/.github/workflows/docs_preview.yaml
+++ b/.github/workflows/docs_preview.yaml
@@ -4,12 +4,12 @@ on:
   workflow_run:
     workflows:
       - Build documentation
-      - Rebuild documentation
     types:
       - completed
 
 jobs:
   post-build:
+    if: github.event.workflow_run.conclusion == 'success'
     permissions: write-all
     concurrency:
       group: preview-documentation-${{ github.event.workflow_run.id }}
@@ -18,7 +18,6 @@ jobs:
     steps:
       - name: Upload
         uses: diplodoc-platform/docs-upload-action@v1
-        if: github.event.workflow_run.conclusion == 'success'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           storage-endpoint: ${{ vars.DOCS_AWS_ENDPOINT }}

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -48,16 +48,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
 
-  trigger-translation-ci:
+  trigger-translation-docs-build:
     needs: ydbdoc-review
     if: ${{ !cancelled() && needs.ydbdoc-review.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger PR-check and docs rebuild on translation PR
+      - name: Dispatch docs build on translation PR
         uses: actions/github-script@v8
         with:
-          # PAT only here (no checkout): cascades into PR-check/docs rebuild without
-          # exposing YDBOT_TOKEN next to untrusted fork PR code.
+          # PAT only here (no checkout): dispatch docs build without exposing
+          # YDBOT_TOKEN next to untrusted fork PR code.
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
             const owner = context.repo.owner;
@@ -88,18 +88,23 @@ jobs:
 
             if (!translationPr) {
               core.warning(
-                `Open translation PR not found for head ${head}. Labels were not added; CI can be triggered manually.`
+                `Open translation PR not found for head ${head}. Docs build was not dispatched.`
               );
               return;
             }
 
-            await github.rest.issues.addLabels({
+            // Commits pushed by GITHUB_TOKEN require maintainer approval for
+            // pull_request workflows. workflow_dispatch bypasses that gate.
+            await github.rest.actions.createWorkflowDispatch({
               owner,
               repo,
-              issue_number: translationPr.number,
-              labels: ['ok-to-test'],
+              workflow_id: 'docs_build.yaml',
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pull_number: String(translationPr.number),
+              },
             });
 
             core.info(
-              `Added ok-to-test to translation PR #${translationPr.number}`
+              `Dispatched Build documentation for translation PR #${translationPr.number}`
             );

--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -49,18 +49,30 @@ jobs:
     if: ${{ !cancelled() && needs.ydbdoc-verify.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger PR-check and docs rebuild on translation PR
+      - name: Trigger PR-check and docs build on translation PR
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.YDBOT_TOKEN }}
           script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
             const prNumber = context.payload.pull_request.number;
+
             await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               issue_number: prNumber,
               labels: ['ok-to-test'],
             });
-            core.info(
-              `Added ok-to-test to translation PR #${prNumber}`
-            );
+            core.info(`Added ok-to-test to translation PR #${prNumber}`);
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'docs_build.yaml',
+              ref: context.payload.repository.default_branch,
+              inputs: {
+                pull_number: String(prNumber),
+              },
+            });
+            core.info(`Dispatched Build documentation for translation PR #${prNumber}`);


### PR DESCRIPTION
## Summary
- After `doc_translate`, dispatch `Build documentation` via `workflow_dispatch` instead of adding `ok-to-test` — avoids the GitHub approval gate on bot-pushed commits and skips premature PR-check runs.
- After `doc_verify`, add `ok-to-test` (for merge) and dispatch docs build the same way.
- Preview workflow listens only to successful `Build documentation` runs (no `Rebuild documentation`).

## Test plan
- [ ] Trigger `doc_translate` on a docs PR and confirm translation PR gets docs build + preview without "workflow awaiting approval".
- [ ] Confirm translation PR does **not** get `ok-to-test` until `doc_verify` completes.
- [ ] Trigger `doc_verify` on a translation PR and confirm `ok-to-test` + PR-check + docs build + preview.
- [ ] Manually apply `rebuild_docs` on a docs PR still works via `docs_build_rebuild.yaml`.


Made with [Cursor](https://cursor.com)