### PR TITLE
Use context which is not depending on hardware in RDMA tests

### DIFF
--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -308,7 +308,7 @@ public:
         IExecutorPool *pool = CreateTestExecutorPool(nodeId);
         setup->Executors[0].Reset(pool);
 #if !defined(_msan_enabled_)
-        auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+        auto memPool = NInterconnect::NRdma::CreateDummyMemPool(/*emulateRegistration=*/true);
         setup->RcBufAllocator = std::make_shared<TRdmaAllocatorWithFallback>(memPool);
 #endif
 

--- a/ydb/library/actors/interconnect/rdma/mem_pool.cpp
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.cpp
@@ -629,8 +629,8 @@ namespace NInterconnect::NRdma {
 
     class TDummyMemPool: public TMemPoolBase {
     public:
-        TDummyMemPool()
-            : TMemPoolBase(-1, MakeCounters(nullptr), /* emulateRegistration=*/true)
+        explicit TDummyMemPool(bool emulateRegistration = false)
+            : TMemPoolBase(-1, MakeCounters(nullptr), emulateRegistration)
         {}
 
         TMemRegionPtr AllocImpl(int size, ui32) noexcept override {
@@ -961,8 +961,21 @@ namespace NInterconnect::NRdma {
 
     thread_local TSlotMemPool::TSlotMemPoolCache TSlotMemPool::LocalCache;
 
-    std::shared_ptr<IMemPool> CreateDummyMemPool() noexcept {
-        auto* pool = Singleton<TDummyMemPool>();
+    namespace {
+        struct TDummyMemPoolRealTag : public TDummyMemPool {
+            TDummyMemPoolRealTag() : TDummyMemPool(/*emulateRegistration=*/false) {}
+        };
+        struct TDummyMemPoolEmulatedTag : public TDummyMemPool {
+            TDummyMemPoolEmulatedTag() : TDummyMemPool(/*emulateRegistration=*/true) {}
+        };
+    }
+
+    std::shared_ptr<IMemPool> CreateDummyMemPool(bool emulateRegistration) noexcept {
+        if (emulateRegistration) {
+            auto* pool = Singleton<TDummyMemPoolEmulatedTag>();
+            return std::shared_ptr<TDummyMemPool>(pool, [](TDummyMemPool*) {});
+        }
+        auto* pool = Singleton<TDummyMemPoolRealTag>();
         return std::shared_ptr<TDummyMemPool>(pool, [](TDummyMemPool*) {});
     }
 

--- a/ydb/library/actors/interconnect/rdma/mem_pool.cpp
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.cpp
@@ -476,8 +476,8 @@ namespace NInterconnect::NRdma {
 
     class TMemPoolBase: public IMemPool {
     public:
-        TMemPoolBase(size_t maxChunk, NMonitoring::TDynamicCounterPtr counter)
-            : Ctxs(GetAllCtxs())
+        TMemPoolBase(size_t maxChunk, NMonitoring::TDynamicCounterPtr counter, bool emulateRegistration = false)
+            : Ctxs(emulateRegistration ? NInterconnect::NRdma::NLinkMgr::TCtxsMap{} : GetAllCtxs())
             , MaxChunk(maxChunk)
             , Alignment(NSystemInfo::GetPageSize())
         {
@@ -630,7 +630,7 @@ namespace NInterconnect::NRdma {
     class TDummyMemPool: public TMemPoolBase {
     public:
         TDummyMemPool()
-            : TMemPoolBase(-1, MakeCounters(nullptr))
+            : TMemPoolBase(-1, MakeCounters(nullptr), /* emulateRegistration=*/true)
         {}
 
         TMemRegionPtr AllocImpl(int size, ui32) noexcept override {

--- a/ydb/library/actors/interconnect/rdma/mem_pool.h
+++ b/ydb/library/actors/interconnect/rdma/mem_pool.h
@@ -108,6 +108,6 @@ namespace NInterconnect::NRdma {
         virtual void Tick(NMonotonic::TMonotonic time) noexcept = 0;
     };
 
-    std::shared_ptr<IMemPool> CreateDummyMemPool() noexcept;
+    std::shared_ptr<IMemPool> CreateDummyMemPool(bool emulateRegistration = false) noexcept;
     std::shared_ptr<IMemPool> CreateSlotMemPool(NMonitoring::TDynamicCounters* counters, std::optional<TMemPoolSettings> settings) noexcept;
 }

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1774,7 +1774,7 @@ namespace NActors {
         }
 
         if (UseRdmaAllocator) {
-            auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+            auto memPool = NInterconnect::NRdma::CreateDummyMemPool(/*emulateRegistration=*/true);
             setup->RcBufAllocator = std::make_shared<TRdmaAllocatorWithFallback>(memPool);
         }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix RDMA unit tests by using virtual context which doesn't rely on hardware

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)