### PR TITLE
ydb/core/tablet_flat: fix ODR violation in test storage mock

### DIFF
--- a/ydb/core/tablet_flat/test/libs/exec/storage.h
+++ b/ydb/core/tablet_flat/test/libs/exec/storage.h
@@ -10,14 +10,14 @@
 namespace NKikimr {
 namespace NFake {
 
-    class TStorage : public ::NActors::IActorCallback {
+    class TStorageMock : public ::NActors::IActorCallback {
     public:
         using TEventHandlePtr = TAutoPtr<::NActors::IEventHandle>;
         using ELnLev = NUtil::ELnLev;
         using NStore = TEvBlobStorage;
 
-        TStorage(ui32 group)
-            : ::NActors::IActorCallback(static_cast<TReceiveFunc>(&TStorage::Inbox), NKikimrServices::TActivity::FAKE_ENV_A)
+        TStorageMock(ui32 group)
+            : ::NActors::IActorCallback(static_cast<TReceiveFunc>(&TStorageMock::Inbox), NKikimrServices::TActivity::FAKE_ENV_A)
             , Group(group)
             , Model(new NFake::TProxyDS)
         {

--- a/ydb/core/tablet_flat/test/libs/exec/warden.h
+++ b/ydb/core/tablet_flat/test/libs/exec/warden.h
@@ -129,7 +129,7 @@ namespace NFake {
             if (auto logl = Logger->Log(ELnLev::Info))
                 logl << "Starting storage for BS group " << group;
 
-            auto actor = Register(new NFake::TStorage(group));
+            auto actor = Register(new NFake::TStorageMock(group));
 
             Sys->RegisterLocalService(MakeBlobStorageProxyID(group), actor);
         }


### PR DESCRIPTION
The test helper in ydb/core/tablet_flat/test/libs/exec/storage.h was named `NKikimr::NFake::TStorage`, colliding with the unrelated `NKikimr::NFake::TStorage` configuration struct in
ydb/core/testlib/basics/helpers.h.

Rename the tablet_flat test actor to TStorageMock.

### Changelog category <!-- remove all except one -->

* Bugfix 