### PR TITLE
[26-1-1-ent] add another variant of backpressure to sl + fix an issue in stream lookup

### DIFF
--- a/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_actor.cpp
@@ -314,6 +314,7 @@ private:
 
     i64 GetAsyncInputData(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, TMaybe<TInstant>&, bool& finished, i64 freeSpace) final {
         YQL_ENSURE(!batch.IsWide(), "Wide stream is not supported");
+        SentResultsAvailable = false;
 
         if (ResolveShardsInProgress) {
             finished = false;
@@ -324,7 +325,10 @@ private:
         ReadRowsCount += replyResultStats.ReadRowsCount;
         ReadBytesCount += replyResultStats.ReadBytesCount;
 
-        FetchInputRows();
+        // Fetch input rows if we have less than max in flight reads in the scheduled queue.
+        if (StreamLookupWorker->ScheduledRequestsCount() < MaxInFlightReads) {
+            FetchInputRows();
+        }
 
         if (Partitioning) {
             ProcessInputRows();
@@ -335,9 +339,16 @@ private:
         const bool allRowsProcessed = StreamLookupWorker->AllRowsProcessed();
         const bool hasPendingResults = StreamLookupWorker->HasPendingResults();
 
-        if (hasPendingResults) {
+        // If we have no new reads and no pending results, we can fetch input rows again.
+        bool noNewReads = (
+            Partitioning && Reads.InFlightReads() + StreamLookupWorker->ScheduledRequestsCount() == 0
+            && LastFetchStatus == NUdf::EFetchStatus::Ok);
+        if (hasPendingResults || noNewReads) {
             // has more results
-            Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+            if (!SentResultsAvailable) {
+                Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+                SentResultsAvailable = true;
+            }
         }
 
         finished = inputRowsFinished && allReadsFinished && allRowsProcessed;
@@ -419,7 +430,10 @@ private:
 
         ProcessInputRows();
 
-        Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+        if (!SentResultsAvailable) {
+            Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+            SentResultsAvailable = true;
+        }
     }
 
     void Handle(TEvDataShard::TEvReadResult::TPtr& ev) {
@@ -584,7 +598,10 @@ private:
             shardId, THolder<TEventHandle<TEvDataShard::TEvReadResult>>(ev.Release()),
             &guard.GetMutex()->Ref()
         ));
-        Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+        if (!SentResultsAvailable) {
+            Send(ComputeActorId, new TEvNewAsyncInputDataArrived(InputIndex));
+            SentResultsAvailable = true;
+        }
     }
 
     void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
@@ -653,8 +670,15 @@ private:
             return;
         }
 
+        size_t fetchCount = 0;
         while ((LastFetchStatus = Input.Fetch(row)) == NUdf::EFetchStatus::Ok) {
             StreamLookupWorker->AddInputRow(std::move(row));
+            ++fetchCount;
+            // avoid fetching too many rows at once
+            // todo: it might be better to check memory usage instead of rows count
+            if (fetchCount >= MaxRowsProcessing) {
+                break;
+            }
         }
     }
 
@@ -877,6 +901,7 @@ private:
     const TMaybe<NKikimrDataEvents::ELockMode> LockMode;
     const ui64 QuerySpanId;
     TReads Reads;
+    bool SentResultsAvailable = false;
     NUdf::EFetchStatus LastFetchStatus = NUdf::EFetchStatus::Yield;
     std::shared_ptr<const TVector<TKeyDesc::TPartitionInfo>> Partitioning;
     const TDuration SchemeCacheRequestTimeout;

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -279,6 +279,9 @@ public:
                 }).second);
         }
     }
