### PR TITLE
Background column statistics collection based on change ratio

### DIFF
--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3233,6 +3233,11 @@ message TStatisticsConfig {
 
     optional uint32 AnalyzeMaxTotalScanActorsInFlight = 6 [default = 100];
     optional uint32 AnalyzeMaxPerNodeScanActorsInFlight = 7 [default = 1];
+
+    // Threshold percentage of changed rows that triggers background ANALYZE.
+    // When (RowModifications since last ANALYZE) / RowCount * 100 >= this value,
+    // column statistics are considered stale and will be recalculated.
+    optional uint32 BackgroundAnalyzeChangeRatioThresholdPercent = 8 [default = 20];
 };
 
 message TSystemTabletBackupConfig {

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -3235,7 +3235,7 @@ message TStatisticsConfig {
     optional uint32 AnalyzeMaxPerNodeScanActorsInFlight = 7 [default = 1];
 
     // Threshold percentage of changed rows that triggers background ANALYZE.
-    // When (RowModifications since last ANALYZE) / RowCount * 100 >= this value,
+    // When (RowUpdates + RowDeletes since last ANALYZE) / RowCount * 100 >= this value,
     // column statistics are considered stale and will be recalculated.
     optional uint32 BackgroundAnalyzeChangeRatioThresholdPercent = 8 [default = 20];
 };

--- a/ydb/core/protos/statistics.proto
+++ b/ydb/core/protos/statistics.proto
@@ -14,6 +14,7 @@ message TEvConfigureAggregator {
 message TPathEntry {
     optional NKikimrProto.TPathID PathId = 1;
     optional uint64 RowCount = 2;
+    optional uint64 RowModifications = 6;
     optional uint64 BytesSize = 3;
     optional bool IsColumnTable = 4;
     optional bool AreStatsFull = 5;

--- a/ydb/core/protos/statistics.proto
+++ b/ydb/core/protos/statistics.proto
@@ -14,7 +14,8 @@ message TEvConfigureAggregator {
 message TPathEntry {
     optional NKikimrProto.TPathID PathId = 1;
     optional uint64 RowCount = 2;
-    optional uint64 RowModifications = 6;
+    optional uint64 RowUpdates = 6;
+    optional uint64 RowDeletes = 7;
     optional uint64 BytesSize = 3;
     optional bool IsColumnTable = 4;
     optional bool AreStatsFull = 5;

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -52,6 +52,8 @@ void TStatisticsAggregator::OnActivateExecutor(const TActorContext& ctx) {
     Y_ABORT_UNLESS(appData);
     StatisticsConfig = appData->StatisticsConfig;
 
+    InitAnalyzeCounters();
+
     Executor()->RegisterExternalTabletCounters(TabletCountersPtr);
     Execute(CreateTxInitSchema(), ctx);
 }
@@ -840,7 +842,8 @@ void TStatisticsAggregator::ScheduleNextAnalyze(NIceDb::TNiceDb& db, const TActo
                 };
                 AnalyzeActorId = ctx.Register(new TAnalyzeActor(
                     SelfId(), operation.OperationId, operation.DatabaseName, operationTable.PathId,
-                    operationTable.ColumnTags, analyzeActorConfig));
+                    operationTable.ColumnTags, analyzeActorConfig),
+                    TMailboxType::HTSwap, AppData()->BatchPoolId);
                 YDB_LOG_DEBUG("ScheduleNextAnalyze. started analyzing table",
                     {"tabletId", TabletID()},
                     {"operationId", operation.OperationId.Quote()},
@@ -866,54 +869,58 @@ void TStatisticsAggregator::ScheduleNextBackgroundTraversal(NIceDb::TNiceDb& db)
         {"tabletId", TabletID()});
     Y_ABORT_UNLESS(!TraversalPathId);
 
-    TString databaseName;
-    TPathId pathId;
-
-    if (!ScheduleTraversalsByTime.Empty()){
-        auto* oldestTable = ScheduleTraversalsByTime.Top();
-        if (TInstant::Now() < oldestTable->LastUpdateTime + ScheduleTraversalPeriod) {
-            YDB_LOG_TRACE("Background traversal is skipped. The oldest table update time is too fresh",
-                {"tabletId", TabletID()},
-                {"pathId", oldestTable->PathId},
-                {"lastUpdateTime", oldestTable->LastUpdateTime});
-            return;
-        }
-
-        databaseName = ""; // it's intentional, because ScheduleTraversalsByTime is filled by SchemeShards
-        pathId = oldestTable->PathId;
-    }
-
-    if (!pathId) {
+    if (ScheduleTraversalsByTime.Empty()) {
         YDB_LOG_TRACE("No traversal request to send",
             {"tabletId", TabletID()});
         return;
     }
 
-    TraversalDatabase = databaseName;
+    // Select the table to traverse. The heap top is the table analyzed longest ago;
+    // it becomes due once the periodic interval elapses (this also covers
+    // never-analyzed tables, whose LastUpdateTime is 0). Otherwise, look for a
+    // column table whose statistics are stale by change ratio anywhere in the
+    // schedule — staleness is independent of the time ordering, so we cannot
+    // decide it from the heap top alone.
+    auto* oldestTable = ScheduleTraversalsByTime.Top();
+    TScheduleTraversal* chosenTable = nullptr;
+    if (TInstant::Now() >= oldestTable->LastUpdateTime + ScheduleTraversalPeriod) {
+        chosenTable = oldestTable;
+    } else {
+        chosenTable = FindStaleColumnTable();
+    }
+
+    if (!chosenTable) {
+        YDB_LOG_TRACE("Background traversal is skipped. No table is stale and no traversal interval elapsed",
+            {"tabletId", TabletID()},
+            {"oldestPathId", oldestTable->PathId},
+            {"oldestLastUpdateTime", oldestTable->LastUpdateTime});
+        return;
+    }
+
+    TPathId pathId = chosenTable->PathId;
+
+    TraversalDatabase = "";  // background traversals use empty database
     TraversalPathId = pathId;
     TraversalStartTime = TInstant::Now();
     LastTraversalWasForce = false;
 
     std::optional<bool> isColumnTable = IsColumnTable(pathId);
-    if (!isColumnTable){
-        DeleteStatisticsFromTable();
-        return;
-    }
-
-    // Datashard traversal is temporary disabled
-    if (!*isColumnTable) {
-        YDB_LOG_DEBUG("ScheduleNextBackgroundTraversal. Skip traversal for datashard table",
-            {"tabletId", TabletID()},
-            {"pathId", pathId});
+    if (!isColumnTable) {
+        PersistTraversal(db);
         DeleteStatisticsFromTable();
         return;
     }
 
     TraversalIsColumnTable = *isColumnTable;
 
-    YDB_LOG_DEBUG("Start background traversal navigate for path",
-        {"tabletId", TabletID()},
-        {"pathId", pathId});
+    if (!*isColumnTable) {
+        YDB_LOG_DEBUG("ScheduleNextBackgroundTraversal. Skip traversal for datashard table",
+            {"tabletId", TabletID()},
+            {"pathId", pathId});
+        PersistTraversal(db);
+        DeleteStatisticsFromTable();
+        return;
+    }
 
     StartTraversal(db);
 }
@@ -931,20 +938,74 @@ void TStatisticsAggregator::StartTraversal(NIceDb::TNiceDb& db) {
 
 void TStatisticsAggregator::FinishTraversal(
     NIceDb::TNiceDb& db,
+    NKikimrStat::TEvAnalyzeResponse::EStatus status,
     std::optional<Ydb::Table::AnalyzeState::State> forceTerminalState,
     NYql::TIssues issues)
 {
     auto pathId = TraversalPathId;
 
+    bool traversalSucceeded = (status == NKikimrStat::TEvAnalyzeResponse::STATUS_SUCCESS);
+
     auto pathIt = ScheduleTraversals.find(pathId);
     if (pathIt != ScheduleTraversals.end()) {
         auto& traversalTable = pathIt->second;
         traversalTable.LastUpdateTime = TraversalStartTime;
-        db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
-            NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()));
+
+        if (traversalSucceeded) {
+            auto [currentModifications, _] = GetCurrentChangeCounters(pathId);
+            traversalTable.LastAnalyzeRowModifications = currentModifications;
+
+            db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()),
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowModifications>(currentModifications));
+        } else {
+            db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()));
+        }
 
         if (ScheduleTraversalsByTime.Has(&traversalTable)) {
             ScheduleTraversalsByTime.Update(&traversalTable);
+        }
+    }
+
+    // The BackgroundAnalyze counters track background traversals only; force
+    // (user-initiated) ANALYZE has its own reporting and must not inflate them.
+    if (!LastTraversalWasForce) {
+        if (traversalSucceeded) {
+            BackgroundAnalyzeCompletedCounter->Inc();
+        } else {
+            BackgroundAnalyzeFailedCounter->Inc();
+        }
+    }
+    ReportAnalyzeCounters();
+
+    // When a background traversal completes successfully, check whether there
+    // are pending force (user-initiated) ANALYZE requests for the same table
+    // that have not started yet. If so, mark them as finished — the background
+    // traversal just collected the same statistics, so re-traversing would be
+    // redundant. This deduplication only applies to background traversals;
+    // force traversals have their own completion path below.
+    if (!LastTraversalWasForce && traversalSucceeded) {
+        for (auto& operation : ForceTraversals) {
+            if (IsTerminalAnalyzeState(operation.State)) {
+                continue;
+            }
+            for (auto& table : operation.Tables) {
+                if (table.PathId == pathId
+                        && table.Status == TForceTraversalTable::EStatus::None) {
+                    UpdateForceTraversalTableStatus(
+                        TForceTraversalTable::EStatus::TraversalFinished,
+                        operation.OperationId, table, db);
+                }
+            }
+            bool tablesRemained = std::any_of(operation.Tables.begin(), operation.Tables.end(),
+                [](const TForceTraversalTable& elem) {
+                    return elem.Status != TForceTraversalTable::EStatus::TraversalFinished;
+                });
+            if (!tablesRemained) {
+                MarkForceTraversalOperationFinished(operation.OperationId,
+                    Ydb::Table::AnalyzeState::STATE_DONE, TActivationContext::Now(), db);
+            }
         }
     }
 
@@ -1411,5 +1472,123 @@ bool TStatisticsAggregator::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev
     TabletCounters->Simple()[COUNTER_BASE_STATISTICS_TOTAL_ROW_COUNT].Set(totalRowCount);
     TabletCounters->Simple()[COUNTER_BASE_STATISTICS_TOTAL_BYTES_SIZE].Set(totalBytesSize);
  }
+
+std::pair<ui64, ui64> TStatisticsAggregator::GetCurrentChangeCounters(const TPathId& pathId) const {
+    // A path is owned by the schemeshard identified by pathId.OwnerId, so its
+    // base stats live in that schemeshard's blob (see IsKnownTable).
+    auto it = BaseStatistics.find(pathId.OwnerId);
+    if (it == BaseStatistics.end() || !it->second.Latest) {
+        return {0, 0};
+    }
+    NKikimrStat::TSchemeShardStats stats;
+    if (!stats.ParseFromString(*it->second.Latest)) {
+        return {0, 0};
+    }
+    for (const auto& entry : stats.GetEntries()) {
+        if (TPathId::FromProto(entry.GetPathId()) == pathId) {
+            return {entry.GetRowModifications(), entry.GetRowCount()};
+        }
+    }
+    return {0, 0};
+}
+
+bool TStatisticsAggregator::IsChangeRatioAboveThreshold(
+    ui64 lastAnalyzeRowModifications, ui64 currentRowModifications, ui64 rowCount) const
+{
+    if (lastAnalyzeRowModifications == Max<ui64>()) {
+        return true;  // Never analyzed — stale (primary collection)
+    }
+    // RowModifications is a monotonic cumulative counter, so current should not
+    // fall below the snapshot taken at the last ANALYZE. Guard against underflow.
+    if (rowCount == 0 || currentRowModifications <= lastAnalyzeRowModifications) {
+        return false;
+    }
+
+    ui64 changesSinceAnalyze = currentRowModifications - lastAnalyzeRowModifications;
+    double ratio = static_cast<double>(changesSinceAnalyze) / rowCount * 100.0;
+    auto threshold = StatisticsConfig.GetBackgroundAnalyzeChangeRatioThresholdPercent();
+
+    return ratio >= static_cast<double>(threshold);
+}
+
+THashMap<TPathId, std::pair<ui64, ui64>> TStatisticsAggregator::CollectCurrentChangeCounters() const {
+    // Parse each schemeshard's base stats once into a pathId -> (rowModifications,
+    // rowCount) lookup. Doing per-table GetCurrentChangeCounters() calls instead
+    // would re-parse the whole blob for every table (quadratic on large databases).
+    THashMap<TPathId, std::pair<ui64, ui64>> currentCounters;
+    for (const auto& [ssId, serializedStats] : BaseStatistics) {
+        if (!serializedStats.Latest) {
+            continue;
+        }
+        NKikimrStat::TSchemeShardStats stats;
+        if (!stats.ParseFromString(*serializedStats.Latest)) {
+            continue;
+        }
+        for (const auto& entry : stats.GetEntries()) {
+            currentCounters[TPathId::FromProto(entry.GetPathId())] =
+                {entry.GetRowModifications(), entry.GetRowCount()};
+        }
+    }
+    return currentCounters;
+}
+
+TStatisticsAggregator::TScheduleTraversal* TStatisticsAggregator::FindStaleColumnTable() {
+    // Column statistics staleness (change ratio) is independent of the time-based
+    // ordering in ScheduleTraversalsByTime, so we must scan all tables rather than
+    // inspecting only the heap top. Among the stale column tables pick the one
+    // analyzed longest ago.
+    auto currentCounters = CollectCurrentChangeCounters();
+
+    TScheduleTraversal* stalest = nullptr;
+    for (auto& [pathId, traversal] : ScheduleTraversals) {
+        if (!traversal.IsColumnTable) {
+            continue;
+        }
+        auto it = currentCounters.find(pathId);
+        auto [currentModifications, rowCount] = it != currentCounters.end()
+            ? it->second : std::pair<ui64, ui64>{0, 0};
+        if (!IsChangeRatioAboveThreshold(traversal.LastAnalyzeRowModifications, currentModifications, rowCount)) {
+            continue;
+        }
+        if (!stalest || traversal.LastUpdateTime < stalest->LastUpdateTime) {
+            stalest = &traversal;
+        }
+    }
+    return stalest;
+}
+
+void TStatisticsAggregator::InitAnalyzeCounters() {
+    // Initialize dynamic counters for background ANALYZE monitoring.
+    // Uses GetSubgroup to create a single metric with a "status" label:
+    //   BackgroundAnalyze{status="pending"}   — gauge: tables needing ANALYZE
+    //   BackgroundAnalyze{status="completed"} — cumulative: successful ANALYZE
+    //   BackgroundAnalyze{status="failed"}    — cumulative: failed ANALYZE
+    auto analyzeCounters = GetServiceCounters(AppData()->Counters, "statistics")
+        ->GetSubgroup("subsystem", "background_analyze");
+    BackgroundAnalyzePendingCounter = analyzeCounters
+        ->GetSubgroup("status", "pending")->GetCounter("BackgroundAnalyze", false);
+    BackgroundAnalyzeCompletedCounter = analyzeCounters
+        ->GetSubgroup("status", "completed")->GetCounter("BackgroundAnalyze", true);
+    BackgroundAnalyzeFailedCounter = analyzeCounters
+        ->GetSubgroup("status", "failed")->GetCounter("BackgroundAnalyze", true);
+}
+
+void TStatisticsAggregator::ReportAnalyzeCounters() {
+    auto currentCounters = CollectCurrentChangeCounters();
+
+    ui64 pendingTables = 0;
+    for (const auto& [pathId, traversal] : ScheduleTraversals) {
+        if (!traversal.IsColumnTable) {
+            continue;
+        }
+        auto it = currentCounters.find(pathId);
+        auto [currentModifications, rowCount] = it != currentCounters.end()
+            ? it->second : std::pair<ui64, ui64>{0, 0};
+        if (IsChangeRatioAboveThreshold(traversal.LastAnalyzeRowModifications, currentModifications, rowCount)) {
+            ++pendingTables;
+        }
+    }
+    *BackgroundAnalyzePendingCounter = pendingTables;
+}
 
 } // NKikimr::NStat

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -952,12 +952,14 @@ void TStatisticsAggregator::FinishTraversal(
         traversalTable.LastUpdateTime = TraversalStartTime;
 
         if (traversalSucceeded) {
-            auto [currentModifications, _] = GetCurrentChangeCounters(pathId);
-            traversalTable.LastAnalyzeRowModifications = currentModifications;
+            auto [currentRowUpdates, currentRowDeletes, _] = GetCurrentChangeCounters(pathId);
+            traversalTable.LastAnalyzeRowUpdates = currentRowUpdates;
+            traversalTable.LastAnalyzeRowDeletes = currentRowDeletes;
 
             db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
                 NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()),
-                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowModifications>(currentModifications));
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(currentRowUpdates),
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(currentRowDeletes));
         } else {
             db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
                 NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()));
