### PR TITLE
CancelAfter timeout in rate limiter must be related to quota handling only

### DIFF
--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -1119,7 +1119,7 @@ void TQuoterService::Handle(TEvQuota::TEvProxySession::TPtr &ev) {
         if (req.Deadline != TDuration::Max() && !ResourceInResolvingState(reqId)) {
             const TInstant now = TActivationContext::Now();
             TryTickSchedule(now);
-            ScheduleRequestDeadline(reqId, TimeToGranularity(now + req.Deadline));
+            ScheduleRequestDeadline(reqId, TimeToGranularity(now + req.Deadline)); // Can invalidate req
         }
     }
 

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -460,8 +460,8 @@ void TQuoterService::ForgetRequest(TRequest &request, TRequestId reqIdx) {
             break;
         case EResourceState::ResolveResource:
             if (TQuoterState *quoter = Quoters.FindPtr(leaf.QuoterId))
-                if (TSet<TRequestId> *resWaitMap = quoter->WaitingResource.FindPtr(leaf.ResourceName))
-                    resWaitMap->erase(reqIdx);
+                if (TResourceResolve *resolve = quoter->WaitingResource.FindPtr(leaf.ResourceName))
+                    resolve->Requests.erase(reqIdx);
             break;
         }
 
@@ -579,6 +579,7 @@ TQuoterService::EInitLeafStatus TQuoterService::InitResourceLeaf(const TEvQuota:
             QuotersIndex.emplace(leaf.Quoter, quoterId);
 
             quoter = &Quoters.emplace(quoterId, TQuoterState(leaf.Quoter, Counters.ServiceCounters)).first->second;
+            quoter->ResolveStartTime = TActivationContext::Now();
             Counters.ActiveQuoterProxies->Inc();
 
             THolder<NSchemeCache::TSchemeCacheNavigate> req(new NSchemeCache::TSchemeCacheNavigate());
@@ -632,8 +633,11 @@ TQuoterService::EInitLeafStatus TQuoterService::InitResourceLeaf(const TEvQuota:
         }
 
         if (resHolder == nullptr) {
-            auto rIndxIt = quoter->WaitingResource.emplace(leaf.Resource, TSet<TRequestId>());
-            rIndxIt.first->second.emplace(reqIdx);
+            auto rIndxIt = quoter->WaitingResource.emplace(leaf.Resource, TResourceResolve());
+            if (rIndxIt.second) {
+                rIndxIt.first->second.StartTime = TActivationContext::Now();
+            }
+            rIndxIt.first->second.Requests.emplace(reqIdx);
 
             const TResourceLeafId resLeafIdx = ResState.Allocate(nullptr, leaf.Amount, leaf.IsUsedAmount, reqIdx);
             TResourceLeaf& resLeaf = ResState.Get(resLeafIdx);
@@ -1034,13 +1038,25 @@ void TQuoterService::Handle(TEvQuota::TEvProxySession::TPtr &ev) {
     if (quoter.ProxyId != ev->Sender)
         return;
 
-    auto resIt = quoter.WaitingResource.find(resourceName);
-    Y_ABORT_UNLESS(resIt != quoter.WaitingResource.end());
-
-    TSet<TRequestId> waitingRequests = std::move(resIt->second);
-    quoter.WaitingResource.erase(resIt);
-
     const bool isError = msg->Result != msg->Success;
+
+    // Collect the requests waiting for this resolve. The entry can be gone if the
+    // resolve hung and was cancelled by the cleanup: then there are no waiters,
+    // but for a successful session the proxy still considers it established, so
+    // we register the resource anyway to keep both views consistent (a future
+    // request reuses it, and idle cleanup closes it later) — unless we already
+    // track it, which would break the "no duplicating resources" invariant below.
+    TSet<TRequestId> waitingRequests;
+    if (auto resIt = quoter.WaitingResource.find(resourceName); resIt != quoter.WaitingResource.end()) {
+        waitingRequests = std::move(resIt->second.Requests);
+        quoter.WaitingResource.erase(resIt);
+    } else if (!isError && quoter.Resources.contains(msg->ResourceId)) {
+        YDB_LOG_INFO("Ignoring duplicate resource session",
+            {"quoterName", quoter.QuoterName},
+            {"resourceName", resourceName});
+        return;
+    }
+
     if (isError) {
         YDB_LOG_INFO("Resource session failed",
             {"quoterName", quoter.QuoterName},
@@ -1223,6 +1239,27 @@ void TQuoterService::HandleCleanup() {
             continue;
         }
 
+        // A quoter that hasn't been resolved for too long is considered hung:
+        // drop it and cancel its waiting requests (guards against a resolve that
+        // never gets an answer).
+        if (!quoterIt->second.ProxyId
+            && now - quoterIt->second.ResolveStartTime > CleanupPeriod)
+        {
+            CancelTimedOutQuoterResolve(quoterIt);
+            continue; // quoter erased, iterator is invalid
+        }
+
+        // Likewise, drop resource resolves that hung for too long.
+        TVector<TString> resolvesToCancel;
+        for (const auto& [resourceName, resolve] : quoterIt->second.WaitingResource) {
+            if (now - resolve.StartTime > CleanupPeriod) {
+                resolvesToCancel.push_back(resourceName);
+            }
+        }
+        for (const TString& resourceName : resolvesToCancel) {
+            CancelTimedOutResourceResolve(quoterIt->second, resourceName);
+        }
+
         TVector<ui64> resourcesToEvict;
         for (const auto& [resourceId, resHolder] : quoterIt->second.Resources) {
             ++resourcesProcessed;
@@ -1252,6 +1289,46 @@ void TQuoterService::HandleCleanup() {
     }
 
     ScheduleNextCleanupPass();
+}
+
+void TQuoterService::CancelTimedOutQuoterResolve(decltype(Quoters)::iterator quoterIt) {
+    TQuoterState& quoter = quoterIt->second;
+    YDB_LOG_WARN("Cancel hanging quoter resolve",
+        {"quoterName", quoter.QuoterName});
+
+    // Fail every request waiting for the quoter to be resolved. ForgetRequest
+    // removes each request from WaitingQueueResolve, so iterate over a copy.
+    TSet<TRequestId> waiting(std::move(quoter.WaitingQueueResolve));
+    for (TRequestId reqIdx : waiting) {
+        TRequest& req = ReqState.Get(reqIdx);
+        req.EndWaitSpan("ResolveTimeout", false);
+        FailRequest(req, reqIdx);
+    }
+
+    // A still-resolving quoter has no proxy and no resources, so BreakQuoter
+    // just drops the (now empty) quoter state and its index entry.
+    BreakQuoter(quoterIt, "ResolveTimeout");
+}
+
+void TQuoterService::CancelTimedOutResourceResolve(TQuoterState& quoter, const TString& resourceName) {
+    auto resIt = quoter.WaitingResource.find(resourceName);
+    if (resIt == quoter.WaitingResource.end()) {
+        return;
+    }
+
+    YDB_LOG_WARN("Cancel hanging resource resolve",
+        {"quoterName", quoter.QuoterName},
+        {"resourceName", resourceName});
+
+    // Take the requests out and drop the resolve entry before failing them, so
+    // ForgetRequest (which looks the entry up) sees it already gone.
+    TSet<TRequestId> waiting(std::move(resIt->second.Requests));
+    quoter.WaitingResource.erase(resIt);
+    for (TRequestId reqIdx : waiting) {
+        TRequest& req = ReqState.Get(reqIdx);
+        req.EndWaitSpan("ResolveTimeout", false);
+        FailRequest(req, reqIdx);
+    }
 }
 
 void TQuoterService::EvictResource(TQuoterState& quoter, ui64 resourceId, TStringBuf reason) {
@@ -1352,8 +1429,11 @@ void TQuoterService::CreateKesusQuoter(NSchemeCache::TSchemeCacheNavigate::TEntr
                 leaf.State = EResourceState::ResolveResource;
                 req.StartWaitSpan(leaf, "QuoterService.ResolveResource");
 
-                auto itpair = quoter.WaitingResource.emplace(leaf.ResourceName, TSet<TRequestId>());
-                itpair.first->second.emplace(reqIdx);
+                auto itpair = quoter.WaitingResource.emplace(leaf.ResourceName, TResourceResolve());
+                if (itpair.second) {
+                    itpair.first->second.StartTime = TActivationContext::Now();
+                }
+                itpair.first->second.Requests.emplace(reqIdx);
 
                 if (itpair.second) { // new resolve entry, request
                     YDB_LOG_INFO("Resolve resource on quoter",
@@ -1387,9 +1467,9 @@ void TQuoterService::BreakQuoter(decltype(QuotersIndex)::iterator indexIt, declt
         DeclineRequest(req, reqIdx);
     }
 
-    TMap<TString, TSet<TRequestId>> waitingResource(std::move(quoter.WaitingResource));
+    TMap<TString, TResourceResolve> waitingResource(std::move(quoter.WaitingResource));
     for (auto &xpair : waitingResource) {
-        for (TRequestId reqIdx : xpair.second) {
+        for (TRequestId reqIdx : xpair.second.Requests) {
             auto& req = ReqState.Get(reqIdx);
             req.EndWaitSpan(waitStatus, false);
             DeclineRequest(req, reqIdx);

--- a/ydb/core/quoter/quoter_service.cpp
+++ b/ydb/core/quoter/quoter_service.cpp
@@ -776,7 +776,7 @@ void TQuoterService::InitialRequestProcessing(TEvQuota::TEvRequest::TPtr &ev, co
     TRequest &request = ReqState.Get(reqIdx);
 
     request.Operator = msg->Operator;
-    request.Deadline = TInstant::Max();
+    request.Deadline = TDuration::Max();
     Y_ABORT_UNLESS(request.Operator == EResourceOperator::And); // todo: support other modes
 
     Y_ABORT_UNLESS(msg->Reqs.size() >= 1);
@@ -811,28 +811,45 @@ void TQuoterService::InitialRequestProcessing(TEvQuota::TEvRequest::TPtr &ev, co
     }
 
     if (msg->Deadline != TDuration::Max()) {
-        const TDuration delay = Min(TDuration::Days(1), msg->Deadline);
-        const TInstant now = TActivationContext::Now();
-        TryTickSchedule(now);
-        request.Deadline = TimeToGranularity(now + delay);
-
-        auto deadlineIt = ScheduleDeadline.find(request.Deadline);
-        if (deadlineIt == ScheduleDeadline.end()) {
-            TInstant deadline = request.Deadline; // allocate could invalidate request&
-            deadlineIt = ScheduleDeadline.emplace(deadline, ReqState.Allocate(TActorId(0, "placeholder"), 0)).first;
+        request.Deadline = Min(TDuration::Days(1), msg->Deadline);
+        // While a new session is being resolved, postpone scheduling the deadline
+        // so the session setup time is not accounted (see Handle(TEvProxySession)).
+        if (!ResourceInResolvingState(reqIdx)) {
+            const TInstant now = TActivationContext::Now();
+            TryTickSchedule(now);
+            ScheduleRequestDeadline(reqIdx, TimeToGranularity(now + request.Deadline));
         }
-
-        const TRequestId placeholderIdx = deadlineIt->second;
-        TRequest &placeholder = ReqState.Get(placeholderIdx);
-        TRequest &reqq = ReqState.Get(reqIdx);
-
-        if (placeholder.NextDeadlineRequest != Max<ui32>()) {
-            reqq.NextDeadlineRequest = placeholder.NextDeadlineRequest;
-            ReqState.Get(placeholder.NextDeadlineRequest).PrevDeadlineRequest = reqIdx;
-        }
-        reqq.PrevDeadlineRequest = placeholderIdx;
-        placeholder.NextDeadlineRequest = reqIdx;
     }
+}
+
+bool TQuoterService::ResourceInResolvingState(TRequestId reqIdx) {
+    const TRequest &request = ReqState.Get(reqIdx);
+    for (TResourceLeafId leafIdx = request.ResourceLeaf; leafIdx != TResourceLeafId{}; ) {
+        const TResourceLeaf &leaf = ResState.Get(leafIdx);
+        if (leaf.State == EResourceState::ResolveQuoter || leaf.State == EResourceState::ResolveResource) {
+            return true;
+        }
+        leafIdx = leaf.NextResourceLeaf;
+    }
+    return false;
+}
+
+void TQuoterService::ScheduleRequestDeadline(TRequestId reqIdx, TInstant deadline) {
+    auto deadlineIt = ScheduleDeadline.find(deadline);
+    if (deadlineIt == ScheduleDeadline.end()) {
+        deadlineIt = ScheduleDeadline.emplace(deadline, ReqState.Allocate(TActorId(0, "placeholder"), 0)).first;
+    }
+
+    const TRequestId placeholderIdx = deadlineIt->second;
+    TRequest &placeholder = ReqState.Get(placeholderIdx);
+    TRequest &reqq = ReqState.Get(reqIdx);
+
+    if (placeholder.NextDeadlineRequest != Max<ui32>()) {
+        reqq.NextDeadlineRequest = placeholder.NextDeadlineRequest;
+        ReqState.Get(placeholder.NextDeadlineRequest).PrevDeadlineRequest = reqIdx;
+    }
+    reqq.PrevDeadlineRequest = placeholderIdx;
+    placeholder.NextDeadlineRequest = reqIdx;
 }
 
 void TQuoterService::Handle(NMon::TEvHttpInfo::TPtr &ev) {
@@ -1095,6 +1112,14 @@ void TQuoterService::Handle(TEvQuota::TEvProxySession::TPtr &ev) {
             }
             // initial charge would be in first session update
             resIdx = leaf.NextResourceLeaf;
+        }
+
+        // The session is set up: schedule the postponed deadline counting from
+        // now, once no other session for this request is still being resolved.
+        if (req.Deadline != TDuration::Max() && !ResourceInResolvingState(reqId)) {
+            const TInstant now = TActivationContext::Now();
+            TryTickSchedule(now);
+            ScheduleRequestDeadline(reqId, TimeToGranularity(now + req.Deadline));
         }
     }
 

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -72,7 +72,7 @@ struct TRequest {
 
     TInstant StartTime;
     EResourceOperator Operator = EResourceOperator::Unknown;
-    TInstant Deadline = TInstant::Max();
+    TDuration Deadline = TDuration::Max();
     TResourceLeafId ResourceLeaf;
 
     TRequestId PrevDeadlineRequest;
@@ -317,6 +317,9 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void FailRequest(TRequest &request, TRequestId reqIdx);
     void AllowRequest(TRequest &request, TRequestId reqIdx);
     void DeadlineRequest(TRequest &request, TRequestId reqIdx);
+
+    bool ResourceInResolvingState(TRequestId reqIdx);
+    void ScheduleRequestDeadline(TRequestId reqIdx, TInstant deadline);
 
     EInitLeafStatus InitSystemLeaf(const TEvQuota::TResourceLeaf &leaf, TRequest &request, TRequestId reqIdx);
     EInitLeafStatus InitResourceLeaf(const TEvQuota::TResourceLeaf &leaf, TRequest &request, TRequestId reqIdx);

--- a/ydb/core/quoter/quoter_service_impl.h
+++ b/ydb/core/quoter/quoter_service_impl.h
@@ -223,15 +223,25 @@ struct TScheduleTick {
     ui32 ActivationHead = Max<ui32>();
 };
 
+// Requests waiting for a resource session to be resolved, plus the moment the
+// resolve started (used to detect and clean up hung resolves).
+struct TResourceResolve {
+    TInstant StartTime;
+    TSet<TRequestId> Requests;
+};
+
 struct TQuoterState {
     const TString QuoterName;
     TActorId ProxyId;
+    // When the quoter resolve started (meaningful only while ProxyId is empty).
+    // Used to detect a hung quoter resolve during cleanup.
+    TInstant ResolveStartTime;
 
     THashMap<ui64, THolder<TResource>> Resources;
     THashMap<TString, ui64> ResourcesIndex;
 
     TSet<TRequestId> WaitingQueueResolve; // => requests
-    TMap<TString, TSet<TRequestId>> WaitingResource; // => requests
+    TMap<TString, TResourceResolve> WaitingResource; // resource name => resolve
 
     struct {
         ::NMonitoring::TDynamicCounterPtr QuoterCounters;
@@ -338,6 +348,10 @@ class TQuoterService : public TActorBootstrapped<TQuoterService> {
     void StartCleanupPass();
     void ScheduleNextCleanupPass();
     void HandleCleanup();
+    // Cleanup of resolves that hung longer than CleanupPeriod: cancels the
+    // waiting requests and drops the resolving quoter / resource.
+    void CancelTimedOutQuoterResolve(decltype(Quoters)::iterator quoterIt);
+    void CancelTimedOutResourceResolve(TQuoterState& quoter, const TString& resourceName);
     void EvictResource(TQuoterState& quoter, ui64 resourceId, TStringBuf reason);
     bool CloseQuoterIfEmpty(decltype(Quoters)::iterator quoterIt, TStringBuf reason);
 

--- a/ydb/core/quoter/quoter_service_ut.cpp
+++ b/ydb/core/quoter/quoter_service_ut.cpp
@@ -180,11 +180,11 @@ Y_UNIT_TEST_SUITE(TQuoterServiceTest) {
     }
 
     // Async helper: create resource on Kesus tablet
-    void CreateKesusResourceAsync(TTestActorRuntime* runtime, double rate) {
+    void CreateKesusResourceAsync(TTestActorRuntime* runtime, double rate, const TString& resourcePath = "/Res") {
         const ui64 tabletId = GetKesusTabletIdAsync(runtime);
 
         TAutoPtr<NKesus::TEvKesus::TEvAddQuoterResource> request(new NKesus::TEvKesus::TEvAddQuoterResource());
-        request->Record.MutableResource()->SetResourcePath("/Res");
+        request->Record.MutableResource()->SetResourcePath(resourcePath);
         request->Record.MutableResource()->MutableHierarchicalDRRResourceConfig()->SetMaxUnitsPerSecond(rate);
 
         TActorId sender = runtime->AllocateEdgeActor();
@@ -641,6 +641,180 @@ Y_UNIT_TEST_SUITE(TQuoterServiceTest) {
             {sender},
             [](const auto& ev) { return ev->Cookie == 1; });
         UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+    }
+
+    // If the quoter resolve hangs (no answer ever comes), the cleanup must
+    // eventually cancel the waiting request instead of leaving it stuck.
+    Y_UNIT_TEST(CancelsHangingQuoterResolve) {
+        TPortManager portManager;
+        TServerSettings serverSettings(portManager.GetPort());
+        serverSettings.SetUseRealThreads(false);
+        TServer server = TServer(serverSettings, true);
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        const TActorId serviceId = MakeQuoterServiceID();
+        const TActorId serviceActorId = runtime->Register(CreateQuoterService());
+        runtime->RegisterService(serviceId, serviceActorId);
+
+        auto dispatch = [&] {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back([](IEventHandle&) { return false; });
+            runtime->DispatchEvents(options, TDuration::MilliSeconds(1));
+        };
+
+        InitRootSchemeAsync(runtime);
+        CreateKesusAsync(runtime);
+        CreateKesusResourceAsync(runtime, 1000.0);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+        dispatch();
+
+        const TActorId sender = runtime->AllocateEdgeActor();
+        const TEvQuota::TResourceLeaf resLeaf(
+            TStringBuilder() << "/" << Tests::TestDomainName,
+            TStringBuilder() << "/" << Tests::TestDomainName << "/KesusQuoter",
+            "Res",
+            1);
+
+        // Drop the quoter path resolve answer so the quoter never gets resolved.
+        THolder<IEventHandle> heldNavigate;
+        auto observer = runtime->AddObserver<TEvTxProxySchemeCache::TEvNavigateKeySetResult>(
+            [&](TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
+                if (!heldNavigate && ev->Recipient == serviceActorId) {
+                    heldNavigate.Reset(ev.Release());
+                }
+            });
+
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And, {resLeaf},
+                TDuration::Max()), 0, 1));
+
+        // The quoter resolve is now hung.
+        runtime->WaitFor("intercepted quoter resolve", [&] { return (bool)heldNavigate; });
+
+        // Advance past the hang threshold (CleanupPeriod) so cleanup cancels it.
+        runtime->AdvanceCurrentTime(TDuration::Minutes(2));
+        dispatch();
+
+        auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+            {sender},
+            [](const auto& ev) { return ev->Cookie == 1; });
+        UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::GenericError);
+
+        // A late resolve answer after cleanup must be ignored, not crash.
+        // Remove the observer first so the re-sent answer is delivered.
+        observer.Remove();
+        runtime->Send(heldNavigate.Release());
+        dispatch();
+
+        // The dropped quoter was fully cleaned up, so a new request must
+        // re-resolve it from scratch and succeed.
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And, {resLeaf},
+                TDuration::Max()), 0, 2));
+        {
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender}, [](const auto& ev) { return ev->Cookie == 2; });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+        }
+    }
+
+    // If the resource resolve hangs (the session answer never comes), the cleanup
+    // must cancel the waiting request, and a late session must not crash the
+    // service (the resolve entry is already gone).
+    Y_UNIT_TEST(CancelsHangingResourceResolve) {
+        TPortManager portManager;
+        TServerSettings serverSettings(portManager.GetPort());
+        serverSettings.SetUseRealThreads(false);
+        TServer server = TServer(serverSettings, true);
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        const TActorId serviceId = MakeQuoterServiceID();
+        const TActorId serviceActorId = runtime->Register(CreateQuoterService());
+        runtime->RegisterService(serviceId, serviceActorId);
+
+        auto dispatch = [&] {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back([](IEventHandle&) { return false; });
+            runtime->DispatchEvents(options, TDuration::MilliSeconds(1));
+        };
+
+        InitRootSchemeAsync(runtime);
+        CreateKesusAsync(runtime);
+        CreateKesusResourceAsync(runtime, 1000.0, "/Res");
+        CreateKesusResourceAsync(runtime, 1000.0, "/Res2");
+        runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+        dispatch();
+
+        const TActorId sender = runtime->AllocateEdgeActor();
+        const TString database = TStringBuilder() << "/" << Tests::TestDomainName;
+        const TString quoter = TStringBuilder() << "/" << Tests::TestDomainName << "/KesusQuoter";
+
+        // Establish "Res" first so the quoter stays alive after the hung "Res2"
+        // resolve is cancelled (this is what lets us exercise the late-session
+        // path with the quoter still present).
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And,
+                {TEvQuota::TResourceLeaf(database, quoter, "Res", 1)}, TDuration::Max()), 0, 1));
+        {
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender}, [](const auto& ev) { return ev->Cookie == 1; });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+        }
+
+        // Drop the "Res2" session answer so its resource resolve hangs.
+        THolder<IEventHandle> heldSession;
+        auto observer = runtime->AddObserver<TEvQuota::TEvProxySession>(
+            [&](TEvQuota::TEvProxySession::TPtr& ev) {
+                if (!heldSession && ev->Get()->Resource == "Res2") {
+                    heldSession.Reset(ev.Release());
+                }
+            });
+
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And,
+                {TEvQuota::TResourceLeaf(database, quoter, "Res2", 1)}, TDuration::Max()), 0, 2));
+
+        // The "Res2" resource resolve is now hung.
+        runtime->WaitFor("intercepted resource resolve", [&] { return (bool)heldSession; });
+
+        // Advance past the hang threshold (CleanupPeriod) so cleanup cancels it.
+        runtime->AdvanceCurrentTime(TDuration::Minutes(2));
+        dispatch();
+
+        {
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender}, [](const auto& ev) { return ev->Cookie == 2; });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::GenericError);
+        }
+
+        // A late session after cleanup must not crash: the resolve entry is gone,
+        // but the session is established on the proxy, so the service registers
+        // the resource to stay consistent with it. Remove the observer first so
+        // the re-sent session is delivered.
+        observer.Remove();
+        runtime->Send(heldSession.Release());
+        dispatch();
+
+        // Sanity: the quoter still serves requests for the established resource.
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And,
+                {TEvQuota::TResourceLeaf(database, quoter, "Res", 1)}, TDuration::Max()), 0, 3));
+        {
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender}, [](const auto& ev) { return ev->Cookie == 3; });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+        }
+
+        // A new request for "Res2" must succeed via the resource registered from
+        // the late session.
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And,
+                {TEvQuota::TResourceLeaf(database, quoter, "Res2", 1)}, TDuration::Max()), 0, 4));
+        {
+            auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+                {sender}, [](const auto& ev) { return ev->Cookie == 4; });
+            UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+        }
     }
 }
 