+    size_t ScheduledRequestsCount() final {
+        return ScheduledReads.size();
+    }
 
     std::pair<ui64, THolder<TEvDataShard::TEvRead>> PopNextRequest() final {
         if (ScheduledReads.empty()) {
@@ -641,6 +644,10 @@ public:
 
     void AddInputRow(TConstArrayRef<TCell>) final {
         YQL_ENSURE(false);
+    }
+
+    size_t ScheduledRequestsCount() final {
+        return ScheduledReads.size();
     }
 
     std::pair<ui64, THolder<TEvDataShard::TEvRead>> PopNextRequest() final {

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.cpp
@@ -461,7 +461,8 @@ public:
     bool AllRowsProcessed() final {
         return UnprocessedKeys.empty()
             && ReadStateByReadId.empty()
-            && ReadResults.empty();
+            && ReadResults.empty()
+            && ScheduledReads.empty();
     }
 
     void ResetRowsProcessing(ui64 readId) final {
@@ -622,6 +623,11 @@ public:
             }
             it->second.ResultSeqNos.push_back(resultBatch);
             resultBatch->AddJoinKey(it->second.JoinKeyId);
+            if (!success) {
+                for (const auto& cachedRow : it->second.CachedRows) {
+                    resultBatch->TryBuildResultRow(cachedRow);
+                }
+            }
         }
     }
 
@@ -913,7 +919,8 @@ public:
             && ReadStateByReadId.empty()
             && ResultRowsBySeqNo.empty()
             && PendingLeftRowsByKey.empty()
-            && FlushedResultRows.empty();
+            && FlushedResultRows.empty()
+            && ScheduledReads.empty();
     }
 
     void ResetRowsProcessing(ui64 readId) final {

--- a/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
+++ b/ydb/core/kqp/runtime/kqp_stream_lookup_worker.h
@@ -100,6 +100,7 @@ public:
     virtual void RebuildRequest(const ui64 shardId, const ui64& prevReadId, ui64& newReadId) = 0;
     virtual void BuildRequests(const TPartitionInfo& partitioning, ui64& readId) = 0;
     virtual std::pair<ui64, THolder<TEvDataShard::TEvRead>> PopNextRequest() = 0;
+    virtual size_t ScheduledRequestsCount() = 0;
     virtual void AddResult(TStreamLookupShardReadResult result) = 0;
     virtual TReadResultStats ReplyResult(NKikimr::NMiniKQL::TUnboxedValueBatch& batch, i64 freeSpace) = 0;
     virtual TReadResultStats ReadAllResult(std::function<void(TConstArrayRef<TCell>)> reader) = 0;

--- a/ydb/core/kqp/ut/join/index_lookup/kqp_join_ut.cpp
+++ b/ydb/core/kqp/ut/join/index_lookup/kqp_join_ut.cpp
@@ -1,6 +1,7 @@
 #include <ydb/core/kqp/ut/common/kqp_ut_common.h>
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
+#include <ydb/core/kqp/runtime/kqp_read_iterator_common.h>
 
 namespace NKikimr {
 namespace NKqp {
@@ -2071,6 +2072,94 @@ Y_UNIT_TEST_SUITE(KqpJoin) {
 
         UNIT_ASSERT_C(leftTableChecked, "No reads found for /Root/TableLeft");
         UNIT_ASSERT_C(rightTableChecked, "No reads found for /Root/TableRight");
+    }
+
+    Y_UNIT_TEST(StreamLookupJoinOverloadDeadlock) {
+        auto serverSettings = TKikimrSettings().SetWithSampleTables(false);
+        serverSettings.AppConfig.MutableTableServiceConfig()->SetEnableKqpDataQueryStreamIdxLookupJoin(true);
+        auto* retrySettings = serverSettings.AppConfig.MutableTableServiceConfig()->MutableIteratorReadsRetrySettings();
+        retrySettings->SetMaxShardRetries(100);
+        retrySettings->SetMaxShardResolves(100);
+        retrySettings->SetMaxTotalRetries(100);
+        retrySettings->SetMaxRowsProcessingStreamLookup(1);
+
+        TKikimrRunner kikimr(serverSettings);
+        auto client = kikimr.GetTableClient();
+        auto db = kikimr.GetQueryClient();
+
+        auto savedReadSettings = NKqp::GetDefaultReadSettings();
+        auto savedReadAckSettings = NKqp::GetDefaultReadAckSettings();
+        Y_DEFER {
+            NKqp::SetDefaultReadSettings(savedReadSettings->Record);
+            NKqp::SetDefaultReadAckSettings(savedReadAckSettings->Record);
+        };
+
+        // Limit rows per read response to force incremental result production.
+        {
+            NKikimrTxDataShard::TEvRead evread;
+            evread.SetMaxRows(1);
+            NKqp::SetDefaultReadSettings(evread);
+
+            NKikimrTxDataShard::TEvReadAck evreadack;
+            evreadack.SetMaxRows(1);
+            NKqp::SetDefaultReadAckSettings(evreadack);
+        }
+
+        {
+            auto session = client.CreateSession().GetValueSync().GetSession();
+            // ta: left table, scanned
+            auto result = session.ExecuteSchemeQuery(Q_(R"(
+                CREATE TABLE `/Root/ta`(a Int64 NOT NULL, fk Int64, PRIMARY KEY(a));
+            )")).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            auto session = client.CreateSession().GetValueSync().GetSession();
+            // tb: right table with a secondary index on fk.
+            // Multiple tb rows share the same fk → one-to-many join via index.
+            // The index lookup + main table lookup creates the triplet chain.
+            auto result = session.ExecuteSchemeQuery(Q_(R"(
+                CREATE TABLE `/Root/tb`(
+                    b Int64 NOT NULL,
+                    fk Int64,
+                    bval Int64,
+                    PRIMARY KEY(b),
+                    INDEX idx_fk GLOBAL ON (fk)
+                );
+            )")).ExtractValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+        {
+            // ta: multiple rows sharing fk=1 → interleaved output from index lookup
+            // tb: multiple rows with fk=1 → one-to-many join
+            auto result = db.ExecuteQuery(R"(
+                UPSERT INTO `/Root/ta`(a, fk) VALUES
+                    (1, 1), (2, 1), (3, 1), (4, 1), (5, 1),
+                    (6, 1), (7, 1), (8, 1), (9, 1), (10, 1);
+                UPSERT INTO `/Root/tb`(b, fk, bval) VALUES
+                    (101, 1, 10), (102, 1, 20), (103, 1, 30);
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            // 10 ta rows × 3 tb matches = 30 expected results.
+            // The join uses the secondary index idx_fk on tb.
+            // With the bug, the main table stream lookup hangs on overload.
+            auto result = db.ExecuteQuery(R"(
+                SELECT ta.a, tb.bval
+                FROM `/Root/ta` AS ta
+                INNER JOIN `/Root/tb` VIEW idx_fk AS tb ON ta.fk = tb.fk
+                ORDER BY ta.a, tb.bval;
+            )", NYdb::NQuery::TTxControl::BeginTx().CommitTx()).ExtractValueSync();
+
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            ui64 totalCount = 0;
+            for(size_t i = 0; i < result.GetResultSets().size(); i++) {
+                totalCount += result.GetResultSet(i).RowsCount();
+                UNIT_ASSERT(!result.GetResultSet(i).Truncated());
+            }
+            UNIT_ASSERT_VALUES_EQUAL(totalCount, 30);
+        }
     }
 }
 


### PR DESCRIPTION
backporting https://github.com/ydb-platform/ydb/pull/37983 + https://github.com/ydb-platform/ydb/pull/38128

### Depends on
- #47326 (#37471)
- #47586 (#37587)

stable-25-3-1-enterprise: 5cf32126d + 912784a40 
stable-25-4-1-enterprise: 2bd5fc7d3 + ca324971a