### PR TITLE
More support for disabling old secrets creation and usage

### DIFF
--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -94,7 +94,7 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         sa.SetId(GetOrEmpty(settings, "service_account_id"));
         sa.SetSecretName(GetSecretName(settings, "service_account_secret"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation,sa.GetSecretName());
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, sa.GetSecretName());
             status.IsFail()
         ) {
             return status;
@@ -116,7 +116,7 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         mdbBasic.SetLogin(GetOrEmpty(settings, "login"));
         mdbBasic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation,mdbBasic.GetServiceAccountSecretName());
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetServiceAccountSecretName());
             status.IsFail()
         ) {
             return status;

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -83,8 +83,8 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
     externalDataSourceDesc.SetLocation(GetOrEmpty(settings, "location"));
     externalDataSourceDesc.SetInstallation(GetOrEmpty(settings, "installation"));
 
-    const bool disableOldSecretCreation = actorSystem
-        && AppData(actorSystem)->FeatureFlags.GetDisableOldSecretCreation();
+    const bool disableOldSecretCreation = actorSystem &&
+        AppData(actorSystem)->FeatureFlags.GetDisableOldSecretCreation();
 
     const TString& authMethod = GetOrEmpty(settings, "auth_method");
     if (authMethod == "NONE") {
@@ -93,14 +93,20 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         auto& sa = *externalDataSourceDesc.MutableAuth()->MutableServiceAccount();
         sa.SetId(GetOrEmpty(settings, "service_account_id"));
         sa.SetSecretName(GetSecretName(settings, "service_account_secret"));
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, sa.GetSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation,sa.GetSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
     } else if (authMethod == "BASIC") {
         auto& basic = *externalDataSourceDesc.MutableAuth()->MutableBasic();
         basic.SetLogin(GetOrEmpty(settings, "login"));
         basic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, basic.GetPasswordSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, basic.GetPasswordSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
     } else if (authMethod == "MDB_BASIC") {
@@ -109,10 +115,16 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         mdbBasic.SetServiceAccountSecretName(GetSecretName(settings, "service_account_secret"));
         mdbBasic.SetLogin(GetOrEmpty(settings, "login"));
         mdbBasic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetServiceAccountSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation,mdbBasic.GetServiceAccountSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetPasswordSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetPasswordSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
     } else if (authMethod == "AWS") {
@@ -120,16 +132,25 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         aws.SetAwsAccessKeyIdSecretName(GetSecretName(settings, "aws_access_key_id_secret"));
         aws.SetAwsSecretAccessKeySecretName(GetSecretName(settings, "aws_secret_access_key_secret"));
         aws.SetAwsRegion(GetOrEmpty(settings, "aws_region"));
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsAccessKeyIdSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsAccessKeyIdSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsSecretAccessKeySecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsSecretAccessKeySecretName());
+            status.IsFail()
+        ) {
             return status;
         }
     } else if (authMethod == "TOKEN") {
         auto& token = *externalDataSourceDesc.MutableAuth()->MutableToken();
         token.SetTokenSecretName(GetSecretName(settings, "token_secret"));
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, token.GetTokenSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, token.GetTokenSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
     } else if (authMethod == "IAM") {
@@ -138,7 +159,10 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         iam.SetInitialTokenSecretName(GetSecretName(settings, "initial_token_secret"));
         // Note: user must not be allowed to specify resource_id;
         // database authorization relies on resource_id lookup;
-        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, iam.GetInitialTokenSecretName()); status.IsFail()) {
+        if (const auto status =
+            CheckOldSecretCreationAllowed(disableOldSecretCreation, iam.GetInitialTokenSecretName());
+            status.IsFail()
+        ) {
             return status;
         }
     } else {

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -67,7 +67,7 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
     if (disableOldSecretCreation && secretName && !NSecret::IsSchemeSecret(secretName)) {
         return TYqlConclusionStatus::Fail(
             NYql::TIssuesIds::KIKIMR_BAD_REQUEST,
-            "Old secrets creation syntax is disabled now. Please use the new one");
+            "Old secrets are disabled for creating new objects. Please use the new secrets");
     }
     return TYqlConclusionStatus::Success();
 }

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -10,6 +10,7 @@
 #include <ydb/library/conclusion/generic/result.h>
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/core/external_sources/iceberg_fields.h>
+#include <ydb/services/scheme_secret/resolver.h>
 
 namespace NKikimr::NKqp {
 
@@ -60,6 +61,17 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
     return GetOrEmpty(settings, secretKeyPrefix + "_path");
 }
 
+[[nodiscard]] TYqlConclusionStatus CheckOldSecretCreationAllowed(
+    bool disableOldSecretCreation, const TString& secretName)
+{
+    if (disableOldSecretCreation && secretName && !NSecret::IsSchemeSecret(secretName)) {
+        return TYqlConclusionStatus::Fail(
+            NYql::TIssuesIds::KIKIMR_BAD_REQUEST,
+            "Old secrets creation syntax is disabled now. Please use the new one");
+    }
+    return TYqlConclusionStatus::Success();
+}
+
 [[nodiscard]] TYqlConclusionStatus FillCreateExternalDataSourceDesc(
     NKikimrSchemeOp::TExternalDataSourceDescription& externalDataSourceDesc,
     const TString& name,
@@ -71,6 +83,9 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
     externalDataSourceDesc.SetLocation(GetOrEmpty(settings, "location"));
     externalDataSourceDesc.SetInstallation(GetOrEmpty(settings, "installation"));
 
+    const bool disableOldSecretCreation = actorSystem
+        && AppData(actorSystem)->FeatureFlags.GetDisableOldSecretCreation();
+
     const TString& authMethod = GetOrEmpty(settings, "auth_method");
     if (authMethod == "NONE") {
         externalDataSourceDesc.MutableAuth()->MutableNone();
@@ -78,30 +93,54 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         auto& sa = *externalDataSourceDesc.MutableAuth()->MutableServiceAccount();
         sa.SetId(GetOrEmpty(settings, "service_account_id"));
         sa.SetSecretName(GetSecretName(settings, "service_account_secret"));
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, sa.GetSecretName()); status.IsFail()) {
+            return status;
+        }
     } else if (authMethod == "BASIC") {
         auto& basic = *externalDataSourceDesc.MutableAuth()->MutableBasic();
         basic.SetLogin(GetOrEmpty(settings, "login"));
         basic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, basic.GetPasswordSecretName()); status.IsFail()) {
+            return status;
+        }
     } else if (authMethod == "MDB_BASIC") {
         auto& mdbBasic = *externalDataSourceDesc.MutableAuth()->MutableMdbBasic();
         mdbBasic.SetServiceAccountId(GetOrEmpty(settings, "service_account_id"));
         mdbBasic.SetServiceAccountSecretName(GetSecretName(settings, "service_account_secret"));
         mdbBasic.SetLogin(GetOrEmpty(settings, "login"));
         mdbBasic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetServiceAccountSecretName()); status.IsFail()) {
+            return status;
+        }
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetPasswordSecretName()); status.IsFail()) {
+            return status;
+        }
     } else if (authMethod == "AWS") {
         auto& aws = *externalDataSourceDesc.MutableAuth()->MutableAws();
         aws.SetAwsAccessKeyIdSecretName(GetSecretName(settings, "aws_access_key_id_secret"));
         aws.SetAwsSecretAccessKeySecretName(GetSecretName(settings, "aws_secret_access_key_secret"));
         aws.SetAwsRegion(GetOrEmpty(settings, "aws_region"));
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsAccessKeyIdSecretName()); status.IsFail()) {
+            return status;
+        }
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsSecretAccessKeySecretName()); status.IsFail()) {
+            return status;
+        }
     } else if (authMethod == "TOKEN") {
         auto& token = *externalDataSourceDesc.MutableAuth()->MutableToken();
         token.SetTokenSecretName(GetSecretName(settings, "token_secret"));
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, token.GetTokenSecretName()); status.IsFail()) {
+            return status;
+        }
     } else if (authMethod == "IAM") {
         auto& iam = *externalDataSourceDesc.MutableAuth()->MutableIam();
         iam.SetServiceAccountId(GetOrEmpty(settings, "service_account_id"));
         iam.SetInitialTokenSecretName(GetSecretName(settings, "initial_token_secret"));
         // Note: user must not be allowed to specify resource_id;
         // database authorization relies on resource_id lookup;
+        if (auto status = CheckOldSecretCreationAllowed(disableOldSecretCreation, iam.GetInitialTokenSecretName()); status.IsFail()) {
+            return status;
+        }
     } else {
         return TYqlConclusionStatus::Fail(NYql::TIssuesIds::KIKIMR_INTERNAL_ERROR, TStringBuilder() << "Internal error. Unknown auth method: " << authMethod);
     }

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/manager.cpp
@@ -62,12 +62,13 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
 }
 
 [[nodiscard]] TYqlConclusionStatus CheckOldSecretCreationAllowed(
-    bool disableOldSecretCreation, const TString& secretName)
+    bool disableOldSecretCreation,
+    const TString& secretName)
 {
     if (disableOldSecretCreation && secretName && !NSecret::IsSchemeSecret(secretName)) {
         return TYqlConclusionStatus::Fail(
             NYql::TIssuesIds::KIKIMR_BAD_REQUEST,
-            "Old secrets are disabled for creating new objects. Please use the new secrets");
+            "Old secrets are disabled for creating new objects. Please use new secrets");
     }
     return TYqlConclusionStatus::Success();
 }
