### PR TITLE
Fix C++ SDK compatibility with libc++ and Clang 21

### DIFF
--- a/util/stream/output.cpp
+++ b/util/stream/output.cpp
@@ -292,6 +292,10 @@ void Out<TNullPtr>(IOutputStream& o, TTypeTraits<TNullPtr>::TFuncParam) {
 DEF_OPTIONAL(ui32);
 DEF_OPTIONAL(i64);
 DEF_OPTIONAL(ui64);
+#if defined(_darwin_) && defined(_64_)
+DEF_OPTIONAL(long long);
+DEF_OPTIONAL(unsigned long long);
+#endif
 DEF_OPTIONAL(std::string);
 DEF_OPTIONAL(TString);
 DEF_OPTIONAL(TStringBuf);

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/read_events.h
@@ -6,6 +6,7 @@
 
 #include <util/datetime/base.h>
 
+#include <span>
 
 namespace NYdb::inline Dev::NTopic {
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/write_session.h
@@ -12,6 +12,8 @@
 
 #include <util/generic/size_literals.h>
 
+#include <concepts>
+
 namespace NYdb::inline Dev::NTopic {
 
 //! Result of close operation.

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/retry/retry_policy.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/library/retry/retry_policy.h
@@ -126,7 +126,7 @@ struct TExponentialBackoffPolicy : IRetryPolicy<TArgs...> {
 
         TMaybe<TDuration> GetNextRetryDelay(typename TTypeTraits<TArgs>::TFuncParam... args) override {
             const ERetryErrorClass errorClass = RetryClassFunction(args...);
-            if (errorClass == ERetryErrorClass::NoRetry || AttemptsDone >= MaxRetries || StartTime && TInstant::Now() - StartTime >= MaxTime) {
+            if (errorClass == ERetryErrorClass::NoRetry || AttemptsDone >= MaxRetries || (StartTime && TInstant::Now() - StartTime >= MaxTime)) {
                 return {};
             }
 
@@ -215,7 +215,7 @@ struct TFixedIntervalPolicy : IRetryPolicy<TArgs...> {
 
         TMaybe<TDuration> GetNextRetryDelay(typename TTypeTraits<TArgs>::TFuncParam... args) override {
             const ERetryErrorClass errorClass = RetryClassFunction(args...);
-            if (errorClass == ERetryErrorClass::NoRetry || AttemptsDone >= MaxRetries || StartTime && TInstant::Now() - StartTime >= MaxTime) {
+            if (errorClass == ERetryErrorClass::NoRetry || AttemptsDone >= MaxRetries || (StartTime && TInstant::Now() - StartTime >= MaxTime)) {
                 return {};
             }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed C++ SDK Topic header compatibility with libc++ and Darwin builds.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds missing standard-library includes, parenthesizes retry deadline conditions for Clang, and adds fixed-width optional stream specializations for Darwin.
