### PR TITLE
[26-1-1-ent] trace_id  for top_queries_* (#44418)

### DIFF
--- a/ydb/core/kqp/session_actor/kqp_query_stats.cpp
+++ b/ydb/core/kqp/session_actor/kqp_query_stats.cpp
@@ -32,7 +32,7 @@ template <typename T>
 void CollectQueryStatsImpl(const TActorContext& ctx, const T* queryStats,
     TDuration queryDuration, const TString& queryText,
     const TString& userSID, ui64 parametersSize, const TString& database,
-    const NKikimrKqp::EQueryType type, ui64 requestUnits)
+    const NKikimrKqp::EQueryType type, ui64 requestUnits, const TString& traceId)
 {
     auto collectEv = MakeHolder<NSysView::TEvSysView::TEvCollectQueryStats>();
     collectEv->Database = database;
@@ -78,6 +78,10 @@ void CollectQueryStatsImpl(const TActorContext& ctx, const T* queryStats,
         break;
     }
     stats.SetType(strType);
+
+    if (traceId) {
+        stats.SetTraceId(traceId);
+    }
 
     if (!queryStats || queryStats->GetExecutions().empty()) {
         ctx.Send(NSysView::MakeSysViewServiceID(nodeId), std::move(collectEv));
@@ -152,21 +156,21 @@ void CollectQueryStatsImpl(const TActorContext& ctx, const T* queryStats,
 void CollectQueryStats(const TActorContext& ctx, const NKqpProto::TKqpStatsQuery* queryStats,
     TDuration queryDuration, const TString& queryText,
     const TString& userSID, ui64 parametersSize, const TString& database,
-    const NKikimrKqp::EQueryType type, ui64 requestUnits)
+    const NKikimrKqp::EQueryType type, ui64 requestUnits, const TString& traceId)
 {
     CollectQueryStatsImpl(
         ctx, queryStats, queryDuration, queryText, userSID,
-        parametersSize, database, type, requestUnits);
+        parametersSize, database, type, requestUnits, traceId);
 }
 
 void CollectQueryStats(const TActorContext& ctx, const TKqpQueryStats* queryStats,
     TDuration queryDuration, const TString& queryText,
     const TString& userSID, ui64 parametersSize, const TString& database,
-    const NKikimrKqp::EQueryType type, ui64 requestUnits)
+    const NKikimrKqp::EQueryType type, ui64 requestUnits, const TString& traceId)
 {
     CollectQueryStatsImpl(
         ctx, queryStats, queryDuration, queryText, userSID,
-        parametersSize, database, type, requestUnits);
+        parametersSize, database, type, requestUnits, traceId);
 }
 
 // Attribute LocksBrokenAsVictim to the original query that acquired the locks

--- a/ydb/core/kqp/session_actor/kqp_query_stats.h
+++ b/ydb/core/kqp/session_actor/kqp_query_stats.h
@@ -30,12 +30,12 @@ struct TKqpQueryStats {
 void CollectQueryStats(const TActorContext& ctx, const NKqpProto::TKqpStatsQuery* queryStats,
     TDuration queryDuration, const TString& queryText,
     const TString& userSID, ui64 parametersSize, const TString& database,
-    const NKikimrKqp::EQueryType type, ui64 requestUnits);
+    const NKikimrKqp::EQueryType type, ui64 requestUnits, const TString& traceId);
 
 void CollectQueryStats(const TActorContext& ctx, const TKqpQueryStats* queryStats,
     TDuration queryDuration, const TString& queryText,
     const TString& userSID, ui64 parametersSize, const TString& database,
-    const NKikimrKqp::EQueryType type, ui64 requestUnits);
+    const NKikimrKqp::EQueryType type, ui64 requestUnits, const TString& traceId);
 
 void SendVictimStats(const TActorContext& ctx, ui64 locksBrokenAsVictim,
     const TString& victimQueryText, const TString& database);

--- a/ydb/core/kqp/session_actor/kqp_session_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_session_actor.cpp
@@ -2733,7 +2733,8 @@ public:
                 if (!NKikimr::IsQueryWithSensitiveInfo(text)) {
                     auto userSID = QueryState->UserToken->GetUserSID();
                     CollectQueryStats(TlsActivationContext->AsActorContext(), stats, queryDuration, text,
-                        userSID, QueryState->ParametersSize, database, type, requestUnits);
+                        userSID, QueryState->ParametersSize, database, type, requestUnits,
+                        QueryState->RequestEv->GetTraceId());
                 }
                 break;
             }

