### PR TITLE
Fix YAML config Tribool feature flags written as booleans truncating later flags

### DIFF
--- a/ydb/core/cms/console/configs_dispatcher.cpp
+++ b/ydb/core/cms/console/configs_dispatcher.cpp
@@ -509,8 +509,8 @@ NKikimrConfig::TAppConfig TConfigsDispatcher::ParseYamlProtoConfig()
             f->SetDeprecated(deprecatedPaths.contains(path));
         }
     } catch (const yexception& ex) {
-        YDB_LOG_ERROR("Got invalid config from console",
-            {"error", ex.what()});
+        // Never deliver a partially-parsed config; fail loudly instead.
+        Y_ABORT("Failed to parse resolved YAML config into proto: %s", ex.what());
     }
 
     return newYamlProtoConfig;

--- a/ydb/core/cms/console/configs_dispatcher_ut.cpp
+++ b/ydb/core/cms/console/configs_dispatcher_ut.cpp
@@ -1019,6 +1019,54 @@ selector_config:
         UNIT_ASSERT_VALUES_EQUAL(expectedConfig.ShortDebugString(), reply->Config.ShortDebugString());
     }
 
+    Y_UNIT_TEST(TestYamlFeatureFlagsTriboolBoolDeliveredInFull) {
+        // End-to-end regression for the FeatureFlags truncation bug: a YAML config
+        // that sets a Tribool feature flag (enable_mvcc) as a boolean together with
+        // a high proto-tag flag (enable_arrow_format_at_datashard, tag 49) must be
+        // delivered to subscribers in full. Previously the json->proto merge aborted
+        // at enable_mvcc (tag 47) and every higher-tag flag was silently dropped;
+        // ParseYamlProtoConfig swallowed the error and shipped the truncated config.
+        NKikimrConfig::TAppConfig config;
+        auto *label = config.AddLabels();
+        label->SetName("test");
+        label->SetValue("true");
+
+        TTenantTestRuntime runtime(DefaultConsoleTestConfig(), config);
+        TAutoPtr<IEventHandle> handle;
+        InitConfigsDispatcher(runtime);
+
+        AddSubscriber(runtime, {(ui32)NKikimrConsole::TConfigItem::FeatureFlagsItem});
+        // Initial notification for the fresh subscription (base config, no yaml).
+        runtime.GrabEdgeEventRethrow<TEvPrivate::TEvGotNotification>(handle);
+
+        TString yamlConfig = R"(
+---
+metadata:
+  cluster: ""
+  version: 0
+config:
+  yaml_config_enabled: true
+  feature_flags:
+    enable_mvcc: true
+    enable_arrow_format_at_datashard: true
+allowed_labels:
+  test:
+    type: enum
+    values:
+      ? true
+selector_config: []
+)";
+        CheckReplaceConfig(runtime, Ydb::StatusIds::SUCCESS, yamlConfig);
+
+        auto reply = runtime.GrabEdgeEventRethrow<TEvPrivate::TEvGotNotification>(handle);
+        UNIT_ASSERT(reply->Config.HasFeatureFlags());
+        UNIT_ASSERT_C(reply->Config.GetFeatureFlags().GetEnableArrowFormatAtDatashard(),
+            "enable_arrow_format_at_datashard (tag 49) was dropped from the config "
+            "delivered by the dispatcher");
+        UNIT_ASSERT_VALUES_EQUAL((int)reply->Config.GetFeatureFlags().GetEnableMvcc(),
+            (int)NKikimrConfig::TFeatureFlags::VALUE_TRUE);
+    }
+
     Y_UNIT_TEST(TestYamlConfigAndIcb) {
         NKikimrConfig::TAppConfig config;
         auto *label = config.AddLabels();

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:890: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:929: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:894: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:933: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -169,6 +169,45 @@ namespace NKikimr::NYaml {
         return config;
     }
 
+    // Tribool feature flags (VALUE_TRUE/VALUE_FALSE) are commonly written as YAML
+    // booleans; the json->proto merge cannot map a bool onto an enum, so rewrite
+    // such booleans to the enum value names before merging, guided by the schema.
+    void CoerceBoolEnumsToNames(NJson::TJsonValue& json, const google::protobuf::Descriptor* descriptor) {
+        using ::google::protobuf::FieldDescriptor;
+        if (!descriptor || !json.IsMap()) {
+            return;
+        }
+        auto& map = json.GetMapSafe();
+        for (int i = 0; i < descriptor->field_count(); ++i) {
+            const FieldDescriptor* field = descriptor->field(i);
+            TString key = field->name();
+            NProtobufJson::ToSnakeCaseDense(&key);
+            auto it = map.find(key);
+            if (it == map.end()) {
+                continue;
+            }
+            NJson::TJsonValue& value = it->second;
+            if (field->cpp_type() == FieldDescriptor::CPPTYPE_ENUM) {
+                if (value.IsBoolean()) {
+                    const char* name = value.GetBoolean() ? "VALUE_TRUE" : "VALUE_FALSE";
+                    if (field->enum_type()->FindValueByName(name)) {
+                        value = TString(name);
+                    }
+                }
+            } else if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
+                if (field->is_repeated()) {
+                    if (value.IsArray()) {
+                        for (auto& elem : value.GetArraySafe()) {
+                            CoerceBoolEnumsToNames(elem, field->message_type());
+                        }
+                    }
+                } else {
+                    CoerceBoolEnumsToNames(value, field->message_type());
+                }
+            }
+        }
+    }
+
     void ExtractExtraFields(NJson::TJsonValue& json, TTransformContext& ctx) {
         // for static group
         Iterate(json, COMBINED_DISK_INFO_PATH, [&ctx](const std::vector<ui32>& ids, const NJson::TJsonValue& node) {
@@ -1714,6 +1753,7 @@ endDiskTypeCheck:   ;
         }
 
         CaptureOpaqueConfigFields(jsonNode);
+        CoerceBoolEnumsToNames(jsonNode, config.GetDescriptor());
         runPhase(EParsePhase::JsonToProto, [&] {
             NProtobufJson::MergeJson2Proto(jsonNode, config, convertConfig);
         });

--- a/ydb/library/yaml_config/yaml_config_parser_ut.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser_ut.cpp
@@ -3,6 +3,7 @@
 #include "yaml_config_helpers.h"
 
 #include <ydb/core/protos/key.pb.h>
+#include <ydb/core/protos/feature_flags.pb.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -76,6 +77,71 @@ pdisk_key_config:
         UNIT_ASSERT_VALUES_EQUAL(keys.end() - keys.begin(), 1);
         auto key = keys.at(0);
         UNIT_ASSERT_VALUES_EQUAL("c2FtcGxlLXBpbgo=", key.pin());
+    }
+
+    Y_UNIT_TEST(FeatureFlagsWithTriboolAsBoolKeepsLaterFlags) {
+        // Regression: EnableMvcc (tag 47) is a Tribool enum. A YAML boolean given
+        // to it used to abort the whole FeatureFlags json->proto merge (which walks
+        // fields in tag order), silently dropping every feature flag with a higher
+        // tag, e.g. EnableArrowFormatAtDatashard (tag 49).
+        TString config = R"(
+feature_flags:
+  enable_mvcc: true
+  enable_arrow_format_at_datashard: true
+)";
+        NKikimrConfig::TAppConfig cfg = Parse(config, false);
+
+        UNIT_ASSERT(cfg.HasFeatureFlags());
+        UNIT_ASSERT_C(cfg.GetFeatureFlags().GetEnableArrowFormatAtDatashard(),
+            "EnableArrowFormatAtDatashard (tag 49) was dropped because a Tribool "
+            "flag given as a YAML bool aborted the FeatureFlags parse");
+    }
+
+    Y_UNIT_TEST(FeatureFlagsWithoutTriboolParseFully) {
+        // Control: without the Tribool-as-bool trigger the same high-tag flag
+        // parses fine, isolating enable_mvcc as the cause.
+        TString config = R"(
+feature_flags:
+  enable_arrow_format_at_datashard: true
+)";
+        NKikimrConfig::TAppConfig cfg = Parse(config, false);
+
+        UNIT_ASSERT(cfg.HasFeatureFlags());
+        UNIT_ASSERT(cfg.GetFeatureFlags().GetEnableArrowFormatAtDatashard());
+    }
+
+    Y_UNIT_TEST(TriboolFeatureFlagAcceptsYamlBool) {
+        // A Tribool feature flag may be written as a YAML boolean; true maps to
+        // VALUE_TRUE and false maps to VALUE_FALSE.
+        TString configTrue = R"(
+feature_flags:
+  enable_mvcc: true
+)";
+        NKikimrConfig::TAppConfig cfgTrue = Parse(configTrue, false);
+        UNIT_ASSERT(cfgTrue.HasFeatureFlags());
+        UNIT_ASSERT_VALUES_EQUAL((int)cfgTrue.GetFeatureFlags().GetEnableMvcc(),
+            (int)NKikimrConfig::TFeatureFlags::VALUE_TRUE);
+
+        TString configFalse = R"(
+feature_flags:
+  enable_mvcc: false
+)";
+        NKikimrConfig::TAppConfig cfgFalse = Parse(configFalse, false);
+        UNIT_ASSERT(cfgFalse.HasFeatureFlags());
+        UNIT_ASSERT_VALUES_EQUAL((int)cfgFalse.GetFeatureFlags().GetEnableMvcc(),
+            (int)NKikimrConfig::TFeatureFlags::VALUE_FALSE);
+    }
+
+    Y_UNIT_TEST(TriboolFeatureFlagAcceptsEnumName) {
+        // The explicit enum spelling keeps working alongside the boolean form.
+        TString config = R"(
+feature_flags:
+  enable_mvcc: VALUE_FALSE
+)";
+        NKikimrConfig::TAppConfig cfg = Parse(config, false);
+        UNIT_ASSERT(cfg.HasFeatureFlags());
+        UNIT_ASSERT_VALUES_EQUAL((int)cfg.GetFeatureFlags().GetEnableMvcc(),
+            (int)NKikimrConfig::TFeatureFlags::VALUE_FALSE);
     }
 
     Y_UNIT_TEST(PdiskCategoryFromString) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

