### PR TITLE
Revert "[YDB_LOG] Migrate ydb/core/persqueue/public"

### DIFF
--- a/ydb/core/persqueue/public/cloud_events/actor.cpp
+++ b/ydb/core/persqueue/public/cloud_events/actor.cpp
@@ -19,8 +19,6 @@
 #include <google/protobuf/util/json_util.h>
 #include <google/protobuf/util/time_util.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE
-
 namespace NKikimr::NPQ::NCloudEvents {
 
 using TCreateTopicEvent = yandex::cloud::events::ydb::topics::CreateTopic;
@@ -327,7 +325,8 @@ template<typename TEvent>
 TString SerializeEventToProtobuf(const TEvent& ev) {
     TString data;
     if (!ev.SerializeToString(&data)) {
-        YDB_LOG_ERROR("SerializeToString failed");
+        LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE,
+            "SerializeToString failed");
         return TString();
     }
     return data;
@@ -340,7 +339,8 @@ TString SerializeEventToJson(const TEvent& ev) {
     opts.preserve_proto_field_names = true;
     opts.always_print_primitive_fields = true;
     if (!google::protobuf::util::MessageToJsonString(ev, &data, opts).ok()) {
-        YDB_LOG_ERROR("MessageToJsonString failed");
+        LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE,
+            "MessageToJsonString failed");
         return TString();
     }
     return data;
@@ -412,7 +412,8 @@ void TCloudEventsActor::Bootstrap() {
 
 void TCloudEventsActor::Handle(TCloudEvent::TPtr& ev) {
     if (!EventsWriter) {
-        YDB_LOG_ERROR("No events writer configured");
+        LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE,
+            "No events writer configured");
         PassAway();
         return;
     }
@@ -420,14 +421,15 @@ void TCloudEventsActor::Handle(TCloudEvent::TPtr& ev) {
     try {
         TString data = BuildTopicCloudEvent(ev.Get()->Get()->Info);
         if (data.empty()) {
-            YDB_LOG_ERROR("Failed to build cloud event");
+            LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE,
+                "Failed to build cloud event");
             PassAway();
             return;
         }
         EventsWriter->Write(data);
     } catch (const std::exception& e) {
-        YDB_LOG_ERROR("Failed to write cloud",
-            {"event", e.what()});
+        LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PERSQUEUE,
+            "Failed to write cloud event: " << e.what());
     }
 
     PassAway();

--- a/ydb/core/persqueue/public/cluster_tracker/cluster_tracker.cpp
+++ b/ydb/core/persqueue/public/cluster_tracker/cluster_tracker.cpp
@@ -15,8 +15,6 @@
 #include <ranges>
 #include <tuple>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE_CLUSTER_TRACKER
-
 namespace NKikimr::NPQ::NClusterTracker {
 
 inline auto& Ctx() {
@@ -70,8 +68,7 @@ public:
 
 private:
     void AddSubscriber(const TActorId subscriberId) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "AddSubscriber",
-            {"subscribersSize", Subscribers.size()});
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "Subscribers.size: " << Subscribers.size() << " AddSubscriber");
 
         Subscribers.insert(subscriberId);
     }
@@ -84,7 +81,7 @@ private:
     }
 
     void HandleWhileWaiting(TEvClusterTracker::TEvSubscribe::TPtr& ev) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "AddSubscriber TEvSubscriber");
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "AddSubscriber TEvSubscriber");
 
         // if (Cfg().GetTopicsAreFirstClassCitizen()) {
         //     return SendClustersList(ev->Sender);
@@ -97,7 +94,7 @@ private:
     }
 
     void HandleWhileWaiting(TEvClusterTracker::TEvGetClustersList::TPtr& ev) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "HandleWhileWaiting TEvGetClustersList");
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "HandleWhileWaiting TEvGetClustersList");
 
         // if (Cfg().GetTopicsAreFirstClassCitizen()) {
         //     return SendGetClustersListResponse(ev->Sender);
@@ -137,7 +134,7 @@ private:
     }
 
     void SendClustersList(const TActorId& subscriberId) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "SendClustersList");
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "SendClustersList");
 
         auto ev = MakeHolder<TEvClusterTracker::TEvClustersUpdate>();
 
@@ -148,9 +145,7 @@ private:
     }
 
     void HandleWhileWorking(TEvClusterTracker::TEvSubscribe::TPtr& ev) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "HandleWhileWorking TEvSubscribe",
-            {"subscribersSize", Subscribers.size()},
-            {"clustersList", (ClustersList == nullptr ? "null" : std::to_string(ClustersList->Clusters.size()))});
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "HandleWhileWorking TEvSubscribe Subscribers.size: " << Subscribers.size() << " ClustersList: " << (ClustersList == nullptr ? "null" : std::to_string(ClustersList->Clusters.size())));
 
         AddSubscriber(ev->Sender);
 
@@ -161,7 +156,7 @@ private:
     }
 
     void HandleWhileWorking(TEvClusterTracker::TEvGetClustersList::TPtr& ev) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "HandleWhileWorking TEvGetClustersList");
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "HandleWhileWorking TEvGetClustersList");
 
         if (ClustersList) {
             SendGetClustersListResponse(ev->Sender);
@@ -171,8 +166,7 @@ private:
     }
 
     void SendGetClustersListResponse(const TActorId& senderId, bool success = true) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "SendGetClustersListResponse",
-            {"senderId", senderId});
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "SendGetClustersListResponse to " << senderId);
 
         auto ev = MakeHolder<TEvClusterTracker::TEvGetClustersListResponse>();
         ev->Success = success;
@@ -182,19 +176,16 @@ private:
     }
 
     void BroadcastClustersUpdate() {
-        YDB_LOG_DEBUG_CTX(Ctx(), "BroadcastClustersUpdate",
-            {"subscribersSize", Subscribers.size()});
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "BroadcastClustersUpdate Subscribers.size: " << Subscribers.size());
 
         for (const auto& subscriberId : Subscribers) {
-            YDB_LOG_DEBUG_CTX(Ctx(), "BroadcastClustersUpdate",
-                {"subscriberId", subscriberId});
+            LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "BroadcastClustersUpdate subscriberId: " << subscriberId);
             SendClustersList(subscriberId);
         }
     }
 
     void ReplyAllGetClustersListRequests(bool success = true) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "ReplyAllGetClustersListRequests",
