### PR TITLE
TEvLockRows: fix skipAbsent of already locked keys

### DIFF
--- a/ydb/core/kqp/ut/tx/kqp_read_committed_pg_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_read_committed_pg_ut.cpp
@@ -1365,6 +1365,145 @@ Y_UNIT_TEST_SUITE(KqpReadCommittedPg) {
         tester.Execute();
     }
 
+    // =========================================================================
+    // INSERT then UPDATE within the same RC transaction should see the inserted row
+    // =========================================================================
+    class TInsertThenUpdateSameTx : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto client = Kikimr->GetQueryClient();
+            auto session = Kikimr->RunCall([&] { return client.GetSession().GetValueSync().GetSession(); });
+
+            auto result1 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    INSERT INTO `/Root/Test` (Group, Name, Amount, Comment) VALUES (998u, "NewRow", 500u, "Initial");
+                )"), TTxControl::BeginTx(TTxSettings::ReadCommittedRW())).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result1.GetStatus(), EStatus::SUCCESS, result1.GetIssues().ToString());
+            auto tx = result1.GetTransaction();
+            UNIT_ASSERT(tx && tx->IsActive());
+
+            auto result2 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    UPDATE `/Root/Test` SET Comment = "Updated" WHERE Group = 998u AND Name = "NewRow";
+                )"), TTxControl::Tx(*tx)).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result2.GetStatus(), EStatus::SUCCESS, result2.GetIssues().ToString());
+            tx = result2.GetTransaction();
+            UNIT_ASSERT(tx && tx->IsActive());
+
+            auto result3 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    SELECT Comment FROM `/Root/Test` WHERE Group = 998u AND Name = "NewRow";
+                )"), TTxControl::Tx(*tx).CommitTx()).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result3.GetStatus(), EStatus::SUCCESS, result3.GetIssues().ToString());
+            CompareYson(R"([[["Updated"]]])", FormatResultSetYson(result3.GetResultSet(0)));
+        }
+    };
+
+    Y_UNIT_TEST(TInsertThenUpdateSameTx) {
+        TInsertThenUpdateSameTx tester;
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
+    // =========================================================================
+    // INSERT then DELETE within the same RC transaction should delete the inserted row
+    // =========================================================================
+    class TInsertThenDeleteSameTx : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto client = Kikimr->GetQueryClient();
+            auto session = Kikimr->RunCall([&] { return client.GetSession().GetValueSync().GetSession(); });
+
+            auto result1 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    INSERT INTO `/Root/Test` (Group, Name, Amount, Comment) VALUES (998u, "NewRow", 500u, "Initial");
+                )"), TTxControl::BeginTx(TTxSettings::ReadCommittedRW())).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result1.GetStatus(), EStatus::SUCCESS, result1.GetIssues().ToString());
+            auto tx = result1.GetTransaction();
+            UNIT_ASSERT(tx && tx->IsActive());
+
+            auto result2 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    DELETE FROM `/Root/Test` WHERE Group = 998u AND Name = "NewRow";
+                )"), TTxControl::Tx(*tx)).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result2.GetStatus(), EStatus::SUCCESS, result2.GetIssues().ToString());
+            tx = result2.GetTransaction();
+            UNIT_ASSERT(tx && tx->IsActive());
+
+            auto result3 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    SELECT Comment FROM `/Root/Test` WHERE Group = 998u AND Name = "NewRow";
+                )"), TTxControl::Tx(*tx).CommitTx()).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result3.GetStatus(), EStatus::SUCCESS, result3.GetIssues().ToString());
+            CompareYson(R"([])", FormatResultSetYson(result3.GetResultSet(0)));
+        }
+    };
+
+    Y_UNIT_TEST(TInsertThenDeleteSameTx) {
+        TInsertThenDeleteSameTx tester;
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
+    // =========================================================================
+    // INSERT, DELETE, INSERT within the same RC transaction: final row should survive
+    // =========================================================================
+    class TInsertDeleteInsertSameTx : public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto client = Kikimr->GetQueryClient();
+            auto session = Kikimr->RunCall([&] { return client.GetSession().GetValueSync().GetSession(); });
+
+            auto result1 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    INSERT INTO `/Root/Test` (Group, Name, Amount, Comment) VALUES (998u, "NewRow", 500u, "First");
+                )"), TTxControl::BeginTx(TTxSettings::ReadCommittedRW())).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result1.GetStatus(), EStatus::SUCCESS, result1.GetIssues().ToString());
+            auto tx = result1.GetTransaction();
+            UNIT_ASSERT(tx && tx->IsActive());
+
+            auto result2 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    DELETE FROM `/Root/Test` WHERE Group = 998u AND Name = "NewRow";
+                )"), TTxControl::Tx(*tx)).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result2.GetStatus(), EStatus::SUCCESS, result2.GetIssues().ToString());
+            tx = result2.GetTransaction();
+            UNIT_ASSERT(tx && tx->IsActive());
+
+            auto result3 = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    INSERT INTO `/Root/Test` (Group, Name, Amount, Comment) VALUES (998u, "NewRow", 500u, "Second");
+                )"), TTxControl::Tx(*tx).CommitTx()).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(result3.GetStatus(), EStatus::SUCCESS, result3.GetIssues().ToString());
+
+            auto verify = Kikimr->RunCall([&] {
+                return session.ExecuteQuery(Q_(R"(
+                    SELECT Comment FROM `/Root/Test` WHERE Group = 998u AND Name = "NewRow";
+                )"), TTxControl::BeginTx(TTxSettings::SnapshotRW()).CommitTx()).ExtractValueSync();
+            });
+            UNIT_ASSERT_VALUES_EQUAL_C(verify.GetStatus(), EStatus::SUCCESS, verify.GetIssues().ToString());
+            CompareYson(R"([[["Second"]]])", FormatResultSetYson(verify.GetResultSet(0)));
+        }
+    };
+
+    Y_UNIT_TEST(TInsertDeleteInsertSameTx) {
+        TInsertDeleteInsertSameTx tester;
+        tester.SetIsOlap(false);
+        tester.SetUseRealThreads(false);
+        tester.Execute();
+    }
+
     class TLockOnlyShardDistributedCommit : public TTableDataModificationTester {
     protected:
         void DoExecute() override {

--- a/ydb/core/protos/data_events.proto
+++ b/ydb/core/protos/data_events.proto
@@ -212,6 +212,7 @@ message TEvLockRows {
     // When true, keys that are absent or deleted in the latest version are skipped
     // and not locked. If the skipped key was modified/deleted above the snapshot,
     // its index will NOT appear in the ModifiedKeys result field.
+    // If this transaction already locked a key, it will NOT be skipped.
     optional bool SkipAbsent = 13;
 
     // Destination global table id, must include SchemaVersion to detect schema changes

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -650,13 +650,6 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     return ETxLockRows::Restart;
                 }
 
-                if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
-                    success->Record.AddSkippedAbsentKeys(processedKeys);
-                    runtimeLock.Reset();
-                    ++processedKeys;
-                    continue;
-                }
-
                 // Undecided volatile transactions will have non-zero VolatileVersion
                 // We don't wait until they are decided and return a modified flag
                 // instead. A subsequent re-read will wait for the decision.
@@ -707,6 +700,19 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                         setLockMode(combinedLockMode, lockId);
                     }
                     finishLocked();
