### PR TITLE
Fix BadDep in ydb/core/persqueue/pqrb/ut (gtest vs unittest)

### DIFF
--- a/ydb/core/persqueue/pqrb/ut/partitions_location_queue_ut.cpp
+++ b/ydb/core/persqueue/pqrb/ut/partitions_location_queue_ut.cpp
@@ -1,7 +1,7 @@
 #include <ydb/core/persqueue/events/global.h>
 #include <ydb/core/persqueue/ut/common/pq_ut_common.h>
 
-#include <library/cpp/testing/gtest/gtest.h>
+#include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr::NPQ {
 namespace {
@@ -18,19 +18,21 @@ THolder<TEvPersQueue::TEvGetPartitionsLocationResponse> SendLocationRequest(
 void WaitBalancerReady(TTestContext& tc, ui32 retries = 20) {
     for (ui32 i = 0; i < retries; ++i) {
         auto response = SendLocationRequest(tc, new TEvPersQueue::TEvGetPartitionsLocation());
-        ASSERT_TRUE(response);
+        UNIT_ASSERT(response);
         if (response->Record.GetStatus()) {
             return;
         }
         tc.Runtime->AdvanceCurrentTime(TDuration::MilliSeconds(100));
         tc.Runtime->DispatchEvents();
     }
-    FAIL() << "Could not get positive response from balancer";
+    UNIT_ASSERT_C(false, "Could not get positive response from balancer");
 }
 
 } // namespace
 
-TEST(TPartitionsLocationQueue, AnswerAfterPipesBecomeReady) {
+Y_UNIT_TEST_SUITE(TPartitionsLocationQueue) {
+
+Y_UNIT_TEST(AnswerAfterPipesBecomeReady) {
     TTestContext tc;
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
@@ -49,7 +51,7 @@ TEST(TPartitionsLocationQueue, AnswerAfterPipesBecomeReady) {
     PQTabletPrepare({}, {}, tc);
     PQBalancerPrepare("topic", {{0, {tc.TabletId, 1}}}, /*ssId=*/1, tc);
 
-    ASSERT_FALSE(delayedConnects.empty());
+    UNIT_ASSERT(!delayedConnects.empty());
 
     tc.Runtime->SendToPipe(
         tc.BalancerTabletId,
@@ -63,7 +65,7 @@ TEST(TPartitionsLocationQueue, AnswerAfterPipesBecomeReady) {
     auto earlyResponse = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::MilliSeconds(200)
     );
-    ASSERT_FALSE(earlyResponse) << "Location response must not arrive before pipes are ready";
+    UNIT_ASSERT_C(!earlyResponse, "Location response must not arrive before pipes are ready");
 
     tc.Runtime->SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
     for (auto& ev : delayedConnects) {
@@ -73,14 +75,14 @@ TEST(TPartitionsLocationQueue, AnswerAfterPipesBecomeReady) {
     auto response = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::Seconds(10)
     );
-    ASSERT_TRUE(response);
-    ASSERT_TRUE(response->Record.GetStatus());
-    ASSERT_EQ(response->Record.LocationsSize(), 1u);
-    ASSERT_EQ(response->Record.GetLocations(0).GetPartitionId(), 0u);
-    ASSERT_GT(response->Record.GetLocations(0).GetNodeId(), 0u);
+    UNIT_ASSERT(response);
+    UNIT_ASSERT(response->Record.GetStatus());
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.LocationsSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.GetLocations(0).GetPartitionId(), 0u);
+    UNIT_ASSERT_GT(response->Record.GetLocations(0).GetNodeId(), 0u);
 }
 
-TEST(TPartitionsLocationQueue, ExpireQueuedRequest) {
+Y_UNIT_TEST(ExpireQueuedRequest) {
     TTestContext tc;
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
@@ -100,7 +102,7 @@ TEST(TPartitionsLocationQueue, ExpireQueuedRequest) {
     auto earlyResponse = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::MilliSeconds(200)
     );
-    ASSERT_FALSE(earlyResponse) << "Location response must wait in queue before timeout";
+    UNIT_ASSERT_C(!earlyResponse, "Location response must wait in queue before timeout");
 
     tc.Runtime->ResetScheduledCount();
     tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(5) + TDuration::MilliSeconds(1));
@@ -108,11 +110,11 @@ TEST(TPartitionsLocationQueue, ExpireQueuedRequest) {
     auto response = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::Seconds(10)
     );
-    ASSERT_TRUE(response);
-    ASSERT_FALSE(response->Record.GetStatus());
+    UNIT_ASSERT(response);
+    UNIT_ASSERT(!response->Record.GetStatus());
 }
 
-TEST(TPartitionsLocationQueue, HappyPathAfterPipesReady) {
+Y_UNIT_TEST(HappyPathAfterPipesReady) {
     TTestContext tc;
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
@@ -123,26 +125,26 @@ TEST(TPartitionsLocationQueue, HappyPathAfterPipesReady) {
     WaitBalancerReady(tc);
 
     auto response = SendLocationRequest(tc, new TEvPersQueue::TEvGetPartitionsLocation());
-    ASSERT_TRUE(response);
-    ASSERT_TRUE(response->Record.GetStatus());
-    ASSERT_EQ(response->Record.LocationsSize(), 1u);
+    UNIT_ASSERT(response);
+    UNIT_ASSERT(response->Record.GetStatus());
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.LocationsSize(), 1u);
 
     auto* specific = new TEvPersQueue::TEvGetPartitionsLocation();
     specific->Record.AddPartitions(0);
     response = SendLocationRequest(tc, specific);
-    ASSERT_TRUE(response);
-    ASSERT_TRUE(response->Record.GetStatus());
-    ASSERT_EQ(response->Record.LocationsSize(), 1u);
-    ASSERT_EQ(response->Record.GetLocations(0).GetPartitionId(), 0u);
+    UNIT_ASSERT(response);
+    UNIT_ASSERT(response->Record.GetStatus());
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.LocationsSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.GetLocations(0).GetPartitionId(), 0u);
 
     auto* unknown = new TEvPersQueue::TEvGetPartitionsLocation();
     unknown->Record.AddPartitions(50);
     response = SendLocationRequest(tc, unknown);
-    ASSERT_TRUE(response);
-    ASSERT_FALSE(response->Record.GetStatus());
+    UNIT_ASSERT(response);
+    UNIT_ASSERT(!response->Record.GetStatus());
 }
 
-TEST(TPartitionsLocationQueue, SinglePartitionNotBlockedByAllPartitions) {
+Y_UNIT_TEST(SinglePartitionNotBlockedByAllPartitions) {
     TTestContext tc;
     tc.Prepare();
     tc.Runtime->SetScheduledLimit(10000);
@@ -168,7 +170,7 @@ TEST(TPartitionsLocationQueue, SinglePartitionNotBlockedByAllPartitions) {
         tc
     );
 
-    ASSERT_FALSE(delayedConnects.empty());
+    UNIT_ASSERT(!delayedConnects.empty());
 
     // Head of queue: all partitions (blocked on dead tablet).
     tc.Runtime->SendToPipe(
@@ -193,7 +195,7 @@ TEST(TPartitionsLocationQueue, SinglePartitionNotBlockedByAllPartitions) {
     auto earlyResponse = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::MilliSeconds(200)
     );
-    ASSERT_FALSE(earlyResponse) << "Neither request can be answered before partition-0 pipe is ready";
+    UNIT_ASSERT_C(!earlyResponse, "Neither request can be answered before partition-0 pipe is ready");
 
     tc.Runtime->SetObserverFunc(TTestActorRuntime::DefaultObserverFunc);
     for (auto& ev : delayedConnects) {
@@ -204,15 +206,15 @@ TEST(TPartitionsLocationQueue, SinglePartitionNotBlockedByAllPartitions) {
     auto response = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::Seconds(10)
     );
-    ASSERT_TRUE(response);
-    ASSERT_TRUE(response->Record.GetStatus());
-    ASSERT_EQ(response->Record.LocationsSize(), 1u);
-    ASSERT_EQ(response->Record.GetLocations(0).GetPartitionId(), 0u);
+    UNIT_ASSERT(response);
+    UNIT_ASSERT(response->Record.GetStatus());
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.LocationsSize(), 1u);
+    UNIT_ASSERT_VALUES_EQUAL(response->Record.GetLocations(0).GetPartitionId(), 0u);
 
     auto stillWaiting = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::MilliSeconds(200)
     );
-    ASSERT_FALSE(stillWaiting) << "All-partitions request must stay queued while dead tablet is down";
+    UNIT_ASSERT_C(!stillWaiting, "All-partitions request must stay queued while dead tablet is down");
 
     tc.Runtime->ResetScheduledCount();
     tc.Runtime->AdvanceCurrentTime(TDuration::Seconds(5) + TDuration::MilliSeconds(1));
@@ -220,8 +222,10 @@ TEST(TPartitionsLocationQueue, SinglePartitionNotBlockedByAllPartitions) {
     auto expired = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvGetPartitionsLocationResponse>(
         TDuration::Seconds(10)
     );
-    ASSERT_TRUE(expired);
-    ASSERT_FALSE(expired->Record.GetStatus());
+    UNIT_ASSERT(expired);
+    UNIT_ASSERT(!expired->Record.GetStatus());
 }
+
+} // Y_UNIT_TEST_SUITE(TPartitionsLocationQueue)
 
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqrb/ut/ya.make
+++ b/ydb/core/persqueue/pqrb/ut/ya.make
@@ -1,4 +1,4 @@
-GTEST()
+UNITTEST()
 
 SIZE(MEDIUM)
 


### PR DESCRIPTION
## Summary
- `ydb/core/persqueue/pqrb/ut` was declared as `GTEST()` but peers `pq_ut_common` / `testlib`, which pulls unittest → configure `BadDep` on `test_framework`
- Convert the suite to `UNITTEST()` + unittest assertions (same pattern as other persqueue UTs using `pq_ut_common`)

## Test plan
- [ ] Configure `ydb/` with `--test-size=small,medium,large` succeeds (no BadDep)
- [ ] Run `ydb/core/persqueue/pqrb/ut` medium tests


Made with [Cursor](https://cursor.com)