### PR TITLE
Add IC subscriber liveness checks

### DIFF
--- a/ydb/library/actors/core/actor.cpp
+++ b/ydb/library/actors/core/actor.cpp
@@ -93,6 +93,16 @@ namespace NActors {
         return TActivationContext::Send(ev);
     }
 
+    bool IActor::SendActorLivenessCheck(const TActorId& target, ui64 cookie) const noexcept {
+        return Send(new IEventHandle(
+            TEvents::TSystem::CheckActorLiveness,
+            TEvents::TEvCheckActorLiveness::RequestFlags,
+            target,
+            SelfId(),
+            nullptr,
+            cookie));
+    }
+
     bool IActor::Send(const TActorId& recipient, IEventBase* ev, ui32 flags, ui64 cookie, NWilson::TTraceId traceId) const noexcept {
         return SelfActorId.Send(recipient, ev, flags, cookie, std::move(traceId));
     }

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -793,6 +793,7 @@ namespace NActors {
 
         void Describe(IOutputStream&) const override;
         bool Send(TAutoPtr<IEventHandle> ev) const noexcept;
+        bool SendActorLivenessCheck(const TActorId& target, ui64 cookie = 0) const noexcept;
         bool Send(const TActorId& recipient, IEventBase* ev, TEventFlags flags = 0, ui64 cookie = 0, NWilson::TTraceId traceId = {}) const noexcept final;
         bool Send(const TActorId& recipient, THolder<IEventBase> ev, TEventFlags flags = 0, ui64 cookie = 0, NWilson::TTraceId traceId = {}) const{
             return Send(recipient, ev.Release(), flags, cookie, std::move(traceId));

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -781,7 +781,7 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
 
         void Bootstrap() {
             Become(&TThis::StateWork);
-            CheckActorLiveness(AliveCookie);
+            SendActorLivenessCheck(Target, AliveCookie);
         }
 
         STRICT_STFUNC(StateWork,
@@ -795,7 +795,7 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
             Y_ABORT_UNLESS(ev->Cookie == AliveCookie);
 
             Send(Target, new TEvents::TEvPoison());
-            CheckActorLiveness(DeadCookie);
+            SendActorLivenessCheck(Target, DeadCookie);
         }
 
         void Handle(TEvents::TEvActorDead::TPtr& ev) {
@@ -810,16 +810,6 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
                 DonePad->Unpark();
             }
             PassAway();
-        }
-
-        void CheckActorLiveness(ui64 cookie) {
-            Send(new IEventHandle(
-                TEvents::TSystem::CheckActorLiveness,
-                TEvents::TEvCheckActorLiveness::RequestFlags,
-                Target,
-                SelfId(),
-                nullptr,
-                cookie));
         }
 
         const TActorId Target;
@@ -838,13 +828,7 @@ Y_UNIT_TEST_SUITE(TestActorLiveness) {
 
         void Bootstrap() {
             Become(&TThis::StateWork);
-            Send(new IEventHandle(
-                TEvents::TSystem::CheckActorLiveness,
-                TEvents::TEvCheckActorLiveness::RequestFlags,
-                Target,
-                SelfId(),
-                nullptr,
-                Cookie));
+            SendActorLivenessCheck(Target, Cookie);
         }
 
         STRICT_STFUNC(StateWork,

--- a/ydb/library/actors/helpers/actor_liveness_checker.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker.cpp
@@ -17,8 +17,8 @@ namespace NActors {
         public:
             TActorLivenessChecker(
                     TVector<TActorLivenessCheckTarget> targets,
-                    TActorLivenessCheckerCallbacks callbacks)
-                : Callbacks(std::move(callbacks))
+                    const TActorId& notify)
+                : Notify(notify)
             {
                 for (const auto& target : targets) {
                     PendingTargets.emplace(target.ActorId, target.Cookie);
@@ -41,7 +41,7 @@ namespace NActors {
                         actorId,
                         SelfId(),
                         nullptr,
-                        0));
+                        cookie));
                 }
             }
 
@@ -57,15 +57,8 @@ namespace NActors {
             }
 
             void Handle(TEvents::TEvActorDead::TPtr& ev) {
-                if (const auto it = PendingTargets.find(ev->Sender); it != PendingTargets.end()) {
-                    DeadTargets.push_back({
-                        .ActorId = it->first,
-                        .Cookie = it->second,
-                    });
-                    PendingTargets.erase(it);
-                    if (Callbacks.OnActorDead) {
-                        Callbacks.OnActorDead(DeadTargets.back());
-                    }
+                if (PendingTargets.erase(ev->Sender)) {
+                    TActivationContext::Send(ev->Forward(Notify));
                     CompleteIfDone();
                 }
             }
@@ -87,24 +80,21 @@ namespace NActors {
             }
 
             void Complete() {
-                if (Callbacks.OnComplete) {
-                    Callbacks.OnComplete(DeadTargets);
-                }
+                Send(Notify, new TEvents::TEvGone);
                 PassAway();
             }
 
         private:
-            const TActorLivenessCheckerCallbacks Callbacks;
+            const TActorId Notify;
             THashMap<TActorId, ui64> PendingTargets;
-            TVector<TActorLivenessCheckTarget> DeadTargets;
         };
 
     }
 
     IActor* CreateActorLivenessChecker(
             TVector<TActorLivenessCheckTarget> targets,
-            TActorLivenessCheckerCallbacks callbacks) {
-        return new TActorLivenessChecker(std::move(targets), std::move(callbacks));
+            const TActorId& notify) {
+        return new TActorLivenessChecker(std::move(targets), notify);
     }
 
 }

--- a/ydb/library/actors/helpers/actor_liveness_checker.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker.cpp
@@ -1,0 +1,110 @@
+#include "actor_liveness_checker.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+
+#include <util/generic/hash.h>
+
+#include <utility>
+
+namespace NActors {
+    namespace {
+
+        class TActorLivenessChecker
+            : public TActorBootstrapped<TActorLivenessChecker>
+        {
+        public:
+            TActorLivenessChecker(
+                    TVector<TActorLivenessCheckTarget> targets,
+                    TActorLivenessCheckerCallbacks callbacks)
+                : Callbacks(std::move(callbacks))
+            {
+                for (const auto& target : targets) {
+                    PendingTargets.emplace(target.ActorId, target.Cookie);
+                }
+            }
+
+            void Bootstrap() {
+                if (PendingTargets.empty()) {
+                    return Complete();
+                }
+
+                Become(&TThis::StateFunc);
+                // Every local liveness probe eventually produces ActorAlive or ActorDead.
+                // Remote probes currently produce ActorLivenessUnsure.
+                for (const auto& [actorId, cookie] : PendingTargets) {
+                    Y_UNUSED(cookie);
+                    TActivationContext::Send(new IEventHandle(
+                        TEvents::TSystem::CheckActorLiveness,
+                        TEvents::TEvCheckActorLiveness::RequestFlags,
+                        actorId,
+                        SelfId(),
+                        nullptr,
+                        0));
+                }
+            }
+
+        private:
+            STRICT_STFUNC(StateFunc,
+                hFunc(TEvents::TEvActorAlive, Handle)
+                hFunc(TEvents::TEvActorDead, Handle)
+                hFunc(TEvents::TEvActorLivenessUnsure, Handle)
+            )
+
+            void Handle(TEvents::TEvActorAlive::TPtr& ev) {
+                CompleteTarget(ev->Sender);
+            }
+
+            void Handle(TEvents::TEvActorDead::TPtr& ev) {
+                if (const auto it = PendingTargets.find(ev->Sender); it != PendingTargets.end()) {
+                    DeadTargets.push_back({
+                        .ActorId = it->first,
+                        .Cookie = it->second,
+                    });
+                    PendingTargets.erase(it);
+                    if (Callbacks.OnActorDead) {
+                        Callbacks.OnActorDead(DeadTargets.back());
+                    }
+                    CompleteIfDone();
+                }
+            }
+
+            void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
+                CompleteTarget(ev->Sender);
+            }
+
+            void CompleteTarget(const TActorId& actorId) {
+                if (PendingTargets.erase(actorId)) {
+                    CompleteIfDone();
+                }
+            }
+
+            void CompleteIfDone() {
+                if (PendingTargets.empty()) {
+                    Complete();
+                }
+            }
+
+            void Complete() {
+                if (Callbacks.OnComplete) {
+                    Callbacks.OnComplete(DeadTargets);
+                }
+                PassAway();
+            }
+
+        private:
+            const TActorLivenessCheckerCallbacks Callbacks;
+            THashMap<TActorId, ui64> PendingTargets;
+            TVector<TActorLivenessCheckTarget> DeadTargets;
+        };
+
+    }
+
+    IActor* CreateActorLivenessChecker(
+            TVector<TActorLivenessCheckTarget> targets,
+            TActorLivenessCheckerCallbacks callbacks) {
+        return new TActorLivenessChecker(std::move(targets), std::move(callbacks));
+    }
+
+}

--- a/ydb/library/actors/helpers/actor_liveness_checker.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker.cpp
@@ -18,13 +18,7 @@ namespace NActors {
         // Every local liveness probe eventually produces ActorAlive or ActorDead.
         // Remote probes currently produce ActorLivenessUnsure.
         for (const auto& [actorId, cookie] : PendingTargets) {
-            TActivationContext::Send(new IEventHandle(
-                TEvents::TSystem::CheckActorLiveness,
-                TEvents::TEvCheckActorLiveness::RequestFlags,
-                actorId,
-                SelfId(),
-                nullptr,
-                cookie));
+            SendActorLivenessCheck(actorId, cookie);
         }
     }
 

--- a/ydb/library/actors/helpers/actor_liveness_checker.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker.cpp
@@ -1,100 +1,102 @@
 #include "actor_liveness_checker.h"
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
-#include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
 
