### PR TITLE
Replace IValueArrowCodec with switch-based dispatch

### DIFF
--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -50,7 +50,7 @@ public:
     class TIterator {
     private:
         ui32 KeyIndex;
-        std::shared_ptr<const IValueArrowCodec> Codec;
+        EValueType ValueType;
         std::shared_ptr<IChunkedArray> GlobalChunkedArray;
         const arrow::Array* CurrentArrayData;
         std::optional<IChunkedArray::TFullChunkedArrayAddress> FullArrayAddress;
@@ -62,7 +62,7 @@ public:
     public:
         TIterator(const ui32 keyIndex, const EValueType valueType, const std::shared_ptr<IChunkedArray>& chunkedArray)
             : KeyIndex(keyIndex)
-            , Codec(GetCodecForValueType(valueType))
+            , ValueType(valueType)
             , GlobalChunkedArray(chunkedArray) {
             InitArrays();
         }
@@ -85,7 +85,7 @@ public:
         }
 
         NArrow::NAccessor::TJsonValueView GetValue() const {
-            return Codec->ReadValueView(*CurrentArrayData, GetLocalIndex());
+            return ArrayElementToJsonValueView(*CurrentArrayData, GetLocalIndex(), ValueType);
         }
 
         bool HasValue() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/columns_storage.h
@@ -50,7 +50,7 @@ public:
     class TIterator {
     private:
         ui32 KeyIndex;
-        EValueType ValueType;
+        std::shared_ptr<const IValueArrowCodec> Codec;
         std::shared_ptr<IChunkedArray> GlobalChunkedArray;
         const arrow::Array* CurrentArrayData;
         std::optional<IChunkedArray::TFullChunkedArrayAddress> FullArrayAddress;
@@ -62,7 +62,7 @@ public:
     public:
         TIterator(const ui32 keyIndex, const EValueType valueType, const std::shared_ptr<IChunkedArray>& chunkedArray)
             : KeyIndex(keyIndex)
-            , ValueType(valueType)
+            , Codec(GetCodecForValueType(valueType))
             , GlobalChunkedArray(chunkedArray) {
             InitArrays();
         }
@@ -85,7 +85,7 @@ public:
         }
 
         NArrow::NAccessor::TJsonValueView GetValue() const {
-            return GetCodecForValueType(ValueType)->ReadValueView(*CurrentArrayData, GetLocalIndex());
+            return Codec->ReadValueView(*CurrentArrayData, GetLocalIndex());
         }
 
         bool HasValue() const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/direct_builder.cpp
@@ -15,7 +15,7 @@ namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 void TColumnElements::BuildSparsedAccessor(const ui32 recordsCount, const EValueType valueType) {
     AFL_VERIFY(!Accessor);
-    TEncodingSparsedBuilder builder(GetCodecForValueType(valueType), RecordIndexes.size(), DataSize);
+    TEncodingSparsedBuilder builder(valueType, RecordIndexes.size(), DataSize);
     for (ui32 i = 0; i < RecordIndexes.size(); ++i) {
         builder.AddFromBinaryJson(RecordIndexes[i], Values[i]);
     }
@@ -24,7 +24,7 @@ void TColumnElements::BuildSparsedAccessor(const ui32 recordsCount, const EValue
 
 void TColumnElements::BuildPlainAccessor(const ui32 recordsCount, const EValueType valueType) {
     AFL_VERIFY(!Accessor);
-    TEncodingPlainBuilder builder(GetCodecForValueType(valueType), recordsCount, DataSize);
+    TEncodingPlainBuilder builder(valueType, recordsCount, DataSize);
     for (ui32 i = 0; i < RecordIndexes.size(); ++i) {
         builder.AddFromBinaryJson(RecordIndexes[i], Values[i]);
     }
@@ -33,7 +33,7 @@ void TColumnElements::BuildPlainAccessor(const ui32 recordsCount, const EValueTy
 
 void TColumnElements::BuildDictionaryAccessor(const ui32 recordsCount, const EValueType valueType) {
     BuildPlainAccessor(recordsCount, valueType);
-    const TChunkConstructionData cData(recordsCount, nullptr, GetCodecForValueType(valueType)->GetArrowType(),
+    const TChunkConstructionData cData(recordsCount, nullptr, GetArrowTypeForValueType(valueType),
         NSerialization::TSerializerContainer::GetDefaultSerializer());
     Accessor = NDictionary::TConstructor().Construct(Accessor, cData).DetachResult();
 }

--- a/ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h
@@ -28,7 +28,6 @@ public:
     }
 
     void AddArrayElement(const ui32 recordIndex, const arrow::Array& array, const ui32 position) {
-        AFL_VERIFY(GetBuilder().type()->id() == array.type_id())("builder", GetBuilder().type()->ToString())("array", array.type()->ToString());
         AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AFL_VERIFY(NArrow::Append(builder, array, position)); });
     }
 };
@@ -49,7 +48,6 @@ public:
     }
 
     void AddArrayElement(const ui32 recordIndex, const arrow::Array& array, const ui32 position) {
-        AFL_VERIFY(GetValueBuilder().type()->id() == array.type_id())("builder", GetValueBuilder().type()->ToString())("array", array.type()->ToString());
         AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AFL_VERIFY(NArrow::Append(builder, array, position)); });
     }
 };

