### PR TITLE
Revert "[YDB_LOG] Migrate ydb/core/persqueue/writer"

### DIFF
--- a/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
@@ -11,15 +11,19 @@
 
 namespace NKikimr::NPQ::NPartitionChooser {
 
-#if defined(LOG_PREFIX)
-#error "Already defined LOG_PREFIX"
+#if defined(LOG_PREFIX) || defined(TRACE) || defined(DEBUG) || defined(INFO) || defined(ERROR)
+#error "Already defined LOG_PREFIX or TRACE or DEBUG or INFO or ERROR"
 #endif
 
 
-#define LOG_PREFIX TStringBuilder() << "TPartitionChooser " << SelfId()                  \
+#define LOG_PREFIX "TPartitionChooser " << SelfId()                  \
                     << " (SourceId=" << SourceId                     \
                     << ", PreferedPartition=" << PreferedPartition   \
                     << ") "
+#define TRACE(message) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define DEBUG(message) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define INFO(message)  LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define ERROR(message) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
 
 using TPartitionInfo = typename IPartitionChooser::TPartitionInfo;
 
@@ -79,11 +83,9 @@ protected:
     void InitTable(const NActors::TActorContext& ctx) {
         TThis::Become(&TThis::StateInitTable);
         const auto& pqConfig = AppData(ctx)->PQConfig;
-        YDB_LOG_TRACE_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "InitTable",
-            {"logPrefix", LOG_PREFIX},
-            {"sourceId", SourceId},
-            {"topicsAreFirstClassCitizen", pqConfig.GetTopicsAreFirstClassCitizen()},
-            {"useSrcIdMetaMappingInFirstClass", pqConfig.GetUseSrcIdMetaMappingInFirstClass()});
+        TRACE("InitTable: SourceId="<< SourceId
+              << " TopicsAreFirstClassCitizen=" << pqConfig.GetTopicsAreFirstClassCitizen()
+              << " UseSrcIdMetaMappingInFirstClass=" <<pqConfig.GetUseSrcIdMetaMappingInFirstClass());
         if (SourceId && pqConfig.GetTopicsAreFirstClassCitizen() && pqConfig.GetUseSrcIdMetaMappingInFirstClass()) {
             TableHelper.SendInitTableRequest(ctx);
         } else {
@@ -106,8 +108,7 @@ protected:
 protected:
     void StartKqpSession(const NActors::TActorContext& ctx) {
         if (NeedTable(ctx)) {
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "StartKqpSession",
-                {"logPrefix", LOG_PREFIX});
+            DEBUG("StartKqpSession")
             TThis::Become(&TThis::StateCreateKqpSession);
             TableHelper.SendCreateSessionRequest(ctx);
         } else {
@@ -138,8 +139,7 @@ protected:
 protected:
     void SendSelectRequest(const NActors::TActorContext& ctx) {
         TThis::Become(&TThis::StateSelect);
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "Select from the table",
-            {"logPrefix", LOG_PREFIX});
+        DEBUG("Select from the table");
         TableHelper.SendSelectRequest(ctx);
     }
 
@@ -148,10 +148,7 @@ protected:
             return ReplyError(ErrorCode::INITIALIZING, TStringBuilder() << "kqp error Marker# PQ50 : " <<  ev->Get()->Record.DebugString(), ctx);
         }
 
-        YDB_LOG_TRACE_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "Selected from table",
-            {"logPrefix", LOG_PREFIX},
-            {"partitionId", TableHelper.PartitionId()},
-            {"seqNo", TableHelper.SeqNo()});
+        TRACE("Selected from table PartitionId=" << TableHelper.PartitionId() << " SeqNo=" << TableHelper.SeqNo());
         if (TableHelper.PartitionId()) {
             Partition = Chooser->GetPartition(TableHelper.PartitionId().value());
         }
