### PR TITLE
[detailed-metrics] propagate METRICS_LEVEL to DataShard via subdomain subscription

### DIFF
--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -536,4 +536,5 @@ enum ETxTypes {
     TXTYPE_COMPLETE_VACUUM = 86                           [(TxTypeOpts) = {Name: "TxCompleteVacuum"}];
     TXTYPE_LOCK_ROWS = 87                                 [(TxTypeOpts) = {Name: "TxLockRows"}];
     TXTYPE_S3_DIRECT_WRITE_FINISH = 88                    [(TxTypeOpts) = {Name: "TxS3DirectWriteFinish"}];
+    TXTYPE_PERSIST_SUBDOMAIN_TABLES_METRICS_LEVEL = 89    [(TxTypeOpts) = {Name: "TxPersistSubDomainTablesMetricsLevel"}];
 }

--- a/ydb/core/protos/subdomains.proto
+++ b/ydb/core/protos/subdomains.proto
@@ -144,6 +144,14 @@ message TDomainDescription {
     optional NLoginProto.TSecurityState SecurityState = 20;
 
     optional TAuditSettings AuditSettings = 21;
+
+    // Database-wide default detailed metrics level for row/column tables
+    // (spec's TABLES_METRICS_LEVEL). Values match
+    // NKikimrSchemeOp.TTableDetailedMetricsSettings.EMetricsLevel; kept as a
+    // raw int here (rather than that enum type) because flat_scheme_op.proto
+    // (which defines it) already imports this file, and referencing it back
+    // would create a proto import cycle.
+    optional uint32 TablesMetricsLevel = 26;
 }
 
 message TSchemeQuotas {

--- a/ydb/core/tablet/tablet_counters_aggregator.h
+++ b/ydb/core/tablet/tablet_counters_aggregator.h
@@ -12,6 +12,8 @@
 #include <ydb/core/protos/tablet_counters_aggregator.pb.h>
 #include <ydb/core/sys_view/common/events.h>
 
+#include <optional>
+
 ////////////////////////////////////////////
 namespace NKikimr {
 
@@ -50,15 +52,28 @@ struct TEvTabletCounters {
         TAutoPtr<TTabletCountersBase> ExecutorCounters;
         TAutoPtr<TTabletCountersBase> AppCounters;
         TIntrusivePtr<TInFlightCookie> InFlightCounter;     // Used to detect when previous event has been consumed by the aggregator
+        const ui32 FollowerId;                              // 0 = leader, >0 = replica
+
+        // Mirrors NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo
+        struct TTableInfo {
+            TPathId TableId;
+            TString TablePath;
+            ui64 SchemaVersion = 0;
+        };
+        std::optional<TTableInfo> TableInfo;
 
         TEvTabletAddCounters(TIntrusivePtr<TInFlightCookie> inFlightCounter, ui64 tabletID, NKikimrTabletBase::TTabletTypes::EType tabletType, TPathId tenantPathId,
-            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters)
+            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters,
+            ui32 followerId = 0,
+            std::optional<TTableInfo> tableInfo = std::nullopt)
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
             , ExecutorCounters(executorCounters)
             , AppCounters(appCounters)
             , InFlightCounter(inFlightCounter)
+            , FollowerId(followerId)
+            , TableInfo(std::move(tableInfo))
         {}
     };
 

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -953,4 +953,30 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
     }
 }
 
