### PR TITLE
some decommission fixes

### DIFF
--- a/ydb/core/cms/console/console_tenants_manager.cpp
+++ b/ydb/core/cms/console/console_tenants_manager.cpp
@@ -4136,7 +4136,7 @@ void TTenantsManager::Handle(TEvHive::TEvShrinkStoragePoolDone::TPtr &ev, const 
         return;
     }
     auto pool = poolIt->second;
-    if (pool->State != TStoragePool::EState::SHRINKING) {
+    if (pool->State != TStoragePool::EState::SHRINKING && pool->State != TStoragePool::EState::NOT_UPDATED) {
         return;
     }
 

--- a/ydb/core/mind/hive/hive.cpp
+++ b/ydb/core/mind/hive/hive.cpp
@@ -207,5 +207,9 @@ const std::unordered_map<TTabletTypes::EType, TString> TABLET_TYPE_SHORT_NAMES =
 
 const std::unordered_map<TString, TTabletTypes::EType> TABLET_TYPE_BY_SHORT_NAME = MakeReverseMap(TABLET_TYPE_SHORT_NAMES);
 
+TFullTabletId ToFullTabletId(TTabletId tabletId) {
+    return {tabletId, 0};
+}
+
 } // NHive
 } // NKikimr

--- a/ydb/core/mind/hive/hive.h
+++ b/ydb/core/mind/hive/hive.h
@@ -435,6 +435,8 @@ struct TReassignOperation {
     }
 };
 
+TFullTabletId ToFullTabletId(TTabletId tabletId);
+
 } // NHive
 } // NKikimr
 

--- a/ydb/core/mind/hive/hive_events.h
+++ b/ydb/core/mind/hive/hive_events.h
@@ -41,7 +41,7 @@ struct TEvPrivate {
         EvUpdateBalanceCounters,
         EvProcessTabletMetrics,
         EvReassignInactiveGroupsComplete,
-        EvCompactComplete,
+        EvMoveDataComplete,
         EvEnd
     };
 
@@ -157,11 +157,11 @@ struct TEvPrivate {
         TEvReassignInactiveGroupsComplete(const TString& poolName) : PoolName(poolName) {};
     };
 
-    struct TEvCompactComplete : TEventLocal<TEvCompactComplete, EvCompactComplete> {
+    struct TEvMoveDataComplete : TEventLocal<TEvMoveDataComplete, EvMoveDataComplete> {
         TString PoolName;
         bool Success;
 
-        TEvCompactComplete(const TString& poolName, bool success) : PoolName(poolName), Success(success) {}
+        TEvMoveDataComplete(const TString& poolName, bool success) : PoolName(poolName), Success(success) {}
     };
 };
 

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -4538,7 +4538,7 @@ bool THive::MoveDataInactiveGroups(TStoragePoolInfo& pool) {
     if (tabletsToMoveData.empty()) {
         return false;
     } else {
-        YDB_LOG_INFO("ShrinkPool: starting compact for tablets",
+        YDB_LOG_INFO("ShrinkPool: starting move data for tablets",
             {"logPrefix", GetLogPrefix()},
             {"tabletsToMoveDataCount", tabletsToMoveData.size()});
         StartMoveDataActor(std::move(tabletsToMoveData), pool.InactiveGroups, pool.Name);

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -4272,9 +4272,9 @@ void THive::Handle(TEvHive::TEvShrinkStoragePool::TPtr& ev) {
         THolder<NKikimrBlobStorage::TEvControllerSelectGroups::TGroupParameters> item = pool.BuildRefreshRequest();
         ++pool.RefreshRequestInFlight;
         THolder<TEvBlobStorage::TEvControllerSelectGroups> request = MakeHolder<TEvBlobStorage::TEvControllerSelectGroups>();
-        NKikimrBlobStorage::TEvControllerSelectGroups& record = request->Record;
-        record.SetReturnAllMatchingGroups(true);
-        record.MutableGroupParameters()->AddAllocated(std::move(item).Release());
+        NKikimrBlobStorage::TEvControllerSelectGroups& selectRecord = request->Record;
+        selectRecord.SetReturnAllMatchingGroups(true);
+        selectRecord.MutableGroupParameters()->AddAllocated(std::move(item).Release());
         SendToBSControllerPipe(request.Release());
     }
 }

--- a/ydb/core/mind/hive/hive_impl.cpp
+++ b/ydb/core/mind/hive/hive_impl.cpp
@@ -551,6 +551,9 @@ TVector<TTabletId> THive::UpdateStoragePools(const google::protobuf::RepeatedPtr
         for (TTabletId tabletId : tabletsWaiting) {
             tabletsToUpdate.emplace_back(tabletId);
         }
+        if (storagePool.ShrinkRequest) {
+            Execute(CreateShrinkPool(std::move(storagePool.ShrinkRequest)));
+        }
     }
     return tabletsToUpdate;
 }
@@ -3697,7 +3700,7 @@ void THive::ProcessEvent(std::unique_ptr<IEventHandle> event) {
         hFunc(TEvHive::TEvShrinkStoragePoolReply, Handle);
         hFunc(TEvHive::TEvShrinkStoragePoolDone, Handle);
         hFunc(TEvPrivate::TEvReassignInactiveGroupsComplete, Handle);
-        hFunc(TEvPrivate::TEvCompactComplete, Handle);
+        hFunc(TEvPrivate::TEvMoveDataComplete, Handle);
     }
 }
 
