### PR TITLE
Catch TMemoryLimitExceededException by const reference in dq_hash_combine

### DIFF
--- a/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
+++ b/ydb/library/yql/dq/comp_nodes/dq_hash_combine.cpp
@@ -1320,7 +1320,7 @@ protected:
                 }
                 return true;
             }
-            catch (TMemoryLimitExceededException) {
+            catch (const TMemoryLimitExceededException&) {
             }
             return false;
         };


### PR DESCRIPTION
## Summary
- Fix SAST `misc-throw-by-value-catch-by-reference` in `dq_hash_combine.cpp`: catch `TMemoryLimitExceededException` by `const&` instead of by value.
- Prevents potential slicing for the polymorphic exception hierarchy (`THardMemoryLimitException` derives from `TMemoryLimitExceededException`).

## Test plan
- [ ] Confirm the change is limited to the catch clause in `TryAllocMapForRowCount`
- [ ] Optional: build/compiles with existing dq_hash_combine targets if convenient


Made with [Cursor](https://cursor.com)