--- a/ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/encoding_builders.h
@@ -6,6 +6,7 @@
 #include <ydb/core/formats/arrow/accessor/sparsed/accessor.h>
 
 #include <ydb/library/actors/core/log.h>
+#include <ydb/library/formats/arrow/arrow_helpers.h>
 
 #include <yql/essentials/types/binary_json/format.h>
 
@@ -14,17 +15,17 @@ namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 class TEncodingPlainBuilder: public TTrivialArray::TPlainBuilderBase {
 private:
-    std::shared_ptr<const IValueArrowCodec> Codec;
+    EValueType ValueType;
 
 public:
-    TEncodingPlainBuilder(const std::shared_ptr<const IValueArrowCodec>& codec, const ui32 reserveItems, const ui32 reserveData)
-        : TPlainBuilderBase(codec->MakeBuilder(reserveItems, reserveData))
-        , Codec(codec)
+    TEncodingPlainBuilder(const EValueType valueType, const ui32 reserveItems, const ui32 reserveData)
+        : TPlainBuilderBase(MakeBuilderForValueType(valueType, reserveItems, reserveData))
+        , ValueType(valueType)
     {
     }
 
     void AddFromBinaryJson(const ui32 recordIndex, const NBinaryJson::TBinaryJson& blob) {
-        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { Codec->AppendFromBinaryJson(builder, blob); });
+        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AppendValueFromBinaryJson(builder, blob, ValueType); });
     }
 
     void AddArrayElement(const ui32 recordIndex, const arrow::Array& array, const ui32 position) {
@@ -34,17 +35,17 @@ public:
 
 class TEncodingSparsedBuilder: public TSparsedArray::TSparsedBuilderBase {
 private:
-    std::shared_ptr<const IValueArrowCodec> Codec;
+    EValueType ValueType;
 
 public:
-    TEncodingSparsedBuilder(const std::shared_ptr<const IValueArrowCodec>& codec, const ui32 reserveItems, const ui32 reserveData)
-        : TSparsedBuilderBase(codec->MakeBuilder(reserveItems, reserveData), codec->GetArrowType(), nullptr, reserveItems)
-        , Codec(codec)
+    TEncodingSparsedBuilder(const EValueType valueType, const ui32 reserveItems, const ui32 reserveData)
+        : TSparsedBuilderBase(MakeBuilderForValueType(valueType, reserveItems, reserveData), GetArrowTypeForValueType(valueType), nullptr, reserveItems)
+        , ValueType(valueType)
     {
     }
 
     void AddFromBinaryJson(const ui32 recordIndex, const NBinaryJson::TBinaryJson& blob) {
-        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { Codec->AppendFromBinaryJson(builder, blob); });
+        AddAt(recordIndex, [&](arrow::ArrayBuilder& builder) { AppendValueFromBinaryJson(builder, blob, ValueType); });
     }
 
     void AddArrayElement(const ui32 recordIndex, const arrow::Array& array, const ui32 position) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/iterators.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/iterators.cpp
@@ -5,7 +5,7 @@ namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 NJson::TJsonValue TGeneralIterator::GetValue() const {
     AFL_VERIFY(IsValidFlag);
-    return Codec->ReadValueView(*CurrentArray, LocalIndex).ToJsonValue();
+    return ArrayElementToJsonValueView(*CurrentArray, LocalIndex, ValueType).ToJsonValue();
 }
 
 }   // namespace NKikimr::NArrow::NAccessor::NSubColumns

