### PR TITLE
NBS-7457: monitoring page VChunk tab

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -221,7 +221,7 @@ public:
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) = 0;
 
     // Builds this DBG's monitoring snapshot on the executor thread (like Dump).
-    virtual NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() = 0;
+    virtual NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() const = 0;
 };
 
 using IDirectBlockGroupPtr = std::shared_ptr<IDirectBlockGroup>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -1152,7 +1152,7 @@ NThreading::TFuture<TDBGDumpResponse> TDirectBlockGroup::Dump()
     return future;
 }
 
-NThreading::TFuture<TDbgSnapshot> TDirectBlockGroup::BuildMonSnapshot()
+NThreading::TFuture<TDbgSnapshot> TDirectBlockGroup::BuildMonSnapshot() const
 {
     auto promise = NewPromise<TDbgSnapshot>();
     auto future = promise.GetFuture();
@@ -1774,7 +1774,7 @@ void TDirectBlockGroup::HandleBlockedGeneration(
     Service->StopTablet(reason);
 }
 
-TDBGDumpResponse TDirectBlockGroup::DoDebugPrintDirtyMap()
+TDBGDumpResponse TDirectBlockGroup::DoDebugPrintDirtyMap() const
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
@@ -1804,7 +1804,7 @@ TDBGDumpResponse TDirectBlockGroup::DoDebugPrintDirtyMap()
     return result;
 }
 
-TDbgSnapshot TDirectBlockGroup::DoBuildMonSnapshot()
+TDbgSnapshot TDirectBlockGroup::DoBuildMonSnapshot() const
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -145,7 +145,7 @@ public:
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) override;
 
-    NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() override;
+    NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() const override;
 
     // IHostStateController implementation
     void SetHostState(
@@ -253,9 +253,9 @@ private:
 
     void HandleBlockedGeneration(THostIndex hostIndex, TStringBuf context);
 
-    TDBGDumpResponse DoDebugPrintDirtyMap();
+    [[nodiscard]] TDBGDumpResponse DoDebugPrintDirtyMap() const;
 
-    TDbgSnapshot DoBuildMonSnapshot();
+    [[nodiscard]] TDbgSnapshot DoBuildMonSnapshot() const;
 
     [[nodiscard]] TConnectionSnapshot MakeConnectionSnapshot(
         size_t hostIndex) const;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -390,7 +390,8 @@ void TDirectBlockGroupMock::OnAddHostResult(
         std::move(pbufferId));
 }
 
-NThreading::TFuture<TDbgSnapshot> TDirectBlockGroupMock::BuildMonSnapshot()
+NThreading::TFuture<TDbgSnapshot>
+TDirectBlockGroupMock::BuildMonSnapshot() const
 {
     return NThreading::MakeFuture(TDbgSnapshot{});
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -248,7 +248,7 @@ public:
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) override;
 
-    NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() override;
+    NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() const override;
 };
 
 using TDirectBlockGroupMockPtr = std::shared_ptr<TDirectBlockGroupMock>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -399,11 +399,11 @@ void TFastPathService::StopTablet(const TString& reason)
 
 TFastPathServiceInfo TFastPathService::GetMonInfo() const
 {
-    const ui64 vchunkSize = StorageConfig->GetVChunkSize();
-    Y_ABORT_UNLESS(vchunkSize != 0);
     return {
         .LsnCounter = SequenceGenerator.load(),
-        .TotalVChunks = Regions.size() * (RegionSize / vchunkSize),
+        .LastSafeBarrier = LastSafeBarrier.load(),
+        .TotalVChunks =
+            Regions.size() * GetVChunksPerRegion(VolumeConfig->VChunkSize),
         .DbgCount = DirectBlockGroups.size(),
     };
 }
@@ -523,6 +523,8 @@ void TFastPathService::FinishPBufferCleanup()
         // dirty map, so its records are not accounted for yet. Skip the tick.
         return;
     }
+
+    LastSafeBarrier.store(*globalMin);
 
     const ui64 cleanupBound = *globalMin - 1;
     for (const auto& dbg: DirectBlockGroups) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -2,7 +2,8 @@
 
 #include "direct_block_group.h"
 #include "partition_direct_events_private.h"
-#include "range_translate.h"
+#include "region_geometry.h"
+#include "vchunk.h"
 
 #include <ydb/core/nbs/cloud/blockstore/config/config.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/common/block_range.h>
@@ -431,6 +432,33 @@ NThreading::TFuture<TVector<TDbgSnapshot>> TFastPathService::GatherMonSnapshots(
             }
             return snapshots;
         });
