### PR TITLE
Fix data race in VChunk tests

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -58,6 +58,8 @@ void TVChunk::Start()
 {
     // ActorSystem thread
 
+    LogTitle.SetDiskId(PartitionDirectService->GetVolumeConfig()->DiskId);
+
     Executor->ExecuteSimple(
         [weakSelf = weak_from_this()]() mutable
         {
@@ -396,7 +398,6 @@ void TVChunk::DoStart()
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
-    LogTitle.SetDiskId(PartitionDirectService->GetVolumeConfig()->DiskId);
     DirectBlockGroup->Register(weak_from_this());
 
     LOG_DEBUG(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed data race over VChunk's LogTitle by moving LogTitle.SetTitle from Executor thread to AS thread

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Data race was discovered during #45118 reproduction attempts.