+                    continue;
+                }
+
+                // Note: we run the skipAbsent check *after* we check that we already have the lock
+                // for this key. The purpose of skipAbsent is to allow other transactions to lock and
+                // insert a row to this key if this transaction is trying to update/delete a row that
+                // is not there. If we already locked the key, this means that previously in this
+                // transaction we inserted the row, so it should be able to do other operations
+                // to it, and we shouldn't skip even if no committed row exists.
+                if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
+                    success->Record.AddSkippedAbsentKeys(processedKeys);
+                    runtimeLock.Reset();
+                    ++processedKeys;
                     continue;
                 }
 

--- a/ydb/core/tx/datashard/datashard__lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard__lock_rows.cpp
@@ -703,19 +703,6 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     continue;
                 }
 
-                // Note: we run the skipAbsent check *after* we check that we already have the lock
-                // for this key. The purpose of skipAbsent is to allow other transactions to lock and
-                // insert a row to this key if this transaction is trying to update/delete a row that
-                // is not there. If we already locked the key, this means that previously in this
-                // transaction we inserted the row, so it should be able to do other operations
-                // to it, and we shouldn't skip even if no committed row exists.
-                if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
-                    success->Record.AddSkippedAbsentKeys(processedKeys);
-                    runtimeLock.Reset();
-                    ++processedKeys;
-                    continue;
-                }
-
                 // The first conflicting owner we need to wait for
                 TLockInfo::TPtr currentOwner;
                 NTable::ELockMode currentLockMode = NTable::ELockMode::None;
