### PR TITLE
token accessor client: fix integer overflow in backoff calculation

### DIFF
--- a/ydb/library/yql/providers/common/token_accessor/client/token_accessor_client.cpp
+++ b/ydb/library/yql/providers/common/token_accessor/client/token_accessor_client.cpp
@@ -111,8 +111,8 @@ private:
                         << "\" internal: " << status.InternalError;
                 }
                 RequestInflight = false;
-                Sleep(std::min(BackoffTimeout, BACKOFF_MAX));
-                BackoffTimeout *= 2;
+                Sleep(BackoffTimeout);
+                BackoffTimeout = std::min(BackoffTimeout + BackoffTimeout, BACKOFF_MAX);
                 UpdateTicket(sync);
             } else {
                 with_lock(Lock) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

YQ-5515
After about 60 failures it either ABORT (debug) or turn timeout to 0 (release) and flood TA service with requests.
Note: `operator+` uses saturating arithmetic (safe), but `operator*` is not (it has debug assert, but it is disabled in release code)
( There were similar bugfix in sdk: #15874 )