### PR TITLE
Pragma to force fallback to legacy optimizer

### DIFF
--- a/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
+++ b/ydb/core/kqp/opt/rbo/kqp_rbo_transformer.cpp
@@ -86,6 +86,10 @@ bool IsRboTraceLogEnabled() {
 } // anonymous namespace
 
 IGraphTransformer::TStatus TKqpRewriteSelectTransformer::DoTransform(TExprNode::TPtr input, TExprNode::TPtr& output, TExprContext& ctx) {
+    if (KqpCtx.Config->OptFallbackToLegacyOptimizer.Get()) {
+        Y_ENSURE(false, "Forced fallback to legacy optimizer");
+    }
+    
     output = input;
     TOptimizeExprSettings settings(&TypeCtx);
     const bool needTraceAst = IsRboTraceLogEnabled();

--- a/ydb/core/kqp/provider/yql_kikimr_settings.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.cpp
@@ -100,6 +100,7 @@ TKikimrConfiguration::TKikimrConfiguration() {
     REGISTER_SETTING(*this, OptDisallowFuseJoins);
     REGISTER_SETTING(*this, OptCreateStageForAggregation);
     REGISTER_SETTING(*this, OptValidateStreamingConstraints);
+    REGISTER_SETTING(*this, OptFallbackToLegacyOptimizer);
     REGISTER_SETTING(*this, OverridePlanner);
     REGISTER_SETTING(*this, UseGraceJoinCoreForMap);
     REGISTER_SETTING(*this, UseBlockHashJoin);

--- a/ydb/core/kqp/provider/yql_kikimr_settings.h
+++ b/ydb/core/kqp/provider/yql_kikimr_settings.h
@@ -98,6 +98,7 @@ public:
     NCommon::TConfSetting<bool, Static> OptDisallowFuseJoins;
     NCommon::TConfSetting<bool, Static> OptCreateStageForAggregation;
     NCommon::TConfSetting<bool, Static> OptValidateStreamingConstraints;
+    NCommon::TConfSetting<bool, Static> OptFallbackToLegacyOptimizer;
 
     // Use CostBasedOptimizationLevel for internal usage. This is a dummy flag that is mapped to the optimization level during parsing.
     NCommon::TConfSetting<TString, Static> CostBasedOptimization;

--- a/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
+++ b/ydb/core/kqp/ut/rbo/kqp_rbo_yql_ut.cpp
@@ -7704,6 +7704,11 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
             R"(
                 select t1.a from `/Root/t1` as t1;
             )",
+            // Simple query with a fallback pragma
+            R"(
+                PRAGMA ydb.OptFallbackToLegacyOptimizer = 'true';
+                select t1.a from `/Root/t1` as t1;
+            )"
         };
 
         return queries;
@@ -7713,7 +7718,8 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
         // Represents the number of successes and fails for each query with new RBO compiler pipeline.
         std::vector<std::pair<ui32, ui32>> expectedCompileCounters = {
             {0, 1},
-            {1, 0}
+            {1, 0},
+            {0, 1}
         };
 
         return expectedCompileCounters;
@@ -7721,14 +7727,14 @@ Y_UNIT_TEST_SUITE(KqpRboYql) {
 
     Y_UNIT_TEST(FallbackToYqlEnabled) {
         // All queries should succeded because fallback to yql is enabled.
-        const std::vector<bool> expectedResult{true, true};
+        const std::vector<bool> expectedResult{true, true, true};
         TestFallbackToYql(/*fallbackToYqlEnabled=*/true, GetQueriesToTestFallbackToYql(), GetCompileCountersToTestFallbackToYql(),
                           expectedResult);
     }
 
     Y_UNIT_TEST(FallbackToYqlDisabled) {
         // First 2 queries should fail because fallback to yql is disabled.
-        const std::vector<bool> expectedResult{false, true};
+        const std::vector<bool> expectedResult{false, true, false};
         TestFallbackToYql(/*fallbackToYqlEnabled=*/false, GetQueriesToTestFallbackToYql(), GetCompileCountersToTestFallbackToYql(),
                           expectedResult);
     }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

OptFallbackToLegacyOptimizer pragma is added, when set the new optimizer will fallback to legacy optimizer for this query

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
