### PR TITLE
CI: не пропускать BadDep под ya make -k

### DIFF
--- a/.github/actions/test_ya/action.yml
+++ b/.github/actions/test_ya/action.yml
@@ -319,6 +319,9 @@ runs:
             exit $RC
           fi
 
+          # graph_compare may still return 0 under some ya versions while logging BadDep.
+          python3 .github/scripts/tests/check_ya_configure_integrity.py "$GRAPH_COMPARE_OUTPUT"
+
           git checkout $ORIGINAL_HEAD
           YA_MAKE_TARGET="ydb"
         else
@@ -331,9 +334,22 @@ runs:
           if [ true = ${{ inputs.run_tests }} ]; then
             YA_MAKE_COMMAND+=" --retest"
           fi
+          # Keep -k for noisy configure warnings, but fail on integrity errors (BadDep etc.).
+          # See https://github.com/ydb-platform/ydb/issues/47524
+          GRAPH_SAVE_LOG="$PUBLIC_DIR/ya_graph_save_log.txt"
+          set +e
           $YA_MAKE_COMMAND -k --cache-tests \
             --save-graph-to $GRAPH_PATH --save-context-to $CONTEXT_PATH \
-            $YA_MAKE_TARGET
+            $YA_MAKE_TARGET |& tee "$GRAPH_SAVE_LOG"
+          GRAPH_SAVE_RC=${PIPESTATUS[0]}
+          set -e
+          python3 .github/scripts/tests/check_ya_configure_integrity.py "$GRAPH_SAVE_LOG"
+          if [ "$GRAPH_SAVE_RC" -ne 0 ]; then
+            echo "ya make (graph save) returned $GRAPH_SAVE_RC, build failed"
+            echo "status=failed" >> $GITHUB_OUTPUT
+            BUILD_FAILED=1
+            exit "$GRAPH_SAVE_RC"
+          fi
         fi
 
         export MUTED_YA_FILE="$(python3 .github/scripts/tests/mute/mute_helper.py resolve-path --preset "${{ inputs.build_preset }}")"

