### PR TITLE
Refactor run_and_debug_tests workflow inputs

### DIFF
--- a/.github/workflows/run_and_debug_tests.yml
+++ b/.github/workflows/run_and_debug_tests.yml
@@ -3,113 +3,152 @@ name: Run and debug tests
 on:
   workflow_dispatch:
     inputs:
-      test_targets:
-        description: 'Paths to tests (e.g., "ydb/tests/olap/" or "ydb/tests/olap/, ydb/tests/functional/")'
-        required: false
-        type: string
-        default: 'ydb/tests/olap/'
       build_preset:
-        description: 'Build preset types (comma-separated: "relwithdebinfo, release-asan" or single: "relwithdebinfo")'
+        description: 'Build preset'
+        required: false
+        type: choice
+        default: relwithdebinfo
+        options:
+          - relwithdebinfo
+          - release
+          - debug
+          - release-asan
+          - release-tsan
+          - release-msan
+      build_target:
+        description: 'ya make target'
         required: false
         type: string
-        default: 'relwithdebinfo, release-asan'
-      branches:
-        description: 'Branches to test (comma-separated: "main, stable-25-3" or JSON array: ["main", "stable-25-3"], empty = use branches_config_path)'
-        required: false
-        type: string
-        default: ''
-      use_branches_config:
-        description: 'If true, use branches from .github/config/stable_tests_branches.json'
-        required: false
-        type: boolean
-        default: false
+        default: 'ydb/apps/ydbd'
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      branches_json: ${{ steps.format-branches.outputs.branches_json }}
-      build_preset_array: ${{ steps.format-build-preset.outputs.build_preset_array }}
+  clean_build_benchmark:
+    name: Clean build (${{ inputs.build_preset }})
+    runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', inputs.build_preset) }}" ]
+    timeout-minutes: 600
     steps:
-      - name: Format branches
-        id: format-branches
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Clean local caches
+        shell: bash
         run: |
-          if [ -z "${{ inputs.branches }}" ]; then
-            # Empty - will use branches_config_path or default
-            echo "branches_json=" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.branches }}" == \[* ]]; then
-            # Already JSON array
-            echo "branches_json=${{ inputs.branches }}" >> $GITHUB_OUTPUT
-          else
-            # Comma-separated format: "main, stable-25-3" -> ["main", "stable-25-3"]
-            IFS=',' read -ra BRANCHES <<< "${{ inputs.branches }}"
-            JSON_BRANCHES="["
-            FIRST=true
-            for branch in "${BRANCHES[@]}"; do
-              branch=$(echo "$branch" | xargs)  # trim whitespace
-              if [ -n "$branch" ]; then
-                if [ "$FIRST" = true ]; then
-                  FIRST=false
-                else
-                  JSON_BRANCHES+=", "
-                fi
-                JSON_BRANCHES+="\"$branch\""
-              fi
-            done
-            JSON_BRANCHES+="]"
-            echo "branches_json=$JSON_BRANCHES" >> $GITHUB_OUTPUT
-            echo "Converted '${{ inputs.branches }}' to $JSON_BRANCHES"
+          set -x
+          rm -rf ~/.ya
+          rm -rf .ya
+          if command -v ccache >/dev/null 2>&1; then
+            ccache -C || true
+            ccache -z || true
           fi
 
-      - name: Format build presets
-        id: format-build-preset
+      - name: Run clean build (no caches)
+        id: build
+        shell: bash
         run: |
