### PR TITLE
Fix invalid root certificate false positive

### DIFF
--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
@@ -8,7 +8,6 @@
 #include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
-#include <openssl/x509v3.h>
 
 #include <memory>
 #include <string>
@@ -67,16 +66,8 @@ bool ValidateRootCertificates(const std::string& pemRootCerts, std::string& erro
             return false;
         }
 
-        std::unique_ptr<BASIC_CONSTRAINTS, decltype(&BASIC_CONSTRAINTS_free)> basicConstraints(
-            static_cast<BASIC_CONSTRAINTS*>(X509_get_ext_d2i(cert.get(), NID_basic_constraints, nullptr, nullptr)),
-            &BASIC_CONSTRAINTS_free);
-        const auto isCaCert = basicConstraints && basicConstraints->ca;
-
-        if (!isCaCert) {
-            ERR_clear_error();
-            errorMessage = "root CA PEM: certificate is not a CA (BasicConstraints)";
-            return false;
-        }
+        // Match gRPC trust store semantics: with X509_V_FLAG_PARTIAL_CHAIN an
+        // explicitly trusted non-CA certificate may also be a trust anchor.
         ERR_clear_error();
         ++certsParsed;
     }

--- a/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
+++ b/ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.cpp
@@ -54,16 +54,18 @@ bool ValidateRootCertificates(const std::string& pemRootCerts, std::string& erro
     size_t certsParsed = 0;
     while (true) {
         std::unique_ptr<X509, decltype(&X509_free)> cert(
-            PEM_read_bio_X509(rootCertsBio, nullptr, nullptr, nullptr),
+            PEM_read_bio_X509_AUX(rootCertsBio, nullptr, nullptr, nullptr),
             &X509_free);
         if (!cert) {
-            const unsigned long errorCode = ERR_peek_last_error();
-            if (errorCode == 0 || ERR_GET_REASON(errorCode) == PEM_R_NO_START_LINE) {
-                ERR_clear_error();
-                break;
+            if (certsParsed == 0) {
+                errorMessage = "root CA PEM: failed to parse certificate #1: " + DrainOpenSslErrors();
+                return false;
             }
-            errorMessage = "root CA PEM: " + DrainOpenSslErrors();
-            return false;
+
+            // gRPC treats a read error as the end of the bundle and uses all
+            // certificates parsed before it.
+            ERR_clear_error();
+            break;
         }
 
         // Match gRPC trust store semantics: with X509_V_FLAG_PARTIAL_CHAIN an
@@ -72,10 +74,6 @@ bool ValidateRootCertificates(const std::string& pemRootCerts, std::string& erro
         ++certsParsed;
     }
 
-    if (certsParsed == 0) {
-        errorMessage = "root CA PEM: no certificates parsed";
-        return false;
-    }
     return true;
 }
 

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -239,26 +239,22 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "root CA PEM:");
     }
 
-    Y_UNIT_TEST(NonCaTrustAnchorPassesValidation) {
-        const std::string nonCaCertificate = R"(-----BEGIN CERTIFICATE-----
-MIICODCCAd2gAwIBAgIUMizwaqRBfZMqZLAfqOon9LxVUwswCgYIKoZIzj0EAwIw
-RjELMAkGA1UEBhMCUlUxDzANBgNVBAcMBk1vc2NvdzEPMA0GA1UECgwGWWFuZGV4
-MRUwEwYDVQQDDAxMb2NhbGhvc3QgQ0EwHhcNMjUwNTEyMTQxOTEzWhcNMzUwNTEw
-MTQxOTEzWjBDMQswCQYDVQQGEwJSVTEPMA0GA1UEBwwGTW9zY293MQ8wDQYDVQQK
-DAZZYW5kZXgxEjAQBgNVBAMMCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49
-AwEHA0IABOM5UtoWuYTndtECRIdexT/5o5M7Dj5sBe4mPcydByC8AY6sSUghpzTD
-HU/gNnfja8unXt1gukZEe9h03uoH37mjgaswgagwHQYDVR0OBBYEFD3bqNr1fG99
-dKCFAsKkTHwNHkF+MB8GA1UdIwQYMBaAFMX2CNtuUf7N2udXp3Xn9YdWy9czMCwG
-A1UdEQQlMCOCCWxvY2FsaG9zdIcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATAMBgNV
-HRMBAf8EAjAAMAsGA1UdDwQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB
-BQUHAwIwCgYIKoZIzj0EAwIDSQAwRgIhANIfRVOvxINkIBKeW60zD7BkrYBXWczl
-FmSagrLHbVpDAiEA+HkxWw0d1mFaF5ZQ03DEbeb0gFQQDQCrqk/hS6ofCbs=
+    Y_UNIT_TEST(LegacyV1TrustAnchorPassesValidation) {
+        const std::string legacyV1Certificate = R"(-----BEGIN CERTIFICATE-----
+MIIBbTCCARMCFBthJdWIg/H6ITeelffnCYoK8fDFMAoGCCqGSM49BAMCMDkxCzAJ
+BgNVBAYTAlJVMQwwCgYDVQQKDANZREIxHDAaBgNVBAMME0xlZ2FjeSBUZXN0IFJv
+b3QgQ0EwHhcNMjYwNzI3MDk0NDU2WhcNMzYwNzI0MDk0NDU2WjA5MQswCQYDVQQG
+EwJSVTEMMAoGA1UECgwDWURCMRwwGgYDVQQDDBNMZWdhY3kgVGVzdCBSb290IENB
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4zlS2ha5hOd20QJEh17FP/mjkzsO
+PmwF7iY9zJ0HILwBjqxJSCGnNMMdT+A2d+Nry6de3WC6RkR72HTe6gffuTAKBggq
+hkjOPQQDAgNIADBFAiEA/0rBKAconmtFcliTZ0i9HzIkQeG+E/zVMiUvlhwpylYC
+IGfPhGBVwOMnr+uhwtpj4PAOIrlOQD/fBsaRtYuBRdg2
 -----END CERTIFICATE-----)";
 
         auto driver = TDriver(
             TDriverConfig()
                 .SetEndpoint("localhost:100")
-                .UseSecureConnection(nonCaCertificate));
+                .UseSecureConnection(legacyV1Certificate));
         auto client = NTable::TTableClient(driver);
 
         auto result = client.CreateSession().GetValueSync();

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -4,6 +4,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/exceptions/exceptions.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/type_switcher.h>
 #include <ydb/public/sdk/cpp/src/client/impl/observability/constants.h>
