### PR TITLE
LOGBROKER-10550 Fix memory leak

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
@@ -6,6 +6,8 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
 
+#include <util/generic/scope.h>
+
 using namespace NYdb::NConsoleClient;
 
 void TTopicWorkloadReader::RetryableReaderLoop(const TTopicWorkloadReaderParams& params) {
@@ -65,6 +67,12 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
         NYdb::NTopic::TPartitionSession::TPtr Stream;
     };
     THashMap<std::pair<TString, ui64>, TPartitionStreamState> streamState;
+    Y_DEFER {
+        streamState.clear();
+        if (!readSession->Close(TDuration::Seconds(5))) {
+            WRITE_LOG(params.Log, ELogPriority::TLOG_WARNING, "Reader session was not gracefully closed.");
+        }
+    };
 
     TInstant LastPartitionStatusRequestTime = TInstant::Zero();
 
@@ -154,10 +162,6 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
     if (txSupport) {
         TryCommitTableChanges(params, txSupport);
         GracefullShutdown(stopPartitionSessionEvents);
-    }
-    streamState.clear();
-    if (!readSession->Close(TDuration::Seconds(5))) {
-        WRITE_LOG(params.Log, ELogPriority::TLOG_WARNING, "Reader session was not gracefully closed.");
     }
 }
 

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_reader.cpp
@@ -150,6 +150,15 @@ void TTopicWorkloadReader::ReaderLoop(const TTopicWorkloadReaderParams& params, 
             TryCommitTx(params, txSupport, commitTime, stopPartitionSessionEvents);
         }
     }
