### PR TITLE
fix issue #26733 (tablet crash on oversized index blob). [1/2]

### DIFF
--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -656,6 +656,17 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
         csController->WaitActualization(TDuration::Seconds(5));
         tieringHelper.CheckAllDataInTier(DEFAULT_TIER_PATH);
 
+        // The oversized filter must be split into several chunks fitting the blob limit, not dropped.
+        {
+            auto selectQuery = TStringBuilder() << R"(
+                SELECT *
+                FROM `/Root/olapStore/olapTable/.sys/primary_index_stats`
+                WHERE Activity == 1 AND EntityName == "index_ngramm_uid"
+            )";
+            auto rows = ExecuteScanQuery(tableClient, selectQuery);
+            UNIT_ASSERT_GT(rows.size(), 0);
+        }
+
         ExecuteScanQuery(tableClient, "SELECT * FROM `/Root/olapStore/olapTable`");
     }
 

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -626,6 +626,39 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
         ExecuteScanQuery(tableClient, "SELECT *  FROM `/Root/olapStore/olapTable`");
     }
 
+    // Issue #26733: a ngramm bloom index whose rebuilt filter exceeds the storage MaxBlobSize used to abort
+    // the tablet with "blob size for secondary data ... bigger than limit" during tiering actualization.
+    Y_UNIT_TEST(OversizedNGrammIndexOnTiering) {
+        TTieringTestHelper tieringHelper;
+        auto& csController = tieringHelper.GetCsController();
+        auto& olapHelper = tieringHelper.GetOlapHelper();
+        auto& testHelper = tieringHelper.GetTestHelper();
+        olapHelper.CreateTestOlapTable();
+        testHelper.CreateTier(DEFAULT_TIER_NAME);
+
+        NYdb::NTable::TTableClient tableClient = testHelper.GetKikimr().GetTableClient();
+
+        {
+            auto alterQuery =
+                R"(ALTER OBJECT `/Root/olapStore` (TYPE TABLESTORE) SET (ACTION=UPSERT_INDEX, NAME=index_ngramm_uid, TYPE=BLOOM_NGRAMM_FILTER,
+                    FEATURES=`{"column_name" : "uid", "ngramm_size" : 3, "hashes_count" : 2, "filter_size_bytes" : 512, "records_count" : 1024}`);
+                )";
+            auto session = tableClient.CreateSession().GetValueSync().GetSession();
+            auto alterResult = session.ExecuteSchemeQuery(alterQuery).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(alterResult.GetStatus(), NYdb::EStatus::SUCCESS, alterResult.GetIssues().ToString());
+        }
+
+        tieringHelper.WriteSampleData();
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        testHelper.SetTiering(DEFAULT_TABLE_PATH, DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        tieringHelper.CheckAllDataInTier(DEFAULT_TIER_PATH);
+
+        ExecuteScanQuery(tableClient, "SELECT * FROM `/Root/olapStore/olapTable`");
+    }
+
     Y_UNIT_TEST_DUO(MinMaxIndexInheritsTiering, InheritPortionStorage) {
         TTieringTestHelper tieringHelper;
         auto& csController = tieringHelper.GetCsController();

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
@@ -496,6 +496,17 @@ NKikimr::TConclusionStatus TIndexInfo::ReuseIndexChunks(std::vector<std::shared_
     auto opStorage = operators->GetOperatorVerified(indexStorageId);
     for (auto&& chunk : chunks) {
         if ((i64)chunk->GetPackedSize() > opStorage->GetBlobSplitSettings().GetMaxBlobSize()) {
+            if (indexStorageId == IStoragesManager::LocalMetadataStorageId) {
+                // An inplace index must stay a single chunk and cannot be split into several blobs: drop it.
+                // The portion stays correct without it, like a portion older than the index itself, only the
+                // skip optimization is lost.
+                YDB_LOG_WARN("",
+                    {"event", "index_skipped"},
+                    {"index_id", indexId},
+                    {"packed_size", chunk->GetPackedSize()},
+                    {"limit", opStorage->GetBlobSplitSettings().GetMaxBlobSize()});
+                return TConclusionStatus::Success();
+            }
             return TConclusionStatus::Fail("blob size for secondary data (" + ::ToString(indexId) + ":" + ::ToString(chunk->GetPackedSize()) +
                                            ":" + ::ToString(recordsCount) + ") bigger than limit (" +
                                            ::ToString(opStorage->GetBlobSplitSettings().GetMaxBlobSize()) + ")");
@@ -518,7 +529,8 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
     auto& index = it->second;
     TMemoryProfileGuard mpg("IndexConstruction::" + index->GetIndexName());
     // An inplace (_LOCAL) index must stay a single chunk, so no size budget is passed and an oversize one is
-    // dropped below. For blob storages the builder splits the index into several chunks fitting MaxBlobSize.
+    // dropped by ReuseIndexChunks. For blob storages the builder splits the index into several chunks fitting
+    // MaxBlobSize, so an oversize chunk there is a real failure and propagates to the caller.
     std::optional<ui64> chunkSizeLimit;
     const TString& indexStorageId = GetIndexStorageId(indexId, specialTier);
     if (indexStorageId != IStoragesManager::LocalMetadataStorageId) {
@@ -534,17 +546,7 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
     }
     std::vector<std::shared_ptr<IPortionDataChunk>> chunks(
         std::make_move_iterator(indexChunkConclusion->begin()), std::make_move_iterator(indexChunkConclusion->end()));
-    auto conclusion = ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
-    if (conclusion.IsFail()) {
-        // The index does not fit the target storage even after chunk splitting (or is inplace and cannot be
-        // split). Store the portion without it, like a portion older than the index itself: the data stays
-        // correct, only the skip optimization is lost.
-        YDB_LOG_WARN("",
-            {"event", "index_skipped"},
-            {"index_name", index->GetIndexName()},
-            {"reason", conclusion.GetErrorMessage()});
-    }
-    return TConclusionStatus::Success();
+    return ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
 }
 
 std::shared_ptr<NIndexes::NMax::TIndexMeta> TIndexInfo::GetIndexMetaMax(const ui32 columnId) const {

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
@@ -527,7 +527,16 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
     }
     std::vector<std::shared_ptr<IPortionDataChunk>> chunks(
         std::make_move_iterator(indexChunkConclusion->begin()), std::make_move_iterator(indexChunkConclusion->end()));
-    return ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
+    auto conclusion = ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
+    if (conclusion.IsFail()) {
+        // The index does not fit the target storage. Store the portion without it, like a portion older than
+        // the index itself: the data stays correct, only the skip optimization is lost.
+        YDB_LOG_WARN("",
+            {"event", "index_skipped"},
+            {"index_name", index->GetIndexName()},
+            {"reason", conclusion.GetErrorMessage()});
+    }
+    return TConclusionStatus::Success();
 }
 
 std::shared_ptr<NIndexes::NMax::TIndexMeta> TIndexInfo::GetIndexMetaMax(const ui32 columnId) const {

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
@@ -517,8 +517,15 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
     AFL_VERIFY(it != Indexes.end());
     auto& index = it->second;
     TMemoryProfileGuard mpg("IndexConstruction::" + index->GetIndexName());
+    // An inplace (_LOCAL) index must stay a single chunk, so no size budget is passed and an oversize one is
+    // dropped below. For blob storages the builder splits the index into several chunks fitting MaxBlobSize.
+    std::optional<ui64> chunkSizeLimit;
+    const TString& indexStorageId = GetIndexStorageId(indexId, specialTier);
+    if (indexStorageId != IStoragesManager::LocalMetadataStorageId) {
+        chunkSizeLimit = operators->GetOperatorVerified(indexStorageId)->GetBlobSplitSettings().GetMaxBlobSize();
+    }
     TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> indexChunkConclusion =
-        index->BuildIndexOptional(originalData, recordsCount, *this);
+        index->BuildIndexOptional(originalData, recordsCount, *this, chunkSizeLimit);
     if (indexChunkConclusion.IsFail()) {
         return indexChunkConclusion;
     }
@@ -529,8 +536,9 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
         std::make_move_iterator(indexChunkConclusion->begin()), std::make_move_iterator(indexChunkConclusion->end()));
     auto conclusion = ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
     if (conclusion.IsFail()) {
-        // The index does not fit the target storage. Store the portion without it, like a portion older than
-        // the index itself: the data stays correct, only the skip optimization is lost.
+        // The index does not fit the target storage even after chunk splitting (or is inplace and cannot be
+        // split). Store the portion without it, like a portion older than the index itself: the data stays
+        // correct, only the skip optimization is lost.
         YDB_LOG_WARN("",
             {"event", "index_skipped"},
             {"index_name", index->GetIndexName()},

--- a/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/index_info.cpp
@@ -530,7 +530,16 @@ NKikimr::TConclusionStatus TIndexInfo::AppendIndex(const THashMap<ui32, std::vec
     }
     std::vector<std::shared_ptr<IPortionDataChunk>> chunks(
         std::make_move_iterator(indexChunkConclusion->begin()), std::make_move_iterator(indexChunkConclusion->end()));
-    return ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
+    auto conclusion = ReuseIndexChunks(std::move(chunks), indexId, operators, recordsCount, specialTier, result);
+    if (conclusion.IsFail()) {
+        // The index does not fit the target storage. Store the portion without it, like a portion older than
+        // the index itself: the data stays correct, only the skip optimization is lost.
+        YDB_LOG_WARN("",
+            {"event", "index_skipped"},
+            {"index_name", index->GetIndexName()},
+            {"reason", conclusion.GetErrorMessage()});
+    }
+    return TConclusionStatus::Success();
 }
 
 std::shared_ptr<NIndexes::NMax::TIndexMeta> TIndexInfo::GetIndexMetaMax(const ui32 columnId) const {

--- a/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/meta.cpp
@@ -56,8 +56,9 @@ std::optional<ui64> IIndexMeta::CalcCategory(const TString& subColumnName) const
 }
 
 TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> IIndexMeta::BuildIndexOptional(
-    const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo) const {
-    auto conclusion = DoBuildIndexOptional(data, recordsCount, indexInfo);
+    const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo,
+    const std::optional<ui64> chunkSizeLimit) const {
+    auto conclusion = DoBuildIndexOptional(data, recordsCount, indexInfo, chunkSizeLimit);
     if (conclusion.IsFail()) {
         return conclusion;
     }

--- a/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/meta.h
+++ b/ydb/core/tx/columnshard/engines/scheme/indexes/abstract/meta.h
@@ -62,8 +62,8 @@ private:
 
 protected:
     virtual TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> DoBuildIndexOptional(
-        const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount,
-        const TIndexInfo& indexInfo) const = 0;
+        const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo,
+        const std::optional<ui64> chunkSizeLimit) const = 0;
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) = 0;
     virtual void DoSerializeToProto(NKikimrSchemeOp::TOlapIndexDescription& proto) const = 0;
     virtual TConclusionStatus DoCheckModificationCompatibility(const IIndexMeta& newMeta) const = 0;
@@ -128,7 +128,8 @@ public:
     virtual ~IIndexMeta() = default;
 
     TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> BuildIndexOptional(
-        const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo) const;
+        const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo,
+        const std::optional<ui64> chunkSizeLimit) const;
 
     bool DeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto);
     void SerializeToProto(NKikimrSchemeOp::TOlapIndexDescription& proto) const;

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.cpp
@@ -15,7 +15,7 @@
 namespace NKikimr::NOlap::NIndexes {
 
 std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TBloomIndexMeta::DoBuildIndexImpl(
-    TChunkedBatchReader& reader, const ui32 recordsCount) const {
+    TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> /*chunkSizeLimit*/) const {
     const ui32 hashesCount = Request.ResolvedHashesCount();
     std::deque<std::shared_ptr<NArrow::NAccessor::IChunkedArray>> dataOwners;
     ui32 indexHitsCount = 0;

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom/meta.h
@@ -35,7 +35,7 @@ private:
 protected:
     virtual TConclusionStatus DoCheckModificationCompatibility(const IIndexMeta& newMeta) const override;
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const override;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
     virtual void DoSerializeToProto(NKikimrSchemeOp::TOlapIndexDescription& proto) const override;

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.cpp
@@ -190,34 +190,52 @@ public:
 namespace {
 
 template <class TBuilder, class TFiller>
+void VisitChunkWithBuilder(const std::shared_ptr<NArrow::NAccessor::IChunkedArray>& chunk, const TReadDataExtractorContainer& dataExtractor,
+    const ui32 nGrammSize, TBuilder& builder, TFiller& filler) {
+    dataExtractor->VisitAll(
+        chunk,
+        [&](const std::shared_ptr<arrow::Array>& arr, const ui32 /*hashBase*/) {
+            builder.FillNGrammHashes(nGrammSize, arr, filler);
+        },
+        [&](const NArrow::NAccessor::TJsonValueView& data, const ui32 /*hashBase*/) {
+            auto view = data.GetScalarOptional();
+            if (!view.has_value()) {
+                return;
+            }
+
+            builder.BuildNGramms(view->data(), view->size(), {}, nGrammSize, filler);
+        });
+}
+
+template <class TBuilder, class TFiller>
 void VisitAllChunksWithBuilder(
     TChunkedBatchReader& reader, const TReadDataExtractorContainer& dataExtractor, const ui32 nGrammSize, TBuilder& builder, TFiller& filler) {
     for (reader.Start(); reader.IsCorrect();) {
         AFL_VERIFY(reader.GetColumnsCount() == 1);
         for (auto&& r : reader) {
-            dataExtractor->VisitAll(
-                r.GetCurrentChunk(),
-                [&](const std::shared_ptr<arrow::Array>& arr, const ui32 /*hashBase*/) {
-                    builder.FillNGrammHashes(nGrammSize, arr, filler);
-                },
-                [&](const NArrow::NAccessor::TJsonValueView& data, const ui32 /*hashBase*/) {
-                    auto view = data.GetScalarOptional();
-                    if (!view.has_value()) {
-                        return;
-                    }
-
-                    builder.BuildNGramms(view->data(), view->size(), {}, nGrammSize, filler);
-                });
+            VisitChunkWithBuilder(r.GetCurrentChunk(), dataExtractor, nGrammSize, builder, filler);
         }
 
         reader.ReadNext(reader.begin()->GetCurrentChunk()->GetRecordsCount());
     }
 }
 
+std::vector<std::pair<std::shared_ptr<NArrow::NAccessor::IChunkedArray>, ui32>> CollectChunks(TChunkedBatchReader& reader) {
+    std::vector<std::pair<std::shared_ptr<NArrow::NAccessor::IChunkedArray>, ui32>> result;
+    for (reader.Start(); reader.IsCorrect();) {
+        AFL_VERIFY(reader.GetColumnsCount() == 1);
+        auto chunk = reader.begin()->GetCurrentChunk();
+        const ui32 records = chunk->GetRecordsCount();
+        result.emplace_back(std::move(chunk), records);
+        reader.ReadNext(records);
+    }
+    return result;
+}
+
 }   // namespace
 
 std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
-    TChunkedBatchReader& reader, const ui32 recordsCount) const {
+    TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const {
     AFL_VERIFY(reader.GetColumnsCount() == 1)("count", reader.GetColumnsCount());
     const ui32 hashesCount = Request.ResolvedHashesCount();
     const bool caseSensitive = Request.ResolvedCaseSensitive();
@@ -228,64 +246,98 @@ std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildInd
     const ui32 resolvedRecordsCount = Request.ResolvedRecordsCount();
     TNGrammBuilder builder(hashesCount, caseSensitive);
 
+    static constexpr ui64 BitsPerUi64 = sizeof(ui64) * CHAR_BIT;
+    static constexpr ui64 MaxBitsSize = static_cast<ui64>(TConstants::MaxFilterSizeBytes) * CHAR_BIT;
+
+    // Splits the source chunks into consecutive groups of at most maxRecordsPerChunk records and emits one
+    // index chunk per group, so every produced blob fits the storage limit. The scan applies each chunk to its
+    // own record range (TIndexColumnChunked), so per-range filters are equivalent to the single one.
+    const auto buildBatched = [&](const ui32 maxRecordsPerChunk, const auto& buildChunkData) {
+        std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> result;
+        const auto chunks = CollectChunks(reader);
+        ui32 chunkIdx = 0;
+        for (ui32 pos = 0; pos < chunks.size();) {
+            ui32 batchRecords = chunks[pos].second;
+            ui32 end = pos + 1;
+            while (end < chunks.size() && batchRecords + chunks[end].second <= maxRecordsPerChunk) {
+                batchRecords += chunks[end].second;
+                ++end;
+            }
+            TString indexData = buildChunkData(chunks, pos, end, batchRecords);
+            result.emplace_back(std::make_shared<NChunks::TPortionIndexChunk>(
+                TChunkAddress(GetIndexId(), chunkIdx++), batchRecords, indexData.size(), indexData));
+            pos = end;
+        }
+        return result;
+    };
+
     if (!useOldSizing) {
-        static constexpr ui64 BitsPerUi64 = sizeof(ui64) * CHAR_BIT;
-        static constexpr ui64 MaxBitsSize = static_cast<ui64>(TConstants::MaxFilterSizeBytes) * CHAR_BIT;
+        const auto foldAndSerialize = [&](TArrayPower2BitsStorage&& maxStorage) {
+            const ui64 setBitsCount = maxStorage.CountSetBits();
+
+            const double m = static_cast<double>(MaxBitsSize);
+            const double k = static_cast<double>(hashesCount);
+            const double ratio = static_cast<double>(setBitsCount) / m;
+            const double estimatedUniqueCount = (ratio >= 1.0) ? m / k : std::max(10.0, -(m / k) * std::log(1.0 - ratio));
+
+            const double requestedBitsSizeDouble =
+                std::ceil((-k * estimatedUniqueCount) / std::log(1.0 - std::pow(falsePositiveProbability, 1.0 / k)));
+            const ui64 requestedBitsSize = std::max<ui64>(BitsPerUi64, static_cast<ui64>(requestedBitsSizeDouble));
+            const ui32 targetSize = std::min<ui64>(MaxBitsSize, std::bit_ceil(requestedBitsSize));
+
+            auto foldedStorage = targetSize < MaxBitsSize ? maxStorage.Fold(MaxBitsSize / targetSize) : std::move(maxStorage);
+
+            return GetBitsStorageConstructor()->SerializeToString(foldedStorage);
+        };
 
         TArrayPower2BitsStorage maxStorage(MaxBitsSize);
         VisitAllChunksWithBuilder(reader, GetDataExtractor(), ngramSize, builder, maxStorage);
-
-        const ui64 setBitsCount = maxStorage.CountSetBits();
-
-        const double m = static_cast<double>(MaxBitsSize);
-        const double k = static_cast<double>(hashesCount);
-        const double ratio = static_cast<double>(setBitsCount) / m;
-        const double estimatedUniqueCount = (ratio >= 1.0) ? m / k : std::max(10.0, -(m / k) * std::log(1.0 - ratio));
-
-        const double requestedBitsSizeDouble =
-            std::ceil((-k * estimatedUniqueCount) / std::log(1.0 - std::pow(falsePositiveProbability, 1.0 / k)));
-        const ui64 requestedBitsSize = std::max<ui64>(BitsPerUi64, static_cast<ui64>(requestedBitsSizeDouble));
-        const ui32 targetSize = std::min<ui64>(MaxBitsSize, std::bit_ceil(requestedBitsSize));
-
-        auto foldedStorage = targetSize < MaxBitsSize ? maxStorage.Fold(MaxBitsSize / targetSize) : std::move(maxStorage);
-
-        TString indexData = GetBitsStorageConstructor()->SerializeToString(foldedStorage);
-        return { std::make_shared<NChunks::TPortionIndexChunk>(TChunkAddress(GetIndexId(), 0), recordsCount, indexData.size(), indexData) };
-    }
-
-    ui32 size = filterSizeBytes * 8;
-    if ((size & (size - 1)) == 0) {
-        ui32 recordsCountBase = resolvedRecordsCount;
-        while (recordsCountBase < recordsCount && size * 2 <= TConstants::MaxFilterSizeBytes) {
-            size <<= 1;
-            recordsCountBase *= 2;
-        }
-    } else {
-        size = std::bit_ceil(size * ((recordsCount + resolvedRecordsCount - 1) / resolvedRecordsCount));
-    }
-
-    size = std::max<ui32>(16, size);
-    TArrayPower2BitsStorage storage(size);
-    for (reader.Start(); reader.IsCorrect();) {
-        AFL_VERIFY(reader.GetColumnsCount() == 1);
-        for (auto&& r : reader) {
-            GetDataExtractor()->VisitAll(
-                r.GetCurrentChunk(),
-                [&](const std::shared_ptr<arrow::Array>& arr, const ui32 /*hashBase*/) {
-                    builder.FillNGrammHashes(ngramSize, arr, storage);
-                },
-                [&](const NArrow::NAccessor::TJsonValueView& data, const ui32 /*hashBase*/) {
-                    auto view = data.GetScalarOptional();
-                    if (!view.has_value()) {
-                        return;
-                    }
-
-                    builder.BuildNGramms(view->data(), view->size(), {}, ngramSize, storage);
-                });
+        TString indexData = foldAndSerialize(std::move(maxStorage));
+        if (!chunkSizeLimit || indexData.size() <= *chunkSizeLimit) {
+            return { std::make_shared<NChunks::TPortionIndexChunk>(TChunkAddress(GetIndexId(), 0), recordsCount, indexData.size(), indexData) };
         }
 
-        reader.ReadNext(reader.begin()->GetCurrentChunk()->GetRecordsCount());
+        const ui32 partsCount = (indexData.size() + *chunkSizeLimit - 1) / *chunkSizeLimit;
+        const ui32 maxRecordsPerChunk = (recordsCount + partsCount - 1) / partsCount;
+        return buildBatched(maxRecordsPerChunk, [&](const auto& chunks, const ui32 begin, const ui32 end, const ui32 /*batchRecords*/) {
+            TArrayPower2BitsStorage batchStorage(MaxBitsSize);
+            for (ui32 i = begin; i < end; ++i) {
+                VisitChunkWithBuilder(chunks[i].first, GetDataExtractor(), ngramSize, builder, batchStorage);
+            }
+            return foldAndSerialize(std::move(batchStorage));
+        });
     }
+
+    const auto calcBitsSize = [&](const ui32 records) {
+        ui32 size = filterSizeBytes * 8;
+        if ((size & (size - 1)) == 0) {
+            ui32 recordsCountBase = resolvedRecordsCount;
+            while (recordsCountBase < records && size * 2 <= TConstants::MaxFilterSizeBytes) {
+                size <<= 1;
+                recordsCountBase *= 2;
+            }
+        } else {
+            size = std::bit_ceil(size * ((records + resolvedRecordsCount - 1) / resolvedRecordsCount));
+        }
+        return std::max<ui32>(16, size);
+    };
+
+    if (chunkSizeLimit && calcBitsSize(recordsCount) / 8 > *chunkSizeLimit && calcBitsSize(1) / 8 <= *chunkSizeLimit) {
+        ui32 maxRecordsPerChunk = 1;
+        while (maxRecordsPerChunk < recordsCount && calcBitsSize(maxRecordsPerChunk * 2) / 8 <= *chunkSizeLimit) {
+            maxRecordsPerChunk *= 2;
+        }
+        return buildBatched(maxRecordsPerChunk, [&](const auto& chunks, const ui32 begin, const ui32 end, const ui32 batchRecords) {
+            TArrayPower2BitsStorage batchStorage(calcBitsSize(batchRecords));
+            for (ui32 i = begin; i < end; ++i) {
+                VisitChunkWithBuilder(chunks[i].first, GetDataExtractor(), ngramSize, builder, batchStorage);
+            }
+            return GetBitsStorageConstructor()->SerializeToString(batchStorage);
+        });
+    }
+
+    TArrayPower2BitsStorage storage(calcBitsSize(recordsCount));
+    VisitAllChunksWithBuilder(reader, GetDataExtractor(), ngramSize, builder, storage);
 
     TString indexData = GetBitsStorageConstructor()->SerializeToString(storage);
     return { std::make_shared<NChunks::TPortionIndexChunk>(TChunkAddress(GetIndexId(), 0), recordsCount, indexData.size(), indexData) };

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.cpp
@@ -271,8 +271,13 @@ std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildInd
         return result;
     };
 
+    // The largest power-of-2 filter strictly below the storage blob limit (the blob splitter requires
+    // chunks < MaxBlobSize): filters above it are either split by record subranges or folded down to it
+    // (a smaller bloom filter stays correct, only its FPR grows), so the builder never emits an oversize chunk.
+    const ui64 clampBits = chunkSizeLimit ? std::max<ui64>(BitsPerUi64, std::bit_floor(*chunkSizeLimit * CHAR_BIT - 1)) : MaxBitsSize;
+
     if (!useOldSizing) {
-        const auto foldAndSerialize = [&](TArrayPower2BitsStorage&& maxStorage) {
+        const auto foldAndSerialize = [&](TArrayPower2BitsStorage&& maxStorage, const ui64 maxTargetBits) {
             const ui64 setBitsCount = maxStorage.CountSetBits();
 
             const double m = static_cast<double>(MaxBitsSize);
@@ -283,7 +288,7 @@ std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildInd
             const double requestedBitsSizeDouble =
                 std::ceil((-k * estimatedUniqueCount) / std::log(1.0 - std::pow(falsePositiveProbability, 1.0 / k)));
             const ui64 requestedBitsSize = std::max<ui64>(BitsPerUi64, static_cast<ui64>(requestedBitsSizeDouble));
-            const ui32 targetSize = std::min<ui64>(MaxBitsSize, std::bit_ceil(requestedBitsSize));
+            const ui32 targetSize = std::min<ui64>({ MaxBitsSize, maxTargetBits, std::bit_ceil(requestedBitsSize) });
 
             auto foldedStorage = targetSize < MaxBitsSize ? maxStorage.Fold(MaxBitsSize / targetSize) : std::move(maxStorage);
 
@@ -292,8 +297,8 @@ std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildInd
 
         TArrayPower2BitsStorage maxStorage(MaxBitsSize);
         VisitAllChunksWithBuilder(reader, GetDataExtractor(), ngramSize, builder, maxStorage);
-        TString indexData = foldAndSerialize(std::move(maxStorage));
-        if (!chunkSizeLimit || indexData.size() <= *chunkSizeLimit) {
+        TString indexData = foldAndSerialize(std::move(maxStorage), MaxBitsSize);
+        if (!chunkSizeLimit || indexData.size() * CHAR_BIT <= clampBits) {
             return { std::make_shared<NChunks::TPortionIndexChunk>(TChunkAddress(GetIndexId(), 0), recordsCount, indexData.size(), indexData) };
         }
 
@@ -304,12 +309,12 @@ std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildInd
             for (ui32 i = begin; i < end; ++i) {
                 VisitChunkWithBuilder(chunks[i].first, GetDataExtractor(), ngramSize, builder, batchStorage);
             }
-            return foldAndSerialize(std::move(batchStorage));
+            return foldAndSerialize(std::move(batchStorage), clampBits);
         });
     }
 
     const auto calcBitsSize = [&](const ui32 records) {
-        ui32 size = filterSizeBytes * 8;
+        ui32 size = filterSizeBytes * CHAR_BIT;
         if ((size & (size - 1)) == 0) {
             ui32 recordsCountBase = resolvedRecordsCount;
             while (recordsCountBase < records && size * 2 <= TConstants::MaxFilterSizeBytes) {
@@ -322,13 +327,13 @@ std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildInd
         return std::max<ui32>(16, size);
     };
 
-    if (chunkSizeLimit && calcBitsSize(recordsCount) / 8 > *chunkSizeLimit && calcBitsSize(1) / 8 <= *chunkSizeLimit) {
+    if (chunkSizeLimit && calcBitsSize(recordsCount) > clampBits) {
         ui32 maxRecordsPerChunk = 1;
-        while (maxRecordsPerChunk < recordsCount && calcBitsSize(maxRecordsPerChunk * 2) / 8 <= *chunkSizeLimit) {
+        while (maxRecordsPerChunk < recordsCount && calcBitsSize(maxRecordsPerChunk * 2) <= clampBits) {
             maxRecordsPerChunk *= 2;
         }
         return buildBatched(maxRecordsPerChunk, [&](const auto& chunks, const ui32 begin, const ui32 end, const ui32 batchRecords) {
-            TArrayPower2BitsStorage batchStorage(calcBitsSize(batchRecords));
+            TArrayPower2BitsStorage batchStorage(std::min<ui64>(calcBitsSize(batchRecords), clampBits));
             for (ui32 i = begin; i < end; ++i) {
                 VisitChunkWithBuilder(chunks[i].first, GetDataExtractor(), ngramSize, builder, batchStorage);
             }

--- a/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.h
@@ -86,7 +86,7 @@ protected:
     }
 
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const override;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override {
         AFL_VERIFY(TBase::DoDeserializeFromProto(proto));

--- a/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.cpp
@@ -93,7 +93,7 @@ public:
 };
 
 std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
-    TChunkedBatchReader& reader, const ui32 /*recordsCount*/) const {
+    TChunkedBatchReader& reader, const ui32 /*recordsCount*/, const std::optional<ui64> /*chunkSizeLimit*/) const {
     std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> result;
     ui32 chunkIdx = 0;
     for (reader.Start(); reader.IsCorrect(); reader.ReadNext(reader.begin()->GetCurrentChunk()->GetRecordsCount())) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/categories_bloom/meta.h
@@ -51,7 +51,7 @@ protected:
     }
 
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const override;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
     virtual void DoSerializeToProto(NKikimrSchemeOp::TOlapIndexDescription& proto) const override;

--- a/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.cpp
@@ -14,7 +14,7 @@
 namespace NKikimr::NOlap::NIndexes::NCountMinSketch {
 
 std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
-    TChunkedBatchReader& reader, const ui32 recordsCount) const {
+    TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> /*chunkSizeLimit*/) const {
     auto sketch = std::unique_ptr<TCountMinSketch>(TCountMinSketch::Create());
 
     for (auto& colReader : reader) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/count_min_sketch/meta.h
@@ -26,7 +26,7 @@ protected:
     }
 
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const override;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override {
         AFL_VERIFY(TBase::DoDeserializeFromProto(proto));

--- a/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.cpp
@@ -12,7 +12,7 @@
 namespace NKikimr::NOlap::NIndexes::NMax {
 
 std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
-    TChunkedBatchReader& reader, const ui32 recordsCount) const {
+    TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> /*chunkSizeLimit*/) const {
     std::shared_ptr<arrow::Scalar> result;
     AFL_VERIFY(reader.GetColumnsCount() == 1)("count", reader.GetColumnsCount());
     {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/max/meta.h
@@ -24,7 +24,7 @@ protected:
     }
 
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const override;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override {
         AFL_VERIFY(TBase::DoDeserializeFromProto(proto));

--- a/ydb/core/tx/columnshard/engines/storage/indexes/min_max/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/min_max/meta.cpp
@@ -35,7 +35,7 @@ TConclusionStatus TIndexMeta::DoCheckModificationCompatibility(const IIndexMeta&
 }
 
 std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> TIndexMeta::DoBuildIndexImpl(
-    TChunkedBatchReader& reader, const ui32 recordsCount) const {
+    TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> /*chunkSizeLimit*/) const {
     reader.Start();
     TChunkedColumnReader cReader = *reader.begin();
     auto thisChunkIndex = NArrow::NAccessor::TMinMax::MakeNull(cReader.GetCurrentChunk()->GetDataType());

--- a/ydb/core/tx/columnshard/engines/storage/indexes/min_max/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/min_max/meta.h
@@ -21,7 +21,7 @@ private:
 protected:
     virtual TConclusionStatus DoCheckModificationCompatibility(const IIndexMeta& newMeta) const override;
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const override;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const override;
 
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
 

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.cpp
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.cpp
@@ -9,7 +9,8 @@
 namespace NKikimr::NOlap::NIndexes {
 
 TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> TIndexByColumns::DoBuildIndexOptional(
-    const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo) const {
+    const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo,
+    const std::optional<ui64> chunkSizeLimit) const {
     AFL_VERIFY(Serializer);
     AFL_VERIFY(data.size());
     std::vector<TChunkedColumnReader> columnReaders;
@@ -30,7 +31,7 @@ TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> TIndexByC
         columnReaders.emplace_back(it->second, indexInfo.GetColumnLoaderVerified(i));
     }
     TChunkedBatchReader reader(std::move(columnReaders));
-    return DoBuildIndexImpl(reader, recordsCount);
+    return DoBuildIndexImpl(reader, recordsCount, chunkSizeLimit);
 }
 
 bool TIndexByColumns::DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& /*proto*/) {

--- a/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.h
+++ b/ydb/core/tx/columnshard/engines/storage/indexes/portions/meta.h
@@ -24,11 +24,11 @@ protected:
     }
 
     virtual std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>> DoBuildIndexImpl(
-        TChunkedBatchReader& reader, const ui32 recordsCount) const = 0;
+        TChunkedBatchReader& reader, const ui32 recordsCount, const std::optional<ui64> chunkSizeLimit) const = 0;
 
     virtual TConclusion<std::vector<std::shared_ptr<NChunks::TPortionIndexChunk>>> DoBuildIndexOptional(
-        const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount,
-        const TIndexInfo& indexInfo) const override final;
+        const THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>>& data, const ui32 recordsCount, const TIndexInfo& indexInfo,
+        const std::optional<ui64> chunkSizeLimit) const override final;
     virtual bool DoDeserializeFromProto(const NKikimrSchemeOp::TOlapIndexDescription& proto) override;
 
     TConclusionStatus CheckSameColumnsForModification(const IIndexMeta& newMeta) const;

--- a/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
@@ -16,6 +16,7 @@
 #include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_primitive.h>
 #include <contrib/libs/apache/arrow/cpp/src/arrow/record_batch.h>
 #include <library/cpp/testing/unittest/registar.h>
+#include <util/generic/size_literals.h>
 
 namespace NKikimr::NOlap::NTest {
 
@@ -195,13 +196,13 @@ Y_UNIT_TEST_SUITE(TIndexBlobSizeLimitTests) {
     // An index above MaxBlobSize of a blob storage is split into several chunks covering record subranges,
     // each fitting the limit, instead of being dropped.
     Y_UNIT_TEST(OversizedIndexOnDefaultStorageIsSplit) {
-        constexpr i64 blobLimit = 10240;
+        constexpr i64 blobLimit = 10_KB;
         auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
         csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings().SetMaxBlobSize(blobLimit).SetMinBlobSize(blobLimit / 4));
 
         // 512 records over 4 column chunks: the whole-portion filter is 32 KB (8 KB doubled twice), while
         // a 128-record subrange keeps the base 8 KB, which fits the 10 KB limit.
-        const auto schema = MakeSchemaWithNGrammIndex(1, 8192, 128);
+        const auto schema = MakeSchemaWithNGrammIndex(1, 8_KB, 128);
         std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
         for (ui32 i = 0; i < 4; ++i) {
             batches.emplace_back(MakeTestBatch(1 + i * 128, 128));

--- a/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
@@ -30,7 +30,8 @@ constexpr ui32 NGrammIndexId = 1001;
 constexpr ui32 FilterSizeBytes = NLocalIndex::NBloom::TConstants::MaxFilterSizeBytes;
 constexpr i64 MaxBlobSize = FilterSizeBytes / 2;
 
-ISnapshotSchema::TPtr MakeSchemaWithNGrammIndex(const ui64 version) {
+ISnapshotSchema::TPtr MakeSchemaWithNGrammIndex(const ui64 version, const ui32 filterSizeBytes = FilterSizeBytes,
+    const ui32 recordsCountBase = 1024, const TString& indexStorageId = IStoragesManager::DefaultStorageId) {
     NKikimrSchemeOp::TColumnTableSchema proto;
     const std::vector<NArrow::NTest::TTestColumn> columns = {
         NArrow::NTest::TTestColumn("pk", NScheme::TTypeInfo(NScheme::NTypeIds::Uint64)),
@@ -47,11 +48,11 @@ ISnapshotSchema::TPtr MakeSchemaWithNGrammIndex(const ui64 version) {
     NLocalIndex::NBloom::TRequestSettings request;
     request.NGrammSize = 3;
     request.DeprecatedHashesCount = 2;
-    request.DeprecatedFilterSizeBytes = FilterSizeBytes;
-    request.DeprecatedRecordsCount = 1024;
+    request.DeprecatedFilterSizeBytes = filterSizeBytes;
+    request.DeprecatedRecordsCount = recordsCountBase;
     *proto.AddIndexes() = NIndexes::TIndexMetaContainer(
-        std::make_shared<NIndexes::NBloomNGramm::TIndexMeta>(NGrammIndexId, "ngramm_value", IStoragesManager::DefaultStorageId, false,
-            ValueColumnId, NIndexes::TReadDataExtractorContainer(std::make_shared<NIndexes::TDefaultDataExtractor>()),
+        std::make_shared<NIndexes::NBloomNGramm::TIndexMeta>(NGrammIndexId, "ngramm_value", indexStorageId, false, ValueColumnId,
+            NIndexes::TReadDataExtractorContainer(std::make_shared<NIndexes::TDefaultDataExtractor>()),
             NIndexes::IBitsStorageConstructor::GetDefault(), request))
                               .SerializeToProto();
 
@@ -61,28 +62,34 @@ ISnapshotSchema::TPtr MakeSchemaWithNGrammIndex(const ui64 version) {
     return std::make_shared<TSnapshotSchema>(cache->UpsertIndexInfo(std::move(*indexInfo)), TSnapshot(1, 1));
 }
 
-std::shared_ptr<arrow::RecordBatch> MakeTestBatch() {
+std::shared_ptr<arrow::RecordBatch> MakeTestBatch(const ui32 firstPk = 1, const ui32 rowsCount = 3) {
     arrow::UInt64Builder pkBuilder;
     arrow::StringBuilder valueBuilder;
-    UNIT_ASSERT(pkBuilder.AppendValues({ 1, 2, 3 }).ok());
-    UNIT_ASSERT(valueBuilder.AppendValues({ "alpha", "beta", "gamma" }).ok());
+    for (ui32 i = 0; i < rowsCount; ++i) {
+        UNIT_ASSERT(pkBuilder.Append(firstPk + i).ok());
+        const TString value = "value_" + ::ToString(firstPk + i);
+        UNIT_ASSERT(valueBuilder.Append(value.data(), value.size()).ok());
+    }
     auto schema = arrow::schema({ arrow::field("pk", arrow::uint64()), arrow::field("value", arrow::utf8()) });
-    return arrow::RecordBatch::Make(schema, 3, { pkBuilder.Finish().ValueOrDie(), valueBuilder.Finish().ValueOrDie() });
+    return arrow::RecordBatch::Make(schema, rowsCount, { pkBuilder.Finish().ValueOrDie(), valueBuilder.Finish().ValueOrDie() });
 }
 
 THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>> BuildColumnChunks(
-    const ISnapshotSchema::TPtr& schema, const std::shared_ptr<arrow::RecordBatch>& batch) {
+    const ISnapshotSchema::TPtr& schema, const std::vector<std::shared_ptr<arrow::RecordBatch>>& batches) {
     THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>> chunks;
-    for (const auto& field : batch->schema()->fields()) {
+    for (const auto& field : batches.front()->schema()->fields()) {
         const ui32 columnId = schema->GetColumnIdVerified(field->name());
         auto loader = schema->GetIndexInfo().GetColumnLoaderVerified(columnId);
         const auto& accessorConstructor = loader->GetAccessorConstructor();
-        auto accessor = std::make_shared<NArrow::NAccessor::TTrivialArray>(batch->GetColumnByName(field->name()));
-        const auto loadContext = loader->BuildAccessorContext(accessor->GetRecordsCount());
-        auto arrToWrite = accessorConstructor->Construct(accessor, loadContext);
-        UNIT_ASSERT(arrToWrite.IsSuccess());
-        chunks[columnId] = { std::make_shared<NChunks::TChunkPreparation>(accessorConstructor->SerializeToString(*arrToWrite, loadContext),
-            *arrToWrite, TChunkAddress(columnId, 0), schema->GetIndexInfo().GetColumnFeaturesVerified(columnId)) };
+        for (ui32 chunkIdx = 0; chunkIdx < batches.size(); ++chunkIdx) {
+            auto accessor = std::make_shared<NArrow::NAccessor::TTrivialArray>(batches[chunkIdx]->GetColumnByName(field->name()));
+            const auto loadContext = loader->BuildAccessorContext(accessor->GetRecordsCount());
+            auto arrToWrite = accessorConstructor->Construct(accessor, loadContext);
+            UNIT_ASSERT(arrToWrite.IsSuccess());
+            chunks[columnId].emplace_back(
+                std::make_shared<NChunks::TChunkPreparation>(accessorConstructor->SerializeToString(*arrToWrite, loadContext), *arrToWrite,
+                    TChunkAddress(columnId, chunkIdx), schema->GetIndexInfo().GetColumnFeaturesVerified(columnId)));
+        }
     }
     return chunks;
 }
@@ -91,7 +98,7 @@ TWritePortionInfoWithBlobsResult BuildPortionWithoutIndexes(const ISnapshotSchem
     const std::shared_ptr<arrow::RecordBatch>& batch, const std::shared_ptr<NColumnShard::TSplitterCounters>& splitterCounters) {
     std::shared_ptr<TDefaultSchemaDetails> schemaDetails(
         new TDefaultSchemaDetails(schema, std::make_shared<NArrow::NSplitter::TSerializationStats>()));
-    TGeneralSerializedSlice slice(BuildColumnChunks(schema, batch), schemaDetails, splitterCounters);
+    TGeneralSerializedSlice slice(BuildColumnChunks(schema, { batch }), schemaDetails, splitterCounters);
 
     const NSplitter::TEntityGroups groups(NSplitter::TSplitSettings(), NBlobOperations::TGlobal::DefaultStorageId);
     std::vector<TSplittedBlob> blobs;
@@ -183,6 +190,73 @@ Y_UNIT_TEST_SUITE(TIndexBlobSizeLimitTests) {
         syncResult->RegisterFakeBlobIds();
         syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
         UNIT_ASSERT(HasIndex(*syncResult, NGrammIndexId));
+    }
+
+    // An index above MaxBlobSize of a blob storage is split into several chunks covering record subranges,
+    // each fitting the limit, instead of being dropped.
+    Y_UNIT_TEST(OversizedIndexOnDefaultStorageIsSplit) {
+        constexpr i64 blobLimit = 10240;
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings().SetMaxBlobSize(blobLimit).SetMinBlobSize(blobLimit / 4));
+
+        // 512 records over 4 column chunks: the whole-portion filter is 32 KB (8 KB doubled twice), while
+        // a 128-record subrange keeps the base 8 KB, which fits the 10 KB limit.
+        const auto schema = MakeSchemaWithNGrammIndex(1, 8192, 128);
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        for (ui32 i = 0; i < 4; ++i) {
+            batches.emplace_back(MakeTestBatch(1 + i * 128, 128));
+        }
+        const auto chunks = BuildColumnChunks(schema, batches);
+
+        TIndexInfo::TSecondaryData secondaryData;
+        secondaryData.MutableExternalData() = chunks;
+        const auto conclusion = schema->GetIndexInfo().AppendIndex(
+            chunks, NGrammIndexId, TTestStoragesManager::GetInstance(), 512, IStoragesManager::DefaultStorageId, secondaryData);
+        UNIT_ASSERT_C(conclusion.Ok(), conclusion.GetErrorMessage());
+
+        const auto it = secondaryData.GetExternalData().find(NGrammIndexId);
+        UNIT_ASSERT(it != secondaryData.GetExternalData().end());
+        UNIT_ASSERT_VALUES_EQUAL(it->second.size(), 4);
+        ui32 recordsSum = 0;
+        for (const auto& chunk : it->second) {
+            UNIT_ASSERT_LE(chunk->GetPackedSize(), blobLimit);
+            recordsSum += chunk->GetRecordsCountVerified();
+        }
+        UNIT_ASSERT_VALUES_EQUAL(recordsSum, 512);
+    }
+
+    // An oversized inplace (_LOCAL) index cannot be split: it is dropped completely, leaving no chunks and
+    // no inplace metadata, so nothing about it is persisted with the portion (IndexColumnsV2 stays clean).
+    Y_UNIT_TEST(OversizedLocalIndexIsSkippedWithoutMeta) {
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings().SetMaxBlobSize(MaxBlobSize).SetMinBlobSize(MaxBlobSize / 4));
+
+        const auto schemaFrom = MakeSchemaWithNGrammIndex(1, FilterSizeBytes, 1024, IStoragesManager::LocalMetadataStorageId);
+        const auto schemaTo = MakeSchemaWithNGrammIndex(2, FilterSizeBytes, 1024, IStoragesManager::LocalMetadataStorageId);
+        const auto splitterCounters = std::make_shared<NColumnShard::TIndexationCounters>("test")->SplitterCounters;
+
+        {
+            TIndexInfo::TSecondaryData secondaryData;
+            const auto chunks = BuildColumnChunks(schemaFrom, { MakeTestBatch() });
+            secondaryData.MutableExternalData() = chunks;
+            const auto conclusion = schemaFrom->GetIndexInfo().AppendIndex(
+                chunks, NGrammIndexId, TTestStoragesManager::GetInstance(), 3, IStoragesManager::DefaultStorageId, secondaryData);
+            UNIT_ASSERT_C(conclusion.Ok(), conclusion.GetErrorMessage());
+            UNIT_ASSERT(!secondaryData.GetExternalData().contains(NGrammIndexId));
+            UNIT_ASSERT(secondaryData.GetSecondaryInplaceData().empty());
+        }
+
+        auto writePortion = BuildPortionWithoutIndexes(schemaFrom, MakeTestBatch(), splitterCounters);
+        auto blobs = ReadBlobs(writePortion);
+        auto readPortion = TReadPortionInfoWithBlobs::RestorePortion(writePortion.GetPortionResult(), blobs, schemaFrom->GetIndexInfo());
+
+        auto syncResult = TReadPortionInfoWithBlobs::SyncPortion(std::move(readPortion), schemaFrom, schemaTo,
+            IStoragesManager::DefaultStorageId, TTestStoragesManager::GetInstance(), splitterCounters);
+
+        UNIT_ASSERT(syncResult);
+        syncResult->RegisterFakeBlobIds();
+        syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
+        UNIT_ASSERT(!HasIndex(*syncResult, NGrammIndexId));
     }
 }
 

--- a/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
@@ -1,0 +1,189 @@
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
+#include <ydb/core/tx/columnshard/blobs_reader/task.h>
+#include <ydb/core/tx/columnshard/counters/indexation.h>
+#include <ydb/core/tx/columnshard/engines/portions/read_with_blobs.h>
+#include <ydb/core/tx/columnshard/engines/portions/write_with_blobs.h>
+#include <ydb/core/tx/columnshard/engines/scheme/versions/snapshot_scheme.h>
+#include <ydb/core/tx/columnshard/engines/storage/chunks/column.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/bits_storage/abstract.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/default.h>
+#include <ydb/core/tx/columnshard/hooks/testing/controller.h>
+#include <ydb/core/tx/columnshard/splitter/batch_slice.h>
+#include <ydb/core/tx/columnshard/test_helper/helper.h>
+
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_binary.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_primitive.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/record_batch.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NOlap::NTest {
+
+namespace {
+
+constexpr ui32 PkColumnId = 1;
+constexpr ui32 ValueColumnId = 2;
+constexpr ui32 NGrammIndexId = 1001;
+
+// The index blob is filter_size_bytes long no matter how few records the portion has, so a filter above the
+// storage limit is reproducible with a three-row portion.
+constexpr ui32 FilterSizeBytes = NLocalIndex::NBloom::TConstants::MaxFilterSizeBytes;
+constexpr i64 MaxBlobSize = FilterSizeBytes / 2;
+
+ISnapshotSchema::TPtr MakeSchemaWithNGrammIndex(const ui64 version) {
+    NKikimrSchemeOp::TColumnTableSchema proto;
+    const std::vector<NArrow::NTest::TTestColumn> columns = {
+        NArrow::NTest::TTestColumn("pk", NScheme::TTypeInfo(NScheme::NTypeIds::Uint64)),
+        NArrow::NTest::TTestColumn("value", NScheme::TTypeInfo(NScheme::NTypeIds::Utf8)),
+    };
+    *proto.MutableColumns()->Add() = columns[0].CreateColumn(PkColumnId);
+    *proto.MutableColumns()->Add() = columns[1].CreateColumn(ValueColumnId);
+    proto.AddKeyColumnNames("pk");
+    proto.SetVersion(version);
+    proto.MutableOptions()->MutableCompactionPlannerConstructor()->SetClassName("l-buckets");
+    *proto.MutableOptions()->MutableCompactionPlannerConstructor()->MutableLBuckets() =
+        NKikimrSchemeOp::TCompactionPlannerConstructorContainer::TLOptimizer();
+
+    NLocalIndex::NBloom::TRequestSettings request;
+    request.NGrammSize = 3;
+    request.DeprecatedHashesCount = 2;
+    request.DeprecatedFilterSizeBytes = FilterSizeBytes;
+    request.DeprecatedRecordsCount = 1024;
+    *proto.AddIndexes() = NIndexes::TIndexMetaContainer(
+        std::make_shared<NIndexes::NBloomNGramm::TIndexMeta>(NGrammIndexId, "ngramm_value", IStoragesManager::DefaultStorageId, false,
+            ValueColumnId, NIndexes::TReadDataExtractorContainer(std::make_shared<NIndexes::TDefaultDataExtractor>()),
+            NIndexes::IBitsStorageConstructor::GetDefault(), request))
+                              .SerializeToProto();
+
+    auto cache = std::make_shared<TSchemaObjectsCache>();
+    auto indexInfo = TIndexInfo::BuildFromProto(version, proto, TTestStoragesManager::GetInstance(), cache);
+    UNIT_ASSERT(indexInfo);
+    return std::make_shared<TSnapshotSchema>(cache->UpsertIndexInfo(std::move(*indexInfo)), TSnapshot(1, 1));
+}
+
+std::shared_ptr<arrow::RecordBatch> MakeTestBatch() {
+    arrow::UInt64Builder pkBuilder;
+    arrow::StringBuilder valueBuilder;
+    UNIT_ASSERT(pkBuilder.AppendValues({ 1, 2, 3 }).ok());
+    UNIT_ASSERT(valueBuilder.AppendValues({ "alpha", "beta", "gamma" }).ok());
+    auto schema = arrow::schema({ arrow::field("pk", arrow::uint64()), arrow::field("value", arrow::utf8()) });
+    return arrow::RecordBatch::Make(schema, 3, { pkBuilder.Finish().ValueOrDie(), valueBuilder.Finish().ValueOrDie() });
+}
+
+THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>> BuildColumnChunks(
+    const ISnapshotSchema::TPtr& schema, const std::shared_ptr<arrow::RecordBatch>& batch) {
+    THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>> chunks;
+    for (const auto& field : batch->schema()->fields()) {
+        const ui32 columnId = schema->GetColumnIdVerified(field->name());
+        auto loader = schema->GetIndexInfo().GetColumnLoaderVerified(columnId);
+        const auto& accessorConstructor = loader->GetAccessorConstructor();
+        auto accessor = std::make_shared<NArrow::NAccessor::TTrivialArray>(batch->GetColumnByName(field->name()));
+        const auto loadContext = loader->BuildAccessorContext(accessor->GetRecordsCount());
+        auto arrToWrite = accessorConstructor->Construct(accessor, loadContext);
+        UNIT_ASSERT(arrToWrite.IsSuccess());
+        chunks[columnId] = { std::make_shared<NChunks::TChunkPreparation>(accessorConstructor->SerializeToString(*arrToWrite, loadContext),
+            *arrToWrite, TChunkAddress(columnId, 0), schema->GetIndexInfo().GetColumnFeaturesVerified(columnId)) };
+    }
+    return chunks;
+}
+
+TWritePortionInfoWithBlobsResult BuildPortionWithoutIndexes(const ISnapshotSchema::TPtr& schema,
+    const std::shared_ptr<arrow::RecordBatch>& batch, const std::shared_ptr<NColumnShard::TSplitterCounters>& splitterCounters) {
+    std::shared_ptr<TDefaultSchemaDetails> schemaDetails(
+        new TDefaultSchemaDetails(schema, std::make_shared<NArrow::NSplitter::TSerializationStats>()));
+    TGeneralSerializedSlice slice(BuildColumnChunks(schema, batch), schemaDetails, splitterCounters);
+
+    const NSplitter::TEntityGroups groups(NSplitter::TSplitSettings(), NBlobOperations::TGlobal::DefaultStorageId);
+    std::vector<TSplittedBlob> blobs;
+    UNIT_ASSERT(slice.GroupBlobs(blobs, groups));
+
+    auto constructor = TWritePortionInfoWithBlobsConstructor::BuildByBlobs(std::move(blobs), {}, TInternalPathId::FromRawValue(1),
+        schema->GetVersion(), schema->GetSnapshot(), TTestStoragesManager::GetInstance(), EPortionType::Written, schema->GetIndexInfo());
+
+    NArrow::TFirstLastSpecialKeys primaryKeys(slice.GetFirstLastPKBatch(schema->GetIndexInfo().GetReplaceKey()));
+    auto& portionCtor = constructor.GetPortionConstructor().MutablePortionConstructor();
+    static_cast<TWrittenPortionInfoConstructor&>(portionCtor).SetInsertWriteId(TInsertWriteId(1));
+    portionCtor.SetPortionId(1);
+    portionCtor.AddMetadata(*schema, 0, primaryKeys, std::nullopt);
+    portionCtor.MutableMeta().SetTierName(IStoragesManager::DefaultStorageId);
+    portionCtor.MutableMeta().SetCompactionLevel(0);
+
+    TWritePortionInfoWithBlobsResult result(std::move(constructor));
+    result.RegisterFakeBlobIds();
+    result.FinalizePortionConstructor(TSnapshot(1, 1));
+    return result;
+}
+
+NBlobOperations::NRead::TCompositeReadBlobs ReadBlobs(TWritePortionInfoWithBlobsResult& portion) {
+    NBlobOperations::NRead::TCompositeReadBlobs blobs;
+    for (auto& blob : portion.MutableBlobs()) {
+        const TString& data = blob.GetResultBlob();
+        for (auto&& chunkAddress : blob.GetChunks()) {
+            const auto* recordInfo = portion.GetPortionResult().GetRecordPointer(chunkAddress);
+            AFL_VERIFY(recordInfo);
+            const auto range = portion.GetPortionResult().RestoreBlobRange(recordInfo->GetBlobRange());
+            blobs.Add(IStoragesManager::DefaultStorageId, range, data.substr(range.Offset, range.Size));
+        }
+    }
+    return blobs;
+}
+
+bool HasIndex(const TWritePortionInfoWithBlobsResult& portion, const ui32 indexId) {
+    for (auto&& index : portion.GetPortionResult().GetIndexesVerified()) {
+        if (index.GetIndexId() == indexId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TIndexBlobSizeLimitTests) {
+    // Issue #26733: actualization rebuilds the index for the target tier, and a filter above the storage
+    // MaxBlobSize used to abort the tablet with "blob size for secondary data ... bigger than limit".
+    Y_UNIT_TEST(OversizedIndexOnActualizationIsSkipped) {
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings().SetMaxBlobSize(MaxBlobSize).SetMinBlobSize(MaxBlobSize / 4));
+
+        const auto schemaFrom = MakeSchemaWithNGrammIndex(1);
+        const auto schemaTo = MakeSchemaWithNGrammIndex(2);
+        const auto splitterCounters = std::make_shared<NColumnShard::TIndexationCounters>("test")->SplitterCounters;
+
+        auto writePortion = BuildPortionWithoutIndexes(schemaFrom, MakeTestBatch(), splitterCounters);
+        auto blobs = ReadBlobs(writePortion);
+        auto readPortion = TReadPortionInfoWithBlobs::RestorePortion(writePortion.GetPortionResult(), blobs, schemaFrom->GetIndexInfo());
+
+        auto syncResult = TReadPortionInfoWithBlobs::SyncPortion(std::move(readPortion), schemaFrom, schemaTo,
+            IStoragesManager::DefaultStorageId, TTestStoragesManager::GetInstance(), splitterCounters);
+
+        UNIT_ASSERT(syncResult);
+        syncResult->RegisterFakeBlobIds();
+        syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
+        UNIT_ASSERT(!HasIndex(*syncResult, NGrammIndexId));
+    }
+
+    // The same index fits when the storage limit is the production one, so the portion keeps its index.
+    Y_UNIT_TEST(IndexUnderLimitIsBuilt) {
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings());
+
+        const auto schemaFrom = MakeSchemaWithNGrammIndex(1);
+        const auto schemaTo = MakeSchemaWithNGrammIndex(2);
+        const auto splitterCounters = std::make_shared<NColumnShard::TIndexationCounters>("test")->SplitterCounters;
+
+        auto writePortion = BuildPortionWithoutIndexes(schemaFrom, MakeTestBatch(), splitterCounters);
+        auto blobs = ReadBlobs(writePortion);
+        auto readPortion = TReadPortionInfoWithBlobs::RestorePortion(writePortion.GetPortionResult(), blobs, schemaFrom->GetIndexInfo());
+
+        auto syncResult = TReadPortionInfoWithBlobs::SyncPortion(std::move(readPortion), schemaFrom, schemaTo,
+            IStoragesManager::DefaultStorageId, TTestStoragesManager::GetInstance(), splitterCounters);
+
+        UNIT_ASSERT(syncResult);
+        syncResult->RegisterFakeBlobIds();
+        syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
+        UNIT_ASSERT(HasIndex(*syncResult, NGrammIndexId));
+    }
+}
+
+}   // namespace NKikimr::NOlap::NTest

--- a/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
@@ -149,8 +149,9 @@ bool HasIndex(const TWritePortionInfoWithBlobsResult& portion, const ui32 indexI
 
 Y_UNIT_TEST_SUITE(TIndexBlobSizeLimitTests) {
     // Issue #26733: actualization rebuilds the index for the target tier, and a filter above the storage
-    // MaxBlobSize used to abort the tablet with "blob size for secondary data ... bigger than limit".
-    Y_UNIT_TEST(OversizedIndexOnActualizationIsSkipped) {
+    // MaxBlobSize used to abort the tablet with "blob size for secondary data ... bigger than limit". A
+    // filter that cannot even be split (its base size is above the limit) is folded down to the limit.
+    Y_UNIT_TEST(OversizedIndexOnActualizationIsClampedToLimit) {
         auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
         csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings().SetMaxBlobSize(MaxBlobSize).SetMinBlobSize(MaxBlobSize / 4));
 
@@ -168,7 +169,12 @@ Y_UNIT_TEST_SUITE(TIndexBlobSizeLimitTests) {
         UNIT_ASSERT(syncResult);
         syncResult->RegisterFakeBlobIds();
         syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
-        UNIT_ASSERT(!HasIndex(*syncResult, NGrammIndexId));
+        UNIT_ASSERT(HasIndex(*syncResult, NGrammIndexId));
+        for (const auto& index : syncResult->GetPortionResult().GetIndexesVerified()) {
+            if (index.GetIndexId() == NGrammIndexId) {
+                UNIT_ASSERT_LE(index.GetDataSize(), MaxBlobSize);
+            }
+        }
     }
 
     // The same index fits when the storage limit is the production one, so the portion keeps its index.

--- a/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_index_blob_size_limit.cpp
@@ -1,0 +1,190 @@
+#include <ydb/core/formats/arrow/accessor/plain/accessor.h>
+#include <ydb/core/tx/columnshard/blobs_reader/task.h>
+#include <ydb/core/tx/columnshard/counters/indexation.h>
+#include <ydb/core/tx/columnshard/engines/portions/read_with_blobs.h>
+#include <ydb/core/tx/columnshard/engines/portions/write_with_blobs.h>
+#include <ydb/core/tx/columnshard/engines/scheme/versions/snapshot_scheme.h>
+#include <ydb/core/tx/columnshard/engines/storage/chunks/column.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/bits_storage/abstract.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm/meta.h>
+#include <ydb/core/tx/columnshard/engines/storage/indexes/portions/extractor/default.h>
+#include <ydb/core/tx/columnshard/hooks/testing/controller.h>
+#include <ydb/core/tx/columnshard/splitter/batch_slice.h>
+#include <ydb/core/tx/columnshard/test_helper/helper.h>
+
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_binary.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/array/builder_primitive.h>
+#include <contrib/libs/apache/arrow/cpp/src/arrow/record_batch.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NOlap::NTest {
+
+namespace {
+
+constexpr ui32 PkColumnId = 1;
+constexpr ui32 ValueColumnId = 2;
+constexpr ui32 NGrammIndexId = 1001;
+
+// The index blob is filter_size_bytes long no matter how few records the portion has, so a filter above the
+// storage limit is reproducible with a three-row portion.
+constexpr ui32 FilterSizeBytes = NLocalIndex::NBloom::TConstants::MaxFilterSizeBytes;
+constexpr i64 MaxBlobSize = FilterSizeBytes / 2;
+
+ISnapshotSchema::TPtr MakeSchemaWithNGrammIndex(const ui64 version) {
+    NKikimrSchemeOp::TColumnTableSchema proto;
+    const std::vector<NArrow::NTest::TTestColumn> columns = {
+        NArrow::NTest::TTestColumn("pk", NScheme::TTypeInfo(NScheme::NTypeIds::Uint64)),
+        NArrow::NTest::TTestColumn("value", NScheme::TTypeInfo(NScheme::NTypeIds::Utf8)),
+    };
+    *proto.MutableColumns()->Add() = columns[0].CreateColumn(PkColumnId);
+    *proto.MutableColumns()->Add() = columns[1].CreateColumn(ValueColumnId);
+    proto.AddKeyColumnNames("pk");
+    proto.SetVersion(version);
+    proto.MutableOptions()->MutableCompactionPlannerConstructor()->SetClassName("l-buckets");
+    *proto.MutableOptions()->MutableCompactionPlannerConstructor()->MutableLBuckets() =
+        NKikimrSchemeOp::TCompactionPlannerConstructorContainer::TLOptimizer();
+
+    NLocalIndex::NBloom::TRequestSettings request;
+    request.NGrammSize = 3;
+    request.DeprecatedHashesCount = 2;
+    request.DeprecatedFilterSizeBytes = FilterSizeBytes;
+    request.DeprecatedRecordsCount = 1024;
+    *proto.AddIndexes() = NIndexes::TIndexMetaContainer(
+        std::make_shared<NIndexes::NBloomNGramm::TIndexMeta>(NGrammIndexId, "ngramm_value", IStoragesManager::DefaultStorageId, false,
+            ValueColumnId, NIndexes::TReadDataExtractorContainer(std::make_shared<NIndexes::TDefaultDataExtractor>()),
+            NIndexes::IBitsStorageConstructor::GetDefault(), request))
+                              .SerializeToProto();
+
+    auto cache = std::make_shared<TSchemaObjectsCache>();
+    auto indexInfo = TIndexInfo::BuildFromProto(version, proto, TTestStoragesManager::GetInstance(), cache);
+    UNIT_ASSERT(indexInfo);
+    return std::make_shared<TSnapshotSchema>(cache->UpsertIndexInfo(std::move(*indexInfo)), TSnapshot(1, 1));
+}
+
+std::shared_ptr<arrow::RecordBatch> MakeTestBatch() {
+    arrow::UInt64Builder pkBuilder;
+    arrow::StringBuilder valueBuilder;
+    UNIT_ASSERT(pkBuilder.AppendValues({ 1, 2, 3 }).ok());
+    UNIT_ASSERT(valueBuilder.AppendValues({ "alpha", "beta", "gamma" }).ok());
+    auto schema = arrow::schema({ arrow::field("pk", arrow::uint64()), arrow::field("value", arrow::utf8()) });
+    return arrow::RecordBatch::Make(schema, 3, { pkBuilder.Finish().ValueOrDie(), valueBuilder.Finish().ValueOrDie() });
+}
+
+THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>> BuildColumnChunks(
+    const ISnapshotSchema::TPtr& schema, const std::shared_ptr<arrow::RecordBatch>& batch) {
+    THashMap<ui32, std::vector<std::shared_ptr<IPortionDataChunk>>> chunks;
+    for (const auto& field : batch->schema()->fields()) {
+        const ui32 columnId = schema->GetColumnIdVerified(field->name());
+        auto loader = schema->GetIndexInfo().GetColumnLoaderVerified(columnId);
+        const auto& accessorConstructor = loader->GetAccessorConstructor();
+        auto accessor = std::make_shared<NArrow::NAccessor::TTrivialArray>(batch->GetColumnByName(field->name()));
+        const auto loadContext = loader->BuildAccessorContext(accessor->GetRecordsCount());
+        auto arrToWrite = accessorConstructor->Construct(accessor, loadContext);
+        UNIT_ASSERT(arrToWrite.IsSuccess());
+        chunks[columnId] = { std::make_shared<NChunks::TChunkPreparation>(
+            accessorConstructor->SerializeToBlobAndMeta(*arrToWrite, loadContext).Blob, *arrToWrite, TChunkAddress(columnId, 0),
+            schema->GetIndexInfo().GetColumnFeaturesVerified(columnId)) };
+    }
+    return chunks;
+}
+
+TWritePortionInfoWithBlobsResult BuildPortionWithoutIndexes(const ISnapshotSchema::TPtr& schema,
+    const std::shared_ptr<arrow::RecordBatch>& batch, const std::shared_ptr<NColumnShard::TSplitterCounters>& splitterCounters) {
+    std::shared_ptr<TDefaultSchemaDetails> schemaDetails(
+        new TDefaultSchemaDetails(schema, std::make_shared<NArrow::NSplitter::TSerializationStats>()));
+    TGeneralSerializedSlice slice(BuildColumnChunks(schema, batch), schemaDetails, splitterCounters);
+
+    const NSplitter::TEntityGroups groups(NSplitter::TSplitSettings(), NBlobOperations::TGlobal::DefaultStorageId);
+    std::vector<TSplittedBlob> blobs;
+    UNIT_ASSERT(slice.GroupBlobs(blobs, groups));
+
+    auto constructor = TWritePortionInfoWithBlobsConstructor::BuildByBlobs(std::move(blobs), {}, TInternalPathId::FromRawValue(1),
+        schema->GetVersion(), schema->GetSnapshot(), TTestStoragesManager::GetInstance(), EPortionType::Written, schema->GetIndexInfo());
+
+    NArrow::TFirstLastSpecialKeys primaryKeys(slice.GetFirstLastPKBatch(schema->GetIndexInfo().GetReplaceKey()));
+    auto& portionCtor = constructor.GetPortionConstructor().MutablePortionConstructor();
+    static_cast<TWrittenPortionInfoConstructor&>(portionCtor).SetInsertWriteId(TInsertWriteId(1));
+    portionCtor.SetPortionId(1);
+    portionCtor.AddMetadata(*schema, 0, primaryKeys, std::nullopt);
+    portionCtor.MutableMeta().SetTierName(IStoragesManager::DefaultStorageId);
+    portionCtor.MutableMeta().SetCompactionLevel(0);
+
+    TWritePortionInfoWithBlobsResult result(std::move(constructor));
+    result.RegisterFakeBlobIds();
+    result.FinalizePortionConstructor(TSnapshot(1, 1));
+    return result;
+}
+
+NBlobOperations::NRead::TCompositeReadBlobs ReadBlobs(TWritePortionInfoWithBlobsResult& portion) {
+    NBlobOperations::NRead::TCompositeReadBlobs blobs;
+    for (auto& blob : portion.MutableBlobs()) {
+        const TString& data = blob.GetResultBlob();
+        for (auto&& chunkAddress : blob.GetChunks()) {
+            const auto* recordInfo = portion.GetPortionResult().GetRecordPointer(chunkAddress);
+            AFL_VERIFY(recordInfo);
+            const auto range = portion.GetPortionResult().RestoreBlobRange(recordInfo->GetBlobRange());
+            blobs.Add(IStoragesManager::DefaultStorageId, range, data.substr(range.Offset, range.Size));
+        }
+    }
+    return blobs;
+}
+
+bool HasIndex(const TWritePortionInfoWithBlobsResult& portion, const ui32 indexId) {
+    for (auto&& index : portion.GetPortionResult().GetIndexesVerified()) {
+        if (index.GetIndexId() == indexId) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}   // namespace
+
+Y_UNIT_TEST_SUITE(TIndexBlobSizeLimitTests) {
+    // Issue #26733: actualization rebuilds the index for the target tier, and a filter above the storage
+    // MaxBlobSize used to abort the tablet with "blob size for secondary data ... bigger than limit".
+    Y_UNIT_TEST(OversizedIndexOnActualizationIsSkipped) {
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings().SetMaxBlobSize(MaxBlobSize).SetMinBlobSize(MaxBlobSize / 4));
+
+        const auto schemaFrom = MakeSchemaWithNGrammIndex(1);
+        const auto schemaTo = MakeSchemaWithNGrammIndex(2);
+        const auto splitterCounters = std::make_shared<NColumnShard::TIndexationCounters>("test")->SplitterCounters;
+
+        auto writePortion = BuildPortionWithoutIndexes(schemaFrom, MakeTestBatch(), splitterCounters);
+        auto blobs = ReadBlobs(writePortion);
+        auto readPortion = TReadPortionInfoWithBlobs::RestorePortion(writePortion.GetPortionResult(), blobs, schemaFrom->GetIndexInfo());
+
+        auto syncResult = TReadPortionInfoWithBlobs::SyncPortion(std::move(readPortion), schemaFrom, schemaTo,
+            IStoragesManager::DefaultStorageId, TTestStoragesManager::GetInstance(), splitterCounters);
+
+        UNIT_ASSERT(syncResult);
+        syncResult->RegisterFakeBlobIds();
+        syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
+        UNIT_ASSERT(!HasIndex(*syncResult, NGrammIndexId));
+    }
+
+    // The same index fits when the storage limit is the production one, so the portion keeps its index.
+    Y_UNIT_TEST(IndexUnderLimitIsBuilt) {
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverrideBlobSplitSettings(NSplitter::TSplitSettings());
+
+        const auto schemaFrom = MakeSchemaWithNGrammIndex(1);
+        const auto schemaTo = MakeSchemaWithNGrammIndex(2);
+        const auto splitterCounters = std::make_shared<NColumnShard::TIndexationCounters>("test")->SplitterCounters;
+
+        auto writePortion = BuildPortionWithoutIndexes(schemaFrom, MakeTestBatch(), splitterCounters);
+        auto blobs = ReadBlobs(writePortion);
+        auto readPortion = TReadPortionInfoWithBlobs::RestorePortion(writePortion.GetPortionResult(), blobs, schemaFrom->GetIndexInfo());
+
+        auto syncResult = TReadPortionInfoWithBlobs::SyncPortion(std::move(readPortion), schemaFrom, schemaTo,
+            IStoragesManager::DefaultStorageId, TTestStoragesManager::GetInstance(), splitterCounters);
+
+        UNIT_ASSERT(syncResult);
+        syncResult->RegisterFakeBlobIds();
+        syncResult->FinalizePortionConstructor(TSnapshot(1, 1));
+        UNIT_ASSERT(HasIndex(*syncResult, NGrammIndexId));
+    }
+}
+
+}   // namespace NKikimr::NOlap::NTest

--- a/ydb/core/tx/columnshard/engines/ut/ya.make
+++ b/ydb/core/tx/columnshard/engines/ut/ya.make
@@ -25,6 +25,7 @@ PEERDIR(
     ydb/core/formats/arrow/program
     ydb/core/tx/columnshard/engines/storage/indexes/min_max
     ydb/core/tx/columnshard/engines/storage/indexes/bloom
+    ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm
 
     yql/essentials/udfs/common/json2
 )
@@ -46,6 +47,7 @@ SRCS(
     ut_script.cpp
     ut_minmax_index.cpp
     ut_sync_portion_index_reuse.cpp
+    ut_index_blob_size_limit.cpp
     ut_predicate_ranges_builder.cpp
     helper.cpp
 )

--- a/ydb/core/tx/columnshard/engines/ut/ya.make
+++ b/ydb/core/tx/columnshard/engines/ut/ya.make
@@ -25,6 +25,7 @@ PEERDIR(
     ydb/core/formats/arrow/program
     ydb/core/tx/columnshard/engines/storage/indexes/min_max
     ydb/core/tx/columnshard/engines/storage/indexes/bloom
+    ydb/core/tx/columnshard/engines/storage/indexes/bloom_ngramm
 
     yql/essentials/udfs/common/json2
 )
@@ -48,6 +49,7 @@ SRCS(
     ut_minmax_index.cpp
     ut_sync_portion_index_reuse.cpp
     ut_portion_blob_validation.cpp
+    ut_index_blob_size_limit.cpp
     ut_predicate_ranges_builder.cpp
     ut_index_info_schema_diff.cpp
     helper.cpp


### PR DESCRIPTION

* Bugfix 
* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Fixing verify blobs with sencodary data
...
Clauded with Opus 4.8

 Skip reuse chunk index error  if index chunk exceeds `MaxBlobSize`