### PR TITLE
Fix Interconnect liveness test after ICv2 settings rename

### DIFF
--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -1150,7 +1150,7 @@ void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
 
     auto settingsCustomizer = [=](ui32, TInterconnectSettings& settings) {
         settings.SubscriberLivenessCheckInterval = checkInterval;
-        settings.EnableInterconnectSessionV2 = useSessionV2;
+        settings.V2.Enable = useSessionV2;
     };
     auto logState = std::make_shared<TSubscriberLivenessLogState>();
     auto loggerSettings = MakeIntrusive<NLog::TSettings>(


### PR DESCRIPTION
### Changelog entry

Fix Interconnect subscriber-liveness UT compilation after the ICv2 settings rename.

### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

The subscriber-liveness test still used the removed `EnableInterconnectSessionV2` field after ICv2 settings were moved under `TInterconnectSettings::V2`. Use `settings.V2.Enable` so the test compiles against current `main`. This is test-only and does not change production behavior.

Tested:

* `ssh_ya make ydb/library/actors/interconnect/ut`
* `ssh_ya test ydb/library/actors/interconnect/ut -F '*SubscriberLivenessCheck*'` — 4 tests GOOD; V2 cases skipped because io_uring is unavailable on the build host
