### PR TITLE
EXT-2359 Fix tiny memory-overflow swaps fragment disk index and flood PDisk log with huge entry points

### DIFF
--- a/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/blobstorage_synclogkeeper_state.cpp
@@ -312,8 +312,9 @@ namespace NKikimr {
         }
 
         TMemRecLogSnapshotPtr TSyncLogKeeperState::BuildSwapSnap() {
+            const ui32 pagesInMemory = SyncLogPtr->GetNumberOfPagesInMemory();
             // find mem pages to write to disk
-            const bool stillMemOverflow = SyncLogPtr->GetNumberOfPagesInMemory() > MaxMemPages;
+            const bool stillMemOverflow = pagesInMemory > MaxMemPages;
             const ui64 firstLsnToKeep = CalculateFirstLsnToKeep();
             const bool wantToCutRecoveryLog = FreeUpToLsn > firstLsnToKeep;
 
@@ -322,8 +323,13 @@ namespace NKikimr {
                 // we write those records, that are not written to disk yet
                 const ui64 diskLastLsn = SyncLogPtr->GetDiskLastLsn();
                 // free pages in case of memory overflow
-                const ui32 freeNPages = stillMemOverflow ?
-                    SyncLogPtr->GetNumberOfPagesInMemory() - MaxMemPages : 0;
+                ui32 freeNPages;
+                if (stillMemOverflow) {
+                    const ui32 leavePages = Max<ui32>(1, MaxMemPages / 2);
+                    freeNPages = pagesInMemory - leavePages;
+                } else {
+                    freeNPages = 0;
+                }
 
                 // if wantToCutRecoveryLog, then FreeUpToLsn must > 0
                 Y_ABORT_UNLESS(!wantToCutRecoveryLog || (FreeUpToLsn > 0));

--- a/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
@@ -127,6 +127,36 @@ TString MakeLocalSyncDataBlockPayload(ui32 minPayloadBytes) {
     return result;
 }
 
+void DispatchFor(TTestActorRuntime& runtime, TDuration timeout) {
+    TDispatchOptions options;
+    const TDuration oldDispatchTimeout = runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
+    try {
+        runtime.DispatchEvents(options, timeout);
+    } catch (const TEmptyEventQueueException&) {
+    }
+    runtime.SetDispatchTimeout(oldDispatchTimeout);
+}
+
+template <typename TPredicate>
+bool PumpUntil(TTestActorRuntime& runtime, TPredicate&& predicate, ui32 iterations, TDuration step) {
+    bool ok = predicate();
+    for (ui32 i = 0; i < iterations && !ok; ++i) {
+        DispatchFor(runtime, step);
+        ok = predicate();
+    }
+    return ok;
+}
+
+bool WaitVDiskReady(TTestActorRuntime& runtime, const TActorId& vdiskActorId, const TVDiskID& vdiskId,
+        const TActorId& edge) {
+    return PumpUntil(runtime, [&] {
+        runtime.Send(new IEventHandle(vdiskActorId, edge,
+            new TEvBlobStorage::TEvVStatus(vdiskId), IEventHandle::FlagTrackDelivery), NodeIndex);
+        auto res = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(edge, TDuration::Seconds(1));
+        return res && res->Get()->Record.GetStatus() == NKikimrProto::OK;
+    }, 60, TDuration::MilliSeconds(100));
+}
+
 TIntrusivePtr<TBlobStorageGroupInfo> MakeGroupInfo(ui32 nodeId, ui32 groupId, TBlobStorageGroupType::EErasureSpecies erasure) {
     const TBlobStorageGroupType groupType(erasure);
     const ui32 numVDisks = groupType.BlobSubgroupSize();
@@ -175,6 +205,7 @@ struct TSyncLogFootprint {
     ui32 MemPages = 0;
     ui32 DiskChunks = 0;
     ui32 DiskPages = 0;
+    ui32 DiskIndexRecs = 0;
     ui32 AppendBlockSize = 0;
     ui32 ChunkSize = 0;
     ui64 LastLsn = 0;
@@ -184,6 +215,7 @@ struct TSyncLogFootprint {
             << "{MemPages# " << MemPages
             << " DiskChunks# " << DiskChunks
             << " DiskPages# " << DiskPages
+            << " DiskIndexRecs# " << DiskIndexRecs
             << " AppendBlockSize# " << AppendBlockSize
             << " ChunkSize# " << ChunkSize
             << " LastLsn# " << LastLsn
@@ -233,6 +265,7 @@ TSyncLogFootprint GetSyncLogFootprint(const NSyncLog::TSyncLogSnapshotPtr& snaps
             chunks.insert(chunkIdx);
             footprint.LastLsn = Max(footprint.LastLsn, lastRealLsn);
 
+            footprint.DiskIndexRecs += indexRecsNum;
             for (ui32 indexRec = 0; indexRec < indexRecsNum; ++indexRec) {
                 ui64 firstLsn = 0;
                 ui16 offsetInPages = 0;
@@ -439,30 +472,16 @@ public:
     }
 
     void DispatchFor(TDuration timeout) {
-        TDispatchOptions options;
-        const TDuration oldDispatchTimeout = Runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
-        try {
-            Runtime.DispatchEvents(options, timeout);
-        } catch (const TEmptyEventQueueException&) {
-        }
-        Runtime.SetDispatchTimeout(oldDispatchTimeout);
+        NKikimr::DispatchFor(Runtime, timeout);
     }
 
     template <typename TPredicate>
     bool PumpUntil(TPredicate predicate, ui32 iterations, TDuration step) {
-        for (ui32 i = 0; i < iterations && !predicate(); ++i) {
-            DispatchFor(step);
-        }
-        return predicate();
+        return NKikimr::PumpUntil(Runtime, std::move(predicate), iterations, step);
     }
 
     bool WaitReady() {
-        return PumpUntil([&] {
-            Runtime.Send(new IEventHandle(VDiskActorId, Edge,
-                new TEvBlobStorage::TEvVStatus(VDiskId), IEventHandle::FlagTrackDelivery), NodeIndex);
-            auto res = Runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(Edge, TDuration::Seconds(1));
-            return res && res->Get()->Record.GetStatus() == NKikimrProto::OK;
-        }, 60, TDuration::MilliSeconds(100));
+        return WaitVDiskReady(Runtime, VDiskActorId, VDiskId, Edge);
     }
 
     void SendInterruptedLocalSyncData() {
@@ -733,39 +752,11 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         TTestRuntimeCallbackGuard runtimeCallbackGuard(runtime,
             std::move(previousObserver), std::move(previousEventFilter));
 
-        auto dispatchFor = [&](TDuration timeout) {
-            TDispatchOptions options;
-            const TDuration oldDispatchTimeout = runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
-            try {
-                runtime.DispatchEvents(options, timeout);
-            } catch (const TEmptyEventQueueException&) {
-            }
-            runtime.SetDispatchTimeout(oldDispatchTimeout);
-        };
-
-        auto pumpUntil = [&](auto predicate, ui32 iterations, TDuration step) {
-            bool ok = predicate();
-            for (ui32 i = 0; i < iterations && !ok; ++i) {
-                dispatchFor(step);
-                ok = predicate();
-            }
-            return ok;
-        };
-
-        auto waitReady = [&] {
-            return pumpUntil([&] {
-                runtime.Send(new IEventHandle(vdiskActorId, edge,
-                    new TEvBlobStorage::TEvVStatus(vdiskId), IEventHandle::FlagTrackDelivery), NodeIndex);
-                auto res = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(edge, TDuration::Seconds(1));
-                return res && res->Get()->Record.GetStatus() == NKikimrProto::OK;
-            }, 60, TDuration::MilliSeconds(100));
-        };
-
         ui32 nextStep = 1;
         ui64 nextCookie = 1;
         const TString data = MakeData(1);
 
-        auto writeTargetRecords = [&](ui64 tabletId, ui32 records, const TString& phase) {
+        auto writeTargetRecords = [&](ui64 tabletId, ui32 records) {
             const ui32 batchSize = 64;
             for (ui32 firstRecord = 0; firstRecord < records; firstRecord += batchSize) {
                 const ui32 batch = Min(batchSize, records - firstRecord);
@@ -780,22 +771,21 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
                 runtime.Send(new IEventHandle(putQueue, edge, multiPut.release()), NodeIndex);
                 auto putResult = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVMultiPutResult>(edge,
                     TDuration::Seconds(120));
-                UNIT_ASSERT_C(putResult, "timed out waiting for TEvVMultiPutResult during " << phase);
+                UNIT_ASSERT_C(putResult, "no put result; firstRecord# " << firstRecord
+                    << " lastPDiskError# " << lastPDiskErrorReason);
                 UNIT_ASSERT_C(putResult->Get()->Record.GetStatus() == NKikimrProto::OK,
-                    "TEvVMultiPut failed during " << phase << " at firstRecord# " << firstRecord
-                    << " status# " << NKikimrProto::EReplyStatus_Name(putResult->Get()->Record.GetStatus())
+                    "put status# " << NKikimrProto::EReplyStatus_Name(putResult->Get()->Record.GetStatus())
+                    << " firstRecord# " << firstRecord
                     << " lastPDiskError# " << lastPDiskErrorReason);
                 UNIT_ASSERT_VALUES_EQUAL(putResult->Get()->Record.ItemsSize(), batch);
                 for (ui32 i = 0; i < batch; ++i) {
                     UNIT_ASSERT_C(putResult->Get()->Record.GetItems(i).GetStatus() == NKikimrProto::OK,
-                        "TEvVMultiPut item failed during " << phase
-                        << " firstRecord# " << firstRecord
-                        << " item# " << i
-                        << " status# "
+                        "put item# " << i << " status# "
                         << NKikimrProto::EReplyStatus_Name(putResult->Get()->Record.GetItems(i).GetStatus())
+                        << " firstRecord# " << firstRecord
                         << " lastPDiskError# " << lastPDiskErrorReason);
                 }
-                dispatchFor(TDuration::MilliSeconds(1));
+                DispatchFor(runtime, TDuration::MilliSeconds(1));
             }
         };
 
@@ -803,27 +793,24 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             runtime.Send(new IEventHandle(syncLogKeeperId, edge,
                 new NSyncLog::TEvSyncLogSnapshot()), NodeIndex);
             auto res = runtime.GrabEdgeEvent<NSyncLog::TEvSyncLogSnapshotResult>(edge, TDuration::Seconds(5));
-            UNIT_ASSERT_C(res,
-                "timed out waiting for TEvSyncLogSnapshotResult"
-                << " syncLogId# " << syncLogId
-                << " syncLogKeeperId# " << syncLogKeeperId);
+            UNIT_ASSERT(res);
             return GetSyncLogFootprint(res->Get()->SnapshotPtr);
         };
 
-        UNIT_ASSERT_C(waitReady(), "target VDisk did not become ready");
+        UNIT_ASSERT_C(WaitVDiskReady(runtime, vdiskActorId, vdiskId, edge), "target VDisk did not become ready");
 
-        writeTargetRecords(42, 16, "sync-log actor discovery");
-        UNIT_ASSERT_C(pumpUntil([&] {
+        writeTargetRecords(42, 16);
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
             return syncLogId && syncLogKeeperId && gotOwner && maxObservedDataLsn;
         }, 200, TDuration::MilliSeconds(10)),
             "failed to discover SyncLog actor, SyncLogKeeper actor, PDisk owner, or data LSN");
 
         ui32 nextCollectCounter = 1;
-        auto collectDoNotKeep = [&](ui64 tabletId, ui32 records, const TString& phase) {
+        auto collectDoNotKeep = [&](ui64 tabletId, ui32 records) {
             const ui32 batchSize = 2048;
             for (ui32 firstRecord = 0; firstRecord < records; firstRecord += batchSize) {
                 const ui32 batch = Min(batchSize, records - firstRecord);
-                UNIT_ASSERT_C(batch, "empty collect batch during " << phase);
+                UNIT_ASSERT(batch);
                 TVector<TLogoBlobID> doNotKeep;
                 doNotKeep.reserve(batch);
                 for (ui32 i = 0; i < batch; ++i) {
@@ -836,27 +823,23 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
                 runtime.Send(new IEventHandle(putQueue, edge, collect.release()), NodeIndex);
                 auto collectResult = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVCollectGarbageResult>(edge,
                     TDuration::Seconds(120));
-                UNIT_ASSERT_C(collectResult,
-                    "timed out waiting for TEvVCollectGarbageResult during " << phase);
-                UNIT_ASSERT_C(collectResult->Get()->Record.GetStatus() == NKikimrProto::OK,
-                    "TEvVCollectGarbage failed during " << phase
-                    << " firstRecord# " << firstRecord
-                    << " status# "
-                    << NKikimrProto::EReplyStatus_Name(collectResult->Get()->Record.GetStatus())
+                UNIT_ASSERT_C(collectResult, "no collect result; firstRecord# " << firstRecord
                     << " lastPDiskError# " << lastPDiskErrorReason);
-                dispatchFor(TDuration::MilliSeconds(1));
+                UNIT_ASSERT_C(collectResult->Get()->Record.GetStatus() == NKikimrProto::OK,
+                    "collect status# " << NKikimrProto::EReplyStatus_Name(collectResult->Get()->Record.GetStatus())
+                    << " firstRecord# " << firstRecord
+                    << " lastPDiskError# " << lastPDiskErrorReason);
+                DispatchFor(runtime, TDuration::MilliSeconds(1));
             }
         };
 
-        auto waitForSyncLogCommit = [&](ui32 previousDataCommits, const TString& phase) {
-            UNIT_ASSERT_C(pumpUntil([&] {
+        auto waitForSyncLogCommit = [&](ui32 previousDataCommits) {
+            UNIT_ASSERT_C(PumpUntil(runtime, [&] {
                 return syncLogDataCommits > previousDataCommits &&
                     syncLogCommitDoneEvents >= syncLogDataCommits;
             }, 1000, TDuration::MilliSeconds(10)),
-                "SyncLog commit did not settle during " << phase
-                << " previousDataCommits# " << previousDataCommits
+                "SyncLog commit did not settle; previousDataCommits# " << previousDataCommits
                 << " dataCommits# " << syncLogDataCommits
-                << " deleteCommits# " << syncLogDeleteCommits
                 << " commitDone# " << syncLogCommitDoneEvents
                 << " lastPDiskError# " << lastPDiskErrorReason);
         };
@@ -864,15 +847,15 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         auto requestSyncLogCut = [&] {
             runtime.Send(new IEventHandle(syncLogId, edge,
                 new NPDisk::TEvCutLog(owner, ownerRound, maxObservedDataLsn + 1, 0, 0, 0, 0)), NodeIndex);
-            dispatchFor(TDuration::MilliSeconds(1));
+            DispatchFor(runtime, TDuration::MilliSeconds(1));
         };
 
         for (ui32 pressureIterations = 0; syncLogDeleteCommits < 1 && pressureIterations < 96;
                 ++pressureIterations) {
             const ui32 previousDataCommits = syncLogDataCommits;
-            collectDoNotKeep(43, 2048, "sync-log pressure");
+            collectDoNotKeep(43, 2048);
             requestSyncLogCut();
-            waitForSyncLogCommit(previousDataCommits, "sync-log pressure");
+            waitForSyncLogCommit(previousDataCommits);
         }
 
         UNIT_ASSERT_C(syncLogDeleteCommits,
@@ -910,13 +893,13 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             footprintWithinLimits = memWithinLimits && diskWithinLimits;
             if (!footprintWithinLimits) {
                 if (diskWithinLimits && !memWithinLimits) {
-                    collectDoNotKeep(44, 1, "sync-log memory settling");
-                    dispatchFor(TDuration::MilliSeconds(10));
+                    collectDoNotKeep(44, 1);
+                    DispatchFor(runtime, TDuration::MilliSeconds(10));
                 } else {
                     const ui32 previousDataCommits = syncLogDataCommits;
-                    collectDoNotKeep(44, 512, "sync-log limit settling");
+                    collectDoNotKeep(44, 512);
                     requestSyncLogCut();
-                    waitForSyncLogCommit(previousDataCommits, "sync-log limit settling");
+                    waitForSyncLogCommit(previousDataCommits);
                 }
             }
         }
@@ -935,6 +918,242 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             << " deleteCommits# " << syncLogDeleteCommits
             << " commitDone# " << syncLogCommitDoneEvents
             << " lastPDiskError# " << lastPDiskErrorReason);
+    }
+
+    Y_UNIT_TEST(SyncLogMemOverflowSwapsDoNotFragmentDiskIndex) {
+        /*
+         * Reproduces a production incident: a group loses one VDisk (node is down), so SyncLog gets
+         * no sync confirmations and is never trimmed; with a small SyncLogMaxMemAmount and a large
+         * SyncLogMaxDiskAmount the keeper hits memory overflow on nearly every put batch and swaps
+         * only the overflow excess -- typically a single page -- to the disk sync log. Every such
+         * tiny append adds a separate TDiskIndexRecord (TOneChunkIndex never merges neighboring
+         * appends; IndexBulk only splits large ones), and the whole index is re-serialized into the
+         * SyncLog entry point and written into the PDisk common log on every commit. In production
+         * this produced entry points of several megabytes (IndexRecsNum ~ number of disk pages)
+         * rewritten several times per second per VDisk, which exhausted PDisk log chunks.
+         *
+         * The test drives many small writes through a real VDisk while no group neighbor ever
+         * confirms sync (RunSyncer is false for every group member, which models the dead node),
+         * lets memory-overflow-driven commits move data to disk, and then requires the disk index
+         * to stay dense: on average an append must cover at least minAvgPagesPerAppend pages.
+         * Before BuildSwapSnap started swapping down to a low watermark instead of swapping only
+         * the excess, this produced one index record per page, matching the production pattern.
+         */
+        TTestActorRuntime runtime(1, false);
+        TRealPDiskTestConfig testConfig;
+        testConfig.ChunkSize = 512_KB;
+        testConfig.SyncLogAdvisedIndexedBlockSize = 1_MB;
+        testConfig.SyncLogMaxMemAmount = 256_KB;
+        testConfig.SyncLogMaxDiskAmount = 8 * 512_KB;
+        testConfig.MaxLogoBlobDataSize = 192_KB;
+        testConfig.MinHugeBlobInBytes = 64_KB;
+        testConfig.MilestoneHugeBlobInBytes = 128_KB;
+        testConfig.AdvanceEntryPointTimeout = TDuration::Hours(1);
+        testConfig.RecoveryLogCutterFirstDuration = TDuration::Hours(1);
+        testConfig.RecoveryLogCutterRegularDuration = TDuration::Hours(1);
+        testConfig.PDiskPathSuffix = "synclog_real_index_fragmentation.dat";
+
+        auto storage = SetupRealPDiskAndRealVDisk(runtime, TBlobStorageGroupType::ErasureMirror3of4, testConfig);
+        const auto& info = storage.Info;
+        const TActorId edge = storage.Edge;
+        const TActorId putQueue = storage.PutQueue;
+        const TVDiskID vdiskId = info->GetVDiskId(0);
+        const TActorId vdiskActorId = info->GetActorId(0);
+
+        TActorId syncLogId;
+        TActorId syncLogKeeperId;
+        bool gotOwner = false;
+        NPDisk::TOwner owner = 0;
+        ui64 maxObservedDataLsn = 0;
+        ui32 entryPointCommits = 0;
+        ui64 entryPointBytesMax = 0;
+        ui32 syncLogCommitDoneEvents = 0;
+        TString lastPDiskErrorReason;
+
+        auto observePDiskLog = [&](const NPDisk::TEvLog& msg) {
+            const ui32 signature = msg.Signature.GetUnmasked();
+            const bool syncLogEntryPointCommit = signature == TLogSignature::SignatureSyncLogIdx &&
+                msg.CommitRecord.IsStartingPoint;
+
+            if (!syncLogEntryPointCommit) {
+                if (!gotOwner) {
+                    owner = msg.Owner;
+                    gotOwner = true;
+                } else if (msg.Owner != owner) {
+                    return;
+                }
+                maxObservedDataLsn = Max(maxObservedDataLsn, msg.Lsn);
+                return;
+            }
+
+            if (!gotOwner || msg.Owner != owner) {
+                return;
+            }
+            ++entryPointCommits;
+            entryPointBytesMax = Max<ui64>(entryPointBytesMax, msg.Data.size());
+        };
+
+        auto previousObserver = runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            if (!ev) {
+                return TTestActorRuntime::EEventAction::PROCESS;
+            }
+
+            switch (ev->GetTypeRewrite()) {
+                case TEvBlobStorage::EvSyncLogPut:
+                    if (!syncLogId) {
+                        syncLogId = ev->Recipient;
+                    } else if (!syncLogKeeperId && ev->Recipient != syncLogId) {
+                        syncLogKeeperId = ev->Recipient;
+                    }
+                    break;
+
+                case TEvBlobStorage::EvLog:
+                    if (ev->Recipient == storage.PDiskServiceId) {
+                        observePDiskLog(*ev->Get<NPDisk::TEvLog>());
+                    }
+                    break;
+
+                case TEvBlobStorage::EvMultiLog:
+                    if (ev->Recipient == storage.PDiskServiceId) {
+                        for (const auto& item : ev->Get<NPDisk::TEvMultiLog>()->Logs) {
+                            observePDiskLog(*item.Event);
+                        }
+                    }
+                    break;
+
+                case TEvBlobStorage::EvLogResult: {
+                    const auto *msg = ev->Get<NPDisk::TEvLogResult>();
+                    if (msg->Status != NKikimrProto::OK) {
+                        lastPDiskErrorReason = msg->ErrorReason;
+                    }
+                    break;
+                }
+
+                case TEvBlobStorage::EvSyncLogCommitDone:
+                    ++syncLogCommitDoneEvents;
+                    break;
+            }
+
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+
+        auto previousEventFilter = runtime.SetEventFilter(
+            [](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>&) {
+                return false;
+            });
+        TTestRuntimeCallbackGuard runtimeCallbackGuard(runtime,
+            std::move(previousObserver), std::move(previousEventFilter));
+
+        ui32 nextStep = 1;
+        ui64 nextCookie = 1;
+        const TString data = MakeData(1);
+
+        auto writeTargetRecords = [&](ui64 tabletId, ui32 records) {
+            const ui32 batchSize = 64;
+            for (ui32 firstRecord = 0; firstRecord < records; firstRecord += batchSize) {
+                const ui32 batch = Min(batchSize, records - firstRecord);
+                auto multiPut = std::make_unique<TEvBlobStorage::TEvVMultiPut>(vdiskId, TInstant::Max(),
+                    NKikimrBlobStorage::EPutHandleClass::TabletLog, false);
+
+                for (ui32 i = 0; i < batch; ++i) {
+                    const TLogoBlobID blobId(TLogoBlobID(tabletId, 1, nextStep++, 0, data.size(), nextCookie++), 1);
+                    multiPut->AddVPut(blobId, TRcBuf(data), nullptr, false, false, false, nullptr, {}, false);
+                }
+
+                runtime.Send(new IEventHandle(putQueue, edge, multiPut.release()), NodeIndex);
+                auto putResult = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVMultiPutResult>(edge,
+                    TDuration::Seconds(120));
+                UNIT_ASSERT_C(putResult, "no put result; firstRecord# " << firstRecord
+                    << " lastPDiskError# " << lastPDiskErrorReason);
+                UNIT_ASSERT_C(putResult->Get()->Record.GetStatus() == NKikimrProto::OK,
+                    "put status# " << NKikimrProto::EReplyStatus_Name(putResult->Get()->Record.GetStatus())
+                    << " firstRecord# " << firstRecord
+                    << " lastPDiskError# " << lastPDiskErrorReason);
+                DispatchFor(runtime, TDuration::MilliSeconds(1));
+            }
+        };
+
+        ui32 nextCollectCounter = 1;
+        auto collectDoNotKeep = [&](ui64 tabletId, ui32 records) {
+            TVector<TLogoBlobID> doNotKeep;
+            doNotKeep.reserve(records);
+            for (ui32 i = 0; i < records; ++i) {
+                doNotKeep.emplace_back(tabletId, 1, nextStep++, 0, 1, nextCookie++);
+            }
+
+            auto collect = std::make_unique<TEvBlobStorage::TEvVCollectGarbage>(tabletId, 1,
+                nextCollectCounter++, 0, false, 0, 0, false, nullptr, &doNotKeep, vdiskId,
+                TInstant::Max());
+            runtime.Send(new IEventHandle(putQueue, edge, collect.release()), NodeIndex);
+            auto collectResult = runtime.GrabEdgeEvent<TEvBlobStorage::TEvVCollectGarbageResult>(edge,
+                TDuration::Seconds(120));
+            UNIT_ASSERT_C(collectResult, "no collect result; lastPDiskError# " << lastPDiskErrorReason);
+            UNIT_ASSERT_C(collectResult->Get()->Record.GetStatus() == NKikimrProto::OK,
+                "collect status# " << NKikimrProto::EReplyStatus_Name(collectResult->Get()->Record.GetStatus())
+                << " lastPDiskError# " << lastPDiskErrorReason);
+            DispatchFor(runtime, TDuration::MilliSeconds(1));
+        };
+
+        auto requestFootprint = [&] {
+            runtime.Send(new IEventHandle(syncLogKeeperId, edge,
+                new NSyncLog::TEvSyncLogSnapshot()), NodeIndex);
+            auto res = runtime.GrabEdgeEvent<NSyncLog::TEvSyncLogSnapshotResult>(edge, TDuration::Seconds(5));
+            UNIT_ASSERT(res);
+            return GetSyncLogFootprint(res->Get()->SnapshotPtr);
+        };
+
+        UNIT_ASSERT_C(WaitVDiskReady(runtime, vdiskActorId, vdiskId, edge), "target VDisk did not become ready");
+
+        writeTargetRecords(42, 16);
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
+            return syncLogId && syncLogKeeperId && gotOwner && maxObservedDataLsn;
+        }, 200, TDuration::MilliSeconds(10)),
+            "failed to discover SyncLog actor, SyncLogKeeper actor, PDisk owner, or data LSN");
+
+        // sanity check of the geometry: the invariant below is only meaningful when memory
+        // holds substantially more pages than the required average append size
+        TSyncLogFootprint footprint = requestFootprint();
+        UNIT_ASSERT(footprint.AppendBlockSize);
+        const ui32 maxMemPages = Max<ui32>(2, testConfig.SyncLogMaxMemAmount / footprint.AppendBlockSize);
+        UNIT_ASSERT_C(maxMemPages >= 16,
+            "test geometry is degenerate, SyncLog memory holds too few pages: " << maxMemPages);
+
+        // Never send NPDisk::TEvCutLog here: all commits must be driven by memory overflow,
+        // exactly like on a loaded VDisk whose group neighbor is down.
+        const ui32 targetDiskPages = 128;
+        const ui32 recordsPerBatch = 128;
+        for (ui32 i = 0; i < 1500 && footprint.DiskPages < targetDiskPages; ++i) {
+            collectDoNotKeep(43, recordsPerBatch);
+            if ((i + 1) % 8 == 0) {
+                footprint = requestFootprint();
+            }
+        }
+
+        // let the last commit settle and take the final snapshot
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
+            return entryPointCommits && syncLogCommitDoneEvents >= entryPointCommits;
+        }, 300, TDuration::MilliSeconds(10)),
+            "SyncLog commit did not settle; entryPointCommits# " << entryPointCommits
+            << " commitDone# " << syncLogCommitDoneEvents
+            << " lastPDiskError# " << lastPDiskErrorReason);
+        footprint = requestFootprint();
+
+        UNIT_ASSERT_C(footprint.DiskPages >= targetDiskPages,
+            "test did not push enough SyncLog data to disk"
+            << " footprint# " << footprint.ToString()
+            << " lastPDiskError# " << lastPDiskErrorReason);
+        UNIT_ASSERT(entryPointCommits > 0 && footprint.DiskIndexRecs > 0);
+
+        // The regression itself: overflow-driven swaps must be batched, otherwise the disk index
+        // degenerates into one record per page and the entry point (the full index re-serialized
+        // into the PDisk common log on every commit) grows unbounded together with commit rate.
+        const ui32 minAvgPagesPerAppend = 4;
+        UNIT_ASSERT_C(footprint.DiskPages >= footprint.DiskIndexRecs * minAvgPagesPerAppend,
+            "SyncLog disk index is fragmented by tiny memory-overflow swaps"
+            << " avgPagesPerAppend# " << (footprint.DiskPages / footprint.DiskIndexRecs)
+            << " footprint# " << footprint.ToString()
+            << " entryPointCommits# " << entryPointCommits
+            << " entryPointBytesMax# " << entryPointBytesMax);
     }
 
     Y_UNIT_TEST(SyncLogDuplicateFreeChunkRealPDiskWithoutRestart) {
@@ -1200,23 +1419,6 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         TTestRuntimeCallbackGuard runtimeCallbackGuard(runtime,
             std::move(previousObserver), std::move(previousEventFilter));
 
-        auto dispatchFor = [&](TDuration timeout) {
-            TDispatchOptions options;
-            const TDuration oldDispatchTimeout = runtime.SetDispatchTimeout(TDuration::MilliSeconds(10));
-            try {
-                runtime.DispatchEvents(options, timeout);
-            } catch (const TEmptyEventQueueException&) {
-            }
-            runtime.SetDispatchTimeout(oldDispatchTimeout);
-        };
-
-        auto pumpUntil = [&](auto predicate, ui32 iterations, TDuration step) {
-            for (ui32 i = 0; i < iterations && !predicate(); ++i) {
-                dispatchFor(step);
-            }
-            return predicate();
-        };
-
         auto releasePostponedFreeChunkEvents = [&] {
             while (!postponedFreeChunkEvents.empty()) {
                 TAutoPtr<IEventHandle> ev(postponedFreeChunkEvents.front().Release());
@@ -1225,22 +1427,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             }
         };
 
-        auto sendVStatus = [&] {
-            runtime.Send(new IEventHandle(vdiskActorId, edge, new TEvBlobStorage::TEvVStatus(vdiskId),
-                IEventHandle::FlagTrackDelivery), NodeIndex);
-            return runtime.GrabEdgeEvent<TEvBlobStorage::TEvVStatusResult>(edge, TDuration::Seconds(1));
-        };
-
-        auto waitReady = [&] {
-            return pumpUntil([&] {
-                if (auto res = sendVStatus()) {
-                    return res->Get()->Record.GetStatus() == NKikimrProto::OK;
-                }
-                return false;
-            }, 60, TDuration::MilliSeconds(100));
-        };
-
-        UNIT_ASSERT_C(waitReady(), "target VDisk did not become ready");
+        UNIT_ASSERT_C(WaitVDiskReady(runtime, vdiskActorId, vdiskId, edge), "target VDisk did not become ready");
 
         ui32 nextStep = 1;
         ui64 nextCookie = 1;
@@ -1293,25 +1480,25 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
                         << NKikimrProto::EReplyStatus_Name(putResult->Get()->Record.GetItems(i).GetStatus())
                         << " lastPDiskError# " << lastPDiskErrorReason);
                 }
-                dispatchFor(TDuration::MilliSeconds(1));
+                DispatchFor(runtime, TDuration::MilliSeconds(1));
             }
         };
 
         auto requestSyncLogCut = [&] {
             runtime.Send(new IEventHandle(syncLogId, edge,
                 new NPDisk::TEvCutLog(owner, ownerRound, maxObservedDataLsn + 1, 0, 0, 0, 0)), NodeIndex);
-            dispatchFor(TDuration::MilliSeconds(1));
+            DispatchFor(runtime, TDuration::MilliSeconds(1));
         };
 
         writeTargetRecords(42, 50'000, "initial real-pdisk sync-log fill");
 
-        UNIT_ASSERT_C(pumpUntil([&] {
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
             return syncLogId && syncLogKeeperId && gotOwner && maxObservedDataLsn;
         }, 300, TDuration::MilliSeconds(10)),
             "failed to discover SyncLog, SyncLogKeeper, PDisk owner, or data LSN");
 
         requestSyncLogCut();
-        UNIT_ASSERT_C(pumpUntil([&] {
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
             return observedSyncLogDataCommit && syncLogCommitDoneEvents;
         }, 3000, TDuration::MilliSeconds(10)),
             "initial writes did not move SyncLog data to real PDisk chunks");
@@ -1320,7 +1507,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
         writeTargetRecords(42, 55'000, "pre-race real-pdisk sync-log fill");
         postponeNextSyncLogDataCommit = true;
         requestSyncLogCut();
-        UNIT_ASSERT_C(pumpUntil([&] {
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
             return dataCommitPostponed;
         }, 3000, TDuration::MilliSeconds(10)),
             "failed to postpone a natural SyncLog data commit before the large swap; "
@@ -1332,7 +1519,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
             TAutoPtr<IEventHandle> ev(postponedDataCommit.Release());
             runtime.Send(ev, NodeIndex);
         }
-        UNIT_ASSERT_C(pumpUntil([&] {
+        UNIT_ASSERT_C(PumpUntil(runtime, [&] {
             return syncLogCommitDoneEvents > commitDoneBeforePostponedDataCommit ||
                 observedAppendToDeletedChunk || observedBpd77;
         }, 3000, TDuration::MilliSeconds(10)),

--- a/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/ut_real_pdisk/synclog_real_pdisk_ut.cpp
@@ -1057,7 +1057,7 @@ Y_UNIT_TEST_SUITE(TBlobStorageSyncLogRealPDisk) {
 
                 for (ui32 i = 0; i < batch; ++i) {
                     const TLogoBlobID blobId(TLogoBlobID(tabletId, 1, nextStep++, 0, data.size(), nextCookie++), 1);
-                    multiPut->AddVPut(blobId, TRcBuf(data), nullptr, false, false, false, nullptr, {}, false);
+                    multiPut->AddVPut(blobId, TRcBuf(data), nullptr, nullptr, NWilson::TTraceId());
                 }
 
                 runtime.Send(new IEventHandle(putQueue, edge, multiPut.release()), NodeIndex);


### PR DESCRIPTION
(cherry picked from commit 7a9214b12d7d5e52cc496fa4eb6a3420f4377eb0)