### PR TITLE
Add cgroup OOM trend monitoring

### DIFF
--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_events.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_events.h
@@ -15,6 +15,7 @@ namespace NActors {
         V2Stats,
         MemoryStats,
         OomAlert,
+        OomTrend,
         End,
     };
 
@@ -60,6 +61,33 @@ namespace NActors {
 
         explicit TEvCGroupOomAlert(TCGroupOomAlert alert)
             : Alert(std::move(alert))
+        {
+        }
+    };
+
+    struct TEvCGroupOomTrend
+        : TEventLocal<TEvCGroupOomTrend, static_cast<ui32>(ECGroupEvent::OomTrend)>
+    {
+        // ReadTrend responses are always Active. Subscriptions additionally
+        // receive Stopped when their forecast condition ceases to hold.
+        ECGroupOomTrendState State;
+
+        // Empty when the calculation completed without finding a trend. A
+        // Stopped subscription notification may still contain the current
+        // trend when it exists but no longer meets the subscription threshold.
+        std::optional<TCGroupOomTrend> Trend;
+
+        explicit TEvCGroupOomTrend(
+                std::optional<TCGroupOomTrend> trend,
+                ECGroupOomTrendState state = ECGroupOomTrendState::Active)
+            : State(state)
+            , Trend(std::move(trend))
+        {
+        }
+
+        explicit TEvCGroupOomTrend(TCGroupOomTrend trend)
+            : State(ECGroupOomTrendState::Active)
+            , Trend(std::move(trend))
         {
         }
     };

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_events.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_events.h
@@ -68,8 +68,9 @@ namespace NActors {
     struct TEvCGroupOomTrend
         : TEventLocal<TEvCGroupOomTrend, static_cast<ui32>(ECGroupEvent::OomTrend)>
     {
-        // ReadTrend responses are always Active. Subscriptions additionally
-        // receive Stopped when their forecast condition ceases to hold.
+        // ReadTrend responses are Active when a trend was found and Stopped
+        // otherwise. Subscriptions additionally receive Stopped when their
+        // forecast condition ceases to hold.
         ECGroupOomTrendState State;
 
         // Empty when the calculation completed without finding a trend. A
@@ -77,11 +78,17 @@ namespace NActors {
         // trend when it exists but no longer meets the subscription threshold.
         std::optional<TCGroupOomTrend> Trend;
 
+        // Set only for subscription notifications so an actor can distinguish
+        // multiple subscriptions for the same window.
+        std::optional<TDuration> TimeToOomThreshold;
+
         explicit TEvCGroupOomTrend(
                 std::optional<TCGroupOomTrend> trend,
-                ECGroupOomTrendState state = ECGroupOomTrendState::Active)
+                ECGroupOomTrendState state = ECGroupOomTrendState::Active,
+                std::optional<TDuration> timeToOomThreshold = std::nullopt)
             : State(state)
             , Trend(std::move(trend))
+            , TimeToOomThreshold(timeToOomThreshold)
         {
         }
 

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
@@ -14,6 +14,7 @@
 
 #include <util/generic/hash_set.h>
 #include <util/generic/vector.h>
+#include <util/stream/output.h>
 
 #include <algorithm>
 #include <array>
@@ -179,7 +180,9 @@ namespace NActors {
                 const size_t providerIndex = ev->Cookie;
 
                 if (ev->Get()->Stats) {
-                    Evaluate(std::move(ev->Get()->Stats));
+                    if (!Evaluate(std::move(ev->Get()->Stats))) {
+                        return;
+                    }
                     Schedule(Config.PollPeriod, new TEvPoll());
                 } else if (providerIndex + 1 < Providers.size()) {
                     RequestProvider(providerIndex + 1);
@@ -205,6 +208,7 @@ namespace NActors {
                             ? ECGroupOomTrendState::Active
                             : ECGroupOomTrendState::Stopped,
                         trend,
+                        std::nullopt,
                         ev->Get()->Cookie);
                 } else {
                     PendingTrendRequests[CGroupOomTrendWindowIndex(
@@ -254,18 +258,28 @@ namespace NActors {
                 }
             }
 
-            void Evaluate(TCGroupMemoryStatsPtr stats) {
+            bool Evaluate(TCGroupMemoryStatsPtr stats) {
+                if (!CGroupVersion) {
+                    CGroupVersion = stats->Version;
+                    CGroupPath = stats->CGroupPath;
+                } else if (*CGroupVersion != stats->Version ||
+                        CGroupPath != stats->CGroupPath) {
+                    Cerr
+                        << "ERROR: cgroup memory stats source changed from version "
+                        << static_cast<ui32>(*CGroupVersion)
+                        << " path " << CGroupPath
+                        << " to version " << static_cast<ui32>(stats->Version)
+                        << " path " << stats->CGroupPath << Endl;
+                    Cerr
+                        << "Stopping cgroup OOM monitoring; restart the process "
+                        << "in the target cgroup" << Endl;
+                    PassAway();
+                    return false;
+                }
+
                 const auto recalculated = TrendCalculator.AddSample(
                     TActivationContext::Monotonic(),
                     stats);
-
-                if (!PreviousVersion || *PreviousVersion != stats->Version ||
-                        PreviousCGroupPath != stats->CGroupPath) {
-                    PreviousVersion = stats->Version;
-                    PreviousCGroupPath = stats->CGroupPath;
-                    HasPreviousMemory = false;
-                    ActiveLevelReasons = 0;
-                }
 
                 TCGroupOomAlert alert;
                 alert.Stats = std::move(stats);
@@ -317,6 +331,7 @@ namespace NActors {
                         UpdateTrendSubscriptions(window);
                     }
                 }
+                return true;
             }
 
             void Notify(const TCGroupOomAlert& alert) {
@@ -349,7 +364,8 @@ namespace NActors {
                     active
                         ? ECGroupOomTrendState::Active
                         : ECGroupOomTrendState::Stopped,
-                    trend);
+                    trend,
+                    subscription.TimeToOomThreshold);
                 subscription.Active = active;
             }
 
@@ -365,10 +381,11 @@ namespace NActors {
                     const TActorId& recipient,
                     ECGroupOomTrendState state,
                     const std::optional<TCGroupOomTrend>& trend,
+                    std::optional<TDuration> timeToOomThreshold = std::nullopt,
                     ui64 cookie = 0) {
                 Send(
                     recipient,
-                    new TEvCGroupOomTrend(trend, state),
+                    new TEvCGroupOomTrend(trend, state, timeToOomThreshold),
                     0,
                     cookie);
             }
@@ -388,6 +405,7 @@ namespace NActors {
                         request.Recipient,
                         state,
                         trend,
+                        std::nullopt,
                         request.Cookie);
                 }
                 requests.clear();
@@ -406,8 +424,8 @@ namespace NActors {
                 TVector<TPendingTrendRequest>,
                 CGroupOomTrendWindows.size()> PendingTrendRequests;
 
-            std::optional<ECGroupVersion> PreviousVersion;
-            TString PreviousCGroupPath;
+            std::optional<ECGroupVersion> CGroupVersion;
+            TString CGroupPath;
             TCGroupMemoryStats PreviousMemory;
             ui32 ActiveLevelReasons = 0;
             bool HasPreviousMemory = false;

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
@@ -1,6 +1,7 @@
 #include "cgroup_oom.h"
 
 #include "cgroup_events.h"
+#include "cgroup_oom_trend.h"
 #include "cgroup_v1.h"
 #include "cgroup_v2.h"
 
@@ -11,9 +12,11 @@
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 
-#include <util/generic/hash.h>
 #include <util/generic/hash_set.h>
 #include <util/generic/vector.h>
+
+#include <algorithm>
+#include <array>
 
 namespace NActors {
 
@@ -33,35 +36,14 @@ namespace NActors {
 
         enum : ui32 {
             EvPoll = EventSpaceBegin(TEvents::ES_PRIVATE),
-            EvSubscribeCallback,
-            EvUnsubscribeCallback,
             EvSubscribeActor,
             EvUnsubscribeActor,
+            EvReadTrend,
+            EvSubscribeTrendActor,
+            EvUnsubscribeTrendActor,
         };
 
         struct TEvPoll : TEventLocal<TEvPoll, EvPoll> {
-        };
-
-        struct TEvSubscribeCallback : TEventLocal<TEvSubscribeCallback, EvSubscribeCallback> {
-            TCGroupOomSubSystem::TSubscriptionId SubscriptionId;
-            TCGroupOomSubSystem::TCallback Callback;
-
-            TEvSubscribeCallback(
-                    TCGroupOomSubSystem::TSubscriptionId subscriptionId,
-                    TCGroupOomSubSystem::TCallback callback)
-                : SubscriptionId(subscriptionId)
-                , Callback(std::move(callback))
-            {
-            }
-        };
-
-        struct TEvUnsubscribeCallback : TEventLocal<TEvUnsubscribeCallback, EvUnsubscribeCallback> {
-            TCGroupOomSubSystem::TSubscriptionId SubscriptionId;
-
-            explicit TEvUnsubscribeCallback(TCGroupOomSubSystem::TSubscriptionId subscriptionId)
-                : SubscriptionId(subscriptionId)
-            {
-            }
         };
 
         struct TEvSubscribeActor : TEventLocal<TEvSubscribeActor, EvSubscribeActor> {
@@ -82,6 +64,51 @@ namespace NActors {
             }
         };
 
+        struct TEvReadTrend : TEventLocal<TEvReadTrend, EvReadTrend> {
+            TActorId Recipient;
+            ECGroupOomTrendWindow Window;
+            ui64 Cookie;
+
+            TEvReadTrend(
+                    TActorId recipient,
+                    ECGroupOomTrendWindow window,
+                    ui64 cookie)
+                : Recipient(recipient)
+                , Window(window)
+                , Cookie(cookie)
+            {
+            }
+        };
+
+        struct TEvSubscribeTrendActor
+            : TEventLocal<TEvSubscribeTrendActor, EvSubscribeTrendActor>
+        {
+            TActorId ActorId;
+            ECGroupOomTrendWindow Window;
+            TDuration TimeToOomThreshold;
+
+            TEvSubscribeTrendActor(
+                    TActorId actorId,
+                    ECGroupOomTrendWindow window,
+                    TDuration timeToOomThreshold)
+                : ActorId(actorId)
+                , Window(window)
+                , TimeToOomThreshold(timeToOomThreshold)
+            {
+            }
+        };
+
+        struct TEvUnsubscribeTrendActor
+            : TEventLocal<TEvUnsubscribeTrendActor, EvUnsubscribeTrendActor>
+        {
+            TActorId ActorId;
+
+            explicit TEvUnsubscribeTrendActor(TActorId actorId)
+                : ActorId(actorId)
+            {
+            }
+        };
+
         class TCGroupOomActor : public TActorBootstrapped<TCGroupOomActor> {
         public:
             TCGroupOomActor(
@@ -89,6 +116,7 @@ namespace NActors {
                     TCGroupOomConfig config)
                 : Providers(std::move(providers))
                 , Config(std::move(config))
+                , TrendCalculator(Config.TrendWindows)
             {
             }
 
@@ -100,14 +128,42 @@ namespace NActors {
             STRICT_STFUNC(StateWork,
                 hFunc(TEvPoll, Handle)
                 hFunc(TEvCGroupMemoryStats, Handle)
-                hFunc(TEvSubscribeCallback, Handle)
-                hFunc(TEvUnsubscribeCallback, Handle)
                 hFunc(TEvSubscribeActor, Handle)
                 hFunc(TEvUnsubscribeActor, Handle)
+                hFunc(TEvReadTrend, Handle)
+                hFunc(TEvSubscribeTrendActor, Handle)
+                hFunc(TEvUnsubscribeTrendActor, Handle)
                 cFunc(TEvents::TSystem::Poison, PassAway)
             )
 
         private:
+            struct TTrendSubscription {
+                TDuration TimeToOomThreshold;
+                bool Active = false;
+
+                explicit TTrendSubscription(TDuration timeToOomThreshold)
+                    : TimeToOomThreshold(timeToOomThreshold)
+                {
+                }
+            };
+
+            struct TPendingTrendRequest {
+                TActorId Recipient;
+                ui64 Cookie;
+            };
+
+            struct TTrendActorSubscription : TTrendSubscription {
+                TActorId ActorId;
+
+                TTrendActorSubscription(
+                        TActorId actorId,
+                        TDuration timeToOomThreshold)
+                    : TTrendSubscription(timeToOomThreshold)
+                    , ActorId(actorId)
+                {
+                }
+            };
+
             void Handle(TEvPoll::TPtr&) {
                 RequestProvider(0);
             }
@@ -132,14 +188,6 @@ namespace NActors {
                 }
             }
 
-            void Handle(TEvSubscribeCallback::TPtr& ev) {
-                Callbacks.emplace(ev->Get()->SubscriptionId, std::move(ev->Get()->Callback));
-            }
-
-            void Handle(TEvUnsubscribeCallback::TPtr& ev) {
-                Callbacks.erase(ev->Get()->SubscriptionId);
-            }
-
             void Handle(TEvSubscribeActor::TPtr& ev) {
                 ActorSubscribers.insert(ev->Get()->ActorId);
             }
@@ -148,7 +196,69 @@ namespace NActors {
                 ActorSubscribers.erase(ev->Get()->ActorId);
             }
 
+            void Handle(TEvReadTrend::TPtr& ev) {
+                if (TrendCalculator.HasResult(ev->Get()->Window)) {
+                    const auto trend = GetTrend(ev->Get()->Window);
+                    SendTrend(
+                        ev->Get()->Recipient,
+                        trend
+                            ? ECGroupOomTrendState::Active
+                            : ECGroupOomTrendState::Stopped,
+                        trend,
+                        ev->Get()->Cookie);
+                } else {
+                    PendingTrendRequests[CGroupOomTrendWindowIndex(
+                        ev->Get()->Window)].push_back({
+                        .Recipient = ev->Get()->Recipient,
+                        .Cookie = ev->Get()->Cookie,
+                    });
+                }
+            }
+
+            void Handle(TEvSubscribeTrendActor::TPtr& ev) {
+                const auto* event = ev->Get();
+                auto& subscriptions =
+                    TrendActors[CGroupOomTrendWindowIndex(event->Window)];
+                const auto existing = std::find_if(
+                    subscriptions.begin(),
+                    subscriptions.end(),
+                    [event](const TTrendActorSubscription& subscription) {
+                        return subscription.ActorId == event->ActorId &&
+                            subscription.TimeToOomThreshold == event->TimeToOomThreshold;
+                    });
+                if (existing == subscriptions.end()) {
+                    subscriptions.push_back({
+                        event->ActorId,
+                        event->TimeToOomThreshold,
+                    });
+                    if (TrendCalculator.HasResult(event->Window)) {
+                        const auto trend = GetTrend(event->Window);
+                        UpdateTrendActorSubscription(
+                            trend,
+                            subscriptions.back());
+                    }
+                }
+            }
+
+            void Handle(TEvUnsubscribeTrendActor::TPtr& ev) {
+                const TActorId actorId = ev->Get()->ActorId;
+                for (auto& subscriptions : TrendActors) {
+                    subscriptions.erase(
+                        std::remove_if(
+                            subscriptions.begin(),
+                            subscriptions.end(),
+                            [actorId](const TTrendActorSubscription& subscription) {
+                                return subscription.ActorId == actorId;
+                            }),
+                        subscriptions.end());
+                }
+            }
+
             void Evaluate(TCGroupMemoryStatsPtr stats) {
+                const auto recalculated = TrendCalculator.AddSample(
+                    TActivationContext::Monotonic(),
+                    stats);
+
                 if (!PreviousVersion || *PreviousVersion != stats->Version ||
                         PreviousCGroupPath != stats->CGroupPath) {
                     PreviousVersion = stats->Version;
@@ -201,6 +311,12 @@ namespace NActors {
                 if (alert.Reasons) {
                     Notify(alert);
                 }
+                for (ECGroupOomTrendWindow window : CGroupOomTrendWindows) {
+                    if (recalculated.Contains(window)) {
+                        ReplyToPendingTrendRequests(window);
+                        UpdateTrendSubscriptions(window);
+                    }
+                }
             }
 
             void Notify(const TCGroupOomAlert& alert) {
@@ -208,23 +324,87 @@ namespace NActors {
                 for (const TActorId& actorId : ActorSubscribers) {
                     actorContext.Send(actorId, new TEvCGroupOomAlert(alert));
                 }
+            }
 
-                for (const auto& item : Callbacks) {
-                    try {
-                        item.second(alert);
-                    } catch (...) {
-                        // One callback must not prevent other subscribers from
-                        // releasing memory.
-                    }
+            void UpdateTrendSubscriptions(ECGroupOomTrendWindow window) {
+                const auto windowIndex = CGroupOomTrendWindowIndex(window);
+                const auto trend = GetTrend(window);
+
+                for (auto& subscription : TrendActors[windowIndex]) {
+                    UpdateTrendActorSubscription(trend, subscription);
                 }
+            }
+
+            void UpdateTrendActorSubscription(
+                    const std::optional<TCGroupOomTrend>& trend,
+                    TTrendActorSubscription& subscription) {
+                const bool active =
+                    trend && trend->TimeToOom <= subscription.TimeToOomThreshold;
+                if (!active && !subscription.Active) {
+                    return;
+                }
+
+                SendTrend(
+                    subscription.ActorId,
+                    active
+                        ? ECGroupOomTrendState::Active
+                        : ECGroupOomTrendState::Stopped,
+                    trend);
+                subscription.Active = active;
+            }
+
+            std::optional<TCGroupOomTrend> GetTrend(
+                    ECGroupOomTrendWindow window) const {
+                if (const auto* trend = TrendCalculator.FindTrend(window)) {
+                    return *trend;
+                }
+                return std::nullopt;
+            }
+
+            void SendTrend(
+                    const TActorId& recipient,
+                    ECGroupOomTrendState state,
+                    const std::optional<TCGroupOomTrend>& trend,
+                    ui64 cookie = 0) {
+                Send(
+                    recipient,
+                    new TEvCGroupOomTrend(trend, state),
+                    0,
+                    cookie);
+            }
+
+            void ReplyToPendingTrendRequests(ECGroupOomTrendWindow window) {
+                auto& requests =
+                    PendingTrendRequests[CGroupOomTrendWindowIndex(window)];
+                if (!TrendCalculator.HasResult(window)) {
+                    return;
+                }
+                const auto trend = GetTrend(window);
+                const auto state = trend
+                    ? ECGroupOomTrendState::Active
+                    : ECGroupOomTrendState::Stopped;
+                for (const auto& request : requests) {
+                    SendTrend(
+                        request.Recipient,
+                        state,
+                        trend,
+                        request.Cookie);
+                }
+                requests.clear();
             }
 
         private:
             const TVector<const ICGroupMemoryStatsProvider*> Providers;
             const TCGroupOomConfig Config;
+            TCGroupOomTrendCalculator TrendCalculator;
 
-            THashMap<TCGroupOomSubSystem::TSubscriptionId, TCGroupOomSubSystem::TCallback> Callbacks;
             THashSet<TActorId> ActorSubscribers;
+            std::array<
+                TVector<TTrendActorSubscription>,
+                CGroupOomTrendWindows.size()> TrendActors;
+            std::array<
+                TVector<TPendingTrendRequest>,
+                CGroupOomTrendWindows.size()> PendingTrendRequests;
 
             std::optional<ECGroupVersion> PreviousVersion;
             TString PreviousCGroupPath;
@@ -247,6 +427,30 @@ namespace NActors {
             (*Config.MemoryPressureFullAvg10Threshold >= 0 &&
                 *Config.MemoryPressureFullAvg10Threshold <= 100),
             "cgroup OOM PSI threshold must be in [0, 100]");
+
+        const auto validateTrendWindow = [this](
+                const std::optional<TCGroupOomTrendWindowConfig>& window) {
+            if (!window) {
+                return;
+            }
+            Y_ABORT_UNLESS(window->Duration >= Config.PollPeriod,
+                "cgroup OOM trend window must be at least one poll period");
+            Y_ABORT_UNLESS(
+                window->RecalculationPeriod >= Config.PollPeriod &&
+                    window->RecalculationPeriod <= window->Duration,
+                "cgroup OOM trend recalculation period must be between the poll period and window");
+            Y_ABORT_UNLESS(
+                window->MinimumRSquared >= 0 && window->MinimumRSquared <= 1,
+                "cgroup OOM minimum trend R-squared must be in [0, 1]");
+        };
+        validateTrendWindow(Config.TrendWindows.ShortWindow);
+        validateTrendWindow(Config.TrendWindows.LongWindow);
+        Y_ABORT_UNLESS(
+            !Config.TrendWindows.ShortWindow ||
+                !Config.TrendWindows.LongWindow ||
+                Config.TrendWindows.ShortWindow->Duration <
+                    Config.TrendWindows.LongWindow->Duration,
+            "cgroup OOM short trend window must be shorter than the long trend window");
     }
 
     TSubSystemDependencies TCGroupOomSubSystem::GetDependencies() const {
@@ -266,25 +470,6 @@ namespace NActors {
         }
     }
 
-    TCGroupOomSubSystem::TSubscriptionId TCGroupOomSubSystem::Subscribe(TCallback callback) {
-        Y_ABORT_UNLESS(callback, "cannot subscribe an empty cgroup OOM callback");
-
-        Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
-
-        const TSubscriptionId subscriptionId =
-            NextSubscriptionId.fetch_add(1, std::memory_order_relaxed);
-        ActorSystem->Send(MonitorActorId,
-            new NDetail::TEvSubscribeCallback(subscriptionId, std::move(callback)));
-        return subscriptionId;
-    }
-
-    void TCGroupOomSubSystem::Unsubscribe(TSubscriptionId subscriptionId) {
-        Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
-
-        ActorSystem->Send(MonitorActorId,
-            new NDetail::TEvUnsubscribeCallback(subscriptionId));
-    }
-
     void TCGroupOomSubSystem::Subscribe(const TActorId& actorId) {
         Y_ABORT_UNLESS(actorId, "cannot subscribe an empty actor id to cgroup OOM alerts");
 
@@ -297,6 +482,60 @@ namespace NActors {
         Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
 
         ActorSystem->Send(MonitorActorId, new NDetail::TEvUnsubscribeActor(actorId));
+    }
+
+    void TCGroupOomSubSystem::ReadTrend(
+            const TActorId& recipient,
+            ECGroupOomTrendWindow window,
+            ui64 cookie) const {
+        Y_ABORT_UNLESS(recipient, "cannot send a cgroup OOM trend to an empty actor id");
+        Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
+        ValidateTrendWindow(window);
+
+        ActorSystem->Send(
+            MonitorActorId,
+            new NDetail::TEvReadTrend(recipient, window, cookie));
+    }
+
+    void TCGroupOomSubSystem::SubscribeToTrend(
+            const TActorId& actorId,
+            ECGroupOomTrendWindow window,
+            TDuration timeToOomThreshold) {
+        Y_ABORT_UNLESS(
+            actorId,
+            "cannot subscribe an empty actor id to cgroup OOM trends");
+        Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
+        ValidateTrendSubscription(window, timeToOomThreshold);
+
+        ActorSystem->Send(
+            MonitorActorId,
+            new NDetail::TEvSubscribeTrendActor(
+                actorId,
+                window,
+                timeToOomThreshold));
+    }
+
+    void TCGroupOomSubSystem::UnsubscribeFromTrend(const TActorId& actorId) {
+        Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
+
+        ActorSystem->Send(
+            MonitorActorId,
+            new NDetail::TEvUnsubscribeTrendActor(actorId));
+    }
+
+    void TCGroupOomSubSystem::ValidateTrendWindow(ECGroupOomTrendWindow window) const {
+        Y_ABORT_UNLESS(
+            Config.TrendWindows.Find(window),
+            "cgroup OOM trend window is not configured");
+    }
+
+    void TCGroupOomSubSystem::ValidateTrendSubscription(
+            ECGroupOomTrendWindow window,
+            TDuration timeToOomThreshold) const {
+        ValidateTrendWindow(window);
+        Y_ABORT_UNLESS(
+            timeToOomThreshold > TDuration::Zero(),
+            "cgroup OOM trend time threshold must be positive");
     }
 
     void TCGroupOomSubSystem::OnAfterStart(TActorSystem& actorSystem) {

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
@@ -105,6 +105,10 @@ namespace NActors {
         ui32 ExecutorPoolId = 0;
         TDuration PollPeriod = TDuration::Seconds(1);
 
+        // The cgroup version and path are fixed by the first memory snapshot.
+        // Moving a running process between cgroups stops OOM monitoring; restart
+        // the process in the target cgroup instead.
+
         // An empty optional disables the corresponding threshold.
         std::optional<double> MemoryUsageThreshold = 0.9;
         std::optional<ui64> AvailableBytesThreshold;

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
@@ -9,8 +9,6 @@
 #include <util/datetime/base.h>
 #include <util/generic/vector.h>
 
-#include <atomic>
-#include <functional>
 #include <memory>
 #include <optional>
 
@@ -53,9 +51,57 @@ namespace NActors {
         }
     };
 
+    enum class ECGroupOomTrendWindow : ui8 {
+        ShortWindow = 0,
+        LongWindow = 1,
+    };
+
+    struct TCGroupOomTrendWindowConfig {
+        // The fixed sample window used for linear regression.
+        TDuration Duration;
+
+        // Samples are collected on every poll, while regression and the OOM
+        // forecast are updated no more often than this period.
+        TDuration RecalculationPeriod = TDuration::Seconds(1);
+
+        // A trend is available only when the coefficient of determination
+        // reaches this value.
+        double MinimumRSquared = 0.8;
+    };
+
+    struct TCGroupOomTrendWindowsConfig {
+        std::optional<TCGroupOomTrendWindowConfig> ShortWindow;
+        std::optional<TCGroupOomTrendWindowConfig> LongWindow;
+
+        const TCGroupOomTrendWindowConfig* Find(ECGroupOomTrendWindow window) const {
+            switch (window) {
+                case ECGroupOomTrendWindow::ShortWindow:
+                    return ShortWindow ? &*ShortWindow : nullptr;
+                case ECGroupOomTrendWindow::LongWindow:
+                    return LongWindow ? &*LongWindow : nullptr;
+            }
+            return nullptr;
+        }
+    };
+
+    struct TCGroupOomTrend {
+        TCGroupMemoryStatsPtr Stats;
+        ECGroupOomTrendWindow Window;
+        TDuration WindowDuration;
+        double GrowthBytesPerSecond = 0;
+        double RSquared = 0;
+        TDuration TimeToOom;
+        ui64 SampleCount = 0;
+    };
+
+    enum class ECGroupOomTrendState {
+        Active,
+        Stopped,
+    };
+
     struct TCGroupOomConfig {
-        // The monitor actor and callbacks run in this pool. Actual cgroup file
-        // reads use the pools configured by the selected stats providers.
+        // The monitor actor runs in this pool. Actual cgroup file reads use the
+        // pools configured by the selected stats providers.
         ui32 ExecutorPoolId = 0;
         TDuration PollPeriod = TDuration::Seconds(1);
 
@@ -63,13 +109,14 @@ namespace NActors {
         std::optional<double> MemoryUsageThreshold = 0.9;
         std::optional<ui64> AvailableBytesThreshold;
         std::optional<double> MemoryPressureFullAvg10Threshold;
+
+        // Trend windows are fixed for the lifetime of the subsystem. Each
+        // window is disabled when the corresponding optional is empty.
+        TCGroupOomTrendWindowsConfig TrendWindows;
     };
 
     class TCGroupOomSubSystem : public ISubSystem {
     public:
-        using TSubscriptionId = ui64;
-        using TCallback = std::function<void(const TCGroupOomAlert&)>;
-
         explicit TCGroupOomSubSystem(TCGroupOomConfig config);
 
         const TCGroupOomConfig& GetConfig() const {
@@ -79,22 +126,39 @@ namespace NActors {
         TSubSystemDependencies GetDependencies() const override;
         void OnDependenciesResolved(const TResolvedSubSystemDependencies& dependencies) override;
 
-        // Subscription changes are applied asynchronously by the monitor
-        // actor. The actor system must be running when these methods are
-        // called. A notification already ahead of Unsubscribe in the actor's
-        // mailbox may still be delivered. Threshold notifications are
-        // edge-triggered; counter deltas trigger notifications whenever they
-        // increase.
-        TSubscriptionId Subscribe(TCallback callback);
-        void Unsubscribe(TSubscriptionId subscriptionId);
-
         // Actor subscriptions are local and keyed by ActorId. Repeated
-        // Subscribe and Unsubscribe calls are idempotent.
+        // Subscribe and Unsubscribe calls are idempotent. Subscription changes
+        // are applied asynchronously by the monitor actor.
         void Subscribe(const TActorId& actorId);
         void Unsubscribe(const TActorId& actorId);
 
+        // Sends TEvCGroupOomTrend after the first calculation for the window.
+        // The request remains pending while the window is accumulating. Once
+        // calculated, the response is sent even when no trend was found.
+        void ReadTrend(
+            const TActorId& recipient,
+            ECGroupOomTrendWindow window,
+            ui64 cookie = 0) const;
+
+        // Repeated actor subscriptions with the same window and threshold are
+        // idempotent. Active is delivered after every window recalculation
+        // while the threshold is met; Stopped is delivered once when it ceases
+        // to hold. UnsubscribeFromTrend removes all trend subscriptions for the
+        // actor.
+        void SubscribeToTrend(
+            const TActorId& actorId,
+            ECGroupOomTrendWindow window,
+            TDuration timeToOomThreshold);
+        void UnsubscribeFromTrend(const TActorId& actorId);
+
         void OnAfterStart(TActorSystem& actorSystem) override;
         void OnBeforeStop(TActorSystem& actorSystem) override;
+
+    private:
+        void ValidateTrendWindow(ECGroupOomTrendWindow window) const;
+        void ValidateTrendSubscription(
+            ECGroupOomTrendWindow window,
+            TDuration timeToOomThreshold) const;
 
     private:
         const TCGroupOomConfig Config;
@@ -102,7 +166,6 @@ namespace NActors {
 
         TActorSystem* ActorSystem = nullptr;
         TActorId MonitorActorId;
-        alignas(64) std::atomic<TSubscriptionId> NextSubscriptionId = 1;
     };
 
     std::unique_ptr<TCGroupOomSubSystem> MakeCGroupOomSubSystem(TCGroupOomConfig config);

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.cpp
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.cpp
@@ -39,11 +39,7 @@ namespace NActors::NDetail {
             return recalculated;
         }
 
-        if (!Version || *Version != stats->Version || CGroupPath != stats->CGroupPath) {
-            Reset();
-            Version = stats->Version;
-            CGroupPath = stats->CGroupPath;
-        } else if (!Samples.empty() && timestamp <= Samples.back().Timestamp) {
+        if (!Samples.empty() && timestamp <= Samples.back().Timestamp) {
             Reset();
         }
 

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.cpp
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.cpp
@@ -1,0 +1,189 @@
+#include "cgroup_oom_trend.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace NActors::NDetail {
+
+    namespace {
+
+        double RelativeBytes(ui64 value, ui64 base) {
+            return value >= base
+                ? static_cast<double>(value - base)
+                : -static_cast<double>(base - value);
+        }
+
+    } // namespace
+
+    TCGroupOomTrendCalculator::TCGroupOomTrendCalculator(
+            TCGroupOomTrendWindowsConfig windows) {
+        if (windows.ShortWindow) {
+            MaxWindow = std::max(MaxWindow, windows.ShortWindow->Duration);
+            Windows[CGroupOomTrendWindowIndex(
+                ECGroupOomTrendWindow::ShortWindow)].Config =
+                    std::move(windows.ShortWindow);
+        }
+        if (windows.LongWindow) {
+            MaxWindow = std::max(MaxWindow, windows.LongWindow->Duration);
+            Windows[CGroupOomTrendWindowIndex(
+                ECGroupOomTrendWindow::LongWindow)].Config =
+                    std::move(windows.LongWindow);
+        }
+    }
+
+    TRecalculatedCGroupOomTrendWindows TCGroupOomTrendCalculator::AddSample(
+            TMonotonic timestamp,
+            TCGroupMemoryStatsPtr stats) {
+        TRecalculatedCGroupOomTrendWindows recalculated;
+        if (MaxWindow == TDuration::Zero()) {
+            return recalculated;
+        }
+
+        if (!Version || *Version != stats->Version || CGroupPath != stats->CGroupPath) {
+            Reset();
+            Version = stats->Version;
+            CGroupPath = stats->CGroupPath;
+        } else if (!Samples.empty() && timestamp <= Samples.back().Timestamp) {
+            Reset();
+        }
+
+        if (!HistoryStartedAt) {
+            HistoryStartedAt = timestamp;
+        }
+        Samples.push_back({
+            .Timestamp = timestamp,
+            .CurrentBytes = stats->CurrentBytes,
+        });
+        Prune(timestamp);
+
+        for (ECGroupOomTrendWindow window : CGroupOomTrendWindows) {
+            auto& state = Windows[CGroupOomTrendWindowIndex(window)];
+            if (!state.Config) {
+                continue;
+            }
+            if (!state.LastCalculatedAt ||
+                    timestamp - *state.LastCalculatedAt >=
+                        state.Config->RecalculationPeriod) {
+                state.HasResult =
+                    timestamp - *HistoryStartedAt >= state.Config->Duration;
+                state.Trend =
+                    CalculateTrend(window, state, timestamp, stats);
+                state.LastCalculatedAt = timestamp;
+                recalculated.Add(window);
+            }
+        }
+        return recalculated;
+    }
+
+    bool TCGroupOomTrendCalculator::HasResult(ECGroupOomTrendWindow window) const {
+        const auto& state = Windows[CGroupOomTrendWindowIndex(window)];
+        return state.Config && state.HasResult;
+    }
+
+    const TCGroupOomTrend* TCGroupOomTrendCalculator::FindTrend(
+            ECGroupOomTrendWindow window) const {
+        const auto& state = Windows[CGroupOomTrendWindowIndex(window)];
+        return state.Trend
+            ? &*state.Trend
+            : nullptr;
+    }
+
+    void TCGroupOomTrendCalculator::Reset() {
+        Samples.clear();
+        HistoryStartedAt.reset();
+        for (auto& state : Windows) {
+            state.Trend.reset();
+            state.LastCalculatedAt.reset();
+            state.HasResult = false;
+        }
+    }
+
+    void TCGroupOomTrendCalculator::Prune(TMonotonic timestamp) {
+        const TMonotonic cutoff = timestamp - MaxWindow;
+        while (Samples.size() > 1 && Samples[1].Timestamp <= cutoff) {
+            Samples.pop_front();
+        }
+    }
+
+    std::optional<TCGroupOomTrend> TCGroupOomTrendCalculator::CalculateTrend(
+            ECGroupOomTrendWindow window,
+            const TWindowState& state,
+            TMonotonic timestamp,
+            const TCGroupMemoryStatsPtr& stats) const {
+        const auto& config = *state.Config;
+        if (!HistoryStartedAt || timestamp - *HistoryStartedAt < config.Duration ||
+                !stats->MaxBytes || stats->MaxBytes->Unlimited ||
+                !stats->MaxBytes->Value) {
+            return std::nullopt;
+        }
+
+        const TMonotonic cutoff = timestamp - config.Duration;
+        size_t first = 0;
+        while (first + 1 < Samples.size() && Samples[first + 1].Timestamp <= cutoff) {
+            ++first;
+        }
+
+        const size_t sampleCount = Samples.size() - first;
+        // Two points always form a perfect line and do not provide a useful
+        // linearity check.
+        if (sampleCount < 3) {
+            return std::nullopt;
+        }
+
+        const TMonotonic baseTimestamp = Samples[first].Timestamp;
+        const ui64 baseBytes = Samples[first].CurrentBytes;
+        double sumX = 0;
+        double sumY = 0;
+        for (size_t index = first; index < Samples.size(); ++index) {
+            sumX += (Samples[index].Timestamp - baseTimestamp).SecondsFloat();
+            sumY += RelativeBytes(Samples[index].CurrentBytes, baseBytes);
+        }
+
+        const double meanX = sumX / sampleCount;
+        const double meanY = sumY / sampleCount;
+        double sumXX = 0;
+        double sumXY = 0;
+        double sumYY = 0;
+        for (size_t index = first; index < Samples.size(); ++index) {
+            const double x =
+                (Samples[index].Timestamp - baseTimestamp).SecondsFloat() - meanX;
+            const double y =
+                RelativeBytes(Samples[index].CurrentBytes, baseBytes) - meanY;
+            sumXX += x * x;
+            sumXY += x * y;
+            sumYY += y * y;
+        }
+
+        if (sumXX <= 0 || sumYY <= 0) {
+            return std::nullopt;
+        }
+
+        const double growthBytesPerSecond = sumXY / sumXX;
+        const double rSquared = std::clamp(
+            sumXY * sumXY / (sumXX * sumYY),
+            0.0,
+            1.0);
+        if (!std::isfinite(growthBytesPerSecond) ||
+                !std::isfinite(rSquared) ||
+                growthBytesPerSecond <= 0 ||
+                rSquared < config.MinimumRSquared) {
+            return std::nullopt;
+        }
+
+        const ui64 maxBytes = stats->MaxBytes->Value;
+        const double remainingBytes = stats->CurrentBytes < maxBytes
+            ? static_cast<double>(maxBytes - stats->CurrentBytes)
+            : 0.0;
+
+        return TCGroupOomTrend{
+            .Stats = stats,
+            .Window = window,
+            .WindowDuration = config.Duration,
+            .GrowthBytesPerSecond = growthBytesPerSecond,
+            .RSquared = rSquared,
+            .TimeToOom = TDuration::Seconds(remainingBytes / growthBytesPerSecond),
+            .SampleCount = sampleCount,
+        };
+    }
+
+} // namespace NActors::NDetail

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.h
@@ -73,8 +73,6 @@ namespace NActors::NDetail {
         TDeque<TSample> Samples;
         TDuration MaxWindow;
         std::optional<TMonotonic> HistoryStartedAt;
-        std::optional<ECGroupVersion> Version;
-        TString CGroupPath;
     };
 
 } // namespace NActors::NDetail

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom_trend.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "cgroup_oom.h"
+
+#include <ydb/library/actors/core/monotonic.h>
+
+#include <util/generic/deque.h>
+
+#include <array>
+#include <optional>
+
+namespace NActors::NDetail {
+
+    inline constexpr std::array<ECGroupOomTrendWindow, 2> CGroupOomTrendWindows = {
+        ECGroupOomTrendWindow::ShortWindow,
+        ECGroupOomTrendWindow::LongWindow,
+    };
+
+    constexpr size_t CGroupOomTrendWindowIndex(ECGroupOomTrendWindow window) {
+        return static_cast<size_t>(window);
+    }
+
+    class TRecalculatedCGroupOomTrendWindows {
+    public:
+        void Add(ECGroupOomTrendWindow window) {
+            Recalculated[CGroupOomTrendWindowIndex(window)] = true;
+        }
+
+        bool Contains(ECGroupOomTrendWindow window) const {
+            return Recalculated[CGroupOomTrendWindowIndex(window)];
+        }
+
+    private:
+        std::array<bool, CGroupOomTrendWindows.size()> Recalculated = {};
+    };
+
+    class TCGroupOomTrendCalculator {
+    public:
+        explicit TCGroupOomTrendCalculator(
+            TCGroupOomTrendWindowsConfig windows);
+
+        // Stores every sample and reports only windows whose regression was
+        // recalculated for this sample.
+        TRecalculatedCGroupOomTrendWindows AddSample(
+            TMonotonic timestamp,
+            TCGroupMemoryStatsPtr stats);
+        bool HasResult(ECGroupOomTrendWindow window) const;
+        const TCGroupOomTrend* FindTrend(ECGroupOomTrendWindow window) const;
+
+    private:
+        struct TSample {
+            TMonotonic Timestamp;
+            ui64 CurrentBytes = 0;
+        };
+
+        struct TWindowState {
+            std::optional<TCGroupOomTrendWindowConfig> Config;
+            std::optional<TCGroupOomTrend> Trend;
+            std::optional<TMonotonic> LastCalculatedAt;
+            bool HasResult = false;
+        };
+
+        void Reset();
+        void Prune(TMonotonic timestamp);
+        std::optional<TCGroupOomTrend> CalculateTrend(
+            ECGroupOomTrendWindow window,
+            const TWindowState& state,
+            TMonotonic timestamp,
+            const TCGroupMemoryStatsPtr& stats) const;
+
+    private:
+        std::array<TWindowState, CGroupOomTrendWindows.size()> Windows;
+        TDeque<TSample> Samples;
+        TDuration MaxWindow;
+        std::optional<TMonotonic> HistoryStartedAt;
+        std::optional<ECGroupVersion> Version;
+        TString CGroupPath;
+    };
+
+} // namespace NActors::NDetail

--- a/ydb/library/actors/core/subsystems/ya.make
+++ b/ydb/library/actors/core/subsystems/ya.make
@@ -15,6 +15,7 @@ ENDIF()
 
 SRCS(
     cgroup/cgroup_oom.cpp
+    cgroup/cgroup_oom_trend.cpp
     cgroup/cgroup_v1.cpp
     cgroup/cgroup_v2.cpp
     stats.cpp

--- a/ydb/library/actors/core/ut/cgroup_ut.cpp
+++ b/ydb/library/actors/core/ut/cgroup_ut.cpp
@@ -199,6 +199,12 @@ namespace {
     private:
         void Handle(TEvCGroupOomTrend::TPtr& ev) {
             Y_ABORT_UNLESS(ev->Cookie == RequestCookie);
+            Y_ABORT_UNLESS(
+                ev->Get()->State ==
+                    (ev->Get()->Trend
+                        ? ECGroupOomTrendState::Active
+                        : ECGroupOomTrendState::Stopped));
+            Y_ABORT_UNLESS(!ev->Get()->TimeToOomThreshold);
             Result.Set(std::move(ev->Get()->Trend));
             PassAway();
         }
@@ -250,10 +256,12 @@ namespace {
         TTrendSubscriberActor(
                 TResultWaiter<std::optional<TCGroupOomTrend>>& activeResult,
                 TResultWaiter<std::optional<TCGroupOomTrend>>& stoppedResult,
+                TDuration timeToOomThreshold,
                 std::atomic<ui32>& activeNotifications,
                 std::atomic<ui32>& stoppedNotifications)
             : ActiveResult(activeResult)
             , StoppedResult(stoppedResult)
+            , TimeToOomThreshold(timeToOomThreshold)
             , ActiveNotifications(activeNotifications)
             , StoppedNotifications(stoppedNotifications)
         {
@@ -269,6 +277,8 @@ namespace {
 
     private:
         void Handle(TEvCGroupOomTrend::TPtr& ev) {
+            Y_ABORT_UNLESS(
+                ev->Get()->TimeToOomThreshold == TimeToOomThreshold);
             if (ev->Get()->State == ECGroupOomTrendState::Active) {
                 ActiveNotifications.fetch_add(1, std::memory_order_relaxed);
                 if (!HasActiveResult) {
@@ -285,6 +295,7 @@ namespace {
     private:
         TResultWaiter<std::optional<TCGroupOomTrend>>& ActiveResult;
         TResultWaiter<std::optional<TCGroupOomTrend>>& StoppedResult;
+        const TDuration TimeToOomThreshold;
         std::atomic<ui32>& ActiveNotifications;
         std::atomic<ui32>& StoppedNotifications;
         bool HasActiveResult = false;
@@ -534,10 +545,12 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
         TResultWaiter<std::optional<TCGroupOomTrend>> stoppedResult;
         std::atomic<ui32> activeNotifications = 0;
         std::atomic<ui32> stoppedNotifications = 0;
+        const TDuration timeToOomThreshold = TDuration::Seconds(10);
         const TActorId subscriber = actorSystem->Register(
             new TTrendSubscriberActor(
                 activeResult,
                 stoppedResult,
+                timeToOomThreshold,
                 activeNotifications,
                 stoppedNotifications),
             TMailboxType::Simple,
@@ -547,7 +560,7 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
         oom.SubscribeToTrend(
             subscriber,
             trendWindow,
-            TDuration::Seconds(10));
+            timeToOomThreshold);
 
         TResultWaiter<std::optional<TCGroupOomTrend>> noTrendResult;
         RequestOomTrend(*actorSystem, oom, trendWindow, noTrendResult);

--- a/ydb/library/actors/core/ut/cgroup_ut.cpp
+++ b/ydb/library/actors/core/ut/cgroup_ut.cpp
@@ -1,5 +1,6 @@
 #include <subsystems/cgroup/cgroup_events.h>
 #include <subsystems/cgroup/cgroup_oom.h>
+#include <subsystems/cgroup/cgroup_oom_trend.h>
 #include <subsystems/cgroup/cgroup_v1.h>
 #include <subsystems/cgroup/cgroup_v2.h>
 
@@ -11,12 +12,14 @@
 #include <scheduler_basic.h>
 
 #include <library/cpp/testing/unittest/registar.h>
-#include <library/cpp/threading/future/core/future.h>
 
 #include <util/folder/path.h>
 #include <util/folder/tempdir.h>
 #include <util/stream/file.h>
+#include <util/string/cast.h>
+#include <util/system/event.h>
 
+#include <atomic>
 #include <functional>
 
 using namespace NActors;
@@ -26,6 +29,27 @@ namespace {
     constexpr ui32 SystemPoolId = 0;
     constexpr ui32 IoPoolId = 1;
     constexpr ui64 RequestCookie = 42;
+
+    template<class TResult>
+    class TResultWaiter {
+    public:
+        void Set(TResult result) {
+            Result = std::move(result);
+            Ready.Signal();
+        }
+
+        bool Wait(TDuration timeout) {
+            return Ready.WaitT(timeout);
+        }
+
+        const TResult& GetValue() const {
+            return Result;
+        }
+
+    private:
+        TManualEvent Ready;
+        TResult Result;
+    };
 
     void WriteFile(const TFsPath& root, const TString& path, const TString& content) {
         const TFsPath fullPath = root / path;
@@ -89,9 +113,9 @@ namespace {
         using TThis = TRequestActor<TEvent, TResult>;
         using TRequest = std::function<void(const TActorId&, ui64)>;
 
-        TRequestActor(TRequest request, NThreading::TPromise<TResult> promise)
+        TRequestActor(TRequest request, TResultWaiter<TResult>& result)
             : Request(std::move(request))
-            , Promise(std::move(promise))
+            , Result(result)
         {
         }
 
@@ -109,29 +133,29 @@ namespace {
     private:
         void Handle(typename TResultEvent::TPtr& ev) {
             Y_ABORT_UNLESS(ev->Cookie == RequestCookie);
-            Promise.SetValue(std::move(ev->Get()->Stats));
+            Result.Set(std::move(ev->Get()->Stats));
             this->PassAway();
         }
 
     private:
         const TRequest Request;
-        NThreading::TPromise<TResult> Promise;
+        TResultWaiter<TResult>& Result;
     };
 
     template<class TEvent, class TResult>
-    NThreading::TFuture<TResult> RequestStats(
+    TResult RequestStats(
             TActorSystem& actorSystem,
             typename TRequestActor<TEvent, TResult>::TRequest request) {
-        auto promise = NThreading::NewPromise<TResult>();
-        auto future = promise.GetFuture();
+        TResultWaiter<TResult> result;
         actorSystem.Register(
-            new TRequestActor<TEvent, TResult>(std::move(request), std::move(promise)),
+            new TRequestActor<TEvent, TResult>(std::move(request), result),
             TMailboxType::Simple,
             SystemPoolId);
-        return future;
+        UNIT_ASSERT(result.Wait(TDuration::Seconds(5)));
+        return result.GetValue();
     }
 
-    NThreading::TFuture<TCGroupV2StatsPtr> RequestV2Stats(
+    TCGroupV2StatsPtr RequestV2Stats(
             TActorSystem& actorSystem,
             const TCGroupV2StatsSubSystem& subsystem) {
         return RequestStats<TEvCGroupV2Stats, TCGroupV2StatsPtr>(
@@ -141,7 +165,7 @@ namespace {
             });
     }
 
-    NThreading::TFuture<TCGroupMemoryStatsPtr> RequestMemoryStats(
+    TCGroupMemoryStatsPtr RequestMemoryStats(
             TActorSystem& actorSystem,
             const ICGroupMemoryStatsProvider& provider) {
         return RequestStats<TEvCGroupMemoryStats, TCGroupMemoryStatsPtr>(
@@ -149,6 +173,132 @@ namespace {
             [&provider](const TActorId& recipient, ui64 cookie) {
                 provider.ReadMemoryStats(recipient, cookie);
             });
+    }
+
+    class TTrendRequestActor : public TActorBootstrapped<TTrendRequestActor> {
+    public:
+        TTrendRequestActor(
+                const TCGroupOomSubSystem& subsystem,
+                ECGroupOomTrendWindow window,
+                TResultWaiter<std::optional<TCGroupOomTrend>>& result)
+            : Subsystem(subsystem)
+            , Window(window)
+            , Result(result)
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+            Subsystem.ReadTrend(SelfId(), Window, RequestCookie);
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvCGroupOomTrend, Handle)
+        )
+
+    private:
+        void Handle(TEvCGroupOomTrend::TPtr& ev) {
+            Y_ABORT_UNLESS(ev->Cookie == RequestCookie);
+            Result.Set(std::move(ev->Get()->Trend));
+            PassAway();
+        }
+
+    private:
+        const TCGroupOomSubSystem& Subsystem;
+        const ECGroupOomTrendWindow Window;
+        TResultWaiter<std::optional<TCGroupOomTrend>>& Result;
+    };
+
+    void RequestOomTrend(
+            TActorSystem& actorSystem,
+            const TCGroupOomSubSystem& subsystem,
+            ECGroupOomTrendWindow window,
+            TResultWaiter<std::optional<TCGroupOomTrend>>& result) {
+        actorSystem.Register(
+            new TTrendRequestActor(subsystem, window, result),
+            TMailboxType::Simple,
+            SystemPoolId);
+    }
+
+    class TOomAlertSubscriberActor : public TActorBootstrapped<TOomAlertSubscriberActor> {
+    public:
+        explicit TOomAlertSubscriberActor(TResultWaiter<TCGroupOomAlert>& result)
+            : Result(result)
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvCGroupOomAlert, Handle)
+        )
+
+    private:
+        void Handle(TEvCGroupOomAlert::TPtr& ev) {
+            Result.Set(std::move(ev->Get()->Alert));
+            PassAway();
+        }
+
+    private:
+        TResultWaiter<TCGroupOomAlert>& Result;
+    };
+
+    class TTrendSubscriberActor : public TActorBootstrapped<TTrendSubscriberActor> {
+    public:
+        TTrendSubscriberActor(
+                TResultWaiter<std::optional<TCGroupOomTrend>>& activeResult,
+                TResultWaiter<std::optional<TCGroupOomTrend>>& stoppedResult,
+                std::atomic<ui32>& activeNotifications,
+                std::atomic<ui32>& stoppedNotifications)
+            : ActiveResult(activeResult)
+            , StoppedResult(stoppedResult)
+            , ActiveNotifications(activeNotifications)
+            , StoppedNotifications(stoppedNotifications)
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvCGroupOomTrend, Handle)
+        )
+
+    private:
+        void Handle(TEvCGroupOomTrend::TPtr& ev) {
+            if (ev->Get()->State == ECGroupOomTrendState::Active) {
+                ActiveNotifications.fetch_add(1, std::memory_order_relaxed);
+                if (!HasActiveResult) {
+                    ActiveResult.Set(std::move(ev->Get()->Trend));
+                    HasActiveResult = true;
+                }
+            } else {
+                StoppedNotifications.fetch_add(1, std::memory_order_relaxed);
+                StoppedResult.Set(std::move(ev->Get()->Trend));
+                PassAway();
+            }
+        }
+
+    private:
+        TResultWaiter<std::optional<TCGroupOomTrend>>& ActiveResult;
+        TResultWaiter<std::optional<TCGroupOomTrend>>& StoppedResult;
+        std::atomic<ui32>& ActiveNotifications;
+        std::atomic<ui32>& StoppedNotifications;
+        bool HasActiveResult = false;
+    };
+
+    TCGroupMemoryStatsPtr MakeMemoryStats(ui64 currentBytes, ui64 maxBytes) {
+        auto stats = std::make_shared<TCGroupMemoryStats>();
+        stats->Version = ECGroupVersion::V2;
+        stats->CGroupPath = "/trend";
+        stats->CurrentBytes = currentBytes;
+        stats->MaxBytes = TCGroupMemoryLimit{
+            .Value = maxBytes,
+        };
+        return stats;
     }
 
 } // namespace
@@ -166,7 +316,7 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
         actorSystem->Start();
         auto stats = RequestV2Stats(
             *actorSystem,
-            GetCGroupV2StatsSubSystem(*actorSystem)).GetValueSync();
+            GetCGroupV2StatsSubSystem(*actorSystem));
 
         UNIT_ASSERT(stats);
         UNIT_ASSERT_VALUES_EQUAL(stats->CGroupPath, "/test");
@@ -185,9 +335,9 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
             MakeV2Config(root, TDuration::Hours(1))));
         actorSystem->Start();
         const auto& subsystem = GetCGroupV2StatsSubSystem(*actorSystem);
-        auto first = RequestV2Stats(*actorSystem, subsystem).GetValueSync();
+        auto first = RequestV2Stats(*actorSystem, subsystem);
         WriteFile(root, "sys/fs/cgroup/memory.current", "200\n");
-        auto second = RequestV2Stats(*actorSystem, subsystem).GetValueSync();
+        auto second = RequestV2Stats(*actorSystem, subsystem);
 
         UNIT_ASSERT(first);
         UNIT_ASSERT(first == second);
@@ -208,7 +358,7 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
         actorSystem->Start();
         auto stats = RequestMemoryStats(
             *actorSystem,
-            GetCGroupV1StatsSubSystem(*actorSystem)).GetValueSync();
+            GetCGroupV1StatsSubSystem(*actorSystem));
 
         UNIT_ASSERT(stats);
         UNIT_ASSERT(stats->Version == ECGroupVersion::V1);
@@ -218,7 +368,7 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
         actorSystem->Stop();
     }
 
-    Y_UNIT_TEST(OomControllerNotifiesCallback) {
+    Y_UNIT_TEST(OomControllerNotifiesActor) {
         TTempDir tempDir;
         const TFsPath root = tempDir.Path();
         WriteFile(root, "proc/self/cgroup", "0::/\n");
@@ -236,21 +386,221 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
             MakeCGroupOomSubSystem(oomConfig));
         actorSystem->Start();
 
-        auto promise = NThreading::NewPromise<TCGroupOomAlert>();
-        auto future = promise.GetFuture();
+        TResultWaiter<TCGroupOomAlert> result;
+        const TActorId subscriber = actorSystem->Register(
+            new TOomAlertSubscriberActor(result),
+            TMailboxType::Simple,
+            SystemPoolId);
         auto& oom = GetCGroupOomSubSystem(*actorSystem);
-        const auto subscriptionId = oom.Subscribe(
-            [promise](const TCGroupOomAlert& alert) mutable {
-                promise.TrySetValue(alert);
-            });
+        oom.Subscribe(subscriber);
 
         WriteFile(root, "sys/fs/cgroup/memory.current", "950\n");
-        UNIT_ASSERT(future.Wait(TDuration::Seconds(5)));
-        const auto& alert = future.GetValue();
+        UNIT_ASSERT(result.Wait(TDuration::Seconds(5)));
+        const auto& alert = result.GetValue();
         UNIT_ASSERT(alert.HasReason(ECGroupOomReason::MemoryUsageThreshold));
         UNIT_ASSERT_DOUBLES_EQUAL(*alert.MemoryUsage, 0.95, 1e-12);
 
-        oom.Unsubscribe(subscriptionId);
+        oom.Unsubscribe(subscriber);
+        actorSystem->Stop();
+    }
+
+    Y_UNIT_TEST(CalculatesOomTrendForMultipleWindows) {
+        constexpr ui64 MaxBytes = 10'000;
+        constexpr ui64 InitialBytes = 1'000;
+        constexpr ui64 GrowthBytesPerSecond = 2;
+
+        NActors::NDetail::TCGroupOomTrendCalculator calculator({
+            .ShortWindow = TCGroupOomTrendWindowConfig{
+                .Duration = TDuration::Minutes(1),
+                .RecalculationPeriod = TDuration::Seconds(1),
+                .MinimumRSquared = 0.99,
+            },
+            .LongWindow = TCGroupOomTrendWindowConfig{
+                .Duration = TDuration::Hours(1),
+                .RecalculationPeriod = TDuration::Minutes(1),
+                .MinimumRSquared = 0.99,
+            },
+        });
+
+        for (ui64 seconds = 0; seconds <= 3'600; seconds += 30) {
+            const auto recalculated = calculator.AddSample(
+                TMonotonic::Seconds(seconds),
+                MakeMemoryStats(
+                    InitialBytes + GrowthBytesPerSecond * seconds,
+                    MaxBytes));
+            UNIT_ASSERT(
+                recalculated.Contains(ECGroupOomTrendWindow::ShortWindow));
+            UNIT_ASSERT_VALUES_EQUAL(
+                recalculated.Contains(ECGroupOomTrendWindow::LongWindow),
+                seconds % 60 == 0);
+
+            if (seconds == 60) {
+                const auto* shortTrend =
+                    calculator.FindTrend(ECGroupOomTrendWindow::ShortWindow);
+                UNIT_ASSERT(shortTrend);
+                UNIT_ASSERT_DOUBLES_EQUAL(
+                    shortTrend->GrowthBytesPerSecond,
+                    GrowthBytesPerSecond,
+                    1e-12);
+                UNIT_ASSERT_DOUBLES_EQUAL(shortTrend->RSquared, 1.0, 1e-12);
+                UNIT_ASSERT_VALUES_EQUAL(shortTrend->TimeToOom.Seconds(), 4'440);
+                UNIT_ASSERT_VALUES_EQUAL(shortTrend->SampleCount, 3);
+                UNIT_ASSERT(
+                    !calculator.FindTrend(ECGroupOomTrendWindow::LongWindow));
+            }
+        }
+
+        const auto* shortTrend =
+            calculator.FindTrend(ECGroupOomTrendWindow::ShortWindow);
+        const auto* longTrend =
+            calculator.FindTrend(ECGroupOomTrendWindow::LongWindow);
+        UNIT_ASSERT(shortTrend);
+        UNIT_ASSERT(longTrend);
+        UNIT_ASSERT_VALUES_EQUAL(shortTrend->TimeToOom.Seconds(), 900);
+        UNIT_ASSERT_VALUES_EQUAL(longTrend->TimeToOom.Seconds(), 900);
+        UNIT_ASSERT_VALUES_EQUAL(shortTrend->SampleCount, 3);
+        UNIT_ASSERT_VALUES_EQUAL(longTrend->SampleCount, 121);
+
+        auto recalculated = calculator.AddSample(
+            TMonotonic::Seconds(3'630),
+            MakeMemoryStats(
+                InitialBytes + GrowthBytesPerSecond * 3'630,
+                MaxBytes));
+        UNIT_ASSERT(
+            recalculated.Contains(ECGroupOomTrendWindow::ShortWindow));
+        UNIT_ASSERT(
+            !recalculated.Contains(ECGroupOomTrendWindow::LongWindow));
+        shortTrend = calculator.FindTrend(ECGroupOomTrendWindow::ShortWindow);
+        longTrend = calculator.FindTrend(ECGroupOomTrendWindow::LongWindow);
+        UNIT_ASSERT_VALUES_EQUAL(shortTrend->Stats->CurrentBytes, 8'260);
+        UNIT_ASSERT_VALUES_EQUAL(longTrend->Stats->CurrentBytes, 8'200);
+
+        recalculated = calculator.AddSample(
+            TMonotonic::Seconds(3'660),
+            MakeMemoryStats(
+                InitialBytes + GrowthBytesPerSecond * 3'660,
+                MaxBytes));
+        UNIT_ASSERT(
+            recalculated.Contains(ECGroupOomTrendWindow::ShortWindow));
+        UNIT_ASSERT(
+            recalculated.Contains(ECGroupOomTrendWindow::LongWindow));
+        longTrend = calculator.FindTrend(ECGroupOomTrendWindow::LongWindow);
+        UNIT_ASSERT_VALUES_EQUAL(longTrend->Stats->CurrentBytes, 8'320);
+        UNIT_ASSERT_VALUES_EQUAL(longTrend->TimeToOom.Seconds(), 840);
+    }
+
+    Y_UNIT_TEST(RejectsNonLinearOomTrend) {
+        NActors::NDetail::TCGroupOomTrendCalculator calculator({
+            .ShortWindow = TCGroupOomTrendWindowConfig{
+                .Duration = TDuration::Minutes(1),
+                .MinimumRSquared = 0.99,
+            },
+        });
+
+        calculator.AddSample(TMonotonic::Seconds(0), MakeMemoryStats(1'000, 10'000));
+        calculator.AddSample(TMonotonic::Seconds(30), MakeMemoryStats(1'600, 10'000));
+        UNIT_ASSERT(!calculator.HasResult(ECGroupOomTrendWindow::ShortWindow));
+        calculator.AddSample(TMonotonic::Seconds(60), MakeMemoryStats(1'100, 10'000));
+
+        UNIT_ASSERT(calculator.HasResult(ECGroupOomTrendWindow::ShortWindow));
+        UNIT_ASSERT(!calculator.FindTrend(ECGroupOomTrendWindow::ShortWindow));
+    }
+
+    Y_UNIT_TEST(OomControllerNotifiesAndReturnsTrend) {
+        TTempDir tempDir;
+        const TFsPath root = tempDir.Path();
+        WriteFile(root, "proc/self/cgroup", "0::/\n");
+        WriteFile(root, "sys/fs/cgroup/memory.current", "100\n");
+        WriteFile(root, "sys/fs/cgroup/memory.max", "10000\n");
+
+        constexpr auto trendWindow = ECGroupOomTrendWindow::ShortWindow;
+        TCGroupOomConfig oomConfig;
+        oomConfig.ExecutorPoolId = SystemPoolId;
+        oomConfig.PollPeriod = TDuration::MilliSeconds(10);
+        oomConfig.MemoryUsageThreshold.reset();
+        oomConfig.TrendWindows.ShortWindow = TCGroupOomTrendWindowConfig{
+            .Duration = TDuration::MilliSeconds(500),
+            .RecalculationPeriod = TDuration::MilliSeconds(50),
+            .MinimumRSquared = 0,
+        };
+
+        auto actorSystem = MakeActorSystem(
+            MakeCGroupV2StatsSubSystem(MakeV2Config(root)),
+            {},
+            MakeCGroupOomSubSystem(oomConfig));
+        actorSystem->Start();
+
+        TResultWaiter<std::optional<TCGroupOomTrend>> activeResult;
+        TResultWaiter<std::optional<TCGroupOomTrend>> stoppedResult;
+        std::atomic<ui32> activeNotifications = 0;
+        std::atomic<ui32> stoppedNotifications = 0;
+        const TActorId subscriber = actorSystem->Register(
+            new TTrendSubscriberActor(
+                activeResult,
+                stoppedResult,
+                activeNotifications,
+                stoppedNotifications),
+            TMailboxType::Simple,
+            SystemPoolId);
+
+        auto& oom = GetCGroupOomSubSystem(*actorSystem);
+        oom.SubscribeToTrend(
+            subscriber,
+            trendWindow,
+            TDuration::Seconds(10));
+
+        TResultWaiter<std::optional<TCGroupOomTrend>> noTrendResult;
+        RequestOomTrend(*actorSystem, oom, trendWindow, noTrendResult);
+        UNIT_ASSERT(!noTrendResult.Wait(TDuration::MilliSeconds(20)));
+        UNIT_ASSERT(noTrendResult.Wait(TDuration::Seconds(5)));
+        UNIT_ASSERT(!noTrendResult.GetValue());
+
+        for (ui64 currentBytes = 150;
+                currentBytes < 10'000 &&
+                    activeNotifications.load(std::memory_order_relaxed) == 0;
+                currentBytes += 50) {
+            WriteFile(
+                root,
+                "sys/fs/cgroup/memory.current",
+                ToString(currentBytes) + "\n");
+            Sleep(TDuration::MilliSeconds(20));
+        }
+
+        UNIT_ASSERT(activeResult.Wait(TDuration::Seconds(5)));
+        const auto& notification = activeResult.GetValue();
+        UNIT_ASSERT(notification);
+        UNIT_ASSERT(notification->Window == trendWindow);
+        UNIT_ASSERT_VALUES_EQUAL(
+            notification->WindowDuration,
+            TDuration::MilliSeconds(500));
+        UNIT_ASSERT(notification->GrowthBytesPerSecond > 0);
+        UNIT_ASSERT(notification->TimeToOom <= TDuration::Seconds(10));
+
+        for (size_t attempt = 0;
+                attempt < 100 &&
+                    activeNotifications.load(std::memory_order_relaxed) < 2;
+                ++attempt) {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_ASSERT(
+            activeNotifications.load(std::memory_order_relaxed) >= 2);
+
+        TResultWaiter<std::optional<TCGroupOomTrend>> latestResult;
+        RequestOomTrend(*actorSystem, oom, trendWindow, latestResult);
+        UNIT_ASSERT(latestResult.Wait(TDuration::Seconds(5)));
+        const auto& latest = latestResult.GetValue();
+        UNIT_ASSERT(latest);
+        UNIT_ASSERT(latest->Window == trendWindow);
+        UNIT_ASSERT(latest->TimeToOom <= TDuration::Seconds(10));
+
+        WriteFile(root, "sys/fs/cgroup/memory.current", "100\n");
+        UNIT_ASSERT(stoppedResult.Wait(TDuration::Seconds(5)));
+        Sleep(TDuration::MilliSeconds(50));
+        UNIT_ASSERT_VALUES_EQUAL(
+            stoppedNotifications.load(std::memory_order_relaxed),
+            1);
+
+        oom.UnsubscribeFromTrend(subscriber);
         actorSystem->Stop();
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add cgroup OOM trend forecasting using linear regression over configurable short and long memory-usage windows, estimates the time to OOM, and provide actor-based reads and threshold subscriptions with Active updates and Stopped notifications. The implementation separates sampling, recalculation, and notification paths and uses an actor-only API without callbacks or futures

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