@@ -1474,44 +1476,54 @@ bool TStatisticsAggregator::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev
     TabletCounters->Simple()[COUNTER_BASE_STATISTICS_TOTAL_BYTES_SIZE].Set(totalBytesSize);
  }
 
-std::pair<ui64, ui64> TStatisticsAggregator::GetCurrentChangeCounters(const TPathId& pathId) const {
+std::tuple<ui64, ui64, ui64> TStatisticsAggregator::GetCurrentChangeCounters(const TPathId& pathId) const {
     // A path is owned by the schemeshard identified by pathId.OwnerId, so its
     // base stats live in that schemeshard's blob (see IsKnownTable).
     auto it = BaseStatistics.find(pathId.OwnerId);
     if (it == BaseStatistics.end() || !it->second.Latest) {
-        return {0, 0};
+        return {0, 0, 0};
     }
     NKikimrStat::TSchemeShardStats stats;
     if (!stats.ParseFromString(*it->second.Latest)) {
-        return {0, 0};
+        return {0, 0, 0};
     }
     for (const auto& entry : stats.GetEntries()) {
         if (TPathId::FromProto(entry.GetPathId()) == pathId) {
-            return {entry.GetRowModifications(), entry.GetRowCount()};
+            return {entry.GetRowUpdates(), entry.GetRowDeletes(), entry.GetRowCount()};
         }
     }
-    return {0, 0};
+    return {0, 0, 0};
 }
 
 bool TStatisticsAggregator::IsChangeRatioAboveThreshold(
-    ui64 lastAnalyzeRowModifications, ui64 currentRowModifications, ui64 rowCount) const
+    ui64 lastAnalyzeRowUpdates, ui64 lastAnalyzeRowDeletes,
+    ui64 currentRowUpdates, ui64 currentRowDeletes,
+    ui64 rowCount) const
 {
-    if (lastAnalyzeRowModifications == Max<ui64>()) {
+    if (lastAnalyzeRowUpdates == Max<ui64>() || lastAnalyzeRowDeletes == Max<ui64>()) {
         return true;  // Never analyzed — stale (primary collection)
     }
-    // RowModifications is a monotonic cumulative counter, so current should not
-    // fall below the snapshot taken at the last ANALYZE. Guard against underflow.
-    if (rowCount == 0 || currentRowModifications <= lastAnalyzeRowModifications) {
+    // RowUpdates and RowDeletes are monotonic cumulative counters, so current
+    // should not fall below the snapshot taken at the last ANALYZE. Guard
+    // against underflow.
+    if (rowCount == 0) {
+        return false;
+    }
+    if (currentRowUpdates <= lastAnalyzeRowUpdates && currentRowDeletes <= lastAnalyzeRowDeletes) {
         return false;
     }
 
     // Use integer arithmetic to avoid floating-point precision loss for very
     // large counters (> 2^53). The comparison is:
-    //   changesSinceAnalyze / rowCount * 100 >= threshold
+    //   (changesSinceAnalyze) / rowCount * 100 >= threshold
     // rewritten as:
     //   changesSinceAnalyze * 100 >= threshold * rowCount
     // using __int128 to avoid overflow.
-    ui64 changesSinceAnalyze = currentRowModifications - lastAnalyzeRowModifications;
+    ui64 updatesSinceAnalyze = currentRowUpdates > lastAnalyzeRowUpdates
+        ? currentRowUpdates - lastAnalyzeRowUpdates : 0;
+    ui64 deletesSinceAnalyze = currentRowDeletes > lastAnalyzeRowDeletes
+        ? currentRowDeletes - lastAnalyzeRowDeletes : 0;
+    ui64 changesSinceAnalyze = updatesSinceAnalyze + deletesSinceAnalyze;
     auto threshold = StatisticsConfig.GetBackgroundAnalyzeChangeRatioThresholdPercent();
 
     __int128 lhs = static_cast<__int128>(changesSinceAnalyze) * 100;
@@ -1520,11 +1532,12 @@ bool TStatisticsAggregator::IsChangeRatioAboveThreshold(
     return lhs >= rhs;
 }
 
-const THashMap<TPathId, std::pair<ui64, ui64>>& TStatisticsAggregator::GetCachedChangeCounters() {
+const THashMap<TPathId, std::tuple<ui64, ui64, ui64>>& TStatisticsAggregator::GetCachedChangeCounters() {
     if (!CachedChangeCountersValid) {
-        // Parse each schemeshard's base stats once into a pathId -> (rowModifications,
-        // rowCount) lookup. The cache is reused across scheduling ticks and counter
-        // reports, avoiding re-parsing all BaseStatistics blobs every second.
+        // Parse each schemeshard's base stats once into a pathId -> (rowUpdates,
+        // rowDeletes, rowCount) lookup. The cache is reused across scheduling
+        // ticks and counter reports, avoiding re-parsing all BaseStatistics
+        // blobs every second.
         CachedChangeCounters.clear();
         for (const auto& [ssId, serializedStats] : BaseStatistics) {
             if (!serializedStats.Latest) {
@@ -1536,7 +1549,7 @@ const THashMap<TPathId, std::pair<ui64, ui64>>& TStatisticsAggregator::GetCached
             }
             for (const auto& entry : stats.GetEntries()) {
                 CachedChangeCounters[TPathId::FromProto(entry.GetPathId())] =
-                    {entry.GetRowModifications(), entry.GetRowCount()};
+                    {entry.GetRowUpdates(), entry.GetRowDeletes(), entry.GetRowCount()};
             }
         }
         CachedChangeCountersValid = true;
@@ -1561,9 +1574,11 @@ TStatisticsAggregator::TScheduleTraversal* TStatisticsAggregator::FindStaleColum
             continue;
         }
         auto it = currentCounters.find(pathId);
-        auto [currentModifications, rowCount] = it != currentCounters.end()
-            ? it->second : std::pair<ui64, ui64>{0, 0};
-        if (!IsChangeRatioAboveThreshold(traversal.LastAnalyzeRowModifications, currentModifications, rowCount)) {
+        auto [currentRowUpdates, currentRowDeletes, rowCount] = it != currentCounters.end()
+            ? it->second : std::tuple<ui64, ui64, ui64>{0, 0, 0};
+        if (!IsChangeRatioAboveThreshold(
+                traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes,
+                currentRowUpdates, currentRowDeletes, rowCount)) {
             continue;
         }
         if (!stalest || traversal.LastUpdateTime < stalest->LastUpdateTime) {
@@ -1598,9 +1613,11 @@ void TStatisticsAggregator::ReportAnalyzeCounters() {
             continue;
         }
         auto it = currentCounters.find(pathId);
-        auto [currentModifications, rowCount] = it != currentCounters.end()
-            ? it->second : std::pair<ui64, ui64>{0, 0};
-        if (IsChangeRatioAboveThreshold(traversal.LastAnalyzeRowModifications, currentModifications, rowCount)) {
+        auto [currentRowUpdates, currentRowDeletes, rowCount] = it != currentCounters.end()
+            ? it->second : std::tuple<ui64, ui64, ui64>{0, 0, 0};
+        if (IsChangeRatioAboveThreshold(
+                traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes,
+                currentRowUpdates, currentRowDeletes, rowCount)) {
             ++pendingTables;
         }
     }

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -977,6 +977,7 @@ void TStatisticsAggregator::FinishTraversal(
             BackgroundAnalyzeFailedCounter->Inc();
         }
     }
+    InvalidateCachedChangeCounters();
     ReportAnalyzeCounters();
 
     // When a background traversal completes successfully, check whether there
@@ -1504,32 +1505,47 @@ bool TStatisticsAggregator::IsChangeRatioAboveThreshold(
         return false;
     }
 
+    // Use integer arithmetic to avoid floating-point precision loss for very
+    // large counters (> 2^53). The comparison is:
+    //   changesSinceAnalyze / rowCount * 100 >= threshold
+    // rewritten as:
+    //   changesSinceAnalyze * 100 >= threshold * rowCount
+    // using __int128 to avoid overflow.
     ui64 changesSinceAnalyze = currentRowModifications - lastAnalyzeRowModifications;
-    double ratio = static_cast<double>(changesSinceAnalyze) / rowCount * 100.0;
     auto threshold = StatisticsConfig.GetBackgroundAnalyzeChangeRatioThresholdPercent();
 
-    return ratio >= static_cast<double>(threshold);
+    __int128 lhs = static_cast<__int128>(changesSinceAnalyze) * 100;
+    __int128 rhs = static_cast<__int128>(threshold) * static_cast<__int128>(rowCount);
+
+    return lhs >= rhs;
 }
 
-THashMap<TPathId, std::pair<ui64, ui64>> TStatisticsAggregator::CollectCurrentChangeCounters() const {
-    // Parse each schemeshard's base stats once into a pathId -> (rowModifications,
-    // rowCount) lookup. Doing per-table GetCurrentChangeCounters() calls instead
-    // would re-parse the whole blob for every table (quadratic on large databases).
-    THashMap<TPathId, std::pair<ui64, ui64>> currentCounters;
-    for (const auto& [ssId, serializedStats] : BaseStatistics) {
-        if (!serializedStats.Latest) {
-            continue;
+const THashMap<TPathId, std::pair<ui64, ui64>>& TStatisticsAggregator::GetCachedChangeCounters() {
+    if (!CachedChangeCountersValid) {
+        // Parse each schemeshard's base stats once into a pathId -> (rowModifications,
+        // rowCount) lookup. The cache is reused across scheduling ticks and counter
+        // reports, avoiding re-parsing all BaseStatistics blobs every second.
+        CachedChangeCounters.clear();
+        for (const auto& [ssId, serializedStats] : BaseStatistics) {
+            if (!serializedStats.Latest) {
+                continue;
+            }
+            NKikimrStat::TSchemeShardStats stats;
+            if (!stats.ParseFromString(*serializedStats.Latest)) {
+                continue;
+            }
+            for (const auto& entry : stats.GetEntries()) {
+                CachedChangeCounters[TPathId::FromProto(entry.GetPathId())] =
+                    {entry.GetRowModifications(), entry.GetRowCount()};
+            }
         }
-        NKikimrStat::TSchemeShardStats stats;
-        if (!stats.ParseFromString(*serializedStats.Latest)) {
-            continue;
-        }
-        for (const auto& entry : stats.GetEntries()) {
-            currentCounters[TPathId::FromProto(entry.GetPathId())] =
-                {entry.GetRowModifications(), entry.GetRowCount()};
-        }
+        CachedChangeCountersValid = true;
     }
-    return currentCounters;
+    return CachedChangeCounters;
+}
+
+void TStatisticsAggregator::InvalidateCachedChangeCounters() {
+    CachedChangeCountersValid = false;
 }
 
 TStatisticsAggregator::TScheduleTraversal* TStatisticsAggregator::FindStaleColumnTable() {
@@ -1537,7 +1553,7 @@ TStatisticsAggregator::TScheduleTraversal* TStatisticsAggregator::FindStaleColum
     // ordering in ScheduleTraversalsByTime, so we must scan all tables rather than
     // inspecting only the heap top. Among the stale column tables pick the one
     // analyzed longest ago.
-    auto currentCounters = CollectCurrentChangeCounters();
+    const auto& currentCounters = GetCachedChangeCounters();
 
     TScheduleTraversal* stalest = nullptr;
     for (auto& [pathId, traversal] : ScheduleTraversals) {
@@ -1574,7 +1590,7 @@ void TStatisticsAggregator::InitAnalyzeCounters() {
 }
 
 void TStatisticsAggregator::ReportAnalyzeCounters() {
-    auto currentCounters = CollectCurrentChangeCounters();
+    const auto& currentCounters = GetCachedChangeCounters();
 
     ui64 pendingTables = 0;
     for (const auto& [pathId, traversal] : ScheduleTraversals) {

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -952,14 +952,14 @@ void TStatisticsAggregator::FinishTraversal(
         traversalTable.LastUpdateTime = TraversalStartTime;
 
         if (traversalSucceeded) {
-            auto [currentRowUpdates, currentRowDeletes, _] = GetCurrentChangeCounters(pathId);
-            traversalTable.LastAnalyzeRowUpdates = currentRowUpdates;
-            traversalTable.LastAnalyzeRowDeletes = currentRowDeletes;
+            auto current = GetCurrentChangeCounters(pathId);
+            traversalTable.LastAnalyzeRowUpdates = current.RowUpdates;
+            traversalTable.LastAnalyzeRowDeletes = current.RowDeletes;
 
             db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
                 NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()),
-                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(currentRowUpdates),
-                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(currentRowDeletes));
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(current.RowUpdates),
+                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(current.RowDeletes));
         } else {
             db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
                 NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()));
@@ -1416,6 +1416,16 @@ bool TStatisticsAggregator::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev
                 PrintContainerStart(ForceTraversals, 2, str, extr);
             }
 
+            // Per-table change counters (from cached BaseStatistics).
+            const auto& cachedCounters = GetCachedChangeCounters();
+            str << "CachedChangeCounters: " << cachedCounters.size() << Endl;
+            for (const auto& [pathId, counters] : cachedCounters) {
+                str << "  " << pathId
+                    << " RowUpdates=" << counters.RowUpdates
+                    << " RowDeletes=" << counters.RowDeletes
+                    << " RowCount=" << counters.RowCount << Endl;
+            }
+
             str << Endl;
             str << "NavigatePathId: " << NavigatePathId << Endl;
 
@@ -1476,68 +1486,61 @@ bool TStatisticsAggregator::OnRenderAppHtmlPage(NMon::TEvRemoteHttpInfo::TPtr ev
     TabletCounters->Simple()[COUNTER_BASE_STATISTICS_TOTAL_BYTES_SIZE].Set(totalBytesSize);
  }
 
-std::tuple<ui64, ui64, ui64> TStatisticsAggregator::GetCurrentChangeCounters(const TPathId& pathId) const {
+TStatisticsAggregator::TChangeCounters TStatisticsAggregator::GetCurrentChangeCounters(const TPathId& pathId) const {
     // A path is owned by the schemeshard identified by pathId.OwnerId, so its
     // base stats live in that schemeshard's blob (see IsKnownTable).
     auto it = BaseStatistics.find(pathId.OwnerId);
     if (it == BaseStatistics.end() || !it->second.Latest) {
-        return {0, 0, 0};
+        return {};
     }
     NKikimrStat::TSchemeShardStats stats;
     if (!stats.ParseFromString(*it->second.Latest)) {
-        return {0, 0, 0};
+        return {};
     }
     for (const auto& entry : stats.GetEntries()) {
         if (TPathId::FromProto(entry.GetPathId()) == pathId) {
             return {entry.GetRowUpdates(), entry.GetRowDeletes(), entry.GetRowCount()};
         }
     }
-    return {0, 0, 0};
+    return {};
 }
 
 bool TStatisticsAggregator::IsChangeRatioAboveThreshold(
-    ui64 lastAnalyzeRowUpdates, ui64 lastAnalyzeRowDeletes,
-    ui64 currentRowUpdates, ui64 currentRowDeletes,
-    ui64 rowCount) const
+    const TChangeCounters& lastAnalyze, const TChangeCounters& current) const
 {
-    if (lastAnalyzeRowUpdates == Max<ui64>() || lastAnalyzeRowDeletes == Max<ui64>()) {
+    if (lastAnalyze.RowUpdates == Max<ui64>() || lastAnalyze.RowDeletes == Max<ui64>()) {
         return true;  // Never analyzed — stale (primary collection)
     }
     // RowUpdates and RowDeletes are monotonic cumulative counters, so current
     // should not fall below the snapshot taken at the last ANALYZE. Guard
     // against underflow.
-    if (rowCount == 0) {
+    if (current.RowCount == 0) {
         return false;
     }
-    if (currentRowUpdates <= lastAnalyzeRowUpdates && currentRowDeletes <= lastAnalyzeRowDeletes) {
+    if (current.RowUpdates <= lastAnalyze.RowUpdates && current.RowDeletes <= lastAnalyze.RowDeletes) {
         return false;
     }
 
-    // Use integer arithmetic to avoid floating-point precision loss for very
-    // large counters (> 2^53). The comparison is:
-    //   (changesSinceAnalyze) / rowCount * 100 >= threshold
-    // rewritten as:
-    //   changesSinceAnalyze * 100 >= threshold * rowCount
-    // using __int128 to avoid overflow.
-    ui64 updatesSinceAnalyze = currentRowUpdates > lastAnalyzeRowUpdates
-        ? currentRowUpdates - lastAnalyzeRowUpdates : 0;
-    ui64 deletesSinceAnalyze = currentRowDeletes > lastAnalyzeRowDeletes
-        ? currentRowDeletes - lastAnalyzeRowDeletes : 0;
+    // RowUpdates and RowDeletes are monotonic cumulative counters, so current
+    // should not fall below the snapshot taken at the last ANALYZE. Guard
+    // against underflow.
+    ui64 updatesSinceAnalyze = current.RowUpdates > lastAnalyze.RowUpdates
+        ? current.RowUpdates - lastAnalyze.RowUpdates : 0;
+    ui64 deletesSinceAnalyze = current.RowDeletes > lastAnalyze.RowDeletes
+        ? current.RowDeletes - lastAnalyze.RowDeletes : 0;
     ui64 changesSinceAnalyze = updatesSinceAnalyze + deletesSinceAnalyze;
     auto threshold = StatisticsConfig.GetBackgroundAnalyzeChangeRatioThresholdPercent();
 
-    __int128 lhs = static_cast<__int128>(changesSinceAnalyze) * 100;
-    __int128 rhs = static_cast<__int128>(threshold) * static_cast<__int128>(rowCount);
 
-    return lhs >= rhs;
+    double changeRatio = static_cast<double>(changesSinceAnalyze) / current.RowCount * 100.0;
+    return changeRatio >= static_cast<double>(threshold);
 }
 
-const THashMap<TPathId, std::tuple<ui64, ui64, ui64>>& TStatisticsAggregator::GetCachedChangeCounters() {
+const THashMap<TPathId, TStatisticsAggregator::TChangeCounters>& TStatisticsAggregator::GetCachedChangeCounters() {
     if (!CachedChangeCountersValid) {
-        // Parse each schemeshard's base stats once into a pathId -> (rowUpdates,
-        // rowDeletes, rowCount) lookup. The cache is reused across scheduling
-        // ticks and counter reports, avoiding re-parsing all BaseStatistics
-        // blobs every second.
+        // Parse each schemeshard's base stats once into a pathId -> TChangeCounters
+        // lookup. The cache is reused across scheduling ticks and counter reports,
+        // avoiding re-parsing all BaseStatistics blobs every second.
         CachedChangeCounters.clear();
         for (const auto& [ssId, serializedStats] : BaseStatistics) {
             if (!serializedStats.Latest) {
@@ -1574,11 +1577,9 @@ TStatisticsAggregator::TScheduleTraversal* TStatisticsAggregator::FindStaleColum
             continue;
         }
         auto it = currentCounters.find(pathId);
-        auto [currentRowUpdates, currentRowDeletes, rowCount] = it != currentCounters.end()
-            ? it->second : std::tuple<ui64, ui64, ui64>{0, 0, 0};
-        if (!IsChangeRatioAboveThreshold(
-                traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes,
-                currentRowUpdates, currentRowDeletes, rowCount)) {
+        TChangeCounters current = it != currentCounters.end() ? it->second : TChangeCounters{};
+        TChangeCounters lastAnalyze{traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes, 0};
+        if (!IsChangeRatioAboveThreshold(lastAnalyze, current)) {
             continue;
         }
         if (!stalest || traversal.LastUpdateTime < stalest->LastUpdateTime) {
@@ -1613,11 +1614,9 @@ void TStatisticsAggregator::ReportAnalyzeCounters() {
             continue;
         }
         auto it = currentCounters.find(pathId);
-        auto [currentRowUpdates, currentRowDeletes, rowCount] = it != currentCounters.end()
-            ? it->second : std::tuple<ui64, ui64, ui64>{0, 0, 0};
-        if (IsChangeRatioAboveThreshold(
-                traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes,
-                currentRowUpdates, currentRowDeletes, rowCount)) {
+        TChangeCounters current = it != currentCounters.end() ? it->second : TChangeCounters{};
+        TChangeCounters lastAnalyze{traversal.LastAnalyzeRowUpdates, traversal.LastAnalyzeRowDeletes, 0};
+        if (IsChangeRatioAboveThreshold(lastAnalyze, current)) {
             ++pendingTables;
         }
     }

--- a/ydb/core/statistics/aggregator/aggregator_impl.cpp
+++ b/ydb/core/statistics/aggregator/aggregator_impl.cpp
@@ -953,13 +953,22 @@ void TStatisticsAggregator::FinishTraversal(
 
         if (traversalSucceeded) {
             auto current = GetCurrentChangeCounters(pathId);
-            traversalTable.LastAnalyzeRowUpdates = current.RowUpdates;
-            traversalTable.LastAnalyzeRowDeletes = current.RowDeletes;
+            // Do not baseline at (0, 0): that happens when FinishTraversal races
+            // ahead of the first full SchemeShard stats report, and the next
+            // full report then looks like a huge change ratio. Keep Max so the
+            // table stays "never analyzed" until real counters arrive.
+            if (current.RowCount > 0 || current.RowUpdates > 0 || current.RowDeletes > 0) {
+                traversalTable.LastAnalyzeRowUpdates = current.RowUpdates;
+                traversalTable.LastAnalyzeRowDeletes = current.RowDeletes;
 
-            db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
-                NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()),
-                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(current.RowUpdates),
-                NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(current.RowDeletes));
+                db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()),
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(current.RowUpdates),
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(current.RowDeletes));
+            } else {
+                db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()));
+            }
         } else {
             db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
                 NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(TraversalStartTime.MicroSeconds()));
@@ -1509,7 +1518,10 @@ bool TStatisticsAggregator::IsChangeRatioAboveThreshold(
     const TChangeCounters& lastAnalyze, const TChangeCounters& current) const
 {
     if (lastAnalyze.RowUpdates == Max<ui64>() || lastAnalyze.RowDeletes == Max<ui64>()) {
-        return true;  // Never analyzed — stale (primary collection)
+        // Never analyzed — but only treat as stale once SchemeShard has sent
+        // real counters. Otherwise FinishTraversal would keep baselining at
+        // zero and we would re-analyze on every scheduling tick.
+        return current.RowCount > 0 || current.RowUpdates > 0 || current.RowDeletes > 0;
     }
     // RowUpdates and RowDeletes are monotonic cumulative counters, so current
     // should not fall below the snapshot taken at the last ANALYZE. Guard

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -7,6 +7,7 @@
 #include <ydb/core/protos/analyze_operation.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
 
+#include <ydb/core/base/counters.h>
 #include <ydb/core/base/hive.h>
 #include <ydb/core/base/tablet_pipe.h>
 #include <ydb/core/base/tablet_pipecache.h>
@@ -21,6 +22,8 @@
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <yql/essentials/core/minsketch/count_min_sketch.h>
 #include <ydb/core/util/intrusive_heap.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 
 #include <util/generic/intrlist.h>
 
@@ -195,10 +198,18 @@ private:
     void StartTraversal(NIceDb::TNiceDb& db);
     void FinishTraversal(
         NIceDb::TNiceDb& db,
+        NKikimrStat::TEvAnalyzeResponse::EStatus status,
         std::optional<Ydb::Table::AnalyzeState::State> forceTerminalState,
         NYql::TIssues issues = {});
 
     void ReportBaseStatisticsCounters();
+    void ReportAnalyzeCounters();
+    void InitAnalyzeCounters();
+
+    bool IsChangeRatioAboveThreshold(
+        ui64 lastAnalyzeRowModifications, ui64 currentRowModifications, ui64 rowCount) const;
+    std::pair<ui64, ui64> GetCurrentChangeCounters(const TPathId& pathId) const;
+    THashMap<TPathId, std::pair<ui64, ui64>> CollectCurrentChangeCounters() const;
 
     std::optional<bool> IsKnownTable(const TPathId& pathId) const;
     std::optional<bool> IsColumnTable(const TPathId& pathId) const;
@@ -272,6 +283,11 @@ private:
     TTabletCountersBase* TabletCounters;
     TAutoPtr<TTabletCountersBase> TabletCountersPtr;
 
+    // Dynamic counters for background ANALYZE monitoring (with status label via GetSubgroup)
+    NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzePendingCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzeCompletedCounter;
+    NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzeFailedCounter;
+
     TInstant AggregationRequestBeginTime;
 
     bool EnableStatistics = false;
@@ -340,6 +356,8 @@ private:
         TInstant LastUpdateTime;
         bool IsColumnTable = false;
 
+        ui64 LastAnalyzeRowModifications = Max<ui64>();
+
         size_t HeapIndexByTime = -1;
 
         struct THeapIndexByTime {
@@ -354,6 +372,11 @@ private:
             }
         };
     };
+
+    // Returns the column table analyzed longest ago whose statistics are stale by
+    // change ratio, or nullptr if none is stale. Declared after TScheduleTraversal
+    // because it returns a pointer into ScheduleTraversals.
+    TScheduleTraversal* FindStaleColumnTable();
 
     size_t ResolveRound = 0;
     static constexpr size_t MaxResolveRoundCount = 5;

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -207,13 +207,15 @@ private:
     void InitAnalyzeCounters();
 
     bool IsChangeRatioAboveThreshold(
-        ui64 lastAnalyzeRowModifications, ui64 currentRowModifications, ui64 rowCount) const;
-    std::pair<ui64, ui64> GetCurrentChangeCounters(const TPathId& pathId) const;
+        ui64 lastAnalyzeRowUpdates, ui64 lastAnalyzeRowDeletes,
+        ui64 currentRowUpdates, ui64 currentRowDeletes,
+        ui64 rowCount) const;
+    std::tuple<ui64, ui64, ui64> GetCurrentChangeCounters(const TPathId& pathId) const;
 
     // Returns cached change counters, rebuilding the cache from BaseStatistics
     // if it is invalid. The cache is invalidated when BaseStatistics is updated
     // (TTxSchemeShardStats::Complete) or when a traversal finishes (FinishTraversal).
-    const THashMap<TPathId, std::pair<ui64, ui64>>& GetCachedChangeCounters();
+    const THashMap<TPathId, std::tuple<ui64, ui64, ui64>>& GetCachedChangeCounters();
     void InvalidateCachedChangeCounters();
 
     std::optional<bool> IsKnownTable(const TPathId& pathId) const;
@@ -297,7 +299,7 @@ private:
     // Invalidated when BaseStatistics is updated (TTxSchemeShardStats::Complete)
     // or when a traversal finishes (FinishTraversal). This avoids re-parsing
     // all BaseStatistics protobuf blobs on every 1-second scheduling tick.
-    THashMap<TPathId, std::pair<ui64, ui64>> CachedChangeCounters;
+    THashMap<TPathId, std::tuple<ui64, ui64, ui64>> CachedChangeCounters;
     bool CachedChangeCountersValid = false;
 
     TInstant AggregationRequestBeginTime;
@@ -368,7 +370,8 @@ private:
         TInstant LastUpdateTime;
         bool IsColumnTable = false;
 
-        ui64 LastAnalyzeRowModifications = Max<ui64>();
+        ui64 LastAnalyzeRowUpdates = Max<ui64>();
+        ui64 LastAnalyzeRowDeletes = Max<ui64>();
 
         size_t HeapIndexByTime = -1;
 

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -209,7 +209,12 @@ private:
     bool IsChangeRatioAboveThreshold(
         ui64 lastAnalyzeRowModifications, ui64 currentRowModifications, ui64 rowCount) const;
     std::pair<ui64, ui64> GetCurrentChangeCounters(const TPathId& pathId) const;
-    THashMap<TPathId, std::pair<ui64, ui64>> CollectCurrentChangeCounters() const;
+
+    // Returns cached change counters, rebuilding the cache from BaseStatistics
+    // if it is invalid. The cache is invalidated when BaseStatistics is updated
+    // (TTxSchemeShardStats::Complete) or when a traversal finishes (FinishTraversal).
+    const THashMap<TPathId, std::pair<ui64, ui64>>& GetCachedChangeCounters();
+    void InvalidateCachedChangeCounters();
 
     std::optional<bool> IsKnownTable(const TPathId& pathId) const;
     std::optional<bool> IsColumnTable(const TPathId& pathId) const;
@@ -287,6 +292,13 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzePendingCounter;
     NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzeCompletedCounter;
     NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzeFailedCounter;
+
+    // Cached parsed change counters (pathId -> (rowModifications, rowCount)).
+    // Invalidated when BaseStatistics is updated (TTxSchemeShardStats::Complete)
+    // or when a traversal finishes (FinishTraversal). This avoids re-parsing
+    // all BaseStatistics protobuf blobs on every 1-second scheduling tick.
+    THashMap<TPathId, std::pair<ui64, ui64>> CachedChangeCounters;
+    bool CachedChangeCountersValid = false;
 
     TInstant AggregationRequestBeginTime;
 

--- a/ydb/core/statistics/aggregator/aggregator_impl.h
+++ b/ydb/core/statistics/aggregator/aggregator_impl.h
@@ -206,16 +206,21 @@ private:
     void ReportAnalyzeCounters();
     void InitAnalyzeCounters();
 
+    // Per-table change counters parsed from BaseStatistics.
+    struct TChangeCounters {
+        ui64 RowUpdates = 0;
+        ui64 RowDeletes = 0;
+        ui64 RowCount = 0;
+    };
+
     bool IsChangeRatioAboveThreshold(
-        ui64 lastAnalyzeRowUpdates, ui64 lastAnalyzeRowDeletes,
-        ui64 currentRowUpdates, ui64 currentRowDeletes,
-        ui64 rowCount) const;
-    std::tuple<ui64, ui64, ui64> GetCurrentChangeCounters(const TPathId& pathId) const;
+        const TChangeCounters& lastAnalyze, const TChangeCounters& current) const;
+    TChangeCounters GetCurrentChangeCounters(const TPathId& pathId) const;
 
     // Returns cached change counters, rebuilding the cache from BaseStatistics
     // if it is invalid. The cache is invalidated when BaseStatistics is updated
     // (TTxSchemeShardStats::Complete) or when a traversal finishes (FinishTraversal).
-    const THashMap<TPathId, std::tuple<ui64, ui64, ui64>>& GetCachedChangeCounters();
+    const THashMap<TPathId, TChangeCounters>& GetCachedChangeCounters();
     void InvalidateCachedChangeCounters();
 
     std::optional<bool> IsKnownTable(const TPathId& pathId) const;
@@ -295,11 +300,11 @@ private:
     NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzeCompletedCounter;
     NMonitoring::TDynamicCounters::TCounterPtr BackgroundAnalyzeFailedCounter;
 
-    // Cached parsed change counters (pathId -> (rowModifications, rowCount)).
+    // Cached parsed change counters (pathId -> TChangeCounters).
     // Invalidated when BaseStatistics is updated (TTxSchemeShardStats::Complete)
     // or when a traversal finishes (FinishTraversal). This avoids re-parsing
     // all BaseStatistics protobuf blobs on every 1-second scheduling tick.
-    THashMap<TPathId, std::tuple<ui64, ui64, ui64>> CachedChangeCounters;
+    THashMap<TPathId, TChangeCounters> CachedChangeCounters;
     bool CachedChangeCountersValid = false;
 
     TInstant AggregationRequestBeginTime;

--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -418,7 +418,7 @@ void TAnalyzeActor::DispatchSomeScanActors() {
         auto actor = std::make_unique<TScanActor>(
             SelfId(), DatabaseName,
             SelectBuilder->Build(TableName, tabletId), SelectBuilder->ColumnCount());
-        ScanActorsInFlight[Register(actor.release())] = TScanActorInfo{
+        ScanActorsInFlight[Register(actor.release(), TMailboxType::HTSwap, AppData()->BatchPoolId)] = TScanActorInfo{
             .TabletNodeId = nodeId,
         };
     };

--- a/ydb/core/statistics/aggregator/schema.h
+++ b/ydb/core/statistics/aggregator/schema.h
@@ -35,6 +35,7 @@ struct TAggregatorSchema : NIceDb::Schema {
         struct LastUpdateTime : Column<3, NScheme::NTypeIds::Timestamp> {};
         struct SchemeShardId  : Column<4, NScheme::NTypeIds::Uint64> {};
         struct IsColumnTable  : Column<5, NScheme::NTypeIds::Bool> {};
+        struct LastAnalyzeRowModifications : Column<6, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<OwnerId, LocalPathId>;
         using TColumns = TableColumns<
@@ -42,7 +43,8 @@ struct TAggregatorSchema : NIceDb::Schema {
             LocalPathId,
             LastUpdateTime,
             SchemeShardId,
-            IsColumnTable
+            IsColumnTable,
+            LastAnalyzeRowModifications
         >;
     };
 

--- a/ydb/core/statistics/aggregator/schema.h
+++ b/ydb/core/statistics/aggregator/schema.h
@@ -35,7 +35,8 @@ struct TAggregatorSchema : NIceDb::Schema {
         struct LastUpdateTime : Column<3, NScheme::NTypeIds::Timestamp> {};
         struct SchemeShardId  : Column<4, NScheme::NTypeIds::Uint64> {};
         struct IsColumnTable  : Column<5, NScheme::NTypeIds::Bool> {};
-        struct LastAnalyzeRowModifications : Column<6, NScheme::NTypeIds::Uint64> {};
+        struct LastAnalyzeRowUpdates : Column<6, NScheme::NTypeIds::Uint64> {};
+        struct LastAnalyzeRowDeletes : Column<7, NScheme::NTypeIds::Uint64> {};
 
         using TKey = TableKey<OwnerId, LocalPathId>;
         using TColumns = TableColumns<
@@ -44,7 +45,8 @@ struct TAggregatorSchema : NIceDb::Schema {
             LastUpdateTime,
             SchemeShardId,
             IsColumnTable,
-            LastAnalyzeRowModifications
+            LastAnalyzeRowUpdates,
+            LastAnalyzeRowDeletes
         >;
     };
 

--- a/ydb/core/statistics/aggregator/tx_finish_trasersal.cpp
+++ b/ydb/core/statistics/aggregator/tx_finish_trasersal.cpp
@@ -52,7 +52,7 @@ struct TStatisticsAggregator::TTxFinishTraversal : public TTxBase {
                 forceTerminalState = Ydb::Table::AnalyzeState::STATE_FAILED;
                 break;
         }
-        Self->FinishTraversal(db, forceTerminalState, Issues);
+        Self->FinishTraversal(db, Status, forceTerminalState, Issues);
 
         return true;
     }

--- a/ydb/core/statistics/aggregator/tx_init.cpp
+++ b/ydb/core/statistics/aggregator/tx_init.cpp
@@ -191,6 +191,7 @@ struct TStatisticsAggregator::TTxInit : public TTxBase {
                 ui64 lastUpdateTime = rowset.GetValue<Schema::ScheduleTraversals::LastUpdateTime>();
                 ui64 schemeShardId = rowset.GetValue<Schema::ScheduleTraversals::SchemeShardId>();
                 bool isColumnTable = rowset.GetValue<Schema::ScheduleTraversals::IsColumnTable>();
+                ui64 lastAnalyzeRowModifications = rowset.GetValueOrDefault<Schema::ScheduleTraversals::LastAnalyzeRowModifications>(Max<ui64>());
 
                 auto pathId = TPathId(ownerId, localPathId);
 
@@ -199,6 +200,7 @@ struct TStatisticsAggregator::TTxInit : public TTxBase {
                 scheduleTraversal.SchemeShardId = schemeShardId;
                 scheduleTraversal.LastUpdateTime = TInstant::MicroSeconds(lastUpdateTime);
                 scheduleTraversal.IsColumnTable = isColumnTable;
+                scheduleTraversal.LastAnalyzeRowModifications = lastAnalyzeRowModifications;
 
                 auto [it, _] = Self->ScheduleTraversals.emplace(pathId, scheduleTraversal);
                 Self->ScheduleTraversalsByTime.Add(&it->second);

--- a/ydb/core/statistics/aggregator/tx_init.cpp
+++ b/ydb/core/statistics/aggregator/tx_init.cpp
@@ -191,7 +191,8 @@ struct TStatisticsAggregator::TTxInit : public TTxBase {
                 ui64 lastUpdateTime = rowset.GetValue<Schema::ScheduleTraversals::LastUpdateTime>();
                 ui64 schemeShardId = rowset.GetValue<Schema::ScheduleTraversals::SchemeShardId>();
                 bool isColumnTable = rowset.GetValue<Schema::ScheduleTraversals::IsColumnTable>();
-                ui64 lastAnalyzeRowModifications = rowset.GetValueOrDefault<Schema::ScheduleTraversals::LastAnalyzeRowModifications>(Max<ui64>());
+                ui64 lastAnalyzeRowUpdates = rowset.GetValueOrDefault<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(Max<ui64>());
+                ui64 lastAnalyzeRowDeletes = rowset.GetValueOrDefault<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(Max<ui64>());
 
                 auto pathId = TPathId(ownerId, localPathId);
 
@@ -200,7 +201,8 @@ struct TStatisticsAggregator::TTxInit : public TTxBase {
                 scheduleTraversal.SchemeShardId = schemeShardId;
                 scheduleTraversal.LastUpdateTime = TInstant::MicroSeconds(lastUpdateTime);
                 scheduleTraversal.IsColumnTable = isColumnTable;
-                scheduleTraversal.LastAnalyzeRowModifications = lastAnalyzeRowModifications;
+                scheduleTraversal.LastAnalyzeRowUpdates = lastAnalyzeRowUpdates;
+                scheduleTraversal.LastAnalyzeRowDeletes = lastAnalyzeRowDeletes;
 
                 auto [it, _] = Self->ScheduleTraversals.emplace(pathId, scheduleTraversal);
                 Self->ScheduleTraversalsByTime.Add(&it->second);

--- a/ydb/core/statistics/aggregator/tx_navigate.cpp
+++ b/ydb/core/statistics/aggregator/tx_navigate.cpp
@@ -33,7 +33,7 @@ struct TStatisticsAggregator::TTxNavigate : public TTxBase {
                 Self->DeleteStatisticsFromTable();
             } else {
                 // Navigate failure -> traversal cannot proceed; mark the operation FAILED.
-                Self->FinishTraversal(db, Ydb::Table::AnalyzeState::STATE_FAILED);
+                Self->FinishTraversal(db, NKikimrStat::TEvAnalyzeResponse::STATUS_ERROR, Ydb::Table::AnalyzeState::STATE_FAILED);
             }
             return true;
         }

--- a/ydb/core/statistics/aggregator/tx_resolve.cpp
+++ b/ydb/core/statistics/aggregator/tx_resolve.cpp
@@ -35,7 +35,7 @@ struct TStatisticsAggregator::TTxResolve : public TTxBase {
                 Self->DeleteStatisticsFromTable();
             } else {
                 // Resolve failure -> mark the operation FAILED.
-                Self->FinishTraversal(db, Ydb::Table::AnalyzeState::STATE_FAILED);
+                Self->FinishTraversal(db, NKikimrStat::TEvAnalyzeResponse::STATUS_ERROR, Ydb::Table::AnalyzeState::STATE_FAILED);
             }
             return true;
         }
@@ -66,7 +66,7 @@ struct TStatisticsAggregator::TTxResolve : public TTxBase {
         if (Self->TraversalIsColumnTable && Self->TabletsForReqDistribution.empty()) {
             // Natural completion of an empty table — pass nullopt so FinishTraversal marks only the
             // current table done; the operation flips to STATE_DONE when all its tables are done.
-            Self->FinishTraversal(db, std::nullopt);
+            Self->FinishTraversal(db, NKikimrStat::TEvAnalyzeResponse::STATUS_SUCCESS, std::nullopt);
             StartColumnShardEventDistribution = false;
         }
 

--- a/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
+++ b/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
@@ -47,6 +47,7 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
 
             struct TOldStats {
                 ui64 RowCount = 0;
+                ui64 RowModifications = 0;
                 ui64 BytesSize = 0;
             };
             THashMap<TPathId, TOldStats> oldStatsMap;
@@ -54,6 +55,7 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
             for (const auto& entry : oldStatRecord.GetEntries()) {
                 auto& oldEntry = oldStatsMap[TPathId::FromProto(entry.GetPathId())];
                 oldEntry.RowCount = entry.GetRowCount();
+                oldEntry.RowModifications = entry.GetRowModifications();
                 oldEntry.BytesSize = entry.GetBytesSize();
             }
 
@@ -66,14 +68,17 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
 
                 if (entry.GetAreStatsFull()) {
                     newEntry->SetRowCount(entry.GetRowCount());
+                    newEntry->SetRowModifications(entry.GetRowModifications());
                     newEntry->SetBytesSize(entry.GetBytesSize());
                 } else {
                     auto oldIter = oldStatsMap.find(TPathId::FromProto(entry.GetPathId()));
                     if (oldIter != oldStatsMap.end()) {
                         newEntry->SetRowCount(oldIter->second.RowCount);
+                        newEntry->SetRowModifications(oldIter->second.RowModifications);
                         newEntry->SetBytesSize(oldIter->second.BytesSize);
                     } else {
                         newEntry->SetRowCount(0);
+                        newEntry->SetRowModifications(0);
                         newEntry->SetBytesSize(0);
                     }
                 }
@@ -103,6 +108,7 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
                 traversalTable.SchemeShardId = schemeShardId;
                 traversalTable.LastUpdateTime = TInstant::MicroSeconds(0);
                 traversalTable.IsColumnTable = entry.GetIsColumnTable();
+                traversalTable.LastAnalyzeRowModifications = Max<ui64>();
                 auto [it, _] = Self->ScheduleTraversals.emplace(pathId, traversalTable);
                 if (!Self->ScheduleTraversalsByTime.Has(&it->second)) {
                     Self->ScheduleTraversalsByTime.Add(&it->second);
@@ -110,7 +116,8 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
                 db.Table<Schema::ScheduleTraversals>().Key(pathId.OwnerId, pathId.LocalPathId).Update(
                     NIceDb::TUpdate<Schema::ScheduleTraversals::SchemeShardId>(schemeShardId),
                     NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(0),
-                    NIceDb::TUpdate<Schema::ScheduleTraversals::IsColumnTable>(entry.GetIsColumnTable()));
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::IsColumnTable>(entry.GetIsColumnTable()),
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowModifications>(Max<ui64>()));
             }
         }
 
@@ -137,6 +144,7 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
             {"tabletId", Self->TabletID()});
         Self->BaseStatistics[Record.GetSchemeShardId()].Committed = UpdatedStats;
         Self->ReportBaseStatisticsCounters();
+        Self->ReportAnalyzeCounters();
     }
 };
 

--- a/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
+++ b/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
@@ -143,6 +143,8 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
         YDB_LOG_DEBUG("TTxSchemeShardStats::Complete",
             {"tabletId", Self->TabletID()});
         Self->BaseStatistics[Record.GetSchemeShardId()].Committed = UpdatedStats;
+
+        Self->InvalidateCachedChangeCounters();
         Self->ReportBaseStatisticsCounters();
         Self->ReportAnalyzeCounters();
     }

--- a/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
+++ b/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
@@ -47,7 +47,8 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
 
             struct TOldStats {
                 ui64 RowCount = 0;
-                ui64 RowModifications = 0;
+                ui64 RowUpdates = 0;
+                ui64 RowDeletes = 0;
                 ui64 BytesSize = 0;
             };
             THashMap<TPathId, TOldStats> oldStatsMap;
@@ -55,7 +56,8 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
             for (const auto& entry : oldStatRecord.GetEntries()) {
                 auto& oldEntry = oldStatsMap[TPathId::FromProto(entry.GetPathId())];
                 oldEntry.RowCount = entry.GetRowCount();
-                oldEntry.RowModifications = entry.GetRowModifications();
+                oldEntry.RowUpdates = entry.GetRowUpdates();
+                oldEntry.RowDeletes = entry.GetRowDeletes();
                 oldEntry.BytesSize = entry.GetBytesSize();
             }
 
@@ -68,17 +70,20 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
 
                 if (entry.GetAreStatsFull()) {
                     newEntry->SetRowCount(entry.GetRowCount());
-                    newEntry->SetRowModifications(entry.GetRowModifications());
+                    newEntry->SetRowUpdates(entry.GetRowUpdates());
+                    newEntry->SetRowDeletes(entry.GetRowDeletes());
                     newEntry->SetBytesSize(entry.GetBytesSize());
                 } else {
                     auto oldIter = oldStatsMap.find(TPathId::FromProto(entry.GetPathId()));
                     if (oldIter != oldStatsMap.end()) {
                         newEntry->SetRowCount(oldIter->second.RowCount);
-                        newEntry->SetRowModifications(oldIter->second.RowModifications);
+                        newEntry->SetRowUpdates(oldIter->second.RowUpdates);
+                        newEntry->SetRowDeletes(oldIter->second.RowDeletes);
                         newEntry->SetBytesSize(oldIter->second.BytesSize);
                     } else {
                         newEntry->SetRowCount(0);
-                        newEntry->SetRowModifications(0);
+                        newEntry->SetRowUpdates(0);
+                        newEntry->SetRowDeletes(0);
                         newEntry->SetBytesSize(0);
                     }
                 }
@@ -108,7 +113,8 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
                 traversalTable.SchemeShardId = schemeShardId;
                 traversalTable.LastUpdateTime = TInstant::MicroSeconds(0);
                 traversalTable.IsColumnTable = entry.GetIsColumnTable();
-                traversalTable.LastAnalyzeRowModifications = Max<ui64>();
+                traversalTable.LastAnalyzeRowUpdates = Max<ui64>();
+                traversalTable.LastAnalyzeRowDeletes = Max<ui64>();
                 auto [it, _] = Self->ScheduleTraversals.emplace(pathId, traversalTable);
                 if (!Self->ScheduleTraversalsByTime.Has(&it->second)) {
                     Self->ScheduleTraversalsByTime.Add(&it->second);
@@ -117,7 +123,8 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
                     NIceDb::TUpdate<Schema::ScheduleTraversals::SchemeShardId>(schemeShardId),
                     NIceDb::TUpdate<Schema::ScheduleTraversals::LastUpdateTime>(0),
                     NIceDb::TUpdate<Schema::ScheduleTraversals::IsColumnTable>(entry.GetIsColumnTable()),
-                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowModifications>(Max<ui64>()));
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowUpdates>(Max<ui64>()),
+                    NIceDb::TUpdate<Schema::ScheduleTraversals::LastAnalyzeRowDeletes>(Max<ui64>()));
             }
         }
 

--- a/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
+++ b/ydb/core/statistics/aggregator/tx_schemeshard_stats.cpp
@@ -33,15 +33,18 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
 
         TSerializedBaseStats& existingStats = Self->BaseStatistics[schemeShardId];
 
-        // if statistics is sent from schemeshard for the first time or
-        // AreAllStatsFull field is not set (schemeshard is working on previous code version) or
-        // statistics is full for all tables
-        // then persist incoming statistics without changes
-        if (!existingStats.Latest ||
-            !statRecord.HasAreAllStatsFull() || statRecord.GetAreAllStatsFull())
-        {
+        // Persist incoming statistics without changes when:
+        //  - AreAllStatsFull is unset (old schemeshard) or true, or
+        //  - this is the first report AND it is already full.
+        // Never bootstrap BaseStatistics from an incomplete (zeroed) snapshot:
+        // FinishTraversal would baseline LastAnalyze at 0 and the next full
+        // report would look like a huge change ratio. Path discovery below
+        // still runs so never-analyzed tables can be scheduled.
+        const bool areAllStatsFull =
+            !statRecord.HasAreAllStatsFull() || statRecord.GetAreAllStatsFull();
+        if (areAllStatsFull) {
             UpdatedStats = std::make_shared<TString>(stats);
-        } else {
+        } else if (existingStats.Latest) {
             NKikimrStat::TSchemeShardStats oldStatRecord;
             Y_PROTOBUF_SUPPRESS_NODISCARD oldStatRecord.ParseFromString(*existingStats.Latest);
 
@@ -93,9 +96,11 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
             Y_PROTOBUF_SUPPRESS_NODISCARD newStatRecord.SerializeToString(UpdatedStats.get());
         }
 
-        db.Table<Schema::BaseStatistics>().Key(schemeShardId).Update(
-            NIceDb::TUpdate<Schema::BaseStatistics::Stats>(*UpdatedStats));
-        existingStats.Latest = UpdatedStats;
+        if (UpdatedStats) {
+            db.Table<Schema::BaseStatistics>().Key(schemeShardId).Update(
+                NIceDb::TUpdate<Schema::BaseStatistics::Stats>(*UpdatedStats));
+            existingStats.Latest = UpdatedStats;
+        }
 
         if (!Self->EnableColumnStatistics) {
             return true;
@@ -149,7 +154,9 @@ struct TStatisticsAggregator::TTxSchemeShardStats : public TTxBase {
     void Complete(const TActorContext&) override {
         YDB_LOG_DEBUG("TTxSchemeShardStats::Complete",
             {"tabletId", Self->TabletID()});
-        Self->BaseStatistics[Record.GetSchemeShardId()].Committed = UpdatedStats;
+        if (UpdatedStats) {
+            Self->BaseStatistics[Record.GetSchemeShardId()].Committed = UpdatedStats;
+        }
 
         Self->InvalidateCachedChangeCounters();
         Self->ReportBaseStatisticsCounters();

--- a/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
@@ -1,0 +1,367 @@
+#include <ydb/core/statistics/ut_common/ut_common.h>
+
+#include <ydb/library/actors/testlib/test_runtime.h>
+
+#include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/statistics/events.h>
+#include <ydb/core/statistics/service/service.h>
+#include <ydb/core/base/counters.h>
+
+namespace NKikimr {
+namespace NStat {
+
+namespace {
+
+TTestEnv CreateTestEnv(ui32 changeRatioThresholdPercent = 20) {
+    return TTestEnv(1, 1, false, [changeRatioThresholdPercent](Tests::TServerSettings& settings) {
+        settings.AppConfig->MutableStatisticsConfig()
+            ->SetEnableBackgroundColumnStatsCollection(true);
+        settings.AppConfig->MutableStatisticsConfig()
+            ->SetBackgroundAnalyzeChangeRatioThresholdPercent(changeRatioThresholdPercent);
+    });
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
+
+    // 1. Primary collection: table never analyzed -> background traversal picks it up immediately
+    //    (no 24h wait)
+    Y_UNIT_TEST(PrimaryCollection) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the background traversal to collect statistics.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Verify statistics were actually collected.
+        auto countMin = ExtractCountMin(runtime, tableInfo.PathId);
+        UNIT_ASSERT(countMin);
+        UNIT_ASSERT_VALUES_EQUAL(countMin->GetElementCount(), ColumnTableRowsNumber);
+    }
+
+    // 2. Change ratio trigger: insert/update/delete rows exceeding threshold -> ANALYZE is triggered
+    Y_UNIT_TEST(ChangeRatioTrigger) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial (primary) background traversal to complete.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Insert a large number of rows to exceed the 20% change ratio threshold.
+        // ColumnTableRowsNumber = 1000, so we need > 200 changes.
+        InsertDataIntoTable(env, "Database", "Table", 500);
+
+        // Wait for the next background traversal triggered by the change ratio.
+        // We observe a new TEvSaveStatisticsQueryResponse for the same path.
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        // Wait for the second save (first was the primary collection).
+        runtime.WaitFor("second TEvSaveStatisticsQueryResponse", [&] {
+            return saveCount >= 1;
+        });
+
+        observer.Remove();
+
+        // Verify statistics were re-collected.
+        auto countMin = ExtractCountMin(runtime, tableInfo.PathId);
+        UNIT_ASSERT(countMin);
+    }
+
+    // 3. No trigger below threshold: small changes below threshold -> no ANALYZE triggered
+    Y_UNIT_TEST(NoTriggerBelowThreshold) {
+        // Use a high threshold (50%) so small changes don't trigger.
+        TTestEnv env = CreateTestEnv(50);
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial (primary) background traversal to complete.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Insert a small number of rows — well below the 50% threshold.
+        // ColumnTableRowsNumber = 1000, threshold = 50%, so we need < 500 changes.
+        // We insert only 10 rows (1% change ratio).
+        InsertDataIntoTable(env, "Database", "Table", 10);
+
+        // Wait a bit and verify no new save was triggered.
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        // Wait for a reasonable time to see if a traversal is triggered.
+        // The ScheduleTraversalPeriod is 24h, so without the change ratio
+        // trigger, no traversal should happen.
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        observer.Remove();
+
+        // No new save should have occurred (change ratio is below threshold).
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
+    }
+
+    // 4. Change counters reset after ANALYZE: after ANALYZE completes,
+    //    LastAnalyzeRowModifications is updated ->
+    //    subsequent small changes do not trigger another ANALYZE
+    Y_UNIT_TEST(CountersResetAfterAnalyze) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial (primary) background traversal to complete.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Insert a moderate number of rows that would exceed the 20% threshold
+        // if the counters had NOT been reset.
+        // After the primary collection, LastAnalyzeRowModifications
+        // is set to the current value. So only NEW changes since the last
+        // ANALYZE count toward the ratio.
+        InsertDataIntoTable(env, "Database", "Table", 50); // 5% change ratio — below 20%
+
+        // Wait and verify no new save was triggered.
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        observer.Remove();
+
+        // No new save should have occurred (change ratio since last ANALYZE is below threshold).
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
+    }
+
+    // 5. Config threshold: change BackgroundAnalyzeChangeRatioThresholdPercent -> verify behavior changes
+    Y_UNIT_TEST(ConfigThresholdHigh) {
+        // With a 100% threshold, even large changes should not trigger.
+        TTestEnv env = CreateTestEnv(100);
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial (primary) background traversal to complete.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Insert 500 rows — 50% change ratio, below the 100% threshold.
+        InsertDataIntoTable(env, "Database", "Table", 500);
+
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        observer.Remove();
+
+        // No new save should have occurred (50% < 100% threshold).
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
+    }
+
+    Y_UNIT_TEST(ConfigThresholdLow) {
+        // With a 1% threshold, even small changes should trigger.
+        TTestEnv env = CreateTestEnv(1);
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial (primary) background traversal to complete.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Insert 20 rows — 2% change ratio, above the 1% threshold.
+        InsertDataIntoTable(env, "Database", "Table", 20);
+
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        runtime.WaitFor("TEvSaveStatisticsQueryResponse after small change", [&] {
+            return saveCount >= 1;
+        });
+
+        observer.Remove();
+
+        // A new save should have occurred (2% > 1% threshold).
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 1);
+    }
+
+    // 6. Table deletion: delete table -> verify change tracking is cleaned up
+    Y_UNIT_TEST(TableDeletion) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial background traversal.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Drop the table.
+        DropTable(env, "Database", "Table");
+
+        // Wait a bit for the SA to process the scheme shard stats update
+        // (which should remove the table from ScheduleTraversals).
+        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        // Verify that no new traversal is triggered for the deleted table.
+        // We can't easily check the internal ScheduleTraversals map, but we
+        // can verify that no TEvSaveStatisticsQueryResponse is sent for the
+        // deleted table's pathId.
+        bool saveOccurred = false;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                saveOccurred = true;
+            }
+        });
+
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        observer.Remove();
+
+        UNIT_ASSERT(!saveOccurred);
+    }
+
+    // 7. Counters: verify BackgroundAnalyze dynamic counter with status label is reported
+    //    This test verifies that the monitoring counters are set correctly.
+    //    We check the dynamic counters via GetSubgroup("status", ...).
+    Y_UNIT_TEST(Counters) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the background traversal to complete.
+        // ReportAnalyzeCounters() is called in TTxSchemeShardStats::Complete(),
+        // which sets the pending counter. After the traversal completes,
+        // FinishTraversal() increments the completed counter and
+        // ReportAnalyzeCounters() resets the pending counter to 0
+        // (since the table is no longer stale after being analyzed).
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // WaitForSavedStatistics returns when TEvSaveStatisticsQueryResponse is
+        // observed, but FinishTraversal (which increments the completed counter)
+        // runs in a subsequent TTxFinishTraversal transaction. Wait a bit for
+        // that transaction to complete.
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // After the traversal, the completed counter should show at least 1.
+        {
+            auto counters = runtime.GetAppData(1).Counters;
+            auto completedCounter = GetServiceCounters(counters, "statistics")
+                ->GetSubgroup("subsystem", "background_analyze")
+                ->GetSubgroup("status", "completed")
+                ->FindCounter("BackgroundAnalyze");
+            UNIT_ASSERT(completedCounter);
+            UNIT_ASSERT_VALUES_EQUAL(completedCounter->Val(), 1);
+        }
+
+        // After the traversal, the pending counter should be 0
+        // (the table is no longer stale after being analyzed).
+        {
+            auto counters = runtime.GetAppData(1).Counters;
+            auto pendingCounter = GetServiceCounters(counters, "statistics")
+                ->GetSubgroup("subsystem", "background_analyze")
+                ->GetSubgroup("status", "pending")
+                ->FindCounter("BackgroundAnalyze");
+            UNIT_ASSERT(pendingCounter);
+            UNIT_ASSERT_VALUES_EQUAL(pendingCounter->Val(), 0);
+        }
+    }
+
+    // 8. The BackgroundAnalyze completed/failed counters must track background
+    //    traversals only. A force (user-initiated) ANALYZE shares FinishTraversal()
+    //    with the background path, so it must not inflate these counters.
+    Y_UNIT_TEST(ForceAnalyzeDoesNotAffectBackgroundCounters) {
+        // Background collection disabled: the only traversal is the force one.
+        TTestEnv env(1, 1);
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        ui64 saTabletId = 0;
+        ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);
+
+        // Run a force ANALYZE to completion.
+        Analyze(runtime, saTabletId, {{tableInfo.PathId}}, "forceOp", "/Root/Database");
+
+        auto backgroundAnalyzeCounters = GetServiceCounters(runtime.GetAppData(1).Counters, "statistics")
+            ->GetSubgroup("subsystem", "background_analyze");
+
+        // Force ANALYZE must not touch the background completed/failed counters.
+        auto completedCounter = backgroundAnalyzeCounters
+            ->GetSubgroup("status", "completed")->FindCounter("BackgroundAnalyze");
+        UNIT_ASSERT(completedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(completedCounter->Val(), 0);
+
+        auto failedCounter = backgroundAnalyzeCounters
+            ->GetSubgroup("status", "failed")->FindCounter("BackgroundAnalyze");
+        UNIT_ASSERT(failedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(failedCounter->Val(), 0);
+    }
+
+    // 9. Deduplication: when a background traversal completes for a table that
+    //    also has a pending force (user-initiated) ANALYZE, the force request
+    //    should be marked as done — the statistics were just collected.
+    Y_UNIT_TEST(BackgroundDeduplicatesForceAnalyze) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the initial (primary) background traversal to complete.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Insert enough rows to exceed the 20% threshold and trigger a
+        // background traversal.
+        InsertDataIntoTable(env, "Database", "Table", 500);
+
+        // Resolve the SA tablet id so we can send a force ANALYZE.
+        ui64 saTabletId = 0;
+        ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);
+
+        // Send a force ANALYZE while the background traversal is in flight.
+        // The force request goes into the queue and waits for the background
+        // traversal to finish.
+        Analyze(runtime, saTabletId, {{tableInfo.PathId}}, "dedupOp", "/Root/Database");
+
+        // After the background traversal completes, the force request for the
+        // same table should be marked as done (deduplicated). The force ANALYZE
+        // should complete successfully without re-traversing.
+        auto countMin = ExtractCountMin(runtime, tableInfo.PathId);
+        UNIT_ASSERT(countMin);
+    }
+
+} // Y_UNIT_TEST_SUITE(BackgroundChangeRatio)
+
+} // namespace NStat
+} // namespace NKikimr

