### PR TITLE
Add CLIENT_TELEMETRY log component for client request telemetry

### DIFF
--- a/ydb/core/grpc_services/grpc_request_proxy.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy.cpp
@@ -629,7 +629,17 @@ void LogRequest(const TEvent& event) {
     };
 
     if constexpr (std::is_same_v<TEvListEndpointsRequest::TPtr, TEvent>) {
-        LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());
+        // Client telemetry (sdk build info, user agent, peer, ...) gets its own log component, so its
+        // verbosity can be tuned independently of the rest of the grpc proxy. Only discovery requests
+        // carry it for now. Requests with failed authentication are demoted to DEBUG.
+        const auto authState = event->Get()->GetAuthState().State;
+        const bool authFailed = authState == NYdbGrpc::TAuthState::AS_FAIL
+            || authState == NYdbGrpc::TAuthState::AS_UNAVAILABLE;
+        if (authFailed) {
+            LOG_DEBUG(*TlsActivationContext, NKikimrServices::CLIENT_TELEMETRY, "%s", getDebugString().c_str());
+        } else {
+            LOG_INFO(*TlsActivationContext, NKikimrServices::CLIENT_TELEMETRY, "%s", getDebugString().c_str());
+        }
     }
     else {
         LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());

--- a/ydb/core/grpc_services/grpc_request_proxy_simple.cpp
+++ b/ydb/core/grpc_services/grpc_request_proxy_simple.cpp
@@ -214,7 +214,17 @@ void LogRequest(const TEvent& event) {
     };
 
     if constexpr (std::is_same_v<TEvListEndpointsRequest::TPtr, TEvent>) {
-        LOG_INFO(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());
+        // Client telemetry (sdk build info, user agent, peer, ...) gets its own log component, so its
+        // verbosity can be tuned independently of the rest of the grpc proxy. Only discovery requests
+        // carry it for now. Requests with failed authentication are demoted to DEBUG.
+        const auto authState = event->Get()->GetAuthState().State;
+        const bool authFailed = authState == NYdbGrpc::TAuthState::AS_FAIL
+            || authState == NYdbGrpc::TAuthState::AS_UNAVAILABLE;
+        if (authFailed) {
+            LOG_DEBUG(*TlsActivationContext, NKikimrServices::CLIENT_TELEMETRY, "%s", getDebugString().c_str());
+        } else {
+            LOG_INFO(*TlsActivationContext, NKikimrServices::CLIENT_TELEMETRY, "%s", getDebugString().c_str());
+        }
     }
     else {
         LOG_DEBUG(*TlsActivationContext, NKikimrServices::GRPC_SERVER, "%s", getDebugString().c_str());

--- a/ydb/library/services/services.proto
+++ b/ydb/library/services/services.proto
@@ -176,6 +176,7 @@ enum EServiceKikimr {
     READ_TABLE_API = 414; // deprecated, use RPC_REQUEST
     RPC_REQUEST = 416;
     GRPC_LIBRARY = 418;
+    CLIENT_TELEMETRY = 419;
 
     // KEY VALUE section
     KEYVALUE = 420;


### PR DESCRIPTION
## What
Route client request telemetry logging to a dedicated `CLIENT_TELEMETRY` log component instead of `GRPC_SERVER`.

## Why
The `LogRequest` line captures client telemetry (SDK build info, grpc user agent, peer, trace id, ...). It was logged at INFO under the shared `GRPC_SERVER` component, so its verbosity couldn't be tuned separately from the rest of the grpc proxy. A dedicated component lets operators control this telemetry noise independently. The fact that only discovery requests carry it today is an implementation detail.

## How
- Add `CLIENT_TELEMETRY` component to `services.proto`.
- In `LogRequest` (both `grpc_request_proxy.cpp` and `grpc_request_proxy_simple.cpp`) log these requests under `CLIENT_TELEMETRY`; successful ones at INFO, requests with failed authentication (AS_FAIL / AS_UNAVAILABLE) demoted to DEBUG. Non-discovery requests keep logging under `GRPC_SERVER`.
