### PR TITLE
Don't report VDisk occupancy metrics for Replication tests

### DIFF
--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -58,6 +58,7 @@ struct TPDiskMockState::TImpl {
     ESpaceColorPolicy SpaceColorPolicy;
     std::shared_ptr<NPDisk::TQuotaRecord> ChunkSharedQuota;
     double Occupancy = 0;
+    bool ReportVDiskMetrics = false;
 
     struct TShredState {
         enum class EPhase : ui8 {
@@ -336,6 +337,10 @@ struct TPDiskMockState::TImpl {
         StatusFlags = SpaceColorToStatusFlag(spaceColor);
     }
 
+    void SetReportVDiskMetrics(bool reportVDiskMetrics) {
+        ReportVDiskMetrics = reportVDiskMetrics;
+    }
+
     void SetReadOnly(const TVDiskID& vDiskId, bool isReadOnly) {
         if (isReadOnly) {
             ReadOnlyVDisks.insert(vDiskId.GroupID.GetRawId());
@@ -396,6 +401,10 @@ void TPDiskMockState::SetStatusFlags(NPDisk::TStatusFlags flags) {
 
 void TPDiskMockState::SetReadOnly(const TVDiskID& vDiskId, bool isReadOnly) {
     Impl->SetReadOnly(vDiskId, isReadOnly);
+}
+
+void TPDiskMockState::SetReportVDiskMetrics(bool reportVDiskMetrics) {
+    Impl->SetReportVDiskMetrics(reportVDiskMetrics);
 }
 
 bool TPDiskMockState::IsDiskReadOnly() const {
@@ -470,22 +479,24 @@ public:
         p->SetAvailableSize((ui64)(Impl.TotalChunks - usedChunks) * Impl.ChunkSize);
         p->SetTotalSize((ui64)Impl.TotalChunks * Impl.ChunkSize);
         p->SetState(NKikimrBlobStorage::TPDiskState::Normal);
-        // report a full performance metrics set (like a real PDisk does) so that BSC considers the PDisk complete
-        p->SetMaxIOPS(1000);
-        p->SetMaxReadThroughput(1'000'000'000);
-        p->SetMaxWriteThroughput(1'000'000'000);
+        if (Impl.ReportVDiskMetrics) {
+            // report a full performance metrics set (like a real PDisk does) so that BSC considers the PDisk complete
+            p->SetMaxIOPS(1000);
+            p->SetMaxReadThroughput(1'000'000'000);
+            p->SetMaxWriteThroughput(1'000'000'000);
 
-        // report per-VDisk metrics with normalized occupancy; deliberately do not touch status flags
-        for (const auto& [ownerId, owner] : Impl.Owners) {
-            auto *m = record.AddVDisksMetrics();
-            VDiskIDFromVDiskID(owner.VDiskId, m->MutableVDiskId());
-            auto *vslotId = m->MutableVSlotId();
-            vslotId->SetNodeId(Impl.NodeId);
-            vslotId->SetPDiskId(Impl.PDiskId);
-            vslotId->SetVSlotId(owner.SlotId);
-            m->SetNormalizedOccupancy(GetOccupancy());
-            m->SetAllocatedSize((ui64)owner.CommittedChunks.size() * Impl.ChunkSize);
-            m->SetAvailableSize(p->GetAvailableSize());
+            // report per-VDisk metrics with normalized occupancy; deliberately do not touch status flags
+            for (const auto& [ownerId, owner] : Impl.Owners) {
+                auto *m = record.AddVDisksMetrics();
+                VDiskIDFromVDiskID(owner.VDiskId, m->MutableVDiskId());
+                auto *vslotId = m->MutableVSlotId();
+                vslotId->SetNodeId(Impl.NodeId);
+                vslotId->SetPDiskId(Impl.PDiskId);
+                vslotId->SetVSlotId(owner.SlotId);
+                m->SetNormalizedOccupancy(GetOccupancy());
+                m->SetAllocatedSize((ui64)owner.CommittedChunks.size() * Impl.ChunkSize);
+                m->SetAvailableSize(p->GetAvailableSize());
+            }
         }
         Send(MakeBlobStorageNodeWardenID(SelfId().NodeId()), ev.release());
 

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.cpp
@@ -479,12 +479,12 @@ public:
         p->SetAvailableSize((ui64)(Impl.TotalChunks - usedChunks) * Impl.ChunkSize);
         p->SetTotalSize((ui64)Impl.TotalChunks * Impl.ChunkSize);
         p->SetState(NKikimrBlobStorage::TPDiskState::Normal);
-        if (Impl.ReportVDiskMetrics) {
-            // report a full performance metrics set (like a real PDisk does) so that BSC considers the PDisk complete
-            p->SetMaxIOPS(1000);
-            p->SetMaxReadThroughput(1'000'000'000);
-            p->SetMaxWriteThroughput(1'000'000'000);
 
+        // report a full performance metrics set (like a real PDisk does) so that BSC considers the PDisk complete
+        p->SetMaxIOPS(1000);
+        p->SetMaxReadThroughput(1'000'000'000);
+        p->SetMaxWriteThroughput(1'000'000'000);
+        if (Impl.ReportVDiskMetrics) {
             // report per-VDisk metrics with normalized occupancy; deliberately do not touch status flags
             for (const auto& [ownerId, owner] : Impl.Owners) {
                 auto *m = record.AddVDisksMetrics();

--- a/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
+++ b/ydb/core/blobstorage/pdisk/mock/pdisk_mock.h
@@ -49,6 +49,7 @@ namespace NKikimr {
         TPtr Snapshot(); // create a copy of PDisk whole state
 
         void SetReadOnly(const TVDiskID& vDiskId, bool isReadOnly);
+        void SetReportVDiskMetrics(bool reportVDiskMetrics);
 
         bool IsDiskReadOnly() const;
     };

--- a/ydb/core/blobstorage/ut_blobstorage/lib/env.h
+++ b/ydb/core/blobstorage/ut_blobstorage/lib/env.h
@@ -67,6 +67,7 @@ struct TEnvironmentSetup {
         const ui64 PDiskSize = 10_TB;
         const ui64 PDiskChunkSize = 0;
         const bool TrackSharedQuotaInPDiskMock = false;
+        const bool ReportVDiskMetricsInPDiskMock = false;
         const bool SelfManagementConfig = false;
         const bool EnableDeepScrubbing = false;
         const ui32 NumPiles = 0;
@@ -103,6 +104,7 @@ struct TEnvironmentSetup {
                         : TPDiskMockState::ESpaceColorPolicy::None;
                 state.Reset(new TPDiskMockState(nodeId, pdiskId, cfg->PDiskGuid, Env.Settings.PDiskSize, chunkSize,
                         cfg->ReadOnly, Env.Settings.DiskType, spaceColorPolicy));
+                state->SetReportVDiskMetrics(Env.Settings.ReportVDiskMetricsInPDiskMock);
             }
             const TActorId& actorId = ctx.Register(CreatePDiskMockActor(state), TMailboxType::HTSwap, poolId);
             const TActorId& serviceId = MakeBlobStoragePDiskID(nodeId, pdiskId);

--- a/ydb/core/blobstorage/ut_blobstorage/select_groups.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/select_groups.cpp
@@ -9,7 +9,9 @@ Y_UNIT_TEST_SUITE(SelectGroups) {
     // VDisk status flags changed too -- which they don't for a fresh empty disk -- so the request hung
     // forever.
     Y_UNIT_TEST(BlockUntilAllResourcesAreComplete) {
-        TEnvironmentSetup env(false);
+        TEnvironmentSetup env(TEnvironmentSetup::TSettings{
+            .ReportVDiskMetricsInPDiskMock = true,
+        });
 
         // create a fresh group; at this point it has no VDisk metrics yet
         env.CreateBoxAndPool();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix ReplicationSpace unit tests that started to fail after enabling exporting of VDisk metrics

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)