--- a/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
@@ -345,18 +345,39 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         // background traversal.
         InsertDataIntoTable(env, "Database", "Table", 500);
 
-        // Resolve the SA tablet id so we can send a force ANALYZE.
+        // Wait for the second background traversal (triggered by the change
+        // ratio) to complete. After it finishes, the table's statistics are
+        // up to date.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        // Now send a force ANALYZE for the same table. Since the background
+        // traversal just collected the statistics, the force request should
+        // be deduplicated — the table is no longer stale.
         ui64 saTabletId = 0;
         ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);
 
-        // Send a force ANALYZE while the background traversal is in flight.
-        // The force request goes into the queue and waits for the background
-        // traversal to finish.
+        // Run the force ANALYZE. It should complete successfully (the table
+        // was just analyzed, so the force traversal finds nothing to do or
+        // the statistics are already current).
         Analyze(runtime, saTabletId, {{tableInfo.PathId}}, "dedupOp", "/Root/Database");
 
-        // After the background traversal completes, the force request for the
-        // same table should be marked as done (deduplicated). The force ANALYZE
-        // should complete successfully without re-traversing.
+        // Wait for any remaining transactions to settle.
+        runtime.SimulateSleep(TDuration::Seconds(1));
+
+        // The BackgroundAnalyze{status="completed"} counter must be at least 2:
+        //   1 = primary collection (never-analyzed table)
+        //   2 = change-ratio triggered re-analysis
+        // The force ANALYZE must not have produced an additional background
+        // completion (it uses the force path, not the background path).
+        auto counters = runtime.GetAppData(1).Counters;
+        auto completedCounter = GetServiceCounters(counters, "statistics")
+            ->GetSubgroup("subsystem", "background_analyze")
+            ->GetSubgroup("status", "completed")
+            ->FindCounter("BackgroundAnalyze");
+        UNIT_ASSERT(completedCounter);
+        UNIT_ASSERT_VALUES_EQUAL(completedCounter->Val(), 2);
+
+        // Verify statistics were actually collected.
         auto countMin = ExtractCountMin(runtime, tableInfo.PathId);
         UNIT_ASSERT(countMin);
     }

