### PR TITLE
Fix migration out-of-order message delivery

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
@@ -83,6 +83,8 @@ namespace NActors {
             size_t UnsentBytes = 0;
             int ReadPendingRingIdx = -1;
             ui32 PreferredRingIdx = 0;
+            std::atomic_uint64_t IncomingSeqNo{1};
+            ui64 ExpectedSeqNo = 1;
 
             EMigrateState MigrateState = EMigrateState::None;
             ui32 MigrateTargetShard = 0;
@@ -93,6 +95,8 @@ namespace NActors {
 
             THashMap<TActorId, TIntrusivePtr<IReceiveCallback>> ReceiveCallbacks;
             NMonitoring::TDynamicCounters::TCounterPtr EventsReceived;
+
+            std::vector<TIncomingEventQueue::TRecord> PendingRecordsHeap;
 
             TRegisteredSession(ui32 shardIdx, TIntrusivePtr<NInterconnect::TStreamSocket> socket,
                     TActorId sessionId, bool checksumming, TScopeId peerScopeId,
@@ -378,6 +382,8 @@ namespace NActors {
             NMonitoring::TDynamicCounters::TCounterPtr WriteUnavail;
             NMonitoring::TDynamicCounters::TCounterPtr SessionsMigratedOut;
             NMonitoring::TDynamicCounters::TCounterPtr SessionsMigratedIn;
+            NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderCameIn;
+            NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderProcessed;
 
             NMonitoring::TDynamicCounters::TCounterPtr OtherTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr CompleteWaitTotalTime;
@@ -494,6 +500,8 @@ namespace NActors {
                 , COUNTER(WriteUnavail, true)
                 , COUNTER(SessionsMigratedOut, true)
                 , COUNTER(SessionsMigratedIn, true)
+                , COUNTER(OutOfOrderCameIn, true)
+                , COUNTER(OutOfOrderProcessed, true)
 #define TOTAL_TIME(NAME) NAME(shardCounters->GetCounter("TotalTime/" #NAME, true))
                 , TOTAL_TIME(OtherTotalTime)
                 , TOTAL_TIME(CompleteWaitTotalTime)
@@ -561,42 +569,71 @@ namespace NActors {
 
             void Register(std::unique_ptr<TRegisteredSession> session) {
                 ++*SessionsRegistered;
+
+                // this would be the session's first event, so its sequencing is not the problem
                 SendInternal(reinterpret_cast<ui64>(session.release()), static_cast<ui32>(ENetwork::EvRegisterSession),
-                    {}, nullptr);
+                    {}, nullptr, false);
             }
 
             void AcceptMigrated(std::unique_ptr<TRegisteredSession> session) {
                 ++*SessionsMigratedIn;
+
+                // this event isn't the first one, but its sequence doesn't matter, because all further events are kept
+                // in order and forwarded to the new processor
                 SendInternal(reinterpret_cast<ui64>(session.release()), static_cast<ui32>(ENetwork::EvRegisterSession),
-                    {}, nullptr);
+                    {}, nullptr, false);
             }
 
-            void Enqueue(ui64 conn, std::unique_ptr<IEventHandle> ev, TIntrusivePtr<IReceiveCallback> replyCallback) {
-                SendImpl(conn, std::move(ev), std::move(replyCallback));
+            void Enqueue(TIncomingEventQueue::TRecord&& record) {
+                const bool first = IncomingEventQueue.Push(std::move(record));
+                if (first) {
+                    ++*PushedAsFirst;
+                }
+                ++*PushedTotal;
+                if (first && WaitingForCQ.load(std::memory_order_acquire)) {
+                    // first command while waiting on CQ: kick the worker via the pipe on ring 0
+                    const ui64 value = 1; // this commands adds 1 to the counter stored in eventfd
+                    ssize_t res;
+                    while ((res = write(EventFd, &value, sizeof(value))) != sizeof(value)) {
+                        if (res == -1 && errno == EINTR) {
+                            continue;
+                        } else {
+                            Y_ABORT("write() to eventfd failed: %s", strerror(errno));
+                        }
+                    }
+                    ++*EventWakeups;
+                }
             }
 
             void Send(ui64 conn, std::unique_ptr<IEventHandle> ev, TIntrusivePtr<IReceiveCallback> replyCallback) {
                 ++*EventsSent;
-                SendImpl(conn, std::move(ev), std::move(replyCallback));
+
+                // this event is strictly sequenced
+                SendImpl(conn, std::move(ev), std::move(replyCallback), true);
             }
 
             void Unregister(ui64 conn) {
                 ++*SessionsUnregistered;
-                SendInternal(conn, static_cast<ui32>(ENetwork::EvUnregisterSession), {}, nullptr);
+
+                // this event is sequenced too
+                SendInternal(conn, static_cast<ui32>(ENetwork::EvUnregisterSession), {}, nullptr, true);
             }
 
             void RegisterReceiveCallback(ui64 conn, TActorId localActorId, TIntrusivePtr<IReceiveCallback> callback) {
                 ++*(callback ? DirectReceiveCallbacksRegistered : DirectReceiveCallbacksUnregistered);
-                SendInternal(conn, static_cast<ui32>(ENetwork::EvRegisterCallback), localActorId, std::move(callback));
+
+                // this event's ordering is important
+                SendInternal(conn, static_cast<ui32>(ENetwork::EvRegisterCallback), localActorId, std::move(callback),
+                    true);
             }
 
             void NotifyMigrateDone(ui64 conn) {
-                SendInternal(conn, static_cast<ui32>(ENetwork::EvMigrateDone), {}, nullptr);
+                SendInternal(conn, static_cast<ui32>(ENetwork::EvMigrateDone), {}, nullptr, false);
             }
 
             void Stop() {
                 if (Worker.joinable()) {
-                    SendInternal(0, static_cast<ui32>(ENetwork::EvStop), {}, nullptr);
+                    SendInternal(0, static_cast<ui32>(ENetwork::EvStop), {}, nullptr, false);
                     Worker.join();
                     // The worker is stopped, so it is now safe to touch the sessions directly. Shut every
                     // socket down so the peer observes the disconnect promptly instead of only when this shard
@@ -615,45 +652,42 @@ namespace NActors {
             // the ownership handling of the worker loop: destroys the embedded TEventPayload and reclaims a
             // TRegisteredSession handed off via an unprocessed EvRegisterSession.
             void DrainQueue() {
-                for (;;) {
-                    if (auto&& [ev, conn, callback, timestamp] = IncomingEventQueue.Pop(); ev) {
-                        if (ev->Type == static_cast<ui32>(ENetwork::EvRegisterSession)) {
-                            delete reinterpret_cast<TRegisteredSession*>(conn);
-                        }
-                    } else {
-                        break;
+                while (auto record = IncomingEventQueue.Pop()) {
+                    if (record->Ev->Type == static_cast<ui32>(ENetwork::EvRegisterSession)) {
+                        delete reinterpret_cast<TRegisteredSession*>(record->Conn);
                     }
                 }
             }
 
-            void SendImpl(ui64 conn, std::unique_ptr<IEventHandle> ev, TIntrusivePtr<IReceiveCallback> replyCallback) {
-                const bool first = IncomingEventQueue.Push(std::move(ev), conn, std::move(replyCallback));
-                if (first) {
-                    ++*PushedAsFirst;
+            void SendImpl(ui64 conn, std::unique_ptr<IEventHandle> ev, TIntrusivePtr<IReceiveCallback> replyCallback,
+                    bool ensureSequence) {
+                ui64 seqNo = 0;
+                if (Y_LIKELY(ensureSequence)) {
+                    Y_DEBUG_ABORT_UNLESS(conn);
+                    auto& session = *reinterpret_cast<TRegisteredSession*>(conn);
+                    seqNo = session.IncomingSeqNo.fetch_add(1);
                 }
-                ++*PushedTotal;
-                if (first && WaitingForCQ.load(std::memory_order_relaxed)) {
-                    // first command while waiting on CQ: kick the worker via the pipe on ring 0
-                    const ui64 value = 1; // this commands adds 1 to the counter stored in eventfd
-                    ssize_t res;
-                    while ((res = write(EventFd, &value, sizeof(value))) != sizeof(value)) {
-                        if (res == -1 && errno == EINTR) {
-                            continue;
-                        } else {
-                            Y_ABORT("write() to eventfd failed: %s", strerror(errno));
-                        }
-                    }
-                    ++*EventWakeups;
-                }
+                Enqueue(TIncomingEventQueue::TRecord{
+                    std::move(ev),
+                    conn,
+                    std::move(replyCallback),
+                    GetCycleCountFast(),
+                    seqNo,
+                });
             }
 
-            void SendInternal(ui64 conn, ui32 type, TActorId sender, TIntrusivePtr<IReceiveCallback> callback) {
-                SendImpl(conn, std::make_unique<IEventHandle>(type, 0, TActorId(), sender, nullptr, 0), std::move(callback));
+            void SendInternal(ui64 conn, ui32 type, TActorId sender, TIntrusivePtr<IReceiveCallback> callback,
+                    bool ensureSequence) {
+                SendImpl(conn, std::make_unique<IEventHandle>(type, 0, TActorId(), sender, nullptr, 0),
+                    std::move(callback), ensureSequence);
             }
 
-            bool ForwardIfMigratingOut(ui64 conn, std::unique_ptr<IEventHandle>& ev, TIntrusivePtr<IReceiveCallback>& callback) {
-                if (const auto it = MigratingOut.find(conn); it != MigratingOut.end()) {
-                    Engine.Shards[it->second]->Enqueue(conn, std::move(ev), std::move(callback));
+            bool ForwardIfMigratingOut(TIncomingEventQueue::TRecord *record) {
+                if (Y_LIKELY(MigratingOut.empty())) {
+                    return false;
+                }
+                if (const auto it = MigratingOut.find(record->Conn); it != MigratingOut.end()) {
+                    Engine.Shards[it->second]->Enqueue(std::move(*record));
                     return true;
                 }
                 return false;
@@ -772,7 +806,7 @@ namespace NActors {
 
                     ui64 waitStartTimestamp = 0;
                     if (!progress) { // wait for something to happen -- no progress were made in this loop
-                        WaitingForCQ.store(true, std::memory_order_relaxed);
+                        WaitingForCQ.store(true, std::memory_order_release);
 
                         // it is critical we first set WaitingForCQ, and then rechecking the queue
                         if (IncomingEventQueue.IsEmpty()) {
@@ -807,99 +841,128 @@ namespace NActors {
                 bool progress = false;
                 ui64 cycleCountOnEnter = 0;
 
-                for (;;) {
-                    auto&& [ev, conn, callback, cycleCountOnSend] = IncomingEventQueue.Pop();
-                    if (!ev) {
+                while (auto record = IncomingEventQueue.Pop()) {
+                    progress = true;
+                    if (record->Ev->Type == static_cast<ui32>(ENetwork::EvStop)) {
+                        *stopping = true;
                         break;
                     }
-                    progress = true;
 
                     if (!cycleCountOnEnter) {
                         cycleCountOnEnter = GetCycleCountFast();
                     }
 
-                    switch (ev->Type) {
-                        case static_cast<ui32>(ENetwork::EvRegisterCallback):
-                            if (ForwardIfMigratingOut(conn, ev, callback)) {
-                                break;
-                            }
-                            if (TRegisteredSession& session = GetSession(conn); callback) {
-                                session.ReceiveCallbacks[ev->Sender] = std::move(callback);
-                            } else {
-                                session.ReceiveCallbacks.erase(ev->Sender);
-                            }
-                            break;
+                    if (Y_LIKELY(record->SeqNo)) {
+                        if (ForwardIfMigratingOut(&record.value())) {
+                            // this record is just sent to the other thread
+                        } else if (auto& session = GetSession(record->Conn); record->SeqNo != session.ExpectedSeqNo) {
+                            Y_DEBUG_ABORT_UNLESS(session.ExpectedSeqNo < record->SeqNo);
+                            session.PendingRecordsHeap.push_back(std::move(*record));
+                            std::ranges::push_heap(session.PendingRecordsHeap, std::greater<ui64>{},
+                                &TIncomingEventQueue::TRecord::SeqNo);
+                            ++*OutOfOrderCameIn;
+                        } else {
+                            // process this event
+                            const bool isUnregister = record->Ev->Type == static_cast<ui32>(ENetwork::EvUnregisterSession);
+                            ProcessIncomingEvent(&record.value());
+                            if (!isUnregister) {
+                                ++session.ExpectedSeqNo;
 
-                        case static_cast<ui32>(ENetwork::EvRegisterSession): {
-                            std::unique_ptr<TRegisteredSession> session(reinterpret_cast<TRegisteredSession*>(conn));
-                            const bool migrated = session->MigrateState == EMigrateState::HandedOff;
-                            const ui32 sourceShard = session->MigrateSourceShard;
-                            session->OwnerShard.store(ShardIdx, std::memory_order_release);
-                            session->MigrateState = EMigrateState::None;
-                            session->MigrateSourceShard = ShardIdx;
-                            session->PreferredRingIdx = OpShift++ % Rings.size();
-                            const auto [it, inserted] = Sessions.emplace(std::move(session));
-                            Y_ABORT_UNLESS(inserted);
-                            (*it)->EventsReceived = EventsReceived;
-                            IssueReadForSession(**it);
-                            if (migrated && sourceShard != ShardIdx) {
-                                Engine.Shards[sourceShard]->NotifyMigrateDone(conn);
+                                // check if there are other events in the process queue
+                                if (auto& heap = session.PendingRecordsHeap; Y_UNLIKELY(!heap.empty())) {
+                                    while (!heap.empty() && heap.front().SeqNo == session.ExpectedSeqNo) {
+                                        std::ranges::pop_heap(heap, std::greater<ui64>{}, &TIncomingEventQueue::TRecord::SeqNo);
+                                        ProcessIncomingEvent(&heap.back());
+                                        ++session.ExpectedSeqNo;
+                                        heap.pop_back();
+                                        ++*OutOfOrderProcessed;
+                                    }
+                                    if (heap.empty()) {
+                                        heap.shrink_to_fit();
+                                    }
+                                }
                             }
-                            break;
                         }
-
-                        case static_cast<ui32>(ENetwork::EvUnregisterSession): {
-                            if (ForwardIfMigratingOut(conn, ev, callback)) {
-                                break;
-                            }
-                            TRegisteredSession& session = GetSession(conn);
-                            // Do NOT free the session while it still has an armed recv or an in-flight
-                            // writev: their io_uring completions carry a raw pointer to this object and
-                            // would dereference freed memory. Mark it terminated (so no new ops are armed)
-                            // and erase only once both are drained. The session actor has already shut the
-                            // socket down before requesting unregistration, so the pending ops complete
-                            // promptly (EOF/EPIPE).
-                            if (session.MigrateState != EMigrateState::None) {
-                                session.MigrateState = EMigrateState::None; // unregister wins over migrate
-                            }
-                            session.Terminated = true;
-                            session.UnregisterRequested = true;
-                            if (session.ReadPending) { // cancel pending read in order to unregister the session
-                                CancelOp(session, kOpRead, session.ReadPendingRingIdx);
-                            }
-                            MaybeEraseSession(session);
-                            break;
-                        }
-
-                        case static_cast<ui32>(ENetwork::EvMigrateDone):
-                            MigratingOut.erase(conn);
-                            break;
-
-                        case static_cast<ui32>(ENetwork::EvStop):
-                            *stopping = true;
-                            return true;
-
-                        default: {
-                            if (ForwardIfMigratingOut(conn, ev, callback)) {
-                                break;
-                            }
-                            TRegisteredSession& session = GetSession(conn);
-                            if (callback) { // register callback coming along with the message
-                                session.ReceiveCallbacks[ev->Sender] = std::move(callback);
-                            }
-                            session.Serializer.Push(std::move(ev));
-                            IssueWritesForSession(session);
-                            break;
-                        }
+                    } else {
+                        // process unsequenced event
+                        ProcessIncomingEvent(&record.value());
                     }
 
                     const ui64 cycleCountOnExit = GetCycleCountFast();
-                    CommandDeliveryTime->Collect(NHPTimer::GetSeconds(cycleCountOnEnter - cycleCountOnSend) * 1e9);
-                    CommandExecTime->Collect(NHPTimer::GetSeconds(cycleCountOnExit - cycleCountOnEnter) * 1e9);
+                    CommandDeliveryTime->Collect((cycleCountOnEnter - record->ReceivedTimestamp) * Freq);
+                    CommandExecTime->Collect((cycleCountOnExit - cycleCountOnEnter) * Freq);
                     cycleCountOnEnter = cycleCountOnExit;
                 }
 
                 return progress;
+            }
+
+            void ProcessIncomingEvent(TIncomingEventQueue::TRecord *record) {
+                switch (record->Ev->Type) {
+                    case static_cast<ui32>(ENetwork::EvRegisterCallback):
+                        if (TRegisteredSession& session = GetSession(record->Conn); record->Callback) {
+                            session.ReceiveCallbacks[record->Ev->Sender] = std::move(record->Callback);
+                        } else {
+                            session.ReceiveCallbacks.erase(record->Ev->Sender);
+                        }
+                        break;
+
+                    case static_cast<ui32>(ENetwork::EvRegisterSession): {
+                        std::unique_ptr<TRegisteredSession> session(reinterpret_cast<TRegisteredSession*>(record->Conn));
+                        if (session->MigrateState == EMigrateState::HandedOff) {
+                            session->OwnerShard.store(ShardIdx, std::memory_order_release); // all new events will arrive here from now on
+                            Engine.Shards[session->MigrateSourceShard]->NotifyMigrateDone(record->Conn);
+                            session->MigrateState = EMigrateState::None;
+                        } else {
+                            Y_DEBUG_ABORT_UNLESS(session->MigrateState == EMigrateState::None);
+                        }
+                        session->PreferredRingIdx = OpShift++ % Rings.size();
+                        const auto [it, inserted] = Sessions.emplace(std::move(session));
+                        Y_ABORT_UNLESS(inserted);
+                        (*it)->EventsReceived = EventsReceived;
+                        IssueReadForSession(**it);
+                        break;
+                    }
+
+                    case static_cast<ui32>(ENetwork::EvUnregisterSession): {
+                        TRegisteredSession& session = GetSession(record->Conn);
+                        // Do NOT free the session while it still has an armed recv or an in-flight
+                        // writev: their io_uring completions carry a raw pointer to this object and
+                        // would dereference freed memory. Mark it terminated (so no new ops are armed)
+                        // and erase only once both are drained. The session actor has already shut the
+                        // socket down before requesting unregistration, so the pending ops complete
+                        // promptly (EOF/EPIPE).
+                        if (session.MigrateState != EMigrateState::None) {
+                            session.MigrateState = EMigrateState::None; // unregister wins over migrate
+                        }
+                        session.Terminated = true;
+                        session.UnregisterRequested = true;
+                        if (session.ReadPending) { // cancel pending read in order to unregister the session
+                            CancelOp(session, kOpRead, session.ReadPendingRingIdx);
+                        }
+                        MaybeEraseSession(session);
+                        break;
+                    }
+
+                    case static_cast<ui32>(ENetwork::EvMigrateDone): {
+                        const size_t num = MigratingOut.erase(record->Conn);
+                        Y_DEBUG_ABORT_UNLESS(num == 1);
+                        break;
+                    }
+
+                    case static_cast<ui32>(ENetwork::EvStop):
+                        Y_ABORT();
+
+                    default: {
+                        TRegisteredSession& session = GetSession(record->Conn);
+                        if (record->Callback) { // register callback coming along with the message
+                            session.ReceiveCallbacks[record->Ev->Sender] = std::move(record->Callback);
+                        }
+                        session.Serializer.Push(std::move(record->Ev));
+                        IssueWritesForSession(session);
+                        break;
+                    }
+                }
             }
 
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -982,8 +1045,6 @@ namespace NActors {
                     return;
                 }
 
-                return; // TODO(alexvru): check for out-of-order when processing old shard queue when new shard is registered
-
                 ui32 bestTarget = ShardIdx;
                 ui32 bestBusy = Max<ui32>();
                 for (ui32 i = 0; i < Engine.Shards.size(); ++i) {
@@ -1013,6 +1074,7 @@ namespace NActors {
                 candidate->MigrateState = EMigrateState::Draining;
                 candidate->MigrateTargetShard = bestTarget;
                 candidate->MigrateSourceShard = ShardIdx;
+                Y_DEBUG_ABORT_UNLESS(candidate->MigrateTargetShard != candidate->MigrateSourceShard);
 
                 if (candidate->ReadPending) {
                     CancelOp(*candidate, kOpRead, candidate->ReadPendingRingIdx);

--- a/ydb/library/actors/interconnect/interconnect_uring_event_queue.h
+++ b/ydb/library/actors/interconnect/interconnect_uring_event_queue.h
@@ -15,6 +15,21 @@ namespace NActors {
         };
         static_assert(sizeof(TEventPayload) <= sizeof(TActorId));
 
+        struct TEventPayload2 {
+            ui64 ReceivedTimestamp; // GetCycleCountFast()
+            ui64 SeqNo;
+        };
+        static_assert(sizeof(TEventPayload2) <= sizeof(TScopeId));
+
+    public:
+        struct TRecord {
+            std::unique_ptr<IEventHandle> Ev;
+            ui64 Conn;
+            TIntrusivePtr<IReceiveCallback> Callback;
+            ui64 ReceivedTimestamp;
+            ui64 SeqNo;
+        };
+
     public:
         TIncomingEventQueue() {
             Stub.NextLinkPtr.store(0, std::memory_order_relaxed);
@@ -24,15 +39,19 @@ namespace NActors {
             Y_DEBUG_ABORT_UNLESS(IsEmpty()); // ensure this event queue has been properly drained by owner
         }
 
-        bool Push(std::unique_ptr<IEventHandle> ev, ui64 conn, TIntrusivePtr<IReceiveCallback> replyCallback) {
-            // store some metadata in event's unmatching fields
-            new(const_cast<TActorId*>(&ev->InterconnectSession)) TEventPayload{
-                .Conn = conn,
-                .Callback = std::move(replyCallback),
-            };
-            reinterpret_cast<ui64&>(const_cast<TScopeId&>(ev->OriginScopeId)) = GetCycleCountFast();
+        bool Push(TRecord&& record) {
+            IEventHandle *last = record.Ev.release();
 
-            IEventHandle *last = ev.release();
+            // store some metadata in event's unmatching fields
+            new(const_cast<TActorId*>(&last->InterconnectSession)) TEventPayload{
+                .Conn = record.Conn,
+                .Callback = std::move(record.Callback),
+            };
+            new(const_cast<TScopeId*>(&last->OriginScopeId)) TEventPayload2{
+                .ReceivedTimestamp = record.ReceivedTimestamp,
+                .SeqNo = record.SeqNo,
+            };
+
             last->NextLinkPtr.store(0, std::memory_order_relaxed);
             IEventHandle *prev = Head.exchange(last, std::memory_order_acq_rel);
             prev->NextLinkPtr.store(reinterpret_cast<uintptr_t>(last), std::memory_order_release);
@@ -46,14 +65,19 @@ namespace NActors {
             return tail == &Stub && !next && tail == head;
         }
 
-        std::tuple<std::unique_ptr<IEventHandle>, ui64, TIntrusivePtr<IReceiveCallback>, ui64> Pop() {
+        std::optional<TRecord> Pop() {
             auto decompose = [&](IEventHandle *ev) {
                 auto& payload = reinterpret_cast<TEventPayload&>(const_cast<TActorId&>(ev->InterconnectSession));
                 ui64 conn = payload.Conn;
                 TIntrusivePtr<IReceiveCallback> callback = std::move(payload.Callback);
                 payload.~TEventPayload();
-                const ui64 timestamp = reinterpret_cast<const ui64&>(ev->OriginScopeId);
-                return std::make_tuple(std::unique_ptr<IEventHandle>(ev), conn, std::move(callback), timestamp);
+
+                auto& payload2 = reinterpret_cast<TEventPayload2&>(const_cast<TScopeId&>(ev->OriginScopeId));
+                ui64 receivedTimestamp = payload2.ReceivedTimestamp;
+                ui64 seqNo = payload2.SeqNo;
+                payload2.~TEventPayload2();
+
+                return TRecord{std::unique_ptr<IEventHandle>(ev), conn, std::move(callback), receivedTimestamp, seqNo};
             };
 
             for (;;) {
@@ -66,7 +90,7 @@ namespace NActors {
                         if (head = Head.load(std::memory_order_acquire); tail != head) {
                             continue;
                         } else {
-                            return {};
+                            return std::nullopt;
                         }
                     }
                     Tail.store(next, std::memory_order_relaxed);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix migration out-of-order message delivery

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This fixes potential out-of-order message delivery in ICv2 when migrating sessions between worker threads.
