### PR TITLE
[KQP] Fix legacy QueryService scan stats

### DIFF
--- a/ydb/core/kqp/opt/kqp_query_plan.cpp
+++ b/ydb/core/kqp/opt/kqp_query_plan.cpp
@@ -2615,6 +2615,7 @@ private:
                 return result;
             }
 
+            const auto effectiveTableStats = ownTableStats ? ownTableStats : inheritedTableStats;
             for (auto p : plan.GetMapSafe().at("Plans").GetArraySafe()) {
                 if (!p.GetMapSafe().contains("Operators") && p.GetMapSafe().contains("CTE Name")) {
                     auto precompute = p.GetMapSafe().at("CTE Name").GetStringSafe();
@@ -2622,7 +2623,7 @@ private:
                         planInputs.AppendValue(ReconstructImpl(Precomputes.at(precompute), 0, taskCount, false, nullptr));
                     }
                 } else if (p.GetMapSafe().at("Node Type").GetStringSafe().find("Precompute") == TString::npos) {
-                    planInputs.AppendValue(ReconstructImpl(p, 0, taskCount, fromBroadcast, inheritedTableStats));
+                    planInputs.AppendValue(ReconstructImpl(p, 0, taskCount, fromBroadcast, effectiveTableStats));
                 }
             }
             result["Plans"] = planInputs;

--- a/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_stats_ut.cpp
@@ -434,6 +434,35 @@ Y_UNIT_TEST(LegacySimplifiedPlanTableFullScanActualStats) {
     UNIT_ASSERT_C(limitedScan.GetMapSafe().at("A-Size").GetDoubleSafe() > 0, limitedPlan);
 }
 
+Y_UNIT_TEST(LegacySimplifiedPlanQueryServiceTableFullScanActualStats) {
+    NKikimrConfig::TAppConfig app;
+    app.MutableTableServiceConfig()->SetEnableNewRBO(false);
+
+    TKikimrRunner kikimr{TKikimrSettings(app)};
+    auto client = kikimr.GetQueryClient();
+    auto settings = NYdb::NQuery::TExecuteQuerySettings()
+        .StatsMode(NYdb::NQuery::EStatsMode::Full);
+
+    auto result = client.ExecuteQuery(R"(
+        SELECT Key, Value1 FROM `/Root/TwoShard`;
+    )", NYdb::NQuery::TTxControl::BeginTx().CommitTx(), settings).ExtractValueSync();
+    UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+    UNIT_ASSERT(result.GetStats());
+    UNIT_ASSERT(result.GetStats()->GetPlan());
+
+    NJson::TJsonValue plan;
+    UNIT_ASSERT_C(
+        NJson::ReadJsonTree(*result.GetStats()->GetPlan(), &plan, true),
+        *result.GetStats()->GetPlan());
+    const auto simplifiedPlan = plan.GetMapSafe().at("SimplifiedPlan");
+    const auto fullScan = FindPlanNodeByKv(simplifiedPlan, "Name", "TableFullScan");
+    UNIT_ASSERT_C(fullScan.IsDefined(), simplifiedPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Rows"), simplifiedPlan);
+    UNIT_ASSERT_VALUES_EQUAL_C(fullScan.GetMapSafe().at("A-Rows").GetDoubleSafe(), 6, simplifiedPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().contains("A-Size"), simplifiedPlan);
+    UNIT_ASSERT_C(fullScan.GetMapSafe().at("A-Size").GetDoubleSafe() > 0, simplifiedPlan);
+}
+
 Y_UNIT_TEST(StatsProfile) {
     auto kikimr = DefaultKikimrRunner();
     auto db = kikimr.GetTableClient();


### PR DESCRIPTION
### Changelog entry

Fixed missing actual row and data-size statistics for full table scans in
legacy QueryService plans.
https://github.com/ydb-platform/ydb-embedded-ui/issues/4135

### Changelog category

* Bugfix

## Summary

- propagate the effective `Stats.Table` context through ordinary structural
  `Plans` recursion in the legacy `SimplifiedPlan` reconstructor;
- keep the exact-path `TableFullScan` fallback and all stage/CTE boundaries
  introduced by #46498;
- add a QueryService regression with legacy RBO and full statistics.

## Context

This is a follow-up to #46498 and the UI work in
[ydb-embedded-ui#4096](https://github.com/ydb-platform/ydb-embedded-ui/pull/4096).

Tracking issue:
[ydb-embedded-ui#4135](https://github.com/ydb-platform/ydb-embedded-ui/issues/4135),
a sub-issue of
[ydb-embedded-ui#4058](https://github.com/ydb-platform/ydb-embedded-ui/issues/4058).

#46498 fixed the plan shape in which an operator-bearing stage reaches its scan
through `ExternalPlanNodeId`. The default QueryService can produce another
legacy shape: a structural `Collect` without `Operators` owns `Stats.Table`,
then ordinary `Plans` recursion reaches the physical scan.

That recursion forwarded only the previously inherited context and discarded
the current `Collect` node's local table stats. The nested `TableFullScan`
therefore had estimates but no `A-Rows` or `A-Size`, even though the response
contained matching `ReadRows` and `ReadBytes`.

Before: QueryService full statistics can return a legacy `TableFullScan` with
no `A-Rows` or `A-Size`.

After: ordinary structural recursion forwards the current node's table stats,
or the already inherited context when the current node has none. The existing
fallback then maps `ReadRows.Sum` to `A-Rows` and `ReadBytes.Sum` to `A-Size`
when the full table path matches.

CTE/precompute recursion still resets the context. A later external edge still
passes only that stage's own table stats, including null, so stats cannot leak
between physical stages. Local stats keep priority.

`A-Cpu` is intentionally unchanged. CPU attribution is a separate problem.

## Tests

Added
`KqpStats::LegacySimplifiedPlanQueryServiceTableFullScanActualStats` with
`EnableNewRBO(false)` and QueryService full statistics:

- `SELECT Key, Value1 FROM /Root/TwoShard`;
- `TableFullScan.A-Rows == 6`;
- `TableFullScan.A-Size > 0`.

The focused local test command cannot start on the current macOS checkout
because YDB's test-tool resource mapping lacks resource `12778653112`; the
build stops before any test suite runs. `git diff --check` passes. Linux PR CI
is therefore the compile/runtime gate.

No public API, JSON schema, migration, configuration, UI, or new-RBO changes.
Rollback is a revert of this single follow-up commit.
