### PR TITLE
Fix Kafka Metadata broker list and ControllerId consistency

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -75,7 +75,6 @@ ydb/tests/functional/sqs/migration/topic_creation/multinode ydb.tests.functional
 ydb/tests/functional/sqs/migration/topic_creation/multinode ydb.tests.functional.sqs.multinode.test_multinode_cluster.py.TestSqsMultinodeCluster.test_has_messages_counters[stop_node-fifo]
 ydb/tests/functional/sqs/migration/topic_creation/multinode ydb.tests.functional.sqs.multinode.test_multinode_cluster.py.TestSqsMultinodeCluster.test_has_messages_counters[stop_node-std]
 ydb/tests/functional/tenants test_remove_storage_groups.py.test_remove_storage_group
-ydb/tests/stress/kafka_serverless/tests test_kafka_streams.py.TestYdbTopicWorkload.test
 ydb/tests/stress/oltp_workload/tests py3test.sole chunk
 ydb/tests/stress/oltp_workload/tests test_workload.py.TestYdbWorkload.test
 ydb/tests/stress/scheme_board/pile_promotion/tests test_scheme_board_workload.py.TestSchemeBoard.test_scheme_board

--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -75,6 +75,7 @@ ydb/tests/functional/sqs/migration/topic_creation/multinode ydb.tests.functional
 ydb/tests/functional/sqs/migration/topic_creation/multinode ydb.tests.functional.sqs.multinode.test_multinode_cluster.py.TestSqsMultinodeCluster.test_has_messages_counters[stop_node-fifo]
 ydb/tests/functional/sqs/migration/topic_creation/multinode ydb.tests.functional.sqs.multinode.test_multinode_cluster.py.TestSqsMultinodeCluster.test_has_messages_counters[stop_node-std]
 ydb/tests/functional/tenants test_remove_storage_groups.py.test_remove_storage_group
+ydb/tests/stress/kafka_serverless/tests test_kafka_streams.py.TestYdbTopicWorkload.test
 ydb/tests/stress/oltp_workload/tests py3test.sole chunk
 ydb/tests/stress/oltp_workload/tests test_workload.py.TestYdbWorkload.test
 ydb/tests/stress/scheme_board/pile_promotion/tests test_scheme_board_workload.py.TestSchemeBoard.test_scheme_board

--- a/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_create_topics_actor.cpp
@@ -175,7 +175,8 @@ void TKafkaCreateTopicsActor::Handle(const NKikimr::NPQ::NSchema::TEvSchemaRespo
     YDB_LOG_DEBUG("Create topics actor. Topic's response received",
         {LogPrefix()},
         {"path", eventPtr->Path},
-        {"status", std::to_string(eventPtr->Status)});
+        {"status", std::to_string(eventPtr->Status)},
+        {"errorMessage", eventPtr->ErrorMessage});
 
     EKafkaErrors status;
     switch(eventPtr->Status) {

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -355,6 +355,33 @@ void TKafkaMetadataActor::AddBroker(ui64 nodeId, const TString& host, ui64 port)
     }
 }
 