--- a/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
@@ -26,8 +26,7 @@ TTestEnv CreateTestEnv(ui32 changeRatioThresholdPercent = 20) {
 
 Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
 
-    // 1. Primary collection: table never analyzed -> background traversal picks it up immediately
-    //    (no 24h wait)
+    // Table never analyzed -> background traversal picks it up immediately (no 24h wait).
     Y_UNIT_TEST(PrimaryCollection) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -44,7 +43,7 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT_VALUES_EQUAL(countMin->GetElementCount(), ColumnTableRowsNumber);
     }
 
-    // 2. Change ratio trigger: insert/update/delete rows exceeding threshold -> ANALYZE is triggered
+    // Insert/update/delete rows exceeding threshold -> ANALYZE is triggered.
     Y_UNIT_TEST(ChangeRatioTrigger) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -80,7 +79,7 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT(countMin);
     }
 
-    // 3. No trigger below threshold: small changes below threshold -> no ANALYZE triggered
+    // Small changes below threshold -> no ANALYZE triggered.
     Y_UNIT_TEST(NoTriggerBelowThreshold) {
         // Use a high threshold (50%) so small changes don't trigger.
         TTestEnv env = CreateTestEnv(50);
@@ -116,9 +115,8 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
     }
 
-    // 4. Change counters reset after ANALYZE: after ANALYZE completes,
-    //    LastAnalyzeRowUpdates and LastAnalyzeRowDeletes are updated ->
-    //    subsequent small changes do not trigger another ANALYZE
+    // After ANALYZE completes, LastAnalyzeRowUpdates/RowDeletes are updated so
+    // subsequent small changes do not trigger another ANALYZE.
     Y_UNIT_TEST(CountersResetAfterAnalyze) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -152,7 +150,7 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
     }
 
