### PR TITLE
[NBS-7485] fix crash on flush with empty comfirmed flushes

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info.cpp
@@ -295,7 +295,9 @@ void TInflightInfo::RemoveHosts(THostMask removed)
     EraseConfirmed = EraseConfirmed.Exclude(removed);
 
     // Check if flush became complete after removing hosts.
-    if (State == EState::PBufferFlushing && FlushDesired == FlushConfirmed) {
+    const bool flushDone =
+        !FlushConfirmed.Empty() && FlushDesired == FlushConfirmed;
+    if (State == EState::PBufferFlushing && flushDone) {
         SetState(EState::PBufferFlushed);
     }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/dirty_map/inflight_info_ut.cpp
@@ -670,6 +670,35 @@ Y_UNIT_TEST_SUITE(TInflightInfoTests)
         inflightInfo.UnlockPBuffer();
         UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToErase.contains(123));
     }
+
+    Y_UNIT_TEST(ShouldRemoveHostsNotCompleteFlushWithEmptyConfirmed)
+    {
+        TTestReadyQueue readyQueue;
+        TInflightInfo inflightInfo(&readyQueue, 123, 4096);
+        inflightInfo.OnWritten(MakePrimaryHosts(), MakePrimaryHosts());
+
+        // Request flush for host 0 only; do NOT confirm it.
+        // FlushDesired = {0}, FlushConfirmed = {}.
+        UNIT_ASSERT_VALUES_EQUAL(
+            THostIndex{0},
+            inflightInfo.RequestFlush(THostIndex{0}, THostMask()));
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushing,
+            inflightInfo.GetState());
+
+        // Remove host 0 — this empties FlushDesired while FlushConfirmed is
+        // still empty. The flush must NOT be considered complete.
+        THostMask removed;
+        removed.Set(THostIndex{0});
+        inflightInfo.RemoveHosts(removed);
+
+        // State must stay PBufferFlushing and erase must NOT be registered.
+        UNIT_ASSERT_VALUES_EQUAL(
+            TInflightInfo::EState::PBufferFlushing,
+            inflightInfo.GetState());
+        UNIT_ASSERT_VALUES_EQUAL(false, readyQueue.ReadyToErase.contains(123));
+        UNIT_ASSERT_VALUES_EQUAL(true, readyQueue.ReadyToFlush.contains(123));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->
Исправляем падение сервиса на удалении хоста в случае пустого FlushConfirmed
...