+void TKafkaMetadataActor::EnsureBrokersAndController() {
+    // Unknown topics used to return brokers=[]; AdminClient then cannot CreateTopics.
+    if (!WithProxy && Response->Brokers.empty()) {
+        for (const auto& [id, nodeInfo] : Nodes) {
+            AddBroker(id, nodeInfo.Host, nodeInfo.Port);
+        }
+    }
+
+    if (!WithProxy && NeedAllNodes) {
+        for (const auto& [id, nodeInfo] : Nodes) {
+            AddBroker(id, nodeInfo.Host, nodeInfo.Port);
+        }
+    }
+
+    // ControllerId must be one of Brokers (SelfID may differ from discovery node ids).
+    if (Response->Brokers.empty()) {
+        return;
+    }
+
+    for (const auto& broker : Response->Brokers) {
+        if (broker.NodeId == Response->ControllerId) {
+            return;
+        }
+    }
+    Response->ControllerId = Response->Brokers.front().NodeId;
+}
+
 void TKafkaMetadataActor::ApplyPendingTopicResponses() {
     while (!PendingTopicResponses.empty()) {
         auto& [index, ev] = *PendingTopicResponses.begin();
@@ -379,6 +406,7 @@ void TKafkaMetadataActor::ApplyPendingTopicResponses() {
 
 void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
     auto Respond = [&] {
+        EnsureBrokersAndController();
         CancelRequestTimeout();
         Send(Context->ConnectionId, new TEvKafka::TEvResponse(CorrelationId, Response, ErrorCode));
         Die(ctx);
@@ -397,12 +425,6 @@ void TKafkaMetadataActor::RespondIfRequired(const TActorContext& ctx) {
     }
 
     ApplyPendingTopicResponses();
-
-    if (NeedAllNodes) {
-        for (const auto& [id, nodeInfo] : Nodes)
-            AddBroker(id, nodeInfo.Host, nodeInfo.Port);
-    }
-
     Respond();
 }
 
@@ -417,6 +439,7 @@ void TKafkaMetadataActor::HandleWakeup(TEvents::TEvWakeup::TPtr&, const TActorCo
 
 void TKafkaMetadataActor::RespondWithTimeout(const TActorContext& ctx) {
     ApplyPendingTopicResponses();
+    EnsureBrokersAndController();
 
     ErrorCode = EKafkaErrors::REQUEST_TIMED_OUT;
     for (auto& topic : Response->Topics) {

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -357,13 +357,8 @@ void TKafkaMetadataActor::AddBroker(ui64 nodeId, const TString& host, ui64 port)
 
 void TKafkaMetadataActor::EnsureBrokersAndController() {
     // Unknown topics used to return brokers=[]; AdminClient then cannot CreateTopics.
-    if (!WithProxy && Response->Brokers.empty()) {
-        for (const auto& [id, nodeInfo] : Nodes) {
-            AddBroker(id, nodeInfo.Host, nodeInfo.Port);
-        }
-    }
-
-    if (!WithProxy && NeedAllNodes) {
+    // NeedAllNodes also requires the full discovered broker set.
+    if (!WithProxy && (Response->Brokers.empty() || NeedAllNodes)) {
         for (const auto& [id, nodeInfo] : Nodes) {
             AddBroker(id, nodeInfo.Host, nodeInfo.Port);
         }
@@ -379,6 +374,13 @@ void TKafkaMetadataActor::EnsureBrokersAndController() {
             return;
         }
     }
+
+    // Prefer keeping ControllerId if that node is known from discovery.
+    if (auto it = Nodes.find(Response->ControllerId); it != Nodes.end()) {
+        AddBroker(it->first, it->second.Host, it->second.Port);
+        return;
+    }
+
     Response->ControllerId = Response->Brokers.front().NodeId;
 }
 

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -56,6 +56,7 @@ private:
     void RespondIfRequired(const NActors::TActorContext& ctx);
     void AddProxyNodeToBrokers();
     void AddBroker(ui64 nodeId, const TString& host, ui64 port);
+    void EnsureBrokersAndController();
     void RequestICNodeCache();
     void ProcessTopicsFromRequest();
     void SendDiscoveryRequest();

--- a/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
+++ b/ydb/core/kafka_proxy/ut/metarequest_ut.cpp
@@ -104,6 +104,17 @@ Y_UNIT_TEST_SUITE(TMetadataActorTests) {
         response = dynamic_cast<TMetadataResponseData*>(event->Response.get());
         UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1);
         UNIT_ASSERT(response->Topics[0].ErrorCode == EKafkaErrors::UNKNOWN_TOPIC_OR_PARTITION);
+        UNIT_ASSERT(!response->Brokers.empty());
+        {
+            bool controllerInBrokers = false;
+            for (const auto& broker : response->Brokers) {
+                if (broker.NodeId == response->ControllerId) {
+                    controllerInBrokers = true;
+                    break;
+                }
+            }
+            UNIT_ASSERT(controllerInBrokers);
+        }
 
         event = GetEvent(server, edgeId, {});
         response = dynamic_cast<TMetadataResponseData*>(event->Response.get());


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed Kafka API Metadata responses that could return an empty broker list or a `ControllerId` that did not match any advertised broker. This caused Kafka AdminClient `CreateTopics` calls to time out with "Timed out waiting for a node assignment", which broke Kafka Streams when creating internal changelog topics.

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/46938

**Root cause**

Kafka `METADATA` for an unknown/missing topic could return `brokers=[]`, and `ControllerId` was set to `SelfID.NodeId()` which may differ from discovery node ids (e.g. static node vs serverless dynamic node). Kafka AdminClient then cannot assign a node for `CreateTopics` and fails with `Timed out waiting for a node assignment`. In the stress test this left Kafka Streams changelog topics uncreated and target topics empty.

**Fix**

In `TKafkaMetadataActor::EnsureBrokersAndController()`:
- if `Brokers` is empty, fall back to discovered endpoints;
- if `ControllerId` is not among `Brokers`, set it to the first advertised broker;
- keep previous `NeedAllNodes` behavior.

Also log `errorMessage` in CREATE_TOPICS schema response DEBUG logs, unmute the fixed stress test, and cover unknown-topic metadata in UT.