@@ -94,9 +95,9 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         sa.SetId(GetOrEmpty(settings, "service_account_id"));
         sa.SetSecretName(GetSecretName(settings, "service_account_secret"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, sa.GetSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, sa.GetSecretName()); status.IsFail())
+        {
             return status;
         }
     } else if (authMethod == "BASIC") {
@@ -104,9 +105,9 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         basic.SetLogin(GetOrEmpty(settings, "login"));
         basic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, basic.GetPasswordSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, basic.GetPasswordSecretName()); status.IsFail())
+        {
             return status;
         }
     } else if (authMethod == "MDB_BASIC") {
@@ -116,15 +117,15 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         mdbBasic.SetLogin(GetOrEmpty(settings, "login"));
         mdbBasic.SetPasswordSecretName(GetSecretName(settings, "password_secret"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetServiceAccountSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, mdbBasic.GetServiceAccountSecretName()); status.IsFail())
+        {
             return status;
         }
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, mdbBasic.GetPasswordSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, mdbBasic.GetPasswordSecretName()); status.IsFail())
+        {
             return status;
         }
     } else if (authMethod == "AWS") {
@@ -133,24 +134,24 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         aws.SetAwsSecretAccessKeySecretName(GetSecretName(settings, "aws_secret_access_key_secret"));
         aws.SetAwsRegion(GetOrEmpty(settings, "aws_region"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsAccessKeyIdSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, aws.GetAwsAccessKeyIdSecretName()); status.IsFail())
+        {
             return status;
         }
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, aws.GetAwsSecretAccessKeySecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, aws.GetAwsSecretAccessKeySecretName()); status.IsFail())
+        {
             return status;
         }
     } else if (authMethod == "TOKEN") {
         auto& token = *externalDataSourceDesc.MutableAuth()->MutableToken();
         token.SetTokenSecretName(GetSecretName(settings, "token_secret"));
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, token.GetTokenSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, token.GetTokenSecretName()); status.IsFail())
+        {
             return status;
         }
     } else if (authMethod == "IAM") {
@@ -160,9 +161,9 @@ TString GetSecretName(const NYql::TCreateObjectSettings& settings, const TString
         // Note: user must not be allowed to specify resource_id;
         // database authorization relies on resource_id lookup;
         if (const auto status =
-            CheckOldSecretCreationAllowed(disableOldSecretCreation, iam.GetInitialTokenSecretName());
-            status.IsFail()
-        ) {
+            CheckOldSecretCreationAllowed(
+                disableOldSecretCreation, iam.GetInitialTokenSecretName()); status.IsFail())
+        {
             return status;
         }
     } else {

--- a/ydb/core/kqp/gateway/behaviour/external_data_source/ya.make
+++ b/ydb/core/kqp/gateway/behaviour/external_data_source/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     ydb/services/metadata/abstract
     ydb/services/metadata/initializer
     ydb/services/metadata/secret
+    ydb/services/scheme_secret
 )
 
 YQL_LAST_ABI_VERSION()

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1094,7 +1094,7 @@ namespace {
                 // Keep in sync with NKikimr::NSecret::IsSchemeSecret.
                 if (secretName && !secretName.StartsWith('/')) {
                     ctx.AddError(TIssue(ctx.GetPosition(pos),
-                        "Old secrets creation syntax is disabled now. Please use the new one"));
+                        "Old secrets are disabled for creating new objects. Please use the new secrets"));
                     return false;
                 }
                 return true;

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -990,7 +990,7 @@ namespace {
 
     bool ParseAsyncReplicationSettingsBase(
         TReplicationSettingsBase& dstSettings, const TCoNameValueTupleList& srcSettings, TExprContext& ctx, TPositionHandle pos,
-        const TString& objectName = "replication"
+        bool disableOldSecretCreation, const TString& objectName = "replication"
     ) {
         for (auto setting : srcSettings) {
             auto name = setting.Name().Value();
@@ -1089,14 +1089,37 @@ namespace {
             return false;
         }
 
+        if (disableOldSecretCreation) {
+            auto checkSecret = [&](const TString& secretName) {
+                // Keep in sync with NKikimr::NSecret::IsSchemeSecret.
+                if (secretName && !secretName.StartsWith('/')) {
+                    ctx.AddError(TIssue(ctx.GetPosition(pos),
+                        "Old secrets creation syntax is disabled now. Please use the new one"));
+                    return false;
+                }
+                return true;
+            };
+
+            if (const auto& x = dstSettings.OAuthToken; x && !checkSecret(x->TokenSecretName)) {
+                return false;
+            }
+            if (const auto& x = dstSettings.StaticCredentials; x && !checkSecret(x->PasswordSecretName)) {
+                return false;
+            }
+            if (const auto& x = dstSettings.IamCredentials; x && !checkSecret(x->InitialToken.TokenSecretName)) {
+                return false;
+            }
+        }
+
         return true;
     }
 
     bool ParseAsyncReplicationSettings(
-        TReplicationSettings& dstSettings, const TCoNameValueTupleList& srcSettings, TExprContext& ctx, TPositionHandle pos
+        TReplicationSettings& dstSettings, const TCoNameValueTupleList& srcSettings, TExprContext& ctx, TPositionHandle pos,
+        bool disableOldSecretCreation
     ) {
 
-        if (!ParseAsyncReplicationSettingsBase(dstSettings, srcSettings, ctx, pos)) {
+        if (!ParseAsyncReplicationSettingsBase(dstSettings, srcSettings, ctx, pos, disableOldSecretCreation)) {
             return false;
         }
 
@@ -1138,9 +1161,10 @@ namespace {
     }
 
     bool ParseTransferSettings(
-        TTransferSettings& dstSettings, const TCoNameValueTupleList& srcSettings, TExprContext& ctx, TPositionHandle pos
+        TTransferSettings& dstSettings, const TCoNameValueTupleList& srcSettings, TExprContext& ctx, TPositionHandle pos,
+        bool disableOldSecretCreation
     ) {
-        if (!ParseAsyncReplicationSettingsBase(dstSettings, srcSettings, ctx, pos, "transfer")) {
+        if (!ParseAsyncReplicationSettingsBase(dstSettings, srcSettings, ctx, pos, disableOldSecretCreation, "transfer")) {
             return false;
         }
 
@@ -3392,7 +3416,8 @@ public:
                 );
             }
 
-            if (!ParseAsyncReplicationSettings(settings.Settings, createReplication.ReplicationSettings(), ctx, createReplication.Pos())) {
+            if (!ParseAsyncReplicationSettings(settings.Settings, createReplication.ReplicationSettings(), ctx, createReplication.Pos(),
+                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
                 return SyncError();
             }
 
@@ -3448,7 +3473,8 @@ public:
             TAlterReplicationSettings settings;
             settings.Name = TString(alterReplication.Replication());
 
-            if (!ParseAsyncReplicationSettings(settings.Settings, alterReplication.ReplicationSettings(), ctx, alterReplication.Pos())) {
+            if (!ParseAsyncReplicationSettings(settings.Settings, alterReplication.ReplicationSettings(), ctx, alterReplication.Pos(),
+                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
                 return SyncError();
             }
 
@@ -3503,7 +3529,8 @@ public:
                 createTransfer.TransformLambda()
             };
 
-            if (!ParseTransferSettings(settings.Settings, createTransfer.TransferSettings(), ctx, createTransfer.Pos())) {
+            if (!ParseTransferSettings(settings.Settings, createTransfer.TransferSettings(), ctx, createTransfer.Pos(),
+                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
                 return SyncError();
             }
 
@@ -3560,7 +3587,8 @@ public:
             settings.Name = TString(alterTransfer.Transfer());
             settings.TranformLambda = alterTransfer.TransformLambda();
 
-            if (!ParseTransferSettings(settings.Settings, alterTransfer.TransferSettings(), ctx, alterTransfer.Pos())) {
+            if (!ParseTransferSettings(settings.Settings, alterTransfer.TransferSettings(), ctx, alterTransfer.Pos(),
+                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
                 return SyncError();
             }
 

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1091,10 +1091,13 @@ namespace {
 
         if (disableOldSecretCreation) {
             auto checkSecret = [&](const TString& secretName) {
-                // Keep in sync with NKikimr::NSecret::IsSchemeSecret.
                 if (secretName && !secretName.StartsWith('/')) {
-                    ctx.AddError(TIssue(ctx.GetPosition(pos),
-                        "Old secrets are disabled for creating new objects. Please use the new secrets"));
+                    ctx.AddError(
+                        TIssue(
+                            ctx.GetPosition(pos),
+                            "Old secrets are disabled for creating new objects. Please use the new secrets"
+                        )
+                    );
                     return false;
                 }
                 return true;
@@ -3416,8 +3419,9 @@ public:
                 );
             }
 
-            if (!ParseAsyncReplicationSettings(settings.Settings, createReplication.ReplicationSettings(), ctx, createReplication.Pos(),
-                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
+            if (!ParseAsyncReplicationSettings(settings.Settings, createReplication.ReplicationSettings(), ctx,
+                createReplication.Pos(), SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
+            ) {
                 return SyncError();
             }
 
@@ -3473,8 +3477,10 @@ public:
             TAlterReplicationSettings settings;
             settings.Name = TString(alterReplication.Replication());
 
-            if (!ParseAsyncReplicationSettings(settings.Settings, alterReplication.ReplicationSettings(), ctx, alterReplication.Pos(),
-                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
+            if (!ParseAsyncReplicationSettings(
+                settings.Settings, alterReplication.ReplicationSettings(), ctx, alterReplication.Pos(),
+                SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
+            ) {
                 return SyncError();
             }
 
@@ -3530,7 +3536,8 @@ public:
             };
 
             if (!ParseTransferSettings(settings.Settings, createTransfer.TransferSettings(), ctx, createTransfer.Pos(),
-                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
+                SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
+            ) {
                 return SyncError();
             }
 
@@ -3588,7 +3595,8 @@ public:
             settings.TranformLambda = alterTransfer.TransformLambda();
 
             if (!ParseTransferSettings(settings.Settings, alterTransfer.TransferSettings(), ctx, alterTransfer.Pos(),
-                    SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())) {
+                SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
+            ) {
                 return SyncError();
             }
 

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -1095,7 +1095,7 @@ namespace {
                     ctx.AddError(
                         TIssue(
                             ctx.GetPosition(pos),
-                            "Old secrets are disabled for creating new objects. Please use the new secrets"
+                            "Old secrets are disabled for creating new objects. Please use new secrets"
                         )
                     );
                     return false;
@@ -3419,8 +3419,12 @@ public:
                 );
             }
 
-            if (!ParseAsyncReplicationSettings(settings.Settings, createReplication.ReplicationSettings(), ctx,
-                createReplication.Pos(), SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
+            if (!ParseAsyncReplicationSettings(
+                settings.Settings,
+                createReplication.ReplicationSettings(),
+                ctx,
+                createReplication.Pos(),
+                SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
             ) {
                 return SyncError();
             }
@@ -3535,7 +3539,11 @@ public:
                 createTransfer.TransformLambda()
             };
 
-            if (!ParseTransferSettings(settings.Settings, createTransfer.TransferSettings(), ctx, createTransfer.Pos(),
+            if (!ParseTransferSettings(
+                settings.Settings,
+                createTransfer.TransferSettings(),
+                ctx,
+                createTransfer.Pos(),
                 SessionCtx->Config().FeatureFlags.GetDisableOldSecretCreation())
             ) {
                 return SyncError();

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -15029,7 +15029,7 @@ END DO)",
 
             UNIT_ASSERT_STRING_CONTAINS_C(
                 result.GetIssues().ToString(),
-                "Old secrets creation syntax is disabled now. Please use the new one",
+                "Old secrets creation syntax is disabled now. Please use the new secrets",
                 result.GetIssues().ToString());
         }
         { // upsert
@@ -15041,7 +15041,7 @@ END DO)",
 
             UNIT_ASSERT_STRING_CONTAINS_C(
                 result.GetIssues().ToString(),
-                "Old secrets creation syntax is disabled now. Please use the new one",
+                "Old secrets creation syntax is disabled now. Please use the new secrets",
                 result.GetIssues().ToString());
         }
         { // alter

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -15066,6 +15066,37 @@ END DO)",
         }
     }
 
+    Y_UNIT_TEST(CreateExternalDataSourceWithOldSecretDisabled) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableExternalDataSources(true);
+        featureFlags.SetDisableOldSecretCreation(true);
+        featureFlags.SetDisableOldSecrets(true);
+
+        NKqp::TKikimrSettings settings;
+        settings.SetFeatureFlags(featureFlags);
+        settings.AppConfig.MutableQueryServiceConfig()->AddAvailableExternalDataSources("ObjectStorage");
+        TKikimrRunner kikimr(settings);
+
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+
+        static const auto query = R"sql(
+            CREATE EXTERNAL DATA SOURCE `/Root/ExternalDataSource` WITH (
+                SOURCE_TYPE="ObjectStorage",
+                LOCATION="my-bucket",
+                AUTH_METHOD="SERVICE_ACCOUNT",
+                SERVICE_ACCOUNT_ID="mysa",
+                SERVICE_ACCOUNT_SECRET_NAME="OldSecret"
+            );
+        )sql";
+        const auto result = session.ExecuteSchemeQuery(query).GetValueSync();
+        UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
+        UNIT_ASSERT_STRING_CONTAINS_C(
+            result.GetIssues().ToString(),
+            "Old secrets are disabled for creating new objects. Please use the new secrets",
+            result.GetIssues().ToString());
+    }
+
     Y_UNIT_TEST(SimpleTruncateTableFullPathTableClient) {
         TestTruncateTable("`/Root/TestTable`", false);
     }

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -15029,7 +15029,7 @@ END DO)",
 
             UNIT_ASSERT_STRING_CONTAINS_C(
                 result.GetIssues().ToString(),
-                "Old secrets creation syntax is disabled now. Please use the new secrets",
+                "Old secrets creation syntax is disabled now. Please use the new one",
                 result.GetIssues().ToString());
         }
         { // upsert
@@ -15041,7 +15041,7 @@ END DO)",
 
             UNIT_ASSERT_STRING_CONTAINS_C(
                 result.GetIssues().ToString(),
-                "Old secrets creation syntax is disabled now. Please use the new secrets",
+                "Old secrets creation syntax is disabled now. Please use the new one",
                 result.GetIssues().ToString());
         }
         { // alter
@@ -15093,7 +15093,7 @@ END DO)",
         UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::BAD_REQUEST, result.GetIssues().ToString());
         UNIT_ASSERT_STRING_CONTAINS_C(
             result.GetIssues().ToString(),
-            "Old secrets are disabled for creating new objects. Please use the new secrets",
+            "Old secrets are disabled for creating new objects. Please use new secrets",
             result.GetIssues().ToString());
     }
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -356,4 +356,5 @@ message TFeatureFlags {
     optional bool EnableHasPredicatesInResourcePoolClassifiers = 303 [default = false];
     optional bool EnableRejectActionInResourcePoolClassifiers = 304 [default = false];
     optional bool EnableMoveWithColumnTableReplace = 305 [default = false];
+    optional bool DisableOldSecrets = 306 [default = false];
 }

--- a/ydb/core/tx/replication/controller/secret_resolver.cpp
+++ b/ydb/core/tx/replication/controller/secret_resolver.cpp
@@ -61,7 +61,7 @@ class TSecretResolver: public TActorBootstrapped<TSecretResolver> {
                 actorSystem->Send(replyActorId, new NKqp::TEvDescribeSecretsResponse(result.GetValue()));
             });
         } else if (AppData()->FeatureFlags.GetDisableOldSecrets()) {
-            return Reply(false, "Old secrets usage is disabled now. Please use the new one");
+            return Reply(false, "Usage of old secrets is disabled now. Please use the new secrets");
         } else {
             Send(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()),
                 new NMetadata::NProvider::TEvAskSnapshot(SnapshotFetcher()));

--- a/ydb/core/tx/replication/controller/secret_resolver.cpp
+++ b/ydb/core/tx/replication/controller/secret_resolver.cpp
@@ -61,6 +61,7 @@ class TSecretResolver: public TActorBootstrapped<TSecretResolver> {
                 actorSystem->Send(replyActorId, new NKqp::TEvDescribeSecretsResponse(result.GetValue()));
             });
         } else if (AppData()->FeatureFlags.GetDisableOldSecrets()) {
+            // Just in case - when we disable old secrets, we'll make sure they are not needed any more
             return Reply(false, "Usage of old secrets is disabled now. Please use the new secrets");
         } else {
             Send(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()),

--- a/ydb/core/tx/replication/controller/secret_resolver.cpp
+++ b/ydb/core/tx/replication/controller/secret_resolver.cpp
@@ -60,6 +60,8 @@ class TSecretResolver: public TActorBootstrapped<TSecretResolver> {
             future.Subscribe([actorSystem, replyActorId](const NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription>& result) {
                 actorSystem->Send(replyActorId, new NKqp::TEvDescribeSecretsResponse(result.GetValue()));
             });
+        } else if (AppData()->FeatureFlags.GetDisableOldSecrets()) {
+            return Reply(false, "Old secrets usage is disabled now. Please use the new one");
         } else {
             Send(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()),
                 new NMetadata::NProvider::TEvAskSnapshot(SnapshotFetcher()));

--- a/ydb/core/tx/replication/controller/secret_resolver.cpp
+++ b/ydb/core/tx/replication/controller/secret_resolver.cpp
@@ -62,7 +62,7 @@ class TSecretResolver: public TActorBootstrapped<TSecretResolver> {
             });
         } else if (AppData()->FeatureFlags.GetDisableOldSecrets()) {
             // Just in case - when we disable old secrets, we'll make sure they are not needed any more
-            return Reply(false, "Usage of old secrets is disabled now. Please use the new secrets");
+            return Reply(false, "Usage of old secrets is disabled now. Please use new secrets");
         } else {
             Send(NMetadata::NProvider::MakeServiceId(SelfId().NodeId()),
                 new NMetadata::NProvider::TEvAskSnapshot(SnapshotFetcher()));

--- a/ydb/services/metadata/manager/abstract.cpp
+++ b/ydb/services/metadata/manager/abstract.cpp
@@ -19,7 +19,7 @@ bool IsOldSecretType(const TString& typeId) {
 } // namespace
 
 const TString& GetOldSecretCreationDisabledMessage() {
-    static const TString message("Old secrets creation syntax is disabled now. Please use the new one");
+    static const TString message("Old secrets creation syntax is disabled now. Please use the new secrets");
     return message;
 }
 

--- a/ydb/services/metadata/manager/abstract.cpp
+++ b/ydb/services/metadata/manager/abstract.cpp
@@ -19,7 +19,7 @@ bool IsOldSecretType(const TString& typeId) {
 } // namespace
 
 const TString& GetOldSecretCreationDisabledMessage() {
-    static const TString message("Old secrets creation syntax is disabled now. Please use the new secrets");
+    static const TString message("Old secrets creation syntax is disabled now. Please use the new one");
     return message;
 }
 

--- a/ydb/services/scheme_secret/resolver.h
+++ b/ydb/services/scheme_secret/resolver.h
@@ -29,9 +29,7 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
     TDescribeSecretSettings settings = {}
 );
 
-inline bool IsSchemeSecret(const TString& secretName) {
-    return secretName.StartsWith('/');
-}
+bool IsSchemeSecret(const TString& secretName);
 
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TVector<TString>& secretNames);
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TString& secretName);

--- a/ydb/services/scheme_secret/resolver.h
+++ b/ydb/services/scheme_secret/resolver.h
@@ -29,6 +29,10 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
     TDescribeSecretSettings settings = {}
 );
 
+inline bool IsSchemeSecret(const TString& secretName) {
+    return secretName.StartsWith('/');
+}
+
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TVector<TString>& secretNames);
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TString& secretName);
 