-    // 5. Config threshold: change BackgroundAnalyzeChangeRatioThresholdPercent -> verify behavior changes
+    // BackgroundAnalyzeChangeRatioThresholdPercent controls when ANALYZE fires.
     Y_UNIT_TEST(ConfigThresholdHigh) {
         // With a 100% threshold, even large changes should not trigger.
         TTestEnv env = CreateTestEnv(100);
@@ -213,7 +211,7 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT_VALUES_EQUAL(saveCount, 1);
     }
 
-    // 6. Table deletion: delete table -> verify change tracking is cleaned up
+    // Delete table -> change tracking is cleaned up.
     Y_UNIT_TEST(TableDeletion) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -249,9 +247,8 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT(!saveOccurred);
     }
 
-    // 7. Counters: verify BackgroundAnalyze dynamic counter with status label is reported
-    //    This test verifies that the monitoring counters are set correctly.
-    //    We check the dynamic counters via GetSubgroup("status", ...).
+    // Verify BackgroundAnalyze dynamic counter with status label is reported
+    // via GetSubgroup("status", ...).
     Y_UNIT_TEST(Counters) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -297,9 +294,9 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         }
     }
 
-    // 8. The BackgroundAnalyze completed/failed counters must track background
-    //    traversals only. A force (user-initiated) ANALYZE shares FinishTraversal()
-    //    with the background path, so it must not inflate these counters.
+    // BackgroundAnalyze completed/failed counters must track background
+    // traversals only. A force (user-initiated) ANALYZE shares FinishTraversal()
+    // with the background path, so it must not inflate these counters.
     Y_UNIT_TEST(ForceAnalyzeDoesNotAffectBackgroundCounters) {
         // Background collection disabled: the only traversal is the force one.
         TTestEnv env(1, 1);
@@ -329,9 +326,8 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT_VALUES_EQUAL(failedCounter->Val(), 0);
     }
 