-#include <util/generic/hash.h>
-
-#include <utility>
-
 namespace NActors {
-    namespace {
-
-        class TActorLivenessChecker
-            : public TActorBootstrapped<TActorLivenessChecker>
-        {
-        public:
-            TActorLivenessChecker(
-                    TVector<TActorLivenessCheckTarget> targets,
-                    const TActorId& notify)
-                : Notify(notify)
-            {
-                for (const auto& target : targets) {
-                    PendingTargets.emplace(target.ActorId, target.Cookie);
-                }
-            }
-
-            void Bootstrap() {
-                if (PendingTargets.empty()) {
-                    return Complete();
-                }
-
-                Become(&TThis::StateFunc);
-                // Every local liveness probe eventually produces ActorAlive or ActorDead.
-                // Remote probes currently produce ActorLivenessUnsure.
-                for (const auto& [actorId, cookie] : PendingTargets) {
-                    Y_UNUSED(cookie);
-                    TActivationContext::Send(new IEventHandle(
-                        TEvents::TSystem::CheckActorLiveness,
-                        TEvents::TEvCheckActorLiveness::RequestFlags,
-                        actorId,
-                        SelfId(),
-                        nullptr,
-                        cookie));
-                }
-            }
-
-        private:
-            STRICT_STFUNC(StateFunc,
-                hFunc(TEvents::TEvActorAlive, Handle)
-                hFunc(TEvents::TEvActorDead, Handle)
-                hFunc(TEvents::TEvActorLivenessUnsure, Handle)
-            )
-
-            void Handle(TEvents::TEvActorAlive::TPtr& ev) {
-                CompleteTarget(ev->Sender);
-            }
-
-            void Handle(TEvents::TEvActorDead::TPtr& ev) {
-                if (PendingTargets.erase(ev->Sender)) {
-                    TActivationContext::Send(ev->Forward(Notify));
-                    CompleteIfDone();
-                }
-            }
-
-            void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
-                CompleteTarget(ev->Sender);
-            }
-
-            void CompleteTarget(const TActorId& actorId) {
-                if (PendingTargets.erase(actorId)) {
-                    CompleteIfDone();
-                }
-            }
-
-            void CompleteIfDone() {
-                if (PendingTargets.empty()) {
-                    Complete();
-                }
-            }
-
-            void Complete() {
-                Send(Notify, new TEvents::TEvGone);
-                PassAway();
-            }
-
-        private:
-            const TActorId Notify;
-            THashMap<TActorId, ui64> PendingTargets;
-        };
-
+    TActorLivenessChecker::TActorLivenessChecker(TVector<TActorLivenessCheckTarget> targets) {
+        for (const auto& target : targets) {
+            PendingTargets.emplace(target.ActorId, target.Cookie);
+        }
     }
 
-    IActor* CreateActorLivenessChecker(
-            TVector<TActorLivenessCheckTarget> targets,
-            const TActorId& notify) {
-        return new TActorLivenessChecker(std::move(targets), notify);
+    void TActorLivenessChecker::Bootstrap() {
+        if (PendingTargets.empty()) {
+            return Complete();
+        }
+
+        Become(&TThis::StateFunc);
+        // Every local liveness probe eventually produces ActorAlive or ActorDead.
+        // Remote probes currently produce ActorLivenessUnsure.
+        for (const auto& [actorId, cookie] : PendingTargets) {
+            TActivationContext::Send(new IEventHandle(
+                TEvents::TSystem::CheckActorLiveness,
+                TEvents::TEvCheckActorLiveness::RequestFlags,
+                actorId,
+                SelfId(),
+                nullptr,
+                cookie));
+        }
+    }
+
+    STFUNC(TActorLivenessChecker::StateFunc) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvents::TEvActorAlive, Handle)
+            hFunc(TEvents::TEvActorDead, Handle)
+            hFunc(TEvents::TEvActorLivenessUnsure, Handle)
+        }
+    }
+
+    void TActorLivenessChecker::OnAlive(const TActorLivenessCheckTarget&) {
+    }
+
+    void TActorLivenessChecker::OnDead(const TActorLivenessCheckTarget&) {
+    }
+
+    void TActorLivenessChecker::OnUnsure(const TActorLivenessCheckTarget&) {
+    }
+
+    void TActorLivenessChecker::OnFinish() {
+    }
+
+    void TActorLivenessChecker::Handle(TEvents::TEvActorAlive::TPtr& ev) {
+        TActorLivenessCheckTarget target;
+        if (ExtractTarget(ev->Sender, target)) {
+            OnAlive(target);
+            CompleteIfDone();
+        }
+    }
+
+    void TActorLivenessChecker::Handle(TEvents::TEvActorDead::TPtr& ev) {
+        TActorLivenessCheckTarget target;
+        if (ExtractTarget(ev->Sender, target)) {
+            OnDead(target);
+            CompleteIfDone();
+        }
+    }
+
+    void TActorLivenessChecker::Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
+        TActorLivenessCheckTarget target;
+        if (ExtractTarget(ev->Sender, target)) {
+            OnUnsure(target);
+            CompleteIfDone();
+        }
+    }
+
+    bool TActorLivenessChecker::ExtractTarget(
+            const TActorId& actorId,
+            TActorLivenessCheckTarget& target) {
+        const auto it = PendingTargets.find(actorId);
+        if (it == PendingTargets.end()) {
+            return false;
+        }
+
+        target = {
+            .ActorId = it->first,
+            .Cookie = it->second,
+        };
+        PendingTargets.erase(it);
+        return true;
+    }
+
+    void TActorLivenessChecker::CompleteIfDone() {
+        if (PendingTargets.empty()) {
+            Complete();
+        }
+    }
+
+    void TActorLivenessChecker::Complete() {
+        OnFinish();
+        PassAway();
     }
 
 }

--- a/ydb/library/actors/helpers/actor_liveness_checker.h
+++ b/ydb/library/actors/helpers/actor_liveness_checker.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+
+#include <util/generic/vector.h>
+
+#include <functional>
+
+namespace NActors {
+
+    struct TActorLivenessCheckTarget {
+        TActorId ActorId;
+        ui64 Cookie = 0;
+    };
+
+    struct TActorLivenessCheckerCallbacks {
+        // Callbacks run synchronously in the checker actor context.
+        std::function<void(const TActorLivenessCheckTarget&)> OnActorDead;
+        // Called exactly once after every target has produced a liveness response.
+        std::function<void(const TVector<TActorLivenessCheckTarget>&)> OnComplete;
+    };
+
+    IActor* CreateActorLivenessChecker(
+        TVector<TActorLivenessCheckTarget> targets,
+        TActorLivenessCheckerCallbacks callbacks = {});
+
+}

--- a/ydb/library/actors/helpers/actor_liveness_checker.h
+++ b/ydb/library/actors/helpers/actor_liveness_checker.h
@@ -4,8 +4,6 @@
 
 #include <util/generic/vector.h>
 
-#include <functional>
-
 namespace NActors {
 
     struct TActorLivenessCheckTarget {
@@ -13,15 +11,11 @@ namespace NActors {
         ui64 Cookie = 0;
     };
 
-    struct TActorLivenessCheckerCallbacks {
-        // Callbacks run synchronously in the checker actor context.
-        std::function<void(const TActorLivenessCheckTarget&)> OnActorDead;
-        // Called exactly once after every target has produced a liveness response.
-        std::function<void(const TVector<TActorLivenessCheckTarget>&)> OnComplete;
-    };
-
+    // Forwards TEvActorDead to notify for each target confirmed dead, preserving
+    // the target as event sender and Cookie as event cookie. Sends TEvGone after
+    // every target has produced a liveness response.
     IActor* CreateActorLivenessChecker(
         TVector<TActorLivenessCheckTarget> targets,
-        TActorLivenessCheckerCallbacks callbacks = {});
+        const TActorId& notify);
 
 }

--- a/ydb/library/actors/helpers/actor_liveness_checker.h
+++ b/ydb/library/actors/helpers/actor_liveness_checker.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
 
+#include <util/generic/hash.h>
 #include <util/generic/vector.h>
 
 namespace NActors {
@@ -11,11 +13,35 @@ namespace NActors {
         ui64 Cookie = 0;
     };
 
-    // Forwards TEvActorDead to notify for each target confirmed dead, preserving
-    // the target as event sender and Cookie as event cookie. Sends TEvGone after
-    // every target has produced a liveness response.
-    IActor* CreateActorLivenessChecker(
-        TVector<TActorLivenessCheckTarget> targets,
-        const TActorId& notify);
+    class TActorLivenessChecker
+        : public TActorBootstrapped<TActorLivenessChecker>
+    {
+    public:
+        explicit TActorLivenessChecker(TVector<TActorLivenessCheckTarget> targets);
+
+        void Bootstrap();
+
+        STFUNC(StateFunc);
+
+    protected:
+        // Hooks run synchronously in the checker actor context. OnFinish is
+        // called exactly once after every target has produced a response.
+        virtual void OnAlive(const TActorLivenessCheckTarget& target);
+        virtual void OnDead(const TActorLivenessCheckTarget& target);
+        virtual void OnUnsure(const TActorLivenessCheckTarget& target);
+        virtual void OnFinish();
+
+    private:
+        void Handle(TEvents::TEvActorAlive::TPtr& ev);
+        void Handle(TEvents::TEvActorDead::TPtr& ev);
+        void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev);
+
+        bool ExtractTarget(const TActorId& actorId, TActorLivenessCheckTarget& target);
+        void CompleteIfDone();
+        void Complete();
+
+    private:
+        THashMap<TActorId, ui64> PendingTargets;
+    };
 
 }