--- a/ydb/core/formats/arrow/accessor/sub_columns/iterators.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/iterators.h
@@ -15,7 +15,7 @@ private:
     bool IsValidFlag = false;
     bool HasValueFlag = false;
     bool IsColumnKeyFlag = false;
-    std::shared_ptr<const IValueArrowCodec> Codec;
+    EValueType ValueType = EValueType::BinaryJson;
     // Current physical position as (array, local index)
     const arrow::Array* CurrentArray = nullptr;
     ui32 LocalIndex = 0;
@@ -72,14 +72,14 @@ public:
     TGeneralIterator(TColumnsData::TIterator&& iterator, const EValueType valueType, const std::optional<ui32> remappedKey = {})
         : Iterator(iterator)
         , RemappedKey(remappedKey)
-        , Codec(GetCodecForValueType(valueType)) {
+        , ValueType(valueType) {
         Initialize();
     }
 
     TGeneralIterator(TOthersData::TIterator&& iterator, const std::vector<ui32>& remapKeys = {})
         : Iterator(iterator)
         , RemapKeys(remapKeys)
-        , Codec(GetCodecForValueType(EValueType::BinaryJson)) {
+        , ValueType(EValueType::BinaryJson) {
         Initialize();
     }
     bool IsColumnKey() const {
@@ -161,11 +161,11 @@ public:
     // Re-encode the current value to BinaryJson.
     NBinaryJson::TBinaryJson GetValueAsBinaryJson() const {
         AFL_VERIFY(IsValidFlag);
-        return Codec->ReadValueView(*CurrentArray, LocalIndex).ToBinaryJson();
+        return ArrayElementToBinaryJson(*CurrentArray, LocalIndex, ValueType);
     }
 
     EValueType GetValueType() const {
-        return Codec->GetValueType();
+        return ValueType;
     }
     const arrow::Array& GetArray() const {
         AFL_VERIFY(IsValidFlag);
@@ -177,7 +177,7 @@ public:
     }
     ui32 GetValueSize() const {
         AFL_VERIFY(IsValidFlag);
-        return Codec->GetElementSize(*CurrentArray, LocalIndex);
+        return ArrayElementSize(*CurrentArray, LocalIndex, ValueType);
     }
 
     NJson::TJsonValue GetValue() const;

--- a/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/json_value_path.cpp
@@ -139,7 +139,6 @@ void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {
         return;
     }
 
-    const auto codec = GetCodecForValueType(ValueType);
     ChunkedArrayAccessor->VisitValues([&](std::shared_ptr<arrow::Array> arr) {
         AFL_VERIFY(arr);
         for (int64_t i = 0; i < arr->length(); ++i) {
@@ -148,7 +147,7 @@ void TJsonPathAccessor::VisitValues(const TValuesVisitor& visitor) const {
                 continue;
             }
 
-            const auto value = codec->ReadValueView(*arr, i);
+            const auto value = ArrayElementToJsonValueView(*arr, i, ValueType);
             if (auto scalar = value.GetScalarOptional()) {
                 // A scalar has no sub-structure, so a remaining path cannot resolve against it.
                 visitor(RemainingPathPtr ? std::nullopt : scalar);

--- a/ydb/core/formats/arrow/accessor/sub_columns/stats.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/stats.h
@@ -194,7 +194,7 @@ public:
     std::shared_ptr<arrow::Field> GetField(const ui32 index) const {
         AFL_VERIFY(index < DataNames->length());
         auto name = DataNames->GetView(index);
-        return std::make_shared<arrow::Field>(std::string(name.data(), name.size()), GetCodecForValueType(GetValueType(index))->GetArrowType());
+        return std::make_shared<arrow::Field>(std::string(name.data(), name.size()), GetArrowTypeForValueType(GetValueType(index)));
     }
 
     TRTStats GetRTStats(const ui32 index) const {

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -48,21 +48,11 @@ EValueType ValueTypeForItem(const NBinaryJson::TBinaryJson& blob) {
     }
 }
 
-TStringBuf BinaryView(const arrow::Array& array, const i64 index) {
-    AFL_VERIFY(array.type()->id() == arrow::Type::BINARY);
-    const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
-    return TStringBuf(view.data(), view.size());
-}
-
 // BinaryJson and String share arrow::binary() storage; they differ only in what the bytes mean.
 class TBinaryBackedCodec: public IValueArrowCodec {
 public:
     std::shared_ptr<arrow::DataType> GetArrowType() const override {
         return arrow::binary();
-    }
-
-    ui32 GetElementSize(const arrow::Array& array, const i64 index) const override {
-        return BinaryView(array, index).size();
     }
     std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const override {
         return NArrow::MakeBuilder(arrow::binary(), reserveItems, reserveData);
@@ -71,12 +61,6 @@ public:
 
 class TBinaryJsonCodec: public TBinaryBackedCodec {
 public:
-    EValueType GetValueType() const override {
-        return EValueType::BinaryJson;
-    }
-    TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const override {
-        return TJsonValueView::OfBinaryJson(BinaryView(array, index));
-    }
     void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
         AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(blob.data(), blob.size())));
     }
@@ -84,36 +68,17 @@ public:
 
 class TStringCodec: public TBinaryBackedCodec {
 public:
-    EValueType GetValueType() const override {
-        return EValueType::String;
-    }
-    TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const override {
-        return TJsonValueView::OfString(BinaryView(array, index));
-    }
     void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
         const auto scalar = ExtractStringScalar(blob);
         AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(scalar.data(), scalar.size())));
     }
 };
 
-template <class TArrow, EValueType ValueType, auto ExtractScalar, auto MakeView>
+template <class TArrow, auto ExtractScalar>
 class TNativeScalarCodec: public IValueArrowCodec {
-private:
-    using TArray = typename arrow::TypeTraits<TArrow>::ArrayType;
-
 public:
-    EValueType GetValueType() const override {
-        return ValueType;
-    }
     std::shared_ptr<arrow::DataType> GetArrowType() const override {
         return arrow::TypeTraits<TArrow>::type_singleton();
-    }
-    ui32 GetElementSize(const arrow::Array& /*array*/, const i64 /*index*/) const override {
-        return sizeof(typename TArrow::c_type);
-    }
-    TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const override {
-        AFL_VERIFY(array.type()->id() == TArrow::type_id);
-        return MakeView(static_cast<const TArray&>(array).Value(index));
     }
     std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 /*reserveData*/) const override {
         return NArrow::MakeBuilder(arrow::TypeTraits<TArrow>::type_singleton(), reserveItems, 0);
@@ -123,13 +88,47 @@ public:
     }
 };
 
-using TDoubleCodec = TNativeScalarCodec<arrow::DoubleType, EValueType::Double, ExtractDoubleScalar, TJsonValueView::OfNumber>;
-using TBoolCodec = TNativeScalarCodec<arrow::BooleanType, EValueType::Bool, ExtractBoolScalar, TJsonValueView::OfBool>;
+using TDoubleCodec = TNativeScalarCodec<arrow::DoubleType, ExtractDoubleScalar>;
+using TBoolCodec = TNativeScalarCodec<arrow::BooleanType, ExtractBoolScalar>;
 
 }   // namespace
 
 bool CanBeDictionaryEncoded(EValueType valueType) {
     return valueType == EValueType::BinaryJson || valueType == EValueType::String;
+}
+
+TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType) {
+    switch (valueType) {
+        case EValueType::String: {
+            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
+            return TJsonValueView::OfString(TStringBuf(view.data(), view.size()));
+        }
+        case EValueType::Double:
+            return TJsonValueView::OfNumber(static_cast<const arrow::DoubleArray&>(array).Value(index));
+        case EValueType::Bool:
+            return TJsonValueView::OfBool(static_cast<const arrow::BooleanArray&>(array).Value(index));
+        case EValueType::BinaryJson: {
+            const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
+            return TJsonValueView::OfBinaryJson(TStringBuf(view.data(), view.size()));
+        }
+    }
+}
+
+NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, const i64 index, const EValueType valueType) {
+    return ArrayElementToJsonValueView(array, index, valueType).ToBinaryJson();
+}
+
+ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType) {
+    switch (valueType) {
+        case EValueType::BinaryJson:
+        case EValueType::String:
+            return static_cast<const arrow::BinaryArray&>(array).GetView(index).size();
+        case EValueType::Double:
+            return sizeof(double);
+        case EValueType::Bool:
+            // actually only 1 bit in arrow representation, not 1 byte, but let's not overcomplicate things
+            return 1;
+    }
 }
 
 std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType) {

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -69,14 +69,18 @@ bool CanBeDictionaryEncoded(EValueType valueType) {
 TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType) {
     switch (valueType) {
         case EValueType::String: {
+            AFL_VERIFY(array.type_id() == arrow::Type::BINARY)("actual", (ui32)array.type_id());
             const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
             return TJsonValueView::OfString(TStringBuf(view.data(), view.size()));
         }
         case EValueType::Double:
+            AFL_VERIFY(array.type_id() == arrow::Type::DOUBLE)("actual", (ui32)array.type_id());
             return TJsonValueView::OfNumber(static_cast<const arrow::DoubleArray&>(array).Value(index));
         case EValueType::Bool:
+            AFL_VERIFY(array.type_id() == arrow::Type::BOOL)("actual", (ui32)array.type_id());
             return TJsonValueView::OfBool(static_cast<const arrow::BooleanArray&>(array).Value(index));
         case EValueType::BinaryJson: {
+            AFL_VERIFY(array.type_id() == arrow::Type::BINARY)("actual", (ui32)array.type_id());
             const auto view = static_cast<const arrow::BinaryArray&>(array).GetView(index);
             return TJsonValueView::OfBinaryJson(TStringBuf(view.data(), view.size()));
         }

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.cpp
@@ -48,50 +48,19 @@ EValueType ValueTypeForItem(const NBinaryJson::TBinaryJson& blob) {
     }
 }
 
-// BinaryJson and String share arrow::binary() storage; they differ only in what the bytes mean.
-class TBinaryBackedCodec: public IValueArrowCodec {
-public:
-    std::shared_ptr<arrow::DataType> GetArrowType() const override {
-        return arrow::binary();
-    }
-    std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const override {
-        return NArrow::MakeBuilder(arrow::binary(), reserveItems, reserveData);
-    }
-};
-
-class TBinaryJsonCodec: public TBinaryBackedCodec {
-public:
-    void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
-        AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(blob.data(), blob.size())));
-    }
-};
-
-class TStringCodec: public TBinaryBackedCodec {
-public:
-    void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
-        const auto scalar = ExtractStringScalar(blob);
-        AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(scalar.data(), scalar.size())));
-    }
-};
-
-template <class TArrow, auto ExtractScalar>
-class TNativeScalarCodec: public IValueArrowCodec {
-public:
-    std::shared_ptr<arrow::DataType> GetArrowType() const override {
-        return arrow::TypeTraits<TArrow>::type_singleton();
-    }
-    std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 /*reserveData*/) const override {
-        return NArrow::MakeBuilder(arrow::TypeTraits<TArrow>::type_singleton(), reserveItems, 0);
-    }
-    void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const override {
-        AFL_VERIFY(NArrow::Append<TArrow>(builder, ExtractScalar(blob)));
-    }
-};
-
-using TDoubleCodec = TNativeScalarCodec<arrow::DoubleType, ExtractDoubleScalar>;
-using TBoolCodec = TNativeScalarCodec<arrow::BooleanType, ExtractBoolScalar>;
-
 }   // namespace