+
+    if (txSupport) {
+        TryCommitTableChanges(params, txSupport);
+        GracefullShutdown(stopPartitionSessionEvents);
+    }
+    streamState.clear();
+    if (!readSession->Close(TDuration::Seconds(5))) {
+        WRITE_LOG(params.Log, ELogPriority::TLOG_WARNING, "Reader session was not gracefully closed.");
+    }
 }
 
 std::vector<NYdb::NTopic::TReadSessionEvent::TEvent> TTopicWorkloadReader::GetEvents(NYdb::NTopic::IReadSession& readSession,

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -193,6 +193,7 @@ bool TReadSession::Close(TDuration timeout) {
 
     std::shared_ptr<TCallbackContext<TSingleClusterReadSessionImpl<false>>> cbContextToCancel;
     std::shared_ptr<TCallbackContext<TCountersLogger<false>>> dumpCountersContextToCancel;
+    TInstant closeDeadline;
     bool result = false;
     {
         TDeferredActions<false> deferred;
@@ -222,6 +223,7 @@ bool TReadSession::Close(TDuration timeout) {
             AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
             return false;
         }
+        closeDeadline = TInstant::Now() + timeout;
         Connections->ScheduleCallback(timeout,
                                       std::move(timeoutCallback),
                                       timeoutContext);
@@ -250,7 +252,7 @@ bool TReadSession::Close(TDuration timeout) {
             dumpCountersContextToCancel = DumpCountersContext;
         }
     }
-    if (!session->WaitAllDecompressionTasks(TInstant::Now() + timeout)) {
+    if (!session->WaitAllDecompressionTasks(closeDeadline)) {
         LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
     }
     ClearAllEvents();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -250,11 +250,15 @@ bool TReadSession::Close(TDuration timeout) {
             dumpCountersContextToCancel = DumpCountersContext;
         }
     }
-    ClearAllEvents();
-    session->ClearAllPartitionStreamEvents();
-    session->WaitAllDecompressionTasks(TInstant::Now() + timeout);
-    ClearAllEvents();
-    session->ClearAllPartitionStreamEvents();
+    auto clearPendingEvents = [&] {
+        ClearAllEvents();
+        session->ClearAllPartitionStreamEvents();
+    };
+    clearPendingEvents();
+    if (!session->WaitAllDecompressionTasks(TInstant::Now() + timeout)) {
+        LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+    }
+    clearPendingEvents();
     if (cbContextToCancel) {
         cbContextToCancel->Cancel();
     }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -40,7 +40,20 @@ TReadSession::~TReadSession() {
     Close(TDuration::Zero());
 
     Abort(EStatus::ABORTED, "Aborted");
-    ClearAllEvents();
+    if (CbContext) {
+        if (auto session = CbContext->LockShared()) {
+            const TInstant closeDeadline = TInstant::Now() + TDuration::Seconds(5);
+            if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+                LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session destroy timeout");
+            }
+            ClearAllEvents();
+            session->ClearAllPartitionStreamEvents();
+        } else {
+            ClearAllEvents();
+        }
+    } else {
+        ClearAllEvents();
+    }
 
     if (CbContext) {
         CbContext->Cancel();

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -250,15 +250,11 @@ bool TReadSession::Close(TDuration timeout) {
             dumpCountersContextToCancel = DumpCountersContext;
         }
     }
-    auto clearPendingEvents = [&] {
-        ClearAllEvents();
-        session->ClearAllPartitionStreamEvents();
-    };
-    clearPendingEvents();
     if (!session->WaitAllDecompressionTasks(TInstant::Now() + timeout)) {
         LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
     }
-    clearPendingEvents();
+    ClearAllEvents();
+    session->ClearAllPartitionStreamEvents();
     if (cbContextToCancel) {
         cbContextToCancel->Cancel();
     }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -191,57 +191,75 @@ bool TReadSession::Close(TDuration timeout) {
         promise.TrySetValue(true);
     };
 
-    TDeferredActions<false> deferred;
-    with_lock(Lock) {
-        if (Closing || Aborting) {
-            return false;
-        }
-
-        if (!timeout) {
-            AbortImpl(EStatus::ABORTED, "Close with zero timeout", deferred);
-            return false;
-        }
-
-        Closing = true;
-        session = CbContext->TryGet();
-    }
-    session->Close(callback);
-
-    callback(); // For the case when there are no subsessions yet.
-
-    auto timeoutCallback = [=](bool) mutable {
-        promise.TrySetValue(false);
-    };
-
-    auto timeoutContext = Connections->CreateContext();
-    if (!timeoutContext) {
-        AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
-        return false;
-    }
-    Connections->ScheduleCallback(timeout,
-                                  std::move(timeoutCallback),
-                                  timeoutContext);
-
-    // Wait.
-    NThreading::TFuture<bool> resultFuture = promise.GetFuture();
-    const bool result = resultFuture.GetValueSync();
-    if (result) {
-        Cancel(timeoutContext);
-
-        NYdb::NIssue::TIssues issues;
-        issues.AddIssue("Session was gracefully closed");
-        EventsQueue->Close(TSessionClosedEvent(EStatus::SUCCESS, std::move(issues)), deferred);
-    } else {
-        ++*Settings.Counters_->Errors;
-        session->Abort();
-
-        NYdb::NIssue::TIssues issues;
-        issues.AddIssue(TStringBuilder() << "Session was closed after waiting " << timeout);
-        EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
-    }
+    std::shared_ptr<TCallbackContext<TSingleClusterReadSessionImpl<false>>> cbContextToCancel;
+    std::shared_ptr<TCallbackContext<TCountersLogger<false>>> dumpCountersContextToCancel;
+    bool result = false;
     {
-        std::lock_guard guard(Lock);
-        Aborting = true; // Set abort flag for doing nothing on destructor.
+        TDeferredActions<false> deferred;
+        with_lock(Lock) {
+            if (Closing || Aborting) {
+                return false;
+            }
+
+            if (!timeout) {
+                AbortImpl(EStatus::ABORTED, "Close with zero timeout", deferred);
+                return false;
+            }
+
+            Closing = true;
+            session = CbContext->TryGet();
+        }
+        session->Close(callback);
+
+        callback(); // For the case when there are no subsessions yet.
+
+        auto timeoutCallback = [=](bool) mutable {
+            promise.TrySetValue(false);
+        };
+
+        auto timeoutContext = Connections->CreateContext();
+        if (!timeoutContext) {
+            AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
+            return false;
+        }
+        Connections->ScheduleCallback(timeout,
+                                      std::move(timeoutCallback),
+                                      timeoutContext);
+
+        // Wait.
+        NThreading::TFuture<bool> resultFuture = promise.GetFuture();
+        result = resultFuture.GetValueSync();
+        if (result) {
+            Cancel(timeoutContext);
+
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue("Session was gracefully closed");
+            EventsQueue->Close(TSessionClosedEvent(EStatus::SUCCESS, std::move(issues)), deferred);
+        } else {
+            ++*Settings.Counters_->Errors;
+            session->Abort();
+
+            NYdb::NIssue::TIssues issues;
+            issues.AddIssue(TStringBuilder() << "Session was closed after waiting " << timeout);
+            EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
+        }
+        {
+            std::lock_guard guard(Lock);
+            Aborting = true; // Set abort flag for doing nothing on destructor.
+            cbContextToCancel = CbContext;
+            dumpCountersContextToCancel = DumpCountersContext;
+        }
+    }
+    ClearAllEvents();
+    session->ClearAllPartitionStreamEvents();
+    session->WaitAllDecompressionTasks(TInstant::Now() + timeout);
+    ClearAllEvents();
+    session->ClearAllPartitionStreamEvents();
+    if (cbContextToCancel) {
+        cbContextToCancel->Cancel();
+    }
+    if (dumpCountersContextToCancel) {
+        dumpCountersContextToCancel->Cancel();
     }
     return result;
 }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session.cpp
@@ -264,12 +264,12 @@ bool TReadSession::Close(TDuration timeout) {
             cbContextToCancel = CbContext;
             dumpCountersContextToCancel = DumpCountersContext;
         }
+        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+        }
+        ClearAllEvents();
+        session->ClearAllPartitionStreamEvents();
     }
