### PR TITLE
Add cgroup OOM subscriber liveness checks

### DIFF
--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
@@ -10,10 +10,14 @@
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log_iface.h>
+#include <ydb/library/actors/core/log_settings.h>
+#include <ydb/library/actors/protos/services_common.pb.h>
 
 #include <util/generic/hash.h>
-#include <util/generic/hash_set.h>
+#include <util/generic/map.h>
 #include <util/generic/vector.h>
+#include <util/string/builder.h>
 
 namespace NActors {
 
@@ -27,6 +31,28 @@ namespace NActors {
             return current >= previous ? current - previous : 0;
         }
 
+        ui32 ExtractSubscriberActivityIndex(const TActorId& actorId) {
+            if (!TlsActivationContext) {
+                return Max<ui32>();
+            }
+
+            const TActorContext& context = TActivationContext::AsActorContext();
+            if (actorId.NodeId() != context.SelfID.NodeId()) {
+                return Max<ui32>();
+            }
+            if (IActor* actor = context.Mailbox.FindActor(actorId.LocalId())) {
+                return actor->GetActivityType().GetIndex();
+            }
+            if (IActor* actor = context.Mailbox.FindAlias(actorId.LocalId())) {
+                return actor->GetActivityType().GetIndex();
+            }
+            return Max<ui32>();
+        }
+
+        TStringBuf FormatSubscriberActivityName(ui32 activityIndex) {
+            return activityIndex == Max<ui32>() ? TStringBuf("manual") : GetActivityTypeName(activityIndex);
+        }
+
     } // namespace
 
     namespace NDetail {
@@ -37,6 +63,7 @@ namespace NActors {
             EvUnsubscribeCallback,
             EvSubscribeActor,
             EvUnsubscribeActor,
+            EvCheckActorSubscribersLiveness,
         };
 
         struct TEvPoll : TEventLocal<TEvPoll, EvPoll> {
@@ -66,9 +93,11 @@ namespace NActors {
 
         struct TEvSubscribeActor : TEventLocal<TEvSubscribeActor, EvSubscribeActor> {
             TActorId ActorId;
+            ui32 ActivityIndex;
 
-            explicit TEvSubscribeActor(TActorId actorId)
+            TEvSubscribeActor(TActorId actorId, ui32 activityIndex)
                 : ActorId(actorId)
+                , ActivityIndex(activityIndex)
             {
             }
         };
@@ -80,6 +109,115 @@ namespace NActors {
                 : ActorId(actorId)
             {
             }
+        };
+
+        struct TEvCheckActorSubscribersLiveness
+            : TEventLocal<TEvCheckActorSubscribersLiveness, EvCheckActorSubscribersLiveness>
+        {
+        };
+
+        class TCGroupOomSubscriberLivenessChecker
+            : public TActorBootstrapped<TCGroupOomSubscriberLivenessChecker>
+        {
+        public:
+            TCGroupOomSubscriberLivenessChecker(
+                    const TActorId& subscriptionOwner,
+                    THashMap<TActorId, ui32> subscribers)
+                : SubscriptionOwner(subscriptionOwner)
+                , PendingSubscribers(std::move(subscribers))
+            {
+            }
+
+            void Bootstrap() {
+                if (PendingSubscribers.empty()) {
+                    return PassAway();
+                }
+
+                Become(&TThis::StateWork);
+                // Every liveness probe is guaranteed to eventually produce exactly one response:
+                // ActorAlive or ActorDead for a local target, and ActorLivenessUnsure for a remote one.
+                // The checker can therefore wait for all responses without a timeout.
+                for (const auto& [subscriber, activityIndex] : PendingSubscribers) {
+                    Y_UNUSED(activityIndex);
+                    TActivationContext::Send(new IEventHandle(
+                        TEvents::TSystem::CheckActorLiveness,
+                        TEvents::TEvCheckActorLiveness::RequestFlags,
+                        subscriber,
+                        SelfId(),
+                        nullptr,
+                        0));
+                }
+            }
+
+        private:
+            STRICT_STFUNC(StateWork,
+                hFunc(TEvents::TEvActorAlive, Handle)
+                hFunc(TEvents::TEvActorDead, Handle)
+                hFunc(TEvents::TEvActorLivenessUnsure, Handle)
+            )
+
+            void Handle(TEvents::TEvActorAlive::TPtr& ev) {
+                Complete(ev->Sender);
+            }
+
+            void Handle(TEvents::TEvActorDead::TPtr& ev) {
+                if (const auto it = PendingSubscribers.find(ev->Sender);
+                        it != PendingSubscribers.end()) {
+                    ++LeakedSubscribersByActivity[it->second];
+                    PendingSubscribers.erase(it);
+                    Send(SubscriptionOwner, new TEvUnsubscribeActor(ev->Sender));
+                    PassAwayIfDone();
+                }
+            }
+
+            void Handle(TEvents::TEvActorLivenessUnsure::TPtr& ev) {
+                Complete(ev->Sender);
+            }
+
+            void Complete(const TActorId& subscriber) {
+                if (PendingSubscribers.erase(subscriber)) {
+                    PassAwayIfDone();
+                }
+            }
+
+            void PassAwayIfDone() {
+                if (PendingSubscribers.empty()) {
+                    LogLeakedSubscribers();
+                    PassAway();
+                }
+            }
+
+            void LogLeakedSubscribers() const {
+                if (LeakedSubscribersByActivity.empty()) {
+                    return;
+                }
+
+                TStringBuilder details;
+                bool first = true;
+                for (const auto& [activityIndex, count] : LeakedSubscribersByActivity) {
+                    if (!first) {
+                        details << ", ";
+                    }
+                    first = false;
+                    details << "{activity# " << FormatSubscriberActivityName(activityIndex)
+                        << " actors# " << count << '}';
+                }
+                NLog::TSettings* loggerSettings = TlsActivationContext->LoggerSettings();
+                if (loggerSettings &&
+                        loggerSettings->Satisfies(NLog::PRI_WARN, NActorsServices::GLOBAL)) {
+                    Send(loggerSettings->LoggerActorId, new NLog::TEvLog(
+                        NLog::PRI_WARN,
+                        NActorsServices::GLOBAL,
+                        TStringBuilder()
+                            << "CGroup OOM subscriber liveness check found leaked subscriptions: "
+                            << details));
+                }
+            }
+
+        private:
+            const TActorId SubscriptionOwner;
+            THashMap<TActorId, ui32> PendingSubscribers;
+            TMap<ui32, ui64> LeakedSubscribersByActivity;
         };
 
         class TCGroupOomActor : public TActorBootstrapped<TCGroupOomActor> {
@@ -95,6 +233,10 @@ namespace NActors {
             void Bootstrap() {
                 Become(&TThis::StateWork);
                 Send(SelfId(), new TEvPoll());
+                if (Config.SubscriberLivenessCheckInterval != TDuration::Zero()) {
+                    Schedule(Config.SubscriberLivenessCheckInterval,
+                        new TEvCheckActorSubscribersLiveness());
+                }
             }
 
             STRICT_STFUNC(StateWork,
@@ -104,6 +246,7 @@ namespace NActors {
                 hFunc(TEvUnsubscribeCallback, Handle)
                 hFunc(TEvSubscribeActor, Handle)
                 hFunc(TEvUnsubscribeActor, Handle)
+                hFunc(TEvCheckActorSubscribersLiveness, Handle)
                 cFunc(TEvents::TSystem::Poison, PassAway)
             )
 
@@ -141,11 +284,25 @@ namespace NActors {
             }
 
             void Handle(TEvSubscribeActor::TPtr& ev) {
-                ActorSubscribers.insert(ev->Get()->ActorId);
+                ActorSubscribers[ev->Get()->ActorId] = ev->Get()->ActivityIndex;
             }
 
             void Handle(TEvUnsubscribeActor::TPtr& ev) {
                 ActorSubscribers.erase(ev->Get()->ActorId);
+            }
+
+            void Handle(TEvCheckActorSubscribersLiveness::TPtr&) {
+                const TDuration interval = Config.SubscriberLivenessCheckInterval;
+                if (interval == TDuration::Zero()) {
+                    return;
+                }
+
+                if (!ActorSubscribers.empty()) {
+                    TActivationContext::Register(
+                        new TCGroupOomSubscriberLivenessChecker(SelfId(), ActorSubscribers),
+                        SelfId());
+                }
+                Schedule(interval, new TEvCheckActorSubscribersLiveness());
             }
 
             void Evaluate(TCGroupMemoryStatsPtr stats) {
@@ -205,7 +362,8 @@ namespace NActors {
 
             void Notify(const TCGroupOomAlert& alert) {
                 const TActorContext& actorContext = TActivationContext::AsActorContext();
-                for (const TActorId& actorId : ActorSubscribers) {
+                for (const auto& [actorId, activityIndex] : ActorSubscribers) {
+                    Y_UNUSED(activityIndex);
                     actorContext.Send(actorId, new TEvCGroupOomAlert(alert));
                 }
 
@@ -224,7 +382,7 @@ namespace NActors {
             const TCGroupOomConfig Config;
 
             THashMap<TCGroupOomSubSystem::TSubscriptionId, TCGroupOomSubSystem::TCallback> Callbacks;
-            THashSet<TActorId> ActorSubscribers;
+            THashMap<TActorId, ui32> ActorSubscribers;
 
             std::optional<ECGroupVersion> PreviousVersion;
             TString PreviousCGroupPath;
@@ -290,7 +448,8 @@ namespace NActors {
 
         Y_ABORT_UNLESS(ActorSystem, "cgroup OOM subsystem is not running");
 
-        ActorSystem->Send(MonitorActorId, new NDetail::TEvSubscribeActor(actorId));
+        ActorSystem->Send(MonitorActorId,
+            new NDetail::TEvSubscribeActor(actorId, ExtractSubscriberActivityIndex(actorId)));
     }
 
     void TCGroupOomSubSystem::Unsubscribe(const TActorId& actorId) {

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.cpp
@@ -4,19 +4,15 @@
 #include "cgroup_v1.h"
 #include "cgroup_v2.h"
 
-#include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorsystem.h>
-#include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/events.h>
 #include <ydb/library/actors/core/hfunc.h>
-#include <ydb/library/actors/core/log_iface.h>
 #include <ydb/library/actors/core/log_settings.h>
 #include <ydb/library/actors/protos/services_common.pb.h>
 
 #include <util/generic/hash.h>
 #include <util/generic/map.h>
-#include <util/generic/vector.h>
 #include <util/string/builder.h>
 
 namespace NActors {
@@ -393,6 +389,10 @@ namespace NActors {
 
     } // namespace NDetail
 
+    bool TCGroupOomAlert::HasReason(ECGroupOomReason reason) const {
+        return Reasons & static_cast<ui32>(reason);
+    }
+
     TCGroupOomSubSystem::TCGroupOomSubSystem(TCGroupOomConfig config)
         : Config(std::move(config))
     {
@@ -405,6 +405,10 @@ namespace NActors {
             (*Config.MemoryPressureFullAvg10Threshold >= 0 &&
                 *Config.MemoryPressureFullAvg10Threshold <= 100),
             "cgroup OOM PSI threshold must be in [0, 100]");
+    }
+
+    const TCGroupOomConfig& TCGroupOomSubSystem::GetConfig() const {
+        return Config;
     }
 
     TSubSystemDependencies TCGroupOomSubSystem::GetDependencies() const {

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
@@ -58,6 +58,8 @@ namespace NActors {
         // reads use the pools configured by the selected stats providers.
         ui32 ExecutorPoolId = 0;
         TDuration PollPeriod = TDuration::Seconds(1);
+        // Zero disables actor subscriber liveness checks.
+        TDuration SubscriberLivenessCheckInterval = TDuration::Hours(1);
 
         // An empty optional disables the corresponding threshold.
         std::optional<double> MemoryUsageThreshold = 0.9;

--- a/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
+++ b/ydb/library/actors/core/subsystems/cgroup/cgroup_oom.h
@@ -48,9 +48,7 @@ namespace NActors {
         ui64 NewHighEvents = 0;
         ui64 NewMaxEvents = 0;
 
-        bool HasReason(ECGroupOomReason reason) const {
-            return Reasons & static_cast<ui32>(reason);
-        }
+        bool HasReason(ECGroupOomReason reason) const;
     };
 
     struct TCGroupOomConfig {
@@ -74,9 +72,7 @@ namespace NActors {
 
         explicit TCGroupOomSubSystem(TCGroupOomConfig config);
 
-        const TCGroupOomConfig& GetConfig() const {
-            return Config;
-        }
+        const TCGroupOomConfig& GetConfig() const;
 
         TSubSystemDependencies GetDependencies() const override;
         void OnDependenciesResolved(const TResolvedSubSystemDependencies& dependencies) override;

--- a/ydb/library/actors/core/ut/cgroup_ut.cpp
+++ b/ydb/library/actors/core/ut/cgroup_ut.cpp
@@ -13,8 +13,6 @@
 
 #include <ydb/library/actors/protos/services_common.pb.h>
 
-#include <library/cpp/logger/backend.h>
-#include <library/cpp/logger/record.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/core/future.h>

--- a/ydb/library/actors/core/ut/cgroup_ut.cpp
+++ b/ydb/library/actors/core/ut/cgroup_ut.cpp
@@ -8,16 +8,26 @@
 #include <executor_pool_basic.h>
 #include <executor_pool_io.h>
 #include <hfunc.h>
+#include <log.h>
 #include <scheduler_basic.h>
 
+#include <ydb/library/actors/protos/services_common.pb.h>
+
+#include <library/cpp/logger/backend.h>
+#include <library/cpp/logger/record.h>
+#include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <library/cpp/threading/future/core/future.h>
 
 #include <util/folder/path.h>
 #include <util/folder/tempdir.h>
 #include <util/stream/file.h>
+#include <util/string/builder.h>
+#include <util/system/mutex.h>
 
+#include <atomic>
 #include <functional>
+#include <memory>
 
 using namespace NActors;
 
@@ -26,6 +36,123 @@ namespace {
     constexpr ui32 SystemPoolId = 0;
     constexpr ui32 IoPoolId = 1;
     constexpr ui64 RequestCookie = 42;
+
+    struct TCGroupOomLogState {
+        std::atomic<ui32> Warnings = 0;
+        TMutex Mutex;
+        TString LastWarning;
+    };
+
+    class TCGroupOomLogBackend : public TLogBackend {
+    public:
+        explicit TCGroupOomLogBackend(std::shared_ptr<TCGroupOomLogState> state)
+            : State(std::move(state))
+        {
+        }
+
+        void WriteData(const TLogRecord& rec) override {
+            const TStringBuf line(rec.Data, rec.Len);
+            if (rec.Priority == TLOG_WARNING &&
+                    line.Contains("CGroup OOM subscriber liveness check found leaked subscriptions")) {
+                with_lock (State->Mutex) {
+                    State->LastWarning = line;
+                }
+                State->Warnings.fetch_add(1, std::memory_order_release);
+            }
+        }
+
+        void ReopenLog() override {
+        }
+
+    private:
+        std::shared_ptr<TCGroupOomLogState> State;
+    };
+
+    struct TCGroupOomSubscriberState {
+        std::atomic<ui32> Started = 0;
+        std::atomic<ui32> Alerts = 0;
+        std::atomic<ui32> Stopped = 0;
+    };
+
+    class TCGroupOomSubscriberA : public TActorBootstrapped<TCGroupOomSubscriberA> {
+    public:
+        static constexpr char ActorName[] = "CGroupOomSubscriberA";
+
+        explicit TCGroupOomSubscriberA(std::shared_ptr<TCGroupOomSubscriberState> state)
+            : State(std::move(state))
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+            GetCGroupOomSubSystem().Subscribe(SelfId());
+            State->Started.fetch_add(1, std::memory_order_release);
+        }
+
+    private:
+        void Handle(TEvCGroupOomAlert::TPtr&) {
+            State->Alerts.fetch_add(1, std::memory_order_release);
+        }
+
+        void HandlePoison() {
+            State->Stopped.fetch_add(1, std::memory_order_release);
+            PassAway();
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvCGroupOomAlert, Handle)
+            cFunc(TEvents::TSystem::Poison, HandlePoison)
+        )
+
+    private:
+        const std::shared_ptr<TCGroupOomSubscriberState> State;
+    };
+
+    class TCGroupOomSubscriberB : public TActorBootstrapped<TCGroupOomSubscriberB> {
+    public:
+        static constexpr char ActorName[] = "CGroupOomSubscriberB";
+
+        explicit TCGroupOomSubscriberB(std::shared_ptr<TCGroupOomSubscriberState> state)
+            : State(std::move(state))
+        {
+        }
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+            GetCGroupOomSubSystem().Subscribe(SelfId());
+            State->Started.fetch_add(1, std::memory_order_release);
+        }
+
+    private:
+        void Handle(TEvCGroupOomAlert::TPtr&) {
+            State->Alerts.fetch_add(1, std::memory_order_release);
+        }
+
+        void HandlePoison() {
+            State->Stopped.fetch_add(1, std::memory_order_release);
+            PassAway();
+        }
+
+        STRICT_STFUNC(StateWork,
+            hFunc(TEvCGroupOomAlert, Handle)
+            cFunc(TEvents::TSystem::Poison, HandlePoison)
+        )
+
+    private:
+        const std::shared_ptr<TCGroupOomSubscriberState> State;
+    };
+
+    template <typename TPredicate>
+    void WaitForCondition(TPredicate&& predicate, TStringBuf description) {
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(5);
+        while (TInstant::Now() < deadline) {
+            if (predicate()) {
+                return;
+            }
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        UNIT_FAIL(TStringBuilder() << "timed out waiting for " << description);
+    }
 
     void WriteFile(const TFsPath& root, const TString& path, const TString& content) {
         const TFsPath fullPath = root / path;
@@ -62,7 +189,8 @@ namespace {
     THolder<TActorSystem> MakeActorSystem(
             std::unique_ptr<TCGroupV2StatsSubSystem> v2 = {},
             std::unique_ptr<TCGroupV1StatsSubSystem> v1 = {},
-            std::unique_ptr<TCGroupOomSubSystem> oom = {}) {
+            std::unique_ptr<TCGroupOomSubSystem> oom = {},
+            std::shared_ptr<TCGroupOomLogState> logState = {}) {
         auto setup = MakeHolder<TActorSystemSetup>();
         setup->NodeId = 1;
         setup->ExecutorsCount = 2;
@@ -80,7 +208,32 @@ namespace {
         if (oom) {
             setup->RegisterSubSystem(std::move(oom));
         }
-        return MakeHolder<TActorSystem>(setup);
+
+        TIntrusivePtr<NLog::TSettings> loggerSettings;
+        if (logState) {
+            loggerSettings = MakeIntrusive<NLog::TSettings>(
+                TActorId(0, "logger"),
+                static_cast<NLog::EComponent>(NActorsServices::LOGGER),
+                NLog::PRI_DEBUG,
+                NLog::PRI_DEBUG,
+                0U);
+            loggerSettings->Append(
+                NActorsServices::EServiceCommon_MIN,
+                NActorsServices::EServiceCommon_MAX,
+                NActorsServices::EServiceCommon_Name);
+            loggerSettings->SetAllowDrop(false);
+            loggerSettings->SetThrottleDelay(TDuration::Zero());
+            setup->LocalServices.emplace_back(
+                loggerSettings->LoggerActorId,
+                TActorSetupCmd(
+                    new TLoggerActor(
+                        loggerSettings,
+                        TAutoPtr<TLogBackend>(new TCGroupOomLogBackend(std::move(logState))),
+                        MakeIntrusive<NMonitoring::TDynamicCounters>()),
+                    TMailboxType::Simple,
+                    SystemPoolId));
+        }
+        return MakeHolder<TActorSystem>(setup, nullptr, loggerSettings);
     }
 
     template<class TEvent, class TResult>
@@ -251,6 +404,74 @@ Y_UNIT_TEST_SUITE(TCGroupStatsSubSystemTest) {
         UNIT_ASSERT_DOUBLES_EQUAL(*alert.MemoryUsage, 0.95, 1e-12);
 
         oom.Unsubscribe(subscriptionId);
+        actorSystem->Stop();
+    }
+
+    Y_UNIT_TEST(OomControllerRemovesDeadActorSubscribersAndLogsByActivity) {
+        TTempDir tempDir;
+        const TFsPath root = tempDir.Path();
+        WriteFile(root, "proc/self/cgroup", "0::/\n");
+        WriteFile(root, "sys/fs/cgroup/memory.current", "500\n");
+        WriteFile(root, "sys/fs/cgroup/memory.max", "1000\n");
+
+        const TDuration livenessCheckInterval = TDuration::MilliSeconds(200);
+        TCGroupOomConfig oomConfig;
+        oomConfig.ExecutorPoolId = SystemPoolId;
+        oomConfig.PollPeriod = TDuration::MilliSeconds(10);
+        oomConfig.SubscriberLivenessCheckInterval = livenessCheckInterval;
+        oomConfig.MemoryUsageThreshold = 0.9;
+
+        auto logState = std::make_shared<TCGroupOomLogState>();
+        auto actorSystem = MakeActorSystem(
+            MakeCGroupV2StatsSubSystem(MakeV2Config(root)),
+            {},
+            MakeCGroupOomSubSystem(oomConfig),
+            logState);
+        actorSystem->Start();
+
+        auto subscriberState = std::make_shared<TCGroupOomSubscriberState>();
+        TVector<TActorId> subscriberIds;
+        subscriberIds.push_back(actorSystem->Register(
+            new TCGroupOomSubscriberA(subscriberState), TMailboxType::Simple, SystemPoolId));
+        subscriberIds.push_back(actorSystem->Register(
+            new TCGroupOomSubscriberA(subscriberState), TMailboxType::Simple, SystemPoolId));
+        subscriberIds.push_back(actorSystem->Register(
+            new TCGroupOomSubscriberB(subscriberState), TMailboxType::Simple, SystemPoolId));
+
+        WaitForCondition([&] {
+            return subscriberState->Started.load(std::memory_order_acquire) == subscriberIds.size();
+        }, "cgroup OOM subscribers to start");
+        Sleep(TDuration::MilliSeconds(100));
+
+        WriteFile(root, "sys/fs/cgroup/memory.current", "950\n");
+        WaitForCondition([&] {
+            return subscriberState->Alerts.load(std::memory_order_acquire) == subscriberIds.size();
+        }, "cgroup OOM alert delivery");
+
+        Sleep(2 * livenessCheckInterval);
+        UNIT_ASSERT_VALUES_EQUAL(logState->Warnings.load(std::memory_order_acquire), 0);
+
+        for (const TActorId& actorId : subscriberIds) {
+            actorSystem->Send(actorId, new TEvents::TEvPoison());
+        }
+        WaitForCondition([&] {
+            return subscriberState->Stopped.load(std::memory_order_acquire) == subscriberIds.size();
+        }, "cgroup OOM subscribers to stop");
+        WaitForCondition([&] {
+            return logState->Warnings.load(std::memory_order_acquire) == 1;
+        }, "leaked cgroup OOM subscriber warning");
+
+        with_lock (logState->Mutex) {
+            UNIT_ASSERT_STRING_CONTAINS(
+                logState->LastWarning,
+                "{activity# CGroupOomSubscriberA actors# 2}");
+            UNIT_ASSERT_STRING_CONTAINS(
+                logState->LastWarning,
+                "{activity# CGroupOomSubscriberB actors# 1}");
+        }
+
+        Sleep(2 * livenessCheckInterval);
+        UNIT_ASSERT_VALUES_EQUAL(logState->Warnings.load(std::memory_order_acquire), 1);
         actorSystem->Stop();
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Adds periodic liveness checks for CGroup OOM actor subscribers. Dead subscribers are automatically removed, with a single WARN summarizing leaked subscriptions by actor activity. The interval defaults to one hour and can be disabled with Zero(). Callback subscriptions remain unchanged.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
