### PR TITLE
ydb/kqp: fix use-after-free in TKqpJoinRows::ReplyResult

### DIFF
--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -1056,8 +1056,8 @@ public:
         while (!FlushedResultRows.empty()) {
             TResultBatch::TResultRow& row = FlushedResultRows.front();
             batch.emplace_back(std::move(row.Data));
-            FlushedResultRows.pop_front();
             resultStats.Add(row.Stats);
+            FlushedResultRows.pop_front();
         }
 
         return resultStats;


### PR DESCRIPTION
`row` is a reference into FlushedResultRows, so pop_front() destroys the element it points at. Read the stats before popping.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Bugfix

### Changelog category <!-- remove all except one -->
* Bugfix 
