### PR TITLE
spilling file leak

### DIFF
--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -536,10 +536,6 @@ private:
             Send(msg.Client, new TEvDqSpilling::TEvError(*fd.Error));
 
             fd.Ops.clear();
-            // The operation whose response we are handling has finished, so the file no longer
-            // has an active op. Reset the flag before CloseFile() so that its cleanup operation
-            // (which closes handles and unlinks the partially written files) is actually
-            // dispatched to the IO thread pool instead of being queued behind a phantom active op.
             fd.HasActiveOp = false;
             CloseFile(it, fd.Error);
             return;
@@ -689,9 +685,6 @@ private:
             Send(msg.Client, new TEvDqSpilling::TEvError(*fd.Error));
 
             fd.Ops.clear();
-            // See the corresponding comment in the write error path: reset HasActiveOp so that
-            // CloseFile() can dispatch its cleanup operation instead of enqueueing it behind a
-            // phantom active op that will never complete, leaking file handles and on-disk files.
             fd.HasActiveOp = false;
             CloseFile(it, fd.Error);
             return;

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -205,7 +205,7 @@ private:
             ui32 NodeId;
             TString SpillingSessionId;
 
-            TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString spillingSessionId) 
+            TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString spillingSessionId)
                 : TmpRoot(std::move(tmpRoot)), NodeId(nodeId), SpillingSessionId(std::move(spillingSessionId)) {}
         };
     };
@@ -243,7 +243,7 @@ public:
             Become(&TDqLocalFileSpillingService::BrokenState);
             return;
         }
-        
+
         Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(rootToRemoveOldTmp, nodeId, sessionId));
 
         Become(&TDqLocalFileSpillingService::WorkState);
@@ -483,7 +483,7 @@ private:
             LOG_E(error);
 
             Send(ev->Sender, new TEvDqSpilling::TEvError(error));
-        } 
+        }
     }
 
     void HandleWork(TEvPrivate::TEvWriteFileResponse::TPtr& ev) {
@@ -536,6 +536,11 @@ private:
             Send(msg.Client, new TEvDqSpilling::TEvError(*fd.Error));
 
             fd.Ops.clear();
+            // The operation whose response we are handling has finished, so the file no longer
+            // has an active op. Reset the flag before CloseFile() so that its cleanup operation
+            // (which closes handles and unlinks the partially written files) is actually
+            // dispatched to the IO thread pool instead of being queued behind a phantom active op.
+            fd.HasActiveOp = false;
             CloseFile(it, fd.Error);
             return;
         }
@@ -630,7 +635,7 @@ private:
             LOG_E(error);
 
             Send(ev->Sender, new TEvDqSpilling::TEvError(error));
-        } 
+        }
     }
 
     void HandleWork(TEvPrivate::TEvReadFileResponse::TPtr& ev) {
@@ -684,6 +689,10 @@ private:
             Send(msg.Client, new TEvDqSpilling::TEvError(*fd.Error));
 
             fd.Ops.clear();
+            // See the corresponding comment in the write error path: reset HasActiveOp so that
+            // CloseFile() can dispatch its cleanup operation instead of enqueueing it behind a
+            // phantom active op that will never complete, leaking file handles and on-disk files.
+            fd.HasActiveOp = false;
             CloseFile(it, fd.Error);
             return;
         }
@@ -792,7 +801,7 @@ private:
 
         LOG_I("[RemoveOldTmp] removing at root: " << root);
 