--- a/ydb/core/kqp/session_actor/kqp_worker_actor.cpp
+++ b/ydb/core/kqp/session_actor/kqp_worker_actor.cpp
@@ -916,7 +916,8 @@ private:
                 if (!NKikimr::IsQueryWithSensitiveInfo(text)) {
                     auto userSID = QueryState->RequestEv->GetUserToken()->GetUserSID();
                     CollectQueryStats(ctx, stats, queryDuration, text,
-                        userSID, QueryState->RequestEv->GetParametersSize(), database, type, requestUnits);
+                        userSID, QueryState->RequestEv->GetParametersSize(), database, type, requestUnits,
+                        QueryState->RequestEv->GetTraceId());
                 }
                 break;
             }

--- a/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
+++ b/ydb/core/kqp/ut/sysview/kqp_sys_view_ut.cpp
@@ -931,6 +931,60 @@ order by SessionId;)", "%Y-%m-%d %H:%M:%S %Z", sessionsSet.front().GetId().data(
         checkTable("`/Root/.sys/top_queries_by_cpu_time_one_hour`");
     }
 
+    Y_UNIT_TEST(TopQueriesTraceId) {
+        TKikimrSettings settings;
+        settings.SetWithSampleTables(false);
+        settings.SetAuthToken("root@builtin");
+        TKikimrRunner kikimr(settings);
+
+        auto client = kikimr.GetQueryClient();
+        auto session = client.GetSession().GetValueSync().GetSession();
+
+        const TString traceId = "top-queries-trace-id-42";
+        const TString marker = "top_queries_trace_marker";
+
+        {
+            NYdb::NQuery::TExecuteQuerySettings execSettings;
+            execSettings.TraceId(std::string(traceId));
+
+            auto result = session.ExecuteQuery(Sprintf(R"(--!syntax_v1
+                SELECT 1 AS %s;
+            )", marker.c_str()),
+                NYdb::NQuery::TTxControl::NoTx(), execSettings).GetValueSync();
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+        }
+
+        // Query stats collection is asynchronous; retry until the marker query
+        // shows up in the top_queries view with the trace id we supplied.
+        bool checked = false;
+        for (ui32 attempt = 0; attempt < 50 && !checked; ++attempt) {
+            auto readSession = client.GetSession().GetValueSync().GetSession();
+            auto result = readSession.ExecuteQuery(Sprintf(R"(--!syntax_v1
+                SELECT QueryText, TraceId
+                FROM `/Root/.sys/top_queries_by_cpu_time_one_minute`
+                WHERE QueryText LIKE "%%%s%%";
+            )", marker.c_str()),
+                NYdb::NQuery::TTxControl::NoTx()).GetValueSync();
+
+            UNIT_ASSERT_C(result.IsSuccess(), result.GetIssues().ToString());
+
+            NYdb::TResultSetParser parser(result.GetResultSet(0));
+            while (parser.TryNextRow()) {
+                auto trace = parser.ColumnParser("TraceId").GetOptionalUtf8();
+                if (trace.has_value() && *trace == std::string(traceId)) {
+                    checked = true;
+                    break;
+                }
+            }
+
+            if (!checked) {
+                ::Sleep(TDuration::MilliSeconds(200));
+            }
+        }
+
+        UNIT_ASSERT_C(checked, "Query with the supplied trace id not found in top_queries_by_cpu_time_one_minute");
+    }
+
     Y_UNIT_TEST(QueryStatsScan) {
         auto checkTable = [&] (const TStringBuf tableName) {
             auto kikimr = DefaultKikimrRunner();

--- a/ydb/core/protos/sys_view.proto
+++ b/ydb/core/protos/sys_view.proto
@@ -123,6 +123,7 @@ message TQueryStats {
     optional uint64 RequestUnits = 17;
     optional uint64 LocksBrokenAsBreaker = 18;
     optional uint64 LocksBrokenAsVictim = 19;
+    optional string TraceId = 20;
 }
 
 message TTopQueryStats {

--- a/ydb/core/sys_view/common/registry.h
+++ b/ydb/core/sys_view/common/registry.h
@@ -206,6 +206,7 @@ struct Schema : NIceDb::Schema {
         struct ProcessCPUTime    : Column<27, NScheme::NTypeIds::Uint64> {};
         struct TypeCol           : Column<28, NScheme::NTypeIds::Utf8> { static TString GetColumnName(const TString&) { return "Type"; } };
         struct RequestUnits      : Column<29, NScheme::NTypeIds::Uint64> {};
+        struct TraceId           : Column<30, NScheme::NTypeIds::Utf8> {};
 
         using TKey = TableKey<IntervalEnd, Rank>;
         using TColumns = TableColumns<
@@ -237,7 +238,8 @@ struct Schema : NIceDb::Schema {
             CompileCPUTime,
             ProcessCPUTime,
             TypeCol,
-            RequestUnits>;
+            RequestUnits,
+            TraceId>;
     };
 
     struct PDisks : Table<4> {

--- a/ydb/core/sys_view/query_stats/query_stats.cpp
+++ b/ydb/core/sys_view/query_stats/query_stats.cpp
@@ -400,6 +400,14 @@ private:
             insert({TSchema::RequestUnits::ColumnId, [] (const TEntry& entry) {
                 return TCell::Make<ui64>(entry.GetStats().GetRequestUnits());
             }});
+            insert({TSchema::TraceId::ColumnId, [] (const TEntry& entry) {
+                const auto& stats = entry.GetStats();
+                if (!stats.HasTraceId()) {
+                    return TCell();
+                }
+                const auto& traceId = stats.GetTraceId();
+                return TCell(traceId.data(), traceId.size());
+            }});
         }
     };
 

--- a/ydb/core/sys_view/service/query_history.h
+++ b/ydb/core/sys_view/service/query_history.h
@@ -113,6 +113,9 @@ inline void CopyQueryStatsNoText(NKikimrSysView::TQueryStats* to, const NKikimrS
     to->SetTotalCpuTimeUs(from.GetTotalCpuTimeUs());
     to->SetType(from.GetType());
     to->SetRequestUnits(from.GetRequestUnits());
+    if (from.HasTraceId()) {
+        to->SetTraceId(from.GetTraceId());
+    }
 }
 
 template <typename TGreater>

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_domain_sysviews_registry/root_sysviews.json
@@ -1322,10 +1322,6 @@
   "top_queries_by_cpu_time_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1435,6 +1431,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1446,10 +1450,6 @@
   "top_queries_by_cpu_time_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1559,6 +1559,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1570,10 +1578,6 @@
   "top_queries_by_duration_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1683,6 +1687,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1694,10 +1706,6 @@
   "top_queries_by_duration_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1807,6 +1815,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1818,10 +1834,6 @@
   "top_queries_by_read_bytes_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1931,6 +1943,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1942,10 +1962,6 @@
   "top_queries_by_read_bytes_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -2055,6 +2071,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -2066,10 +2090,6 @@
   "top_queries_by_request_units_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -2179,6 +2199,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -2190,10 +2218,6 @@
   "top_queries_by_request_units_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -2303,6 +2327,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],

--- a/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
+++ b/ydb/tests/functional/tenants/canondata/test_system_views.TestSysViewsRegistry.test_tenant_sysviews_registry/tenant_sysviews.json
@@ -914,10 +914,6 @@
   "top_queries_by_cpu_time_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1027,6 +1023,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1038,10 +1042,6 @@
   "top_queries_by_cpu_time_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1151,6 +1151,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1162,10 +1170,6 @@
   "top_queries_by_duration_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1275,6 +1279,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1286,10 +1298,6 @@
   "top_queries_by_duration_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1399,6 +1407,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1410,10 +1426,6 @@
   "top_queries_by_read_bytes_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1523,6 +1535,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1534,10 +1554,6 @@
   "top_queries_by_read_bytes_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1647,6 +1663,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1658,10 +1682,6 @@
   "top_queries_by_request_units_one_hour": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1771,6 +1791,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],
@@ -1782,10 +1810,6 @@
   "top_queries_by_request_units_one_minute": {
     "columns": [
       {
-        "name": "RequestUnits",
-        "type": "Uint64?"
-      },
-      {
         "name": "IntervalEnd",
         "type": "Timestamp?"
       },
@@ -1895,6 +1919,14 @@
       },
       {
         "name": "Type",
+        "type": "Utf8?"
+      },
+      {
+        "name": "RequestUnits",
+        "type": "Uint64?"
+      },
+      {
+        "name": "TraceId",
         "type": "Utf8?"
       }
     ],


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added a TraceId column to .sys/top_queries_by_* system views, showing the trace-id of the query execution that produced the reported metric.

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

(cherry picked from commit 00052fdcdad7b83197599075307e62816958b520)

...
