### PR TITLE
Add actor liveness system messages

### DIFF
--- a/ydb/library/actors/async/async.cpp
+++ b/ydb/library/actors/async/async.cpp
@@ -42,7 +42,10 @@ namespace NActors::NDetail {
                 TActorRunnableQueue::Schedule(this);
             } else {
                 // Send an event using the actor system
-                ActorSystem->Send(SelfId, new TEvents::TEvResumeRunnable(this));
+                ActorSystem->Send(
+                    SelfId,
+                    new TEvents::TEvResumeRunnable(this),
+                    TEvents::TEvResumeRunnable::EventFlags);
             }
         }
 
@@ -117,7 +120,10 @@ namespace NActors::NDetail {
                     TActorRunnableQueue::Schedule(this);
                 } else {
                     // Send an event using the actor system
-                    Self.ActorSystem->Send(Self.SelfId, new TEvents::TEvResumeRunnable(this));
+                    Self.ActorSystem->Send(
+                        Self.SelfId,
+                        new TEvents::TEvResumeRunnable(this),
+                        TEvents::TEvResumeRunnable::EventFlags);
                 }
             }
 

--- a/ydb/library/actors/async/low_priority.h
+++ b/ydb/library/actors/async/low_priority.h
@@ -122,7 +122,10 @@ namespace NActors {
 
         void Start(TAsyncLowPriorityQueueAwaiter* awaiter) {
             auto selfId = awaiter->Actor->SelfId();
-            bool ok = selfId.Send(selfId, (Event = new TEvents::TEvResumeRunnable(this)));
+            bool ok = selfId.Send(
+                selfId,
+                (Event = new TEvents::TEvResumeRunnable(this)),
+                TEvents::TEvResumeRunnable::EventFlags);
             Y_ABORT_UNLESS(ok, "Unexpected failure to send an event to SelfId");
         }
 

--- a/ydb/library/actors/async/sleep.h
+++ b/ydb/library/actors/async/sleep.h
@@ -40,7 +40,10 @@ namespace NActors::NDetail {
             auto selfId = actor.SelfId();
             if (IsImmediate()) {
                 // Use a simple Send, everything is synchronized to the mailbox
-                bool ok = selfId.Send(selfId, (Event = new TEvents::TEvResumeRunnable(this)));
+                bool ok = selfId.Send(
+                    selfId,
+                    (Event = new TEvents::TEvResumeRunnable(this)),
+                    TEvents::TEvResumeRunnable::EventFlags);
                 if (!ok) [[unlikely]] {
                     throw std::runtime_error("unexpected failure to send an event to SelfId");
                 }
@@ -50,7 +53,13 @@ namespace NActors::NDetail {
                 Bridge.Reset(new TBridge(this));
                 // Extra reference will be used by the event
                 Bridge->Ref();
-                selfId.Schedule(When, new TEvents::TEvResumeRunnable(Bridge.Get()));
+                TActivationContext::Schedule(
+                    When,
+                    new IEventHandle(
+                        selfId,
+                        {},
+                        new TEvents::TEvResumeRunnable(Bridge.Get()),
+                        TEvents::TEvResumeRunnable::EventFlags));
             }
         }
 

--- a/ydb/library/actors/async/timeout.h
+++ b/ydb/library/actors/async/timeout.h
@@ -42,7 +42,13 @@ namespace NActors::NDetail {
             auto selfId = this->GetActor().SelfId();
             Bridge.Reset(new TBridge(this));
             Bridge->Ref(); // extra reference used by the event
-            selfId.Schedule(When, new TEvents::TEvResumeRunnable(Bridge.Get()));
+            TActivationContext::Schedule(
+                When,
+                new IEventHandle(
+                    selfId,
+                    {},
+                    new TEvents::TEvResumeRunnable(Bridge.Get()),
+                    TEvents::TEvResumeRunnable::EventFlags));
 
             return TBase::Start();
         }

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -412,8 +412,10 @@ namespace NActors {
                         HandleCheckActorLiveness(ev);
                         break;
                     default:
-                        // Event flags are controlled by senders, so an unknown
-                        // system message must not terminate the actor system.
+                        // System messages must never reach actor
+                        // awaiters or user state functions. Event flags are
+                        // controlled by senders, so unknown values are ignored
+                        // instead of terminating the actor system.
                         break;
                 }
             } else if (!HandleRegisteredEvent(ev)) {

--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -2,6 +2,7 @@
 #include "debug.h"
 #include "actorsystem.h"
 #include "cpu_manager.h"
+#include "events.h"
 #include "executor_thread.h"
 #include <ydb/library/actors/util/datetime.h>
 #include <util/datetime/cputimer.h>
@@ -351,17 +352,25 @@ namespace NActors {
         return NHPTimer::GetSeconds(ElapsedTicks);
     }
 
-    bool IActor::HandleResumeRunnable(TAutoPtr<IEventHandle>& ev) {
-        if (ev->GetTypeRewrite() == TEvents::TSystem::ResumeRunnable) {
-            auto* msg = ev->Get<TEvents::TEvResumeRunnable>();
-            auto* item = msg->Item;
-            if (item != nullptr) {
-                msg->Item = nullptr;
-                item->Run(this);
-            }
-            return true;
+    void IActor::HandleCheckActorLiveness(TAutoPtr<IEventHandle>& ev) {
+        TActivationContext::Send(new IEventHandle(
+            TEvents::TSystem::ActorAlive,
+            0,
+            ev->Sender,
+            ev->Recipient,
+            nullptr,
+            ev->Cookie,
+            nullptr,
+            std::move(ev->TraceId)));
+    }
+
+    void IActor::HandleResumeRunnable(TAutoPtr<IEventHandle>& ev) {
+        auto* msg = ev->Get<TEvents::TEvResumeRunnable>();
+        auto* item = msg->Item;
+        if (item != nullptr) {
+            msg->Item = nullptr;
+            item->Run(this);
         }
-        return false;
     }
 
     bool IActor::HandleRegisteredEvent(TAutoPtr<IEventHandle>& ev) {
@@ -390,7 +399,24 @@ namespace NActors {
         TActorRunnableQueue queue(this);
 
         try {
-            if (!HandleResumeRunnable(ev) && !HandleRegisteredEvent(ev)) {
+            if (ev->Flags & IEventHandle::FlagSystemMessage) {
+                switch (ev->GetTypeRewrite()) {
+                    case TEvents::TSystem::ResumeRunnable:
+                        // ResumeRunnable is local-only and legitimate senders
+                        // always provide its in-process event object.
+                        if (ev->HasEvent()) {
+                            HandleResumeRunnable(ev);
+                        }
+                        break;
+                    case TEvents::TSystem::CheckActorLiveness:
+                        HandleCheckActorLiveness(ev);
+                        break;
+                    default:
+                        // Event flags are controlled by senders, so an unknown
+                        // system message must not terminate the actor system.
+                        break;
+                }
+            } else if (!HandleRegisteredEvent(ev)) {
                 (this->*StateFunc_)(ev);
             }
         } catch (...) {

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -589,7 +589,8 @@ namespace NActors {
         void UnregisterActorTask(TActorTask* task);
         void RegisterEventAwaiter(ui64 cookie, TActorEventAwaiter* awaiter);
         void UnregisterEventAwaiter(ui64 cookie, TActorEventAwaiter* awaiter);
-        bool HandleResumeRunnable(TAutoPtr<IEventHandle>& ev);
+        void HandleCheckActorLiveness(TAutoPtr<IEventHandle>& ev);
+        void HandleResumeRunnable(TAutoPtr<IEventHandle>& ev);
         bool HandleRegisteredEvent(TAutoPtr<IEventHandle>& ev);
 
     public:

--- a/ydb/library/actors/core/actorsystem.cpp
+++ b/ydb/library/actors/core/actorsystem.cpp
@@ -292,6 +292,32 @@ namespace NActors {
         if (Y_UNLIKELY(!ev))
             return false;
 
+        if (Y_UNLIKELY(ev->Flags & IEventHandle::FlagSystemMessage)) {
+            switch (ev->Type) {
+                case TEvents::TSystem::CheckActorLiveness: {
+                    const TActorId recipient = ev->GetRecipientRewrite();
+                    const ui32 recipientNodeId = recipient.NodeId();
+                    if (recipientNodeId != NodeId && recipientNodeId != 0) {
+                        // TODO: Support distributed actor liveness checks
+                        // through interconnect. Liveness events are local-only
+                        // for now.
+                        return Send(std::make_unique<IEventHandle>(
+                            TEvents::TSystem::ActorLivenessUnsure,
+                            0,
+                            ev->Sender,
+                            recipient,
+                            nullptr,
+                            ev->Cookie,
+                            nullptr,
+                            std::move(ev->TraceId)));
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_SEND, false> activityGuard;
 #ifdef USE_ACTOR_CALLSTACK
         ev->Callstack.TraceIfEmpty();

--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -144,6 +144,7 @@ namespace NActors {
             FlagDebugTrackReceive = 1 << 6,
             FlagFailFastWhenDisconnected = 1 << 7,
             FlagDisablePayloadChecksums = 1 << 8, // When set, IC will not calculate or check XDC/RDMA checksums
+            FlagSystemMessage = 1 << 9, // Handled by IActor before its state function
         };
         using TEventFlags = ui32;
 

--- a/ydb/library/actors/core/event.h
+++ b/ydb/library/actors/core/event.h
@@ -144,7 +144,9 @@ namespace NActors {
             FlagDebugTrackReceive = 1 << 6,
             FlagFailFastWhenDisconnected = 1 << 7,
             FlagDisablePayloadChecksums = 1 << 8, // When set, IC will not calculate or check XDC/RDMA checksums
-            FlagSystemMessage = 1 << 9, // Handled by IActor before its state function
+            // System messages are handled by the actor runtime and must never
+            // reach actor awaiters or the user state function.
+            FlagSystemMessage = 1 << 9,
         };
         using TEventFlags = ui32;
 

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -113,6 +113,9 @@ namespace NActors {
                 Wilson,
                 Preemption,
                 ResumeRunnable,
+                CheckActorLiveness,
+                ActorAlive,
+                ActorDead,
                 End,
 
                 // Compatibility section
@@ -218,6 +221,24 @@ namespace NActors {
         struct TEvGone: public TEventLocal<TEvGone, TSystem::Gone> {
         };
 
+        struct TEvCheckActorLiveness
+            : public TEventSimpleNonLocal<TEvCheckActorLiveness, TSystem::CheckActorLiveness>
+        {
+            static constexpr IEventHandle::TEventFlags RequestFlags =
+                IEventHandle::FlagTrackDelivery |
+                IEventHandle::FlagSystemMessage;
+        };
+
+        struct TEvActorAlive
+            : public TEventSimpleNonLocal<TEvActorAlive, TSystem::ActorAlive>
+        {
+        };
+
+        struct TEvActorDead
+            : public TEventSimpleNonLocal<TEvActorDead, TSystem::ActorDead>
+        {
+        };
+
         struct TEvInvokeResult;
 
         using TEvPoisonPill = TEvPoison; // Legacy name, deprecated
@@ -235,6 +256,9 @@ namespace NActors {
          * be executed with the actor argument equal to nullptr.
          */
         struct TEvResumeRunnable: public TEventLocal<TEvResumeRunnable, TSystem::ResumeRunnable> {
+            static constexpr IEventHandle::TEventFlags EventFlags =
+                IEventHandle::FlagSystemMessage;
+
             TActorRunnableItem* Item; // or nullptr
 
             TEvResumeRunnable(TActorRunnableItem* item) : Item(item) {}

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -116,6 +116,7 @@ namespace NActors {
                 CheckActorLiveness,
                 ActorAlive,
                 ActorDead,
+                ActorLivenessUnsure,
                 End,
 
                 // Compatibility section
@@ -222,21 +223,25 @@ namespace NActors {
         };
 
         struct TEvCheckActorLiveness
-            : public TEventSimpleNonLocal<TEvCheckActorLiveness, TSystem::CheckActorLiveness>
-        {
+            : public TEventSimpleNonLocal<TEvCheckActorLiveness, TSystem::CheckActorLiveness> {
             static constexpr IEventHandle::TEventFlags RequestFlags =
                 IEventHandle::FlagTrackDelivery |
                 IEventHandle::FlagSystemMessage;
         };
 
         struct TEvActorAlive
-            : public TEventSimpleNonLocal<TEvActorAlive, TSystem::ActorAlive>
-        {
+            : public TEventSimpleNonLocal<TEvActorAlive, TSystem::ActorAlive> {
         };
 
+        // The actor registry confirmed that the requested actor does not exist.
         struct TEvActorDead
-            : public TEventSimpleNonLocal<TEvActorDead, TSystem::ActorDead>
-        {
+            : public TEventSimpleNonLocal<TEvActorDead, TSystem::ActorDead> {
+        };
+
+        // The target is remote and distributed liveness checks are not
+        // supported yet.
+        struct TEvActorLivenessUnsure
+            : public TEventSimpleNonLocal<TEvActorLivenessUnsure, TSystem::ActorLivenessUnsure> {
         };
 
         struct TEvInvokeResult;

--- a/ydb/library/actors/core/events_undelivered.cpp
+++ b/ydb/library/actors/core/events_undelivered.cpp
@@ -2,6 +2,25 @@
 #include "actorsystem.h"
 
 namespace NActors {
+    namespace {
+        std::unique_ptr<IEventHandle> CreateActorDeadResponse(
+                std::unique_ptr<IEventHandle> ev) {
+            static_assert(
+                TEvents::TEvCheckActorLiveness::RequestFlags ==
+                (IEventHandle::FlagTrackDelivery | IEventHandle::FlagSystemMessage));
+
+            return std::make_unique<IEventHandle>(
+                TEvents::TSystem::ActorDead,
+                0,
+                ev->Sender,
+                ev->Recipient,
+                nullptr,
+                ev->Cookie,
+                nullptr,
+                std::move(ev->TraceId));
+        }
+    }
+
     TString TEvents::TEvUndelivered::ToStringHeader() const {
         return "TSystem::Undelivered";
     }
@@ -50,7 +69,15 @@ namespace NActors {
         }
 
         if (ev->Flags & FlagTrackDelivery) {
-            const ui32 updatedFlags = ev->Flags & ~(FlagTrackDelivery | FlagSubscribeOnSession | FlagGenerateUnsureUndelivered);
+            if (ev->Type == TEvents::TSystem::CheckActorLiveness) {
+                return CreateActorDeadResponse(std::move(ev));
+            }
+
+            const ui32 updatedFlags = ev->Flags & ~(
+                FlagTrackDelivery |
+                FlagSubscribeOnSession |
+                FlagGenerateUnsureUndelivered |
+                FlagSystemMessage);
             return std::unique_ptr<IEventHandle>(new IEventHandle(ev->Sender, ev->Recipient, new TEvents::TEvUndelivered(ev->Type, reason, unsure), updatedFlags,
                 ev->Cookie, nullptr, std::move(ev->TraceId)));
         }

--- a/ydb/library/actors/core/events_undelivered.cpp
+++ b/ydb/library/actors/core/events_undelivered.cpp
@@ -3,14 +3,16 @@
 
 namespace NActors {
     namespace {
-        std::unique_ptr<IEventHandle> CreateActorDeadResponse(
-                std::unique_ptr<IEventHandle> ev) {
+        std::unique_ptr<IEventHandle> CreateActorLivenessResponse(
+                std::unique_ptr<IEventHandle> ev,
+                ui32 responseType) {
             static_assert(
                 TEvents::TEvCheckActorLiveness::RequestFlags ==
-                (IEventHandle::FlagTrackDelivery | IEventHandle::FlagSystemMessage));
+                (IEventHandle::FlagTrackDelivery |
+                    IEventHandle::FlagSystemMessage));
 
             return std::make_unique<IEventHandle>(
-                TEvents::TSystem::ActorDead,
+                responseType,
                 0,
                 ev->Sender,
                 ev->Recipient,
@@ -70,7 +72,10 @@ namespace NActors {
 
         if (ev->Flags & FlagTrackDelivery) {
             if (ev->Type == TEvents::TSystem::CheckActorLiveness) {
-                return CreateActorDeadResponse(std::move(ev));
+                const ui32 responseType = reason == TEvents::TEvUndelivered::ReasonActorUnknown
+                    ? TEvents::TSystem::ActorDead
+                    : TEvents::TSystem::ActorLivenessUnsure;
+                return CreateActorLivenessResponse(std::move(ev), responseType);
             }
 
             const ui32 updatedFlags = ev->Flags & ~(

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -754,6 +754,120 @@ Y_UNIT_TEST_SUITE(TestAliases) {
     }
 }
 
+Y_UNIT_TEST_SUITE(TestActorLiveness) {
+    struct TTargetActor : TActorBootstrapped<TTargetActor> {
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+        }
+
+        STRICT_STFUNC(StateWork,
+            cFunc(TEvents::TSystem::Poison, PassAway)
+        )
+    };
+
+    struct TProbeActor : TActorBootstrapped<TProbeActor> {
+        static constexpr ui64 AliveCookie = 1;
+        static constexpr ui64 DeadCookie = 2;
+
+        TProbeActor(
+                TActorId target,
+                TThreadParkPad* donePad,
+                std::atomic<bool>* doneFlag)
+            : Target(target)
+            , DonePad(donePad)
+            , DoneFlag(doneFlag)
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+            CheckActorLiveness(AliveCookie);
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvents::TEvActorAlive, Handle)
+            hFunc(TEvents::TEvActorDead, Handle)
+        )
+
+        void Handle(TEvents::TEvActorAlive::TPtr& ev) {
+            Y_ABORT_UNLESS(!ev->HasEvent());
+            Y_ABORT_UNLESS(ev->Sender == Target);
+            Y_ABORT_UNLESS(ev->Cookie == AliveCookie);
+
+            Send(Target, new TEvents::TEvPoison());
+            CheckActorLiveness(DeadCookie);
+        }
+
+        void Handle(TEvents::TEvActorDead::TPtr& ev) {
+            Y_ABORT_UNLESS(!ev->HasEvent());
+            Y_ABORT_UNLESS(ev->Sender == Target);
+            Y_ABORT_UNLESS(ev->Cookie == DeadCookie);
+
+            if (DoneFlag) {
+                DoneFlag->store(true, std::memory_order_release);
+            }
+            if (DonePad) {
+                DonePad->Unpark();
+            }
+            PassAway();
+        }
+
+        void CheckActorLiveness(ui64 cookie) {
+            Send(new IEventHandle(
+                TEvents::TSystem::CheckActorLiveness,
+                TEvents::TEvCheckActorLiveness::RequestFlags,
+                Target,
+                SelfId(),
+                nullptr,
+                cookie));
+        }
+
+        const TActorId Target;
+        TThreadParkPad* const DonePad;
+        std::atomic<bool>* const DoneFlag;
+    };
+
+    Y_UNIT_TEST(ActorSystemHandlesLivenessCheck) {
+        using TActorBenchmark = NActors::NTests::TActorBenchmark<>;
+
+        auto setup = TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, 1, true, false);
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        const TActorId target = actorSystem.Register(
+            new TTargetActor(),
+            TMailboxType::HTSwap,
+            0);
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TProbeActor(target, &done, nullptr),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+    }
+
+    Y_UNIT_TEST(TestRuntimeHandlesLivenessCheck) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId target = runtime.Register(new TTargetActor());
+        std::atomic<bool> done = false;
+        runtime.Register(new TProbeActor(target, nullptr, &done));
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&] {
+            return done.load(std::memory_order_acquire);
+        };
+        runtime.DispatchEvents(options);
+
+        UNIT_ASSERT(done.load(std::memory_order_acquire));
+    }
+}
+
 Y_UNIT_TEST_SUITE(TestThreadContextQueueTimestamps) {
     using namespace NThreading;
 

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -827,6 +827,42 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
         std::atomic<bool>* const DoneFlag;
     };
 
+    struct TRemoteProbeActor : TActorBootstrapped<TRemoteProbeActor> {
+        static constexpr ui64 Cookie = 1;
+
+        TRemoteProbeActor(TActorId target, TThreadParkPad& done)
+            : Target(target)
+            , Done(done)
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+            Send(new IEventHandle(
+                TEvents::TSystem::CheckActorLiveness,
+                TEvents::TEvCheckActorLiveness::RequestFlags,
+                Target,
+                SelfId(),
+                nullptr,
+                Cookie));
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvents::TEvActorLivenessUnsure, Handle)
+        )
+
+        void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
+            Y_ABORT_UNLESS(!ev->HasEvent());
+            Y_ABORT_UNLESS(ev->Sender == Target);
+            Y_ABORT_UNLESS(ev->Cookie == Cookie);
+            Done.Unpark();
+            PassAway();
+        }
+
+        const TActorId Target;
+        TThreadParkPad& Done;
+    };
+
     Y_UNIT_TEST(ActorSystemHandlesLivenessCheck) {
         using TActorBenchmark = NActors::NTests::TActorBenchmark<>;
 
@@ -843,6 +879,26 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
         TThreadParkPad done;
         actorSystem.Register(
             new TProbeActor(target, &done, nullptr),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+    }
+
+    Y_UNIT_TEST(ActorSystemReportsRemoteLivenessAsUnsure) {
+        using TActorBenchmark = NActors::NTests::TActorBenchmark<>;
+
+        auto setup = TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, 1, true, false);
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        const TActorId remoteTarget(2, 0, 1, 0);
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TRemoteProbeActor(remoteTarget, done),
             TMailboxType::HTSwap,
             0);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add lightweight actor liveness checks using type-only system messages. The actor runtime handles CheckActorLiveness without invoking actor state and returns ActorAlive or ActorDead without payload allocation or serialization.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