+}
+
+NThreading::TFuture<std::optional<TVChunkSnapshot>>
+TFastPathService::GatherVChunkMonSnapshot(ui32 vchunkIndex) const
+{
+    const auto notFound =
+        MakeFuture<std::optional<TVChunkSnapshot>>(std::nullopt);
+
+    const size_t regionIndex =
+        GetRegionIndexByVChunk(*VolumeConfig, vchunkIndex);
+    if (regionIndex >= Regions.size()) {
+        return notFound;
+    }
+    const size_t vChunkIndexInRegion =
+        GetVChunkIndexInRegion(*VolumeConfig, vchunkIndex);
+    auto vchunk = Regions[regionIndex]->GetVChunk(vChunkIndexInRegion);
+    if (!vchunk) {
+        return notFound;
+    }
+
+    // The vchunk state is confined to its executor (the one of its DBG).
+    auto executor = vchunk->GetExecutor();
+    auto promise = NewPromise<std::optional<TVChunkSnapshot>>();
+    auto future = promise.GetFuture();
+    executor->ExecuteSimple([vchunk = std::move(vchunk), promise]() mutable
+                            { promise.SetValue(vchunk->BuildMonSnapshot()); });
+    return future;
 }
 
 void TFastPathService::MaybeTriggerPBufferCleanup(ui64 lsn)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -54,6 +54,10 @@ private:
 
     TPBufferCleanupGather CleanupGather;
 
+    // Result of the last finished cleanup round: the minimum safe barrier
+    // across all DBGs. 0 until the first round finishes.
+    std::atomic<ui64> LastSafeBarrier{0};
+
 public:
     TFastPathService(
         NActors::TActorSystem* actorSystem,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -121,6 +121,11 @@ public:
     [[nodiscard]] NThreading::TFuture<TVector<TDbgSnapshot>> GatherMonSnapshots(
         std::optional<size_t> dbgIndex) const;
 
+    // Snapshot of one vchunk by its global index, built on the owning DBG's
+    // executor. Resolves to nullopt when there is no such vchunk.
+    [[nodiscard]] NThreading::TFuture<std::optional<TVChunkSnapshot>>
+    GatherVChunkMonSnapshot(ui32 vchunkIndex) const;
+
 private:
     void ScheduleDirtyMapDebugPrint();
     void QueryDirtyMapDebugDump();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -37,6 +37,9 @@ struct TTabletInfo
 struct TFastPathServiceInfo
 {
     ui64 LsnCounter = 0;
+    // Minimum safe barrier across all DBGs from the last finished cleanup
+    // round; 0 until the first round finishes.
+    ui64 LastSafeBarrier = 0;
     size_t TotalVChunks = 0;
     size_t DbgCount = 0;
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -71,21 +71,10 @@ struct TDbgSnapshot
     TVector<TConnectionSnapshot> Connections;
 };
 
-struct TVChunkHostRole
-{
-    THostIndex HostIndex = InvalidHostIndex;
-    EHostRole PBufferRole = EHostRole::None;
-    EHostRole DDiskRole = EHostRole::None;
-    bool Enabled = false;
-    std::optional<ui64> Watermark;
-};
-
 struct TVChunkSnapshot
 {
-    ui32 Index = 0;
-    ui32 DbgIndex = 0;
+    TVChunkConfig VChunkConfig;
     std::optional<ui64> SafeBarrier;
-    TVector<TVChunkHostRole> HostRoles;
     TString DirtyMapDump;
 };
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h
@@ -23,6 +23,7 @@ enum class EMonPage
     Overview,
     Dbg,
     LocalDb,
+    VChunk,
 };
 
 struct TTabletInfo
@@ -67,6 +68,24 @@ struct TDbgSnapshot
     TVector<TConnectionSnapshot> Connections;
 };
 
+struct TVChunkHostRole
+{
+    THostIndex HostIndex = InvalidHostIndex;
+    EHostRole PBufferRole = EHostRole::None;
+    EHostRole DDiskRole = EHostRole::None;
+    bool Enabled = false;
+    std::optional<ui64> Watermark;
+};
+
+struct TVChunkSnapshot
+{
+    ui32 Index = 0;
+    ui32 DbgIndex = 0;
+    std::optional<ui64> SafeBarrier;
+    TVector<TVChunkHostRole> HostRoles;
+    TString DirtyMapDump;
+};
+
 // Persisted tablet state (local DB). Protos are pre-dumped to text; an absent
 // value means the row was never persisted.
 struct TLocalDbContents
@@ -91,6 +110,10 @@ struct TMonPageData
     std::optional<ui32> SelectedDbg;
     // Local DB tab.
     std::optional<TLocalDbContents> LocalDb;
+    // VChunk tab: the requested index (absent => only the input form) and the
+    // snapshot (absent => no such vchunk).
+    std::optional<ui32> SelectedVChunk;
+    std::optional<TVChunkSnapshot> VChunk;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -37,6 +37,8 @@ const char* PageParam(EMonPage page)
             return "dbg";
         case EMonPage::LocalDb:
             return "localdb";
