### PR TITLE
 [EXT-2347] Meta support-link URL parameter collection 

### DIFF
--- a/ydb/mvp/meta/support_links/grafana_dashboard_common.cpp
+++ b/ydb/mvp/meta/support_links/grafana_dashboard_common.cpp
@@ -29,25 +29,8 @@ void InsertOrReplaceDashboardVar(TCgiParameters& queryParameters, TStringBuf lab
     queryParameters.InsertUnescaped(varName, value);
 }
 
-void ApplyGrafanaDashboardBindingPolicy(
-    TCgiParameters& queryParameters,
-    const THashMap<TString, TString>& clusterInfo,
-    const TCgiParameters& requestQueryParameters,
-    const TResolvedParamBindings& paramBindings)
-{
-    for (const auto& [name, value] : BuildNonIdentityRequestParamValues(requestQueryParameters)) {
-        InsertOrReplaceDashboardVar(queryParameters, name, value);
-    }
-
-    for (const auto& [label, value] : BuildClusterInfoParamValues(clusterInfo, paramBindings.ClusterInfoMappings)) {
-        InsertOrReplaceDashboardVar(queryParameters, label, value);
-    }
-
-    for (const auto& [label, value] : BuildStaticParamValues(paramBindings.StaticMappings)) {
-        InsertOrReplaceDashboardVar(queryParameters, label, value);
-    }
-
-    for (const auto& [label, value] : BuildRequestParamValues(requestQueryParameters, paramBindings.RequestMappings)) {
+void ApplyGrafanaDashboardBindingPolicy(TCgiParameters& queryParameters, const TVector<std::pair<TString, TString>>& parametersToAdd) {
+    for (const auto& [label, value] : parametersToAdd) {
         InsertOrReplaceDashboardVar(queryParameters, label, value);
     }
 }
@@ -78,7 +61,7 @@ TString BuildGrafanaDashboardUrl(
     const TResolvedParamBindings& paramBindings)
 {
     auto [path, queryParameters] = BuildGrafanaDashboardUrlParts(grafanaEndpoint, url);
-    ApplyGrafanaDashboardBindingPolicy(queryParameters, clusterInfo, requestQueryParameters, paramBindings);
+    ApplyGrafanaDashboardBindingPolicy(queryParameters, BuildParametersToAdd(requestQueryParameters, clusterInfo, paramBindings));
 
     return queryParameters.empty()
         ? path

--- a/ydb/mvp/meta/support_links/grafana_logging_source.cpp
+++ b/ydb/mvp/meta/support_links/grafana_logging_source.cpp
@@ -91,25 +91,15 @@ bool TryBuildGrafanaLoggingUrl(
     }
 
     const TCgiParameters forwardedParameters = BuildForwardedParameters(input.Identity, input.AdditionalRequestParams);
-    TVector<std::pair<TString, TString>> bindings = BuildNonIdentityRequestParamValues(forwardedParameters);
-    for (auto& binding : BuildRequestParamValues(forwardedParameters, paramBindings.RequestMappings)) {
-        bindings.push_back(std::move(binding));
-    }
-    for (auto& binding : BuildClusterInfoParamValues(input.ClusterInfo, paramBindings.ClusterInfoMappings)) {
-        bindings.push_back(std::move(binding));
-    }
-    for (auto& binding : BuildStaticParamValues(paramBindings.StaticMappings)) {
-        bindings.push_back(std::move(binding));
-    }
-
-    TVector<std::pair<TString, TString>> resolvedBindings;
-    resolvedBindings.reserve(bindings.size());
-    for (auto& binding : bindings) {
-        if (binding.first == "datasource") {
-            datasource = std::move(binding.second);
+    auto parametersToAdd = BuildParametersToAdd(forwardedParameters, input.ClusterInfo, paramBindings);
+    TVector<std::pair<TString, TString>> bindings;
+    bindings.reserve(parametersToAdd.size());
+    for (auto& paramValue : parametersToAdd) {
+        if (paramValue.first == "datasource") {
+            datasource = std::move(paramValue.second);
             continue;
         }
-        resolvedBindings.push_back(std::move(binding));
+        bindings.push_back(std::move(paramValue));
     }
 
     if (datasource.empty()) {
@@ -120,7 +110,7 @@ bool TryBuildGrafanaLoggingUrl(
     TCgiParameters queryParameters;
     queryParameters.InsertUnescaped("schemaVersion", "1");
     queryParameters.InsertUnescaped("panes", NJson::WriteJson(
-        BuildGrafanaLoggingPanesJson(datasource, resolvedBindings),
+        BuildGrafanaLoggingPanesJson(datasource, bindings),
         false));
     queryParameters.InsertUnescaped("orgId", "1");
 

--- a/ydb/mvp/meta/support_links/param_bindings.cpp
+++ b/ydb/mvp/meta/support_links/param_bindings.cpp
@@ -84,6 +84,28 @@ void ValidateParamsAreUnique(const TResolvedParamBindings& paramBindings, const 
     }
 }
 
+TVector<std::pair<TString, TString>> BuildParametersToAdd(
+    const TCgiParameters& requestParameters,
+    const THashMap<TString, TString>& clusterInfo,
+    const TResolvedParamBindings& paramBindings)
+{
+    TVector<std::pair<TString, TString>> parametersToAdd = BuildNonIdentityRequestParamValues(requestParameters);
+
+    for (auto& paramValue : BuildRequestParamValues(requestParameters, paramBindings.RequestMappings)) {
+        parametersToAdd.push_back(std::move(paramValue));
+    }
+
+    for (auto& paramValue : BuildClusterInfoParamValues(clusterInfo, paramBindings.ClusterInfoMappings)) {
+        parametersToAdd.push_back(std::move(paramValue));
+    }
+
+    for (auto& paramValue : BuildStaticParamValues(paramBindings.StaticMappings)) {
+        parametersToAdd.push_back(std::move(paramValue));
+    }
+
+    return parametersToAdd;
+}
+
 TVector<std::pair<TString, TString>> BuildRequestParamValues(
     const TCgiParameters& requestParameters,
     const TVector<std::pair<TString, TString>>& requestMappings)

--- a/ydb/mvp/meta/support_links/param_bindings.h
+++ b/ydb/mvp/meta/support_links/param_bindings.h
@@ -16,6 +16,10 @@ struct TResolvedParamBindings {
 
 TResolvedParamBindings ResolveParamBindings(const TSupportLinkEntryConfig& config, const TResolvedParamBindings& defaultParamBindings);
 void ValidateParamsAreUnique(const TResolvedParamBindings& paramBindings, const TSupportLinkEntryConfig& config);
+TVector<std::pair<TString, TString>> BuildParametersToAdd(
+    const TCgiParameters& requestParameters,
+    const THashMap<TString, TString>& clusterInfo,
+    const TResolvedParamBindings& paramBindings);
 TVector<std::pair<TString, TString>> BuildRequestParamValues(
     const TCgiParameters& requestParameters,
     const TVector<std::pair<TString, TString>>& requestMappings);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Refactors support-link URL parameter collection by extracting shared “parameters to add” construction into a single helper, and reuses it across Grafana dashboard/logging link builders to reduce duplication.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
