### PR TITLE
Implement DataBytes and IndexBytes ColumnShard counters

### DIFF
--- a/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
@@ -1,4 +1,5 @@
 
+#include <ydb/core/base/counters.h>
 #include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/kqp/ut/common/olap_indexes_enums.h>
 #include <ydb/core/kqp/ut/olap/combinatory/variator.h>
@@ -3867,6 +3868,38 @@ Y_UNIT_TEST(RenameLocalBloomIndex, EUseQueryService) {
             --!syntax_v1
             SELECT COUNT(*) FROM `/Root/olapTableBloomWithDict` WHERE resource_id LIKE "alp%";
         )"), "[[2u]]");
+    }
+
+    Y_UNIT_TEST(DataAndIndexBytesCounters) {
+        auto settings = TKikimrSettings().SetWithSampleTables(false).SetColumnShardAlterObjectEnabled(true);
+        TKikimrRunner kikimr(settings);
+
+        auto csController = NYDBTest::TControllers::RegisterCSControllerGuard<NYDBTest::NColumnShard::TController>();
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+
+        auto helper = TLocalHelper(kikimr);
+        helper.CreateTestOlapTable();
+
+        // A MIN_MAX index gives compacted portions index blobs, so IndexBytes becomes non-zero.
+        ExecQuery(kikimr, false, R"(ALTER OBJECT `/Root/olapStore` (TYPE TABLESTORE) SET (ACTION=UPSERT_INDEX, NAME=index_uid, TYPE=MIN_MAX,
+            FEATURES=`{"column_name" : "uid"}`);)");
+
+        for (ui32 i = 0; i < 5; ++i) {
+            WriteTestData(kikimr, "/Root/olapStore/olapTable", 1000000 + i * 100000, 300000000 + i * 100000, 10000);
+        }
+
+        auto* runtime = kikimr.GetTestServer().GetRuntime();
+        auto appCounters = GetServiceCounters(runtime->GetAppData().Counters, "tablets")
+                               ->GetSubgroup("type", "ColumnShard")
+                               ->GetSubgroup("category", "app");
+        auto dataBytes = appCounters->GetCounter("SUM(ColumnShard/DataBytes)", false);
+        auto indexBytes = appCounters->GetCounter("SUM(ColumnShard/IndexBytes)", false);
+
+        // Index blobs are produced by async background compaction, and each shard's counters roll up into
+        // the SUM(...) aggregate sensor only periodically, so poll until both surface.
+        csController->WaitCondition(TDuration::Seconds(30), [&]() { return dataBytes->Val() > 0 && indexBytes->Val() > 0; });
+        UNIT_ASSERT_GT(dataBytes->Val(), 0);
+        UNIT_ASSERT_GT(indexBytes->Val(), 0);
     }
 }
 

