### PR TITLE
Add rows_limit option to QueryService ExecuteQuery

### DIFF
--- a/ydb/core/grpc_services/query/rpc_execute_query.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_query.cpp
@@ -79,9 +79,7 @@ public:
         if (resultSet.has_arrow_format_meta()) {
             limitedResultSet.mutable_arrow_format_meta()->Swap(resultSet.mutable_arrow_format_meta());
         }
-        if (resultSet.has_data()) {
-            limitedResultSet.set_data(resultSet.data());
-        }
+        limitedResultSet.mutable_data()->swap(*resultSet.mutable_data());
 
         bool truncated = false;
         for (auto& row : *resultSet.mutable_rows()) {

--- a/ydb/core/grpc_services/query/rpc_execute_query.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_query.cpp
@@ -340,6 +340,12 @@ private:
         Ydb::Query::SchemaInclusionMode schemaInclusionMode = req->schema_inclusion_mode();
         Ydb::ResultSet::Format resultSetFormat = req->result_set_format();
 
+        if (req->has_rows_limit() && resultSetFormat == Ydb::ResultSet::FORMAT_ARROW) {
+            issues.AddIssue(MakeIssue(NKikimrIssues::TIssuesIds::DEFAULT_ERROR,
+                "rows_limit is not supported with FORMAT_ARROW result set format"));
+            return ReplyFinishStream(Ydb::StatusIds::BAD_REQUEST, std::move(issues));
+        }
+
         std::optional<NKqp::NFormats::TArrowFormatSettings> arrowFormatSettings;
         if (req->has_arrow_format_settings()) {
             arrowFormatSettings = NKqp::NFormats::TArrowFormatSettings::ImportFromProto(req->arrow_format_settings());

--- a/ydb/core/grpc_services/query/rpc_execute_query.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_query.cpp
@@ -31,9 +31,10 @@ struct TProducerState {
     TActorId ActorId;
     ui64 ChannelId = 0;
 
-    void SendAck(const NActors::TActorIdentity& actor) const {
+    void SendAck(const NActors::TActorIdentity& actor, bool enough = false) const {
         auto resp = MakeHolder<NKqp::TEvKqpExecuter::TEvStreamDataAck>(*LastSeqNo, ChannelId);
         resp->Record.SetFreeSpace(AckedFreeSpaceBytes);
+        resp->Record.SetEnough(enough);
 
         actor.Send(ActorId, resp.Release());
     }
@@ -46,6 +47,66 @@ struct TProducerState {
         }
         return false;
     }
+};
+
+class TStreamRowsLimitState {
+public:
+    bool ApplyLimit(TMaybe<ui64> rowsLimit, i64 resultSetIndex, Ydb::ResultSet& resultSet) {
+        if (!rowsLimit) {
+            return false;
+        }
+
+        if (Truncated_.contains(resultSetIndex)) {
+            resultSet.clear_rows();
+            resultSet.set_truncated(true);
+            return true;
+        }
+
+        auto& rowCount = RowCount_[resultSetIndex];
+        if (*rowsLimit == 0) {
+            const bool hadRows = resultSet.rows_size() > 0;
+            resultSet.clear_rows();
+            if (hadRows) {
+                resultSet.set_truncated(true);
+                Truncated_.insert(resultSetIndex);
+            }
+            return hadRows;
+        }
+
+        Ydb::ResultSet limitedResultSet;
+        limitedResultSet.mutable_columns()->Swap(resultSet.mutable_columns());
+        limitedResultSet.set_format(resultSet.format());
+        if (resultSet.has_arrow_format_meta()) {
+            limitedResultSet.mutable_arrow_format_meta()->Swap(resultSet.mutable_arrow_format_meta());
+        }
+        if (resultSet.has_data()) {
+            limitedResultSet.set_data(resultSet.data());
+        }
+
+        bool truncated = false;
+        for (auto& row : *resultSet.mutable_rows()) {
+            if (rowCount + 1 > *rowsLimit) {
+                truncated = true;
+                break;
+            }
+            ++rowCount;
+            limitedResultSet.add_rows()->Swap(&row);
+        }
+
+        if (truncated) {
+            limitedResultSet.set_truncated(true);
+            Truncated_.insert(resultSetIndex);
+        } else if (resultSet.truncated()) {
+            limitedResultSet.set_truncated(true);
+        }
+
+        resultSet.Swap(&limitedResultSet);
+        return truncated;
+    }
+
+private:
+    THashMap<i64, ui64> RowCount_;
+    THashSet<i64> Truncated_;
 };
 
 bool FillTxSettings(const Ydb::Query::TransactionSettings& from, Ydb::Table::TransactionSettings& to,
@@ -305,6 +366,10 @@ private:
             .SetOutputChunkMaxSize(req->response_part_limit_bytes())
             .SetSchemaInclusionMode(schemaInclusionMode)
             .SetResultSetFormat(resultSetFormat);
+        if (req->has_rows_limit()) {
+            settings.SetRowsLimit(req->rows_limit());
+        }
+        RowsLimit_ = req->has_rows_limit() ? TMaybe<ui64>(req->rows_limit()) : Nothing();
 
         auto ev = MakeHolder<NKqp::TEvKqp::TEvQueryRequest>(
             QueryAction,
@@ -375,6 +440,9 @@ private:
         response->set_result_set_index(ev->Get()->Record.GetQueryResultIndex());
         response->mutable_result_set()->Swap(ev->Get()->Record.MutableResultSet());
 
+        const bool truncated = StreamRowsLimitState_.ApplyLimit(
+            RowsLimit_, response->result_set_index(), *response->mutable_result_set());
+
         if (ev->Get()->Record.HasVirtualTimestamp()) {
             auto snap = response->mutable_snapshot_timestamp();
             auto& ts = ev->Get()->Record.GetVirtualTimestamp();
@@ -402,7 +470,13 @@ private:
             << ", to: " << ev->Sender
             << ", queue: " << FlowControl_.QueueSize());
 
-        channel.SendAck(SelfId());
+        channel.SendAck(SelfId(), truncated);
+
+        if (truncated) {
+            LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << "Stop stream by rows limit"
+                << ", resultSetIndex: " << response->result_set_index()
+                << ", rowsLimit: " << (RowsLimit_ ? ToString(*RowsLimit_) : "none"));
+        }
     }
 
     void Handle(NKqp::TEvKqpExecuter::TEvExecuterProgress::TPtr& ev) {
@@ -464,6 +538,7 @@ private:
                     hasTrailingMessage = true;
                     response.set_result_set_index(i);
                     response.mutable_result_set()->Swap(record.MutableResponse()->MutableYdbResults(i));
+                    StreamRowsLimitState_.ApplyLimit(RowsLimit_, i, *response.mutable_result_set());
                 }
             }
 
@@ -569,6 +644,8 @@ private:
     NKikimrKqp::EQueryAction QueryAction;
     TRpcFlowControlState FlowControl_;
     TMap<ui64, TProducerState> StreamChannels_;
+    TMaybe<ui64> RowsLimit_;
+    TStreamRowsLimitState StreamRowsLimitState_;
 
     NWilson::TSpan Span_;
 };