A `Tribool` feature flag (e.g. `enable_mvcc`, proto tag 47) written as a YAML
boolean aborted the whole `TFeatureFlags` JSON→proto merge. The merge walks
fields in proto-tag order, so the abort at tag 47 silently dropped **every**
feature flag with a higher tag (`enable_arrow_format_at_datashard`, …) from the
config delivered to components. `TConfigsDispatcher::ParseYamlProtoConfig`
caught the parse exception, logged it, and returned the partially-populated
proto — so a truncated config was shipped to subscribers while the monitoring
page still showed the full resolved YAML. The effect: a dynamic-config flag
appeared set in the UI but never reached the runtime without a node restart.

Changes:
- **Accept booleans on `Tribool` fields.** `yaml_config_parser` now coerces a
  YAML/JSON boolean on any `Tribool`-style enum field to `VALUE_TRUE` /
  `VALUE_FALSE` before the merge, guided by the target proto schema
  (`CoerceBoolEnumsToNames`). This is done entirely in YDB code — the vendored
  `library/cpp/protobuf/json` is untouched.
- **Fail loudly instead of silently truncating.** `ParseYamlProtoConfig` now
  `Y_ABORT`s on a parse failure rather than delivering a partially-parsed
  config.
- **Tests:** parser unit tests (bool→`VALUE_TRUE`/`VALUE_FALSE`, enum-name form
  still works, later-tag flag survives, control) and a ConfigsDispatcher
  end-to-end test asserting the full FeatureFlags is delivered.
