### PR TITLE
Backport: use cached iam auth providers

### DIFF
--- a/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
+++ b/ydb/public/sdk/cpp/src/client/iam_private/common/iam.h
@@ -59,20 +59,26 @@ public:
     // returns a TOwningFacilityCredentialsProvider). Sharing a TSimpleCoreFacility between two gRPC
     // IAM providers would abort: each one registers a periodic task and the facility allows only one.
     TCredentialsProviderPtr CreateProvider() const override final {
-        auto authProvider = Params_.SystemServiceAccountCredentials->CreateProvider();
-        auto outerFacility = CreateSimpleCoreFacility();
-        auto serviceProvider = std::make_shared<TCredentialsProvider>(
-            Params_, std::weak_ptr<ICoreFacility>(outerFacility), std::move(authProvider));
-        return std::make_shared<TOwningFacilityCredentialsProvider>(
-            std::move(outerFacility), std::move(serviceProvider));
+        std::lock_guard guard(Lock_);
+        if (!Provider_) {
+            auto authProvider = Params_.SystemServiceAccountCredentials->CreateProvider();
+            auto outerFacility = CreateSimpleCoreFacility();
+            auto serviceProvider = std::make_shared<TCredentialsProvider>(
+                Params_, std::weak_ptr<ICoreFacility>(outerFacility), std::move(authProvider));
+            Provider_ = std::make_shared<TOwningFacilityCredentialsProvider>(
+                std::move(outerFacility), std::move(serviceProvider));
+        }
+        return Provider_;
     }
 
-    TCredentialsProviderPtr CreateProvider(std::weak_ptr<ICoreFacility> facility) const override {
-        return std::make_shared<TCredentialsProvider>(Params_, std::move(facility));
+    TCredentialsProviderPtr CreateProvider(std::weak_ptr<ICoreFacility> /*facility*/) const override {
+        return CreateProvider();
     }
 
 private:
-    TIamServiceParams Params_;
+    const TIamServiceParams Params_;
+    mutable std::mutex Lock_;
+    mutable TCredentialsProviderPtr Provider_;
 };
 
 }

--- a/ydb/public/sdk/cpp/src/client/iam_private/iam.cpp
+++ b/ydb/public/sdk/cpp/src/client/iam_private/iam.cpp
@@ -4,6 +4,9 @@
 
 #include <ydb/public/api/client/yc_private/iam/iam_token_service.pb.h>
 #include <ydb/public/api/client/yc_private/iam/iam_token_service.grpc.pb.h>
+#include <mutex>
+#include <string>
+#include <util/generic/hash.h>
 
 using namespace yandex::cloud::priv::iam::v1;
 
@@ -27,12 +30,41 @@ TCredentialsProviderFactoryPtr CreateIamJwtParamsCredentialsProviderFactoryPriva
     return CreateIamJwtCredentialsProviderFactoryImplPrivate(std::move(jwtParams));
 }
 
+class TIamserviceProviderFactories{
+    std::mutex Mutex;
+    THashMap<std::string, TCredentialsProviderFactoryPtr> Factories;
+    std::string GetKey(const TIamServiceParams& params) {
+        return TStringBuilder()
+                << '\t' << params.ServiceId
+                << '\t' << params.MicroserviceId
+                << '\t' << params.ResourceId
+                << '\t' << params.ResourceType
+                << '\t' << params.TargetServiceAccountId
+                ;
+        
+    }
+public:
+    TCredentialsProviderFactoryPtr GetFactory(const TIamServiceParams& params) {
+        std::lock_guard<std::mutex> lock(Mutex);
+        auto key = GetKey(params);
+        const auto p = Factories.FindPtr(key);
+        if (p) {
+            return *p;
+        }
+        Factories[key] = std::make_shared<TIamServiceCredentialsProviderFactory<
+                CreateIamTokenForServiceRequest,
+                CreateIamTokenResponse,
+                IamTokenService
+            >>(params);
+        return Factories[key];
+    }
+};
+
+
+
 TCredentialsProviderFactoryPtr CreateIamServiceCredentialsProviderFactory(const TIamServiceParams& params) {
-    return std::make_shared<TIamServiceCredentialsProviderFactory<
-                    CreateIamTokenForServiceRequest,
-                    CreateIamTokenResponse,
-                    IamTokenService
-                >>(params);
+    static TIamserviceProviderFactories iamServiceProviderFactories;
+    return iamServiceProviderFactories.GetFactory(params);
 }
 
 }


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

Backport of #45863 to `stable-26-2-1-7-iamprovider`.