### PR TITLE
Fixed ydb/tests/stress/topic/tests

### DIFF
--- a/ydb/tests/stress/topic/tests/test_workload_topic.py
+++ b/ydb/tests/stress/topic/tests/test_workload_topic.py
@@ -28,7 +28,7 @@ def create_test_methods(chunk_size):
         for k in range(count):
             def make_test_method(index):
                 def test_method(self):
-                    self._run_chunk(k, chunk_size)
+                    self._run_chunk(index, chunk_size)
                 test_method.__name__ = f"test_{index}"
                 return test_method
             setattr(cls, f"test_{k}", make_test_method(k))

--- a/ydb/tests/stress/topic/workload/__init__.py
+++ b/ydb/tests/stress/topic/workload/__init__.py
@@ -244,7 +244,8 @@ class YdbTopicWorkload(WorkloadBase):
         self._run_workload(
             self.workload_topic_name,
             self.duration,
-            "10M",  # 100M DEFAULT_BYTE_RATE overloads a single CI node
+            # DEFAULT_BYTE_RATE (100M) overloads a single CI node
+            self.config.SMALL_BYTE_RATE,
             self.producers,
             self.consumers,
             with_config=True
@@ -327,8 +328,8 @@ class YdbTopicWorkload(WorkloadBase):
             return tests
         chunk = tests[self.chunk_index * self.chunk_size:(self.chunk_index + 1) * self.chunk_size]
 
-        # Sequential: WorkloadBase runs each returned func in a parallel thread;
-        # several topic stresses at once overload CI (#46635).
+        # One callable so WorkloadBase starts a single worker; run chunk
+        # scenarios one by one (parallel topic stresses overload CI, #46635).
         def run_chunk():
             for f in chunk:
                 f()

--- a/ydb/tests/stress/topic/workload/__init__.py
+++ b/ydb/tests/stress/topic/workload/__init__.py
@@ -214,13 +214,14 @@ class YdbTopicWorkload(WorkloadBase):
         ))
 
     def __non_transactional_workload(self):
+        # Keep wide partition coverage; lower byte_rate only to ease gRPC drain on teardown (#46635).
         self.run_topic_write_without_tx(TestConfig(
             partitions=200,
             partitions_per_tablet=10,
             producers=20,  # producers=int(self.producers),
             consumers=int(self.consumers),
             consumer_threads=int(self.consumers),
-            byte_rate="10M"  # byte_rate=self.config.DEFAULT_BYTE_RATE
+            byte_rate="1M"  # byte_rate=self.config.DEFAULT_BYTE_RATE
         ))
 
     @property
@@ -243,7 +244,7 @@ class YdbTopicWorkload(WorkloadBase):
         self._run_workload(
             self.workload_topic_name,
             self.duration,
-            self.config.DEFAULT_BYTE_RATE,
+            "10M",  # 100M DEFAULT_BYTE_RATE overloads a single CI node
             self.producers,
             self.consumers,
             with_config=True
@@ -324,4 +325,12 @@ class YdbTopicWorkload(WorkloadBase):
         ]
         if (self.chunk_index is None) or (self.chunk_size is None):
             return tests
-        return tests[self.chunk_index * self.chunk_size:(self.chunk_index + 1) * self.chunk_size]
+        chunk = tests[self.chunk_index * self.chunk_size:(self.chunk_index + 1) * self.chunk_size]
+
+        # Sequential: WorkloadBase runs each returned func in a parallel thread;
+        # several topic stresses at once overload CI (#46635).
+        def run_chunk():
+            for f in chunk:
+                f()
+
+        return [run_chunk]


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/46635

`TestYdbTopicWorkload.test_0` was flaky because of a Python closure bug in `create_test_methods()`: all `test_0/1/2` captured the loop variable `k` and ran chunk 2 (heavy non-tx workload). Under that load, cluster teardown often failed with gRPC shutdown assertion (`grpc_cq_begin_op`) after the 30s deadline.

Changes:
- Bind chunk index via `make_test_method(index)` so each test runs its intended chunk
- Run scenarios inside a chunk sequentially (WorkloadBase starts each returned func in a parallel thread; several topic stresses at once overload a single CI node)
- Soften `__loop` byte-rate (100M → 10M) and non-tx byte-rate (10M → 1M); keep 200 partitions for wide coverage

Local check: all three tests GOOD with default 60s duration (including wide p200 scenarios in `test_1` and ntx p200 in `test_2`).
