### PR TITLE
Speed up and fix ydb CLI tests

### DIFF
--- a/ydb/apps/ydb/README.md
+++ b/ydb/apps/ydb/README.md
@@ -21,7 +21,11 @@ You can use --help option on root or any subcommand for more info.
 
 ### Tests
 
-Run with `./ya make -tA <dir>` (Linux only):
+Run testsuit with `./ya make -tA <dir>` (Linux only):
 
 - Unit and binary tests (C++): `ut/` dirs next to the code, plus `ydb/apps/ydb/ut/` (drives the built `ydb` binary against a YDB recipe).
 - Functional tests (Python): `ydb/tests/functional/ydb_cli/` (start a real cluster and run the `ydb` binary against it).
+
+
+Run a specific test with `./ya make -tA <dir> -F <test_name>`
+- Use actual test name for <test_name> like YdbWorkloadTopic::ReadWrite_Statistics, or use * as a mask like YdbWorkloadTopic::*

--- a/ydb/apps/ydb/ut/workload-topic.cpp
+++ b/ydb/apps/ydb/ut/workload-topic.cpp
@@ -97,7 +97,10 @@ Y_UNIT_TEST_SUITE_F(YdbWorkloadTopic, TFixture) {
 
 Y_UNIT_TEST(Default_RunFull) {
     ExecYdb({"init"});
-    auto output = ExecYdb({"run", "full", "-s", "10"});
+    // This test only checks that the reported "Full time" is a sane value, which a
+    // short run exercises just as well as the default 60s (and the workload reader
+    // keeps running for --seconds + 3, so every second here costs a second of test).
+    auto output = ExecYdb({"run", "full", "-s", "3", "--warmup", "1"});
 
     ui64 fullTime = GetFullTimeValue(output);
     UNIT_ASSERT_GE(fullTime, 0);
@@ -192,21 +195,26 @@ Y_UNIT_TEST(Full_Statistics_UseTx)
 
 Y_UNIT_TEST(WriteInTx)
 {
-    // In the test, 6 writers write messages within 10 seconds.
-    // Then the number of recorded messages is checked. Commit transactions every second.
-    // It is expected that at least 60 messages will be written.
+    // In the test, 6 writers write messages. Then the number of recorded messages is
+    // checked. Commit transactions every second. It is expected that at least 60
+    // messages will be written.
+    //
+    // The workload writer keeps running for --seconds + 3, so the expected number of
+    // messages is roughly byte-rate/message-size * (seconds + 3). We use a shorter run
+    // with a proportionally higher rate to keep the same message volume while spending
+    // less wall-clock time.
 
     ExecYdb({"init",
             "--partitions", "3"});
 
     auto output = ExecYdb({"run", "write",
                           "--threads", "6",
-                          "--byte-rate", "102400",
+                          "--byte-rate", "204800",
                           "--message-size", "10240",
                           "--use-tx",
                           "--commit-messages", "10",
-                          "--warmup", "2",
-                          "--seconds", "10"});
+                          "--warmup", "1",
+                          "--seconds", "5"});
     ui64 commitTimeValue = GetCommitTimeValue(output);
 
     output = RunYdb({},

--- a/ydb/apps/ydb/ut/workload-transfer-topic-to-table.cpp
+++ b/ydb/apps/ydb/ut/workload-transfer-topic-to-table.cpp
@@ -25,12 +25,16 @@ class TFixture : public NUnitTest::TBaseFixture {
 
             try {
                 ExecYdb({
-                    "init", 
-                    "--topic", TopicName, 
+                    "init",
+                    "--topic", TopicName,
                     "--table", TableName,
-                    // we run with 3 partitions cause CI doesn't manage to start 
+                    // we run with 3 partitions cause CI doesn't manage to start
                     // reading default 128 partitions in 10 seconds of DEFAULT_RUN test
-                    "--topic-partitions", "3"
+                    "--topic-partitions", "3",
+                    // keep setup cheap: a single table partition and a tiny read-only
+                    // table seed are enough for these tests (the default seeds 1M rows)
+                    "--table-partitions", "1",
+                    "--initial-rows", "100"
                 });
             } catch (const yexception) {
                 // ignore errors
@@ -132,7 +136,8 @@ class TFixture : public NUnitTest::TBaseFixture {
                              const TVector<TString>& columns1,
                              const TVector<TString>& columns2)
         {
-            ExecYdb({"init"});
+            // The topic and table are already created by SetUp() and the workload
+            // in `args` runs against them, so no extra init/clean is needed here.
             auto output = ExecYdb(args, false);
 
             TVector<TString> lines;
@@ -140,8 +145,6 @@ class TFixture : public NUnitTest::TBaseFixture {
 
             UnitAssertColumnsOrder(lines[0], columns1);
             UnitAssertColumnsOrder(lines[1], columns2);
-
-            ExecYdb({"clean"});
         }
 
         TString GenerateTopicName()
@@ -169,7 +172,18 @@ Y_UNIT_TEST_SUITE_F(YdbWorkloadTransferTopicToTable, TFixture) {
 
 Y_UNIT_TEST(Default_Run)
 {
-    auto output = ExecYdb({"run", "-s", "10", "--topic", TopicName});
+    // --table must match the table created in SetUp(); otherwise the workload runs
+    // against a nonexistent default table.
+    //
+    // Without a rate limit the producer writes as fast as possible, so the reader
+    // accumulates a huge batch of rows and commits it in a single transaction at the
+    // end of the run (the default commit period equals the whole run). That commit
+    // grows super-linearly with the run duration and took minutes. Capping the byte
+    // rate and committing every second keeps the workload bounded and fast.
+    auto output = ExecYdb({"run", "-s", "10", "--warmup", "2",
+                           "--topic", TopicName, "--table", TableName,
+                           "--byte-rate", "100000",
+                           "--tx-commit-interval", "1000"});
 
     ui64 fullTime = GetFullTimeValue(output);
 
@@ -183,7 +197,8 @@ Y_UNIT_TEST(Default_Init_Clean)
     TopicName = GenerateTopicName();;
     TableName = GenerateTableName();
 
-    ExecYdb({"init", "--topic", TopicName, "--table", TableName});
+    ExecYdb({"init", "--topic", TopicName, "--table", TableName,
+             "--topic-partitions", "3", "--table-partitions", "1", "--initial-rows", "100"});
     ExecYdb({"clean", "--topic", TopicName, "--table", TableName});
 }
 
@@ -194,7 +209,7 @@ Y_UNIT_TEST(Specific_Init_Clean)
 
     RunYdbAndAssertTopicAndTableProps({"init",
            "--topic", topic, "--topic-partitions", "3", "--consumers", "5",
-           "--table", table, "--table-partitions", "8"},
+           "--table", table, "--table-partitions", "8", "--initial-rows", "100"},
            topic, 3, 5,
            table, 8);
     RunYdbAndAssertTopicAndTableProps({"clean",

--- a/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_init.cpp
+++ b/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_init.cpp
@@ -3,6 +3,7 @@
 
 #include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
 
+#include <util/generic/utility.h>
 #include <util/random/random.h>
 
 using namespace NYdb::NConsoleClient;
@@ -45,12 +46,16 @@ void TCommandWorkloadTransferTopicToTableInit::TScenario::CreateReadOnlyTable(co
 
     ExecSchemeQuery(query);
 
-    for (int i = 0; i < 10; ++i) {
-        UpsertRandomKeyBlock();
+    // Seed the read-only table in blocks of at most 100'000 rows.
+    constexpr ui64 BLOCK_SIZE = 100'000;
+    for (ui64 remaining = InitialRowCount; remaining > 0; ) {
+        const ui64 block = Min(remaining, BLOCK_SIZE);
+        UpsertRandomKeyBlock(block);
+        remaining -= block;
     }
 }
 
-void TCommandWorkloadTransferTopicToTableInit::TScenario::UpsertRandomKeyBlock()
+void TCommandWorkloadTransferTopicToTableInit::TScenario::UpsertRandomKeyBlock(ui64 rowCount)
 {
     TString query = R"(
         DECLARE $rows AS List<Struct<
@@ -64,7 +69,7 @@ void TCommandWorkloadTransferTopicToTableInit::TScenario::UpsertRandomKeyBlock()
 
     auto& rows = builder.AddParam("$rows");
     rows.BeginList();
-    for (int i = 0; i < 100'000; ++i) {
+    for (ui64 i = 0; i < rowCount; ++i) {
         rows.AddListItem()
             .BeginStruct()
             .AddMember("id").Uint64(RandomNumber<ui64>())
@@ -109,6 +114,10 @@ void TCommandWorkloadTransferTopicToTableInit::Config(TConfig& config)
     config.Opts->AddLongOption("table-partitions", "Number of partitons in table.")
         .DefaultValue(128)
         .StoreResult(&Scenario.TablePartitionCount);
+    config.Opts->AddLongOption("initial-rows", "Number of rows preloaded into the read-only table.")
+        .DefaultValue(1'000'000)
+        .Hidden()
+        .StoreResult(&Scenario.InitialRowCount);
 }
 
 void TCommandWorkloadTransferTopicToTableInit::Parse(TConfig& config)

--- a/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_init.h
+++ b/ydb/public/lib/ydb_cli/commands/transfer_workload/transfer_workload_topic_to_table_init.h
@@ -15,12 +15,18 @@ public:
 
 private:
     class TScenario : public TTopicOperationsScenario {
+    public:
+        // Number of rows preloaded into the read-only table. Configurable (hidden)
+        // primarily to keep tests fast; the default preserves the original behavior.
+        ui64 InitialRowCount = 1'000'000;
+
+    private:
         int DoRun(const TConfig& config) override;
 
         void CreateWriteOnlyTable(const TString& table, ui32 partitionCount);
         void CreateReadOnlyTable(const TString& table, ui32 partitionCount);
 
-        void UpsertRandomKeyBlock();
+        void UpsertRandomKeyBlock(ui64 rowCount);
     };
 
     TScenario Scenario;

--- a/ydb/tests/functional/ydb_cli/test_ydb_backup.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_backup.py
@@ -2096,7 +2096,7 @@ class TestReplaceSysACLOption(BaseTestBackupInFiles):
         # Backup the domain
         backup_files_dir = output_path(self.test_name, 'test_replace_sys_acl_disabled', 'backup_files_dir')
         self.ydb_cli(['tools', 'dump', '--path', '/Root', '--output', backup_files_dir])
-        assert_that(os.listdir(backup_files_dir), is_(['.sys', 'folder']))
+        assert_that(os.listdir(backup_files_dir), contains_inanyorder('.sys', 'folder'))
 
         # Remove directory
         self.driver.scheme_client.remove_directory('/Root/folder')
@@ -2177,7 +2177,7 @@ class TestReplaceSysACLOption(BaseTestBackupInFiles):
         # Backup the domain
         backup_files_dir = output_path(self.test_name, 'test_replace_sys_acl_disabled', 'backup_files_dir')
         self.ydb_cli(['tools', 'dump', '--path', '/Root', '--output', backup_files_dir])
-        assert_that(os.listdir(backup_files_dir), is_(['.sys', 'folder']))
+        assert_that(os.listdir(backup_files_dir), contains_inanyorder('.sys', 'folder'))
 
         # Remove directory
         self.driver.scheme_client.remove_directory('/Root/folder')


### PR DESCRIPTION
- Optimize tests for ydb cli in ydb/apps/ydb/ut, in particular YdbWorkloadTransferTopicToTable::*
- Optimize YdbWorkloadTopic::* test run time for tests in ydb/apps/ydb/ut
- Fix flaky tests in ydb/tests/functional/ydb_cli test_ydb_backup.py::TestReplaceSysACLOption::test_*_option

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
