### PR TITLE
Make StreamWrite ext_publication_id optional

### DIFF
--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -178,7 +178,9 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
         NKikimrPQ::TWriteId proto;
         auto* deferred = proto.MutableDeferredPublicationApi();
         deferred->SetIntPublicationId(Opts.DeferredPublish->IntPublicationId);
-        deferred->SetExtPublicationId(Opts.DeferredPublish->ExtPublicationId);
+        if (Opts.DeferredPublish->ExtPublicationId) {
+            deferred->SetExtPublicationId(*Opts.DeferredPublish->ExtPublicationId);
+        }
         return TWriteId(std::move(proto));
     }
 

--- a/ydb/core/persqueue/writer/writer.h
+++ b/ydb/core/persqueue/writer/writer.h
@@ -17,7 +17,7 @@ namespace NKikimr::NPQ {
 
 struct TDeferredPublishWriterOpts {
     ui64 IntPublicationId = 0;
-    TString ExtPublicationId;
+    TMaybe<TString> ExtPublicationId;
 };
 
 struct TEvPartitionWriter {
@@ -257,8 +257,8 @@ struct TPartitionWriterOpts {
     TPartitionWriterOpts& WithKafkaProducerInstanceId(const std::optional<NKafka::TProducerInstanceId>& value) { KafkaProducerInstanceId = value; return *this; }
     TPartitionWriterOpts& WithKafkaTransactionalId(const std::optional<TString>& value) { KafkaTransactionalId = value; return *this; }
     TPartitionWriterOpts& WithTrackProducerId(bool value) { TrackProducerId = value; return *this; }
-    TPartitionWriterOpts& WithDeferredPublish(ui64 intPublicationId, const TString& extPublicationId) {
-        DeferredPublish = TDeferredPublishWriterOpts{intPublicationId, extPublicationId};
+    TPartitionWriterOpts& WithDeferredPublish(ui64 intPublicationId, TMaybe<TString> extPublicationId = Nothing()) {
+        DeferredPublish = TDeferredPublishWriterOpts{intPublicationId, std::move(extPublicationId)};
         return *this;
     }
 };

--- a/ydb/public/api/protos/ydb_topic.proto
+++ b/ydb/public/api/protos/ydb_topic.proto
@@ -722,9 +722,10 @@ message TransactionIdentity {
 }
 
 // Identity of a deferred topic publication for StreamWrite.
-// int_publication_id is assigned by the server in BeginPublication.
-// ext_publication_id is optional. When set, the server does not check that it
-// matches the value passed to BeginPublication.
+// int_publication_id is assigned by the server in BeginPublication and is authoritative.
+// ext_publication_id is optional and informational only (diagnostics / TWriteId display).
+// When set, the server does not require a non-empty value and does not check that it
+// matches BeginPublication. Omitting the field and setting an empty string are both allowed.
 message DeferredPublishIdentity {
     uint64 int_publication_id = 1;
 

--- a/ydb/public/api/protos/ydb_topic.proto
+++ b/ydb/public/api/protos/ydb_topic.proto
@@ -723,11 +723,12 @@ message TransactionIdentity {
 
 // Identity of a deferred topic publication for StreamWrite.
 // int_publication_id is assigned by the server in BeginPublication.
-// ext_publication_id is repeated from BeginPublication on each write batch.
+// ext_publication_id is optional. When set, the server does not check that it
+// matches the value passed to BeginPublication.
 message DeferredPublishIdentity {
     uint64 int_publication_id = 1;
 
-    string ext_publication_id = 2 [(Ydb.length).le = 2048];
+    optional string ext_publication_id = 2 [(Ydb.length).le = 2048];
 }
 
 // Add offsets to transaction request sent from client to server.

--- a/ydb/services/persqueue_v1/actors/write_request_info.h
+++ b/ydb/services/persqueue_v1/actors/write_request_info.h
@@ -91,7 +91,9 @@ TMaybe<NPQ::TDeferredPublishWriterOpts> TWriteRequestInfoImpl<TEvWrite>::GetDefe
         const auto& deferredPublish = request.deferred_publish();
         return NPQ::TDeferredPublishWriterOpts{
             deferredPublish.int_publication_id(),
-            deferredPublish.ext_publication_id(),
+            deferredPublish.has_ext_publication_id()
+                ? deferredPublish.ext_publication_id()
+                : TString{},
         };
     }
 }

--- a/ydb/services/persqueue_v1/actors/write_request_info.h
+++ b/ydb/services/persqueue_v1/actors/write_request_info.h
@@ -92,8 +92,8 @@ TMaybe<NPQ::TDeferredPublishWriterOpts> TWriteRequestInfoImpl<TEvWrite>::GetDefe
         return NPQ::TDeferredPublishWriterOpts{
             deferredPublish.int_publication_id(),
             deferredPublish.has_ext_publication_id()
-                ? deferredPublish.ext_publication_id()
-                : TString{},
+                ? TMaybe<TString>(deferredPublish.ext_publication_id())
+                : Nothing(),
         };
     }
 }

--- a/ydb/services/persqueue_v1/actors/write_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.cpp
@@ -1571,14 +1571,8 @@ void TWriteSessionActor<UseMigrationProtocol>::Handle(typename TEvWrite::TPtr& e
                     ctx);
                 return;
             }
