### PR TITLE
Fix missing peerdirs extra peerdirs in tx/columnshard tx/schemeshard/olap

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -219,6 +219,7 @@
 #include <ydb/core/tx/columnshard/column_fetching/cache_policy.h>
 #include <ydb/core/tx/general_cache/usage/service.h>
 #include <ydb/core/tx/priorities/usage/config.h>
+#include <ydb/core/tx/priorities/service/service.h>
 #include <ydb/core/tx/priorities/usage/service.h>
 
 #include <ydb/core/tx/limiter/grouped_memory/usage/config.h>
@@ -2593,7 +2594,7 @@ void TCompPrioritiesInitializer::InitializeServices(NActors::TActorSystemSetup* 
         TIntrusivePtr<::NMonitoring::TDynamicCounters> tabletGroup = GetServiceCounters(appData->Counters, "tablets");
         TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorGroup = tabletGroup->GetSubgroup("type", "TX_COMP_PRIORITIES");
 
-        auto service = NPrioritiesQueue::TCompServiceOperator::CreateService(serviceConfig, conveyorGroup);
+        auto service = NPrioritiesQueue::CreateService<NPrioritiesQueue::TCompConveyorPolicy>(serviceConfig, conveyorGroup);
 
         setup->LocalServices.push_back(std::make_pair(
             NPrioritiesQueue::TCompServiceOperator::MakeServiceId(NodeId),

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -121,6 +121,8 @@ PEERDIR(
     ydb/core/tx/long_tx_service
     ydb/core/tx/long_tx_service/public
     ydb/core/tx/mediator
+    ydb/core/tx/priorities/service
+    ydb/core/tx/priorities/usage
     ydb/core/tx/replication/controller
     ydb/core/tx/replication/service
     ydb/core/tx/scheme_board

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -134,6 +134,7 @@
 #include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 #include <ydb/core/tx/conveyor_composite/service/service.h>
+#include <ydb/core/tx/priorities/service/service.h>
 #include <ydb/core/tx/priorities/usage/service.h>
 #include <ydb/core/tx/limiter/grouped_memory/usage/service.h>
 #include <ydb/core/tx/columnshard/data_accessor/cache_policy/policy.h>
@@ -1267,7 +1268,7 @@ namespace Tests {
             Runtime->RegisterService(NOlap::NGroupedMemoryManager::TDeduplicationMemoryLimiterOperator::MakeServiceId(Runtime->GetNodeId(nodeIdx)), aid, nodeIdx);
         }
         {
-            auto* actor = NPrioritiesQueue::TCompServiceOperator::CreateService(NPrioritiesQueue::TConfig(), appData.Counters);
+            auto* actor = NPrioritiesQueue::CreateService<NPrioritiesQueue::TCompConveyorPolicy>(NPrioritiesQueue::TConfig(), appData.Counters);
             const auto aid = Runtime->Register(actor, nodeIdx, appData.UserPoolId, TMailboxType::Revolving, 0);
             Runtime->RegisterService(NPrioritiesQueue::TCompServiceOperator::MakeServiceId(Runtime->GetNodeId(nodeIdx)), aid, nodeIdx);
         }

--- a/ydb/core/testlib/ya.make
+++ b/ydb/core/testlib/ya.make
@@ -112,6 +112,7 @@ PEERDIR(
     ydb/services/ymq
     ydb/core/tx/conveyor/service
     ydb/core/tx/priorities/service
+    ydb/core/tx/priorities/usage
     ydb/core/tx/limiter/grouped_memory/usage
     ydb/services/fq
     ydb/services/kesus

--- a/ydb/core/tx/columnshard/ya.make
+++ b/ydb/core/tx/columnshard/ya.make
@@ -75,7 +75,7 @@ PEERDIR(
     ydb/core/tx/conveyor_composite/service
     ydb/core/tx/general_cache/usage
     ydb/core/tx/long_tx_service/public
-    ydb/core/tx/priorities/service
+    ydb/core/tx/priorities/usage
     ydb/core/tx/tiering
     ydb/core/tx/time_cast
     ydb/core/tx/tracing

--- a/ydb/core/tx/priorities/service/service.h
+++ b/ydb/core/tx/priorities/service/service.h
@@ -3,6 +3,7 @@
 #include "manager.h"
 
 #include <ydb/core/tx/priorities/usage/events.h>
+#include <ydb/core/tx/priorities/usage/service.h>
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
@@ -55,5 +56,12 @@ public:
 
     void Bootstrap();
 };
+
+template <class TQueuePolicy>
+NActors::IActor* CreateService(const TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> queueSignals) {
+    using TOperator = TServiceOperatorImpl<TQueuePolicy>;
+    TOperator::Register(config);
+    return new TDistributor(config, TOperator::GetQueueName(), queueSignals);
+}
 
 }   // namespace NKikimr::NPrioritiesQueue

--- a/ydb/core/tx/priorities/usage/service.h
+++ b/ydb/core/tx/priorities/usage/service.h
@@ -2,7 +2,7 @@
 #include "config.h"
 #include <ydb/library/actors/core/actorid.h>
 #include <ydb/library/actors/core/actor.h>
-#include <ydb/core/tx/priorities/service/service.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/core/tx/priorities/usage/events.h>
 
 namespace NKikimr::NPrioritiesQueue {
@@ -12,6 +12,7 @@ class TServiceOperatorImpl {
 private:
     using TSelf = TServiceOperatorImpl<TQueuePolicy>;
     std::atomic<bool> IsEnabledFlag = false;
+public:
     static void Register(const TConfig& serviceConfig) {
         Singleton<TSelf>()->IsEnabledFlag = serviceConfig.IsEnabled();
     }
@@ -19,7 +20,6 @@ private:
         Y_ABORT_UNLESS(TQueuePolicy::Name.size() == 4);
         return TQueuePolicy::Name;
     }
-public:
     [[nodiscard]] static ui64 RegisterClient() {
         static TAtomicCounter Counter = 0;
         const ui64 id = Counter.Inc();
@@ -60,11 +60,6 @@ public:
     static NActors::TActorId MakeServiceId(const ui64 nodeId) {
         return NActors::TActorId(nodeId, "SrvcPrqe" + GetQueueName());
     }
-    static NActors::IActor* CreateService(const TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> queueSignals) {
-        Register(config);
-        return new TDistributor(config, GetQueueName(), queueSignals);
-    }
-
 };
 
 class TCompConveyorPolicy {

--- a/ydb/core/tx/schemeshard/olap/columns/ya.make
+++ b/ydb/core/tx/schemeshard/olap/columns/ya.make
@@ -7,6 +7,7 @@ SRCS(
 
 PEERDIR(
     ydb/core/protos
+    ydb/core/scheme_types
     ydb/core/formats/arrow/dictionary
     ydb/core/formats/arrow/serializer
     ydb/core/tx/schemeshard/olap/common


### PR DESCRIPTION

* Improvement
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

scheme_types используется тут
https://github.com/ydb-platform/ydb/blob/65000386e126ed074c771a8cf44abfa38e637619/ydb/core/tx/schemeshard/olap/operations/create_store.cpp#L8

в tx/columshard
используется только ydb/core/tx/priorities/usage а пирдирится весь priorites
https://github.com/search?q=repo%3Aydb-platform%2Fydb%20path%3A%2F%5Eydb%5C%2Fcore%5C%2Ftx%5C%2Fcolumnshard%5C%2F%2F%20ydb%2Fcore%2Ftx%2Fpriorities%2Fusage&type=code