### PR TITLE
schemeshard: add flag to disable FileStore ssd_system space accounting to avoid ui64 counter overflow on domains with many large filesystems (#46268)

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -216,4 +216,10 @@ message TFeatureFlags {
     optional bool EnableCompactionOverloadDetection = 197 [default = false];
     reserved 198; // DisableColumnShardBulkUpsertRequireAllColumns
     optional bool EnableVDiskWaitForRecoveryLogCutOnLocalSyncDataReplay = 281 [default = false];
+    // Disables accumulating the SSD-system component of FileStore (filesystem) space into the
+    // owning domain's allocated counter. FileStore shards are resized to the final filesystem
+    // size (up to petabytes), with thousands of shards the per-domain ui64 counter can overflow.
+    // RequireRestart: the in-memory counter is rebuilt from all FileStores at SchemeShard start,
+    // the counter can be re-enabled, which requires restarting the SchemeShard tablet.
+    optional bool DisableFileStoreSSDSystemSpaceAccounting = 302 [default = false, (RequireRestart) = true];
 }

--- a/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_element.cpp
@@ -1,10 +1,57 @@
 #include "schemeshard_path_element.h"
 
+#include <ydb/core/base/appdata.h>
+
 #include <library/cpp/json/json_reader.h>
 
 namespace NKikimr::NSchemeShard {
 
 namespace {
+
+// When set, the SSD-system component of FileStore space is not accumulated into the
+// owning domain's allocated counter. Each FileStore (filesystem) shard is resized to the
+// final filesystem size, which can reach petabytes, summing thousands of such shards into
+// a single ui64 counter can overflow.
+// The accounting only feeds the describe-time `__filestore_space_allocated_ssd_system`
+// attribute and the (effectively unlimited) ssd_system space limit, so skipping it is safe.
+//
+// The flag is (RequireRestart) = true, so its value is fixed for the lifetime of the
+// process.
+bool IsFileStoreSSDSystemSpaceAccountingDisabled() {
+    return AppData()->FeatureFlags.GetDisableFileStoreSSDSystemSpaceAccounting();
+}
+
+// Both helpers are no-ops during normal operation. `CheckSpaceChanged()` already rejects any
+// proposal that would overflow, and a correctly derived counter cannot underflow when a
+// `FileStore` is deleted. These helpers only take effect in scenarios that are not protected
+// by those checks, such as the initial rebuild after the counter has already drifted, for example,
+// when SSD system space accounting was disabled and later re-enabled. In such cases, clamping the
+// value is much preferable to wrapping the counter or aborting the tablet into a crash loop from
+// which it cannot recover.
+void UpdateSpaceBeginSaturating(TSpaceLimits& limits, ui64 newValue, ui64 oldValue) {
+    if (newValue <= oldValue) {
+        return;
+    }
+
+    const ui64 diff = newValue - oldValue;
+    if (limits.Allocated > Max<ui64>() - diff) {
+        // Saturate rather than wrap around
+        limits.Allocated = Max<ui64>();
+        return;
+    }
+
+    limits.Allocated += diff;
+}
+
+void UpdateSpaceCommitSaturating(TSpaceLimits& limits, ui64 newValue, ui64 oldValue) {
+    if (newValue >= oldValue) {
+        return;
+    }
+
+    const ui64 diff = oldValue - newValue;
+    // Clamp at zero
+    limits.Allocated -= Min(limits.Allocated, diff);
+}
 
 void UpdateSpaceBegin(TSpaceLimits& limits, ui64 newValue, ui64 oldValue) {
     if (newValue <= oldValue) {
@@ -422,19 +469,24 @@ bool TPathElement::CheckVolumeSpaceChange(TVolumeSpace newSpace, TVolumeSpace ol
 void TPathElement::ChangeFileStoreSpaceBegin(TFileStoreSpace newSpace, TFileStoreSpace oldSpace) {
     UpdateSpaceBegin(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD);
     UpdateSpaceBegin(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD);
-    UpdateSpaceBegin(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
+    if (!IsFileStoreSSDSystemSpaceAccountingDisabled()) {
+        UpdateSpaceBeginSaturating(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
+    }
 }
 
 void TPathElement::ChangeFileStoreSpaceCommit(TFileStoreSpace newSpace, TFileStoreSpace oldSpace) {
     UpdateSpaceCommit(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD);
     UpdateSpaceCommit(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD);
-    UpdateSpaceCommit(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
+    if (!IsFileStoreSSDSystemSpaceAccountingDisabled()) {
+        UpdateSpaceCommitSaturating(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem);
+    }
 }
 
 bool TPathElement::CheckFileStoreSpaceChange(TFileStoreSpace newSpace, TFileStoreSpace oldSpace, TString& errStr) {
     return (CheckSpaceChanged(FileStoreSpaceSSD, newSpace.SSD, oldSpace.SSD, errStr, "filestore", " (ssd)") &&
             CheckSpaceChanged(FileStoreSpaceHDD, newSpace.HDD, oldSpace.HDD, errStr, "filestore", " (hdd)") &&
-            CheckSpaceChanged(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem, errStr, "filestore", " (ssd_system)"));
+            (IsFileStoreSSDSystemSpaceAccountingDisabled() ||
+             CheckSpaceChanged(FileStoreSpaceSSDSystem, newSpace.SSDSystem, oldSpace.SSDSystem, errStr, "filestore", " (ssd_system)")));
 }
 
 void TPathElement::SetAsyncReplica(bool value) {

--- a/ydb/core/tx/schemeshard/ut_filestore/ut_filestore.cpp
+++ b/ydb/core/tx/schemeshard/ut_filestore/ut_filestore.cpp
@@ -4,6 +4,8 @@
 
 #include <util/generic/size_literals.h>
 
+#include <optional>
+
 using namespace NKikimr;
 using namespace NSchemeShardUT_Private;
 
@@ -11,7 +13,8 @@ namespace {
 
 auto& InitCreateFileStoreConfig(
     const TString& name,
-    NKikimrSchemeOp::TFileStoreDescription& vdescr)
+    NKikimrSchemeOp::TFileStoreDescription& vdescr,
+    bool isSystem = false)
 {
     vdescr.SetName(name);
 
@@ -21,6 +24,10 @@ auto& InitCreateFileStoreConfig(
     config.SetFileSystemId(name);
     config.SetCloudId("cloud");
     config.SetFolderId("folder");
+    if (isSystem) {
+        // Only set when requested.
+        config.SetIsSystem(true);
+    }
 
     config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
     config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-1");
@@ -28,6 +35,26 @@ auto& InitCreateFileStoreConfig(
     config.AddExplicitChannelProfiles()->SetPoolKind("pool-kind-2");
 
     return config;
+}
+
+// Checks the domain's __filestore_space_allocated_ssd_system runtime attribute.
+// std::nullopt means the attribute must be absent, i.e. the allocated counter is zero.
+NLs::TCheckFunc SsdSystemAllocated(std::optional<TString> expected) {
+    return [expected](const NKikimrScheme::TEvDescribeSchemeResult& record) {
+        std::optional<TString> actual;
+        for (const auto& attr : record.GetPathDescription().GetUserAttributes()) {
+            if (attr.GetKey() == "__filestore_space_allocated_ssd_system") {
+                actual = attr.GetValue();
+                break;
+            }
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(expected.has_value(), actual.has_value());
+
+        if (expected) {
+            UNIT_ASSERT_VALUES_EQUAL(*expected, *actual);
+        }
+    };
 }
 
 } // namespace
@@ -61,6 +88,193 @@ Y_UNIT_TEST_SUITE(TFileStore) {
 
         TestDropFileStore(runtime, ++txId, "/MyRoot", "HugeFS");
         env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST_FLAG(SystemSpaceAccountingOverflow, DisableFileStoreSSDSystemSpaceAccounting) {
+        // Each system-SSD FileStore (filesystem) shard is resized to the final filesystem size,
+        // which can reach petabytes. Summing thousands of such shards into the per-domain
+        // ssd_system allocated counter overflows ui64. The feature flag disables that accounting,
+        // so the counter never grows and the overflow can no longer occur.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions()
+            .DisableFileStoreSSDSystemSpaceAccounting(DisableFileStoreSSDSystemSpaceAccounting));
+        ui64 txId = 100;
+
+        constexpr ui64 blockSize = 4_KB;
+        const ui64 hugeBlocks = Max<ui64>() / blockSize; // a single shard nearly fills ui64
+
+        NKikimrSchemeOp::TFileStoreDescription hugeDescr;
+        auto& hugeConfig = InitCreateFileStoreConfig("HugeSystemFS", hugeDescr, /*isSystem*/ true);
+        hugeConfig.SetStorageMediaKind(1); // STORAGE_MEDIA_SSD
+        hugeConfig.SetBlocksCount(hugeBlocks);
+
+        // A single shard always fits within ui64, regardless of the flag.
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", hugeDescr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        // The ssd_system allocated attribute is published on the domain only while accounting is on.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+            DisableFileStoreSSDSystemSpaceAccounting
+                ? SsdSystemAllocated(std::nullopt)
+                : SsdSystemAllocated(ToString(hugeBlocks * blockSize)),
+        });
+
+        // A second system-SSD shard would push the domain counter past Max<ui64>().
+        NKikimrSchemeOp::TFileStoreDescription smallDescr;
+        auto& smallConfig = InitCreateFileStoreConfig("SmallSystemFS", smallDescr, /*isSystem*/ true);
+        smallConfig.SetStorageMediaKind(1);
+        smallConfig.SetBlocksCount(2);
+
+        if (DisableFileStoreSSDSystemSpaceAccounting) {
+            // Accounting disabled: no counter growth => no overflow => the create succeeds.
+            TestCreateFileStore(runtime, ++txId, "/MyRoot", smallDescr.DebugString());
+            env.TestWaitNotification(runtime, txId);
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/SmallSystemFS"), {NLs::PathExist});
+
+            TestDropFileStore(runtime, ++txId, "/MyRoot", "SmallSystemFS");
+            env.TestWaitNotification(runtime, txId);
+        } else {
+            // Accounting enabled: the allocated counter overflows and the create is rejected.
+            TestCreateFileStore(
+                runtime,
+                ++txId,
+                "/MyRoot",
+                smallDescr.DebugString(),
+                {NKikimrScheme::StatusPreconditionFailed});
+            env.TestWaitNotification(runtime, txId);
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/SmallSystemFS"), {NLs::PathNotExist});
+        }
+
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "HugeSystemFS");
+        env.TestWaitNotification(runtime, txId);
+    }
+
+    Y_UNIT_TEST(SystemSpaceAccountingSurvivesReenablingTheFlag) {
+        // Turning accounting off and back on again must not desynchronize the domain counter.
+        // It cannot: the counter is derived state, not persisted, and rebuilt from every FileStoreInfo
+        // on each SchemeShard tablet start. Since the flag is (RequireRestart) = true, it can only change
+        // across a restart, and that restart re-derives the counter with the new flag applied uniformly
+        // to all filestores.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions()
+            .DisableFileStoreSSDSystemSpaceAccounting(true));
+        ui64 txId = 100;
+
+        constexpr ui64 blockSize = 4_KB;
+        constexpr ui64 blocks = 4096;
+
+        // Created while accounting is disabled: nothing is added to the domain counter.
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        auto& config = InitCreateFileStoreConfig("ToggleFS", descr, /*isSystem*/ true);
+        config.SetStorageMediaKind(1); // STORAGE_MEDIA_SSD
+        config.SetBlocksCount(blocks);
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {SsdSystemAllocated(std::nullopt)});
+
+        // The operator re-enables accounting and restarts SchemeShard.
+        runtime.GetAppData().FeatureFlags.SetDisableFileStoreSSDSystemSpaceAccounting(false);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Init re-derives the counter from all persisted FileStores, including the one created
+        // while accounting was off, so the counter is correct for the new mode from the start.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+            SsdSystemAllocated(ToString(blocks * blockSize)),
+        });
+
+        // The drop therefore subtracts exactly what init added: no underflow.
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "ToggleFS");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {SsdSystemAllocated(std::nullopt)});
+    }
+
+    Y_UNIT_TEST(SystemSpaceAccountingSaturatesAndRecovers) {
+        // The worst-case re-enable scenario: while accounting is disabled, the domain
+        // accumulates several filestores whose true ssd_system total does not fit in ui64.
+        // Re-enabling the flag and restarting must not wrap the counter or crash-loop the
+        // tablet: the init rebuild saturates the counter at Max<ui64>(), drops clamp it back
+        // down to zero, and once the huge filestores are gone the domain is fully usable.
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime, TTestEnvOptions()
+            .DisableFileStoreSSDSystemSpaceAccounting(true));
+        ui64 txId = 100;
+
+        constexpr ui64 blockSize = 4_KB;
+        const ui64 hugeBlocks = Max<ui64>() / blockSize; // each filestore is ~2^64 bytes
+
+        // With accounting disabled, several huge filestores can coexist even though their
+        // combined size overflows ui64 several times over.
+        const TVector<TString> hugeNames = {"HugeFS1", "HugeFS2", "HugeFS3"};
+        for (const auto& name : hugeNames) {
+            NKikimrSchemeOp::TFileStoreDescription descr;
+            auto& config = InitCreateFileStoreConfig(name, descr, /*isSystem*/ true);
+            config.SetStorageMediaKind(1); // STORAGE_MEDIA_SSD
+            config.SetBlocksCount(hugeBlocks);
+
+            TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {SsdSystemAllocated(std::nullopt)});
+
+        // Re-enable accounting and restart SchemeShard: the init rebuild sums all three
+        // filestores and saturates at Max<ui64>() instead of silently wrapping around.
+        runtime.GetAppData().FeatureFlags.SetDisableFileStoreSSDSystemSpaceAccounting(false);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+            SsdSystemAllocated(ToString(Max<ui64>())),
+        });
+
+        // While the counter is saturated, new creates fail loudly with a precondition error.
+        {
+            NKikimrSchemeOp::TFileStoreDescription descr;
+            auto& config = InitCreateFileStoreConfig("RejectedFS", descr, /*isSystem*/ true);
+            config.SetStorageMediaKind(1);
+            config.SetBlocksCount(2);
+
+            TestCreateFileStore(
+                runtime,
+                ++txId,
+                "/MyRoot",
+                descr.DebugString(),
+                {NKikimrScheme::StatusPreconditionFailed});
+            env.TestWaitNotification(runtime, txId);
+            TestDescribeResult(DescribePath(runtime, "/MyRoot/RejectedFS"), {NLs::PathNotExist});
+        }
+
+        // Deleting the huge filestores clamps the counter at zero instead of aborting on
+        // underflow (the second and third drops subtract more than the counter holds).
+        for (const auto& name : hugeNames) {
+            TestDropFileStore(runtime, ++txId, "/MyRoot", name);
+            env.TestWaitNotification(runtime, txId);
+        }
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {SsdSystemAllocated(std::nullopt)});
+
+        // The domain has fully recovered: a new filestore is created and accounted normally.
+        constexpr ui64 blocks = 4096;
+        NKikimrSchemeOp::TFileStoreDescription descr;
+        auto& config = InitCreateFileStoreConfig("NewFS", descr, /*isSystem*/ true);
+        config.SetStorageMediaKind(1);
+        config.SetBlocksCount(blocks);
+
+        TestCreateFileStore(runtime, ++txId, "/MyRoot", descr.DebugString());
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {
+            SsdSystemAllocated(ToString(blocks * blockSize)),
+        });
+
+        TestDropFileStore(runtime, ++txId, "/MyRoot", "NewFS");
+        env.TestWaitNotification(runtime, txId);
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {SsdSystemAllocated(std::nullopt)});
     }
 
     Y_UNIT_TEST(SizeMultiplicationOverflowCannotBypassDomainQuota) {

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.cpp
@@ -594,6 +594,7 @@ NSchemeShardUT_Private::TTestEnv::TTestEnv(TTestActorRuntime& runtime, const TTe
     app.FeatureFlags.SetEnableVectorIndex(true);
     app.FeatureFlags.SetEnableColumnStore(true);
     app.FeatureFlags.SetEnableStrictAclCheck(opts.EnableStrictAclCheck_);
+    app.FeatureFlags.SetDisableFileStoreSSDSystemSpaceAccounting(opts.DisableFileStoreSSDSystemSpaceAccounting_);
     app.SetEnableMoveIndex(opts.EnableMoveIndex_);
     app.SetEnableChangefeedInitialScan(opts.EnableChangefeedInitialScan_);
     app.SetEnableNotNullDataColumns(opts.EnableNotNullDataColumns_);

--- a/ydb/core/tx/schemeshard/ut_helpers/test_env.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/test_env.h
@@ -80,6 +80,7 @@ namespace NSchemeShardUT_Private {
         OPTION(std::optional<bool>, EnableLocalDBBtreeIndex, std::nullopt);
         OPTION(TVector<TIntrusivePtr<NFake::TProxyDS>>, DSProxies, {});
         OPTION(std::optional<ui32>, DataShardStatsReportIntervalSeconds, std::nullopt);
+        OPTION(bool, DisableFileStoreSSDSystemSpaceAccounting, false);
 
         #undef OPTION
     };


### PR DESCRIPTION
Cherry-pick of https://github.com/ydb-platform/ydb/pull/46268