### PR TITLE
Add IF NOT EXISTS, IF EXISTS, and CREATE OR REPLACE support for secret DDL

### DIFF
--- a/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
+++ b/ydb/core/kqp/gateway/kqp_ic_gateway.cpp
@@ -2306,8 +2306,17 @@ private:
 
     TFuture<TGenericResult> SendSchemeRequest(TEvTxUserProxy::TEvProposeTransaction* request, bool failedOnAlreadyExists = false)
     {
+        const auto& modifyScheme = request->Record.GetTransaction().GetModifyScheme();
+        bool actualFailedOnAlreadyExists = failedOnAlreadyExists;
+        bool successOnNotExist = false;
+        if (modifyScheme.HasFailedOnAlreadyExists()) {
+            actualFailedOnAlreadyExists = modifyScheme.GetFailedOnAlreadyExists();
+        }
+        if (modifyScheme.HasSuccessOnNotExist()) {
+            successOnNotExist = modifyScheme.GetSuccessOnNotExist();
+        }
         auto promise = NewPromise<TGenericResult>();
-        IActor* requestHandler = new TSchemeOpRequestHandler(request, promise, failedOnAlreadyExists);
+        IActor* requestHandler = new TSchemeOpRequestHandler(request, promise, actualFailedOnAlreadyExists, successOnNotExist);
         RegisterActor(requestHandler);
 
         return promise.GetFuture();

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -3625,6 +3625,14 @@ public:
                 tx.SetWorkingDir(pathPair.first);
                 tx.SetOperationType(GetOperationType());
 
+                // Set flags for IF NOT EXISTS / IF EXISTS handling
+                // FailOnExist is read by schemeshard to decide whether to accept existing paths
+                // FailedOnAlreadyExists is read by KQP gateway to translate StatusAlreadyExists to success
+                // SuccessOnNotExist is read by KQP gateway to translate StatusPathDoesNotExist to success
+                tx.SetFailOnExist(!settings.ExistingOk && !settings.ReplaceIfExists);
+                tx.SetFailedOnAlreadyExists(!settings.ExistingOk && !settings.ReplaceIfExists);
+                tx.SetSuccessOnNotExist(settings.MissingOk);
+
                 TSecretSchemaOp& op = GetSecretSchemaOp(tx);
                 op.SetName(pathPair.second);
                 FillSchemaOperation(settings, op);
@@ -3711,6 +3719,7 @@ public:
             if (settings.InheritPermissions.has_value()) {
                 op.SetInheritPermissions(*settings.InheritPermissions);
             }
+            op.SetReplaceIfExists(settings.ReplaceIfExists);
         }
 
     private:

--- a/ydb/core/kqp/host/kqp_gateway_proxy.cpp
+++ b/ydb/core/kqp/host/kqp_gateway_proxy.cpp
@@ -3632,6 +3632,7 @@ public:
                 tx.SetFailOnExist(!settings.ExistingOk && !settings.ReplaceIfExists);
                 tx.SetFailedOnAlreadyExists(!settings.ExistingOk && !settings.ReplaceIfExists);
                 tx.SetSuccessOnNotExist(settings.MissingOk);
+                tx.SetReplaceIfExists(settings.ReplaceIfExists);
 
                 TSecretSchemaOp& op = GetSecretSchemaOp(tx);
                 op.SetName(pathPair.second);
@@ -3719,7 +3720,6 @@ public:
             if (settings.InheritPermissions.has_value()) {
                 op.SetInheritPermissions(*settings.InheritPermissions);
             }
-            op.SetReplaceIfExists(settings.ReplaceIfExists);
         }
 
     private:

--- a/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_datasink.cpp
@@ -1855,8 +1855,10 @@ public:
                     return nullptr; // Error has been already reported in parsing
                 }
                 auto mode = settings.Mode.Cast();