+        case EMonPage::VChunk:
+            return "vchunk";
     }
     return "overview";
 }
@@ -50,6 +52,8 @@ const char* PageTitle(EMonPage page)
             return "DBGs";
         case EMonPage::LocalDb:
             return "Local DB";
+        case EMonPage::VChunk:
+            return "VChunk";
     }
     return "";
 }
@@ -166,6 +170,7 @@ void RenderMenu(
         EMonPage::Overview,
         EMonPage::Dbg,
         EMonPage::LocalDb,
+        EMonPage::VChunk,
     };
     str << "<div style='margin:0.5em 0 1em;'>";
     for (EMonPage page: pages) {
@@ -501,6 +506,124 @@ void RenderLocalDb(IOutputStream& str, const TLocalDbContents& db)
     }
 }
 
+void RenderVChunk(IOutputStream& str, const TMonPageData& data)
+{
+    // Looking up a vchunk changes nothing, so this is a GET form. On submit a
+    // GET form rebuilds the query string from its fields ALONE and drops the
+    // current one - so TabletID and page (which live in the URL as
+    // ?TabletID=..&page=vchunk) must be repeated as hidden fields, otherwise
+    // the submit lands on ?vchunk=N with no tablet and no page.
+    str << "<form method='get' action='' style='margin-bottom:1em;'>"
+           "<input type='hidden' name='TabletID' value='"
+        << data.TabletInfo.TabletId
+        << "'/>"
+           "<input type='hidden' name='page' value='vchunk'/>"
+           "VChunk index: <input type='number' name='vchunk' min='0' value='";
+    if (data.SelectedVChunk) {
+        str << *data.SelectedVChunk;
+    }
+    str << "'/> <button type='submit' class='btn btn-default'>Show</button>"
+           "</form>";
+
+    if (!data.SelectedVChunk) {
+        return;
+    }
+    if (!data.VChunk) {
+        HTML (str) {
+            DIV_CLASS ("alert alert-warning") {
+                str << "VChunk #" << *data.SelectedVChunk << " not found.";
+            }
+        }
+        return;
+    }
+
+    const TVChunkSnapshot& vchunk = *data.VChunk;
+    HTML (str) {
+        TAG (TH3) {
+            str << "VChunk #" << vchunk.Index;
+        }
+        TABLE_CLASS ("table table-condensed") {
+            TABLEBODY () {
+                TABLER () {
+                    TABLED () {
+                        str << "DBG";
+                    }
+                    TABLED () {
+                        str << "<a href='?TabletID=" << data.TabletInfo.TabletId
+                            << "&page=dbg&dbg=" << vchunk.DbgIndex << "'>#"
+                            << vchunk.DbgIndex << "</a>";
+                    }
+                }
+                TABLER () {
+                    TABLED () {
+                        str << "Safe barrier";
+                    }
+                    TABLED () {
+                        if (vchunk.SafeBarrier) {
+                            str << *vchunk.SafeBarrier;
+                        } else {
+                            str << "-";
+                        }
+                    }
+                }
+            }
+        }
+        TAG (TH4) {
+            str << "Host roles";
+        }
+        TABLE_CLASS ("table table-condensed") {
+            TABLEHEAD () {
+                TABLER () {
+                    TABLEH () {
+                        str << "Host";
+                    }
+                    TABLEH () {
+                        str << "PBuffer role";
+                    }
+                    TABLEH () {
+                        str << "DDisk role";
+                    }
+                    TABLEH () {
+                        str << "Enabled";
+                    }
+                    TABLEH () {
+                        str << "Watermark";
+                    }
+                }
+            }
+            TABLEBODY () {
+                for (const auto& role: vchunk.HostRoles) {
+                    TABLER () {
+                        TABLED () {
+                            str << PrintHostIndex(role.HostIndex);
+                        }
+                        TABLED () {
+                            str << ToString(role.PBufferRole);
+                        }
+                        TABLED () {
+                            str << ToString(role.DDiskRole);
+                        }
+                        TABLED () {
+                            str << (role.Enabled ? "yes" : "no");
+                        }
+                        TABLED () {
+                            if (role.Watermark) {
+                                str << *role.Watermark;
+                            } else {
+                                str << "-";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        str << "<details style='margin-bottom:0.5em;'>"
+               "<summary style='display:list-item; cursor:pointer;'>"
+               "Dirty map dump</summary><pre>"
+            << HtmlEscape(vchunk.DirtyMapDump) << "</pre></details>";
+    }
+}
+
 void RenderDbg(IOutputStream& str, const TMonPageData& data)
 {
     if (!data.SelectedDbg) {
@@ -553,6 +676,9 @@ TString RenderMonPage(const TMonPageData& data)
             if (data.LocalDb) {
                 RenderLocalDb(str, *data.LocalDb);
             }
+            break;
+        case EMonPage::VChunk:
+            RenderVChunk(str, data);
             break;
     }
     return str.Str();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -550,9 +550,10 @@ void RenderVChunk(IOutputStream& str, const TMonPageData& data)
     }
 
     const TVChunkSnapshot& vchunk = *data.VChunk;
+    const TVChunkConfig& config = vchunk.VChunkConfig;
     HTML (str) {
         TAG (TH3) {
-            str << "VChunk #" << vchunk.Index;
+            str << "VChunk #" << config.GetVChunkIndex();
         }
         TABLE_CLASS ("table table-condensed") {
             TABLEBODY () {
@@ -562,8 +563,8 @@ void RenderVChunk(IOutputStream& str, const TMonPageData& data)
                     }
                     TABLED () {
                         str << "<a href='?TabletID=" << data.TabletInfo.TabletId
-                            << "&page=dbg&dbg=" << vchunk.DbgIndex << "'>#"
-                            << vchunk.DbgIndex << "</a>";
+                            << "&page=dbg&dbg=" << config.GetDBGIndex() << "'>#"
+                            << config.GetDBGIndex() << "</a>";
                     }
                 }
                 TABLER () {
@@ -604,23 +605,26 @@ void RenderVChunk(IOutputStream& str, const TMonPageData& data)
                 }
             }
             TABLEBODY () {
-                for (const auto& role: vchunk.HostRoles) {
+                const auto disabled = config.GetDisabledHosts();
+                for (THostIndex host = 0; host < config.GetHostCount(); ++host)
+                {
                     TABLER () {
                         TABLED () {
-                            str << PrintHostIndex(role.HostIndex);
+                            str << PrintHostIndex(host);
                         }
                         TABLED () {
-                            str << ToString(role.PBufferRole);
+                            str << ToString(config.GetPBufferRole(host));
                         }
                         TABLED () {
-                            str << ToString(role.DDiskRole);
+                            str << ToString(config.GetDDiskRole(host));
                         }
                         TABLED () {
-                            str << (role.Enabled ? "yes" : "no");
+                            str << (disabled.Get(host) ? "no" : "yes");
                         }
                         TABLED () {
-                            if (role.Watermark) {
-                                str << *role.Watermark;
+                            const auto watermark = config.GetWatermark(host);
+                            if (watermark) {
+                                str << *watermark;
                             } else {
                                 str << "-";
                             }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render.cpp
@@ -217,6 +217,18 @@ void RenderOverview(IOutputStream& str, const TFastPathServiceInfo& info)
                         str << info.LsnCounter;
                     }
                 }
+                TABLER () {
+                    TABLED () {
+                        str << "Last safe barrier";
+                    }
+                    TABLED () {
+                        if (info.LastSafeBarrier != 0) {
+                            str << info.LastSafeBarrier;
+                        } else {
+                            str << "-";
+                        }
+                    }
+                }
             }
         }
     }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -71,6 +71,7 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
         UNIT_ASSERT_STRING_CONTAINS(html, "page=overview");
         UNIT_ASSERT_STRING_CONTAINS(html, "page=dbg");
         UNIT_ASSERT_STRING_CONTAINS(html, "page=localdb");
+        UNIT_ASSERT_STRING_CONTAINS(html, "page=vchunk");
         UNIT_ASSERT_STRING_CONTAINS(html, "DirectBlockGroups");
         UNIT_ASSERT_STRING_CONTAINS(html, "VChunks (total)");
         UNIT_ASSERT_STRING_CONTAINS(html, "LSN counter");
@@ -174,6 +175,72 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
 
         const TString html = RenderMonPage(data);
         UNIT_ASSERT_STRING_CONTAINS(html, "not found");
+    }
+
+    Y_UNIT_TEST(VChunkPageShowsInputForm)
+    {
+        const TMonPageData data{
+            .Page = EMonPage::VChunk,
+            .TabletInfo = {.TabletId = 42},
+        };
+
+        const TString html = RenderMonPage(data);
+        UNIT_ASSERT_STRING_CONTAINS(html, "name='vchunk'");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "<input type='hidden' name='page' value='vchunk'/>");
+        UNIT_ASSERT(!html.Contains("not found"));
+    }
+
+    Y_UNIT_TEST(VChunkPageShowsSnapshot)
+    {
+        const TVChunkHostRole primaryHost{
+            .HostIndex = 0,
+            .PBufferRole = EHostRole::Primary,
+            .DDiskRole = EHostRole::Primary,
+            .Enabled = true,
+            .Watermark = 7,
+        };
+        const TVChunkHostRole handOffHost{
+            .HostIndex = 1,
+            .PBufferRole = EHostRole::HandOff,
+            .DDiskRole = EHostRole::None,
+            .Enabled = false,
+        };
+        const TMonPageData data{
+            .Page = EMonPage::VChunk,
+            .TabletInfo = {.TabletId = 42},
+            .SelectedVChunk = 5,
+            .VChunk =
+                TVChunkSnapshot{
+                    .Index = 5,
+                    .DbgIndex = 1,
+                    .SafeBarrier = 100,
+                    .HostRoles = {primaryHost, handOffHost},
+                    .DirtyMapDump = "DDiskStates: dump-text",
+                },
+        };
+
+        const TString html = RenderMonPage(data);
+        UNIT_ASSERT_STRING_CONTAINS(html, "VChunk #5");
+        UNIT_ASSERT_STRING_CONTAINS(html, "page=dbg&dbg=1");
+        UNIT_ASSERT_STRING_CONTAINS(html, "Safe barrier");
+        UNIT_ASSERT_STRING_CONTAINS(html, "<td>H0</td>");
+        UNIT_ASSERT_STRING_CONTAINS(html, "Primary");
+        UNIT_ASSERT_STRING_CONTAINS(html, "HandOff");
+        UNIT_ASSERT_STRING_CONTAINS(html, "DDiskStates: dump-text");
+    }
+
+    Y_UNIT_TEST(VChunkPageNotFound)
+    {
+        const TMonPageData data{
+            .Page = EMonPage::VChunk,
+            .TabletInfo = {.TabletId = 42},
+            .SelectedVChunk = 999,
+        };
+
+        const TString html = RenderMonPage(data);
+        UNIT_ASSERT_STRING_CONTAINS(html, "VChunk #999 not found");
     }
 
     Y_UNIT_TEST(LocalDbShowsPersistedState)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -195,29 +195,20 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
 
     Y_UNIT_TEST(VChunkPageShowsSnapshot)
     {
-        const TVChunkHostRole primaryHost{
-            .HostIndex = 0,
-            .PBufferRole = EHostRole::Primary,
-            .DDiskRole = EHostRole::Primary,
-            .Enabled = true,
-            .Watermark = 7,
-        };
-        const TVChunkHostRole handOffHost{
-            .HostIndex = 1,
-            .PBufferRole = EHostRole::HandOff,
-            .DDiskRole = EHostRole::None,
-            .Enabled = false,
-        };
+        auto config = TVChunkConfig::MakeDefault(
+            /*vChunkIndex*/ 5,
+            /*hostCount*/ 3,
+            /*primaryCount*/ 1);
+        config.SetDBGIndex(1);
+        config.SetWatermark(0, 7);
         const TMonPageData data{
             .Page = EMonPage::VChunk,
             .TabletInfo = {.TabletId = 42},
             .SelectedVChunk = 5,
             .VChunk =
                 TVChunkSnapshot{
-                    .Index = 5,
-                    .DbgIndex = 1,
+                    .VChunkConfig = config,
                     .SafeBarrier = 100,
-                    .HostRoles = {primaryHost, handOffHost},
                     .DirtyMapDump = "DDiskStates: dump-text",
                 },
         };
@@ -229,6 +220,8 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
         UNIT_ASSERT_STRING_CONTAINS(html, "<td>H0</td>");
         UNIT_ASSERT_STRING_CONTAINS(html, "Primary");
         UNIT_ASSERT_STRING_CONTAINS(html, "HandOff");
+        // Host 0's watermark set above renders in its row.
+        UNIT_ASSERT_STRING_CONTAINS(html, "<td>7</td>");
         UNIT_ASSERT_STRING_CONTAINS(html, "DDiskStates: dump-text");
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_render_ut.cpp
@@ -75,6 +75,7 @@ Y_UNIT_TEST_SUITE(TMonRenderTest)
         UNIT_ASSERT_STRING_CONTAINS(html, "DirectBlockGroups");
         UNIT_ASSERT_STRING_CONTAINS(html, "VChunks (total)");
         UNIT_ASSERT_STRING_CONTAINS(html, "LSN counter");
+        UNIT_ASSERT_STRING_CONTAINS(html, "Last safe barrier");
         UNIT_ASSERT_STRING_CONTAINS(html, "vol-1");
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
@@ -36,6 +36,9 @@ EMonPage ParsePage(const TCgiParameters& cgi)
     if (page == "localdb") {
         return EMonPage::LocalDb;
     }
+    if (page == "vchunk") {
+        return EMonPage::VChunk;
+    }
     return EMonPage::Overview;
 }
 
@@ -44,6 +47,15 @@ std::optional<size_t> ParseSelectedDbg(const TCgiParameters& cgi)
     ui32 dbgIndex = 0;
     if (cgi.Has("dbg") && TryFromString(cgi.Get("dbg"), dbgIndex)) {
         return dbgIndex;
+    }
+    return std::nullopt;
+}
+
+std::optional<ui32> ParseSelectedVChunk(const TCgiParameters& cgi)
+{
+    ui32 vchunkIndex = 0;
+    if (cgi.Has("vchunk") && TryFromString(cgi.Get("vchunk"), vchunkIndex)) {
+        return vchunkIndex;
     }
     return std::nullopt;
 }
@@ -110,6 +122,44 @@ void TPartitionActor::HandleHttpInfo(
     // CompleteMonitoring renders and replies.
     if (page == EMonPage::LocalDb) {
         ExecuteTx(ctx, CreateTx<TMonitoring>(ev->Sender));
+        return;
+    }
+
+    // VChunk page: no index - just the input form (synchronous); with an
+    // index - gather the snapshot from the owning DBG's executor.
+    if (page == EMonPage::VChunk) {
+        const std::optional<ui32> selectedVChunk = ParseSelectedVChunk(cgi);
+        if (!selectedVChunk) {
+            TMonPageData data{
+                .Page = page,
+                .TabletInfo = MakeMonTabletInfo(),
+            };
+            ctx.Send(
+                ev->Sender,
+                new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
+            return;
+        }
+
+        auto* actorSystem = TActivationContext::ActorSystem();
+        const TActorId requester = ev->Sender;
+        FastPathService->GatherVChunkMonSnapshot(*selectedVChunk)
+            .Subscribe(
+                [tabletInfo = MakeMonTabletInfo(),
+                 page,
+                 selectedVChunk,
+                 requester,
+                 actorSystem](const auto& future)
+                {
+                    TMonPageData data{
+                        .Page = page,
+                        .TabletInfo = tabletInfo,
+                        .SelectedVChunk = selectedVChunk,
+                        .VChunk = future.GetValue(),
+                    };
+                    actorSystem->Send(
+                        requester,
+                        new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
+                });
         return;
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
@@ -84,7 +84,7 @@ TLocalDbContents MakeLocalDbContents(const TTxPartition::TMonitoring& args)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TTabletInfo TPartitionActor::MakeMonTabletInfo()
+TTabletInfo TPartitionActor::MakeMonTabletInfo() const
 {
     return {
         .TabletId = TabletID(),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -179,7 +179,7 @@ private:
         size_t dbgId,
         const TString& message);
 
-    TTabletInfo MakeMonTabletInfo();
+    [[nodiscard]] TTabletInfo MakeMonTabletInfo() const;
 
     void Start(
         const NActors::TActorContext& ctx,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.cpp
@@ -1,6 +1,6 @@
 #include "region.h"
 
-#include "range_translate.h"
+#include "region_geometry.h"
 #include "vchunk.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
@@ -34,8 +34,7 @@ TRegion::TRegion(
     NMonitoring::TDynamicCounterPtr counters)
     : ActorSystem(actorSystem)
 {
-    Y_ABORT_UNLESS(vChunkSize > 0 && vChunkSize <= RegionSize);
-    const ui64 vChunksPerRegionCount = RegionSize / vChunkSize;
+    const ui64 vChunksPerRegionCount = GetVChunksPerRegion(vChunkSize);
     for (size_t i = 0; i < vChunksPerRegionCount; i++) {
         const size_t vChunkIndex = (regionIndex * vChunksPerRegionCount) + i;
         const size_t dbgIndex = vChunkIndex % directBlockGroups.size();
@@ -90,6 +89,14 @@ NThreading::TFuture<void> TRegion::Stop()
             }
         });
     return result;
+}
+
+TVChunkPtr TRegion::GetVChunk(size_t vChunkIndex) const
+{
+    if (vChunkIndex >= VChunks.size()) {
+        return nullptr;
+    }
+    return VChunks[vChunkIndex];
 }
 
 NThreading::TFuture<TReadBlocksLocalResponse> TRegion::ReadBlocksLocal(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region.h
@@ -30,7 +30,10 @@ public:
         NMonitoring::TDynamicCounterPtr counters);
 
     void Run();
+
     NThreading::TFuture<void> Stop();
+
+    [[nodiscard]] TVChunkPtr GetVChunk(size_t vChunkIndex) const;
 
     NThreading::TFuture<TReadBlocksLocalResponse> ReadBlocksLocal(
         TCallContextPtr callContext,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region_geometry.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region_geometry.cpp
@@ -1,4 +1,4 @@
-#include "range_translate.h"
+#include "region_geometry.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
 
@@ -6,10 +6,31 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+size_t GetVChunksPerRegion(ui64 vChunkSize)
+{
+    Y_ABORT_UNLESS(vChunkSize > 0 && vChunkSize <= RegionSize);
+    Y_ABORT_UNLESS(RegionSize % vChunkSize == 0);
+    return RegionSize / vChunkSize;
+}
+
 size_t GetRegionIndex(const TVolumeConfig& volumeConfig, TBlockRange64 range)
 {
     const ui64 blocksPerRegion = RegionSize / volumeConfig.BlockSize;
     return range.Start / blocksPerRegion;
+}
+
+size_t GetRegionIndexByVChunk(
+    const TVolumeConfig& volumeConfig,
+    size_t vChunkIndex)
+{
+    return vChunkIndex / GetVChunksPerRegion(volumeConfig.VChunkSize);
+}
+
+size_t GetVChunkIndexInRegion(
+    const TVolumeConfig& volumeConfig,
+    size_t vChunkIndex)
+{
+    return vChunkIndex % GetVChunksPerRegion(volumeConfig.VChunkSize);
 }
 
 TBlockRange64 TranslateToRegion(
@@ -25,15 +46,13 @@ size_t GetVChunkIndex(
     const TVolumeConfig& volumeConfig,
     TBlockRange64 regionRange)
 {
-    Y_ABORT_UNLESS(
-        volumeConfig.VChunkSize > 0 && volumeConfig.VChunkSize <= RegionSize);
-    Y_ABORT_UNLESS(RegionSize % volumeConfig.VChunkSize == 0);
     Y_ABORT_UNLESS(volumeConfig.BlockSize > 0);
     Y_ABORT_UNLESS(volumeConfig.BlocksPerStripe >= regionRange.Size());
 
     const size_t blocksPerStripe = volumeConfig.BlocksPerStripe;
     const size_t stripeIndex = regionRange.Start / blocksPerStripe;
-    const ui32 vChunksPerRegionCount = RegionSize / volumeConfig.VChunkSize;
+    const size_t vChunksPerRegionCount =
+        GetVChunksPerRegion(volumeConfig.VChunkSize);
     return stripeIndex % vChunksPerRegionCount;
 }
 
@@ -41,15 +60,13 @@ TBlockRange64 TranslateToVChunk(
     const TVolumeConfig& volumeConfig,
     TBlockRange64 regionRange)
 {
-    Y_ABORT_UNLESS(
-        volumeConfig.VChunkSize > 0 && volumeConfig.VChunkSize <= RegionSize);
-    Y_ABORT_UNLESS(RegionSize % volumeConfig.VChunkSize == 0);
     Y_ABORT_UNLESS(volumeConfig.BlockSize > 0);
     Y_ABORT_UNLESS(volumeConfig.BlocksPerStripe >= regionRange.Size());
 
     const size_t blocksPerStripe = volumeConfig.BlocksPerStripe;
     const size_t stripeIndex = regionRange.Start / blocksPerStripe;
-    const ui32 vChunksPerRegionCount = RegionSize / volumeConfig.VChunkSize;
+    const size_t vChunksPerRegionCount =
+        GetVChunksPerRegion(volumeConfig.VChunkSize);
     const size_t stripeIndexInVChunk = stripeIndex / vChunksPerRegionCount;
     const size_t blockIndexInStripe = regionRange.Start % blocksPerStripe;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region_geometry.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/region_geometry.h
@@ -8,7 +8,17 @@ namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+size_t GetVChunksPerRegion(ui64 vChunkSize);
+
 size_t GetRegionIndex(const TVolumeConfig& volumeConfig, TBlockRange64 range);
+
+size_t GetRegionIndexByVChunk(
+    const TVolumeConfig& volumeConfig,
+    size_t vChunkIndex);
+
+size_t GetVChunkIndexInRegion(
+    const TVolumeConfig& volumeConfig,
+    size_t vChunkIndex);
 
 TBlockRange64 TranslateToRegion(
     const TVolumeConfig& volumeConfig,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -1,8 +1,8 @@
 #include "vchunk.h"
 
 #include "flush_request.h"
-#include "range_translate.h"
 #include "read_request_executor.h"
+#include "region_geometry.h"
 #include "write_request.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
@@ -258,6 +258,11 @@ const TVChunkConfig& TVChunk::GetConfig() const
     return VChunkConfig;
 }
 
+TExecutorPtr TVChunk::GetExecutor() const
+{
+    return Executor;
+}
+
 ui64 TVChunk::GetPBufferUsedSize(THostIndex hostIndex) const
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
@@ -296,6 +301,32 @@ TString TVChunk::DebugPrintDirtyMap()
     sb << "FlushQueue: " << BlocksDirtyMap.DebugPrintReadyToFlush() << "\n";
     sb << "EraseQueue: " << BlocksDirtyMap.DebugPrintReadyToErase() << "\n";
     return sb;
+}
+
+TVChunkSnapshot TVChunk::BuildMonSnapshot()
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    const auto disabled = VChunkConfig.GetDisabledHosts();
+    TVector<TVChunkHostRole> hostRoles;
+    hostRoles.reserve(VChunkConfig.GetHostCount());
+    for (THostIndex host = 0; host < VChunkConfig.GetHostCount(); ++host) {
+        hostRoles.push_back({
+            .HostIndex = host,
+            .PBufferRole = VChunkConfig.GetPBufferRole(host),
+            .DDiskRole = VChunkConfig.GetDDiskRole(host),
+            .Enabled = !disabled.Get(host),
+            .Watermark = VChunkConfig.GetWatermark(host),
+        });
+    }
+
+    return {
+        .Index = VChunkConfig.GetVChunkIndex(),
+        .DbgIndex = VChunkConfig.GetDBGIndex(),
+        .SafeBarrier = GetSafeBarrierForErase(),
+        .HostRoles = std::move(hostRoles),
+        .DirtyMapDump = DebugPrintDirtyMap(),
+    };
 }
 
 void TVChunk::OnWriteBlocksResponse(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -307,24 +307,9 @@ TVChunkSnapshot TVChunk::BuildMonSnapshot()
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
-    const auto disabled = VChunkConfig.GetDisabledHosts();
-    TVector<TVChunkHostRole> hostRoles;
-    hostRoles.reserve(VChunkConfig.GetHostCount());
-    for (THostIndex host = 0; host < VChunkConfig.GetHostCount(); ++host) {
-        hostRoles.push_back({
-            .HostIndex = host,
-            .PBufferRole = VChunkConfig.GetPBufferRole(host),
-            .DDiskRole = VChunkConfig.GetDDiskRole(host),
-            .Enabled = !disabled.Get(host),
-            .Watermark = VChunkConfig.GetWatermark(host),
-        });
-    }
-
     return {
-        .Index = VChunkConfig.GetVChunkIndex(),
-        .DbgIndex = VChunkConfig.GetDBGIndex(),
+        .VChunkConfig = VChunkConfig,
         .SafeBarrier = GetSafeBarrierForErase(),
-        .HostRoles = std::move(hostRoles),
         .DirtyMapDump = DebugPrintDirtyMap(),
     };
 }

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -17,6 +17,7 @@
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/dirty_map.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host_state.h>
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/mon_page/mon_model.h>
 
 #include <ydb/core/nbs/cloud/storage/core/libs/common/public.h>
 
@@ -62,8 +63,8 @@ public:
     void OnHostAppended(size_t newHostCount);
 
     [[nodiscard]] const TVChunkConfig& GetConfig() const;
+    [[nodiscard]] TExecutorPtr GetExecutor() const;
     [[nodiscard]] ui64 GetPBufferUsedSize(THostIndex hostIndex) const;
-    [[nodiscard]] TString DebugPrintDirtyMap();
 
     // This vchunk's contribution to the tablet-wide cleanup watermark: the
     // smallest lsn still held in PBuffers, or nullopt when nothing is inflight.
@@ -71,6 +72,11 @@ public:
     // the cleanup cannot erase records that are not accounted for yet.
     // Must run on the executor thread.
     [[nodiscard]] std::optional<ui64> GetSafeBarrierForErase() const;
+
+    [[nodiscard]] TString DebugPrintDirtyMap();
+
+    // Snapshot for the mon page. Must run on the executor thread.
+    [[nodiscard]] TVChunkSnapshot BuildMonSnapshot();
 
     // IWriteClient implementation
     void OnWriteBlocksResponse(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -21,7 +21,7 @@ SRCS(
     part_monitoring.cpp
     partition_direct_actor.cpp
     partition_direct.cpp
-    range_translate.cpp
+    region_geometry.cpp
     read_request_executor.cpp
     read_request_multiple_location.cpp
     read_request_single_location.cpp


### PR DESCRIPTION
Three changes to the partition_direct tablet mon page:

- **VChunk tab**: an index input; for the requested vchunk — its DBG (link), safe barrier, per-host roles (PBuffer/DDisk role, enabled, watermark) and the dirty map dump collapsed. The snapshot is built on the owning DBG's executor (the vchunk layout is a ring: `index % DbgCount`); an out-of-range index renders "not found".
- **Last safe barrier on Overview**: the minimum safe barrier across all DBGs from the last finished cleanup round, cached at the point the round completes; "-" until the first round finishes.
- `DoDebugPrintDirtyMap` / `DoBuildMonSnapshot` are `const` now.
<img width="1624" height="971" alt="Снимок экрана — 2026-07-15 в 18 43 01" src="https://github.com/user-attachments/assets/aaf28fef-9958-453d-9131-7edd8b0a7cdf" />