-            if (deferredPublish.ext_publication_id().empty()) {
-                CloseSession(
-                    "WriteRequest.deferred_publish.ext_publication_id must not be empty",
-                    PersQueue::ErrorCode::BAD_REQUEST,
-                    ctx);
-                return;
-            }
-            if (deferredPublish.ext_publication_id().size() > NPQ::NDeferredPublish::MaxDeferredPublishStringLength) {
+            if (deferredPublish.has_ext_publication_id()
+                && deferredPublish.ext_publication_id().size() > NPQ::NDeferredPublish::MaxDeferredPublishStringLength) {
                 CloseSession(
                     "WriteRequest.deferred_publish.ext_publication_id is too long",
                     PersQueue::ErrorCode::BAD_REQUEST,
@@ -1587,16 +1581,19 @@ void TWriteSessionActor<UseMigrationProtocol>::Handle(typename TEvWrite::TPtr& e
             }
 
             const ui64 intPublicationId = deferredPublish.int_publication_id();
-            const auto knownExt = DeferredPublicationExtByInt.FindPtr(intPublicationId);
-            if (knownExt && *knownExt != deferredPublish.ext_publication_id()) {
-                YDB_LOG_WARN_CTX(ctx, "Deferred publish ext_publication_id mismatch",
-                    {"cookie", Cookie},
-                    {"sessionId", OwnerCookie},
-                    {"intPublicationId", intPublicationId},
-                    {"expectedExtPublicationId", *knownExt},
-                    {"actualExtPublicationId", deferredPublish.ext_publication_id()});
-            } else if (!knownExt) {
-                DeferredPublicationExtByInt[intPublicationId] = deferredPublish.ext_publication_id();
+            if (deferredPublish.has_ext_publication_id()) {
+                const auto& extPublicationId = deferredPublish.ext_publication_id();
+                const auto knownExt = DeferredPublicationExtByInt.FindPtr(intPublicationId);
+                if (knownExt && *knownExt != extPublicationId) {
+                    YDB_LOG_WARN_CTX(ctx, "Deferred publish ext_publication_id mismatch",
+                        {"cookie", Cookie},
+                        {"sessionId", OwnerCookie},
+                        {"intPublicationId", intPublicationId},
+                        {"expectedExtPublicationId", *knownExt},
+                        {"actualExtPublicationId", extPublicationId});
+                } else if (!knownExt) {
+                    DeferredPublicationExtByInt[intPublicationId] = extPublicationId;
+                }
             }
         }
     }

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -811,7 +811,9 @@ Ydb::Topic::StreamWriteMessage::FromClient MakeStreamWriteRequest(
     if (deferredPublish) {
         auto* deferred = write->mutable_deferred_publish();
         deferred->set_int_publication_id(deferredPublish->first);
-        deferred->set_ext_publication_id(deferredPublish->second);
+        if (!deferredPublish->second.empty()) {
+            deferred->set_ext_publication_id(deferredPublish->second);
+        }
     }
     if (tx) {
         write->mutable_tx()->set_session(tx->first);
@@ -1954,15 +1956,28 @@ Y_UNIT_TEST(StreamWriteDeferredPublishDisabledByDefault) {
         TString(DisabledMessage));
 }
 
-Y_UNIT_TEST(StreamWriteRejectsEmptyExtPublicationId) {
+Y_UNIT_TEST(StreamWriteAllowsOmitExtPublicationId) {
     auto fixture = TDeferredStreamWriteFixture::Enabled();
-    auto session = fixture.OpenWriteStream("producer-empty-ext");
+    auto session = fixture.OpenWriteStream("producer-omit-ext");
+
+    WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
+        1,
+        "payload",
+        std::make_pair(fixture.IntPublicationId, TString())));
+}
+
+Y_UNIT_TEST(StreamWriteRejectsTooLongExtPublicationId) {
+    auto fixture = TDeferredStreamWriteFixture::Enabled();
+    auto session = fixture.OpenWriteStream("producer-long-ext");
 
     WriteAndExpectFailure(
         *session->Stream,
-        MakeStreamWriteRequest(1, "payload", std::make_pair(fixture.IntPublicationId, TString(""))),
+        MakeStreamWriteRequest(
+            1,
+            "payload",
+            std::make_pair(fixture.IntPublicationId, TString(MaxDeferredPublishStringLength + 1, 'x'))),
         Ydb::StatusIds::BAD_REQUEST,
-        TString("WriteRequest.deferred_publish.ext_publication_id must not be empty"));
+        TString("WriteRequest.deferred_publish.ext_publication_id is too long"));
 }
 
 Y_UNIT_TEST(StreamWriteFailsOnUnknownIntPublicationId) {

--- a/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/topic_deferred_publish_ut.cpp
@@ -801,7 +801,7 @@ void InitStreamWriteSession(
 Ydb::Topic::StreamWriteMessage::FromClient MakeStreamWriteRequest(
     ui64 seqNo,
     const TString& data,
-    const TMaybe<std::pair<ui64, TString>>& deferredPublish = Nothing(),
+    const TMaybe<std::pair<ui64, TMaybe<TString>>>& deferredPublish = Nothing(),
     const TMaybe<std::pair<TString, TString>>& tx = Nothing())
 {
     Ydb::Topic::StreamWriteMessage::FromClient req;
@@ -811,8 +811,8 @@ Ydb::Topic::StreamWriteMessage::FromClient MakeStreamWriteRequest(
     if (deferredPublish) {
         auto* deferred = write->mutable_deferred_publish();
         deferred->set_int_publication_id(deferredPublish->first);
-        if (!deferredPublish->second.empty()) {
-            deferred->set_ext_publication_id(deferredPublish->second);
+        if (deferredPublish->second) {
+            deferred->set_ext_publication_id(*deferredPublish->second);
         }
     }
     if (tx) {
@@ -826,6 +826,14 @@ Ydb::Topic::StreamWriteMessage::FromClient MakeStreamWriteRequest(
     msg->set_uncompressed_size(data.size());
     *msg->mutable_created_at() = google::protobuf::util::TimeUtil::MillisecondsToTimestamp(TInstant::Now().MilliSeconds());
     return req;
+}
+
+std::pair<ui64, TMaybe<TString>> DeferredPublishOmitExt(ui64 intPublicationId) {
+    return {intPublicationId, Nothing()};
+}
+
+std::pair<ui64, TMaybe<TString>> DeferredPublishWithExt(ui64 intPublicationId, const TString& extPublicationId) {
+    return {intPublicationId, MakeMaybe(extPublicationId)};
 }
 
 void WriteAndExpectWriteResponse(
@@ -1927,7 +1935,7 @@ Y_UNIT_TEST(StreamWriteDeferredPublishAcksWrite) {
     WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
         1,
         "deferred-payload",
-        std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+        DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
 
     AssertDestinationRowCount(fixture.Server, "root@builtin", fixture.IntPublicationId, 1);
 
@@ -1951,7 +1959,7 @@ Y_UNIT_TEST(StreamWriteDeferredPublishDisabledByDefault) {
 
     WriteAndExpectFailure(
         *session->Stream,
-        MakeStreamWriteRequest(1, "payload", std::make_pair(1u, TString("ext-disabled"))),
+        MakeStreamWriteRequest(1, "payload", DeferredPublishWithExt(1u, TString("ext-disabled"))),
         Ydb::StatusIds::UNSUPPORTED,
         TString(DisabledMessage));
 }
@@ -1963,7 +1971,27 @@ Y_UNIT_TEST(StreamWriteAllowsOmitExtPublicationId) {
     WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
         1,
         "payload",
-        std::make_pair(fixture.IntPublicationId, TString())));
+        DeferredPublishOmitExt(fixture.IntPublicationId)));
+}
+
+Y_UNIT_TEST(StreamWriteAllowsEmptyExtPublicationId) {
+    auto fixture = TDeferredStreamWriteFixture::Enabled();
+    auto session = fixture.OpenWriteStream("producer-empty-ext");
+
+    WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
+        1,
+        "payload",
+        DeferredPublishWithExt(fixture.IntPublicationId, TString())));
+}
+
+Y_UNIT_TEST(StreamWriteAllowsNonEmptyExtPublicationId) {
+    auto fixture = TDeferredStreamWriteFixture::Enabled();
+    auto session = fixture.OpenWriteStream("producer-nonempty-ext");
+
+    WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
+        1,
+        "payload",
+        DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
 }
 
 Y_UNIT_TEST(StreamWriteRejectsTooLongExtPublicationId) {
@@ -1975,7 +2003,7 @@ Y_UNIT_TEST(StreamWriteRejectsTooLongExtPublicationId) {
         MakeStreamWriteRequest(
             1,
             "payload",
-            std::make_pair(fixture.IntPublicationId, TString(MaxDeferredPublishStringLength + 1, 'x'))),
+            DeferredPublishWithExt(fixture.IntPublicationId, TString(MaxDeferredPublishStringLength + 1, 'x'))),
         Ydb::StatusIds::BAD_REQUEST,
         TString("WriteRequest.deferred_publish.ext_publication_id is too long"));
 }
@@ -1988,7 +2016,7 @@ Y_UNIT_TEST(StreamWriteFailsOnUnknownIntPublicationId) {
     UNIT_ASSERT(session->Stream->Write(MakeStreamWriteRequest(
         1,
         "payload",
-        std::make_pair(999999u, TString("missing-ext")))));
+        DeferredPublishWithExt(999999u, TString("missing-ext")))));
     UNIT_ASSERT(session->Stream->Read(&resp));
     UNIT_ASSERT(resp.status() != Ydb::StatusIds::SUCCESS);
 }
