### PR TITLE
Generate new style kikimr cfg for dynamic nodes

### DIFF
--- a/ydb/tools/cfg/static.py
+++ b/ydb/tools/cfg/static.py
@@ -30,6 +30,7 @@ from ydb.tools.cfg import base, types, utils
 from ydb.tools.cfg.templates import (
     dynamic_cfg_new_style,
     kikimr_cfg_for_dynamic_node,
+    kikimr_cfg_for_dynamic_node_new_style,
     kikimr_cfg_for_dynamic_slot,
     kikimr_cfg_for_static_node,
     kikimr_cfg_for_static_node_new_style,
@@ -568,6 +569,22 @@ class StaticConfigGenerator(object):
     @property
     def kikimr_cfg(self):
         if self.__is_dynamic_node:
+            if self.__cluster_details.use_new_style_kikimr_cfg:
+                return kikimr_cfg_for_dynamic_node_new_style(
+                    self.__node_broker_port,
+                    self._database,
+                    self.__ic_port,
+                    self.__grpc_port,
+                    self.__mon_port,
+                    self.__kikimr_home,
+                    self._enable_cores,
+                    self.__cluster_details.default_log_level,
+                    kikimr_binaries_base_path='/Berkanavt/kikimr',
+                    mon_address=self.__cluster_details.monitor_address,
+                    cert_params=self.__cluster_details.ic_cert_params,
+                    use_auth_token_file=self._use_auth_token_file,
+                )
+
             return kikimr_cfg_for_dynamic_node(
                 self.__node_broker_port,
                 self._database,

--- a/ydb/tools/cfg/templates.py
+++ b/ydb/tools/cfg/templates.py
@@ -65,6 +65,33 @@ kikimr_arg="${kikimr_arg}${kikimr_ca:+ --ca=${kikimr_ca}}${kikimr_cert:+ --cert=
 
 """
 
+NEW_STYLE_DYNAMIC_NODE_CONFIG = """
+kikimr_config="${kikimr_home}/cfg"
+kikimr_key_file="${kikimr_config}/key.txt"
+
+kikimr_arg="${kikimr_arg} server --yaml-config ${kikimr_config}/config.yaml"
+kikimr_arg="${kikimr_arg}${kikimr_mon_port:+ --mon-port ${kikimr_mon_port}}"
+kikimr_arg="${kikimr_arg}${kikimr_mon_threads:+ --mon-threads ${kikimr_mon_threads}}"
+kikimr_arg="${kikimr_arg}${kikimr_grpc_port:+ --grpc-port ${kikimr_grpc_port}}"
+kikimr_arg="${kikimr_arg}${kikimr_ic_port:+ --ic-port ${kikimr_ic_port}}"
+
+if [ ! -z "${kikimr_mon_address}" ]; then
+    kikimr_arg="${kikimr_arg}${kikimr_mon_address:+ --mon-address ${kikimr_mon_address}}"
+else
+    echo "Monitoring address is not defined."
+fi
+
+kikimr_arg="${kikimr_arg}${kikimr_auth_token_file:+ --auth-token-file ${kikimr_auth_token_file}}"
+
+if [ -f "${kikimr_key_file}" ]; then
+    kikimr_arg="${kikimr_arg}${kikimr_key_file:+ --key-file ${kikimr_key_file}}"
+else
+    echo "Key file not found!"
+fi
+kikimr_arg="${kikimr_arg}${kikimr_ca:+ --ca=${kikimr_ca}}${kikimr_cert:+ --cert=${kikimr_cert}}${kikimr_key:+ --key=${kikimr_key}}"
+
+"""
+
 
 CONFIG_V2 = """
 kikimr_config="${kikimr_home}/cfg"
@@ -657,6 +684,46 @@ def kikimr_cfg_for_dynamic_node(
         + rb_arguments(rb_txt_enabled)
         + metering_arguments(metering_txt_enabled)
         + audit_arguments(audit_txt_enabled)
+    )
+
+
+def kikimr_cfg_for_dynamic_node_new_style(
+    node_broker_port=2135,
+    tenant=None,
+    ic_port=19001,
+    grpc_port=2135,
+    mon_port=8765,
+    kikimr_home='/Berkanavt/kikimr',
+    enable_cores=False,
+    default_log_level=3,
+    kikimr_binaries_base_path='/Berkanavt/kikimr',
+    mon_address="",
+    cert_params=None,
+    use_auth_token_file=False,
+):
+    return "\n".join(
+        [
+            local_vars(
+                tenant,
+                node_broker_port=node_broker_port,
+                ic_port=ic_port,
+                grpc_port=grpc_port,
+                mon_port=mon_port,
+                kikimr_home=kikimr_home,
+                kikimr_binaries_base_path=kikimr_binaries_base_path,
+                pq_enable=False,
+                enable_cores=enable_cores,
+                default_log_level=default_log_level,
+                mon_address=mon_address,
+                cert_params=cert_params,
+                new_style_kikimr_cfg=True,
+                use_auth_token_file=use_auth_token_file,
+            ),
+            CUSTOM_CONFIG_INJECTOR,
+            NEW_STYLE_DYNAMIC_NODE_CONFIG,
+            NODE_BROKER_ARGUMENT,
+            tenant_argument(tenant),
+        ]
     )
 
 

--- a/ydb/tools/cfg/templates.py
+++ b/ydb/tools/cfg/templates.py
@@ -713,7 +713,7 @@ def kikimr_cfg_for_dynamic_node_new_style(
                 kikimr_binaries_base_path=kikimr_binaries_base_path,
                 pq_enable=False,
                 enable_cores=enable_cores,
-                default_log_level=default_log_level,
+                default_log_level=0,
                 mon_address=mon_address,
                 cert_params=cert_params,
                 new_style_kikimr_cfg=True,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Generate new-style `kikimr.cfg` with yaml-config `config.yaml` usage for dynamic nodes when enabled.

### Changelog category <!-- remove all except one -->

- Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

This change adds dynamic node support for `use_new_style_kikimr_cfg`.

When the option is enabled, dynamic node `kikimr.cfg` generation now uses a new-style startup template with `server --yaml-config ...` instead of the legacy txt files.