### PR TITLE
Increase SPLIT_FACTOR in ut_export_reboots_s3 to avoid chunk timeouts

### DIFF
--- a/ydb/core/tx/schemeshard/ut_export_reboots_s3/ya.make
+++ b/ydb/core/tx/schemeshard/ut_export_reboots_s3/ya.make
@@ -2,7 +2,7 @@ UNITTEST_FOR(ydb/core/tx/schemeshard)
 
 FORK_SUBTESTS()
 
-SPLIT_FACTOR(50)
+SPLIT_FACTOR(200)
 
 REQUIREMENTS(ram:32 cpu:4)
 


### PR DESCRIPTION
Fixes the flaky TIMEOUT of `TExportToS3WithRebootsTests.ShouldSucceedOnManyTablesWithParquet[TabletRebootsBucket0]` (#47680).

The test itself is fine (~77s in isolation). With `SPLIT_FACTOR(50)` the 328 suite tests are packed ~6 per chunk sharing one 600s MEDIUM budget, and the chunk containing this test also holds the three heaviest tests of the suite (`ShouldSucceedOnManyTables-IsFs`, 518s total in the failing CI run). Under CI load the chunk needs ~1000s, so whichever test is running at the 600s mark gets killed — reproduced locally 6/6 times under CI-like CPU contention.

`SPLIT_FACTOR(200)` caps chunks at 2 tests; the worst pair fits in ~410s under the same contention.

### Changelog category
* Not for changelog (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)