### PR TITLE
Handle already-applied commits in cherry-pick backport workflow

### DIFF
--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -56,6 +56,10 @@ class BackportResult:
         return len(self.conflict_files) > 0
 
 
+class ChangesAlreadyAppliedError(Exception):
+    """Raised when all requested commits are already present in the target branch."""
+
+
 def run_git(repo_path: str, cmd: List[str], logger, check=True) -> subprocess.CompletedProcess:
     """Run git command"""
     result = subprocess.run(
@@ -129,6 +133,15 @@ def create_pr_source(pull: Any, allow_unmerged: bool, logger) -> Source:
         body_item=f"* PR {pull.html_url}",
         author=pull.user.login,
         pull_requests=[pull]
+    )
+
+
+def is_empty_cherry_pick(output: str) -> bool:
+    """Detects git empty cherry-pick when patch is already present in the branch."""
+    output_lower = output.lower()
+    return (
+        'now empty' in output_lower
+        or 'nothing added to commit' in output_lower
     )
 
 
@@ -494,6 +507,17 @@ def process_branch(
             output = (result.stdout or '') + (('\n' + result.stderr) if result.stderr else '')
             
             if result.returncode != 0:
+                if is_empty_cherry_pick(output):
+                    run_git(repo_path, ['cherry-pick', '--skip'], logger, check=False)
+                    logger.info(
+                        "Commit %s is already present in %s, skipping",
+                        commit_sha[:7], target_branch
+                    )
+                    cherry_pick_logs.append(
+                        f"=== Cherry-picking {commit_sha[:7]} ===\n"
+                        f"Skipped: changes already present in branch\n{output}"
+                    )
+                    continue
                 if "conflict" in output.lower():
                     conflicts = detect_conflicts(repo_path, logger)
                     if conflicts:
@@ -510,6 +534,15 @@ def process_branch(
                 cherry_pick_logs.append(f"=== Cherry-picking {commit_sha[:7]} ===\n{output}")
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Cherry-pick failed for commit {commit_sha[:7]}: {e}")
+
+    ahead_result = run_git(
+        repo_path, ['rev-list', '--count', f'{target_branch}..HEAD'], logger, check=False
+    )
+    commits_ahead = int((ahead_result.stdout or '0').strip() or 0)
+    if commits_ahead == 0:
+        raise ChangesAlreadyAppliedError(
+            f"All requested changes are already present in {target_branch}"
+        )
     
     # Push branch
     run_git(repo_path, ['push', '--set-upstream', 'origin', dev_branch_name], logger)
@@ -781,6 +814,12 @@ def main():
                     repo_name, repo, token, sources, workflow_triggerer, workflow_url, summary_path, logger
                 )
                 results.append(result)
+            except ChangesAlreadyAppliedError as e:
+                logger.info("Branch %s skipped: %s", target_branch, e)
+                if summary_path:
+                    with open(summary_path, 'a') as f:
+                        f.write(f"Branch `{target_branch}`: skipped (changes already present)\n\n")
+                skipped_branches.append((target_branch, "changes already present"))
             except Exception as e:
                 has_errors = True
                 error_msg = f"UNEXPECTED_ERROR: Branch {target_branch} - {type(e).__name__}: {e}"

--- a/.github/scripts/cherry_pick_v2.py
+++ b/.github/scripts/cherry_pick_v2.py
@@ -538,6 +538,11 @@ def process_branch(
     ahead_result = run_git(
         repo_path, ['rev-list', '--count', f'{target_branch}..HEAD'], logger, check=False
     )
+    if ahead_result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to count commits ahead of {target_branch}: "
+            f"{(ahead_result.stderr or ahead_result.stdout or '').strip()}"
+        )
     commits_ahead = int((ahead_result.stdout or '0').strip() or 0)
     if commits_ahead == 0:
         raise ChangesAlreadyAppliedError(


### PR DESCRIPTION
## Summary

- Detect git empty cherry-pick (`now empty` / `nothing added to commit`) when changes are already present in the target branch
- Skip such branches with reason `changes already present` instead of raising `RuntimeError`
- Treat the workflow as successful when all branches are either backported or already contain the changes

Fixes false failures like [workflow run #29327641073](https://github.com/ydb-platform/ydb/actions/runs/29327641073), where backport of PR #46364 failed on `stable-26-3` and `stable-26-3-1` because the fix had already arrived via prestable merge (#46379).

## Test plan

- [ ] Trigger cherry-pick backport for a commit already present in a stable branch — branch should be reported as `skipped (changes already present)`, workflow should succeed
- [ ] Trigger backport for a commit not yet in the target branch — PR should be created as before
- [ ] Trigger backport with a real merge conflict — draft PR with conflicts should still be created


Made with [Cursor](https://cursor.com)