### PR TITLE
Validate Kafka array lengths before allocation

### DIFF
--- a/ydb/public/sdk/cpp/src/library/kafka/kafka_messages_int.h
+++ b/ydb/public/sdk/cpp/src/library/kafka/kafka_messages_int.h
@@ -607,6 +607,9 @@ public:
                 ythrow yexception() << "non-nullable field " << Meta::Name << " was serialized as null";
             }
         }
+        if (static_cast<size_t>(length) > readable.left()) {
+            ythrow yexception() << "array field " << Meta::Name << " is longer than the remaining input";
+        }
         value.resize(length);
 
         for (int i = 0; i < length; ++i) {

--- a/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_messages_int_ut.cpp
+++ b/ydb/public/sdk/cpp/src/library/kafka/ut/kafka_messages_int_ut.cpp
@@ -237,6 +237,20 @@ Y_UNIT_TEST_SUITE(KafkaMessagesInt) {
         UNIT_ASSERT_EQUAL(result, value);
     }
 
+    Y_UNIT_TEST(TKafkaArray_RejectsLengthLargerThanRemainingInput) {
+        TKafkaWriteBuffer buffer(BUFFER_SIZE);
+        TKafkaWritable writable(buffer);
+        writable << TKafkaInt32{2};
+
+        TKafkaReadable readable(buffer.GetFrontBuffer());
+        Meta_TKafkaArray::Type result;
+
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            NKafka::NPrivate::Read<Meta_TKafkaArray>(readable, 3, result),
+            yexception,
+            "array field value is longer than the remaining input");
+    }
+
     Y_UNIT_TEST(TKafkaArray_PresentVersion_TaggedVersion) {
         TString v = "some value";
         SIMPLE_HEAD(TKafkaArray, { v });


### PR DESCRIPTION
## What changed

- Reject Kafka array lengths that exceed the number of bytes left in the input before resizing the destination vector.
- Add a regression test for a truncated array payload.

## Why

An input-controlled array length was passed directly to `value.resize(length)` before the decoder knew whether the payload contained enough data. A malformed request could therefore trigger an excessive allocation before normal EOF validation.

Extracted from #47246 so the production fix can be reviewed and merged independently from the fuzz targets.