+#include <ydb/public/sdk/cpp/src/library/grpc/client/grpc_common.h>
 #include <ydb/public/sdk/cpp/tests/common/fake_metric_registry.h>
 #include <ydb/public/sdk/cpp/tests/common/fake_trace_provider.h>
 
@@ -28,6 +29,17 @@ using namespace NYdb;
 using namespace NYdb::NTable;
 
 namespace {
+
+    constexpr const char LegacyV1Certificate[] = R"(-----BEGIN CERTIFICATE-----
+MIIBbTCCARMCFBthJdWIg/H6ITeelffnCYoK8fDFMAoGCCqGSM49BAMCMDkxCzAJ
+BgNVBAYTAlJVMQwwCgYDVQQKDANZREIxHDAaBgNVBAMME0xlZ2FjeSBUZXN0IFJv
+b3QgQ0EwHhcNMjYwNzI3MDk0NDU2WhcNMzYwNzI0MDk0NDU2WjA5MQswCQYDVQQG
+EwJSVTEMMAoGA1UECgwDWURCMRwwGgYDVQQDDBNMZWdhY3kgVGVzdCBSb290IENB
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4zlS2ha5hOd20QJEh17FP/mjkzsO
+PmwF7iY9zJ0HILwBjqxJSCGnNMMdT+A2d+Nry6de3WC6RkR72HTe6gffuTAKBggq
+hkjOPQQDAgNIADBFAiEA/0rBKAconmtFcliTZ0i9HzIkQeG+E/zVMiUvlhwpylYC
+IGfPhGBVwOMnr+uhwtpj4PAOIrlOQD/fBsaRtYuBRdg2
+-----END CERTIFICATE-----)";
 
     std::string ReadBuildInfo(grpc::ServerContext* context) {
         const auto& metadata = context->client_metadata();
@@ -237,24 +249,14 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
         UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "Client TLS credentials validation failed");
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "root CA PEM:");
+        UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "failed to parse certificate #1");
     }
 
     Y_UNIT_TEST(LegacyV1TrustAnchorPassesValidation) {
-        const std::string legacyV1Certificate = R"(-----BEGIN CERTIFICATE-----
-MIIBbTCCARMCFBthJdWIg/H6ITeelffnCYoK8fDFMAoGCCqGSM49BAMCMDkxCzAJ
-BgNVBAYTAlJVMQwwCgYDVQQKDANZREIxHDAaBgNVBAMME0xlZ2FjeSBUZXN0IFJv
-b3QgQ0EwHhcNMjYwNzI3MDk0NDU2WhcNMzYwNzI0MDk0NDU2WjA5MQswCQYDVQQG
-EwJSVTEMMAoGA1UECgwDWURCMRwwGgYDVQQDDBNMZWdhY3kgVGVzdCBSb290IENB
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4zlS2ha5hOd20QJEh17FP/mjkzsO
-PmwF7iY9zJ0HILwBjqxJSCGnNMMdT+A2d+Nry6de3WC6RkR72HTe6gffuTAKBggq
-hkjOPQQDAgNIADBFAiEA/0rBKAconmtFcliTZ0i9HzIkQeG+E/zVMiUvlhwpylYC
-IGfPhGBVwOMnr+uhwtpj4PAOIrlOQD/fBsaRtYuBRdg2
------END CERTIFICATE-----)";
-
         auto driver = TDriver(
             TDriverConfig()
                 .SetEndpoint("localhost:100")
-                .UseSecureConnection(legacyV1Certificate));
+                .UseSecureConnection(LegacyV1Certificate));
         auto client = NTable::TTableClient(driver);
 
         auto result = client.CreateSession().GetValueSync();
