### PR TITLE
Fix Kafka consumer metadata version parsing

### DIFF
--- a/ydb/core/kafka_proxy/actors/kafka_read_session_utils.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_utils.cpp
@@ -32,10 +32,11 @@ std::optional<TConsumerProtocolSubscription> GetSubscriptions(const TJoinGroupRe
         return std::nullopt;
     }
 
-    TKafkaVersion version = *(TKafkaVersion*)(metadata.value().data() + sizeof(TKafkaVersion));
-
-    TBuffer buffer(metadata.value().data() + sizeof(TKafkaVersion), metadata.value().size_bytes() - sizeof(TKafkaVersion));
+    TBuffer buffer(metadata.value().data(), metadata.value().size_bytes());
     TKafkaReadable readable(buffer);
+
+    TKafkaVersion version;
+    readable >> version;
 
     TConsumerProtocolSubscription result;
     result.Read(readable, version);

--- a/ydb/core/kafka_proxy/ut/ut_kafka_functions.cpp
+++ b/ydb/core/kafka_proxy/ut/ut_kafka_functions.cpp
@@ -1,5 +1,6 @@
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <ydb/core/kafka_proxy/actors/kafka_read_session_utils.h>
 #include <ydb/core/kafka_proxy/kafka_messages.h>
 
 using namespace NKafka;
@@ -26,6 +27,38 @@ Y_UNIT_TEST(CreateResponse) {
         auto result = CreateResponse(apiKey);
         UNIT_ASSERT_EQUAL(result->ApiKey(), apiKey);
     }
+}
+
+Y_UNIT_TEST(GetSubscriptionsReadsVersionPrefix) {
+    constexpr TKafkaVersion version = 3;
+
+    TConsumerProtocolSubscription subscription;
+    subscription.Topics = {"topic"};
+    subscription.GenerationId = 42;
+    subscription.RackId = "rack";
+
+    TKafkaWriteBuffer buffer(1024);
+    TKafkaWritable writable(buffer);
+    writable << version;
+    subscription.Write(writable, version);
+
+    const TString metadata = buffer.AsString();
+
+    TJoinGroupRequestData request;
+    request.ProtocolType = SUPPORTED_JOIN_GROUP_PROTOCOL;
+    auto& protocol = request.Protocols.emplace_back();
+    protocol.Name = ASSIGN_STRATEGY_ROUNDROBIN;
+    protocol.Metadata = TKafkaRawBytes(metadata.data(), metadata.size());
+
+    const auto result = GetSubscriptions(request);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL(result->Topics.size(), 1u);
+    UNIT_ASSERT(result->Topics.front());
+    UNIT_ASSERT_VALUES_EQUAL(*result->Topics.front(), "topic");
+    UNIT_ASSERT_VALUES_EQUAL(result->GenerationId, 42);
+    UNIT_ASSERT(result->RackId);
+    UNIT_ASSERT_VALUES_EQUAL(*result->RackId, "rack");
 }
 
 }


### PR DESCRIPTION
## What changed

- Read the consumer metadata version from offset 0 through `TKafkaReadable`.
- Continue parsing the subscription with the same reader after the version prefix.
- Add a regression test for a version 3 subscription.

## Why

The previous code read `TKafkaVersion` one field-width past the start of the metadata and used an unaligned, aliasing-unsafe pointer cast. It also bypassed Kafka byte-order normalization. This could parse consumer-group metadata with the wrong schema version.

Extracted from #47246 so the production fix can be reviewed and merged independently from the fuzz targets.