--- a/ydb/core/grpc_services/query/rpc_execute_query.cpp
+++ b/ydb/core/grpc_services/query/rpc_execute_query.cpp
@@ -51,6 +51,10 @@ struct TProducerState {
 
 class TStreamRowsLimitState {
 public:
+    bool IsTruncated(i64 resultSetIndex) const {
+        return Truncated_.contains(resultSetIndex);
+    }
+
     bool ApplyLimit(TMaybe<ui64> rowsLimit, i64 resultSetIndex, Ydb::ResultSet& resultSet) {
         if (!rowsLimit) {
             return false;
@@ -439,13 +443,31 @@ private:
     }
 
     void Handle(NKqp::TEvKqpExecuter::TEvStreamData::TPtr& ev, const TActorContext& ctx) {
+        const auto resultSetIndex = ev->Get()->Record.GetQueryResultIndex();
+
+        auto& channel = StreamChannels_[ev->Get()->Record.GetChannelId()];
+        channel.ActorId = ev->Sender;
+        channel.LastSeqNo = ev->Get()->Record.GetSeqNo();
+        channel.ChannelId = ev->Get()->Record.GetChannelId();
+        channel.AckedFreeSpaceBytes = FlowControl_.FreeSpaceBytes();
+
+        if (StreamRowsLimitState_.IsTruncated(resultSetIndex)) {
+            LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << "Skip stream data for truncated result set"
+                << ", resultSetIndex: " << resultSetIndex
+                << ", seqNo: " << ev->Get()->Record.GetSeqNo()
+                << ", to: " << ev->Sender);
+
+            channel.SendAck(SelfId(), true);
+            return;
+        }
+
         Ydb::Query::ExecuteQueryResponsePart *response = ev->Get()->Arena->Allocate<Ydb::Query::ExecuteQueryResponsePart>();
         response->set_status(Ydb::StatusIds::SUCCESS);
-        response->set_result_set_index(ev->Get()->Record.GetQueryResultIndex());
+        response->set_result_set_index(resultSetIndex);
         response->mutable_result_set()->Swap(ev->Get()->Record.MutableResultSet());
 
         const bool truncated = StreamRowsLimitState_.ApplyLimit(
-            RowsLimit_, response->result_set_index(), *response->mutable_result_set());
+            RowsLimit_, resultSetIndex, *response->mutable_result_set());
 
         if (ev->Get()->Record.HasVirtualTimestamp()) {
             auto snap = response->mutable_snapshot_timestamp();
@@ -462,11 +484,7 @@ private:
 
         Request_->SendSerializedResult(std::move(out), Ydb::StatusIds::SUCCESS);
 
-        auto& channel = StreamChannels_[ev->Get()->Record.GetChannelId()];
-        channel.ActorId = ev->Sender;
-        channel.LastSeqNo = ev->Get()->Record.GetSeqNo();
         channel.AckedFreeSpaceBytes = freeSpaceBytes;
-        channel.ChannelId = ev->Get()->Record.GetChannelId();
 
         LOG_DEBUG_S(ctx, NKikimrServices::RPC_REQUEST, this->SelfId() << "Send stream data ack"
             << ", seqNo: " << ev->Get()->Record.GetSeqNo()

--- a/ydb/core/kqp/common/events/query.h
+++ b/ydb/core/kqp/common/events/query.h
@@ -65,6 +65,11 @@ struct TQueryRequestSettings {
         return *this;
     }
 
+    TQueryRequestSettings& SetRowsLimit(TMaybe<ui64> limit) {
+        RowsLimit = limit;
+        return *this;
+    }
+
     ui64 OutputChunkMaxSize = 0;
     bool KeepSession = false;
     bool UseCancelAfter = true;
@@ -72,6 +77,7 @@ struct TQueryRequestSettings {
     ::Ydb::Query::SchemaInclusionMode SchemaInclusionMode = Ydb::Query::SchemaInclusionMode::SCHEMA_INCLUSION_MODE_UNSPECIFIED;
     ::Ydb::ResultSet::Format ResultSetFormat = Ydb::ResultSet::FORMAT_UNSPECIFIED;
     bool SupportsStreamTrailingResult = false;
+    TMaybe<ui64> RowsLimit;
 };
 
 struct TEvQueryRequest: public NActors::TEventLocal<TEvQueryRequest, TKqpEvents::EvQueryRequest> {
@@ -434,6 +440,16 @@ public:
 
     ::Ydb::ResultSet::Format GetResultSetFormat() const {
         return RequestCtx ? QuerySettings.ResultSetFormat : Record.GetRequest().GetResultSetFormat();
+    }
+
+    TMaybe<ui64> GetRowsLimit() const {
+        if (RequestCtx) {
+            return QuerySettings.RowsLimit;
+        }
+        if (Record.GetRequest().HasRowsLimit()) {
+            return Record.GetRequest().GetRowsLimit();
+        }
+        return Nothing();
     }
 
     bool HasArrowFormatSettings() const {

--- a/ydb/core/kqp/common/kqp_event_impl.cpp
+++ b/ydb/core/kqp/common/kqp_event_impl.cpp
@@ -155,6 +155,9 @@ void TEvKqp::TEvQueryRequest::PrepareRemote() const {
         Record.MutableRequest()->SetOutputChunkMaxSize(QuerySettings.OutputChunkMaxSize);
         Record.MutableRequest()->SetSchemaInclusionMode(QuerySettings.SchemaInclusionMode);
         Record.MutableRequest()->SetResultSetFormat(QuerySettings.ResultSetFormat);
+        if (QuerySettings.RowsLimit) {
+            Record.MutableRequest()->SetRowsLimit(*QuerySettings.RowsLimit);
+        }
 
         RequestCtx.reset();
     }

--- a/ydb/core/kqp/common/simple/settings.h
+++ b/ydb/core/kqp/common/simple/settings.h
@@ -21,6 +21,7 @@ struct TKqpQuerySettings {
     NKikimrKqp::EQueryType QueryType = NKikimrKqp::EQueryType::QUERY_TYPE_UNDEFINED;
     Ydb::Query::Syntax Syntax = Ydb::Query::Syntax::SYNTAX_UNSPECIFIED;
     bool UsePessimisticLocks = false;
+    TMaybe<ui64> RowsLimit;
 
     explicit TKqpQuerySettings(NKikimrKqp::EQueryType queryType)
         : QueryType(queryType) {}
@@ -33,7 +34,8 @@ struct TKqpQuerySettings {
             Syntax == other.Syntax &&
             UsePessimisticLocks == other.UsePessimisticLocks &&
             RuntimeParameterSizeLimit == other.RuntimeParameterSizeLimit &&
-            RuntimeParameterSizeLimitSatisfied == other.RuntimeParameterSizeLimitSatisfied;
+            RuntimeParameterSizeLimitSatisfied == other.RuntimeParameterSizeLimitSatisfied &&
+            RowsLimit == other.RowsLimit;
     }
 
     bool operator!=(const TKqpQuerySettings& other) {
@@ -48,7 +50,7 @@ struct TKqpQuerySettings {
     size_t GetHash() const noexcept {
         auto tuple = std::make_tuple(
             DocumentApiRestricted, IsInternalCall, QueryType, Syntax,
-            UsePessimisticLocks, RuntimeParameterSizeLimitSatisfied);
+            UsePessimisticLocks, RuntimeParameterSizeLimitSatisfied, RowsLimit);
         return THash<decltype(tuple)>()(tuple);
     }
 
@@ -60,7 +62,8 @@ struct TKqpQuerySettings {
             << "Syntax: " << static_cast<int>(Syntax) << ", "
             << "UsePessimisticLocks: " << UsePessimisticLocks << ", "
             << "RuntimeParameterSizeLimit: " << RuntimeParameterSizeLimit << ", "
-            << "RuntimeParameterSizeLimitSatisfied: " << RuntimeParameterSizeLimitSatisfied
+            << "RuntimeParameterSizeLimitSatisfied: " << RuntimeParameterSizeLimitSatisfied << ", "
+            << "RowsLimit: " << (RowsLimit.Defined() ? ToString(*RowsLimit) : "undefined")
             << "}";
         return result;
     }

--- a/ydb/core/kqp/common/simple/settings.h
+++ b/ydb/core/kqp/common/simple/settings.h
@@ -4,9 +4,11 @@
 #include <ydb/core/protos/kqp_physical.pb.h>
 #include <ydb/public/api/protos/ydb_query.pb.h>
 
+#include <util/generic/maybe.h>
 #include <util/generic/string.h>
 #include <util/str_stl.h>
 #include <util/string/builder.h>
+#include <util/string/cast.h>
 
 #include <tuple>
 

--- a/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
+++ b/ydb/core/kqp/compile_service/kqp_compile_actor.cpp
@@ -127,7 +127,13 @@ public:
         // This is either the default setting or the explicit exclusion of a new RBO when compilation fails and recompilation is attempted.
         config->SetEnableNewRBO(EnableNewRBO);
 
-        if (QueryId.Settings.QueryType == NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT || QueryId.Settings.QueryType == NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY) {
+        if (QueryId.Settings.RowsLimit.Defined()) {
+            config->_ResultRowsLimit = QueryId.Settings.RowsLimit.GetRef();
+        } else if (IsIn({
+                NKikimrKqp::QUERY_TYPE_SQL_GENERIC_SCRIPT,
+                NKikimrKqp::QUERY_TYPE_SQL_GENERIC_QUERY,
+                NKikimrKqp::QUERY_TYPE_SQL_GENERIC_CONCURRENT_QUERY},
+            QueryId.Settings.QueryType)) {
             ui32 scriptResultRowsLimit = QueryServiceConfig.GetScriptResultRowsLimit();
             if (scriptResultRowsLimit > 0) {
                 config->_ResultRowsLimit = scriptResultRowsLimit;

--- a/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasource.cpp
@@ -915,7 +915,11 @@ public:
         IOptimizationContext& optCtx) override
     {
         auto queryType = SessionCtx->Query().Type;
-        if (queryType == EKikimrQueryType::Scan || queryType == EKikimrQueryType::Query) {
+        if (queryType == EKikimrQueryType::Scan) {
+            return source;
+        }
+
+        if (queryType == EKikimrQueryType::Query && !fillSettings.RowsLimitPerWrite) {
             return source;
         }
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_state.cpp
@@ -7,6 +7,16 @@ namespace NKikimr::NKqp {
 
 using namespace NSchemeCache;
 
+namespace {
+
+void ApplyRowsLimitToSettings(const TEvKqp::TEvQueryRequest& request, TKqpQuerySettings& settings) {
+    if (auto rowsLimit = request.GetRowsLimit()) {
+        settings.RowsLimit = *rowsLimit;
+    }
+}
+
+} // namespace
+
 #define LOG_C(msg) LOG_CRIT_S(*TlsActivationContext, NKikimrServices::KQP_SESSION, msg)
 #define LOG_E(msg) LOG_ERROR_S(*TlsActivationContext, NKikimrServices::KQP_SESSION, msg)
 #define LOG_W(msg) LOG_WARN_S(*TlsActivationContext, NKikimrServices::KQP_SESSION, msg)
@@ -224,6 +234,7 @@ bool TKqpQueryState::TryGetFromCache(
     settings.RuntimeParameterSizeLimit = RuntimeParameterSizeLimit;
     settings.RuntimeParameterSizeLimitSatisfied = RuntimeParameterSizeLimitSatisfied;
     settings.UsePessimisticLocks = (GetIsolationLevel(txCtx) == NKqpProto::ISOLATION_LEVEL_READ_COMMITTED_RW);
+    ApplyRowsLimitToSettings(*RequestEv, settings);
 
     TGUCSettings gUCSettings = gUCSettingsPtr ? *gUCSettingsPtr : TGUCSettings();
     bool keepInCache = false;
@@ -287,6 +298,7 @@ std::unique_ptr<TEvKqp::TEvCompileRequest> TKqpQueryState::BuildCompileRequest(s
     settings.RuntimeParameterSizeLimit = RuntimeParameterSizeLimit;
     settings.RuntimeParameterSizeLimitSatisfied = RuntimeParameterSizeLimitSatisfied;
     settings.UsePessimisticLocks = (GetIsolationLevel(txCtx) == NKqpProto::ISOLATION_LEVEL_READ_COMMITTED_RW);
+    ApplyRowsLimitToSettings(*RequestEv, settings);
 
     bool keepInCache = false;
     bool perStatementResult = HasImplicitTx();
@@ -349,6 +361,7 @@ std::unique_ptr<TEvKqp::TEvRecompileRequest> TKqpQueryState::BuildReCompileReque
     settings.RuntimeParameterSizeLimit = RuntimeParameterSizeLimit;
     settings.RuntimeParameterSizeLimitSatisfied = RuntimeParameterSizeLimitSatisfied;
     settings.UsePessimisticLocks = (GetIsolationLevel(txCtx) == NKqpProto::ISOLATION_LEVEL_READ_COMMITTED_RW);
+    ApplyRowsLimitToSettings(*RequestEv, settings);
 
     TGUCSettings gUCSettings = gUCSettingsPtr ? *gUCSettingsPtr : TGUCSettings();
 
@@ -398,6 +411,7 @@ std::unique_ptr<TEvKqp::TEvCompileRequest> TKqpQueryState::BuildCompileSplittedR
     settings.RuntimeParameterSizeLimit = RuntimeParameterSizeLimit;
     settings.RuntimeParameterSizeLimitSatisfied = RuntimeParameterSizeLimitSatisfied;
     settings.UsePessimisticLocks = (GetIsolationLevel(txCtx) == NKqpProto::ISOLATION_LEVEL_READ_COMMITTED_RW);
+    ApplyRowsLimitToSettings(*RequestEv, settings);
     TGUCSettings gUCSettings = gUCSettingsPtr ? *gUCSettingsPtr : TGUCSettings();
 
 

--- a/ydb/core/kqp/session_actor/kqp_query_state.h
+++ b/ydb/core/kqp/session_actor/kqp_query_state.h
@@ -263,6 +263,10 @@ public:
         return RequestEv->GetSyntax();
     }
 
+    TMaybe<ui64> GetRowsLimit() const {
+        return RequestEv->GetRowsLimit();
+    }
+
     const TString& GetRequestType() const {
         return RequestEv->GetRequestType();
     }

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -3107,7 +3107,8 @@ public:
                 if (QueryState->IsStreamResult()) {
                     if (QueryState->QueryData->HasTrailingTxResult(phyQuery.GetResultBindings(i))) {
                         TMaybe<ui64> effectiveRowsLimit = FillSettings.RowsLimitPerWrite;
-                        if (QueryState->PreparedQuery->GetResults(i).GetRowsLimit()) {
+                        if (i < QueryState->PreparedQuery->ResultsSize()
+                                && QueryState->PreparedQuery->GetResults(i).GetRowsLimit()) {
                             effectiveRowsLimit = QueryState->PreparedQuery->GetResults(i).GetRowsLimit();
                         } else if (auto requestRowsLimit = QueryState->GetRowsLimit()) {
                             effectiveRowsLimit = *requestRowsLimit;

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -336,6 +336,9 @@ public:
         QueryState = std::make_shared<TKqpQueryState>(
             ev, QueryId, Settings.Database, Settings.ApplicationName, Settings.Cluster, Settings.DbCounters, Settings.LongSession,
             Settings.TableService, Settings.QueryService, SessionId, AppData()->MonotonicTimeProvider->Now(), Settings.MutableExecuterConfig->RuntimeParameterSizeLimit.load());
+        if (auto rowsLimit = QueryState->GetRowsLimit()) {
+            FillSettings.RowsLimitPerWrite = *rowsLimit;
+        }
         if (QueryState->UserRequestContext->TraceId.empty()) {
             QueryState->UserRequestContext->TraceId = UlidGen.Next().ToString();
         }
@@ -3103,9 +3106,16 @@ public:
             for (size_t i = 0; i < phyQuery.ResultBindingsSize(); ++i) {
                 if (QueryState->IsStreamResult()) {
                     if (QueryState->QueryData->HasTrailingTxResult(phyQuery.GetResultBindings(i))) {
+                        TMaybe<ui64> effectiveRowsLimit = FillSettings.RowsLimitPerWrite;
+                        if (QueryState->PreparedQuery->GetResults(i).GetRowsLimit()) {
+                            effectiveRowsLimit = QueryState->PreparedQuery->GetResults(i).GetRowsLimit();
+                        } else if (auto requestRowsLimit = QueryState->GetRowsLimit()) {
+                            effectiveRowsLimit = *requestRowsLimit;
+                        }
+
                         auto ydbResult = QueryState->QueryData->GetYdbTxResult(
                             phyQuery.GetResultBindings(i), response->GetArena(),
-                            QueryState->GetFormatsSettings(), {});
+                            QueryState->GetFormatsSettings(), effectiveRowsLimit);
 
                         YQL_ENSURE(ydbResult);
                         ++trailingResultsCount;
@@ -3119,6 +3129,8 @@ public:
                 TMaybe<ui64> effectiveRowsLimit = FillSettings.RowsLimitPerWrite;
                 if (QueryState->PreparedQuery->GetResults(i).GetRowsLimit()) {
                     effectiveRowsLimit = QueryState->PreparedQuery->GetResults(i).GetRowsLimit();
+                } else if (auto requestRowsLimit = QueryState->GetRowsLimit()) {
+                    effectiveRowsLimit = *requestRowsLimit;
                 }
 
                 auto* ydbResult = QueryState->QueryData->GetYdbTxResult(

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -87,6 +87,17 @@ void FillColumnsMeta(const NKqpProto::TKqpPhyQuery& phyQuery, NKikimrKqp::TQuery
     }
 }
 
+TMaybe<ui64> GetExplicitRowsLimit(const TKqpQueryState& queryState, size_t resultIndex) {
+    if (auto requestRowsLimit = queryState.GetRowsLimit()) {
+        return *requestRowsLimit;
+    }
+    if (queryState.PreparedQuery && resultIndex < queryState.PreparedQuery->ResultsSize()
+            && queryState.PreparedQuery->GetResults(resultIndex).GetRowsLimit()) {
+        return queryState.PreparedQuery->GetResults(resultIndex).GetRowsLimit();
+    }
+    return Nothing();
+}
+
 template<typename TSinkProto>
 bool FillTableSinkSettings(NKikimrKqp::TKqpTableSinkSettings& settings, const TSinkProto& sink) {
     if (sink.GetTypeCase() == TSinkProto::kInternalSink
@@ -338,6 +349,8 @@ public:
             Settings.TableService, Settings.QueryService, SessionId, AppData()->MonotonicTimeProvider->Now(), Settings.MutableExecuterConfig->RuntimeParameterSizeLimit.load());
         if (auto rowsLimit = QueryState->GetRowsLimit()) {
             FillSettings.RowsLimitPerWrite = *rowsLimit;
+        } else {
+            FillSettings.RowsLimitPerWrite = Config->_ResultRowsLimit.Get();
         }
         if (QueryState->UserRequestContext->TraceId.empty()) {
             QueryState->UserRequestContext->TraceId = UlidGen.Next().ToString();
@@ -3106,17 +3119,9 @@ public:
             for (size_t i = 0; i < phyQuery.ResultBindingsSize(); ++i) {
                 if (QueryState->IsStreamResult()) {
                     if (QueryState->QueryData->HasTrailingTxResult(phyQuery.GetResultBindings(i))) {
-                        TMaybe<ui64> effectiveRowsLimit = FillSettings.RowsLimitPerWrite;
-                        if (i < QueryState->PreparedQuery->ResultsSize()
-                                && QueryState->PreparedQuery->GetResults(i).GetRowsLimit()) {
-                            effectiveRowsLimit = QueryState->PreparedQuery->GetResults(i).GetRowsLimit();
-                        } else if (auto requestRowsLimit = QueryState->GetRowsLimit()) {
-                            effectiveRowsLimit = *requestRowsLimit;
-                        }
-
                         auto ydbResult = QueryState->QueryData->GetYdbTxResult(
                             phyQuery.GetResultBindings(i), response->GetArena(),
-                            QueryState->GetFormatsSettings(), effectiveRowsLimit);
+                            QueryState->GetFormatsSettings(), GetExplicitRowsLimit(*QueryState, i));
 
                         YQL_ENSURE(ydbResult);
                         ++trailingResultsCount;
@@ -3127,11 +3132,9 @@ public:
                     continue;
                 }
 
-                TMaybe<ui64> effectiveRowsLimit = FillSettings.RowsLimitPerWrite;
-                if (QueryState->PreparedQuery->GetResults(i).GetRowsLimit()) {
-                    effectiveRowsLimit = QueryState->PreparedQuery->GetResults(i).GetRowsLimit();
-                } else if (auto requestRowsLimit = QueryState->GetRowsLimit()) {
-                    effectiveRowsLimit = *requestRowsLimit;
+                TMaybe<ui64> effectiveRowsLimit = GetExplicitRowsLimit(*QueryState, i);
+                if (!effectiveRowsLimit) {
+                    effectiveRowsLimit = FillSettings.RowsLimitPerWrite;
                 }
 
                 auto* ydbResult = QueryState->QueryData->GetYdbTxResult(

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -348,7 +348,9 @@ public:
             ev, QueryId, Settings.Database, Settings.ApplicationName, Settings.Cluster, Settings.DbCounters, Settings.LongSession,
             Settings.TableService, Settings.QueryService, SessionId, AppData()->MonotonicTimeProvider->Now(), Settings.MutableExecuterConfig->RuntimeParameterSizeLimit.load());
         if (auto rowsLimit = QueryState->GetRowsLimit()) {
-            FillSettings.RowsLimitPerWrite = *rowsLimit;
+            // RowsLimitPerWrite is incremented by one before Take(n+1) in the result provider,
+            // so the DQ executer must be allowed to stream one extra row for truncation detection.
+            FillSettings.RowsLimitPerWrite = *rowsLimit + 1;
         } else {
             FillSettings.RowsLimitPerWrite = Config->_ResultRowsLimit.Get();
         }

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -1407,6 +1407,35 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
         UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 8);
     }
 
+    Y_UNIT_TEST(GenericQueryWithRowsLimit) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        auto result = db.ExecuteQuery(Q_(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::NQuery::TExecuteQuerySettings().RowsLimit(5)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        UNIT_ASSERT(result.GetResultSet(0).Truncated());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 5);
+    }
+
+    Y_UNIT_TEST(GenericQueryRowsLimitZero) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        auto result = db.ExecuteQuery(Q_(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::NQuery::TExecuteQuerySettings().RowsLimit(0)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        UNIT_ASSERT(result.GetResultSet(0).Truncated());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 0);
+        UNIT_ASSERT(result.GetResultSet(0).ColumnsCount() > 0);
+    }
+
     Y_UNIT_TEST(GenericQueryNoRowsLimitLotsOfRows) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetQueryClient();

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -1436,6 +1436,70 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
         UNIT_ASSERT(result.GetResultSet(0).ColumnsCount() > 0);
     }
 
+    Y_UNIT_TEST(GenericQueryRejectRowsLimitWithArrowFormat) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        auto settings = NYdb::NQuery::TExecuteQuerySettings()
+            .Format(TResultSet::EFormat::Arrow)
+            .RowsLimit(5);
+
+        auto result = db.ExecuteQuery(Q_(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(), settings).ExtractValueSync();
+
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS_C(result.GetIssues().ToString(),
+            "rows_limit is not supported with FORMAT_ARROW result set format", result.GetIssues().ToString());
+    }
+
+    Y_UNIT_TEST(GenericQueryRowsLimitExactMatch) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        auto result = db.ExecuteQuery(Q_(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::NQuery::TExecuteQuerySettings().RowsLimit(8)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        UNIT_ASSERT(!result.GetResultSet(0).Truncated());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 8u);
+    }
+
+    Y_UNIT_TEST(GenericQueryRowsLimitExceedsRowCount) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        auto result = db.ExecuteQuery(Q_(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::NQuery::TExecuteQuerySettings().RowsLimit(100)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+        UNIT_ASSERT(!result.GetResultSet(0).Truncated());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 8u);
+    }
+
+    Y_UNIT_TEST(GenericQueryRowsLimitMultipleResultSets) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        auto result = db.ExecuteQuery(Q_(R"(
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(),
+            NYdb::NQuery::TExecuteQuerySettings().RowsLimit(5)).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSets().size(), 2u);
+
+        UNIT_ASSERT(result.GetResultSet(0).Truncated());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(0).RowsCount(), 5u);
+
+        UNIT_ASSERT(result.GetResultSet(1).Truncated());
+        UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(1).RowsCount(), 5u);
+    }
+
     Y_UNIT_TEST(GenericQueryNoRowsLimitLotsOfRows) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetQueryClient();

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -1500,6 +1500,56 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
         UNIT_ASSERT_VALUES_EQUAL(result.GetResultSet(1).RowsCount(), 5u);
     }
 
+    Y_UNIT_TEST(GenericQueryRowsLimitMultiChunkCounting) {
+        TKikimrRunner kikimr;
+        auto db = kikimr.GetQueryClient();
+
+        constexpr ui32 rowsLimit = 5;
+        auto settings = NYdb::NQuery::TExecuteQuerySettings()
+            .OutputChunkMaxSize(100)
+            .RowsLimit(rowsLimit);
+
+        auto it = db.StreamExecuteQuery(Q_(R"(
+            SELECT * FROM AS_TABLE(ListMap(ListFromRange(1, 101), ($x) -> {
+                RETURN AsStruct($x AS key);
+            }));
+        )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(), settings).ExtractValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
+
+        ui32 totalRows = 0;
+        ui32 resultSetParts = 0;
+        ui32 truncatedParts = 0;
+        bool seenTruncated = false;
+        for (;;) {
+            auto part = it.ReadNext().GetValueSync();
+            if (!part.IsSuccess()) {
+                UNIT_ASSERT_C(part.EOS(), part.GetIssues().ToString());
+                break;
+            }
+
+            if (!part.HasResultSet()) {
+                continue;
+            }
+
+            if (seenTruncated) {
+                UNIT_FAIL("Unexpected result set part after truncation");
+            }
+
+            const auto& resultSet = part.GetResultSet();
+            totalRows += resultSet.RowsCount();
+            ++resultSetParts;
+            if (resultSet.Truncated()) {
+                seenTruncated = true;
+                ++truncatedParts;
+            }
+        }
+
+        UNIT_ASSERT_C(resultSetParts > 1, "Expected multiple stream parts, got " << resultSetParts);
+        UNIT_ASSERT(seenTruncated);
+        UNIT_ASSERT_VALUES_EQUAL(truncatedParts, 1u);
+        UNIT_ASSERT_VALUES_EQUAL(totalRows, rowsLimit);
+    }
+
     Y_UNIT_TEST(GenericQueryNoRowsLimitLotsOfRows) {
         TKikimrRunner kikimr;
         auto db = kikimr.GetQueryClient();

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -1510,9 +1510,7 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
             .RowsLimit(rowsLimit);
 
         auto it = db.StreamExecuteQuery(Q_(R"(
-            SELECT * FROM AS_TABLE(ListMap(ListFromRange(1, 101), ($x) -> {
-                RETURN AsStruct($x AS key);
-            }));
+            SELECT * FROM `/Root/EightShard` WHERE Text = "Value2";
         )"), NYdb::NQuery::TTxControl::BeginTx().CommitTx(), settings).ExtractValueSync();
         UNIT_ASSERT_VALUES_EQUAL_C(it.GetStatus(), EStatus::SUCCESS, it.GetIssues().ToString());
 

--- a/ydb/core/kqp/ut/query/kqp_query_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_ut.cpp
@@ -1506,7 +1506,7 @@ Y_UNIT_TEST_SUITE(KqpQuery) {
 
         constexpr ui32 rowsLimit = 5;
         auto settings = NYdb::NQuery::TExecuteQuerySettings()
-            .OutputChunkMaxSize(100)
+            .OutputChunkMaxSize(40)
             .RowsLimit(rowsLimit);
 
         auto it = db.StreamExecuteQuery(Q_(R"(

--- a/ydb/core/protos/kqp.proto
+++ b/ydb/core/protos/kqp.proto
@@ -198,6 +198,7 @@ message TQueryRequest {
     optional Ydb.ResultSet.Format ResultSetFormat = 39;
     optional Ydb.Formats.ArrowFormatSettings ArrowFormatSettings = 40;
     optional bool IsWarmupCompilation = 41;
+    optional uint64 RowsLimit = 43;
 }
 
 message TVectorIndexKmeansTreeDescription {

--- a/ydb/public/api/protos/ydb_query.proto
+++ b/ydb/public/api/protos/ydb_query.proto
@@ -233,6 +233,11 @@ message ExecuteQueryRequest {
 
     // Format settings, only used for Ydb.ResultSet.Format.FORMAT_ARROW
     Ydb.Formats.ArrowFormatSettings arrow_format_settings = 14;
+
+    // Optional maximum number of rows in each result set.
+    // When not set, there is no row limit (unlimited results).
+    // Value 0 returns result set metadata without data rows.
+    optional int64 rows_limit = 15 [(Ydb.value) = ">= 0"];
 }
 
 message ResultSetMeta {

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/query.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/query.h
@@ -116,6 +116,7 @@ struct TExecuteQuerySettings : public TRequestSettings<TExecuteQuerySettings> {
     FLUENT_SETTING_DEFAULT(ESchemaInclusionMode, SchemaInclusionMode, ESchemaInclusionMode::Unspecified);
     FLUENT_SETTING_DEFAULT(TResultSet::EFormat, Format, TResultSet::EFormat::Unspecified);
     FLUENT_SETTING_OPTIONAL(TArrowFormatSettings, ArrowFormatSettings);
+    FLUENT_SETTING_OPTIONAL(uint64_t, RowsLimit);
     FLUENT_SETTING_OPTIONAL(TRetryOperationSettings, RetrySettings);
 };
 

--- a/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
@@ -267,6 +267,10 @@ private:
         for (const auto& row : inRsProto.rows()) {
             *resultSet.mutable_rows()->Add() = row;
         }
+
+        if (inRsProto.truncated()) {
+            resultSet.set_truncated(true);
+        }
     }
 
     void CollectArrowBytes(Ydb::ResultSet& resultSet, Ydb::ResultSet& mutableInRsProto, uint64_t index) {

--- a/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
+++ b/ydb/public/sdk/cpp/src/client/query/impl/exec_query.cpp
@@ -346,6 +346,10 @@ public:
             }
         }
 
+        if (settings.RowsLimit_) {
+            request.set_rows_limit(*settings.RowsLimit_);
+        }
+
         if (txControl.HasTx()) {
             auto requestTxControl = request.mutable_tx_control();
             requestTxControl->set_commit_tx(txControl.CommitTx_);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Implements [ydb-platform/ydb#30721](https://github.com/ydb-platform/ydb/issues/30721): an optional `rows_limit` parameter on `QueryService.ExecuteQuery` to cap the number of rows returned per result set.

The behavior follows TableClient semantics:
- When `rows_limit` is set to `n > 0`, the query plan gets an implicit `Take(n+1)` and the result set is marked `truncated` if more rows exist.
- When `rows_limit` is `0`, only result set metadata (schema) is returned; `truncated` is set if data rows exist.
- When `rows_limit` is not set, QueryService behavior is unchanged (unlimited results).

Includes C++ SDK support via TExecuteQuerySettings::RowsLimit and unit tests GenericQueryWithRowsLimit and GenericQueryRowsLimitZero.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

```bash
./ya make --build relwithdebinfo -tA ydb/core/kqp/ut/query -F '*GenericQueryWithRowsLimit*'
./ya make --build relwithdebinfo -tA ydb/core/kqp/ut/query -F '*GenericQueryRowsLimitZero*'
```
