### PR TITLE
[EXT-2347] Meta: url source

### DIFF
--- a/ydb/mvp/meta/examples/support_links_config.yaml
+++ b/ydb/mvp/meta/examples/support_links_config.yaml
@@ -25,6 +25,23 @@ meta:
 
   support_links:
     cluster:
+      - title: Support
+        source: url
+        # url source supports named placeholders.
+        # Template values are percent-encoded before they are put into the URL.
+        # Placeholders are resolved from request parameters and cluster info fields with the same name.
+        url: https://service.example.net/instance/{host}?dc={support_dc}
+        # link_parameter_mappings are used only for extra query parameters.
+        link_parameter_mappings:
+          - parameter: cluster_name
+            # Get the value from a request parameter.
+            from_request: cluster
+          - parameter: workspace
+            # Get the value from a cluster info field.
+            from_cluster_info: namespace
+          - parameter: bucket
+            # Use the same value for every link.
+            static_value: support
       - source: grafana/dashboard
         title: Cluster Overview
         url: /d/ydb_cluster/overview

--- a/ydb/mvp/meta/meta_ut.cpp
+++ b/ydb/mvp/meta/meta_ut.cpp
@@ -170,7 +170,7 @@ meta:
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             mvp.TryGetMetaOptionsFromConfig(appConfig),
             yexception,
-            "tag is not supported when source is omitted"
+            "tag is not supported for source=url"
         );
     }
 

--- a/ydb/mvp/meta/meta_ut.cpp
+++ b/ydb/mvp/meta/meta_ut.cpp
@@ -135,7 +135,7 @@ Y_UNIT_TEST_SUITE(SupportLinksSourceValidation) {
         return NMVP::TMVP(1, argv);
     }
 
-    Y_UNIT_TEST(RejectsMissingSourceInConfig) {
+    Y_UNIT_TEST(AllowsUrlSourceWithoutSourceField) {
         auto mvp = MakeTestMvp();
         const TString yaml = R"(
 generic:
@@ -149,7 +149,51 @@ meta:
         url: "https://example.test"
 )";
         const NMvp::NMeta::TMetaAppConfig appConfig = ParseConfig(yaml);
-        UNIT_ASSERT_EXCEPTION_CONTAINS(mvp.TryGetMetaOptionsFromConfig(appConfig), yexception, "source is required");
+        UNIT_ASSERT_NO_EXCEPTION(mvp.TryGetMetaOptionsFromConfig(appConfig));
+    }
+
+    Y_UNIT_TEST(UrlSourceRejectsGrafanaOnlyFields) {
+        auto mvp = MakeTestMvp();
+        const TString yaml = R"(
+generic:
+  access_service_type: "yandex_v2"
+meta:
+  meta_api_endpoint: "grpc://meta.ydb.example.net:2135"
+  meta_database: "/Root/meta"
+  support_links:
+    cluster:
+      - title: "Broken"
+        url: "https://example.test"
+        tag: ["ui-cluster"]
+)";
+        const NMvp::NMeta::TMetaAppConfig appConfig = ParseConfig(yaml);
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            mvp.TryGetMetaOptionsFromConfig(appConfig),
+            yexception,
+            "tag is not supported when source is omitted"
+        );
+    }
+
+    Y_UNIT_TEST(NonUrlSourceRejectsTemplatePlaceholdersInUrl) {
+        auto mvp = MakeTestMvp();
+        const TString yaml = R"(
+generic:
+  access_service_type: "yandex_v2"
+meta:
+  meta_api_endpoint: "grpc://meta.ydb.example.net:2135"
+  meta_database: "/Root/meta"
+  support_links:
+    cluster:
+      - source: "grafana/dashboard"
+        title: "Broken"
+        url: "/d/{dashboard}"
+)";
+        const NMvp::NMeta::TMetaAppConfig appConfig = ParseConfig(yaml);
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            mvp.TryGetMetaOptionsFromConfig(appConfig),
+            yexception,
+            "url template placeholders are not supported for source=grafana/dashboard"
+        );
     }
 
     Y_UNIT_TEST(UnsupportedSourceInConfigThrows) {

--- a/ydb/mvp/meta/protos/config.proto
+++ b/ydb/mvp/meta/protos/config.proto
@@ -26,7 +26,8 @@ message TMetaConfig {
             }
 
             // Link source identifier (for example: grafana/dashboard/search).
-            optional string Source = 1;
+            // Defaults to source=url.
+            optional string Source = 1 [default = "url"];
             // Optional display name shown in UI.
             optional string Title = 2;
             // Source-specific URL. Can be absolute or relative, depending on source.
@@ -35,7 +36,7 @@ message TMetaConfig {
             repeated string Tag = 4;
             // Grafana folder UID filters (for source=grafana/dashboard/search).
             repeated string Folder = 5;
-            // Optional override for source-specific generated link parameters.
+            // Optional override for source-specific generated query parameters.
             // When omitted, source defaults are used.
             repeated TLinkParameterMapping LinkParameterMappings = 6;
         }

--- a/ydb/mvp/meta/support_links/grafana_dashboard_search_source.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_search_source.cpp
@@ -210,6 +210,9 @@ private:
 } // namespace
 
 void ValidateGrafanaDashboardSearchSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