--- a/ydb/library/actors/helpers/actor_liveness_checker_ut.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker_ut.cpp
@@ -5,6 +5,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <utility>
+
 namespace NActors {
 namespace {
 
@@ -23,39 +25,39 @@ namespace {
     };
 
     struct TCheckResult {
+        TVector<TActorLivenessCheckTarget> AliveTargets;
         TVector<TActorLivenessCheckTarget> DeadTargets;
-        bool Complete = false;
+        TVector<TActorLivenessCheckTarget> UnsureTargets;
+        size_t FinishCount = 0;
     };
 
-    class TCheckObserver
-        : public TActorBootstrapped<TCheckObserver>
+    class TTestActorLivenessChecker
+        : public TActorLivenessChecker
     {
     public:
-        explicit TCheckObserver(TCheckResult& result)
-            : Result(result)
+        TTestActorLivenessChecker(
+                TVector<TActorLivenessCheckTarget> targets,
+                TCheckResult& result)
+            : TActorLivenessChecker(std::move(targets))
+            , Result(result)
         {
         }
 
-        void Bootstrap() {
-            Become(&TThis::StateFunc);
-        }
-
     private:
-        STRICT_STFUNC(StateFunc,
-            hFunc(TEvents::TEvActorDead, Handle)
-            hFunc(TEvents::TEvGone, Handle)
-        )
-
-        void Handle(TEvents::TEvActorDead::TPtr& ev) {
-            Result.DeadTargets.push_back({
-                .ActorId = ev->Sender,
-                .Cookie = ev->Cookie,
-            });
+        void OnAlive(const TActorLivenessCheckTarget& target) override {
+            Result.AliveTargets.push_back(target);
         }
 
-        void Handle(TEvents::TEvGone::TPtr&) {
-            Result.Complete = true;
-            PassAway();
+        void OnDead(const TActorLivenessCheckTarget& target) override {
+            Result.DeadTargets.push_back(target);
+        }
+
+        void OnUnsure(const TActorLivenessCheckTarget& target) override {
+            Result.UnsureTargets.push_back(target);
+        }
+
+        void OnFinish() override {
+            ++Result.FinishCount;
         }
 
     private:
@@ -71,22 +73,25 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
 
         const TActorId target = runtime.Register(new TTargetActor());
         TCheckResult result;
-        const TActorId observer = runtime.Register(new TCheckObserver(result));
-        runtime.Register(CreateActorLivenessChecker(
+        runtime.Register(new TTestActorLivenessChecker(
             {{
                 .ActorId = target,
                 .Cookie = 10,
             }},
-            observer));
+            result));
 
         TDispatchOptions options;
         options.CustomFinalCondition = [&result] {
-            return result.Complete;
+            return result.FinishCount;
         };
         runtime.DispatchEvents(options);
 
-        UNIT_ASSERT(result.Complete);
+        UNIT_ASSERT_VALUES_EQUAL(result.FinishCount, 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.AliveTargets.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.AliveTargets.front().ActorId, target);
+        UNIT_ASSERT_VALUES_EQUAL(result.AliveTargets.front().Cookie, 10);
         UNIT_ASSERT(result.DeadTargets.empty());
+        UNIT_ASSERT(result.UnsureTargets.empty());
     }
 
     Y_UNIT_TEST(ReportsDeadActorWithCookie) {
@@ -96,24 +101,25 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
         const TActorId target(runtime.GetNodeId(), 0, Max<ui64>(), 0);
         constexpr ui64 Cookie = 42;
         TCheckResult result;
-        const TActorId observer = runtime.Register(new TCheckObserver(result));
-        runtime.Register(CreateActorLivenessChecker(
+        runtime.Register(new TTestActorLivenessChecker(
             {{
                 .ActorId = target,
                 .Cookie = Cookie,
             }},
-            observer));
+            result));
 
         TDispatchOptions options;
         options.CustomFinalCondition = [&result] {
-            return result.Complete;
+            return result.FinishCount;
         };
         runtime.DispatchEvents(options);
 
-        UNIT_ASSERT(result.Complete);
+        UNIT_ASSERT_VALUES_EQUAL(result.FinishCount, 1);
+        UNIT_ASSERT(result.AliveTargets.empty());
         UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.front().ActorId, target);
         UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.front().Cookie, Cookie);
+        UNIT_ASSERT(result.UnsureTargets.empty());
     }
 
     Y_UNIT_TEST(KeepsRemoteActorWhenLivenessIsUnsure) {
@@ -121,23 +127,27 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
         runtime.Initialize();
 
         const TActorId target(runtime.GetNodeId() + 1, 0, 1, 0);
+        constexpr ui64 Cookie = 10;
         TCheckResult result;
-        const TActorId observer = runtime.Register(new TCheckObserver(result));
-        runtime.Register(CreateActorLivenessChecker(
+        runtime.Register(new TTestActorLivenessChecker(
             {{
                 .ActorId = target,
-                .Cookie = 10,
+                .Cookie = Cookie,
             }},
-            observer));
+            result));
 
         TDispatchOptions options;
         options.CustomFinalCondition = [&result] {
-            return result.Complete;
+            return result.FinishCount;
         };
         runtime.DispatchEvents(options);
 
-        UNIT_ASSERT(result.Complete);
+        UNIT_ASSERT_VALUES_EQUAL(result.FinishCount, 1);
+        UNIT_ASSERT(result.AliveTargets.empty());
         UNIT_ASSERT(result.DeadTargets.empty());
+        UNIT_ASSERT_VALUES_EQUAL(result.UnsureTargets.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.UnsureTargets.front().ActorId, target);
+        UNIT_ASSERT_VALUES_EQUAL(result.UnsureTargets.front().Cookie, Cookie);
     }
 }
 

--- a/ydb/library/actors/helpers/actor_liveness_checker_ut.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker_ut.cpp
@@ -1,0 +1,134 @@
+#include "actor_liveness_checker.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/testlib/test_runtime.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NActors {
+namespace {
+
+    class TTargetActor
+        : public TActorBootstrapped<TTargetActor>
+    {
+    public:
+        void Bootstrap() {
+            Become(&TThis::StateFunc);
+        }
+
+    private:
+        STRICT_STFUNC(StateFunc,
+            cFunc(TEvents::TSystem::Poison, PassAway)
+        )
+    };
+
+    struct TCheckResult {
+        TVector<TActorLivenessCheckTarget> DeadTargets;
+        ui32 DeadCallbacks = 0;
+        bool Complete = false;
+    };
+
+}
+
+Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
+    Y_UNIT_TEST(KeepsLiveActor) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId target = runtime.Register(new TTargetActor());
+        TCheckResult result;
+        runtime.Register(CreateActorLivenessChecker(
+            {{
+                .ActorId = target,
+                .Cookie = 10,
+            }},
+            {
+                .OnActorDead = [&result](const TActorLivenessCheckTarget&) {
+                    ++result.DeadCallbacks;
+                },
+                .OnComplete = [&result](const TVector<TActorLivenessCheckTarget>& deadTargets) {
+                    result.DeadTargets = deadTargets;
+                    result.Complete = true;
+                },
+            }));
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&result] {
+            return result.Complete;
+        };
+        runtime.DispatchEvents(options);
+
+        UNIT_ASSERT(result.Complete);
+        UNIT_ASSERT_VALUES_EQUAL(result.DeadCallbacks, 0);
+        UNIT_ASSERT(result.DeadTargets.empty());
+    }
+
+    Y_UNIT_TEST(ReportsDeadActorWithCookie) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId target(runtime.GetNodeId(), 0, Max<ui64>(), 0);
+        constexpr ui64 Cookie = 42;
+        TCheckResult result;
+        runtime.Register(CreateActorLivenessChecker(
+            {{
+                .ActorId = target,
+                .Cookie = Cookie,
+            }},
+            {
+                .OnActorDead = [&result](const TActorLivenessCheckTarget&) {
+                    ++result.DeadCallbacks;
+                },
+                .OnComplete = [&result](const TVector<TActorLivenessCheckTarget>& deadTargets) {
+                    result.DeadTargets = deadTargets;
+                    result.Complete = true;
+                },
+            }));
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&result] {
+            return result.Complete;
+        };
+        runtime.DispatchEvents(options);
+
+        UNIT_ASSERT(result.Complete);
+        UNIT_ASSERT_VALUES_EQUAL(result.DeadCallbacks, 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.front().ActorId, target);
+        UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.front().Cookie, Cookie);
+    }
+
+    Y_UNIT_TEST(KeepsRemoteActorWhenLivenessIsUnsure) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId target(runtime.GetNodeId() + 1, 0, 1, 0);
+        TCheckResult result;
+        runtime.Register(CreateActorLivenessChecker(
+            {{
+                .ActorId = target,
+                .Cookie = 10,
+            }},
+            {
+                .OnActorDead = [&result](const TActorLivenessCheckTarget&) {
+                    ++result.DeadCallbacks;
+                },
+                .OnComplete = [&result](const TVector<TActorLivenessCheckTarget>& deadTargets) {
+                    result.DeadTargets = deadTargets;
+                    result.Complete = true;
+                },
+            }));
+
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&result] {
+            return result.Complete;
+        };
+        runtime.DispatchEvents(options);
+
+        UNIT_ASSERT(result.Complete);
+        UNIT_ASSERT_VALUES_EQUAL(result.DeadCallbacks, 0);
+        UNIT_ASSERT(result.DeadTargets.empty());
+    }
+}
+
+}

--- a/ydb/library/actors/helpers/actor_liveness_checker_ut.cpp
+++ b/ydb/library/actors/helpers/actor_liveness_checker_ut.cpp
@@ -24,8 +24,42 @@ namespace {
 
     struct TCheckResult {
         TVector<TActorLivenessCheckTarget> DeadTargets;
-        ui32 DeadCallbacks = 0;
         bool Complete = false;
+    };
+
+    class TCheckObserver
+        : public TActorBootstrapped<TCheckObserver>
+    {
+    public:
+        explicit TCheckObserver(TCheckResult& result)
+            : Result(result)
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateFunc);
+        }
+
+    private:
+        STRICT_STFUNC(StateFunc,
+            hFunc(TEvents::TEvActorDead, Handle)
+            hFunc(TEvents::TEvGone, Handle)
+        )
+
+        void Handle(TEvents::TEvActorDead::TPtr& ev) {
+            Result.DeadTargets.push_back({
+                .ActorId = ev->Sender,
+                .Cookie = ev->Cookie,
+            });
+        }
+
+        void Handle(TEvents::TEvGone::TPtr&) {
+            Result.Complete = true;
+            PassAway();
+        }
+
+    private:
+        TCheckResult& Result;
     };
 
 }
@@ -37,20 +71,13 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
 
         const TActorId target = runtime.Register(new TTargetActor());
         TCheckResult result;
+        const TActorId observer = runtime.Register(new TCheckObserver(result));
         runtime.Register(CreateActorLivenessChecker(
             {{
                 .ActorId = target,
                 .Cookie = 10,
             }},
-            {
-                .OnActorDead = [&result](const TActorLivenessCheckTarget&) {
-                    ++result.DeadCallbacks;
-                },
-                .OnComplete = [&result](const TVector<TActorLivenessCheckTarget>& deadTargets) {
-                    result.DeadTargets = deadTargets;
-                    result.Complete = true;
-                },
-            }));
+            observer));
 
         TDispatchOptions options;
         options.CustomFinalCondition = [&result] {
@@ -59,7 +86,6 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
         runtime.DispatchEvents(options);
 
         UNIT_ASSERT(result.Complete);
-        UNIT_ASSERT_VALUES_EQUAL(result.DeadCallbacks, 0);
         UNIT_ASSERT(result.DeadTargets.empty());
     }
 
@@ -70,20 +96,13 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
         const TActorId target(runtime.GetNodeId(), 0, Max<ui64>(), 0);
         constexpr ui64 Cookie = 42;
         TCheckResult result;
