### PR TITLE
Fix ASAN leak in PersQueue read session teardown

### DIFF
--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
@@ -373,6 +373,12 @@ bool TReadSession::Close(TDuration timeout) {
         // Log final counters.
         CountersLogger->Stop();
     }
+    {
+        std::lock_guard guard(Lock);
+        if (DumpCountersContext) {
+            DumpCountersContext->Cancel();
+        }
+    }
 
     std::vector<TSingleClusterReadSessionImpl::TPtr> sessions;
     NThreading::TPromise<bool> promise = NThreading::NewPromise<bool>();
@@ -383,6 +389,8 @@ bool TReadSession::Close(TDuration timeout) {
         }
     };
 
+    std::vector<TCallbackContextPtr> cbContextsToCancel;
+    std::shared_ptr<TCallbackContext<TCountersLogger>> dumpCountersContextToCancel;
     TDeferredActions deferred;
     {
         std::lock_guard guard(Lock);
@@ -447,6 +455,8 @@ bool TReadSession::Close(TDuration timeout) {
     {
         std::lock_guard guard(Lock);
         Aborting = true; // Set abort flag for doing nothing on destructor.
+        cbContextsToCancel = CbContexts;
+        dumpCountersContextToCancel = DumpCountersContext;
     }
 
     for (const auto& session : sessions) {
@@ -457,6 +467,13 @@ bool TReadSession::Close(TDuration timeout) {
     ClearAllEvents();
     for (const auto& session : sessions) {
         session->ClearAllPartitionStreamEvents();
+    }
+
+    for (const auto& ctx : cbContextsToCancel) {
+        ctx->Cancel();
+    }
+    if (dumpCountersContextToCancel) {
+        dumpCountersContextToCancel->Cancel();
     }
 
     return result;

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
@@ -424,6 +424,7 @@ bool TReadSession::Close(TDuration timeout) {
 
     auto timeoutContext = Connections->CreateContext();
     if (!timeoutContext) {
+        std::lock_guard guard(Lock);
         AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
         return false;
     }

--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/read_session.cpp
@@ -59,7 +59,28 @@ TReadSession::~TReadSession() {
     }
 
     Abort();
+
+    std::vector<TSingleClusterReadSessionImpl::TPtr> sessions;
+    {
+        std::lock_guard guard(Lock);
+        sessions.reserve(ClusterSessions.size());
+        for (auto& [_, sessionInfo] : ClusterSessions) {
+            if (sessionInfo.Session) {
+                sessions.push_back(sessionInfo.Session);
+            }
+        }
+    }
+
+    const TInstant closeDeadline = TInstant::Now() + TDuration::Seconds(5);
+    for (const auto& session : sessions) {
+        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session destroy timeout");
+        }
+    }
     ClearAllEvents();
+    for (const auto& session : sessions) {
+        session->ClearAllPartitionStreamEvents();
+    }
 
     for (const auto& ctx : CbContexts) {
         ctx->Cancel();
@@ -398,6 +419,7 @@ bool TReadSession::Close(TDuration timeout) {
         AbortImpl(EStatus::ABORTED, DRIVER_IS_STOPPING_DESCRIPTION, deferred);
         return false;
     }
+    const TInstant closeDeadline = TInstant::Now() + timeout;
     Connections->ScheduleCallback(timeout,
                                   std::move(timeoutCallback),
                                   timeoutContext);
@@ -422,8 +444,21 @@ bool TReadSession::Close(TDuration timeout) {
         EventsQueue->Close(TSessionClosedEvent(EStatus::TIMEOUT, std::move(issues)), deferred);
     }
 
-    std::lock_guard guard(Lock);
-    Aborting = true; // Set abort flag for doing nothing on destructor.
+    {
+        std::lock_guard guard(Lock);
+        Aborting = true; // Set abort flag for doing nothing on destructor.
+    }
+
+    for (const auto& session : sessions) {
+        if (!session->WaitAllDecompressionTasks(closeDeadline)) {
+            LOG_LAZY(Log, TLOG_WARNING, GetLogPrefix() << "Some decompression tasks are still running after read session close timeout");
+        }
+    }
+    ClearAllEvents();
+    for (const auto& session : sessions) {
+        session->ClearAllPartitionStreamEvents();
+    }
+
     return result;
 }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

## Контекст

ASAN leak в PQv1 read session (#45135): цикл `TDataDecompressionInfo` ↔ `TDecompressionTask::Parent` при teardown без полной очистки.

В shared impl (`NTopic::TSingleClusterReadSessionImpl`) это уже чинилось для Topic API (`UseMigrationProtocol=false`). Для PersQueue / PQv1 (`true`) дыра оставалась в обёртке `persqueue_public/impl/read_session.cpp`.

Связанные исправления Topic SDK:
- https://github.com/ydb-platform/ydb/pull/45159 — `AbortImpl` + deferred cleanup decompression queue / event queues
- https://github.com/ydb-platform/ydb/pull/46748 — `WaitAllDecompressionTasks` + `ClearAllPartitionStreamEvents` в Topic `Close`/destructor; cancel callback contexts после cleanup
- https://github.com/ydb-platform/ydb/pull/46840 — сопутствующий fix verify on shutdown в SDK

Этот PR переносит нужное поведение teardown на PQv1-обёртку.

## Суть изменений

1. **Destructor и `Close(timeout > 0)`** — после abort/close:
   - `WaitAllDecompressionTasks`
   - `ClearAllEvents` + `ClearAllPartitionStreamEvents` по cluster sessions  
   (аналог https://github.com/ydb-platform/ydb/pull/46748)

2. **`Close(timeout > 0)`** — после cleanup cancel `CbContexts` и `DumpCountersContext`, чтобы late callbacks не планировали работу после Close  
   (как в Topic в https://github.com/ydb-platform/ydb/pull/46748)

3. **`Close(0)`** — по-прежнему только abort; cleanup делает destructor.

4. **Lock перед `AbortImpl`**, если `CreateContext()` вернул null при Close (driver stopping) — иначе `Y_ABORT_UNLESS(Lock.IsLocked())`. Тот же баг есть в Topic `Close` (`topic/impl/read_session.cpp`), здесь правим только PQ-путь.