+    if (config.GetUrl().Contains('{') || config.GetUrl().Contains('}')) {
+        ythrow yexception() << "url template placeholders are not supported for source=" << config.GetSource();
+    }
     if (metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
         ythrow yexception() << "grafana.endpoint is required for source=" << config.GetSource();
     }

--- a/ydb/mvp/meta/support_links/grafana_dashboard_source.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_source.cpp
@@ -46,6 +46,9 @@ void ValidateGrafanaDashboardSourceConfig(const TSupportLinkEntryConfig& config,
     if (config.GetUrl().empty()) {
         ythrow yexception() << "url is required for source=" << config.GetSource();
     }
+    if (config.GetUrl().Contains('{') || config.GetUrl().Contains('}')) {
+        ythrow yexception() << "url template placeholders are not supported for source=" << config.GetSource();
+    }
     if (!IsAbsoluteUrl(config.GetUrl()) && metaSettings.SupportLinks.GrafanaEndpoint.empty()) {
         ythrow yexception() << "grafana.endpoint is required for relative url";
     }

--- a/ydb/mvp/meta/support_links/grafana_logging_source.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.cpp
@@ -44,10 +44,7 @@ TString BuildGrafanaLoggingExpr(const TVector<std::pair<TString, TString>>& bind
     return expr;
 }
 
-NJson::TJsonValue BuildGrafanaLoggingPanesJson(
-    const TString& datasource,
-    const TVector<std::pair<TString, TString>>& bindings)
-{
+NJson::TJsonValue BuildGrafanaLoggingPanesJson(const TString& datasource, const TVector<std::pair<TString, TString>>& bindings) {
     NJson::TJsonValue panesJson(NJson::JSON_MAP);
     NJson::TJsonValue paneJson(NJson::JSON_MAP);
     NJson::TJsonValue queryJson(NJson::JSON_MAP);
@@ -171,6 +168,9 @@ void ValidateGrafanaLoggingSourceConfig(const TSupportLinkEntryConfig& config, c
     const TStringBuf url = config.GetUrl().empty()
         ? GRAFANA_LOGGING_DEFAULT_URL
         : TStringBuf(config.GetUrl());
+    if (url.Contains('{') || url.Contains('}')) {
+        ythrow yexception() << "url template placeholders are not supported for source=" << config.GetSource();
+    }
     if (url.Contains('?')) {
         ythrow yexception() << "query parameters are not supported in url for source=" << config.GetSource();
     }

--- a/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source_ut.cpp
@@ -83,11 +83,7 @@ struct TGrafanaLoggingTestContext {
     }
 };
 
-void AssertPanesQuery(
-    const TString& url,
-    TStringBuf expectedBaseUrl,
-    TStringBuf expectedExpr,
-    TStringBuf expectedDatasource) {
+void AssertPanesQuery(const TString& url, TStringBuf expectedBaseUrl, TStringBuf expectedExpr, TStringBuf expectedDatasource) {
     const TStringBuf actualUrl = url;
     UNIT_ASSERT_VALUES_EQUAL(actualUrl.Before('?'), expectedBaseUrl);
 

--- a/ydb/mvp/meta/support_links/param_bindings.cpp
+++ b/ydb/mvp/meta/support_links/param_bindings.cpp
@@ -52,7 +52,6 @@ TResolvedParamBindings ResolveParamBindings(const TSupportLinkEntryConfig& confi
 
     return defaultParamBindings;
 }
-
 void ValidateParamsAreUnique(const TResolvedParamBindings& paramBindings, const TSupportLinkEntryConfig& config) {
     THashSet<TString> labels;
 

--- a/ydb/mvp/meta/support_links/source.cpp
+++ b/ydb/mvp/meta/support_links/source.cpp
@@ -2,6 +2,7 @@
 #include "grafana_dashboard_source.h"
 #include "grafana_dashboard_search_source.h"
 #include "grafana_logging_source.h"
+#include "url_source.h"
 
 #include <util/generic/yexception.h>
 
@@ -23,10 +24,10 @@ void ValidateSupportLinksConfig(const TSupportLinksConfig& supportLinks, const T
 }
 
 void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings) {
-    if (config.GetSource().empty()) {
-        ythrow yexception() << "source is required";
+    if (config.GetSource() == "url") {
+        ValidateUrlSourceConfig(config, metaSettings);
+        return;
     }
-
     if (config.GetSource() == "grafana/dashboard") {
         ValidateGrafanaDashboardSourceConfig(config, metaSettings);
         return;
@@ -46,6 +47,9 @@ void ValidateLinkSourceConfig(const TSupportLinkEntryConfig& config, const TMeta
 std::shared_ptr<ILinkSource> MakeLinkSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
     ValidateLinkSourceConfig(config, metaSettings);
 
+    if (config.GetSource() == "url") {
+        return MakeUrlSource(std::move(config), metaSettings);
+    }
     if (config.GetSource() == "grafana/dashboard") {
         return MakeGrafanaDashboardSource(std::move(config), metaSettings);
     }

--- a/ydb/mvp/meta/support_links/url_source.cpp
+++ b/ydb/mvp/meta/support_links/url_source.cpp
@@ -168,9 +168,7 @@ private:
 } // namespace
 
 void ValidateUrlSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings&) {
-    const TString sourceDescription = config.HasSource()
-        ? TStringBuilder() << "for source=" << config.GetSource()
-        : TString("when source is omitted");
+    const TString sourceDescription = TStringBuilder() << "for source=" << config.GetSource();
     if (config.GetUrl().empty()) {
         ythrow yexception() << "url is required " << sourceDescription;
     }

--- a/ydb/mvp/meta/support_links/url_source.cpp
+++ b/ydb/mvp/meta/support_links/url_source.cpp
@@ -1,0 +1,197 @@
+#include "url_source.h"
+
+#include "param_bindings.h"
+#include "source_common.h"
+#include "url_template.h"
+
+#include <fmt/args.h>
+#include <fmt/format.h>
+
+#include <library/cpp/uri/encode.h>
+#include <library/cpp/string_utils/url/url.h>
+
+#include <util/generic/hash_set.h>
+#include <util/generic/yexception.h>
+#include <util/stream/str.h>
+
+namespace NMVP::NSupportLinks {
+namespace {
+
+using TResolvedParamPool = THashMap<TString, TString>;
+using TQueryParamSet = THashSet<TString>;
+
+TResolvedParamBindings BuildDefaultUrlSourceQueryParamBindings(TStringBuf url) {
+    if (HasUrlTemplateExpressions(url)) {
+        return TResolvedParamBindings{
+            .RequestMappings = {},
+            .ClusterInfoMappings = {},
+            .StaticMappings = {},
+        };
+    }
+
+    return TResolvedParamBindings{
+        .RequestMappings = {
+            {"cluster", "cluster"},
+            {"database", "database"},
+            {"node", "node"},
+            {"host", "host"},
+        },
+        .ClusterInfoMappings = {},
+        .StaticMappings = {},
+    };
+}
+
+TVector<std::pair<TString, TString>> RemoveUrlTemplateParams(const TVector<std::pair<TString, TString>>& parametersToAdd, TStringBuf url) {
+    TVector<std::pair<TString, TString>> filteredParams;
+    filteredParams.reserve(parametersToAdd.size());
+
+    for (const auto& [parameter, value] : parametersToAdd) {
+        if (!HasUrlTemplateParameter(url, parameter)) {
+            filteredParams.emplace_back(parameter, value);
+        }
+    }
+
+    return filteredParams;
+}
+
+void ApplyQueryParams(TCgiParameters& queryParameters, const TVector<std::pair<TString, TString>>& parametersToAdd) {
+    TQueryParamSet renderedQueryParameters;
+    for (const auto& [name, value] : queryParameters) {
+        Y_UNUSED(value);
+        renderedQueryParameters.insert(name);
+    }
+
+    for (const auto& [parameter, value] : parametersToAdd) {
+        if (renderedQueryParameters.contains(parameter)) {
+            continue;
+        }
+        queryParameters.ReplaceUnescaped(parameter, value);
+    }
+}
+
+void PutResolvedParam(TResolvedParamPool& resolvedParams, TStringBuf name, TStringBuf value) {
+    if (!name.empty() && !value.empty()) {
+        resolvedParams[TString(name)] = TString(value);
+    }
+}
+
+TResolvedParamPool BuildResolvedTemplateParams(const TCgiParameters& requestParameters, const THashMap<TString, TString>& clusterInfo) {
+    TResolvedParamPool resolvedParams;
+    for (const auto& [name, value] : clusterInfo) {
+        PutResolvedParam(resolvedParams, name, value);
+    }
+    for (const auto& [name, value] : requestParameters) {
+        PutResolvedParam(resolvedParams, name, value);
+    }
+    return resolvedParams;
+}
+
+TString RenderTemplatedUrl(TStringBuf urlTemplate, const TResolvedParamPool& resolvedParams) {
+    TVector<TString> escapedValues;
+    escapedValues.reserve(resolvedParams.size());
+    fmt::dynamic_format_arg_store<fmt::format_context> store;
+
+    for (const auto& [name, value] : resolvedParams) {
+        escapedValues.emplace_back();
+        TString& escapedValue = escapedValues.back();
+        TStringOutput out(escapedValue);
+        NUri::NEncode::TEncoder::Encode(out, value);
+        store.push_back(fmt::arg(name.c_str(), escapedValue));
+    }
+
+    try {
+        return TString(fmt::vformat(std::string_view(urlTemplate.data(), urlTemplate.size()), store));
+    } catch (const fmt::format_error& e) {
+        ythrow yexception() << "failed to render URL template '" << urlTemplate << "': " << e.what();
+    }
+}
+
+TString BuildUrlSourceUrl(const TString& url, const ILinkSource::TLinkResolveInput& input, const TResolvedParamBindings& queryParamBindings) {
+    const TCgiParameters requestParameters = BuildForwardedParameters(input.Identity, input.AdditionalRequestParams);
+    const TResolvedParamPool resolvedTemplateParams = BuildResolvedTemplateParams(requestParameters, input.ClusterInfo);
+    const TString renderedUrl = RenderTemplatedUrl(url, resolvedTemplateParams);
+    TStringBuf path;
+    TStringBuf queryString;
+    TStringBuf fragment;
+    SeparateUrlFromQueryAndFragment(renderedUrl, path, queryString, fragment);
+    TCgiParameters queryParameters(queryString);
+    const auto parametersToAdd = RemoveUrlTemplateParams(
+        BuildParametersToAdd(requestParameters, input.ClusterInfo, queryParamBindings),
+        url);
+
+    ApplyQueryParams(queryParameters, parametersToAdd);
+
+    TStringBuilder builder;
+    builder << path;
+    if (!queryParameters.empty()) {
+        builder << '?' << queryParameters.Print();
+    }
+    if (!fragment.empty()) {
+        builder << '#' << fragment;
+    }
+    return builder;
+}
+
+class TUrlSource : public ILinkSource {
+public:
+    TUrlSource(TString sourceName, TString title, TString url, TResolvedParamBindings queryParamBindings) : SourceName(std::move(sourceName))
+        , Title(std::move(title))
+        , Url(std::move(url))
+        , QueryParamBindings(std::move(queryParamBindings))
+    {}
+
+    TResolveOutput Resolve(const ILinkSource::TLinkResolveInput& input, const ILinkSource::TResolveContext&) const override {
+        TResolveOutput result{
+            .Name = SourceName,
+        };
+        try {
+            result.Links.emplace_back(TResolvedLink{
+                .Title = Title,
+                .Url = BuildUrlSourceUrl(Url, input, QueryParamBindings),
+            });
+        } catch (const std::exception& e) {
+            result.Errors.emplace_back(TSupportError{
+                .Source = SourceName,
+                .Message = e.what(),
+            });
+        }
+        return result;
+    }
+
+private:
+    TString SourceName;
+    TString Title;
+    TString Url;
+    TResolvedParamBindings QueryParamBindings;
+};
+
+} // namespace
+
+void ValidateUrlSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings&) {
+    const TString sourceDescription = config.HasSource()
+        ? TStringBuilder() << "for source=" << config.GetSource()
+        : TString("when source is omitted");
+    if (config.GetUrl().empty()) {
+        ythrow yexception() << "url is required " << sourceDescription;
+    }
+    if (config.TagSize() != 0) {
+        ythrow yexception() << "tag is not supported " << sourceDescription;
+    }
+    if (config.FolderSize() != 0) {
+        ythrow yexception() << "folder is not supported " << sourceDescription;
+    }
+    ValidateUrlTemplateSyntax(config.GetUrl());
+    ValidateParamsAreUnique(ResolveParamBindings(config, BuildDefaultUrlSourceQueryParamBindings(config.GetUrl())), config);
+}
+
+std::shared_ptr<ILinkSource> MakeUrlSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings) {
+    ValidateUrlSourceConfig(config, metaSettings);
+    auto queryParamBindings = ResolveParamBindings(config, BuildDefaultUrlSourceQueryParamBindings(config.GetUrl()));
+    return std::make_shared<TUrlSource>(
+        config.GetSource(),
+        config.GetTitle(),
+        config.GetUrl(),
+        std::move(queryParamBindings));
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/url_source.h
+++ b/ydb/mvp/meta/support_links/url_source.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "source.h"
+
+namespace NMVP::NSupportLinks {
+
+void ValidateUrlSourceConfig(const TSupportLinkEntryConfig& config, const TMetaSettings& metaSettings);
+std::shared_ptr<ILinkSource> MakeUrlSource(TSupportLinkEntryConfig config, const TMetaSettings& metaSettings);
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/url_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/url_source_ut.cpp
@@ -1,0 +1,266 @@
+#include <library/cpp/cgiparam/cgiparam.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/library/actors/http/http.h>
+#include <ydb/mvp/meta/support_links/source.h>
+
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+
+namespace {
+
+using EEntityType = NMVP::NSupportLinks::EEntityType;
+
+NHttp::TUrlParametersBuilder MakeUrlParameters(TStringBuf query) {
+    NHttp::TUrlParametersBuilder builder;
+    for (TStringBuf param = query.NextTok('&'); !param.empty(); param = query.NextTok('&')) {
+        TStringBuf name = param.NextTok('=');
+        builder.Set(name, param);
+    }
+    return builder;
+}
+
+std::pair<TStringBuf, TStringBuf> SplitFragment(TStringBuf url) {
+    const size_t fragmentPos = url.find('#');
+    if (fragmentPos == TStringBuf::npos) {
+        return {url, TStringBuf()};
+    }
+    return {
+        url.SubStr(0, fragmentPos),
+        url.SubStr(fragmentPos + 1),
+    };
+}
+
+void AssertSingleResolvedLink(const NMVP::TResolveOutput& result, TStringBuf expectedUrl) {
+    UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 0u);
+
+    const auto [actualUrl, actualFragment] = SplitFragment(result.Links[0].Url);
+    const auto [expectedUrlWithoutFragment, expectedFragment] = SplitFragment(expectedUrl);
+    UNIT_ASSERT_VALUES_EQUAL(actualFragment, expectedFragment);
+    UNIT_ASSERT_VALUES_EQUAL(actualUrl.Before('?'), expectedUrlWithoutFragment.Before('?'));
+
+    TCgiParameters actualQuery;
+    TCgiParameters expectedQuery;
+    actualQuery.Scan(actualUrl.After('?'));
+    expectedQuery.Scan(expectedUrlWithoutFragment.After('?'));
+    UNIT_ASSERT_VALUES_EQUAL(actualQuery.Print(), expectedQuery.Print());
+}
+
+void AssertSingleResolveErrorContains(const NMVP::TResolveOutput& result, TStringBuf expectedMessagePart) {
+    UNIT_ASSERT_VALUES_EQUAL(result.Links.size(), 0u);
+    UNIT_ASSERT_VALUES_EQUAL(result.Errors.size(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(result.Errors[0].Source, "url");
+    UNIT_ASSERT_STRING_CONTAINS(result.Errors[0].Message, expectedMessagePart);
+}
+
+struct TUrlSourceTestContext {
+    NMVP::TSupportLinkEntryConfig Config;
+    NMVP::TMetaSettings Settings;
+    THashMap<TString, TString> ClusterInfo;
+    NHttp::TUrlParametersBuilder UrlParameters;
+    EEntityType EntityType;
+    NActors::TActorId Owner;
+    NActors::TActorId HttpProxyId;
+    NMVP::NSupportLinks::ILinkSource::TResolveContext Context;
+
+    explicit TUrlSourceTestContext(TStringBuf url = "https://support.example.net/link")
+        : UrlParameters("")
+        , EntityType(EEntityType::Cluster)
+        , Owner(1, "ow")
+        , HttpProxyId(2, "hp")
+        , Context{
+            .Place = 0,
+            .Owner = Owner,
+            .HttpProxyId = HttpProxyId,
+        }
+    {
+        Config.SetTitle("Support");
+        Config.SetUrl(TString(url));
+    }
+
+    std::shared_ptr<NMVP::NSupportLinks::ILinkSource> CreateSource() const {
+        return NMVP::NSupportLinks::MakeLinkSource(Config, Settings);
+    }
+
+    NMVP::TResolveOutput Resolve() const {
+        const TCgiParameters additionalRequestParams = NMVP::NSupportLinks::BuildAdditionalRequestParameters(UrlParameters);
+        const auto identity = NMVP::NSupportLinks::BuildEntityIdentity(EntityType, UrlParameters);
+        return CreateSource()->Resolve(NMVP::NSupportLinks::ILinkSource::TLinkResolveInput{
+            .ClusterInfo = ClusterInfo,
+            .AdditionalRequestParams = additionalRequestParams,
+            .Identity = identity,
+        }, Context);
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(SupportLinksUrlSource) {
+    Y_UNIT_TEST(AllowsExplicitUrlSource) {
+        TUrlSourceTestContext context;
+        context.Config.SetSource("url");
+        UNIT_ASSERT_NO_EXCEPTION(context.CreateSource());
+    }
+
+    Y_UNIT_TEST(ValidationRejectsEmptyUrl) {
+        TUrlSourceTestContext context("");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "url is required when source is omitted"
+        );
+    }
+
+    Y_UNIT_TEST(ValidationRejectsTagAndFolder) {
+        TUrlSourceTestContext context;
+        context.Config.AddTag("ui-cluster");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "tag is not supported when source is omitted"
+        );
+
+        context.Config.ClearTag();
+        context.Config.AddFolder("folder-1");
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            context.CreateSource(),
+            yexception,
+            "folder is not supported when source is omitted"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveReturnsStaticUrlWithoutMappings) {
+        TUrlSourceTestContext context;
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(result, "https://support.example.net/link");
+        UNIT_ASSERT_VALUES_EQUAL(result.Links[0].Title, "Support");
+    }
+
+    Y_UNIT_TEST(ResolveForwardsCurrentRequestParametersWithoutMappings) {
+        TUrlSourceTestContext context;
+        context.EntityType = EEntityType::Host;
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net&ticket=ABC-42&node=ignored-node");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://support.example.net/link?cluster=ydb-global&host=node-1.example.net&ticket=ABC-42"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesIdentityAndAdditionalRequestClusterInfoAndStaticMappings) {
+        TUrlSourceTestContext context;
+        auto* clusterMapping = context.Config.AddLinkParameterMappings();
+        clusterMapping->SetParameter("cluster_name");
+        clusterMapping->SetFromRequest("cluster");
+        auto* customMapping = context.Config.AddLinkParameterMappings();
+        customMapping->SetParameter("ticket");
+        customMapping->SetFromRequest("ticket");
+        auto* dcMapping = context.Config.AddLinkParameterMappings();
+        dcMapping->SetParameter("dc");
+        dcMapping->SetFromClusterInfo("support_dc");
+        auto* bucketMapping = context.Config.AddLinkParameterMappings();
+        bucketMapping->SetParameter("bucket");
+        bucketMapping->SetStaticValue("ydb");
+
+        context.ClusterInfo["support_dc"] = "man-testing";
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&ticket=ABC-42");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://support.example.net/link?ticket=ABC-42&dc=man-testing&bucket=ydb&cluster_name=ydb-global"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesHostIdentityAndPreservesExistingQueryAndSkipsMissingValues) {
+        TUrlSourceTestContext context("https://support.example.net/link?tab=overview");
+        auto* hostMapping = context.Config.AddLinkParameterMappings();
+        hostMapping->SetParameter("host");
+        hostMapping->SetFromRequest("host");
+        auto* missingMapping = context.Config.AddLinkParameterMappings();
+        missingMapping->SetParameter("dc");
+        missingMapping->SetFromClusterInfo("missing_dc");
+
+        context.EntityType = EEntityType::Host;
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net&node=ignored-node");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://support.example.net/link?tab=overview&host=node-1.example.net"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveUsesRequestValueForTemplateParameter) {
+        TUrlSourceTestContext context("https://service.example.net/instance/{host}?dc={dc}");
+        context.Config.SetSource("url");
+
+        context.EntityType = EEntityType::Host;
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net&dc=req");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://service.example.net/instance/node-1.example.net?dc=req"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveEscapesTemplateValuesUsedInQueryTemplateParameters) {
+        TUrlSourceTestContext context("https://service.example.net/instance/{host}?ticket={ticket}");
+        context.Config.SetSource("url");
+
+        context.EntityType = EEntityType::Host;
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net");
+        context.ClusterInfo["ticket"] = "A&B?x=1";
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://service.example.net/instance/node-1.example.net?ticket=A%26B%3Fx%3D1"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveDoesNotUseQueryMappingsForTemplateParameters) {
+        TUrlSourceTestContext context("https://service.example.net/instance/{host}?dc={dc}");
+        context.Config.SetSource("url");
+        auto* dcMapping = context.Config.AddLinkParameterMappings();
+        dcMapping->SetParameter("dc");
+        dcMapping->SetFromClusterInfo("support_dc");
+
+        context.EntityType = EEntityType::Host;
+        context.ClusterInfo["support_dc"] = "man";
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net");
+        auto result = context.Resolve();
+
+        AssertSingleResolveErrorContains(result, "failed to render URL template");
+    }
+
+    Y_UNIT_TEST(ResolvePreservesUrlFragmentAfterQueryMerge) {
+        TUrlSourceTestContext context("https://service.example.net/instance/{host}?dc={dc}#details");
+        context.Config.SetSource("url");
+
+        context.EntityType = EEntityType::Host;
+        context.ClusterInfo["dc"] = "man";
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net&ticket=ABC-42");
+        auto result = context.Resolve();
+
+        AssertSingleResolvedLink(
+            result,
+            "https://service.example.net/instance/node-1.example.net?dc=man&ticket=ABC-42#details"
+        );
+    }
+
+    Y_UNIT_TEST(ResolveReturnsErrorForMissingTemplateParameter) {
+        TUrlSourceTestContext context("https://service.example.net/instance/{host}?dc={dc}");
+        context.Config.SetSource("url");
+        context.EntityType = EEntityType::Host;
+        context.UrlParameters = MakeUrlParameters("cluster=ydb-global&host=node-1.example.net");
+
+        auto result = context.Resolve();
+
+        AssertSingleResolveErrorContains(result, "failed to render URL template");
+    }
+}

--- a/ydb/mvp/meta/support_links/url_source_ut.cpp
+++ b/ydb/mvp/meta/support_links/url_source_ut.cpp
@@ -108,7 +108,7 @@ Y_UNIT_TEST_SUITE(SupportLinksUrlSource) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             context.CreateSource(),
             yexception,
-            "url is required when source is omitted"
+            "url is required for source=url"
         );
     }
 
@@ -118,7 +118,7 @@ Y_UNIT_TEST_SUITE(SupportLinksUrlSource) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             context.CreateSource(),
             yexception,
-            "tag is not supported when source is omitted"
+            "tag is not supported for source=url"
         );
 
         context.Config.ClearTag();
@@ -126,7 +126,7 @@ Y_UNIT_TEST_SUITE(SupportLinksUrlSource) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(
             context.CreateSource(),
             yexception,
-            "folder is not supported when source is omitted"
+            "folder is not supported for source=url"
         );
     }
 
@@ -239,7 +239,7 @@ Y_UNIT_TEST_SUITE(SupportLinksUrlSource) {
     }
 
     Y_UNIT_TEST(ResolvePreservesUrlFragmentAfterQueryMerge) {
-        TUrlSourceTestContext context("https://service.example.net/instance/{host}?dc={dc}#details");
+        TUrlSourceTestContext context("https://service.example.net/instance/{host}?dc={dc}#details-{host}");
         context.Config.SetSource("url");
 
         context.EntityType = EEntityType::Host;
@@ -249,7 +249,7 @@ Y_UNIT_TEST_SUITE(SupportLinksUrlSource) {
 
         AssertSingleResolvedLink(
             result,
-            "https://service.example.net/instance/node-1.example.net?dc=man&ticket=ABC-42#details"
+            "https://service.example.net/instance/node-1.example.net?dc=man&ticket=ABC-42#details-node-1.example.net"
         );
     }
 

--- a/ydb/mvp/meta/support_links/url_template.cpp
+++ b/ydb/mvp/meta/support_links/url_template.cpp
@@ -29,14 +29,14 @@ bool ScanUrlTemplateExpressions(TStringBuf urlTemplate, TStringBuf parameterName
     const bool findParameter = !parameterNameToFind.empty();
     TStringBuf tail = urlTemplate;
     while (!tail.empty()) {
-        TStringBuf literal;
+        TStringBuf prefix;
         TStringBuf rest;
-        if (!tail.TrySplit('{', literal, rest)) {
+        if (!tail.TrySplit('{', prefix, rest)) {
             ValidateLiteralSegment(tail);
             break;
         }
 
-        ValidateLiteralSegment(literal);
+        ValidateLiteralSegment(prefix);
         tail = rest;
 
         TStringBuf name;

--- a/ydb/mvp/meta/support_links/url_template.cpp
+++ b/ydb/mvp/meta/support_links/url_template.cpp
@@ -1,0 +1,81 @@
+#include "url_template.h"
+
+#include <regex>
+
+#include <util/generic/yexception.h>
+
+namespace NMVP::NSupportLinks {
+namespace {
+
+constexpr TStringBuf UrlTemplateNamePattern = R"([A-Za-z_][A-Za-z0-9_]*)";
+static const std::regex UrlTemplateNameRegexp(TString(UrlTemplateNamePattern).c_str());
+
+void ValidateUrlTemplateName(TStringBuf name) {
+    if (!std::regex_match(name.begin(), name.end(), UrlTemplateNameRegexp)) {
+        ythrow yexception()
+            << "url template placeholders must use the form {name}, where name matches "
+            << UrlTemplateNamePattern;
+    }
+}
+
+void ValidateLiteralSegment(TStringBuf text) {
+    if (text.Contains('}')) {
+        ythrow yexception() << "unmatched '}' in url template";
+    }
+}
+
+bool ScanUrlTemplateExpressions(TStringBuf urlTemplate, TStringBuf parameterNameToFind = {}, bool* hasExpressions = nullptr) {
+    bool foundExpression = false;
+    const bool findParameter = !parameterNameToFind.empty();
+    TStringBuf tail = urlTemplate;
+    while (!tail.empty()) {
+        TStringBuf literal;
+        TStringBuf rest;
+        if (!tail.TrySplit('{', literal, rest)) {
+            ValidateLiteralSegment(tail);
+            break;
+        }
+
+        ValidateLiteralSegment(literal);
+        tail = rest;
+
+        TStringBuf name;
+        if (!tail.TrySplit('}', name, rest)) {
+            ythrow yexception() << "missing '}' in url template";
+        }
+
+        ValidateUrlTemplateName(name);
+        foundExpression = true;
+        if (findParameter && name == parameterNameToFind) {
+            if (hasExpressions != nullptr) {
+                *hasExpressions = true;
+            }
+            return true;
+        }
+
+        tail = rest;
+    }
+
+    if (hasExpressions != nullptr) {
+        *hasExpressions = foundExpression;
+    }
+    return false;
+}
+
+} // namespace
+
+bool HasUrlTemplateExpressions(TStringBuf urlTemplate) {
+    bool hasExpressions = false;
+    ScanUrlTemplateExpressions(urlTemplate, {}, &hasExpressions);
+    return hasExpressions;
+}
+
+bool HasUrlTemplateParameter(TStringBuf urlTemplate, TStringBuf parameterName) {
+    return ScanUrlTemplateExpressions(urlTemplate, parameterName);
+}
+
+void ValidateUrlTemplateSyntax(TStringBuf urlTemplate) {
+    ScanUrlTemplateExpressions(urlTemplate);
+}
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/url_template.h
+++ b/ydb/mvp/meta/support_links/url_template.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NMVP::NSupportLinks {
+
+bool HasUrlTemplateExpressions(TStringBuf urlTemplate);
+bool HasUrlTemplateParameter(TStringBuf urlTemplate, TStringBuf parameterName);
+void ValidateUrlTemplateSyntax(TStringBuf urlTemplate);
+
+} // namespace NMVP::NSupportLinks

--- a/ydb/mvp/meta/support_links/url_template_ut.cpp
+++ b/ydb/mvp/meta/support_links/url_template_ut.cpp
@@ -1,0 +1,45 @@
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <ydb/mvp/meta/support_links/url_template.h>
+
+static void AssertTemplateValidationError(TStringBuf urlTemplate, TStringBuf expectedMessagePart) {
+    UNIT_ASSERT_EXCEPTION_CONTAINS(
+        NMVP::NSupportLinks::ValidateUrlTemplateSyntax(urlTemplate),
+        yexception,
+        expectedMessagePart
+    );
+}
+
+Y_UNIT_TEST_SUITE(SupportLinksUrlTemplate) {
+    constexpr TStringBuf InvalidNameError =
+        "url template placeholders must use the form {name}, where name matches [A-Za-z_][A-Za-z0-9_]*";
+
+    Y_UNIT_TEST(RecognizesTemplateExpressionsAndParameters) {
+        const TStringBuf urlTemplate = "https://service.example.net/{host}?dc={dc}&copy={host}";
+        UNIT_ASSERT(NMVP::NSupportLinks::HasUrlTemplateExpressions(urlTemplate));
+        UNIT_ASSERT(NMVP::NSupportLinks::HasUrlTemplateParameter(urlTemplate, "host"));
+        UNIT_ASSERT(NMVP::NSupportLinks::HasUrlTemplateParameter(urlTemplate, "dc"));
+        UNIT_ASSERT(!NMVP::NSupportLinks::HasUrlTemplateParameter(urlTemplate, "literal"));
+    }
+
+    Y_UNIT_TEST(ValidationRejectsMissingClosingBrace) {
+        AssertTemplateValidationError(
+            "https://service.example.net/{host",
+            "missing '}' in url template"
+        );
+    }
+
+    Y_UNIT_TEST(ValidationRejectsUnmatchedClosingBrace) {
+        AssertTemplateValidationError(
+            "https://service.example.net/host}",
+            "unmatched '}' in url template"
+        );
+    }
+
+    Y_UNIT_TEST(ValidationRejectsInvalidPlaceholderNameCharacters) {
+        AssertTemplateValidationError(
+            "https://service.example.net/{host-name}",
+            InvalidNameError
+        );
+    }
+}

--- a/ydb/mvp/meta/support_links/url_template_ut.cpp
+++ b/ydb/mvp/meta/support_links/url_template_ut.cpp
@@ -14,6 +14,10 @@ Y_UNIT_TEST_SUITE(SupportLinksUrlTemplate) {
     constexpr TStringBuf InvalidNameError =
         "url template placeholders must use the form {name}, where name matches [A-Za-z_][A-Za-z0-9_]*";
 
+    Y_UNIT_TEST(NoParamsAreOk) {
+        UNIT_ASSERT_NO_EXCEPTION(NMVP::NSupportLinks::ValidateUrlTemplateSyntax("https://service.example.net/"));
+    }
+
     Y_UNIT_TEST(RecognizesTemplateExpressionsAndParameters) {
         const TStringBuf urlTemplate = "https://service.example.net/{host}?dc={dc}&copy={host}";
         UNIT_ASSERT(NMVP::NSupportLinks::HasUrlTemplateExpressions(urlTemplate));

--- a/ydb/mvp/meta/support_links/ut/ya.make
+++ b/ydb/mvp/meta/support_links/ut/ya.make
@@ -3,6 +3,8 @@ UNITTEST_FOR(ydb/mvp/meta/support_links)
 SIZE(SMALL)
 
 SRCS(
+    url_template_ut.cpp
+    url_source_ut.cpp
     grafana_dashboard_source_ut.cpp
     grafana_dashboard_search_source_ut.cpp
     grafana_logging_source_ut.cpp

--- a/ydb/mvp/meta/support_links/ya.make
+++ b/ydb/mvp/meta/support_links/ya.make
@@ -1,6 +1,8 @@
 LIBRARY()
 
 SRCS(
+    url_template.cpp
+    url_source.cpp
     entity.cpp
     grafana_dashboard_common.cpp
     grafana_dashboard_search_source.cpp
@@ -13,6 +15,9 @@ SRCS(
 )
 
 PEERDIR(
+    contrib/libs/fmt
+    library/cpp/uri
+    library/cpp/string_utils/url
     ydb/mvp/core
     ydb/mvp/meta/protos
     library/cpp/json


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds a new url support links source (also used as the default) that can render named URL templates. This extends the existing support-links framework alongside the Grafana sources.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Implemented URL a new url link source with template logic + template validation.
- Updated config example
- Added unit tests covering validation