+Y_UNIT_TEST_SUITE(TEvTabletAddCountersDetailedMetricsFields) {
+    Y_UNIT_TEST(DefaultsToLeaderWithNoTableInfo) {
+        TEvTabletCounters::TEvTabletAddCounters ev(
+            new TEvTabletCounters::TInFlightCookie, 1, TTabletTypes::DataShard, TPathId(1113, 1001),
+            new TTabletCountersBase, new TTabletCountersBase);
+
+        UNIT_ASSERT_VALUES_EQUAL(ev.FollowerId, 0u);
+        UNIT_ASSERT(!ev.TableInfo.has_value());
+    }
+
+    Y_UNIT_TEST(StampsFollowerIdAndTableInfoWhenProvided) {
+        TEvTabletCounters::TEvTabletAddCounters::TTableInfo tableInfo{TPathId(1113, 42), "/Root/table", 3};
+
+        TEvTabletCounters::TEvTabletAddCounters ev(
+            new TEvTabletCounters::TInFlightCookie, 1, TTabletTypes::DataShard, TPathId(1113, 1001),
+            new TTabletCountersBase, new TTabletCountersBase,
+            7, tableInfo);
+
+        UNIT_ASSERT_VALUES_EQUAL(ev.FollowerId, 7u);
+        UNIT_ASSERT(ev.TableInfo.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(ev.TableInfo->TableId, tableInfo.TableId);
+        UNIT_ASSERT_VALUES_EQUAL(ev.TableInfo->TablePath, tableInfo.TablePath);
+        UNIT_ASSERT_VALUES_EQUAL(ev.TableInfo->SchemaVersion, tableInfo.SchemaVersion);
+    }
+}
+
 }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <optional>
 
 #include "flat_executor.h"
 #include "flat_executor_bootlogic.h"
@@ -4142,9 +4143,15 @@ void TExecutor::UpdateCounters(const TActorContext &ctx) {
         auto tabletType = Owner->TabletType();
         auto tenantPathId = Owner->Info()->TenantPathId;
 
+        std::optional<TEvTabletCounters::TEvTabletAddCounters::TTableInfo> tableInfo;
+        if (const auto *ti = Owner->GetTableInfo()) {
+            tableInfo = TEvTabletCounters::TEvTabletAddCounters::TTableInfo{ti->TableId, ti->TablePath, ti->SchemaVersion};
+        }
+
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters,
+            FollowerId, std::move(tableInfo)));
 
         if (ResourceMetrics) {
             ResourceMetrics->TryUpdate(ctx);
@@ -4171,9 +4178,15 @@ void TExecutor::ForceSendCounters() {
         auto tabletType = Owner->TabletType();
         auto tenantPathId = Owner->Info()->TenantPathId;
 
+        std::optional<TEvTabletCounters::TEvTabletAddCounters::TTableInfo> tableInfo;
+        if (const auto *ti = Owner->GetTableInfo()) {
+            tableInfo = TEvTabletCounters::TEvTabletAddCounters::TTableInfo{ti->TableId, ti->TablePath, ti->SchemaVersion};
+        }
+
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters,
+            FollowerId, std::move(tableInfo)));
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -3,6 +3,7 @@
 #include "util_fmt_abort.h"
 #include "shared_cache_counters.h"
 #include <ydb/core/base/counters.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/testlib/actors/wait_events.h>
 
@@ -440,6 +441,11 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
     ui64 ScanCookie;
     ui64 SnapshotId;
     TActorId Sender;
+    std::optional<NFlatExecutorSetup::TTabletTableInfo> TableInfoOverride;
+
+    const NFlatExecutorSetup::TTabletTableInfo* GetTableInfo() const override {
+        return TableInfoOverride ? &*TableInfoOverride : nullptr;
+    }
 
     void SnapshotComplete(TIntrusivePtr<TTableSnapshotContext> snapContext, const TActorContext&) override {
         Send(Sender, new TEvTestFlatTablet::TEvSnapshotComplete(std::move(snapContext)));
@@ -549,7 +555,8 @@ class TTestFlatTablet : public TActor<TTestFlatTablet>, public TTabletExecutedFl
     }
 
 public:
-    TTestFlatTablet(const TActorId &sender, const TActorId &tablet, TTabletStorageInfo *info)
+    TTestFlatTablet(const TActorId &sender, const TActorId &tablet, TTabletStorageInfo *info,
+            std::optional<NFlatExecutorSetup::TTabletTableInfo> tableInfoOverride = std::nullopt)
         : TActor(&TThis::StateInit)
         , TTabletExecutedFlat(info, tablet, nullptr)
         , Scan(nullptr)
