### PR TITLE
NBS-7457: partition_direct standard tablet page

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_monitoring.cpp
@@ -94,10 +94,16 @@ TTabletInfo TPartitionActor::MakeMonTabletInfo() const
     };
 }
 
-void TPartitionActor::HandleHttpInfo(
-    NMon::TEvRemoteHttpInfo::TPtr& ev,
+bool TPartitionActor::OnRenderAppHtmlPage(
+    NMon::TEvRemoteHttpInfo::TPtr ev,
     const TActorContext& ctx)
 {
+    if (!ev) {
+        // Probe from the standard tablet page: report that the App page exists
+        // so its link is shown.
+        return true;
+    }
+
     const auto& cgi = ev->Get()->Cgi();
     const EMonPage page = ParsePage(cgi);
 
@@ -115,14 +121,14 @@ void TPartitionActor::HandleHttpInfo(
         ctx.Send(
             ev->Sender,
             new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
-        return;
+        return true;
     }
 
     // Local DB page: read the persisted state in a transaction;
     // CompleteMonitoring renders and replies.
     if (page == EMonPage::LocalDb) {
         ExecuteTx(ctx, CreateTx<TMonitoring>(ev->Sender));
-        return;
+        return true;
     }
 
     // VChunk page: no index - just the input form (synchronous); with an
@@ -137,7 +143,7 @@ void TPartitionActor::HandleHttpInfo(
             ctx.Send(
                 ev->Sender,
                 new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
-            return;
+            return true;
         }
 
         auto* actorSystem = TActivationContext::ActorSystem();
@@ -160,7 +166,7 @@ void TPartitionActor::HandleHttpInfo(
                         requester,
                         new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
                 });
-        return;
+        return true;
     }
 
     const std::optional<size_t> selectedDbg = ParseSelectedDbg(cgi);
@@ -198,7 +204,7 @@ void TPartitionActor::HandleHttpInfo(
         reply << "<meta http-equiv='refresh' content='0; ?TabletID="
               << TabletID() << "&page=dbg&dbg=" << *selectedDbg << "'/>";
         ctx.Send(ev->Sender, new NMon::TEvRemoteHttpInfoRes(reply));
-        return;
+        return true;
     }
 
     // DBG page: gather snapshots, then render + reply in the callback. Safe
@@ -230,6 +236,7 @@ void TPartitionActor::HandleHttpInfo(
                     requester,
                     new NMon::TEvRemoteHttpInfoRes(RenderMonPage(data)));
             });
+    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -640,8 +640,6 @@ STFUNC(TPartitionActor::StateWork)
             TEvPartitionDirectPrivate::TEvPoison,
             HandlePoisonByBlockedGeneration);
 
-        HFunc(NMon::TEvRemoteHttpInfo, HandleHttpInfo);
-
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {
                 LOG_ERROR(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.h
@@ -82,9 +82,12 @@ private:
     void StateInit(TAutoPtr<NActors::IEventHandle>& ev);
     STFUNC(StateWork);
 
-    void HandleHttpInfo(
-        NActors::NMon::TEvRemoteHttpInfo::TPtr& ev,
-        const NActors::TActorContext& ctx);
+    // The tablet's own monitoring page, reached via the standard tablet page's
+    // "App" link. The base class passes a null event to ask whether that link
+    // should appear - it always should.
+    bool OnRenderAppHtmlPage(
+        NActors::NMon::TEvRemoteHttpInfo::TPtr ev,
+        const NActors::TActorContext& ctx) override;
 
     void OnDetach(const NActors::TActorContext& ctx) override;
     void OnTabletDead(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_ut.cpp
@@ -1439,6 +1439,46 @@ Y_UNIT_TEST_SUITE(TPartitionDirectTest)
         UNIT_ASSERT_STRING_CONTAINS(html, "Overview");
     }
 
+    Y_UNIT_TEST(StandardTabletPageRenders)
+    {
+        TEnvironmentSetup env{{
+            .NodeCount = 8,
+            .Erasure = TBlobStorageGroupType::Erasure4Plus2Block,
+        }};
+        auto& runtime = env.Runtime;
+
+        auto scopedService = SetupStorage(env, EWriteMode::DirectWrite);
+        const ui64 tabletId = CreatePartitionTablet(env);
+
+        const TActorId edge = runtime->AllocateEdgeActor(
+            env.Settings.ControllerNodeId,
+            __FILE__,
+            __LINE__);
+
+        // Empty path (not "/app") renders the standard flat-tablet page.
+        runtime->SendToPipe(
+            tabletId,
+            edge,
+            new NActors::NMon::TEvRemoteHttpInfo(
+                "?TabletID=" + ToString(tabletId)),
+            0,
+            TTestActorSystem::GetPipeConfigWithRetries());
+
+        auto response =
+            env.WaitForEdgeActorEvent<NActors::NMon::TEvRemoteHttpInfoRes>(
+                edge);
+        UNIT_ASSERT(response);
+
+        const TString& html = response->Get()->Html;
+        // The standard tablet page: the info block, the Restart action, and the
+        // "App" link to this tablet's own monitoring page.
+        UNIT_ASSERT_STRING_CONTAINS(html, "Tablet generation");
+        UNIT_ASSERT_STRING_CONTAINS(
+            html,
+            "RestartTabletID=" + ToString(tabletId));
+        UNIT_ASSERT_STRING_CONTAINS(html, "tablets/app?");
+    }
+
     Y_UNIT_TEST(ShouldSuicideOnPoisonByBlockedGeneration)
     {
         TEnvironmentSetup env{{


### PR DESCRIPTION
The partition_direct tablet intercepted `NMon::TEvRemoteHttpInfo` in `StateWork` and rendered its custom monitoring page at the tablet root, which hid the standard flat-tablet page and its actions.

This moves the custom page to an `OnRenderAppHtmlPage` override (the idiomatic pattern used by SchemeShard/DataShard), so:

- the tablet root (`/tablets?TabletID=<id>`) now shows the standard tablet page with NodeID/uptime/type/generation and the **Restart / Counters / Executor DB internals / Connect to follower / State Storage** actions;
- the Overview / DBGs / Local DB page moves behind the standard **App** link.

`mon_render` is unchanged: the monitoring proxy preserves the request path and the page's links are query-only, so they (and the add-host POST form) keep working under `/app`.

Tests: `StandardTabletPageRenders` (root renders the standard page with the Restart and App links); the existing `MonitoringPageRenders` already exercises the `/app` custom page.