### PR TITLE
Propagate node-domain in cfg templates

### DIFF
--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -566,11 +566,19 @@ class StaticConfigGenerator(object):
         return self.__proto_config("hive", config_pb2.THiveConfig, self.__cluster_details.get_service("hive_config"))
 
     @property
+    def _domain_name(self):
+        domain_name = ""
+        if len(self.__cluster_details.domains) == 1:
+            domain_name = self.__cluster_details.domains[0].domain_name
+        return domain_name
+
+    @property
     def kikimr_cfg(self):
         if self.__is_dynamic_node:
             return kikimr_cfg_for_dynamic_node(
                 self.__node_broker_port,
                 self._database,
+                self._domain_name,
                 self.__ic_port,
                 self.__mon_port,
                 self.__kikimr_home,
@@ -2053,10 +2061,7 @@ class StaticConfigGenerator(object):
     @property
     def dynamic_server_common_args(self):
         if self.__cluster_details.use_new_style_kikimr_cfg:
-            domain = ""
-            if len(self.__cluster_details.domains) == 1:
-                domain = self.__cluster_details.domains[0].domain_name
-            return dynamic_cfg_new_style(self._enable_cores, use_auth_token_file=self.__use_auth_token_file, domain=domain)
+            return dynamic_cfg_new_style(self._enable_cores, use_auth_token_file=self.__use_auth_token_file, domain=self._domain_name)
         return kikimr_cfg_for_dynamic_slot(
-            self._enable_cores, cert_params=self.__cluster_details.ic_cert_params
+            self._enable_cores, cert_params=self.__cluster_details.ic_cert_params, domain=self._domain_name
         )

--- a/ydb/tools/cfg/templates.py
+++ b/ydb/tools/cfg/templates.py
@@ -164,6 +164,7 @@ kikimr_arg="${kikimr_arg}${kikimr_mon_port:+ --mon-port ${kikimr_mon_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_grpc_port:+ --grpc-port ${kikimr_grpc_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_ic_port:+ --ic-port ${kikimr_ic_port}}"
 kikimr_arg="${kikimr_arg}${kikimr_node_broker_port:+ --node-broker-port ${kikimr_node_broker_port}}"
+kikimr_arg="${kikimr_arg}${kikimr_node_domain:+ --node-domain ${kikimr_node_domain}}"
 kikimr_arg="${kikimr_arg}${kikimr_syslog_service_tag:+ --syslog-service-tag ${kikimr_syslog_service_tag}}"
 
 kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
@@ -250,6 +251,9 @@ NODE_ID_ARGUMENT = """kikimr_arg="${kikimr_arg}${kikimr_node_id:+ --node ${kikim
 NODE_BROKER_ARGUMENT = """kikimr_arg="${kikimr_arg}${kikimr_node_broker_port:+ --node-broker-port ${kikimr_node_broker_port}}"
 """
 
+NODE_DOMAIN_ARGUMENT = """kikimr_arg="${kikimr_arg}${kikimr_node_domain:+ --node-domain ${kikimr_node_domain}}"
+"""
+
 SYS_LOG_SERVICE_TAG = """kikimr_arg="${kikimr_arg}${kikimr_syslog_service_tag:+ --syslog-service-tag ${kikimr_syslog_service_tag}}"
 """
 
@@ -260,6 +264,7 @@ DEFAULT_KIKIMR_MBUS_MAX_MESSAGE_SIZE = 140000000
 
 def local_vars(
     tenant,
+    domain=None,
     node_broker_port=None,
     ic_port=19001,
     mon_port=8765,
@@ -296,6 +301,9 @@ def local_vars(
 
     if tenant:
         cur_vars.append(('kikimr_tenant', tenant))
+
+    if domain:
+        cur_vars.append(('kikimr_node_domain', domain))
 
     if node_broker_port:
         cur_vars.append(('kikimr_node_broker_port', node_broker_port))
@@ -466,10 +474,12 @@ def dynamic_cfg_new_style(
 def dynamic_cfg_new_style_v2(
     extra_args="",
     use_auth_token_file=False,
+    domain="",
 ):
     return "\n".join(
         [
             "kikimr_auth_token_file=${kikimr_home}/token/kikimr.token" if use_auth_token_file else "",
+            f'kikimr_node_domain="{domain}"' if domain else "",
             DYNAMIC_CFG_V2,
         ]
         + ydbd_extra_args(extra_args)
@@ -609,6 +619,7 @@ def kikimr_cfg_for_static_node(
 def kikimr_cfg_for_dynamic_node(
     node_broker_port=2135,
     tenant=None,
+    domain=None,
     ic_port=19001,
     mon_port=8765,
     kikimr_home='/Berkanavt/kikimr',
@@ -630,6 +641,7 @@ def kikimr_cfg_for_dynamic_node(
         [
             local_vars(
                 tenant,
+                domain=domain,
                 node_broker_port=node_broker_port,
                 ic_port=ic_port,
                 mon_port=mon_port,
@@ -651,6 +663,7 @@ def kikimr_cfg_for_dynamic_node(
             CUSTOM_CONFIG_INJECTOR,
             DEFAULT_ARGUMENTS_SET,
             NODE_BROKER_ARGUMENT,
+            NODE_DOMAIN_ARGUMENT,
             tenant_argument(tenant),
             sqs_arguments(sqs_enable),
         ]
@@ -679,6 +692,7 @@ def expected_vars(**kwargs):
 def kikimr_cfg_for_dynamic_slot(
     enable_cores=False,
     cert_params=None,
+    domain="",
     rb_txt_enabled=False,
     metering_txt_enabled=False,
     audit_txt_enabled=False,
@@ -688,6 +702,7 @@ def kikimr_cfg_for_dynamic_slot(
     return "\n".join(
         [
             'kikimr_coregen="--core"' if enable_cores else "",
+            f'kikimr_node_domain="{domain}"' if domain else "",
             expected_vars(
                 node_broker_port=2135,
                 kikimr_binaries_base_path="/Berkanavt/kikimr",
@@ -708,6 +723,7 @@ def kikimr_cfg_for_dynamic_slot(
             CUSTOM_SYS_CONFIG_INJECTOR,
             DEFAULT_ARGUMENTS_SET,
             NODE_BROKER_ARGUMENT,
+            NODE_DOMAIN_ARGUMENT,
             SYS_LOG_SERVICE_TAG,
             tenant_argument(True),
         ]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Propagate node domain to generated YDB dynamic node configuration.

### Changelog category <!-- remove all except one -->

- Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change passes the resolved domain name into cfg templates and generated dynamic node startup arguments via `--node-domain`. The domain is derived from cluster details when there is exactly one configured domain, and reused for both dynamic node cfg generation and dynamic slot common args.