--- a/ydb/core/quoter/quoter_service_ut.cpp
+++ b/ydb/core/quoter/quoter_service_ut.cpp
@@ -556,6 +556,92 @@ Y_UNIT_TEST_SUITE(TQuoterServiceTest) {
         UNIT_ASSERT_VALUES_EQUAL(proxySessions, 2);
         UNIT_ASSERT_VALUES_EQUAL(proxyCloseSessions, 1);
     }
+
+    // The request deadline must be accounted only from the moment the resource
+    // session is established, not from the request arrival: the (possibly slow)
+    // session setup time must not count against the deadline.
+    Y_UNIT_TEST(DeadlineCountsFromSessionEstablished) {
+        TPortManager portManager;
+        TServerSettings serverSettings(portManager.GetPort());
+        serverSettings.SetUseRealThreads(false);
+        TServer server = TServer(serverSettings, true);
+        TTestActorRuntime* runtime = server.GetRuntime();
+
+        const TActorId serviceId = MakeQuoterServiceID();
+        const TActorId serviceActorId = runtime->Register(CreateQuoterService());
+        runtime->RegisterService(serviceId, serviceActorId);
+
+        auto dispatch = [&] {
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back([](IEventHandle&) { return false; });
+            runtime->DispatchEvents(options, TDuration::MilliSeconds(1));
+        };
+
+        InitRootSchemeAsync(runtime);
+        CreateKesusAsync(runtime);
+        CreateKesusResourceAsync(runtime, 1000.0);
+        runtime->AdvanceCurrentTime(TDuration::Seconds(2));
+        dispatch();
+
+        const TActorId sender = runtime->AllocateEdgeActor();
+        const TEvQuota::TResourceLeaf resLeaf(
+            TStringBuilder() << "/" << Tests::TestDomainName,
+            TStringBuilder() << "/" << Tests::TestDomainName << "/KesusQuoter",
+            "Res",
+            1);
+
+        // Intercept the resource session together with the proxy updates that
+        // carry the initial quota, so they can be replayed later, after a delay
+        // that is longer than the request deadline. The updates are needed too:
+        // after the session the service has no balance until an update arrives,
+        // and the next real update is only sent on the proxy's 100ms tick, which
+        // is well past the 1ms deadline.
+        THolder<IEventHandle> heldSession;
+        TVector<THolder<IEventHandle>> heldUpdates;
+        bool replaying = false;
+        auto sessionObserver = runtime->AddObserver<TEvQuota::TEvProxySession>(
+            [&](TEvQuota::TEvProxySession::TPtr& ev) {
+                if (replaying || heldSession) {
+                    return;
+                }
+                if (ev->Get()->Result == TEvQuota::TEvProxySession::Success) {
+                    heldSession.Reset(ev.Release());
+                }
+            });
+        auto updateObserver = runtime->AddObserver<TEvQuota::TEvProxyUpdate>(
+            [&](TEvQuota::TEvProxyUpdate::TPtr& ev) {
+                if (replaying) {
+                    return;
+                }
+                heldUpdates.emplace_back(ev.Release());
+            });
+
+        // Request with a 1ms deadline that has to start a new session.
+        runtime->Send(new IEventHandle(MakeQuoterServiceID(), sender,
+            new TEvQuota::TEvRequest(TEvQuota::EResourceOperator::And, {resLeaf},
+                TDuration::MilliSeconds(1)), 0, 1));
+
+        // Let the session be established and the initial quota update be produced
+        // (and intercepted). This takes far longer than the 1ms deadline.
+        runtime->WaitFor("resource session and initial quota update",
+            [&] { return heldSession && !heldUpdates.empty(); });
+
+        // Sleep well past the deadline while the session is still not delivered.
+        runtime->AdvanceCurrentTime(TDuration::MilliSeconds(10));
+
+        // Deliver the session (and the quota) now: the deadline must be counted
+        // from this moment, so the request must succeed.
+        replaying = true;
+        runtime->Send(heldSession.Release());
+        for (auto& update : heldUpdates) {
+            runtime->Send(update.Release());
+        }
+
+        auto event = runtime->GrabEdgeEventIf<TEvQuota::TEvClearance>(
+            {sender},
+            [](const auto& ev) { return ev->Cookie == 1; });
+        UNIT_ASSERT_VALUES_EQUAL(event->Get()->Result, TEvQuota::TEvClearance::EResult::Success);
+    }
 }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Rate Limiter API has two timeouts:
- standard OperationTimeout - timeout for grpc call, is handled the same as for every grpc method
- CancelAfter timeout - timeout for QuoterService request only: does not include all infrastructure things, such as rights checks, database resolving etc.

CancelTimeout is passed as a Deadline field in QuoterService events API, and this Deadline includes not only quota handling, but quoter and quoter resource resolving (if the request arrives for the first time). It results in problems with stability of returned status codes: we can not distinguish infrastructure errors and quota issues, especially if CancelAfter holds relatively small value.

I removed communication with Kesus from this timeout: now it handles only quota related issues.