@@ -174,8 +171,7 @@ protected:
     void SendUpdateRequests(const TActorContext& ctx) {
         if (NeedTable(ctx)) {
             TThis::Become(&TThis::StateUpdate);
-            YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "Update the table",
-                {"logPrefix", LOG_PREFIX});
+            DEBUG("Update the table");
             TableHelper.SendUpdateRequest(Partition->PartitionId, SeqNo, ctx);
         } else {
             ReplyResult(ctx);
@@ -184,10 +180,7 @@ protected:
 
     void HandleUpdate(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& ctx) {
         auto& record = ev->Get()->Record;
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "HandleUpdate",
-            {"logPrefix", LOG_PREFIX},
-            {"partitionPersisted", PartitionPersisted},
-            {"status", record.GetYdbStatus()});
+        DEBUG("HandleUpdate PartitionPersisted=" << PartitionPersisted << " Status=" << record.GetYdbStatus());
 
         if (record.GetYdbStatus() == Ydb::StatusIds::ABORTED) {
             if (!PartitionPersisted) {
@@ -272,8 +265,7 @@ protected:
 protected:
     void StartIdle() {
         TThis::Become(&TThis::StateIdle);
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "Start idle",
-            {"logPrefix", LOG_PREFIX});
+        DEBUG("Start idle");
     }
 
     void HandleIdle(TEvPartitionChooser::TEvRefreshRequest::TPtr&, const TActorContext& ctx) {
@@ -310,19 +302,14 @@ protected:
             return;
         }
         ResultWasSent = true;
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "ReplyResult",
-            {"logPrefix", LOG_PREFIX},
-            {"partition", Partition->PartitionId},
-            {"seqNo", SeqNo});
+        DEBUG("ReplyResult: Partition=" << Partition->PartitionId << ", SeqNo=" << SeqNo);
         Span.EndOk();
         Span = {};
         ctx.Send(Parent, new TEvPartitionChooser::TEvChooseResult(Partition->PartitionId, Partition->TabletId, SeqNo));
     }
 
     void ReplyError(ErrorCode code, TString&& errorMessage, const NActors::TActorContext& ctx) {
-        YDB_LOG_INFO_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "Reply error",
-            {"logPrefix", LOG_PREFIX},
-            {"replyError", errorMessage});
+        INFO("ReplyError: " << errorMessage);
         Span.EndError(errorMessage);
         ctx.Send(Parent, new TEvPartitionChooser::TEvChooseError(code, std::move(errorMessage)));
 
@@ -349,5 +336,9 @@ protected:
 };
 
 #undef LOG_PREFIX
+#undef TRACE
+#undef DEBUG
+#undef INFO
+#undef ERROR
 
 } // namespace NKikimr::NPQ::NPartitionChooser

