### PR TITLE
tpcc: combine commit with last query to save a network round-trip

### DIFF
--- a/ydb/library/workload/tpcc/transaction_delivery.cpp
+++ b/ydb/library/workload/tpcc/transaction_delivery.cpp
@@ -290,7 +290,7 @@ TAsyncExecuteQueryResult GetCustomerData(
 
 TAsyncExecuteQueryResult UpdateCustomerBalanceAndDeliveryCount(
     TSession& session, const TTransaction& tx, TTransactionContext& context,
-    int warehouseID, int districtID, const TOrderData& orderData)
+    int warehouseID, int districtID, const TOrderData& orderData, bool commit = false)
 {
     auto& Log = context.Log;
     static std::string query = std::format(R"(
@@ -316,7 +316,7 @@ TAsyncExecuteQueryResult UpdateCustomerBalanceAndDeliveryCount(
 
     auto result = session.ExecuteQuery(
         query,
-        TTxControl::Tx(tx),
+        TxControl(tx, commit),
         std::move(params));
 
     LOG_T("Terminal " << context.TerminalID << " waiting for customer balance and delivery count update result");
@@ -467,6 +467,14 @@ NThreading::TFuture<TStatus> GetDeliveryTask(
         currentOrder.DeliveryCount += 1;
     }
 
+    int lastDistrictWithOrder = -1;
+    for (int districtID = DISTRICT_LOW_ID; districtID <= DISTRICT_HIGH_ID; ++districtID) {
+        if (orders[districtID - 1]) {
+            lastDistrictWithOrder = districtID;
+        }
+    }
+
+    TStatus lastResult(EStatus::SUCCESS, NIssue::TIssues());
     for (int districtID = DISTRICT_LOW_ID; districtID <= DISTRICT_HIGH_ID; ++districtID) {
         if (!orders[districtID - 1]) {
             continue;
@@ -521,7 +529,8 @@ NThreading::TFuture<TStatus> GetDeliveryTask(
         }
 
         auto updateCustomerFuture = UpdateCustomerBalanceAndDeliveryCount(
-            session, *tx, context, warehouseID, districtID, currentOrder);
+            session, *tx, context, warehouseID, districtID, currentOrder,
+            /*commit=*/districtID == lastDistrictWithOrder);
         auto updateCustomerResult = co_await TSuspendWithFuture(updateCustomerFuture, context.TaskQueue, context.TerminalID);
         if (!updateCustomerResult.IsSuccess()) {
             if (ShouldExit(updateCustomerResult)) {
@@ -535,20 +544,20 @@ NThreading::TFuture<TStatus> GetDeliveryTask(
             co_return updateCustomerResult;
         }
 
+        lastResult = updateCustomerResult;
+
         // Add this order to the processed orders
         ++processedOrderCount;
     }
 
-    LOG_T("Terminal " << context.TerminalID
-        << " is committing Delivery transaction, processed " << processedOrderCount << " districts, session: " << session.GetId());
-
-    auto commitFuture = tx->Commit();
-    auto commitResult = co_await TSuspendWithFuture(commitFuture, context.TaskQueue, context.TerminalID);
-
     TMonotonic endTs = TMonotonic::Now();
     latency = endTs - startTs;
 
-    co_return commitResult;
+    if (processedOrderCount == 0) {
+        co_return TStatus(EStatus::SUCCESS, NIssue::TIssues());
+    }
+
+    co_return lastResult;
 }
 
 } // namespace NYdb::NTPCC

--- a/ydb/library/workload/tpcc/transaction_neworder.cpp
+++ b/ydb/library/workload/tpcc/transaction_neworder.cpp
@@ -468,7 +468,7 @@ TAsyncExecuteQueryResult UpdateStocks(
 
 TAsyncExecuteQueryResult InsertOrderLines(
     TSession& session, const TTransaction& tx, TTransactionContext& context,
-    const std::vector<OrderLine>& orderLines) {
+    const std::vector<OrderLine>& orderLines, bool commit = false) {
     auto& Log = context.Log;
     static std::string query = std::format(R"(
         PRAGMA TablePathPrefix("{}");
@@ -502,7 +502,7 @@ TAsyncExecuteQueryResult InsertOrderLines(
 
     auto result = session.ExecuteQuery(
         query,
-        TTxControl::Tx(tx),
+        TxControl(tx, commit),
         std::move(params));
 
     LOG_T("Terminal " << context.TerminalID << " waiting for order lines insert result");
@@ -716,6 +716,7 @@ NThreading::TFuture<TStatus> GetNewOrderTask(
     }
 
     if (hasInvalidItem) {
+        // TPC-C rollback path: explicit RollbackTransaction, not CommitTx on the last operator.
         co_await tx.Rollback();
         throw TUserAbortedException();
     }
@@ -850,9 +851,9 @@ NThreading::TFuture<TStatus> GetNewOrderTask(
         co_return updateStocksResult;
     }
 
-    // Insert order lines
+    // Insert order lines and commit in a single round-trip.
 
-    auto orderLinesFuture = InsertOrderLines(session, tx, context, orderLines);
+    auto orderLinesFuture = InsertOrderLines(session, tx, context, orderLines, /*commit=*/true);
     auto orderLinesResult = co_await TSuspendWithFuture(orderLinesFuture, context.TaskQueue, context.TerminalID);
     if (!orderLinesResult.IsSuccess()) {
         if (ShouldExit(orderLinesResult)) {
@@ -866,15 +867,10 @@ NThreading::TFuture<TStatus> GetNewOrderTask(
         co_return orderLinesResult;
     }
 
-    LOG_T("Terminal " << context.TerminalID << " is committing NewOrder transaction, session: " << session.GetId());
-
-    auto commitFuture = tx.Commit();
-    auto commitResult = co_await TSuspendWithFuture(commitFuture, context.TaskQueue, context.TerminalID);
-
     TMonotonic endTs = TMonotonic::Now();
     latency = endTs - startTs;
 
-    co_return commitResult;
+    co_return orderLinesResult;
 }
 
 } // namespace NYdb::NTPCC

--- a/ydb/library/workload/tpcc/transaction_orderstatus.cpp
+++ b/ydb/library/workload/tpcc/transaction_orderstatus.cpp
@@ -73,7 +73,7 @@ TAsyncExecuteQueryResult GetOrderByCustomer(
 
 TAsyncExecuteQueryResult GetOrderLines(
     TSession& session, const TTransaction& tx, TTransactionContext& context,
-    int warehouseID, int districtID, int orderID)
+    int warehouseID, int districtID, int orderID, bool commit = false)
 {
     auto& Log = context.Log;
     static std::string query = std::format(R"(
@@ -98,7 +98,7 @@ TAsyncExecuteQueryResult GetOrderLines(
 
     auto result = session.ExecuteQuery(
         query,
-        TTxControl::Tx(tx),
+        TxControl(tx, commit),
         std::move(params));
 
     LOG_T("Terminal " << context.TerminalID << " waiting for order lines result");
@@ -218,7 +218,7 @@ NThreading::TFuture<TStatus> GetOrderStatusTask(
 
     // Get the order lines for this order
 
-    auto orderLinesFuture = GetOrderLines(session, *tx, context, warehouseID, districtID, orderID);
+    auto orderLinesFuture = GetOrderLines(session, *tx, context, warehouseID, districtID, orderID, /*commit=*/true);
     auto orderLinesResult = co_await TSuspendWithFuture(orderLinesFuture, context.TaskQueue, context.TerminalID);
     if (!orderLinesResult.IsSuccess()) {
         if (ShouldExit(orderLinesResult)) {
@@ -232,17 +232,10 @@ NThreading::TFuture<TStatus> GetOrderStatusTask(
         co_return orderLinesResult;
     }
 
-    LOG_T("Terminal " << context.TerminalID << " is committing OrderStatus transaction: "
-        << "customer " << customer.c_id << ", order " << orderID
-        << ", lines " << orderLinesResult.GetResultSet(0).RowsCount() << ", session: " << session.GetId());
-
-    auto commitFuture = tx->Commit();
-    auto commitResult = co_await TSuspendWithFuture(commitFuture, context.TaskQueue, context.TerminalID);
-
     TMonotonic endTs = TMonotonic::Now();
     latency = endTs - startTs;
 
-    co_return commitResult;
+    co_return orderLinesResult;
 }
 
 } // namespace NYdb::NTPCC

--- a/ydb/library/workload/tpcc/transaction_payment.cpp
+++ b/ydb/library/workload/tpcc/transaction_payment.cpp
@@ -213,7 +213,8 @@ TAsyncExecuteQueryResult UpdateCustomer(
 TAsyncExecuteQueryResult InsertHistoryRecord(
     TSession& session, const TTransaction& tx, TTransactionContext& context,
     int customerDistrictID, int customerWarehouseID, int customerID,
-    int districtID, int warehouseID, double amount, const TString& data)
+    int districtID, int warehouseID, double amount, const TString& data,
+    bool commit = false)
 {
     auto& Log = context.Log;
     static std::string query = std::format(R"(
@@ -251,7 +252,7 @@ TAsyncExecuteQueryResult InsertHistoryRecord(
 
     auto result = session.ExecuteQuery(
         query,
-        TTxControl::Tx(tx),
+        TxControl(tx, commit),
         std::move(params));
 
     LOG_T("Terminal " << context.TerminalID << " waiting for history insert result");
@@ -493,7 +494,7 @@ NThreading::TFuture<TStatus> GetPaymentTask(
 
     auto historyFuture = InsertHistoryRecord(session, tx, context,
         customerDistrictID, customerWarehouseID, customer.c_id,
-        districtID, warehouseID, paymentAmount, historyData);
+        districtID, warehouseID, paymentAmount, historyData, /*commit=*/true);
 
     auto historyResult = co_await TSuspendWithFuture(historyFuture, context.TaskQueue, context.TerminalID);
     if (!historyResult.IsSuccess()) {
@@ -508,16 +509,10 @@ NThreading::TFuture<TStatus> GetPaymentTask(
         co_return historyResult;
     }
 
-    LOG_T("Terminal " << context.TerminalID << " is committing Payment transaction: "
-        << "customer " << customer.c_id << ", amount " << paymentAmount << ", session: " << session.GetId());
-
-    auto commitFuture = tx.Commit();
-    auto commitResult = co_await TSuspendWithFuture(commitFuture, context.TaskQueue, context.TerminalID);
-
     TMonotonic endTs = TMonotonic::Now();
     latency = endTs - startTs;
 
-    co_return commitResult;
+    co_return historyResult;
 }
 
 } // namespace NYdb::NTPCC

--- a/ydb/library/workload/tpcc/transaction_simulation.cpp
+++ b/ydb/library/workload/tpcc/transaction_simulation.cpp
@@ -25,7 +25,8 @@ using namespace NYdb::NQuery;
 NYdb::NQuery::TAsyncExecuteQueryResult Select1(
     NQuery::TSession& session,
     const std::optional<NYdb::NQuery::TTransaction>& tx,
-    TTransactionContext& context)
+    TTransactionContext& context,
+    bool commit = false)
 {
     auto& Log = context.Log;
     static std::string query = std::format(R"(
@@ -40,7 +41,7 @@ NYdb::NQuery::TAsyncExecuteQueryResult Select1(
         .AddParam("$count").Int32(1).Build()
         .Build();
 
-    auto txControl = tx ? TTxControl::Tx(*tx) : TTxControl::BeginTx(context.TxMode);
+    auto txControl = tx ? TxControl(*tx, commit) : TTxControl::BeginTx(context.TxMode);
     auto result = session.ExecuteQuery(
         query,
         txControl,
@@ -84,8 +85,10 @@ NThreading::TFuture<TStatus> GetSimulationTask(
     // sleep 1 sumulation
 
     std::optional<TTransaction> tx;
+    TStatus lastResult(EStatus::SUCCESS, NIssue::TIssues());
     for (int i = 0; i < context.SimulateTransactionSelect1; ++i) {
-        auto future = Select1(session, tx, context);
+        const bool commit = (i + 1 == context.SimulateTransactionSelect1);
+        auto future = Select1(session, tx, context, commit);
         auto result = co_await TSuspendWithFuture(future, context.TaskQueue, context.TerminalID);
         if (!result.IsSuccess()) {
             co_return result;
@@ -95,15 +98,14 @@ NThreading::TFuture<TStatus> GetSimulationTask(
             tx = *result.GetTransaction();
             LOG_T("Terminal " << context.TerminalID << " simulated transaction txId " << tx->GetId());
         }
-    }
 
-    auto commitFuture = tx->Commit();
-    auto commitResult = co_await TSuspendWithFuture(commitFuture, context.TaskQueue, context.TerminalID);
+        lastResult = result;
+    }
 
     TMonotonic endTs = TMonotonic::Now();
     latency = endTs - startTs;
 
-    co_return commitResult;
+    co_return lastResult;
 }
 
 } // namespace NYdb::NTPCC

--- a/ydb/library/workload/tpcc/transaction_stocklevel.cpp
+++ b/ydb/library/workload/tpcc/transaction_stocklevel.cpp
@@ -55,7 +55,7 @@ TAsyncExecuteQueryResult GetDistrictOrderId(
 
 TAsyncExecuteQueryResult GetStockCount(
     TSession& session, const TTransaction& tx, TTransactionContext& context,
-    int warehouseID, int districtID, int orderID, int threshold)
+    int warehouseID, int districtID, int orderID, int threshold, bool commit = false)
 {
     auto& Log = context.Log;
     static std::string query = std::format(R"(
@@ -89,7 +89,7 @@ TAsyncExecuteQueryResult GetStockCount(
 
     auto result = session.ExecuteQuery(
         query,
-        TTxControl::Tx(tx),
+        TxControl(tx, commit),
         std::move(params));
 
     LOG_T("Terminal " << context.TerminalID << " waiting for stock count result");
@@ -148,7 +148,7 @@ NThreading::TFuture<TStatus> GetStockLevelTask(
     int nextOrderID = *districtParser.ColumnParser("D_NEXT_O_ID").GetOptionalInt32();
 
     // Get stock count
-    auto stockCountFuture = GetStockCount(session, tx, context, warehouseID, districtID, nextOrderID, threshold);
+    auto stockCountFuture = GetStockCount(session, tx, context, warehouseID, districtID, nextOrderID, threshold, /*commit=*/true);
     auto stockCountResult = co_await TSuspendWithFuture(stockCountFuture, context.TaskQueue, context.TerminalID);
     if (!stockCountResult.IsSuccess()) {
         if (ShouldExit(stockCountResult)) {
@@ -162,15 +162,10 @@ NThreading::TFuture<TStatus> GetStockLevelTask(
         co_return stockCountResult;
     }
 
-    LOG_T("Terminal " << context.TerminalID << " is committing StockLevel transaction, session: " << session.GetId());
-
-    auto commitFuture = tx.Commit();
-    auto commitResult = co_await TSuspendWithFuture(commitFuture, context.TaskQueue, context.TerminalID);
-
     TMonotonic endTs = TMonotonic::Now();
     latency = endTs - startTs;
 
-    co_return commitResult;
+    co_return stockCountResult;
 }
 
 } // namespace NYdb::NTPCC

--- a/ydb/library/workload/tpcc/transactions.h
+++ b/ydb/library/workload/tpcc/transactions.h
@@ -45,6 +45,15 @@ struct TTransactionContext {
 struct TUserAbortedException : public yexception {
 };
 
+// Build TTxControl for an in-flight transaction, optionally committing with the query.
+inline NQuery::TTxControl TxControl(const NQuery::TTransaction& tx, bool commit = false) {
+    auto control = NQuery::TTxControl::Tx(tx);
+    if (commit) {
+        control.CommitTx(true);
+    }
+    return control;
+}
+
 //-----------------------------------------------------------------------------
 
 NThreading::TFuture<TStatus> GetNewOrderTask(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add TxControl(tx, commit) helper and set CommitTx on the final operator for all TPC-C transaction types. NewOrder rollback still uses an explicit RollbackTransaction call when an invalid item triggers user abort.

This saves one roundtrip per transaction, and helps to reduce the latencies.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
