### PR TITLE
Fix flaky test_create_drop_and_alter_database audit test

### DIFF
--- a/ydb/tests/functional/audit/test_canonical_records.py
+++ b/ydb/tests/functional/audit/test_canonical_records.py
@@ -98,7 +98,8 @@ def test_create_drop_and_alter_database(ydb_cluster):
             token=TOKEN
         )
         database_nodes = ydb_cluster.register_and_start_slots(database, count=1)
-    ydb_cluster.wait_tenant_up(database, token=TOKEN)
+        # Wait inside the capture so tenant initialization audit records are captured
+        ydb_cluster.wait_tenant_up(database, token=TOKEN)
 
     with capture_audit_alter:
         alter_subdomain_enable_scheme_shard_audit = '''


### PR DESCRIPTION
Move wait_tenant_up inside the audit capture context. Tenant
initialization emits asynchronous `metadata@system` audit records
(`CREATE DIRECTORY .sys`, `CREATE SYSTEM VIEW`, `CREATE TABLE
.metadata/statistics_v2`). When wait_tenant_up was called outside
the capture, these records could arrive after the capture's
silence window closed, causing them to be missed and making the
test flaky.