### PR TITLE
Resolve federation topics via LbUserDatabaseRoot in Topic Describer

### DIFF
--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -1,5 +1,8 @@
 #include "describer.h"
 
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
+
 #include <util/generic/algorithm.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
@@ -25,6 +28,14 @@ bool HasAccess(const TDescribeSettings& settings, TIntrusivePtr<TSecurityObject>
     return false;
 }
 
+TString MakeLbUserTopicPath(const TString& lbUserDatabaseRoot, const TString& topicPath) {
+    auto parts = NKikimr::SplitPath(lbUserDatabaseRoot);
+    for (const auto& part : NKikimr::SplitPath(topicPath)) {
+        parts.push_back(part);
+    }
+    return CanonizePath(NKikimr::JoinPath(parts));
+}
+
 class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
 public:
     TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, const std::unordered_set<TString>&& topicPaths, const TDescribeSettings& settings)
@@ -37,6 +48,7 @@ public:
 
     void Bootstrap() {
         Become(&TDescribeActor::StateWork);
+        LbUserDatabaseRoot = AppData()->PQConfig.GetPQDiscoveryConfig().GetLbUserDatabaseRoot();
         RetryWithSyncVersion = Settings.ForceSyncVersion;
         UsedSyncVersion = Settings.ForceSyncVersion;
         DoRequest(TopicPaths);
@@ -64,7 +76,8 @@ public:
 
         for (const auto& topic : topicPath) {
             auto normalizedPath = NKikimr::NormalizePath(DatabasePath, CanonizePath(topic));
-            PathToOriginalPath[normalizedPath] = topic;
+            // Keep the originally requested path across retries (sync / LbRoot / CDC).
+            PathToOriginalPath.try_emplace(normalizedPath, topic);
             addEntry(normalizedPath);
         }
 
@@ -92,6 +105,8 @@ public:
                 originalPath = it->second.OriginalPath;
                 isCDCStream = true;
                 cdcStreamName = it->second.CdcStreamName;
+            } else if (auto lbIt = LbRootPaths.find(realPath); lbIt != LbRootPaths.end()) {
+                originalPath = lbIt->second.OriginalPath;
             }
 
             switch (entry.Status) {
@@ -104,17 +119,19 @@ public:
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
 
-                            Result[originalPath] = TTopicInfo{
-                                .Status = EStatus::UNAUTHORIZED
-                            };
+                            SetErrorResult(originalPath, EStatus::UNAUTHORIZED);
+                        } else if (TryScheduleLbRootRetry(originalPath, realPath)) {
+                            YDB_LOG_DEBUG("Path not found, will try LbUserDatabaseRoot",
+                                {"logPrefix", LOG_PREFIX},
+                                {"realPath", realPath},
+                                {"originalPath", originalPath},
+                                {"lbUserDatabaseRoot", LbUserDatabaseRoot});
                         } else {
                             YDB_LOG_DEBUG("Path not found",
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
 
-                            Result[originalPath] = TTopicInfo{
-                                .Status = EStatus::NOT_FOUND
-                            };
+                            SetErrorResult(originalPath, EStatus::NOT_FOUND);
                         }
                     } else {
                         unknownPaths.insert(realPath);
@@ -144,12 +161,18 @@ public:
                     } else if (entry.Kind == TSchemeCacheNavigate::EKind::KindTopic) {
                         if (!entry.PQGroupInfo || entry.PQGroupInfo->Description.GetBalancerTabletID() == 0) {
                             if (RetryWithSyncVersion) {
-                                YDB_LOG_DEBUG("Path not found",
-                                    {"logPrefix", LOG_PREFIX},
-                                    {"realPath", realPath});
-                                Result[originalPath] = TTopicInfo{
-                                    .Status = EStatus::NOT_FOUND
-                                };
+                                if (TryScheduleLbRootRetry(originalPath, realPath)) {
+                                    YDB_LOG_DEBUG("Path not found, will try LbUserDatabaseRoot",
+                                        {"logPrefix", LOG_PREFIX},
+                                        {"realPath", realPath},
+                                        {"originalPath", originalPath},
+                                        {"lbUserDatabaseRoot", LbUserDatabaseRoot});
+                                } else {
+                                    YDB_LOG_DEBUG("Path not found",
+                                        {"logPrefix", LOG_PREFIX},
+                                        {"realPath", realPath});
+                                    SetErrorResult(originalPath, EStatus::NOT_FOUND);
+                                }
                             } else {
                                 unknownPaths.insert(realPath);
                             }
@@ -219,6 +242,20 @@ public:
             return DoRequest(unknownPaths);
         }
 
+        if (!LbRootPaths.empty() && !RetryWithLbRoot) {
+            RetryWithLbRoot = true;
+            // Same local→global pattern as for the original topic paths.
+            RetryWithSyncVersion = false;
+
+            std::unordered_set<TString> newPath;
+            newPath.reserve(LbRootPaths.size());
+            for (const auto& [path, _] : LbRootPaths) {
+                newPath.insert(path);
+            }
+
+            return DoRequest(newPath);
+        }
+
         if (!CDCPaths.empty() && !RetryWithCDC) {
             RetryWithSyncVersion = false;
             RetryWithCDC = true;
@@ -244,6 +281,47 @@ public:
     }
 
 private:
+    bool TryScheduleLbRootRetry(const TString& originalPath, const TString& realPath) {
+        if (LbUserDatabaseRoot.empty()) {
+            return false;
+        }
+        if (LbRootPaths.contains(realPath)) {
+            // This response is already for an LbUserDatabaseRoot path.
+            return false;
+        }
+        for (const auto& [_, info] : LbRootPaths) {
+            if (info.OriginalPath == originalPath) {
+                // LbUserDatabaseRoot path is already scheduled.
+                return true;
+            }
+        }
+        if (RetryWithLbRoot) {
+            return false;
+        }
+
+        const auto lbPath = MakeLbUserTopicPath(LbUserDatabaseRoot, originalPath);
+        if (lbPath == realPath) {
+            return false;
+        }
+
+        LbRootPaths[lbPath] = TLbRootTopicInfo{
+            .OriginalPath = originalPath
+        };
+        return true;
+    }
+
+    void SetErrorResult(const TString& originalPath, EStatus status, const TString& realPath = {}) {
+        auto it = Result.find(originalPath);
+        if (it != Result.end() && it->second.Status == EStatus::SUCCESS) {
+            return;
+        }
+        Result[originalPath] = TTopicInfo{
+            .Status = status,
+            .RealPath = realPath
+        };
+    }
+
+private:
     const NActors::TActorId Parent;
     const TString DatabasePath;
     const std::unordered_set<TString> TopicPaths;
@@ -254,12 +332,19 @@ private:
     bool RetryWithSyncVersion = false;
     bool UsedSyncVersion = false;
     bool RetryWithCDC = false;
+    bool RetryWithLbRoot = false;
+    TString LbUserDatabaseRoot;
     // CDC topic path -> original topic path
     struct TCDCTopicInfo {
         TString OriginalPath;
         TString CdcStreamName;
     };
     std::unordered_map<TString, TCDCTopicInfo> CDCPaths;
+    // LbUserDatabaseRoot-prefixed path -> original topic path
+    struct TLbRootTopicInfo {
+        TString OriginalPath;
+    };
+    std::unordered_map<TString, TLbRootTopicInfo> LbRootPaths;
     std::unordered_map<TString, TTopicInfo> Result;
 };
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -39,6 +39,19 @@ TString MakeLbUserTopicPath(const TString& lbUserDatabaseRoot, const TString& to
     return CanonizePath(NKikimr::JoinPath(parts));
 }
 
+// First path component is federation account; requires account/topic shape.
+TMaybe<TString> ExtractFederationAccount(const TString& topicPath) {
+    auto parts = NKikimr::SplitPath(topicPath);
+    if (parts.size() < 2 || parts[0].empty()) {
+        return Nothing();
+    }
+    return parts[0];
+}
+
+TString MakeLbUserAccountDatabase(const TString& lbUserDatabaseRoot, const TString& account) {
+    return CanonizePath(NKikimr::JoinPath({lbUserDatabaseRoot, account}));
+}
+
 class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
 public:
     TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings)
@@ -56,6 +69,7 @@ public:
         }
         RetryWithSyncVersion = Settings.ForceSyncVersion;
         UsedSyncVersion = Settings.ForceSyncVersion;
+        RequestDatabaseName = DatabasePath;
         DoRequest(TopicPaths);
     }
 
@@ -63,10 +77,11 @@ public:
         YDB_LOG_DEBUG("Create request with",
             {"logPrefix", LOG_PREFIX},
             {"topicPaths", JoinRange(", ", topicPath.begin(), topicPath.end())},
-            {"syncVersion", RetryWithSyncVersion});
+            {"syncVersion", RetryWithSyncVersion},
+            {"databaseName", RequestDatabaseName});
 
         auto schemeRequest = std::make_unique<TSchemeCacheNavigate>(1);
-        schemeRequest->DatabaseName = DatabasePath;
+        schemeRequest->DatabaseName = RequestDatabaseName;
 
         auto addEntry = [&](const TString& topic) {
             auto split = NKikimr::SplitPath(topic);
@@ -80,7 +95,7 @@ public:
         };
 
         for (const auto& topic : topicPath) {
-            auto normalizedPath = NKikimr::NormalizePath(DatabasePath, CanonizePath(topic));
+            auto normalizedPath = NKikimr::NormalizePath(RequestDatabaseName, CanonizePath(topic));
             // Keep the originally requested path across retries (sync / LbRoot / CDC).
             PathToOriginalPath.try_emplace(normalizedPath, topic);
             addEntry(normalizedPath);
@@ -247,23 +262,14 @@ public:
             return DoRequest(unknownPaths);
         }
 
-        if (!LbRootPaths.empty() && !RetryWithLbRoot) {
-            RetryWithLbRoot = true;
-            // Same local→global pattern as for the original topic paths.
-            RetryWithSyncVersion = false;
-
-            absl::flat_hash_set<TString> newPath;
-            newPath.reserve(LbRootPaths.size());
-            for (const auto& [path, _] : LbRootPaths) {
-                newPath.insert(path);
-            }
-
-            return DoRequest(newPath);
+        if (TryStartNextLbRootDatabaseRequest()) {
+            return;
         }
 
         if (!CDCPaths.empty() && !RetryWithCDC) {
             RetryWithSyncVersion = false;
             RetryWithCDC = true;
+            RequestDatabaseName = DatabasePath;
 
             absl::flat_hash_set<TString> newPath;
             newPath.reserve(CDCPaths.size());
@@ -304,14 +310,52 @@ private:
             return false;
         }
 
+        const auto account = ExtractFederationAccount(originalPath);
+        if (!account.Defined()) {
+            return false;
+        }
+
+        const auto accountDatabase = MakeLbUserAccountDatabase(LbUserDatabaseRoot, *account);
         const auto lbPath = MakeLbUserTopicPath(LbUserDatabaseRoot, originalPath);
-        if (lbPath == realPath) {
+        // Same path string can still need a retry with DatabaseName = account DB
+        // (e.g. DatabasePath == LbUserDatabaseRoot: /Root/account/topic under /Root).
+        if (lbPath == realPath && RequestDatabaseName == accountDatabase) {
             return false;
         }
 
         LbRootPaths[lbPath] = TLbRootTopicInfo{
-            .OriginalPath = originalPath
+            .OriginalPath = originalPath,
+            .AccountDatabase = accountDatabase
         };
+        return true;
+    }
+
+    // One SchemeCache request per account database (DatabaseName = LbRoot/account).
+    bool TryStartNextLbRootDatabaseRequest() {
+        TString nextDatabase;
+        for (const auto& [_, info] : LbRootPaths) {
+            if (!RequestedLbRootDatabases.contains(info.AccountDatabase)) {
+                nextDatabase = info.AccountDatabase;
+                break;
+            }
+        }
+        if (nextDatabase.empty()) {
+            return false;
+        }
+
+        RetryWithLbRoot = true;
+        RetryWithSyncVersion = false;
+        RequestDatabaseName = nextDatabase;
+        RequestedLbRootDatabases.insert(nextDatabase);
+
+        absl::flat_hash_set<TString> newPath;
+        for (const auto& [path, info] : LbRootPaths) {
+            if (info.AccountDatabase == nextDatabase) {
+                newPath.insert(path);
+            }
+        }
+
+        DoRequest(newPath);
         return true;
     }
 
@@ -339,6 +383,9 @@ private:
     bool RetryWithCDC = false;
     bool RetryWithLbRoot = false;
     TString LbUserDatabaseRoot;
+    // DatabaseName for the current SchemeCache request (account DB on LbRoot retry).
+    TString RequestDatabaseName;
+    absl::flat_hash_set<TString> RequestedLbRootDatabases;
     // CDC topic path -> original topic path
     struct TCDCTopicInfo {
         TString OriginalPath;
@@ -348,6 +395,7 @@ private:
     // LbUserDatabaseRoot-prefixed path -> original topic path
     struct TLbRootTopicInfo {
         TString OriginalPath;
+        TString AccountDatabase;
     };
     absl::flat_hash_map<TString, TLbRootTopicInfo> LbRootPaths;
     absl::flat_hash_map<TString, TTopicInfo> Result;

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -3,6 +3,9 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
 
+#include <library/cpp/containers/absl/flat_hash_map.h>
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
 #include <util/generic/algorithm.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
@@ -38,7 +41,7 @@ TString MakeLbUserTopicPath(const TString& lbUserDatabaseRoot, const TString& to
 
 class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
 public:
-    TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, const std::unordered_set<TString>&& topicPaths, const TDescribeSettings& settings)
+    TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings)
         : Parent(parent)
         , DatabasePath(databasePath)
         , TopicPaths(std::move(topicPaths))
@@ -54,7 +57,7 @@ public:
         DoRequest(TopicPaths);
     }
 
