### PR TITLE
Сhange default access level of viewer endpoints

### DIFF
--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -253,7 +253,8 @@ public:
                 }
             };
 
-            if (AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer()) {
+            const bool enableExtraSidsControl = AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer();
+            if (enableExtraSidsControl) {
                 // Every endpoint must be registered with an explicit access level below,
                 // see GetEndpointAccessType.
                 applyAccessRules({
@@ -365,15 +366,6 @@ public:
             addV2JsonAlias("/viewer/v2/json/tabletinfo", "/viewer/tabletinfo");
             addV2JsonAlias("/viewer/v2/json/nodeinfo", "/viewer/nodeinfo");
 
-            if (AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer()) {
-                // Every handler path must have an explicit access level, so it has to be registered
-                // in the rules above. Check it at the start: a path without an explicit access level
-                // is reported as an error by GetEndpointAccessType.
-                for (const auto& [name, handler] : JsonHandlers.JsonHandlersIndex) {
-                    Y_UNUSED(GetEndpointAccessType(name));
-                }
-            }
-
             struct TEndpointAuthSettings {
                 const TMon::EAuthMode AuthMode;
                 const TVector<TString>& AllowedSIDs;
@@ -399,16 +391,23 @@ public:
                 Y_ABORT("unknown access type of the endpoint %s", path.c_str());
             };
 
-            for (const auto& [name, handler] : JsonHandlers.JsonHandlersIndex) {
+            for (const auto& [path, handler] : JsonHandlers.JsonHandlersIndex) {
                 // temporary handling of new handlers
                 if (handler->IsHttpEvent()) {
-                    const auto auth = resolveEndpointAuth(name);
+                    const auto auth = resolveEndpointAuth(path);
                     mon->RegisterActorHandler({
-                        .Path = name,
+                        .Path = path,
                         .Handler = ctx.SelfID,
                         .AuthMode = auth.AuthMode,
                         .AllowedSIDs = auth.AllowedSIDs,
                     });
+                }
+
+                if (enableExtraSidsControl) {
+                    // Every handler path must have an explicit access level, so it has to be registered
+                    // in the rules above. Check it at the start: a path without an explicit access level
+                    // is reported as an error by GetEndpointAccessType.
+                    GetEndpointAccessType(path);
                 }
             }
         }

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -48,7 +48,8 @@ enum class EViewerEndpointAccessType {
     Administration,
     Monitoring,
     Viewer,
-    Database
+    Database,
+    Any
 };
 
 struct TEndpointAccessSettings {
@@ -60,6 +61,17 @@ struct TEndpointAccessRule {
     TStringBuf Path;
     TEndpointAccessSettings Settings;
 };
+
+// Returns the legacy /X/json/Y alias of the /X/Y path, or an empty string if the path has no such alias.
+TString GetLegacyJsonPathAlias(TStringBuf path) {
+    path.SkipPrefix("/");
+    TStringBuf prefix;
+    TStringBuf rest;
+    if (!path.TrySplit('/', prefix, rest) || rest.StartsWith("json/")) {
+        return {};
+    }
+    return TStringBuilder() << '/' << prefix << "/json/" << rest;
+}
 
 }
 
@@ -221,20 +233,18 @@ public:
 
             for (const auto& handler : JsonHandlers.JsonHandlersList) {
                 // temporary handling of old paths
-                TStringBuf newPath(handler);
-                TString oldPath = "/" + TString(newPath.After('/').Before('/')) + "/json/" + TString(newPath.After('/').After('/'));
-                JsonHandlers.JsonHandlersIndex[oldPath] = JsonHandlers.JsonHandlersIndex[newPath];
+                const TString oldPath = GetLegacyJsonPathAlias(handler);
+                Y_ENSURE(!oldPath.empty());
+                JsonHandlers.JsonHandlersIndex[oldPath] = JsonHandlers.JsonHandlersIndex[handler];
             }
 
             auto applyAccessRule = [this](const TEndpointAccessRule& rule) {
                 EndpointAccess[TString(rule.Path)] = rule.Settings;
-                // Auto-register legacy /viewer/json/X alias for /viewer/X (same as JsonHandlers aliases).
-                TStringBuf path(rule.Path);
-                TStringBuf prefix = path.After('/').Before('/');
-                TStringBuf rest = path.After('/').After('/');
-                if (prefix == "viewer" && !rest.empty() && !rest.StartsWith("json/")) {
-                    EndpointAccess["/viewer/json/" + TString(rest)] = rule.Settings;
-                }
+
+                // The legacy alias of the endpoint has the same access settings.
+                const TString oldPath = GetLegacyJsonPathAlias(rule.Path);
+                Y_ENSURE(!oldPath.empty());
+                EndpointAccess[oldPath] = rule.Settings;
             };
 
             auto applyAccessRules = [&](std::initializer_list<TEndpointAccessRule> rules) {
@@ -244,8 +254,10 @@ public:
             };
 
             if (AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer()) {
+                // Every endpoint must be registered with an explicit access level below,
+                // see GetEndpointAccessType.
                 applyAccessRules({
-                    // "/viewer" prefix endpoints (/viewer/json/* aliases are registered automatically).
+                    // /X/json/Y aliases are registered automatically for every /X/Y endpoint.
 
                     // Administration-level endpoints.
                     {"/viewer/bscontrollerinfo", {EViewerEndpointAccessType::Administration}},
@@ -253,7 +265,7 @@ public:
                     // Monitoring-level endpoints.
                     // restart pdisk and evict vdisk endpoints below have some query-parameters,
                     // which require Administration-level access. This is checked in the handler.
-                    // So the Monitoring-level access is not always enough got a successull call.
+                    // So the Monitoring-level access is not always enough for a successull call.
                     {"/pdisk/restart", {EViewerEndpointAccessType::Monitoring}},
                     {"/vdisk/evict", {EViewerEndpointAccessType::Monitoring}},
 
@@ -324,6 +336,15 @@ public:
                     {"/viewer/plan2svg", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/storage_stats", {EViewerEndpointAccessType::Database, true}},
                     {"/viewer/database_stats", {EViewerEndpointAccessType::Database, true}},
+                    // The effective access level of healthcheck endpoint is checked in the handler:
+                    // it requires the Monitoring level, except for the prometheus format,
+                    // which is checked separately (see RequireHealthcheckAuthentication).
+                    {"/viewer/healthcheck", {EViewerEndpointAccessType::Database, false}},
+
+                    // Endpoints which are intentionally available to anyone.
+                    // This handler is used to discover capabilities, including auth requirements,
+                    // so it must be always available without authentication.
+                    {"/viewer/capabilities", {EViewerEndpointAccessType::Any, false}},
                 });
             }
 
@@ -345,39 +366,50 @@ public:
             addV2JsonAlias("/viewer/v2/json/tabletinfo", "/viewer/tabletinfo");
             addV2JsonAlias("/viewer/v2/json/nodeinfo", "/viewer/nodeinfo");
 
-            auto resolveAllowedSids = [&](const TString& path) -> const TVector<TString>& {
-                auto accessType = GetEndpointAccessType(path, EViewerEndpointAccessType::Database);
-                switch (accessType) {
-                    case EViewerEndpointAccessType::Administration:
-                        return administrationAllowedSIDs;
-                    case EViewerEndpointAccessType::Viewer:
-                        return viewerAllowedSIDs;
-                    case EViewerEndpointAccessType::Monitoring:
-                        return monitoringAllowedSIDs;
-                    case EViewerEndpointAccessType::Database:
-                    default:
-                        return databaseAllowedSIDs;
+            if (AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer()) {
+                // Every handler path must have an explicit access level, so it has to be registered
+                // in the rules above. Check it at the start: a path without an explicit access level
+                // is reported as an error by GetEndpointAccessType.
+                for (const auto& [name, handler] : JsonHandlers.JsonHandlersIndex) {
+                    Y_UNUSED(GetEndpointAccessType(name));
                 }
+            }
+
+            struct TEndpointAuthSettings {
+                const TMon::EAuthMode AuthMode;
+                const TVector<TString>& AllowedSIDs;
+            };
+            auto resolveEndpointAuth = [&](const TString& path) -> TEndpointAuthSettings {
+                switch (GetEndpointAccessType(path)) {
+                    case EViewerEndpointAccessType::Administration:
+                        return {TMon::EAuthMode::Enforce, administrationAllowedSIDs};
+                    case EViewerEndpointAccessType::Monitoring:
+                        return {TMon::EAuthMode::Enforce, monitoringAllowedSIDs};
+                    case EViewerEndpointAccessType::Viewer:
+                        return {TMon::EAuthMode::Enforce, viewerAllowedSIDs};
+                    case EViewerEndpointAccessType::Database:
+                        return {TMon::EAuthMode::Enforce, databaseAllowedSIDs};
+                    case EViewerEndpointAccessType::Any: {
+                        static const TVector<TString> emptyAllowedSIDs; // empty list allows any SID to proceed
+                        // The endpoint is available to anyone, so it needs no authentication at all.
+                        return {TMon::EAuthMode::Disabled, emptyAllowedSIDs};
+                    }
+                }
+                // The switch above is exhaustive, so this code is unreachable.
+                // It is still required, otherwise the compiler complains about a missing return.
+                Y_ABORT("unknown access type of the endpoint %s", path.c_str());
             };
 
             for (const auto& [name, handler] : JsonHandlers.JsonHandlersIndex) {
                 // temporary handling of new handlers
                 if (handler->IsHttpEvent()) {
-                    if (name == "/viewer/capabilities" || name == "/viewer/json/capabilities") {
-                        // this handler is used to discover capabilities, including auth requirements, so it must be always available without authentication
-                        mon->RegisterActorHandler({
-                            .Path = name,
-                            .Handler = ctx.SelfID,
-                            .AuthMode = TMon::EAuthMode::Disabled,
-                        });
-                    } else {
-                        mon->RegisterActorHandler({
-                            .Path = name,
-                            .Handler = ctx.SelfID,
-                            .AuthMode = TMon::EAuthMode::Enforce,
-                            .AllowedSIDs = resolveAllowedSids(name),
-                        });
-                    }
+                    const auto auth = resolveEndpointAuth(name);
+                    mon->RegisterActorHandler({
+                        .Path = name,
+                        .Handler = ctx.SelfID,
+                        .AuthMode = auth.AuthMode,
+                        .AllowedSIDs = auth.AllowedSIDs,
+                    });
                 }
             }
         }
@@ -611,31 +643,37 @@ private:
     TString CurrentWorkerName;
     NProtobufJson::TProto2JsonConfig Proto2JsonConfig;
 
-    EViewerEndpointAccessType GetEndpointAccessType(const TString& path, EViewerEndpointAccessType defaultAccessType) const {
+    // An endpoint without an explicit access level requires the maximum (administration) one,
+    // so a newly added endpoint is never exposed by accident.
+    EViewerEndpointAccessType GetEndpointAccessType(const TString& path) const {
         const auto itAccess = EndpointAccess.find(path);
-        return itAccess != EndpointAccess.end()
-            ? itAccess->second.AccessType
-            : defaultAccessType;
+        if (itAccess != EndpointAccess.end()) {
+            return itAccess->second.AccessType;
+        }
+
+        // The access level of the endpoint is missing in the rules, it must be added there.
+        YDB_LOG_ERROR("Endpoint without an explicit access level", {"path", path});
+
+        if (!AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer()) {
+            return EViewerEndpointAccessType::Database;
+        }
+        return EViewerEndpointAccessType::Administration;
     }
 
     bool IsDatabaseAccessEndpoint(const TString& path) const {
-        auto accessType = GetEndpointAccessType(path, EViewerEndpointAccessType::Database);
-        return accessType == EViewerEndpointAccessType::Database;
+        return GetEndpointAccessType(path) == EViewerEndpointAccessType::Database;
     }
 
     // Returns true if the token has sufficient access for the endpoint's required access level.
     // Used for old-style (non-IsHttpEvent) handlers where per-endpoint SID enforcement is not
-    // done at the monitoring layer.
-    bool CheckEndpointAccess(const TString& path, const TString& serializedToken) const {
+    // done at the monitoring layer. Database-level endpoints are out of scope here, they are
+    // checked by ValidateDatabaseScopedRequest instead.
+    bool CheckNonDatabaseEndpointAccess(const TString& path, const TString& serializedToken) const {
         if (!AppData()->FeatureFlags.GetEnableExtraSidsControlForHttpViewer()) {
             return true;
         }
-        const auto itAccess = EndpointAccess.find(path);
-        if (itAccess == EndpointAccess.end()) {
-            return true; // no specific access requirement
-        }
         const auto& sec = AppData()->DomainsConfig.GetSecurityConfig();
-        switch (itAccess->second.AccessType) {
+        switch (GetEndpointAccessType(path)) {
             case EViewerEndpointAccessType::Administration:
                 return IsTokenAllowed(serializedToken, sec.GetAdministrationAllowedSIDs());
             case EViewerEndpointAccessType::Monitoring:
@@ -645,10 +683,14 @@ private:
                 return IsTokenAllowed(serializedToken, sec.GetViewerAllowedSIDs())
                     || IsTokenAllowed(serializedToken, sec.GetMonitoringAllowedSIDs())
                     || IsTokenAllowed(serializedToken, sec.GetAdministrationAllowedSIDs());
+            case EViewerEndpointAccessType::Any:
+                return true;
             case EViewerEndpointAccessType::Database:
-            default:
-                return false;
+                Y_ENSURE(false, "database-level endpoint is not expected here: " << path);
         }
+        // The switch above is exhaustive, so this code is unreachable.
+        // It is still required, otherwise the compiler complains about a missing return.
+        Y_ABORT("unknown access type of the endpoint %s", path.c_str());
     }
 
     enum class EDatabaseScopedRequestValidationResult {
@@ -903,7 +945,7 @@ private:
             // For old-style (non-IsHttpEvent) handlers the per-endpoint SID check is not done at
             // the monitoring layer, so we enforce it here based on EndpointAccess.
             // Database-level endpoints are validated by ValidateDatabaseScopedRequest instead.
-            if (!handler->IsHttpEvent() && !IsDatabaseAccessEndpoint(path) && !CheckEndpointAccess(path, msg->UserToken)) {
+            if (!handler->IsHttpEvent() && !IsDatabaseAccessEndpoint(path) && !CheckNonDatabaseEndpointAccess(path, msg->UserToken)) {
                 Send(ev->Sender, new NMon::TEvHttpInfoRes(GETHTTPACCESSDENIED(ev->Get(), "text/plain", "Access denied"), 0, NMon::IEvHttpInfoRes::EContentType::Custom));
                 return;
             }

--- a/ydb/core/viewer/viewer.cpp
+++ b/ydb/core/viewer/viewer.cpp
@@ -265,7 +265,7 @@ public:
                     // Monitoring-level endpoints.
                     // restart pdisk and evict vdisk endpoints below have some query-parameters,
                     // which require Administration-level access. This is checked in the handler.
-                    // So the Monitoring-level access is not always enough for a successull call.
+                    // So the Monitoring-level access is not always enough for a successful call.
                     {"/pdisk/restart", {EViewerEndpointAccessType::Monitoring}},
                     {"/vdisk/evict", {EViewerEndpointAccessType::Monitoring}},
 
@@ -340,13 +340,12 @@ public:
                     // it requires the Monitoring level, except for the prometheus format,
                     // which is checked separately (see RequireHealthcheckAuthentication).
                     {"/viewer/healthcheck", {EViewerEndpointAccessType::Database, false}},
-
-                    // Endpoints which are intentionally available to anyone.
-                    // This handler is used to discover capabilities, including auth requirements,
-                    // so it must be always available without authentication.
-                    {"/viewer/capabilities", {EViewerEndpointAccessType::Any, false}},
                 });
             }
+            // Endpoints which are intentionally available to anyone.
+            // The capabilities handler is used to discover capabilities, including auth requirements,
+            // so it must be always available without authentication, regardless of any feature flags.
+            applyAccessRule({"/viewer/capabilities", {EViewerEndpointAccessType::Any, false}});
 
             auto addV2JsonAlias = [&](TStringBuf aliasPath, TStringBuf canonicalPath) {
                 JsonHandlers.JsonHandlersIndex[TString(aliasPath)] = JsonHandlers.JsonHandlersIndex[TString(canonicalPath)];

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-no_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 403,
         "root@builtin": 403
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_disabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_disabled-with_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 200,
         "root@builtin": 200
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-no_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-no_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 403,
         "root@builtin": 403
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_enforce_user_token_enabled-with_schema_grants_/mon_endpoints_auth-enforce_user_token_enabled-with_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 200,
         "root@builtin": 200
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-no_schema_grants_/mon_endpoints_auth-require_counters_authentication-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-no_schema_grants_/mon_endpoints_auth-require_counters_authentication-no_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 403,
         "root@builtin": 403
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-with_schema_grants_/mon_endpoints_auth-require_counters_authentication-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_counters_authentication-with_schema_grants_/mon_endpoints_auth-require_counters_authentication-with_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 200,
         "root@builtin": 200
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-no_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-no_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-no_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-no_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 403,
         "root@builtin": 403
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 403
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 403,
+        "root@builtin": 403
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-with_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-with_schema_grants.json
+++ b/ydb/tests/functional/security/mon/canonical/canondata/test_mon_endpoints_auth.test_require_healthcheck_authentication-with_schema_grants_/mon_endpoints_auth-require_healthcheck_authentication-with_schema_grants.json
@@ -1480,6 +1480,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -1507,6 +1533,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 200,
+        "monitoring@builtin": 200,
+        "root@builtin": 200
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,
@@ -2068,6 +2112,16 @@
         "viewer@builtin": 403,
         "monitoring@builtin": 200,
         "root@builtin": 200
+      }
+    },
+    "/unexisted": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 403,
+        "monitoring@builtin": 404,
+        "root@builtin": 404
       }
     },
     "/vdisk/blobindexstat": {
@@ -5322,6 +5376,32 @@
         "root@builtin": 400
       }
     },
+    "/operation/json/get": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?database=/Root/Tenant": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 400,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
     "/operation/list": {
       "": {
         "__none__": 401,
@@ -5349,6 +5429,24 @@
       }
     },
     "/pdisk/info": {
+      "": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      },
+      "?node_id=1&pdisk_id=1": {
+        "__none__": 401,
+        "user@builtin": 403,
+        "database@builtin": 403,
+        "viewer@builtin": 400,
+        "monitoring@builtin": 400,
+        "root@builtin": 400
+      }
+    },
+    "/pdisk/json/info": {
       "": {
         "__none__": 401,
         "user@builtin": 403,

--- a/ydb/tests/functional/security/mon/canonical/test_mon_endpoints_auth.py
+++ b/ydb/tests/functional/security/mon/canonical/test_mon_endpoints_auth.py
@@ -22,6 +22,10 @@ TOKENS = [
 DATABASE = '/Root'
 TENANT_DATABASE = '/Root/Tenant'
 
+_NO_QUERY_PARAMS = [
+    {},
+]
+
 _DEFAULT_QUERIES = [
     {},
     {'database': DATABASE},
@@ -117,8 +121,12 @@ ENDPOINT_SPECS = [
     {'path': '/operation/cancel'},
     {'path': '/operation/forget'},
     {'path': '/operation/get'},
+    # The legacy /X/json/Y alias must be protected exactly like the /X/Y path above.
+    {'path': '/operation/json/get'},
     {'path': '/operation/list'},
     {'path': '/pdisk/info', 'queries': _PDISK_INFO_QUERIES},
+    # The legacy /X/json/Y alias must be protected exactly like the /X/Y path above.
+    {'path': '/pdisk/json/info', 'queries': _PDISK_INFO_QUERIES},
     {'path': '/pdisk/restart'},
     {'path': '/pdisk/status'},
     {'path': '/ping'},
@@ -140,6 +148,9 @@ ENDPOINT_SPECS = [
     {'path': '/tablet'},
     {'path': '/tablets'},
     {'path': '/trace'},
+    # There is no handler for this path, so it must be not found for monitoring and admin levels
+    # and it must be unauthorized for database and viewer level (by default they don't have access to http handlers)
+    {'path': '/unexisted', 'queries': _NO_QUERY_PARAMS, 'methods': ('GET',)},
     {'path': '/vdisk/blobindexstat', 'queries': _VDISK_READ_QUERIES},
     {'path': '/vdisk/evict'},
     {'path': '/vdisk/getblob', 'queries': _VDISK_READ_QUERIES},

--- a/ydb/tests/functional/security/mon/functional/conftest.py
+++ b/ydb/tests/functional/security/mon/functional/conftest.py
@@ -102,6 +102,24 @@ def ydb_cluster_with_extra_sids_controls(certificates):
     cluster.stop()
 
 
+@pytest.fixture
+def mon_base_url_without_extra_sids_control(ydb_cluster_without_extra_sids_controls):
+    return get_mon_base_url(ydb_cluster_without_extra_sids_controls)
+
+
+@pytest.fixture(scope='module')
+def ydb_cluster_without_extra_sids_controls(certificates):
+    configurator = create_ydb_configurator(
+        certificates,
+        enforce_user_token_requirement=True,
+    )
+    configurator.yaml_config.setdefault('feature_flags', {})['enable_extra_sids_control_for_http_viewer'] = False
+    cluster = KiKiMR(configurator)
+    cluster.start()
+    yield cluster
+    cluster.stop()
+
+
 @pytest.fixture(scope='module')
 def ydb_cluster_with_enforce_user_token_and_tablet_devui_secure_path_flag(certificates):
     configurator = create_ydb_configurator(

--- a/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
+++ b/ydb/tests/functional/security/mon/functional/test_mon_viewer_access_controls.py
@@ -84,6 +84,19 @@ def topic_created(mon_base_url_with_extra_sids_control):
         yield
 
 
+# The capabilities handler is used to discover capabilities, including whether authentication
+# is required at all, so it must be available without authentication regardless of the
+# enable_extra_sids_control_for_http_viewer feature flag.
+def test_capabilities_available_without_auth(
+    mon_base_url_with_extra_sids_control,
+    mon_base_url_without_extra_sids_control,
+):
+    for base_url in (mon_base_url_with_extra_sids_control, mon_base_url_without_extra_sids_control):
+        for ep in ['/viewer/capabilities', '/viewer/json/capabilities']:
+            _assert_status(base_url, ep, None, 200)
+            _assert_status(base_url, ep, 'user@builtin', 200)
+
+
 # External viewer access controls move these endpoints to viewer-level access.
 def test_viewer_config_access_controls(mon_base_url_with_extra_sids_control):
     for ep in ['/viewer/config', '/viewer/json/config']:


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
- Под существующим фичефлагом: дефолтный уровень доступа новых HTTP-хендлеров становится максимально высоким, то есть админским, чтобы для добавляемых хендлеров понижали уровень доступа до требуемого, а не повышали до нужного.
- Добавлен тест на неизвестный урл `/unexisted`, чтобы убедиться, что там нет падений 