-        const auto isDirOldTmp = [&nodePrefix, &nodeIdString, &sessionId](const TString& dirName) -> bool {            
+        const auto isDirOldTmp = [&nodePrefix, &nodeIdString, &sessionId](const TString& dirName) -> bool {
             // dirName: node_<nodeId>_<sessionId>
             TVector<TString> parts;
             StringSplitter(dirName).Split('_').Limit(3).Collect(&parts);
@@ -805,13 +814,13 @@ private:
 
         try {
             TDirIterator iter(root, TDirIterator::TOptions().SetMaxLevel(1));
-            
+
             TVector<TString> oldTmps;
             for (const auto& dirEntry : iter) {
                 if (dirEntry.fts_info == FTS_DP) {
                     continue;
                 }
-                
+
                 const auto dirName = dirEntry.fts_name;
                 if (isDirOldTmp(dirName)) {
                     LOG_D("[RemoveOldTmp] found old temporary at " << (root / dirName));

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -496,6 +496,103 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
             UNIT_ASSERT_C(err.Contains("No such file or directory"), err);
             UNIT_ASSERT_C(err.Contains(expected), err);
         }
+
+        // The read error must trigger a proper cleanup: the file has to be closed and its
+        // descriptor released. If the close operation is not dispatched (e.g. because the
+        // active-op flag was left set), EvCloseFileResponse never arrives and the file stays
+        // stuck in the active list, keeping the file descriptor counter above zero.
+        {
+            std::atomic<bool> closed = false;
+            runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+                if (event->GetRecipientRewrite() == spillingSvc) {
+                    if (event->GetTypeRewrite() == 2146435074 /* EvCloseFileResponse */) {
+                        closed = true;
+                    }
+                }
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            });
+
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&]() {
+                return (bool) closed;
+            };
+            runtime.DispatchEvents(options, TDuration::Seconds(1));
+            UNIT_ASSERT_C(closed, "file was not closed after read error");
+        }
+
+        {
+            THttpRequest httpReq(HTTP_METHOD_GET);
+            NMonitoring::TMonService2HttpRequest monReq(nullptr, &httpReq, nullptr, nullptr, "", nullptr);
+
+            runtime.Send(new IEventHandle(spillingSvc, tester, new NMon::TEvHttpInfo(monReq)));
+            auto resp = runtime.GrabEdgeEvent<NMon::TEvHttpInfoRes>(tester, TDuration::Seconds(1));
+            UNIT_ASSERT(((NMon::TEvHttpInfoRes*) resp->Get())->Answer.Contains("Used file descriptors (compute): 0"));
+        }
+    }
+
+    Y_UNIT_TEST(WriteError) {
+        TTestActorRuntime runtime;
+        runtime.Initialize();
+
+        auto spillingSvc = runtime.StartSpillingService(1000, 100, 25);
+        auto tester = runtime.AllocateEdgeActor();
+        auto spillingActor = runtime.StartSpillingActor(tester);
+
+        runtime.WaitBootstrap();
+
+        auto nodePath = TFsPath("node_" + std::to_string(spillingSvc.NodeId()) + "_" + runtime.GetSpillingSessionId());
+        const TFsPath spillingDir = runtime.GetSpillingRoot() / nodePath;
+        const TFsPath firstFile = spillingDir / "1_test_0";
+        const TFsPath secondFile = spillingDir / "1_test_1";
+
+        // Write the first blob. Because MaxFilePartSize is small and RemoveBlobsAfterRead is on,
+        // this blob lands in its own file part "1_test_0".
+        {
+            auto ev = new TEvDqSpilling::TEvWrite(0, CreateRope(20, 'a'));
+            runtime.Send(new IEventHandle(spillingActor, tester, ev));
+
+            auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester);
+            UNIT_ASSERT_VALUES_EQUAL(0, resp->Get()->BlobId);
+        }
+        UNIT_ASSERT(NFs::Exists(firstFile.GetPath()));
+
+        // File part names are predictable, so occupy the name of the would-be next file part
+        // ("1_test_1") with a directory. Opening it for writing will fail and produce an IO error.
+        secondFile.MkDirs();
+
+        // Write the second blob. It requires a fresh file part ("1_test_1"), whose creation now
+        // fails with an IO error.
+        {
+            auto ev = new TEvDqSpilling::TEvWrite(1, CreateRope(20, 'b'));
+            runtime.Send(new IEventHandle(spillingActor, tester, ev));
+
+            auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvError>(tester);
+            UNIT_ASSERT_C(resp->Get()->Message.Contains("1_test_1"), resp->Get()->Message);
+        }
+
+        // The write error must trigger cleanup of the whole file, including the already-written
+        // "1_test_0" part. Wait for the close operation to complete.
+        {
+            std::atomic<bool> closed = false;
+            runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+                if (event->GetRecipientRewrite() == spillingSvc) {
+                    if (event->GetTypeRewrite() == 2146435074 /* EvCloseFileResponse */) {
+                        closed = true;
+                    }
+                }
+                return TTestActorRuntimeBase::EEventAction::PROCESS;
+            });
+
+            TDispatchOptions options;
+            options.CustomFinalCondition = [&]() {
+                return (bool) closed;
+            };
+            runtime.DispatchEvents(options, TDuration::Seconds(1));
+            UNIT_ASSERT_C(closed, "file was not closed after write error");
+        }
+
+        // The successfully written part must have been removed from disk during cleanup.
+        UNIT_ASSERT_C(!NFs::Exists(firstFile.GetPath()), "partially written file was not cleaned up");
     }
 
     Y_UNIT_TEST(ThreadPoolQueueOverflow) {


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->
* Not for changelog (changelog entry is not required)

We have to clear the IsActiveOp flag on i/o errors, otherwise the CloseFile operation will never run (since `RunOp(TCloseFileOp)` requires IsActiveOp == false)
