### PR TITLE
Use mailbox finish notification for DSProxy batching

### DIFF
--- a/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_impl.h
@@ -20,8 +20,6 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
     enum {
         EvUpdateResponsiveness = EventSpaceBegin(TKikimrEvents::ES_PRIVATE),
         EvUpdateGroupStat,
-        EvStopBatchingPutRequests,
-        EvStopBatchingGetRequests,
         EvConfigureQueryTimeout,
         EvEstablishingSessionTimeout,
         Ev5min,
@@ -30,8 +28,6 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
 
     struct TEvUpdateResponsiveness : TEventLocal<TEvUpdateResponsiveness, EvUpdateResponsiveness> {};
     struct TEvUpdateGroupStat : TEventLocal<TEvUpdateGroupStat, EvUpdateGroupStat> {};
-    struct TEvStopBatchingPutRequests : TEventLocal<TEvStopBatchingPutRequests, EvStopBatchingPutRequests> {};
-    struct TEvStopBatchingGetRequests : TEventLocal<TEvStopBatchingGetRequests, EvStopBatchingGetRequests> {};
     struct TEvConfigureQueryTimeout : TEventLocal<TEvConfigureQueryTimeout, EvConfigureQueryTimeout> {};
     struct TEvEstablishingSessionTimeout : TEventLocal<TEvEstablishingSessionTimeout, EvEstablishingSessionTimeout> {};
 
@@ -91,7 +87,6 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
     TDiskResponsivenessTracker ResponsivenessTracker = {ResponsivenessTrackerMaxQueue, ResponsivenessTrackerWindow};
     TDiskResponsivenessTracker::TPerDiskStatsPtr PerDiskStats = MakeIntrusive<TDiskResponsivenessTracker::TPerDiskStats>();
 
-    TEvStopBatchingPutRequests::TPtr StopPutBatchingEvent;
     ui64 BatchedPutRequestCount = 0;
 
     static constexpr ui64 PutHandleClassCount = NKikimrBlobStorage::EPutHandleClass_MAX + 1;
@@ -105,7 +100,6 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
     TStackVec<TPutBatchedBucket, PutBatchedBucketCount> PutBatchedBucketQueue;
     THashSet<TLogoBlobID> BatchedPutIds;
 
-    TEvStopBatchingGetRequests::TPtr StopGetBatchingEvent;
     ui64 BatchedGetRequestCount = 0;
 
     static constexpr ui64 GetHandleClassCount = NKikimrBlobStorage::EGetHandleClass_MAX + 1;
@@ -283,8 +277,7 @@ class TBlobStorageGroupProxy : public TActorBootstrapped<TBlobStorageGroupProxy>
 
     void ProcessBatchedPutRequests(TBatchedPutQueue &batchedPuts, NKikimrBlobStorage::EPutHandleClass handleClass,
         TEvBlobStorage::TEvPut::ETactic tactic, bool reduceInterpileTraffic);
-    void Handle(TEvStopBatchingPutRequests::TPtr& ev);
-    void Handle(TEvStopBatchingGetRequests::TPtr& ev);
+    void Handle(TEvents::TEvMailboxProcessingFinished::TPtr&);
 
     // todo: in-fly tracking for cancelation and
     void PushRequest(IActor *actor, TInstant deadline);
@@ -383,8 +376,7 @@ public:
     // State functions
 
     STRICT_STFUNC(StateCommon,
-        hFunc(TEvStopBatchingPutRequests, Handle);
-        hFunc(TEvStopBatchingGetRequests, Handle);
+        hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
         hFunc(TEvDeathNote, Handle);
         hFunc(TEvRequestProxySessionsState, Handle);
         hFunc(TEvBlobStorage::TEvBunchOfEvents, Handle);

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -33,7 +33,10 @@ namespace NKikimr {
             return;
         }
 
-        BatchedGetRequestCount++;
+        if (!BatchedGetRequestCount && !BatchedPutRequestCount) {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+        }
+        ++BatchedGetRequestCount;
 
         EnsureMonitoring(true);
         LWTRACK(DSProxyGetHandle, ev->Get()->Orbit);
@@ -187,7 +190,10 @@ namespace NKikimr {
             return;
         }
 
-        BatchedPutRequestCount++;
+        if (!BatchedGetRequestCount && !BatchedPutRequestCount) {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+        }
+        ++BatchedPutRequestCount;
 
         Send(MonActor, new TEvThroughputAddRequest(ev->Get()->HandleClass, bytes));
         EnableWilsonTracing(ev, Mon->PutSamplePPM);
@@ -695,6 +701,8 @@ namespace NKikimr {
             LWPROBE(DSProxyBatchedGetRequest, BatchedGetRequestCount, GroupId.GetRawId());
             BatchedGetRequestCount = 0;
         }
+
+        ClearSystemFlag(ESystemFlag::MailboxProcessingFinished);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -682,6 +682,10 @@ namespace NKikimr {
 
     void TBlobStorageGroupProxy::Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
         if (BatchedPutRequestCount) {
+            // This direct callback intentionally performs the flush here. In StateWork each batch is capped at
+            // MaxBatchedPutRequests, and flushing only walks these small queues and registers request actors; their
+            // actual work remains subject to normal mailbox scheduling. A self-event would add queue traffic and
+            // another activation for this bounded bookkeeping.
             for (auto &bucket : PutBatchedBucketQueue) {
                 auto &batchedPuts = BatchedPuts[bucket.HandleClass][bucket.Tactic][bucket.ReduceInterpileTraffic];
                 Y_ABORT_UNLESS(!batchedPuts.Queue.empty());

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -33,9 +33,6 @@ namespace NKikimr {
             return;
         }
 
-        if (StopGetBatchingEvent) {
-            TActivationContext::Send(StopGetBatchingEvent.Release());
-        }
         BatchedGetRequestCount++;
 
         EnsureMonitoring(true);
@@ -190,9 +187,6 @@ namespace NKikimr {
             return;
         }
 
-        if (StopPutBatchingEvent) {
-            TActivationContext::Send(StopPutBatchingEvent.Release());
-        }
         BatchedPutRequestCount++;
 
         Send(MonActor, new TEvThroughputAddRequest(ev->Get()->HandleClass, bytes));
@@ -680,27 +674,27 @@ namespace NKikimr {
         batchedPuts.Bytes = 0;
     }
 
-    void TBlobStorageGroupProxy::Handle(TEvStopBatchingPutRequests::TPtr& ev) {
-        StopPutBatchingEvent = ev;
-        for (auto &bucket : PutBatchedBucketQueue) {
-            auto &batchedPuts = BatchedPuts[bucket.HandleClass][bucket.Tactic][bucket.ReduceInterpileTraffic];
-            Y_ABORT_UNLESS(!batchedPuts.Queue.empty());
-            *Mon->PutsSentViaPutBatching += batchedPuts.Queue.size();
-            ++*Mon->PutBatchesSent;
-            ProcessBatchedPutRequests(batchedPuts, bucket.HandleClass, bucket.Tactic, bucket.ReduceInterpileTraffic);
+    void TBlobStorageGroupProxy::Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
+        if (BatchedPutRequestCount) {
+            for (auto &bucket : PutBatchedBucketQueue) {
+                auto &batchedPuts = BatchedPuts[bucket.HandleClass][bucket.Tactic][bucket.ReduceInterpileTraffic];
+                Y_ABORT_UNLESS(!batchedPuts.Queue.empty());
+                *Mon->PutsSentViaPutBatching += batchedPuts.Queue.size();
+                ++*Mon->PutBatchesSent;
+                ProcessBatchedPutRequests(batchedPuts, bucket.HandleClass, bucket.Tactic, bucket.ReduceInterpileTraffic);
+            }
+            PutBatchedBucketQueue.clear();
+            ++*Mon->EventStopPutBatching;
+            LWPROBE(DSProxyBatchedPutRequest, BatchedPutRequestCount, GroupId.GetRawId());
+            BatchedPutRequestCount = 0;
+            Controls.EnablePutBatching.Update(TActivationContext::Now());
         }
-        PutBatchedBucketQueue.clear();
-        ++*Mon->EventStopPutBatching;
-        LWPROBE(DSProxyBatchedPutRequest, BatchedPutRequestCount, GroupId.GetRawId());
-        BatchedPutRequestCount = 0;
-        Controls.EnablePutBatching.Update(TActivationContext::Now());
-    }
 
-    void TBlobStorageGroupProxy::Handle(TEvStopBatchingGetRequests::TPtr& ev) {
-        StopGetBatchingEvent = ev;
-        ++*Mon->EventStopGetBatching;
-        LWPROBE(DSProxyBatchedGetRequest, BatchedGetRequestCount, GroupId.GetRawId());
-        BatchedGetRequestCount = 0;
+        if (BatchedGetRequestCount) {
+            ++*Mon->EventStopGetBatching;
+            LWPROBE(DSProxyBatchedGetRequest, BatchedGetRequestCount, GroupId.GetRawId());
+            BatchedGetRequestCount = 0;
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -686,6 +686,10 @@ namespace NKikimr {
 
     void TBlobStorageGroupProxy::Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
         if (BatchedPutRequestCount) {
+            // This direct callback intentionally performs the flush here. In StateWork each batch is capped at
+            // MaxBatchedPutRequests, and flushing only walks these small queues and registers request actors; their
+            // actual work remains subject to normal mailbox scheduling. A self-event would add queue traffic and
+            // another activation for this bounded bookkeeping.
             for (auto &bucket : PutBatchedBucketQueue) {
                 auto &batchedPuts = BatchedPuts[bucket.HandleClass][bucket.Tactic][bucket.ReduceInterpileTraffic];
                 Y_ABORT_UNLESS(!batchedPuts.Queue.empty());

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -33,9 +33,6 @@ namespace NKikimr {
             return;
         }
 
-        if (StopGetBatchingEvent) {
-            TActivationContext::Send(StopGetBatchingEvent.Release());
-        }
         BatchedGetRequestCount++;
 
         EnsureMonitoring(true);
@@ -191,9 +188,6 @@ namespace NKikimr {
             return;
         }
 
-        if (StopPutBatchingEvent) {
-            TActivationContext::Send(StopPutBatchingEvent.Release());
-        }
         BatchedPutRequestCount++;
 
         Send(MonActor, new TEvThroughputAddRequest(ev->Get()->HandleClass, bytes));
@@ -684,27 +678,27 @@ namespace NKikimr {
         batchedPuts.Bytes = 0;
     }
 
-    void TBlobStorageGroupProxy::Handle(TEvStopBatchingPutRequests::TPtr& ev) {
-        StopPutBatchingEvent = ev;
-        for (auto &bucket : PutBatchedBucketQueue) {
-            auto &batchedPuts = BatchedPuts[bucket.HandleClass][bucket.Tactic][bucket.ReduceInterpileTraffic];
-            Y_ABORT_UNLESS(!batchedPuts.Queue.empty());
-            *Mon->PutsSentViaPutBatching += batchedPuts.Queue.size();
-            ++*Mon->PutBatchesSent;
-            ProcessBatchedPutRequests(batchedPuts, bucket.HandleClass, bucket.Tactic, bucket.ReduceInterpileTraffic);
+    void TBlobStorageGroupProxy::Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
+        if (BatchedPutRequestCount) {
+            for (auto &bucket : PutBatchedBucketQueue) {
+                auto &batchedPuts = BatchedPuts[bucket.HandleClass][bucket.Tactic][bucket.ReduceInterpileTraffic];
+                Y_ABORT_UNLESS(!batchedPuts.Queue.empty());
+                *Mon->PutsSentViaPutBatching += batchedPuts.Queue.size();
+                ++*Mon->PutBatchesSent;
+                ProcessBatchedPutRequests(batchedPuts, bucket.HandleClass, bucket.Tactic, bucket.ReduceInterpileTraffic);
+            }
+            PutBatchedBucketQueue.clear();
+            ++*Mon->EventStopPutBatching;
+            LWPROBE(DSProxyBatchedPutRequest, BatchedPutRequestCount, GroupId.GetRawId());
+            BatchedPutRequestCount = 0;
+            Controls.EnablePutBatching.Update(TActivationContext::Now());
         }
-        PutBatchedBucketQueue.clear();
-        ++*Mon->EventStopPutBatching;
-        LWPROBE(DSProxyBatchedPutRequest, BatchedPutRequestCount, GroupId.GetRawId());
-        BatchedPutRequestCount = 0;
-        Controls.EnablePutBatching.Update(TActivationContext::Now());
-    }
 
-    void TBlobStorageGroupProxy::Handle(TEvStopBatchingGetRequests::TPtr& ev) {
-        StopGetBatchingEvent = ev;
-        ++*Mon->EventStopGetBatching;
-        LWPROBE(DSProxyBatchedGetRequest, BatchedGetRequestCount, GroupId.GetRawId());
-        BatchedGetRequestCount = 0;
+        if (BatchedGetRequestCount) {
+            ++*Mon->EventStopGetBatching;
+            LWPROBE(DSProxyBatchedGetRequest, BatchedGetRequestCount, GroupId.GetRawId());
+            BatchedGetRequestCount = 0;
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_request.cpp
@@ -33,7 +33,10 @@ namespace NKikimr {
             return;
         }
 
-        BatchedGetRequestCount++;
+        if (!BatchedGetRequestCount && !BatchedPutRequestCount) {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+        }
+        ++BatchedGetRequestCount;
 
         EnsureMonitoring(true);
         LWTRACK(DSProxyGetHandle, ev->Get()->Orbit);
@@ -188,7 +191,10 @@ namespace NKikimr {
             return;
         }
 
-        BatchedPutRequestCount++;
+        if (!BatchedGetRequestCount && !BatchedPutRequestCount) {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+        }
+        ++BatchedPutRequestCount;
 
         Send(MonActor, new TEvThroughputAddRequest(ev->Get()->HandleClass, bytes));
         EnableWilsonTracing(ev, Mon->PutSamplePPM);
@@ -699,6 +705,8 @@ namespace NKikimr {
             LWPROBE(DSProxyBatchedGetRequest, BatchedGetRequestCount, GroupId.GetRawId());
             BatchedGetRequestCount = 0;
         }
+
+        ClearSystemFlag(ESystemFlag::MailboxProcessingFinished);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
@@ -303,10 +303,7 @@ namespace NKikimr {
             }
             Become(&TThis::StateEjected);
         } else {
-            StopPutBatchingEvent = static_cast<TEventHandle<TEvStopBatchingPutRequests>*>(
-                    new IEventHandle(SelfId(), SelfId(), new TEvStopBatchingPutRequests));
-            StopGetBatchingEvent = static_cast<TEventHandle<TEvStopBatchingGetRequests>*>(
-                    new IEventHandle(SelfId(), SelfId(), new TEvStopBatchingGetRequests));
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
             ApplyGroupInfo(std::exchange(Info, {}), std::exchange(NodeLayoutInfo, {}), std::exchange(StoragePoolCounters, {}));
             CheckDeadlines();
         }

--- a/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
+++ b/ydb/core/blobstorage/dsproxy/dsproxy_state.cpp
@@ -303,7 +303,6 @@ namespace NKikimr {
             }
             Become(&TThis::StateEjected);
         } else {
-            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
             ApplyGroupInfo(std::exchange(Info, {}), std::exchange(NodeLayoutInfo, {}), std::exchange(StoragePoolCounters, {}));
             CheckDeadlines();
         }

--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -692,8 +692,10 @@ public:
                 const ui32 type = ev->GetTypeRewrite();
 
                 THPTimer timer;
+                const ui64 activationStart = GetCycleCountFast();
                 actor->Receive(ev);
                 const TDuration timing = TDuration::Seconds(timer.Passed());
+                const ui64 elapsedCycles = GetCycleCountFast() - activationStart;
 
                 const auto it = ActorName.find(actor);
                 Y_ABORT_UNLESS(it != ActorName.end(), "%p", actor);
@@ -703,6 +705,25 @@ public:
                 stats.TotalTime += timing;
 
                 ++EventsProcessed;
+
+                bool actorPassedAway = false;
+                for (const auto& unregisteredActor : GetNode(CurrentNodeId)->ExecutorThread->GetUnregistered()) {
+                    if (unregisteredActor.Get() == actor) {
+                        actorPassedAway = true;
+                        break;
+                    }
+                }
+                if (!actorPassedAway && NActors::NDetail::TActorSystemFlagAccessor::HasSystemFlag(
+                        *actor, IActor::ESystemFlag::MailboxProcessingFinished)) {
+                    TAutoPtr<IEventHandle> finishedEv = new IEventHandle(
+                        actor->SelfId(),
+                        TActorId(),
+                        new TEvents::TEvMailboxProcessingFinished(
+                            TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty,
+                            1,
+                            elapsedCycles));
+                    actor->Receive(finishedEv);
+                }
             });
             if (!success) { // can't find the actor
                 event = IEventHandle::ForwardOnNondelivery(std::move(event), TEvents::TEvUndelivered::ReasonActorUnknown);

--- a/ydb/core/util/actorsys_test/testactorsys.h
+++ b/ydb/core/util/actorsys_test/testactorsys.h
@@ -140,6 +140,12 @@ class TTestActorSystem {
     TActorId CurrentRecipient;
     ui32 CurrentNodeId = 0;
     ui64 EventsProcessed = 0;
+    struct TMailboxProcessingBatch {
+        ui32 ExecutedEvents = 0;
+        ui64 ElapsedCycles = 0;
+        std::vector<TActorId> Actors;
+    };
+    std::map<TMailboxId, TMailboxProcessingBatch> MailboxProcessingBatches;
     TSingleThreadInterconnectMock InterconnectMock;
     std::unordered_map<ui32, TPerNodeInfo> PerNodeInfo;
     std::set<TActorId> LoggerActorIds;
@@ -682,6 +688,9 @@ public:
             if (FilterFunction && !FilterFunction(item->NodeId, event)) { // event is dropped by the filter function
                 continue;
             }
+            std::optional<TMailboxProcessingBatch> finishedBatch;
+            std::optional<TMailboxId> processedMailbox;
+            auto finishReason = TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty;
             const bool success = WrapInActorContext(TransformEvent(event.get(), item->NodeId), [&](IActor *actor, bool alias) {
                 TAutoPtr<IEventHandle> ev(event.release());
 
@@ -706,6 +715,12 @@ public:
 
                 ++EventsProcessed;
 
+                const TMailboxId mailboxId(actor->SelfId());
+                processedMailbox.emplace(mailboxId);
+                auto& batch = MailboxProcessingBatches[mailboxId];
+                ++batch.ExecutedEvents;
+                batch.ElapsedCycles += elapsedCycles;
+
                 bool actorPassedAway = false;
                 for (const auto& unregisteredActor : GetNode(CurrentNodeId)->ExecutorThread->GetUnregistered()) {
                     if (unregisteredActor.Get() == actor) {
@@ -715,19 +730,56 @@ public:
                 }
                 if (!actorPassedAway && NActors::NDetail::TActorSystemFlagAccessor::HasSystemFlag(
                         *actor, IActor::ESystemFlag::MailboxProcessingFinished)) {
-                    TAutoPtr<IEventHandle> finishedEv = new IEventHandle(
-                        actor->SelfId(),
-                        TActorId(),
-                        new TEvents::TEvMailboxProcessingFinished(
-                            TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty,
-                            1,
-                            elapsedCycles));
-                    actor->Receive(finishedEv);
+                    if (std::find(batch.Actors.begin(), batch.Actors.end(), actor->SelfId()) == batch.Actors.end()) {
+                        batch.Actors.push_back(actor->SelfId());
+                    }
                 }
+
             });
             if (!success) { // can't find the actor
                 event = IEventHandle::ForwardOnNondelivery(std::move(event), TEvents::TEvUndelivered::ReasonActorUnknown);
                 SendImpl(event.release(), item->NodeId);
+            }
+            if (processedMailbox) {
+                auto batchIt = MailboxProcessingBatches.find(*processedMailbox);
+                Y_ABORT_UNLESS(batchIt != MailboxProcessingBatches.end());
+
+                bool hasMoreEvents = false;
+                if (const auto scheduleIt = ScheduleQ.find(Clock); scheduleIt != ScheduleQ.end()) {
+                    for (const TScheduleItem& scheduled : scheduleIt->second) {
+                        if (TMailboxId(TransformEvent(scheduled.Event.get(), scheduled.NodeId)) == *processedMailbox) {
+                            hasMoreEvents = true;
+                            break;
+                        }
+                    }
+                }
+
+                static constexpr ui32 TestEventsPerMailbox = 8;
+                if (batchIt->second.ExecutedEvents == TestEventsPerMailbox || !hasMoreEvents) {
+                    finishReason = batchIt->second.ExecutedEvents == TestEventsPerMailbox
+                        ? TEvents::TEvMailboxProcessingFinished::EReason::EventCountLimitReached
+                        : TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty;
+                    finishedBatch.emplace(std::move(batchIt->second));
+                    MailboxProcessingBatches.erase(batchIt);
+                }
+            }
+            if (finishedBatch) {
+                for (const TActorId& actorId : finishedBatch->Actors) {
+                    WrapInActorContext(actorId, [&](IActor* actor) {
+                        if (NActors::NDetail::TActorSystemFlagAccessor::HasSystemFlag(
+                                *actor, IActor::ESystemFlag::MailboxProcessingFinished)) {
+                            TAutoPtr<IEventHandle> finishedEv = new IEventHandle(
+                                actor->SelfId(),
+                                TActorId(),
+                                new TEvents::TEvMailboxProcessingFinished(
+                                    finishReason,
+                                    finishedBatch->ExecutedEvents,
+                                    finishedBatch->ElapsedCycles));
+                            actor->Receive(finishedEv);
+                            ++EventsProcessed;
+                        }
+                    });
+                }
             }
         }
     }

--- a/ydb/core/util/actorsys_test/ut/testactorsys_ut.cpp
+++ b/ydb/core/util/actorsys_test/ut/testactorsys_ut.cpp
@@ -1,0 +1,60 @@
+#include <ydb/core/util/actorsys_test/testactorsys.h>
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+namespace {
+
+    class TMailboxProcessingFinishedActor
+        : public TActorBootstrapped<TMailboxProcessingFinishedActor>
+    {
+    public:
+        explicit TMailboxProcessingFinishedActor(TActorId edgeActor)
+            : EdgeActor(edgeActor)
+        {}
+
+        void Bootstrap() {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingFinished::TPtr& ev) {
+            UNIT_ASSERT(
+                ev->Get()->Reason ==
+                TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty);
+            Send(EdgeActor, new TEvents::TEvWakeup(ev->Get()->ExecutedEvents));
+            PassAway();
+        }
+
+    private:
+        const TActorId EdgeActor;
+    };
+
+}
+
+Y_UNIT_TEST_SUITE(TTestActorSystemMailboxProcessingFinished) {
+
+    Y_UNIT_TEST(DeliversNotification) {
+        TTestActorSystem runtime(1);
+        runtime.Start();
+
+        const TActorId edgeActor = runtime.AllocateEdgeActor(1);
+        runtime.Register(new TMailboxProcessingFinishedActor(edgeActor), 1);
+
+        const std::unique_ptr<IEventHandle> result = runtime.WaitForEdgeActorEvent({edgeActor});
+        UNIT_ASSERT(result->GetTypeRewrite() == TEvents::TSystem::Wakeup);
+        UNIT_ASSERT_VALUES_EQUAL(result->Get<TEvents::TEvWakeup>()->Tag, 1);
+
+        runtime.Stop();
+    }
+
+}
+}

--- a/ydb/core/util/actorsys_test/ut/ya.make
+++ b/ydb/core/util/actorsys_test/ut/ya.make
@@ -1,0 +1,10 @@
+UNITTEST_FOR(ydb/core/util/actorsys_test)
+
+FORK_SUBTESTS()
+SIZE(SMALL)
+
+SRCS(
+    testactorsys_ut.cpp
+)
+
+END()

--- a/ydb/core/util/actorsys_test/ya.make
+++ b/ydb/core/util/actorsys_test/ya.make
@@ -36,3 +36,7 @@ PEERDIR(
 )
 
 END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/ydb/core/util/ya.make
+++ b/ydb/core/util/ya.make
@@ -91,6 +91,7 @@ PEERDIR(
 END()
 
 RECURSE_FOR_TESTS(
+    actorsys_test
     btree_benchmark
     ut
 )

--- a/ydb/core/util/ya.make
+++ b/ydb/core/util/ya.make
@@ -89,6 +89,7 @@ PEERDIR(
 END()
 
 RECURSE_FOR_TESTS(
+    actorsys_test
     btree_benchmark
     ut
 )

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -541,6 +541,7 @@ namespace NActors {
     };
 
     namespace NDetail {
+        class TActorSystemFlagAccessor;
         class TActorAsyncHandlerPromise;
         template<class TEvent>
         class TActorSpecificEventAwaiter;
@@ -580,6 +581,7 @@ namespace NActors {
         ui64 SystemFlags = 0;
 
     private:
+        friend class NDetail::TActorSystemFlagAccessor;
         friend class NDetail::TActorAsyncHandlerPromise;
         template<class TEvent>
         friend class NDetail::TActorSpecificEventAwaiter;
@@ -880,6 +882,15 @@ namespace NActors {
             SelfActorId = actorId;
         }
     };
+
+    namespace NDetail {
+        class TActorSystemFlagAccessor {
+        public:
+            static bool HasSystemFlag(const IActor& actor, IActor::ESystemFlag flag) noexcept {
+                return actor.HasSystemFlag(flag);
+            }
+        };
+    }
 
     inline size_t GetActivityTypeCount() {
         return TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetCount();

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -543,6 +543,7 @@ namespace NActors {
     };
 
     namespace NDetail {
+        class TActorSystemFlagAccessor;
         class TActorAsyncHandlerPromise;
         template<class TEvent>
         class TActorSpecificEventAwaiter;
@@ -582,6 +583,7 @@ namespace NActors {
         ui64 SystemFlags = 0;
 
     private:
+        friend class NDetail::TActorSystemFlagAccessor;
         friend class NDetail::TActorAsyncHandlerPromise;
         template<class TEvent>
         friend class NDetail::TActorSpecificEventAwaiter;
@@ -881,6 +883,15 @@ namespace NActors {
             SelfActorId = actorId;
         }
     };
+
+    namespace NDetail {
+        class TActorSystemFlagAccessor {
+        public:
+            static bool HasSystemFlag(const IActor& actor, IActor::ESystemFlag flag) noexcept {
+                return actor.HasSystemFlag(flag);
+            }
+        };
+    }
 
     inline size_t GetActivityTypeCount() {
         return TLocalProcessKeyState<TActorActivityTag>::GetInstance().GetCount();

--- a/ydb/library/actors/testlib/mailbox_processing_finished_ut.cpp
+++ b/ydb/library/actors/testlib/mailbox_processing_finished_ut.cpp
@@ -1,0 +1,58 @@
+#include "test_runtime.h"
+
+#include <ydb/library/actors/core/actor_bootstrapped.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NActors {
+namespace {
+
+    class TMailboxProcessingFinishedActor
+        : public TActorBootstrapped<TMailboxProcessingFinishedActor>
+    {
+    public:
+        explicit TMailboxProcessingFinishedActor(TActorId edgeActor)
+            : EdgeActor(edgeActor)
+        {}
+
+        void Bootstrap() {
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingFinished::TPtr& ev) {
+            UNIT_ASSERT(
+                ev->Get()->Reason ==
+                TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty);
+            Send(EdgeActor, new TEvents::TEvWakeup(ev->Get()->ExecutedEvents));
+            PassAway();
+        }
+
+    private:
+        const TActorId EdgeActor;
+    };
+
+}
+
+Y_UNIT_TEST_SUITE(TTestActorRuntimeMailboxProcessingFinished) {
+
+    Y_UNIT_TEST(DeliversNotification) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId edgeActor = runtime.AllocateEdgeActor();
+        runtime.Register(new TMailboxProcessingFinishedActor(edgeActor));
+
+        TAutoPtr<IEventHandle> handle;
+        const auto* result = runtime.GrabEdgeEventRethrow<TEvents::TEvWakeup>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(result->Tag, 1);
+    }
+
+}
+}

--- a/ydb/library/actors/testlib/mailbox_processing_finished_ut.cpp
+++ b/ydb/library/actors/testlib/mailbox_processing_finished_ut.cpp
@@ -11,31 +11,43 @@ namespace {
         : public TActorBootstrapped<TMailboxProcessingFinishedActor>
     {
     public:
-        explicit TMailboxProcessingFinishedActor(TActorId edgeActor)
+        TMailboxProcessingFinishedActor(
+                TActorId edgeActor,
+                TEvents::TEvMailboxProcessingFinished::EReason expectedReason,
+                ui32 messages = 0)
             : EdgeActor(edgeActor)
+            , ExpectedReason(expectedReason)
+            , Messages(messages)
         {}
 
         void Bootstrap() {
             SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
             Become(&TThis::StateWork);
+            for (ui32 i = 0; i < Messages; ++i) {
+                Send(SelfId(), new TEvents::TEvWakeup(i));
+            }
         }
 
         STFUNC(StateWork) {
             switch (ev->GetTypeRewrite()) {
                 hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+                cFunc(TEvents::TSystem::Wakeup, Ignore);
             }
         }
 
         void Handle(TEvents::TEvMailboxProcessingFinished::TPtr& ev) {
-            UNIT_ASSERT(
-                ev->Get()->Reason ==
-                TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty);
+            UNIT_ASSERT(ev->Get()->Reason == ExpectedReason);
             Send(EdgeActor, new TEvents::TEvWakeup(ev->Get()->ExecutedEvents));
             PassAway();
         }
 
+        void Ignore() {
+        }
+
     private:
         const TActorId EdgeActor;
+        const TEvents::TEvMailboxProcessingFinished::EReason ExpectedReason;
+        const ui32 Messages;
     };
 
 }
@@ -47,11 +59,28 @@ Y_UNIT_TEST_SUITE(TTestActorRuntimeMailboxProcessingFinished) {
         runtime.Initialize();
 
         const TActorId edgeActor = runtime.AllocateEdgeActor();
-        runtime.Register(new TMailboxProcessingFinishedActor(edgeActor));
+        runtime.Register(new TMailboxProcessingFinishedActor(
+            edgeActor,
+            TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty));
 
         TAutoPtr<IEventHandle> handle;
         const auto* result = runtime.GrabEdgeEventRethrow<TEvents::TEvWakeup>(handle);
         UNIT_ASSERT_VALUES_EQUAL(result->Tag, 1);
+    }
+
+    Y_UNIT_TEST(BatchesAtLeastEightEvents) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId edgeActor = runtime.AllocateEdgeActor();
+        runtime.Register(new TMailboxProcessingFinishedActor(
+            edgeActor,
+            TEvents::TEvMailboxProcessingFinished::EReason::EventCountLimitReached,
+            8));
+
+        TAutoPtr<IEventHandle> handle;
+        const auto* result = runtime.GrabEdgeEventRethrow<TEvents::TEvWakeup>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(result->Tag, 8);
     }
 
 }

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1720,8 +1720,23 @@ namespace NActors {
                 TCallstack::GetTlsCallstack() = ev->Callstack;
                 TCallstack::GetTlsCallstack().SetLinesToSkip();
 #endif
+                const ui64 activationStart = GetCycleCountFast();
                 recipientActor->Receive(ev);
                 node->ExecutorThread->DropUnregistered();
+
+                recipientActor = mailbox->FindActor(actorId.LocalId());
+                if (recipientActor && NDetail::TActorSystemFlagAccessor::HasSystemFlag(
+                        *recipientActor, IActor::ESystemFlag::MailboxProcessingFinished)) {
+                    TAutoPtr<IEventHandle> finishedEv = new IEventHandle(
+                        recipientActor->SelfId(),
+                        TActorId(),
+                        new TEvents::TEvMailboxProcessingFinished(
+                            TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty,
+                            1,
+                            GetCycleCountFast() - activationStart));
+                    recipientActor->Receive(finishedEv);
+                    node->ExecutorThread->DropUnregistered();
+                }
             }
         } else {
             if (VERBOSE) {

--- a/ydb/library/actors/testlib/test_runtime.cpp
+++ b/ydb/library/actors/testlib/test_runtime.cpp
@@ -1654,6 +1654,8 @@ namespace NActors {
     }
 
     void TTestActorRuntimeBase::SendInternal(TAutoPtr<IEventHandle> ev, ui32 nodeIndex, bool viaActorSystem) {
+        static constexpr ui32 TestRuntimeEventsPerMailbox = 8;
+
         Y_ABORT_UNLESS(nodeIndex < NodeCount);
         ui32 nodeId = FirstNodeId + nodeIndex;
         TNodeDataBase* node = Nodes[nodeId].Get();
@@ -1683,6 +1685,13 @@ namespace NActors {
             mbox.PushFront(ev);
             return;
         }
+
+        const TEventMailboxId mailboxId(nodeId, mailboxHint);
+        auto [batchIt, ownsBatch] = MailboxProcessingBatches.try_emplace(mailboxId);
+        if (ownsBatch) {
+            batchIt->second.StartCycles = GetCycleCountFast();
+        }
+        ++batchIt->second.ExecutedEvents;
 
         ui64 recipientLocalId = ev->GetRecipientRewrite().LocalId();
         if ((BlockedOutput.find(ev->Sender) == BlockedOutput.end()) && VERBOSE) {
@@ -1720,23 +1729,17 @@ namespace NActors {
                 TCallstack::GetTlsCallstack() = ev->Callstack;
                 TCallstack::GetTlsCallstack().SetLinesToSkip();
 #endif
-                const ui64 activationStart = GetCycleCountFast();
                 recipientActor->Receive(ev);
-                node->ExecutorThread->DropUnregistered();
 
-                recipientActor = mailbox->FindActor(actorId.LocalId());
-                if (recipientActor && NDetail::TActorSystemFlagAccessor::HasSystemFlag(
+                if (NDetail::TActorSystemFlagAccessor::HasSystemFlag(
                         *recipientActor, IActor::ESystemFlag::MailboxProcessingFinished)) {
-                    TAutoPtr<IEventHandle> finishedEv = new IEventHandle(
-                        recipientActor->SelfId(),
-                        TActorId(),
-                        new TEvents::TEvMailboxProcessingFinished(
-                            TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty,
-                            1,
-                            GetCycleCountFast() - activationStart));
-                    recipientActor->Receive(finishedEv);
-                    node->ExecutorThread->DropUnregistered();
+                    auto& actors = MailboxProcessingBatches.at(TEventMailboxId(nodeId, mailboxHint)).Actors;
+                    if (std::find(actors.begin(), actors.end(), actorId) == actors.end()) {
+                        actors.push_back(actorId);
+                    }
                 }
+
+                node->ExecutorThread->DropUnregistered();
             }
         } else {
             if (VERBOSE) {
@@ -1745,6 +1748,79 @@ namespace NActors {
 
             auto fw = IEventHandle::ForwardOnNondelivery(ev, TEvents::TEvUndelivered::ReasonActorUnknown);
             node->ActorSystem->Send(fw);
+        }
+
+        if (!ownsBatch) {
+            return;
+        }
+
+        while (batchIt->second.ExecutedEvents < TestRuntimeEventsPerMailbox && !mbox.IsEmpty()) {
+            auto nextEv = mbox.Pop();
+            ++DispatchedEventsCount;
+            if (DispatchedEventsCount > DispatchedEventsLimit) {
+                ythrow TWithBackTrace<yexception>() << "Dispatched "
+                    << DispatchedEventsLimit << " events, limit reached.";
+            }
+
+            EEventAction action;
+            {
+                TInverseGuard<TMutex> inverseGuard(Mutex);
+                for (auto& observer : ObserverFuncs) {
+                    observer(nextEv);
+                    if (!nextEv) {
+                        break;
+                    }
+                }
+                action = nextEv ? ObserverFunc(nextEv) : EEventAction::DROP;
+            }
+
+            if (action == EEventAction::PROCESS) {
+                UpdateFinalEventsStatsForEachContext(*nextEv);
+                SendInternal(nextEv.Release(), nodeIndex, false);
+            } else if (action == EEventAction::RESCHEDULE) {
+                mbox.Freeze(TInstant::MicroSeconds(CurrentTimestamp) + ReschedulingDelay);
+                mbox.PushFront(nextEv);
+                break;
+            }
+
+            batchIt = MailboxProcessingBatches.find(mailboxId);
+            Y_ABORT_UNLESS(batchIt != MailboxProcessingBatches.end());
+        }
+
+        batchIt = MailboxProcessingBatches.find(mailboxId);
+        if (batchIt == MailboxProcessingBatches.end() ||
+                (batchIt->second.ExecutedEvents < TestRuntimeEventsPerMailbox && !mbox.IsEmpty())) {
+            return;
+        }
+
+        TMailboxProcessingBatch batch = std::move(batchIt->second);
+        MailboxProcessingBatches.erase(batchIt);
+        const auto reason = batch.ExecutedEvents == TestRuntimeEventsPerMailbox
+            ? TEvents::TEvMailboxProcessingFinished::EReason::EventCountLimitReached
+            : TEvents::TEvMailboxProcessingFinished::EReason::QueueEmpty;
+        for (const TActorId& finishedActorId : batch.Actors) {
+            if (IActor* actor = mailbox->FindActor(finishedActorId.LocalId()); actor &&
+                    NDetail::TActorSystemFlagAccessor::HasSystemFlag(
+                        *actor, IActor::ESystemFlag::MailboxProcessingFinished)) {
+                TActorContext ctx(*mailbox, *node->ExecutorThread, GetCycleCountFast(), finishedActorId);
+                TActivationContext* prevTlsActivationContext = TlsActivationContext;
+                TlsActivationContext = &ctx;
+                CurrentRecipient = finishedActorId;
+                Y_DEFER {
+                    CurrentRecipient = TActorId();
+                    TlsActivationContext = prevTlsActivationContext;
+                };
+                TInverseGuard<TMutex> inverseGuard(Mutex);
+                TAutoPtr<IEventHandle> finishedEv = new IEventHandle(
+                    actor->SelfId(),
+                    TActorId(),
+                    new TEvents::TEvMailboxProcessingFinished(
+                        reason,
+                        batch.ExecutedEvents,
+                        GetCycleCountFast() - batch.StartCycles));
+                actor->Receive(finishedEv);
+                node->ExecutorThread->DropUnregistered();
+            }
         }
     }
 

--- a/ydb/library/actors/testlib/test_runtime.h
+++ b/ydb/library/actors/testlib/test_runtime.h
@@ -733,6 +733,12 @@ namespace NActors {
         }
 
    private:
+        struct TMailboxProcessingBatch {
+            ui32 ExecutedEvents = 0;
+            ui64 StartCycles = 0;
+            TVector<TActorId> Actors;
+        };
+
         IActor* FindActor(const TActorId& actorId, TNodeDataBase* node) const;
         void SendInternal(TAutoPtr<IEventHandle> ev, ui32 nodeIndex, bool viaActorSystem);
         TEventMailBox& GetMailbox(ui32 nodeId, ui32 hint);
@@ -744,6 +750,7 @@ namespace NActors {
     private:
         ui64 ScheduledCount;
         ui64 ScheduledLimit;
+        THashMap<TEventMailboxId, TMailboxProcessingBatch, TEventMailboxId::THash> MailboxProcessingBatches;
         THolder<TTempDir> TmpDir;
         const TThread::TId MainThreadId;
 

--- a/ydb/library/actors/testlib/ut/ya.make
+++ b/ydb/library/actors/testlib/ut/ya.make
@@ -10,6 +10,7 @@ PEERDIR(
 
 SRCS(
     decorator_ut.cpp
+    mailbox_processing_finished_ut.cpp
 )
 
 END()


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->


Use `TEvMailboxProcessingFinished` to flush DSProxy put batches at the end of the current mailbox activation.

The notification is armed only when the first put/get request enters batching and cleared after processing. This removes the extra stop-batching self-events and avoids an additional mailbox activation.
