### PR TITLE
Fix solomon emulator point overwrite by timestamp

### DIFF
--- a/ydb/library/yql/tools/solomon_emulator/lib/shard.py
+++ b/ydb/library/yql/tools/solomon_emulator/lib/shard.py
@@ -48,9 +48,13 @@ class Shard(object):
         def __init__(self, labels, kind="DGAUGE", timestamps=[], values=[]):
             self.labels = labels
             self.kind = kind
-            self.data = []
+            self.points = {}
             for i in range(len(timestamps)):
-                self.data.append((int(timestamps[i] * 1000), values[i]))
+                self.add_point(int(timestamps[i] * 1000), values[i])
+
+        @property
+        def data(self):
+            return self.points.items()
 
         def match(self, selectors):
             for key, value in selectors.items():
@@ -73,7 +77,7 @@ class Shard(object):
             return True
 
         def add_point(self, ts, value):
-            self.data.append((ts, value))
+            self.points[ts] = value
 
     def __init__(self, project, cluster, service):
         self._project = project

--- a/ydb/tests/fq/solomon/scalar_write/test_scalar_solomon_write.py
+++ b/ydb/tests/fq/solomon/scalar_write/test_scalar_solomon_write.py
@@ -167,18 +167,18 @@ class TestScalarSolomonWriteInYdb(SolomonTestBase):
 
         kikimr.ydb_client.query(
             f"""INSERT INTO {ref} (Ts, Label, Sensor) VALUES
-                    (CurrentUtcTimestamp(), "my_series", 43),
-                    (CurrentUtcTimestamp() + Interval("PT1M"), "my_other_series", 44),
-                    (CurrentUtcTimestamp() + Interval("PT2M"), "my_series", 45);"""
+                    (Timestamp("2020-01-01T00:00:00Z"), "my_series", 43),
+                    (Timestamp("2020-01-01T00:01:00Z"), "my_other_series", 44),
+                    (Timestamp("2020-01-01T00:02:00Z"), "my_series", 45);"""
         )
         self.assert_shard(shard, [42, 43, 44, 45])
 
         kikimr.ydb_client.query(
             f"""INSERT INTO {ref}
                 SELECT * FROM AS_TABLE([
-                    <|Ts: CurrentUtcTimestamp(), Label: "my_series", Sensor: 46|>,
-                    <|Ts: CurrentUtcTimestamp() + Interval("PT1M"), Label: "my_other_series", Sensor: 47|>,
-                    <|Ts: CurrentUtcTimestamp() + Interval("PT2M"), Label: "my_series", Sensor: 48|>,
+                    <|Ts: Timestamp("2020-01-01T00:10:00Z"), Label: "my_series", Sensor: 46|>,
+                    <|Ts: Timestamp("2020-01-01T00:11:00Z"), Label: "my_other_series", Sensor: 47|>,
+                    <|Ts: Timestamp("2020-01-01T00:12:00Z"), Label: "my_series", Sensor: 48|>,
                 ]);"""
         )
         self.assert_shard(shard, [42, 43, 44, 45, 46, 47, 48])
@@ -291,15 +291,15 @@ class TestScalarSolomonWriteInYdb(SolomonTestBase):
 
         kikimr.ydb_client.query(
             f"""INSERT INTO {ref2} (Ts, Label, Sensor) VALUES
-                    (CurrentUtcTimestamp(), "my_series", 42),
-                    (CurrentUtcTimestamp() + Interval("PT1M"), "my_other_series", 43),
-                    (CurrentUtcTimestamp() + Interval("PT2M"), "my_series", 44);
+                    (Timestamp("2020-01-01T00:00:00Z"), "my_series", 42),
+                    (Timestamp("2020-01-01T00:01:00Z"), "my_other_series", 43),
+                    (Timestamp("2020-01-01T00:02:00Z"), "my_series", 44);
 
                 INSERT INTO {ref2}
                 SELECT * FROM AS_TABLE([
-                    <|Ts: CurrentUtcTimestamp(), Label: "my_series", Sensor: 52|>,
-                    <|Ts: CurrentUtcTimestamp() + Interval("PT1M"), Label: "my_other_series", Sensor: 53|>,
-                    <|Ts: CurrentUtcTimestamp() + Interval("PT2M"), Label: "my_series", Sensor: 54|>,
+                    <|Ts: Timestamp("2020-01-01T00:10:00Z"), Label: "my_series", Sensor: 52|>,
+                    <|Ts: Timestamp("2020-01-01T00:11:00Z"), Label: "my_other_series", Sensor: 53|>,
+                    <|Ts: Timestamp("2020-01-01T00:12:00Z"), Label: "my_series", Sensor: 54|>,
                 ]);
 
                 INSERT INTO {ref2}
@@ -308,8 +308,8 @@ class TestScalarSolomonWriteInYdb(SolomonTestBase):
                     Unwrap(CAST(a.Id AS String)) AS Id,
                     Unwrap(a.Sensor + b.Delta) AS Sensor
                 FROM AS_TABLE([
-                    <|Ts: CurrentUtcTimestamp(), Id: 1, Sensor: 62|>,
-                    <|Ts: CurrentUtcTimestamp() + Interval("PT1M"), Id: 2, Sensor: 63|>
+                    <|Ts: Timestamp("2020-01-01T00:20:00Z"), Id: 1, Sensor: 62|>,
+                    <|Ts: Timestamp("2020-01-01T00:21:00Z"), Id: 2, Sensor: 63|>
                 ]) AS a
                 LEFT JOIN AS_TABLE([<|Id: 1, Delta: 0|>, <|Id: 2, Delta: 0|>]) AS b
                 ON a.Id = b.Id;"""
@@ -396,7 +396,7 @@ class TestScalarSolomonWriteInYdb(SolomonTestBase):
         for i, ts_expr in enumerate(ts_exprs):
             kikimr.ydb_client.query(
                 f"""INSERT INTO {ts_shard.ref(source_name)}
-                    SELECT {ts_expr} AS Ts, "my_series" AS Label, {i} AS Sensor;"""
+                    SELECT {ts_expr} AS Ts, "my_series_{i}" AS Label, {i} AS Sensor;"""
             )
         self.assert_shard(ts_shard, list(range(len(ts_exprs))))
 