-    // 9. Deduplication: when a background traversal completes for a table that
-    //    also has a pending force (user-initiated) ANALYZE, the force request
-    //    should be marked as done — the statistics were just collected.
+    // When a background traversal completes for a table that also has a pending
+    // force (user-initiated) ANALYZE, the force request should be marked as done.
     Y_UNIT_TEST(BackgroundDeduplicatesForceAnalyze) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -383,14 +379,12 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT(countMin);
     }
 
-    // 10. Restart persistence: the analyze baseline (LastAnalyzeRowUpdates
-    //     and LastAnalyzeRowDeletes) and LastUpdateTime live only in the
-    //     SA-local ScheduleTraversals table. After a primary collection, an
-    //     SA tablet restart must reload all of them, so a subsequent
-    //     below-threshold change still does NOT trigger a re-analysis.
-    //     If either field were lost on reload, the table would look either
-    //     "never analyzed" (baseline -> Max<ui64>()) or time-stale
-    //     (LastUpdateTime -> 0) and be re-analyzed immediately.
+    // The analyze baseline (LastAnalyzeRowUpdates/RowDeletes) and LastUpdateTime
+    // live in the SA-local ScheduleTraversals table. After a primary collection,
+    // an SA tablet restart must reload them so a below-threshold change still
+    // does NOT trigger a re-analysis. If either field were lost on reload, the
+    // table would look either "never analyzed" (baseline -> Max<ui64>()) or
+    // time-stale (LastUpdateTime -> 0) and be re-analyzed immediately.
     Y_UNIT_TEST(RestartPreservesAnalyzeBaseline) {
         TTestEnv env = CreateTestEnv();
         auto& runtime = *env.GetServer().GetRuntime();
@@ -429,6 +423,72 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
 
         // No re-analysis: both persisted fields survived the restart.
         UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
+    }
+
+    // SchemeShard restart without persistent partition stats: SS loses
+    // in-memory RowCount/RowUpdates/RowDeletes and first re-sends
+    // AreStatsFull=false (zeros) to SA. TTxSchemeShardStats must keep the
+    // previously committed counters, so the analyze baseline stays
+    // meaningful and a below-threshold change does NOT spuriously
+    // re-trigger ANALYZE. A later above-threshold change still must.
+    Y_UNIT_TEST(SchemeShardRestartWithoutPersistentStats) {
+        TTestEnv env(1, 1, false, [](Tests::TServerSettings& settings) {
+            settings.AppConfig->MutableStatisticsConfig()
+                ->SetEnableBackgroundColumnStatsCollection(true);
+            settings.AppConfig->MutableStatisticsConfig()
+                ->SetBackgroundAnalyzeChangeRatioThresholdPercent(20);
+            // After reboot SS waits 30s before the first SendBaseStatsToSA; keep
+            // the subsequent interval short so recovery is observable quickly.
+            settings.AppConfig->MutableStatisticsConfig()
+                ->SetBaseStatsSendIntervalSecondsDedicated(3);
+            settings.FeatureFlags.SetEnablePersistentPartitionStats(false);
+        });
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        const ui64 ssTabletId = tableInfo.PathId.OwnerId;
+
+        // Wait until SA has a full base-stats snapshot and any catch-up
+        // re-analysis (baselining LastAnalyze from real counters) has finished.
+        WaitForSchemeShardStatsUpdate(runtime, ssTabletId, /*requireFull=*/true);
+        runtime.SimulateSleep(TDuration::Seconds(5));
+
+        // Reboot tenant SchemeShard. Partition stats are not persisted, so
+        // AreStatsFull becomes false until columnshards re-report.
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, ssTabletId, sender);
+
+        // Wait until SS reconnects and delivers a full stats blob again
+        // (incomplete reports must be merged with the previous full values).
+        WaitForSchemeShardStatsUpdate(runtime, ssTabletId, /*requireFull=*/true);
+
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        // Below-threshold change (5% << 20%). Must not re-analyze: proving that
+        // SA did not replace the live counters with zeros from the incomplete
+        // post-reboot report.
+        InsertDataIntoTable(env, "Database", "Table", 50);
+        runtime.SimulateSleep(TDuration::Seconds(10));
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
+
+        // Above-threshold change must still trigger — the pipeline works after
+        // the SchemeShard restart.
+        InsertDataIntoTable(env, "Database", "Table", 500);
+        runtime.WaitFor("TEvSaveStatisticsQueryResponse after SchemeShard restart", [&] {
+            return saveCount >= 1;
+        });
+
+        observer.Remove();
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 1);
     }
 
 } // Y_UNIT_TEST_SUITE(BackgroundChangeRatio)

--- a/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
@@ -3,6 +3,7 @@
 #include <ydb/library/actors/testlib/test_runtime.h>
 
 #include <ydb/core/testlib/actors/block_events.h>
+#include <ydb/core/testlib/tablet_helpers.h>
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/statistics/service/service.h>
 #include <ydb/core/base/counters.h>
@@ -380,6 +381,52 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         // Verify statistics were actually collected.
         auto countMin = ExtractCountMin(runtime, tableInfo.PathId);
         UNIT_ASSERT(countMin);
