### PR TITLE
Leak CloseInternal session settings to fix use-after-dtor

### DIFF
--- a/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/table_client.cpp
@@ -1118,8 +1118,7 @@ TAsyncStatus TTableClient::TImpl::Close(const TKqpSessionCommon* sessionImpl, co
 }
 
 TAsyncStatus TTableClient::TImpl::CloseInternal(const TKqpSessionCommon* sessionImpl) {
-    static const auto internalCloseSessionSettings = TCloseSessionSettings()
-            .ClientTimeout(TDuration::Seconds(2));
+    const auto internalCloseSessionSettings = TCloseSessionSettings().ClientTimeout(TDuration::Seconds(2));
 
     auto driver = Connections_;
     return Close(sessionImpl, internalCloseSessionSettings)


### PR DESCRIPTION
`internalCloseSessionSettings` is a function-local static in `CloseInternal`, so it is constructed on the first session close -- that is, after any static `TTableClient` was constructed. Static destruction runs in reverse order, so the settings are destroyed first, and a later `~TTableClient -> Drain()` -> `CloseInternal` at exit reads them after their destructor has run. `static` was excessive, remove it.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->
* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