@@ -411,7 +411,8 @@ class TestScalarSolomonWriteInYdb(SolomonTestBase):
         for i, label_expr in enumerate(label_exprs):
             kikimr.ydb_client.query(
                 f"""INSERT INTO {label_shard.ref(source_name)}
-                    SELECT CurrentUtcTimestamp() AS Ts, {label_expr} AS Label, {i} AS Sensor;"""
+                    SELECT Timestamp("2020-01-01T00:00:00Z") + Interval("PT{i}S") AS Ts,
+                        {label_expr} AS Label, {i} AS Sensor;"""
             )
         self.assert_shard(label_shard, list(range(len(label_exprs))))
 
@@ -430,10 +431,11 @@ class TestScalarSolomonWriteInYdb(SolomonTestBase):
             "7.0",   # Double
         ]
         sensor_exprs += special_exprs
-        for sensor_expr in sensor_exprs:
+        for i, sensor_expr in enumerate(sensor_exprs):
             kikimr.ydb_client.query(
                 f"""INSERT INTO {sensor_shard.ref(source_name)}
-                    SELECT CurrentUtcTimestamp() AS Ts, "my_series" AS Label, {sensor_expr} AS Sensor;"""
+                    SELECT Timestamp("2020-01-01T00:00:00Z") + Interval("PT{i}S") AS Ts,
+                        "my_series" AS Label, {sensor_expr} AS Sensor;"""
             )
         metrics = self.wait_metrics(sensor_shard, len(sensor_exprs))
         # inf / nan may be serialized as strings by the emulator, so coerce every value to float.

--- a/ydb/tests/stress/federated_queries/workload/__init__.py
+++ b/ydb/tests/stress/federated_queries/workload/__init__.py
@@ -59,6 +59,7 @@ class Workload:
 
         self.successful_inserts = 0
         self.attempted_inserts = 0
+        self._base_ts_sec = int(time.time())
 
         self.driver = None
         self.pool = None
@@ -159,10 +160,11 @@ class Workload:
             f"`{self.SOLOMON_PROJECT}/{self.SOLOMON_CLUSTER}/{self.SOLOMON_SERVICE}`"
         )
         rows = []
-        for _ in range(self.INSERT_BATCH_SIZE):
+        for i in range(self.INSERT_BATCH_SIZE):
             label = random.choice(self.LABEL_VALUES)
             sensor = random.randint(*self.SENSOR_RANGE)
-            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            ts_sec = self._base_ts_sec + self.attempted_inserts * self.INSERT_BATCH_SIZE + i
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts_sec))
             rows.append(
                 f'SELECT Unwrap(CAST("{ts}" AS Timestamp)) AS Ts, '
                 f'"{label}" AS Label, {sensor} AS Sensor'


### PR DESCRIPTION
## Summary
- Restore overwrite semantics for metric points with the same labels and timestamp in the solomon/monitoring emulator
- Store points in a `points` dict keyed by `ts` instead of appending duplicates to a list (regression introduced in 6ca9075e)

## Test plan
- [x] Verified locally that repeated writes with the same labels and `ts` overwrite the value instead of creating duplicates
- [ ] CI green