### PR TITLE
Restore backward compatibility for plain password

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -37,11 +37,6 @@ public:
                 case NKikimrSchemeOp::TAlterLogin::kCreateUser: {
                     const auto& createUser = alterLogin.GetCreateUser();
 
-                    if (!createUser.HasHashedPassword() || createUser.HasPassword()) {
-                        result->SetStatus(NKikimrScheme::StatusPreconditionFailed, "Plain password is no longer supported, use hashed password instead");
-                        break;
-                    }
-
                     NLogin::TLoginProvider::TCreateUserRequest request;
                     request.User = createUser.GetUser();
                     request.HashedPassword = createUser.GetHashedPassword();
@@ -76,11 +71,6 @@ public:
                 }
                 case NKikimrSchemeOp::TAlterLogin::kModifyUser: {
                     const auto& modifyUser = alterLogin.GetModifyUser();
-
-                    if (modifyUser.HasPassword()) {
-                        result->SetStatus(NKikimrScheme::StatusPreconditionFailed, "Plain password is no longer supported, use hashed password instead");
-                        break;
-                    }
 
                     NLogin::TLoginProvider::TModifyUserRequest request;
 


### PR DESCRIPTION
In 26-3 plain password in alter login was deprecated but plain password field became an error in SchemeShard. It broke backward compatibility. This fixes it.
