### PR TITLE
Restore ESysViewType PG enum values (31-33) for backward compatibility

### DIFF
--- a/ydb/core/protos/sys_view_types.proto
+++ b/ydb/core/protos/sys_view_types.proto
@@ -35,7 +35,10 @@ enum ESysViewType {
     EAuthOwners = 28;
     EAuthPermissions = 29;
     EAuthEffectivePermissions = 30;
-    reserved 31 to 33; // EPgTables, EInformationSchemaTables, EPgClass (removed)
+    // Kept for backward compatibility: 31-33 were persisted by older versions.
+    EPgTables = 31;
+    EInformationSchemaTables = 32;
+    EPgClass = 33;
     EShowCreate = 34;
     ECompileCacheQueries = 35;
     EStorePrimaryIndexStats = 36;


### PR DESCRIPTION
### Changelog entry

Restore `ESysViewType` enum values `EPgTables` (31), `EInformationSchemaTables` (32) and `EPgClass` (33), removed in #45922, to preserve backward compatibility.

### Changelog category

* Bugfix

### Description for reviewers

#45922 ("Remove legacy pgwire support from ydbd") deleted these three `ESysViewType` enumerators and `reserved 31 to 33`:

```proto
-    EPgTables = 31;
-    EInformationSchemaTables = 32;
-    EPgClass = 33;
+    reserved 31 to 33; // EPgTables, EInformationSchemaTables, EPgClass (removed)
```

`ESysViewType` values can be persisted by older versions, so removing the enumerators (and reserving the numbers) breaks backward compatibility — an id of 31/32/33 written by an older binary no longer maps to a named enumerator. This change restores the three enum values so those ids stay representable. The PG sys-view functionality itself remains removed; only the enum names return.
