### PR TITLE
Fix tokenizer autoreview issues

### DIFF
--- a/ydb/core/base/fulltext.cpp
+++ b/ydb/core/base/fulltext.cpp
@@ -339,7 +339,7 @@ namespace {
                         }
                         if (tryRead(q, c2, n2) && IsDecdigit(c2)) {
                             p = q + n2;
-                            prev = LETTER;
+                            prev = DIGIT;
                             safeEnd = p;
                         } else {
                             break;

--- a/ydb/core/base/ut/fulltext_ut.cpp
+++ b/ydb/core/base/ut/fulltext_ut.cpp
@@ -540,6 +540,39 @@ Y_UNIT_TEST_SUITE(NFulltext) {
             (TVector<T>{{"foo bar", false}}));
     }
 
+    Y_UNIT_TEST(MidNumberChainedStandard) {
+        // Regression test: after consuming a MidNumber separator + digit, prev was
+        // incorrectly set to LETTER instead of DIGIT, so a second separator would not
+        // satisfy the (prev == DIGIT || prev == MID_DIGIT) guard and the token was cut short.
+        Ydb::Table::FulltextIndexSettings::Analyzers analyzers;
+        analyzers.set_tokenizer(Ydb::Table::FulltextIndexSettings::STANDARD);
+
+        // Two separators: "1,2,3" must be one token.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2,3", analyzers), (TVector<TString>{"1,2,3"}));
+
+        // Mix of MidNumber chars (comma and period).
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2.3", analyzers), (TVector<TString>{"1,2.3"}));
+
+        // Trailing separator does not join — "1," ends at safeEnd before the comma.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2,", analyzers), (TVector<TString>{"1,2"}));
+
+        // Longer chain.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2,3,4,5", analyzers), (TVector<TString>{"1,2,3,4,5"}));
+
+        // Multiple tokens separated by whitespace — each chained number is its own token.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2,3 4,5,6", analyzers), (TVector<TString>{"1,2,3", "4,5,6"}));
+
+        // Mixed: a word token followed by a chained number token.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("price 1,234,567", analyzers), (TVector<TString>{"price", "1,234,567"}));
+
+        // Chained number token followed by a letter token.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2,3 end", analyzers), (TVector<TString>{"1,2,3", "end"}));
+
+        // Punctuation breaks tokens: "1,2.foo" — the period before a letter is MidLetter territory,
+        // but here it follows digits so the chain stops at "1,2" and "foo" is separate.
+        UNIT_ASSERT_VALUES_EQUAL(Analyze("1,2.foo", analyzers), (TVector<TString>{"1,2", "foo"}));
+    }
+
     Y_UNIT_TEST(WordBreakTest) {
         // Generated from
         // http://www.unicode.org/Public/12.1.0/ucd/auxiliary/WordBreakTest.txt

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -391,6 +391,7 @@ public:
         Whitespace,
         Standard,
         Keyword,
+        Alphanumeric,
     };
 
     struct TAnalyzers {

--- a/ydb/public/sdk/cpp/src/client/table/out.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/out.cpp
@@ -97,6 +97,9 @@ Y_DECLARE_OUT_SPEC(, NYdb::NTable::TFulltextIndexSettings::ETokenizer, stream, v
         case NYdb::NTable::TFulltextIndexSettings::ETokenizer::Keyword:
             stream << "keyword";
             break;
+        case NYdb::NTable::TFulltextIndexSettings::ETokenizer::Alphanumeric:
+            stream << "alphanumeric";
+            break;
         case NYdb::NTable::TFulltextIndexSettings::ETokenizer::Unspecified:
             stream << "unspecified";
             break;

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -3040,6 +3040,8 @@ TFulltextIndexSettings::TAnalyzers FromProto(const Ydb::Table::FulltextIndexSett
             return ETokenizer::Standard;
         case Ydb::Table::FulltextIndexSettings::KEYWORD:
             return ETokenizer::Keyword;
+        case Ydb::Table::FulltextIndexSettings::ALPHANUMERIC:
+            return ETokenizer::Alphanumeric;
         default:
             return ETokenizer::Unspecified;
         }
@@ -3093,6 +3095,8 @@ Ydb::Table::FulltextIndexSettings::Analyzers ToProto(const TFulltextIndexSetting
             return Ydb::Table::FulltextIndexSettings::STANDARD;
         case ETokenizer::Keyword:
             return Ydb::Table::FulltextIndexSettings::KEYWORD;
+        case ETokenizer::Alphanumeric:
+            return Ydb::Table::FulltextIndexSettings::ALPHANUMERIC;
         case ETokenizer::Unspecified:
             return Ydb::Table::FulltextIndexSettings::TOKENIZER_UNSPECIFIED;
         }


### PR DESCRIPTION
### Changelog entry
Fix autoreview issues
Critical issues found in the code:

1) SDK FromProto/ToProto not updated after proto enum renumbering: STANDARD is renumbered from 2 to 4 and old value 2 is renamed to ALPHANUMERIC, but the SDK (ydb/public/sdk/cpp/src/client/table/table.cpp) has no case for ALPHANUMERIC. Existing persisted indexes with proto value 2 will round-trip as Unspecified through the SDK. The ETokenizer enum in table.h also lacks an Alphanumeric variant. This issue exists on main as well (PR #46842 was merged without SDK updates).
2) In the tokenizer implementation (ydb/core/base/fulltext.cpp:342), after a MidNumber lookahead succeeds and a digit is consumed, prev is set to LETTER instead of DIGIT, which may break chained mid-number sequences like "1,2,3" (though this may be intentional to match Elasticsearch behavior).

### Changelog category

* Not for changelog 
### Description for reviewers 