-    void DoRequest(const std::unordered_set<TString>& topicPath) {
+    void DoRequest(const absl::flat_hash_set<TString>& topicPath) {
         YDB_LOG_DEBUG("Create request with",
             {"logPrefix", LOG_PREFIX},
             {"topicPaths", JoinRange(", ", topicPath.begin(), topicPath.end())},
@@ -89,7 +92,7 @@ public:
             {"logPrefix", LOG_PREFIX});
         auto& result = ev->Get()->Request;
 
-        std::unordered_set<TString> unknownPaths;
+        absl::flat_hash_set<TString> unknownPaths;
 
         for (size_t i = 0; i < result->ResultSet.size(); ++i) {
             const auto& entry = result->ResultSet[i];
@@ -247,7 +250,7 @@ public:
             // Same local→global pattern as for the original topic paths.
             RetryWithSyncVersion = false;
 
-            std::unordered_set<TString> newPath;
+            absl::flat_hash_set<TString> newPath;
             newPath.reserve(LbRootPaths.size());
             for (const auto& [path, _] : LbRootPaths) {
                 newPath.insert(path);
@@ -260,7 +263,7 @@ public:
             RetryWithSyncVersion = false;
             RetryWithCDC = true;
 
-            std::unordered_set<TString> newPath;
+            absl::flat_hash_set<TString> newPath;
             newPath.reserve(CDCPaths.size());
             for (auto& [path, _] : CDCPaths) {
                 newPath.insert(path);
@@ -324,10 +327,10 @@ private:
 private:
     const NActors::TActorId Parent;
     const TString DatabasePath;
-    const std::unordered_set<TString> TopicPaths;
+    const absl::flat_hash_set<TString> TopicPaths;
     const TDescribeSettings Settings;
     // normalized path -> original path
-    std::unordered_map<TString, TString> PathToOriginalPath;
+    absl::flat_hash_map<TString, TString> PathToOriginalPath;
 
     bool RetryWithSyncVersion = false;
     bool UsedSyncVersion = false;
@@ -339,18 +342,18 @@ private:
         TString OriginalPath;
         TString CdcStreamName;
     };
-    std::unordered_map<TString, TCDCTopicInfo> CDCPaths;
+    absl::flat_hash_map<TString, TCDCTopicInfo> CDCPaths;
     // LbUserDatabaseRoot-prefixed path -> original topic path
     struct TLbRootTopicInfo {
         TString OriginalPath;
     };
-    std::unordered_map<TString, TLbRootTopicInfo> LbRootPaths;
-    std::unordered_map<TString, TTopicInfo> Result;
+    absl::flat_hash_map<TString, TLbRootTopicInfo> LbRootPaths;
+    absl::flat_hash_map<TString, TTopicInfo> Result;
 };
 
 } // namespace
 
-NActors::IActor* CreateDescriberActor(const NActors::TActorId& parent, const TString& databasePath, const std::unordered_set<TString>&& topicPaths, const TDescribeSettings& settings) {
+NActors::IActor* CreateDescriberActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings) {
     return new TDescribeActor(parent, databasePath, std::move(topicPaths), settings);
 }
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -175,7 +175,8 @@ public:
 
                         CDCPaths[TStringBuilder() << realPath << "/streamImpl"] = {
                             .OriginalPath = originalPath,
-                            .CdcStreamName = entry.Self->Info.GetName()
+                            .CdcStreamName = entry.Self->Info.GetName(),
+                            .AccountDatabase = RequestDatabaseName
                         };
                         break;
                     } else if (entry.Kind == TSchemeCacheNavigate::EKind::KindTopic) {
@@ -266,18 +267,8 @@ public:
             return;
         }
 
-        if (!CDCPaths.empty() && !RetryWithCDC) {
-            RetryWithSyncVersion = false;
-            RetryWithCDC = true;
-            RequestDatabaseName = DatabasePath;
-
-            absl::flat_hash_set<TString> newPath;
-            newPath.reserve(CDCPaths.size());
-            for (auto& [path, _] : CDCPaths) {
-                newPath.insert(path);
-            }
-
-            return DoRequest(newPath);
+        if (TryStartNextCdcDatabaseRequest()) {
+            return;
         }
 
         Send(Parent, new TEvDescribeTopicsResponse(std::move(Result), UsedSyncVersion));
@@ -359,6 +350,35 @@ private:
         return true;
     }
 
+    // One SchemeCache request per account database for CDC streamImpl paths.
+    bool TryStartNextCdcDatabaseRequest() {
+        TString nextDatabase;
+        for (const auto& [_, info] : CDCPaths) {
+            if (!RequestedCdcDatabases.contains(info.AccountDatabase)) {
+                nextDatabase = info.AccountDatabase;
+                break;
+            }
+        }
+        if (nextDatabase.empty()) {
+            return false;
+        }
+
+        RetryWithCDC = true;
+        RetryWithSyncVersion = false;
+        RequestDatabaseName = nextDatabase;
+        RequestedCdcDatabases.insert(nextDatabase);
+
+        absl::flat_hash_set<TString> newPath;
+        for (const auto& [path, info] : CDCPaths) {
+            if (info.AccountDatabase == nextDatabase) {
+                newPath.insert(path);
+            }
+        }
+
+        DoRequest(newPath);
+        return true;
+    }
+
     void SetErrorResult(const TString& originalPath, EStatus status, const TString& realPath = {}) {
         auto it = Result.find(originalPath);
         if (it != Result.end() && it->second.Status == EStatus::SUCCESS) {
@@ -386,10 +406,12 @@ private:
     // DatabaseName for the current SchemeCache request (account DB on LbRoot retry).
     TString RequestDatabaseName;
     absl::flat_hash_set<TString> RequestedLbRootDatabases;
-    // CDC topic path -> original topic path
+    absl::flat_hash_set<TString> RequestedCdcDatabases;
+    // CDC streamImpl path -> original changefeed path
     struct TCDCTopicInfo {
         TString OriginalPath;
         TString CdcStreamName;
+        TString AccountDatabase;
     };
     absl::flat_hash_map<TString, TCDCTopicInfo> CDCPaths;
     // LbUserDatabaseRoot-prefixed path -> original topic path

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -51,7 +51,9 @@ public:
 
     void Bootstrap() {
         Become(&TDescribeActor::StateWork);
-        LbUserDatabaseRoot = AppData()->PQConfig.GetPQDiscoveryConfig().GetLbUserDatabaseRoot();
+        if (!AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {
+            LbUserDatabaseRoot = AppData()->PQConfig.GetPQDiscoveryConfig().GetLbUserDatabaseRoot();
+        }
         RetryWithSyncVersion = Settings.ForceSyncVersion;
         UsedSyncVersion = Settings.ForceSyncVersion;
         DoRequest(TopicPaths);

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -32,8 +32,8 @@ bool HasAccess(const TDescribeSettings& settings, TIntrusivePtr<TSecurityObject>
     return false;
 }
 
-TString MakeLbUserTopicPath(const TString& lbUserDatabaseRoot, const TString& topicPath) {
-    auto parts = NKikimr::SplitPath(lbUserDatabaseRoot);
+TString MakeFederationTopicPath(const TString& federationRoot, const TString& topicPath) {
+    auto parts = NKikimr::SplitPath(federationRoot);
     for (const auto& part : NKikimr::SplitPath(topicPath)) {
         parts.push_back(part);
     }
@@ -49,8 +49,8 @@ TMaybe<TString> ExtractFederationAccount(const TString& topicPath) {
     return parts[0];
 }
 
-TString MakeLbUserAccountDatabase(const TString& lbUserDatabaseRoot, const TString& account) {
-    return CanonizePath(NKikimr::JoinPath({lbUserDatabaseRoot, account}));
+TString MakeFederationAccountDatabase(const TString& federationRoot, const TString& account) {
+    return CanonizePath(NKikimr::JoinPath({federationRoot, account}));
 }
 
 class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
@@ -66,7 +66,7 @@ public:
     void Bootstrap() {
         Become(&TDescribeActor::StateWork);
         if (!AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {
-            LbUserDatabaseRoot = AppData()->PQConfig.GetPQDiscoveryConfig().GetLbUserDatabaseRoot();
+            FederationRoot = AppData()->PQConfig.GetPQDiscoveryConfig().GetLbUserDatabaseRoot();
         }
         RetryWithSyncVersion = Settings.ForceSyncVersion;
         UsedSyncVersion = Settings.ForceSyncVersion;
@@ -97,7 +97,7 @@ public:
 
         for (const auto& topic : topicPath) {
             auto normalizedPath = NKikimr::NormalizePath(RequestDatabaseName, CanonizePath(topic));
-            // Keep the originally requested path across retries (sync / LbRoot / CDC).
+            // Keep the originally requested path across retries (sync / Federation / CDC).
             PathToOriginalPath.try_emplace(normalizedPath, topic);
             addEntry(normalizedPath);
         }
@@ -126,8 +126,8 @@ public:
                 originalPath = it->second.OriginalPath;
                 isCDCStream = true;
                 cdcStreamName = it->second.CdcStreamName;
-            } else if (auto lbIt = LbRootPaths.find(realPath); lbIt != LbRootPaths.end()) {
-                originalPath = lbIt->second.OriginalPath;
+            } else if (auto federationIt = FederationPaths.find(realPath); federationIt != FederationPaths.end()) {
+                originalPath = federationIt->second.OriginalPath;
             }
 
             switch (entry.Status) {
@@ -141,12 +141,12 @@ public:
                                 {"realPath", realPath});
 
                             SetErrorResult(originalPath, EStatus::UNAUTHORIZED);
-                        } else if (TryScheduleLbRootRetry(originalPath, realPath)) {
-                            YDB_LOG_DEBUG("Path not found, will try LbUserDatabaseRoot",
+                        } else if (TryScheduleFederationRetry(originalPath, realPath)) {
+                            YDB_LOG_DEBUG("Path not found, will try FederationRoot",
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath},
                                 {"originalPath", originalPath},
-                                {"lbUserDatabaseRoot", LbUserDatabaseRoot});
+                                {"federationRoot", FederationRoot});
                         } else {
                             YDB_LOG_DEBUG("Path not found",
                                 {"logPrefix", LOG_PREFIX},
@@ -183,12 +183,12 @@ public:
                     } else if (entry.Kind == TSchemeCacheNavigate::EKind::KindTopic) {
                         if (!entry.PQGroupInfo || entry.PQGroupInfo->Description.GetBalancerTabletID() == 0) {
                             if (RetryWithSyncVersion) {
-                                if (TryScheduleLbRootRetry(originalPath, realPath)) {
-                                    YDB_LOG_DEBUG("Path not found, will try LbUserDatabaseRoot",
+                                if (TryScheduleFederationRetry(originalPath, realPath)) {
+                                    YDB_LOG_DEBUG("Path not found, will try FederationRoot",
                                         {"logPrefix", LOG_PREFIX},
                                         {"realPath", realPath},
                                         {"originalPath", originalPath},
-                                        {"lbUserDatabaseRoot", LbUserDatabaseRoot});
+                                        {"federationRoot", FederationRoot});
                                 } else {
                                     YDB_LOG_DEBUG("Path not found",
                                         {"logPrefix", LOG_PREFIX},
@@ -264,7 +264,7 @@ public:
             return DoRequest(unknownPaths);
         }
 
-        if (TryStartNextLbRootDatabaseRequest()) {
+        if (TryStartNextFederationDatabaseRequest()) {
             return;
         }
 
@@ -284,21 +284,21 @@ public:
     }
 
 private:
-    bool TryScheduleLbRootRetry(const TString& originalPath, const TString& realPath) {
-        if (LbUserDatabaseRoot.empty()) {
+    bool TryScheduleFederationRetry(const TString& originalPath, const TString& realPath) {
+        if (FederationRoot.empty()) {
             return false;
         }
-        if (LbRootPaths.contains(realPath)) {
-            // This response is already for an LbUserDatabaseRoot path.
+        if (FederationPaths.contains(realPath)) {
+            // This response is already for a FederationRoot path.
             return false;
         }
-        for (const auto& [_, info] : LbRootPaths) {
+        for (const auto& [_, info] : FederationPaths) {
             if (info.OriginalPath == originalPath) {
-                // LbUserDatabaseRoot path is already scheduled.
+                // FederationRoot path is already scheduled.
                 return true;
             }
         }
-        if (RetryWithLbRoot) {
+        if (RetryWithFederation) {
             return false;
         }
 
@@ -307,27 +307,27 @@ private:
             return false;
         }
 
-        const auto accountDatabase = MakeLbUserAccountDatabase(LbUserDatabaseRoot, *account);
-        const auto lbPath = MakeLbUserTopicPath(LbUserDatabaseRoot, originalPath);
+        const auto accountDatabase = MakeFederationAccountDatabase(FederationRoot, *account);
+        const auto federationPath = MakeFederationTopicPath(FederationRoot, originalPath);
         // Same path string can still need a retry with DatabaseName = account DB
-        // (e.g. DatabasePath == LbUserDatabaseRoot: /Root/account/topic under /Root).
-        if (lbPath == realPath && RequestDatabaseName == accountDatabase) {
+        // (e.g. DatabasePath == FederationRoot: /Root/account/topic under /Root).
+        if (federationPath == realPath && RequestDatabaseName == accountDatabase) {
             return false;
         }
 
-        LbRootPaths[lbPath] = TLbRootTopicInfo{
+        FederationPaths[federationPath] = TFederationTopicInfo{
             .OriginalPath = originalPath,
             .AccountDatabase = accountDatabase
         };
         return true;
     }
 
-    // One SchemeCache request per account database (DatabaseName = LbRoot/account).
+    // One SchemeCache request per account database (DatabaseName = FederationRoot/account).
     // Empty AccountDatabase is valid (fetch/API callers may pass Database="").
-    bool TryStartNextLbRootDatabaseRequest() {
+    bool TryStartNextFederationDatabaseRequest() {
         TMaybe<TString> nextDatabase;
-        for (const auto& [_, info] : LbRootPaths) {
-            if (!RequestedLbRootDatabases.contains(info.AccountDatabase)) {
+        for (const auto& [_, info] : FederationPaths) {
+            if (!RequestedFederationDatabases.contains(info.AccountDatabase)) {
                 nextDatabase = info.AccountDatabase;
                 break;
             }
@@ -336,13 +336,13 @@ private:
             return false;
         }
 
-        RetryWithLbRoot = true;
+        RetryWithFederation = true;
         RetryWithSyncVersion = false;
         RequestDatabaseName = *nextDatabase;
-        RequestedLbRootDatabases.insert(*nextDatabase);
+        RequestedFederationDatabases.insert(*nextDatabase);
 
         absl::flat_hash_set<TString> newPath;
-        for (const auto& [path, info] : LbRootPaths) {
+        for (const auto& [path, info] : FederationPaths) {
             if (info.AccountDatabase == *nextDatabase) {
                 newPath.insert(path);
             }
@@ -404,11 +404,11 @@ private:
     bool RetryWithSyncVersion = false;
     bool UsedSyncVersion = false;
     bool RetryWithCDC = false;
-    bool RetryWithLbRoot = false;
-    TString LbUserDatabaseRoot;
-    // DatabaseName for the current SchemeCache request (account DB on LbRoot retry).
+    bool RetryWithFederation = false;
+    TString FederationRoot;
+    // DatabaseName for the current SchemeCache request (account DB on Federation retry).
     TString RequestDatabaseName;
-    absl::flat_hash_set<TString> RequestedLbRootDatabases;
+    absl::flat_hash_set<TString> RequestedFederationDatabases;
     absl::flat_hash_set<TString> RequestedCdcDatabases;
     // CDC streamImpl path -> original changefeed path
     struct TCDCTopicInfo {
@@ -417,12 +417,12 @@ private:
         TString AccountDatabase;
     };
     absl::flat_hash_map<TString, TCDCTopicInfo> CDCPaths;
-    // LbUserDatabaseRoot-prefixed path -> original topic path
-    struct TLbRootTopicInfo {
+    // FederationRoot-prefixed path -> original topic path
+    struct TFederationTopicInfo {
         TString OriginalPath;
         TString AccountDatabase;
     };
-    absl::flat_hash_map<TString, TLbRootTopicInfo> LbRootPaths;
+    absl::flat_hash_map<TString, TFederationTopicInfo> FederationPaths;
     absl::flat_hash_map<TString, TTopicInfo> Result;
 };
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -1,6 +1,14 @@
 #include "describer.h"
 
+#include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
+
+#include <library/cpp/containers/absl/flat_hash_map.h>
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
 #include <util/generic/algorithm.h>
+#include <util/generic/maybe.h>
+#include <util/generic/maybe.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
 
@@ -25,9 +33,30 @@ bool HasAccess(const TDescribeSettings& settings, TIntrusivePtr<TSecurityObject>
     return false;
 }
 
+TString MakeLbUserTopicPath(const TString& lbUserDatabaseRoot, const TString& topicPath) {
+    auto parts = NKikimr::SplitPath(lbUserDatabaseRoot);
+    for (const auto& part : NKikimr::SplitPath(topicPath)) {
+        parts.push_back(part);
+    }
+    return CanonizePath(NKikimr::JoinPath(parts));
+}
+
+// First path component is federation account; requires account/topic shape.
+TMaybe<TString> ExtractFederationAccount(const TString& topicPath) {
+    auto parts = NKikimr::SplitPath(topicPath);
+    if (parts.size() < 2 || parts[0].empty()) {
+        return Nothing();
+    }
+    return parts[0];
+}
+
+TString MakeLbUserAccountDatabase(const TString& lbUserDatabaseRoot, const TString& account) {
+    return CanonizePath(NKikimr::JoinPath({lbUserDatabaseRoot, account}));
+}
+
 class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
 public:
-    TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, const std::unordered_set<TString>&& topicPaths, const TDescribeSettings& settings)
+    TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings)
         : Parent(parent)
         , DatabasePath(databasePath)
         , TopicPaths(std::move(topicPaths))
@@ -37,19 +66,24 @@ public:
 
     void Bootstrap() {
         Become(&TDescribeActor::StateWork);
+        if (!AppData()->PQConfig.GetTopicsAreFirstClassCitizen()) {
+            LbUserDatabaseRoot = AppData()->PQConfig.GetPQDiscoveryConfig().GetLbUserDatabaseRoot();
+        }
         RetryWithSyncVersion = Settings.ForceSyncVersion;
         UsedSyncVersion = Settings.ForceSyncVersion;
+        RequestDatabaseName = DatabasePath;
         DoRequest(TopicPaths);
     }
 
-    void DoRequest(const std::unordered_set<TString>& topicPath) {
+    void DoRequest(const absl::flat_hash_set<TString>& topicPath) {
         YDB_LOG_DEBUG("Create request with",
             {"logPrefix", LOG_PREFIX},
             {"topicPaths", JoinRange(", ", topicPath.begin(), topicPath.end())},
-            {"syncVersion", RetryWithSyncVersion});
+            {"syncVersion", RetryWithSyncVersion},
+            {"databaseName", RequestDatabaseName});
 
         auto schemeRequest = std::make_unique<TSchemeCacheNavigate>(1);
-        schemeRequest->DatabaseName = DatabasePath;
+        schemeRequest->DatabaseName = RequestDatabaseName;
 
         auto addEntry = [&](const TString& topic) {
             auto split = NKikimr::SplitPath(topic);
@@ -63,8 +97,9 @@ public:
         };
 
         for (const auto& topic : topicPath) {
-            auto normalizedPath = NKikimr::NormalizePath(DatabasePath, CanonizePath(topic));
-            PathToOriginalPath[normalizedPath] = topic;
+            auto normalizedPath = NKikimr::NormalizePath(RequestDatabaseName, CanonizePath(topic));
+            // Keep the originally requested path across retries (sync / LbRoot / CDC).
+            PathToOriginalPath.try_emplace(normalizedPath, topic);
             addEntry(normalizedPath);
         }
 
@@ -76,7 +111,7 @@ public:
             {"logPrefix", LOG_PREFIX});
         auto& result = ev->Get()->Request;
 
-        std::unordered_set<TString> unknownPaths;
+        absl::flat_hash_set<TString> unknownPaths;
 
         for (size_t i = 0; i < result->ResultSet.size(); ++i) {
             const auto& entry = result->ResultSet[i];
@@ -92,6 +127,8 @@ public:
                 originalPath = it->second.OriginalPath;
                 isCDCStream = true;
                 cdcStreamName = it->second.CdcStreamName;
+            } else if (auto lbIt = LbRootPaths.find(realPath); lbIt != LbRootPaths.end()) {
+                originalPath = lbIt->second.OriginalPath;
             }
 
             switch (entry.Status) {
@@ -104,17 +141,19 @@ public:
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
 
-                            Result[originalPath] = TTopicInfo{
-                                .Status = EStatus::UNAUTHORIZED
-                            };
+                            SetErrorResult(originalPath, EStatus::UNAUTHORIZED);
+                        } else if (TryScheduleLbRootRetry(originalPath, realPath)) {
+                            YDB_LOG_DEBUG("Path not found, will try LbUserDatabaseRoot",
+                                {"logPrefix", LOG_PREFIX},
+                                {"realPath", realPath},
+                                {"originalPath", originalPath},
+                                {"lbUserDatabaseRoot", LbUserDatabaseRoot});
                         } else {
                             YDB_LOG_DEBUG("Path not found",
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
 
-                            Result[originalPath] = TTopicInfo{
-                                .Status = EStatus::NOT_FOUND
-                            };
+                            SetErrorResult(originalPath, EStatus::NOT_FOUND);
                         }
                     } else {
                         unknownPaths.insert(realPath);
@@ -138,18 +177,25 @@ public:
 
                         CDCPaths[TStringBuilder() << realPath << "/streamImpl"] = {
                             .OriginalPath = originalPath,
-                            .CdcStreamName = entry.Self->Info.GetName()
+                            .CdcStreamName = entry.Self->Info.GetName(),
+                            .AccountDatabase = RequestDatabaseName
                         };
                         break;
                     } else if (entry.Kind == TSchemeCacheNavigate::EKind::KindTopic) {
                         if (!entry.PQGroupInfo || entry.PQGroupInfo->Description.GetBalancerTabletID() == 0) {
                             if (RetryWithSyncVersion) {
-                                YDB_LOG_DEBUG("Path not found",
-                                    {"logPrefix", LOG_PREFIX},
-                                    {"realPath", realPath});
-                                Result[originalPath] = TTopicInfo{
-                                    .Status = EStatus::NOT_FOUND
-                                };
+                                if (TryScheduleLbRootRetry(originalPath, realPath)) {
+                                    YDB_LOG_DEBUG("Path not found, will try LbUserDatabaseRoot",
+                                        {"logPrefix", LOG_PREFIX},
+                                        {"realPath", realPath},
+                                        {"originalPath", originalPath},
+                                        {"lbUserDatabaseRoot", LbUserDatabaseRoot});
+                                } else {
+                                    YDB_LOG_DEBUG("Path not found",
+                                        {"logPrefix", LOG_PREFIX},
+                                        {"realPath", realPath});
+                                    SetErrorResult(originalPath, EStatus::NOT_FOUND);
+                                }
                             } else {
                                 unknownPaths.insert(realPath);
                             }
@@ -189,7 +235,7 @@ public:
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
                             Result[originalPath] = TTopicInfo{
-                                .Status = EStatus::UNAUTHORIZED
+                                .Status = EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS
                             };
                         } else {
                             Result[originalPath] = TTopicInfo{
@@ -219,17 +265,12 @@ public:
             return DoRequest(unknownPaths);
         }
 
-        if (!CDCPaths.empty() && !RetryWithCDC) {
-            RetryWithSyncVersion = false;
-            RetryWithCDC = true;
+        if (TryStartNextLbRootDatabaseRequest()) {
+            return;
+        }
 
-            std::unordered_set<TString> newPath;
-            newPath.reserve(CDCPaths.size());
-            for (auto& [path, _] : CDCPaths) {
-                newPath.insert(path);
-            }
-
-            return DoRequest(newPath);
+        if (TryStartNextCdcDatabaseRequest()) {
+            return;
         }
 
         Send(Parent, new TEvDescribeTopicsResponse(std::move(Result), UsedSyncVersion));
@@ -244,28 +285,151 @@ public:
     }
 
 private:
+    bool TryScheduleLbRootRetry(const TString& originalPath, const TString& realPath) {
+        if (LbUserDatabaseRoot.empty()) {
+            return false;
+        }
+        if (LbRootPaths.contains(realPath)) {
+            // This response is already for an LbUserDatabaseRoot path.
+            return false;
+        }
+        for (const auto& [_, info] : LbRootPaths) {
+            if (info.OriginalPath == originalPath) {
+                // LbUserDatabaseRoot path is already scheduled.
+                return true;
+            }
+        }
+        if (RetryWithLbRoot) {
+            return false;
+        }
+
+        const auto account = ExtractFederationAccount(originalPath);
+        if (!account.Defined()) {
+            return false;
+        }
+
+        const auto accountDatabase = MakeLbUserAccountDatabase(LbUserDatabaseRoot, *account);
+        const auto lbPath = MakeLbUserTopicPath(LbUserDatabaseRoot, originalPath);
+        // Same path string can still need a retry with DatabaseName = account DB
+        // (e.g. DatabasePath == LbUserDatabaseRoot: /Root/account/topic under /Root).
+        if (lbPath == realPath && RequestDatabaseName == accountDatabase) {
+            return false;
+        }
+
+        LbRootPaths[lbPath] = TLbRootTopicInfo{
+            .OriginalPath = originalPath,
+            .AccountDatabase = accountDatabase
+        };
+        return true;
+    }
+
+    // One SchemeCache request per account database (DatabaseName = LbRoot/account).
+    // Empty AccountDatabase is valid (fetch/API callers may pass Database="").
+    bool TryStartNextLbRootDatabaseRequest() {
+        TMaybe<TString> nextDatabase;
+        for (const auto& [_, info] : LbRootPaths) {
+            if (!RequestedLbRootDatabases.contains(info.AccountDatabase)) {
+                nextDatabase = info.AccountDatabase;
+                break;
+            }
+        }
+        if (!nextDatabase.Defined()) {
+            return false;
+        }
+
+        RetryWithLbRoot = true;
+        RetryWithSyncVersion = false;
+        RequestDatabaseName = *nextDatabase;
+        RequestedLbRootDatabases.insert(*nextDatabase);
+
+        absl::flat_hash_set<TString> newPath;
+        for (const auto& [path, info] : LbRootPaths) {
+            if (info.AccountDatabase == *nextDatabase) {
+                newPath.insert(path);
+            }
+        }
+
+        DoRequest(newPath);
+        return true;
+    }
+
+    // One SchemeCache request per account database for CDC streamImpl paths.
+    // Empty AccountDatabase is valid (fetch/API callers may pass Database="").
+    bool TryStartNextCdcDatabaseRequest() {
+        TMaybe<TString> nextDatabase;
+        for (const auto& [_, info] : CDCPaths) {
+            if (!RequestedCdcDatabases.contains(info.AccountDatabase)) {
+                nextDatabase = info.AccountDatabase;
+                break;
+            }
+        }
+        if (!nextDatabase.Defined()) {
+            return false;
+        }
+
+        RetryWithCDC = true;
+        RetryWithSyncVersion = false;
+        RequestDatabaseName = *nextDatabase;
+        RequestedCdcDatabases.insert(*nextDatabase);
+
+        absl::flat_hash_set<TString> newPath;
+        for (const auto& [path, info] : CDCPaths) {
+            if (info.AccountDatabase == *nextDatabase) {
+                newPath.insert(path);
+            }
+        }
+
+        DoRequest(newPath);
+        return true;
+    }
+
+    void SetErrorResult(const TString& originalPath, EStatus status, const TString& realPath = {}) {
+        auto it = Result.find(originalPath);
+        if (it != Result.end() && it->second.Status == EStatus::SUCCESS) {
+            return;
+        }
+        Result[originalPath] = TTopicInfo{
+            .Status = status,
+            .RealPath = realPath
+        };
+    }
+
+private:
     const NActors::TActorId Parent;
     const TString DatabasePath;
-    const std::unordered_set<TString> TopicPaths;
+    const absl::flat_hash_set<TString> TopicPaths;
     const TDescribeSettings Settings;
     // normalized path -> original path
-    std::unordered_map<TString, TString> PathToOriginalPath;
+    absl::flat_hash_map<TString, TString> PathToOriginalPath;
 
     bool RetryWithSyncVersion = false;
     bool UsedSyncVersion = false;
     bool RetryWithCDC = false;
-    // CDC topic path -> original topic path
+    bool RetryWithLbRoot = false;
+    TString LbUserDatabaseRoot;
+    // DatabaseName for the current SchemeCache request (account DB on LbRoot retry).
+    TString RequestDatabaseName;
+    absl::flat_hash_set<TString> RequestedLbRootDatabases;
+    absl::flat_hash_set<TString> RequestedCdcDatabases;
+    // CDC streamImpl path -> original changefeed path
     struct TCDCTopicInfo {
         TString OriginalPath;
         TString CdcStreamName;
+        TString AccountDatabase;
     };
-    std::unordered_map<TString, TCDCTopicInfo> CDCPaths;
-    std::unordered_map<TString, TTopicInfo> Result;
+    absl::flat_hash_map<TString, TCDCTopicInfo> CDCPaths;
+    // LbUserDatabaseRoot-prefixed path -> original topic path
+    struct TLbRootTopicInfo {
+        TString OriginalPath;
+        TString AccountDatabase;
+    };
+    absl::flat_hash_map<TString, TLbRootTopicInfo> LbRootPaths;
+    absl::flat_hash_map<TString, TTopicInfo> Result;
 };
 
 } // namespace
 
-NActors::IActor* CreateDescriberActor(const NActors::TActorId& parent, const TString& databasePath, const std::unordered_set<TString>&& topicPaths, const TDescribeSettings& settings) {
+NActors::IActor* CreateDescriberActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings) {
     return new TDescribeActor(parent, databasePath, std::move(topicPaths), settings);
 }
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -190,9 +190,7 @@ public:
                     YDB_LOG_DEBUG("Path ACCESS DENIED",
                         {"logPrefix", LOG_PREFIX},
                         {"realPath", realPath});
-                    Result[originalPath] = TTopicInfo{
-                        .Status = EStatus::UNAUTHORIZED
-                    };
+                    SetErrorResult(originalPath, EStatus::UNAUTHORIZED);
                     break;
                 }
                 case TSchemeCacheNavigate::EStatus::Ok: {
@@ -313,6 +311,10 @@ public:
 private:
     bool TryScheduleFederationRetry(const TString& originalPath, const TString& realPath) {
         if (FederationRoot.empty()) {
+            return false;
+        }
+        if (CDCPaths.contains(realPath)) {
+            // streamImpl miss must not spawn FederationRoot/<...>/streamImpl retries.
             return false;
         }
         if (FederationPaths.contains(realPath)) {

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -7,7 +7,8 @@
 #include <library/cpp/containers/absl/flat_hash_set.h>
 
 #include <util/generic/algorithm.h>
-#include <util/generic/maybe.h>
+
+#include <optional>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
 
@@ -41,10 +42,10 @@ TString MakeFederationTopicPath(const TString& federationRoot, const TString& to
 }
 
 // First path component is federation account; requires account/topic shape.
-TMaybe<TString> ExtractFederationAccount(const TString& topicPath) {
+std::optional<TString> ExtractFederationAccount(const TString& topicPath) {
     auto parts = NKikimr::SplitPath(topicPath);
     if (parts.size() < 2 || parts[0].empty()) {
-        return Nothing();
+        return std::nullopt;
     }
     return parts[0];
 }
@@ -56,16 +57,16 @@ TString MakeFederationAccountDatabase(const TString& federationRoot, const TStri
 // Federation retries append account/topic under FederationRoot. Build that relative
 // suffix from the navigated absolute path vs the request database — never from a
 // database-prefixed originalPath (would become FederationRoot/Root/account/...).
-TMaybe<TString> MakeFederationRelativeTopicPath(const TString& databasePath, const TString& originalPath, const TString& realPath) {
+std::optional<TString> MakeFederationRelativeTopicPath(const TString& databasePath, const TString& originalPath, const TString& realPath) {
     if (!databasePath.empty()) {
         const auto dbParts = NKikimr::SplitPath(databasePath);
         const auto realParts = NKikimr::SplitPath(realPath);
         if (realParts.size() <= dbParts.size()) {
-            return Nothing();
+            return std::nullopt;
         }
         for (size_t i = 0; i < dbParts.size(); ++i) {
             if (dbParts[i] != realParts[i]) {
-                return Nothing();
+                return std::nullopt;
             }
         }
         return NKikimr::JoinPath(TVector<TString>(realParts.begin() + dbParts.size(), realParts.end()));
@@ -74,7 +75,7 @@ TMaybe<TString> MakeFederationRelativeTopicPath(const TString& databasePath, con
     // No database in the request: originalPath must already be account/topic-shaped.
     const auto parts = NKikimr::SplitPath(originalPath);
     if (parts.size() < 2 || parts[0].empty()) {
-        return Nothing();
+        return std::nullopt;
     }
     return NKikimr::JoinPath(parts);
 }
@@ -329,12 +330,12 @@ private:
         }
 
         const auto relativePath = MakeFederationRelativeTopicPath(DatabasePath, originalPath, realPath);
-        if (!relativePath.Defined()) {
+        if (!relativePath) {
             return false;
         }
 
         const auto account = ExtractFederationAccount(*relativePath);
-        if (!account.Defined()) {
+        if (!account) {
             return false;
         }
 
@@ -356,14 +357,14 @@ private:
     // One SchemeCache request per account database (DatabaseName = FederationRoot/account).
     // Empty AccountDatabase is valid (fetch/API callers may pass Database="").
     bool TryStartNextFederationDatabaseRequest() {
-        TMaybe<TString> nextDatabase;
+        std::optional<TString> nextDatabase;
         for (const auto& [_, info] : FederationPaths) {
             if (!RequestedFederationDatabases.contains(info.AccountDatabase)) {
                 nextDatabase = info.AccountDatabase;
                 break;
             }
         }
-        if (!nextDatabase.Defined()) {
+        if (!nextDatabase) {
             return false;
         }
 
@@ -386,14 +387,14 @@ private:
     // One SchemeCache request per account database for CDC streamImpl paths.
     // Empty AccountDatabase is valid (fetch/API callers may pass Database="").
     bool TryStartNextCdcDatabaseRequest() {
-        TMaybe<TString> nextDatabase;
+        std::optional<TString> nextDatabase;
         for (const auto& [_, info] : CDCPaths) {
             if (!RequestedCdcDatabases.contains(info.AccountDatabase)) {
                 nextDatabase = info.AccountDatabase;
                 break;
             }
         }
-        if (!nextDatabase.Defined()) {
+        if (!nextDatabase) {
             return false;
         }
 

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -8,7 +8,6 @@
 
 #include <util/generic/algorithm.h>
 #include <util/generic/maybe.h>
-#include <util/generic/maybe.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_DESCRIBER
 
@@ -235,7 +234,7 @@ public:
                                 {"logPrefix", LOG_PREFIX},
                                 {"realPath", realPath});
                             Result[originalPath] = TTopicInfo{
-                                .Status = EStatus::UNAUTHORIZED_WITH_DESCRIBE_ACCESS
+                                .Status = EStatus::UNAUTHORIZED
                             };
                         } else {
                             Result[originalPath] = TTopicInfo{

--- a/ydb/core/persqueue/public/describer/describer.cpp
+++ b/ydb/core/persqueue/public/describer/describer.cpp
@@ -53,6 +53,32 @@ TString MakeFederationAccountDatabase(const TString& federationRoot, const TStri
     return CanonizePath(NKikimr::JoinPath({federationRoot, account}));
 }
 
+// Federation retries append account/topic under FederationRoot. Build that relative
+// suffix from the navigated absolute path vs the request database — never from a
+// database-prefixed originalPath (would become FederationRoot/Root/account/...).
+TMaybe<TString> MakeFederationRelativeTopicPath(const TString& databasePath, const TString& originalPath, const TString& realPath) {
+    if (!databasePath.empty()) {
+        const auto dbParts = NKikimr::SplitPath(databasePath);
+        const auto realParts = NKikimr::SplitPath(realPath);
+        if (realParts.size() <= dbParts.size()) {
+            return Nothing();
+        }
+        for (size_t i = 0; i < dbParts.size(); ++i) {
+            if (dbParts[i] != realParts[i]) {
+                return Nothing();
+            }
+        }
+        return NKikimr::JoinPath(TVector<TString>(realParts.begin() + dbParts.size(), realParts.end()));
+    }
+
+    // No database in the request: originalPath must already be account/topic-shaped.
+    const auto parts = NKikimr::SplitPath(originalPath);
+    if (parts.size() < 2 || parts[0].empty()) {
+        return Nothing();
+    }
+    return NKikimr::JoinPath(parts);
+}
+
 class TDescribeActor : public TActorBootstrapped<TDescribeActor> {
 public:
     TDescribeActor(const NActors::TActorId& parent, const TString& databasePath, absl::flat_hash_set<TString>&& topicPaths, const TDescribeSettings& settings)
@@ -302,13 +328,18 @@ private:
             return false;
         }
 
-        const auto account = ExtractFederationAccount(originalPath);
+        const auto relativePath = MakeFederationRelativeTopicPath(DatabasePath, originalPath, realPath);
+        if (!relativePath.Defined()) {
+            return false;
+        }
+
+        const auto account = ExtractFederationAccount(*relativePath);
         if (!account.Defined()) {
             return false;
         }
 
         const auto accountDatabase = MakeFederationAccountDatabase(FederationRoot, *account);
-        const auto federationPath = MakeFederationTopicPath(FederationRoot, originalPath);
+        const auto federationPath = MakeFederationTopicPath(FederationRoot, *relativePath);
         // Same path string can still need a retry with DatabaseName = account DB
         // (e.g. DatabasePath == FederationRoot: /Root/account/topic under /Root).
         if (federationPath == realPath && RequestDatabaseName == accountDatabase) {

--- a/ydb/core/persqueue/public/describer/describer.h
+++ b/ydb/core/persqueue/public/describer/describer.h
@@ -5,6 +5,9 @@
 #include <ydb/library/actors/core/actorsystem_fwd.h>
 #include <ydb/public/api/protos/ydb_status_codes.pb.h>
 
+#include <library/cpp/containers/absl/flat_hash_map.h>
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
 namespace NKikimr::NPQ::NDescriber {
 
 enum EEv : ui32 {
@@ -56,14 +59,14 @@ struct TTopicInfo {
 
 struct TEvDescribeTopicsResponse : public NActors::TEventLocal<TEvDescribeTopicsResponse, EEv::EvDescribeTopicsResponse> {
 
-    TEvDescribeTopicsResponse(std::unordered_map<TString, TTopicInfo>&& topics, bool usedSyncVersion)
+    TEvDescribeTopicsResponse(absl::flat_hash_map<TString, TTopicInfo>&& topics, bool usedSyncVersion)
         : Topics(std::move(topics))
         , UsedSyncVersion(usedSyncVersion)
     {
     }
 
     // The original topic path (from request) -> TopicInfo
-    std::unordered_map<TString, TTopicInfo> Topics;
+    absl::flat_hash_map<TString, TTopicInfo> Topics;
     bool UsedSyncVersion = false;
 };
 
@@ -75,7 +78,7 @@ struct TDescribeSettings {
 
 NActors::IActor* CreateDescriberActor(const NActors::TActorId& parent,
                                       const TString& databasePath,
-                                      const std::unordered_set<TString>&& topicPaths,
+                                      absl::flat_hash_set<TString>&& topicPaths,
                                       const TDescribeSettings& settings = {});
 
 Ydb::StatusIds::StatusCode Convert(const EStatus status);

--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -274,6 +274,30 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NOT_FOUND);
     }
 
+    Y_UNIT_TEST(CdcStreamImplNotFoundSkipsFederation) {
+        // Broken streamImpl must not schedule a FederationRoot rewrite of .../streamImpl.
+        ui32 requests = 0;
+        TDescribeEnv env([&](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            requests = requestIndex + 1;
+            if (requestIndex == 0) {
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+                FillCdcStream(entry);
+                return;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+            UNIT_ASSERT(EntryPath(entry).EndsWith("/streamImpl"));
+            entry.Status = TNavigate::EStatus::PathErrorUnknown;
+        });
+        env.EnableFederationRoot("/Root/Federation");
+
+        env.StartDescribe({"/Root/table1/feed"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(requests, 3u); // feed + streamImpl + sync streamImpl
+        UNIT_ASSERT(ev->UsedSyncVersion);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
     Y_UNIT_TEST(CdcWithEmptyDatabase) {
         // Regression: empty DatabaseName must still schedule streamImpl retry.
         TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {

--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -1,9 +1,11 @@
 #include "describer.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/core/base/path.h>
 #include <ydb/core/testlib/basics/appdata.h>
 #include <ydb/core/testlib/basics/runtime.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/library/aclib/aclib.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 
@@ -14,7 +16,7 @@ using namespace NActors;
 using namespace NSchemeCache;
 
 using TNavigate = TSchemeCacheNavigate;
-using TFiller = std::function<void(ui32 /*requestIndex*/, TNavigate::TEntry&)>;
+using TFiller = std::function<void(ui32 /*requestIndex*/, TNavigate& /*request*/, TNavigate::TEntry&)>;
 
 class TFakeSchemeCacheActor : public TActorBootstrapped<TFakeSchemeCacheActor> {
 public:
@@ -36,7 +38,7 @@ private:
         const ui32 index = RequestIndex++;
         auto request = std::move(ev->Get()->Request);
         for (auto& entry : request->ResultSet) {
-            Filler(index, entry);
+            Filler(index, *request, entry);
         }
         Send(ev->Sender, new TEvTxProxySchemeCache::TEvNavigateKeySetResult(std::move(request)));
     }
@@ -45,6 +47,10 @@ private:
     ui32 RequestIndex = 0;
 };
 
+TString EntryPath(const TNavigate::TEntry& entry) {
+    return CanonizePath(JoinPath(entry.Path));
+}
+
 void FillOkTopic(TNavigate::TEntry& entry, ui64 balancerTabletId) {
     entry.Status = TNavigate::EStatus::Ok;
     entry.Kind = TNavigate::EKind::KindTopic;
@@ -52,6 +58,14 @@ void FillOkTopic(TNavigate::TEntry& entry, ui64 balancerTabletId) {
     pqInfo->Description.SetBalancerTabletID(balancerTabletId);
     entry.PQGroupInfo = pqInfo;
     entry.CreateStep = 1;
+}
+
+void FillCdcStream(TNavigate::TEntry& entry, const TString& streamName = "feed") {
+    entry.Status = TNavigate::EStatus::Ok;
+    entry.Kind = TNavigate::EKind::KindCdcStream;
+    auto self = MakeIntrusive<TNavigate::TDirEntryInfo>();
+    self->Info.SetName(streamName);
+    entry.Self = self;
 }
 
 struct TDescribeEnv {
@@ -69,6 +83,12 @@ struct TDescribeEnv {
         Runtime.RegisterService(MakeSchemeCacheID(), schemeCacheId);
 
         EdgeId = Runtime.AllocateEdgeActor();
+    }
+
+    void EnableLbRoot(const TString& lbRoot = "/Root/LbAccount") {
+        auto& appData = Runtime.GetAppData();
+        appData.PQConfig.SetTopicsAreFirstClassCitizen(false);
+        appData.PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(lbRoot);
     }
 
     TActorId StartDescribe(
@@ -97,7 +117,7 @@ struct TDescribeEnv {
 Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
 
     Y_UNIT_TEST(AccessDeniedFromSchemeCache) {
-        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate::TEntry& entry) {
+        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate& /*request*/, TNavigate::TEntry& entry) {
             entry.Status = TNavigate::EStatus::AccessDenied;
         });
 
@@ -110,7 +130,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
     }
 
     Y_UNIT_TEST(IncompleteTopicBalancerZero) {
-        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate::TEntry& entry) {
+        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate& /*request*/, TNavigate::TEntry& entry) {
             // KindTopic without balancer — incomplete create; triggers sync retry then NOT_FOUND.
             entry.Status = TNavigate::EStatus::Ok;
             entry.Kind = TNavigate::EKind::KindTopic;
@@ -126,7 +146,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
     }
 
     Y_UNIT_TEST(IncompleteTopicBalancerTabletIdZero) {
-        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate::TEntry& entry) {
+        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate& /*request*/, TNavigate::TEntry& entry) {
             FillOkTopic(entry, /*balancerTabletId=*/0);
         });
 
@@ -138,8 +158,29 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::NOT_FOUND);
     }
 
+    Y_UNIT_TEST(IncompleteTopicThenSuccessOnSync) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& /*request*/, TNavigate::TEntry& entry) {
+            if (requestIndex == 0) {
+                UNIT_ASSERT(!entry.SyncVersion);
+                entry.Status = TNavigate::EStatus::Ok;
+                entry.Kind = TNavigate::EKind::KindTopic;
+                entry.PQGroupInfo = nullptr;
+                return;
+            }
+            UNIT_ASSERT(entry.SyncVersion);
+            FillOkTopic(entry, /*balancerTabletId=*/77);
+        });
+
+        env.StartDescribe({"/Root/topic1"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT(ev->UsedSyncVersion);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/topic1"].Info->Description.GetBalancerTabletID(), 77u);
+    }
+
     Y_UNIT_TEST(UsedSyncVersionOnCacheMiss) {
-        TDescribeEnv env([](ui32 requestIndex, TNavigate::TEntry& entry) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& /*request*/, TNavigate::TEntry& entry) {
             if (requestIndex == 0) {
                 UNIT_ASSERT(!entry.SyncVersion);
                 entry.Status = TNavigate::EStatus::PathErrorUnknown;
@@ -161,7 +202,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
     }
 
     Y_UNIT_TEST(UnknownErrorFromSchemeCache) {
-        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate::TEntry& entry) {
+        TDescribeEnv env([](ui32 /*requestIndex*/, TNavigate& /*request*/, TNavigate::TEntry& entry) {
             entry.Status = TNavigate::EStatus::LookupError;
         });
 
@@ -175,7 +216,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
     }
 
     Y_UNIT_TEST(RootUnknownTriggersSyncThenNotFound) {
-        TDescribeEnv env([](ui32 requestIndex, TNavigate::TEntry& entry) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& /*request*/, TNavigate::TEntry& entry) {
             if (requestIndex == 0) {
                 entry.Status = TNavigate::EStatus::RootUnknown;
                 return;
@@ -189,6 +230,165 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT(ev->Topics.contains("/Root/missing"));
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/missing"].Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(CdcThenStreamImplSuccess) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+            if (requestIndex == 0) {
+                UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/table1/feed");
+                FillCdcStream(entry, "feed");
+                return;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(requestIndex, 1u);
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/table1/feed/streamImpl");
+            FillOkTopic(entry, /*balancerTabletId=*/99);
+        });
+
+        env.StartDescribe({"/Root/table1/feed"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT(ev->Topics.contains("/Root/table1/feed"));
+        auto& info = ev->Topics["/Root/table1/feed"];
+        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/table1/feed/streamImpl");
+        UNIT_ASSERT(info.CdcStream);
+        UNIT_ASSERT_VALUES_EQUAL(info.CdcStreamName, "feed");
+        UNIT_ASSERT_VALUES_EQUAL(info.Info->Description.GetBalancerTabletID(), 99u);
+    }
+
+    Y_UNIT_TEST(CdcThenStreamImplNotFound) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& /*request*/, TNavigate::TEntry& entry) {
+            if (requestIndex == 0) {
+                FillCdcStream(entry);
+                return;
+            }
+            // streamImpl miss → sync retry → still miss → NOT_FOUND
+            entry.Status = TNavigate::EStatus::PathErrorUnknown;
+        });
+
+        env.StartDescribe({"/Root/table1/feed"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT(ev->UsedSyncVersion);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(CdcWithEmptyDatabase) {
+        // Regression: empty DatabaseName must still schedule streamImpl retry.
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            UNIT_ASSERT(request.DatabaseName.empty());
+            if (requestIndex == 0) {
+                UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/table1/feed");
+                FillCdcStream(entry);
+                return;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/table1/feed/streamImpl");
+            FillOkTopic(entry, /*balancerTabletId=*/55);
+        });
+
+        env.StartDescribe({"/Root/table1/feed"}, {}, /*databasePath=*/"");
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT(ev->Topics["/Root/table1/feed"].CdcStream);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].RealPath, "/Root/table1/feed/streamImpl");
+    }
+
+    Y_UNIT_TEST(CdcThenStreamImplAccessDenied) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& /*request*/, TNavigate::TEntry& entry) {
+            if (requestIndex == 0) {
+                FillCdcStream(entry);
+                return;
+            }
+            entry.Status = TNavigate::EStatus::AccessDenied;
+        });
+
+        env.StartDescribe({"/Root/table1/feed"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::UNAUTHORIZED);
+    }
+
+    Y_UNIT_TEST(LbRootRetryAfterMiss) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            if (requestIndex == 0) {
+                // Local resolve under /Root misses federation-style short path.
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+                entry.Status = TNavigate::EStatus::PathErrorUnknown;
+                return;
+            }
+            if (requestIndex == 1) {
+                // Sync retry still misses.
+                UNIT_ASSERT(entry.SyncVersion);
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+                entry.Status = TNavigate::EStatus::PathErrorUnknown;
+                return;
+            }
+            // LbRoot account DB request.
+            UNIT_ASSERT_VALUES_EQUAL(requestIndex, 2u);
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/LbAccount/account");
+            UNIT_ASSERT(!entry.SyncVersion);
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/LbAccount/account/topic1");
+            FillOkTopic(entry, /*balancerTabletId=*/123);
+        });
+        env.EnableLbRoot("/Root/LbAccount");
+
+        env.StartDescribe({"account/topic1"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT(ev->UsedSyncVersion);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].RealPath, "/Root/LbAccount/account/topic1");
+    }
+
+    Y_UNIT_TEST(LbRootSkippedForSingleComponentPath) {
+        ui32 requests = 0;
+        TDescribeEnv env([&](ui32 /*requestIndex*/, TNavigate& request, TNavigate::TEntry& entry) {
+            ++requests;
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+            entry.Status = TNavigate::EStatus::PathErrorUnknown;
+        });
+        env.EnableLbRoot("/Root/LbAccount");
+
+        // No account/topic shape → ExtractFederationAccount fails → no LbRoot retry.
+        env.StartDescribe({"topic1"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(requests, 2u); // local + sync only
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(SetErrorResultPreservesSuccess) {
+        // One topic succeeds locally; another misses into LbRoot and fails there.
+        // Failure for the second must not erase the first SUCCESS.
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            const auto path = EntryPath(entry);
+            if (requestIndex == 0) {
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+                if (path == "/Root/local") {
+                    FillOkTopic(entry, /*balancerTabletId=*/1);
+                } else {
+                    entry.Status = TNavigate::EStatus::PathErrorUnknown;
+                }
+                return;
+            }
+            if (request.DatabaseName == "/Root") {
+                // Sync retry for the missing federation topic only.
+                entry.Status = TNavigate::EStatus::PathErrorUnknown;
+                return;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/LbAccount/account");
+            entry.Status = TNavigate::EStatus::PathErrorUnknown;
+        });
+        env.EnableLbRoot("/Root/LbAccount");
+
+        env.StartDescribe({"/Root/local", "account/missing"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/local"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/missing"].Status, NDescriber::EStatus::NOT_FOUND);
     }
 
 }

--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -85,10 +85,10 @@ struct TDescribeEnv {
         EdgeId = Runtime.AllocateEdgeActor();
     }
 
-    void EnableLbRoot(const TString& lbRoot = "/Root/LbAccount") {
+    void EnableFederationRoot(const TString& federationRoot = "/Root/Federation") {
         auto& appData = Runtime.GetAppData();
         appData.PQConfig.SetTopicsAreFirstClassCitizen(false);
-        appData.PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(lbRoot);
+        appData.PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(federationRoot);
     }
 
     TActorId StartDescribe(
@@ -310,7 +310,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/table1/feed"].Status, NDescriber::EStatus::UNAUTHORIZED);
     }
 
-    Y_UNIT_TEST(LbRootRetryAfterMiss) {
+    Y_UNIT_TEST(FederationRetryAfterMiss) {
         TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
             if (requestIndex == 0) {
                 // Local resolve under /Root misses federation-style short path.
@@ -325,33 +325,33 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
                 entry.Status = TNavigate::EStatus::PathErrorUnknown;
                 return;
             }
-            // LbRoot account DB request.
+            // Federation account DB request.
             UNIT_ASSERT_VALUES_EQUAL(requestIndex, 2u);
-            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/LbAccount/account");
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/Federation/account");
             UNIT_ASSERT(!entry.SyncVersion);
-            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/LbAccount/account/topic1");
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/Federation/account/topic1");
             FillOkTopic(entry, /*balancerTabletId=*/123);
         });
-        env.EnableLbRoot("/Root/LbAccount");
+        env.EnableFederationRoot("/Root/Federation");
 
         env.StartDescribe({"account/topic1"});
         auto ev = env.WaitResponse();
 
         UNIT_ASSERT(ev->UsedSyncVersion);
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].Status, NDescriber::EStatus::SUCCESS);
-        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].RealPath, "/Root/LbAccount/account/topic1");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].RealPath, "/Root/Federation/account/topic1");
     }
 
-    Y_UNIT_TEST(LbRootSkippedForSingleComponentPath) {
+    Y_UNIT_TEST(FederationSkippedForSingleComponentPath) {
         ui32 requests = 0;
         TDescribeEnv env([&](ui32 /*requestIndex*/, TNavigate& request, TNavigate::TEntry& entry) {
             ++requests;
             UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
             entry.Status = TNavigate::EStatus::PathErrorUnknown;
         });
-        env.EnableLbRoot("/Root/LbAccount");
+        env.EnableFederationRoot("/Root/Federation");
 
-        // No account/topic shape → ExtractFederationAccount fails → no LbRoot retry.
+        // No account/topic shape → ExtractFederationAccount fails → no Federation retry.
         env.StartDescribe({"topic1"});
         auto ev = env.WaitResponse();
 
@@ -360,7 +360,7 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
     }
 
     Y_UNIT_TEST(SetErrorResultPreservesSuccess) {
-        // One topic succeeds locally; another misses into LbRoot and fails there.
+        // One topic succeeds locally; another misses into Federation and fails there.
         // Failure for the second must not erase the first SUCCESS.
         TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
             const auto path = EntryPath(entry);
@@ -378,10 +378,10 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
                 entry.Status = TNavigate::EStatus::PathErrorUnknown;
                 return;
             }
-            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/LbAccount/account");
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/Federation/account");
             entry.Status = TNavigate::EStatus::PathErrorUnknown;
         });
-        env.EnableLbRoot("/Root/LbAccount");
+        env.EnableFederationRoot("/Root/Federation");
 
         env.StartDescribe({"/Root/local", "account/missing"});
         auto ev = env.WaitResponse();

--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -72,7 +72,7 @@ struct TDescribeEnv {
     }
 
     TActorId StartDescribe(
-        std::unordered_set<TString> topics,
+        absl::flat_hash_set<TString> topics,
         const NDescriber::TDescribeSettings& settings = {},
         const TString& databasePath = "/Root")
     {

--- a/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_fake_scheme_cache_ut.cpp
@@ -342,6 +342,62 @@ Y_UNIT_TEST_SUITE(TDescriberFakeSchemeCacheTests) {
         UNIT_ASSERT_VALUES_EQUAL(ev->Topics["account/topic1"].RealPath, "/Root/Federation/account/topic1");
     }
 
+    Y_UNIT_TEST(FederationRetryAbsoluteDatabasePrefixedPath) {
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            if (requestIndex < 2) {
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+                UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/account/topic1");
+                entry.Status = TNavigate::EStatus::PathErrorUnknown;
+                return;
+            }
+            // Must not navigate FederationRoot/Root/account/topic1.
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/Federation/account");
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/Federation/account/topic1");
+            FillOkTopic(entry, /*balancerTabletId=*/7);
+        });
+        env.EnableFederationRoot("/Root/Federation");
+
+        env.StartDescribe({"/Root/account/topic1"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/account/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Topics["/Root/account/topic1"].RealPath, "/Root/Federation/account/topic1");
+    }
+
+    Y_UNIT_TEST(FederationThenCdcKeepsAccountDatabase) {
+        // CDC discovered under a Federation account DB must retry streamImpl with
+        // the same AccountDatabase, not the original DatabasePath.
+        TDescribeEnv env([](ui32 requestIndex, TNavigate& request, TNavigate::TEntry& entry) {
+            if (requestIndex < 2) {
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root");
+                entry.Status = TNavigate::EStatus::PathErrorUnknown;
+                return;
+            }
+            if (requestIndex == 2) {
+                UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/Federation/account");
+                UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/Federation/account/table1/feed");
+                FillCdcStream(entry, "feed");
+                return;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(requestIndex, 3u);
+            UNIT_ASSERT_VALUES_EQUAL(request.DatabaseName, "/Root/Federation/account");
+            UNIT_ASSERT_VALUES_EQUAL(EntryPath(entry), "/Root/Federation/account/table1/feed/streamImpl");
+            FillOkTopic(entry, /*balancerTabletId=*/88);
+        });
+        env.EnableFederationRoot("/Root/Federation");
+
+        env.StartDescribe({"account/table1/feed"});
+        auto ev = env.WaitResponse();
+
+        UNIT_ASSERT(ev->Topics.contains("account/table1/feed"));
+        auto& info = ev->Topics["account/table1/feed"];
+        UNIT_ASSERT_VALUES_EQUAL(info.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT(info.CdcStream);
+        UNIT_ASSERT_VALUES_EQUAL(info.CdcStreamName, "feed");
+        UNIT_ASSERT_VALUES_EQUAL(info.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
+        UNIT_ASSERT_VALUES_EQUAL(info.Info->Description.GetBalancerTabletID(), 88u);
+    }
+
     Y_UNIT_TEST(FederationSkippedForSingleComponentPath) {
         ui32 requests = 0;
         TDescribeEnv env([&](ui32 /*requestIndex*/, TNavigate& request, TNavigate::TEntry& entry) {

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -1,7 +1,13 @@
 #include "describer.h"
 
+#include <ydb/core/base/channel_profiles.h>
+#include <ydb/core/cms/console/console.h>
+#include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/testlib/basics/helpers.h>
 #include <ydb/core/testlib/tenant_runtime.h>
+#include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -28,9 +34,9 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         driver.Stop(true);
     }
 
-    void CreateActor(NActors::TTestActorRuntime& runtime, absl::flat_hash_set<TString>&& topics) {
+    void CreateActor(NActors::TTestActorRuntime& runtime, absl::flat_hash_set<TString>&& topics, const TString& databasePath = "/Root") {
         auto edgeId = runtime.AllocateEdgeActor();
-        auto describerId = runtime.Register(NDescriber::CreateDescriberActor(edgeId, "/Root", std::move(topics)));
+        auto describerId = runtime.Register(NDescriber::CreateDescriberActor(edgeId, databasePath, std::move(topics)));
         runtime.EnableScheduleForActor(describerId);
         runtime.DispatchEvents();
     }
@@ -38,6 +44,97 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
     absl::flat_hash_map<TString, NDescriber::TTopicInfo> WaitResult(NActors::TTestActorRuntime& runtime) {
         auto ev = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>();
         return std::move(ev->Topics);
+    }
+
+    void TestSleep(NActors::TTestActorRuntime& runtime, TDuration duration) {
+        if (runtime.IsRealThreads()) {
+            Sleep(duration);
+        } else {
+            runtime.SimulateSleep(duration);
+        }
+    }
+
+    void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& path) {
+        using namespace NKikimr::NConsole;
+
+        Ydb::Cms::GetDatabaseStatusResult status;
+        const TActorId edgeActor = runtime.AllocateEdgeActor();
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline) {
+            auto request = std::make_unique<TEvConsole::TEvGetTenantStatusRequest>();
+            request->Record.MutableRequest()->set_path(path);
+            runtime.SendToPipe(MakeConsoleID(), edgeActor, request.release(), 0, GetPipeConfigWithRetries());
+
+            auto response = runtime.GrabEdgeEvent<TEvConsole::TEvGetTenantStatusResponse>(edgeActor, TDuration::Seconds(5));
+            if (response) {
+                response->Get()->Record.GetResponse().operation().result().UnpackTo(&status);
+                if (status.state() == Ydb::Cms::GetDatabaseStatusResult::RUNNING) {
+                    return;
+                }
+            }
+            TestSleep(runtime, TDuration::MilliSeconds(100));
+        }
+        UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
+    }
+
+    void PrepareNodeChannelProfilesForPool(NActors::TTestActorRuntime& runtime, ui32 nodeIdx, const TString& poolKind) {
+        auto& appData = runtime.GetAppData(nodeIdx);
+        UNIT_ASSERT(appData.ChannelProfiles);
+        // Nodes share ChannelProfiles by default; clone so tenant schemeshard binds to this DB's pool.
+        auto profiles = MakeIntrusive<TChannelProfiles>();
+        profiles->Profiles = appData.ChannelProfiles->Profiles;
+        for (auto& profile : profiles->Profiles) {
+            for (auto& channel : profile.Channels) {
+                channel.PoolKind = poolKind;
+            }
+        }
+        appData.ChannelProfiles = profiles;
+    }
+
+    void CreateDedicatedDatabase(::NPersQueue::TTestServer& server, const TString& path, ui32 dynamicNodeIdx) {
+        auto& runtime = *server.CleverServer->GetRuntime();
+
+        using TEvCreateDatabaseRequest = NKikimr::NGRpcService::TGrpcRequestOperationCall<
+            Ydb::Cms::CreateDatabaseRequest,
+            Ydb::Cms::CreateDatabaseResponse>;
+
+        Ydb::Cms::CreateDatabaseRequest request;
+        request.set_path(path);
+        auto* storage = request.mutable_resources()->add_storage_units();
+        // Pool kind must match AddStoragePoolType(...) for this tenant path.
+        storage->set_unit_kind(path);
+        storage->set_count(1);
+
+        const auto response = NKikimr::NRpcService::DoLocalRpc<TEvCreateDatabaseRequest>(
+            std::move(request), "", "", runtime.GetActorSystem(0), true).ExtractValueSync();
+        UNIT_ASSERT_C(response.operation().ready(), response.ShortDebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(response.operation().status(), Ydb::StatusIds::SUCCESS, response.ShortDebugString());
+
+        PrepareNodeChannelProfilesForPool(runtime, dynamicNodeIdx, path);
+        server.CleverServer->SetupDynamicLocalService(dynamicNodeIdx, path);
+        WaitDatabaseRunning(runtime, path);
+    }
+
+    void SetPqChannelPoolKind(NActors::TTestActorRuntime& runtime, const TString& poolKind) {
+        for (auto& profile : *runtime.GetAppData().PQConfig.MutableChannelProfiles()) {
+            profile.SetPoolKind(poolKind);
+        }
+    }
+
+    void ExecuteDDLInDatabase(const TString& endpoint, const TString& database, const TString& query) {
+        TDriver driver(TDriverConfig()
+            .SetEndpoint(endpoint)
+            .SetDatabase(database)
+            .SetAuthToken("root@builtin")
+            .SetDiscoveryMode(EDiscoveryMode::Off));
+        TQueryClient client(driver);
+        auto session = client.GetSession().GetValueSync().GetSession();
+
+        Cerr << "DDL [" << database << "]: " << query << Endl << Flush;
+        auto res = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+
+        driver.Stop(true);
     }
 
     Y_UNIT_TEST(TopicExists) {
@@ -247,6 +344,55 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT(topics.contains(shortTopicName));
         auto& topicInfo = topics[shortTopicName];
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootMultipleAccounts) {
+        auto settings = NKikimr::NPersQueueTests::PQSettings(0, 1);
+        settings.SetNodeCount(1);
+        settings.SetDynamicNodeCount(2);
+        settings.AddStoragePoolType("/Root/account1");
+        settings.AddStoragePoolType("/Root/account2");
+        // Create topics with FICC=true; LbRoot describe path requires FICC=false later.
+        settings.PQConfig.SetTopicsAreFirstClassCitizen(true);
+        settings.PQConfig.SetRoot("/Root");
+        settings.PQConfig.SetDatabase("/Root");
+        settings.PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root");
+
+        ::NPersQueue::TTestServer server(settings, false);
+        server.StartServer(false);
+        server.AnnoyingClient->GrantConnect("root@builtin");
+        server.EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER },
+                NActors::NLog::PRI_DEBUG
+        );
+
+        const ui32 firstDynamicNode = server.CleverServer->StaticNodes();
+        CreateDedicatedDatabase(server, "/Root/account1", firstDynamicNode);
+        CreateDedicatedDatabase(server, "/Root/account2", firstDynamicNode + 1);
+
+        auto& runtime = *server.GetRuntime();
+        // CREATE TOPIC embeds PQ channel PoolKind from AppData; match each tenant's storage pool.
+        SetPqChannelPoolKind(runtime, "/Root/account1");
+        ExecuteDDLInDatabase(server.Endpoint, "/Root/account1", "CREATE TOPIC topic");
+        SetPqChannelPoolKind(runtime, "/Root/account2");
+        ExecuteDDLInDatabase(server.Endpoint, "/Root/account2", "CREATE TOPIC topic");
+
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+
+        // Primary resolve under /Root misses into account tenants; LbRoot retries
+        // with DatabaseName=/Root/account1 and /Root/account2.
+        CreateActor(runtime, {"account1/topic", "account2/topic"}, "/Root");
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL(topics.size(), 2);
+
+        UNIT_ASSERT(topics.contains("account1/topic"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].RealPath, "/Root/account1/topic");
+
+        UNIT_ASSERT(topics.contains("account2/topic"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].RealPath, "/Root/account2/topic");
     }
 }
 

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -28,14 +28,14 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         driver.Stop(true);
     }
 
-    void CreateActor(NActors::TTestActorRuntime& runtime, std::unordered_set<TString>&& topics) {
+    void CreateActor(NActors::TTestActorRuntime& runtime, absl::flat_hash_set<TString>&& topics) {
         auto edgeId = runtime.AllocateEdgeActor();
         auto describerId = runtime.Register(NDescriber::CreateDescriberActor(edgeId, "/Root", std::move(topics)));
         runtime.EnableScheduleForActor(describerId);
         runtime.DispatchEvents();
     }
 
-    std::unordered_map<TString, NDescriber::TTopicInfo> WaitResult(NActors::TTestActorRuntime& runtime) {
+    absl::flat_hash_map<TString, NDescriber::TTopicInfo> WaitResult(NActors::TTestActorRuntime& runtime) {
         auto ev = runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>();
         return std::move(ev->Topics);
     }

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -152,6 +152,50 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/topic1");
     }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRoot) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        setup->GetServer().EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER },
+                NActors::NLog::PRI_DEBUG
+        );
+
+        const TString dbRoot = "/Root/LbAccount";
+        const TString account = "account";
+        const TString shortTopicName = account + "/topic1";
+        const TString fullTopicPath = dbRoot + "/" + shortTopicName;
+
+        setup->GetRuntime().GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+
+        auto& runtime = setup->GetRuntime();
+        CreateActor(runtime, {shortTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(shortTopicName));
+        auto& topicInfo = topics[shortTopicName];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootNotFound) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        setup->GetServer().EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER },
+                NActors::NLog::PRI_DEBUG
+        );
+
+        setup->GetRuntime().GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
+
+        auto& runtime = setup->GetRuntime();
+        CreateActor(runtime, {"account/topic_not_exists"});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("account/topic_not_exists"));
+        auto& topicInfo = topics["account/topic_not_exists"];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+    }
 }
 
 }

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -165,11 +165,38 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         const TString shortTopicName = account + "/topic1";
         const TString fullTopicPath = dbRoot + "/" + shortTopicName;
 
-        setup->GetRuntime().GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
-
         ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
 
         auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
+        CreateActor(runtime, {shortTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(shortTopicName));
+        auto& topicInfo = topics[shortTopicName];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootLeadingSlash) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        setup->GetServer().EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER },
+                NActors::NLog::PRI_DEBUG
+        );
+
+        const TString dbRoot = "/Root/LbAccount";
+        const TString shortTopicName = "/account/topic";
+        const TString fullTopicPath = dbRoot + "/account/topic";
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
         CreateActor(runtime, {shortTopicName});
         auto topics = WaitResult(runtime);
 
@@ -186,14 +213,39 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
                 NActors::NLog::PRI_DEBUG
         );
 
-        setup->GetRuntime().GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
-
         auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
+
         CreateActor(runtime, {"account/topic_not_exists"});
         auto topics = WaitResult(runtime);
 
         UNIT_ASSERT(topics.contains("account/topic_not_exists"));
         auto& topicInfo = topics["account/topic_not_exists"];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootIgnoredForFirstClassCitizen) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        setup->GetServer().EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER },
+                NActors::NLog::PRI_DEBUG
+        );
+
+        const TString dbRoot = "/Root/LbAccount";
+        const TString shortTopicName = "account/topic1";
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
+        CreateActor(runtime, {shortTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(shortTopicName));
+        auto& topicInfo = topics[shortTopicName];
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
     }
 }

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -804,6 +804,103 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].RealPath, "/Root/account2/topic");
     }
 
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootSingleComponentPath) {
+        // Federation retry needs account/topic shape; a single component must not
+        // be rewritten under LbUserDatabaseRoot.
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
+
+        StartDescribe(runtime, {"topic1"});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("topic1"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(CDCWithEmptyDatabase) {
+        // Same empty-Database contract as fetch/API callers (TFetchRequestTests.CDC).
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+        ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+
+        auto& runtime = setup->GetRuntime();
+        StartDescribe(runtime, {"/Root/table1/feed"}, {}, /*databasePath=*/"");
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("/Root/table1/feed"));
+        auto& topicInfo = topics["/Root/table1/feed"];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/table1/feed/streamImpl");
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, true);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStreamName, "feed");
+    }
+
+    Y_UNIT_TEST(TopicWithEmptyDatabaseAbsolutePath) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        ExecuteDDL(*setup, "CREATE TOPIC topic1");
+
+        auto& runtime = setup->GetRuntime();
+        StartDescribe(runtime, {"/Root/topic1"}, {}, /*databasePath=*/"");
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("/Root/topic1"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/topic1"].RealPath, "/Root/topic1");
+    }
+
+    Y_UNIT_TEST(NotTopicWithDescribeAccess) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+
+        NACLib::TDiffACL acl;
+        acl.AddAccess(NACLib::EAccessType::Allow, NACLib::DescribeSchema, "user1@staff");
+        setup->GetServer().AnnoyingClient->ModifyACL("/Root", "table1", acl.SerializeAsString());
+
+        auto& runtime = setup->GetRuntime();
+        auto settings = WithToken(
+            MakeIntrusiveConst<NACLib::TUserToken>("user1@staff", TVector<TString>{}),
+            NACLib::EAccessRights::SelectRow
+        );
+        StartDescribe(runtime, {"/Root/table1"}, settings);
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("/Root/table1"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1"].Status, NDescriber::EStatus::NOT_TOPIC);
+    }
+
+    Y_UNIT_TEST(MultipleCDC) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        ExecuteDDL(*setup, "CREATE TABLE table1 (id Uint64, PRIMARY KEY (id))");
+        ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed1 WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+        ExecuteDDL(*setup, "ALTER TABLE table1 ADD CHANGEFEED feed2 WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+
+        auto& runtime = setup->GetRuntime();
+        StartDescribe(runtime, {"/Root/table1/feed1", "/Root/table1/feed2"});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL(topics.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].CdcStream, true);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed1"].RealPath, "/Root/table1/feed1/streamImpl");
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].CdcStream, true);
+        UNIT_ASSERT_VALUES_EQUAL(topics["/Root/table1/feed2"].RealPath, "/Root/table1/feed2/streamImpl");
+    }
+
 }
 
 }

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -668,23 +668,23 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
     }
 
     // -------------------------------------------------------------------------
-    // LbUserDatabaseRoot / federation-style paths
+    // FederationRoot / federation-style paths
     // -------------------------------------------------------------------------
 
-    Y_UNIT_TEST(TopicWithLbUserDatabaseRoot) {
+    Y_UNIT_TEST(TopicWithFederationRoot) {
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableDescriberLogs(*setup);
 
-        const TString dbRoot = "/Root/LbAccount";
+        const TString federationRoot = "/Root/Federation";
         const TString account = "account";
         const TString shortTopicName = account + "/topic1";
-        const TString fullTopicPath = dbRoot + "/" + shortTopicName;
+        const TString fullTopicPath = federationRoot + "/" + shortTopicName;
 
-        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+        ExecuteDDL(*setup, "CREATE TOPIC `Federation/account/topic1`");
 
         auto& runtime = setup->GetRuntime();
         runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
-        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(federationRoot);
 
         StartDescribe(runtime, {shortTopicName});
         auto topics = WaitResult(runtime);
@@ -695,19 +695,19 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
     }
 
-    Y_UNIT_TEST(TopicWithLbUserDatabaseRootLeadingSlash) {
+    Y_UNIT_TEST(TopicWithFederationRootLeadingSlash) {
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableDescriberLogs(*setup);
 
-        const TString dbRoot = "/Root/LbAccount";
+        const TString federationRoot = "/Root/Federation";
         const TString shortTopicName = "/account/topic";
-        const TString fullTopicPath = dbRoot + "/account/topic";
+        const TString fullTopicPath = federationRoot + "/account/topic";
 
-        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic`");
+        ExecuteDDL(*setup, "CREATE TOPIC `Federation/account/topic`");
 
         auto& runtime = setup->GetRuntime();
         runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
-        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(federationRoot);
 
         StartDescribe(runtime, {shortTopicName});
         auto topics = WaitResult(runtime);
@@ -718,13 +718,13 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
     }
 
-    Y_UNIT_TEST(TopicWithLbUserDatabaseRootNotFound) {
+    Y_UNIT_TEST(TopicWithFederationRootNotFound) {
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableDescriberLogs(*setup);
 
         auto& runtime = setup->GetRuntime();
         runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
-        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/Federation");
 
         StartDescribe(runtime, {"account/topic_not_exists"});
         auto topics = WaitResult(runtime);
@@ -734,18 +734,18 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
     }
 
-    Y_UNIT_TEST(TopicWithLbUserDatabaseRootIgnoredForFirstClassCitizen) {
+    Y_UNIT_TEST(TopicWithFederationRootIgnoredForFirstClassCitizen) {
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableDescriberLogs(*setup);
 
-        const TString dbRoot = "/Root/LbAccount";
+        const TString federationRoot = "/Root/Federation";
         const TString shortTopicName = "account/topic1";
 
-        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+        ExecuteDDL(*setup, "CREATE TOPIC `Federation/account/topic1`");
 
         auto& runtime = setup->GetRuntime();
         runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
-        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(federationRoot);
 
         StartDescribe(runtime, {shortTopicName});
         auto topics = WaitResult(runtime);
@@ -755,13 +755,13 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
     }
 
-    Y_UNIT_TEST(TopicWithLbUserDatabaseRootMultipleAccounts) {
+    Y_UNIT_TEST(TopicWithFederationRootMultipleAccounts) {
         auto settings = NKikimr::NPersQueueTests::PQSettings(0, 1);
         settings.SetNodeCount(1);
         settings.SetDynamicNodeCount(2);
         settings.AddStoragePoolType("/Root/account1");
         settings.AddStoragePoolType("/Root/account2");
-        // Create topics with FICC=true; LbRoot describe path requires FICC=false later.
+        // Create topics with FICC=true; Federation describe path requires FICC=false later.
         settings.PQConfig.SetTopicsAreFirstClassCitizen(true);
         settings.PQConfig.SetRoot("/Root");
         settings.PQConfig.SetDatabase("/Root");
@@ -788,7 +788,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
 
-        // Primary resolve under /Root misses into account tenants; LbRoot retries
+        // Primary resolve under /Root misses into account tenants; Federation retries
         // with DatabaseName=/Root/account1 and /Root/account2.
         StartDescribe(runtime, {"account1/topic", "account2/topic"}, {}, "/Root");
         auto topics = WaitResult(runtime);
@@ -804,17 +804,17 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].RealPath, "/Root/account2/topic");
     }
 
-    Y_UNIT_TEST(TopicWithLbUserDatabaseRootSingleComponentPath) {
+    Y_UNIT_TEST(TopicWithFederationRootSingleComponentPath) {
         // Federation retry needs account/topic shape; a single component must not
-        // be rewritten under LbUserDatabaseRoot.
+        // be rewritten under FederationRoot.
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableDescriberLogs(*setup);
 
-        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+        ExecuteDDL(*setup, "CREATE TOPIC `Federation/account/topic1`");
 
         auto& runtime = setup->GetRuntime();
         runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
-        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/Federation");
 
         StartDescribe(runtime, {"topic1"});
         auto topics = WaitResult(runtime);

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -695,6 +695,31 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
     }
 
+    Y_UNIT_TEST(TopicWithFederationRootAbsoluteDatabasePrefixedPath) {
+        // originalPath includes DatabasePath (/Root/...). Federation retry must strip
+        // that prefix, not append FederationRoot + /Root/account/...
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        const TString federationRoot = "/Root/Federation";
+        const TString absoluteTopicName = "/Root/account/topic1";
+        const TString fullTopicPath = federationRoot + "/account/topic1";
+
+        ExecuteDDL(*setup, "CREATE TOPIC `Federation/account/topic1`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(federationRoot);
+
+        StartDescribe(runtime, {absoluteTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(absoluteTopicName));
+        auto& topicInfo = topics[absoluteTopicName];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
+    }
+
     Y_UNIT_TEST(TopicWithFederationRootLeadingSlash) {
         auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
         EnableDescriberLogs(*setup);
@@ -821,6 +846,28 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
         UNIT_ASSERT(topics.contains("topic1"));
         UNIT_ASSERT_VALUES_EQUAL(topics["topic1"].Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(CDCWithFederationRoot) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        ExecuteDDL(*setup, "CREATE TABLE `Federation/account/table1` (id Uint64, PRIMARY KEY (id))");
+        ExecuteDDL(*setup, "ALTER TABLE `Federation/account/table1` ADD CHANGEFEED feed WITH (FORMAT = 'JSON', MODE = 'UPDATES')");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/Federation");
+
+        StartDescribe(runtime, {"account/table1/feed"});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("account/table1/feed"));
+        auto& topicInfo = topics["account/table1/feed"];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStream, true);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.CdcStreamName, "feed");
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, "/Root/Federation/account/table1/feed/streamImpl");
     }
 
     Y_UNIT_TEST(CDCWithEmptyDatabase) {

--- a/ydb/core/persqueue/public/describer/describer_ut.cpp
+++ b/ydb/core/persqueue/public/describer/describer_ut.cpp
@@ -1,8 +1,14 @@
 #include "describer.h"
 
+#include <ydb/core/base/channel_profiles.h>
+#include <ydb/core/cms/console/console.h>
+#include <ydb/core/grpc_services/local_rpc/local_rpc.h>
+#include <ydb/core/testlib/basics/helpers.h>
 #include <ydb/core/testlib/tenant_runtime.h>
 #include <ydb/library/aclib/aclib.h>
+#include <ydb/public/api/grpc/ydb_cms_v1.grpc.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/query/client.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 
 #include <library/cpp/testing/unittest/registar.h>
@@ -45,7 +51,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
     TDescribeRun RegisterDescribe(
         NActors::TTestActorRuntime& runtime,
-        std::unordered_set<TString> topics,
+        absl::flat_hash_set<TString> topics,
         const NDescriber::TDescribeSettings& settings = {},
         const TString& databasePath = "/Root")
     {
@@ -63,7 +69,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
 
     TDescribeRun StartDescribe(
         NActors::TTestActorRuntime& runtime,
-        std::unordered_set<TString> topics,
+        absl::flat_hash_set<TString> topics,
         const NDescriber::TDescribeSettings& settings = {},
         const TString& databasePath = "/Root")
     {
@@ -76,7 +82,7 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         return runtime.GrabEdgeEvent<NDescriber::TEvDescribeTopicsResponse>();
     }
 
-    std::unordered_map<TString, NDescriber::TTopicInfo> WaitResult(NActors::TTestActorRuntime& runtime) {
+    absl::flat_hash_map<TString, NDescriber::TTopicInfo> WaitResult(NActors::TTestActorRuntime& runtime) {
         auto ev = WaitResponse(runtime);
         return std::move(ev->Topics);
     }
@@ -91,6 +97,97 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
             .AccessRights = accessRights,
             .ForceSyncVersion = true,
         };
+    }
+
+    void TestSleep(NActors::TTestActorRuntime& runtime, TDuration duration) {
+        if (runtime.IsRealThreads()) {
+            Sleep(duration);
+        } else {
+            runtime.SimulateSleep(duration);
+        }
+    }
+
+    void WaitDatabaseRunning(NActors::TTestActorRuntime& runtime, const TString& path) {
+        using namespace NKikimr::NConsole;
+
+        Ydb::Cms::GetDatabaseStatusResult status;
+        const TActorId edgeActor = runtime.AllocateEdgeActor();
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (TInstant::Now() < deadline) {
+            auto request = std::make_unique<TEvConsole::TEvGetTenantStatusRequest>();
+            request->Record.MutableRequest()->set_path(path);
+            runtime.SendToPipe(MakeConsoleID(), edgeActor, request.release(), 0, GetPipeConfigWithRetries());
+
+            auto response = runtime.GrabEdgeEvent<TEvConsole::TEvGetTenantStatusResponse>(edgeActor, TDuration::Seconds(5));
+            if (response) {
+                response->Get()->Record.GetResponse().operation().result().UnpackTo(&status);
+                if (status.state() == Ydb::Cms::GetDatabaseStatusResult::RUNNING) {
+                    return;
+                }
+            }
+            TestSleep(runtime, TDuration::MilliSeconds(100));
+        }
+        UNIT_FAIL(TStringBuilder() << "Database " << path << " is not RUNNING, last status:\n" << status.DebugString());
+    }
+
+    void PrepareNodeChannelProfilesForPool(NActors::TTestActorRuntime& runtime, ui32 nodeIdx, const TString& poolKind) {
+        auto& appData = runtime.GetAppData(nodeIdx);
+        UNIT_ASSERT(appData.ChannelProfiles);
+        // Nodes share ChannelProfiles by default; clone so tenant schemeshard binds to this DB's pool.
+        auto profiles = MakeIntrusive<TChannelProfiles>();
+        profiles->Profiles = appData.ChannelProfiles->Profiles;
+        for (auto& profile : profiles->Profiles) {
+            for (auto& channel : profile.Channels) {
+                channel.PoolKind = poolKind;
+            }
+        }
+        appData.ChannelProfiles = profiles;
+    }
+
+    void CreateDedicatedDatabase(::NPersQueue::TTestServer& server, const TString& path, ui32 dynamicNodeIdx) {
+        auto& runtime = *server.CleverServer->GetRuntime();
+
+        using TEvCreateDatabaseRequest = NKikimr::NGRpcService::TGrpcRequestOperationCall<
+            Ydb::Cms::CreateDatabaseRequest,
+            Ydb::Cms::CreateDatabaseResponse>;
+
+        Ydb::Cms::CreateDatabaseRequest request;
+        request.set_path(path);
+        auto* storage = request.mutable_resources()->add_storage_units();
+        // Pool kind must match AddStoragePoolType(...) for this tenant path.
+        storage->set_unit_kind(path);
+        storage->set_count(1);
+
+        const auto response = NKikimr::NRpcService::DoLocalRpc<TEvCreateDatabaseRequest>(
+            std::move(request), "", "", runtime.GetActorSystem(0), true).ExtractValueSync();
+        UNIT_ASSERT_C(response.operation().ready(), response.ShortDebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(response.operation().status(), Ydb::StatusIds::SUCCESS, response.ShortDebugString());
+
+        PrepareNodeChannelProfilesForPool(runtime, dynamicNodeIdx, path);
+        server.CleverServer->SetupDynamicLocalService(dynamicNodeIdx, path);
+        WaitDatabaseRunning(runtime, path);
+    }
+
+    void SetPqChannelPoolKind(NActors::TTestActorRuntime& runtime, const TString& poolKind) {
+        for (auto& profile : *runtime.GetAppData().PQConfig.MutableChannelProfiles()) {
+            profile.SetPoolKind(poolKind);
+        }
+    }
+
+    void ExecuteDDLInDatabase(const TString& endpoint, const TString& database, const TString& query) {
+        TDriver driver(TDriverConfig()
+            .SetEndpoint(endpoint)
+            .SetDatabase(database)
+            .SetAuthToken("root@builtin")
+            .SetDiscoveryMode(EDiscoveryMode::Off));
+        TQueryClient client(driver);
+        auto session = client.GetSession().GetValueSync().GetSession();
+
+        Cerr << "DDL [" << database << "]: " << query << Endl << Flush;
+        auto res = session.ExecuteQuery(query, TTxControl::NoTx()).GetValueSync();
+        UNIT_ASSERT_C(res.IsSuccess(), res.GetIssues().ToString());
+
+        driver.Stop(true);
     }
 
     // -------------------------------------------------------------------------
@@ -568,6 +665,143 @@ Y_UNIT_TEST_SUITE(TDescriberTests) {
         runtime.Send(new IEventHandle(run.DescriberId, run.EdgeId, new TEvents::TEvPoison()));
         runtime.DispatchEvents();
         // Actor must handle poison without crashing the runtime.
+    }
+
+    // -------------------------------------------------------------------------
+    // LbUserDatabaseRoot / federation-style paths
+    // -------------------------------------------------------------------------
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRoot) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        const TString dbRoot = "/Root/LbAccount";
+        const TString account = "account";
+        const TString shortTopicName = account + "/topic1";
+        const TString fullTopicPath = dbRoot + "/" + shortTopicName;
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
+        StartDescribe(runtime, {shortTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(shortTopicName));
+        auto& topicInfo = topics[shortTopicName];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootLeadingSlash) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        const TString dbRoot = "/Root/LbAccount";
+        const TString shortTopicName = "/account/topic";
+        const TString fullTopicPath = dbRoot + "/account/topic";
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
+        StartDescribe(runtime, {shortTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(shortTopicName));
+        auto& topicInfo = topics[shortTopicName];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.RealPath, fullTopicPath);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootNotFound) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root/LbAccount");
+
+        StartDescribe(runtime, {"account/topic_not_exists"});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains("account/topic_not_exists"));
+        auto& topicInfo = topics["account/topic_not_exists"];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootIgnoredForFirstClassCitizen) {
+        auto setup = std::make_shared<TTopicSdkTestSetup>(TEST_CASE_NAME);
+        EnableDescriberLogs(*setup);
+
+        const TString dbRoot = "/Root/LbAccount";
+        const TString shortTopicName = "account/topic1";
+
+        ExecuteDDL(*setup, "CREATE TOPIC `LbAccount/account/topic1`");
+
+        auto& runtime = setup->GetRuntime();
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+        runtime.GetAppData().PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot(dbRoot);
+
+        StartDescribe(runtime, {shortTopicName});
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT(topics.contains(shortTopicName));
+        auto& topicInfo = topics[shortTopicName];
+        UNIT_ASSERT_VALUES_EQUAL(topicInfo.Status, NDescriber::EStatus::NOT_FOUND);
+    }
+
+    Y_UNIT_TEST(TopicWithLbUserDatabaseRootMultipleAccounts) {
+        auto settings = NKikimr::NPersQueueTests::PQSettings(0, 1);
+        settings.SetNodeCount(1);
+        settings.SetDynamicNodeCount(2);
+        settings.AddStoragePoolType("/Root/account1");
+        settings.AddStoragePoolType("/Root/account2");
+        // Create topics with FICC=true; LbRoot describe path requires FICC=false later.
+        settings.PQConfig.SetTopicsAreFirstClassCitizen(true);
+        settings.PQConfig.SetRoot("/Root");
+        settings.PQConfig.SetDatabase("/Root");
+        settings.PQConfig.MutablePQDiscoveryConfig()->SetLbUserDatabaseRoot("/Root");
+
+        ::NPersQueue::TTestServer server(settings, false);
+        server.StartServer(false);
+        server.AnnoyingClient->GrantConnect("root@builtin");
+        server.EnableLogs(
+                { NKikimrServices::TX_PROXY_SCHEME_CACHE, NKikimrServices::PQ_DESCRIBER },
+                NActors::NLog::PRI_DEBUG
+        );
+
+        const ui32 firstDynamicNode = server.CleverServer->StaticNodes();
+        CreateDedicatedDatabase(server, "/Root/account1", firstDynamicNode);
+        CreateDedicatedDatabase(server, "/Root/account2", firstDynamicNode + 1);
+
+        auto& runtime = *server.GetRuntime();
+        // CREATE TOPIC embeds PQ channel PoolKind from AppData; match each tenant's storage pool.
+        SetPqChannelPoolKind(runtime, "/Root/account1");
+        ExecuteDDLInDatabase(server.Endpoint, "/Root/account1", "CREATE TOPIC topic");
+        SetPqChannelPoolKind(runtime, "/Root/account2");
+        ExecuteDDLInDatabase(server.Endpoint, "/Root/account2", "CREATE TOPIC topic");
+
+        runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(false);
+
+        // Primary resolve under /Root misses into account tenants; LbRoot retries
+        // with DatabaseName=/Root/account1 and /Root/account2.
+        StartDescribe(runtime, {"account1/topic", "account2/topic"}, {}, "/Root");
+        auto topics = WaitResult(runtime);
+
+        UNIT_ASSERT_VALUES_EQUAL(topics.size(), 2);
+
+        UNIT_ASSERT(topics.contains("account1/topic"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["account1/topic"].RealPath, "/Root/account1/topic");
+
+        UNIT_ASSERT(topics.contains("account2/topic"));
+        UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].Status, NDescriber::EStatus::SUCCESS);
+        UNIT_ASSERT_VALUES_EQUAL(topics["account2/topic"].RealPath, "/Root/account2/topic");
     }
 
 }

--- a/ydb/core/persqueue/public/describer/ut/ya.make
+++ b/ydb/core/persqueue/public/describer/ut/ya.make
@@ -11,8 +11,11 @@ SRCS(
 
 PEERDIR(
     library/cpp/testing/unittest
+    ydb/core/cms/console
+    ydb/core/grpc_services/local_rpc
     ydb/core/testlib/basics
     ydb/library/aclib
+    ydb/public/api/grpc
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
     ydb/public/sdk/cpp/src/client/query

--- a/ydb/core/persqueue/public/describer/ut/ya.make
+++ b/ydb/core/persqueue/public/describer/ut/ya.make
@@ -1,5 +1,7 @@
 UNITTEST_FOR(ydb/core/persqueue/public/describer)
 
+SIZE(MEDIUM)
+
 YQL_LAST_ABI_VERSION()
 
 SRCS(
@@ -8,11 +10,13 @@ SRCS(
 
 PEERDIR(
     library/cpp/testing/unittest
+    ydb/core/cms/console
+    ydb/core/grpc_services/local_rpc
+    ydb/core/testlib/basics
+    ydb/public/api/grpc
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
     ydb/public/sdk/cpp/src/client/query
-
-
 )
 
 END()

--- a/ydb/core/persqueue/public/describer/ya.make
+++ b/ydb/core/persqueue/public/describer/ya.make
@@ -5,6 +5,7 @@ SRCS(
 )
 
 PEERDIR(
+    library/cpp/containers/absl
     ydb/core/persqueue/events
 #    ydb/core/persqueue/public
 )

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -169,7 +169,7 @@ public:
         YDB_LOG_DEBUG("DescribeTopics",
             {"logPrefix", LOG_PREFIX});
 
-        std::unordered_set<TString> topics;
+        absl::flat_hash_set<TString> topics;
         for (const auto& part : Settings.Partitions) {
             topics.insert(part.Topic);
         }

--- a/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
+++ b/ydb/core/persqueue/public/fetcher/fetch_request_actor.cpp
@@ -11,6 +11,8 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/log.h>
 
+#include <library/cpp/containers/absl/flat_hash_set.h>
+
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_FETCH_REQUEST
 
 #define LOG_PREFIX TStringBuilder() << "[" << NActors::TlsActivationContext->AsActorContext().SelfID << "] "

--- a/ydb/services/sqs_topic/list_queues.cpp
+++ b/ydb/services/sqs_topic/list_queues.cpp
@@ -113,7 +113,8 @@ namespace NKikimr::NSqsTopic::V1 {
             .UserToken = MakeIntrusive<NACLib::TUserToken>(this->Request_->GetSerializedToken()),
             .AccessRights = NACLib::EAccessRights::DescribeSchema,
         };
-        std::unordered_set<TString> topicsSet(topics.size());
+        absl::flat_hash_set<TString> topicsSet;
+        topicsSet.reserve(topics.size());
         for (const auto& topic : topics) {
             TString fullTopicPath = CanonizePath(NKikimr::JoinPath({DatabaseName_, topic}));
             topicsSet.insert(std::move(fullTopicPath));

--- a/ydb/services/sqs_topic/list_queues.cpp
+++ b/ydb/services/sqs_topic/list_queues.cpp
@@ -114,7 +114,8 @@ namespace NKikimr::NSqsTopic::V1 {
             .UserToken = MakeIntrusive<NACLib::TUserToken>(this->Request_->GetSerializedToken()),
             .AccessRights = NACLib::EAccessRights::DescribeSchema,
         };
-        std::unordered_set<TString> topicsSet(topics.size());
+        absl::flat_hash_set<TString> topicsSet;
+        topicsSet.reserve(topics.size());
         for (const auto& topic : topics) {
             TString fullTopicPath = CanonizePath(NKikimr::JoinPath({DatabaseName_, topic}));
             topicsSet.insert(std::move(fullTopicPath));


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Teach Topic Describer to resolve federation-style topics under `LbUserDatabaseRoot`, including topics and CDC streams that live in different account databases.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Port federation (`LbUserDatabaseRoot`) lookup from PQ metacache into `CreateDescriberActor`.

Internal naming uses **Federation** (`FederationRoot`, `FederationPaths`, …); the config field stays `PQDiscoveryConfig.LbUserDatabaseRoot`.

**Behavior**
- After a local SchemeCache miss (and sync retry), if `TopicsAreFirstClassCitizen=false` and `LbUserDatabaseRoot` is set, retry under `FederationRoot/<account>/...`
- For topics from different accounts, issue separate SchemeCache requests with `DatabaseName=/FederationRoot/<account>` (one request per account DB)
- Build the federation relative path from `realPath` vs `DatabasePath` (not from a possibly DB-prefixed `originalPath`), so absolute inputs like `/Root/account/topic` do not become `FederationRoot/Root/account/topic`
- CDC `/streamImpl` retries keep the account `DatabaseName` from discovery time (`AccountDatabase` per CDC entry); empty `Database` is a valid next DB (fixes fetch crash on CDC with empty database)
- Topic path containers use `absl::flat_hash_set` / `flat_hash_map` (`std::optional` for optional strings)

**Tests**
- Federation success / not-found / leading slash / absolute DB-prefixed path / single-component skip / FICC ignore
- Multi-account tenants (`/Root/account1`, `/Root/account2`) in one request
- CDC: empty Database, Federation+CDC (`AccountDatabase` preserved), multi-CDC; fake scheme-cache coverage for the same paths
- Regression: non-topic without DescribeSchema → `UNAUTHORIZED`