+        const TActorId observer = runtime.Register(new TCheckObserver(result));
         runtime.Register(CreateActorLivenessChecker(
             {{
                 .ActorId = target,
                 .Cookie = Cookie,
             }},
-            {
-                .OnActorDead = [&result](const TActorLivenessCheckTarget&) {
-                    ++result.DeadCallbacks;
-                },
-                .OnComplete = [&result](const TVector<TActorLivenessCheckTarget>& deadTargets) {
-                    result.DeadTargets = deadTargets;
-                    result.Complete = true;
-                },
-            }));
+            observer));
 
         TDispatchOptions options;
         options.CustomFinalCondition = [&result] {
@@ -92,7 +111,6 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
         runtime.DispatchEvents(options);
 
         UNIT_ASSERT(result.Complete);
-        UNIT_ASSERT_VALUES_EQUAL(result.DeadCallbacks, 1);
         UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.size(), 1);
         UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.front().ActorId, target);
         UNIT_ASSERT_VALUES_EQUAL(result.DeadTargets.front().Cookie, Cookie);
@@ -104,20 +122,13 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
 
         const TActorId target(runtime.GetNodeId() + 1, 0, 1, 0);
         TCheckResult result;
+        const TActorId observer = runtime.Register(new TCheckObserver(result));
         runtime.Register(CreateActorLivenessChecker(
             {{
                 .ActorId = target,
                 .Cookie = 10,
             }},
-            {
-                .OnActorDead = [&result](const TActorLivenessCheckTarget&) {
-                    ++result.DeadCallbacks;
-                },
-                .OnComplete = [&result](const TVector<TActorLivenessCheckTarget>& deadTargets) {
-                    result.DeadTargets = deadTargets;
-                    result.Complete = true;
-                },
-            }));
+            observer));
 
         TDispatchOptions options;
         options.CustomFinalCondition = [&result] {
@@ -126,7 +137,6 @@ Y_UNIT_TEST_SUITE(TActorLivenessCheckerTest) {
         runtime.DispatchEvents(options);
 
         UNIT_ASSERT(result.Complete);
-        UNIT_ASSERT_VALUES_EQUAL(result.DeadCallbacks, 0);
         UNIT_ASSERT(result.DeadTargets.empty());
     }
 }

--- a/ydb/library/actors/helpers/ut/ya.make
+++ b/ydb/library/actors/helpers/ut/ya.make
@@ -20,6 +20,7 @@ PEERDIR(
 )
 
 SRCS(
+    actor_liveness_checker_ut.cpp
     selfping_actor_ut.cpp
 )
 

