### PR TITLE
schemeshard: fix crash on alter-user-attrs/drop race

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -227,7 +227,7 @@ void TSchemeShard::CollectLocalIndexMigrations(const TActorContext& ctx) {
                     continue;
                 }
             }
-            
+
             if (indexProto.GetImplementationCase() == NKikimrSchemeOp::TOlapIndexDescription::kMaxIndex) {
                 continue;
             }
@@ -2351,6 +2351,19 @@ void TSchemeShard::PersistUserAttributes(NIceDb::TNiceDb& db, TPathId pathId,
     }
 }
 
+void TSchemeShard::PersistRemoveUserAttributesAlter(NIceDb::TNiceDb& db, TPathElement::TPtr pathElement) {
+    if (pathElement->UserAttrs->AlterData) {
+        const TPathId& pathId = pathElement->PathId;
+        for (const auto& name : pathElement->UserAttrs->AlterData->Attrs | std::views::keys) {
+            if (IsLocalId(pathId)) {
+                db.Table<Schema::UserAttributesAlterData>().Key(pathId.LocalPathId, name).Delete();
+            } else {
+                db.Table<Schema::MigratedUserAttributesAlterData>().Key(pathId.OwnerId, pathId.LocalPathId, name).Delete();
+            }
+        }
+        pathElement->UserAttrs->AlterData.Reset();
+    }
+}
 
 void TSchemeShard::PersistLastTxId(NIceDb::TNiceDb& db, const TPathElement::TPtr path) {
     if (path->PathId.OwnerId == TabletID()) {
@@ -2416,6 +2429,12 @@ void TSchemeShard::PersistRemovePath(NIceDb::TNiceDb& db, const TPathElement::TP
             db.Table<Schema::MigratedUserAttributes>().Key(path->PathId.OwnerId, path->PathId.LocalPathId, name).Delete();
         }
     }
+
+    // Defensively clean up any pending UserAttributesAlterData rows that may have been left
+    // orphaned if the path was dropped while AlterUserAttributes was still in progress.
+    // Normally DropNode() takes care of this, but PersistRemovePath is the final removal
+    // point and must guarantee no dangling rows survive path deletion.
+    PersistRemoveUserAttributesAlter(db, path);
 
     if (IsLocalId(path->PathId)) {
         db.Table<Schema::Paths>().Key(path->PathId.LocalPathId).Delete();
@@ -6556,6 +6575,13 @@ void TSchemeShard::DropNode(TPathElement::TPtr node, TStepId step, TTxId txId, N
             // not all path types support removal
             break;
     }
+
+    // If there was a pending AlterUserAttributes in progress when the path was dropped,
+    // the UserAttributesAlterData rows in the local DB must be cleaned up explicitly.
+    // PersistUserAttributes(..., nullptr) only removes UserAttributes rows and returns early
+    // without touching UserAttributesAlterData, which would leave them orphaned and cause
+    // a Y_VERIFY_S crash in ReadEverything on restart.
+    PersistRemoveUserAttributesAlter(db, node);
 
     PersistUserAttributes(db, node->PathId, node->UserAttrs, nullptr);
 }

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -819,9 +819,10 @@ public:
     void PersistDropStep(NIceDb::TNiceDb& db, const TPathId pathId, TStepId step, TOperationId opId);
 
     // user attrs
+    void PersistAlterUserAttributes(NIceDb::TNiceDb& db, TPathId pathId);
     void ApplyAndPersistUserAttrs(NIceDb::TNiceDb& db, const TPathId& pathId);
     void PersistUserAttributes(NIceDb::TNiceDb& db, TPathId pathId, TUserAttributes::TPtr oldAttrs, TUserAttributes::TPtr alterAttrs);
-    void PersistAlterUserAttributes(NIceDb::TNiceDb& db, TPathId pathId);
+    void PersistRemoveUserAttributesAlter(NIceDb::TNiceDb& db, TPathElement::TPtr pathElement);
 
     // table index
     void PersistTableIndex(NIceDb::TNiceDb& db, const TPathId& pathId);

--- a/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/ut_extsubdomain/ut_extsubdomain.cpp
@@ -1,5 +1,6 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 #include <ydb/core/testlib/actors/wait_events.h>  // for TWaitForFirstEvent
+#include <ydb/core/testlib/actors/block_events.h>  // for TBlockEvents
 
 #include <ydb/public/lib/value/value.h>
 
@@ -1693,6 +1694,88 @@ Y_UNIT_TEST_SUITE(TSchemeShardExtSubDomainTest) {
             UNIT_ASSERT(bool(entry.ListNodeEntry));
             UNIT_ASSERT_VALUES_EQUAL_C(entry.ListNodeEntry->Children.size(), 1, "extsubdomain exist: " << entry.ListNodeEntry->Children.at(0).Name);
         }
+    }
+
+    // Regression test for a bug where dropping a tenant while AlterUserAttributes is
+    // in-flight (after Propose, before the coordinator plan is applied) left orphaned
+    // UserAttributesAlterData rows in the local database.
+    // On schemeshard restart, ReadEverything hit Y_VERIFY_S(PathsById.contains(pathId)) and crashed.
+    Y_UNIT_TEST_FLAG(DropWhileAlteringUserAttrs, ExternalHive) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Prepare phase.
+        // Create extsubdomain
+
+        TestCreateExtSubDomain(runtime, ++txId,  "/MyRoot",
+            R"(Name: "USER_0")"
+        );
+        TestAlterExtSubDomain(runtime, ++txId,  "/MyRoot",
+            Sprintf(R"(
+                    Name: "USER_0"
+                    ExternalSchemeShard: true
+                    PlanResolution: 50
+                    Coordinators: 1
+                    Mediators: 1
+                    TimeCastBucketsPerMediator: 2
+                    StoragePools {
+                        Name: "pool-1"
+                        Kind: "hdd"
+                    }
+
+                    ExternalHive: %s
+                )",
+                ToString(ExternalHive).c_str()
+            )
+        );
+        env.TestWaitNotification(runtime, {txId, txId - 1});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {
+            NLs::PathExist,
+            NLs::IsExternalSubDomain("USER_0")
+        });
+
+        // Alter user attrs but hang it at the right moment.
+        // Intercept TEvTxProcessing::TEvPlanStep for the upcoming AlterUserAttrs to keep it in
+        // Propose state (UserAttributesAlterData written to DB, but not yet applied).
+        const ui64 alterTxId = ++txId;
+        TBlockEvents<TEvTxProcessing::TEvPlanStep> blockedPlan(runtime, [alterTxId](const auto& ev) {
+            const auto& record = ev->Get()->Record;
+            for (const auto& tx : record.GetTransactions()) {
+                if (tx.GetTxId() == alterTxId) {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        // Send AlterUserAttrs — this writes UserAttributesAlterData rows to the DB.
+        TestUserAttrs(runtime, alterTxId, "/MyRoot", "USER_0", AlterUserAttrs({{"key", "value"}}));
+
+        // Wait until the plan is blocked (alter is in Propose, AlterData is persisted).
+        runtime.WaitFor("blocked plan", [&] { return !blockedPlan.empty(); });
+
+        // Test body.
+        // Drop extsubdomain while alter user attrs is still in progress
+
+        TestForceDropExtSubDomain(runtime, ++txId, "/MyRoot", "USER_0");
+
+        // Unblock the intercepted plan so the runtime does not stall
+        blockedPlan.Unblock().Stop();
+
+        env.TestWaitNotification(runtime, {alterTxId, txId});
+
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/USER_0"), {NLs::PathNotExist});
+
+        // Reboot root schemeshard.
+        // Without the fix, ReadEverything crashes here with Y_VERIFY_S(PathsById.contains(pathId))
+        // on the orphaned AlterData rows
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Verify schemeshard is alive after restart
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {NLs::PathExist});
     }
 
     Y_UNIT_TEST_FLAGS(CreateAndAlterThenDropChangesParent, AlterDatabaseCreateHiveFirst, ExternalHive) {

--- a/ydb/core/tx/schemeshard/ut_user_attributes/ut_user_attributes.cpp
+++ b/ydb/core/tx/schemeshard/ut_user_attributes/ut_user_attributes.cpp
@@ -1,3 +1,4 @@
+#include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
 using namespace NKikimr;
@@ -234,5 +235,61 @@ Y_UNIT_TEST_SUITE(TSchemeShardUserAttrsTest) {
 
         TUserAttrs dirDAttrs{{"__extra_path_symbols_allowed", "./_"}};
         TestMkDir(runtime, txId++, "/MyRoot", "DirD", {NKikimrScheme::StatusInvalidParameter}, AlterUserAttrs(dirDAttrs));
+    }
+
+    // Regression test for a bug where dropping a tenant while AlterUserAttributes is
+    // in-flight (after Propose, before the coordinator plan is applied) left orphaned
+    // UserAttributesAlterData rows in the local database.
+    // On schemeshard restart, ReadEverything hit Y_VERIFY_S(PathsById.contains(pathId)) and crashed.
+    Y_UNIT_TEST(DropPathWhileAlteringUserAttrs) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // Create a directory with initial user attributes.
+        TestMkDir(runtime, ++txId, "/MyRoot", "DirA", {NKikimrScheme::StatusAccepted}, AlterUserAttrs({{"key1", "val1"}}));
+        env.TestWaitNotification(runtime, txId);
+        ui64 dirAPathId = DescribePath(runtime, "/MyRoot/DirA").GetPathId();
+
+        // Intercept TEvTxProcessing::TEvPlanStep for the upcoming AlterUserAttrs to keep it in
+        // Propose state (UserAttributesAlterData written to DB, but not yet applied).
+        const ui64 alterTxId = ++txId;
+        TBlockEvents<TEvTxProcessing::TEvPlanStep> blockedPlan(runtime, [alterTxId](const auto& ev) {
+            const auto& record = ev->Get()->Record;
+            for (const auto& tx : record.GetTransactions()) {
+                if (tx.GetTxId() == alterTxId) {
+                    return true;
+                }
+            }
+            return false;
+        });
+
+        // Send AlterUserAttrs — this writes UserAttributesAlterData rows to the DB.
+        TestUserAttrs(runtime, alterTxId, "/MyRoot", "DirA", AlterUserAttrs({{"key2", "val2"}}));
+
+        // Wait until the plan is blocked (alter is in Propose, AlterData is persisted).
+        runtime.WaitFor("blocked plan", [&] { return !blockedPlan.empty(); });
+
+        // Force-drop the directory while AlterUserAttrs is in-flight.
+        // This calls AbortUnsafe on the alter operation (which does NOT clean up
+        // UserAttributesAlterData from DB), then calls DropNode which — with the fix —
+        // must clean up those orphaned rows.
+        TestForceDropUnsafe(runtime, ++txId, dirAPathId);
+
+        // Unblock the intercepted plan so the runtime does not stall.
+        blockedPlan.Unblock().Stop();
+
+        env.TestWaitNotification(runtime, {alterTxId, txId});
+
+        // Verify the directory is gone.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot/DirA"), {NLs::PathNotExist});
+
+        // Reboot schemeshard.  Without the fix, ReadEverything crashes here with
+        // Y_VERIFY_S(PathsById.contains(pathId)) on the orphaned AlterData rows.
+        TActorId sender = runtime.AllocateEdgeActor();
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, sender);
+
+        // Verify schemeshard is alive after restart.
+        TestDescribeResult(DescribePath(runtime, "/MyRoot"), {NLs::PathExist});
     }
 }


### PR DESCRIPTION
When a database path (or any path via force-drop-unsafe) is dropped while an alter-user-attrs operation is in-flight (after Propose but before the coordinator plan is applied), `UserAttributesAlterData` / `MigratedUserAttributesAlterData` rows are left orphaned in the local database, causing a crash on the next schemeshard reboot.

http://st/KIKIMR-25931