### PR TITLE
Change default for ForbidRequestsToStaticNodesWithoutDatabase

### DIFF
--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -306,7 +306,7 @@ message TFeatureFlags {
     optional bool EnableDqSourceStreamLookupJoinFullscan = 265 [default = false];
     optional bool EnableTopicsPredicatePushdown = 266 [default = false];
     optional bool EnableJsonIndexAutoSelect = 267 [default = false];
-    optional bool ForbidRequestsToStaticNodesWithoutDatabase = 268 [default = true];
+    optional bool ForbidRequestsToStaticNodesWithoutDatabase = 268 [default = false];
     optional bool EnableTabletDevUiSecurePath = 269 [default = false];
     optional bool EnableExtraSidsControlForHttpViewer = 270 [default = false];
     // Use TablePartitionsByShardIdx (keyed by ShardIdx) instead of TablePartitions


### PR DESCRIPTION
Disabled flag ForbidRequestsToStaticNodesWithoutDatabase to prevent release failures.
