### PR TITLE
Add mailbox processing finished notifications

### DIFF
--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -570,9 +570,13 @@ namespace NActors {
 
     public:
         using TReceiveFunc = void (IActor::*)(TAutoPtr<IEventHandle>& ev);
+        enum class ESystemFlag : ui64 {
+            MailboxProcessingFinished = 1ull << 0,
+        };
 
     private:
         TReceiveFunc StateFunc_;
+        ui64 SystemFlags = 0;
 
     private:
         friend class NDetail::TActorAsyncHandlerPromise;
@@ -690,6 +694,22 @@ namespace NActors {
         } // must not be called for registered actors, see Die method instead
 
     protected:
+        void SetSystemFlag(ESystemFlag flag) noexcept {
+            SystemFlags |= static_cast<ui64>(flag);
+        }
+
+        void ClearSystemFlag(ESystemFlag flag) noexcept {
+            SystemFlags &= ~static_cast<ui64>(flag);
+        }
+
+        ui64 GetSystemFlags() const noexcept {
+            return SystemFlags;
+        }
+
+        bool HasSystemFlag(ESystemFlag flag) const noexcept {
+            return GetSystemFlags() & static_cast<ui64>(flag);
+        }
+
         virtual void Die(const TActorContext& ctx); // would unregister actor so call exactly once and only from inside of message processing
         virtual void PassAway();
 

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -571,6 +571,9 @@ namespace NActors {
     public:
         using TReceiveFunc = void (IActor::*)(TAutoPtr<IEventHandle>& ev);
         enum class ESystemFlag : ui64 {
+            // Notify this actor only after an activation that processed one of
+            // its events. Activations of other actors in the same mailbox are
+            // not reported.
             MailboxProcessingFinished = 1ull << 0,
         };
 

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -111,7 +111,7 @@ namespace NActors {
                 CoroTimeout,
                 InvokeQuery,
                 Wilson,
-                Preemption,
+                MailboxProcessingFinished,
                 ResumeRunnable,
                 CheckActorLiveness,
                 ActorAlive,
@@ -139,12 +139,25 @@ namespace NActors {
             const ui64 Tag = 0;
         };
 
-        struct TEvPreemption: public TEventLocal<TEvPreemption, TSystem::Preemption> {
-            bool ByEventCount = false;
-            bool ByCycles = false;
-            bool ByTailSend = false;
-            ui32 EventCount = 0;
-            ui64 Cycles = 0;
+        struct TEvMailboxProcessingFinished
+            : public TEventLocal<TEvMailboxProcessingFinished, TSystem::MailboxProcessingFinished> {
+            enum class EReason : ui8 {
+                QueueEmpty,
+                EventCountLimitReached,
+                TimeLimitReached,
+                SoftDeadlineReached,
+                TailSend,
+            };
+
+            const EReason Reason;
+            const ui32 ExecutedEvents;
+            const ui64 ElapsedCycles;
+
+            TEvMailboxProcessingFinished(EReason reason, ui32 executedEvents, ui64 elapsedCycles)
+                : Reason(reason)
+                , ExecutedEvents(executedEvents)
+                , ElapsedCycles(elapsedCycles)
+            {}
         };
 
         struct TEvSubscribe: public TEventLocal<TEvSubscribe, TSystem::Subscribe> {

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -28,6 +28,8 @@
 #include <util/system/type_name.h>
 #include <util/system/datetime.h>
 
+#include <algorithm>
+
 LWTRACE_USING(ACTORLIB_PROVIDER)
 
 
@@ -184,10 +186,6 @@ namespace NActors {
         ThreadCtx.SetOverwrittenTimePerMailboxTs(Max(value, ThreadCtx.TimePerMailboxTs()));
     }
 
-    void TExecutorThread::SubscribeToPreemption(TActorId actorId) {
-        ThreadCtx.ExecutionContext.PreemptionSubscribed.push_back(actorId);
-    }
-
     TExecutorThread::TProcessingResult TExecutorThread::Execute(TMailbox* mailbox, bool isTailExecution,
             NHPTimer::STime mailboxScheduledTimestampTs) {
         EXECUTOR_THREAD_DEBUG(EDebugLevel::Activation, "Execute mailbox");
@@ -206,10 +204,12 @@ namespace NActors {
         ui32 prevActivityType = std::numeric_limits<ui32>::max();
         TActorId recipient;
         bool firstEvent = true;
-        bool preemptedByEventCount = false;
-        bool preemptedByCycles = false;
-        bool preemptedByTailSend = false;
+        using EFinishReason = TEvents::TEvMailboxProcessingFinished::EReason;
+        EFinishReason finishReason = EFinishReason::EventCountLimitReached;
+        ui32 finishedExecutedEvents = execCtx.ExecutedEvents;
+        bool isPreempted = false;
         bool wasWorking = false;
+        TStackVec<TActorId, 1> mailboxProcessingFinishedActors;
         NHPTimer::STime hpnow = execCtx.HPStart;
         NHPTimer::STime hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
         ExecutionStats.AddElapsedCycles(ActorSystemIndex, hpnow - hpprev);
@@ -278,6 +278,21 @@ namespace NActors {
 
                     actor->Receive(ev);
 
+                    const ui64 systemFlags = actor->GetSystemFlags();
+                    if (Y_UNLIKELY(systemFlags != 0)) {
+                        if (evTypeForTracing != TEvents::TSystem::MailboxProcessingFinished &&
+                                (systemFlags & static_cast<ui64>(
+                                    IActor::ESystemFlag::MailboxProcessingFinished))) {
+                            const TActorId actorId = actor->SelfId();
+                            if (std::find(
+                                    mailboxProcessingFinishedActors.begin(),
+                                    mailboxProcessingFinishedActors.end(),
+                                    actorId) == mailboxProcessingFinishedActors.end()) {
+                                mailboxProcessingFinishedActors.push_back(actorId);
+                            }
+                        }
+                    }
+
                     hpnow = GetCycleCountFast();
                     hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
 
@@ -321,6 +336,7 @@ namespace NActors {
                     ExecutionStats.AddElapsedCycles(ActorSystemIndex, hpnow - hpprev);
                 }
                 eventStart = hpnow;
+                finishedExecutedEvents = execCtx.ExecutedEvents + 1;
 
                 if (TlsThreadContext->CheckCapturedSendingType(ESendingType::Tail)) {
                     ExecutionStats.IncrementMailboxPushedOutByTailSending();
@@ -333,7 +349,7 @@ namespace NActors {
                             ThreadCtx.WorkerId(),
                             recipient.ToString(),
                             SafeTypeName(actorType));
-                    preemptedByTailSend = true;
+                    finishReason = EFinishReason::TailSend;
                     break;
                 }
 
@@ -349,7 +365,8 @@ namespace NActors {
                             ThreadCtx.WorkerId(),
                             recipient.ToString(),
                             SafeTypeName(actorType));
-                    preemptedByCycles = true;
+                    finishReason = EFinishReason::SoftDeadlineReached;
+                    isPreempted = true;
                     break;
                 }
 
@@ -365,7 +382,8 @@ namespace NActors {
                             ThreadCtx.WorkerId(),
                             recipient.ToString(),
                             SafeTypeName(actorType));
-                    preemptedByCycles = true;
+                    finishReason = EFinishReason::TimeLimitReached;
+                    isPreempted = true;
                     break;
                 }
 
@@ -380,7 +398,8 @@ namespace NActors {
                             ThreadCtx.WorkerId(),
                             recipient.ToString(),
                             SafeTypeName(actorType));
-                    preemptedByEventCount = true;
+                    finishReason = EFinishReason::EventCountLimitReached;
+                    isPreempted = true;
                     break;
                 }
             } else {
@@ -395,24 +414,23 @@ namespace NActors {
                         ThreadCtx.WorkerId(),
                         recipient.ToString(),
                         SafeTypeName(actor));
+                finishReason = EFinishReason::QueueEmpty;
                 break; // empty queue, leave
             }
         }
-        if (execCtx.PreemptionSubscribed.size()) {
-            std::unique_ptr<TEvents::TEvPreemption> event = std::make_unique<TEvents::TEvPreemption>();
-            event->ByEventCount = preemptedByEventCount;
-            event->ByCycles = preemptedByCycles;
-            event->ByTailSend = preemptedByTailSend;
-            event->EventCount = execCtx.ExecutedEvents;
-            event->Cycles = hpnow - execCtx.HPStart;
-            TAutoPtr<IEventHandle> ev = new IEventHandle(TActorId(), TActorId(), event.release());
-            for (const auto& actorId : execCtx.PreemptionSubscribed) {
-                IActor *actor = mailbox->FindActor(actorId.LocalId());
-                if (actor) {
-                    actor->Receive(ev);
-                }
+        for (auto it = mailboxProcessingFinishedActors.rbegin();
+                it != mailboxProcessingFinishedActors.rend(); ++it) {
+            if (IActor* actor = mailbox->FindActor(it->LocalId());
+                    actor && (actor->GetSystemFlags() & static_cast<ui64>(
+                        IActor::ESystemFlag::MailboxProcessingFinished))) {
+                mailbox->PushFront(std::make_unique<IEventHandle>(
+                    actor->SelfId(),
+                    TActorId(),
+                    new TEvents::TEvMailboxProcessingFinished(
+                        finishReason,
+                        finishedExecutedEvents,
+                        hpnow - execCtx.HPStart)));
             }
-            execCtx.PreemptionSubscribed.clear();
         }
         TlsThreadContext->ActivityContext.ActivationStartTS.store(hpnow, std::memory_order_release);
         TlsThreadContext->ActivityContext.ElapsingActorActivity.store(ActorSystemIndex, std::memory_order_release);
@@ -425,7 +443,7 @@ namespace NActors {
         } else {
             mailbox->Unlock(ThreadCtx.Pool(), hpnow, RevolvingWriteCounter);
         }
-        return {preemptedByEventCount || preemptedByCycles, wasWorking};
+        return {isPreempted, wasWorking};
     }
 
     TThreadId TExecutorThread::GetThreadId() const {

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -216,6 +216,46 @@ namespace NActors {
         NHPTimer::STime eventStart = execCtx.HPStart;
         TlsThreadContext->ActivityContext.ActivationStartTS.store(execCtx.HPStart, std::memory_order_release);
 
+        auto finishActorEvent = [&](IActor*& currentActor, IEventHandle* ev, ui32 eventType,
+                const std::type_info* currentActorType, ui32 activityType) {
+            hpnow = GetCycleCountFast();
+            hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
+
+            const size_t dyingActorsCnt = DyingActors.size();
+            EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "dyingActorsCnt ", dyingActorsCnt);
+            ExecutionStats.UpdateActorsStats(dyingActorsCnt, ThreadCtx.Pool());
+            if (dyingActorsCnt) {
+                DropUnregistered();
+                currentActor = nullptr;
+            }
+
+            if (mailbox->IsEmpty()) {
+                // had actors and became empty, prepare to reclaim mailbox
+                mailbox->LockToFree();
+            }
+
+            ExecutionStats.AddElapsedCycles(activityType, hpnow - hpprev);
+            const NHPTimer::STime elapsed = ExecutionStats.AddEventProcessingStats(
+                eventStart, hpnow, activityType, CurrentActorScheduledEventsCounter);
+            mailbox->AddElapsedCycles(elapsed);
+            if (elapsed > 1000000) {
+                LwTraceSlowEvent(
+                    ev,
+                    eventType,
+                    currentActorType,
+                    ThreadCtx.PoolId(),
+                    CurrentRecipient,
+                    NHPTimer::GetSeconds(elapsed) * 1000.0);
+            }
+
+            // The actor might have been destroyed
+            if (currentActor) {
+                currentActor->AddElapsedTicks(elapsed);
+            }
+
+            CurrentRecipient = TActorId();
+        };
+
         ThreadCtx.ResetOverwrittenEventsPerMailbox();
         ThreadCtx.ResetOverwrittenTimePerMailboxTs();
         Y_ABORT_UNLESS(mailboxScheduledTimestampTs, "mailbox scheduled timestamp must be set");
@@ -280,9 +320,8 @@ namespace NActors {
 
                     const ui64 systemFlags = actor->GetSystemFlags();
                     if (Y_UNLIKELY(systemFlags != 0)) {
-                        if (evTypeForTracing != TEvents::TSystem::MailboxProcessingFinished &&
-                                (systemFlags & static_cast<ui64>(
-                                    IActor::ESystemFlag::MailboxProcessingFinished))) {
+                        if (systemFlags & static_cast<ui64>(
+                                IActor::ESystemFlag::MailboxProcessingFinished)) {
                             const TActorId actorId = actor->SelfId();
                             if (std::find(
                                     mailboxProcessingFinishedActors.begin(),
@@ -293,34 +332,7 @@ namespace NActors {
                         }
                     }
 
-                    hpnow = GetCycleCountFast();
-                    hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
-
-                    size_t dyingActorsCnt = DyingActors.size();
-                    EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "dyingActorsCnt ", dyingActorsCnt);
-                    ExecutionStats.UpdateActorsStats(dyingActorsCnt, ThreadCtx.Pool());
-                    if (dyingActorsCnt) {
-                        DropUnregistered();
-                        actor = nullptr;
-                    }
-
-                    if (mailbox->IsEmpty()) {
-                        // had actors and became empty, prepare to reclaim mailbox
-                        mailbox->LockToFree();
-                    }
-
-                    ExecutionStats.AddElapsedCycles(activityType, hpnow - hpprev);
-                    NHPTimer::STime elapsed = ExecutionStats.AddEventProcessingStats(eventStart, hpnow, activityType, CurrentActorScheduledEventsCounter);
-                    mailbox->AddElapsedCycles(elapsed);
-                    if (elapsed > 1000000) {
-                        LwTraceSlowEvent(ev.Get(), evTypeForTracing, actorType, ThreadCtx.PoolId(), CurrentRecipient, NHPTimer::GetSeconds(elapsed) * 1000.0);
-                    }
-
-                    // The actor might have been destroyed
-                    if (actor)
-                        actor->AddElapsedTicks(elapsed);
-
-                    CurrentRecipient = TActorId();
+                    finishActorEvent(actor, ev.Get(), evTypeForTracing, actorType, activityType);
                 } else {
                     EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is null");
                     actorType = nullptr;
@@ -418,18 +430,40 @@ namespace NActors {
                 break; // empty queue, leave
             }
         }
-        for (auto it = mailboxProcessingFinishedActors.rbegin();
-                it != mailboxProcessingFinishedActors.rend(); ++it) {
-            if (IActor* actor = mailbox->FindActor(it->LocalId());
+        const ui64 finishedElapsedCycles = hpnow - execCtx.HPStart;
+        // Deliver notifications directly so they do not enter the mailbox
+        // queue or consume its event processing budget.
+        for (const TActorId& actorId : mailboxProcessingFinishedActors) {
+            if (IActor* actor = mailbox->FindActor(actorId.LocalId());
                     actor && (actor->GetSystemFlags() & static_cast<ui64>(
                         IActor::ESystemFlag::MailboxProcessingFinished))) {
-                mailbox->PushFront(std::make_unique<IEventHandle>(
+                const TActorId recipient = actor->SelfId();
+                TActorContext ctx(*mailbox, *this, eventStart, recipient);
+                TlsActivationContext = &ctx;
+                TAutoPtr<IEventHandle> ev = new IEventHandle(
                     actor->SelfId(),
                     TActorId(),
                     new TEvents::TEvMailboxProcessingFinished(
                         finishReason,
                         finishedExecutedEvents,
-                        hpnow - execCtx.HPStart)));
+                        finishedElapsedCycles));
+
+                const std::type_info* notificationActorType = &typeid(*actor);
+                const ui32 activityType = actor->GetActivityType().GetIndex();
+                NProfiling::TMemoryTagScope::Reset(activityType);
+                TlsThreadContext->ActivityContext.ElapsingActorActivity.store(activityType, std::memory_order_release);
+                CurrentRecipient = recipient;
+                CurrentActorScheduledEventsCounter = 0;
+
+                actor->Receive(ev);
+
+                finishActorEvent(
+                    actor,
+                    ev.Get(),
+                    TEvents::TSystem::MailboxProcessingFinished,
+                    notificationActorType,
+                    activityType);
+                eventStart = hpnow;
             }
         }
         TlsThreadContext->ActivityContext.ActivationStartTS.store(hpnow, std::memory_order_release);

--- a/ydb/library/actors/core/executor_thread.h
+++ b/ydb/library/actors/core/executor_thread.h
@@ -78,7 +78,6 @@ namespace NActors {
         TThreadId GetThreadId() const; // blocks, must be called after Start()
         TWorkerId GetWorkerId() const;
 
-        void SubscribeToPreemption(TActorId actorId);
         ui32 GetOverwrittenEventsPerMailbox() const;
         void SetOverwrittenEventsPerMailbox(ui32 value);
         ui64 GetOverwrittenTimePerMailboxTs() const;

--- a/ydb/library/actors/core/thread_context.h
+++ b/ydb/library/actors/core/thread_context.h
@@ -68,7 +68,6 @@ namespace NActors {
         ui32 ExecutedEvents = 0;
         ui32 OverwrittenEventsPerMailbox = 0;
         ui64 OverwrittenTimePerMailboxTs = 0;
-        TStackVec<TActorId, 1> PreemptionSubscribed;
         bool IsNeededToWaitNextActivation = true;
         ESendingType SendingType = ESendingType::Common;
         NHPTimer::STime HPStart = 0;

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -924,6 +924,143 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
     }
 }
 
+Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
+    using EFinishReason = TEvents::TEvMailboxProcessingFinished::EReason;
+    using TActorBenchmark = NActors::NTests::TActorBenchmark<>;
+
+    struct TResult {
+        EFinishReason Reason = EFinishReason::QueueEmpty;
+        ui32 ExecutedEvents = 0;
+        ui64 ElapsedCycles = 0;
+    };
+
+    class TObserverActor : public TActorBootstrapped<TObserverActor> {
+    public:
+        TObserverActor(TResult& result, TThreadParkPad& done)
+            : Result(result)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingFinished::TPtr& ev) {
+            Result.Reason = ev->Get()->Reason;
+            Result.ExecutedEvents = ev->Get()->ExecutedEvents;
+            Result.ElapsedCycles = ev->Get()->ElapsedCycles;
+            Done.Unpark();
+            PassAway();
+        }
+
+    private:
+        TResult& Result;
+        TThreadParkPad& Done;
+    };
+
+    class TPersistentObserverActor : public TActorBootstrapped<TPersistentObserverActor> {
+    public:
+        TPersistentObserverActor(ui32& notifications, TThreadParkPad& done)
+            : Notifications(notifications)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
+            ++Notifications;
+            if (Notifications == 1) {
+                Send(SelfId(), new TEvents::TEvWakeup(1));
+            } else if (Notifications == 2) {
+                ClearSystemFlag(ESystemFlag::MailboxProcessingFinished);
+                Send(SelfId(), new TEvents::TEvWakeup(2));
+            } else {
+                Done.Unpark();
+                PassAway();
+            }
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr& ev) {
+            if (ev->Get()->Tag == 2) {
+                Send(SelfId(), new TEvents::TEvWakeup(3));
+            } else if (ev->Get()->Tag == 3) {
+                Done.Unpark();
+                PassAway();
+            }
+        }
+
+    private:
+        ui32& Notifications;
+        TThreadParkPad& Done;
+    };
+
+    TResult Run(bool activateEveryEvent) {
+        auto setup = TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, 1, activateEveryEvent, false);
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TResult result;
+        TThreadParkPad done;
+        actorSystem.Register(new TObserverActor(result, done), TMailboxType::HTSwap, 0);
+
+        done.Park();
+        actorSystem.Stop();
+        return result;
+    }
+
+    Y_UNIT_TEST(NotifiesWhenQueueIsEmpty) {
+        const TResult result = Run(false);
+
+        UNIT_ASSERT(result.Reason == EFinishReason::QueueEmpty);
+        UNIT_ASSERT_VALUES_EQUAL(result.ExecutedEvents, 1);
+        UNIT_ASSERT_C(result.ElapsedCycles > 0, "Expected non-zero mailbox processing time");
+    }
+
+    Y_UNIT_TEST(NotifiesWhenEventCountLimitIsReached) {
+        const TResult result = Run(true);
+
+        UNIT_ASSERT(result.Reason == EFinishReason::EventCountLimitReached);
+        UNIT_ASSERT_VALUES_EQUAL(result.ExecutedEvents, 1);
+        UNIT_ASSERT_C(result.ElapsedCycles > 0, "Expected non-zero mailbox processing time");
+    }
+
+    Y_UNIT_TEST(SystemFlagStaysSetUntilExplicitlyCleared) {
+        auto setup = TActorBenchmark::GetActorSystemSetup();
+        TActorBenchmark::AddBasicPool(setup, 1, true, false);
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        ui32 notifications = 0;
+        TThreadParkPad done;
+        actorSystem.Register(new TPersistentObserverActor(notifications, done), TMailboxType::HTSwap, 0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        UNIT_ASSERT_VALUES_EQUAL(notifications, 2);
+    }
+}
+
 Y_UNIT_TEST_SUITE(TestThreadContextQueueTimestamps) {
     using namespace NThreading;
 

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -5,6 +5,7 @@
 #include "scheduler_basic.h"
 #include "actor_bootstrapped.h"
 #include "actor_benchmark_helper.h"
+#include "thread_context.h"
 #include "subsystems/stats.h"
 
 #include <ydb/library/actors/testlib/test_runtime.h>
@@ -936,13 +937,15 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
 
     class TObserverActor : public TActorBootstrapped<TObserverActor> {
     public:
-        TObserverActor(TResult& result, TThreadParkPad& done)
-            : Result(result)
+        TObserverActor(EFinishReason expectedReason, TResult& result, TThreadParkPad& done)
+            : ExpectedReason(expectedReason)
+            , Result(result)
             , Done(done)
         {}
 
         void Bootstrap() {
             SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            ForceFinishReason();
             Become(&TThis::StateWork);
         }
 
@@ -953,6 +956,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         }
 
         void Handle(TEvents::TEvMailboxProcessingFinished::TPtr& ev) {
+            RestoreExecutorState();
             Result.Reason = ev->Get()->Reason;
             Result.ExecutedEvents = ev->Get()->ExecutedEvents;
             Result.ElapsedCycles = ev->Get()->ElapsedCycles;
@@ -961,8 +965,48 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         }
 
     private:
+        void ForceFinishReason() {
+            OriginalEventsPerMailbox = TlsThreadContext->WorkerContext.EventsPerMailbox;
+            OriginalTimePerMailboxTs = TlsThreadContext->WorkerContext.TimePerMailboxTs;
+            OriginalSoftDeadlineTs = TlsThreadContext->WorkerContext.SoftDeadlineTs;
+            OriginalCapturedSendingType =
+                TlsThreadContext->ExecutionContext.CapturedActivation.SendingType;
+
+            switch (ExpectedReason) {
+                case EFinishReason::QueueEmpty:
+                    break;
+                case EFinishReason::EventCountLimitReached:
+                    TlsThreadContext->WorkerContext.EventsPerMailbox = 1;
+                    break;
+                case EFinishReason::TimeLimitReached:
+                    TlsThreadContext->WorkerContext.TimePerMailboxTs = 0;
+                    break;
+                case EFinishReason::SoftDeadlineReached:
+                    TlsThreadContext->WorkerContext.SoftDeadlineTs = 0;
+                    break;
+                case EFinishReason::TailSend:
+                    TlsThreadContext->ExecutionContext.CapturedActivation.SendingType =
+                        ESendingType::Tail;
+                    break;
+            }
+        }
+
+        void RestoreExecutorState() {
+            TlsThreadContext->WorkerContext.EventsPerMailbox = OriginalEventsPerMailbox;
+            TlsThreadContext->WorkerContext.TimePerMailboxTs = OriginalTimePerMailboxTs;
+            TlsThreadContext->WorkerContext.SoftDeadlineTs = OriginalSoftDeadlineTs;
+            TlsThreadContext->ExecutionContext.CapturedActivation.SendingType =
+                OriginalCapturedSendingType;
+        }
+
+    private:
+        const EFinishReason ExpectedReason;
         TResult& Result;
         TThreadParkPad& Done;
+        ui32 OriginalEventsPerMailbox = 0;
+        ui64 OriginalTimePerMailboxTs = 0;
+        ui64 OriginalSoftDeadlineTs = 0;
+        ESendingType OriginalCapturedSendingType = ESendingType::Common;
     };
 
     class TPersistentObserverActor : public TActorBootstrapped<TPersistentObserverActor> {
@@ -1011,36 +1055,45 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         TThreadParkPad& Done;
     };
 
-    TResult Run(bool activateEveryEvent) {
+    TResult Run(EFinishReason expectedReason) {
         auto setup = TActorBenchmark::GetActorSystemSetup();
-        TActorBenchmark::AddBasicPool(setup, 1, activateEveryEvent, false);
+        TActorBenchmark::AddBasicPool(setup, 1, false, false);
 
         TActorSystem actorSystem(setup);
         actorSystem.Start();
 
         TResult result;
         TThreadParkPad done;
-        actorSystem.Register(new TObserverActor(result, done), TMailboxType::HTSwap, 0);
+        actorSystem.Register(
+            new TObserverActor(expectedReason, result, done),
+            TMailboxType::HTSwap,
+            0);
 
         done.Park();
         actorSystem.Stop();
         return result;
     }
 
-    Y_UNIT_TEST(NotifiesWhenQueueIsEmpty) {
-        const TResult result = Run(false);
+    Y_UNIT_TEST(NotifiesForEveryFinishReason) {
+        const EFinishReason expectedReasons[] = {
+            EFinishReason::QueueEmpty,
+            EFinishReason::EventCountLimitReached,
+            EFinishReason::TimeLimitReached,
+            EFinishReason::SoftDeadlineReached,
+            EFinishReason::TailSend,
+        };
 
-        UNIT_ASSERT(result.Reason == EFinishReason::QueueEmpty);
-        UNIT_ASSERT_VALUES_EQUAL(result.ExecutedEvents, 1);
-        UNIT_ASSERT_C(result.ElapsedCycles > 0, "Expected non-zero mailbox processing time");
-    }
+        for (const EFinishReason expectedReason : expectedReasons) {
+            const TResult result = Run(expectedReason);
 
-    Y_UNIT_TEST(NotifiesWhenEventCountLimitIsReached) {
-        const TResult result = Run(true);
-
-        UNIT_ASSERT(result.Reason == EFinishReason::EventCountLimitReached);
-        UNIT_ASSERT_VALUES_EQUAL(result.ExecutedEvents, 1);
-        UNIT_ASSERT_C(result.ElapsedCycles > 0, "Expected non-zero mailbox processing time");
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<ui8>(result.Reason),
+                static_cast<ui8>(expectedReason));
+            UNIT_ASSERT_VALUES_EQUAL(result.ExecutedEvents, 1);
+            UNIT_ASSERT_C(
+                result.ElapsedCycles > 0,
+                "Expected non-zero mailbox processing time");
+        }
     }
 
     Y_UNIT_TEST(SystemFlagStaysSetUntilExplicitlyCleared) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds TEvMailboxProcessingFinished, replacing the unused TEvPreemption, to notify opted-in actors when mailbox processing stops due to an empty queue, event or time limit, soft deadline, or tail send. Actors opt in through persistent 64-bit system flags, which can be retrieved in a single read and remain set until explicitly cleared. The notification includes the finish reason, number of processed events, and elapsed cycles, while the common executor path adds only one ui64 read and handles additional work only when system flags are non-zero.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
