### PR TITLE
Set not null state rejected

### DIFF
--- a/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
+++ b/ydb/core/kqp/executer_actor/kqp_scheme_executer.cpp
@@ -1233,7 +1233,8 @@ public:
 
         if (state == Ydb::Table::SetNotNullState::STATE_DONE) {
             return ReplyErrorAndDie(Ydb::StatusIds::SUCCESS, record.MutableIssues());
-        } else if (state == Ydb::Table::SetNotNullState::STATE_CANCELLED) {
+        } else if (state == Ydb::Table::SetNotNullState::STATE_CANCELLED ||
+                   state == Ydb::Table::SetNotNullState::STATE_REJECTED) {
             return ReplyErrorAndDie(Ydb::StatusIds::PRECONDITION_FAILED, record.MutableIssues());
         } else {
             return ReplyErrorAndDie(Ydb::StatusIds::INTERNAL_ERROR, record.MutableIssues());

--- a/ydb/core/tx/schemeshard/index/index_build_info.h
+++ b/ydb/core/tx/schemeshard/index/index_build_info.h
@@ -896,7 +896,7 @@ public:
         return State == EState::Cancelled || State == EState::Rejected;
     }
 
-    bool IsFinished() const {
+    virtual bool IsFinished() const {
         return IsDone() || IsCancelled();
     }
 
@@ -1022,6 +1022,10 @@ struct TSetColumnConstraintOperationInfo: public TIndexBuildInfo {
 
     bool IsDone() const override {
         return OperationState == EOperationState::Done;
+    }
+
+    bool IsFinished() const override {
+        return IsDone();
     }
 
     bool IsCloseToCompletion() const {

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint.cpp
@@ -80,7 +80,12 @@ void FillSetColumnConstraint(
     // Map internal state to proto state
     proto.SetProgress(CalcProgress(operationInfo));
 
-    if (operationInfo.IsCancelled) {
+    if (operationInfo.ValidationFailed) {
+        // Validation found NULL values (or hit an internal error) in the column(s)
+        // being altered. This is distinct from an explicit user cancellation.
+        proto.SetState(ProtoState::STATE_REJECTED);
+    } else if (operationInfo.IsCancelled) {
+        // Operation was cancelled by an explicit user request.
         proto.SetState(ProtoState::STATE_CANCELLED);
     } else {
         switch (operationInfo.OperationState) {
@@ -96,9 +101,6 @@ void FillSetColumnConstraint(
             proto.SetState(ProtoState::STATE_APPLYING);
             break;
         case EState::Done:
-            // There is no way when IsValidationFailed equals `true`,
-            // because IsValidationFailed is true exactly when IsCancelled is true.
-            // Therefore, there cannot be STATE_CANCELLED.
             proto.SetState(ProtoState::STATE_DONE);
             break;
         case EState::Invalid:

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -70,7 +70,9 @@ public:
         // - TTxReplyValidateRowCondition ignores incoming validation messages due to IsCancelled flag
         // - AlterMainTableUnlockNullWritesPropose will NOT set NOT NULL constraint due to IsCancelled check
         // - The operation will complete naturally in Done state without setting the constraint
-        Progress(BuildId);
+        if (operationInfo.OperationState == TSetColumnConstraintOperationInfo::EOperationState::Validating) {
+            Progress(BuildId);
+        }
 
         return Reply();
     }

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__cancel.cpp
@@ -66,10 +66,26 @@ public:
         operationInfo.MarkAsCancelled(TString("Cancelled by user request"));
         Self->PersistSetColumnConstraintCancellation(db, operationInfo);
 
-        // Note: The operation will continue through its natural stages:
+        // Note: cancellation is de facto acted upon only while the operation is in the
+        // Validating stage:
         // - TTxReplyValidateRowCondition ignores incoming validation messages due to IsCancelled flag
         // - AlterMainTableUnlockNullWritesPropose will NOT set NOT NULL constraint due to IsCancelled check
         // - The operation will complete naturally in Done state without setting the constraint
+        //
+        // Trying to react to cancellation on earlier or later stages introduces non-trivial
+        // logic that can easily lead to unwanted bugs (e.g. a stale reply for an already
+        // abandoned stage racing with a message for the newly entered one). We sidestep that
+        // entirely here:
+        // - Later stages (Finishing, Unlocking) are already forbidden for cancellation by the
+        //   IsCloseToCompletion() check above.
+        // - Earlier stages (Locking, LockingNullWrites) simply ignore the fact of cancellation
+        //   until the Validating stage is reached; the IsCancelled flag is already persisted,
+        //   so once Validating starts (or is already running), the operation will pick it up
+        //   and unwind normally.
+        //
+        // This is not a practical concern because Validating is by far the longest-running
+        // stage of this metadata operation, and it is also the very reason a user would want
+        // to cancel a SET NOT NULL metadata operation in the first place.
         if (operationInfo.OperationState == TSetColumnConstraintOperationInfo::EOperationState::Validating) {
             Progress(BuildId);
         }

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__get.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__get.cpp
@@ -56,14 +56,14 @@ public:
         FillSetColumnConstraint(*proto, operationInfo, Self);
 
         // Add issue for cancelled operations
-        if (operationInfo.IsCancelled && !operationInfo.CancellationReason.empty()) {
+        if (operationInfo.IsCancelled) {
             auto* issue = respRecord.AddIssues();
             issue->set_message(operationInfo.CancellationReason);
             issue->set_issue_code(0);
             issue->set_severity(NYql::TSeverityIds::S_ERROR);
         }
 
-        if (operationInfo.ValidationFailed && operationInfo.OperationState == TSetColumnConstraintOperationInfo::EOperationState::Done) {
+        if (operationInfo.ValidationFailed) {
             TPath tablePath = TPath::Init(operationInfo.TablePathId, Self);
             auto* issue = respRecord.AddIssues();
             issue->set_message(TStringBuilder()

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -389,7 +389,6 @@ public:
         }
 
         auto oldValidationFailedValue = operationInfo.ValidationFailed;
-        TString cancellationReason;
 
         auto& shardStatus = operationInfo.ValidationShards.at(shardIdx);
         shardStatus.ValidateStatus = record.GetStatus();
@@ -409,7 +408,6 @@ public:
             if (!record.GetIsValid()) {
                 LOG_N("TTxReplyValidateRowCondition: validation failed on shard# " << shardIdx);
                 operationInfo.ValidationFailed = true;
-                cancellationReason = "Validation failed: found NULL values in column(s) being set to NOT NULL";
             }
 
             operationInfo.InProgressValidationShards.erase(shardIdx);
@@ -422,7 +420,6 @@ public:
                 << ", status# " << record.GetStatus());
 
             operationInfo.ValidationFailed = true;
-            cancellationReason = "Validation failed: internal error";
 
             operationInfo.InProgressValidationShards.erase(shardIdx);
             operationInfo.DoneValidationShards.insert(shardIdx);

--- a/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_set_column_constraint__progress.cpp
@@ -357,6 +357,11 @@ public:
             return true;
         }
 
+        if (operationInfo.ValidationFailed) {
+            LOG_I("TTxReplyValidateRowCondition: operation is rejected, ignoring message, id# " << BuildId);
+            return true;
+        }
+
         TShardIdx shardIdx;
         bool found = false;
         for (const auto& [idx, shardStatus] : operationInfo.ValidationShards) {
@@ -434,9 +439,6 @@ public:
 
             if (oldValidationFailedValue != operationInfo.ValidationFailed) {
                 Self->PersistSetColumnConstraintValidationFailedValue(db, operationInfo);
-
-                operationInfo.MarkAsCancelled(std::move(cancellationReason));
-                Self->PersistSetColumnConstraintCancellation(db, operationInfo);
             }
 
             Self->PersistSetColumnConstraintShardDone(db, BuildId, shardIdx, operationInfo);
@@ -640,7 +642,8 @@ public:
 
         LOG_D("TTxProgressSetColumnConstraint::DoExecute, id# " << BuildId
             << "; OperationState = " << ToString(operationInfo.OperationState)
-            << "; IsCancelled = " << operationInfo.IsCancelled);
+            << "; IsCancelled = " << operationInfo.IsCancelled
+            << "; ValidationFailed = " << operationInfo.ValidationFailed);
 
         switch (operationInfo.OperationState) {
             case TSetColumnConstraintOperationInfo::EOperationState::Invalid: {
@@ -662,15 +665,6 @@ public:
                 break;
             }
             case TSetColumnConstraintOperationInfo::EOperationState::LockingNullWrites: {
-                // If cancelled, skip to Finishing to release locks without setting constraint
-                if (operationInfo.IsCancelled) {
-                    LOG_I("TTxProgressSetColumnConstraint: operation cancelled in LockingNullWrites, jumping to Finishing, id# " << BuildId);
-                    NIceDb::TNiceDb db(txc.DB);
-                    ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
-                    Progress(BuildId);
-                    break;
-                }
-
                 if (operationInfo.LockNullWritesTxId == InvalidTxId) {
                     AllocateTxId(BuildId);
                 } else if (operationInfo.LockNullWritesTxStatus == NKikimrScheme::StatusSuccess) {
@@ -686,8 +680,13 @@ public:
             }
             case TSetColumnConstraintOperationInfo::EOperationState::Validating: {
                 // If cancelled, skip to Finishing to release locks without setting constraint
-                if (operationInfo.IsCancelled) {
-                    LOG_I("TTxProgressSetColumnConstraint: operation cancelled in Validating, jumping to Finishing, id# " << BuildId);
+                if (operationInfo.IsCancelled || operationInfo.ValidationFailed) {
+                    if (operationInfo.IsCancelled) {
+                        LOG_I("TTxProgressSetColumnConstraint: operation cancelled in Validating, jumping to Finishing, id# " << BuildId);
+                    } else {
+                        LOG_I("TTxProgressSetColumnConstraint: validation failed in Validating, jumping to Finishing, id# " << BuildId);
+                    }
+
                     NIceDb::TNiceDb db(txc.DB);
                     ChangeState(BuildId, TSetColumnConstraintOperationInfo::EOperationState::Finishing);
                     Progress(BuildId);

--- a/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
+++ b/ydb/core/tx/schemeshard/ut_set_column_constraint/ut_set_column_constraint.cpp
@@ -1087,9 +1087,9 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             Ydb::Table::SetNotNullState::STATE_PREPARING,
             Ydb::Table::SetNotNullState::STATE_PREPARING,
             Ydb::Table::SetNotNullState::STATE_VALIDATING,
-            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_CANCELLED : Ydb::Table::SetNotNullState::STATE_APPLYING),
-            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_CANCELLED : Ydb::Table::SetNotNullState::STATE_APPLYING),
-            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_CANCELLED : Ydb::Table::SetNotNullState::STATE_DONE)
+            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_REJECTED : Ydb::Table::SetNotNullState::STATE_APPLYING),
+            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_REJECTED : Ydb::Table::SetNotNullState::STATE_APPLYING),
+            (isShouldBeFailed ? Ydb::Table::SetNotNullState::STATE_REJECTED : Ydb::Table::SetNotNullState::STATE_DONE)
         };
 
         runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
@@ -1123,7 +1123,7 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
 
         env.TestWaitNotification(runtime, setConstraintTxId, TTestTxConfig::SchemeShard);
 
-        // STATE_DONE/STATE_CANCELLED
+        // STATE_DONE/STATE_REJECTED
         answers.push_back(DoGetRequest(setConstraintTxId, runtime, root).GetState());
 
         UNIT_ASSERT_VALUES_EQUAL_C(
@@ -1385,7 +1385,7 @@ Y_UNIT_TEST_SUITE(SetNotNullTest) {
             }
             if (entry.GetId() == setConstraintTxId2) {
                 foundOp2 = true;
-                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetNotNullState::STATE_CANCELLED));
+                UNIT_ASSERT_VALUES_EQUAL(static_cast<int>(entry.GetState()), static_cast<int>(Ydb::Table::SetNotNullState::STATE_REJECTED));
                 UNIT_ASSERT_VALUES_EQUAL(columns.size(), 1);
                 UNIT_ASSERT_VALUES_EQUAL(columns.Get(0), "value2");
             }

--- a/ydb/public/api/protos/ydb_table.proto
+++ b/ydb/public/api/protos/ydb_table.proto
@@ -482,6 +482,7 @@ message SetNotNullState {
         STATE_APPLYING = 3;
         STATE_DONE = 4;
         STATE_CANCELLED = 5;
+        STATE_REJECTED = 6;
     }
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

As part of the SET NOT NULL implementation, a basic pull request was created (https://github.com/ydb-platform/ydb/pull/36152). It left a large number of gaps. This pull request addresses one of them.

See https://github.com/ydb-platform/ydb/pull/45799#discussion_r3569882035

Moreover, there is one fix with cancel operation during EOperationState::LockingNullWrites state.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