-            {"clustersListRequestsSize", GetClustersListRequests.size()});
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "ReplyAllGetClustersListRequests GetClustersListRequests.size: " << GetClustersListRequests.size());
 
         for (const auto& requestId : GetClustersListRequests) {
             SendGetClustersListResponse(requestId, success);
@@ -220,13 +211,13 @@ private:
     }
 
     void HandleWhileWorking(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev) {
-        YDB_LOG_DEBUG_CTX(Ctx(), "HandleWhileWorking TEvQueryResponse");
+        LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "HandleWhileWorking TEvQueryResponse");
 
         const auto& record = ev->Get()->Record;
         if (record.GetYdbStatus() == Ydb::StatusIds::SUCCESS) {
             NYdb::TResultSetParser parser(record.GetResponse().GetYdbResults(0));
             if (parser.RowsCount()) {
-                YDB_LOG_DEBUG_CTX(Ctx(), "HandleWhileWorking TEvQueryResponse UpdateClustersList");
+                LOG_DEBUG_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "HandleWhileWorking TEvQueryResponse UpdateClustersList");
                 UpdateClustersList(parser);
 
                 AFL_ENSURE(ClustersList);
@@ -241,8 +232,7 @@ private:
             }
         }
 
-        YDB_LOG_ERROR_CTX(Ctx(), "Failed to list",
-            {"clusters", record});
+        LOG_ERROR_S(Ctx(), NKikimrServices::PERSQUEUE_CLUSTER_TRACKER, "failed to list clusters: " << record);
 
         ClustersList = nullptr;
         Schedule(TDuration::Seconds(Cfg().GetClustersUpdateTimeoutOnErrorSec()), new TEvents::TEvWakeup);

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -2,9 +2,11 @@
 
 #include <util/generic/algorithm.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
-
 #define LOG_PREFIX NActors::TlsActivationContext->AsActorContext().SelfID
+#define LOG_E(stream) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_DESCRIBER, LOG_PREFIX << stream)
+#define LOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PQ_DESCRIBER, LOG_PREFIX << stream)
+#define LOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_DESCRIBER, LOG_PREFIX << stream)
+#define LOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_DESCRIBER, LOG_PREFIX << stream)
 
 namespace NKikimr::NPQ::NDescriber {
 
@@ -43,10 +45,7 @@ public:
     }
 
     void DoRequest(const std::unordered_set<TString>& topicPath) {
-        YDB_LOG_DEBUG("Create request with",
-            {"logPrefix", LOG_PREFIX},
-            {"topicPaths", JoinRange(", ", topicPath.begin(), topicPath.end())},
-            {"syncVersion", RetryWithSyncVersion});
+        LOG_D("Create request [" << JoinRange(", ", topicPath.begin(), topicPath.end()) << "] with SyncVersion=" << RetryWithSyncVersion);
 
         auto schemeRequest = std::make_unique<TSchemeCacheNavigate>(1);
         schemeRequest->DatabaseName = DatabasePath;
@@ -72,8 +71,7 @@ public:
     }
 
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult",
-            {"logPrefix", LOG_PREFIX});
+        LOG_D("Handle TEvTxProxySchemeCache::TEvNavigateKeySetResult");
         auto& result = ev->Get()->Request;
 
         std::unordered_set<TString> unknownPaths;