@@ -2000,7 +2028,7 @@ Y_UNIT_TEST(StreamWriteDeferredThenRegularInSameSession) {
     WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
         1,
         "deferred-part",
-        std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+        DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(2, "regular-part"));
 }
 
@@ -2012,14 +2040,14 @@ Y_UNIT_TEST(StreamWriteMergesPartitionsIntoDestinationBlob) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "partition-0",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
     {
         auto session = fixture.OpenWriteStream("producer-part-1", 1);
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "partition-1",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     AssertDestinationRowCount(fixture.Server, "root@builtin", fixture.IntPublicationId, 1);
@@ -2046,7 +2074,7 @@ Y_UNIT_TEST(PublishAfterStreamWriteClearsRegistryAndMakesDataVisible) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payload),
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto publishOutcome = CallPublish(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2070,14 +2098,14 @@ Y_UNIT_TEST(PublishAfterStreamWriteToTwoPartitionsMakesDataVisible) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payload0),
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
     {
         auto session = fixture.OpenWriteStream("producer-part-1", 1);
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payload1),
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto publishOutcome = CallPublish(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2102,14 +2130,14 @@ Y_UNIT_TEST(CancelAfterStreamWriteToTwoPartitionsClearsRegistryWithoutData) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "deferred-payload-cancel-0",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
     {
         auto session = fixture.OpenWriteStream("producer-cancel-1", 1);
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "deferred-payload-cancel-1",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto cancelOutcome = CallCancelPublication(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2130,7 +2158,7 @@ Y_UNIT_TEST(CancelAfterStreamWriteClearsRegistryWithoutData) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "deferred-payload-cancel",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto cancelOutcome = CallCancelPublication(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2150,7 +2178,7 @@ Y_UNIT_TEST(RepeatFinalizeReturnsNotFound) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "payload-repeat",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto firstPublish = CallPublish(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2214,14 +2242,14 @@ Y_UNIT_TEST(PublishMultipleDestinations) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "topic-a-payload",
-            std::make_pair(intPublicationId, TString("ext-multi"))));
+            DeferredPublishWithExt(intPublicationId, TString("ext-multi"))));
     }
     {
         auto session = TStreamWriteSession::Open(*topicStub, "finalize-multi-topic-b", "producer-b", 0);
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "topic-b-payload",
-            std::make_pair(intPublicationId, TString("ext-multi"))));
+            DeferredPublishWithExt(intPublicationId, TString("ext-multi"))));
     }
 
     const auto publishOutcome = CallPublish(*deferredStub, "/Root", intPublicationId);