--- a/ydb/library/actors/helpers/ya.make
+++ b/ydb/library/actors/helpers/ya.make
@@ -3,6 +3,8 @@ LIBRARY()
 SRCS(
     activeactors.cpp
     activeactors.h
+    actor_liveness_checker.cpp
+    actor_liveness_checker.h
     collector_counters.cpp
     future_callback.h
     mon_histogram_helper.h
@@ -20,4 +22,3 @@ END()
 RECURSE_FOR_TESTS(
     ut
 )
-

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -83,6 +83,7 @@ namespace NActors {
         // 5s * 2^8 = 1280s, about 21 minutes with the current RDMA retry base delay.
         ui32 MaxRdmaRetryBackoffLevel = 8;
         bool CollectSubscriptionStackTrace = false;
+        TDuration SubscriberLivenessCheckInterval = TDuration::Hours(1);
         bool UseUring = false;
         bool EnableUringSQPOLL = false; // only effective when UseUring is set
         // Enables negotiation and usage of TInterconnectSessionTCPv2 (no session continuation, no encryption).

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -2,6 +2,7 @@
 #include "interconnect_tcp_session.h"
 #include "interconnect_handshake.h"
 #include "interconnect_zc_processor.h"
+#include "subscriber_liveness_checker.h"
 
 #include <ydb/library/actors/core/probes.h>
 #include <ydb/library/actors/core/log.h>
@@ -77,6 +78,7 @@ namespace NActors {
         Pool = std::make_unique<TEventHolderPool>(Proxy->Common, std::move(destroyCallback));
         ChannelScheduler.ConstructInPlace(Proxy->PeerNodeId, Proxy->Common->ChannelsConfig, Proxy->Metrics,
             Proxy->Common->Settings.MaxSerializedEventSize, Params, Proxy->Common->RdmaMemPool);
+        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval, new TEvCheckSubscriberLiveness);
 
         LOG_INFO(*TlsActivationContext, NActorsServices::INTERCONNECT_STATUS, "[%u] session created", Proxy->PeerNodeId);
         SetPrefix(Sprintf("Session %s [node %" PRIu32 "]", SelfId().ToString().data(), Proxy->PeerNodeId));
@@ -313,6 +315,18 @@ namespace NActors {
             Subscribers.erase(it);
             Proxy->Metrics->SubSubscribersCount(1);
         }
+    }
+
+    void TInterconnectSessionTCP::CheckSubscriberLiveness() {
+        if (!Subscribers.empty()) {
+            TVector<TActorId> subscribers;
+            subscribers.reserve(Subscribers.size());
+            for (const auto& [actorId, _] : Subscribers) {
+                subscribers.push_back(actorId);
+            }
+            Register(CreateSubscriberLivenessChecker(SelfId(), std::move(subscribers)));
+        }
+        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval, new TEvCheckSubscriberLiveness);
     }
 
     void TInterconnectSessionTCP::UpdateSubscriber(const TActorId& actorId, ui64 cookie, ui32 activityIndex, TString eventTypeName,

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -78,7 +78,10 @@ namespace NActors {
         Pool = std::make_unique<TEventHolderPool>(Proxy->Common, std::move(destroyCallback));
         ChannelScheduler.ConstructInPlace(Proxy->PeerNodeId, Proxy->Common->ChannelsConfig, Proxy->Metrics,
             Proxy->Common->Settings.MaxSerializedEventSize, Params, Proxy->Common->RdmaMemPool);
-        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval, new TEvCheckSubscriberLiveness);
+        if (const TDuration interval = Proxy->Common->Settings.SubscriberLivenessCheckInterval;
+                interval != TDuration::Zero()) {
+            Schedule(interval, new TEvCheckSubscriberLiveness);
+        }
 
         LOG_INFO(*TlsActivationContext, NActorsServices::INTERCONNECT_STATUS, "[%u] session created", Proxy->PeerNodeId);
         SetPrefix(Sprintf("Session %s [node %" PRIu32 "]", SelfId().ToString().data(), Proxy->PeerNodeId));
@@ -318,15 +321,13 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCP::CheckSubscriberLiveness() {
-        if (!Subscribers.empty()) {
-            TVector<TActorId> subscribers;
-            subscribers.reserve(Subscribers.size());
-            for (const auto& [actorId, _] : Subscribers) {
-                subscribers.push_back(actorId);
-            }
-            Register(CreateSubscriberLivenessChecker(SelfId(), std::move(subscribers)));
+        const TDuration interval = Proxy->Common->Settings.SubscriberLivenessCheckInterval;
+        if (interval == TDuration::Zero()) {
+            return;
         }
-        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval, new TEvCheckSubscriberLiveness);
+
+        RegisterSubscriberLivenessChecker(SelfId(), Subscribers);
+        Schedule(interval, new TEvCheckSubscriberLiveness);
     }
 
     void TInterconnectSessionTCP::UpdateSubscriber(const TActorId& actorId, ui64 cookie, ui32 activityIndex, TString eventTypeName,

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -457,10 +457,13 @@ namespace NActors {
             EvRam,
             EvTerminate,
             EvFreeItems,
+            EvCheckSubscriberLiveness,
         };
 
         struct TEvCheckCloseOnIdle : TEventLocal<TEvCheckCloseOnIdle, EvCheckCloseOnIdle> {};
         struct TEvCheckLostConnection : TEventLocal<TEvCheckLostConnection, EvCheckLostConnection> {};
+        struct TEvCheckSubscriberLiveness
+            : TEventLocal<TEvCheckSubscriberLiveness, EvCheckSubscriberLiveness> {};
 
         struct TEvRam : TEventLocal<TEvRam, EvRam> {
             const bool Batching;
@@ -553,6 +556,7 @@ namespace NActors {
         void ForwardDelayed();
         void Subscribe(STATEFN_SIG);
         void Unsubscribe(STATEFN_SIG);
+        void CheckSubscriberLiveness();
         void EnqueueForward(TAutoPtr<IEventHandle> ev);
         void UpdateSubscriber(const TActorId& actorId, ui64 cookie, ui32 activityIndex = Max<ui32>(),
             TString eventTypeName = {},
@@ -571,6 +575,7 @@ namespace NActors {
                 fFunc(TEvInterconnect::TEvConnectNode::EventType, Subscribe)
                 fFunc(TEvents::TEvSubscribe::EventType, Subscribe)
                 fFunc(TEvents::TEvUnsubscribe::EventType, Unsubscribe)
+                cFunc(TEvCheckSubscriberLiveness::EventType, CheckSubscriberLiveness)
                 cFunc(TEvFlush::EventType, HandleFlush)
                 hFunc(TEvPollerReady, Handle)
                 hFunc(TEvPollerRegisterResult, Handle)

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -112,8 +112,8 @@ namespace NActors {
             XdcSocket->Shutdown(SHUT_RDWR);
         }
 
-        for (const auto& [actorId, cookie] : Subscribers) {
-            Send(actorId, new TEvInterconnect::TEvNodeDisconnected(Proxy->PeerNodeId), 0, cookie);
+        for (const auto& [actorId, info] : Subscribers) {
+            Send(actorId, new TEvInterconnect::TEvNodeDisconnected(Proxy->PeerNodeId), 0, info.Cookie);
         }
         Subscribers.clear();
 
@@ -149,8 +149,11 @@ namespace NActors {
         Terminate(TDisconnectReason::UserRequest());
     }
 
-    void TInterconnectSessionTCPv2::AddSubscriber(const TActorId& actorId, ui64 cookie) {
-        Subscribers[actorId] = cookie;
+    void TInterconnectSessionTCPv2::AddSubscriber(const TActorId& actorId, ui64 cookie, ui32 activityIndex) {
+        Subscribers[actorId] = {
+            .Cookie = cookie,
+            .ActivityIndex = activityIndex,
+        };
     }
 
     IEventBase* TInterconnectSessionTCPv2::MakeNodeConnectedEvent() const {
@@ -177,7 +180,7 @@ namespace NActors {
         Proxy->ValidateEvent(ev, "ForwardWithSubscribe");
         auto msg = ev->Release<TEvForwardSubscribeSession>();
         Y_ABORT_UNLESS(msg->Event);
-        AddSubscriber(msg->Event->Sender, msg->Event->Cookie);
+        AddSubscriber(msg->Event->Sender, msg->Event->Cookie, msg->ActivityIndex);
         Send(msg->Event->Sender, MakeNodeConnectedEvent(), 0, msg->Event->Cookie);
         EnqueueOutgoing(TAutoPtr<IEventHandle>(msg->Event.Release()));
     }

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -57,8 +57,10 @@ namespace NActors {
         Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
         Proxy->Metrics->SetConnected(0);
         SetPrefix(Sprintf("SessionV2 %s [node %" PRIu32 "]", SelfId().ToString().data(), Proxy->PeerNodeId));
-        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval,
-            new TEvPrivate::TEvCheckSubscriberLiveness);
+        if (const TDuration interval = Proxy->Common->Settings.SubscriberLivenessCheckInterval;
+                interval != TDuration::Zero()) {
+            Schedule(interval, new TEvPrivate::TEvCheckSubscriberLiveness);
+        }
         LOG_INFO_IC_SESSION("ICS90", "v2 session created");
     }
 
@@ -192,16 +194,13 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCPv2::CheckSubscriberLiveness() {
-        if (!Subscribers.empty()) {
-            TVector<TActorId> subscribers;
-            subscribers.reserve(Subscribers.size());
-            for (const auto& [actorId, _] : Subscribers) {
-                subscribers.push_back(actorId);
-            }
-            Register(CreateSubscriberLivenessChecker(SelfId(), std::move(subscribers)));
+        const TDuration interval = Proxy->Common->Settings.SubscriberLivenessCheckInterval;
+        if (interval == TDuration::Zero()) {
+            return;
         }
-        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval,
-            new TEvPrivate::TEvCheckSubscriberLiveness);
+
+        RegisterSubscriberLivenessChecker(SelfId(), Subscribers);
+        Schedule(interval, new TEvPrivate::TEvCheckSubscriberLiveness);
     }
 
     void TInterconnectSessionTCPv2::HandlePoison() {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -1,5 +1,6 @@
 #include "interconnect_tcp_session_v2.h"
 #include "interconnect_tcp_proxy.h"
+#include "subscriber_liveness_checker.h"
 
 #include <util/stream/str.h>
 #include <util/string/cast.h>
@@ -56,6 +57,8 @@ namespace NActors {
         Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
         Proxy->Metrics->SetConnected(0);
         SetPrefix(Sprintf("SessionV2 %s [node %" PRIu32 "]", SelfId().ToString().data(), Proxy->PeerNodeId));
+        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval,
+            new TEvPrivate::TEvCheckSubscriberLiveness);
         LOG_INFO_IC_SESSION("ICS90", "v2 session created");
     }
 
@@ -188,6 +191,19 @@ namespace NActors {
         Subscribers.erase(ev->Sender);
     }
 
+    void TInterconnectSessionTCPv2::CheckSubscriberLiveness() {
+        if (!Subscribers.empty()) {
+            TVector<TActorId> subscribers;
+            subscribers.reserve(Subscribers.size());
+            for (const auto& [actorId, _] : Subscribers) {
+                subscribers.push_back(actorId);
+            }
+            Register(CreateSubscriberLivenessChecker(SelfId(), std::move(subscribers)));
+        }
+        Schedule(Proxy->Common->Settings.SubscriberLivenessCheckInterval,
+            new TEvPrivate::TEvCheckSubscriberLiveness);
+    }
+
     void TInterconnectSessionTCPv2::HandlePoison() {
         Terminate(TDisconnectReason::UserRequest());
     }
@@ -204,6 +220,7 @@ namespace NActors {
 //        str << "<tr><td>OutstandingWrites</td><td>" << PendingBatches.size() << "</td></tr>";
         str << "<tr><td>BytesSent</td><td>" << BytesSent << "</td></tr>";
         str << "<tr><td>BytesReceived</td><td>" << BytesReceived << "</td></tr>";
+        str << "<tr><td>Subscribers.size()</td><td>" << Subscribers.size() << "</td></tr>";
         str << "</table>";
         str << "</div></div>";
         TActivationContext::Send(new IEventHandle(ev->Recipient, ev->Sender, new NMon::TEvHttpInfoRes(str.Str())));

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
@@ -72,6 +72,7 @@ namespace NActors {
         struct TEvPrivate {
             enum {
                 EvTerminate = EventSpaceBegin(TEvents::ES_PRIVATE),
+                EvCheckSubscriberLiveness,
             };
 
             struct TEvTerminate : TEventLocal<TEvTerminate, EvTerminate> {
@@ -79,6 +80,9 @@ namespace NActors {
 
                 TEvTerminate(TDisconnectReason reason) : Reason(reason) {}
             };
+
+            struct TEvCheckSubscriberLiveness
+                : TEventLocal<TEvCheckSubscriberLiveness, EvCheckSubscriberLiveness> {};
         };
 
         STATEFN(StateFunc) {
@@ -88,6 +92,7 @@ namespace NActors {
                 fFunc(TEvInterconnect::TEvConnectNode::EventType, HandleSubscribe)
                 fFunc(TEvents::TEvSubscribe::EventType, HandleSubscribe)
                 fFunc(TEvents::TEvUnsubscribe::EventType, HandleUnsubscribe)
+                cFunc(TEvPrivate::TEvCheckSubscriberLiveness::EventType, CheckSubscriberLiveness)
                 cFunc(TEvents::TEvPoisonPill::EventType, HandlePoison)
                 cFunc(TEvInterconnect::EvForwardDelayed, IgnoreForwardDelayed)
                 hFunc(TEvPrivate::TEvTerminate, [&](auto& ev) { Terminate(ev->Get()->Reason); });
@@ -98,6 +103,7 @@ namespace NActors {
         void ForwardWithSubscribe(STATEFN_SIG);
         void HandleSubscribe(STATEFN_SIG);
         void HandleUnsubscribe(STATEFN_SIG);
+        void CheckSubscriberLiveness();
         void HandlePoison();
         void IgnoreForwardDelayed() {}
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
@@ -109,7 +109,7 @@ namespace NActors {
 
         void EnqueueOutgoing(TAutoPtr<IEventHandle> ev);
 
-        void AddSubscriber(const TActorId& actorId, ui64 cookie);
+        void AddSubscriber(const TActorId& actorId, ui64 cookie, ui32 activityIndex = Max<ui32>());
         IEventBase* MakeNodeConnectedEvent() const;
 
     private:
@@ -129,8 +129,13 @@ namespace NActors {
         ui64 BytesSent = 0;
         ui64 BytesReceived = 0;
 
-        // subscribers awaiting connection state notifications (actor id -> cookie)
-        THashMap<TActorId, ui64> Subscribers;
+        struct TSubscriberInfo {
+            ui64 Cookie = 0;
+            ui32 ActivityIndex = Max<ui32>();
+        };
+
+        // subscribers awaiting connection state notifications
+        THashMap<TActorId, TSubscriberInfo> Subscribers;
 
         std::shared_ptr<std::atomic<int64_t>> ClockSkew = std::make_shared<std::atomic<int64_t>>();
         std::shared_ptr<std::atomic<uint64_t>> PingRTT = std::make_shared<std::atomic<uint64_t>>();

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
@@ -3,11 +3,19 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/actors/protos/services_common.pb.h>
 
-#include <util/generic/hash_set.h>
+#include <util/generic/hash.h>
+#include <util/generic/map.h>
+#include <util/string/builder.h>
 
 namespace NActors {
     namespace {
+
+        TStringBuf FormatSubscriberActivityName(ui32 activityIndex) {
+            return activityIndex == Max<ui32>() ? TStringBuf("manual") : GetActivityTypeName(activityIndex);
+        }
 
         class TSubscriberLivenessChecker
             : public TActorBootstrapped<TSubscriberLivenessChecker>
@@ -15,10 +23,13 @@ namespace NActors {
         public:
             TSubscriberLivenessChecker(
                     const TActorId& subscriptionOwner,
-                    TVector<TActorId> subscribers)
+                    TVector<TSubscriberLivenessInfo> subscribers)
                 : SubscriptionOwner(subscriptionOwner)
-                , PendingSubscribers(subscribers.begin(), subscribers.end())
-            {}
+            {
+                for (const auto& subscriber : subscribers) {
+                    PendingSubscribers.emplace(subscriber.ActorId, subscriber.ActivityIndex);
+                }
+            }
 
             void Bootstrap() {
                 if (PendingSubscribers.empty()) {
@@ -29,7 +40,8 @@ namespace NActors {
                 // Every liveness probe is guaranteed to eventually produce exactly one response:
                 // ActorAlive or ActorDead for a local target, and ActorLivenessUnsure for a remote one.
                 // The checker can therefore wait for all responses without a timeout.
-                for (const TActorId& subscriber : PendingSubscribers) {
+                for (const auto& [subscriber, activityIndex] : PendingSubscribers) {
+                    Y_UNUSED(activityIndex);
                     TActivationContext::Send(new IEventHandle(
                         TEvents::TSystem::CheckActorLiveness,
                         TEvents::TEvCheckActorLiveness::RequestFlags,
@@ -52,7 +64,9 @@ namespace NActors {
             }
 
             void Handle(TEvents::TEvActorDead::TPtr& ev) {
-                if (PendingSubscribers.erase(ev->Sender)) {
+                if (const auto it = PendingSubscribers.find(ev->Sender); it != PendingSubscribers.end()) {
+                    ++LeakedSubscribersByActivity[it->second];
+                    PendingSubscribers.erase(it);
                     // The IC session identifies the subscription by event sender.
                     TActivationContext::Send(new IEventHandle(
                         SubscriptionOwner,
@@ -74,20 +88,41 @@ namespace NActors {
 
             void PassAwayIfDone() {
                 if (PendingSubscribers.empty()) {
+                    LogLeakedSubscribers();
                     PassAway();
                 }
             }
 
+            void LogLeakedSubscribers() const {
+                if (LeakedSubscribersByActivity.empty()) {
+                    return;
+                }
+
+                TStringBuilder details;
+                bool first = true;
+                for (const auto& [activityIndex, count] : LeakedSubscribersByActivity) {
+                    if (!first) {
+                        details << ", ";
+                    }
+                    first = false;
+                    details << "{activity# " << FormatSubscriberActivityName(activityIndex)
+                        << " actors# " << count << '}';
+                }
+                LOG_WARN_S(*TlsActivationContext, NActorsServices::INTERCONNECT_SESSION,
+                    "Subscriber liveness check found leaked subscriptions: " << details);
+            }
+
         private:
             const TActorId SubscriptionOwner;
-            THashSet<TActorId> PendingSubscribers;
+            THashMap<TActorId, ui32> PendingSubscribers;
+            TMap<ui32, ui64> LeakedSubscribersByActivity;
         };
 
     }
 
     IActor* CreateSubscriberLivenessChecker(
             const TActorId& subscriptionOwner,
-            TVector<TActorId> subscribers) {
+            TVector<TSubscriberLivenessInfo> subscribers) {
         return new TSubscriberLivenessChecker(subscriptionOwner, std::move(subscribers));
     }
 

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
@@ -26,6 +26,9 @@ namespace NActors {
                 }
 
                 Become(&TThis::StateFunc);
+                // Every liveness probe is guaranteed to eventually produce exactly one response:
+                // ActorAlive or ActorDead for a local target, and ActorLivenessUnsure for a remote one.
+                // The checker can therefore wait for all responses without a timeout.
                 for (const TActorId& subscriber : PendingSubscribers) {
                     TActivationContext::Send(new IEventHandle(
                         TEvents::TSystem::CheckActorLiveness,

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
@@ -1,12 +1,9 @@
 #include "subscriber_liveness_checker.h"
 
-#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
-#include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 
-#include <util/generic/hash.h>
 #include <util/generic/map.h>
 #include <util/string/builder.h>
 
@@ -17,113 +14,52 @@ namespace NActors {
             return activityIndex == Max<ui32>() ? TStringBuf("manual") : GetActivityTypeName(activityIndex);
         }
 
-        class TSubscriberLivenessChecker
-            : public TActorBootstrapped<TSubscriberLivenessChecker>
-        {
-        public:
-            TSubscriberLivenessChecker(
-                    const TActorId& subscriptionOwner,
-                    TVector<TSubscriberLivenessInfo> subscribers)
-                : SubscriptionOwner(subscriptionOwner)
-            {
-                for (const auto& subscriber : subscribers) {
-                    PendingSubscribers.emplace(subscriber.ActorId, subscriber.ActivityIndex);
-                }
+        void LogLeakedSubscribers(const TVector<TActorLivenessCheckTarget>& deadSubscribers) {
+            if (deadSubscribers.empty()) {
+                return;
             }
 
-            void Bootstrap() {
-                if (PendingSubscribers.empty()) {
-                    return PassAway();
-                }
-
-                Become(&TThis::StateFunc);
-                // Every liveness probe is guaranteed to eventually produce exactly one response:
-                // ActorAlive or ActorDead for a local target, and ActorLivenessUnsure for a remote one.
-                // The checker can therefore wait for all responses without a timeout.
-                for (const auto& [subscriber, activityIndex] : PendingSubscribers) {
-                    Y_UNUSED(activityIndex);
-                    TActivationContext::Send(new IEventHandle(
-                        TEvents::TSystem::CheckActorLiveness,
-                        TEvents::TEvCheckActorLiveness::RequestFlags,
-                        subscriber,
-                        SelfId(),
-                        nullptr,
-                        0));
-                }
+            TMap<ui32, ui64> leakedSubscribersByActivity;
+            for (const auto& subscriber : deadSubscribers) {
+                ++leakedSubscribersByActivity[static_cast<ui32>(subscriber.Cookie)];
             }
 
-        private:
-            STRICT_STFUNC(StateFunc,
-                hFunc(TEvents::TEvActorAlive, Handle)
-                hFunc(TEvents::TEvActorDead, Handle)
-                hFunc(TEvents::TEvActorLivenessUnsure, Handle)
-            )
-
-            void Handle(TEvents::TEvActorAlive::TPtr& ev) {
-                Complete(ev->Sender);
-            }
-
-            void Handle(TEvents::TEvActorDead::TPtr& ev) {
-                if (const auto it = PendingSubscribers.find(ev->Sender); it != PendingSubscribers.end()) {
-                    ++LeakedSubscribersByActivity[it->second];
-                    PendingSubscribers.erase(it);
-                    // The IC session identifies the subscription by event sender.
-                    TActivationContext::Send(new IEventHandle(
-                        SubscriptionOwner,
-                        ev->Sender,
-                        new TEvents::TEvUnsubscribe));
-                    PassAwayIfDone();
+            TStringBuilder details;
+            bool first = true;
+            for (const auto& [activityIndex, count] : leakedSubscribersByActivity) {
+                if (!first) {
+                    details << ", ";
                 }
+                first = false;
+                details << "{activity# " << FormatSubscriberActivityName(activityIndex)
+                    << " actors# " << count << '}';
             }
-
-            void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
-                Complete(ev->Sender);
-            }
-
-            void Complete(const TActorId& subscriber) {
-                if (PendingSubscribers.erase(subscriber)) {
-                    PassAwayIfDone();
-                }
-            }
-
-            void PassAwayIfDone() {
-                if (PendingSubscribers.empty()) {
-                    LogLeakedSubscribers();
-                    PassAway();
-                }
-            }
-
-            void LogLeakedSubscribers() const {
-                if (LeakedSubscribersByActivity.empty()) {
-                    return;
-                }
-
-                TStringBuilder details;
-                bool first = true;
-                for (const auto& [activityIndex, count] : LeakedSubscribersByActivity) {
-                    if (!first) {
-                        details << ", ";
-                    }
-                    first = false;
-                    details << "{activity# " << FormatSubscriberActivityName(activityIndex)
-                        << " actors# " << count << '}';
-                }
-                LOG_WARN_S(*TlsActivationContext, NActorsServices::INTERCONNECT_SESSION,
-                    "Subscriber liveness check found leaked subscriptions: " << details);
-            }
-
-        private:
-            const TActorId SubscriptionOwner;
-            THashMap<TActorId, ui32> PendingSubscribers;
-            TMap<ui32, ui64> LeakedSubscribersByActivity;
-        };
+            LOG_WARN_S(*TlsActivationContext, NActorsServices::INTERCONNECT_SESSION,
+                "Subscriber liveness check found leaked subscriptions: " << details);
+        }
 
     }
 
-    IActor* CreateSubscriberLivenessChecker(
+    void RegisterSubscriberLivenessChecker(
             const TActorId& subscriptionOwner,
-            TVector<TSubscriberLivenessInfo> subscribers) {
-        return new TSubscriberLivenessChecker(subscriptionOwner, std::move(subscribers));
+            TVector<TActorLivenessCheckTarget> subscribers) {
+        if (subscribers.empty()) {
+            return;
+        }
+
+        TActorLivenessCheckerCallbacks callbacks{
+            .OnActorDead = [subscriptionOwner](const TActorLivenessCheckTarget& subscriber) {
+                // The IC session identifies the subscription by event sender.
+                TActivationContext::Send(new IEventHandle(
+                    subscriptionOwner,
+                    subscriber.ActorId,
+                    new TEvents::TEvUnsubscribe));
+            },
+            .OnComplete = LogLeakedSubscribers,
+        };
+        TActivationContext::Register(
+            CreateActorLivenessChecker(std::move(subscribers), std::move(callbacks)),
+            subscriptionOwner);
     }
 
 }

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
@@ -1,6 +1,8 @@
 #include "subscriber_liveness_checker.h"
 
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 
@@ -14,52 +16,82 @@ namespace NActors {
             return activityIndex == Max<ui32>() ? TStringBuf("manual") : GetActivityTypeName(activityIndex);
         }
 
-        void LogLeakedSubscribers(const TVector<TActorLivenessCheckTarget>& deadSubscribers) {
-            if (deadSubscribers.empty()) {
-                return;
+        class TSubscriberLivenessChecker
+            : public TActorBootstrapped<TSubscriberLivenessChecker>
+        {
+        public:
+            TSubscriberLivenessChecker(
+                    const TActorId& subscriptionOwner,
+                    TVector<TActorLivenessCheckTarget> subscribers)
+                : SubscriptionOwner(subscriptionOwner)
+                , Subscribers(std::move(subscribers))
+            {
             }
 
-            TMap<ui32, ui64> leakedSubscribersByActivity;
-            for (const auto& subscriber : deadSubscribers) {
-                ++leakedSubscribersByActivity[static_cast<ui32>(subscriber.Cookie)];
-            }
-
-            TStringBuilder details;
-            bool first = true;
-            for (const auto& [activityIndex, count] : leakedSubscribersByActivity) {
-                if (!first) {
-                    details << ", ";
+            void Bootstrap() {
+                if (Subscribers.empty()) {
+                    return PassAway();
                 }
-                first = false;
-                details << "{activity# " << FormatSubscriberActivityName(activityIndex)
-                    << " actors# " << count << '}';
+
+                Become(&TThis::StateFunc);
+                Checker = Register(CreateActorLivenessChecker(std::move(Subscribers), SelfId()));
             }
-            LOG_WARN_S(*TlsActivationContext, NActorsServices::INTERCONNECT_SESSION,
-                "Subscriber liveness check found leaked subscriptions: " << details);
-        }
+
+        private:
+            STRICT_STFUNC(StateFunc,
+                hFunc(TEvents::TEvActorDead, Handle)
+                hFunc(TEvents::TEvGone, Handle)
+            )
+
+            void Handle(TEvents::TEvActorDead::TPtr& ev) {
+                ++LeakedSubscribersByActivity[static_cast<ui32>(ev->Cookie)];
+                // The IC session identifies the subscription by event sender.
+                TActivationContext::Send(new IEventHandle(
+                    SubscriptionOwner,
+                    ev->Sender,
+                    new TEvents::TEvUnsubscribe));
+            }
+
+            void Handle(TEvents::TEvGone::TPtr& ev) {
+                if (ev->Sender != Checker) {
+                    return;
+                }
+                LogLeakedSubscribers();
+                PassAway();
+            }
+
+            void LogLeakedSubscribers() const {
+                if (LeakedSubscribersByActivity.empty()) {
+                    return;
+                }
+
+                TStringBuilder details;
+                bool first = true;
+                for (const auto& [activityIndex, count] : LeakedSubscribersByActivity) {
+                    if (!first) {
+                        details << ", ";
+                    }
+                    first = false;
+                    details << "{activity# " << FormatSubscriberActivityName(activityIndex)
+                        << " actors# " << count << '}';
+                }
+                LOG_WARN_S(*TlsActivationContext, NActorsServices::INTERCONNECT_SESSION,
+                    "Subscriber liveness check found leaked subscriptions: " << details);
+            }
+
+        private:
+            const TActorId SubscriptionOwner;
+            TVector<TActorLivenessCheckTarget> Subscribers;
+            TActorId Checker;
+            TMap<ui32, ui64> LeakedSubscribersByActivity;
+        };
 
     }
 
-    void RegisterSubscriberLivenessChecker(
+    IActor* CreateSubscriberLivenessChecker(
             const TActorId& subscriptionOwner,
             TVector<TActorLivenessCheckTarget> subscribers) {
-        if (subscribers.empty()) {
-            return;
-        }
-
-        TActorLivenessCheckerCallbacks callbacks{
-            .OnActorDead = [subscriptionOwner](const TActorLivenessCheckTarget& subscriber) {
-                // The IC session identifies the subscription by event sender.
-                TActivationContext::Send(new IEventHandle(
-                    subscriptionOwner,
-                    subscriber.ActorId,
-                    new TEvents::TEvUnsubscribe));
-            },
-            .OnComplete = LogLeakedSubscribers,
-        };
-        TActivationContext::Register(
-            CreateActorLivenessChecker(std::move(subscribers), std::move(callbacks)),
-            subscriptionOwner);
+        return new TSubscriberLivenessChecker(subscriptionOwner, std::move(subscribers));
     }
 
 }

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
@@ -1,0 +1,91 @@
+#include "subscriber_liveness_checker.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/hfunc.h>
+
+#include <util/generic/hash_set.h>
+
+namespace NActors {
+    namespace {
+
+        class TSubscriberLivenessChecker
+            : public TActorBootstrapped<TSubscriberLivenessChecker>
+        {
+        public:
+            TSubscriberLivenessChecker(
+                    const TActorId& subscriptionOwner,
+                    TVector<TActorId> subscribers)
+                : SubscriptionOwner(subscriptionOwner)
+                , PendingSubscribers(subscribers.begin(), subscribers.end())
+            {}
+
+            void Bootstrap() {
+                if (PendingSubscribers.empty()) {
+                    return PassAway();
+                }
+
+                Become(&TThis::StateFunc);
+                for (const TActorId& subscriber : PendingSubscribers) {
+                    TActivationContext::Send(new IEventHandle(
+                        TEvents::TSystem::CheckActorLiveness,
+                        TEvents::TEvCheckActorLiveness::RequestFlags,
+                        subscriber,
+                        SelfId(),
+                        nullptr,
+                        0));
+                }
+            }
+
+        private:
+            STRICT_STFUNC(StateFunc,
+                hFunc(TEvents::TEvActorAlive, Handle)
+                hFunc(TEvents::TEvActorDead, Handle)
+                hFunc(TEvents::TEvActorLivenessUnsure, Handle)
+            )
+
+            void Handle(TEvents::TEvActorAlive::TPtr& ev) {
+                Complete(ev->Sender);
+            }
+
+            void Handle(TEvents::TEvActorDead::TPtr& ev) {
+                if (PendingSubscribers.erase(ev->Sender)) {
+                    // The IC session identifies the subscription by event sender.
+                    TActivationContext::Send(new IEventHandle(
+                        SubscriptionOwner,
+                        ev->Sender,
+                        new TEvents::TEvUnsubscribe));
+                    PassAwayIfDone();
+                }
+            }
+
+            void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
+                Complete(ev->Sender);
+            }
+
+            void Complete(const TActorId& subscriber) {
+                if (PendingSubscribers.erase(subscriber)) {
+                    PassAwayIfDone();
+                }
+            }
+
+            void PassAwayIfDone() {
+                if (PendingSubscribers.empty()) {
+                    PassAway();
+                }
+            }
+
+        private:
+            const TActorId SubscriptionOwner;
+            THashSet<TActorId> PendingSubscribers;
+        };
+
+    }
+
+    IActor* CreateSubscriberLivenessChecker(
+            const TActorId& subscriptionOwner,
+            TVector<TActorId> subscribers) {
+        return new TSubscriberLivenessChecker(subscriptionOwner, std::move(subscribers));
+    }
+
+}

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.cpp
@@ -17,47 +17,29 @@ namespace NActors {
         }
 
         class TSubscriberLivenessChecker
-            : public TActorBootstrapped<TSubscriberLivenessChecker>
+            : public TActorLivenessChecker
         {
         public:
             TSubscriberLivenessChecker(
                     const TActorId& subscriptionOwner,
                     TVector<TActorLivenessCheckTarget> subscribers)
-                : SubscriptionOwner(subscriptionOwner)
-                , Subscribers(std::move(subscribers))
+                : TActorLivenessChecker(std::move(subscribers))
+                , SubscriptionOwner(subscriptionOwner)
             {
             }
 
-            void Bootstrap() {
-                if (Subscribers.empty()) {
-                    return PassAway();
-                }
-
-                Become(&TThis::StateFunc);
-                Checker = Register(CreateActorLivenessChecker(std::move(Subscribers), SelfId()));
-            }
-
         private:
-            STRICT_STFUNC(StateFunc,
-                hFunc(TEvents::TEvActorDead, Handle)
-                hFunc(TEvents::TEvGone, Handle)
-            )
-
-            void Handle(TEvents::TEvActorDead::TPtr& ev) {
-                ++LeakedSubscribersByActivity[static_cast<ui32>(ev->Cookie)];
+            void OnDead(const TActorLivenessCheckTarget& target) override {
+                ++LeakedSubscribersByActivity[static_cast<ui32>(target.Cookie)];
                 // The IC session identifies the subscription by event sender.
                 TActivationContext::Send(new IEventHandle(
                     SubscriptionOwner,
-                    ev->Sender,
+                    target.ActorId,
                     new TEvents::TEvUnsubscribe));
             }
 
-            void Handle(TEvents::TEvGone::TPtr& ev) {
-                if (ev->Sender != Checker) {
-                    return;
-                }
+            void OnFinish() override {
                 LogLeakedSubscribers();
-                PassAway();
             }
 
             void LogLeakedSubscribers() const {
@@ -81,8 +63,6 @@ namespace NActors {
 
         private:
             const TActorId SubscriptionOwner;
-            TVector<TActorLivenessCheckTarget> Subscribers;
-            TActorId Checker;
             TMap<ui32, ui64> LeakedSubscribersByActivity;
         };
 

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.h
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.h
@@ -4,10 +4,30 @@
 
 #include <util/generic/vector.h>
 
+#include <utility>
+
 namespace NActors {
 
     IActor* CreateSubscriberLivenessChecker(
         const TActorId& subscriptionOwner,
         TVector<TActorId> subscribers);
+
+    template <typename TSubscribers>
+    void RegisterSubscriberLivenessChecker(
+            const TActorId& subscriptionOwner,
+            const TSubscribers& subscribers) {
+        if (subscribers.empty()) {
+            return;
+        }
+
+        TVector<TActorId> subscriberIds;
+        subscriberIds.reserve(subscribers.size());
+        for (const auto& item : subscribers) {
+            subscriberIds.push_back(item.first);
+        }
+        TActivationContext::Register(
+            CreateSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberIds)),
+            subscriptionOwner);
+    }
 
 }

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.h
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ydb/library/actors/core/actor.h>
+
+#include <util/generic/vector.h>
+
+namespace NActors {
+
+    IActor* CreateSubscriberLivenessChecker(
+        const TActorId& subscriptionOwner,
+        TVector<TActorId> subscribers);
+
+}

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.h
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.h
@@ -8,7 +8,7 @@
 
 namespace NActors {
 
-    void RegisterSubscriberLivenessChecker(
+    IActor* CreateSubscriberLivenessChecker(
         const TActorId& subscriptionOwner,
         TVector<TActorLivenessCheckTarget> subscribers);
 
@@ -28,7 +28,9 @@ namespace NActors {
                 .Cookie = item.second.ActivityIndex,
             });
         }
-        RegisterSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberInfos));
+        TActivationContext::Register(
+            CreateSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberInfos)),
+            subscriptionOwner);
     }
 
 }

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.h
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/helpers/actor_liveness_checker.h>
 
 #include <util/generic/vector.h>
 
@@ -8,14 +8,9 @@
 
 namespace NActors {
 
-    struct TSubscriberLivenessInfo {
-        TActorId ActorId;
-        ui32 ActivityIndex = Max<ui32>();
-    };
-
-    IActor* CreateSubscriberLivenessChecker(
+    void RegisterSubscriberLivenessChecker(
         const TActorId& subscriptionOwner,
-        TVector<TSubscriberLivenessInfo> subscribers);
+        TVector<TActorLivenessCheckTarget> subscribers);
 
     template <typename TSubscribers>
     void RegisterSubscriberLivenessChecker(
@@ -25,17 +20,15 @@ namespace NActors {
             return;
         }
 
-        TVector<TSubscriberLivenessInfo> subscriberInfos;
+        TVector<TActorLivenessCheckTarget> subscriberInfos;
         subscriberInfos.reserve(subscribers.size());
         for (const auto& item : subscribers) {
             subscriberInfos.push_back({
                 .ActorId = item.first,
-                .ActivityIndex = item.second.ActivityIndex,
+                .Cookie = item.second.ActivityIndex,
             });
         }
-        TActivationContext::Register(
-            CreateSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberInfos)),
-            subscriptionOwner);
+        RegisterSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberInfos));
     }
 
 }

--- a/ydb/library/actors/interconnect/subscriber_liveness_checker.h
+++ b/ydb/library/actors/interconnect/subscriber_liveness_checker.h
@@ -8,9 +8,14 @@
 
 namespace NActors {
 
+    struct TSubscriberLivenessInfo {
+        TActorId ActorId;
+        ui32 ActivityIndex = Max<ui32>();
+    };
+
     IActor* CreateSubscriberLivenessChecker(
         const TActorId& subscriptionOwner,
-        TVector<TActorId> subscribers);
+        TVector<TSubscriberLivenessInfo> subscribers);
 
     template <typename TSubscribers>
     void RegisterSubscriberLivenessChecker(
@@ -20,13 +25,16 @@ namespace NActors {
             return;
         }
 
-        TVector<TActorId> subscriberIds;
-        subscriberIds.reserve(subscribers.size());
+        TVector<TSubscriberLivenessInfo> subscriberInfos;
+        subscriberInfos.reserve(subscribers.size());
         for (const auto& item : subscribers) {
-            subscriberIds.push_back(item.first);
+            subscriberInfos.push_back({
+                .ActorId = item.first,
+                .ActivityIndex = item.second.ActivityIndex,
+            });
         }
         TActivationContext::Register(
-            CreateSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberIds)),
+            CreateSubscriberLivenessChecker(subscriptionOwner, std::move(subscriberInfos)),
             subscriptionOwner);
     }
 

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -1112,13 +1112,12 @@ void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
     UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 0ULL);
 }
 
-void RunSubscriberLivenessCheck(bool useSessionV2) {
+void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
     if (useSessionV2 && !TUringContext::IsAvailable()) {
         Cerr << "io_uring not available; skipping" << Endl;
         return;
     }
 
-    const TDuration checkInterval = TDuration::MilliSeconds(100);
     auto settingsCustomizer = [=](ui32, TInterconnectSettings& settings) {
         settings.SubscriberLivenessCheckInterval = checkInterval;
         settings.EnableInterconnectSessionV2 = useSessionV2;
@@ -1141,17 +1140,24 @@ void RunSubscriberLivenessCheck(bool useSessionV2) {
         }
     }, "live subscriber registered");
 
-    Sleep(3 * checkInterval);
-    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "Subscribers.size()"), 1);
+    if (checkInterval != TDuration::Zero()) {
+        Sleep(3 * checkInterval);
+        UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "Subscribers.size()"), 1);
+    }
 
     cluster.KillActor(2, subscriberId);
-    WaitForCondition(TDuration::Seconds(10), [&] {
-        try {
-            return GetSessionCounter(cluster, 2, 1, "Subscribers.size()") == 0;
-        } catch (const TPatternNotFound&) {
-            return false;
-        }
-    }, "dead subscriber removed");
+    if (checkInterval != TDuration::Zero()) {
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            try {
+                return GetSessionCounter(cluster, 2, 1, "Subscribers.size()") == 0;
+            } catch (const TPatternNotFound&) {
+                return false;
+            }
+        }, "dead subscriber removed");
+    } else {
+        Sleep(TDuration::MilliSeconds(300));
+        UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "Subscribers.size()"), 1);
+    }
 }
 
 } // namespace
@@ -1165,11 +1171,19 @@ Y_UNIT_TEST_SUITE(Interconnect) {
     }
 
     Y_UNIT_TEST(SubscriberLivenessCheck) {
-        RunSubscriberLivenessCheck(false);
+        RunSubscriberLivenessCheck(false, TDuration::MilliSeconds(100));
     }
 
     Y_UNIT_TEST(SubscriberLivenessCheckV2) {
-        RunSubscriberLivenessCheck(true);
+        RunSubscriberLivenessCheck(true, TDuration::MilliSeconds(100));
+    }
+
+    Y_UNIT_TEST(SubscriberLivenessCheckDisabled) {
+        RunSubscriberLivenessCheck(false, TDuration::Zero());
+    }
+
+    Y_UNIT_TEST(SubscriberLivenessCheckDisabledV2) {
+        RunSubscriberLivenessCheck(true, TDuration::Zero());
     }
 
     Y_UNIT_TEST(RdmaRetryWatchdogPendingSessionsAggregated) {

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -162,6 +162,37 @@ private:
     std::atomic<size_t> Received = 0;
 };
 
+class TConnectionSubscriberActor : public TActorBootstrapped<TConnectionSubscriberActor> {
+public:
+    explicit TConnectionSubscriberActor(ui32 peerNodeId)
+        : PeerNodeId(peerNodeId)
+    {}
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvents::TEvSubscribe);
+    }
+
+    bool IsConnected() const {
+        return Connected.load(std::memory_order_acquire);
+    }
+
+private:
+    void Handle(TEvInterconnect::TEvNodeConnected::TPtr&) {
+        Connected.store(true, std::memory_order_release);
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvInterconnect::TEvNodeConnected, Handle)
+        cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, PassAway)
+        cFunc(TEvents::TSystem::Poison, PassAway)
+    )
+
+private:
+    const ui32 PeerNodeId;
+    std::atomic<bool> Connected = false;
+};
+
 class TBurstSenderActor : public TActorBootstrapped<TBurstSenderActor> {
 public:
     TBurstSenderActor(TActorId recipient, size_t messages, size_t payloadSize)
@@ -1081,6 +1112,48 @@ void RunKernelLivenessReconnectLocalFallbackNotApplied(bool withRdma) {
     UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 0ULL);
 }
 
+void RunSubscriberLivenessCheck(bool useSessionV2) {
+    if (useSessionV2 && !TUringContext::IsAvailable()) {
+        Cerr << "io_uring not available; skipping" << Endl;
+        return;
+    }
+
+    const TDuration checkInterval = TDuration::MilliSeconds(100);
+    auto settingsCustomizer = [=](ui32, TInterconnectSettings& settings) {
+        settings.SubscriberLivenessCheckInterval = checkInterval;
+        settings.EnableInterconnectSessionV2 = useSessionV2;
+    };
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr,
+        useSessionV2 ? TTestICCluster::EMPTY : TTestICCluster::DISABLE_RDMA,
+        {}, TDuration::Seconds(2), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* subscriber = new TConnectionSubscriberActor(1);
+    const TActorId subscriberId = cluster.RegisterActor(subscriber, 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return subscriber->IsConnected();
+    }, "subscriber connected");
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        try {
+            return GetSessionCounter(cluster, 2, 1, "Subscribers.size()") == 1;
+        } catch (const TPatternNotFound&) {
+            return false;
+        }
+    }, "live subscriber registered");
+
+    Sleep(3 * checkInterval);
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "Subscribers.size()"), 1);
+
+    cluster.KillActor(2, subscriberId);
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        try {
+            return GetSessionCounter(cluster, 2, 1, "Subscribers.size()") == 0;
+        } catch (const TPatternNotFound&) {
+            return false;
+        }
+    }, "dead subscriber removed");
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(Interconnect) {
@@ -1089,6 +1162,14 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         RunScopeClassCounterRebindTest(TScopeId(0, 1), "system");
         RunScopeClassCounterRebindTest(TScopeId(1, 42), "same_tenant");
         RunScopeClassCounterRebindTest(TScopeId(2, 42), "other_tenant");
+    }
+
+    Y_UNIT_TEST(SubscriberLivenessCheck) {
+        RunSubscriberLivenessCheck(false);
+    }
+
+    Y_UNIT_TEST(SubscriberLivenessCheckV2) {
+        RunSubscriberLivenessCheck(true);
     }
 
     Y_UNIT_TEST(RdmaRetryWatchdogPendingSessionsAggregated) {

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -556,6 +556,36 @@ private:
     std::shared_ptr<THandshakeFailureLogCounters> OutgoingHandshakeFailures;
 };
 
+struct TSubscriberLivenessLogState {
+    std::atomic<ui32> Warnings = 0;
+    TMutex Mutex;
+    TString LastWarning;
+};
+
+class TSubscriberLivenessLogBackend : public TLogBackend {
+public:
+    explicit TSubscriberLivenessLogBackend(std::shared_ptr<TSubscriberLivenessLogState> state)
+        : State(std::move(state))
+    {}
+
+    void WriteData(const TLogRecord& rec) override {
+        const TStringBuf line(rec.Data, rec.Len);
+        if (rec.Priority == TLOG_WARNING &&
+                line.Contains("Subscriber liveness check found leaked subscriptions")) {
+            with_lock (State->Mutex) {
+                State->LastWarning = line;
+            }
+            State->Warnings.fetch_add(1, std::memory_order_release);
+        }
+    }
+
+    void ReopenLog() override {
+    }
+
+private:
+    std::shared_ptr<TSubscriberLivenessLogState> State;
+};
+
 } // namespace
 
 class TSenderActor : public TActorBootstrapped<TSenderActor> {
@@ -1122,9 +1152,25 @@ void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
         settings.SubscriberLivenessCheckInterval = checkInterval;
         settings.EnableInterconnectSessionV2 = useSessionV2;
     };
-    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr,
+    auto logState = std::make_shared<TSubscriberLivenessLogState>();
+    auto loggerSettings = MakeIntrusive<NLog::TSettings>(
+        TActorId(0, "logger"),
+        static_cast<NLog::EComponent>(NActorsServices::LOGGER),
+        NLog::PRI_DEBUG,
+        NLog::PRI_DEBUG,
+        0U);
+    loggerSettings->Append(
+        NActorsServices::EServiceCommon_MIN,
+        NActorsServices::EServiceCommon_MAX,
+        NActorsServices::EServiceCommon_Name);
+    loggerSettings->SetAllowDrop(false);
+    loggerSettings->SetThrottleDelay(TDuration::Zero());
+    auto logBackendFactory = [logState] {
+        return TAutoPtr<TLogBackend>(new TSubscriberLivenessLogBackend(logState));
+    };
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, loggerSettings,
         useSessionV2 ? TTestICCluster::EMPTY : TTestICCluster::DISABLE_RDMA,
-        {}, TDuration::Seconds(2), TNode::DefaultInflight(), settingsCustomizer);
+        {}, TDuration::Seconds(2), TNode::DefaultInflight(), settingsCustomizer, logBackendFactory);
 
     auto* subscriber = new TConnectionSubscriberActor(1);
     const TActorId subscriberId = cluster.RegisterActor(subscriber, 2);