@@ -262,6 +264,20 @@ IGfPhGBVwOMnr+uhwtpj4PAOIrlOQD/fBsaRtYuBRdg2
 
         UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
         UNIT_ASSERT(issues.find("Client TLS credentials validation failed") == std::string::npos);
+    }
+
+    Y_UNIT_TEST(MalformedCertificateAfterValidRootPassesValidation) {
+        const std::string rootBundle = std::string(LegacyV1Certificate) + R"(
+-----BEGIN CERTIFICATE-----
+not-base64
+-----END CERTIFICATE-----)";
+        grpc::SslCredentialsOptions sslOptions{
+            .pem_root_certs = NYdb::TStringType{rootBundle},
+        };
+        std::string validationDetail;
+
+        UNIT_ASSERT(NYdbGrpc::ValidateTlsCredentials(sslOptions, validationDetail));
+        UNIT_ASSERT(validationDetail.empty());
     }
 
     Y_UNIT_TEST(EmptyRootCertificateWithoutClientCredentialsKeepsBehavior) {

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -239,6 +239,35 @@ Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {
         UNIT_ASSERT_STRING_CONTAINS(result.GetIssues().ToString(), "root CA PEM:");
     }
 
+    Y_UNIT_TEST(NonCaTrustAnchorPassesValidation) {
+        const std::string nonCaCertificate = R"(-----BEGIN CERTIFICATE-----
+MIICODCCAd2gAwIBAgIUMizwaqRBfZMqZLAfqOon9LxVUwswCgYIKoZIzj0EAwIw
+RjELMAkGA1UEBhMCUlUxDzANBgNVBAcMBk1vc2NvdzEPMA0GA1UECgwGWWFuZGV4
+MRUwEwYDVQQDDAxMb2NhbGhvc3QgQ0EwHhcNMjUwNTEyMTQxOTEzWhcNMzUwNTEw
+MTQxOTEzWjBDMQswCQYDVQQGEwJSVTEPMA0GA1UEBwwGTW9zY293MQ8wDQYDVQQK
+DAZZYW5kZXgxEjAQBgNVBAMMCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49
+AwEHA0IABOM5UtoWuYTndtECRIdexT/5o5M7Dj5sBe4mPcydByC8AY6sSUghpzTD
+HU/gNnfja8unXt1gukZEe9h03uoH37mjgaswgagwHQYDVR0OBBYEFD3bqNr1fG99
+dKCFAsKkTHwNHkF+MB8GA1UdIwQYMBaAFMX2CNtuUf7N2udXp3Xn9YdWy9czMCwG
+A1UdEQQlMCOCCWxvY2FsaG9zdIcEfwAAAYcQAAAAAAAAAAAAAAAAAAAAATAMBgNV
+HRMBAf8EAjAAMAsGA1UdDwQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB
+BQUHAwIwCgYIKoZIzj0EAwIDSQAwRgIhANIfRVOvxINkIBKeW60zD7BkrYBXWczl
+FmSagrLHbVpDAiEA+HkxWw0d1mFaF5ZQ03DEbeb0gFQQDQCrqk/hS6ofCbs=
+-----END CERTIFICATE-----)";
+
+        auto driver = TDriver(
+            TDriverConfig()
+                .SetEndpoint("localhost:100")
+                .UseSecureConnection(nonCaCertificate));
+        auto client = NTable::TTableClient(driver);
+
+        auto result = client.CreateSession().GetValueSync();
+        auto issues = result.GetIssues().ToString();
+
+        UNIT_ASSERT_EQUAL(result.GetStatus(), EStatus::TRANSPORT_UNAVAILABLE);
+        UNIT_ASSERT(issues.find("Client TLS credentials validation failed") == std::string::npos);
+    }
+
     Y_UNIT_TEST(EmptyRootCertificateWithoutClientCredentialsKeepsBehavior) {
         auto driver = TDriver(
             TDriverConfig()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->
The fail-fast check didn't allow running any grpc requests if even one certificate was broken. This pr asserts the behaviour of the root certificate checker same way the grpc does: https://github.com/ydb-platform/ydb/blob/a0f7efcc6e2c76b9c632b5540534729f61ab1344/contrib/libs/grpc/src/core/tsi/ssl_transport_security.cc#L721-L758 - it treats a broken certificate as the end of the bundle and only fails if there was 0 valid certificates before.