+    }
+
+    // 10. Restart persistence: the analyze baseline (LastAnalyzeRowModifications)
+    //     and LastUpdateTime live only in the SA-local ScheduleTraversals table.
+    //     After a primary collection, an SA tablet restart must reload both, so a
+    //     subsequent below-threshold change still does NOT trigger a re-analysis.
+    //     If either field were lost on reload, the table would look either
+    //     "never analyzed" (baseline -> Max<ui64>()) or time-stale
+    //     (LastUpdateTime -> 0) and be re-analyzed immediately.
+    Y_UNIT_TEST(RestartPreservesAnalyzeBaseline) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
+
+        // Wait for the primary background traversal: this persists both
+        // LastUpdateTime and LastAnalyzeRowModifications for the table.
+        WaitForSavedStatistics(runtime, tableInfo.PathId);
+
+        ui64 saTabletId = 0;
+        ResolvePathId(runtime, "/Root/Database/Table", nullptr, &saTabletId);
+
+        // Restart the SA tablet, forcing a reload from the local database.
+        auto sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, saTabletId, sender);
+
+        // Insert a below-threshold number of rows (5% << 20%). This only
+        // stays below threshold if the reloaded baseline still reflects the
+        // primary collection; a lost baseline would treat the table as
+        // never-analyzed and re-collect regardless.
+        InsertDataIntoTable(env, "Database", "Table", 50);
+
+        size_t saveCount = 0;
+        auto observer = runtime.AddObserver<TEvStatistics::TEvSaveStatisticsQueryResponse>([&](auto& ev) {
+            if (ev->Get()->PathId == tableInfo.PathId) {
+                ++saveCount;
+            }
+        });
+
+        runtime.SimulateSleep(TDuration::Seconds(10));
+
+        observer.Remove();
+
+        // No re-analysis: both persisted fields survived the restart.
+        UNIT_ASSERT_VALUES_EQUAL(saveCount, 0);
     }
 
 } // Y_UNIT_TEST_SUITE(BackgroundChangeRatio)

--- a/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_background_change_ratio.cpp
@@ -117,7 +117,7 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
     }
 
     // 4. Change counters reset after ANALYZE: after ANALYZE completes,
-    //    LastAnalyzeRowModifications is updated ->
+    //    LastAnalyzeRowUpdates and LastAnalyzeRowDeletes are updated ->
     //    subsequent small changes do not trigger another ANALYZE
     Y_UNIT_TEST(CountersResetAfterAnalyze) {
         TTestEnv env = CreateTestEnv();
@@ -131,9 +131,9 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
 
         // Insert a moderate number of rows that would exceed the 20% threshold
         // if the counters had NOT been reset.
-        // After the primary collection, LastAnalyzeRowModifications
-        // is set to the current value. So only NEW changes since the last
-        // ANALYZE count toward the ratio.
+        // After the primary collection, LastAnalyzeRowUpdates and
+        // LastAnalyzeRowDeletes are set to the current values. So only
+        // NEW changes since the last ANALYZE count toward the ratio.
         InsertDataIntoTable(env, "Database", "Table", 50); // 5% change ratio — below 20%
 
         // Wait and verify no new save was triggered.
@@ -383,10 +383,11 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         UNIT_ASSERT(countMin);
     }
 
-    // 10. Restart persistence: the analyze baseline (LastAnalyzeRowModifications)
-    //     and LastUpdateTime live only in the SA-local ScheduleTraversals table.
-    //     After a primary collection, an SA tablet restart must reload both, so a
-    //     subsequent below-threshold change still does NOT trigger a re-analysis.
+    // 10. Restart persistence: the analyze baseline (LastAnalyzeRowUpdates
+    //     and LastAnalyzeRowDeletes) and LastUpdateTime live only in the
+    //     SA-local ScheduleTraversals table. After a primary collection, an
+    //     SA tablet restart must reload all of them, so a subsequent
+    //     below-threshold change still does NOT trigger a re-analysis.
     //     If either field were lost on reload, the table would look either
     //     "never analyzed" (baseline -> Max<ui64>()) or time-stale
     //     (LastUpdateTime -> 0) and be re-analyzed immediately.
@@ -397,8 +398,9 @@ Y_UNIT_TEST_SUITE(BackgroundChangeRatio) {
         CreateDatabase(env, "Database");
         const auto tableInfo = PrepareColumnTableWithIndexes(env, "Database", "Table", 1);
 
-        // Wait for the primary background traversal: this persists both
-        // LastUpdateTime and LastAnalyzeRowModifications for the table.
+        // Wait for the primary background traversal: this persists
+        // LastUpdateTime, LastAnalyzeRowUpdates, and LastAnalyzeRowDeletes
+        // for the table.
         WaitForSavedStatistics(runtime, tableInfo.PathId);
 
         ui64 saTabletId = 0;

--- a/ydb/core/statistics/aggregator/ut/ya.make
+++ b/ydb/core/statistics/aggregator/ut/ya.make
@@ -29,6 +29,7 @@ SRCS(
     ut_analyze_op.cpp
     ut_traverse_datashard.cpp
     ut_traverse_columnshard.cpp
+    ut_background_change_ratio.cpp
 )
 
 END()

--- a/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
+++ b/ydb/core/statistics/service/ut/ut_basic_statistics.cpp
@@ -67,7 +67,11 @@ void WaitForStatsUpdateFromSchemeShard(
             txnCommitted = true;
         }
     });
-    runtime.WaitFor("stats update from SchemeShard", [&]{ return txnCommitted; });
+    // The SA may skip the DB write for an incomplete first stats report (no
+    // commit), so wait for either a commit or just the event being received.
+    runtime.WaitFor("stats update from SchemeShard", [&]{
+        return txnCommitted || statsUpdateSent;
+    });
 }
 
 void WaitForStatsPropagate(TTestActorRuntime& runtime, ui32 nodeIdx) {
@@ -242,20 +246,35 @@ Y_UNIT_TEST_SUITE(BasicStatistics) {
         ui64 ssTabletId = pathId.OwnerId;
 
         // Block stats updates from one of the shards and pass others through.
+        // Datashards set TableLocalId/DatashardId at the top level of the record;
+        // column shards put them in the repeated Tables field. We handle both.
         std::optional<ui64> blockedShardId;
         THashSet<ui64> updatedShardIds;
         auto blockPredicate = [&](const TEvDataShard::TEvPeriodicTableStats::TPtr& ev) {
             const auto& record = ev->Get()->Record;
-            if (record.GetTableLocalId() != pathId.LocalPathId) {
+            // Resolve the datashard id for this event. For datashards it's the
+            // top-level field; for column shards it's in the matching Tables entry.
+            ui64 datashardId = 0;
+            if (record.GetTableLocalId() == pathId.LocalPathId) {
+                datashardId = record.GetDatashardId();
+            } else {
+                for (const auto& table : record.GetTables()) {
+                    if (table.GetTableLocalId() == pathId.LocalPathId) {
+                        datashardId = table.GetDatashardId();
+                        break;
+                    }
+                }
+            }
+            if (datashardId == 0) {
                 return false;
             }
             if (!blockedShardId) {
-                blockedShardId = record.GetDatashardId();
+                blockedShardId = datashardId;
                 return true;
-            } else if (blockedShardId == record.GetDatashardId()) {
+            } else if (blockedShardId == datashardId) {
                 return true;
             } else {
-                updatedShardIds.insert(record.GetDatashardId());
+                updatedShardIds.insert(datashardId);
                 return false;
             }
         };

--- a/ydb/core/statistics/ut_common/ut_common.cpp
+++ b/ydb/core/statistics/ut_common/ut_common.cpp
@@ -798,6 +798,31 @@ void WaitForSavedStatistics(TTestActorRuntime& runtime, const TPathId& pathId) {
     waiter.Wait();
 }
 
+void WaitForSchemeShardStatsUpdate(
+    TTestActorRuntime& runtime, ui64 ssTabletId, bool requireFull)
+{
+    bool statsUpdateSent = false;
+    auto sendObserver = runtime.AddObserver<TEvStatistics::TEvSchemeShardStats>([&](auto& ev) {
+        if (ev->Get()->Record.GetSchemeShardId() != ssTabletId) {
+            return;
+        }
+        if (!requireFull) {
+            statsUpdateSent = true;
+            return;
+        }
+        NKikimrStat::TSchemeShardStats statRecord;
+        if (statRecord.ParseFromString(ev->Get()->Record.GetStats())
+                && statRecord.GetAreAllStatsFull())
+        {
+            statsUpdateSent = true;
+        }
+    });
+    runtime.WaitFor(
+        requireFull ? "full TEvSchemeShardStats from SchemeShard"
+                    : "TEvSchemeShardStats from SchemeShard",
+        [&]{ return statsUpdateSent; });
+}
+
 ui64 GetRowCount(TTestActorRuntime& runtime, ui32 nodeIndex, TPathId pathId) {
     auto statServiceId = NStat::MakeStatServiceID(runtime.GetNodeId(nodeIndex));
     NStat::TRequest req;

--- a/ydb/core/statistics/ut_common/ut_common.h
+++ b/ydb/core/statistics/ut_common/ut_common.h
@@ -199,6 +199,9 @@ void AnalyzeStatus(TTestActorRuntime& runtime, TActorId sender, ui64 saTabletId,
 
 void WaitForSavedStatistics(TTestActorRuntime& runtime, const TPathId& pathId);
 
+void WaitForSchemeShardStatsUpdate(
+    TTestActorRuntime& runtime, ui64 ssTabletId, bool requireFull = false);
+
 ui64 GetRowCount(TTestActorRuntime& runtime, ui32 nodeIndex, TPathId pathId);
 void ValidateRowCount(TTestActorRuntime& runtime, ui32 nodeIndex, TPathId pathId, size_t expectedRowCount);
 void WaitForRowCount(

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -227,7 +227,7 @@ void TSchemeShard::CollectLocalIndexMigrations(const TActorContext& ctx) {
                     continue;
                 }
             }
-            
+
             if (indexProto.GetImplementationCase() == NKikimrSchemeOp::TOlapIndexDescription::kMaxIndex) {
                 continue;
             }
@@ -9417,6 +9417,7 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         entryPathId->SetOwnerId(pathId.OwnerId);
         entryPathId->SetLocalId(pathId.LocalPathId);
         entry->SetRowCount(areStatsFull ? aggregated.RowCount : 0);
+        entry->SetRowModifications(areStatsFull ? (aggregated.RowUpdates + aggregated.RowDeletes) : 0);
         entry->SetBytesSize(areStatsFull ? aggregated.DataSize : 0);
         entry->SetIsColumnTable(false);
         entry->SetAreStatsFull(areStatsFull);
@@ -9451,6 +9452,7 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         entryPathId->SetOwnerId(pathId.OwnerId);
         entryPathId->SetLocalId(pathId.LocalPathId);
         entry->SetRowCount(areStatsFull ? aggregated.RowCount : 0);
+        entry->SetRowModifications(areStatsFull ? (aggregated.RowUpdates + aggregated.RowDeletes) : 0);
         entry->SetBytesSize(areStatsFull ? aggregated.DataSize : 0);
         entry->SetIsColumnTable(true);
         entry->SetAreStatsFull(areStatsFull);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -9417,7 +9417,8 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         entryPathId->SetOwnerId(pathId.OwnerId);
         entryPathId->SetLocalId(pathId.LocalPathId);
         entry->SetRowCount(areStatsFull ? aggregated.RowCount : 0);
-        entry->SetRowModifications(areStatsFull ? (aggregated.RowUpdates + aggregated.RowDeletes) : 0);
+        entry->SetRowUpdates(areStatsFull ? aggregated.RowUpdates : 0);
+        entry->SetRowDeletes(areStatsFull ? aggregated.RowDeletes : 0);
         entry->SetBytesSize(areStatsFull ? aggregated.DataSize : 0);
         entry->SetIsColumnTable(false);
         entry->SetAreStatsFull(areStatsFull);
@@ -9452,7 +9453,8 @@ TDuration TSchemeShard::SendBaseStatsToSA() {
         entryPathId->SetOwnerId(pathId.OwnerId);
         entryPathId->SetLocalId(pathId.LocalPathId);
         entry->SetRowCount(areStatsFull ? aggregated.RowCount : 0);
-        entry->SetRowModifications(areStatsFull ? (aggregated.RowUpdates + aggregated.RowDeletes) : 0);
+        entry->SetRowUpdates(areStatsFull ? aggregated.RowUpdates : 0);
+        entry->SetRowDeletes(areStatsFull ? aggregated.RowDeletes : 0);
         entry->SetBytesSize(areStatsFull ? aggregated.DataSize : 0);
         entry->SetIsColumnTable(true);
         entry->SetAreStatsFull(areStatsFull);

--- a/ydb/core/tx/schemeshard/ut_base/ut_table_info.cpp
+++ b/ydb/core/tx/schemeshard/ut_base/ut_table_info.cpp
@@ -290,6 +290,48 @@ Y_UNIT_TEST(ApplySplitMerge_AggregatedStatsSubtracted) {
     UNIT_ASSERT_VALUES_EQUAL(info->GetPartitions().size(), 2u);
 }
 
+Y_UNIT_TEST(ApplySplitMerge_PreservesRowUpdatesAndDeletes) {
+    // Unlike RowCount/DataSize, RowUpdates/RowDeletes are cumulative counters. On
+    // split/merge, RemoveShardStats subtracts the removed shard's RowCount/DataSize but
+    // must NOT subtract its RowUpdates/RowDeletes, so they survive the reshard.
+    auto info = MakeTable();
+    // Shards: A(1/0), B(1/1), C(1/2), D(1/3)
+    info->SetPartitioning(MakeShards(4));
+
+    TDiskSpaceUsageDelta delta;
+    TPartitionStats sA;
+    sA.SeqNo = TMessageSeqNo{1, 0};
+    sA.RowCount = 100;
+    sA.RowUpdates = 700;
+    sA.RowDeletes = 150;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), sA, TInstant::Zero());
+
+    TPartitionStats sB;
+    sB.SeqNo = TMessageSeqNo{1, 0};
+    sB.RowCount = 200;
+    sB.RowUpdates = 300;
+    sB.RowDeletes = 50;
+    info->UpdateShardStats(&delta, TShardIdx(1, 1), sB, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 300u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowUpdates, 1000u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowDeletes, 200u);
+
+    // Split A (position 0) into A1+A2 — B, C, D shift right by 1.
+    TVector<TTableShardInfo> dst;
+    dst.emplace_back(TShardIdx(2, 0), TString(1, '\x01'), 0, 0);
+    dst.emplace_back(TShardIdx(2, 1), TString(1, '\x02'), 0, 0);
+    TVector<TShardIdx> removed = {TShardIdx(1, 0)};
+
+    info->ApplySplitMerge(std::move(dst), removed, /*splitFirstIdx=*/0, TInstant::Zero());
+
+    // Current-state metric (RowCount) drops by the removed shard A's contribution...
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowCount, 200u);
+    // ...but the cumulative modification counters are preserved across the split.
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowUpdates, 1000u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowDeletes, 200u);
+}
+
 Y_UNIT_TEST(ApplySplitMerge_TTL_SrcInFlightCleared) {
     auto info = MakeTable();
     EnableTTL(*info);
@@ -520,6 +562,36 @@ Y_UNIT_TEST(UpdateShardStats_GenerationRollover) {
     info->UpdateShardStats(&delta, TShardIdx(1, 0), gen2, TInstant::Zero());
 
     UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.ImmediateTxCompleted, 110u);
+}
+
+Y_UNIT_TEST(UpdateShardStats_GenerationRollover_RowUpdatesAndDeletes) {
+    // RowUpdates/RowDeletes are cumulative counters kept in the shard's memory, so they
+    // reset to zero on tablet restart. A generation bump must re-baseline them so the
+    // aggregate is preserved and keeps growing, never decrements.
+    auto info = MakeTable();
+    info->SetPartitioning(MakeShards(1));
+
+    TDiskSpaceUsageDelta delta;
+
+    // Generation 1: shard has accumulated 1000 updates and 200 deletes.
+    TPartitionStats gen1;
+    gen1.SeqNo = TMessageSeqNo{1, 0};
+    gen1.RowUpdates = 1000;
+    gen1.RowDeletes = 200;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), gen1, TInstant::Zero());
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowUpdates, 1000u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowDeletes, 200u);
+
+    // Generation 2: shard restarted, counters restarted from zero and reached 50/10.
+    // The aggregate must keep the gen1 totals and add gen2 from a zero baseline.
+    TPartitionStats gen2;
+    gen2.SeqNo = TMessageSeqNo{2, 0};
+    gen2.RowUpdates = 50;
+    gen2.RowDeletes = 10;
+    info->UpdateShardStats(&delta, TShardIdx(1, 0), gen2, TInstant::Zero());
+
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowUpdates, 1050u);
+    UNIT_ASSERT_VALUES_EQUAL(info->GetStats().Aggregated.RowDeletes, 210u);
 }
 
 // --- RemoveShardStats ---