@@ -100,18 +98,12 @@ public:
                 case TSchemeCacheNavigate::EStatus::RootUnknown: {
                     if (RetryWithSyncVersion) {
                         if (entry.SecurityObject && !HasAccess(Settings, entry.SecurityObject)) {
-                            YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                {"logPrefix", LOG_PREFIX},
-                                {"realPath", realPath});
-
+                            LOG_D("Path '" << realPath << "' UNAUTHORIZED");
                             Result[originalPath] = TTopicInfo{
                                 .Status = EStatus::UNAUTHORIZED
                             };
                         } else {
-                            YDB_LOG_DEBUG("Path not found",
-                                {"logPrefix", LOG_PREFIX},
-                                {"realPath", realPath});
-
+                            LOG_D("Path '" << realPath << "' not found");
                             Result[originalPath] = TTopicInfo{
                                 .Status = EStatus::NOT_FOUND
                             };
@@ -122,9 +114,7 @@ public:
                     break;
                 }
                 case TSchemeCacheNavigate::EStatus::AccessDenied: {
-                    YDB_LOG_DEBUG("Path ACCESS DENIED",
-                        {"logPrefix", LOG_PREFIX},
-                        {"realPath", realPath});
+                    LOG_D("Path '" << realPath << "' ACCESS DENIED");
                     Result[originalPath] = TTopicInfo{
                         .Status = EStatus::UNAUTHORIZED
                     };
@@ -132,10 +122,7 @@ public:
                 }
                 case TSchemeCacheNavigate::EStatus::Ok: {
                     if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
-                        YDB_LOG_DEBUG("Path is CDC",
-                            {"logPrefix", LOG_PREFIX},
-                            {"realPath", realPath});
-
+                        LOG_D("Path '" << realPath << "' is a CDC");
                         CDCPaths[TStringBuilder() << realPath << "/streamImpl"] = {
                             .OriginalPath = originalPath,
                             .CdcStreamName = entry.Self->Info.GetName()
@@ -144,9 +131,7 @@ public:
                     } else if (entry.Kind == TSchemeCacheNavigate::EKind::KindTopic) {
                         if (!entry.PQGroupInfo || entry.PQGroupInfo->Description.GetBalancerTabletID() == 0) {
                             if (RetryWithSyncVersion) {
-                                YDB_LOG_DEBUG("Path not found",
-                                    {"logPrefix", LOG_PREFIX},
-                                    {"realPath", realPath});
+                                LOG_D("Path '" << realPath << "' not found");
                                 Result[originalPath] = TTopicInfo{
                                     .Status = EStatus::NOT_FOUND
                                 };
@@ -155,18 +140,13 @@ public:
                             }
                         } else {
                             if (!HasAccess(Settings, entry.SecurityObject)) {
-                                YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                    {"logPrefix", LOG_PREFIX},
-                                    {"realPath", realPath});
-
+                                LOG_D("Path '" << realPath << "' UNAUTHORIZED");
                                 Result[originalPath] = TTopicInfo{
                                     .Status = entry.SecurityObject->CheckAccess(NACLib::EAccessRights::DescribeSchema, *Settings.UserToken)
                                             ? EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS : EStatus::UNAUTHORIZED
                                 };
                             } else {
-                                YDB_LOG_DEBUG("Path SUCCESS",
-                                    {"logPrefix", LOG_PREFIX},
-                                    {"realPath", realPath});
+                                LOG_D("Path '" << realPath << "' SUCCESS");
                                 Result[originalPath] = TTopicInfo{
                                     .Status = EStatus::SUCCESS,
                                     .RealPath = realPath,
@@ -180,14 +160,9 @@ public:
                             }
                         }
                     } else {
-                        YDB_LOG_DEBUG("Path is not a",
-                            {"logPrefix", LOG_PREFIX},
-                            {"realPath", realPath},
-                            {"topic", entry.Kind});
+                        LOG_D("Path '" << realPath << "' is not a topic: " << entry.Kind);
                         if (Settings.UserToken && !entry.SecurityObject->CheckAccess(NACLib::EAccessRights::DescribeSchema, *Settings.UserToken)) {
-                            YDB_LOG_DEBUG("Path UNAUTHORIZED",
-                                {"logPrefix", LOG_PREFIX},
-                                {"realPath", realPath});
+                            LOG_D("Path '" << realPath << "' UNAUTHORIZED");
                             Result[originalPath] = TTopicInfo{
                                 .Status = EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS
                             };
@@ -201,9 +176,7 @@ public:
                     break;
                 }
                 default: {
-                    YDB_LOG_DEBUG("Path unknown error",
-                        {"logPrefix", LOG_PREFIX},
-                        {"realPath", realPath});
+                    LOG_D("Path '" << realPath << "' unknown error");
                     Result[originalPath] = TTopicInfo{
                         .Status = EStatus::UNKNOWN_ERROR,
                         .RealPath = realPath

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -11,9 +11,12 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_FETCH_REQUEST
-
-#define LOG_PREFIX TStringBuilder() << "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "
+#define LOG_PREFIX "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "
+#define LOG_E(stream) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG_W(stream) LOG_WARN_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG_I(stream) LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG_D(stream) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
+#define LOG(level, stream) LOG_LOG_S(*NActors::TlsActivationContext, level, NKikimrServices::PQ_FETCH_REQUEST, LOG_PREFIX << stream)
 
 namespace NKikimr::NPQ {
 
@@ -149,9 +152,7 @@ public:
     }
 
     void Bootstrap(const TActorContext& ctx) {
-        YDB_LOG_INFO("Fetch request actor boostrapped. Request is",
-            {"logPrefix", LOG_PREFIX},
-            {"valid", (!Response)});
+        LOG_I("Fetch request actor boostrapped. Request is valid: " << (!Response));
 
         // handle error from constructor
         if (Response) {
@@ -166,8 +167,7 @@ public:
     }
 
     void DescribeTopics(const TActorContext&) {
-        YDB_LOG_DEBUG("DescribeTopics",
-            {"logPrefix", LOG_PREFIX});
+        LOG_D("DescribeTopics");
 
         std::unordered_set<TString> topics;
         for (const auto& part : Settings.Partitions) {
@@ -182,8 +182,7 @@ public:
     }
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev, const TActorContext& ctx) {
-        YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-            {"logPrefix", LOG_PREFIX});
+        LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
         for (auto& [topicPath, info] : ev->Get()->Topics) {
             switch (info.Status) {
@@ -246,9 +245,7 @@ public:
             auto& fetchInfo = topicInfo.HasDataRequests[partitionId];
             const auto partitionIndex = fetchInfo->Record.GetCookie();
             tabletInfo.PartitionIndexes.push_back(partitionIndex);
-            YDB_LOG_DEBUG("Sending TEvPersQueue::TEvHasDataInfo",
-                {"logPrefix", LOG_PREFIX},
-                {"fetchInfoRecord", fetchInfo->Record.ShortDebugString()});
+            LOG_D("Sending TEvPersQueue::TEvHasDataInfo " << fetchInfo->Record.ShortDebugString());
             NTabletPipe::SendData(ctx, tabletInfo.PipeClient, fetchInfo.Release());
             PartitionStatus[partitionIndex] = EPartitionStatus::HasDataRequested;
         }
@@ -263,11 +260,8 @@ public:
 
     void ProceedFetchRequest(const TActorContext& ctx) {
         if (FetchRequestCurrentReadTablet) { //already got active read request
-            YDB_LOG_DEBUG("Fetch request is pending. /",
-                {"logPrefix", LOG_PREFIX},
-                {"tabletId", FetchRequestCurrentReadTablet},
-                {"partitionIndex", FetchRequestCurrentPartitionIndex},
-                {"settingsPartitionsSize", Settings.Partitions.size()});
+            LOG_D("Fetch request is pending. TabletId=" << FetchRequestCurrentReadTablet
+                << " partitionIndex=" << FetchRequestCurrentPartitionIndex << "/" << Settings.Partitions.size());
             return;
         }
 
@@ -276,10 +270,7 @@ public:
             ("r", Settings.Partitions.size());
 
         while (true) {
-            YDB_LOG_DEBUG("Processing /",
-                {"logPrefix", LOG_PREFIX},
-                {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
-                {"settingsPartitionsSize", Settings.Partitions.size()});
+            LOG_D("Processing " << FetchRequestCurrentPartitionIndex << "/" << Settings.Partitions.size());
             if (FetchRequestCurrentPartitionIndex == Settings.Partitions.size()) {
                 CreateOkResponse();
                 return SendReplyAndDie(std::move(Response), ctx);
@@ -287,19 +278,13 @@ public:
 
             auto& status = PartitionStatus[FetchRequestCurrentPartitionIndex];
             if (status == EPartitionStatus::DataReceived) {
-                YDB_LOG_DEBUG("Skip partition because status is DataReceived",
-                    {"logPrefix", LOG_PREFIX},
-                    {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex});
+                LOG_D("Skip partition " << FetchRequestCurrentPartitionIndex << " because status is DataReceived");
                 ++FetchRequestCurrentPartitionIndex;
                 continue;
             }
 
             if (FetchRequestBytesLeft == 0) {
-                YDB_LOG_DEBUG("Partition status is",
-                    {"logPrefix", LOG_PREFIX},
-                    {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
-                    {"status", (int)status},
-                    {"bytesLeft", FetchRequestBytesLeft});
+                LOG_D("Partition " << FetchRequestCurrentPartitionIndex << " status is " << (int)status << " bytesLeft=" << FetchRequestBytesLeft);
                 if (status == EPartitionStatus::HasDataReceived) {
                     ++FetchRequestCurrentPartitionIndex;
                     continue;
@@ -331,9 +316,7 @@ public:
 
             //Form read request
             auto request = CreateReadRequest(topic, req);
-            YDB_LOG_DEBUG("Sending",
-                {"logPrefix", LOG_PREFIX},
-                {"request", request->Record.ShortDebugString()});
+            LOG_D("Sending request: " << request->Record.ShortDebugString());
             NTabletPipe::SendData(ctx, tabletInfo.PipeClient, request.release());
 
             break;
@@ -343,18 +326,13 @@ public:
     void Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
         auto partitionIndex = record.GetCookie();
-        YDB_LOG_DEBUG("Handle TEvPersQueue::TEvHasDataInfoResponse",
-            {"logPrefix", LOG_PREFIX},
-            {"ev", record.ShortDebugString()});
+        LOG_D("Handle TEvPersQueue::TEvHasDataInfoResponse " << record.ShortDebugString());
         if (partitionIndex >= PartitionStatus.size()) {
             Y_VERIFY_DEBUG(partitionIndex < PartitionStatus.size());
             return;
         }
         auto& status = PartitionStatus[partitionIndex];
-        YDB_LOG_DEBUG("Partition status is",
-            {"logPrefix", LOG_PREFIX},
-            {"partitionIndex", partitionIndex},
-            {"status", (int)status});
+        LOG_D("Partition " << partitionIndex << " status is " << (int)status);
         if (status != EPartitionStatus::HasDataRequested) {
             // On timeout we resend send HasData
             return;
@@ -376,17 +354,12 @@ public:
 
     void Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
-        YDB_LOG_DEBUG("Handle TEvPersQueue::TEvResponse",
-            {"logPrefix", LOG_PREFIX},
-            {"ev", record.ShortDebugString()});
+        LOG_D("Handle TEvPersQueue::TEvResponse " << record.ShortDebugString());
         AFL_ENSURE(record.HasPartitionResponse());
 
         if (record.GetPartitionResponse().GetCookie() != FetchRequestCurrentPartitionIndex || FetchRequestCurrentReadTablet == 0) {
-            YDB_LOG_WARN("Proxy fetch error: got response from tablet while waiting from and requested tablet is",
-                {"logPrefix", LOG_PREFIX},
-                {"partitionResponseCookie", record.GetPartitionResponse().GetCookie()},
-                {"fetchRequestCurrentPartitionIndex", FetchRequestCurrentPartitionIndex},
-                {"fetchRequestCurrentReadTablet", FetchRequestCurrentReadTablet});
+            LOG_W("proxy fetch error: got response from tablet " << record.GetPartitionResponse().GetCookie()
+                                << " while waiting from " << FetchRequestCurrentPartitionIndex << " and requested tablet is " << FetchRequestCurrentReadTablet);
             return;
         }
 
@@ -428,9 +401,7 @@ public:
             Response->Response.SetTimestampType(timestampType);
         }
 
-        YDB_LOG_DEBUG("After processing result",
-            {"logPrefix", LOG_PREFIX},
-            {"fetchRequestBytesLeft", FetchRequestBytesLeft});
+        LOG_D("After processing result FetchRequestBytesLeft=" << FetchRequestBytesLeft);
         if (FetchRequestBytesLeft == 0) {
             FinishProcessing(ctx);
         } else if (IsQuotaRequired()) {
@@ -518,9 +489,7 @@ public:
                 fetchInfo->Record.SetDeadline(0);
 
                 auto tabletId = topicInfo.PartitionToTablet[p.Partition];
-                YDB_LOG_DEBUG("Sending TEvPersQueue::TEvHasDataInfo",
-                    {"logPrefix", LOG_PREFIX},
-                    {"fetchInfoRecord", fetchInfo->Record.ShortDebugString()});
+                LOG_D("Sending TEvPersQueue::TEvHasDataInfo " << fetchInfo->Record.ShortDebugString());
                 NTabletPipe::SendData(ctx, TabletInfo[tabletId].PipeClient, fetchInfo.release());
             }
         }
@@ -572,10 +541,7 @@ public:
     }
 
     void SendReplyAndDie(THolder<TEvPQ::TEvFetchResponse> event, const TActorContext& ctx) {
-        YDB_LOG_DEBUG("Reply",
-            {"logPrefix", LOG_PREFIX},
-            {"requesterId", RequesterId},
-            {"response", event->Response.ShortDebugString()});
+        LOG_D("Reply to " << RequesterId << ": " << event->Response.ShortDebugString());
         ctx.Send(RequesterId, event.Release());
         Die(ctx);
     }

--- a/ydb/core/persqueue/public/mlp/mlp_changer.h
+++ b/ydb/core/persqueue/public/mlp/mlp_changer.h
@@ -48,8 +48,7 @@ public:
 private:
 
     void DoDescribe() {
-        YDB_LOG_DEBUG_COMP(Service, "Start describe",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Start describe");
         TBase::Become(&TThis::DescribeState);
 
         NDescriber::TDescribeSettings settings = {
@@ -60,8 +59,7 @@ private:
     }
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-        YDB_LOG_DEBUG_COMP(Service, "Handle NDescriber::TEvDescribeTopicsResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
         ChildActorId = {};
 
@@ -95,8 +93,7 @@ private:
     }
 
     void DoChanges() {
-        YDB_LOG_DEBUG_COMP(Service, "Start DoChanges",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Start DoChanges");
         TBase::Become(&TThis::ChangesState);
 
         for (const TMessageId& messageId: Settings.Messages) {
@@ -124,16 +121,12 @@ private:
     }
 
     void Handle(typename TResponse::TPtr& ev) {
-        YDB_LOG_DEBUG_COMP(Service, "Handle response",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"ev", ev->Get()->Record.ShortDebugString()});
+        LOG_D("Handle response " << ev->Get()->Record.ShortDebugString());
         auto partitionId = ev->Cookie;
 
         auto it = PendingPartitions.find(partitionId);
         if (it == PendingPartitions.end()) {
-            YDB_LOG_DEBUG_COMP(Service, "Received response fron unexpected partition",
-                {"logPrefix", NPQ_LOG_PREFIX},
-                {"partitionId", partitionId});
+            LOG_D("Received response fron unexpected partition " << partitionId);
             return;
         }
 
@@ -151,17 +144,13 @@ private:
     }
 
     void Handle(TEvPQ::TEvMLPErrorResponse::TPtr& ev) {
-        YDB_LOG_DEBUG_COMP(Service, "Handle TEvPQ::TEvMLPErrorResponse",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"ev", ev->Get()->Record.ShortDebugString()});
+        LOG_D("Handle TEvPQ::TEvMLPErrorResponse " << ev->Get()->Record.ShortDebugString());
 
         auto partitionId = ev->Cookie;
 
         auto it = PendingPartitions.find(partitionId);
         if (it == PendingPartitions.end()) {
-            YDB_LOG_DEBUG_COMP(Service, "Received response from unexpected partition",
-                {"logPrefix", NPQ_LOG_PREFIX},
-                {"partitionId", partitionId});
+            LOG_D("Received response from unexpected partition " << partitionId);
             return;
         }
 
@@ -175,15 +164,11 @@ private:
     }
 
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
-        YDB_LOG_DEBUG_COMP(Service, "Handle TEvPipeCache::TEvDeliveryProblem",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"TabletId", ev->Get()->TabletId});
+        LOG_D("Handle TEvPipeCache::TEvDeliveryProblem " << ev->Get()->TabletId);
 
         auto it = Pipes.find(ev->Get()->TabletId);
         if (it == Pipes.end()) {
-            YDB_LOG_DEBUG_COMP(Service, "Received pipe error for unexpected tablet",
-                {"logPrefix", NPQ_LOG_PREFIX},
-                {"TabletId", ev->Get()->TabletId});
+            LOG_D("Received pipe error for unexpected tablet " << ev->Get()->TabletId);
             return;
         }
 
@@ -256,9 +241,7 @@ private:
     }
 
     void ReplyErrorAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-        YDB_LOG_INFO_COMP(Service, "Reply error",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"statusCodeName", Ydb::StatusIds::StatusCode_Name(errorCode)});
+        LOG_I("Reply error " << Ydb::StatusIds::StatusCode_Name(errorCode));
         TBase::Send(ParentId, new TEvChangeResponse(errorCode, std::move(errorMessage)));
         PassAway();
     }

--- a/ydb/core/persqueue/public/mlp/mlp_describer.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_describer.cpp
@@ -3,8 +3,6 @@
 #include <ydb/core/persqueue/public/constants.h>
 #include <ydb/core/persqueue/public/utils.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NMLP {
 
 TDescriberActor::TDescriberActor(const TActorId& parentId, const TDescribeSettings& settings)
@@ -19,8 +17,7 @@ void TDescriberActor::Bootstrap() {
 }
 
 void TDescriberActor::DoDescribe() {
-    YDB_LOG_DEBUG("Start describe",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start describe");
     Become(&TDescriberActor::DescribeState);
 
     NDescriber::TDescribeSettings settings = {
@@ -31,8 +28,7 @@ void TDescriberActor::DoDescribe() {
 }
 
 void TDescriberActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
     ChildActorId = {};
 
@@ -65,16 +61,13 @@ STFUNC(TDescriberActor::DescribeState) {
 }
 
 void TDescriberActor::DoRuntimeAttributes() {
-    YDB_LOG_DEBUG("Start DoRuntimeAttributes",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start DoRuntimeAttributes");
     Become(&TDescriberActor::RuntimeAttributesState);
     SendToTablet(TopicInfo.Info->Description.GetBalancerTabletID(), new TEvPQ::TEvMLPGetRuntimeAttributesRequest(Settings.TopicName, Settings.Consumer));
 }
 
 void TDescriberActor::Handle(TEvPQ::TEvMLPGetRuntimeAttributesResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPGetRuntimeAttributesResponse",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPGetRuntimeAttributesResponse " << ev->Get()->Record.ShortDebugString());
     auto* result = ev->Get();
 
     auto response = std::make_unique<TEvDescribeResponse>();
@@ -91,8 +84,7 @@ void TDescriberActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
     if (ev->Cookie != Cookie) {
         return;
     }
-    YDB_LOG_DEBUG("Handle TEvPipeCache::TEvDeliveryProblem",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPipeCache::TEvDeliveryProblem");
     if (Backoff.HasMore()) {
         Backoff.Next();
         return DoRuntimeAttributes();
@@ -111,9 +103,7 @@ STFUNC(TDescriberActor::RuntimeAttributesState) {
 
 
 void TDescriberActor::Handle(TEvPQ::TEvMLPErrorResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPErrorResponse",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPErrorResponse " << ev->Get()->Record.ShortDebugString());
     ReplyErrorAndDie(ev->Get()->GetStatus(), std::move(ev->Get()->GetErrorMessage()));
 }
 
@@ -123,9 +113,7 @@ void TDescriberActor::SendToTablet(ui64 tabletId, IEventBase *ev) {
 }
 
 void TDescriberActor::ReplyErrorAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-    YDB_LOG_INFO("Reply error",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"statusCodeName", Ydb::StatusIds::StatusCode_Name(errorCode)});
+    LOG_I("Reply error " << Ydb::StatusIds::StatusCode_Name(errorCode));
     Send(ParentId, new TEvDescribeResponse(errorCode, std::move(errorMessage)));
     PassAway();
 }

--- a/ydb/core/persqueue/public/mlp/mlp_purger.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_purger.cpp
@@ -1,7 +1,5 @@
 #include "mlp_purger.h"
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NMLP {
 
 TPurgerActor::TPurgerActor(const TActorId& parentId, const TPurgerSettings& settings)
@@ -16,8 +14,7 @@ void TPurgerActor::Bootstrap() {
 }
 
 void TPurgerActor::DoDescribe() {
-    YDB_LOG_DEBUG("Start describe",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start describe");
     Become(&TPurgerActor::DescribeState);
 
     NDescriber::TDescribeSettings settings = {
@@ -28,8 +25,7 @@ void TPurgerActor::DoDescribe() {
 }
 
 void TPurgerActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
     ChildActorId = {};
 
@@ -57,8 +53,7 @@ STFUNC(TPurgerActor::DescribeState) {
 }
 
 void TPurgerActor::DoPurge() {
-    YDB_LOG_DEBUG("Start purge",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start purge");
     Become(&TPurgerActor::PurgeState);
 
     for (auto& partition : TopicInfo.Info->Description.GetPartitions()) {
@@ -74,9 +69,7 @@ void TPurgerActor::DoPurge() {
 
 void TPurgerActor::Handle(TEvPQ::TEvMLPPurgeResponse::TPtr& ev)
 {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPPurgeResponse",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPPurgeResponse " << ev->Get()->Record.ShortDebugString());
 
     auto partitionId = ev->Get()->GetPartitionId();
     auto& partitionStatus = Partitions[partitionId];
@@ -107,9 +100,7 @@ void TPurgerActor::RetryIfPossible(ui32 partitionId, TPartitionStatus& partition
 
 void TPurgerActor::Handle(TEvPQ::TEvMLPErrorResponse::TPtr& ev)
 {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPErrorResponse",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPErrorResponse " << ev->Get()->Record.ShortDebugString());
 
     auto partitionId = ev->Get()->GetPartitionId();
     auto& partitionStatus = Partitions[partitionId];
@@ -127,8 +118,7 @@ void TPurgerActor::Handle(TEvPQ::TEvMLPErrorResponse::TPtr& ev)
 
 void TPurgerActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev)
 {
-    YDB_LOG_DEBUG("Handle TEvPipeCache::TEvDeliveryProblem",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPipeCache::TEvDeliveryProblem");
 
     auto tabletId = ev->Get()->TabletId;
     ++TabletCookies[tabletId];
@@ -143,8 +133,7 @@ void TPurgerActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev)
 }
 
 void TPurgerActor::Handle(TEvents::TEvWakeup::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvents::TEvWakeup",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvents::TEvWakeup");
 
     auto partitionId = ev->Get()->Tag;
     auto& partitionStatus = Partitions[partitionId];
@@ -179,10 +168,7 @@ void TPurgerActor::RequestPartitionIfNeeded(ui32 partitionId,TPartitionStatus& s
 }
 
 void TPurgerActor::ReplyIfPossible() {
-    YDB_LOG_DEBUG("ReplyIfPossible: PendingPartitions PendingRetries",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"pendingPartitions", PendingPartitions},
-        {"pendingRetries", PendingRetries});
+    LOG_D("ReplyIfPossible: PendingPartitions " << PendingPartitions << " PendingRetries " << PendingRetries);
     if (PendingPartitions > 0 || PendingRetries > 0) {
         return;
     }
@@ -204,9 +190,7 @@ void TPurgerActor::SendToTablet(ui64 tabletId, IEventBase *ev, ui64 cookie) {
 }
 
 void TPurgerActor::ReplyErrorAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-    YDB_LOG_INFO("Reply error",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"statusCodeName", Ydb::StatusIds::StatusCode_Name(errorCode)});
+    LOG_I("Reply error " << Ydb::StatusIds::StatusCode_Name(errorCode));
     Send(ParentId, new TEvPurgeResponse(errorCode, std::move(errorMessage)));
     PassAway();
 }

--- a/ydb/core/persqueue/public/mlp/mlp_reader.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_reader.cpp
@@ -7,8 +7,6 @@
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/codecs.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NMLP {
 
 TReaderActor::TReaderActor(const TActorId& parentId, const TReaderSettings& settings)
@@ -23,8 +21,7 @@ void TReaderActor::Bootstrap() {
 }
 
 void TReaderActor::DoDescribe() {
-    YDB_LOG_DEBUG("Start describe",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start describe");
     Become(&TReaderActor::DescribeState);
 
     NDescriber::TDescribeSettings settings = {
@@ -35,8 +32,7 @@ void TReaderActor::DoDescribe() {
 }
 
 void TReaderActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
     ChildActorId = {};
 
@@ -69,16 +65,13 @@ STFUNC(TReaderActor::DescribeState) {
 }
 
 void TReaderActor::DoSelectPartition() {
-    YDB_LOG_DEBUG("Start select partition",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start select partition");
     Become(&TReaderActor::SelectPartitionState);
     SendToTablet(Info->Description.GetBalancerTabletID(), new TEvPQ::TEvMLPGetPartitionRequest(Settings.TopicName, Settings.Consumer, Settings.ReceiveAttemptId));
 }
 
 void TReaderActor::Handle(TEvPQ::TEvMLPGetPartitionResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPGetPartitionResponse",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPGetPartitionResponse " << ev->Get()->Record.ShortDebugString());
     auto* result = ev->Get();
     switch (result->GetStatus()) {
         case Ydb::StatusIds::SUCCESS: {
@@ -95,8 +88,7 @@ void TReaderActor::HandleOnSelectPartition(TEvPipeCache::TEvDeliveryProblem::TPt
     if (ev->Cookie != Cookie) {
         return;
     }
-    YDB_LOG_DEBUG("Handle TEvPipeCache::TEvDeliveryProblem",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPipeCache::TEvDeliveryProblem");
     if (Backoff.HasMore()) {
         Backoff.Next();
         return DoSelectPartition();
@@ -114,8 +106,7 @@ STFUNC(TReaderActor::SelectPartitionState) {
 }
 
 void TReaderActor::DoRead() {
-    YDB_LOG_DEBUG("Start read",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start read");
     Become(&TReaderActor::ReadState);
 
     auto* request = new TEvPQ::TEvMLPReadRequest(
@@ -132,8 +123,7 @@ void TReaderActor::DoRead() {
 }
 
 void TReaderActor::Handle(TEvPQ::TEvMLPReadResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPReadResponse",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPQ::TEvMLPReadResponse");
 
     auto response = std::make_unique<TEvReadResponse>();
     response->BalancerTabletId = Info->Description.GetBalancerTabletID();
@@ -141,9 +131,7 @@ void TReaderActor::Handle(TEvPQ::TEvMLPReadResponse::TPtr& ev) {
         NKikimrPQClient::TDataChunk proto;
         bool res = proto.ParseFromString(message.GetData());
         if (!res) {
-            YDB_LOG_WARN("Error parsing data. Offset",
-                {"logPrefix", NPQ_LOG_PREFIX},
-                {"messageIdOffset", message.GetId().GetOffset()});
+            LOG_W("Error parsing data. Offset " << message.GetId().GetOffset());
             // Skip message
             continue;
         }
@@ -185,9 +173,7 @@ void TReaderActor::Handle(TEvPQ::TEvMLPReadResponse::TPtr& ev) {
 
 void TReaderActor::Handle(TEvPQ::TEvMLPErrorResponse::TPtr& ev) {
     // TODO MLP Retry
-    YDB_LOG_DEBUG("Handle TEvPQ::TEvMLPErrorResponse",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"ev", ev->Get()->Record.ShortDebugString()});
+    LOG_D("Handle TEvPQ::TEvMLPErrorResponse " << ev->Get()->Record.ShortDebugString());
     ReplyErrorAndDie(ev->Get()->GetStatus(), std::move(ev->Get()->GetErrorMessage()));
 }
 
@@ -195,8 +181,7 @@ void TReaderActor::HandleOnRead(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
     if (ev->Cookie != Cookie) {
         return;
     }
-    YDB_LOG_DEBUG("Handle TEvPipeCache::TEvDeliveryProblem",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPipeCache::TEvDeliveryProblem");
     if (Backoff.HasMore()) {
         Backoff.Next();
         return DoRead();
@@ -220,9 +205,7 @@ void TReaderActor::SendToTablet(ui64 tabletId, IEventBase *ev) {
 }
 
 void TReaderActor::ReplyErrorAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-    YDB_LOG_INFO("Reply error",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"statusCodeName", Ydb::StatusIds::StatusCode_Name(errorCode)});
+    LOG_I("Reply error " << Ydb::StatusIds::StatusCode_Name(errorCode));
     Send(ParentId, new TEvReadResponse(errorCode, std::move(errorMessage)));
     PassAway();
 }

--- a/ydb/core/persqueue/public/mlp/mlp_writer.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.cpp
@@ -5,8 +5,6 @@
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/codecs.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NMLP {
 
 TWriterActor::TWriterActor(const TActorId& parentId, const TWriterSettings& settings)
@@ -29,8 +27,7 @@ void TWriterActor::PassAway() {
 }
 
 void TWriterActor::DoDescribe() {
-    YDB_LOG_DEBUG("Start describe",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start describe");
     Become(&TWriterActor::DescribeState);
 
     NDescriber::TDescribeSettings settings = {
@@ -41,8 +38,7 @@ void TWriterActor::DoDescribe() {
 }
 
 void TWriterActor::Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
     ChildActorId = {};
 
@@ -122,8 +118,7 @@ size_t SerializeTo(TWriterSettings::TMessage& item, ::NKikimrClient::TPersQueueP
 }
 
 void TWriterActor::DoWrite() {
-    YDB_LOG_DEBUG("Start write",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Start write");
     Become(&TWriterActor::WriteState);
 
     struct TInfo {
@@ -182,8 +177,7 @@ void TWriterActor::DoWrite() {
 }
 
 void TWriterActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPersQueue::TEvResponse",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPersQueue::TEvResponse");
 
     bool alreadyReceived = false;
     auto& record = ev->Get()->Record;
@@ -216,8 +210,7 @@ void TWriterActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev) {
 }
 
 void TWriterActor::Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
-    YDB_LOG_DEBUG("Handle TEvPipeCache::TEvDeliveryProblem",
-        {"logPrefix", NPQ_LOG_PREFIX});
+    LOG_D("Handle TEvPipeCache::TEvDeliveryProblem");
 
     const auto tabletId = ev->Get()->TabletId;
 
@@ -249,12 +242,8 @@ void TWriterActor::SendToTablet(ui64 tabletId, IEventBase *ev) {
 }
 
 bool TWriterActor::OnUnhandledException(const std::exception& exc) {
-    YDB_LOG_CRIT("Unhandled exception",
-        {"logPrefix", NPQ_LOG_PREFIX},
-        {"exceptionType", TypeName(exc)},
-        {"exceptionMessage", exc.what()},
-        {"endl", Endl},
-        {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
+    LOG_C("unhandled exception " << TypeName(exc) << ": " << exc.what() << Endl
+        << TBackTrace::FromCurrentException().PrintToString());
 
     PendingRequests = 0;
     ReplyIfPossible();
@@ -264,15 +253,11 @@ bool TWriterActor::OnUnhandledException(const std::exception& exc) {
 
 bool TWriterActor::IsSuccess(const NKikimrClient::TResponse& record) {
     if (record.HasErrorCode() && record.GetErrorCode() != NPersQueue::NErrorCode::OK) {
-        YDB_LOG_WARN("Write",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"error", record.ShortDebugString()});
+        LOG_W("Write error: " << record.ShortDebugString());
         return false;
     }
     if (!record.HasPartitionResponse()) {
-        YDB_LOG_WARN("Missing partition",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"response", record.ShortDebugString()});
+        LOG_W("Missing partition response: " << record.ShortDebugString());
         return false;
     }
 

--- a/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_internal.cpp
@@ -4,8 +4,6 @@
 #include <ydb/services/persqueue_v1/actors/events.h>
 #include <ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NSchema {
 
 namespace {
@@ -32,9 +30,7 @@ public:
     }
 
     void OnException(const std::exception& exc) override {
-        YDB_LOG_ERROR("Catch exception",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"onException", exc.what()});
+        LOG_E("OnException: " << exc.what());
 
         TEvSchemaResponse response(Path, Ydb::StatusIds::INTERNAL_ERROR, exc.what());
 
@@ -47,10 +43,7 @@ public:
 
 private:
     void Handle(NPQ::NSchema::TEvSchemaResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvSchemaResponse",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"status", ev->Get()->Status},
-            {"errorMessage", ev->Get()->ErrorMessage});
+        LOG_D("Handle TEvSchemaResponse. Status: " << ev->Get()->Status << ", ErrorMessage: " << ev->Get()->ErrorMessage);
 
         Promise.SetValue({
             .Path = Path,

--- a/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/alter_topic_operation.cpp
@@ -6,8 +6,6 @@
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NSchema {
 
 namespace {
@@ -39,8 +37,7 @@ public:
 
 private:
     void DoDescribe() {
-        YDB_LOG_DEBUG("DoDescribe",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("DoDescribe");
         Become(&TAlterTopicOperationActor::DescribeState);
 
         RegisterWithSameMailbox(NDescriber::CreateDescriberActor(
@@ -55,8 +52,7 @@ private:
     }
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
         auto& topics = ev->Get()->Topics;
         AFL_ENSURE(topics.size() == 1)("s", topics.size());
@@ -94,16 +90,14 @@ private:
 
 private:
     void DoGetClustersList() {
-        YDB_LOG_DEBUG("DoGetClustersList",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("DoGetClustersList");
         Become(&TAlterTopicOperationActor::GetClustersListState);
         Send(NPQ::NClusterTracker::MakeClusterTrackerID(), new NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersList());
     }
 
     void Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersListResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"getClustersListResponse", (ev->Get()->Success ? ev->Get()->ClustersList->DebugString() : "error")});
+        LOG_D("Handle NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersListResponse: "
+            << (ev->Get()->Success ? ev->Get()->ClustersList->DebugString() : "error"));
 
         auto& response = *ev->Get();
         if (response.Success) {
@@ -122,8 +116,7 @@ private:
 
 private:
     void DoAlter() {
-        YDB_LOG_DEBUG("DoAlter",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("DoAlter");
 
         Become(&TAlterTopicOperationActor::AlterState);
 
@@ -185,8 +178,7 @@ private:
     }
 
     void Handle(TEvSchemaOperationResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvSchemaOperationResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle TEvSchemaOperationResponse");
         auto& response = *ev->Get();
         return ReplyAndDie(response.Status, std::move(response.ErrorMessage));
     }
@@ -200,10 +192,7 @@ private:
 
 private:
     void ReplyAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-        YDB_LOG_DEBUG("ReplyAndDie",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"errorCode", errorCode},
-            {"errorMessage", errorMessage});
+        LOG_D("ReplyAndDie " << errorCode << " '" << errorMessage << "'");
         if (errorCode == Ydb::StatusIds::SUCCESS && !Settings.PrepareOnly) {
             ModifyScheme = {};
         }

--- a/ydb/core/persqueue/public/schema/create_topic_internal.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_internal.cpp
@@ -4,8 +4,6 @@
 #include <ydb/services/persqueue_v1/actors/events.h>
 #include <ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NSchema {
 
 namespace {
@@ -32,9 +30,7 @@ public:
     }
 
     void OnException(const std::exception& exc) override {
-        YDB_LOG_ERROR("Catch exception",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"onException", exc.what()});
+        LOG_E("OnException: " << exc.what());
 
         TEvSchemaResponse response(Path, Ydb::StatusIds::INTERNAL_ERROR, exc.what());
 
@@ -47,10 +43,7 @@ public:
 
 private:
     void Handle(NPQ::NSchema::TEvSchemaResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvSchemaResponse",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"status", ev->Get()->Status},
-            {"errorMessage", ev->Get()->ErrorMessage});
+        LOG_D("Handle TEvSchemaResponse. Status: " << ev->Get()->Status << ", ErrorMessage: " << ev->Get()->ErrorMessage);
 
         Promise.SetValue({
             .Path = Path,

--- a/ydb/core/persqueue/public/schema/create_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/create_topic_operation.cpp
@@ -8,8 +8,6 @@
 #include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NSchema {
 
 namespace {
@@ -44,15 +42,13 @@ public:
 
 private:
     void DoGetClustersList() {
-        YDB_LOG_DEBUG("DoGetClustersList",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("DoGetClustersList");
         Become(&TCreateTopicOperationActor::GetClustersListState);
         Send(NPQ::NClusterTracker::MakeClusterTrackerID(), new NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersList());
     }
 
     void Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersListResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersListResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle NPQ::NClusterTracker::TEvClusterTracker::TEvGetClustersListResponse");
 
         auto& response = *ev->Get();
         if (response.Success) {
@@ -71,9 +67,7 @@ private:
 
 private:
     void DoCreate() {
-        YDB_LOG_DEBUG("DoCreate",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"ifNotExists", Settings.IfNotExists});
+        LOG_D("DoCreate IfNotExists: " << Settings.IfNotExists);
         Become(&TCreateTopicOperationActor::CreateState);
 
         auto database = CanonizePath(Settings.Database);
@@ -123,8 +117,7 @@ private:
     }
 
     void Handle(TEvSchemaOperationResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvSchemaOperationResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle TEvSchemaOperationResponse");
         auto& response = *ev->Get();
         return ReplyAndDie(response.Status, std::move(response.ErrorMessage));
     }
@@ -138,10 +131,7 @@ private:
 
 private:
     void ReplyAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-        YDB_LOG_DEBUG("ReplyAndDie",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"errorCode", errorCode},
-            {"errorMessage", errorMessage});
+        LOG_D("ReplyAndDie " << errorCode << " '" << errorMessage << "'");
         if ((errorCode == Ydb::StatusIds::SUCCESS || errorCode == Ydb::StatusIds::ALREADY_EXISTS) && !Settings.PrepareOnly) {
             ModifyScheme = {};
         }

--- a/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
+++ b/ydb/core/persqueue/public/schema/drop_topic_operation.cpp
@@ -8,8 +8,6 @@
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/tx/tx_proxy/proxy.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NSchema {
 
 namespace {
@@ -41,8 +39,7 @@ public:
 
 private:
     void DoDescribe() {
-        YDB_LOG_DEBUG("DoDescribe",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("DoDescribe");
         Become(&TDropTopicOperationActor::DescribeState);
 
         RegisterWithSameMailbox(NDescriber::CreateDescriberActor(
@@ -57,8 +54,7 @@ private:
     }
 
     void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle NDescriber::TEvDescribeTopicsResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle NDescriber::TEvDescribeTopicsResponse");
 
         auto& topics = ev->Get()->Topics;
         AFL_ENSURE(topics.size() == 1)("s", topics.size());
@@ -95,8 +91,7 @@ private:
 
 private:
     void DoDrop() {
-        YDB_LOG_DEBUG("DoDrop",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("DoDrop");
 
         Become(&TDropTopicOperationActor::DropState);
 
@@ -131,8 +126,7 @@ private:
     }
 
     void Handle(TEvSchemaOperationResponse::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvSchemaOperationResponse",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle TEvSchemaOperationResponse");
         auto& response = *ev->Get();
         return ReplyAndDie(response.Status, std::move(response.ErrorMessage));
     }

--- a/ydb/core/persqueue/public/schema/schema_operation.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation.cpp
@@ -10,8 +10,6 @@
 #include <ydb/core/ydb_convert/tx_proxy_status.h>
 #include <ydb/library/services/services.pb.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT Service
-
 namespace NKikimr::NPQ::NSchema {
 
 namespace {
@@ -57,9 +55,7 @@ public:
 
 private:
     void DoPropose() {
-        YDB_LOG_DEBUG("DoPropose",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"retry", ProposeBackoff.GetIteration()});
+        LOG_D("DoPropose retry: " << ProposeBackoff.GetIteration());
         Become(&TSchemaOperationActor::ProposeState);
 
         auto request = std::make_unique<TEvTxUserProxy::TEvProposeTransaction>();
@@ -80,8 +76,7 @@ private:
     }
 
     void Handle(TEvTxUserProxy::TEvProposeTransactionStatus::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvTxUserProxy::TEvProposeTransactionStatus",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle TEvTxUserProxy::TEvProposeTransactionStatus");
 
         const auto status = ev->Get()->Status();
         const auto& record = ev->Get()->Record;
@@ -115,8 +110,7 @@ private:
     }
 
     void HandleOnPropose(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
-        YDB_LOG_DEBUG("HandleOnPropose TEvPipeCache::TEvDeliveryProblem",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("HandleOnPropose TEvPipeCache::TEvDeliveryProblem");
         if (TPipeCacheClient::OnUndelivered(ev)) {
             return ReplyErrorAndDie(Ydb::StatusIds::UNAVAILABLE,
                 TStringBuilder() << "SchemeShard " << ev->Get()->TabletId << " is unavailable");
@@ -135,10 +129,7 @@ private:
 
 private:
     void DoWaitCompletion() {
-        YDB_LOG_DEBUG("DoWaitTxCompletion",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"schemeShardTabletId", SchemeShardTabletId},
-            {"txId", TxId});
+        LOG_D("DoWaitTxCompletion SchemeShardTabletId: " << SchemeShardTabletId << " TxId: " << TxId);
         Become(&TSchemaOperationActor::WaitCompletionState);
 
         auto request = std::make_unique<NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletion>(TxId);
@@ -146,14 +137,12 @@ private:
     }
 
     void Handle(NSchemeShard::TEvSchemeShard::TEvNotifyTxCompletionResult::TPtr&) {
-        YDB_LOG_DEBUG("Handle TEvSchemeShard::TEvNotifyTxCompletionResult",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle TEvSchemeShard::TEvNotifyTxCompletionResult");
         ReplyOkAndDie();
     }
 
     void HandleOnWaitCompletion(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
-        YDB_LOG_DEBUG("Handle TEvPipeCache::TEvDeliveryProblem",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("Handle TEvPipeCache::TEvDeliveryProblem");
         OnUndelivered(ev);
         if (++WaitTxCompletionRetries > MaxWaitTxCompletionRetries) {
             return ReplyErrorAndDie(Ydb::StatusIds::UNAVAILABLE,
@@ -177,17 +166,13 @@ private:
     }
 
     void ReplyErrorAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {
-        YDB_LOG_DEBUG("Dump NPQLOGPREFIX, replyErrorAndDie, errorMessage",
-            {"logPrefix", NPQ_LOG_PREFIX},
-            {"replyErrorAndDie", errorCode},
-            {"errorMessage", errorMessage});
+        LOG_D("ReplyErrorAndDie: " << errorCode << " " << errorMessage);
         Send(ParentId, new TEvSchemaOperationResponse(errorCode, std::move(errorMessage)), 0, Cookie);
         PassAway();
     }
 
     void ReplyOkAndDie() {
-        YDB_LOG_DEBUG("ReplyOkAndDie",
-            {"logPrefix", NPQ_LOG_PREFIX});
+        LOG_D("ReplyOkAndDie");
         Send(ParentId, new TEvSchemaOperationResponse(), 0, Cookie);
         PassAway();
     }


### PR DESCRIPTION
Reverts ydb-platform/ydb#45809

Reason https://github.com/ydb-platform/ydb/pull/46624#issuecomment-4982197919
```
/home/runner/actions_runner/_work/ydb/ydb/ydb/library/actors/struct_log/create_message_impl.h:190:27: error: static assertion failed: It is not allowed to pass function into structured message
  190 |             static_assert(false, "It is not allowed to pass function into structured message");
      |                           ^~~~~
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/persqueue/public/mlp/mlp_writer.cpp:256:9: note: in instantiation of function template specialization 'NActors::NStructuredLog::TCreateMessageArg::TCreateMessageArg<void (IOutputStream &), const char (&)[5]>' requested here
  256 |         {"endl", Endl},
      |         ^
1 error generated.
```