--- a/ydb/core/persqueue/writer/partition_chooser_impl__old_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__old_chooser_actor.h
@@ -5,15 +5,19 @@
 
 namespace NKikimr::NPQ::NPartitionChooser {
 
-#if defined(LOG_PREFIX)
-#error "Already defined LOG_PREFIX"
+#if defined(LOG_PREFIX) || defined(TRACE) || defined(DEBUG) || defined(INFO) || defined(ERROR)
+#error "Already defined LOG_PREFIX or TRACE or DEBUG or INFO or ERROR"
 #endif
 
 
-#define LOG_PREFIX TStringBuilder() << "TPartitionChooser " << SelfId()                         \
+#define LOG_PREFIX "TPartitionChooser " << SelfId()                         \
                     << " (SourceId=" << TThis::SourceId                     \
                     << ", PreferedPartition=" << TThis::PreferedPartition   \
                     << ") "
+#define TRACE(message) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define DEBUG(message) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define INFO(message)  LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define ERROR(message) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
 
 template<typename TPipeCreator>
 class TPartitionChooserActor: public TAbstractPartitionChooserActor<TPartitionChooserActor<TPipeCreator>, TPipeCreator> {
@@ -60,8 +64,7 @@ public:
 
 private:
     void RequestPQRB(const NActors::TActorContext& ctx) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "RequestPQRB",
-            {"logPrefix", LOG_PREFIX});
+        DEBUG("RequestPQRB")
         TThis::Become(&TThis::StatePQRB);
 
         if (PQRBHelper.PartitionId()) {
@@ -74,10 +77,7 @@ private:
 
     void Handle(TEvPersQueue::TEvGetPartitionIdForWriteResponse::TPtr& ev, const TActorContext& ctx) {
         PartitionId = PQRBHelper.Handle(ev, ctx);
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "Received partition from PQRB",
-            {"logPrefix", LOG_PREFIX},
-            {"partitionId", PartitionId},
-            {"sourceId", TThis::SourceId});
+        DEBUG("Received partition " << PartitionId << " from PQRB for SourceId=" << TThis::SourceId);
         TThis::Partition = TThis::Chooser->GetPartition(PQRBHelper.PartitionId().value());
 
         PQRBHelper.Close(ctx);
@@ -110,8 +110,7 @@ private:
 
 private:
     void OnPartitionChosen(const TActorContext& ctx) {
-        YDB_LOG_TRACE_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "OnPartitionChosen",
-            {"logPrefix", LOG_PREFIX});
+        TRACE("OnPartitionChosen");
 
         if (!TThis::Partition && TThis::PreferedPartition) {
             return TThis::ReplyError(ErrorCode::BAD_REQUEST,
@@ -155,5 +154,9 @@ private:
 };
 
 #undef LOG_PREFIX
+#undef TRACE
+#undef DEBUG
+#undef INFO
+#undef ERROR
 
 } // namespace NKikimr::NPQ::NPartitionChooser

--- a/ydb/core/persqueue/writer/partition_chooser_impl__sm_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__sm_chooser_actor.h
@@ -6,15 +6,19 @@
 
 namespace NKikimr::NPQ::NPartitionChooser {
 
-#if defined(LOG_PREFIX)
-#error "Already defined LOG_PREFIX"
+#if defined(LOG_PREFIX) || defined(TRACE) || defined(DEBUG) || defined(INFO) || defined(ERROR)
+#error "Already defined LOG_PREFIX or TRACE or DEBUG or INFO or ERROR"
 #endif
 
 
-#define LOG_PREFIX TStringBuilder() << "TPartitionChooser " << SelfId()                         \
+#define LOG_PREFIX "TPartitionChooser " << SelfId()                         \
                     << " (SourceId=" << TThis::SourceId                     \
                     << ", PreferedPartition=" << TThis::PreferedPartition   \
                     << ") "
+#define TRACE(message) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define DEBUG(message) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define INFO(message)  LOG_INFO_S (*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define ERROR(message) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
 
 template<typename TPipeCreator>
 class TSMPartitionChooserActor: public TAbstractPartitionChooserActor<TSMPartitionChooserActor<TPipeCreator>, TPipeCreator> {
@@ -109,10 +113,7 @@ private:
             return TThis::ReplyError(TThis::PreferedPartition ? ErrorCode::WRITE_ERROR_PARTITION_INACTIVE : ErrorCode::INITIALIZING, "A partition not choosed", ctx);
         }
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "GetOwnershipFast",
-            {"logPrefix", LOG_PREFIX},
-            {"partition", BoundaryPartition->PartitionId},
-            {"tabletId", BoundaryPartition->TabletId});
+        DEBUG("GetOwnershipFast Partition=" << BoundaryPartition->PartitionId << " TabletId=" << BoundaryPartition->TabletId);
 
         TThis::PartitionHelper.Open(BoundaryPartition->TabletId, ctx);
         TThis::PartitionHelper.SendCheckPartitionStatusRequest(BoundaryPartition->PartitionId, TThis::SourceId, ctx);
@@ -147,8 +148,7 @@ private:
 
 private:
     void GetOldSeqNo(const TActorContext &ctx) {
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "GetOldSeqNo",
-            {"logPrefix", LOG_PREFIX});
+        DEBUG("GetOldSeqNo");
         TThis::Become(&TThis::StateGetMaxSeqNo);
 
         const auto* oldNode = Graph->GetPartition(TThis::TableHelper.PartitionId().value());
@@ -210,8 +210,7 @@ private:
 
 private:
     void OnPartitionChosen(const TActorContext& ctx) {
-        YDB_LOG_TRACE_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "OnPartitionChosen",
-            {"logPrefix", LOG_PREFIX});
+        TRACE("OnPartitionChosen");
 
         if (!TThis::Partition && TThis::PreferedPartition) {
             return TThis::ReplyError(ErrorCode::BAD_REQUEST,
@@ -253,5 +252,9 @@ private:
 };
 
 #undef LOG_PREFIX
+#undef TRACE
+#undef DEBUG
+#undef INFO
+#undef ERROR
 
 } // namespace NKikimr::NPQ::NPartitionChooser

--- a/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
@@ -15,6 +15,18 @@
 
 namespace NKikimr::NPQ::NPartitionChooser {
 
+#if defined(LOG_PREFIX) || defined(TRACE) || defined(DEBUG) || defined(INFO) || defined(ERROR)
+#error "Already defined LOG_PREFIX or TRACE or DEBUG or INFO or ERROR"
+#endif
+
+
+#define LOG_PREFIX "TTableHelper "
+#define TRACE(message) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define DEBUG(message) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define INFO(message)  LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+#define ERROR(message) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_PARTITION_CHOOSER, LOG_PREFIX << message);
+
+
 class TTableHelper {
 public:
     TTableHelper(const TString& topicName, const TString& topicHashName)
@@ -47,12 +59,9 @@ public:
         UpdateQuery = GetUpdateSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
         UpdateAccessTimeQuery = GetUpdateAccessTimeQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
 
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "TTableHelper",
-            {"selectQuery", SelectQuery});
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "TTableHelper",
-            {"updateQuery", UpdateQuery});
-        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "TTableHelper",
-            {"updateAccessTimeQuery", UpdateAccessTimeQuery});
+        DEBUG("SelectQuery: " << SelectQuery);
+        DEBUG("UpdateQuery: " << UpdateQuery);
+        DEBUG("UpdateAccessTimeQuery: " << UpdateAccessTimeQuery);
 
         return true;
     }