+
+std::shared_ptr<arrow::DataType> GetArrowTypeForValueType(const EValueType valueType) {
+    switch (valueType) {
+        case EValueType::BinaryJson:
+        case EValueType::String:
+            return arrow::binary();
+        case EValueType::Double:
+            return arrow::float64();
+        case EValueType::Bool:
+            return arrow::boolean();
+    }
+}
 
 bool CanBeDictionaryEncoded(EValueType valueType) {
     return valueType == EValueType::BinaryJson || valueType == EValueType::String;
@@ -131,20 +100,28 @@ ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueTy
     }
 }
 
-std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType) {
-    static const std::shared_ptr<const IValueArrowCodec> binaryJson = std::make_shared<TBinaryJsonCodec>();
-    static const std::shared_ptr<const IValueArrowCodec> string = std::make_shared<TStringCodec>();
-    static const std::shared_ptr<const IValueArrowCodec> doubleValue = std::make_shared<TDoubleCodec>();
-    static const std::shared_ptr<const IValueArrowCodec> boolValue = std::make_shared<TBoolCodec>();
+std::unique_ptr<arrow::ArrayBuilder> MakeBuilderForValueType(const EValueType valueType, const ui32 reserveItems, const ui32 reserveData) {
+    // Only variable-length (BinaryJson/String) storage makes use of a data-size reservation.
+    const bool variableLength = valueType == EValueType::BinaryJson || valueType == EValueType::String;
+    return NArrow::MakeBuilder(GetArrowTypeForValueType(valueType), reserveItems, variableLength ? reserveData : 0);
+}
+
+void AppendValueFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob, const EValueType valueType) {
     switch (valueType) {
         case EValueType::BinaryJson:
-            return binaryJson;
-        case EValueType::String:
-            return string;
+            AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(blob.data(), blob.size())));
+            return;
+        case EValueType::String: {
+            const auto scalar = ExtractStringScalar(blob);
+            AFL_VERIFY(NArrow::Append<arrow::BinaryType>(builder, arrow::util::string_view(scalar.data(), scalar.size())));
+            return;
+        }
         case EValueType::Double:
