### PR TITLE
Fix YCSB load test RPS division-by-zero due to operator precedence

### DIFF
--- a/ydb/core/load_test/ycsb/test_load_actor.cpp
+++ b/ydb/core/load_test/ycsb/test_load_actor.cpp
@@ -470,7 +470,7 @@ public:
             actualDurationMs += test.Report.GetDurationMs();
         }
 
-        size_t rps = oks * 1000 / actualDurationMs ? actualDurationMs : 1;
+        size_t rps = oks * 1000 / (actualDurationMs ? actualDurationMs : 1);
 
         TIntrusivePtr<TEvLoad::TLoadReport> report(new TEvLoad::TLoadReport());
         report->Duration = duration;


### PR DESCRIPTION
## Summary
- Fix operator precedence in YCSB load-test RPS calculation so the ternary guards the divisor (`actualDurationMs`) instead of the already-computed quotient.
- Prevents integer division by zero (UB) when `actualDurationMs == 0` and restores intended RPS semantics: `oks * 1000 / max(durationMs, 1)`.

## Test plan
- [ ] Inspect the one-line change in `ydb/core/load_test/ycsb/test_load_actor.cpp`
- [ ] Optionally build/run load_test YCSB-related tests: `./ya make --build relwithdebinfo -tA ydb/core/load_test`


Made with [Cursor](https://cursor.com)