### PR TITLE
CI: allow fork checkout in PR-check (allow-unsafe-pr-checkout)

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -249,9 +249,7 @@ jobs:
         ref: ${{ needs.check-running-allowed.outputs.commit_sha }}
         fetch-depth: 2
         # Fork code is checked out only after the check-running-allowed gate
-        # (collaborator/owner or a maintainer-applied `ok-to-test` label), which
-        # is the review-the-risks mitigation required by actions/checkout@v5 for
-        # pull_request_target workflows.
+        # (collaborator/owner or a maintainer-applied `ok-to-test` label)
         allow-unsafe-pr-checkout: true
     - name: Setup ydb access
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -248,6 +248,11 @@ jobs:
       with:
         ref: ${{ needs.check-running-allowed.outputs.commit_sha }}
         fetch-depth: 2
+        # Fork code is checked out only after the check-running-allowed gate
+        # (collaborator/owner or a maintainer-applied `ok-to-test` label), which
+        # is the review-the-risks mitigation required by actions/checkout@v5 for
+        # pull_request_target workflows.
+        allow-unsafe-pr-checkout: true
     - name: Setup ydb access
       uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
       with:


### PR DESCRIPTION
## Проблема

Для PR от внешних контрибьюторов (например #42140) шаг `Checkout` в джобе `build_and_test` падает **ещё до сборки** с ошибкой:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow… To opt in… set `allow-unsafe-pr-checkout: true` on the actions/checkout step.

`actions/checkout@v5` включил по умолчанию новую защиту: он отказывается чекаутить код форка внутри `pull_request_target`-воркфлоу (доверенный контекст с секретами и `GITHUB_TOKEN` базового репозитория — вектор «pwn request»). YAML не менялся — поменялось поведение экшена в рантайме, поэтому сборка «вдруг» перестала запускаться.

Более подробно: 
- https://gh.io/securely-using-pull_request_target 
- https://thehackernews.com/2026/06/github-updates-actionscheckout-to-block.html?m=1 

## Решение

Добавлен `allow-unsafe-pr-checkout: true` на шаг Checkout в джобе `build_and_test`.

Это безопасно именно здесь: код форка чекаутится только после гейта `check-running-allowed`, который пропускает сборку лишь если автор — коллаборатор/владелец **или** мейнтейнер вручную повесил лейбл `ok-to-test`. То есть ревью кода форка перед запуском в доверенном контексте уже есть — это и есть mitigation, которую требует `actions/checkout`.