--- a/ydb/core/protos/counters_columnshard.proto
+++ b/ydb/core/protos/counters_columnshard.proto
@@ -50,6 +50,8 @@ enum ESimpleCounters {
     COUNTER_EVICTED_RAW_BYTES = 40                          [(CounterOpts) = {Name: "Index/EvictedBytesRaw"}];
     COUNTER_WRITES_IN_FLY = 41                              [(CounterOpts) = {Name: "WritesInFly"}];
     COUNTER_TX_COMPLETE_LAG = 42                            [(CounterOpts) = {Name: "TxCompleteLag"}];
+    COUNTER_DATA_BYTES = 43                                 [(CounterOpts) = {Name: "DataBytes"}];
+    COUNTER_INDEX_BYTES = 44                                [(CounterOpts) = {Name: "IndexBytes"}];
 }
 
 enum ECumulativeCounters {

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -341,6 +341,10 @@ void TColumnShard::UpdateIndexCounters() {
     const std::shared_ptr<const TTabletCountersHandle>& counters = Counters.GetTabletCounters();
     counters->SetCounter(COUNTER_INDEX_TABLES, Counters.GetPortionIndexCounters()->GetTablesCount());
 
+    auto diskUsedStats = Counters.GetPortionIndexCounters()->GetTotalStats(TPortionIndexStats::TDiskUsedPortions());
+    counters->SetCounter(COUNTER_DATA_BYTES, diskUsedStats.GetDataBlobBytes());
+    counters->SetCounter(COUNTER_INDEX_BYTES, diskUsedStats.GetIndexBlobBytes());
+
     auto insertedStats =
         Counters.GetPortionIndexCounters()->GetTotalStats(TPortionIndexStats::TPortionsByType<NOlap::NPortion::EProduced::INSERTED>());
     counters->SetCounter(COUNTER_INSERTED_PORTIONS, insertedStats.GetCount());

--- a/ydb/core/tx/columnshard/counters/portions.cpp
+++ b/ydb/core/tx/columnshard/counters/portions.cpp
@@ -27,6 +27,7 @@ namespace NKikimr::NOlap {
 
 void TSimplePortionsGroupInfo::RemovePortion(const TPortionInfo& p) {
     BlobBytes.Sub(p.GetTotalBlobBytes());
+    IndexBlobBytes.Sub(p.GetIndexBlobBytes());
     RawBytes.Sub(p.GetTotalRawBytes());
     Count.Sub(1);
     RecordsCount.Sub(p.GetRecordsCount());
@@ -34,6 +35,7 @@ void TSimplePortionsGroupInfo::RemovePortion(const TPortionInfo& p) {
 
 void TSimplePortionsGroupInfo::AddPortion(const TPortionInfo& p) {
     BlobBytes.Add(p.GetTotalBlobBytes());
+    IndexBlobBytes.Add(p.GetIndexBlobBytes());
     RawBytes.Add(p.GetTotalRawBytes());
     Count.Inc();
     RecordsCount.Add(p.GetRecordsCount());

--- a/ydb/core/tx/columnshard/counters/portions.h
+++ b/ydb/core/tx/columnshard/counters/portions.h
@@ -19,6 +19,7 @@ class TSimplePortionsGroupInfo {
 private:
     using TCountByChannel = THashMap<ui16, i64>;
     TPositiveControlInteger BlobBytes;
+    TPositiveControlInteger IndexBlobBytes;
     TPositiveControlInteger RawBytes;
     TPositiveControlInteger Count;
     TPositiveControlInteger RecordsCount;
@@ -26,6 +27,7 @@ private:
 protected:
     void Add(const TSimplePortionsGroupInfo& item) {
         BlobBytes.Add(item.BlobBytes);
+        IndexBlobBytes.Add(item.IndexBlobBytes);
         RawBytes.Add(item.RawBytes);
         Count.Add(item.Count);
         RecordsCount.Add(item.RecordsCount);
@@ -44,6 +46,15 @@ public:
         return BlobBytes.Val();
     }
 
+    ui64 GetIndexBlobBytes() const {
+        return IndexBlobBytes.Val();
+    }
+
+    ui64 GetDataBlobBytes() const {
+        AFL_VERIFY(BlobBytes.Val() >= IndexBlobBytes.Val())("blob", BlobBytes.Val())("index", IndexBlobBytes.Val());
+        return BlobBytes.Val() - IndexBlobBytes.Val();
+    }
+
     ui64 GetRawBytes() const {
         return RawBytes.Val();
     }
@@ -51,6 +62,7 @@ public:
     NJson::TJsonValue SerializeToJson() const {
         NJson::TJsonValue result = NJson::JSON_MAP;
         result.InsertValue("blob_bytes", BlobBytes.Val());
+        result.InsertValue("index_blob_bytes", IndexBlobBytes.Val());
         result.InsertValue("raw_bytes", RawBytes.Val());
         result.InsertValue("count", Count.Val());
         result.InsertValue("records_count", RecordsCount.Val());
@@ -66,8 +78,8 @@ public:
     }
 
     TString DebugString() const {
-        return TStringBuilder() << "{blob_bytes=" << BlobBytes.Val() << ";raw_bytes=" << RawBytes.Val() << ";count=" << Count.Val()
-                                << ";records=" << RecordsCount.Val() << "}";
+        return TStringBuilder() << "{blob_bytes=" << BlobBytes.Val() << ";index_blob_bytes=" << IndexBlobBytes.Val()
+                                << ";raw_bytes=" << RawBytes.Val() << ";count=" << Count.Val() << ";records=" << RecordsCount.Val() << "}";
     }
 
     TSimplePortionsGroupInfo& operator+=(const TSimplePortionsGroupInfo& item) {
@@ -98,6 +110,7 @@ public:
     bool IsEmpty() const {
         if (!Count.Val()) {
             AFL_VERIFY(!BlobBytes.Val())("this", DebugString());
+            AFL_VERIFY(!IndexBlobBytes.Val())("this", DebugString());
             AFL_VERIFY(!RawBytes.Val())("this", DebugString());
             AFL_VERIFY(!RecordsCount.Val())("this", DebugString());
             return true;

--- a/ydb/core/tx/columnshard/counters/portions.h
+++ b/ydb/core/tx/columnshard/counters/portions.h
@@ -51,8 +51,10 @@ public:
     }
 
     ui64 GetDataBlobBytes() const {
-        AFL_VERIFY(BlobBytes.Val() >= IndexBlobBytes.Val())("blob", BlobBytes.Val())("index", IndexBlobBytes.Val());
-        return BlobBytes.Val() - IndexBlobBytes.Val();
+        const ui64 blob = BlobBytes.Val();
+        const ui64 index = IndexBlobBytes.Val();
+        AFL_VERIFY(blob >= index)("blob", blob)("index", index);
+        return blob - index;
     }
 
     ui64 GetRawBytes() const {


### PR DESCRIPTION
~~Existing BaseStatisticsTotalBytesSize metric remains unchanged and reports data-only size for Datashard and data+index for Columnshard.~~

~~Columnshard now properly reports data and index size separately in corresponding counters.~~

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)
