### PR TITLE
Configurable CPU-usage window for actor-system harmonizer

### DIFF
--- a/ydb/core/driver_lib/run/config_helpers.cpp
+++ b/ydb/core/driver_lib/run/config_helpers.cpp
@@ -51,6 +51,10 @@ NActors::EASProfile ConvertActorSystemProfile(NKikimrConfig::TActorSystemConfig:
 }  // anonymous namespace
 
 void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig::TActorSystemConfig::TExecutor& poolConfig, const NKikimrConfig::TActorSystemConfig& systemConfig, ui32 poolId, NMonitoring::TDynamicCounterPtr counters) {
+    Y_ABORT_UNLESS(!poolConfig.HasHarmonizerNeedyCpuWindowSeconds()
+        || poolConfig.GetType() == NKikimrConfig::TActorSystemConfig::TExecutor::BASIC,
+        "HarmonizerNeedyCpuWindowSeconds is supported only for BASIC executors");
+
     switch (poolConfig.GetType()) {
         case NKikimrConfig::TActorSystemConfig::TExecutor::BASIC: {
             NActors::TBasicExecutorPoolConfig basic;
@@ -86,6 +90,11 @@ void AddExecutorPool(NActors::TCpuManagerConfig& cpuManager, const NKikimrConfig
             basic.MaxThreadCount = poolConfig.GetMaxThreads();
             basic.DefaultThreadCount = poolConfig.GetThreads();
             basic.Priority = poolConfig.GetPriority();
+            const ui32 harmonizerNeedyCpuWindowSeconds = poolConfig.GetHarmonizerNeedyCpuWindowSeconds();
+            Y_ABORT_UNLESS(harmonizerNeedyCpuWindowSeconds >= 1 && harmonizerNeedyCpuWindowSeconds <= 32,
+                "HarmonizerNeedyCpuWindowSeconds must be in range [1, 32], got %" PRIu32,
+                harmonizerNeedyCpuWindowSeconds);
+            basic.HarmonizerNeedyCpuWindowSeconds = static_cast<ui8>(harmonizerNeedyCpuWindowSeconds);
             if (poolConfig.HasMinLocalQueueSize()) {
                 basic.MinLocalQueueSize = poolConfig.GetMinLocalQueueSize();
             }

--- a/ydb/core/driver_lib/run/run_ut.cpp
+++ b/ydb/core/driver_lib/run/run_ut.cpp
@@ -1,4 +1,5 @@
 #include "run.h"
+#include "config_helpers.h"
 #include <library/cpp/testing/unittest/registar.h>
 
 Y_UNIT_TEST_SUITE(XdsBootstrapConfigInitializer) {
@@ -104,3 +105,33 @@ Y_UNIT_TEST(CanNotSetGrpcXdsBootstrapConfigEnvIfVariableAlreadySet) {
 }
 
 } // XdsBootstrapConfigInitializer
+
+Y_UNIT_TEST_SUITE(ActorSystemConfigHelpers) {
+
+using namespace NKikimr;
+
+Y_UNIT_TEST(HarmonizerNeedyCpuWindow) {
+    NKikimrConfig::TActorSystemConfig systemConfig;
+    NActors::TCpuManagerConfig cpuManager;
+
+    auto* defaultExecutor = systemConfig.AddExecutor();
+    defaultExecutor->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
+    defaultExecutor->SetName("System");
+    defaultExecutor->SetThreads(1);
+    defaultExecutor->SetMaxThreads(2);
+    NActorSystemConfigHelpers::AddExecutorPool(cpuManager, *defaultExecutor, systemConfig, 0, nullptr);
+
+    auto* configuredExecutor = systemConfig.AddExecutor();
+    configuredExecutor->SetType(NKikimrConfig::TActorSystemConfig::TExecutor::BASIC);
+    configuredExecutor->SetName("User");
+    configuredExecutor->SetThreads(1);
+    configuredExecutor->SetMaxThreads(2);
+    configuredExecutor->SetHarmonizerNeedyCpuWindowSeconds(30);
+    NActorSystemConfigHelpers::AddExecutorPool(cpuManager, *configuredExecutor, systemConfig, 1, nullptr);
+
+    UNIT_ASSERT_VALUES_EQUAL(cpuManager.Basic.size(), 2);
+    UNIT_ASSERT_VALUES_EQUAL(cpuManager.Basic[0].HarmonizerNeedyCpuWindowSeconds, 1);
+    UNIT_ASSERT_VALUES_EQUAL(cpuManager.Basic[1].HarmonizerNeedyCpuWindowSeconds, 30);
+}
+
+} // ActorSystemConfigHelpers

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -92,6 +92,7 @@ message TActorSystemConfig {
         optional uint32 MaxThreads = 13; // Higher balancing bound, should be not lower than `Threads`
         optional int32 Priority = 16;
         optional int32 MaxAvgPingDeviation = 17;
+        optional uint32 HarmonizerNeedyCpuWindowSeconds = 26 [default = 1]; // Supported for BASIC executors, range is [1, 32]
 
         optional bool HasSharedThread = 18;
         optional bool AllThreadsAreShared = 24;

--- a/ydb/library/actors/core/config.h
+++ b/ydb/library/actors/core/config.h
@@ -27,6 +27,7 @@ namespace NActors {
         i16 MaxThreadCount = 0;
         i16 DefaultThreadCount = 0;
         i16 Priority = 0;
+        ui8 HarmonizerNeedyCpuWindowSeconds = 1;
         i16 SharedExecutorsCount = 0;
         i16 SoftProcessingDurationTs = 0;
         EASProfile ActorSystemProfile = EASProfile::Default;

--- a/ydb/library/actors/core/cpu_manager.cpp
+++ b/ydb/library/actors/core/cpu_manager.cpp
@@ -106,9 +106,16 @@ namespace NActors {
         for (ui32 excIdx = 0; excIdx != ExecutorPoolCount; ++excIdx) {
             Executors[excIdx].Reset(CreateExecutorPool(excIdx));
             bool ignoreThreads = dynamic_cast<TIOExecutorPool*>(Executors[excIdx].Get());
+            ui8 harmonizerNeedyCpuWindowSeconds = 1;
+            for (const auto& cfg : Config.Basic) {
+                if (cfg.PoolId == excIdx) {
+                    harmonizerNeedyCpuWindowSeconds = cfg.HarmonizerNeedyCpuWindowSeconds;
+                    break;
+                }
+            }
             TSelfPingInfo *pingInfo = (excIdx < Config.PingInfoByPool.size()) ? &Config.PingInfoByPool[excIdx] : nullptr;
             ignoreThreads &= (Shared != nullptr);
-            Harmonizer->AddPool(Executors[excIdx].Get(), pingInfo, ignoreThreads);
+            Harmonizer->AddPool(Executors[excIdx].Get(), pingInfo, ignoreThreads, harmonizerNeedyCpuWindowSeconds);
         }
         ACTORLIB_DEBUG(EDebugLevel::ActorSystem, "TCpuManager::Setup: created");
     }

--- a/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
+++ b/ydb/library/actors/core/harmonizer/cpu_consumption.cpp
@@ -10,6 +10,7 @@ void TCpuConsumptionInfo::Clear() {
     Cpu = 0.0;
     LastSecondElapsed = 0.0;
     LastSecondCpu = 0.0;
+    NeedyWindowCpu = 0.0;
 }
 
 void THarmonizerCpuConsumption::Init(i16 poolCount) {
@@ -43,6 +44,11 @@ namespace {
             poolFullThreadConsumption->LastSecondElapsed += threadLastSecondElapsed;
             poolFullThreadConsumption->Cpu += threadCpu;
             poolFullThreadConsumption->LastSecondCpu += threadLastSecondCpu;
+            float threadNeedyWindowCpu = pool.NeedyCpuWindowSeconds == 1
+                ? threadLastSecondCpu
+                : Rescale(pool.GetCpuForLastSeconds(threadIdx, pool.NeedyCpuWindowSeconds));
+            poolConsumption->NeedyWindowCpu += threadNeedyWindowCpu;
+            poolFullThreadConsumption->NeedyWindowCpu += threadNeedyWindowCpu;
             LWPROBE_WITH_DEBUG(HarmonizeCheckPoolByThread, pool.Pool->PoolId, pool.Pool->GetName(), threadIdx, threadElapsed, threadCpu, threadLastSecondElapsed, threadLastSecondCpu);
         }
         for (i16 sharedIdx = 0; sharedIdx < static_cast<i16>(pool.SharedInfo.size()); ++sharedIdx) {
@@ -50,10 +56,14 @@ namespace {
             float sharedLastSecondElapsed = pool.GetLastSecondSharedElapsed(sharedIdx);
             float sharedCpu = pool.GetSharedCpu(sharedIdx);
             float sharedLastSecondCpu = pool.GetLastSecondSharedCpu(sharedIdx);
+            float sharedNeedyWindowCpu = pool.NeedyCpuWindowSeconds == 1
+                ? sharedLastSecondCpu
+                : pool.GetSharedCpuForLastSeconds(sharedIdx, pool.NeedyCpuWindowSeconds);
             poolConsumption->Elapsed += sharedElapsed;
             poolConsumption->LastSecondElapsed += sharedLastSecondElapsed;
             poolConsumption->Cpu += sharedCpu;
             poolConsumption->LastSecondCpu += sharedLastSecondCpu;
+            poolConsumption->NeedyWindowCpu += sharedNeedyWindowCpu;
             LWPROBE_WITH_DEBUG(HarmonizeCheckPoolByThread, pool.Pool->PoolId, pool.Pool->GetName(), -1 - sharedIdx, sharedElapsed, sharedCpu, sharedLastSecondElapsed, sharedLastSecondCpu);
         }
     }
@@ -110,8 +120,11 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             "cpu:", PoolConsumption[poolIdx].Cpu,
             "last second elapsed:", PoolConsumption[poolIdx].LastSecondElapsed,
             "last second cpu:", PoolConsumption[poolIdx].LastSecondCpu,
+            "needy cpu window seconds:", pool.NeedyCpuWindowSeconds,
+            "needy window cpu:", PoolConsumption[poolIdx].NeedyWindowCpu,
             "full thread elapsed:", PoolFullThreadConsumption[poolIdx].Elapsed,
             "full thread cpu:", PoolFullThreadConsumption[poolIdx].Cpu,
+            "needy window full thread cpu:", PoolFullThreadConsumption[poolIdx].NeedyWindowCpu,
             "last second full thread elapsed:", PoolFullThreadConsumption[poolIdx].LastSecondElapsed,
             "last second full thread cpu:", PoolFullThreadConsumption[poolIdx].LastSecondCpu,
             "foreign elapsed:", PoolForeignConsumption[poolIdx].Elapsed,
@@ -126,10 +139,12 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
 
         bool hasSharedThread = sharedInfo.OwnedThreads[poolIdx] != -1;
         float expectedThreadCount = pool.GetFullThreadCount() + (hasSharedThread ? 1 : 0) + 0.5;
-        bool isMoreThanExpected = (PoolConsumption[poolIdx].LastSecondCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].LastSecondCpu >= currentFullThreadCount - 1);
+        bool isMoreThanExpected = (PoolConsumption[poolIdx].NeedyWindowCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].NeedyWindowCpu >= currentFullThreadCount - 1);
+        bool isMoreThanExpectedLastSecond = (PoolConsumption[poolIdx].LastSecondCpu >= expectedThreadCount) && (PoolFullThreadConsumption[poolIdx].LastSecondCpu >= currentFullThreadCount - 1);
+        bool hasCurrentCpuDemand = (PoolConsumption[poolIdx].LastSecondCpu >= currentThreadCount || isMoreThanExpectedLastSecond);
         bool isNeedy = (pool.IsAvgPingGood() || pool.NewNotEnoughCpuExecutions);
         if (isNeedy && !pool.IsSharedOnly) {
-            isNeedy = (PoolConsumption[poolIdx].LastSecondCpu >= currentThreadCount || isMoreThanExpected);
+            isNeedy = (PoolConsumption[poolIdx].NeedyWindowCpu >= currentThreadCount || isMoreThanExpected) && hasCurrentCpuDemand;
         } else if (pool.IsSharedOnly) {
             isNeedy = sharedInfo.FreeCpu < 0.1f;
         }
@@ -161,7 +176,10 @@ void THarmonizerCpuConsumption::Pull(const std::vector<std::unique_ptr<TPoolInfo
             pool.MaxFullThreadCount,
             isStarved,
             isNeedy,
-            isHoggish
+            isHoggish,
+            pool.NeedyCpuWindowSeconds,
+            PoolConsumption[poolIdx].NeedyWindowCpu,
+            PoolFullThreadConsumption[poolIdx].NeedyWindowCpu
         );
     }
 

--- a/ydb/library/actors/core/harmonizer/cpu_consumption.h
+++ b/ydb/library/actors/core/harmonizer/cpu_consumption.h
@@ -12,6 +12,7 @@ struct TCpuConsumptionInfo {
     float Cpu;
     float LastSecondElapsed;
     float LastSecondCpu;
+    float NeedyWindowCpu;
 
     void Clear();
 }; // struct TCpuConsumptionInfo

--- a/ydb/library/actors/core/harmonizer/harmonizer.cpp
+++ b/ydb/library/actors/core/harmonizer/harmonizer.cpp
@@ -76,7 +76,7 @@ public:
     double Rescale(double value) const;
     void Harmonize(ui64 ts) override;
     void DeclareEmergency(ui64 ts) override;
-    void AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ignoreFullThreadQuota = false) override;
+    void AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ignoreFullThreadQuota = false, ui8 needyCpuWindowSeconds = 1) override;
     void Enable(bool enable) override;
     TPoolHarmonizerStats GetPoolStats(i16 poolId) const override;
     void GetStats(THarmonizerStats &stats) const override;
@@ -454,13 +454,15 @@ void THarmonizer::DeclareEmergency(ui64 ts) {
     NextHarmonizeTs = ts;
 }
 
-void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ignoreFullThreadQuota) {
+void THarmonizer::AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo, bool ignoreFullThreadQuota, ui8 needyCpuWindowSeconds) {
+    Y_ABORT_UNLESS(needyCpuWindowSeconds >= 1 && needyCpuWindowSeconds <= TThreadInfo::CpuHistorySize);
     TGuard<TSpinLock> guard(Lock);
     Pools.emplace_back(new TPoolInfo);
     TPoolInfo &poolInfo = *Pools.back();
     poolInfo.Pool = pool;
     poolInfo.Shared = Shared;
     poolInfo.BasicPool = dynamic_cast<TBasicExecutorPool*>(pool);
+    poolInfo.NeedyCpuWindowSeconds = needyCpuWindowSeconds;
 
     poolInfo.DefaultThreadCount = pool->GetDefaultThreadCount();
     poolInfo.ThreadQuota = ignoreFullThreadQuota ? 0 : poolInfo.DefaultThreadCount;

--- a/ydb/library/actors/core/harmonizer/harmonizer.h
+++ b/ydb/library/actors/core/harmonizer/harmonizer.h
@@ -18,7 +18,7 @@ namespace NActors {
         virtual ~IHarmonizer() {}
         virtual void Harmonize(ui64 ts) = 0;
         virtual void DeclareEmergency(ui64 ts) = 0;
-        virtual void AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo = nullptr, bool ignoreFullThreadQuota = false) = 0;
+        virtual void AddPool(IExecutorPool* pool, TSelfPingInfo *pingInfo = nullptr, bool ignoreFullThreadQuota = false, ui8 needyCpuWindowSeconds = 1) = 0;
         virtual void Enable(bool enable) = 0;
         virtual TPoolHarmonizerStats GetPoolStats(i16 poolId) const = 0;
         virtual void GetStats(THarmonizerStats &stats) const = 0;

--- a/ydb/library/actors/core/harmonizer/pool.cpp
+++ b/ydb/library/actors/core/harmonizer/pool.cpp
@@ -11,35 +11,41 @@ namespace NActors {
 
 LWTRACE_USING(ACTORLIB_PROVIDER);
 
+namespace {
+    constexpr ui8 LegacyCpuWindowSeconds = 8;
+}
+
 TPoolInfo::TPoolInfo()
 {}
 
 double TPoolInfo::GetCpu(i16 threadIdx) const {
+    return GetCpuForLastSeconds(threadIdx, LegacyCpuWindowSeconds);
+}
+
+double TPoolInfo::GetCpuForLastSeconds(i16 threadIdx, ui8 seconds) const {
     if ((size_t)threadIdx < ThreadInfo.size()) {
-        return ThreadInfo[threadIdx].UsedCpu.GetAvgPart();
+        return ThreadInfo[threadIdx].UsedCpu.GetAvgPartForLastSeconds<true>(seconds);
     }
     return 0.0;
 }
 
 double TPoolInfo::GetSharedCpu(i16 sharedThreadIdx) const {
+    return GetSharedCpuForLastSeconds(sharedThreadIdx, LegacyCpuWindowSeconds);
+}
+
+double TPoolInfo::GetSharedCpuForLastSeconds(i16 sharedThreadIdx, ui8 seconds) const {
     if ((size_t)sharedThreadIdx < SharedInfo.size()) {
-        return SharedInfo[sharedThreadIdx].UsedCpu.GetAvgPart();
+        return SharedInfo[sharedThreadIdx].UsedCpu.GetAvgPartForLastSeconds<true>(seconds);
     }
     return 0.0;
 }
 
 double TPoolInfo::GetLastSecondCpu(i16 threadIdx) const {
-    if ((size_t)threadIdx < ThreadInfo.size()) {
-        return ThreadInfo[threadIdx].UsedCpu.GetAvgPartForLastSeconds<true>(1);
-    }
-    return 0.0;
+    return GetCpuForLastSeconds(threadIdx, 1);
 }
 
 double TPoolInfo::GetLastSecondSharedCpu(i16 sharedThreadIdx) const {
-    if ((size_t)sharedThreadIdx < SharedInfo.size()) {
-        return SharedInfo[sharedThreadIdx].UsedCpu.GetAvgPartForLastSeconds<true>(1);
-    }
-    return 0.0;
+    return GetSharedCpuForLastSeconds(sharedThreadIdx, 1);
 }
 
 double TPoolInfo::GetElapsed(i16 threadIdx) const {

--- a/ydb/library/actors/core/harmonizer/pool.h
+++ b/ydb/library/actors/core/harmonizer/pool.h
@@ -16,7 +16,9 @@ template <typename T>
 struct TWaitingStats;
 
 struct TThreadInfo {
-    TValueHistory<8> UsedCpu;
+    static constexpr ui8 CpuHistorySize = 32;
+
+    TValueHistory<CpuHistorySize> UsedCpu;
     TValueHistory<8> ElapsedCpu;
 }; // struct TThreadInfo
 
@@ -42,6 +44,7 @@ struct TPoolInfo {
     ui16 MinLocalQueueSize = 0;
 
     i16 Priority = 0;
+    ui8 NeedyCpuWindowSeconds = 1;
     NMonitoring::TDynamicCounters::TCounterPtr AvgPingCounter;
     NMonitoring::TDynamicCounters::TCounterPtr AvgPingCounterWithSmallWindow;
     ui32 MaxAvgPingUs = 0;
@@ -74,11 +77,13 @@ struct TPoolInfo {
     TPoolInfo();
 
     double GetCpu(i16 threadIdx) const;
+    double GetCpuForLastSeconds(i16 threadIdx, ui8 seconds) const;
     double GetElapsed(i16 threadIdx) const;
     double GetLastSecondCpu(i16 threadIdx) const;
     double GetLastSecondElapsed(i16 threadIdx) const;
 
     double GetSharedCpu(i16 sharedThreadIdx) const;
+    double GetSharedCpuForLastSeconds(i16 sharedThreadIdx, ui8 seconds) const;
     double GetSharedElapsed(i16 sharedThreadIdx) const;
     double GetLastSecondSharedCpu(i16 sharedThreadIdx) const;
     double GetLastSecondSharedElapsed(i16 sharedThreadIdx) const;

--- a/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/harmonizer_ut.cpp
@@ -1,6 +1,8 @@
 #include "harmonizer.h"
+#include "cpu_consumption.h"
 #include "debug.h"
 #include <library/cpp/testing/unittest/registar.h>
+#include <ydb/library/actors/core/executor_pool_basic.h>
 #include <ydb/library/actors/core/executor_pool_shared.h>
 #include <ydb/library/actors/core/executor_thread_ctx.h>
 #include <ydb/library/actors/helpers/pool_stats_collector.h>
@@ -204,6 +206,233 @@ Y_UNIT_TEST_SUITE(HarmonizerTests) {
         auto stats = harmonizer->GetPoolStats(0);
         Y_UNUSED(stats);
         UNIT_ASSERT_VALUES_EQUAL(mockPool->ThreadCount, 4);  // Should start with default
+    }
+
+    Y_UNIT_TEST(TestDefaultNeedyCpuWindowIsOneSecond) {
+        ui64 currentTs = Us2Ts(1'000'000);
+        std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));
+        TMockExecutorPoolParams hotParams {
+            .DefaultFullThreadCount = 1,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 2,
+            .DefaultThreadCount = 1.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 2.0f,
+        };
+        TMockExecutorPoolParams idleParams {
+            .DefaultFullThreadCount = 1,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 1,
+            .DefaultThreadCount = 1.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 1.0f,
+            .PoolId = 1,
+        };
+        auto hotPool = std::make_unique<TMockExecutorPool>(hotParams);
+        auto idlePool = std::make_unique<TMockExecutorPool>(idleParams);
+        harmonizer->AddPool(hotPool.get());
+        harmonizer->AddPool(idlePool.get());
+
+        harmonizer->Harmonize(currentTs);
+        hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 1);
+        currentTs += Us2Ts(1'000'000);
+        harmonizer->Harmonize(currentTs);
+
+        auto stats = harmonizer->GetPoolStats(hotParams.PoolId);
+        CHECK_IS_NEEDY(stats);
+        CHECK_CHANGING_THREADS(stats, 1, 0, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(hotPool->ThreadCount, 2);
+    }
+
+    Y_UNIT_TEST(TestThirtySecondNeedyCpuWindowBoundary) {
+        ui64 currentTs = Us2Ts(1'000'000);
+        std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));
+        TMockExecutorPoolParams hotParams {
+            .DefaultFullThreadCount = 1,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 2,
+            .DefaultThreadCount = 1.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 2.0f,
+        };
+        TMockExecutorPoolParams idleParams {
+            .DefaultFullThreadCount = 1,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 1,
+            .DefaultThreadCount = 1.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 1.0f,
+            .PoolId = 1,
+        };
+        auto hotPool = std::make_unique<TMockExecutorPool>(hotParams);
+        auto idlePool = std::make_unique<TMockExecutorPool>(idleParams);
+        harmonizer->AddPool(hotPool.get(), nullptr, false, 30);
+        harmonizer->AddPool(idlePool.get());
+
+        harmonizer->Harmonize(currentTs);
+        for (ui8 second = 1; second <= 26; ++second) {
+            hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 1);
+            currentTs += Us2Ts(1'000'000);
+            harmonizer->Harmonize(currentTs);
+            UNIT_ASSERT_VALUES_EQUAL_C(hotPool->ThreadCount, 1, "second: " << static_cast<ui32>(second));
+        }
+
+        auto stats = harmonizer->GetPoolStats(hotParams.PoolId);
+        CHECK_IS_NOT_NEEDY(stats);
+        CHECK_CHANGING_THREADS(stats, 0, 0, 0, 0, 0);
+
+        hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 1);
+        currentTs += Us2Ts(1'000'000);
+        harmonizer->Harmonize(currentTs);
+
+        stats = harmonizer->GetPoolStats(hotParams.PoolId);
+        CHECK_IS_NEEDY(stats);
+        CHECK_CHANGING_THREADS(stats, 1, 0, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(hotPool->ThreadCount, 2);
+    }
+
+    Y_UNIT_TEST(TestThirtySecondNeedyWindowKeepsOneSecondSafetyBudget) {
+        ui64 currentTs = Us2Ts(1'000'000);
+        std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));
+        TMockExecutorPoolParams hotParams {
+            .DefaultFullThreadCount = 1,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 3,
+            .DefaultThreadCount = 1.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 3.0f,
+        };
+        TMockExecutorPoolParams idleParams {
+            .DefaultFullThreadCount = 2,
+            .MinFullThreadCount = 2,
+            .MaxFullThreadCount = 2,
+            .DefaultThreadCount = 2.0f,
+            .MinThreadCount = 2.0f,
+            .MaxThreadCount = 2.0f,
+            .PoolId = 1,
+        };
+        auto hotPool = std::make_unique<TMockExecutorPool>(hotParams);
+        auto idlePool = std::make_unique<TMockExecutorPool>(idleParams);
+        harmonizer->AddPool(hotPool.get(), nullptr, false, 30);
+        harmonizer->AddPool(idlePool.get());
+
+        harmonizer->Harmonize(currentTs);
+        for (ui8 second = 1; second <= 27; ++second) {
+            hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 1);
+            currentTs += Us2Ts(1'000'000);
+            harmonizer->Harmonize(currentTs);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(hotPool->ThreadCount, 2);
+
+        for (ui8 second = 1; second <= 26; ++second) {
+            hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 2);
+            currentTs += Us2Ts(1'000'000);
+            harmonizer->Harmonize(currentTs);
+            UNIT_ASSERT_VALUES_EQUAL_C(hotPool->ThreadCount, 2, "second after first growth: " << static_cast<ui32>(second));
+        }
+
+        hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 2);
+        idlePool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 1);
+        currentTs += Us2Ts(1'000'000);
+        harmonizer->Harmonize(currentTs);
+
+        auto stats = harmonizer->GetPoolStats(hotParams.PoolId);
+        CHECK_IS_NEEDY(stats);
+        CHECK_CHANGING_THREADS(stats, 1, 0, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(hotPool->ThreadCount, 2);
+
+        hotPool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 2);
+        currentTs += Us2Ts(1'000'000);
+        harmonizer->Harmonize(currentTs);
+
+        stats = harmonizer->GetPoolStats(hotParams.PoolId);
+        CHECK_CHANGING_THREADS(stats, 2, 0, 0, 0, 0);
+        UNIT_ASSERT_VALUES_EQUAL(hotPool->ThreadCount, 3);
+    }
+
+    Y_UNIT_TEST(TestThirtySecondNeedyWindowDoesNotRegrowFromStaleStoppedWorkerHistory) {
+        ui64 currentTs = Us2Ts(1'000'000);
+        std::unique_ptr<IHarmonizer> harmonizer(MakeHarmonizer(currentTs));
+        TMockExecutorPoolParams params {
+            .DefaultFullThreadCount = 2,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 2,
+            .DefaultThreadCount = 2.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 2.0f,
+        };
+        auto pool = std::make_unique<TMockExecutorPool>(params);
+        harmonizer->AddPool(pool.get(), nullptr, false, 30);
+
+        harmonizer->Harmonize(currentTs);
+        for (ui8 second = 1; second <= 27; ++second) {
+            pool->IncreaseThreadCpuConsumption({1'000'000.0, 1'000'000.0}, 0, 2);
+            currentTs += Us2Ts(1'000'000);
+            harmonizer->Harmonize(currentTs);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(pool->ThreadCount, 2);
+
+        for (ui8 second = 1; second <= 8; ++second) {
+            currentTs += Us2Ts(1'000'000);
+            harmonizer->Harmonize(currentTs);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(pool->ThreadCount, 1);
+
+        currentTs += Us2Ts(1'000'000);
+        harmonizer->Harmonize(currentTs);
+
+        auto stats = harmonizer->GetPoolStats(params.PoolId);
+        UNIT_ASSERT_VALUES_EQUAL(pool->ThreadCount, 1);
+        UNIT_ASSERT_VALUES_EQUAL(stats.IncreasingThreadsByNeedyState, 0);
+    }
+
+    Y_UNIT_TEST(TestThirtySecondNeedyWindowIncludesSharedCpuHistory) {
+        TMockExecutorPoolParams params {
+            .DefaultFullThreadCount = 1,
+            .MinFullThreadCount = 1,
+            .MaxFullThreadCount = 1,
+            .DefaultThreadCount = 1.0f,
+            .MinThreadCount = 1.0f,
+            .MaxThreadCount = 1.0f,
+        };
+        auto pool = std::make_unique<TMockExecutorPool>(params);
+        auto poolInfo = std::make_unique<TPoolInfo>();
+        poolInfo->Pool = pool.get();
+        poolInfo->DefaultFullThreadCount = 1;
+        poolInfo->MinFullThreadCount = 1;
+        poolInfo->MaxFullThreadCount = 1;
+        poolInfo->DefaultThreadCount = 1.0f;
+        poolInfo->MinThreadCount = 1.0f;
+        poolInfo->MaxThreadCount = 1.0f;
+        poolInfo->ThreadQuota = 1.0f;
+        poolInfo->NeedyCpuWindowSeconds = 30;
+        poolInfo->ThreadInfo.resize(1);
+        poolInfo->SharedInfo.resize(1);
+
+        ui64 currentTs = Us2Ts(1'000'000);
+        poolInfo->ThreadInfo[0].UsedCpu.Register(currentTs, 0.0);
+        poolInfo->ThreadInfo[0].ElapsedCpu.Register(currentTs, 0.0);
+        poolInfo->SharedInfo[0].UsedCpu.Register(currentTs, 0.0);
+        poolInfo->SharedInfo[0].ElapsedCpu.Register(currentTs, 0.0);
+        for (ui8 second = 1; second <= 30; ++second) {
+            currentTs += Us2Ts(1'000'000);
+            poolInfo->ThreadInfo[0].UsedCpu.Register(currentTs, second * 0.9);
+            poolInfo->ThreadInfo[0].ElapsedCpu.Register(currentTs, second * 0.9);
+            poolInfo->SharedInfo[0].UsedCpu.Register(currentTs, second * 0.5);
+            poolInfo->SharedInfo[0].ElapsedCpu.Register(currentTs, second * 0.5);
+        }
+
+        std::vector<std::unique_ptr<TPoolInfo>> pools;
+        pools.emplace_back(std::move(poolInfo));
+        TSharedInfo sharedInfo;
+        sharedInfo.OwnedThreads.push_back(0);
+        sharedInfo.CpuConsumption.resize(1);
+        THarmonizerCpuConsumption cpuConsumption;
+        cpuConsumption.Init(1);
+        cpuConsumption.Pull(pools, sharedInfo);
+
+        UNIT_ASSERT_DOUBLES_EQUAL(cpuConsumption.PoolFullThreadConsumption[0].NeedyWindowCpu, 1.0, 1e-6);
+        UNIT_ASSERT_DOUBLES_EQUAL(cpuConsumption.PoolConsumption[0].NeedyWindowCpu, 1.5, 1e-6);
     }
 
     Y_UNIT_TEST(TestToNeedyNextToHoggish) {

--- a/ydb/library/actors/core/harmonizer/ut/history_ut.cpp
+++ b/ydb/library/actors/core/harmonizer/ut/history_ut.cpp
@@ -180,6 +180,36 @@ Y_UNIT_TEST_SUITE(ValueHistoryTests) {
         UNIT_ASSERT_DOUBLES_EQUAL(history.GetAvgPartForLastSeconds(4), 1.0, 1e-6);
     }
 
+    Y_UNIT_TEST(TestThirtySecondWindowWithIncompleteData) {
+        TValueHistory<32> history;
+        ui64 baseTs = 1'000'000;
+
+        history.Register(baseTs, 0.0);
+        for (size_t second = 1; second <= 27; ++second) {
+            history.Register(baseTs + second * secondInTs, second);
+        }
+
+        UNIT_ASSERT_DOUBLES_EQUAL(history.GetAvgPartForLastSeconds<true>(30), 0.9, 1e-6);
+    }
+
+    Y_UNIT_TEST(TestThirtySecondWindowWrapsThirtyTwoSecondBuffer) {
+        TValueHistory<32> history;
+        ui64 baseTs = 1'000'000;
+        double accumulated = 0.0;
+
+        history.Register(baseTs, accumulated);
+        for (size_t second = 1; second <= 40; ++second) {
+            accumulated += second <= 10 ? 1.0 : 2.0;
+            history.Register(baseTs + second * secondInTs, accumulated);
+        }
+
+        UNIT_ASSERT_DOUBLES_EQUAL(history.GetAvgPartForLastSeconds<true>(30), 2.0, 1e-6);
+
+        accumulated += 4.0;
+        history.Register(baseTs + 41 * secondInTs, accumulated);
+        UNIT_ASSERT_DOUBLES_EQUAL(history.GetAvgPartForLastSeconds<true>(30), (29.0 * 2.0 + 4.0) / 30.0, 1e-6);
+    }
+
     Y_UNIT_TEST(TestGetMaxForLastSeconds) {
         TValueHistory<4> history;
         ui64 baseTs = 1000000;

--- a/ydb/library/actors/core/probes.h
+++ b/ydb/library/actors/core/probes.h
@@ -155,9 +155,10 @@
           TYPES(ui32, TString, ui32, ui32, ui32, ui32),                                                                               \
           NAMES("poolId", "pool", "threacCount", "minThreadCount", "maxThreadCount", "defaultThreadCount"))                           \
     PROBE(HarmonizeCheckPool, GROUPS("Harmonizer"),                                                                                   \
-          TYPES(ui32, TString, double, double, double, double, ui32, ui32, bool, bool, bool),                                         \
+          TYPES(ui32, TString, double, double, double, double, ui32, ui32, bool, bool, bool, ui32, double, double),                    \
           NAMES("poolId", "pool", "elapsed", "cpu", "lastSecondElapsed", "lastSecondCpu", "threadCount", "maxThreadCount",    \
-                  "isStarved", "isNeedy", "isHoggish"))                                                                               \
+                  "isStarved", "isNeedy", "isHoggish", "needyCpuWindowSeconds", "needyWindowCpu",                              \
+                  "needyWindowFullThreadCpu"))                                                                                        \
     PROBE(HarmonizeCheckPoolByThread, GROUPS("Harmonizer"),                                                                           \
           TYPES(ui32, TString, i16, double, double, double, double),                                                                  \
           NAMES("poolId", "pool", "threadIdx", "elapsed", "cpu", "lastSecondElapsed", "lastSecondCpu"))                       \

--- a/ydb/library/yaml_config/static_validator/builders.cpp
+++ b/ydb/library/yaml_config/static_validator/builders.cpp
@@ -192,12 +192,23 @@ TMapBuilder ActorSystemConfigBuilder() {
           .Min(0)
           .Optional();
         })