@@ -2241,7 +2269,7 @@ Y_UNIT_TEST(PublishBeforeWriteAckKeepsRegistry) {
     UNIT_ASSERT(session->Stream->Write(MakeStreamWriteRequest(
         1,
         "payload-before-ack",
-        std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId))));
+        DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId))));
     publishThread.join();
 
     UNIT_ASSERT_VALUES_UNEQUAL(publishOutcome.Operation.status(), Ydb::StatusIds::SUCCESS);
@@ -2256,7 +2284,7 @@ Y_UNIT_TEST(PublishFailureOnInvalidDestinationKeepsRegistry) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "payload-bad-dest",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const TString badBlob = NPQ::NDeferredPublish::SerializeDestinationBlob(
@@ -2306,7 +2334,7 @@ Y_UNIT_TEST(PublishMakesDataVisible) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payload),
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto publishOutcome = CallPublish(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2328,7 +2356,7 @@ Y_UNIT_TEST(CancelDiscardsData) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             "lifecycle-cancel-payload",
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto cancelOutcome = CallCancelPublication(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);
@@ -2347,7 +2375,7 @@ Y_UNIT_TEST(StagingNotVisibleBeforePublish) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payload),
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     AssertTopicNotVisible(fixture.Server, fixture.TopicShortName);
@@ -2381,14 +2409,14 @@ Y_UNIT_TEST(MultiDestinationSinglePublication) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payloadA),
-            std::make_pair(intPublicationId, TString("ext-lifecycle-multi-dest"))));
+            DeferredPublishWithExt(intPublicationId, TString("ext-lifecycle-multi-dest"))));
     }
     {
         auto session = TStreamWriteSession::Open(*topicStub, "lifecycle-multi-topic-b", "producer-b", 0);
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payloadB),
-            std::make_pair(intPublicationId, TString("ext-lifecycle-multi-dest"))));
+            DeferredPublishWithExt(intPublicationId, TString("ext-lifecycle-multi-dest"))));
     }
 
     const auto publishOutcome = CallPublish(*deferredStub, "/Root", intPublicationId);
@@ -2408,7 +2436,7 @@ Y_UNIT_TEST(RepeatFinalizeNotFound) {
         WriteAndExpectWriteResponse(*session->Stream, MakeStreamWriteRequest(
             1,
             TString(payload),
-            std::make_pair(fixture.IntPublicationId, fixture.ExtPublicationId)));
+            DeferredPublishWithExt(fixture.IntPublicationId, fixture.ExtPublicationId)));
     }
 
     const auto firstPublish = CallPublish(*fixture.DeferredStub, "/Root", fixture.IntPublicationId);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- DeferredPublishIdentity.ext_publication_id → optional
- Server accepts omit; still rejects overlong values
- No match check against BeginPublication (informational field)
- UT: omit allowed; too-long rejected

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
