### PR TITLE
Use destroying delete for TSelectRangeLazyRow to fix use-after-dtor

### DIFF
--- a/ydb/core/engine/minikql/minikql_engine_host.cpp
+++ b/ydb/core/engine/minikql/minikql_engine_host.cpp
@@ -11,6 +11,8 @@
 
 #include <library/cpp/containers/stack_vector/stack_vec.h>
 
+#include <new>
+
 namespace NKikimr {
 namespace NMiniKQL {
 
@@ -310,10 +312,14 @@ public:
 
     void* operator new(size_t sz) = delete;
     void* operator new[](size_t sz) = delete;
-    void operator delete(void *mem, std::size_t sz) {
-        auto ptr = (TSelectRangeLazyRow*)mem;
-        auto extraSize = ptr->Size() * sizeof(NUdf::TUnboxedValue) + ptr->GetMaskSize() * sizeof(ui64);
-        TBase::FreeWithSize(mem, sz + extraSize);
+    // Destroying delete: reads Size()/GetMaskSize() before running the destructor, since
+    // with -fsanitize-memory-use-after-dtor the destructor poisons the object's storage.
+    void operator delete(TSelectRangeLazyRow* self, std::destroying_delete_t) {
+        const auto fullSize = sizeof(TSelectRangeLazyRow)
+            + self->Size() * sizeof(NUdf::TUnboxedValue)
+            + self->GetMaskSize() * sizeof(ui64);
+        self->~TSelectRangeLazyRow();
+        TBase::FreeWithSize(self, fullSize);
     }
 
     void operator delete[](void *mem, std::size_t sz) = delete;


### PR DESCRIPTION
Switch to a destroying operator delete so the sizes are read while the object is still alive, then destroy it explicitly.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
--

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
