### PR TITLE
tpcc: reuse fixed transaction inputs across RetryQuery attempts

### DIFF
--- a/ydb/library/workload/tpcc/terminal.cpp
+++ b/ydb/library/workload/tpcc/terminal.cpp
@@ -169,6 +169,9 @@ NThreading::TFuture<void> TTerminal::Run() {
 
             // the block helps to ensure, that session is destroyed before we sleep right after the block
             {
+                // Reset so each business transaction gets fresh inputs; retries reuse FixedInputs.
+                Context.FixedInputs.reset();
+
                 bool real = Context.SimulateTransactionMs == 0 && Context.SimulateTransactionSelect1 == 0;
                 auto future = Context.Client->RetryQuery(
                     [this, real, &transaction, &execCount, &latencyPure](TSession session) mutable {

--- a/ydb/library/workload/tpcc/transaction_delivery.cpp
+++ b/ydb/library/workload/tpcc/transaction_delivery.cpp
@@ -339,8 +339,20 @@ NThreading::TFuture<TStatus> GetDeliveryTask(
 
     auto& Log = context.Log;
 
-    const int warehouseID = context.WarehouseID;
-    const int carrierID = RandomNumber(1, 10);
+    struct TInputs {
+        int WarehouseID;
+        int CarrierID;
+    };
+
+    const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
+        return TInputs{
+            .WarehouseID = static_cast<int>(context.WarehouseID),
+            .CarrierID = static_cast<int>(RandomNumber(1, 10)),
+        };
+    });
+
+    const int warehouseID = in.WarehouseID;
+    const int carrierID = in.CarrierID;
 
     LOG_T("Terminal " << context.TerminalID << " started Delivery transaction in " << warehouseID
         << ", session: " << session.GetId());

--- a/ydb/library/workload/tpcc/transaction_neworder.cpp
+++ b/ydb/library/workload/tpcc/transaction_neworder.cpp
@@ -541,46 +541,65 @@ NThreading::TFuture<TStatus> GetNewOrderTask(
 
     auto& Log = context.Log;
 
-    const int warehouseID = context.WarehouseID;
-    const int districtID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
-    const int customerID = GetRandomCustomerID();
+    struct TInputs {
+        int WarehouseID;
+        int DistrictID;
+        int CustomerID;
+        int NumItems;
+        std::vector<int> ItemIDs;
+        std::vector<int> SupplierWarehouseIDs;
+        std::vector<int> OrderQuantities;
+        int AllLocal;
+        bool HasInvalidItem;
+    };
+
+    const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
+        TInputs generated;
+        generated.WarehouseID = context.WarehouseID;
+        generated.DistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
+        generated.CustomerID = GetRandomCustomerID();
+        generated.NumItems = RandomNumber(MIN_ITEMS, MAX_ITEMS);
+        generated.ItemIDs.reserve(generated.NumItems);
+        generated.SupplierWarehouseIDs.reserve(generated.NumItems);
+        generated.OrderQuantities.reserve(generated.NumItems);
+        generated.AllLocal = 1;
+
+        for (int i = 0; i < generated.NumItems; ++i) {
+            generated.ItemIDs.push_back(GetRandomItemID());
+            if (RandomNumber(1, 100) > 1) {
+                generated.SupplierWarehouseIDs.push_back(generated.WarehouseID);
+            } else {
+                int supplierID;
+                do {
+                    supplierID = RandomNumber(1, context.WarehouseCount);
+                } while (supplierID == generated.WarehouseID && context.WarehouseCount > 1);
+                generated.SupplierWarehouseIDs.push_back(supplierID);
+                generated.AllLocal = 0;
+            }
+            generated.OrderQuantities.push_back(RandomNumber(1, 10));
+        }
+
+        // we need to cause 1% of the new orders to be rolled back.
+        generated.HasInvalidItem = false;
+        if (RandomNumber(1, 100) == 1) {
+            generated.ItemIDs[generated.NumItems - 1] = INVALID_ITEM_ID;
+            generated.HasInvalidItem = true;
+        }
+        return generated;
+    });
+
+    const int warehouseID = in.WarehouseID;
+    const int districtID = in.DistrictID;
+    const int customerID = in.CustomerID;
+    const int numItems = in.NumItems;
+    const auto& itemIDs = in.ItemIDs;
+    const auto& supplierWarehouseIDs = in.SupplierWarehouseIDs;
+    const auto& orderQuantities = in.OrderQuantities;
+    const int allLocal = in.AllLocal;
+    const bool hasInvalidItem = in.HasInvalidItem;
 
     LOG_T("Terminal " << context.TerminalID << " started NewOrder transaction in "
         << warehouseID << ", " << districtID << " for " << customerID << ", session: " << session.GetId());
-
-    // Generate order line items
-
-    const int numItems = RandomNumber(MIN_ITEMS, MAX_ITEMS);
-
-    std::vector<int> itemIDs;
-    std::vector<int> supplierWarehouseIDs;
-    std::vector<int> orderQuantities;
-    itemIDs.reserve(numItems);
-    supplierWarehouseIDs.reserve(numItems);
-    orderQuantities.reserve(numItems);
-    int allLocal = 1;
-
-    for (int i = 0; i < numItems; ++i) {
-        itemIDs.push_back(GetRandomItemID());
-        if (RandomNumber(1, 100) > 1) {
-            supplierWarehouseIDs.push_back(warehouseID);
-        } else {
-            int supplierID;
-            do {
-                supplierID = RandomNumber(1, context.WarehouseCount);
-            } while (supplierID == warehouseID && context.WarehouseCount > 1);
-            supplierWarehouseIDs.push_back(supplierID);
-            allLocal = 0;
-        }
-        orderQuantities.push_back(RandomNumber(1, 10));
-    }
-
-    // we need to cause 1% of the new orders to be rolled back.
-    bool hasInvalidItem = false;
-    if (RandomNumber(1, 100) == 1) {
-        itemIDs[numItems - 1] = INVALID_ITEM_ID;
-        hasInvalidItem = true;
-    }
 
     // Get customer info
 

--- a/ydb/library/workload/tpcc/transaction_neworder.cpp
+++ b/ydb/library/workload/tpcc/transaction_neworder.cpp
@@ -555,7 +555,7 @@ NThreading::TFuture<TStatus> GetNewOrderTask(
 
     const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
         TInputs generated;
-        generated.WarehouseID = context.WarehouseID;
+        generated.WarehouseID = static_cast<int>(context.WarehouseID);
         generated.DistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
         generated.CustomerID = GetRandomCustomerID();
         generated.NumItems = RandomNumber(MIN_ITEMS, MAX_ITEMS);

--- a/ydb/library/workload/tpcc/transaction_orderstatus.cpp
+++ b/ydb/library/workload/tpcc/transaction_orderstatus.cpp
@@ -121,14 +121,35 @@ NThreading::TFuture<TStatus> GetOrderStatusTask(
 
     auto& Log = context.Log;
 
-    const int warehouseID = context.WarehouseID;
-    const int districtID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
+    struct TInputs {
+        int WarehouseID;
+        int DistrictID;
+        bool LookupByName;
+        TString LastName;
+        int CustomerID;
+    };
+
+    const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
+        TInputs generated;
+        generated.WarehouseID = context.WarehouseID;
+        generated.DistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
+        // Determine lookup method (60% by name, 40% by id)
+        generated.LookupByName = RandomNumber(1, 100) <= 60;
+        if (generated.LookupByName) {
+            generated.LastName = GetNonUniformRandomLastNameForRun();
+            generated.CustomerID = 0;
+        } else {
+            generated.CustomerID = GetRandomCustomerID();
+        }
+        return generated;
+    });
+
+    const int warehouseID = in.WarehouseID;
+    const int districtID = in.DistrictID;
+    const bool lookupByName = in.LookupByName;
 
     LOG_T("Terminal " << context.TerminalID << " started OrderStatus transaction in "
         << warehouseID << ", " << districtID << ", session: " << session.GetId());
-
-    // Determine lookup method (60% by name, 40% by id)
-    bool lookupByName = RandomNumber(1, 100) <= 60;
 
     TCustomer customer;
     std::optional<TTransaction> tx;
@@ -137,7 +158,7 @@ NThreading::TFuture<TStatus> GetOrderStatusTask(
 
     if (lookupByName) {
         // by last name
-        TString lastName = GetNonUniformRandomLastNameForRun();
+        const TString& lastName = in.LastName;
 
         auto customersFuture = GetCustomersByLastName(session, std::nullopt, context, warehouseID, districtID, lastName);
         auto customersResult = co_await TSuspendWithFuture(customersFuture, context.TaskQueue, context.TerminalID);
@@ -165,7 +186,7 @@ NThreading::TFuture<TStatus> GetOrderStatusTask(
         customer = std::move(*selectedCustomer);
     } else {
         // by ID
-        int customerID = GetRandomCustomerID();
+        const int customerID = in.CustomerID;
 
         auto customerFuture = GetCustomerById(session, std::nullopt, context, warehouseID, districtID, customerID);
         auto customerResult = co_await TSuspendWithFuture(customerFuture, context.TaskQueue, context.TerminalID);

--- a/ydb/library/workload/tpcc/transaction_orderstatus.cpp
+++ b/ydb/library/workload/tpcc/transaction_orderstatus.cpp
@@ -131,7 +131,7 @@ NThreading::TFuture<TStatus> GetOrderStatusTask(
 
     const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
         TInputs generated;
-        generated.WarehouseID = context.WarehouseID;
+        generated.WarehouseID = static_cast<int>(context.WarehouseID);
         generated.DistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
         // Determine lookup method (60% by name, 40% by id)
         generated.LookupByName = RandomNumber(1, 100) <= 60;

--- a/ydb/library/workload/tpcc/transaction_payment.cpp
+++ b/ydb/library/workload/tpcc/transaction_payment.cpp
@@ -274,9 +274,50 @@ NThreading::TFuture<TStatus> GetPaymentTask(
 
     auto& Log = context.Log;
 
-    const int warehouseID = context.WarehouseID;
-    const int districtID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
-    const double paymentAmount = static_cast<double>(RandomNumber(100, 500000)) / 100.0;
+    struct TInputs {
+        int WarehouseID;
+        int DistrictID;
+        double PaymentAmount;
+        int CustomerDistrictID;
+        int CustomerWarehouseID;
+        bool LookupByName;
+        TString LastName;
+        int CustomerID;
+    };
+
+    const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
+        TInputs generated;
+        generated.WarehouseID = context.WarehouseID;
+        generated.DistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
+        generated.PaymentAmount = static_cast<double>(RandomNumber(100, 500000)) / 100.0;
+
+        // 85% are home warehouse
+        if (RandomNumber(1, 100) <= 85) {
+            generated.CustomerDistrictID = generated.DistrictID;
+            generated.CustomerWarehouseID = generated.WarehouseID;
+        } else {
+            generated.CustomerDistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
+            do {
+                generated.CustomerWarehouseID = RandomNumber(1, context.WarehouseCount);
+            } while (generated.CustomerWarehouseID == generated.WarehouseID && context.WarehouseCount > 1);
+        }
+
+        // 60% look up by last name, 40% by customer ID
+        generated.LookupByName = RandomNumber(1, 100) <= 60;
+        if (generated.LookupByName) {
+            generated.LastName = GetNonUniformRandomLastNameForRun();
+            generated.CustomerID = 0;
+        } else {
+            generated.CustomerID = GetRandomCustomerID();
+        }
+        return generated;
+    });
+
+    const int warehouseID = in.WarehouseID;
+    const int districtID = in.DistrictID;
+    const double paymentAmount = in.PaymentAmount;
+    const int customerDistrictID = in.CustomerDistrictID;
+    const int customerWarehouseID = in.CustomerWarehouseID;
 
     LOG_T("Terminal " << context.TerminalID << " started Payment transaction in "
         << warehouseID << ", " << districtID << ", session: " << session.GetId());
@@ -333,28 +374,11 @@ NThreading::TFuture<TStatus> GetPaymentTask(
     }
     std::string districtName = *districtParser.ColumnParser("D_NAME").GetOptionalUtf8();
 
-    // Determine which warehouse and district the customer belongs to
-    int customerDistrictID;
-    int customerWarehouseID;
-
-    // 85% are home warehouse
-    if (RandomNumber(1, 100) <= 85) {
-        customerDistrictID = districtID;
-        customerWarehouseID = warehouseID;
-    } else {
-        customerDistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
-
-        do {
-            customerWarehouseID = RandomNumber(1, context.WarehouseCount);
-        } while (customerWarehouseID == warehouseID && context.WarehouseCount > 1);
-    }
-
     // Get customer
     TCustomer customer;
 
-    // 60% look up by last name, 40% by customer ID
-    if (RandomNumber(1, 100) <= 60) {
-        TString lastName = GetNonUniformRandomLastNameForRun();
+    if (in.LookupByName) {
+        const TString& lastName = in.LastName;
 
         auto customersFuture = GetCustomersByLastName(session, tx, context, customerWarehouseID, customerDistrictID, lastName);
         auto customersResult = co_await TSuspendWithFuture(customersFuture, context.TaskQueue, context.TerminalID);
@@ -381,7 +405,7 @@ NThreading::TFuture<TStatus> GetPaymentTask(
         }
         customer = std::move(*selectedCustomer);
     } else {
-        int customerID = GetRandomCustomerID();
+        const int customerID = in.CustomerID;
 
         auto customerFuture = GetCustomerById(session, tx, context, customerWarehouseID, customerDistrictID, customerID);
         auto customerResult = co_await TSuspendWithFuture(customerFuture, context.TaskQueue, context.TerminalID);

--- a/ydb/library/workload/tpcc/transaction_payment.cpp
+++ b/ydb/library/workload/tpcc/transaction_payment.cpp
@@ -287,7 +287,7 @@ NThreading::TFuture<TStatus> GetPaymentTask(
 
     const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
         TInputs generated;
-        generated.WarehouseID = context.WarehouseID;
+        generated.WarehouseID = static_cast<int>(context.WarehouseID);
         generated.DistrictID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
         generated.PaymentAmount = static_cast<double>(RandomNumber(100, 500000)) / 100.0;
 

--- a/ydb/library/workload/tpcc/transaction_stocklevel.cpp
+++ b/ydb/library/workload/tpcc/transaction_stocklevel.cpp
@@ -112,9 +112,23 @@ NThreading::TFuture<TStatus> GetStockLevelTask(
 
     auto& Log = context.Log;
 
-    const int warehouseID = context.WarehouseID;
-    const int districtID = RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID);
-    const int threshold = RandomNumber(10, 20);
+    struct TInputs {
+        int WarehouseID;
+        int DistrictID;
+        int Threshold;
+    };
+
+    const auto& in = FixedTransactionInputs<TInputs>(context, [&] {
+        return TInputs{
+            .WarehouseID = static_cast<int>(context.WarehouseID),
+            .DistrictID = static_cast<int>(RandomNumber(DISTRICT_LOW_ID, DISTRICT_HIGH_ID)),
+            .Threshold = static_cast<int>(RandomNumber(10, 20)),
+        };
+    });
+
+    const int warehouseID = in.WarehouseID;
+    const int districtID = in.DistrictID;
+    const int threshold = in.Threshold;
 
     LOG_T("Terminal " << context.TerminalID << " started StockLevel transaction in "
         << warehouseID << ", " << districtID << ", session: " << session.GetId());

--- a/ydb/library/workload/tpcc/transactions.h
+++ b/ydb/library/workload/tpcc/transactions.h
@@ -8,6 +8,7 @@
 #include <library/cpp/threading/future/core/coroutine_traits.h>
 
 #include <memory>
+#include <utility>
 
 class TLog;
 
@@ -40,7 +41,20 @@ struct TTransactionContext {
     const TString Path;
     std::shared_ptr<TLog> Log;
     NQuery::TTxSettings TxMode;
+
+    // User input for the current business transaction. Generated once and reused
+    // across SDK RetryQuery attempts so a retry does not become a different txn.
+    std::shared_ptr<void> FixedInputs;
 };
+
+// Lazily generate and pin transaction inputs for the duration of RetryQuery.
+template <typename TInputs, typename TGen>
+const TInputs& FixedTransactionInputs(TTransactionContext& context, TGen&& gen) {
+    if (!context.FixedInputs) {
+        context.FixedInputs = std::make_shared<TInputs>(std::forward<TGen>(gen)());
+    }
+    return *std::static_pointer_cast<TInputs>(context.FixedInputs);
+}
 
 struct TUserAbortedException : public yexception {
 };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

TPC-C workload: keep the same user input when RetryQuery retries a transaction.

Fixes https://github.com/ydb-platform/ydb/issues/47311

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Generate user input once per business transaction and cache it in TTransactionContext so SDK retries do not re-roll RandomNumber and execute a different business transaction.