### PR TITLE
Fixed flaky sqs tests

### DIFF
--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -14,7 +14,7 @@ import pytest
 
 import ydb
 from hamcrest import assert_that, equal_to, not_none, has_item, has_items, is_not, contains_string
-from hamcrest import raises, greater_than, not_, less_than
+from hamcrest import raises, greater_than
 from ydb.tests.library.sqs.test_base import IS_FIFO_PARAMS, TABLES_FORMAT_PARAMS
 from ydb.tests.library.sqs.cloud_test_base import YandexCloudSqsTestBase
 from ydb.tests.library.sqs.test_base import get_test_with_sqs_tenant_installation
@@ -422,10 +422,12 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(YandexCloudSq
 
         def get_messages_count(queue_url):
             attrs = self._sqs_api.get_queue_attributes(queue_url)
-            msg_count = int(attrs['ApproximateNumberOfMessages'])
-            infly_msg_count = int(attrs['ApproximateNumberOfMessagesNotVisible'])
-            assert_that(infly_msg_count, not_(greater_than(msg_count)))
-            return msg_count
+            msg_count = int(attrs.get('ApproximateNumberOfMessages', 0))
+            infly_msg_count = int(attrs.get('ApproximateNumberOfMessagesNotVisible', 0))
+            # Inflight and total can briefly diverge while attributes update asynchronously.
+            if infly_msg_count <= msg_count:
+                return msg_count
+            return None
 
         # check that messages are actually moved to dlq and this doesn't break both queues
         lst = [queue1_url, queue2_url]
@@ -437,16 +439,21 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(YandexCloudSq
                 self._send_message_and_assert(q1, msg_body, seq_no=str(seq_no) if is_fifo else None, group_id='group' if is_fifo else None)
                 seq_no += 1
 
+                messages_count_before = None
                 messages_count_metric_update_attempts = 20
                 while messages_count_metric_update_attempts:
                     messages_count_metric_update_attempts -= 1
 
                     messages_count_before = get_messages_count(q1)
-                    assert_that(messages_count_before, not_(less_than(0)))
-                    if messages_count_before == 0:
-                        logging.debug('Wait for proper messages count metric and retry. Attempts left: {}'.format(messages_count_metric_update_attempts))
+                    if messages_count_before is None or messages_count_before == 0:
+                        logging.debug(
+                            'Wait for proper messages count metric and retry. Attempts left: {}'.format(
+                                messages_count_metric_update_attempts
+                            )
+                        )
                         time.sleep(1)
                         continue
+                    break
 
                 assert_that(messages_count_before, greater_than(0))
 
@@ -459,8 +466,7 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(YandexCloudSq
                 if self._is_topic_migration_stage():
                     msg_from_dlq = self._wait_for_message_body_in_dlq(q2, msg_body)
                 else:
-                    messages_count_after = get_messages_count(q1)
-                    assert_that(messages_count_after, equal_to(messages_count_before - 1))
+                    self._wait_for_approximate_messages_count(q1, messages_count_before - 1)
                     msg_from_dlq = self._read_single_message_no_wait(q2)[0]
                 assert_that(msg_from_dlq['Body'], equal_to(msg_body))
 

--- a/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
+++ b/ydb/tests/functional/sqs/cloud/test_yandex_cloud_mode.py
@@ -455,6 +455,7 @@ class TestSqsYandexCloudMode(get_test_with_sqs_tenant_installation(YandexCloudSq
                         continue
                     break
 
+                assert_that(messages_count_before, not_none())
                 assert_that(messages_count_before, greater_than(0))
 
                 for i in range(max_receive_count):

--- a/ydb/tests/functional/sqs/common/test_queue_counters.py
+++ b/ydb/tests/functional/sqs/common/test_queue_counters.py
@@ -114,27 +114,28 @@ class TestSqsGettingCounters(KikimrSqsTestBase):
         self._sqs_api.send_message(queue_url, message_payload)
         self._read_while_not_empty(queue_url, 1)
 
-        sqs_counters = self._get_sqs_counters()
+        def assert_action_counters(sqs_counters):
+            successes = self._get_counter_value(sqs_counters, {
+                'queue': self.queue_name,
+                'sensor': 'ReceiveMessage_Success',
+            })
+            assert successes == 1
 
-        successes = self._get_counter_value(sqs_counters, {
-            'queue': self.queue_name,
-            'sensor': 'ReceiveMessage_Success',
-        })
-        assert successes == 1
+            durations = self._get_counter(sqs_counters, {
+                'queue': self.queue_name,
+                'sensor': 'ReceiveMessage_Duration',
+            })
+            duration_buckets = durations['hist']['buckets']
+            assert any(map(lambda x: x > 0, duration_buckets))
 
-        durations = self._get_counter(sqs_counters, {
-            'queue': self.queue_name,
-            'sensor': 'ReceiveMessage_Duration',
-        })
-        duration_buckets = durations['hist']['buckets']
-        assert any(map(lambda x: x > 0, duration_buckets))
+            working_durations = self._get_counter(sqs_counters, {
+                'queue': self.queue_name,
+                'sensor': 'ReceiveMessage_WorkingDuration',
+            })
+            working_duration_buckets = working_durations['hist']['buckets']
+            assert any(map(lambda x: x > 0, working_duration_buckets))
 
-        working_durations = self._get_counter(sqs_counters, {
-            'queue': self.queue_name,
-            'sensor': 'ReceiveMessage_WorkingDuration',
-        })
-        working_duration_buckets = working_durations['hist']['buckets']
-        assert any(map(lambda x: x > 0, working_duration_buckets))
+        self._wait_for_sqs_counters(assert_action_counters)
 
     def test_receive_message_immediate_duration_counter(self):
         if self._is_topic_migration_stage():

--- a/ydb/tests/functional/sqs/common/test_queue_counters.py
+++ b/ydb/tests/functional/sqs/common/test_queue_counters.py
@@ -125,6 +125,7 @@ class TestSqsGettingCounters(KikimrSqsTestBase):
                 'queue': self.queue_name,
                 'sensor': 'ReceiveMessage_Duration',
             })
+            assert durations is not None
             duration_buckets = durations['hist']['buckets']
             assert any(map(lambda x: x > 0, duration_buckets))
 
@@ -132,6 +133,7 @@ class TestSqsGettingCounters(KikimrSqsTestBase):
                 'queue': self.queue_name,
                 'sensor': 'ReceiveMessage_WorkingDuration',
             })
+            assert working_durations is not None
             working_duration_buckets = working_durations['hist']['buckets']
             assert any(map(lambda x: x > 0, working_duration_buckets))
 

--- a/ydb/tests/functional/sqs/multinode/test_multinode_cluster.py
+++ b/ydb/tests/functional/sqs/multinode/test_multinode_cluster.py
@@ -12,7 +12,13 @@ from ydb.tests.library.common.types import Erasure
 
 from ydb.tests.library.sqs.matchers import ReadResponseMatcher
 
-from ydb.tests.library.sqs.test_base import KikimrSqsTestBase, STOP_NODE_PARAMS, IS_FIFO_PARAMS, TABLES_FORMAT_PARAMS
+from ydb.tests.library.sqs.test_base import (
+    KikimrSqsTestBase,
+    STOP_NODE_PARAMS,
+    IS_FIFO_PARAMS,
+    TABLES_FORMAT_PARAMS,
+    SQS_MIGRATION_STAGES,
+)
 
 
 class TestSqsMultinodeCluster(KikimrSqsTestBase):
@@ -61,7 +67,7 @@ class TestSqsMultinodeCluster(KikimrSqsTestBase):
     @pytest.mark.parametrize(**STOP_NODE_PARAMS)
     @pytest.mark.skipif(
         # topic_creation also reports MessagesCount via PQ read balancer since #45354
-        os.environ.get('YDB_SQS_MIGRATION_STAGE') is not None,
+        os.environ.get('YDB_SQS_MIGRATION_STAGE') in SQS_MIGRATION_STAGES,
         reason='MessagesCount counters use different semantics on topic path',
     )
     def test_has_messages_counters(self, is_fifo, stop_node):

--- a/ydb/tests/functional/sqs/multinode/test_multinode_cluster.py
+++ b/ydb/tests/functional/sqs/multinode/test_multinode_cluster.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import logging
+import os
 import time
 import threading
 
@@ -59,7 +60,8 @@ class TestSqsMultinodeCluster(KikimrSqsTestBase):
     @pytest.mark.parametrize(**IS_FIFO_PARAMS)
     @pytest.mark.parametrize(**STOP_NODE_PARAMS)
     @pytest.mark.skipif(
-        KikimrSqsTestBase._is_topic_migration_stage(),
+        # topic_creation also reports MessagesCount via PQ read balancer since #45354
+        os.environ.get('YDB_SQS_MIGRATION_STAGE') is not None,
         reason='MessagesCount counters use different semantics on topic path',
     )
     def test_has_messages_counters(self, is_fifo, stop_node):


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix flaky SQS functional tests after async metrics / migration dual-write (#45354).

**`test_sqs_action_counters`** (`common`, also migration `compatibility` / `finished`)
- Root cause: single-shot read of async counters (`ReceiveMessage_Duration` / `WorkingDuration` could still be empty).
- Fix: wrap assertions in `_wait_for_sqs_counters()`, same pattern as sibling counter tests.

**`test_dlq_mechanics_in_cloud[fifo]`**
- Root cause: wait-loop for `ApproximateNumberOfMessages` had no `break` on success; after DLQ move the count was asserted without retry (async attributes).
- Fix: break when count is ready; use `_wait_for_approximate_messages_count` after move; tolerate transient inflight/total divergence while waiting.

**`test_has_messages_counters`** (migration `topic_creation` / `compatibility` / `finished`)
- Root cause: under any `YDB_SQS_MIGRATION_STAGE`, `MessagesCount` / `Infly` / `Age` are also written by pqrb into the same sensor path as the queue leader, so the “counters only on master node” invariant no longer holds. Proper fix (gauges only on leader) is deferred.
- Fix for now: skip the test when `YDB_SQS_MIGRATION_STAGE` is set (including `topic_creation`, which `_is_topic_migration_stage()` does not cover).

Fixes https://github.com/ydb-platform/ydb/issues/45794
Fixes https://github.com/ydb-platform/ydb/issues/45781
Fixes https://github.com/ydb-platform/ydb/issues/45713
Fixes https://github.com/ydb-platform/ydb/issues/46397
Fixes https://github.com/ydb-platform/ydb/issues/46163
Fixes https://github.com/ydb-platform/ydb/issues/46058