--- a/.github/scripts/graph_compare.py
+++ b/.github/scripts/graph_compare.py
@@ -36,6 +36,13 @@ def main(ya_make_command: str, graph_path: str, context_path: str, base_commit: 
 
     log('Checkout head commit...')
     exec(f'git checkout {head_commit}')
+    # Base configure leaves ymakes caches under ~/.ya/build. Reusing them for head can
+    # hide configure integrity errors (e.g. BadDep / conflicting PROVIDES) that a cold
+    # configure would report — see https://github.com/ydb-platform/ydb/issues/47524
+    ya_build_cache = os.path.expanduser('~/.ya/build')
+    if os.path.exists(ya_build_cache):
+        log(f'Clear {ya_build_cache} before head configure...')
+        exec(f'rm -rf {ya_build_cache}')
     log('Build graph for head commit...')
     exec(f'{ya_make_command} ydb --cache-tests --save-graph-to {workdir}/graph_head.json --save-context-to {workdir}/context_head.json')
 

--- a/.github/scripts/tests/check_ya_configure_integrity.py
+++ b/.github/scripts/tests/check_ya_configure_integrity.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Fail CI on configure integrity errors that `ya make -k` may otherwise swallow.
+
+Keeps PR-check resilient to noisy configure warnings, but blocks merges when the
+build graph is invalid (e.g. conflicting PROVIDES / BadDep).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Extend this list carefully: only errors that mean the graph must not land in main.
+FATAL_CONFIGURE_PATTERNS = (
+    re.compile(r"Error\[-WBadDep\]"),
+)
+
+
+def find_hits(text: str) -> list[str]:
+    hits: list[str] = []
+    for line in text.splitlines():
+        if any(pat.search(line) for pat in FATAL_CONFIGURE_PATTERNS):
+            hits.append(line.rstrip())
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "log_file",
+        nargs="?",
+        help="ya configure/make log path (default: stdin)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.log_file:
+        text = Path(args.log_file).read_text(encoding="utf-8", errors="replace")
+    else:
+        text = sys.stdin.read()
+
+    hits = find_hits(text)
+    if not hits:
+        return 0
+
+    print(
+        "Configure integrity errors (not allowed even with ya -k):",
+        file=sys.stderr,
+    )
+    for line in hits[:50]:
+        print(f"  {line}", file=sys.stderr)
+    if len(hits) > 50:
+        print(f"  ... and {len(hits) - 50} more", file=sys.stderr)
+    print(
+        "See https://github.com/ydb-platform/ydb/issues/47524",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/check_ya_configure_integrity.py
+++ b/.github/scripts/tests/check_ya_configure_integrity.py
@@ -14,7 +14,8 @@ from pathlib import Path
 
 # Extend this list carefully: only errors that mean the graph must not land in main.
 FATAL_CONFIGURE_PATTERNS = (
-    re.compile(r"Error\[-WBadDep\]"),
+    re.compile(r"(?:Error|Warning)\[-WBadDep\]"),
+    re.compile(r"PROVIDES same feature"),
 )
 
 

--- a/.github/scripts/tests/test_check_ya_configure_integrity.py
+++ b/.github/scripts/tests/test_check_ya_configure_integrity.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_ya_configure_integrity import find_hits, main
+
+
+class TestCheckYaConfigureIntegrity(unittest.TestCase):
+    def test_baddep_is_fatal(self):
+        log = (
+            "Configuring dependencies for platform tools\n"
+            "Error[-WBadDep]: in $B/ydb/core/persqueue/pqrb/ut/ydb-core-persqueue-pqrb-ut: "
+            "depends on two modules which PROVIDES same feature 'test_framework':\n"
+            "Configure error (use -k to proceed)\n"
+        )
+        hits = find_hits(log)
+        self.assertEqual(len(hits), 1)
+        self.assertIn("BadDep", hits[0])
+
+    def test_noise_is_ignored(self):
+        log = (
+            "Warn: Path is not buildable target: /tmp/docker-compose.yml\n"
+            "Configuration done. Preparing for execution\n"
+        )
+        self.assertEqual(find_hits(log), [])
+
+    def test_main_exit_codes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ok = Path(tmp) / "ok.txt"
+            bad = Path(tmp) / "bad.txt"
+            ok.write_text("Configuration done.\n", encoding="utf-8")
+            bad.write_text("Error[-WBadDep]: conflict\n", encoding="utf-8")
+            self.assertEqual(main([str(ok)]), 0)
+            self.assertEqual(main([str(bad)]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_check_ya_configure_integrity.py
+++ b/.github/scripts/tests/test_check_ya_configure_integrity.py
@@ -18,6 +18,10 @@ class TestCheckYaConfigureIntegrity(unittest.TestCase):
         self.assertEqual(len(hits), 1)
         self.assertIn("BadDep", hits[0])
 
+    def test_provides_conflict_is_fatal(self):
+        log = "depends on two modules which PROVIDES same feature 'test_framework':\n"
+        self.assertTrue(find_hits(log))
+
     def test_noise_is_ignored(self):
         log = (
             "Warn: Path is not buildable target: /tmp/docker-compose.yml\n"


### PR DESCRIPTION
## Summary
- Закрывает https://github.com/ydb-platform/ydb/issues/47524
- `-k` оставляем (шумные warning’ы не валят job)
- После graph save / graph_compare парсим лог и **фейлим** на `Error[-WBadDep]`

## Test plan
- [x] `python3 -m unittest test_check_ya_configure_integrity`
- [ ] PR-check зелёный на этой ветке
- [ ] Регрессия: лог с `Error[-WBadDep]` → exit 1 checker’а


Made with [Cursor](https://cursor.com)