@@ -557,6 +564,7 @@ public:
         , ScanCookie(123)
         , SnapshotId(0)
         , Sender(sender)
+        , TableInfoOverride(std::move(tableInfoOverride))
     {}
 
     STFUNC(StateInit) {
@@ -672,6 +680,80 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_CompactionScan) {
     }
 }
 
+// MakeTabletCountersAggregatorID(...) is a named-service ActorId: sends to it go through the real
+// ActorSystem, bypassing TTestActorRuntime's mailbox-dispatch loop (so AddObserver never sees them).
+// Register a catcher in its place that forwards the raw message to an edge actor instead.
+class TCountersCatcher : public TActor<TCountersCatcher> {
+public:
+    explicit TCountersCatcher(TActorId forwardTo)
+        : TActor(&TThis::StateWork)
+        , ForwardTo(forwardTo)
+    {}
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTabletCounters::TEvTabletAddCounters, Handle);
+            hFunc(TEvents::TEvPoison, HandlePoison);
+        default:
+            break;
+        }
+    }
+
+    void Handle(TEvTabletCounters::TEvTabletAddCounters::TPtr &ev) {
+        Send(ForwardTo, ev->Release().Release());
+    }
+
+    // The model's TLeader shuts children down by poisoning them and waits for a
+    // TEvGone reply before advancing the run level; reply and die so it doesn't stall.
+    void HandlePoison(TEvents::TEvPoison::TPtr &ev) {
+        Send(ev->Sender, new TEvents::TEvGone);
+        PassAway();
+    }
+
+private:
+    TActorId ForwardTo;
+};
+
+Y_UNIT_TEST_SUITE(TFlatTableExecutor_DetailedMetricsCounters) {
+    Y_UNIT_TEST(TestAddCountersStampsFollowerIdAndTableInfo) {
+        TMyEnvBase env;
+        env.RunOn(2, MakeTabletCountersAggregatorID(env.NodeId, false), new TCountersCatcher(env.Edge), NFake::EMail::Simple);
+
+        NFlatExecutorSetup::TTabletTableInfo tableInfo{TPathId(1113, 42), "/Root/table", 3};
+
+        env.FireTablet(env.Edge, env.Tablet, [&](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info, tableInfo);
+        });
+        env.WaitForWakeUp();
+
+        // DetachTablet() (reached via TEvPoison) unconditionally calls ForceSendCounters().
+        env.SendSync(new TEvents::TEvPoison, false, true);
+
+        auto ev = env.GrabEdgeEvent<TEvTabletCounters::TEvTabletAddCounters>();
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->FollowerId, 0u);
+
+        UNIT_ASSERT(ev->Get()->TableInfo.has_value());
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->TableInfo->TableId, tableInfo.TableId);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->TableInfo->TablePath, tableInfo.TablePath);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->TableInfo->SchemaVersion, tableInfo.SchemaVersion);
+    }
+
+    Y_UNIT_TEST(TestAddCountersDefaultsToNoTableInfo) {
+        TMyEnvBase env;
+        env.RunOn(2, MakeTabletCountersAggregatorID(env.NodeId, false), new TCountersCatcher(env.Edge), NFake::EMail::Simple);
+
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        env.SendSync(new TEvents::TEvPoison, false, true);
+
+        auto ev = env.GrabEdgeEvent<TEvTabletCounters::TEvTabletAddCounters>();
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->FollowerId, 0u);
+        UNIT_ASSERT(!ev->Get()->TableInfo.has_value());
+    }
+}
 
 Y_UNIT_TEST_SUITE(TFlatTableExecutor_ExecutorTxLimit) {
 

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -6,6 +6,7 @@
 
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/base/blobstorage.h>
+#include <ydb/core/scheme/scheme_pathid.h>
 #include <ydb/library/actors/wilson/wilson_span.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <library/cpp/lwtrace/shuttle.h>
@@ -490,6 +491,12 @@ struct TScanOptions {
 };
 
 namespace NFlatExecutorSetup {
+    struct TTabletTableInfo {
+        TPathId TableId;
+        TString TablePath;
+        ui64 SchemaVersion = 0;
+    };
+
     struct ITablet : TNonCopyable {
         virtual ~ITablet() {}
 
@@ -520,6 +527,8 @@ namespace NFlatExecutorSetup {
         virtual ui64 GetMemoryUsage() const { return 50 << 10; }
 
         virtual void OnLeaderUserAuxUpdate(TString) { /* default */ }
+
+        virtual const TTabletTableInfo* GetTableInfo() const { return nullptr; }
 
         virtual bool ReadOnlyLeaseEnabled();
         virtual TDuration ReadOnlyLeaseDuration();

--- a/ydb/core/tablet_flat/tablet_flat_executor.h
+++ b/ydb/core/tablet_flat/tablet_flat_executor.h
@@ -495,6 +495,12 @@ namespace NFlatExecutorSetup {
         TPathId TableId;
         TString TablePath;
         ui64 SchemaVersion = 0;
+
+        // Effective detailed METRICS_LEVEL for this table (per-table override,
+        // falling back to the database-wide default). Raw NKikimrSchemeOp::
+        // TTableDetailedMetricsSettings::EMetricsLevel value; kept as a plain
+        // integer to keep this generic header free of the schemeshard proto.
+        ui32 MetricsLevel = 0;
     };
 
     struct ITablet : TNonCopyable {

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2437,6 +2437,15 @@ const NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo* TDataShard::Get
     TableInfoCache.TableId = TPathId(GetPathOwnerId(), TableInfos.begin()->first);
     TableInfoCache.TablePath = table.Path;
     TableInfoCache.SchemaVersion = table.GetTableSchemaVersion();
+
+    // Effective level: the table's own override wins; otherwise fall back to
+    // the database-wide default learned via the subdomain subscription.
+    const auto tableLevel = table.GetDetailedMetricsLevel();
+    const auto effectiveLevel = tableLevel != NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        ? tableLevel
+        : GetSubDomainTablesMetricsLevel();
+    TableInfoCache.MetricsLevel = static_cast<ui32>(effectiveLevel);
+
     return &TableInfoCache;
 }
 

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2426,6 +2426,20 @@ ui64 TDataShard::GetMemoryUsage() const {
     return res;
 }
 
+const NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo* TDataShard::GetTableInfo() const {
+    if (TableInfos.empty()) {
+        return nullptr;
+    }
+
+    // Expected that it's almost always one table here, hence only TableInfos.begin()
+    // IsBackup can be filtered out though
+    const auto& table = *TableInfos.begin()->second;
+    TableInfoCache.TableId = TPathId(GetPathOwnerId(), TableInfos.begin()->first);
+    TableInfoCache.TablePath = table.Path;
+    TableInfoCache.SchemaVersion = table.GetTableSchemaVersion();
+    return &TableInfoCache;
+}
+
 bool TDataShard::ByKeyFilterDisabled() const {
     return DisableByKeyFilter;
 }

--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -371,6 +371,13 @@ bool TDataShard::TTxInit::ReadEverything(TTransactionContext &txc) {
     LOAD_SYS_BOOL(db, Schema::Sys_SubDomainOutOfSpace, Self->SubDomainOutOfSpace);
 
     {
+        ui64 subDomainTablesMetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
+        LOAD_SYS_UI64(db, Schema::Sys_SubDomainTablesMetricsLevel, subDomainTablesMetricsLevel);
+        Self->SubDomainTablesMetricsLevel =
+            static_cast<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel>(subDomainTablesMetricsLevel);
+    }
+
+    {
         TString rawProcessingParams;
         LOAD_SYS_BYTES(db, Schema::Sys_SubDomainInfo, rawProcessingParams);
         if (!rawProcessingParams.empty()) {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1921,6 +1921,7 @@ public:
     void OnRejectProbabilityRelaxed() override;
     void OnFollowersCountChanged() override;
     ui64 GetMemoryUsage() const override;
+    const NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo* GetTableInfo() const override;
 
     bool HasPipeServer(const TActorId& pipeServerId);
     bool AddOverloadSubscriber(const TActorId& pipeServerId, const TActorId& actorId, ui64 seqNo, ERejectReasons reasons);
@@ -2882,6 +2883,7 @@ private:
     TInstant StopKeyAccessSamplingAt;
 
     TUserTable::TTableInfos TableInfos;  // tableId -> local table info
+    mutable NTabletFlatExecutor::NFlatExecutorSetup::TTabletTableInfo TableInfoCache;
     TTransQueue TransQueue;
     TOutReadSets OutReadSets;
     TPipeline Pipeline;

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -326,6 +326,7 @@ class TDataShard
 
     class TTxPersistSubDomainPathId;
     class TTxPersistSubDomainOutOfSpace;
+    class TTxPersistSubDomainTablesMetricsLevel;
 
     class TTxRequestChangeRecords;
     class TTxRemoveChangeRecords;
@@ -1227,6 +1228,11 @@ class TDataShard
 
             Sys_VacuumCompletedGeneration = 47,
 
+            // Database-wide default detailed metrics level (TABLES_METRICS_LEVEL),
+            // learned from the subdomain description publish. Values match
+            // NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel.
+            Sys_SubDomainTablesMetricsLevel = 48,
+
             // reserved
             SysPipeline_Flags = 1000,
             SysPipeline_LimitActiveTx,
@@ -1239,6 +1245,7 @@ class TDataShard
         static_assert(ESysTableKeys::SysMvcc_UnprotectedReads == 38, "SysMvcc_UnprotectedReads changed its value");
         static_assert(ESysTableKeys::SysMvcc_ImmediateWriteEdgeStep == 39, "SysMvcc_ImmediateWriteEdgeStep changed its value");
         static_assert(ESysTableKeys::SysMvcc_ImmediateWriteEdgeTxId == 40, "SysMvcc_ImmediateWriteEdgeTxId changed its value");
+        static_assert(ESysTableKeys::Sys_SubDomainTablesMetricsLevel == 48, "Sys_SubDomainTablesMetricsLevel changed its value");
         static_assert(ESysTableKeys::Sys_LastLoanTableTid == 41, "Sys_LastLoanTableTid changed its value");
 
         static constexpr ui64 MinLocalTid = TSysTables::SysTableMAX + 1; // 1000
@@ -2005,6 +2012,11 @@ public:
     bool IsSubDomainOutOfSpace() const
     {
         return SubDomainOutOfSpace;
+    }
+
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel GetSubDomainTablesMetricsLevel() const
+    {
+        return SubDomainTablesMetricsLevel;
     }
 
     ui64 GetExecutorStep() const
@@ -2837,6 +2849,8 @@ private:
     std::optional<TPathId> SubDomainPathId;
     std::optional<TPathId> WatchingSubDomainPathId;
     bool SubDomainOutOfSpace = false;
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel SubDomainTablesMetricsLevel =
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
 
     THashSet<TActorId> Actors;
     TLoanReturnTracker LoanReturnTracker;

--- a/ydb/core/tx/datashard/datashard_subdomain_path_id.cpp
+++ b/ydb/core/tx/datashard/datashard_subdomain_path_id.cpp
@@ -167,19 +167,53 @@ private:
     const bool OutOfSpace;
 };
 
+class TDataShard::TTxPersistSubDomainTablesMetricsLevel : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+public:
+    TTxPersistSubDomainTablesMetricsLevel(TDataShard* self, NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level)
+        : TTransactionBase(self)
+        , Level(level)
+    { }
+
+    TTxType GetTxType() const override { return TXTYPE_PERSIST_SUBDOMAIN_TABLES_METRICS_LEVEL; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        if (Self->SubDomainTablesMetricsLevel != Level) {
+            Self->PersistSys(db, Schema::Sys_SubDomainTablesMetricsLevel, ui64(Level));
+            Self->SubDomainTablesMetricsLevel = Level;
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext&) override {
+        // nothing
+    }
+
+private:
+    const NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel Level;
+};
+
 void TDataShard::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx) {
     const auto* msg = ev->Get();
     if (SubDomainPathId && msg->PathId == *SubDomainPathId) {
-        const bool outOfSpace = msg->Result->GetPathDescription()
-            .GetDomainDescription()
-            .GetDomainState()
-            .GetDiskQuotaExceeded();
+        const auto& domainDescription = msg->Result->GetPathDescription().GetDomainDescription();
+
+        const bool outOfSpace = domainDescription.GetDomainState().GetDiskQuotaExceeded();
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD,
             "Discovered subdomain " << msg->PathId << " state, outOfSpace = " << outOfSpace
             << " at datashard " << TabletID());
 
         Execute(new TTxPersistSubDomainOutOfSpace(this, outOfSpace), ctx);
+
+        const auto tablesMetricsLevel = static_cast<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel>(
+            domainDescription.GetTablesMetricsLevel());
+
+        if (tablesMetricsLevel != SubDomainTablesMetricsLevel) {
+            Execute(new TTxPersistSubDomainTablesMetricsLevel(this, tablesMetricsLevel), ctx);
+        }
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -325,6 +325,11 @@ void TUserTable::ParseProto(const NKikimrSchemeOp::TTableDescription& descr)
 
     TableSchemaVersion = descr.GetTableSchemaVersion();
     IsBackup = descr.GetIsBackup();
+    // descr is the full merged table description (not a delta), so an absent
+    // Configured status means the override was never set or was dropped.
+    DetailedMetricsLevel = descr.GetDetailedMetricsSettings().HasConfigured()
+        ? descr.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel()
+        : NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
     ReplicationConfig = TReplicationConfig(descr.GetReplicationConfig());
     IncrementalBackupConfig = TIncrementalBackupConfig(descr.GetIncrementalBackupConfig());
     if (descr.GetPartitionConfig().HasUniqueIndexKeySize()) {

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -325,8 +325,9 @@ void TUserTable::ParseProto(const NKikimrSchemeOp::TTableDescription& descr)
 
     TableSchemaVersion = descr.GetTableSchemaVersion();
     IsBackup = descr.GetIsBackup();
-    // descr is the full merged table description (not a delta), so an absent
-    // Configured status means the override was never set or was dropped.
+    // On the alter path descr is a delta, but the schemeshard always resends the
+    // current detailed metrics settings in it, so an absent Configured status
+    // means the override was never set or was dropped.
     DetailedMetricsLevel = descr.GetDetailedMetricsSettings().HasConfigured()
         ? descr.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel()
         : NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
@@ -426,6 +427,15 @@ void TUserTable::AlterSchema() {
 
     ReplicationConfig.Serialize(*schema.MutableReplicationConfig());
     IncrementalBackupConfig.Serialize(*schema.MutableIncrementalBackupConfig());
+
+    // Keep the persisted schema in sync with the parsed level, so that a restart
+    // does not resurrect an override, which an alter has just dropped
+    if (DetailedMetricsLevel != NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified) {
+        schema.MutableDetailedMetricsSettings()->MutableConfigured()
+            ->SetMetricsLevel(DetailedMetricsLevel);
+    } else {
+        schema.ClearDetailedMetricsSettings();
+    }
 
     schema.SetName(Name);
     schema.SetPath(Path);

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -464,6 +464,10 @@ struct TUserTable : public TThrRefBase {
     TReplicationConfig ReplicationConfig;
     TIncrementalBackupConfig IncrementalBackupConfig;
     bool IsBackup = false;
+    // Per-table METRICS_LEVEL override (Unspecified = falls back to the
+    // database-wide TABLES_METRICS_LEVEL default).
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel DetailedMetricsLevel =
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
     ui32 UniqueIndexKeySize = 0;
     NKikimrSchemeOp::ESpecialTableType SpecialTableType = NKikimrSchemeOp::ESpecialTableType::ESpecialTableTypeNone;
 
@@ -541,6 +545,10 @@ struct TUserTable : public TThrRefBase {
     ui64 GetTableSchemaVersion() const { return TableSchemaVersion; }
     void SetTableSchemaVersion(ui64 schemaVersion);
     bool ResetTableSchemaVersion();
+
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel GetDetailedMetricsLevel() const {
+        return DetailedMetricsLevel;
+    }
 
     void AddIndex(const NKikimrSchemeOp::TIndexDescription& indexDesc);
     void SwitchIndexState(const TPathId& indexPathId, TTableIndex::EState state);

--- a/ydb/core/tx/datashard/datashard_ut_init.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_init.cpp
@@ -155,6 +155,35 @@ Y_UNIT_TEST_SUITE(TTxDataShardTestInit) {
     Y_UNIT_TEST(TestResolvePathAfterRestart) {
         TestTablePath(true, true);
     }
+
+    Y_UNIT_TEST(TestGetTableInfoReflectsRename) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root").SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        auto shard = GetTableShards(server, sender, "/Root/table-1")[0];
+        auto *dataShard = dynamic_cast<NDataShard::TDataShard*>(runtime.FindActor(ResolveTablet(runtime, shard)));
+        UNIT_ASSERT(dataShard);
+
+        const auto *info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->TablePath, "/Root/table-1");
+        auto prevTableId = info->TableId;
+
+        WaitTxNotification(server, sender, AsyncMoveTable(server, "/Root/table-1", "/Root/table-1-moved"));
+
+        info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->TablePath, "/Root/table-1-moved");
+        UNIT_ASSERT_UNEQUAL(info->TableId, prevTableId);
+    }
 }
 
 }

--- a/ydb/core/tx/datashard/datashard_ut_init.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_init.cpp
@@ -184,6 +184,48 @@ Y_UNIT_TEST_SUITE(TTxDataShardTestInit) {
         UNIT_ASSERT_VALUES_EQUAL(info->TablePath, "/Root/table-1-moved");
         UNIT_ASSERT_UNEQUAL(info->TableId, prevTableId);
     }
+
+    Y_UNIT_TEST(TestGetTableInfoReflectsMetricsLevel) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableDataShardDetailedMetrics(true);
+
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root").SetUseRealThreads(false)
+            .SetFeatureFlags(featureFlags);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        auto shard = GetTableShards(server, sender, "/Root/table-1")[0];
+        auto *dataShard = dynamic_cast<NDataShard::TDataShard*>(runtime.FindActor(ResolveTablet(runtime, shard)));
+        UNIT_ASSERT(dataShard);
+
+        const auto *info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->MetricsLevel,
+            static_cast<ui32>(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified));
+
+        WaitTxNotification(server, sender, AsyncAlterSetMetricsLevel(server, "/Root", "table-1",
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable));
+
+        info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->MetricsLevel,
+            static_cast<ui32>(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable));
+
+        WaitTxNotification(server, sender, AsyncAlterSetMetricsLevel(server, "/Root", "table-1",
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+
+        info = dataShard->GetTableInfo();
+        UNIT_ASSERT(info);
+        UNIT_ASSERT_VALUES_EQUAL(info->MetricsLevel,
+            static_cast<ui32>(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+    }
 }
 
 }

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -1705,6 +1705,20 @@ ui64 AsyncAlterDropColumn(
     return RunSchemeTx(*server->GetRuntime(), std::move(request));
 }
 
+ui64 AsyncAlterSetMetricsLevel(
+        Tests::TServer::TPtr server,
+        const TString& workingDir,
+        const TString& name,
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level)
+{
+    auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpAlterTable, workingDir);
+    auto& desc = *request->Record.MutableTransaction()->MutableModifyScheme()->MutableAlterTable();
+    desc.SetName(name);
+    desc.MutableDetailedMetricsSettings()->MutableConfigured()->SetMetricsLevel(level);
+
+    return RunSchemeTx(*server->GetRuntime(), std::move(request));
+}
+
 ui64 AsyncSetEnableFilterByKey(
         Tests::TServer::TPtr server,
         const TString& workingDir,

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -651,6 +651,12 @@ ui64 AsyncAlterDropColumn(
         const TString& name,
         const TString& colName);
 
+ui64 AsyncAlterSetMetricsLevel(
+        Tests::TServer::TPtr server,
+        const TString& workingDir,
+        const TString& name,
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level);
+
 ui64 AsyncSetEnableFilterByKey(
         Tests::TServer::TPtr server,
         const TString& workingDir,

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -8181,6 +8181,19 @@ TString TSchemeShard::FillAlterTableTxBody(TPathId pathId, TShardIdx shardIdx, T
         proto->MutableIncrementalBackupConfig()->CopyFrom(tableInfo->IncrementalBackupConfig());
     }
 
+    // The detailed metrics settings have to be resent on every alter, because the shard
+    // parses the alter body as if it was the full table description and treats an absent
+    // DetailedMetricsSettings as a request to drop the currently configured settings
+    if (alterData->TableDescriptionFull.Defined() && alterData->TableDescriptionFull->HasDetailedMetricsSettings()) {
+        // The alter carries either the new settings (Configured) or a request
+        // to drop the existing ones (NotConfigured), pass it through as is
+        proto->MutableDetailedMetricsSettings()->CopyFrom(
+            alterData->TableDescriptionFull->GetDetailedMetricsSettings());
+    } else if (tableInfo->HasDetailedMetricsSettings()) {
+        proto->MutableDetailedMetricsSettings()->MutableConfigured()->CopyFrom(
+            tableInfo->GetDetailedMetricsSettings());
+    }
+
     TString txBody;
     Y_PROTOBUF_SUPPRESS_NODISCARD tx.SerializeToString(&txBody);
     return txBody;

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -2752,6 +2752,14 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         ServerlessComputeResourcesMode = serverlessComputeResourcesMode;
     }
 
+    // Database-wide default detailed metrics level for row/column tables
+    // (TABLES_METRICS_LEVEL). No setter yet: storage + ALTER DATABASE wiring
+    // lands with the monitoring_project_id step; this only rides the publish
+    // path to DataShard with its Unspecified default.
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel GetTablesMetricsLevel() const {
+        return TablesMetricsLevel;
+    }
+
 private:
     bool InitiatedAsGlobal = false;
     NKikimrSubDomains::TProcessingParams ProcessingParams;
@@ -2763,6 +2771,8 @@ private:
     bool SmallBlobsQuotaExceeded = false;
     // Cached (data_size_hard_quota / 10 TiB) factor used to derive the small-blobs quotas
     double SmallBlobsStorageUnits = 0;
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel TablesMetricsLevel =
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
 
     TVector<TShardIdx> PrivateShards;
     TStoragePools StoragePools;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -996,6 +996,9 @@ void TPathDescriber::DescribeDomainRoot(TPathElement::TPtr pathEl) {
         entry->MutableDomainState()->SetSmallBlobsQuotaExceeded(true);
     }
 
+
+    entry->SetTablesMetricsLevel(static_cast<ui32>(subDomainInfo->GetTablesMetricsLevel()));
+
     if (const auto& auditSettings = subDomainInfo->GetAuditSettings()) {
         entry->MutableAuditSettings()->CopyFrom(*auditSettings);
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Only publish the database-wide TABLES_METRICS_LEVEL default from SchemeShard's subdomain description. Persist it on DataShard through the existing subdomain-subscription mechanism, and surface the effective level (per-table override else DB default) via GetTableInfo()'s TTabletTableInfo.