### PR TITLE
Update CODEOWNERS stable-26-1-1-ent

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @ydb-platform/ReleaseApprovers @ydb-platform/entbuilders
 /.github @ydb-platform/ci @ydb-platform/entbuilders
-/CHANGELOG.md @ydb-platform/changelog-reviewers
+/CHANGELOG.md @ydb-platform/changelog-reviewers @ydb-platform/entbuilders
 /ydb/docs/ @ydb-platform/docs @ydb-platform/entbuilders


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add @ydb-platform/entbuilders as an alternative code owner for /CHANGELOG.md so that an approval from entbuilders alone is sufficient to merge into this branch, matching the CODEOWNERS setup already in place on stable-25-3-1-enterprise and stable-25-4-1-enterprise.