@@ -1143,6 +1189,7 @@ void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
     if (checkInterval != TDuration::Zero()) {
         Sleep(3 * checkInterval);
         UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "Subscribers.size()"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(logState->Warnings.load(std::memory_order_acquire), 0);
     }
 
     cluster.KillActor(2, subscriberId);
@@ -1154,9 +1201,17 @@ void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
                 return false;
             }
         }, "dead subscriber removed");
+        WaitForCondition(TDuration::Seconds(10), [&] {
+            return logState->Warnings.load(std::memory_order_acquire) == 1;
+        }, "leaked subscriber warning");
+        with_lock (logState->Mutex) {
+            UNIT_ASSERT_STRING_CONTAINS(logState->LastWarning, "activity# manual");
+            UNIT_ASSERT_STRING_CONTAINS(logState->LastWarning, "actors# 1");
+        }
     } else {
         Sleep(TDuration::MilliSeconds(300));
         UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "Subscribers.size()"), 1);
+        UNIT_ASSERT_VALUES_EQUAL(logState->Warnings.load(std::memory_order_acquire), 0);
     }
 }
 

--- a/ydb/library/actors/interconnect/ya.make
+++ b/ydb/library/actors/interconnect/ya.make
@@ -56,6 +56,8 @@ SRCS(
     packet.h
     profiler.h
     slowpoke_actor.h
+    subscriber_liveness_checker.cpp
+    subscriber_liveness_checker.h
     subscription_manager.cpp
     subscription_manager.h
     types.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add periodic cleanup of stale Interconnect subscriptions.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Every hour, IC sessions pass their subscriber snapshot to a one-shot liveness checker actor. The checker probes each subscriber using TEvCheckActorLiveness and sends TEvUnsubscribe for actors confirmed dead. Both v1 and v2 sessions are supported.
