### PR TITLE
Fix CpuTopology UT testdata path for Arcadia layout

### DIFF
--- a/ydb/library/actors/util/cpu_topology_ut.cpp
+++ b/ydb/library/actors/util/cpu_topology_ut.cpp
@@ -90,7 +90,7 @@ public:
 };
 
 TFsPath SnapshotSystemRoot(const TString& name) {
-    return TFsPath(ArcadiaSourceRoot()) / "ydb/library/actors/util/testdata/cpu_topology" / name / "sys/devices/system";
+    return TFsPath(SRC_("testdata/cpu_topology")) / name / "sys/devices/system";
 }
 
 TCpuTopology LoadSnapshot(const TString& name) {


### PR DESCRIPTION
## Summary
- `CpuTopology` snapshot tests resolve fixtures via `SRC_("testdata/cpu_topology")` instead of a hardcoded `ArcadiaSourceRoot()/ydb/...` path.
- Fixes Arcadia import failures where sources live under `contrib/ydb/...` (same pattern as `mvp/meta`, `kqp` view/join UTs).
- Follow-up for #45733 / #45904 (@tindarid): unmuted assert on FAST+FULL after GitHub→Arcadia import.

## Test plan
- [x] `ya make -t ydb/library/actors/util/ut` (or local equivalent) — `CpuTopology` snapshot tests pass
- [ ] Confirm path resolves under both GitHub (`ydb/...`) and Arcadia (`contrib/ydb/...`) layouts

Made with [Cursor](https://cursor.com)