+        .Int64("harmonizer_needy_cpu_window_seconds", [](auto& window){
+          window
+          .Range(1, 32)
+          .Optional();
+        })
         .Int64("time_per_mailbox_micro_secs", [](auto& timePerMailboxMicroSecs){
           timePerMailboxMicroSecs
           .Optional()
           .Min(0);
         })
-        .Enum("type", {"IO", "BASIC"});
+        .Enum("type", {"IO", "BASIC"})
+        .AddCheck("Harmonizer needy CPU window is supported only for BASIC executors", [](auto& executorContext){
+          auto node = executorContext.Node();
+          if (node["harmonizer_needy_cpu_window_seconds"].Exists()) {
+            executorContext.Expect(node["type"].Enum().Value() == "BASIC");
+          }
+        });
       });
     })
     .Map("scheduler", [](auto& scheduler){

--- a/ydb/library/yaml_config/static_validator/ut/test.cpp
+++ b/ydb/library/yaml_config/static_validator/ut/test.cpp
@@ -3,6 +3,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/library/yaml_config/validator/validator.h>
 #include <ydb/library/yaml_config/validator/validator_builder.h>
+#include <util/string/builder.h>
 
 namespace NKikimr {
 
@@ -316,6 +317,34 @@ Y_UNIT_TEST_SUITE(StaticValidator) {
         Y_ENSURE(HasOnlyThisIssues(v.Validate(yaml), {
             {"/domains_config/state_storage/0/ring", "nto_select must not be greater, than node array size"}
         }));
+    }
+
+    Y_UNIT_TEST(HarmonizerNeedyCpuWindowSeconds) {
+        auto validator = TMapBuilder()
+            .Field("actor_system_config", ActorSystemConfigBuilder())
+            .CreateValidator();
+        auto makeConfig = [](ui32 windowSeconds, TStringBuf executorType) {
+            return ::TStringBuilder()
+                << "actor_system_config:\n"
+                << "  executor:\n"
+                << "  - name: User\n"
+                << "    threads: 1\n"
+                << "    max_threads: 2\n"
+                << "    harmonizer_needy_cpu_window_seconds: " << windowSeconds << "\n"
+                << "    type: " << executorType << "\n"
+                << "  scheduler:\n"
+                << "    progress_threshold: 10000\n"
+                << "    resolution: 64\n"
+                << "    spin_threshold: 0\n";
+        };
+
+        for (ui32 windowSeconds : {1, 30, 32}) {
+            UNIT_ASSERT_C(Valid(validator.Validate(makeConfig(windowSeconds, "BASIC"))), "window: " << windowSeconds);
+        }
+        for (ui32 windowSeconds : {0, 33}) {
+            UNIT_ASSERT_C(!validator.Validate(makeConfig(windowSeconds, "BASIC")).Ok(), "window: " << windowSeconds);
+        }
+        UNIT_ASSERT(!validator.Validate(makeConfig(30, "IO")).Ok());
     }
 }
 

--- a/ydb/tools/cfg/validation.py
+++ b/ydb/tools/cfg/validation.py
@@ -87,8 +87,16 @@ EXECUTOR_SCHEMA = {
             "type": "integer",
             "min": 1,
         },
+        "harmonizer_needy_cpu_window_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 32,
+        },
     },
 }
+
+IO_EXECUTOR_SCHEMA = copy.deepcopy(EXECUTOR_SCHEMA)
+IO_EXECUTOR_SCHEMA["not"] = {"required": ["harmonizer_needy_cpu_window_seconds"]}
 
 SYS_SCHEMA = {
     "type": "object",
@@ -103,7 +111,7 @@ SYS_SCHEMA = {
                 "system": copy.deepcopy(EXECUTOR_SCHEMA),
                 "batch": copy.deepcopy(EXECUTOR_SCHEMA),
                 "user": copy.deepcopy(EXECUTOR_SCHEMA),
-                "io": copy.deepcopy(EXECUTOR_SCHEMA),
+                "io": copy.deepcopy(IO_EXECUTOR_SCHEMA),
                 "ic": copy.deepcopy(EXECUTOR_SCHEMA),
             },
             "additionalProperties": False,


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added a configurable CPU-usage window for actor-system harmonizer decisions via HarmonizerNeedyCpuWindowSeconds for BASIC executor pools.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

The setting accepts 1–32 seconds and defaults to 1, preserving existing behavior. A longer window smooths transient CPU spikes, while the last-second check prevents pool expansion after demand disappears. 