--- a/ydb/core/tx/schemeshard/ut_base_reboots/ut_base_reboots.cpp
+++ b/ydb/core/tx/schemeshard/ut_base_reboots/ut_base_reboots.cpp
@@ -1,4 +1,5 @@
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/table_stats.pb.h>
 #include <ydb/core/tx/datashard/datashard.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/test_with_reboots.h>
@@ -1052,5 +1053,143 @@ Y_UNIT_TEST_SUITE(TTablesWithReboots) {
                 static_cast<int>(NKikimrSchemeOp::TTableIncrementalBackupConfig::RESTORE_MODE_INCREMENTAL_BACKUP)
             );
         }
+    }
+
+    // Base-stat fields sent to the Statistics Aggregator (RowCount, RowUpdates,
+    // RowDeletes) are persisted in the schemeshard local DB and must survive a reboot.
+    Y_UNIT_TEST_WITH_REBOOTS(BaseStatsSurviveReboot) {
+        t.GetTestEnvOptions().EnablePersistentPartitionStats(true);
+
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            constexpr ui32 WrittenRows = 50;
+            constexpr ui32 DeletedRows = 10;
+
+            ui64 rowCountBefore = 0;
+            ui64 rowUpdatesBefore = 0;
+            ui64 rowDeletesBefore = 0;
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "Simple"
+                    Columns { Name: "key"   Type: "Uint32" }
+                    Columns { Name: "value" Type: "Utf8" }
+                    KeyColumnNames: ["key"]
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                for (ui32 key = 0; key < WrittenRows; ++key) {
+                    WriteRow(runtime, ++t.TxId, "/MyRoot/Simple", 0, key, "value");
+                }
+                for (ui32 key = 0; key < DeletedRows; ++key) {
+                    DeleteRow(runtime, ++t.TxId, "/MyRoot/Simple", 0, key);
+                }
+
+                while (rowUpdatesBefore < WrittenRows || rowDeletesBefore < DeletedRows) {
+                    auto describe = DescribePrivatePath(runtime, "/MyRoot/Simple", true, true);
+                    const auto& stats = describe.GetPathDescription().GetTableStats();
+                    rowCountBefore = stats.GetRowCount();
+                    rowUpdatesBefore = stats.GetRowUpdates();
+                    rowDeletesBefore = stats.GetRowDeletes();
+                    t.TestEnv->SimulateSleep(runtime, TDuration::Seconds(1));
+                }
+            }
+
+            TActorId sender = runtime.AllocateEdgeActor();
+            RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                auto describe = DescribePrivatePath(runtime, "/MyRoot/Simple", true, true);
+                const auto& stats = describe.GetPathDescription().GetTableStats();
+
+                // All three fields are persisted in the schemeshard local DB and
+                // must be restored to the same values after the reboot.
+                UNIT_ASSERT_VALUES_EQUAL(stats.GetRowCount(), rowCountBefore);
+                UNIT_ASSERT_VALUES_EQUAL(stats.GetRowUpdates(), rowUpdatesBefore);
+                UNIT_ASSERT_VALUES_EQUAL(stats.GetRowDeletes(), rowDeletesBefore);
+            }
+        });
+    }
+
+    // Without EnablePersistentPartitionStats, schemeshard loses in-memory base stats on
+    // reboot. Datashards keep their counters and re-send them via PeriodicTableStats,
+    // so the table aggregate must recover after some time.
+    Y_UNIT_TEST_WITH_REBOOTS(BaseStatsRecoverAfterRebootWithoutPersistence) {
+        t.GetTestEnvOptions()
+            .EnablePersistentPartitionStats(false)
+            .DataShardStatsReportIntervalSeconds(1);
+
+        t.Run([&](TTestActorRuntime& runtime, bool& activeZone) {
+            constexpr ui32 WrittenRows = 50;
+            constexpr ui32 DeletedRows = 10;
+
+            ui64 rowCountBefore = 0;
+            ui64 rowUpdatesBefore = 0;
+            ui64 rowDeletesBefore = 0;
+
+            {
+                TInactiveZone inactive(activeZone);
+
+                TestCreateTable(runtime, ++t.TxId, "/MyRoot", R"(
+                    Name: "Simple"
+                    Columns { Name: "key"   Type: "Uint32" }
+                    Columns { Name: "value" Type: "Utf8" }
+                    KeyColumnNames: ["key"]
+                )");
+                t.TestEnv->TestWaitNotification(runtime, t.TxId);
+
+                for (ui32 key = 0; key < WrittenRows; ++key) {
+                    WriteRow(runtime, ++t.TxId, "/MyRoot/Simple", 0, key, "value");
+                }
+                for (ui32 key = 0; key < DeletedRows; ++key) {
+                    DeleteRow(runtime, ++t.TxId, "/MyRoot/Simple", 0, key);
+                }
+
+                while (rowUpdatesBefore < WrittenRows || rowDeletesBefore < DeletedRows) {
+                    auto describe = DescribePrivatePath(runtime, "/MyRoot/Simple", true, true);
+                    const auto& stats = describe.GetPathDescription().GetTableStats();
+                    rowCountBefore = stats.GetRowCount();
+                    rowUpdatesBefore = stats.GetRowUpdates();
+                    rowDeletesBefore = stats.GetRowDeletes();
+                    t.TestEnv->SimulateSleep(runtime, TDuration::Seconds(1));
+                }
+
+                // Reboot only schemeshard; leave the datashard running so its in-memory
+                // RowUpdates/RowDeletes survive and can be re-reported.
+                TActorId sender = runtime.AllocateEdgeActor();
+                RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+                // Stats were not persisted, so they start empty after the reboot.
+                {
+                    auto describe = DescribePrivatePath(runtime, "/MyRoot/Simple", true, true);
+                    const auto& stats = describe.GetPathDescription().GetTableStats();
+                    UNIT_ASSERT_VALUES_EQUAL(stats.GetRowCount(), 0u);
+                    UNIT_ASSERT_VALUES_EQUAL(stats.GetRowUpdates(), 0u);
+                    UNIT_ASSERT_VALUES_EQUAL(stats.GetRowDeletes(), 0u);
+                }
+
+                ui64 rowCountAfter = 0;
+                ui64 rowUpdatesAfter = 0;
+                ui64 rowDeletesAfter = 0;
+                while (rowCountAfter < rowCountBefore
+                        || rowUpdatesAfter < rowUpdatesBefore
+                        || rowDeletesAfter < rowDeletesBefore)
+                {
+                    auto describe = DescribePrivatePath(runtime, "/MyRoot/Simple", true, true);
+                    const auto& stats = describe.GetPathDescription().GetTableStats();
+                    rowCountAfter = stats.GetRowCount();
+                    rowUpdatesAfter = stats.GetRowUpdates();
+                    rowDeletesAfter = stats.GetRowDeletes();
+                    t.TestEnv->SimulateSleep(runtime, TDuration::Seconds(1));
+                }
+
+                UNIT_ASSERT_VALUES_EQUAL(rowCountAfter, rowCountBefore);
+                UNIT_ASSERT_VALUES_EQUAL(rowUpdatesAfter, rowUpdatesBefore);
+                UNIT_ASSERT_VALUES_EQUAL(rowDeletesAfter, rowDeletesBefore);
+            }
+        });
     }
 }

--- a/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
+++ b/ydb/core/tx/schemeshard/ut_stats/ut_stats.cpp
@@ -175,6 +175,35 @@ TTableId ResolveTableId(TTestActorRuntime& runtime, const TString& path) {
     return response->ResultSet.at(0).TableId;
 }
 
+ui64 GetRowUpdates(TTestActorRuntime& runtime, const TString& path) {
+    auto description = DescribePrivatePath(runtime, TTestTxConfig::SchemeShard, path, true, true);
+    return description.GetPathDescription().GetTableStats().GetRowUpdates();
+}
+
+void WaitRowUpdatesAtLeast(TTestActorRuntime& runtime, TTestEnv& env, const TString& path, ui64 expected) {
+    while (GetRowUpdates(runtime, path) < expected) {
+        env.SimulateSleep(runtime, TDuration::MilliSeconds(100));
+    }
+}
+
+// A single-shard table whose writes go through the datashard write path, so they
+// increment the RowUpdates counter (LocalMiniKQL writes do not).
+void CreateSimpleTable(TTestActorRuntime& runtime, TTestEnv& env, ui64& txId) {
+    TestCreateTable(runtime, TTestTxConfig::SchemeShard, ++txId, "/MyRoot", R"(
+        Name: "Simple"
+        Columns { Name: "key"   Type: "Uint32" }
+        Columns { Name: "value" Type: "Utf8" }
+        KeyColumnNames: ["key"]
+    )");
+    env.TestWaitNotification(runtime, txId);
+}
+
+void WriteRows(TTestActorRuntime& runtime, ui64& txId, int partitionIdx, ui32 fromKeyInclusive, ui32 toKey) {
+    for (ui32 key = fromKeyInclusive; key < toKey; ++key) {
+        WriteRow(runtime, ++txId, "/MyRoot/Simple", partitionIdx, key, "value");
+    }
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
@@ -617,6 +646,75 @@ Y_UNIT_TEST_SUITE(TSchemeshardStatsBatchingTest) {
         InjectPeriodicTopicStats(runtime, allowInjectedTopicStats, topic1Id, generation, round - 1, 19, 7);
 
         AssertTopicSize(17, 7); // not changed because round is less
+    }
+
+    Y_UNIT_TEST(RowUpdatesSurviveShardRestart) {
+        // A datashard keeps RowUpdates in memory, so a restart resets it to zero.
+        // The schemeshard re-baselines the shard on the generation bump, so the table
+        // aggregate must keep growing across the restart, never drop.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.DisableStatsBatching(true);
+        opts.EnableBackgroundCompaction(false);
+        opts.DataShardStatsReportIntervalSeconds(0);
+        TTestEnv env(runtime, opts);
+
+        ui64 txId = 1000;
+        CreateSimpleTable(runtime, env, txId);
+        WriteRows(runtime, txId, 0, 0, INITIAL_ROWS_COUNT);
+
+        WaitRowUpdatesAtLeast(runtime, env, "/MyRoot/Simple", INITIAL_ROWS_COUNT);
+
+        // Restart the datashard: its in-memory RowUpdates counter resets to zero.
+        auto shards = GetTableShards(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, shards[0], sender);
+
+        // Write more rows after the restart.
+        const ui32 extraRows = 50;
+        WriteRows(runtime, txId, 0, INITIAL_ROWS_COUNT, INITIAL_ROWS_COUNT + extraRows);
+
+        // The aggregate keeps the pre-restart updates and adds the new ones; if it had
+        // dropped on the generation bump it would stall at extraRows and never reach this.
+        WaitRowUpdatesAtLeast(runtime, env, "/MyRoot/Simple", INITIAL_ROWS_COUNT + extraRows);
+        UNIT_ASSERT_GE(GetRowUpdates(runtime, "/MyRoot/Simple"), INITIAL_ROWS_COUNT + extraRows);
+    }
+
+    Y_UNIT_TEST(RowUpdatesSurviveShardSplit) {
+        // On split the schemeshard removes the parent shard and adds empty children.
+        // RowUpdates is deliberately not subtracted with the parent's current-state
+        // metrics, so the table aggregate survives the reshard.
+        TTestBasicRuntime runtime;
+        TTestEnvOptions opts;
+        opts.DisableStatsBatching(true);
+        opts.EnableBackgroundCompaction(false);
+        opts.DataShardStatsReportIntervalSeconds(0);
+        TTestEnv env(runtime, opts);
+
+        ui64 txId = 1000;
+        // Single-shard table with keys [0, INITIAL_ROWS_COUNT).
+        CreateSimpleTable(runtime, env, txId);
+        WriteRows(runtime, txId, 0, 0, INITIAL_ROWS_COUNT);
+
+        WaitRowUpdatesAtLeast(runtime, env, "/MyRoot/Simple", INITIAL_ROWS_COUNT);
+
+        auto shards = GetTableShards(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(shards.size(), 1u);
+
+        // Split the single shard in two at key = INITIAL_ROWS_COUNT / 2.
+        TestSplitTable(runtime, ++txId, "/MyRoot/Simple", Sprintf(R"(
+                SourceTabletId: %lu
+                SplitBoundary { KeyPrefix { Tuple { Optional { Uint32: %lu } } } }
+            )", shards[0], INITIAL_ROWS_COUNT / 2));
+        env.TestWaitNotification(runtime, txId);
+
+        auto newShards = GetTableShards(runtime, TTestTxConfig::SchemeShard, "/MyRoot/Simple");
+        UNIT_ASSERT_VALUES_EQUAL(newShards.size(), 2u);
+
+        // Children start at zero, but the table aggregate still carries the parent's
+        // updates — they were not lost in the reshard.
+        UNIT_ASSERT_GE(GetRowUpdates(runtime, "/MyRoot/Simple"), INITIAL_ROWS_COUNT);
     }
 
 };


### PR DESCRIPTION
Add a change-ratio-based trigger to the existing 24-hour periodic
background traversal in StatisticsAggregator. The traversal now fires
when either the scheduled time has elapsed OR the percentage of
modified rows since the last ANALYZE exceeds a configurable threshold
(BackgroundAnalyzeChangeRatioThresholdPercent, default 20%).