@@ -266,5 +275,9 @@ private:
 };
 
 #undef LOG_PREFIX
+#undef TRACE
+#undef DEBUG
+#undef INFO
+#undef ERROR
 
 } // namespace NKikimr::NPQ::NPartitionChooser

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -23,16 +23,18 @@
 
 #include <library/cpp/retry/retry_policy.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_WRITE_PROXY
-
 namespace NKikimr::NPQ {
 
-#if defined(LOG_PREFIX)
-#error "Already defined LOG_PREFIX"
+#if defined(LOG_PREFIX) || defined(TRACE) || defined(DEBUG) || defined(INFO) || defined(ERROR)
+#error "Already defined LOG_PREFIX or TRACE or DEBUG or INFO or ERROR"
 #endif
 
 
-#define LOG_PREFIX TStringBuilder() << "TPartitionWriter " << TabletId << " (partition=" << PartitionId << ") "
+#define LOG_PREFIX "TPartitionWriter " << TabletId << " (partition=" << PartitionId << ") "
+#define TRACE(message) LOG_TRACE_S(*NActors::TlsActivationContext, NKikimrServices::PQ_WRITE_PROXY, LOG_PREFIX << message);
+#define DEBUG(message) LOG_DEBUG_S(*NActors::TlsActivationContext, NKikimrServices::PQ_WRITE_PROXY, LOG_PREFIX << message);
+#define INFO(message)  LOG_INFO_S(*NActors::TlsActivationContext, NKikimrServices::PQ_WRITE_PROXY, LOG_PREFIX << message);
+#define ERROR(message) LOG_ERROR_S(*NActors::TlsActivationContext, NKikimrServices::PQ_WRITE_PROXY, LOG_PREFIX << message);
 
 static const ui64 WRITE_BLOCK_SIZE = 4_KB;
 static const ui32 INVALID_PARTITION_ID = Max<ui32>();
@@ -244,9 +246,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         }
 
         if (auto delay = RetryState->GetNextRetryDelay(code); delay.Defined()) {
-            YDB_LOG_DEBUG("Repeat the request to KQP",
-                {"logPrefix", LOG_PREFIX},
-                {"delay", *delay});
+            DEBUG("Repeat the request to KQP in " << *delay);
             Schedule(*delay, new TEvents::TEvWakeup());
         }
     }