-                if (mode == "create") {
+                if (mode == "create" || mode == "create_if_not_exists" || mode == "create_or_replace") {
                     const auto emptyAtom = Build<TCoAtom>(ctx, node->Pos()).Value("").Done();
+                    const auto falseAtom = Build<TCoAtom>(ctx, node->Pos()).Value("0").Done();
+                    const auto trueAtom = Build<TCoAtom>(ctx, node->Pos()).Value("1").Done();
                     return Build<TKiCreateSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
@@ -1864,23 +1866,31 @@ public:
                         .Value(settings.Value.IsValid() ? settings.Value.Cast() : emptyAtom)
                         .InheritPermissions(settings.InheritPermissions.IsValid() ? settings.InheritPermissions.Cast() : emptyAtom)
                         .ValueParamName(settings.ValueParamName.IsValid() ? settings.ValueParamName.Cast() : emptyAtom)
+                        .ReplaceIfExists(mode == "create_or_replace" ? trueAtom : falseAtom)
+                        .ExistingOk(mode == "create_if_not_exists" ? trueAtom : falseAtom)
                         .Done()
                         .Ptr();
-                } else if (mode == "alter") {
+                } else if (mode == "alter" || mode == "alter_if_exists") {
                     const auto emptyAtom = Build<TCoAtom>(ctx, node->Pos()).Value("").Done();
+                    const auto falseAtom = Build<TCoAtom>(ctx, node->Pos()).Value("0").Done();
+                    const auto trueAtom = Build<TCoAtom>(ctx, node->Pos()).Value("1").Done();
                     return Build<TKiAlterSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
                         .Value(settings.Value.IsValid() ? settings.Value.Cast() : emptyAtom)
                         .ValueParamName(settings.ValueParamName.IsValid() ? settings.ValueParamName.Cast() : emptyAtom)
+                        .MissingOk(mode == "alter_if_exists" ? trueAtom : falseAtom)
                         .Done()
                         .Ptr();
-                } else if (mode == "drop") {
+                } else if (mode == "drop" || mode == "drop_if_exists") {
+                    const auto falseAtom = Build<TCoAtom>(ctx, node->Pos()).Value("0").Done();
+                    const auto trueAtom = Build<TCoAtom>(ctx, node->Pos()).Value("1").Done();
                     return Build<TKiDropSecret>(ctx, node->Pos())
                         .World(node->Child(0))
                         .DataSink(node->Child(1))
                         .Secret().Build(key.GetSecretPath())
+                        .MissingOk(mode == "drop_if_exists" ? trueAtom : falseAtom)
                         .Done()
                         .Ptr();
                 } else {
@@ -2032,7 +2042,7 @@ TWriteSecretSettings ParseSecretSettings(NNodes::TExprList node, TExprContext& c
 
     YQL_ENSURE(mode);
     auto modeStr = mode.Cast().Value();
-    if (modeStr == "create" || modeStr == "alter") {
+    if (modeStr == "create" || modeStr == "create_if_not_exists" || modeStr == "create_or_replace" || modeStr == "alter" || modeStr == "alter_if_exists") {
         if (!value && !valueParamName) {
             ctx.AddError(YqlIssue(ctx.GetPosition(node.Pos()), TIssuesIds::KIKIMR_BAD_REQUEST,
                 "Secret value is required: provide a literal or a single string parameter"));

--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -453,6 +453,8 @@ namespace {
         if (auto inheritPermissions = TString(createSecret.InheritPermissions())) {
             settings.InheritPermissions = FromString<bool>(inheritPermissions);
         }
+        settings.ReplaceIfExists = (TString(createSecret.ReplaceIfExists()) == "1");
+        settings.ExistingOk = (TString(createSecret.ExistingOk()) == "1");
         return settings;
     }
 
@@ -465,12 +467,14 @@ namespace {
         if (auto paramName = TString(alterSecret.ValueParamName())) {
             settings.ValueParamName = std::move(paramName);
         }
+        settings.MissingOk = (TString(alterSecret.MissingOk()) == "1");
         return settings;
     }
 
     TSecretSettings ParseSecretSettings(TKiDropSecret dropSecret) {
         TSecretSettings settings;
         settings.Name = TString(dropSecret.Secret());
+        settings.MissingOk = (TString(dropSecret.MissingOk()) == "1");
         return settings;
     }
 

--- a/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
+++ b/ydb/core/kqp/provider/yql_kikimr_expr_nodes.json
@@ -673,7 +673,9 @@
                 {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
                 {"Index": 3, "Name": "Value", "Type": "TCoAtom"},
                 {"Index": 4, "Name": "InheritPermissions", "Type": "TCoAtom"},
-                {"Index": 5, "Name": "ValueParamName", "Type": "TCoAtom"}
+                {"Index": 5, "Name": "ValueParamName", "Type": "TCoAtom"},
+                {"Index": 6, "Name": "ReplaceIfExists", "Type": "TCoAtom"},
+                {"Index": 7, "Name": "ExistingOk", "Type": "TCoAtom"}
             ]
         },
         {
@@ -685,7 +687,8 @@
                 {"Index": 1, "Name": "DataSink", "Type": "TKiDataSink"},
                 {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
                 {"Index": 3, "Name": "Value", "Type": "TCoAtom"},
-                {"Index": 4, "Name": "ValueParamName", "Type": "TCoAtom"}
+                {"Index": 4, "Name": "ValueParamName", "Type": "TCoAtom"},
+                {"Index": 5, "Name": "MissingOk", "Type": "TCoAtom"}
             ]
         },
         {
@@ -695,7 +698,8 @@
             "Children": [
                 {"Index": 0, "Name": "World", "Type": "TExprBase"},
                 {"Index": 1, "Name": "DataSink", "Type": "TKiDataSink"},
-                {"Index": 2, "Name": "Secret", "Type": "TCoAtom"}
+                {"Index": 2, "Name": "Secret", "Type": "TCoAtom"},
+                {"Index": 3, "Name": "MissingOk", "Type": "TCoAtom"}
             ]
         }
     ]

--- a/ydb/core/kqp/provider/yql_kikimr_gateway.h
+++ b/ydb/core/kqp/provider/yql_kikimr_gateway.h
@@ -1410,6 +1410,9 @@ struct TSecretSettings {
     TString Value;
     TString ValueParamName; // when set, the value is taken from parameter at execution
     std::optional<bool> InheritPermissions; // Not set means the option is not specified explicitly
+    bool ReplaceIfExists = false; // CREATE OR REPLACE
+    bool ExistingOk = false; // CREATE IF NOT EXISTS
+    bool MissingOk = false; // ALTER/DROP IF EXISTS
 };
 
 struct TKikimrListPathItem {

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -14925,6 +14925,207 @@ END DO)",
         }
     }
 
+    Y_UNIT_TEST_TWIN(CreateSecretIfNotExists, UseQueryService) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableSchemaSecrets(true);
+        const auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        // Create a secret first
+        {
+            static const auto query = R"sql(
+                CREATE SECRET `/Root/secret-name` WITH (value = "secret-value-1");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // CREATE SECRET IF NOT EXISTS on existing secret should succeed
+        {
+            static const auto query = R"sql(
+                CREATE SECRET IF NOT EXISTS `/Root/secret-name` WITH (value = "secret-value-2");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The version should not have changed (IF NOT EXISTS is a no-op when the secret exists)
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            UNIT_ASSERT_C(describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret has been dropped somehow");
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                describeResult->Record.GetPathDescription().GetSecretDescription().GetVersion(),
+                0,
+                "the secret version should not have changed with IF NOT EXISTS");
+        }
+
+        // CREATE SECRET IF NOT EXISTS on non-existing secret should succeed
+        {
+            static const auto query = R"sql(
+                CREATE SECRET IF NOT EXISTS `/Root/secret-name-new` WITH (value = "secret-value-new");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name-new");
+            UNIT_ASSERT_C(describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret was not created");
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(CreateOrReplaceSecret, UseQueryService) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableSchemaSecrets(true);
+        const auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        // Create a secret first
+        {
+            static const auto query = R"sql(
+                CREATE SECRET `/Root/secret-name` WITH (value = "secret-value-1");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // CREATE OR REPLACE SECRET on existing secret should succeed and replace the value
+        {
+            static const auto query = R"sql(
+                CREATE OR REPLACE SECRET `/Root/secret-name` WITH (value = "secret-value-2");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The version should have changed (CREATE OR REPLACE converts to ALTER when the secret exists)
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            UNIT_ASSERT_C(describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret has been dropped somehow");
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                describeResult->Record.GetPathDescription().GetSecretDescription().GetVersion(),
+                1,
+                "the secret version should have changed with CREATE OR REPLACE");
+        }
+
+        // CREATE OR REPLACE SECRET on non-existing secret should succeed and create it
+        {
+            static const auto query = R"sql(
+                CREATE OR REPLACE SECRET `/Root/secret-name-new` WITH (value = "secret-value-new");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name-new");
+            UNIT_ASSERT_C(describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret was not created");
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(AlterSecretIfExists, UseQueryService) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableSchemaSecrets(true);
+        const auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        // Create a secret first
+        {
+            static const auto query = R"sql(
+                CREATE SECRET `/Root/secret-name` WITH (value = "secret-value-1");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // ALTER SECRET IF EXISTS on existing secret should succeed
+        {
+            static const auto query = R"sql(
+                ALTER SECRET IF EXISTS `/Root/secret-name` WITH (value = "secret-value-2");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The version should have changed (ALTER was applied)
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            UNIT_ASSERT_C(describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret has been dropped somehow");
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                describeResult->Record.GetPathDescription().GetSecretDescription().GetVersion(),
+                1,
+                "the secret version should have changed with ALTER");
+        }
+
+        // ALTER SECRET IF EXISTS on non-existing secret should succeed (no-op)
+        {
+            static const auto query = R"sql(
+                ALTER SECRET IF EXISTS `/Root/secret-name-another` WITH (value = "secret-value-3");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+    }
+
+    Y_UNIT_TEST_TWIN(DropSecretIfExists, UseQueryService) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableSchemaSecrets(true);
+        const auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        // Create a secret first
+        {
+            static const auto query = R"sql(
+                CREATE SECRET `/Root/secret-name` WITH (value = "secret-value");
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // DROP SECRET IF EXISTS on non-existing secret should succeed (no-op)
+        {
+            static const auto query = R"sql(
+                DROP SECRET IF EXISTS `/Root/secret-name-another`;
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The original secret should still exist
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            UNIT_ASSERT_C(describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret has been dropped somehow");
+        }
+
+        // DROP SECRET IF EXISTS on existing secret should succeed
+        {
+            static const auto query = R"sql(
+                DROP SECRET IF EXISTS `/Root/secret-name`;
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            UNIT_ASSERT_C(!describeResult->Record.GetPathDescription().HasSecretDescription(), "the secret somehow exists");
+        }
+    }
+
     Y_UNIT_TEST(SecretsDisabled) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableSchemaSecrets(false);

--- a/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
+++ b/ydb/core/kqp/ut/scheme/kqp_scheme_ut.cpp
@@ -15029,6 +15029,66 @@ END DO)",
         }
     }
 
+    Y_UNIT_TEST_TWIN(CreateOrReplaceSecretInheritPermissions, UseQueryService) {
+        NKikimrConfig::TFeatureFlags featureFlags;
+        featureFlags.SetEnableSchemaSecrets(true);
+        const auto settings = TKikimrSettings()
+            .SetWithSampleTables(false)
+            .SetFeatureFlags(featureFlags);
+        TKikimrRunner kikimr(settings);
+        auto db = kikimr.GetTableClient();
+        auto session = db.CreateSession().GetValueSync().GetSession();
+        auto queryClient = kikimr.GetQueryClient();
+
+        // Create a secret with inherit_permissions = false (ACL is interrupted)
+        {
+            static const auto query = R"sql(
+                CREATE SECRET `/Root/secret-name` WITH (value = "secret-value-1", inherit_permissions = false);
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The ACL should be non-empty (inheritance interrupted)
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            const auto& self = describeResult->Record.GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(!self.GetACL().empty(), "ACL should be non-empty when inherit_permissions = false");
+        }
+
+        // CREATE OR REPLACE SECRET with inherit_permissions = true should restore inheritance (clear ACL)
+        {
+            static const auto query = R"sql(
+                CREATE OR REPLACE SECRET `/Root/secret-name` WITH (value = "secret-value-2", inherit_permissions = true);
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The ACL should now be empty (inheritance restored)
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            const auto& self = describeResult->Record.GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(self.GetACL().empty(), "ACL should be empty when inherit_permissions = true after CREATE OR REPLACE");
+        }
+
+        // CREATE OR REPLACE SECRET with inherit_permissions = false should interrupt inheritance again
+        {
+            static const auto query = R"sql(
+                CREATE OR REPLACE SECRET `/Root/secret-name` WITH (value = "secret-value-3", inherit_permissions = false);
+            )sql";
+            const auto result = ExecuteGeneric<UseQueryService>(queryClient, session, query);
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // The ACL should be non-empty again
+        {
+            const auto describeResult = kikimr.GetTestClient().Ls("/Root/secret-name");
+            const auto& self = describeResult->Record.GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(!self.GetACL().empty(), "ACL should be non-empty when inherit_permissions = false after CREATE OR REPLACE");
+        }
+    }
+
     Y_UNIT_TEST_TWIN(AlterSecretIfExists, UseQueryService) {
         NKikimrConfig::TFeatureFlags featureFlags;
         featureFlags.SetEnableSchemaSecrets(true);

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2687,8 +2687,6 @@ message TSecretSchemaOp {
     // However, this field is supposed to be resolved at KQP to the actual value and be cleared.
     // Schemeshard always uses secret's value from the Value field and asserts that the ValueParamName field is empty.
     optional string ValueParamName = 4;
-    // For CREATE OR REPLACE: if the secret already exists, alter it with the new value
-    optional bool ReplaceIfExists = 5;
 }
 
 message TStreamingQueryProperties {

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2687,6 +2687,8 @@ message TSecretSchemaOp {
     // However, this field is supposed to be resolved at KQP to the actual value and be cleared.
     // Schemeshard always uses secret's value from the Value field and asserts that the ValueParamName field is empty.
     optional string ValueParamName = 4;
+    // For CREATE OR REPLACE: if the secret already exists, alter it with the new value
+    optional bool ReplaceIfExists = 5;
 }
 
 message TStreamingQueryProperties {

--- a/ydb/core/tx/schemeshard/schemeshard__operation.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation.cpp
@@ -1688,7 +1688,7 @@ TVector<ISubOperation::TPtr> TDefaultOperationFactory::MakeOperationParts(
 
     // Secret
     case NKikimrSchemeOp::EOperationType::ESchemeOpCreateSecret:
-        return {CreateNewSecret(op.NextPartId(), tx)};
+        return {CreateNewSecret(op.NextPartId(), tx, context)};
     case NKikimrSchemeOp::EOperationType::ESchemeOpAlterSecret:
         return {CreateAlterSecret(op.NextPartId(), tx)};
     case NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret:

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -164,6 +164,12 @@ public:
             return result;
         }
 
+        if (alterSecretProto.HasValueParamName()) {
+            result->SetError(NKikimrScheme::StatusInvalidParameter,
+                "Secret value must be set via Value, however ValueParamName was passed");
+            return result;
+        }
+
         context.MemChanges.GrabPath(context.SS, secretPath.Base()->PathId);
         context.MemChanges.GrabSecret(context.SS, secretPath.Base()->PathId);
         context.MemChanges.GrabNewTxState(context.SS, OperationId);
@@ -172,27 +178,22 @@ public:
         context.DbChanges.PersistAlterSecret(secretPath.Base()->PathId);
         context.DbChanges.PersistTxState(OperationId);
 
-        // Handle InheritPermissions for CREATE OR REPLACE SECRET: re-apply the ACL
-        // to match the behavior of DROP + CREATE (the secret is treated as if freshly created).
+        // InheritPermissions is set only by CREATE OR REPLACE SECRET over an existing secret:
+        // reapply the ACL so that the result matches a freshly created secret (DROP + CREATE).
+        // Keep the same precedence as TCreateSecret: an explicit ACL wins over InheritPermissions.
         if (alterSecretProto.HasInheritPermissions()) {
             const TString acl = Transaction.GetModifyACL().GetDiffACL();
             if (!acl.empty()) {
                 secretPath.Base()->ApplyACL(acl);
-            } else if (alterSecretProto.GetInheritPermissions()) {
-                // Restore inheritance: clear the ACL
-                secretPath.Base()->ACL.clear();
-                secretPath.Base()->ACLVersion++;
             } else {
-                // Interrupt inheritance: keep only DescribeSchema grant
-                secretPath.Base()->ACL = InterruptInheritanceExceptDescribe(secretPath.GetEffectiveACL());
-                secretPath.Base()->ACLVersion++;
+                if (alterSecretProto.GetInheritPermissions()) {
+                    // Inherit from the parent: no ACL of its own.
+                    secretPath.Base()->ACL.clear();
+                } else {
+                    secretPath.Base()->ACL = InterruptInheritanceExceptDescribe(secretPath.GetEffectiveACL());
+                }
+                ++secretPath.Base()->ACLVersion;
             }
-        }
-
-        if (alterSecretProto.HasValueParamName()) {
-            result->SetError(NKikimrScheme::StatusInvalidParameter,
-                "Secret value must be set via Value, however ValueParamName was passed");
-            return result;
         }
 
         auto alterData = secretInfo->CreateNextVersion();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -6,12 +6,6 @@
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
 
-namespace NKikimr::NSchemeShard {
-
-TString InterruptInheritanceExceptDescribe(const TString& initialAcl);
-
-} // namespace NKikimr::NSchemeShard
-
 namespace {
 
 using namespace NKikimr;

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -190,7 +190,7 @@ public:
                     // Inherit from the parent: no ACL of its own.
                     secretPath.Base()->ACL.clear();
                 } else {
-                    secretPath.Base()->ACL = InterruptInheritanceExceptDescribe(secretPath.GetEffectiveACL());
+                    secretPath.Base()->ACL = InterruptInheritanceExceptDescribe(parentPath.GetEffectiveACL());
                 }
                 ++secretPath.Base()->ACLVersion;
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_secret.cpp
@@ -6,6 +6,12 @@
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
 
+namespace NKikimr::NSchemeShard {
+
+TString InterruptInheritanceExceptDescribe(const TString& initialAcl);
+
+} // namespace NKikimr::NSchemeShard
+
 namespace {
 
 using namespace NKikimr;
@@ -171,6 +177,23 @@ public:
         context.DbChanges.PersistPath(secretPath.Base()->PathId);
         context.DbChanges.PersistAlterSecret(secretPath.Base()->PathId);
         context.DbChanges.PersistTxState(OperationId);
+
+        // Handle InheritPermissions for CREATE OR REPLACE SECRET: re-apply the ACL
+        // to match the behavior of DROP + CREATE (the secret is treated as if freshly created).
+        if (alterSecretProto.HasInheritPermissions()) {
+            const TString acl = Transaction.GetModifyACL().GetDiffACL();
+            if (!acl.empty()) {
+                secretPath.Base()->ApplyACL(acl);
+            } else if (alterSecretProto.GetInheritPermissions()) {
+                // Restore inheritance: clear the ACL
+                secretPath.Base()->ACL.clear();
+                secretPath.Base()->ACLVersion++;
+            } else {
+                // Interrupt inheritance: keep only DescribeSchema grant
+                secretPath.Base()->ACL = InterruptInheritanceExceptDescribe(secretPath.GetEffectiveACL());
+                secretPath.Base()->ACLVersion++;
+            }
+        }
 
         if (alterSecretProto.HasValueParamName()) {
             result->SetError(NKikimrScheme::StatusInvalidParameter,

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common.h
@@ -326,6 +326,9 @@ void AbortRelatedOperations(TOperationId operationId, const THashSet<TTxId>& rel
 
 } // namespace NForceDrop
 
+// Creates an ACL that interrupts inheritance from the parent, keeping only the DescribeSchema grant.
+TString InterruptInheritanceExceptDescribe(const TString& initialAcl);
+
 } // namespace NKikimr::NSchemeShard
 
 namespace NKikimr::NSchemeShard::NTableIndexVersion {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -328,7 +328,39 @@ bool SetName<TTag>(TTag, TTxTransaction& tx, const TString& name) {
 
 }
 
-ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx) {
+ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx, TOperationContext& context) {
+    const auto& createSecretProto = tx.GetCreateSecret();
+    const auto replaceIfExists = createSecretProto.GetReplaceIfExists();
+
+    if (replaceIfExists) {
+        const TString& parentPathStr = tx.GetWorkingDir();
+        const TString& secretName = createSecretProto.GetName();
+        const TPath parentPath = TPath::Resolve(parentPathStr, context.SS);
+        const TPath dstPath = parentPath.Child(secretName);
+
+        const auto isAlreadyExists =
+            dstPath.Check()
+                .IsResolved()
+                .NotDeleted()
+                .NotUnderDeleting()
+                .IsSecret();
+
+        if (isAlreadyExists) {
+            // Convert to alter: build an alter transaction from the create transaction
+            TTxTransaction alterTx = tx;
+            alterTx.SetOperationType(NKikimrSchemeOp::ESchemeOpAlterSecret);
+            auto* alterSecret = alterTx.MutableAlterSecret();
+            alterSecret->SetName(createSecretProto.GetName());
+            if (createSecretProto.HasValue()) {
+                alterSecret->SetValue(createSecretProto.GetValue());
+            }
+            if (createSecretProto.HasValueParamName()) {
+                alterSecret->SetValueParamName(createSecretProto.GetValueParamName());
+            }
+            return CreateAlterSecret(id, alterTx);
+        }
+    }
+
     return MakeSubOperation<TCreateSecret>(id, tx);
 }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -350,6 +350,7 @@ ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx, T
                 .IsResolved()
                 .NotDeleted()
                 .NotUnderDeleting()
+                .NotUnderOperation()
                 .IsSecret();
 
         if (isAlreadyExists) {
@@ -360,9 +361,6 @@ ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx, T
             alterSecret->SetName(createSecretProto.GetName());
             if (createSecretProto.HasValue()) {
                 alterSecret->SetValue(createSecretProto.GetValue());
-            }
-            if (createSecretProto.HasValueParamName()) {
-                alterSecret->SetValueParamName(createSecretProto.GetValueParamName());
             }
             if (createSecretProto.HasInheritPermissions()) {
                 alterSecret->SetInheritPermissions(createSecretProto.GetInheritPermissions());

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -337,7 +337,7 @@ bool SetName<TTag>(TTag, TTxTransaction& tx, const TString& name) {
 
 ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx, TOperationContext& context) {
     const auto& createSecretProto = tx.GetCreateSecret();
-    const auto replaceIfExists = createSecretProto.GetReplaceIfExists();
+    const auto replaceIfExists = tx.GetReplaceIfExists();
 
     if (replaceIfExists) {
         const TString& parentPathStr = tx.GetWorkingDir();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_secret.cpp
@@ -7,11 +7,11 @@
 #define LOG_I(stream) LOG_INFO_S  (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
 #define LOG_D(stream) LOG_DEBUG_S (context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD, "[" << context.SS->SelfTabletId() << "] " << stream)
 
-namespace {
+namespace NKikimr::NSchemeShard {
 
-using namespace NKikimr;
-using namespace NSchemeShard;
-
+// Creates an ACL that interrupts inheritance from the parent, keeping only the DescribeSchema grant.
+// Used by CREATE SECRET and CREATE OR REPLACE SECRET (which converts to ALTER) to ensure that
+// secrets do not inherit permissions from their parent directory by default.
 TString InterruptInheritanceExceptDescribe(const TString& initialAcl) {
     NACLib::TACL secObj(initialAcl);
     NACLib::TACL resultSecObj;
@@ -31,6 +31,13 @@ TString InterruptInheritanceExceptDescribe(const TString& initialAcl) {
     Y_ABORT_UNLESS(resultSecObj.SerializeToString(&resultAcl));
     return resultAcl;
 }
+
+} // namespace NKikimr::NSchemeShard
+
+namespace {
+
+using namespace NKikimr;
+using namespace NSchemeShard;
 
 class TPropose : public TSubOperationState {
 private:
@@ -356,6 +363,9 @@ ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx, T
             }
             if (createSecretProto.HasValueParamName()) {
                 alterSecret->SetValueParamName(createSecretProto.GetValueParamName());
+            }
+            if (createSecretProto.HasInheritPermissions()) {
+                alterSecret->SetInheritPermissions(createSecretProto.GetInheritPermissions());
             }
             return CreateAlterSecret(id, alterTx);
         }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_part.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_part.h
@@ -773,7 +773,7 @@ ISubOperation::TPtr CreateDropSysView(TOperationId id, TTxState::ETxState state)
 
 // Secret
 // Create
-ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx);
+ISubOperation::TPtr CreateNewSecret(TOperationId id, const TTxTransaction& tx, TOperationContext& context);
 ISubOperation::TPtr CreateNewSecret(TOperationId id, TTxState::ETxState state);
 // Alter
 ISubOperation::TPtr CreateAlterSecret(TOperationId id, const TTxTransaction& tx);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.cpp
@@ -1126,6 +1126,13 @@ namespace NSchemeShardUT_Private {
     GENERIC_HELPERS(DropSecret, NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret, &NKikimrSchemeOp::TModifyScheme::MutableDrop)
     DROP_BY_PATH_ID_HELPERS(DropSecret, NKikimrSchemeOp::EOperationType::ESchemeOpDropSecret)
 
+    void TestCreateSecretOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults) {
+        auto* ev = CreateSecretRequest(TTestTxConfig::SchemeShard, txId, parentPath, scheme);
+        ev->Record.MutableTransaction()->Mutable(0)->SetReplaceIfExists(true);
+        AsyncSend(runtime, TTestTxConfig::SchemeShard, ev);
+        TestModificationResults(runtime, txId, expectedResults);
+    }
+
     // streaming query
     GENERIC_HELPERS(CreateStreamingQuery, NKikimrSchemeOp::EOperationType::ESchemeOpCreateStreamingQuery, &NKikimrSchemeOp::TModifyScheme::MutableCreateStreamingQuery)
     GENERIC_HELPERS(AlterStreamingQuery, NKikimrSchemeOp::EOperationType::ESchemeOpAlterStreamingQuery, &NKikimrSchemeOp::TModifyScheme::MutableCreateStreamingQuery)

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -337,6 +337,7 @@ namespace NSchemeShardUT_Private {
     GENERIC_HELPERS(AlterSecret);
     GENERIC_HELPERS(DropSecret);
     DROP_BY_PATH_ID_HELPERS(DropSecret);
+    void TestCreateSecretOrReplace(TTestActorRuntime& runtime, ui64 txId, const TString& parentPath, const TString& scheme, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     // streaming query
     GENERIC_HELPERS(CreateStreamingQuery);

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -898,4 +898,70 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         TestDescribeResult(describeResult, {NLs::Finished, NLs::IsSecret});
         ExpectEqualSecretDescription(describeResult, "test-secret", "test-value-new", 1);
     }
+
+    Y_UNIT_TEST(CreateOrReplaceSecretInheritPermissions) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // setup acl on root
+        NACLib::TDiffACL diffACL;
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::DescribeSchema, "user1");
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::AlterSchema, "user1");
+        AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), /* newOwner */ "");
+        env.TestWaitNotification(runtime, txId);
+
+        // create a secret with InheritPermissions: false (ACL is interrupted)
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "secret"
+                Value: "value1"
+                InheritPermissions: false
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // ACL should be non-empty (inheritance interrupted)
+        {
+            const auto describeSecret = DescribePath(runtime, "/MyRoot/secret").GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(!describeSecret.GetACL().empty(),
+                "ACL should be non-empty when InheritPermissions = false");
+        }
+
+        // CREATE OR REPLACE with InheritPermissions: true should restore inheritance (clear ACL)
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "secret"
+                Value: "value2"
+                InheritPermissions: true
+                ReplaceIfExists: true
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // ACL should now be empty (inheritance restored)
+        {
+            const auto describeSecret = DescribePath(runtime, "/MyRoot/secret").GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(describeSecret.GetACL().empty(),
+                "ACL should be empty when InheritPermissions = true after CREATE OR REPLACE");
+        }
+
+        // CREATE OR REPLACE with InheritPermissions: false should interrupt inheritance again
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "secret"
+                Value: "value3"
+                InheritPermissions: false
+                ReplaceIfExists: true
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // ACL should be non-empty again
+        {
+            const auto describeSecret = DescribePath(runtime, "/MyRoot/secret").GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(!describeSecret.GetACL().empty(),
+                "ACL should be non-empty when InheritPermissions = false after CREATE OR REPLACE");
+        }
+    }
 }

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -929,12 +929,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         }
 
         // CREATE OR REPLACE with InheritPermissions: true should restore inheritance (clear ACL)
-        TestCreateSecret(runtime, ++txId, "/MyRoot",
+        TestCreateSecretOrReplace(runtime, ++txId, "/MyRoot",
             R"(
                 Name: "secret"
                 Value: "value2"
                 InheritPermissions: true
-                ReplaceIfExists: true
             )"
         );
         env.TestWaitNotification(runtime, txId);
@@ -947,12 +946,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         }
 
         // CREATE OR REPLACE with InheritPermissions: false should interrupt inheritance again
-        TestCreateSecret(runtime, ++txId, "/MyRoot",
+        TestCreateSecretOrReplace(runtime, ++txId, "/MyRoot",
             R"(
                 Name: "secret"
                 Value: "value3"
                 InheritPermissions: false
-                ReplaceIfExists: true
             )"
         );
         env.TestWaitNotification(runtime, txId);
@@ -1010,12 +1008,11 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
         env.TestWaitNotification(runtime, txId);
 
         // CREATE OR REPLACE with InheritPermissions: false should pick up the new parent grant
-        TestCreateSecret(runtime, ++txId, "/MyRoot",
+        TestCreateSecretOrReplace(runtime, ++txId, "/MyRoot",
             R"(
                 Name: "secret"
                 Value: "value2"
                 InheritPermissions: false
-                ReplaceIfExists: true
             )"
         );
         env.TestWaitNotification(runtime, txId);

--- a/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
+++ b/ydb/core/tx/schemeshard/ut_secret/ut_secret.cpp
@@ -964,4 +964,80 @@ Y_UNIT_TEST_SUITE(TSchemeShardSecretTest) {
                 "ACL should be non-empty when InheritPermissions = false after CREATE OR REPLACE");
         }
     }
+
+    Y_UNIT_TEST(CreateOrReplaceSecretPicksUpParentAclChanges) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        // setup initial acl on root: user1 gets DescribeSchema + AlterSchema
+        NACLib::TDiffACL diffACL;
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::DescribeSchema, "user1");
+        diffACL.AddAccess(NACLib::EAccessType::Allow, NACLib::AlterSchema, "user1");
+        AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL.SerializeAsString(), /* newOwner */ "");
+        env.TestWaitNotification(runtime, txId);
+
+        // create a secret with InheritPermissions: false (ACL is interrupted from parent)
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "secret"
+                Value: "value1"
+                InheritPermissions: false
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // The interrupted ACL should contain user1's DescribeSchema grant
+        {
+            const auto describeSecret = DescribePath(runtime, "/MyRoot/secret").GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(!describeSecret.GetACL().empty(),
+                "ACL should be non-empty when InheritPermissions = false");
+            NACLib::TACL acl(describeSecret.GetACL());
+            bool foundUser1 = false;
+            for (const auto& ace : acl.GetACE()) {
+                if (ace.GetSID() == "user1" && (ace.GetAccessRight() & NACLib::DescribeSchema)) {
+                    foundUser1 = true;
+                }
+            }
+            UNIT_ASSERT_C(foundUser1, "ACL should contain user1's DescribeSchema grant");
+        }
+
+        // Now add a new grant for user2 on the parent directory
+        NACLib::TDiffACL diffACL2;
+        diffACL2.AddAccess(NACLib::EAccessType::Allow, NACLib::DescribeSchema, "user2");
+        diffACL2.AddAccess(NACLib::EAccessType::Allow, NACLib::AlterSchema, "user2");
+        AsyncModifyACL(runtime, ++txId, "", "MyRoot", diffACL2.SerializeAsString(), /* newOwner */ "");
+        env.TestWaitNotification(runtime, txId);
+
+        // CREATE OR REPLACE with InheritPermissions: false should pick up the new parent grant
+        TestCreateSecret(runtime, ++txId, "/MyRoot",
+            R"(
+                Name: "secret"
+                Value: "value2"
+                InheritPermissions: false
+                ReplaceIfExists: true
+            )"
+        );
+        env.TestWaitNotification(runtime, txId);
+
+        // The interrupted ACL should now contain both user1 and user2 DescribeSchema grants
+        {
+            const auto describeSecret = DescribePath(runtime, "/MyRoot/secret").GetPathDescription().GetSelf();
+            UNIT_ASSERT_C(!describeSecret.GetACL().empty(),
+                "ACL should be non-empty when InheritPermissions = false");
+            NACLib::TACL acl(describeSecret.GetACL());
+            bool foundUser1 = false;
+            bool foundUser2 = false;
+            for (const auto& ace : acl.GetACE()) {
+                if (ace.GetSID() == "user1" && (ace.GetAccessRight() & NACLib::DescribeSchema)) {
+                    foundUser1 = true;
+                }
+                if (ace.GetSID() == "user2" && (ace.GetAccessRight() & NACLib::DescribeSchema)) {
+                    foundUser2 = true;
+                }
+            }
+            UNIT_ASSERT_C(foundUser1, "ACL should contain user1's DescribeSchema grant");
+            UNIT_ASSERT_C(foundUser2, "ACL should contain user2's DescribeSchema grant (picked up from parent)");
+        }
+    }
 }

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -551,25 +551,12 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         return IsCreateRequest(modifyScheme);
     }
 
-    static bool IsReplaceIfExists(const NKikimrSchemeOp::TModifyScheme& modifyScheme) {
-        switch (modifyScheme.GetOperationType()) {
-        case NKikimrSchemeOp::ESchemeOpCreateSecret:
-            return modifyScheme.GetCreateSecret().GetReplaceIfExists();
-        case NKikimrSchemeOp::ESchemeOpCreateExternalDataSource:
-        case NKikimrSchemeOp::ESchemeOpCreateExternalTable:
-        case NKikimrSchemeOp::ESchemeOpCreateStreamingQuery:
-            return modifyScheme.GetReplaceIfExists();
-        default:
-            return false;
-        }
-    }
-
     // Schemeshard executes CREATE OR REPLACE over an existing object as an alter of it,
     // so alter rights on the object are required too: create rights on the parent dir
     // alone must not be enough to overwrite an object owned by somebody else.
     // The object may not exist yet, then it is a plain create and the check is skipped.
     void AddResolveForCreateOrReplace(NKikimrSchemeOp::TModifyScheme& pbModifyScheme, const TVector<TString>& workingDir) {
-        if (!IsReplaceIfExists(pbModifyScheme)) {
+        if (!pbModifyScheme.GetReplaceIfExists()) {
             return;
         }
 

--- a/ydb/core/tx/tx_proxy/schemereq.cpp
+++ b/ydb/core/tx/tx_proxy/schemereq.cpp
@@ -68,6 +68,9 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         TVector<TString> Path;
         bool RequireRedirect = true;
 
+        // Resolve the path only to check access on it if it exists, absence is not an error.
+        bool AllowNotExist = false;
+
         TPathToResolve(const NKikimrSchemeOp::TModifyScheme& modifyScheme)
             : ModifyScheme(modifyScheme)
         {
@@ -548,6 +551,35 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         return IsCreateRequest(modifyScheme);
     }
 
+    static bool IsReplaceIfExists(const NKikimrSchemeOp::TModifyScheme& modifyScheme) {
+        switch (modifyScheme.GetOperationType()) {
+        case NKikimrSchemeOp::ESchemeOpCreateSecret:
+            return modifyScheme.GetCreateSecret().GetReplaceIfExists();
+        case NKikimrSchemeOp::ESchemeOpCreateExternalDataSource:
+        case NKikimrSchemeOp::ESchemeOpCreateExternalTable:
+        case NKikimrSchemeOp::ESchemeOpCreateStreamingQuery:
+            return modifyScheme.GetReplaceIfExists();
+        default:
+            return false;
+        }
+    }
+
+    // Schemeshard executes CREATE OR REPLACE over an existing object as an alter of it,
+    // so alter rights on the object are required too: create rights on the parent dir
+    // alone must not be enough to overwrite an object owned by somebody else.
+    // The object may not exist yet, then it is a plain create and the check is skipped.
+    void AddResolveForCreateOrReplace(NKikimrSchemeOp::TModifyScheme& pbModifyScheme, const TVector<TString>& workingDir) {
+        if (!IsReplaceIfExists(pbModifyScheme)) {
+            return;
+        }
+
+        auto toResolve = TPathToResolve(pbModifyScheme);
+        toResolve.Path = Merge(workingDir, SplitPath(GetPathNameForScheme(pbModifyScheme)));
+        toResolve.RequireAccess = NACLib::EAccessRights::AlterSchema;
+        toResolve.AllowNotExist = true;
+        ResolveForACL.push_back(toResolve);
+    }
+
     static TVector<TString> GetFullPath(NKikimrSchemeOp::TModifyScheme& scheme) {
         switch (scheme.GetOperationType()) {
         case NKikimrSchemeOp::ESchemeOpRestoreMultipleIncrementalBackups:
@@ -872,6 +904,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             toResolve.Path = workingDir;
             toResolve.RequireAccess = NACLib::EAccessRights::CreateTable | accessToUserAttrs;
             ResolveForACL.push_back(toResolve);
+            AddResolveForCreateOrReplace(pbModifyScheme, workingDir);
             break;
         }
         case NKikimrSchemeOp::ESchemeOpAlterTransfer:
@@ -1001,6 +1034,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
             toResolve.Path = workingDir;
             toResolve.RequireAccess = NACLib::EAccessRights::CreateTable | accessToUserAttrs;
             ResolveForACL.push_back(toResolve);
+            AddResolveForCreateOrReplace(pbModifyScheme, workingDir);
             break;
         }
         case NKikimrSchemeOp::ESchemeOpCreateTransfer:
@@ -1301,6 +1335,29 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
         } else {
             return msg;
         }
+    }
+
+    // The only tolerable resolve error is a missing AllowNotExist path.
+    bool HasOnlyTolerableResolveErrors(const NSchemeCache::TSchemeCacheNavigate* navigate) const {
+        if (navigate->ResultSet.size() != ResolveForACL.size()) {
+            return false;
+        }
+
+        for (size_t i = 0; i < navigate->ResultSet.size(); ++i) {
+            switch (navigate->ResultSet[i].Status) {
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::Ok:
+                break;
+            case NSchemeCache::TSchemeCacheNavigate::EStatus::PathErrorUnknown:
+                if (ResolveForACL[i].AllowNotExist) {
+                    break;
+                }
+                return false;
+            default:
+                return false;
+            }
+        }
+
+        return true;
     }
 
     void InterpretResolveError(const NSchemeCache::TSchemeCacheNavigate* navigate, const TActorContext &ctx) {
@@ -1700,7 +1757,7 @@ struct TBaseSchemeReq: public TActorBootstrapped<TDerived> {
 
         Y_ABORT_UNLESS(!navigate->ResultSet.empty());
 
-        if (navigate->ErrorCount > 0) {
+        if (navigate->ErrorCount > 0 && !HasOnlyTolerableResolveErrors(navigate)) {
             InterpretResolveError(navigate, ctx);
             return Die(ctx);
         }

--- a/ydb/library/security/ut/util_ut.cpp
+++ b/ydb/library/security/ut/util_ut.cpp
@@ -20,6 +20,13 @@ Y_UNIT_TEST_SUITE(Util) {
         UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("CReaTE    SECRET x WITH (VALUE = '123')"));
         UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("ALTER\t\n\rSecret x SET VALUE '123'"));
 
+        // true – DDL verbs with keywords between verb and "secret"
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("CREATE OR REPLACE SECRET x WITH (VALUE = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("CREATE IF NOT EXISTS SECRET x WITH (VALUE = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("ALTER IF EXISTS SECRET x WITH (VALUE = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("create or replace secret x with (value = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("create if not exists secret x with (value = '123')"));
+
         // true – many lines
         UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo(
             "CREATE\n"
@@ -50,6 +57,12 @@ Y_UNIT_TEST_SUITE(Util) {
         UNIT_ASSERT_VALUES_EQUAL(
             protectedText,
             "Query text is hidden due to a sensitive marker: create secret");
+
+        // DDL verbs with keywords between verb and "secret"
+        UNIT_ASSERT(NKikimr::ProtectQueryForLoggingIfSensitive("CREATE OR REPLACE SECRET x WITH (VALUE = '123')", protectedText));
+        UNIT_ASSERT_VALUES_EQUAL(
+            protectedText,
+            "Query text is hidden due to a sensitive marker: ddl secret");
     }
 
     Y_UNIT_TEST(ProtectQueryForLoggingIfSensitive) {
@@ -94,6 +107,14 @@ Y_UNIT_TEST_SUITE(Util) {
                 "x\n"
                 "WITH (VALUE = '123')"),
             "Query text is hidden due to a sensitive marker: create secret");
+
+        // DDL verbs with keywords between verb and "secret"
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimr::ProtectQueryForLoggingIfSensitive("CREATE OR REPLACE SECRET x WITH (VALUE = '123')"),
+            "Query text is hidden due to a sensitive marker: ddl secret");
+        UNIT_ASSERT_VALUES_EQUAL(
+            NKikimr::ProtectQueryForLoggingIfSensitive("CREATE IF NOT EXISTS SECRET x WITH (VALUE = '123')"),
+            "Query text is hidden due to a sensitive marker: ddl secret");
 
         // false positives
         UNIT_ASSERT_VALUES_EQUAL(

--- a/ydb/library/security/ut/util_ut.cpp
+++ b/ydb/library/security/ut/util_ut.cpp
@@ -27,6 +27,12 @@ Y_UNIT_TEST_SUITE(Util) {
         UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("create or replace secret x with (value = '123')"));
         UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("create if not exists secret x with (value = '123')"));
 
+        // true – DDL verbs with irregular whitespace (multiple spaces/tabs/newlines) between every word
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("CREATE  OR   REPLACE SECRET x WITH (VALUE = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("CREATE\tOR\nREPLACE\r\nSECRET x WITH (VALUE = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("CREATE  IF  NOT   EXISTS SECRET x WITH (VALUE = '123')"));
+        UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo("ALTER\t IF  EXISTS\nSECRET x WITH (VALUE = '123')"));
+
         // true – many lines
         UNIT_ASSERT(NKikimr::IsQueryWithSensitiveInfo(
             "CREATE\n"
@@ -62,7 +68,7 @@ Y_UNIT_TEST_SUITE(Util) {
         UNIT_ASSERT(NKikimr::ProtectQueryForLoggingIfSensitive("CREATE OR REPLACE SECRET x WITH (VALUE = '123')", protectedText));
         UNIT_ASSERT_VALUES_EQUAL(
             protectedText,
-            "Query text is hidden due to a sensitive marker: ddl secret");
+            "Query text is hidden due to a sensitive marker: create or replace secret");
     }
 
     Y_UNIT_TEST(ProtectQueryForLoggingIfSensitive) {
@@ -111,10 +117,10 @@ Y_UNIT_TEST_SUITE(Util) {
         // DDL verbs with keywords between verb and "secret"
         UNIT_ASSERT_VALUES_EQUAL(
             NKikimr::ProtectQueryForLoggingIfSensitive("CREATE OR REPLACE SECRET x WITH (VALUE = '123')"),
-            "Query text is hidden due to a sensitive marker: ddl secret");
+            "Query text is hidden due to a sensitive marker: create or replace secret");
         UNIT_ASSERT_VALUES_EQUAL(
             NKikimr::ProtectQueryForLoggingIfSensitive("CREATE IF NOT EXISTS SECRET x WITH (VALUE = '123')"),
-            "Query text is hidden due to a sensitive marker: ddl secret");
+            "Query text is hidden due to a sensitive marker: create if not exists secret");
 
         // false positives
         UNIT_ASSERT_VALUES_EQUAL(

--- a/ydb/library/security/util.cpp
+++ b/ydb/library/security/util.cpp
@@ -25,6 +25,8 @@ static const std::vector<TString> SensitiveWords = {
 // Each sequence is a list of keywords that must appear consecutively (only ASCII
 // whitespace allowed between neighboring words, any amount of it, including
 // newlines/tabs/multiple spaces).
+// The first matching sequence is reported as the marker, so the plain verb pairs
+// come first: they never match the variants with keywords in between.
 static const std::vector<TWordSequence> SensitiveWordSequences = {
     {"create", "secret"},
     {"alter", "secret"},

--- a/ydb/library/security/util.cpp
+++ b/ydb/library/security/util.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <regex>
 #include <vector>
 
 namespace NKikimr {
@@ -65,6 +66,17 @@ bool ContainsAdjacentWordsIgnoreSpaces(TStringBuf text, TStringBuf w1, TStringBu
     return false;
 }
 
+// Checks for "secret" after a DDL verb with SQL keywords between verb and "secret".
+// Matches exactly:
+//   CREATE OR REPLACE SECRET, CREATE IF NOT EXISTS SECRET,
+//   ALTER IF EXISTS SECRET
+bool ContainsDdlVerbAndSecret(TStringBuf text) {
+    static const std::regex re(
+        R"((?:create\s+or\s+replace|create\s+if\s+not\s+exists|alter\s+if\s+exists)\s+secret\b)",
+        std::regex::icase);
+    return std::regex_search(text.begin(), text.end(), re);
+}
+
 TMaybe<TString> FindSensitiveQueryMarker(TStringBuf text) {
     for (const TString& word : SensitiveWords) {
         if (ContainsCaseInsensitive(text, word)) {
@@ -75,6 +87,9 @@ TMaybe<TString> FindSensitiveQueryMarker(TStringBuf text) {
         if (ContainsAdjacentWordsIgnoreSpaces(text, pair.First, pair.Second)) {
             return TStringBuilder() << pair.First << ' ' << pair.Second;
         }
+    }
+    if (ContainsDdlVerbAndSecret(text)) {
+        return TString("ddl secret");
     }
     return Nothing();
 }
@@ -141,7 +156,7 @@ TString MaskIAMTicket(const TString& token) {
     TVector<TString> parts;
     StringSplitter(token).Split('.').AddTo(&parts);
     parts.erase(
-        std::remove_if(parts.begin(), parts.end(), 
+        std::remove_if(parts.begin(), parts.end(),
                     [](const TString& value) { return value.empty(); }),
         parts.end()
     );

--- a/ydb/library/security/util.cpp
+++ b/ydb/library/security/util.cpp
@@ -11,24 +11,26 @@
 
 #include <algorithm>
 #include <cctype>
-#include <regex>
 #include <vector>
 
 namespace NKikimr {
 
 namespace {
 
-struct TSensitivePairedWords {
-    TStringBuf First;
-    TStringBuf Second;
-};
+using TWordSequence = std::vector<TStringBuf>;
 
 static const std::vector<TString> SensitiveWords = {
     "password",
 };
-static const TSensitivePairedWords SensitivePairedWords[] = {
+// Each sequence is a list of keywords that must appear consecutively (only ASCII
+// whitespace allowed between neighboring words, any amount of it, including
+// newlines/tabs/multiple spaces).
+static const std::vector<TWordSequence> SensitiveWordSequences = {
     {"create", "secret"},
     {"alter", "secret"},
+    {"create", "or", "replace", "secret"},
+    {"create", "if", "not", "exists", "secret"},
+    {"alter", "if", "exists", "secret"},
 };
 
 bool ContainsCaseInsensitive(TStringBuf text, TStringBuf pattern) {
@@ -49,32 +51,40 @@ bool MatchPrefixIgnoreCase(TStringBuf text, size_t pos, TStringBuf word) {
     return true;
 }
 
-// Two consecutive keywords; only ASCII whitespace between them; case-insensitive.
-bool ContainsAdjacentWordsIgnoreSpaces(TStringBuf text, TStringBuf w1, TStringBuf w2) {
-    for (size_t i = 0; i + w1.size() <= text.size(); ++i) {
-        if (!MatchPrefixIgnoreCase(text, i, w1)) {
+// A sequence of consecutive keywords; only ASCII whitespace (any amount) is
+// allowed between neighboring words; case-insensitive.
+bool ContainsWordSequenceIgnoreSpaces(TStringBuf text, const TWordSequence& words) {
+    if (words.empty()) {
+        return false;
+    }
+    const TStringBuf& first = words.front();
+    for (size_t i = 0; i + first.size() <= text.size(); ++i) {
+        if (!MatchPrefixIgnoreCase(text, i, first)) {
             continue;
         }
-        size_t p = i + w1.size();
-        while (p < text.size() && IsAsciiSpace(static_cast<unsigned char>(text[p]))) {
-            ++p;
+        size_t p = i + first.size();
+        bool matched = true;
+        for (size_t w = 1; w < words.size(); ++w) {
+            size_t spaceStart = p;
+            while (p < text.size() && IsAsciiSpace(static_cast<unsigned char>(text[p]))) {
+                ++p;
+            }
+            if (p == spaceStart) {
+                matched = false;
+                break;
+            }
+            const TStringBuf& word = words[w];
+            if (p + word.size() > text.size() || !MatchPrefixIgnoreCase(text, p, word)) {
+                matched = false;
+                break;
+            }
+            p += word.size();
         }
-        if (p + w2.size() <= text.size() && MatchPrefixIgnoreCase(text, p, w2)) {
+        if (matched) {
             return true;
         }
     }
     return false;
-}
-
-// Checks for "secret" after a DDL verb with SQL keywords between verb and "secret".
-// Matches exactly:
-//   CREATE OR REPLACE SECRET, CREATE IF NOT EXISTS SECRET,
-//   ALTER IF EXISTS SECRET
-bool ContainsDdlVerbAndSecret(TStringBuf text) {
-    static const std::regex re(
-        R"((?:create\s+or\s+replace|create\s+if\s+not\s+exists|alter\s+if\s+exists)\s+secret\b)",
-        std::regex::icase);
-    return std::regex_search(text.begin(), text.end(), re);
 }
 
 TMaybe<TString> FindSensitiveQueryMarker(TStringBuf text) {
@@ -83,13 +93,17 @@ TMaybe<TString> FindSensitiveQueryMarker(TStringBuf text) {
             return word;
         }
     }
-    for (const auto& pair : SensitivePairedWords) {
-        if (ContainsAdjacentWordsIgnoreSpaces(text, pair.First, pair.Second)) {
-            return TStringBuilder() << pair.First << ' ' << pair.Second;
+    for (const auto& seq : SensitiveWordSequences) {
+        if (ContainsWordSequenceIgnoreSpaces(text, seq)) {
+            TStringBuilder marker;
+            for (size_t i = 0; i < seq.size(); ++i) {
+                if (i > 0) {
+                    marker << ' ';
+                }
+                marker << seq[i];
+            }
+            return TString(marker);
         }
-    }
-    if (ContainsDdlVerbAndSecret(text)) {
-        return TString("ddl secret");
     }
     return Nothing();
 }

--- a/ydb/tests/functional/secrets/slow/test_secrets_logging.py
+++ b/ydb/tests/functional/secrets/slow/test_secrets_logging.py
@@ -54,13 +54,18 @@ def _assert_secret_value_not_in_logs(log_paths, secret_value):
 def test_secret_value_from_params_not_in_trace_logs(db_fixture, ydb_cluster):
     secret_value = 'secret-value-rand-value-mf83ezDr7'
     secret_path = 'x'
+    secret_path2 = 'y'
 
     # run all DDL SQL commands for secrets
     query = f"""
         DECLARE $value AS Utf8;
         CREATE SECRET `{secret_path}` WITH (value = $value);
         ALTER SECRET `{secret_path}` WITH (value = $value);
-        DROP SECRET `{secret_path}`;
+        CREATE OR REPLACE SECRET `{secret_path}` WITH (value = $value);
+        CREATE SECRET IF NOT EXISTS `{secret_path}` WITH (value = $value);
+        ALTER SECRET IF EXISTS `{secret_path}` WITH (value = $value);
+        CREATE OR REPLACE SECRET `{secret_path2}` WITH (value = $value);
+        DROP SECRET `{secret_path2}`;
     """
     parameters = {'$value': (secret_value, ydb.PrimitiveType.Utf8.proto)}
     with ydb.Driver(db_fixture) as driver:

--- a/ydb/tests/functional/secrets/slow/test_secrets_logging.py
+++ b/ydb/tests/functional/secrets/slow/test_secrets_logging.py
@@ -55,6 +55,7 @@ def test_secret_value_from_params_not_in_trace_logs(db_fixture, ydb_cluster):
     secret_value = 'secret-value-rand-value-mf83ezDr7'
     secret_path = 'x'
     secret_path2 = 'y'
+    secret_path3 = 'z'
 
     # run all DDL SQL commands for secrets
     query = f"""
@@ -66,6 +67,8 @@ def test_secret_value_from_params_not_in_trace_logs(db_fixture, ydb_cluster):
         ALTER SECRET IF EXISTS `{secret_path}` WITH (value = $value);
         CREATE OR REPLACE SECRET `{secret_path2}` WITH (value = $value);
         DROP SECRET `{secret_path2}`;
+        CREATE SECRET `{secret_path3}` WITH (value = $value);
+        DROP SECRET IF EXISTS `{secret_path3}`;
     """
     parameters = {'$value': (secret_value, ydb.PrimitiveType.Utf8.proto)}
     with ydb.Driver(db_fixture) as driver:
@@ -76,7 +79,7 @@ def test_secret_value_from_params_not_in_trace_logs(db_fixture, ydb_cluster):
     log_paths = _collect_ydbd_log_paths(ydb_cluster)
     assert log_paths, 'Log files are missing'
 
-    _wait_for_log_marker('DROP SECRET', log_paths)
+    _wait_for_log_marker('DROP SECRET IF EXISTS', log_paths)
     time.sleep(2.0)
 
     # assert that the secret value is not in the logs

--- a/ydb/tests/functional/secrets/slow/test_secrets_monitoring.py
+++ b/ydb/tests/functional/secrets/slow/test_secrets_monitoring.py
@@ -22,7 +22,7 @@ def _cell_to_str(value):
 def _secret_value_not_leaked_to_sysviews(config, secret_value):
     sys_table = f"`{DATABASE}/.sys/top_queries_by_cpu_time_one_minute`"
     query = f"""
-    SELECT QueryText FROM {sys_table} WHERE String::Contains(QueryText, "ALTER SECRET")
+    SELECT QueryText FROM {sys_table} WHERE String::Contains(QueryText, "SECRET")
     """
     result_sets = run_with_assert(config, query)
     if not result_sets or not result_sets[0].rows:
@@ -37,7 +37,7 @@ def _secret_value_not_leaked_to_sysviews(config, secret_value):
 def _secret_value_not_leaked_to_query_sessions(config, secret_value):
     sys_table = f"`{DATABASE}/.sys/query_sessions`"
     query = f"""
-    SELECT Query FROM {sys_table} WHERE String::Contains(Query, "ALTER SECRET")
+    SELECT Query FROM {sys_table} WHERE String::Contains(Query, "SECRET")
     """
     result_sets = run_with_assert(config, query)
     if not result_sets or not result_sets[0].rows:
@@ -61,12 +61,26 @@ def test_secret_value_not_leaked_to_sysviews(db_fixture):
             db_fixture,
             f"ALTER SECRET `{secret_name}` WITH (value='{secret_value}');",
         )
+    # Exercise the new DDL syntax variants to ensure they don't leak secret values either
+    for _ in range(5):
+        run_with_assert(
+            db_fixture,
+            f"CREATE OR REPLACE SECRET `{secret_name}` WITH (value='{secret_value}');",
+        )
+    run_with_assert(
+        db_fixture,
+        f"CREATE SECRET IF NOT EXISTS `{secret_name}` WITH (value='{secret_value}');",
+    )
+    run_with_assert(
+        db_fixture,
+        f"ALTER SECRET IF EXISTS `{secret_name}` WITH (value='{secret_value}');",
+    )
 
     # We'll check in 'one_minute' sysview, so we need to wait for two minutes.
     time.sleep(120)
 
     assert not _secret_value_not_leaked_to_sysviews(db_fixture, secret_value), (
-        "secret literal must not appear in ALTER SECRET rows in " ".sys/top_queries_by_cpu_time_one_minute"
+        "secret literal must not appear in SECRET DDL rows in " ".sys/top_queries_by_cpu_time_one_minute"
     )
 
     assert not _secret_value_not_leaked_to_query_sessions(

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -810,3 +810,40 @@ def test_set_secret_value_with_param(db_fixture, ydb_cluster, secret_setup):
     prepare_secret(user1_config, secret_name, secret_value, secret_setup)
     create_async_replication(replication_name, replica_name, table_name, connection_string, secret_name)
     assert_replication_has_processed_all_changes(user1_config, replica_name, rows_cnt)
+
+
+def test_create_or_replace_secret_permissions(db_fixture, ydb_cluster):
+    """
+    Verify that CREATE OR REPLACE SECRET on an existing secret requires
+    alter_schema permission on the secret, not just create_table on the directory.
+
+    When the secret already exists, CREATE OR REPLACE converts to ALTER internally,
+    so the user must have alter permission on the secret itself.
+    """
+    user1 = unique_user_name("user1")
+    user1_config = create_user(ydb_cluster, db_fixture, user1)
+
+    # Grant create_table on the directory (needed for CREATE SECRET)
+    provide_grants(db_fixture, user1, DATABASE, ["ydb.granular.create_table"])
+
+    # Admin creates a secret that user1 does not own
+    secret_path = f'{DATABASE}/secret_replace'
+    run_with_assert(db_fixture, f"CREATE SECRET `{secret_path}` WITH (value='original');")
+
+    # User1 has create_table on the directory but NOT alter permission on the secret.
+    # CREATE OR REPLACE on the existing secret should fail (converts to ALTER, needs alter_schema).
+    run_with_assert(
+        user1_config,
+        f"CREATE OR REPLACE SECRET `{secret_path}` WITH (value='hacked');",
+        "Access denied",
+    )
+
+    # Grant alter permission on the secret to user1
+    provide_grants(db_fixture, user1, secret_path, ALTER_SECRET_GRANTS)
+
+    # Now user1 should succeed with CREATE OR REPLACE on the existing secret
+    run_with_assert(user1_config, f"CREATE OR REPLACE SECRET `{secret_path}` WITH (value='updated');")
+
+    # User1 should also be able to CREATE OR REPLACE a non-existing secret (acts as CREATE)
+    new_secret_path = f'{DATABASE}/secret_new'
+    run_with_assert(user1_config, f"CREATE OR REPLACE SECRET `{new_secret_path}` WITH (value='new');")

--- a/ydb/tests/functional/secrets/test_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_secrets_usage.py
@@ -8,6 +8,7 @@ import time
 import pytest
 
 from ydb.tests.functional.secrets.lib.secrets_plugin import (
+    ALTER_SECRET_GRANTS,
     create_secrets,
     create_user,
     DATABASE,


### PR DESCRIPTION
These changes add IF NOT EXISTS, IF EXISTS, and CREATE OR REPLACE support for YDB secret DDL operations (CREATE SECRET, ALTER SECRET, DROP SECRET).