### PR TITLE
Drop unused http_gateway dependency from dq provider

### DIFF
--- a/ydb/library/yql/providers/dq/provider/ya.make
+++ b/ydb/library/yql/providers/dq/provider/ya.make
@@ -30,7 +30,6 @@ PEERDIR(
     ydb/library/yql/dq/opt
     ydb/library/yql/dq/transform
     ydb/library/yql/dq/type_ann
-    ydb/library/yql/providers/common/http_gateway
     ydb/library/yql/providers/dq/api/protos
     ydb/library/yql/providers/dq/common
     ydb/library/yql/providers/dq/expr_nodes

--- a/ydb/library/yql/providers/dq/provider/yql_dq_gateway.h
+++ b/ydb/library/yql/providers/dq/provider/yql_dq_gateway.h
@@ -7,7 +7,6 @@
 #include <ydb/library/yql/providers/dq/planner/execution_planner.h>
 #include <ydb/library/yql/providers/dq/common/yql_dq_settings.h>
 #include <yql/essentials/core/dq_integration/transform/yql_dq_task_transform.h>
-#include <ydb/library/yql/providers/common/http_gateway/yql_http_gateway.h>
 
 #include <yql/essentials/core/yql_udf_resolver.h>
 #include <yql/essentials/core/yql_execution.h>


### PR DESCRIPTION
## Summary
- Remove unused `#include` of `yql_http_gateway.h` from `yql_dq_gateway.h`
- Drop unused `PEERDIR` on `ydb/library/yql/providers/common/http_gateway` from dq provider `ya.make`

`IDqGateway` does not use any http gateway types; the dependency was leftover after dqrun/gateway implementation cleanup.

## Test plan
- [ ] Build `ydb/library/yql/providers/dq/provider`