### PR TITLE
Mute unstable tests

### DIFF
--- a/.github/config/muted_ya.txt
+++ b/.github/config/muted_ya.txt
@@ -16,6 +16,7 @@ ydb/core/keyvalue/ut_trace TKeyValueTracingTest.ReadHuge
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.ReadSmall
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.WriteHuge
 ydb/core/keyvalue/ut_trace TKeyValueTracingTest.WriteSmall
+ydb/core/kqp/ut/federated_query/s3 KqpFederatedQuery.OverridePlannerDefaults
 ydb/core/kqp/ut/join KqpIndexLookupJoin.LeftJoinRightNullFilter+StreamLookup
 ydb/core/kqp/ut/join KqpIndexLookupJoin.LeftJoinRightNullFilter-StreamLookup
 ydb/core/kqp/ut/olap KqpOlapAggregations.BlockGenericWithDistinct
@@ -30,6 +31,7 @@ ydb/core/kqp/ut/olap KqpOlapJson.DoubleFilterReduceScopeWithPredicateVariants[1,
 ydb/core/kqp/ut/olap KqpOlapJson.QuotedFilterVariants[10,false,1024,0,100,0.5]
 ydb/core/kqp/ut/olap KqpOlapJson.QuotedFilterVariants[10,true,1,1000,1000000,0.5]
 ydb/core/kqp/ut/olap KqpOlapSysView.StatsSysViewTable
+ydb/core/kqp/ut/olap KqpOlapTiering.DeletedTier
 ydb/core/kqp/ut/olap KqpOlapWrite.TierDraftsGCWithRestart
 ydb/core/kqp/ut/olap [*/*] chunk chunk
 ydb/core/kqp/ut/query KqpAnalyze.AnalyzeTable+ColumnStore


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Mute two unstable tests in our branch:
- KqpFederatedQuery.OverridePlannerDefaults - failed one time, but anyway we can mute it as we don't use federated query.
- KqpOlapTiering.DeletedTier - fails very frequently, and, again, we don't use column tables and can mute it.