### PR TITLE
Validate parsed CPU mask ranges

### DIFF
--- a/ydb/library/actors/util/cpumask.h
+++ b/ydb/library/actors/util/cpumask.h
@@ -11,6 +11,9 @@ using TCpuId = ui32;
 
 // Simple data structure to operate with set of cpus
 struct TCpuMask {
+    // Keep malformed text input from requesting an unbounded allocation.
+    static constexpr TCpuId MaxParsedCpuId = 64 * 1024 - 1;
+
     TStackVec<bool, 1024> Cpus;
 
     // Creates empty mask
@@ -39,6 +42,9 @@ struct TCpuMask {
                     StringSplitter(s).Split('-').CollectInto(&l, &r);
                 } else {
                     l = r = FromString<TCpuId>(s);
+                }
+                if (l > r || r > MaxParsedCpuId) {
+                    ythrow yexception() << "invalid cpu range '" << s << "'";
                 }
                 if (r >= Cpus.size()) {
                     Cpus.resize(r + 1, false);

--- a/ydb/library/actors/util/cpumask_ut.cpp
+++ b/ydb/library/actors/util/cpumask_ut.cpp
@@ -1,0 +1,19 @@
+#include "cpumask.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+Y_UNIT_TEST_SUITE(TCpuMaskTest) {
+    Y_UNIT_TEST(RejectsInvertedRange) {
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            TCpuMask("3-1"),
+            yexception,
+            "invalid cpu range '3-1'");
+    }
+
+    Y_UNIT_TEST(RejectsCpuIdAboveSafetyLimit) {
+        UNIT_ASSERT_EXCEPTION_CONTAINS(
+            TCpuMask("65536"),
+            yexception,
+            "invalid cpu range '65536'");
+    }
+}

--- a/ydb/library/actors/util/ut/ya.make
+++ b/ydb/library/actors/util/ut/ya.make
@@ -8,6 +8,7 @@ ENDIF()
 SRCS(
     cpu_load_log_ut.cpp
     cpu_topology_ut.cpp
+    cpumask_ut.cpp
     memory_tracker_ut.cpp
     thread_load_log_ut.cpp
     rope_ut.cpp


### PR DESCRIPTION
## What changed

- Reject inverted CPU ranges before resizing the mask.
- Cap CPU IDs parsed from text at 65535 to bound allocations from malformed input.
- Add regression tests for an inverted range and an ID above the safety limit.

## Why

The parser resized its backing storage directly from an input-controlled CPU ID. A malformed configuration could request a very large allocation, while an inverted range was silently accepted. The explicit, documented parser limit keeps this input path bounded without changing normal CPU mask operations.

Extracted from #47246 so the production fix can be reviewed and merged independently from the fuzz targets.