-          BUILD_PRESET_INPUT="${{ inputs.build_preset }}"
-          if [ -z "$BUILD_PRESET_INPUT" ]; then
-            BUILD_PRESET_INPUT="relwithdebinfo"
-          fi
-          
-          # Check if already JSON array
-          if [[ "$BUILD_PRESET_INPUT" == \[* ]]; then
-            echo "build_preset_array=$BUILD_PRESET_INPUT" >> $GITHUB_OUTPUT
-          else
-            # Comma-separated format: "relwithdebinfo, release-asan" -> ["relwithdebinfo", "release-asan"]
-            IFS=',' read -ra PRESETS <<< "$BUILD_PRESET_INPUT"
-            JSON_PRESETS="["
-            FIRST=true
-            for preset in "${PRESETS[@]}"; do
-              preset=$(echo "$preset" | xargs)  # trim whitespace
-              if [ -n "$preset" ]; then
-                if [ "$FIRST" = true ]; then
-                  FIRST=false
-                else
-                  JSON_PRESETS+=", "
-                fi
-                JSON_PRESETS+="\"$preset\""
-              fi
-            done
-            JSON_PRESETS+="]"
-            echo "build_preset_array=$JSON_PRESETS" >> $GITHUB_OUTPUT
-            echo "Converted '$BUILD_PRESET_INPUT' to $JSON_PRESETS"
-          fi
+          set -o pipefail
+          BUILD_PRESET="${{ inputs.build_preset }}"
+          BUILD_TARGET="${{ inputs.build_target }}"
 
-  main:
-    name: Run and debug tests
-    needs: prepare
-    uses: ./.github/workflows/run_tests.yml
-    secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        build_preset: ${{ fromJson(needs.prepare.outputs.build_preset_array) }}
-    with:
-      test_targets: ${{ inputs.test_targets }}
-      test_size: small,medium
-      build_preset: ${{ matrix.build_preset }}
-      branches: ${{ needs.prepare.outputs.branches_json || '' }}
-      branches_config_path: ${{ inputs.use_branches_config && '.github/config/stable_tests_branches.json' || '' }}
+          params=(
+            --stat
+            -DCONSISTENT_DEBUG
+            --no-dir-outputs
+            --build-all
+            --force-build-depends
+            -DDEBUGINFO_LINES_ONLY
+          )
 
-  collect_combined_summary:
-    needs: main
-    if: always()
-    uses: ./.github/workflows/collect_combined_summary.yml
+          case "$BUILD_PRESET" in
+            debug)
+              params+=(--build debug)
+              ;;
+            release)
+              params+=(--build release)
+              ;;
+            relwithdebinfo)
+              params+=(--build relwithdebinfo)
+              ;;
+            release-asan)
+              params+=(--build release --sanitize=address)
+              ;;
+            release-tsan)
+              params+=(--build release --sanitize=thread)
+              ;;
+            release-msan)
+              params+=(--build release --sanitize=memory)
+              ;;
+            *)
+              echo "Unknown build preset: $BUILD_PRESET"
+              exit 1
+              ;;
+          esac
+
+          echo "Build command: ./ya make ${params[*]} $BUILD_TARGET"
+          START_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          START_SEC=$(date +%s)
+
+          /usr/bin/time -f 'REAL_SECONDS=%e' -o time_result.txt \
+            ./ya make "${params[@]}" "$BUILD_TARGET" 2>&1 | tee ya_make_clean_build.log
+          RC=${PIPESTATUS[0]}
+
+          END_SEC=$(date +%s)
+          END_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          DURATION=$((END_SEC - START_SEC))
+          REAL_SECONDS=$(grep '^REAL_SECONDS=' time_result.txt | cut -d= -f2 || echo "n/a")
+
+          {
+            echo "duration_sec=$DURATION"
+            echo "real_seconds=$REAL_SECONDS"
+            echo "start_ts=$START_TS"
+            echo "end_ts=$END_TS"
+            echo "build_rc=$RC"
+          } >> "$GITHUB_OUTPUT"
+
+          tail -40 ya_make_clean_build.log > ya_stat_tail.txt || true
+          exit "$RC"
+
+      - name: Write summary
+        if: always()
+        shell: bash
+        run: |
+          DURATION_SEC="${{ steps.build.outputs.duration_sec }}"
+          DURATION_SEC="${DURATION_SEC:-0}"
+          DURATION_HUMAN=$(python3 -c "sec=int('${DURATION_SEC}'); h, rem = divmod(sec, 3600); m, s = divmod(rem, 60); print(f'{h}h {m}m {s}s' if h else f'{m}m {s}s')")
+          {
+            echo "## Clean build benchmark (cache-free)"
+            echo ""
+            echo "| Parameter | Value |"
+            echo "|---|---|"
+            echo "| Branch | \`${{ github.ref_name }}\` |"
+            echo "| Commit | [\`${{ github.sha }}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) |"
+            echo "| Runner | \`${{ runner.name }}\` |"
+            echo "| Build preset | \`${{ inputs.build_preset }}\` |"
+            echo "| Build target | \`${{ inputs.build_target }}\` |"
+            echo "| Started (UTC) | ${{ steps.build.outputs.start_ts }} |"
+            echo "| Finished (UTC) | ${{ steps.build.outputs.end_ts }} |"
+            echo "| Wall time | **${{ steps.build.outputs.duration_sec }} sec** ($DURATION_HUMAN) |"
+            echo "| \`/usr/bin/time\` real | **${{ steps.build.outputs.real_seconds }} sec** |"
+            echo "| Exit code | ${{ steps.build.outputs.build_rc }} |"
+            echo ""
+            echo "### Cache policy"
+            echo "- Removed \`~/.ya\` and repo \`.ya\` before build"
+            echo "- Cleared ccache if present"
+            echo "- No bazel-remote / dist cache"
+            echo "- No \`--cache-tests\`"
+            echo ""
+            echo "### ya make stat (tail)"
+            echo '```text'
+            cat ya_stat_tail.txt 2>/dev/null || echo "(no output)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clean-build-benchmark-logs
+          path: |
+            ya_make_clean_build.log
+            ya_stat_tail.txt
+            time_result.txt
+          retention-days: 7

--- a/.github/workflows/run_and_debug_tests.yml
+++ b/.github/workflows/run_and_debug_tests.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: 'ydb/apps/ydbd'
+      build_threads:
+        description: 'ya make -j/--threads (empty = nproc)'
+        required: false
+        type: string
+        default: ''
       link_threads:
         description: 'ya make --link-threads value'
         required: false
@@ -28,7 +33,7 @@ on:
 
 jobs:
   clean_build_benchmark:
-    name: Clean build (${{ inputs.build_preset }}, link-threads=${{ inputs.link_threads }})
+    name: Clean build (${{ inputs.build_preset }}, -j=${{ inputs.build_threads || 'nproc' }}, link=${{ inputs.link_threads }})
     runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', inputs.build_preset) }}" ]
     timeout-minutes: 600
     steps:
@@ -46,6 +51,39 @@ jobs:
             ccache -z || true
           fi
 
+      - name: Capture host info
+        id: host
+        shell: bash
+        run: |
+          set -x
+          NPROC="$(nproc)"
+          LOADAVG="$(cut -d' ' -f1-3 /proc/loadavg)"
+          MEM_TOTAL_KB="$(awk '/MemTotal/ {print $2}' /proc/meminfo)"
+          MEM_AVAIL_KB="$(awk '/MemAvailable/ {print $2}' /proc/meminfo)"
+          MEM_TOTAL_GB="$(python3 -c "print(round(int('${MEM_TOTAL_KB}')/1024/1024, 1))")"
+          MEM_AVAIL_GB="$(python3 -c "print(round(int('${MEM_AVAIL_KB}')/1024/1024, 1))")"
+          CPU_MODEL="$(awk -F: '/model name/ {gsub(/^[ \t]+/, "", $2); print $2; exit}' /proc/cpuinfo)"
+
+          {
+            echo "nproc=$NPROC"
+            echo "loadavg_before=$LOADAVG"
+            echo "mem_total_gb=$MEM_TOTAL_GB"
+            echo "mem_avail_gb=$MEM_AVAIL_GB"
+            echo "cpu_model=$CPU_MODEL"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "nproc=$NPROC"
+            echo "loadavg_before=$LOADAVG"
+            echo "mem_total_gb=$MEM_TOTAL_GB"
+            echo "mem_avail_gb=$MEM_AVAIL_GB"
+            echo "cpu_model=$CPU_MODEL"
+            echo "uname=$(uname -a)"
+            lscpu || true
+          } > host_info.txt
+
+          echo "Host: nproc=$NPROC loadavg=$LOADAVG mem=${MEM_AVAIL_GB}/${MEM_TOTAL_GB} GiB cpu='$CPU_MODEL'"
+
       - name: Run clean build (no caches)
         id: build
         shell: bash
@@ -54,9 +92,16 @@ jobs:
           BUILD_PRESET="${{ inputs.build_preset }}"
           BUILD_TARGET="${{ inputs.build_target }}"
           LINK_THREADS="${{ inputs.link_threads }}"
+          BUILD_THREADS_INPUT="${{ inputs.build_threads }}"
+          if [ -n "$BUILD_THREADS_INPUT" ]; then
+            BUILD_THREADS="$BUILD_THREADS_INPUT"
+          else
+            BUILD_THREADS="${{ steps.host.outputs.nproc }}"
+          fi
 
           params=(
             --stat
+            --threads "$BUILD_THREADS"
             --link-threads "$LINK_THREADS"
             --no-bazel-remote-store
             -DCONSISTENT_DEBUG
@@ -103,6 +148,42 @@ jobs:
           END_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           DURATION=$((END_SEC - START_SEC))
           REAL_SECONDS=$(grep '^REAL_SECONDS=' time_result.txt | cut -d= -f2 || echo "n/a")
+          LOADAVG_AFTER="$(cut -d' ' -f1-3 /proc/loadavg)"
+
+          BINARY_PATH=""
+          BINARY_BASENAME="$(basename "$BUILD_TARGET")"
+          for candidate in \
+            "${BUILD_TARGET}/${BINARY_BASENAME}" \
+            "${BUILD_TARGET}" \
+            "$(find "${BUILD_TARGET}" -maxdepth 1 -type f -executable -name "${BINARY_BASENAME}" 2>/dev/null | head -1)"; do
+            if [ -n "$candidate" ] && [ -f "$candidate" ] && [ -x "$candidate" ]; then
+              BINARY_PATH="$candidate"
+              break
+            fi
+          done
+          if [ -z "$BINARY_PATH" ]; then
+            BINARY_PATH="$(find . -path "*/${BUILD_TARGET}/${BINARY_BASENAME}" -type f -executable 2>/dev/null | head -1 || true)"
+          fi
+
+          BINARY_SIZE_BYTES="n/a"
+          BINARY_SIZE_HUMAN="n/a"
+          BINARY_SIZE_MIB="n/a"
+          if [ -n "$BINARY_PATH" ] && [ -f "$BINARY_PATH" ]; then
+            BINARY_SIZE_BYTES="$(stat -c%s "$BINARY_PATH")"
+            BINARY_SIZE_HUMAN="$(ls -lh "$BINARY_PATH" | awk '{print $5}')"
+            BINARY_SIZE_MIB="$(python3 -c "print(round(int('${BINARY_SIZE_BYTES}')/1024/1024, 2))")"
+            ls -lh "$BINARY_PATH" > binary_info.txt
+            {
+              echo "path=$BINARY_PATH"
+              echo "size_bytes=$BINARY_SIZE_BYTES"
+              echo "size_human=$BINARY_SIZE_HUMAN"
+              echo "size_mib=$BINARY_SIZE_MIB"
+              file "$BINARY_PATH" || true
+            } >> binary_info.txt
+          else
+            echo "binary not found for target=${BUILD_TARGET}" > binary_info.txt
+            BINARY_PATH="not found"
+          fi
 
           {
             echo "duration_sec=$DURATION"
@@ -110,7 +191,24 @@ jobs:
             echo "start_ts=$START_TS"
             echo "end_ts=$END_TS"
             echo "build_rc=$RC"
+            echo "build_threads=$BUILD_THREADS"
+            echo "loadavg_after=$LOADAVG_AFTER"
+            echo "binary_path=$BINARY_PATH"
+            echo "binary_size_bytes=$BINARY_SIZE_BYTES"
+            echo "binary_size_human=$BINARY_SIZE_HUMAN"
+            echo "binary_size_mib=$BINARY_SIZE_MIB"
           } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "build_threads=$BUILD_THREADS"
+            echo "loadavg_after=$LOADAVG_AFTER"
+            echo "duration_sec=$DURATION"
+            echo "real_seconds=$REAL_SECONDS"
+            echo "binary_path=$BINARY_PATH"
+            echo "binary_size_bytes=$BINARY_SIZE_BYTES"
+            echo "binary_size_human=$BINARY_SIZE_HUMAN"
+            echo "binary_size_mib=$BINARY_SIZE_MIB"
+          } >> host_info.txt
 
           tail -40 ya_make_clean_build.log > ya_stat_tail.txt || true
           exit "$RC"
@@ -130,9 +228,17 @@ jobs:
             echo "| Branch | \`${{ github.ref_name }}\` |"
             echo "| Commit | [\`${{ github.sha }}\`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) |"
             echo "| Runner | \`${{ runner.name }}\` |"
+            echo "| CPU model | ${{ steps.host.outputs.cpu_model }} |"
+            echo "| \`nproc\` | **${{ steps.host.outputs.nproc }}** |"
+            echo "| Memory | ${{ steps.host.outputs.mem_avail_gb }} / ${{ steps.host.outputs.mem_total_gb }} GiB available/total |"
+            echo "| loadavg before | \`${{ steps.host.outputs.loadavg_before }}\` |"
+            echo "| loadavg after | \`${{ steps.build.outputs.loadavg_after }}\` |"
             echo "| Build preset | \`${{ inputs.build_preset }}\` |"
             echo "| Build target | \`${{ inputs.build_target }}\` |"
+            echo "| Build threads (\`-j\`) | **${{ steps.build.outputs.build_threads }}** |"
             echo "| Link threads | \`${{ inputs.link_threads }}\` |"
+            echo "| Binary | \`${{ steps.build.outputs.binary_path }}\` |"
+            echo "| Binary size | **${{ steps.build.outputs.binary_size_human }}** (${{ steps.build.outputs.binary_size_mib }} MiB / ${{ steps.build.outputs.binary_size_bytes }} bytes) |"
             echo "| Started (UTC) | ${{ steps.build.outputs.start_ts }} |"
             echo "| Finished (UTC) | ${{ steps.build.outputs.end_ts }} |"
             echo "| Wall time | **${{ steps.build.outputs.duration_sec }} sec** ($DURATION_HUMAN) |"
@@ -143,6 +249,7 @@ jobs:
             echo "- Removed \`~/.ya\` and repo \`.ya\` before build"
             echo "- Cleared ccache if present"
             echo "- Passed \`--no-bazel-remote-store\` (overrides \`build/internal/ya.conf\`)"
+            echo "- Kept \`-DDEBUGINFO_LINES_ONLY\`"
             echo "- No \`--cache-tests\`"
             echo ""
             echo "### ya make stat (tail)"
@@ -155,9 +262,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: clean-build-benchmark-logs
+          name: clean-build-benchmark-logs-j${{ steps.build.outputs.build_threads || 'unknown' }}
           path: |
             ya_make_clean_build.log
             ya_stat_tail.txt
             time_result.txt
+            host_info.txt
+            binary_info.txt
           retention-days: 7

--- a/.github/workflows/run_and_debug_tests.yml
+++ b/.github/workflows/run_and_debug_tests.yml
@@ -20,10 +20,15 @@ on:
         required: false
         type: string
         default: 'ydb/apps/ydbd'
+      link_threads:
+        description: 'ya make --link-threads value'
+        required: false
+        type: string
+        default: '12'
 
 jobs:
   clean_build_benchmark:
-    name: Clean build (${{ inputs.build_preset }})
+    name: Clean build (${{ inputs.build_preset }}, link-threads=${{ inputs.link_threads }})
     runs-on: [ self-hosted, auto-provisioned, "${{ format('build-preset-{0}', inputs.build_preset) }}" ]
     timeout-minutes: 600
     steps:
@@ -48,10 +53,11 @@ jobs:
           set -o pipefail
           BUILD_PRESET="${{ inputs.build_preset }}"
           BUILD_TARGET="${{ inputs.build_target }}"
+          LINK_THREADS="${{ inputs.link_threads }}"
 
           params=(
             --stat
-            --link-threads 12
+            --link-threads "$LINK_THREADS"
             --no-bazel-remote-store
             -DCONSISTENT_DEBUG
             --no-dir-outputs
@@ -126,6 +132,7 @@ jobs:
             echo "| Runner | \`${{ runner.name }}\` |"
             echo "| Build preset | \`${{ inputs.build_preset }}\` |"
             echo "| Build target | \`${{ inputs.build_target }}\` |"
+            echo "| Link threads | \`${{ inputs.link_threads }}\` |"
             echo "| Started (UTC) | ${{ steps.build.outputs.start_ts }} |"
             echo "| Finished (UTC) | ${{ steps.build.outputs.end_ts }} |"
             echo "| Wall time | **${{ steps.build.outputs.duration_sec }} sec** ($DURATION_HUMAN) |"

--- a/.github/workflows/run_and_debug_tests.yml
+++ b/.github/workflows/run_and_debug_tests.yml
@@ -51,6 +51,7 @@ jobs:
 
           params=(
             --stat
+            --link-threads 12
             -DCONSISTENT_DEBUG
             --no-dir-outputs
             --build-all

--- a/.github/workflows/run_and_debug_tests.yml
+++ b/.github/workflows/run_and_debug_tests.yml
@@ -52,6 +52,7 @@ jobs:
           params=(
             --stat
             --link-threads 12
+            --no-bazel-remote-store
             -DCONSISTENT_DEBUG
             --no-dir-outputs
             --build-all
@@ -134,7 +135,7 @@ jobs:
             echo "### Cache policy"
             echo "- Removed \`~/.ya\` and repo \`.ya\` before build"
             echo "- Cleared ccache if present"
-            echo "- No bazel-remote / dist cache"
+            echo "- Passed \`--no-bazel-remote-store\` (overrides \`build/internal/ya.conf\`)"
             echo "- No \`--cache-tests\`"
             echo ""
             echo "### ya make stat (tail)"

--- a/.github/workflows/run_and_debug_tests.yml
+++ b/.github/workflows/run_and_debug_tests.yml
@@ -150,38 +150,43 @@ jobs:
           REAL_SECONDS=$(grep '^REAL_SECONDS=' time_result.txt | cut -d= -f2 || echo "n/a")
           LOADAVG_AFTER="$(cut -d' ' -f1-3 /proc/loadavg)"
 
-          BINARY_PATH=""
+          BINARY_LINK=""
           BINARY_BASENAME="$(basename "$BUILD_TARGET")"
           for candidate in \
             "${BUILD_TARGET}/${BINARY_BASENAME}" \
-            "${BUILD_TARGET}" \
-            "$(find "${BUILD_TARGET}" -maxdepth 1 -type f -executable -name "${BINARY_BASENAME}" 2>/dev/null | head -1)"; do
-            if [ -n "$candidate" ] && [ -f "$candidate" ] && [ -x "$candidate" ]; then
-              BINARY_PATH="$candidate"
+            "${BUILD_TARGET}"; do
+            # -e follows nothing; accept regular files and symlinks to binaries
+            if [ -n "$candidate" ] && { [ -f "$candidate" ] || [ -L "$candidate" ]; } && [ -x "$candidate" ]; then
+              BINARY_LINK="$candidate"
               break
             fi
           done
-          if [ -z "$BINARY_PATH" ]; then
-            BINARY_PATH="$(find . -path "*/${BUILD_TARGET}/${BINARY_BASENAME}" -type f -executable 2>/dev/null | head -1 || true)"
+          if [ -z "$BINARY_LINK" ]; then
+            BINARY_LINK="$(find "${BUILD_TARGET}" -maxdepth 1 \( -type f -o -type l \) -executable -name "${BINARY_BASENAME}" 2>/dev/null | head -1 || true)"
           fi
 
+          BINARY_PATH="n/a"
           BINARY_SIZE_BYTES="n/a"
           BINARY_SIZE_HUMAN="n/a"
           BINARY_SIZE_MIB="n/a"
-          if [ -n "$BINARY_PATH" ] && [ -f "$BINARY_PATH" ]; then
-            BINARY_SIZE_BYTES="$(stat -c%s "$BINARY_PATH")"
-            BINARY_SIZE_HUMAN="$(ls -lh "$BINARY_PATH" | awk '{print $5}')"
+          if [ -n "$BINARY_LINK" ] && [ -e "$BINARY_LINK" ]; then
+            # ya make installs a symlink into the source tree; size the real binary.
+            BINARY_PATH="$(readlink -f "$BINARY_LINK" 2>/dev/null || realpath "$BINARY_LINK" 2>/dev/null || echo "$BINARY_LINK")"
+            BINARY_SIZE_BYTES="$(stat -L -c%s "$BINARY_LINK")"
+            BINARY_SIZE_HUMAN="$(ls -Llh "$BINARY_LINK" | awk '{print $5}')"
             BINARY_SIZE_MIB="$(python3 -c "print(round(int('${BINARY_SIZE_BYTES}')/1024/1024, 2))")"
-            ls -lh "$BINARY_PATH" > binary_info.txt
             {
+              ls -Llh "$BINARY_LINK"
+              echo "link=$BINARY_LINK"
               echo "path=$BINARY_PATH"
               echo "size_bytes=$BINARY_SIZE_BYTES"
               echo "size_human=$BINARY_SIZE_HUMAN"
               echo "size_mib=$BINARY_SIZE_MIB"
-              file "$BINARY_PATH" || true
-            } >> binary_info.txt
+              file -L "$BINARY_LINK" || true
+            } > binary_info.txt
           else
             echo "binary not found for target=${BUILD_TARGET}" > binary_info.txt
+            BINARY_LINK="not found"
             BINARY_PATH="not found"
           fi
 
@@ -193,6 +198,7 @@ jobs:
             echo "build_rc=$RC"
             echo "build_threads=$BUILD_THREADS"
             echo "loadavg_after=$LOADAVG_AFTER"
+            echo "binary_link=$BINARY_LINK"
             echo "binary_path=$BINARY_PATH"
             echo "binary_size_bytes=$BINARY_SIZE_BYTES"
             echo "binary_size_human=$BINARY_SIZE_HUMAN"
@@ -204,6 +210,7 @@ jobs:
             echo "loadavg_after=$LOADAVG_AFTER"
             echo "duration_sec=$DURATION"
             echo "real_seconds=$REAL_SECONDS"
+            echo "binary_link=$BINARY_LINK"
             echo "binary_path=$BINARY_PATH"
             echo "binary_size_bytes=$BINARY_SIZE_BYTES"
             echo "binary_size_human=$BINARY_SIZE_HUMAN"
@@ -237,7 +244,8 @@ jobs:
             echo "| Build target | \`${{ inputs.build_target }}\` |"
             echo "| Build threads (\`-j\`) | **${{ steps.build.outputs.build_threads }}** |"
             echo "| Link threads | \`${{ inputs.link_threads }}\` |"
-            echo "| Binary | \`${{ steps.build.outputs.binary_path }}\` |"
+            echo "| Binary link | \`${{ steps.build.outputs.binary_link }}\` |"
+            echo "| Binary path | \`${{ steps.build.outputs.binary_path }}\` |"
             echo "| Binary size | **${{ steps.build.outputs.binary_size_human }}** (${{ steps.build.outputs.binary_size_mib }} MiB / ${{ steps.build.outputs.binary_size_bytes }} bytes) |"
             echo "| Started (UTC) | ${{ steps.build.outputs.start_ts }} |"
             echo "| Finished (UTC) | ${{ steps.build.outputs.end_ts }} |"


### PR DESCRIPTION
Removed unused inputs and streamlined the workflow for clean builds. Added `link_threads` input for clean-build wall-time comparisons.

### Clean build benchmark (`relwithdebinfo`, target `ydb/apps/ydbd`)

| Run | `--link-threads` | Dist cache | Wall time | Status | Link |
|---|---|---|---|---|---|
| baseline (with dist cache) | 12 | enabled | **69 sec** (1m 9s) | success | https://github.com/ydb-platform/ydb/actions/runs/29750941237 |
| baseline (cache-free) | 12 | `--no-bazel-remote-store` | **2848 sec** (47m 28s) | success | https://github.com/ydb-platform/ydb/actions/runs/29763742090 |
| link-threads=1 (cache-free) | 1 | `--no-bazel-remote-store` | _in progress_ | in progress | https://github.com/ydb-platform/ydb/actions/runs/29872142822 |
| link-threads=20 (cache-free) | 20 | `--no-bazel-remote-store` | _in progress_ | in progress | https://github.com/ydb-platform/ydb/actions/runs/29872144671 |

Notes:
- Wall time is `ya make` duration from the job summary (`/usr/bin/time` real).
- Cache-free runs clear `~/.ya` / `.ya` and pass `--no-bazel-remote-store`.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Clean-build benchmark results for different `--link-threads` values are in the table above. Durations for the 1- and 20-thread runs will be filled in when they finish.