--- a/ydb/services/scheme_secret/service.cpp
+++ b/ydb/services/scheme_secret/service.cpp
@@ -666,6 +666,16 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
         return promise.GetFuture();
     }
 
+    if (AppData()->FeatureFlags.GetDisableOldSecrets()) {
+        promise.SetValue(
+            NKqp::TEvDescribeSecretsResponse::TDescription(
+                Ydb::StatusIds::BAD_REQUEST,
+                { NYql::TIssue("Old secrets usage is disabled now. Please use the new one") }
+            )
+        );
+        return promise.GetFuture();
+    }
+
     actorSystem->Register(CreateDescribeSecretsActor(userToken ? userToken->GetUserSID() : "", secretNames, promise));
     return promise.GetFuture();
 }
@@ -680,7 +690,7 @@ bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TVector<TString
     }
 
     for (const auto& secretName : secretNames) {
-        if (!secretName.StartsWith('/')) {
+        if (!IsSchemeSecret(secretName)) {
             return false;
         }
     }
@@ -689,7 +699,7 @@ bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TVector<TString
 }
 
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TString& secretName) {
-    return flags.GetEnableSchemaSecrets() && secretName.StartsWith('/');
+    return flags.GetEnableSchemaSecrets() && IsSchemeSecret(secretName);
 }
 
 }  // namespace NKikimr::NSecret

