### PR TITLE
Break ownership cycle in IScan::MultiExport

### DIFF
--- a/ydb/core/tx/columnshard/backup/iscan/ut/ut_iscan.cpp
+++ b/ydb/core/tx/columnshard/backup/iscan/ut/ut_iscan.cpp
@@ -93,9 +93,10 @@ class TGrabActor: public TActorBootstrapped<TGrabActor> {
     std::unique_ptr<NTable::IScan> Exporter;
 
 public:
-    TRuntimePtr Runtime;
+    // Non-owning pointer to the actor runtime
+    TTestActorRuntime* Runtime;
 
-    TGrabActor(TRuntimePtr runtime)
+    TGrabActor(TTestActorRuntime* runtime)
         : Runtime(runtime)
     {
     }
@@ -193,7 +194,7 @@ Y_UNIT_TEST_SUITE(IScan) {
         runtime->SetLogPriority(NKikimrServices::DATASHARD_BACKUP, NActors::NLog::PRI_DEBUG);
         SetupTabletServices(*runtime);
 
-        auto grabActor = new TGrabActor(runtime);
+        auto grabActor = new TGrabActor(runtime.get());
         runtime->Register(grabActor);
 
         while (true) {

--- a/ydb/core/tx/columnshard/backup/iscan/ut/ut_iscan.cpp
+++ b/ydb/core/tx/columnshard/backup/iscan/ut/ut_iscan.cpp
@@ -90,7 +90,9 @@ class TGrabActor: public TActorBootstrapped<TGrabActor> {
     std::deque<TAutoPtr<IEventHandle>> Inputs;
     TMutex Mutex;
     std::unique_ptr<NColumnShard::NBackup::TExportDriver> Driver;
-    std::unique_ptr<NTable::IScan> Exporter;
+
+    // non-owning pointer to the exporter actor
+    NTable::IScan* Exporter = nullptr;
 
 public:
     // Non-owning pointer to the actor runtime
@@ -108,12 +110,14 @@ public:
 
         auto exportFactory = std::make_shared<TDataShardExportFactory>();
 
-        Exporter =
+        std::unique_ptr<NTable::IScan> exporter =
             NColumnShard::NBackup::CreateIScanExportUploader(SelfId(), MakeBackupTask("test"), exportFactory.get(), columns, 0).DetachResult();
-        UNIT_ASSERT(Exporter);
+        UNIT_ASSERT(exporter);
+        Exporter = exporter.get();
         Driver = std::make_unique<NColumnShard::NBackup::TExportDriver>(TActorContext::ActorSystem(), SelfId());
         auto initialState = Exporter->Prepare(Driver.get(), MakeSchema());
         UNIT_ASSERT_VALUES_EQUAL(initialState.Scan, NTable::EScan::Feed);
+        Y_UNUSED(exporter.release());
 
         NTable::TLead lead;
         auto seekState = Exporter->Seek(lead, 0);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix unit test IScan::MultiExport by breaking ownership cycle

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)