@@ -780,6 +767,19 @@ void TDataShard::HandleLockRowsRequest(NEvents::TDataEvents::TEvLockRows::TPtr e
                     if (currentOwner) {
                         currentLockMode = row.LockMode;
                     }
+                }
+
+                // Note: we run the skipAbsent check *after* we check that we already have the lock
+                // for this key. The purpose of skipAbsent is to allow other transactions to lock and
+                // insert a row to this key if this transaction is trying to update/delete a row that
+                // is not there. If we already locked the key, this means that previously in this
+                // transaction we inserted the row, so it should be able to do other operations
+                // to it, and we shouldn't skip even if no committed row exists.
+                if (skipAbsent && (row.Ready == NTable::EReady::Gone || row.RowOp == NTable::ERowOp::Erase)) {
+                    success->Record.AddSkippedAbsentKeys(processedKeys);
+                    runtimeLock.Reset();
+                    ++processedKeys;
+                    continue;
                 }
 
                 // Don't bother waiting in skipLocked mode when current owner conflicts with us

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -9,6 +9,7 @@
 
 #include <util/digest/multi.h>
 #include <util/random/fast.h>
+#include <util/string/join.h>
 
 namespace {
     struct TRequestId {

--- a/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_lock_rows.cpp
@@ -2200,35 +2200,41 @@ Y_UNIT_TEST_SUITE(DataShardLockRows) {
             )"),
             "<empty>");
 
+        // Lock key 5 by lock 234
+        auto req2 = lockRows.SendRequest(lock2, tableId, TKeysBuilder().Add(5).Build());
+        lockRows.ExpectResult(req2);
+
         // Try locking keys 1, 2, 3, 4 by lock 234.
-        auto req2 = lockRows.SendRequest(
-            lock2, tableId, TKeysBuilder().Add(1).Add(2).Add(3).Add(4).Build(),
+        auto skippingReq = lockRows.SendRequest(
+            lock2, tableId, TKeysBuilder().Add(1).Add(2).Add(3).Add(4).Add(5).Build(),
             [&](NEvents::TDataEvents::TEvLockRows* ev) {
                 ev->Record.MutableSnapshot()->SetStep(snapshot.Step);
                 ev->Record.MutableSnapshot()->SetTxId(snapshot.TxId);
                 ev->Record.SetSkipLocked(true);
                 ev->Record.SetSkipAbsent(true);
             });
-        auto res = lockRows.ExpectResult(req2);
+        auto res = lockRows.ExpectResult(skippingReq);
 
-        // Key 1 was locked
-        const auto& locked = res->Record.GetLockedKeys();
-        UNIT_ASSERT_VALUES_EQUAL(locked.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(locked[0], 0);
+        // Key 1 was locked because it is present, and key 5 was locked because it was
+        // previously locked by the same transaction.
+        UNIT_ASSERT_VALUES_EQUAL(
+            JoinSeq(",", res->Record.GetLockedKeys()),
+            "0,4");
 
         // Key 2 was skipped because it was previously locked by req1
-        const auto& skippedLocked = res->Record.GetSkippedLockedKeys();
-        UNIT_ASSERT_VALUES_EQUAL(skippedLocked.size(), 1);
-        UNIT_ASSERT_VALUES_EQUAL(skippedLocked[0], 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            JoinSeq(",", res->Record.GetSkippedLockedKeys()),
+            "1");
 
         // Key 3 was skipped because it was deleted, and key 4 was skipped because it was absent.
-        const auto& skippedAbsent = res->Record.GetSkippedAbsentKeys();
-        UNIT_ASSERT_VALUES_EQUAL(skippedAbsent.size(), 2);
-        UNIT_ASSERT_VALUES_EQUAL(skippedAbsent[0], 2);
-        UNIT_ASSERT_VALUES_EQUAL(skippedAbsent[1], 3);
+        UNIT_ASSERT_VALUES_EQUAL(
+            JoinSeq(",", res->Record.GetSkippedAbsentKeys()),
+            "2,3");
 
         // Key 3 was deleted after the snapshot, but it is not in ModifiedKeys because we skipped it.
-        UNIT_ASSERT_VALUES_EQUAL(res->Record.GetModifiedKeys().size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            JoinSeq(",", res->Record.GetModifiedKeys()),
+            "");
     }
 
 } // Y_UNIT_TEST_SUITE(DataShardLockRows)

--- a/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
+++ b/ydb/core/tx/long_tx_service/long_tx_service_impl.cpp
@@ -1796,7 +1796,7 @@ void TLongTxServiceActor::Handle(TEvPrivate::TEvRunDeadlockDetection::TPtr& ev) 
                 continue;
             }
 
-            YDB_LOG_DEBUG("Breaking the wait edge",
+            YDB_LOG_WARN("Breaking the wait edge",
                 {"logPrefix", LogPrefix},
                 {"id", edge.Id},
                 {"awaiter", edge.Awaiter.LockInfo(SelfId())},


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

See KIKIMR-26304 for the problem description
