### PR TITLE
ci: remove msan, tsan compatibility runs

### DIFF
--- a/.github/workflows/regression_run_compatibility.yml
+++ b/.github/workflows/regression_run_compatibility.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: 
-        build_preset: ["relwithdebinfo", "release-asan", "release-tsan", "release-msan"]
+        build_preset: ["relwithdebinfo", "release-asan"]
     with:
       test_targets: ydb/tests/compatibility/
       branches: ${{ inputs.pull_request_input && format('pull/{0}', inputs.pull_request_input) || github.ref_name }}


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

removed masn, tsan compatibility runs - these build types are not produced by nightly
