### PR TITLE
Add support to use YQL to enable or disable content based deduplicaton in topics

### DIFF
--- a/ydb/core/kqp/provider/yql_kikimr_exec.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_exec.cpp
@@ -798,6 +798,9 @@ namespace {
             } else if (name == "setMetricsLevel") {
                 auto metricsLevel = FromString<i32>(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
                 request->set_metrics_level(metricsLevel);
+            } else if (name == "setContentBasedDeduplication") {
+                auto value = FromString<bool>(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
+                request->set_content_based_deduplication(value);
             }
         }
     }
@@ -873,6 +876,9 @@ namespace {
                 request->set_set_metrics_level(metricsLevel);
             } else if (name == "resetMetricsLevel") {
                 request->mutable_reset_metrics_level();
+            } else if (name == "setContentBasedDeduplication") {
+                auto value = FromString<bool>(setting.Value().Cast<TCoDataCtor>().Literal().Cast<TCoAtom>().Value());
+                request->set_set_content_based_deduplication(value);
             }
         }
     }

--- a/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
+++ b/ydb/core/kqp/provider/yql_kikimr_type_ann.cpp
@@ -2311,6 +2311,10 @@ private:
                 );
                 maxPartitions = value;
                 errorPos = ctx.GetPosition(setting.Value().Ref().Pos());
+            } else if (name == "setContentBasedDeduplication") {
+                if (!EnsureAtom(setting.Value().Ref(), ctx)) {
+                    return false;
+                }
             } else if (name.StartsWith("reset")) {
                 ctx.AddError(TIssue(
                         errorPos,


### PR DESCRIPTION
Add support to use YQL to enable or disable content based deduplicaton in topics

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

CREATE TOPIC:

`CREATE TOPIC `/Root/my_topic` WITH (content_based_deduplication = true);`

ALTER TOPIC:

`ALTER TOPIC `/Root/my_topic` SET (content_based_deduplication = false);`



### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->
LOGBROKER-10554
YQL parsing part in arcadia not yet ready
