### PR TITLE
ut_transform: redact source line numbers in golden error results

### DIFF
--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args1-dump_/bridge-mirror-3dc-3-nodes.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args1-dump_/bridge-mirror-3dc-3-nodes.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/deprecated/yaml_config_parser.cpp:524: Condition violated: `json.Has(\"domains_config\")'\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/deprecated/yaml_config_parser.cpp:LINE: Condition violated: `json.Has(\"domains_config\")'\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args1-dump_ds_init_/nvme.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_basic_args1-dump_ds_init_/nvme.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/deprecated/yaml_config_parser.cpp:855: Specify host_configs to use blobstorage init command\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/deprecated/yaml_config_parser.cpp:LINE: Specify host_configs to use blobstorage init command\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-missing-all.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:929: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:LINE: Erasure species is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
+++ b/ydb/library/yaml_config/ut_transform/canondata/test_transform.TestYamlConfigTransformations.test_domains_config_dump_/multinode-unmatched-types.yaml.result.json
@@ -1,1 +1,1 @@
-{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:933: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}
+{"error": true, "stderr": "Terminating due to uncaught exception REDACTED    what() -> \"ydb/library/yaml_config/yaml_config_parser.cpp:LINE: Disk type is not specified for storage pool type, id 0\"\n of type TWithBackTrace<yexception>\n"}

--- a/ydb/library/yaml_config/ut_transform/test_transform.py
+++ b/ydb/library/yaml_config/ut_transform/test_transform.py
@@ -54,6 +54,9 @@ class TestYamlConfigTransformations(object):
     def cleanup_errors(self, errors):
         errors = re.sub(r'address -> 0x[a-zA-Z0-9]+', 'address -> REDACTED', errors)
         errors = re.sub(r'uncaught exception 0x[a-fA-F0-9]+', 'uncaught exception REDACTED', errors)
+        # Redact source line numbers so the golden results don't break on every
+        # unrelated edit that shifts lines in the referenced source file.
+        errors = re.sub(r'(\.(?:cpp|cc|cxx|h|hpp)):\d+', r'\1:LINE', errors)
         return errors
 
     def execute_test(self, data, binary, args=[]):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The `ut_transform` golden (canondata) results for the error cases capture the
process `stderr`, which includes the throw location as `<file>.cpp:<line>`. As a
result, **any** unrelated edit that shifts line numbers in
`yaml_config_parser.cpp` (or the deprecated parser) breaks these golden tests,
even though the observable behavior is unchanged.

This makes `cleanup_errors` redact the line number (`foo.cpp:123` →
`foo.cpp:LINE`), the same way it already redacts exception addresses, and
updates the four affected golden results accordingly. The file path and the
error message are still checked — only the volatile line number is dropped.

No production code changes; test-only.