@@ -3817,7 +3820,7 @@ STFUNC(THive::StateWork) {
         fFunc(TEvHive::TEvShrinkStoragePoolReply::EventType, EnqueueIncomingEvent);
         fFunc(TEvHive::TEvShrinkStoragePoolDone::EventType, EnqueueIncomingEvent);
         fFunc(TEvPrivate::TEvReassignInactiveGroupsComplete::EventType, EnqueueIncomingEvent);
-        fFunc(TEvPrivate::TEvCompactComplete::EventType, EnqueueIncomingEvent);
+        fFunc(TEvPrivate::TEvMoveDataComplete::EventType, EnqueueIncomingEvent);
         hFunc(TEvPrivate::TEvProcessIncomingEvent, Handle);
     default:
         if (!HandleDefaultEvents(ev, SelfId())) {
@@ -4265,7 +4268,15 @@ void THive::Handle(TEvHive::TEvShrinkStoragePool::TPtr& ev) {
         }
     }
 
-    Execute(CreateShrinkPool(std::move(ev)));
+    if (pool.SetShrinkRequest(std::move(ev))) {
+        THolder<NKikimrBlobStorage::TEvControllerSelectGroups::TGroupParameters> item = pool.BuildRefreshRequest();
+        ++pool.RefreshRequestInFlight;
+        THolder<TEvBlobStorage::TEvControllerSelectGroups> request = MakeHolder<TEvBlobStorage::TEvControllerSelectGroups>();
+        NKikimrBlobStorage::TEvControllerSelectGroups& record = request->Record;
+        record.SetReturnAllMatchingGroups(true);
+        record.MutableGroupParameters()->AddAllocated(std::move(item).Release());
+        SendToBSControllerPipe(request.Release());
+    }
 }
 
 void THive::Handle(TEvHive::TEvShrinkStoragePoolReply::TPtr& ev) {
@@ -4274,17 +4285,17 @@ void THive::Handle(TEvHive::TEvShrinkStoragePoolReply::TPtr& ev) {
 
 void THive::Handle(TEvPrivate::TEvReassignInactiveGroupsComplete::TPtr& ev) {
     auto& pool = GetStoragePool(ev->Get()->PoolName);
-    if (!CompactInactiveGroups(pool)) {
+    if (!MoveDataInactiveGroups(pool)) {
         CheckRemainingHistory(pool);
     }
 }
 
-void THive::Handle(TEvPrivate::TEvCompactComplete::TPtr& ev) {
+void THive::Handle(TEvPrivate::TEvMoveDataComplete::TPtr& ev) {
     auto& pool = GetStoragePool(ev->Get()->PoolName);
     if (ev->Get()->Success) {
         CheckRemainingHistory(pool);
     } else {
-        if (!CompactInactiveGroups(pool)) {
+        if (!MoveDataInactiveGroups(pool)) {
             CheckRemainingHistory(pool);
         }
     }
@@ -4455,7 +4466,7 @@ void THive::StartShrinkPool(TStoragePoolInfo& pool) {
     if (ReassignInactiveGroups(pool)) {
         return;
     }
-    if (CompactInactiveGroups(pool)) {
+    if (MoveDataInactiveGroups(pool)) {
         return;
     }
     CheckRemainingHistory(pool);
@@ -4498,9 +4509,9 @@ bool THive::ReassignInactiveGroups(TStoragePoolInfo& pool) {
     }
 }
 
-bool THive::CompactInactiveGroups(TStoragePoolInfo& pool) {
+bool THive::MoveDataInactiveGroups(TStoragePoolInfo& pool) {
     std::unordered_set<TStorageGroupId> inactiveGroups(pool.InactiveGroups.begin(), pool.InactiveGroups.end());
-    std::vector<TTabletId> tabletsToCompact;
+    std::vector<TTabletId> tabletsToMoveData;
     if (pool.RemainingHistory.empty()) {
         for (const auto& [tabletId, tablet] : Tablets) {
             bool foundHistory = false;
@@ -4516,21 +4527,21 @@ bool THive::CompactInactiveGroups(TStoragePoolInfo& pool) {
                 }
             }
             if (foundHistory) {
-                tabletsToCompact.push_back(tabletId);
+                tabletsToMoveData.push_back(tabletId);
             }
         }
     } else {
         auto tabletsWithHistory = pool.RemainingHistory | std::views::transform(&TStoragePoolInfo::THistoryEntry::Tablet);
         std::unordered_set<TTabletId> uniqueTablets(tabletsWithHistory.begin(), tabletsWithHistory.end());
-        tabletsToCompact.assign(uniqueTablets.begin(), uniqueTablets.end());
+        tabletsToMoveData.assign(uniqueTablets.begin(), uniqueTablets.end());
     }
-    if (tabletsToCompact.empty()) {
+    if (tabletsToMoveData.empty()) {
         return false;
     } else {
         YDB_LOG_INFO("ShrinkPool: starting compact for tablets",
             {"logPrefix", GetLogPrefix()},
-            {"tabletsToCompactCount", tabletsToCompact.size()});
-        StartCompactActor(std::move(tabletsToCompact), pool.InactiveGroups, pool.Name);
+            {"tabletsToMoveDataCount", tabletsToMoveData.size()});
+        StartMoveDataActor(std::move(tabletsToMoveData), pool.InactiveGroups, pool.Name);
         return true;
     }
 }

--- a/ydb/core/mind/hive/hive_impl.h
+++ b/ydb/core/mind/hive/hive_impl.h
@@ -171,7 +171,7 @@ protected:
     friend struct TNodeInfo;
     friend struct TLeaderTabletInfo;
     friend class TReassignTabletsActor;
-    friend class TCompactActor;
+    friend class TMoveDataActor;
 
     friend class TTxInitScheme;
     friend class TTxDeleteBase;
@@ -258,7 +258,7 @@ protected:
     void StartHiveStorageBalancer(TStorageBalancerSettings settings);
     void StartReassignActor(std::vector<TReassignOperation> operations, const TActorId& source, ui32 maxInFlight, TString description, std::unique_ptr<IReassignCallback> callback);
     void StartReassignActor(std::vector<TReassignOperation> operations);
-    void StartCompactActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName);
+    void StartMoveDataActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName);
     void CreateEvMonitoring(NMon::TEvRemoteHttpInfo::TPtr& ev, const TActorContext& ctx);
     NJson::TJsonValue GetBalancerProgressJson();
     ITransaction* CreateDeleteTablet(TEvHive::TEvDeleteTablet::TPtr& ev);
@@ -632,7 +632,7 @@ protected:
     void Handle(TEvHive::TEvShrinkStoragePool::TPtr& ev);
     void Handle(TEvHive::TEvShrinkStoragePoolReply::TPtr& ev);
     void Handle(TEvPrivate::TEvReassignInactiveGroupsComplete::TPtr& ev);
-    void Handle(TEvPrivate::TEvCompactComplete::TPtr& ev);
+    void Handle(TEvPrivate::TEvMoveDataComplete::TPtr& ev);
     void Handle(TEvHive::TEvShrinkStoragePoolDone::TPtr& ev);
 
 protected:
@@ -1149,7 +1149,7 @@ protected:
 
     void StartShrinkPool(TStoragePoolInfo& pool);
     bool ReassignInactiveGroups(TStoragePoolInfo& pool);
-    bool CompactInactiveGroups(TStoragePoolInfo& pool);
+    bool MoveDataInactiveGroups(TStoragePoolInfo& pool);
     void CheckRemainingHistory(TStoragePoolInfo& pool);
 };
 

--- a/ydb/core/mind/hive/move_data_actor.cpp
+++ b/ydb/core/mind/hive/move_data_actor.cpp
@@ -6,8 +6,8 @@
 
 namespace NKikimr::NHive {
 
-class TCompactActor
-    : public TActorBootstrapped<TCompactActor>
+class TMoveDataActor
+    : public TActorBootstrapped<TMoveDataActor>
     , public ISubActor
 {
 public:
@@ -21,10 +21,10 @@ public:
     std::vector<TStorageGroupId> Groups;
     TString PoolName;
     std::vector<TPipeClient> PipeClients;
-    i64 CompactsInFlight = 0;
+    i64 MoveDatasInFlight = 0;
     THive* Hive;
 
-    TCompactActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName, ui64 maxInFlight, THive* hive)
+    TMoveDataActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName, ui64 maxInFlight, THive* hive)
         : Tablets(std::move(tablets))
         , NextTablet(Tablets.begin())
         , Groups(groups)
@@ -48,21 +48,21 @@ public:
     }
 
     TString GetDescription() const override {
-        return TStringBuilder() << "Compact(" << PoolName << ")";
+        return TStringBuilder() << "MoveData(" << PoolName << ")";
     }
 
-    void SendCompact(size_t index, TTabletId tablet) {
+    void SendMoveData(size_t index, TTabletId tablet) {
         NTabletPipe::TClientConfig pipeConfig;
         pipeConfig.RetryPolicy = {.RetryLimitCount = 13};
         pipeConfig.CheckAliveness = true;
         PipeClients[index] = {Register(NTabletPipe::CreateClient(SelfId(), tablet, pipeConfig)), tablet};
         NTabletPipe::SendData(SelfId(), PipeClients[index].Client, new TEvTablet::TEvMoveData(Groups));
-        ++CompactsInFlight;
+        ++MoveDatasInFlight;
     }
 
     void CheckCompletion() {
-        if (CompactsInFlight == 0 && NextTablet == Tablets.end()) {
-            Send(Hive->SelfId(), new TEvPrivate::TEvCompactComplete(PoolName, true));
+        if (MoveDatasInFlight == 0 && NextTablet == Tablets.end()) {
+            Send(Hive->SelfId(), new TEvPrivate::TEvMoveDataComplete(PoolName, true));
             return PassAway();
         }
     }
@@ -70,7 +70,7 @@ public:
     void Bootstrap() {
         Become(&TThis::StateWork);
         for (size_t i = 0; i < PipeClients.size() && NextTablet != Tablets.end(); ++i, ++NextTablet) {
-            SendCompact(i, *NextTablet);
+            SendMoveData(i, *NextTablet);
         }
         return CheckCompletion();
     }
@@ -80,9 +80,10 @@ public:
         for (size_t i = 0; i < PipeClients.size(); ++i) {
             if (PipeClients[i].Tablet == tablet) {
                 NTabletPipe::CloseClient(SelfId(), PipeClients[i].Client);
-                --CompactsInFlight;
+                --MoveDatasInFlight;
+                Hive->Execute(Hive->CreateRestartTablet(ToFullTabletId(tablet)));
                 if (NextTablet != Tablets.end()) {
-                    SendCompact(i, *(NextTablet++));
+                    SendMoveData(i, *(NextTablet++));
                     break;
                 }
             }
@@ -93,7 +94,7 @@ public:
     void Handle(TEvTabletPipe::TEvClientConnected::TPtr& ev) {
         if (ev->Get()->Status != NKikimrProto::OK) {
             if (ev->Get()->Dead) {
-                Send(Hive->SelfId(), new TEvPrivate::TEvCompactComplete(PoolName, false));
+                Send(Hive->SelfId(), new TEvPrivate::TEvMoveDataComplete(PoolName, false));
                 return PassAway();
             } else {
                 Retry(ev->Get()->TabletId);
@@ -109,8 +110,8 @@ public:
         for (size_t i = 0; i < PipeClients.size(); ++i) {
             if (PipeClients[i].Tablet == tablet) {
                 NTabletPipe::CloseClient(SelfId(), PipeClients[i].Client);
-                --CompactsInFlight;
-                SendCompact(i, tablet);
+                --MoveDatasInFlight;
+                SendMoveData(i, tablet);
                 break;
             }
         }
@@ -126,8 +127,8 @@ public:
     }
 };
 
-void THive::StartCompactActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName) {
-    auto* actor = new TCompactActor(std::move(tablets), groups, poolName, 1, this);
+void THive::StartMoveDataActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName) {
+    auto* actor = new TMoveDataActor(std::move(tablets), groups, poolName, 1, this);
     SubActors.emplace_back(actor);
     RegisterWithSameMailbox(actor);
 }

--- a/ydb/core/mind/hive/move_data_actor.cpp
+++ b/ydb/core/mind/hive/move_data_actor.cpp
@@ -21,7 +21,7 @@ public:
     std::vector<TStorageGroupId> Groups;
     TString PoolName;
     std::vector<TPipeClient> PipeClients;
-    i64 MoveDatasInFlight = 0;
+    i64 MoveDataInFlight = 0;
     THive* Hive;
 
     TMoveDataActor(std::vector<TTabletId> tablets, const std::vector<TStorageGroupId>& groups, const TString& poolName, ui64 maxInFlight, THive* hive)
@@ -57,11 +57,11 @@ public:
         pipeConfig.CheckAliveness = true;
         PipeClients[index] = {Register(NTabletPipe::CreateClient(SelfId(), tablet, pipeConfig)), tablet};
         NTabletPipe::SendData(SelfId(), PipeClients[index].Client, new TEvTablet::TEvMoveData(Groups));
-        ++MoveDatasInFlight;
+        ++MoveDataInFlight;
     }
 
     void CheckCompletion() {
-        if (MoveDatasInFlight == 0 && NextTablet == Tablets.end()) {
+        if (MoveDataInFlight == 0 && NextTablet == Tablets.end()) {
             Send(Hive->SelfId(), new TEvPrivate::TEvMoveDataComplete(PoolName, true));
             return PassAway();
         }
@@ -80,7 +80,7 @@ public:
         for (size_t i = 0; i < PipeClients.size(); ++i) {
             if (PipeClients[i].Tablet == tablet) {
                 NTabletPipe::CloseClient(SelfId(), PipeClients[i].Client);
-                --MoveDatasInFlight;
+                --MoveDataInFlight;
                 Hive->Execute(Hive->CreateRestartTablet(ToFullTabletId(tablet)));
                 if (NextTablet != Tablets.end()) {
                     SendMoveData(i, *(NextTablet++));
@@ -110,7 +110,7 @@ public:
         for (size_t i = 0; i < PipeClients.size(); ++i) {
             if (PipeClients[i].Tablet == tablet) {
                 NTabletPipe::CloseClient(SelfId(), PipeClients[i].Client);
-                --MoveDatasInFlight;
+                --MoveDataInFlight;
                 SendMoveData(i, tablet);
                 break;
             }

--- a/ydb/core/mind/hive/storage_pool_info.cpp
+++ b/ydb/core/mind/hive/storage_pool_info.cpp
@@ -188,7 +188,7 @@ bool TStoragePoolInfo::AddTabletToWait(TTabletId tabletId) {
 
 bool TStoragePoolInfo::SetShrinkRequest(TEvHive::TEvShrinkStoragePool::TPtr ev) {
     bool result = TabletsWaiting.empty() && !(ShrinkRequest);
-    ShrinkRequest = ev;
+    ShrinkRequest = std::move(ev);
     return result;
 }
 

--- a/ydb/core/mind/hive/storage_pool_info.cpp
+++ b/ydb/core/mind/hive/storage_pool_info.cpp
@@ -35,7 +35,14 @@ void TStoragePoolInfo::UpdateStorageGroup(TStorageGroupId groupId, const TEvCont
 }
 
 void TStoragePoolInfo::DeleteStorageGroup(TStorageGroupId groupId) {
-    Groups.erase(groupId);
+    auto it = Groups.find(groupId);
+    if (it != Groups.end()) {
+        if (!it->second.IsActive()) {
+            auto inactiveIt = std::remove(InactiveGroups.begin(), InactiveGroups.end(), groupId);
+            InactiveGroups.erase(inactiveIt, InactiveGroups.end());
+        }
+        Groups.erase(it);
+    }
 }
 
 template <>
@@ -174,8 +181,14 @@ THolder<TEvControllerSelectGroups::TGroupParameters> TStoragePoolInfo::BuildRefr
 }
 
 bool TStoragePoolInfo::AddTabletToWait(TTabletId tabletId) {
-    bool result = TabletsWaiting.empty();
+    bool result = TabletsWaiting.empty() && !(ShrinkRequest);
     TabletsWaiting.emplace_back(tabletId);
+    return result;
+}
+
+bool TStoragePoolInfo::SetShrinkRequest(TEvHive::TEvShrinkStoragePool::TPtr ev) {
+    bool result = TabletsWaiting.empty() && !(ShrinkRequest);
+    ShrinkRequest = ev;
     return result;
 }
 

--- a/ydb/core/mind/hive/storage_pool_info.h
+++ b/ydb/core/mind/hive/storage_pool_info.h
@@ -74,6 +74,7 @@ struct TStoragePoolInfo {
     ui64 ConsoleVersion = 0;
     THashSet<THistoryEntry, THistoryHash> RemainingHistory;
     bool NeedShrinkFromTenant = false;
+    TEvHive::TEvShrinkStoragePool::TPtr ShrinkRequest;
 
     TStoragePoolInfo(const TString& name, THiveSharedSettings* hive);
     TStoragePoolInfo(const TStoragePoolInfo&) = delete;
@@ -98,6 +99,7 @@ struct TStoragePoolInfo {
     void Invalidate();
     THolder<TEvControllerSelectGroups::TGroupParameters> BuildRefreshRequest() const;
     bool AddTabletToWait(TTabletId tabletId);
+    bool SetShrinkRequest(TEvHive::TEvShrinkStoragePool::TPtr ev);
     TVector<TTabletId> PullWaitingTablets();
     template <NKikimrConfig::THiveConfig::EHiveStorageSelectStrategy Strategy>
     size_t SelectGroup(const TVector<double>& groupCandidateUsages);

--- a/ydb/core/mind/hive/ya.make
+++ b/ydb/core/mind/hive/ya.make
@@ -6,7 +6,6 @@ SRCS(
     boot_queue.cpp
     boot_queue.h
     bridge_pile_info.h
-    compact_actor.cpp
     data_center_info.h
     domain_info.cpp
     domain_info.h
@@ -30,6 +29,7 @@ SRCS(
     metrics.h
     monitoring.cpp
     monitoring.h
+    move_data_actor.cpp
     node_info.cpp
     node_info.h
     object_distribution.h

--- a/ydb/tests/functional/tenants/test_remove_storage_groups.py
+++ b/ydb/tests/functional/tenants/test_remove_storage_groups.py
@@ -93,7 +93,7 @@ def test_remove_storage_group(ydb_cluster, ydb_root, ydb_safe_test_name, ydb_cli
     status = ydb_cluster.get_database_status(database)
     assert_that(status.state, equal_to(cms_pb.GetDatabaseStatusResult.RUNNING))
 
-    # Check data integriy
+    # Check data integrity
     with ydb.QuerySessionPool(driver, size=1) as pool:
         result_sets = pool.execute_with_retries("SELECT * FROM " + table_name)
         assert len(result_sets) == 1

--- a/ydb/tests/functional/tenants/test_remove_storage_groups.py
+++ b/ydb/tests/functional/tenants/test_remove_storage_groups.py
@@ -78,8 +78,6 @@ def test_remove_storage_group(ydb_cluster, ydb_root, ydb_safe_test_name, ydb_cli
         storage_units_to_remove={'hdd': 2},
     )
 
-    ydb_cluster.restart_slots()
-
     def get_storage_units():
         status = ydb_cluster.get_database_status(database)
         units = sum([unit.count for unit in status.allocated_resources.storage_units])
@@ -95,5 +93,13 @@ def test_remove_storage_group(ydb_cluster, ydb_root, ydb_safe_test_name, ydb_cli
     status = ydb_cluster.get_database_status(database)
     assert_that(status.state, equal_to(cms_pb.GetDatabaseStatusResult.RUNNING))
 
-    ydb_cluster.unregister_and_stop_slots(database_nodes)
+    # Check data integriy
+    with ydb.QuerySessionPool(driver, size=1) as pool:
+        result_sets = pool.execute_with_retries("SELECT * FROM " + table_name)
+        assert len(result_sets) == 1
+        assert len(result_sets[0].rows) == 1
+        assert result_sets[0].rows[0].key == 1
+        assert result_sets[0].rows[0].value == b"value1"
+
     ydb_cluster.remove_database(database)
+    ydb_cluster.unregister_and_stop_slots(database_nodes)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

В примерном порядке убывания важности

* Выбирать группы в Hive только после их обновления у BSC - иначе при быстром добавлении+удалении хайв решает, что ничего делать не надо
* Не терять сообщение хайва в консоли когда пул в NOT_UPDATED - гонка, когда удалили группы быстрее, чем консоль переваривала свои локальные транзакции
* Рестартовать таблетки как часть move data процесса, чтобы не ждать рестарта из вне для того, чтобы они почистили историю
* Удалять в памяти хайва группы из неактивных при их удалении из BSC
* Замечания про тест из прошлого пра
* Ренейм Compact -> MoveData во внутренностях хайва