-    if (!session->WaitAllDecompressionTasks(closeDeadline)) {
-        LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
-    }
-    ClearAllEvents();
-    session->ClearAllPartitionStreamEvents();
     if (cbContextToCancel) {
         cbContextToCancel->Cancel();
     }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -1263,6 +1263,8 @@ public:
     void Commit(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, ui64 startOffset, ui64 endOffset);
 
     void OnCreateNewDecompressionTask();
+    bool WaitAllDecompressionTasks(TInstant deadline) const;
+    void ClearAllPartitionStreamEvents();
     void OnDecompressionInfoDestroy(i64 compressedSize, i64 decompressedSize, i64 messagesCount, i64 serverBytesSize);
     void OnDecompressionInfoDestroyImpl(i64 compressedSize,
                                         i64 decompressedSize,

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.h
@@ -27,7 +27,9 @@
 #include <util/digest/numeric.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <deque>
+#include <mutex>
 #include <vector>
 
 
@@ -1263,6 +1265,7 @@ public:
     void Commit(const TPartitionStreamImpl<UseMigrationProtocol>* partitionStream, ui64 startOffset, ui64 endOffset);
 
     void OnCreateNewDecompressionTask();
+    void OnDecompressionTaskFinished();
     bool WaitAllDecompressionTasks(TInstant deadline) const;
     void ClearAllPartitionStreamEvents();
     void OnDecompressionInfoDestroy(i64 compressedSize, i64 decompressedSize, i64 messagesCount, i64 serverBytesSize);
@@ -1549,6 +1552,8 @@ private:
     bool Closing = false;
     std::function<void()> CloseCallback;
     std::atomic<int> DecompressionTasksInflight = 0;
+    mutable std::mutex DecompressionTasksInflightMutex;
+    mutable std::condition_variable DecompressionTasksInflightCondVar;
     i64 ReadSizeBudget;
     i64 ReadSizeServerDelta = 0;
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -25,9 +25,9 @@
 #include <util/generic/utility.h>
 #include <util/generic/yexception.h>
 #include <util/stream/mem.h>
-#include <util/system/thread.h>
 
 #include <atomic>
+#include <chrono>
 #include <utility>
 #include <variant>
 
@@ -1915,11 +1915,27 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnCreateNewDecompressi
 }
 
 template<bool UseMigrationProtocol>
-bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::WaitAllDecompressionTasks(TInstant deadline) const {
-    while (DecompressionTasksInflight.load() > 0 && TInstant::Now() < deadline) {
-        Sleep(TDuration::MilliSeconds(1));
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDecompressionTaskFinished() {
+    Y_ABORT_UNLESS(DecompressionTasksInflight > 0);
+    if (--DecompressionTasksInflight == 0) {
+        DecompressionTasksInflightCondVar.notify_all();
     }
-    return DecompressionTasksInflight.load() == 0;
+}
+
+template<bool UseMigrationProtocol>
+bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::WaitAllDecompressionTasks(TInstant deadline) const {
+    const TDuration timeout = deadline - TInstant::Now();
+    if (timeout <= TDuration::Zero()) {
+        return DecompressionTasksInflight.load() == 0;
+    }
+
+    std::unique_lock guard(DecompressionTasksInflightMutex);
+    return DecompressionTasksInflightCondVar.wait_for(
+        guard,
+        std::chrono::microseconds(timeout.MicroSeconds()),
+        [&] {
+            return DecompressionTasksInflight.load() == 0;
+        });
 }
 
 template<bool UseMigrationProtocol>
@@ -1978,8 +1994,7 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDataDecompressed(i64
 
     TDeferredActions<UseMigrationProtocol> deferred;
 
-    Y_ABORT_UNLESS(DecompressionTasksInflight > 0);
-    --DecompressionTasksInflight;
+    OnDecompressionTaskFinished();
 
     *Settings.Counters_->BytesRead += decompressedSize;
     *Settings.Counters_->BytesReadCompressed += sourceSize;

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -1994,8 +1994,6 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnDataDecompressed(i64
 
     TDeferredActions<UseMigrationProtocol> deferred;
 
-    OnDecompressionTaskFinished();
-
     *Settings.Counters_->BytesRead += decompressedSize;
     *Settings.Counters_->BytesReadCompressed += sourceSize;
     *Settings.Counters_->MessagesRead += messagesCount;
@@ -3647,6 +3645,10 @@ void TDataDecompressionInfo<UseMigrationProtocol>::TDecompressionTask::operator(
     if (bool expected = false; !Ready->Abandoned.compare_exchange_strong(expected, true)) {
         // Message is dropped due to partition stream cancellation, we should release decompressed memory
         parent->OnUserRetrievedEvent(DecompressedSize, messagesProcessed);
+    }
+
+    if (auto session = parent->CbContext->LockShared()) {
+        session->OnDecompressionTaskFinished();
     }
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/read_session_impl.ipp
@@ -25,6 +25,7 @@
 #include <util/generic/utility.h>
 #include <util/generic/yexception.h>
 #include <util/stream/mem.h>
+#include <util/system/thread.h>
 
 #include <atomic>
 #include <utility>
@@ -1911,6 +1912,40 @@ void TSingleClusterReadSessionImpl<UseMigrationProtocol>::CleanupDecompressionQu
 template<bool UseMigrationProtocol>
 void TSingleClusterReadSessionImpl<UseMigrationProtocol>::OnCreateNewDecompressionTask() {
     ++DecompressionTasksInflight;
+}
+
+template<bool UseMigrationProtocol>
+bool TSingleClusterReadSessionImpl<UseMigrationProtocol>::WaitAllDecompressionTasks(TInstant deadline) const {
+    while (DecompressionTasksInflight.load() > 0 && TInstant::Now() < deadline) {
+        Sleep(TDuration::MilliSeconds(1));
+    }
+    return DecompressionTasksInflight.load() == 0;
+}
+
+template<bool UseMigrationProtocol>
+void TSingleClusterReadSessionImpl<UseMigrationProtocol>::ClearAllPartitionStreamEvents() {
+    TDeferredActions<UseMigrationProtocol> deferred;
+    std::vector<TIntrusivePtr<TPartitionStreamImpl<UseMigrationProtocol>>> streams;
+    std::vector<TRawPartitionStreamEventQueue<UseMigrationProtocol>> deferredDelete;
+    {
+        std::lock_guard guard(Lock);
+        streams.reserve(PartitionStreams.size());
+        for (auto& [_, partitionStream] : PartitionStreams) {
+            streams.push_back(partitionStream);
+        }
+    }
+
+    deferredDelete.reserve(streams.size());
+    for (auto& stream : streams) {
+        std::lock_guard guard(stream->GetLock());
+        if (stream->HasEvents()) {
+            deferredDelete.push_back(stream->ExtractQueue());
+        }
+    }
+
+    for (auto& queue : deferredDelete) {
+        queue.Cleanup(deferred);
+    }
 }
 
 template<bool UseMigrationProtocol>

--- a/ydb/tests/stress/topic/tests/test_workload_topic.py
+++ b/ydb/tests/stress/topic/tests/test_workload_topic.py
@@ -28,7 +28,7 @@ def create_test_methods(chunk_size):
         for k in range(count):
             def make_test_method(index):
                 def test_method(self):
-                    self._run_chunk(k, chunk_size)
+                    self._run_chunk(index, chunk_size)
                 test_method.__name__ = f"test_{index}"
                 return test_method
             setattr(cls, f"test_{k}", make_test_method(k))

--- a/ydb/tests/stress/topic/tests/test_workload_topic.py
+++ b/ydb/tests/stress/topic/tests/test_workload_topic.py
@@ -28,7 +28,7 @@ def create_test_methods(chunk_size):
         for k in range(count):
             def make_test_method(index):
                 def test_method(self):
-                    self._run_chunk(index, chunk_size)
+                    self._run_chunk(k, chunk_size)
                 test_method.__name__ = f"test_{index}"
                 return test_method
             setattr(cls, f"test_{k}", make_test_method(k))

--- a/ydb/tests/stress/topic/workload/__init__.py
+++ b/ydb/tests/stress/topic/workload/__init__.py
@@ -98,6 +98,14 @@ class YdbTopicWorkload(WorkloadBase):
             topic_name,
         ])
 
+    def _add_data_holder_consumer_to_topic(self, topic_name) -> None:
+        availability_period = int(self.duration) * self.config.AVAILABILITY_PERIOD_NUMERATOR // self.config.AVAILABILITY_PERIOD_DENOMINATOR
+        self._add_consumer_to_topic(
+            topic_name,
+            self.config.DATA_HOLDER_CONSUMER,
+            availability_period
+        )
+
     def _run_workload(self, topic_name, duration, byte_rate, producers, consumers,
                       consumer_threads=None,
                       tx_commit_interval=None, use_tx=True, with_config=True) -> None:
@@ -229,12 +237,7 @@ class YdbTopicWorkload(WorkloadBase):
 
         # Настраиваем тестовый топик
         self._configure_topic_retention(self.workload_topic_name, self.config.RETENTION)
-        availability_period = int(self.duration) * self.config.AVAILABILITY_PERIOD_NUMERATOR // self.config.AVAILABILITY_PERIOD_DENOMINATOR
-        self._add_consumer_to_topic(
-            self.workload_topic_name,
-            self.config.DATA_HOLDER_CONSUMER,
-            availability_period
-        )
+        self._add_data_holder_consumer_to_topic(self.workload_topic_name)
 
         # Запускаем тестовую нагрузку
         self._run_workload(
@@ -262,6 +265,7 @@ class YdbTopicWorkload(WorkloadBase):
 
         # Настраиваем тестовый топик
         self._configure_topic_retention(topic_name, self.config.RETENTION)
+        self._add_data_holder_consumer_to_topic(topic_name)
 
         # Запускаем тестовую нагрузку
         self._run_workload(
@@ -291,6 +295,7 @@ class YdbTopicWorkload(WorkloadBase):
 
         # Настраиваем тестовый топик
         self._configure_topic_retention(topic_name, self.config.RETENTION)
+        self._add_data_holder_consumer_to_topic(topic_name)
 
         # Запускаем тестовую нагрузку без транзакций
         self._run_workload(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

```md
# Memory Leak

LSan падал в `test_workload_topic.py::TestYdbTopicWorkload::test_0` на выходе из `ydb_cli workload topic run full`.

## Где текло

Утечка была вокруг topic read session:

- `TDataDecompressionInfo<false>`
- `TRawPartitionStreamEventQueue<false>`
- `TPartitionStreamImpl<false>`
- `TCallbackContext<TSingleClusterReadSessionImpl<false>>`

Основной стек:

```text
TDataDecompressionInfo<false>::BuildBatchesMeta()
TDataDecompressionInfo<false>::TDataDecompressionInfo(...)
TSingleClusterReadSessionImpl<false>::OnReadDoneImpl(...)
TSingleClusterReadSessionImpl<false>::OnReadDone(...)
```

## Причина

`workload topic reader` не закрывал read session явно.

В destructor вызывался:

```cpp
Close(TDuration::Zero());
```

Этот путь abort-ит session без ожидания decompression tasks и без полной очистки per-partition event queues.

Часть `TDataDecompressionInfo` оставалась жить в:

- global events queue;
- raw queues внутри `TPartitionStreamImpl`;
- уже запущенных decompression tasks.

## Фикс

- В workload reader добавлен `Y_DEFER`, который всегда делает:

```cpp
streamState.clear();
readSession->Close(TDuration::Seconds(5));
```

- В `TReadSession::Close()` добавлено ожидание decompression tasks до общего close deadline.
- Добавлена очистка per-partition raw queues через `ClearAllPartitionStreamEvents()`.
- Ожидание decompression tasks сделано через `std::condition_variable`, без busy-wait.