@@ -278,10 +278,9 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     /// GetWriteId
 
     void GetWriteId(const TActorContext& ctx) {
-        YDB_LOG_DEBUG("Start of a request to KQP for a WriteId",
-            {"logPrefix", LOG_PREFIX},
-            {"sessionId", Opts.SessionId},
-            {"txId", Opts.TxId});
+        DEBUG("Start of a request to KQP for a WriteId. " <<
+              "SessionId: " << Opts.SessionId <<
+              " TxId: " << Opts.TxId);
 
         auto ev = MakeWriteIdRequest();
         ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release());
@@ -299,11 +298,10 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     void HandleWriteId(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& /*ctx*/) {
-        YDB_LOG_DEBUG("End of the request to KQP for the WriteId",
-            {"logPrefix", LOG_PREFIX},
-            {"sessionId", Opts.SessionId},
-            {"txId", Opts.TxId},
-            {"status", ev->Get()->Record.GetYdbStatus()});
+        DEBUG("End of the request to KQP for the WriteId. " <<
+              "SessionId: " << Opts.SessionId <<
+              " TxId: " << Opts.TxId <<
+              " Status: " << ev->Get()->Record.GetYdbStatus());
 
         auto& record = ev->Get()->Record;
         switch (record.GetYdbStatus()) {
@@ -318,11 +316,9 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         WriteId = NPQ::GetWriteId(record.GetResponse().GetTopicOperations());
 
-        YDB_LOG_DEBUG("Dump LOGPREFIX, sessionId, txId, writeId",
-            {"logPrefix", LOG_PREFIX},
-            {"sessionId", Opts.SessionId},
-            {"txId", Opts.TxId},
-            {"writeId", WriteId});
+        DEBUG("SessionId: " << Opts.SessionId <<
+              " TxId: " << Opts.TxId <<
+              " WriteId: " << WriteId);
 
         GetOwnership();
     }
@@ -537,21 +533,19 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         Y_ENSURE(HasWriteId());
         Y_ENSURE(HasSupportivePartitionId());
 
-        YDB_LOG_DEBUG("Start of a request to KQP to save PartitionId",
-            {"logPrefix", LOG_PREFIX},
-            {"sessionId", Opts.SessionId},
-            {"txId", Opts.TxId});
+        DEBUG("Start of a request to KQP to save PartitionId. " <<
+              "SessionId: " << Opts.SessionId <<
+              " TxId: " << Opts.TxId);
 
         auto ev = MakeWriteIdRequest();
         ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release());
     }
 
     void HandlePartitionIdSaved(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext&) {
-        YDB_LOG_DEBUG("End of a request to KQP to save PartitionId",
-            {"logPrefix", LOG_PREFIX},
-            {"sessionId", Opts.SessionId},
-            {"txId", Opts.TxId},
-            {"status", ev->Get()->Record.GetYdbStatus()});
+        DEBUG("End of a request to KQP to save PartitionId. " <<
+              "SessionId: " << Opts.SessionId <<
+              " TxId: " << Opts.TxId <<
+              " Status: " << ev->Get()->Record.GetYdbStatus());
 
         auto& record = ev->Get()->Record;
         switch (record.GetYdbStatus()) {
@@ -682,9 +676,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     /// Work
 
     STATEFN(StateWork) {
-        YDB_LOG_DEBUG("Received",
-            {"logPrefix", LOG_PREFIX},
-            {"event", (*ev.Get()).GetTypeName()});
+        DEBUG("Received event: " << (*ev.Get()).GetTypeName())
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvPartitionWriter::TEvWriteRequest, Handle);
             hFunc(TEvPersQueue::TEvResponse, Handle);
@@ -709,9 +701,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         auto writeValid = (PendingWrite.empty() || PendingWrite.back().Cookie < cookie);
 
         if (!(pendingValid && reserveValid && writeValid)) {
-            YDB_LOG_ERROR("The cookie of WriteRequest is invalid",
-                {"logPrefix", LOG_PREFIX},
-                {"cookie", cookie});
+            ERROR("The cookie of WriteRequest is invalid. Cookie=" << cookie);
             Disconnected(EErrorCode::InternalError);
             return false;
         }
@@ -806,18 +796,14 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void EnqueueReservedAndProcess(ui64 cookie) {
         if (PendingReserve.empty()) {
-            YDB_LOG_ERROR("The state of the PartitionWriter is invalid. PendingReserve is empty. Marker #01",
-                {"logPrefix", LOG_PREFIX});
+            ERROR("The state of the PartitionWriter is invalid. PendingReserve is empty. Marker #01");
             Disconnected(EErrorCode::InternalError);
             return;
         }
         auto it = PendingReserve.begin();
 
         if(it->first != cookie) {
-            YDB_LOG_ERROR("The order of reservation is invalid",
-                {"logPrefix", LOG_PREFIX},
-                {"cookie", cookie},
-                {"reserveCookie", it->first});
+            ERROR("The order of reservation is invalid. Cookie=" << cookie << ", ReserveCookie=" << it->first);
             Disconnected(EErrorCode::InternalError);
             return;
         }
@@ -834,11 +820,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         while (rit != ReceivedReserve.end() && qit != ReceivedQuota.end()) {
             auto& request = rit->second;
             const auto cookie = rit->first;
-            YDB_LOG_TRACE("Processing quota for request",
-                {"logPrefix", LOG_PREFIX},
-                {"cookie", cookie},
-                {"quotaCheckEnabled", request.QuotaCheckEnabled},
-                {"quotaAccepted", request.QuotaAccepted});
+            TRACE("processing quota for request cookie=" << cookie << ", QuotaCheckEnabled=" << request.QuotaCheckEnabled << ", QuotaAccepted=" << request.QuotaAccepted);
             if (!request.QuotaCheckEnabled || request.QuotaAccepted) {
                 // A situation when a quota was not requested or was received while waiting for a reserve
                 Write(cookie, std::move(request));
@@ -847,10 +829,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             }
 
             if (cookie != *qit) {
-                YDB_LOG_ERROR("The order of reservation and quota requests should be the same",
-                    {"logPrefix", LOG_PREFIX},
-                    {"reserveCookie", cookie},
-                    {"quotaCookie", *qit});
+                ERROR("The order of reservation and quota requests should be the same. ReserveCookie=" << cookie << ", QuotaCookie=" << *qit);
                 Disconnected(EErrorCode::InternalError);
                 return;
             }
@@ -863,11 +842,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         while (rit != ReceivedReserve.end()) {
             auto& request = rit->second;
             const auto cookie = rit->first;
-            YDB_LOG_TRACE("Processing quota for request",
-                {"logPrefix", LOG_PREFIX},
-                {"cookie", cookie},
-                {"quotaCheckEnabled", request.QuotaCheckEnabled},
-                {"quotaAccepted", request.QuotaAccepted});
+            TRACE("processing quota for request cookie=" << cookie << ", QuotaCheckEnabled=" << request.QuotaCheckEnabled << ", QuotaAccepted=" << request.QuotaAccepted);
             if (request.QuotaCheckEnabled && !request.QuotaAccepted) {
                 break;
             }
@@ -879,15 +854,11 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
         while (qit != ReceivedQuota.end()) {
             auto cookie = *qit;
-            YDB_LOG_TRACE("Processing quota for request",
-                {"logPrefix", LOG_PREFIX},
-                {"cookie", cookie});
+            TRACE("processing quota for request cookie=" << cookie);
             auto pit = PendingReserve.find(cookie);
 
             if (pit == PendingReserve.end()) {
-                YDB_LOG_ERROR("The received quota does not apply to any request",
-                    {"logPrefix", LOG_PREFIX},
-                    {"cookie", *qit});
+                ERROR("The received quota does not apply to any request. Cookie=" << *qit);
                 Disconnected(EErrorCode::InternalError);
                 return;
             }
@@ -948,9 +919,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
             auto cookieWriteValid = (PendingWrite.empty() || PendingWrite.back().Cookie < cookie);
             if (!cookieWriteValid) {
-                YDB_LOG_ERROR("The cookie of Write is invalid",
-                    {"logPrefix", LOG_PREFIX},
-                    {"cookie", cookie});
+                ERROR("The cookie of Write is invalid. Cookie=" << cookie);
                 Disconnected(EErrorCode::InternalError);
                 return;
             }
@@ -988,18 +957,11 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
         auto msg = ev->Get();
-        YDB_LOG_DEBUG("TEvClientConnected Status NodeId",
-            {"logPrefix", LOG_PREFIX},
-            {"status", msg->Status},
-            {"tabletId", msg->TabletId},
-            {"serverIdNodeId", msg->ServerId.NodeId()},
-            {"generation", msg->Generation});
+        DEBUG("TEvClientConnected Status " << msg->Status << ", TabletId: " << msg->TabletId << ", NodeId " << msg->ServerId.NodeId() << ", Generation: " << msg->Generation);
         Y_DEBUG_ABORT_UNLESS(msg->TabletId == TabletId);
 
         if (msg->Status != NKikimrProto::OK) {
-            YDB_LOG_ERROR("Received TEvClientConnected with status",
-                {"logPrefix", LOG_PREFIX},
-                {"Status", ev->Get()->Status});
+            ERROR("received TEvClientConnected with status " << ev->Get()->Status);
             Disconnected(EErrorCode::InternalError);
             return;
         }
@@ -1010,19 +972,13 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         {
             if(*ExpectedGeneration != msg->Generation)
             {
-                YDB_LOG_INFO("Received TEvClientConnected with wrong generation. received",
-                    {"logPrefix", LOG_PREFIX},
-                    {"expected", *ExpectedGeneration},
-                    {"generation", msg->Generation});
+                INFO("received TEvClientConnected with wrong generation. Expected: " << *ExpectedGeneration << ", received " << msg->Generation);
                 Disconnected(EErrorCode::PartitionNotLocal);
                 return;
             }
             if (NActors::TActivationContext::ActorSystem()->NodeId != msg->ServerId.NodeId())
             {
-                YDB_LOG_INFO("Received TEvClientConnected with wrong NodeId. received",
-                    {"logPrefix", LOG_PREFIX},
-                    {"expected", NActors::TActivationContext::ActorSystem()->NodeId},
-                    {"serverIdNodeId", msg->ServerId.NodeId()});
+                INFO("received TEvClientConnected with wrong NodeId. Expected: " << NActors::TActivationContext::ActorSystem()->NodeId << ", received " << msg->ServerId.NodeId());
                 Disconnected(EErrorCode::PartitionNotLocal);
                 return;
             }
@@ -1031,8 +987,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
 
     void Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev) {
         if (ev->Get()->TabletId == TabletId) {
-            YDB_LOG_DEBUG("Received TEvClientDestroyed",
-                {"logPrefix", LOG_PREFIX});
+            DEBUG("received TEvClientDestroyed");
             Disconnected(EErrorCode::PartitionDisconnected);
         }
     }
@@ -1217,5 +1172,9 @@ IActor* CreatePartitionWriter(const TActorId& client,
 }
 
 #undef LOG_PREFIX
+#undef TRACE
+#undef DEBUG
+#undef INFO
+#undef ERROR
 
 }


### PR DESCRIPTION
Reverts ydb-platform/ydb#45812

Reason https://github.com/ydb-platform/ydb/pull/46624#issuecomment-4982197919
```
/home/runner/actions_runner/_work/ydb/ydb/ydb/library/actors/struct_log/create_message_impl.h:190:27: error: static assertion failed: It is not allowed to pass function into structured message
  190 |             static_assert(false, "It is not allowed to pass function into structured message");
      |                           ^~~~~
/home/runner/actions_runner/_work/ydb/ydb/ydb/core/persqueue/public/mlp/mlp_writer.cpp:256:9: note: in instantiation of function template specialization 'NActors::NStructuredLog::TCreateMessageArg::TCreateMessageArg<void (IOutputStream &), const char (&)[5]>' requested here
  256 |         {"endl", Endl},
      |         ^
1 error generated.
```