-            return doubleValue;
+            AFL_VERIFY(NArrow::Append<arrow::DoubleType>(builder, ExtractDoubleScalar(blob)));
+            return;
         case EValueType::Bool:
-            return boolValue;
+            AFL_VERIFY(NArrow::Append<arrow::BooleanType>(builder, ExtractBoolScalar(blob)));
+            return;
     }
 }
 

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.h
@@ -14,28 +14,21 @@
 
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
-// Conversion between physical arrow storage and logical JsonValue/BinaryJson in-program representation
-// Write path: initialize a typed builder and decode BinaryJson values into it. Reads use the free
-// ArrayElement* functions below instead (monomorphic/inlinable for hot loops).
-class IValueArrowCodec {
-public:
-    virtual ~IValueArrowCodec() = default;
-
-    virtual std::shared_ptr<arrow::DataType> GetArrowType() const = 0;
-    // reserveData makes sense only for variable-length types (BinaryJson and string).
-    virtual std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const = 0;
-    virtual void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const = 0;
-};
+std::shared_ptr<arrow::DataType> GetArrowTypeForValueType(const EValueType valueType);
 
 bool CanBeDictionaryEncoded(EValueType valueType);
 
-std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType);
-
-// Inline-switch reads of physical element `index` per the column's value type: a native scalar for
-// Double/Bool/String, or a BinaryJson blob for BinaryJson. The view aliases `array`, which must outlive it.
+// Read physical element `index` per the column's value type: a native scalar for Double/Bool/String, or a
+// BinaryJson blob for BinaryJson. The view aliases `array`, which must outlive it.
 TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType);
 NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, const i64 index, const EValueType valueType);
 ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType);
