### PR TITLE
Replace std::deque with single-linked queue

### DIFF
--- a/ydb/library/actors/interconnect/v2_event_serializer.cpp
+++ b/ydb/library/actors/interconnect/v2_event_serializer.cpp
@@ -15,10 +15,7 @@ namespace NActors {
 
     void TEventSerializer::Push(std::unique_ptr<IEventHandle> ev) {
         const ui16 channel = ev->GetChannel();
-        TPerChannelQueue& queue = GetQueue(channel);
-        const bool first = queue.Events.empty();
-        queue.Events.push_back(std::move(ev));
-        if (first) {
+        if (GetQueue(channel).Events.Push(std::move(ev))) {
             // place this new quota into non-zero part of the heap
             Y_ABORT_UNLESS(channel != TChunkHeader::SystemChannel);
             PerChannelQuotaHeap.push_back(TPerChannelQuota{
@@ -81,7 +78,7 @@ namespace NActors {
 
             // update quota
             std::ranges::pop_heap(PerChannelQuotaHeap, std::less<ui16>{}, &TPerChannelQuota::Quota);
-            if (queue.Events.empty() && queue.SystemRequests.empty()) {
+            if (!queue.Events.Peek() && queue.SystemRequests.empty()) {
                 // we have serialized all the events avaiable in this queue, so we drop record from the quota heap
                 PerChannelQuotaHeap.pop_back();
             } else {
@@ -190,8 +187,8 @@ namespace NActors {
             queue.SystemRequests.pop_front();
         }
 
-        while (Min(buffer.size(), maxBytesToProduce) >= MinUsefulQuota && !queue.Events.empty()) {
-            IEventHandle& ev = *queue.Events.front();
+        while (Min(buffer.size(), maxBytesToProduce) >= MinUsefulQuota && queue.Events.Peek()) {
+            IEventHandle& ev = *queue.Events.Peek();
 
             TChunkHeader *header = nullptr;
             auto addEventChunkBytes = [&](const char *ptr, size_t numBytes) {
@@ -312,7 +309,7 @@ namespace NActors {
                             .Event{ev.ReleaseBase().Release()},
                             .EventReceivedTimestamp = reinterpret_cast<const ui64&>(ev.OriginScopeId),
                         });
-                        queue.Events.pop_front();
+                        queue.Events.Pop();
                         queue.SerializeStage = ESerializeStage::kInitial;
                         queue.EventHeaderOffset = 0;
                     }

--- a/ydb/library/actors/interconnect/v2_event_serializer.h
+++ b/ydb/library/actors/interconnect/v2_event_serializer.h
@@ -80,8 +80,44 @@ namespace NActors {
             kChunkSerializer,
             kHeader,
         };
+        class TEventQueue {
+            IEventHandle *First = nullptr;
+            IEventHandle *Last = nullptr;
+
+        public:
+            ~TEventQueue() {
+                while (Peek()) {
+                    Pop();
+                }
+            }
+
+            bool Push(std::unique_ptr<IEventHandle> ev) {
+                const bool res = !First; // was this the first one
+                ev->NextLinkPtr.store(0, std::memory_order_relaxed);
+                if (Last) {
+                    Last->NextLinkPtr.store(reinterpret_cast<uintptr_t>(ev.get()), std::memory_order_relaxed);
+                } else {
+                    First = ev.get();
+                }
+                Last = ev.release();
+                return res;
+            }
+
+            IEventHandle *Peek() const {
+                return First;
+            }
+
+            void Pop() {
+                Y_DEBUG_ABORT_UNLESS(Last && First);
+                std::unique_ptr<IEventHandle> temp(First);
+                First = reinterpret_cast<IEventHandle*>(First->NextLinkPtr.load(std::memory_order_relaxed));
+                if (!First) {
+                    Last = nullptr;
+                }
+            }
+        };
         struct TPerChannelQueue {
-            std::deque<std::unique_ptr<IEventHandle>> Events;
+            TEventQueue Events;
             std::deque<TRcBuf> SystemRequests;
             TEventHeader EventHeader;
             size_t EventHeaderOffset = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Replace std::deque with single-linked queue

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch introduces a minor performance improvement.