--- a/ydb/services/scheme_secret/service.cpp
+++ b/ydb/services/scheme_secret/service.cpp
@@ -670,7 +670,7 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
         promise.SetValue(
             NKqp::TEvDescribeSecretsResponse::TDescription(
                 Ydb::StatusIds::BAD_REQUEST,
-                { NYql::TIssue("Old secrets usage is disabled now. Please use the new one") }
+                { NYql::TIssue("Usage of old secrets is disabled now. Please use the new secrets") }
             )
         );
         return promise.GetFuture();

--- a/ydb/services/scheme_secret/service.cpp
+++ b/ydb/services/scheme_secret/service.cpp
@@ -667,6 +667,7 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
     }
 
     if (AppData()->FeatureFlags.GetDisableOldSecrets()) {
+        // Just in case - when we disable old secrets, we'll make sure they are not needed any more
         promise.SetValue(
             NKqp::TEvDescribeSecretsResponse::TDescription(
                 Ydb::StatusIds::BAD_REQUEST,
@@ -682,6 +683,10 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
 
 IActor* TDescribeSchemaSecretsServiceFactory::CreateService() {
     return new TDescribeSchemaSecretsService();
+}
+
+bool IsSchemeSecret(const TString& secretName) {
+    return secretName.StartsWith('/');
 }
 
 bool UseSchemaSecrets(const NKikimr::TFeatureFlags& flags, const TVector<TString>& secretNames) {

--- a/ydb/services/scheme_secret/service.cpp
+++ b/ydb/services/scheme_secret/service.cpp
@@ -671,7 +671,7 @@ NThreading::TFuture<NKqp::TEvDescribeSecretsResponse::TDescription> DescribeSecr
         promise.SetValue(
             NKqp::TEvDescribeSecretsResponse::TDescription(
                 Ydb::StatusIds::BAD_REQUEST,
-                { NYql::TIssue("Usage of old secrets is disabled now. Please use the new secrets") }
+                { NYql::TIssue("Usage of old secrets is disabled now. Please use new secrets") }
             )
         );
         return promise.GetFuture();

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -14,8 +14,9 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 logger = logging.getLogger(__name__)
 
 DATABASE = "/Root"
-OLD_SECRET_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new one"
-OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Old secrets usage is disabled now. Please use the new one"
+OLD_SECRETS_CREATION_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new secrets"
+CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE = "Old secrets are disabled for creating new objects. Please use the new secrets"
+OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Usage of old secrets is disabled now. Please use the new secrets"
 
 
 def setup_s3():
@@ -307,12 +308,12 @@ def test_disable_old_secret_creation(old_secrets_utils):
     # check that old secret can't be created
     with pytest.raises(Exception) as exc_info:
         old_secrets_utils.create_old_secret("NewOldSecret", value="")
-    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+    assert OLD_SECRETS_CREATION_DISABLED_MESSAGE in str(exc_info.value)
 
     # check that old secret can't be upserted
     with pytest.raises(Exception) as exc_info:
         old_secrets_utils.upsert_old_secret("NewOldSecretUpsert", value="")
-    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+    assert OLD_SECRETS_CREATION_DISABLED_MESSAGE in str(exc_info.value)
 
     # check that old objects are still OK
     old_secrets_utils.assert_path_ready(f"{DATABASE}/eds-old-secret")
@@ -322,7 +323,7 @@ def test_disable_old_secret_creation(old_secrets_utils):
     # check that old secrets can't be used for eds
     with pytest.raises(Exception) as exc_info:
         old_secrets_utils.create_eds("eds-with-old-secret", "OldSecret")
-    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
     # check that old secrets can't be used for replication
     with pytest.raises(Exception) as exc_info:
@@ -332,7 +333,7 @@ def test_disable_old_secret_creation(old_secrets_utils):
             "repl_dst_old",
             "OldSecret",
         )
-    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
     # check that old secrets can't be used for transfer
     with pytest.raises(Exception) as exc_info:
@@ -342,7 +343,7 @@ def test_disable_old_secret_creation(old_secrets_utils):
             "transfer_dst",
             "OldSecret",
         )
-    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
     # check that new secret can be still used
     old_secrets_utils.create_schema_secret(f"{DATABASE}/NewSecret", value="")

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 
+import boto3
 import pytest
+import requests
 
 from ydb.tests.library.common.wait_for import wait_for
 from ydb.tests.library.harness.kikimr_runner import KiKiMR
@@ -11,6 +14,26 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 logger = logging.getLogger(__name__)
 
 DATABASE = "/Root"
+OLD_SECRET_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new one"
+OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Old secrets usage is disabled now. Please use the new one"
+
+
+def setup_s3():
+    s3_endpoint = os.getenv("S3_ENDPOINT")
+    s3_access_key = "minio"
+    s3_secret_key = "minio123"
+    s3_bucket = "test_bucket_old_secrets"
+
+    resource = boto3.resource(
+        "s3", endpoint_url=s3_endpoint, aws_access_key_id=s3_access_key, aws_secret_access_key=s3_secret_key
+    )
+
+    bucket = resource.Bucket(s3_bucket)
+    bucket.create()
+    bucket.objects.all().delete()
+    bucket.put_object(Key="file.txt", Body="Hello S3!")
+
+    return s3_endpoint, s3_access_key, s3_secret_key, s3_bucket
 
 
 class Utils:
@@ -23,14 +46,19 @@ class Utils:
 
         self.driver = None
         self.session_pool = None
+        self.query_session_pool = None
         self._start_client()
 
     def _start_client(self):
         self.driver = ydb.Driver(endpoint=self.cluster.nodes[1].endpoint, database=DATABASE)
         self.driver.wait(5, fail_fast=True)
         self.session_pool = ydb.SessionPool(self.driver)
+        self.query_session_pool = ydb.QuerySessionPool(self.driver)
 
     def _stop_client(self):
+        if self.query_session_pool is not None:
+            self.query_session_pool.stop()
+            self.query_session_pool = None
         if self.session_pool is not None:
             self.session_pool.stop()
             self.session_pool = None
@@ -42,9 +70,15 @@ class Utils:
         self._stop_client()
         self.cluster.stop()
 
-    def restart_cluster(self, disable_old_secret_creation, enable_schema_secrets=True):
+    def restart_cluster(
+        self,
+        disable_old_secret_creation=False,
+        disable_old_secrets=False,
+        enable_schema_secrets=True,
+    ):
         self._stop_client()
         self.config.yaml_config["feature_flags"]["disable_old_secret_creation"] = disable_old_secret_creation
+        self.config.yaml_config["feature_flags"]["disable_old_secrets"] = disable_old_secrets
         self.config.yaml_config["feature_flags"]["enable_schema_secrets"] = enable_schema_secrets
         self.cluster.update_configurator_and_restart(self.config)
         self._start_client_after_restart()
@@ -68,34 +102,166 @@ class Utils:
 
         self.driver = driver_holder["driver"]
         self.session_pool = ydb.SessionPool(self.driver)
+        self.query_session_pool = ydb.QuerySessionPool(self.driver)
 
-    def create_old_secret(self, secret_name, value):
+    def execute_scheme(self, query):
         with self.session_pool.checkout() as session:
-            session.execute_scheme(f"CREATE OBJECT {secret_name} (TYPE SECRET) WITH value='{value}';")
-
-    def upsert_old_secret(self, secret_name, value):
-        with self.session_pool.checkout() as session:
-            session.execute_scheme(f"UPSERT OBJECT {secret_name} (TYPE SECRET) WITH value='{value}';")
-
-    def alter_old_secret(self, secret_name, value):
-        with self.session_pool.checkout() as session:
-            session.execute_scheme(f"ALTER OBJECT {secret_name} (TYPE SECRET) SET value='{value}';")
-
-    def create_eds(self, eds_name, secret_name):
-        with self.session_pool.checkout() as session:
-            query = f"""
-                CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
-                    SOURCE_TYPE="ObjectStorage",
-                    LOCATION="my-bucket",
-                    AUTH_METHOD="SERVICE_ACCOUNT",
-                    SERVICE_ACCOUNT_ID="mysa",
-                    SERVICE_ACCOUNT_SECRET_NAME="{secret_name}"
-                );"""
             session.execute_scheme(query)
 
+    def execute_query(self, query):
+        return self.query_session_pool.execute_with_retries(query)
+
+    def create_old_secret(self, secret_name, value):
+        self.execute_scheme(f"CREATE OBJECT {secret_name} (TYPE SECRET) WITH value='{value}';")
+
+    def upsert_old_secret(self, secret_name, value):
+        self.execute_scheme(f"UPSERT OBJECT {secret_name} (TYPE SECRET) WITH value='{value}';")
+
+    def alter_old_secret(self, secret_name, value):
+        self.execute_scheme(f"ALTER OBJECT {secret_name} (TYPE SECRET) SET value='{value}';")
+
+    def create_eds(self, eds_name, secret_name, schema_secret=False):
+        secret_setting = "SERVICE_ACCOUNT_SECRET_PATH" if schema_secret else "SERVICE_ACCOUNT_SECRET_NAME"
+        query = f"""
+            CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
+                SOURCE_TYPE="ObjectStorage",
+                LOCATION="my-bucket",
+                AUTH_METHOD="SERVICE_ACCOUNT",
+                SERVICE_ACCOUNT_ID="mysa",
+                {secret_setting}="{secret_name}"
+            );"""
+        self.execute_scheme(query)
+
+    def create_eds_aws(self, eds_name, access_key_secret, secret_key_secret, s3_location):
+        query = f"""
+            CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
+                SOURCE_TYPE="ObjectStorage",
+                LOCATION="{s3_location}",
+                AUTH_METHOD="AWS",
+                AWS_ACCESS_KEY_ID_SECRET_NAME="{access_key_secret}",
+                AWS_SECRET_ACCESS_KEY_SECRET_NAME="{secret_key_secret}",
+                AWS_REGION="ru-central-1"
+            );"""
+        self.execute_scheme(query)
+
+    def read_from_eds(self, eds_name):
+        return self.execute_query(
+            f"""
+            SELECT * FROM `{eds_name}`.`file.txt` WITH (
+                FORMAT = "raw",
+                SCHEMA = ( Data String )
+            );"""
+        )
+
     def create_schema_secret(self, secret_name, value):
-        with self.session_pool.checkout() as session:
-            session.execute_scheme(f"CREATE SECRET {secret_name} WITH (value='{value}');")
+        self.execute_scheme(f"CREATE SECRET `{secret_name}` WITH (value='{value}');")
+
+    def create_table(self, table_name):
+        self.execute_scheme(f"CREATE TABLE `{table_name}` (Key Uint64, PRIMARY KEY (Key));")
+
+    def create_transfer_table(self, table_name):
+        self.execute_scheme(
+            f"""
+            CREATE TABLE `{table_name}` (
+                partition Uint32 NOT NULL,
+                offset Uint64 NOT NULL,
+                message Utf8,
+                PRIMARY KEY (partition, offset)
+            );"""
+        )
+
+    def create_topic(self, topic_name):
+        self.execute_scheme(f"CREATE TOPIC `{topic_name}`;")
+
+    def create_async_replication(self, replication_name, table_name, replica_name, secret_name, schema_secret=False):
+        connection_string = (
+            f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].port}/?database={DATABASE}"
+        )
+        secret_setting = "PASSWORD_SECRET_PATH" if schema_secret else "PASSWORD_SECRET_NAME"
+        query = f"""
+            CREATE ASYNC REPLICATION `{replication_name}` FOR `{table_name}` AS `{replica_name}` WITH (
+                CONNECTION_STRING="{connection_string}",
+                USER = "root",
+                {secret_setting} = "{secret_name}"
+            );"""
+        self.execute_scheme(query)
+
+    def create_transfer(self, transfer_name, topic_name, table_name, secret_name, schema_secret=False):
+        connection_string = (
+            f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].port}/?database={DATABASE}"
+        )
+        secret_setting = "PASSWORD_SECRET_PATH" if schema_secret else "PASSWORD_SECRET_NAME"
+        query = f"""
+            $l = ($x) -> {{
+                return [
+                    <|
+                        partition:CAST($x._partition AS Uint32),
+                        offset:CAST($x._offset AS Uint64),
+                        message:CAST($x._data AS Utf8)
+                    |>
+                ];
+            }};
+
+            CREATE TRANSFER `{transfer_name}`
+            FROM `{topic_name}` TO `{table_name}` USING $l
+            WITH (
+                CONNECTION_STRING="{connection_string}",
+                FLUSH_INTERVAL = Interval('PT1S'),
+                BATCH_SIZE_BYTES = 10,
+                USER = "root",
+                {secret_setting} = "{secret_name}"
+            );"""
+        self.execute_scheme(query)
+
+    def mon_endpoint(self):
+        return f"http://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].mon_port}"
+
+    def viewer_describe(self, path):
+        response = requests.get(
+            f"{self.mon_endpoint()}/viewer/json/describe",
+            params={"database": DATABASE, "path": path},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def viewer_describe_replication(self, path):
+        response = requests.get(
+            f"{self.mon_endpoint()}/viewer/json/describe_replication",
+            params={"database": DATABASE, "path": path},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def viewer_describe_transfer(self, path):
+        response = requests.get(
+            f"{self.mon_endpoint()}/viewer/json/describe_transfer",
+            params={"database": DATABASE, "path": path},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def assert_path_ready(self, path):
+        description = self.viewer_describe(path)
+        assert description["Status"] == "StatusSuccess", description
+        assert description["PathDescription"]["Self"]["CreateFinished"] is True, description
+        return description
+
+    def wait_object_error_state(self, describe_fn, path, expected_issue_substr):
+        def ready():
+            description = describe_fn(path)
+            error = description.get("error")
+            if not error:
+                return False
+            return expected_issue_substr in str(error)
+
+        if not wait_for(ready, timeout_seconds=60, step_seconds=1):
+            description = describe_fn(path)
+            raise AssertionError(
+                f"Object {path} didn't enter error state with {expected_issue_substr!r}, got: {description}"
+            )
 
 
 @pytest.fixture
@@ -105,30 +271,160 @@ def old_secrets_utils():
     utils.stop()
 
 
-def test_create_eds_with_old_secret_after_disabling_old_secret_creation(old_secrets_utils):
-    # can create old secrets by default
+def test_disable_old_secret_creation(old_secrets_utils):
+    # create all types of objects with old secrets
+    # secret
     old_secrets_utils.create_old_secret("OldSecret", value="")
 
-    # can use old secrets by default
-    old_secrets_utils.create_eds("eds-before-restart", "OldSecret")
+    # eds
+    old_secrets_utils.create_eds("eds-old-secret", "OldSecret")
 
+    # replication
+    old_secrets_utils.create_table("repl_src")
+    old_secrets_utils.create_async_replication(
+        "replication-old-secret",
+        "repl_src",
+        "repl_dst",
+        "OldSecret",
+    )
+
+    # transfer
+    old_secrets_utils.create_topic("transfer_topic")
+    old_secrets_utils.create_transfer_table("transfer_dst")
+    old_secrets_utils.create_transfer(
+        "transfer-old-secret",
+        "transfer_topic",
+        "transfer_dst",
+        "OldSecret",
+    )
+
+    # restart cluster with disabled old secret creation
     old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
 
-    # can create schema secrets with old secrets disabled
-    old_secrets_utils.create_schema_secret("NewSecret", value="")
-
-    # can use old secrets with old secrets disabled
-    old_secrets_utils.create_eds("eds-after-restart", "OldSecret")
-
-    # can alter old secrets with old secrets disabled
+    # check that old secret can be altered
     old_secrets_utils.alter_old_secret("OldSecret", "NewValue")
 
-    # can not create old secrets with old secrets disabled
+    # check that old secret can't be created
     with pytest.raises(Exception) as exc_info:
         old_secrets_utils.create_old_secret("NewOldSecret", value="")
-    assert "Old secrets creation syntax is disabled now. Please use the new one" in str(exc_info.value)
+    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
 
-    # can not upsert old secrets with old secrets disabled
+    # check that old secret can't be upserted
     with pytest.raises(Exception) as exc_info:
         old_secrets_utils.upsert_old_secret("NewOldSecretUpsert", value="")
-    assert "Old secrets creation syntax is disabled now. Please use the new one" in str(exc_info.value)
+    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+
+    # check that old objects are still OK
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/eds-old-secret")
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/transfer-old-secret")
+
+    # check that old secrets can't be used for eds
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.create_eds("eds-with-old-secret", "OldSecret")
+    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+
+    # check that old secrets can't be used for replication
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.create_async_replication(
+            "replication-with-old-secret",
+            "repl_src",
+            "repl_dst_old",
+            "OldSecret",
+        )
+    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+
+    # check that old secrets can't be used for transfer
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.create_transfer(
+            "transfer-with-old-secret",
+            "transfer_topic",
+            "transfer_dst",
+            "OldSecret",
+        )
+    assert OLD_SECRET_DISABLED_MESSAGE in str(exc_info.value)
+
+    # check that new secret can be still used
+    old_secrets_utils.create_schema_secret(f"{DATABASE}/NewSecret", value="")
+
+    # create eds with new secret
+    old_secrets_utils.create_eds(
+        "eds-with-new-secret",
+        f"{DATABASE}/NewSecret",
+        schema_secret=True,
+    )
+
+    # create replication with new secret
+    old_secrets_utils.create_table("repl_src_new")
+    old_secrets_utils.create_async_replication(
+        "replication-with-new-secret",
+        "repl_src_new",
+        "repl_dst_new",
+        f"{DATABASE}/NewSecret",
+        schema_secret=True,
+    )
+
+    # create transfer with new secret
+    old_secrets_utils.create_topic("transfer_topic_new")
+    old_secrets_utils.create_transfer_table("transfer_dst_new")
+    old_secrets_utils.create_transfer(
+        "transfer-with-new-secret",
+        "transfer_topic_new",
+        "transfer_dst_new",
+        f"{DATABASE}/NewSecret",
+        schema_secret=True,
+    )
+
+
+def test_disable_old_secrets_keeps_existing_objects(old_secrets_utils):
+    s3_endpoint, s3_access_key, s3_secret_key, s3_bucket = setup_s3()
+    s3_location = f"{s3_endpoint}/{s3_bucket}"
+
+    old_secrets_utils.create_old_secret("s3_access_key", value=s3_access_key)
+    old_secrets_utils.create_old_secret("s3_secret_key", value=s3_secret_key)
+    old_secrets_utils.create_old_secret("repl_password", value="")
+
+    eds_name = "eds-old-secret"
+    old_secrets_utils.create_eds_aws(eds_name, "s3_access_key", "s3_secret_key", s3_location)
+
+    old_secrets_utils.create_table("repl_src")
+    old_secrets_utils.create_async_replication(
+        "replication-old-secret",
+        "repl_src",
+        "repl_dst",
+        "repl_password",
+    )
+
+    old_secrets_utils.create_topic("transfer_topic")
+    old_secrets_utils.create_transfer_table("transfer_dst")
+    old_secrets_utils.create_transfer(
+        "transfer-old-secret",
+        "transfer_topic",
+        "transfer_dst",
+        "repl_password",
+    )
+
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/{eds_name}")
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/transfer-old-secret")
+
+    result_sets = old_secrets_utils.read_from_eds(eds_name)
+    data = result_sets[0].rows[0]["Data"]
+    assert isinstance(data, bytes) and data.decode() == "Hello S3!"
+
+    old_secrets_utils.restart_cluster(disable_old_secrets=True)
+
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.read_from_eds(eds_name)
+    assert OLD_SECRETS_USAGE_DISABLED_MESSAGE in str(exc_info.value)
+
+    old_secrets_utils.wait_object_error_state(
+        old_secrets_utils.viewer_describe_replication,
+        f"{DATABASE}/replication-old-secret",
+        OLD_SECRETS_USAGE_DISABLED_MESSAGE,
+    )
+    old_secrets_utils.wait_object_error_state(
+        old_secrets_utils.viewer_describe_transfer,
+        f"{DATABASE}/transfer-old-secret",
+        OLD_SECRETS_USAGE_DISABLED_MESSAGE,
+    )

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -319,6 +319,11 @@ def test_disable_old_secret_creation(old_secrets_utils):
     # restart cluster with disabled old secret creation
     old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
 
+    # check that old secrets can't be used for eds
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.create_eds("eds-with-old-secret", "OldSecret")
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
     # check that old secrets can't be used for replication
     with pytest.raises(Exception) as exc_info:
         old_secrets_utils.create_async_replication("repl-with-old-secret", "repl_src", "repl_dst_old", "OldSecret")
@@ -357,7 +362,7 @@ def test_disable_old_secret_creation(old_secrets_utils):
     )
 
 
-def test_disable_old_secrets_keeps_existing_objects(old_secrets_utils):
+def test_disable_old_secrets_dont_crash_existing_objects(old_secrets_utils):
     s3_endpoint, s3_access_key, s3_secret_key, s3_bucket = setup_s3()
     s3_location = f"{s3_endpoint}/{s3_bucket}"
 

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 
 DATABASE = "/Root"
 OLD_SECRETS_CREATION_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new secrets"
-CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE = "Old secrets are disabled for creating new objects. Please use the new secrets"
+CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE = (
+    "Old secrets are disabled for creating new objects. Please use the new secrets"
+)
 OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Usage of old secrets is disabled now. Please use the new secrets"
 
 
@@ -146,13 +148,11 @@ class Utils:
         self.execute_scheme(query)
 
     def read_from_eds(self, eds_name):
-        return self.execute_query(
-            f"""
+        return self.execute_query(f"""
             SELECT * FROM `{eds_name}`.`file.txt` WITH (
                 FORMAT = "raw",
                 SCHEMA = ( Data String )
-            );"""
-        )
+            );""")
 
     def create_schema_secret(self, secret_name, value):
         self.execute_scheme(f"CREATE SECRET `{secret_name}` WITH (value='{value}');")
@@ -161,23 +161,19 @@ class Utils:
         self.execute_scheme(f"CREATE TABLE `{table_name}` (Key Uint64, PRIMARY KEY (Key));")
 
     def create_transfer_table(self, table_name):
-        self.execute_scheme(
-            f"""
+        self.execute_scheme(f"""
             CREATE TABLE `{table_name}` (
                 partition Uint32 NOT NULL,
                 offset Uint64 NOT NULL,
                 message Utf8,
                 PRIMARY KEY (partition, offset)
-            );"""
-        )
+            );""")
 
     def create_topic(self, topic_name):
         self.execute_scheme(f"CREATE TOPIC `{topic_name}`;")
 
     def create_async_replication(self, replication_name, table_name, replica_name, secret_name, schema_secret=False):
-        connection_string = (
-            f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].port}/?database={DATABASE}"
-        )
+        connection_string = f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].port}/?database={DATABASE}"
         secret_setting = "PASSWORD_SECRET_PATH" if schema_secret else "PASSWORD_SECRET_NAME"
         query = f"""
             CREATE ASYNC REPLICATION `{replication_name}` FOR `{table_name}` AS `{replica_name}` WITH (
@@ -188,9 +184,7 @@ class Utils:
         self.execute_scheme(query)
 
     def create_transfer(self, transfer_name, topic_name, table_name, secret_name, schema_secret=False):
-        connection_string = (
-            f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].port}/?database={DATABASE}"
-        )
+        connection_string = f"grpc://{self.cluster.nodes[1].host}:{self.cluster.nodes[1].port}/?database={DATABASE}"
         secret_setting = "PASSWORD_SECRET_PATH" if schema_secret else "PASSWORD_SECRET_NAME"
         query = f"""
             $l = ($x) -> {{
@@ -272,32 +266,9 @@ def old_secrets_utils():
     utils.stop()
 
 
-def test_disable_old_secret_creation(old_secrets_utils):
-    # create all types of objects with old secrets
-    # secret
+def test_old_secret_creation_is_disabled(old_secrets_utils):
+    # create old secret
     old_secrets_utils.create_old_secret("OldSecret", value="")
-
-    # eds
-    old_secrets_utils.create_eds("eds-old-secret", "OldSecret")
-
-    # replication
-    old_secrets_utils.create_table("repl_src")
-    old_secrets_utils.create_async_replication(
-        "replication-old-secret",
-        "repl_src",
-        "repl_dst",
-        "OldSecret",
-    )
-
-    # transfer
-    old_secrets_utils.create_topic("transfer_topic")
-    old_secrets_utils.create_transfer_table("transfer_dst")
-    old_secrets_utils.create_transfer(
-        "transfer-old-secret",
-        "transfer_topic",
-        "transfer_dst",
-        "OldSecret",
-    )
 
     # restart cluster with disabled old secret creation
     old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
@@ -315,54 +286,63 @@ def test_disable_old_secret_creation(old_secrets_utils):
         old_secrets_utils.upsert_old_secret("NewOldSecretUpsert", value="")
     assert OLD_SECRETS_CREATION_DISABLED_MESSAGE in str(exc_info.value)
 
+
+def test_existing_objects_are_ok_if_old_secret_creation_is_disabled(old_secrets_utils):
+    # create all types of objects with old secrets
+    # secret
+    old_secrets_utils.create_old_secret("OldSecret", value="")
+
+    # eds
+    old_secrets_utils.create_eds("eds-old-secret", "OldSecret")
+
+    # replication
+    old_secrets_utils.create_table("repl_src")
+    old_secrets_utils.create_async_replication("replication-old-secret", "repl_src", "repl_dst", "OldSecret")
+
+    # transfer
+    old_secrets_utils.create_topic("transfer_topic")
+    old_secrets_utils.create_transfer_table("transfer_dst")
+    old_secrets_utils.create_transfer("transfer-old-secret", "transfer_topic", "transfer_dst", "OldSecret")
+
+    # restart cluster with disabled old secret creation
+    old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
+
     # check that old objects are still OK
     old_secrets_utils.assert_path_ready(f"{DATABASE}/eds-old-secret")
     old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
     old_secrets_utils.assert_path_ready(f"{DATABASE}/transfer-old-secret")
 
-    # check that old secrets can't be used for eds
-    with pytest.raises(Exception) as exc_info:
-        old_secrets_utils.create_eds("eds-with-old-secret", "OldSecret")
-    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
+def test_disable_old_secret_creation(old_secrets_utils):
+    old_secrets_utils.create_old_secret("OldSecret", value="")
+
+    # restart cluster with disabled old secret creation
+    old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
 
     # check that old secrets can't be used for replication
     with pytest.raises(Exception) as exc_info:
-        old_secrets_utils.create_async_replication(
-            "replication-with-old-secret",
-            "repl_src",
-            "repl_dst_old",
-            "OldSecret",
-        )
+        old_secrets_utils.create_async_replication("repl-with-old-secret", "repl_src", "repl_dst_old", "OldSecret")
     assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
     # check that old secrets can't be used for transfer
     with pytest.raises(Exception) as exc_info:
-        old_secrets_utils.create_transfer(
-            "transfer-with-old-secret",
-            "transfer_topic",
-            "transfer_dst",
-            "OldSecret",
-        )
+        old_secrets_utils.create_transfer("transfer-with-old-secret", "transfer_topic", "transfer_dst", "OldSecret")
     assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
-    # check that new secret can be still used
-    old_secrets_utils.create_schema_secret(f"{DATABASE}/NewSecret", value="")
+    # check that new secrets can be still used
+    old_secrets_utils.create_schema_secret("NewSecret", value="")
 
     # create eds with new secret
     old_secrets_utils.create_eds(
         "eds-with-new-secret",
-        f"{DATABASE}/NewSecret",
+        "NewSecret",
         schema_secret=True,
     )
 
     # create replication with new secret
     old_secrets_utils.create_table("repl_src_new")
     old_secrets_utils.create_async_replication(
-        "replication-with-new-secret",
-        "repl_src_new",
-        "repl_dst_new",
-        f"{DATABASE}/NewSecret",
-        schema_secret=True,
+        "repl-with-new-secret", "repl_src_new", "repl_dst_new", "NewSecret", schema_secret=True
     )
 
     # create transfer with new secret
@@ -372,7 +352,7 @@ def test_disable_old_secret_creation(old_secrets_utils):
         "transfer-with-new-secret",
         "transfer_topic_new",
         "transfer_dst_new",
-        f"{DATABASE}/NewSecret",
+        "NewSecret",
         schema_secret=True,
     )
 
@@ -383,39 +363,38 @@ def test_disable_old_secrets_keeps_existing_objects(old_secrets_utils):
 
     old_secrets_utils.create_old_secret("s3_access_key", value=s3_access_key)
     old_secrets_utils.create_old_secret("s3_secret_key", value=s3_secret_key)
-    old_secrets_utils.create_old_secret("repl_password", value="")
+    old_secrets_utils.create_old_secret("password", value="")
 
+    # create eds with old secrets
     eds_name = "eds-old-secret"
     old_secrets_utils.create_eds_aws(eds_name, "s3_access_key", "s3_secret_key", s3_location)
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/{eds_name}")
 
+    # create replication with old secret
     old_secrets_utils.create_table("repl_src")
     old_secrets_utils.create_async_replication(
         "replication-old-secret",
         "repl_src",
         "repl_dst",
-        "repl_password",
+        "password",
     )
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
 
+    # create transfer with old secret
     old_secrets_utils.create_topic("transfer_topic")
     old_secrets_utils.create_transfer_table("transfer_dst")
     old_secrets_utils.create_transfer(
         "transfer-old-secret",
         "transfer_topic",
         "transfer_dst",
-        "repl_password",
+        "password",
     )
-
-    old_secrets_utils.assert_path_ready(f"{DATABASE}/{eds_name}")
-    old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
     old_secrets_utils.assert_path_ready(f"{DATABASE}/transfer-old-secret")
-
-    result_sets = old_secrets_utils.read_from_eds(eds_name)
-    data = result_sets[0].rows[0]["Data"]
-    assert isinstance(data, bytes) and data.decode() == "Hello S3!"
 
     old_secrets_utils.restart_cluster(disable_old_secrets=True)
 
     with pytest.raises(Exception) as exc_info:
+        # After restart eds resolves secret only while reading
         old_secrets_utils.read_from_eds(eds_name)
     assert OLD_SECRETS_USAGE_DISABLED_MESSAGE in str(exc_info.value)
 

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -393,6 +393,57 @@ def test_existing_objects_cannot_use_old_secrets_if_old_secret_creation_is_disab
     assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
 
+def test_existing_objects_can_migrate_to_new_secrets_if_old_secret_creation_is_disabled(old_secrets_utils):
+    # create all types of objects with old secrets
+    old_secrets_utils.create_old_secret("OldSecret", value="")
+    old_secrets_utils.create_eds("eds-old-secret", "OldSecret")
+    old_secrets_utils.create_table("repl_src")
+    old_secrets_utils.create_async_replication("replication-old-secret", "repl_src", "repl_dst", "OldSecret")
+    old_secrets_utils.create_topic("transfer_topic")
+    old_secrets_utils.create_transfer_table("transfer_dst")
+    old_secrets_utils.create_transfer("transfer-old-secret", "transfer_topic", "transfer_dst", "OldSecret")
+
+    # restart cluster with disabled old secret creation
+    old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
+
+    # non-secret ALTER (e.g. STATE) must still work for objects that use old secrets
+    old_secrets_utils.execute_scheme("""
+        ALTER ASYNC REPLICATION `replication-old-secret` SET (STATE = "Paused");
+        ALTER ASYNC REPLICATION `replication-old-secret` SET (STATE = "StandBy");
+    """)
+    old_secrets_utils.execute_scheme("""
+        ALTER TRANSFER `transfer-old-secret` SET (STATE = "Paused");
+        ALTER TRANSFER `transfer-old-secret` SET (STATE = "StandBy");
+    """)
+
+    # migrate existing objects to new secrets
+    new_secret = "NewSecret"
+    old_secrets_utils.create_schema_secret(new_secret, value="")
+
+    old_secrets_utils.create_eds(
+        "eds-old-secret",
+        new_secret,
+        schema_secret=True,
+        create_or_replace=True,
+    )
+    old_secrets_utils.alter_password_secret(
+        "ASYNC REPLICATION",
+        "replication-old-secret",
+        new_secret,
+        schema_secret=True,
+    )
+    old_secrets_utils.alter_password_secret(
+        "TRANSFER",
+        "transfer-old-secret",
+        new_secret,
+        schema_secret=True,
+    )
+
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/eds-old-secret")
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
+    old_secrets_utils.assert_path_ready(f"{DATABASE}/transfer-old-secret")
+
+
 def test_disable_old_secret_creation(old_secrets_utils):
     old_secrets_utils.create_old_secret("OldSecret", value="")
 

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -123,10 +123,11 @@ class Utils:
     def alter_old_secret(self, secret_name, value):
         self.execute_scheme(f"ALTER OBJECT {secret_name} (TYPE SECRET) SET value='{value}';")
 
-    def create_eds(self, eds_name, secret_name, schema_secret=False):
+    def create_eds(self, eds_name, secret_name, schema_secret=False, create_or_replace=False):
         secret_setting = "SERVICE_ACCOUNT_SECRET_PATH" if schema_secret else "SERVICE_ACCOUNT_SECRET_NAME"
+        create_type = "CREATE OR REPLACE" if create_or_replace else "CREATE"
         query = f"""
-            CREATE EXTERNAL DATA SOURCE `{eds_name}` WITH (
+            {create_type} EXTERNAL DATA SOURCE `{eds_name}` WITH (
                 SOURCE_TYPE="ObjectStorage",
                 LOCATION="my-bucket",
                 AUTH_METHOD="SERVICE_ACCOUNT",
@@ -146,6 +147,14 @@ class Utils:
                 AWS_REGION="ru-central-1"
             );"""
         self.execute_scheme(query)
+
+    def alter_password_secret(self, object_type, object_name, secret_name, schema_secret=False):
+        secret_setting = "PASSWORD_SECRET_PATH" if schema_secret else "PASSWORD_SECRET_NAME"
+        self.execute_scheme(f"""
+            ALTER {object_type} `{object_name}` SET (STATE = "Paused");
+            ALTER {object_type} `{object_name}` SET ({secret_setting} = "{secret_name}");
+            ALTER {object_type} `{object_name}` SET (STATE = "StandBy");
+        """)
 
     def read_from_eds(self, eds_name):
         return self.execute_query(f"""
@@ -311,6 +320,77 @@ def test_existing_objects_are_ok_if_old_secret_creation_is_disabled(old_secrets_
     old_secrets_utils.assert_path_ready(f"{DATABASE}/eds-old-secret")
     old_secrets_utils.assert_path_ready(f"{DATABASE}/replication-old-secret")
     old_secrets_utils.assert_path_ready(f"{DATABASE}/transfer-old-secret")
+
+    # check that existing objects can't be changed to use old secrets
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.create_eds(
+            "eds-old-secret",
+            "OldSecret",
+            create_or_replace=True,
+        )
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.alter_password_secret(
+            "ASYNC REPLICATION",
+            "replication-old-secret",
+            "OldSecret",
+        )
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.alter_password_secret(
+            "TRANSFER",
+            "transfer-old-secret",
+            "OldSecret",
+        )
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
+
+def test_existing_objects_cannot_use_old_secrets_if_old_secret_creation_is_disabled(old_secrets_utils):
+    # create all types of objects with old secrets
+    # secret
+    old_secrets_utils.create_old_secret("OldSecret", value="")
+
+    # eds
+    old_secrets_utils.create_eds("eds-old-secret", "OldSecret")
+
+    # replication
+    old_secrets_utils.create_table("repl_src")
+    old_secrets_utils.create_async_replication("replication-old-secret", "repl_src", "repl_dst", "OldSecret")
+
+    # transfer
+    old_secrets_utils.create_topic("transfer_topic")
+    old_secrets_utils.create_transfer_table("transfer_dst")
+    old_secrets_utils.create_transfer("transfer-old-secret", "transfer_topic", "transfer_dst", "OldSecret")
+
+    # restart cluster with disabled old secret creation
+    old_secrets_utils.restart_cluster(disable_old_secret_creation=True)
+
+    # check that existing objects can't be changed to use old secrets
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.create_eds(
+            "eds-old-secret",
+            "OldSecret",
+            create_or_replace=True,
+        )
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.alter_password_secret(
+            "ASYNC REPLICATION",
+            "replication-old-secret",
+            "OldSecret",
+        )
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
+
+    with pytest.raises(Exception) as exc_info:
+        old_secrets_utils.alter_password_secret(
+            "TRANSFER",
+            "transfer-old-secret",
+            "OldSecret",
+        )
+    assert CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE in str(exc_info.value)
 
 
 def test_disable_old_secret_creation(old_secrets_utils):

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -14,11 +14,11 @@ from ydb.tests.oss.ydb_sdk_import import ydb
 logger = logging.getLogger(__name__)
 
 DATABASE = "/Root"
-OLD_SECRETS_CREATION_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new secrets"
+OLD_SECRETS_CREATION_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new one"
 CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE = (
-    "Old secrets are disabled for creating new objects. Please use the new secrets"
+    "Old secrets are disabled for creating new objects. Please use new secrets"
 )
-OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Usage of old secrets is disabled now. Please use the new secrets"
+OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Usage of old secrets is disabled now. Please use new secrets"
 
 
 def setup_s3():

--- a/ydb/tests/functional/secrets/ya.make
+++ b/ydb/tests/functional/secrets/ya.make
@@ -25,6 +25,7 @@ DEPENDS(
 
 PEERDIR(
     contrib/python/boto3
+    contrib/python/requests
     ydb/tests/functional/secrets/lib
     ydb/tests/library
     ydb/tests/library/fixtures


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Доработан флаг `DisableOldSecretCreation` (default=false) – он включал запрет создания старых секретов, сейчас ещё добавлен запрет создания объектов со старыми секретами (репликации, трансферы, внешние источники данных)
Поддержан флаг `DisableOldSecrets` (default=false) – запрет обращения к сервису резолвинга старых секретов

ПР планируется к бекпорту в 26-3.