+
+// Make an arrow builder for the value type's storage; reserveData applies only to variable-length types.
+std::unique_ptr<arrow::ArrayBuilder> MakeBuilderForValueType(const EValueType valueType, const ui32 reserveItems, const ui32 reserveData);
+
+// Decode a BinaryJson value and append it to a builder of the value type's arrow storage.
+void AppendValueFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob, const EValueType valueType);
 
 // Element type to represent result of merging arrays with arg types
 EValueType MergeValueTypes(const std::optional<EValueType>& acc, const EValueType next);

--- a/ydb/core/formats/arrow/accessor/sub_columns/types.h
+++ b/ydb/core/formats/arrow/accessor/sub_columns/types.h
@@ -15,21 +15,13 @@
 namespace NKikimr::NArrow::NAccessor::NSubColumns {
 
 // Conversion between physical arrow storage and logical JsonValue/BinaryJson in-program representation
+// Write path: initialize a typed builder and decode BinaryJson values into it. Reads use the free
+// ArrayElement* functions below instead (monomorphic/inlinable for hot loops).
 class IValueArrowCodec {
 public:
     virtual ~IValueArrowCodec() = default;
 
-    virtual EValueType GetValueType() const = 0;
     virtual std::shared_ptr<arrow::DataType> GetArrowType() const = 0;
-
-    // Read path - wrap the physical element `index` as a logical value view (a native scalar for
-    // Double/Bool/String, or a BinaryJson blob for BinaryJson).
-    // The view aliases `array`, which must outlive it.
-    virtual TJsonValueView ReadValueView(const arrow::Array& array, const i64 index) const = 0;
-    // Approximate size of element `index` for accounting: variable for binary values, fixed for scalar types.
-    virtual ui32 GetElementSize(const arrow::Array& array, const i64 index) const = 0;
-
-    // Write path - initialize builder and write values to it.
     // reserveData makes sense only for variable-length types (BinaryJson and string).
     virtual std::unique_ptr<arrow::ArrayBuilder> MakeBuilder(const ui32 reserveItems, const ui32 reserveData) const = 0;
     virtual void AppendFromBinaryJson(arrow::ArrayBuilder& builder, const NBinaryJson::TBinaryJson& blob) const = 0;
@@ -38,6 +30,12 @@ public:
 bool CanBeDictionaryEncoded(EValueType valueType);
 
 std::shared_ptr<const IValueArrowCodec> GetCodecForValueType(const EValueType valueType);
+
+// Inline-switch reads of physical element `index` per the column's value type: a native scalar for
+// Double/Bool/String, or a BinaryJson blob for BinaryJson. The view aliases `array`, which must outlive it.
+TJsonValueView ArrayElementToJsonValueView(const arrow::Array& array, const i64 index, const EValueType valueType);
+NBinaryJson::TBinaryJson ArrayElementToBinaryJson(const arrow::Array& array, const i64 index, const EValueType valueType);
+ui32 ArrayElementSize(const arrow::Array& array, const i64 index, const EValueType valueType);
 
 // Element type to represent result of merging arrays with arg types
 EValueType MergeValueTypes(const std::optional<EValueType>& acc, const EValueType next);

--- a/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_native_scalars.cpp
+++ b/ydb/core/formats/arrow/accessor/sub_columns/ut/ut_native_scalars.cpp
@@ -234,7 +234,7 @@ Y_UNIT_TEST_SUITE(SubColumnsNativeScalars) {
             UNIT_ASSERT(native->GetChunkedArray());   // read-back document reconstruction must not abort
             const auto assertExact = [&](const std::shared_ptr<TSubColumnsArray>& arr) {
                 auto it = arr->GetColumnsData().BuildIterator(0);
-                auto bj = GetCodecForValueType(EValueType::Double)->ReadValueView(it.GetArray(), it.GetLocalIndex()).ToBinaryJson();
+                auto bj = ArrayElementToBinaryJson(it.GetArray(), it.GetLocalIndex(), EValueType::Double);
                 auto reader = NBinaryJson::TBinaryJsonReader::Make(bj);
                 UNIT_ASSERT_VALUES_EQUAL(reader->GetRootCursor().GetElement(0).GetNumber(), expected);
             };

--- a/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/compaction/sub_columns/builder.cpp
@@ -84,12 +84,10 @@ void TMergedBuilder::Initialize() {
         const auto valueType = ResultColumnStats.GetValueType(i);
         switch (ResultColumnStats.GetAccessorType(i)) {
             case NArrow::NAccessor::IChunkedArray::EType::Array:
-                ColumnBuilders.emplace_back(
-                    TEncodingPlainBuilder(NArrow::NAccessor::NSubColumns::GetCodecForValueType(valueType), 0, 0), valueType);
+                ColumnBuilders.emplace_back(TEncodingPlainBuilder(valueType, 0, 0), valueType);
                 break;
             case NArrow::NAccessor::IChunkedArray::EType::SparsedArray:
-                ColumnBuilders.emplace_back(
-                    TEncodingSparsedBuilder(NArrow::NAccessor::NSubColumns::GetCodecForValueType(valueType), 0, 0), valueType);
+                ColumnBuilders.emplace_back(TEncodingSparsedBuilder(valueType, 0, 0), valueType);
                 break;
             case NArrow::NAccessor::IChunkedArray::EType::Undefined:
             case NArrow::NAccessor::IChunkedArray::EType::SerializedChunkedArray:


### PR DESCRIPTION
This partially reverts #46374 for performance reasons - IValueArrowCodec is replaced with switch on value to avoid virtual calls that do not inline on hot path. Also removed virtual builder->type() calls in VERIFY.

TEncoding*Builder classes retained - they provide code deduplication between compression and insertion at the cost of switch dispatch on each value instead of per-column on insertion path - this cost is below noise level on benchmarks.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
