### PR TITLE
[detailed-metrics] expose primary user table identity via `ITablet::GetTableInfo()`

### DIFF
--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -6,6 +6,7 @@
 
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/scheme/scheme_pathid.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <library/cpp/lwtrace/shuttle.h>
@@ -490,6 +491,12 @@ struct TScanOptions {
 };
 
 namespace NFlatExecutorSetup {
+    struct TTabletTableInfo {
+        TPathId TableId;
+        TString TablePath;
+        ui64 SchemaVersion = 0;
+    };
+
     struct ITablet : TNonCopyable {
         virtual ~ITablet() {}
 
@@ -520,6 +527,8 @@ namespace NFlatExecutorSetup {
         virtual ui64 GetMemoryUsage() const { return 50 << 10; }
 
         virtual void OnLeaderUserAuxUpdate(TString) { /* default */ }
+
+        virtual const TTabletTableInfo* GetTableInfo() const { return nullptr; }
 
         virtual bool ReadOnlyLeaseEnabled();
         virtual TDuration ReadOnlyLeaseDuration();

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2426,6 +2426,20 @@ ui64 TDataShard::GetMemoryUsage() const {
     return res;
 }
 
+const NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo* TDataShard::GetTableInfo() const {
+    if (TableInfos.empty()) {
+        return nullptr;
+    }
+
+    // Expected that it's almost always one table here, hence only TableInfos.begin()
+    // IsBackup can be filtered out though
+    const auto& table = *TableInfos.begin()->second;
+    TableInfoCache.TableId = TPathId(GetPathOwnerId(), TableInfos.begin()->first);
+    TableInfoCache.TablePath = table.Path;
+    TableInfoCache.SchemaVersion = table.GetTableSchemaVersion();
+    return &TableInfoCache;
+}
+
 bool TDataShard::ByKeyFilterDisabled() const {
     return DisableByKeyFilter;
 }

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1921,6 +1921,7 @@ public:
     void OnRejectProbabilityRelaxed() override;
     void OnFollowersCountChanged() override;
     ui64 GetMemoryUsage() const override;
+    const NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo* GetTableInfo() const override;
 
     bool HasPipeServer(const TActorId& pipeServerId);
     bool AddOverloadSubscriber(const TActorId& pipeServerId, const TActorId& actorId, ui64 seqNo, ERejectReasons reasons);
@@ -2882,6 +2883,7 @@ private:
     TInstant StopKeyAccessSamplingAt;
 
     TUserTable::TTableInfos TableInfos;  // tableId -> local table info
+    mutable NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo TableInfoCache;
     TTransQueue TransQueue;
     TOutReadSets OutReadSets;
     TPipeline Pipeline;

--- a/ydb/core/tx/datashard/datashard_ut_init.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_init.cpp
@@ -155,6 +155,35 @@ Y_UNIT_TEST_SUITE(TTxDataShardTestInit) {
     Y_UNIT_TEST(TestResolvePathAfterRestart) {
         TestTablePath(true, true);
     }
+
+    Y_UNIT_TEST(TestGetTableInfoReflectsRename) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root").SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        auto shard = GetTableShards(server, sender, "/Root/table-1")[0];
+        auto *dataShard = dynamic_cast<NDataShard::TDataShard*>(runtime.FindActor(ResolveTablet(runtime, shard)));
+        UNIT_ASSERT(dataShard);
+
+        const auto *info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->TablePath, "/Root/table-1");
+        auto prevTableId = info->TableId;
+
+        WaitTxNotification(server, sender, AsyncMoveTable(server, "/Root/table-1", "/Root/table-1-moved"));
+
+        info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->TablePath, "/Root/table-1-moved");
+        UNIT_ASSERT_UNEQUAL(info->TableId, prevTableId);
+    }
 }
 
 }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ITablet::GetTableInfo()` allows generic Executor extract a tablet's table PathId/path/SchemaVersion without DataShard-specific knowledge. DataShard implements it, picking TableInfos' single entry in the common case.