### PR TITLE
Implement mid-traverse yielding in VDisk stats actor

### DIFF
--- a/ydb/core/blobstorage/vdisk/anubis_osiris/blobstorage_anubis.cpp
+++ b/ydb/core/blobstorage/vdisk/anubis_osiris/blobstorage_anubis.cpp
@@ -7,7 +7,7 @@
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_iter.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_sets.h>
 #include <ydb/core/blobstorage/base/vdisk_sync_common.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT BS_SYNCER
 

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_actor.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_actor.cpp
@@ -6,7 +6,7 @@
 #include <ydb/core/blobstorage/vdisk/common/circlebufstream.h>
 #include <ydb/core/blobstorage/vdisk/common/sublog.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 
 #include <ydb/core/util/stlog.h>

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_quantum.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_quantum.cpp
@@ -7,7 +7,7 @@
 #include <ydb/core/blobstorage/vdisk/common/vdisk_hugeblobctx.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <ydb/core/util/stlog.h>
 #include <ydb/library/actors/core/actor_coroutine.h>
 

--- a/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
+++ b/ydb/core/blobstorage/vdisk/defrag/defrag_rewriter.cpp
@@ -1,6 +1,6 @@
 #include "defrag_rewriter.h"
 #include <ydb/core/blobstorage/vdisk/scrub/restore_corrupted_blob_actor.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::BS_VDISK_DEFRAG
 

--- a/ydb/core/blobstorage/vdisk/hulldb/base/hullds_generic_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/base/hullds_generic_it.h
@@ -171,6 +171,11 @@ namespace NKikimr {
             Iter2.Seek(key);
         }
 
+        void SeekToLast() {
+            Iter1.SeekToLast();
+            Iter2.SeekToLast();
+        }
+
     protected:
         TIter1 Iter1;
         TIter2 Iter2;
@@ -409,6 +414,16 @@ namespace NKikimr {
             }
         }
 
+        void SeekToLast() {
+            TPQueue().swap(PQueue); // clear PQueue
+            for (auto &x : Iters) {
+                x->SeekToLast();
+                if (x->Valid()) {
+                    PQueue.push(x);
+                }
+            }
+        }
+
         void Prev() {
             TIterPtr it = PQueue.top();
             PQueue.pop();
@@ -463,4 +478,3 @@ namespace NKikimr {
     };
 
 } // NKikimr
-

--- a/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_appendix.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_appendix.h
@@ -445,6 +445,7 @@ namespace NKikimr {
         using TBase::Prev;
         using TBase::GetCurKey;
         using TBase::Seek;
+        using TBase::SeekToLast;
         using TBase::ToString;
         using TBase::PutToMerger;
         using TBase::PutToHeap;

--- a/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment.h
@@ -147,6 +147,7 @@ namespace NKikimr {
         class TForwardIterator;
         class TBackwardIterator;
         class TIteratorWOMerge;
+        class TBackwardIteratorWOMerge;
         friend class TFreshSegment<TKey, TMemRec>;
 
         // empty snapshot for non-existing fresh segment
@@ -308,4 +309,3 @@ namespace NKikimr {
     extern template class TFreshSegment<TKeyBlock, TMemRecBlock>;
 
  } // NKikimr
-

--- a/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment_impl.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment_impl.h
@@ -681,6 +681,12 @@ namespace NKikimr {
             Next();
         }
 
+        void Seek(const TKey &key) {
+            Recs.clear();
+            It.Seek(key);
+            Next();
+        }
+
         TKey GetUnmergedKey() const {
             return Recs.back().first;
         }

--- a/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment_impl.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/fresh/fresh_segment_impl.h
@@ -626,6 +626,7 @@ namespace NKikimr {
         using TBase::Prev;
         using TBase::Valid;
         using TBase::Seek;
+        using TBase::SeekToLast;
         using TBase::PutToHeap;
     };
 
@@ -697,6 +698,77 @@ namespace NKikimr {
 
     private:
         TForwardIterator It; // generic merging iterator
+        std::vector<std::pair<TKey, TMemRec>> Recs;
+    };
+
+    template <class TKey, class TMemRec>
+    class TFreshSegmentSnapshot<TKey, TMemRec>::TBackwardIteratorWOMerge {
+    public:
+        using TContType = TFreshSegmentSnapshot;
+
+        TBackwardIteratorWOMerge(const THullCtxPtr &hullCtx, const TContType *data)
+            : It(hullCtx, data)
+        {}
+
+        TBackwardIteratorWOMerge(const TBackwardIteratorWOMerge &) = default;
+        TBackwardIteratorWOMerge &operator=(const TBackwardIteratorWOMerge &) = default;
+
+        bool Valid() const {
+            return !Recs.empty();
+        }
+
+        void Prev() {
+            if (!Recs.empty()) {
+                Recs.pop_back();
+                if (!Recs.empty()) {
+                    return; // more records to go with the current key
+                }
+            }
+
+            if (!It.Valid()) {
+                return;
+            }
+
+            struct {
+                std::vector<std::pair<TKey, TMemRec>>& Recs;
+
+                void AddFromSegment(const TMemRec&, const TDiskPart*, const TKey&, ui64, const void*) {
+                    Y_DEBUG_ABORT("should not be called");
+                }
+
+                void AddFromFresh(const TMemRec& memRec, const TRope* /*data*/, const TKey& key, ui64 /*lsn*/) {
+                    Recs.emplace_back(key, memRec);
+                }
+
+                static constexpr bool HaveToMergeData() { return false; }
+            } m{Recs};
+
+            It.PutToMerger(&m);
+            It.Prev();
+        }
+
+        void SeekToLast() {
+            Recs.clear();
+            It.SeekToLast();
+            Prev();
+        }
+
+        void Seek(const TKey &key) {
+            Recs.clear();
+            It.Seek(key);
+            Prev();
+        }
+
+        TKey GetUnmergedKey() const {
+            return Recs.back().first;
+        }
+
+        TMemRec GetUnmergedMemRec() const {
+            return Recs.back().second;
+        }
+
+    private:
+        TBackwardIterator It; // generic merging iterator
         std::vector<std::pair<TKey, TMemRec>> Recs;
     };
 

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sst_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sst_it.h
@@ -65,7 +65,11 @@ namespace NKikimr {
 
         void Prev() {
             Y_DEBUG_ABORT_UNLESS(Ptr && Ptr <= End() && Ptr >= Begin());
-            --Ptr;
+            if (Ptr == Begin()) {
+                Ptr = nullptr;
+            } else {
+                --Ptr;
+            }
         }
 
         TKey GetCurKey() const {
@@ -83,8 +87,7 @@ namespace NKikimr {
         }
 
         void SeekToLast() {
-            Ptr = End();
-            --Ptr;
+            Ptr = Begin() == End() ? nullptr : End() - 1;
         }
 
         void Seek(const TKey& key) {
@@ -174,6 +177,13 @@ namespace NKikimr {
             Y_DEBUG_ABORT_UNLESS(Segment && Low
                     && Low >= Segment->IndexLow.begin() && Low <= Segment->IndexLow.end());
 
+            if (Low == Segment->IndexLow.begin()) {
+                High = {};
+                Low = {};
+                LowRangeBegin = {};
+                return;
+            }
+
             if (Y_UNLIKELY(Low == LowRangeBegin)) {
                 --High;
                 LowRangeBegin = Segment->IndexLow.begin() +
@@ -202,7 +212,9 @@ namespace NKikimr {
         void SeekToLast() {
             High = Segment->IndexHigh.end();
             Low = LowRangeBegin = Segment->IndexLow.end();
-            Prev();
+            if (!Segment->IndexLow.empty()) {
+                Prev();
+            }
         }
 
         void Seek(const TKeyLogoBlob& key) {

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstslice_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstslice_it.h
@@ -57,8 +57,13 @@ namespace NKikimr {
 
         void Prev() {
             Y_DEBUG_ABORT_UNLESS(Valid());
-            --CurLevelIt;
-            --CurLevelNum;
+            if (CurLevelIt == Levels->begin()) {
+                CurLevelIt = Levels->end();
+                CurLevelNum = 0;
+            } else {
+                --CurLevelIt;
+                --CurLevelNum;
+            }
         }
 
         TSortedLevelRef Get() const {

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstslice_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstslice_it.h
@@ -95,6 +95,12 @@ namespace NKikimr {
             PositionItraLevelIt();
         }
 
+        void SeekToLast() {
+            CurLevelIt = Levels->end();
+            CurLevelNum = Levels->size() + 1;
+            PositionIntraLevelItBackward();
+        }
+
         bool Valid() const {
             return Levels && CurLevelIt >= Levels->begin() && CurLevelIt < Levels->end() && IntraLevelIt.Valid();
         }
@@ -106,6 +112,14 @@ namespace NKikimr {
                 ++CurLevelIt;
                 ++CurLevelNum;
                 PositionItraLevelIt();
+            }
+        }
+
+        void Prev() {
+            Y_DEBUG_ABORT_UNLESS(Valid());
+            IntraLevelIt.Prev();
+            if (!IntraLevelIt.Valid()) {
+                PositionIntraLevelItBackward();
             }
         }
 
@@ -132,6 +146,19 @@ namespace NKikimr {
                 }
             }
         }
+
+        void PositionIntraLevelItBackward() {
+            IntraLevelIt = {};
+            while (CurLevelIt != Levels->begin()) {
+                --CurLevelIt;
+                --CurLevelNum;
+                if (!CurLevelIt->Empty()) {
+                    IntraLevelIt = TOrderedLevelSegmentsSstIterator(CurLevelIt->Segs.Get());
+                    IntraLevelIt.SeekToLast();
+                    break;
+                }
+            }
+        }
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -143,6 +170,7 @@ namespace NKikimr {
 
         typename ::NKikimr::TUnorderedLevelSegments<TKey, TMemRec>::TSstIterator Level0It;
         typename TLevelSlice::TSortedLevelsSSTIter SortedLevelsIt;
+        bool Reverse = false;
 
     public:
         TSstIterator(const TLevelSlice *slice, ui32 level0NumLimit)
@@ -151,8 +179,15 @@ namespace NKikimr {
         {}
 
         void SeekToFirst() {
+            Reverse = false;
             Level0It.SeekToFirst();
             SortedLevelsIt.SeekToFirst();
+        }
+
+        void SeekToLast() {
+            Reverse = true;
+            Level0It.SeekToLast();
+            SortedLevelsIt.SeekToLast();
         }
 
         bool Valid() const {
@@ -167,9 +202,19 @@ namespace NKikimr {
                 SortedLevelsIt.Next();
         }
 
+        void Prev() {
+            Y_DEBUG_ABORT_UNLESS(Valid());
+            if (SortedLevelsIt.Valid())
+                SortedLevelsIt.Prev();
+            else
+                Level0It.Prev();
+        }
+
         TLevelSstPtr Get() {
             Y_DEBUG_ABORT_UNLESS(Valid());
-            if (Level0It.Valid())
+            if (Reverse && SortedLevelsIt.Valid())
+                return SortedLevelsIt.Get();
+            else if (Level0It.Valid())
                 return TLevelSstPtr(0, Level0It.Get());
             else
                 return SortedLevelsIt.Get();
@@ -440,4 +485,3 @@ namespace NKikimr {
     };
 
 } // NKikimr
-

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstvec_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstvec_it.h
@@ -177,7 +177,9 @@ namespace NKikimr {
         void SeekToLast() {
             Y_DEBUG_ABORT_UNLESS(S);
             Cur = S->Segments.end();
-            --Cur;
+            if (!S->Segments.empty()) {
+                --Cur;
+            }
         }
 
         void Seek(const TKey &key) {
@@ -200,7 +202,11 @@ namespace NKikimr {
 
         void Prev() {
             Y_DEBUG_ABORT_UNLESS(Valid());
-            --Cur;
+            if (Cur == S->Segments.begin()) {
+                Cur = S->Segments.end();
+            } else {
+                --Cur;
+            }
         }
 
         TLevelSegmentPtr Get() {

--- a/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstvec_it.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/generic/hullds_sstvec_it.h
@@ -243,6 +243,21 @@ namespace NKikimr {
             }
         }
 
+        void SeekToLast() {
+            Y_DEBUG_ABORT_UNLESS(S);
+            if (NumLimit > 0) {
+                Cur = S->Segments.begin();
+                CurNum = 0;
+                while (CurNum + 1 < NumLimit) {
+                    ++Cur;
+                    ++CurNum;
+                }
+            } else {
+                // invalid iterator
+                CurNum = ui32(-1);
+            }
+        }
+
         bool Valid() const {
             return S && CurNum != ui32(-1) && CurNum < NumLimit;
         }
@@ -255,6 +270,16 @@ namespace NKikimr {
                 // otherwise we have a race
                 Y_DEBUG_ABORT_UNLESS(Cur != S->Segments.end());
                 ++Cur;
+            }
+        }
+
+        void Prev() {
+            Y_DEBUG_ABORT_UNLESS(Valid());
+            if (CurNum > 0) {
+                --Cur;
+                --CurNum;
+            } else {
+                CurNum = ui32(-1);
             }
         }
 

--- a/ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "hull_ds_all_snap.h"
+
+namespace NKikimr {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TEvTakeHullSnapshot
+    // Take snapshot of local (Hull) database
+    ////////////////////////////////////////////////////////////////////////////
+    struct TEvTakeHullSnapshot :
+        public TEventLocal<TEvTakeHullSnapshot, TEvBlobStorage::EvTakeHullSnapshot>
+    {
+        const bool Index;
+
+        TEvTakeHullSnapshot(bool index)
+            : Index(index)
+        {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TEvTakeHullSnapshotResult
+    ////////////////////////////////////////////////////////////////////////////
+    struct TEvTakeHullSnapshotResult :
+        public TEventLocal<TEvTakeHullSnapshotResult, TEvBlobStorage::EvTakeHullSnapshot>
+    {
+        THullDsSnap Snap;
+
+        TEvTakeHullSnapshotResult(THullDsSnap &&snap)
+            : Snap(std::move(snap))
+        {}
+    };
+
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/hulldb/ya.make
+++ b/ydb/core/blobstorage/vdisk/hulldb/ya.make
@@ -17,6 +17,7 @@ SRCS(
     blobstorage_hullgcmap.h
     hull_ds_all.h
     hull_ds_all_snap.h
+    hull_ds_all_snap_events.h
 )
 
 END()

--- a/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
+++ b/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
@@ -11,8 +11,8 @@ namespace NKikimr {
 
     struct TDbStatYieldPolicy {
         const ui64 StepsBeforeMeasures = 100'000;
-        const TDuration QuantDuration = TDuration::MilliSeconds(50);
-        const TDuration DelayBetweenQuants = TDuration::MilliSeconds(100);
+        const TDuration QuantumDuration = TDuration::MilliSeconds(50);
+        const TDuration DelayBetweenQuanta = TDuration::MilliSeconds(100);
     };
 
     struct TDbStatYieldChecker {
@@ -21,19 +21,19 @@ namespace NKikimr {
                 TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
             : Policy(std::move(policy))
             , MonotonicTimeProvider(std::move(monotonicTimeProvider))
-            , PhaseStart(TMonotonic::Zero())
+            , QuantumStart(TMonotonic::Zero())
         {
             if (Policy) {
                 if (!MonotonicTimeProvider) {
                     MonotonicTimeProvider = CreateActorSystemMonotonicTimeProvider();
                 }
-                PhaseStart = MonotonicTimeProvider->Now();
+                QuantumStart = MonotonicTimeProvider->Now();
             }
         }
 
         std::optional<TDbStatYieldPolicy> Policy;
         TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> MonotonicTimeProvider;
-        TMonotonic PhaseStart;
+        TMonotonic QuantumStart;
 
         ui64 Step = 0;
 
@@ -42,8 +42,8 @@ namespace NKikimr {
             if (Policy && Policy->StepsBeforeMeasures && Step >= Policy->StepsBeforeMeasures) {
                 Step = 0;
                 const TMonotonic now = MonotonicTimeProvider->Now();
-                if (now - PhaseStart > Policy->QuantDuration) {
-                    PhaseStart = now;
+                if (now - QuantumStart > Policy->QuantumDuration) {
+                    QuantumStart = now;
                     return true;
                 }
             }

--- a/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
+++ b/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "defs.h"
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
+
+#include <optional>
+#include <variant>
+
+namespace NKikimr {
+
+    struct TDbStatYieldPolicy {
+        const ui64 StepsBeforeMeasures = 100'000;
+        const TDuration QuantDuration = TDuration::MilliSeconds(50);
+        const TDuration DelayBetweenQuants = TDuration::MilliSeconds(100);
+    };
+
+    struct TDbStatYieldChecker {
+        TDbStatYieldChecker(std::optional<TDbStatYieldPolicy> policy)
+            : Policy(std::move(policy))
+            , PhaseStart(TActivationContext::Monotonic())
+        {}
+
+        std::optional<TDbStatYieldPolicy> Policy;
+        TMonotonic PhaseStart;
+
+        ui64 Step = 0;
+
+        bool StepAndCheckForYield() {
+            ++Step;
+            if (Policy && Policy->StepsBeforeMeasures && Step >= Policy->StepsBeforeMeasures) {
+                Step = 0;
+                if (TActivationContext::Monotonic() - PhaseStart > Policy->QuantDuration) {
+                    PhaseStart = TActivationContext::Monotonic();
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TDbStatYeildedState
+    // Snapshot of the traversal position, that allows to resume DB traversal
+    // after a yield. A yield releases and later re-captures the Hull snapshot,
+    // so iterators become invalid across yields. Therefore we only remember the
+    // key to continue the processing from (and the phase of the traversal), and
+    // re-seek into the freshly captured snapshot on resume.
+    ////////////////////////////////////////////////////////////////////////////
+    template <class TKey, class TMemRec>
+    struct TDbStatYeildedState {
+        enum class EFreshSegment {
+            Cur = 0,
+            Dreg,
+            Old,
+        };
+
+        // Position inside the fresh part: which segment and the next key to process
+        struct TFreshPosition {
+            EFreshSegment Segment;
+            TKey Key;
+        };
+
+        // Position inside the level (SST) part: the next key to process
+        struct TLevelPosition {
+            TKey Key;
+        };
+
+        std::variant<TFreshPosition, TLevelPosition> Position;
+    };
+
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
+++ b/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
@@ -2,6 +2,7 @@
 
 #include "defs.h"
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
+#include <ydb/core/util/actor_monotonic_time_provider.h>
 
 #include <optional>
 #include <variant>
@@ -15,12 +16,23 @@ namespace NKikimr {
     };
 
     struct TDbStatYieldChecker {
-        TDbStatYieldChecker(std::optional<TDbStatYieldPolicy> policy)
+        TDbStatYieldChecker(
+                std::optional<TDbStatYieldPolicy> policy,
+                TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
             : Policy(std::move(policy))
-            , PhaseStart(TActivationContext::Monotonic())
-        {}
+            , MonotonicTimeProvider(std::move(monotonicTimeProvider))
+            , PhaseStart(TMonotonic::Zero())
+        {
+            if (Policy) {
+                if (!MonotonicTimeProvider) {
+                    MonotonicTimeProvider = CreateActorSystemMonotonicTimeProvider();
+                }
+                PhaseStart = MonotonicTimeProvider->Now();
+            }
+        }
 
         std::optional<TDbStatYieldPolicy> Policy;
+        TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> MonotonicTimeProvider;
         TMonotonic PhaseStart;
 
         ui64 Step = 0;
@@ -29,8 +41,9 @@ namespace NKikimr {
             ++Step;
             if (Policy && Policy->StepsBeforeMeasures && Step >= Policy->StepsBeforeMeasures) {
                 Step = 0;
-                if (TActivationContext::Monotonic() - PhaseStart > Policy->QuantDuration) {
-                    PhaseStart = TActivationContext::Monotonic();
+                const TMonotonic now = MonotonicTimeProvider->Now();
+                if (now - PhaseStart > Policy->QuantDuration) {
+                    PhaseStart = now;
                     return true;
                 }
             }
@@ -60,8 +73,14 @@ namespace NKikimr {
             TKey Key;
         };
 
-        // Position inside the level (SST) part: the next key to process
+        // Position inside the level (SST) part.
         struct TLevelPosition {
+            using TUnsortedLevelDiscriminator = ui64;
+            using TSortedLevelDiscriminator = TKey;
+
+            // Pair (Level, Discriminator) unambiguously specifies the processed SST
+            ui32 Level = 0;
+            std::variant<TUnsortedLevelDiscriminator, TSortedLevelDiscriminator> Discriminator;
             TKey Key;
         };
 

--- a/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
+++ b/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
@@ -52,7 +52,7 @@ namespace NKikimr {
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    // TDbStatYeildedState
+    // TDbStatYieldedState
     // Snapshot of the traversal position, that allows to resume DB traversal
     // after a yield. A yield releases and later re-captures the Hull snapshot,
     // so iterators become invalid across yields. Therefore we only remember the
@@ -60,7 +60,7 @@ namespace NKikimr {
     // re-seek into the freshly captured snapshot on resume.
     ////////////////////////////////////////////////////////////////////////////
     template <class TKey, class TMemRec>
-    struct TDbStatYeildedState {
+    struct TDbStatYieldedState {
         enum class EFreshSegment {
             Cur = 0,
             Dreg,

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -11,32 +11,36 @@ namespace NKikimr {
     ////////////////////////////////////////////////////////////////////////////
     // TraverseFreshSegment
     // Traverses a single fresh segment. May yield mid-traversal and resume
-    // from yielded position later.
+    // from the yielded position later.
+    //
     ////////////////////////////////////////////////////////////////////////////
     template <class TAggr, class TKey, class TMemRec>
     std::optional<TDbStatYeildedState<TKey, TMemRec>> TraverseFreshSegment(
-            const TIntrusivePtr<THullCtx> &hullCtx,
-            TAggr *aggr,
-            const char *segName,
-            const ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec> &seg,
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            TAggr* aggr,
+            const char* segmentName,
+            const ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>& segment,
             typename TDbStatYeildedState<TKey, TMemRec>::EFreshSegment segmentType,
-            std::optional<typename TDbStatYeildedState<TKey, TMemRec>::TFreshIterator> resumeIt,
+            const std::optional<TKey>& resumeKey,
             TDbStatYieldChecker& yeildChecker)
     {
         using TYeildedState = TDbStatYeildedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
-        using TIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
+        using TFreshIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
 
-        TIterator it = resumeIt ? *resumeIt : TIterator(hullCtx, &seg);
-        if (!resumeIt) {
-            it.SeekToFirst();
+        TFreshIterator freshIterator(hullCtx, &segment);
+        if (resumeKey) {
+            freshIterator.Seek(*resumeKey);
+        } else {
+            freshIterator.SeekToFirst();
         }
 
-        while (it.Valid()) {
-            aggr->UpdateFresh(segName, it.GetUnmergedKey(), it.GetUnmergedMemRec());
-            it.Next();
-            if (it.Valid() && yeildChecker.StepAndCheckForYield()) {
-                return TYeildedState{typename TYeildedState::TFreshPosition{segmentType, it}};
+        while (freshIterator.Valid()) {
+            aggr->UpdateFresh(segmentName, freshIterator.GetUnmergedKey(), freshIterator.GetUnmergedMemRec());
+            freshIterator.Next();
+            if (freshIterator.Valid() && yeildChecker.StepAndCheckForYield()) {
+                return TYeildedState{typename TYeildedState::TFreshPosition{
+                    segmentType, freshIterator.GetUnmergedKey()}};
             }
         }
         return std::nullopt;
@@ -48,31 +52,36 @@ namespace NKikimr {
     // for gathering info disregarding garbage collection.
     //
     // Execution may be yielded if according policy is passed and later resumed
-    // from saved state. 
+    // from saved state.
     ////////////////////////////////////////////////////////////////////////////
     template <class TAggr, class TKey, class TMemRec>
     std::optional<TDbStatYeildedState<TKey, TMemRec>> TraverseDbWithoutMerge(
-            const TIntrusivePtr<THullCtx> &hullCtx,
-            TAggr *aggr,
-            const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec> &snap,
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            TAggr* aggr,
+            const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>& snap,
             std::optional<TDbStatYeildedState<TKey, TMemRec>> yeildedState = std::nullopt,
-            std::optional<TDbStatYieldPolicy> yeildPolicy = std::nullopt)
+            std::optional<TDbStatYieldPolicy> yeildPolicy = std::nullopt,
+            TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
     {
         using TYeildedState = TDbStatYeildedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
-        using TSstIterator = typename TYeildedState::TSstIterator;
-        using TMemIterator = typename TYeildedState::TMemIterator;
+        using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
+        using TSstIterator = typename TLevelSliceSnapshot::TSstIterator;
         using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
+        using TMemIterator = typename TLevelSegment::TMemIterator;
         using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
         using EFreshSegment = typename TYeildedState::EFreshSegment;
+        using TLevelPosition = typename TYeildedState::TLevelPosition;
+        using TUnsortedLevelDiscriminator = typename TLevelPosition::TUnsortedLevelDiscriminator;
+        using TSortedLevelDiscriminator = typename TLevelPosition::TSortedLevelDiscriminator;
 
-        TDbStatYieldChecker yeildChecker(std::move(yeildPolicy));
+        TDbStatYieldChecker yeildChecker(std::move(yeildPolicy), std::move(monotonicTimeProvider));
 
         // Description of a single fresh segment to traverse
         struct TSegmentDescription {
             const char* Name;
             EFreshSegment Type;
-            const TFreshSegmentSnapshot& Seg;
+            const TFreshSegmentSnapshot& Segment;
         };
         const TSegmentDescription segments[] = {
             {"FCur", EFreshSegment::Cur, snap.FreshSnap.Cur},
@@ -83,59 +92,103 @@ namespace NKikimr {
         // Figure out where to (re)start traversal
         size_t startFreshSegmentIdx = 0;
         bool resumeLevels = false;
-        std::optional<typename TYeildedState::TFreshIterator> freshResumeIt;
-        std::optional<TSstIterator> sstResumeIt;
-        std::optional<TMemIterator> memResumeIt;
+        std::optional<TKey> freshResumeKey;
+        std::optional<TLevelPosition> levelResumePosition;
 
         if (yeildedState) {
-            if (auto* fresh = std::get_if<typename TYeildedState::TFreshPosition>(&yeildedState->Position)) {
-                startFreshSegmentIdx = static_cast<size_t>(fresh->Segment);
-                freshResumeIt = fresh->Iterator;
+            using TFreshPosition = typename TYeildedState::TFreshPosition;
+            if (TFreshPosition* freshPosition = std::get_if<TFreshPosition>(&yeildedState->Position)) {
+                startFreshSegmentIdx = static_cast<size_t>(freshPosition->Segment);
+                freshResumeKey = freshPosition->Key;
             } else {
-                auto& level = std::get<typename TYeildedState::TLevelPosition>(yeildedState->Position);
+                levelResumePosition = std::get<TLevelPosition>(yeildedState->Position);
                 resumeLevels = true;
-                sstResumeIt = level.SstIt;
-                memResumeIt = level.MemIt;
             }
         }
 
+        auto sstSortsBeforeSavedPosition = [](const TLevelSstPtr& levelSstPtr,
+                const TLevelPosition& savedPosition) -> bool {
+            if (levelSstPtr.Level != savedPosition.Level) {
+                return levelSstPtr.Level < savedPosition.Level;
+            }
+            if (levelSstPtr.Level == 0) {
+                return levelSstPtr.SstPtr->VolatileOrderId <
+                    std::get<TUnsortedLevelDiscriminator>(savedPosition.Discriminator);
+            }
+            return levelSstPtr.SstPtr->FirstKey() <
+                std::get<TSortedLevelDiscriminator>(savedPosition.Discriminator);
+        };
+        auto sstMatchesSavedPosition = [](const TLevelSstPtr& levelSstPtr,
+                const TLevelPosition& savedPosition) -> bool {
+            if (levelSstPtr.Level != savedPosition.Level) {
+                return false;
+            }
+            if (levelSstPtr.Level == 0) {
+                return levelSstPtr.SstPtr->VolatileOrderId ==
+                    std::get<TUnsortedLevelDiscriminator>(savedPosition.Discriminator);
+            }
+            const TKey& firstKey = levelSstPtr.SstPtr->FirstKey();
+            const TKey& savedFirstKey = std::get<TSortedLevelDiscriminator>(savedPosition.Discriminator);
+            return !(firstKey < savedFirstKey) && !(savedFirstKey < firstKey);
+        };
+        auto makeLevelPosition = [](const TLevelSstPtr& levelSstPtr, const TKey& nextKey) -> TLevelPosition {
+            TLevelPosition position;
+            position.Level = levelSstPtr.Level;
+            position.Key = nextKey;
+            if (levelSstPtr.Level == 0) {
+                position.Discriminator = TUnsortedLevelDiscriminator(levelSstPtr.SstPtr->VolatileOrderId);
+            } else {
+                position.Discriminator = TSortedLevelDiscriminator(levelSstPtr.SstPtr->FirstKey());
+            }
+            return position;
+        };
+
         // Traverse Fresh
         if (!resumeLevels) {
-            for (size_t i = startFreshSegmentIdx; i < Y_ARRAY_SIZE(freshSegs); ++i) {
-                const TSegmentDescription& description = freshSegs[i];
-                std::optional<typename TYeildedState::TFreshIterator> resumeIt;
-                if (i == startFreshSegmentIdx) {
-                    resumeIt = std::move(freshResumeIt);
+            for (size_t segmentIdx = startFreshSegmentIdx; segmentIdx < std::size(segments); ++segmentIdx) {
+                const TSegmentDescription &description = segments[segmentIdx];
+                std::optional<TKey> resumeKey;
+                if (segmentIdx == startFreshSegmentIdx) {
+                    resumeKey = freshResumeKey;
                 }
-                if (auto yielded = TraverseFreshSegment(hullCtx, aggr, description.Name, description.Seg,
-                        description.Type, std::move(resumeIt), yeildChecker)) {
+                if (std::optional<TYeildedState> yielded = TraverseFreshSegment(hullCtx, aggr, description.Name,
+                        description.Segment, description.Type, resumeKey, yeildChecker)) {
                     return yielded;
                 }
             }
         }
 
         // Traverse SSTs
-        TSstIterator it = resumeLevels ? *sstResumeIt : TSstIterator(&snap.SliceSnap);
-        if (!resumeLevels) {
-            it.SeekToFirst();
-        }
-        while (it.Valid()) {
-            TLevelSstPtr p = it.Get();
-            TMemIterator c = (resumeLevels && memResumeIt) ? *memResumeIt : TMemIterator(p.SstPtr.Get());
-            if (!(resumeLevels && memResumeIt)) {
-                c.SeekToFirst();
+        TSstIterator sstIterator(&snap.SliceSnap);
+        sstIterator.SeekToFirst();
+
+        // When resuming the level phase, skip SSTs that are ordered strictly before the
+        // saved position.
+        if (resumeLevels) {
+            while (sstIterator.Valid() &&
+                    sstSortsBeforeSavedPosition(sstIterator.Get(), *levelResumePosition)) {
+                sstIterator.Next();
             }
-            // consume the resume state only for the first SST after a resume
+        }
+
+        while (sstIterator.Valid()) {
+            TLevelSstPtr levelSstPtr = sstIterator.Get();
+            TMemIterator memIterator(levelSstPtr.SstPtr.Get());
+            if (resumeLevels && sstMatchesSavedPosition(levelSstPtr, *levelResumePosition)) {
+                memIterator.Seek(levelResumePosition->Key);
+            } else {
+                memIterator.SeekToFirst();
+            }
+            // resume applies only to the first matching SST
             resumeLevels = false;
-            memResumeIt.reset();
-            while (c.Valid()) {
-                aggr->UpdateLevel(p, c.GetCurKey(), c.GetMemRec());
-                c.Next();
-                if (c.Valid() && yeildChecker.StepAndCheckForYield()) {
-                    return TYeildedState{typename TYeildedState::TLevelPosition{it, c}};
+            while (memIterator.Valid()) {
+                aggr->UpdateLevel(levelSstPtr, memIterator.GetCurKey(), memIterator.GetMemRec());
+                memIterator.Next();
+                if (memIterator.Valid() && yeildChecker.StepAndCheckForYield()) {
+                    return TYeildedState{makeLevelPosition(levelSstPtr, memIterator.GetCurKey())};
                 }
             }
-            it.Next();
+            sstIterator.Next();
         }
 
         aggr->Finish();

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -15,16 +15,16 @@ namespace NKikimr {
     //
     ////////////////////////////////////////////////////////////////////////////
     template <class TAggr, class TKey, class TMemRec>
-    std::optional<TDbStatYeildedState<TKey, TMemRec>> TraverseFreshSegment(
+    std::optional<TDbStatYieldedState<TKey, TMemRec>> TraverseFreshSegment(
             const TIntrusivePtr<THullCtx>& hullCtx,
             TAggr* aggr,
             const char* segmentName,
             const ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>& segment,
-            typename TDbStatYeildedState<TKey, TMemRec>::EFreshSegment segmentType,
+            typename TDbStatYieldedState<TKey, TMemRec>::EFreshSegment segmentType,
             const std::optional<TKey>& resumeKey,
             TDbStatYieldChecker& yeildChecker)
     {
-        using TYeildedState = TDbStatYeildedState<TKey, TMemRec>;
+        using TYeildedState = TDbStatYieldedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
         using TFreshIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
 
@@ -55,15 +55,15 @@ namespace NKikimr {
     // from saved state.
     ////////////////////////////////////////////////////////////////////////////
     template <class TAggr, class TKey, class TMemRec>
-    std::optional<TDbStatYeildedState<TKey, TMemRec>> TraverseDbWithoutMerge(
+    std::optional<TDbStatYieldedState<TKey, TMemRec>> TraverseDbWithoutMerge(
             const TIntrusivePtr<THullCtx>& hullCtx,
             TAggr* aggr,
             const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>& snap,
-            std::optional<TDbStatYeildedState<TKey, TMemRec>> yeildedState = std::nullopt,
+            std::optional<TDbStatYieldedState<TKey, TMemRec>> yeildedState = std::nullopt,
             std::optional<TDbStatYieldPolicy> yeildPolicy = std::nullopt,
             TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
     {
-        using TYeildedState = TDbStatYeildedState<TKey, TMemRec>;
+        using TYeildedState = TDbStatYieldedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
         using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
         using TSstIterator = typename TLevelSliceSnapshot::TSstIterator;

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "defs.h"
+#include "query_stat_yield.h"
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
 
 #include <util/stream/length.h>
@@ -8,55 +9,137 @@
 namespace NKikimr {
 
     ////////////////////////////////////////////////////////////////////////////
-    // TraverseDbWithoutMerge
-    // Traversing LevelIndex Database per fresh segment, per Sst, usefull
-    // for gathering info disregarding garbage collection
+    // TraverseFreshSegment
+    // Traverses a single fresh segment. May yield mid-traversal and resume
+    // from yielded position later.
     ////////////////////////////////////////////////////////////////////////////
     template <class TAggr, class TKey, class TMemRec>
-    void TraverseDbWithoutMerge(
+    std::optional<TDbStatYeildedState<TKey, TMemRec>> TraverseFreshSegment(
             const TIntrusivePtr<THullCtx> &hullCtx,
             TAggr *aggr,
-            const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec> &snap)
+            const char *segName,
+            const ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec> &seg,
+            typename TDbStatYeildedState<TKey, TMemRec>::EFreshSegment segmentType,
+            std::optional<typename TDbStatYeildedState<TKey, TMemRec>::TFreshIterator> resumeIt,
+            TDbStatYieldChecker& yeildChecker)
     {
-        using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
-        using TSstIterator = typename TLevelSliceSnapshot::TSstIterator;
-        using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
-        using TMemIterator = typename TLevelSegment::TMemIterator;
-        using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
+        using TYeildedState = TDbStatYeildedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
+        using TIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
 
-        // Fresh Segment Traversal Function
-        auto traverseFreshSeg = [&] (const char *segName, const TFreshSegmentSnapshot &seg) {
-            using TIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
-            TIterator it(hullCtx, &seg);
+        TIterator it = resumeIt ? *resumeIt : TIterator(hullCtx, &seg);
+        if (!resumeIt) {
             it.SeekToFirst();
-            while (it.Valid()) {
-                aggr->UpdateFresh(segName, it.GetUnmergedKey(), it.GetUnmergedMemRec());
-                it.Next();
+        }
+
+        while (it.Valid()) {
+            aggr->UpdateFresh(segName, it.GetUnmergedKey(), it.GetUnmergedMemRec());
+            it.Next();
+            if (it.Valid() && yeildChecker.StepAndCheckForYield()) {
+                return TYeildedState{typename TYeildedState::TFreshPosition{segmentType, it}};
             }
+        }
+        return std::nullopt;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TraverseDbWithoutMerge
+    // Traversing LevelIndex Database per fresh segment, per Sst, usefull
+    // for gathering info disregarding garbage collection.
+    //
+    // Execution may be yielded if according policy is passed and later resumed
+    // from saved state. 
+    ////////////////////////////////////////////////////////////////////////////
+    template <class TAggr, class TKey, class TMemRec>
+    std::optional<TDbStatYeildedState<TKey, TMemRec>> TraverseDbWithoutMerge(
+            const TIntrusivePtr<THullCtx> &hullCtx,
+            TAggr *aggr,
+            const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec> &snap,
+            std::optional<TDbStatYeildedState<TKey, TMemRec>> yeildedState = std::nullopt,
+            std::optional<TDbStatYieldPolicy> yeildPolicy = std::nullopt)
+    {
+        using TYeildedState = TDbStatYeildedState<TKey, TMemRec>;
+        using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
+        using TSstIterator = typename TYeildedState::TSstIterator;
+        using TMemIterator = typename TYeildedState::TMemIterator;
+        using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
+        using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
+        using EFreshSegment = typename TYeildedState::EFreshSegment;
+
+        TDbStatYieldChecker yeildChecker(std::move(yeildPolicy));
+
+        // Description of a single fresh segment to traverse
+        struct TSegmentDescription {
+            const char* Name;
+            EFreshSegment Type;
+            const TFreshSegmentSnapshot& Seg;
+        };
+        const TSegmentDescription segments[] = {
+            {"FCur", EFreshSegment::Cur, snap.FreshSnap.Cur},
+            {"FDreg", EFreshSegment::Dreg, snap.FreshSnap.Dreg},
+            {"FOld", EFreshSegment::Old, snap.FreshSnap.Old},
         };
 
+        // Figure out where to (re)start traversal
+        size_t startFreshSegmentIdx = 0;
+        bool resumeLevels = false;
+        std::optional<typename TYeildedState::TFreshIterator> freshResumeIt;
+        std::optional<TSstIterator> sstResumeIt;
+        std::optional<TMemIterator> memResumeIt;
+
+        if (yeildedState) {
+            if (auto* fresh = std::get_if<typename TYeildedState::TFreshPosition>(&yeildedState->Position)) {
+                startFreshSegmentIdx = static_cast<size_t>(fresh->Segment);
+                freshResumeIt = fresh->Iterator;
+            } else {
+                auto& level = std::get<typename TYeildedState::TLevelPosition>(yeildedState->Position);
+                resumeLevels = true;
+                sstResumeIt = level.SstIt;
+                memResumeIt = level.MemIt;
+            }
+        }
 
         // Traverse Fresh
-        traverseFreshSeg("FCur", snap.FreshSnap.Cur);
-        traverseFreshSeg("FDreg", snap.FreshSnap.Dreg);
-        traverseFreshSeg("FOld", snap.FreshSnap.Old);
+        if (!resumeLevels) {
+            for (size_t i = startFreshSegmentIdx; i < Y_ARRAY_SIZE(freshSegs); ++i) {
+                const TSegmentDescription& description = freshSegs[i];
+                std::optional<typename TYeildedState::TFreshIterator> resumeIt;
+                if (i == startFreshSegmentIdx) {
+                    resumeIt = std::move(freshResumeIt);
+                }
+                if (auto yielded = TraverseFreshSegment(hullCtx, aggr, description.Name, description.Seg,
+                        description.Type, std::move(resumeIt), yeildChecker)) {
+                    return yielded;
+                }
+            }
+        }
 
         // Traverse SSTs
-        TSstIterator it(&snap.SliceSnap);
-        it.SeekToFirst();
+        TSstIterator it = resumeLevels ? *sstResumeIt : TSstIterator(&snap.SliceSnap);
+        if (!resumeLevels) {
+            it.SeekToFirst();
+        }
         while (it.Valid()) {
             TLevelSstPtr p = it.Get();
-            TMemIterator c(p.SstPtr.Get());
-            c.SeekToFirst();
+            TMemIterator c = (resumeLevels && memResumeIt) ? *memResumeIt : TMemIterator(p.SstPtr.Get());
+            if (!(resumeLevels && memResumeIt)) {
+                c.SeekToFirst();
+            }
+            // consume the resume state only for the first SST after a resume
+            resumeLevels = false;
+            memResumeIt.reset();
             while (c.Valid()) {
                 aggr->UpdateLevel(p, c.GetCurKey(), c.GetMemRec());
                 c.Next();
+                if (c.Valid() && yeildChecker.StepAndCheckForYield()) {
+                    return TYeildedState{typename TYeildedState::TLevelPosition{it, c}};
+                }
             }
             it.Next();
         }
 
         aggr->Finish();
+        return std::nullopt;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -165,6 +165,7 @@ namespace NKikimr {
                 }
             }
 
+            bool processedLevelRecord = false;
             while (sstIterator.Valid()) {
                 TLevelSstPtr levelSstPtr = sstIterator.Get();
                 TMemIterator memIterator(levelSstPtr.SstPtr.Get());
@@ -179,11 +180,12 @@ namespace NKikimr {
                 // resume applies only to the first matching SST
                 resumeLevels = false;
                 while (memIterator.Valid()) {
-                    aggr->UpdateLevel(levelSstPtr, memIterator.GetCurKey(), memIterator.GetMemRec());
-                    memIterator.Prev();
-                    if (memIterator.Valid() && yieldChecker.StepAndCheckForYield()) {
+                    if (processedLevelRecord && yieldChecker.StepAndCheckForYield()) {
                         return TYieldedState{makeLevelPosition(levelSstPtr, memIterator.GetCurKey())};
                     }
+                    aggr->UpdateLevel(levelSstPtr, memIterator.GetCurKey(), memIterator.GetMemRec());
+                    processedLevelRecord = true;
+                    memIterator.Prev();
                 }
                 sstIterator.Prev();
             }

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -22,9 +22,9 @@ namespace NKikimr {
             const ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>& segment,
             typename TDbStatYieldedState<TKey, TMemRec>::EFreshSegment segmentType,
             const std::optional<TKey>& resumeKey,
-            TDbStatYieldChecker& yeildChecker)
+            TDbStatYieldChecker& yieldChecker)
     {
-        using TYeildedState = TDbStatYieldedState<TKey, TMemRec>;
+        using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
         using TFreshIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
 
@@ -38,8 +38,8 @@ namespace NKikimr {
         while (freshIterator.Valid()) {
             aggr->UpdateFresh(segmentName, freshIterator.GetUnmergedKey(), freshIterator.GetUnmergedMemRec());
             freshIterator.Next();
-            if (freshIterator.Valid() && yeildChecker.StepAndCheckForYield()) {
-                return TYeildedState{typename TYeildedState::TFreshPosition{
+            if (freshIterator.Valid() && yieldChecker.StepAndCheckForYield()) {
+                return TYieldedState{typename TYieldedState::TFreshPosition{
                     segmentType, freshIterator.GetUnmergedKey()}};
             }
         }
@@ -59,23 +59,23 @@ namespace NKikimr {
             const TIntrusivePtr<THullCtx>& hullCtx,
             TAggr* aggr,
             const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>& snap,
-            std::optional<TDbStatYieldedState<TKey, TMemRec>> yeildedState = std::nullopt,
-            std::optional<TDbStatYieldPolicy> yeildPolicy = std::nullopt,
+            std::optional<TDbStatYieldedState<TKey, TMemRec>> yieldedState = std::nullopt,
+            std::optional<TDbStatYieldPolicy> yieldPolicy = std::nullopt,
             TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
     {
-        using TYeildedState = TDbStatYieldedState<TKey, TMemRec>;
+        using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
         using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
         using TSstIterator = typename TLevelSliceSnapshot::TSstIterator;
         using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
         using TMemIterator = typename TLevelSegment::TMemIterator;
         using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
-        using EFreshSegment = typename TYeildedState::EFreshSegment;
-        using TLevelPosition = typename TYeildedState::TLevelPosition;
+        using EFreshSegment = typename TYieldedState::EFreshSegment;
+        using TLevelPosition = typename TYieldedState::TLevelPosition;
         using TUnsortedLevelDiscriminator = typename TLevelPosition::TUnsortedLevelDiscriminator;
         using TSortedLevelDiscriminator = typename TLevelPosition::TSortedLevelDiscriminator;
 
-        TDbStatYieldChecker yeildChecker(std::move(yeildPolicy), std::move(monotonicTimeProvider));
+        TDbStatYieldChecker yieldChecker(std::move(yieldPolicy), std::move(monotonicTimeProvider));
 
         // Description of a single fresh segment to traverse
         struct TSegmentDescription {
@@ -95,13 +95,13 @@ namespace NKikimr {
         std::optional<TKey> freshResumeKey;
         std::optional<TLevelPosition> levelResumePosition;
 
-        if (yeildedState) {
-            using TFreshPosition = typename TYeildedState::TFreshPosition;
-            if (TFreshPosition* freshPosition = std::get_if<TFreshPosition>(&yeildedState->Position)) {
+        if (yieldedState) {
+            using TFreshPosition = typename TYieldedState::TFreshPosition;
+            if (TFreshPosition* freshPosition = std::get_if<TFreshPosition>(&yieldedState->Position)) {
                 startFreshSegmentIdx = static_cast<size_t>(freshPosition->Segment);
                 freshResumeKey = freshPosition->Key;
             } else {
-                levelResumePosition = std::get<TLevelPosition>(yeildedState->Position);
+                levelResumePosition = std::get<TLevelPosition>(yieldedState->Position);
                 resumeLevels = true;
             }
         }
@@ -151,8 +151,8 @@ namespace NKikimr {
                 if (segmentIdx == startFreshSegmentIdx) {
                     resumeKey = freshResumeKey;
                 }
-                if (std::optional<TYeildedState> yielded = TraverseFreshSegment(hullCtx, aggr, description.Name,
-                        description.Segment, description.Type, resumeKey, yeildChecker)) {
+                if (std::optional<TYieldedState> yielded = TraverseFreshSegment(hullCtx, aggr, description.Name,
+                        description.Segment, description.Type, resumeKey, yieldChecker)) {
                     return yielded;
                 }
             }
@@ -184,8 +184,8 @@ namespace NKikimr {
             while (memIterator.Valid()) {
                 aggr->UpdateLevel(levelSstPtr, memIterator.GetCurKey(), memIterator.GetMemRec());
                 memIterator.Next();
-                if (memIterator.Valid() && yeildChecker.StepAndCheckForYield()) {
-                    return TYeildedState{makeLevelPosition(levelSstPtr, memIterator.GetCurKey())};
+                if (memIterator.Valid() && yieldChecker.StepAndCheckForYield()) {
+                    return TYieldedState{makeLevelPosition(levelSstPtr, memIterator.GetCurKey())};
                 }
             }
             sstIterator.Next();

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -57,6 +57,8 @@ namespace NKikimr {
     //
     // Execution may be yielded if according policy is passed and later resumed
     // from saved state.
+    // Using yield policy may lead to omission of some records after
+    // database mutations.
     ////////////////////////////////////////////////////////////////////////////
     template <class TAggr, class TKey, class TMemRec>
     std::optional<TDbStatYieldedState<TKey, TMemRec>> TraverseDbWithoutMerge(

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -26,19 +26,23 @@ namespace NKikimr {
     {
         using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
         using TFreshSegmentSnapshot = ::NKikimr::TFreshSegmentSnapshot<TKey, TMemRec>;
-        using TFreshIterator = typename TFreshSegmentSnapshot::TIteratorWOMerge;
+        using TFreshIterator = typename TFreshSegmentSnapshot::TBackwardIteratorWOMerge;
 
         TFreshIterator freshIterator(hullCtx, &segment);
         if (resumeKey) {
             freshIterator.Seek(*resumeKey);
         } else {
-            freshIterator.SeekToFirst();
+            freshIterator.SeekToLast();
         }
 
         while (freshIterator.Valid()) {
-            aggr->UpdateFresh(segmentName, freshIterator.GetUnmergedKey(), freshIterator.GetUnmergedMemRec());
-            freshIterator.Next();
-            if (freshIterator.Valid() && yieldChecker.StepAndCheckForYield()) {
+            const TKey key = freshIterator.GetUnmergedKey();
+            aggr->UpdateFresh(segmentName, key, freshIterator.GetUnmergedMemRec());
+            freshIterator.Prev();
+            // The resume position identifies a fresh record by key, so do not yield
+            // between unmerged records having the same key.
+            if (freshIterator.Valid() && freshIterator.GetUnmergedKey() < key &&
+                    yieldChecker.StepAndCheckForYield()) {
                 return TYieldedState{typename TYieldedState::TFreshPosition{
                     segmentType, freshIterator.GetUnmergedKey()}};
             }
@@ -90,7 +94,8 @@ namespace NKikimr {
         };
 
         // Figure out where to (re)start traversal
-        size_t startFreshSegmentIdx = 0;
+        size_t startFreshSegmentIdx = std::size(segments) - 1;
+        bool resumeFresh = false;
         bool resumeLevels = false;
         std::optional<TKey> freshResumeKey;
         std::optional<TLevelPosition> levelResumePosition;
@@ -100,23 +105,24 @@ namespace NKikimr {
             if (TFreshPosition* freshPosition = std::get_if<TFreshPosition>(&yieldedState->Position)) {
                 startFreshSegmentIdx = static_cast<size_t>(freshPosition->Segment);
                 freshResumeKey = freshPosition->Key;
+                resumeFresh = true;
             } else {
                 levelResumePosition = std::get<TLevelPosition>(yieldedState->Position);
                 resumeLevels = true;
             }
         }
 
-        auto sstSortsBeforeSavedPosition = [](const TLevelSstPtr& levelSstPtr,
+        auto sstSortsAfterSavedPosition = [](const TLevelSstPtr& levelSstPtr,
                 const TLevelPosition& savedPosition) -> bool {
             if (levelSstPtr.Level != savedPosition.Level) {
-                return levelSstPtr.Level < savedPosition.Level;
+                return levelSstPtr.Level > savedPosition.Level;
             }
             if (levelSstPtr.Level == 0) {
-                return levelSstPtr.SstPtr->VolatileOrderId <
+                return levelSstPtr.SstPtr->VolatileOrderId >
                     std::get<TUnsortedLevelDiscriminator>(savedPosition.Discriminator);
             }
-            return levelSstPtr.SstPtr->FirstKey() <
-                std::get<TSortedLevelDiscriminator>(savedPosition.Discriminator);
+            return std::get<TSortedLevelDiscriminator>(savedPosition.Discriminator) <
+                levelSstPtr.SstPtr->FirstKey();
         };
         auto sstMatchesSavedPosition = [](const TLevelSstPtr& levelSstPtr,
                 const TLevelPosition& savedPosition) -> bool {
@@ -143,52 +149,56 @@ namespace NKikimr {
             return position;
         };
 
-        // Traverse Fresh
-        if (!resumeLevels) {
-            for (size_t segmentIdx = startFreshSegmentIdx; segmentIdx < std::size(segments); ++segmentIdx) {
-                const TSegmentDescription &description = segments[segmentIdx];
-                std::optional<TKey> resumeKey;
-                if (segmentIdx == startFreshSegmentIdx) {
-                    resumeKey = freshResumeKey;
-                }
-                if (std::optional<TYieldedState> yielded = TraverseFreshSegment(hullCtx, aggr, description.Name,
-                        description.Segment, description.Type, resumeKey, yieldChecker)) {
-                    return yielded;
-                }
-            }
-        }
-
         // Traverse SSTs
-        TSstIterator sstIterator(&snap.SliceSnap);
-        sstIterator.SeekToFirst();
+        if (!resumeFresh) {
+            TSstIterator sstIterator(&snap.SliceSnap);
+            sstIterator.SeekToLast();
 
-        // When resuming the level phase, skip SSTs that are ordered strictly before the
-        // saved position.
-        if (resumeLevels) {
-            while (sstIterator.Valid() &&
-                    sstSortsBeforeSavedPosition(sstIterator.Get(), *levelResumePosition)) {
-                sstIterator.Next();
+            // When resuming the level phase, skip SSTs that are ordered strictly after the
+            // saved position.
+            if (resumeLevels) {
+                while (sstIterator.Valid() &&
+                        sstSortsAfterSavedPosition(sstIterator.Get(), *levelResumePosition)) {
+                    sstIterator.Prev();
+                }
+            }
+
+            while (sstIterator.Valid()) {
+                TLevelSstPtr levelSstPtr = sstIterator.Get();
+                TMemIterator memIterator(levelSstPtr.SstPtr.Get());
+                if (resumeLevels && sstMatchesSavedPosition(levelSstPtr, *levelResumePosition)) {
+                    memIterator.Seek(levelResumePosition->Key);
+                    if (!memIterator.Valid() || levelResumePosition->Key < memIterator.GetCurKey()) {
+                        memIterator.Prev();
+                    }
+                } else {
+                    memIterator.SeekToLast();
+                }
+                // resume applies only to the first matching SST
+                resumeLevels = false;
+                while (memIterator.Valid()) {
+                    aggr->UpdateLevel(levelSstPtr, memIterator.GetCurKey(), memIterator.GetMemRec());
+                    memIterator.Prev();
+                    if (memIterator.Valid() && yieldChecker.StepAndCheckForYield()) {
+                        return TYieldedState{makeLevelPosition(levelSstPtr, memIterator.GetCurKey())};
+                    }
+                }
+                sstIterator.Prev();
             }
         }
 
-        while (sstIterator.Valid()) {
-            TLevelSstPtr levelSstPtr = sstIterator.Get();
-            TMemIterator memIterator(levelSstPtr.SstPtr.Get());
-            if (resumeLevels && sstMatchesSavedPosition(levelSstPtr, *levelResumePosition)) {
-                memIterator.Seek(levelResumePosition->Key);
-            } else {
-                memIterator.SeekToFirst();
+        // Traverse Fresh
+        for (size_t segmentIdx = startFreshSegmentIdx + 1; segmentIdx > 0;) {
+            --segmentIdx;
+            const TSegmentDescription &description = segments[segmentIdx];
+            std::optional<TKey> resumeKey;
+            if (segmentIdx == startFreshSegmentIdx) {
+                resumeKey = freshResumeKey;
             }
-            // resume applies only to the first matching SST
-            resumeLevels = false;
-            while (memIterator.Valid()) {
-                aggr->UpdateLevel(levelSstPtr, memIterator.GetCurKey(), memIterator.GetMemRec());
-                memIterator.Next();
-                if (memIterator.Valid() && yieldChecker.StepAndCheckForYield()) {
-                    return TYieldedState{makeLevelPosition(levelSstPtr, memIterator.GetCurKey())};
-                }
+            if (std::optional<TYieldedState> yielded = TraverseFreshSegment(hullCtx, aggr, description.Name,
+                    description.Segment, description.Type, resumeKey, yieldChecker)) {
+                return yielded;
             }
-            sstIterator.Next();
         }
 
         aggr->Finish();

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.cpp
@@ -250,8 +250,8 @@ namespace NKikimr {
     }
 
     template <>
-    void TLevelIndexStatActor<TKeyLogoBlob, TMemRecLogoBlob>::CalculateStat(IOutputStream &str,
-                                                                            bool pretty) {
+    void TLevelIndexStatActor<TKeyLogoBlob, TMemRecLogoBlob>::PrepareStat(IOutputStream &str,
+                                                                          bool pretty) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyLogoBlob, TMemRecLogoBlob>;
@@ -285,15 +285,13 @@ namespace NKikimr {
             bool Pretty;
         };
 
-        // run aggregation
-        TAggr aggr(str, pretty);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(str, pretty));
     }
 
     template <>
     void TLevelIndexStatActor<TKeyLogoBlob, TMemRecLogoBlob,
             TEvGetLogoBlobIndexStatRequest, TEvGetLogoBlobIndexStatResponse
-    >::CalculateStat(std::unique_ptr<TEvGetLogoBlobIndexStatResponse> &result) {
+    >::PrepareStat(std::unique_ptr<TEvGetLogoBlobIndexStatResponse> &result) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyLogoBlob, TMemRecLogoBlob>;
@@ -326,14 +324,12 @@ namespace NKikimr {
             std::unique_ptr<TEvGetLogoBlobIndexStatResponse> &Result;
         };
 
-        // run aggregation
-        TAggr aggr(result);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(result));
     }
 
     template <>
-    void TLevelIndexStatActor<TKeyBlock, TMemRecBlock>::CalculateStat(IOutputStream &str,
-                                                                      bool pretty) {
+    void TLevelIndexStatActor<TKeyBlock, TMemRecBlock>::PrepareStat(IOutputStream &str,
+                                                                    bool pretty) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyBlock, TMemRecBlock>;
@@ -412,14 +408,12 @@ namespace NKikimr {
         };
 
 
-        // run aggregation
-        TAggr aggr(str, pretty);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(str, pretty));
     }
 
     template <>
-    void TLevelIndexStatActor<TKeyBarrier, TMemRecBarrier>::CalculateStat(IOutputStream &str,
-                                                                          bool pretty) {
+    void TLevelIndexStatActor<TKeyBarrier, TMemRecBarrier>::PrepareStat(IOutputStream &str,
+                                                                        bool pretty) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyBarrier, TMemRecBarrier>;
@@ -513,9 +507,7 @@ namespace NKikimr {
         };
 
 
-        // run aggregation
-        TAggr aggr(str, pretty);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(str, pretty));
     }
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "defs.h"
+#include "query_statalgo.h"
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_response.h>
 
 namespace NKikimr {
@@ -13,6 +15,7 @@ namespace NKikimr {
     class TLevelIndexStatActor : public TActorBootstrapped<TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>> {
 
         using TThis = ::NKikimr::TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>;
+        using TBase = TActorBootstrapped<TThis>;
         using TLevelIndex = ::NKikimr::TLevelIndex<TKey, TMemRec>;
         using TLevelIndexSnapshot = ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>;
         using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
@@ -20,27 +23,85 @@ namespace NKikimr {
         using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
         using TMemIterator = typename TLevelSegment::TMemIterator;
         using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
+        using TYieldedState = TDbStatYeildedState<TKey, TMemRec>;
+        using TTraversal = std::function<std::optional<TYieldedState>(
+            const TLevelIndexSnapshot&, std::optional<TYieldedState>)>;
 
         friend class TActorBootstrapped<TThis>;
 
         void Bootstrap(const TActorContext &ctx) {
-            TStringStream str;
             if constexpr (std::is_same_v<TRequest, TEvBlobStorage::TEvVDbStat>) {
                 const bool prettyPrint = Ev->Get()->Record.GetPrettyPrint();
-                CalculateStat(str, prettyPrint);
-                Result->SetResult(str.Str());
-                SendVDiskResponse(ctx, Ev->Sender, Result.release(), Ev->Cookie, HullCtx->VCtx, {});
+                PrepareStat(Output, prettyPrint);
             } else {
-                CalculateStat(Result);
-                SendVDiskResponse(ctx, Ev->Sender, Result.release(), Ev->Cookie, HullCtx->VCtx, {});
+                PrepareStat(Result);
             }
+            TThis::Become(&TThis::StateFunc);
+            ContinueTraversal(ctx);
+        }
+
+        void PrepareStat(IOutputStream &str, bool pretty);
+
+        void PrepareStat(std::unique_ptr<TResponse> &result);
+
+        template <class TAggr>
+        void SetAggregator(std::shared_ptr<TAggr> aggr) {
+            Traversal = [this, aggr = std::move(aggr)](
+                    const TLevelIndexSnapshot& snapshot,
+                    std::optional<TYieldedState> yieldedState) mutable {
+                return TraverseDbWithoutMerge(
+                    HullCtx,
+                    aggr.get(),
+                    snapshot,
+                    std::move(yieldedState),
+                    YieldPolicy);
+            };
+        }
+
+        void ContinueTraversal(const TActorContext& ctx) {
+            Y_ABORT_UNLESS(Snapshot);
+            YieldedState = Traversal(*Snapshot, std::move(YieldedState));
+            Snapshot->Destroy();
+            Snapshot.reset();
+
+            if (YieldedState) {
+                ctx.Schedule(YieldPolicy.DelayBetweenQuants, new TEvents::TEvWakeup);
+            } else {
+                ReplyAndDie(ctx);
+            }
+        }
+
+        void HandleWakeup(const TActorContext& ctx) {
+            ctx.Send(ParentId, new TEvTakeHullSnapshot(true));
+        }
+
+        void Handle(TEvTakeHullSnapshotResult::TPtr& ev, const TActorContext& ctx) {
+            if constexpr (std::is_same_v<TKey, TKeyLogoBlob>) {
+                Snapshot.emplace(std::move(ev->Get()->Snap.LogoBlobsSnap));
+            } else if constexpr (std::is_same_v<TKey, TKeyBlock>) {
+                Snapshot.emplace(std::move(ev->Get()->Snap.BlocksSnap));
+            } else if constexpr (std::is_same_v<TKey, TKeyBarrier>) {
+                Snapshot.emplace(std::move(ev->Get()->Snap.BarriersSnap));
+            } else {
+                static_assert(!std::is_same_v<TKey, TKey>, "unsupported Hull database key");
+            }
+            ContinueTraversal(ctx);
+        }
+
+        void ReplyAndDie(const TActorContext& ctx) {
+            if constexpr (std::is_same_v<TRequest, TEvBlobStorage::TEvVDbStat>) {
+                Result->SetResult(Output.Str());
+            }
+            SendVDiskResponse(ctx, Ev->Sender, Result.release(), Ev->Cookie, HullCtx->VCtx, {});
             ctx.Send(ParentId, new TEvents::TEvGone);
             TThis::Die(ctx);
         }
 
-        void CalculateStat(IOutputStream &str, bool pretty);
-
-        void CalculateStat(std::unique_ptr<TResponse> &result);
+        STRICT_STFUNC(StateFunc, {
+            CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
+            CFunc(TEvents::TSystem::PoisonPill, TBase::Die);
+            HFunc(TEvTakeHullSnapshotResult, Handle);
+        })
 
     public:
         static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -52,21 +113,27 @@ namespace NKikimr {
                 const TActorId &parentId,
                 TLevelIndexSnapshot &&snapshot,
                 typename TRequest::TPtr &ev,
-                std::unique_ptr<TResponse> result)
+                std::unique_ptr<TResponse> result,
+                TDbStatYieldPolicy yieldPolicy = {})
             : TActorBootstrapped<TThis>()
             , HullCtx(hullCtx)
             , ParentId(parentId)
-            , Snapshot(std::move(snapshot))
+            , Snapshot(std::in_place, std::move(snapshot))
             , Ev(ev)
             , Result(std::move(result))
+            , YieldPolicy(std::move(yieldPolicy))
         {}
 
     private:
         TIntrusivePtr<THullCtx> HullCtx;
         const TActorId ParentId;
-        TLevelIndexSnapshot Snapshot;
+        std::optional<TLevelIndexSnapshot> Snapshot;
         typename TRequest::TPtr Ev;
         std::unique_ptr<TResponse> Result;
+        const TDbStatYieldPolicy YieldPolicy;
+        TStringStream Output;
+        TTraversal Traversal;
+        std::optional<TYieldedState> YieldedState;
     };
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.h
@@ -23,7 +23,7 @@ namespace NKikimr {
         using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
         using TMemIterator = typename TLevelSegment::TMemIterator;
         using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
-        using TYieldedState = TDbStatYeildedState<TKey, TMemRec>;
+        using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
         using TTraversal = std::function<std::optional<TYieldedState>(
             const TLevelIndexSnapshot&, std::optional<TYieldedState>)>;
 

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.h
@@ -29,7 +29,7 @@ namespace NKikimr {
 
         friend class TActorBootstrapped<TThis>;
 
-        void Bootstrap(const TActorContext &ctx) {
+        void Bootstrap() {
             if constexpr (std::is_same_v<TRequest, TEvBlobStorage::TEvVDbStat>) {
                 const bool prettyPrint = Ev->Get()->Record.GetPrettyPrint();
                 PrepareStat(Output, prettyPrint);
@@ -37,7 +37,7 @@ namespace NKikimr {
                 PrepareStat(Result);
             }
             TThis::Become(&TThis::StateFunc);
-            ContinueTraversal(ctx);
+            ContinueTraversal();
         }
 
         void PrepareStat(IOutputStream &str, bool pretty);
@@ -58,24 +58,24 @@ namespace NKikimr {
             };
         }
 
-        void ContinueTraversal(const TActorContext& ctx) {
+        void ContinueTraversal() {
             Y_ABORT_UNLESS(Snapshot);
             YieldedState = Traversal(*Snapshot, std::move(YieldedState));
             Snapshot->Destroy();
             Snapshot.reset();
 
             if (YieldedState) {
-                ctx.Schedule(YieldPolicy.DelayBetweenQuants, new TEvents::TEvWakeup);
+                Schedule(YieldPolicy.DelayBetweenQuanta, new TEvents::TEvWakeup);
             } else {
-                ReplyAndDie(ctx);
+                ReplyAndDie();
             }
         }
 
-        void HandleWakeup(const TActorContext& ctx) {
-            ctx.Send(ParentId, new TEvTakeHullSnapshot(true));
+        void HandleWakeup() {
+            Send(ParentId, new TEvTakeHullSnapshot(true));
         }
 
-        void Handle(TEvTakeHullSnapshotResult::TPtr& ev, const TActorContext& ctx) {
+        void Handle(TEvTakeHullSnapshotResult::TPtr& ev) {
             if constexpr (std::is_same_v<TKey, TKeyLogoBlob>) {
                 Snapshot.emplace(std::move(ev->Get()->Snap.LogoBlobsSnap));
             } else if constexpr (std::is_same_v<TKey, TKeyBlock>) {
@@ -85,22 +85,23 @@ namespace NKikimr {
             } else {
                 static_assert(!std::is_same_v<TKey, TKey>, "unsupported Hull database key");
             }
-            ContinueTraversal(ctx);
+            ContinueTraversal();
         }
 
-        void ReplyAndDie(const TActorContext& ctx) {
+        void ReplyAndDie() {
             if constexpr (std::is_same_v<TRequest, TEvBlobStorage::TEvVDbStat>) {
                 Result->SetResult(Output.Str());
             }
-            SendVDiskResponse(ctx, Ev->Sender, Result.release(), Ev->Cookie, HullCtx->VCtx, {});
-            ctx.Send(ParentId, new TEvents::TEvGone);
-            TThis::Die(ctx);
+            SendVDiskResponse(TActivationContex::AsActorContext(), Ev->Sender, Result.release(),
+                    Ev->Cookie, HullCtx->VCtx, {});
+            Send(ParentId, new TEvents::TEvGone);
+            PassAway();
         }
 
         STRICT_STFUNC(StateFunc, {
-            CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
-            CFunc(TEvents::TSystem::PoisonPill, TBase::Die);
-            HFunc(TEvTakeHullSnapshotResult, Handle);
+            cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
+            cFunc(TEvents::TSystem::PoisonPill, PassAway);
+            hFunc(TEvTakeHullSnapshotResult, Handle);
         })
 
     public:

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.h
@@ -65,14 +65,14 @@ namespace NKikimr {
             Snapshot.reset();
 
             if (YieldedState) {
-                Schedule(YieldPolicy.DelayBetweenQuanta, new TEvents::TEvWakeup);
+                TThis::Schedule(YieldPolicy.DelayBetweenQuanta, new TEvents::TEvWakeup);
             } else {
                 ReplyAndDie();
             }
         }
 
         void HandleWakeup() {
-            Send(ParentId, new TEvTakeHullSnapshot(true));
+            TThis::Send(ParentId, new TEvTakeHullSnapshot(true));
         }
 
         void Handle(TEvTakeHullSnapshotResult::TPtr& ev) {
@@ -92,15 +92,15 @@ namespace NKikimr {
             if constexpr (std::is_same_v<TRequest, TEvBlobStorage::TEvVDbStat>) {
                 Result->SetResult(Output.Str());
             }
-            SendVDiskResponse(TActivationContex::AsActorContext(), Ev->Sender, Result.release(),
+            SendVDiskResponse(TActivationContext::AsActorContext(), Ev->Sender, Result.release(),
                     Ev->Cookie, HullCtx->VCtx, {});
-            Send(ParentId, new TEvents::TEvGone);
-            PassAway();
+            TThis::Send(ParentId, new TEvents::TEvGone);
+            TThis::PassAway();
         }
 
         STRICT_STFUNC(StateFunc, {
             cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
-            cFunc(TEvents::TSystem::PoisonPill, PassAway);
+            cFunc(TEvents::TSystem::PoisonPill, TBase::PassAway);
             hFunc(TEvTakeHullSnapshotResult, Handle);
         })
 

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.h
@@ -113,15 +113,13 @@ namespace NKikimr {
                 const TActorId &parentId,
                 TLevelIndexSnapshot &&snapshot,
                 typename TRequest::TPtr &ev,
-                std::unique_ptr<TResponse> result,
-                TDbStatYieldPolicy yieldPolicy = {})
+                std::unique_ptr<TResponse> result)
             : TActorBootstrapped<TThis>()
             , HullCtx(hullCtx)
             , ParentId(parentId)
             , Snapshot(std::in_place, std::move(snapshot))
             , Ev(ev)
             , Result(std::move(result))
-            , YieldPolicy(std::move(yieldPolicy))
         {}
 
     private:
@@ -130,7 +128,7 @@ namespace NKikimr {
         std::optional<TLevelIndexSnapshot> Snapshot;
         typename TRequest::TPtr Ev;
         std::unique_ptr<TResponse> Result;
-        const TDbStatYieldPolicy YieldPolicy;
+        const TDbStatYieldPolicy YieldPolicy = TDbStatYieldPolicy{};
         TStringStream Output;
         TTraversal Traversal;
         std::optional<TYieldedState> YieldedState;

--- a/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
@@ -31,8 +31,8 @@ namespace {
             TDbStatYieldChecker checker(
                 TDbStatYieldPolicy{
                     .StepsBeforeMeasures = 3,
-                    .QuantDuration = TDuration::MilliSeconds(10),
-                    .DelayBetweenQuants = TDuration::MilliSeconds(100),
+                    .QuantumDuration = TDuration::MilliSeconds(10),
+                    .DelayBetweenQuanta = TDuration::MilliSeconds(100),
                 },
                 timeProvider);
 
@@ -41,7 +41,7 @@ namespace {
             UNIT_ASSERT(!checker.StepAndCheckForYield());
             UNIT_ASSERT(checker.StepAndCheckForYield());
 
-            // The elapsed time must exceed QuantDuration, and the clock is
+            // The elapsed time must exceed QuantumDuration, and the clock is
             // checked only after another StepsBeforeMeasures records.
             timeProvider->Advance(TDuration::MilliSeconds(10));
             UNIT_ASSERT(!checker.StepAndCheckForYield());
@@ -59,8 +59,8 @@ namespace {
             TDbStatYieldChecker checker(
                 TDbStatYieldPolicy{
                     .StepsBeforeMeasures = 2,
-                    .QuantDuration = TDuration::MilliSeconds(50),
-                    .DelayBetweenQuants = TDuration::MilliSeconds(100),
+                    .QuantumDuration = TDuration::MilliSeconds(50),
+                    .DelayBetweenQuanta = TDuration::MilliSeconds(100),
                 },
                 timeProvider);
 

--- a/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
@@ -1,0 +1,87 @@
+#include <ydb/core/blobstorage/vdisk/query/query_stat_yield.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+namespace {
+
+    class TManualMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
+    public:
+        TMonotonic Now() override {
+            ++Calls;
+            return CurrentTime;
+        }
+
+        void Advance(TDuration duration) {
+            CurrentTime += duration;
+        }
+
+        ui32 GetCalls() const {
+            return Calls;
+        }
+
+    private:
+        TMonotonic CurrentTime = TMonotonic::Zero();
+        ui32 Calls = 0;
+    };
+
+    Y_UNIT_TEST_SUITE(TDbStatYieldCheckerTest) {
+        Y_UNIT_TEST(YieldPolicy) {
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TDbStatYieldChecker checker(
+                TDbStatYieldPolicy{
+                    .StepsBeforeMeasures = 3,
+                    .QuantDuration = TDuration::MilliSeconds(10),
+                    .DelayBetweenQuants = TDuration::MilliSeconds(100),
+                },
+                timeProvider);
+
+            timeProvider->Advance(TDuration::MilliSeconds(11));
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(checker.StepAndCheckForYield());
+
+            // The elapsed time must exceed QuantDuration, and the clock is
+            // checked only after another StepsBeforeMeasures records.
+            timeProvider->Advance(TDuration::MilliSeconds(10));
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+
+            timeProvider->Advance(TDuration::MilliSeconds(1));
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(checker.StepAndCheckForYield());
+        }
+
+        Y_UNIT_TEST(UsesInjectedMonotonicTimeProvider) {
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TDbStatYieldChecker checker(
+                TDbStatYieldPolicy{
+                    .StepsBeforeMeasures = 2,
+                    .QuantDuration = TDuration::MilliSeconds(50),
+                    .DelayBetweenQuants = TDuration::MilliSeconds(100),
+                },
+                timeProvider);
+
+            UNIT_ASSERT_VALUES_EQUAL(timeProvider->GetCalls(), 1);
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+
+            timeProvider->Advance(TDuration::MilliSeconds(51));
+            UNIT_ASSERT(checker.StepAndCheckForYield());
+            UNIT_ASSERT_VALUES_EQUAL(timeProvider->GetCalls(), 2);
+
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT_VALUES_EQUAL(timeProvider->GetCalls(), 3);
+        }
+
+        Y_UNIT_TEST(DoesNotNeedTimeProviderWhenYieldingIsDisabled) {
+            TDbStatYieldChecker checker(std::nullopt, {});
+
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+        }
+    }
+
+} // anonymous namespace
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -1,0 +1,448 @@
+#include <ydb/core/blobstorage/vdisk/query/query_statalgo.h>
+
+#include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/random/fast.h>
+#include <util/stream/null.h>
+
+#include <algorithm>
+
+namespace NKikimr {
+namespace {
+
+    constexpr bool IsVerbose = false;
+#define Ctest (IsVerbose ? Cerr : Cnull)
+
+    using TKey = TKeyLogoBlob;
+    using TMemRec = TMemRecLogoBlob;
+    using TLogoBlobsLevelIndex = ::NKikimr::TLevelIndex<TKey, TMemRec>;
+    using TLogoBlobsLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
+    using TYieldedState = TDbStatYeildedState<TKey, TMemRec>;
+
+    TKey MakeKey(ui32 step) {
+        return TKey(TLogoBlobID(1, 1, step, 0, 0, 0));
+    }
+
+    class TManualMonotonicTimeProviderForTraverse : public NMonotonic::IMonotonicTimeProvider {
+    public:
+        TMonotonic Now() override {
+            return CurrentTime;
+        }
+
+        void Advance(TDuration duration) {
+            CurrentTime += duration;
+        }
+
+    private:
+        TMonotonic CurrentTime = TMonotonic::Zero();
+    };
+
+    struct TSstSpec {
+        ui64 Id = 0;
+        TVector<TKey> Keys;
+    };
+
+    enum class EMutation {
+        AddFreshKey,
+        AddSst,
+        RemoveSst,
+        AddKeyToSst,
+        RemoveKeyFromSst,
+        Count,
+    };
+
+    class TRandomizedLogoBlobsBase {
+    public:
+        TRandomizedLogoBlobsBase()
+            : Arena(std::make_shared<TRopeArena>(&TRopeArenaBackend::Allocate))
+            , Index(MakeIntrusive<TLogoBlobsLevelIndex>(Contexts.GetLevelIndexSettings(), Arena))
+        {
+            Index->CurSlice->SortedLevels.emplace_back(TKey());
+            Index->LoadCompleted();
+
+            for (ui32 step = 1'000; step < 1'200; step += 10) {
+                PutFresh(MakeKey(step), true);
+            }
+            for (ui32 sstIdx = 0; sstIdx < 6; ++sstIdx) {
+                Level0.push_back(MakeSstSpec(2'000 + sstIdx * 100, ++NextLevel0Id));
+            }
+            for (ui32 sstIdx = 0; sstIdx < 8; ++sstIdx) {
+                SortedLevel.push_back(MakeSstSpec(4'000 + sstIdx * 100));
+            }
+            RegisterInitialSstKeys(Level0);
+            RegisterInitialSstKeys(SortedLevel);
+            RebuildSsts();
+        }
+
+        TIntrusivePtr<THullCtx> GetHullCtx() {
+            return Contexts.GetHullCtx();
+        }
+
+        TLevelIndexSnapshot<TKey, TMemRec> GetSnapshot() {
+            return Index->GetIndexSnapshot();
+        }
+
+        const TSet<TKey>& GetExpectedKeys() const {
+            return ExpectedKeys;
+        }
+
+        void Mutate(const TYieldedState& yieldedState, TReallyFastRng32& rng) {
+            const EMutation mutation = static_cast<EMutation>(
+                rng() % static_cast<ui32>(EMutation::Count));
+            switch (mutation) {
+                case EMutation::AddFreshKey:
+                    AddFreshKey(yieldedState, rng);
+                    break;
+                case EMutation::AddSst:
+                    AddSst(yieldedState, rng);
+                    break;
+                case EMutation::RemoveSst:
+                    RemoveSst(rng);
+                    break;
+                case EMutation::AddKeyToSst:
+                    AddKeyToSst(rng);
+                    break;
+                case EMutation::RemoveKeyFromSst:
+                    RemoveKeyFromSst(rng);
+                    break;
+                case EMutation::Count:
+                    Y_ABORT("unexpected mutation");
+            }
+            RebuildSsts();
+        }
+
+        void PrintStatistics(ui32 seed, ui32 quanta, ui32 yields, size_t seenKeys) const {
+            Ctest << "TraverseDbWithoutMerge randomized test statistics:"
+                << " seed# " << seed
+                << " quanta# " << quanta
+                << " yields# " << yields
+                << " seenKeys# " << seenKeys
+                << " expectedKeys# " << ExpectedKeys.size()
+                << " finalLevel0Ssts# " << Level0.size()
+                << " finalSortedSsts# " << SortedLevel.size()
+                << " freshKeysAdded# " << FreshKeysAdded
+                << " sstsAdded# " << SstsAdded
+                << " sstsRemoved# " << SstsRemoved
+                << " sstKeysAdded# " << SstKeysAdded
+                << " sstKeysRemoved# " << SstKeysRemoved
+                << Endl;
+        }
+
+        void AssertAllMutationKindsWereUsed() const {
+            UNIT_ASSERT_C(FreshKeysAdded, "no fresh keys were added");
+            UNIT_ASSERT_C(SstsAdded, "no SSTs were added");
+            UNIT_ASSERT_C(SstsRemoved, "no SSTs were removed");
+            UNIT_ASSERT_C(SstKeysAdded, "no keys were added to SSTs");
+            UNIT_ASSERT_C(SstKeysRemoved, "no keys were removed from SSTs");
+        }
+
+    private:
+        static TSstSpec MakeSstSpec(ui32 firstStep, ui64 id = 0) {
+            TSstSpec spec{.Id = id};
+            for (ui32 offset = 0; offset < 60; offset += 10) {
+                spec.Keys.push_back(MakeKey(firstStep + offset));
+            }
+            return spec;
+        }
+
+        void RegisterInitialSstKeys(const TVector<TSstSpec>& specs) {
+            for (const TSstSpec& spec : specs) {
+                for (const TKey& key : spec.Keys) {
+                    UNIT_ASSERT(AllKeys.insert(key).second);
+                    ExpectedKeys.insert(key);
+                }
+            }
+        }
+
+        TIntrusivePtr<TLogoBlobsLevelSegment> MakeSst(const TSstSpec& spec) {
+            TTrackableVector<TLogoBlobsLevelSegment::TRec> records(
+                TMemoryConsumer(Contexts.GetVCtx()->SstIndex));
+            for (const TKey& key : spec.Keys) {
+                records.emplace_back(key, TMemRec());
+            }
+
+            auto sst = MakeIntrusive<TLogoBlobsLevelSegment>(Contexts.GetVCtx());
+            sst->LoadLinearIndex(records);
+            sst->VolatileOrderId = spec.Id;
+            return sst;
+        }
+
+        void RebuildSsts() {
+            auto& level0 = *Index->CurSlice->Level0.Segs;
+            level0.Segments.clear();
+            level0.Num = 0;
+            Sort(Level0, [](const TSstSpec& lhs, const TSstSpec& rhs) {
+                return lhs.Id < rhs.Id;
+            });
+            for (const TSstSpec& spec : Level0) {
+                Index->CurSlice->Level0.Put(MakeSst(spec));
+            }
+
+            auto& sorted = Index->CurSlice->SortedLevels.front().Segs->Segments;
+            sorted.clear();
+            Sort(SortedLevel, [](const TSstSpec& lhs, const TSstSpec& rhs) {
+                return lhs.Keys.front() < rhs.Keys.front();
+            });
+            for (const TSstSpec& spec : SortedLevel) {
+                auto sst = MakeSst(spec);
+                Index->CurSlice->SortedLevels.front().Put(sst);
+            }
+        }
+
+        void PutFresh(const TKey& key, bool expected) {
+            UNIT_ASSERT_C(AllKeys.insert(key).second, "duplicate generated key");
+            Index->PutToFresh(NextLsn++, key, TMemRec());
+            if (expected) {
+                ExpectedKeys.insert(key);
+            }
+        }
+
+        void AddFreshKey(const TYieldedState& yieldedState, TReallyFastRng32& rng) {
+            const auto* freshPosition =
+                std::get_if<typename TYieldedState::TFreshPosition>(&yieldedState.Position);
+            ui32 step = NextLateFreshStep++;
+            bool expected = false;
+            if (freshPosition) {
+                const ui32 resumeStep = freshPosition->Key.LogoBlobID().Step();
+                const bool addAfterResumePosition = rng() % 2;
+                step = addAfterResumePosition ? resumeStep + 1 : resumeStep - 1;
+                while (AllKeys.contains(MakeKey(step))) {
+                    step += addAfterResumePosition ? 1 : -1;
+                }
+                expected = !(MakeKey(step) < freshPosition->Key);
+            }
+            PutFresh(MakeKey(step), expected);
+            ++FreshKeysAdded;
+        }
+
+        void AddSst(const TYieldedState& yieldedState, TReallyFastRng32& rng) {
+            const bool addToLevel0 = rng() % 2;
+            TSstSpec spec;
+            if (addToLevel0) {
+                spec = MakeSstSpec(NextLevel0Step, ++NextLevel0Id);
+                NextLevel0Step += 100;
+            } else {
+                spec = MakeSstSpec(NextSortedStep);
+                NextSortedStep += 100;
+            }
+
+            bool expected = std::holds_alternative<typename TYieldedState::TFreshPosition>(
+                yieldedState.Position);
+            if (const auto* levelPosition =
+                    std::get_if<typename TYieldedState::TLevelPosition>(&yieldedState.Position)) {
+                if (addToLevel0) {
+                    expected = levelPosition->Level == 0 &&
+                        spec.Id > std::get<typename TYieldedState::TLevelPosition::
+                            TUnsortedLevelDiscriminator>(levelPosition->Discriminator);
+                } else if (levelPosition->Level == 0) {
+                    expected = true;
+                } else {
+                    expected = std::get<typename TYieldedState::TLevelPosition::
+                        TSortedLevelDiscriminator>(levelPosition->Discriminator) <
+                        spec.Keys.front();
+                }
+            }
+
+            for (const TKey& key : spec.Keys) {
+                UNIT_ASSERT_C(AllKeys.insert(key).second, "duplicate generated key");
+                if (expected) {
+                    ExpectedKeys.insert(key);
+                }
+            }
+            (addToLevel0 ? Level0 : SortedLevel).push_back(std::move(spec));
+            ++SstsAdded;
+        }
+
+        bool IsFullySeen(const TSstSpec& spec) const {
+            return std::all_of(spec.Keys.begin(), spec.Keys.end(), [this](const TKey& key) {
+                return SeenKeys && SeenKeys->contains(key);
+            });
+        }
+
+        bool IsFullyPending(const TSstSpec& spec) const {
+            return std::all_of(spec.Keys.begin(), spec.Keys.end(), [this](const TKey& key) {
+                return ExpectedKeys.contains(key) && (!SeenKeys || !SeenKeys->contains(key));
+            });
+        }
+
+        TVector<std::pair<TVector<TSstSpec>*, size_t>> GetMutableSstCandidates() {
+            TVector<std::pair<TVector<TSstSpec>*, size_t>> candidates;
+            auto collect = [this, &candidates](TVector<TSstSpec>& specs) {
+                for (size_t idx = 0; idx < specs.size(); ++idx) {
+                    if (IsFullySeen(specs[idx]) || IsFullyPending(specs[idx])) {
+                        candidates.emplace_back(&specs, idx);
+                    }
+                }
+            };
+            collect(Level0);
+            collect(SortedLevel);
+            return candidates;
+        }
+
+        void RemoveSst(TReallyFastRng32& rng) {
+            auto candidates = GetMutableSstCandidates();
+            if (candidates.empty()) {
+                return;
+            }
+            auto [specs, idx] = candidates[rng() % candidates.size()];
+            if (IsFullyPending((*specs)[idx])) {
+                for (const TKey& key : (*specs)[idx].Keys) {
+                    ExpectedKeys.erase(key);
+                }
+            }
+            specs->erase(specs->begin() + idx);
+            ++SstsRemoved;
+        }
+
+        void AddKeyToSst(TReallyFastRng32& rng) {
+            auto candidates = GetMutableSstCandidates();
+            if (candidates.empty()) {
+                return;
+            }
+            auto [specs, idx] = candidates[rng() % candidates.size()];
+            TSstSpec& spec = (*specs)[idx];
+            const bool pending = IsFullyPending(spec);
+
+            size_t gapIdx = rng() % (spec.Keys.size() - 1);
+            ui32 step = spec.Keys[gapIdx].LogoBlobID().Step() + 1;
+            while (AllKeys.contains(MakeKey(step))) {
+                ++step;
+            }
+            UNIT_ASSERT_C(MakeKey(step) < spec.Keys[gapIdx + 1], "SST key gap exhausted");
+
+            const TKey key = MakeKey(step);
+            UNIT_ASSERT(AllKeys.insert(key).second);
+            spec.Keys.push_back(key);
+            Sort(spec.Keys);
+            if (pending) {
+                ExpectedKeys.insert(key);
+            }
+            ++SstKeysAdded;
+        }
+
+        void RemoveKeyFromSst(TReallyFastRng32& rng) {
+            auto candidates = GetMutableSstCandidates();
+            candidates.erase(std::remove_if(candidates.begin(), candidates.end(), [](const auto& candidate) {
+                return (*candidate.first)[candidate.second].Keys.size() < 2;
+            }), candidates.end());
+            if (candidates.empty()) {
+                return;
+            }
+            auto [specs, idx] = candidates[rng() % candidates.size()];
+            TSstSpec& spec = (*specs)[idx];
+            const size_t keyIdx = 1 + rng() % (spec.Keys.size() - 1);
+            const TKey key = spec.Keys[keyIdx];
+            if (!SeenKeys || !SeenKeys->contains(key)) {
+                ExpectedKeys.erase(key);
+            }
+            spec.Keys.erase(spec.Keys.begin() + keyIdx);
+            ++SstKeysRemoved;
+        }
+
+    public:
+        void SetSeenKeys(const TSet<TKey>& seenKeys) {
+            SeenKeys = &seenKeys;
+        }
+
+    private:
+        TTestContexts Contexts;
+        std::shared_ptr<TRopeArena> Arena;
+        TIntrusivePtr<TLogoBlobsLevelIndex> Index;
+        TVector<TSstSpec> Level0;
+        TVector<TSstSpec> SortedLevel;
+        TSet<TKey> AllKeys;
+        TSet<TKey> ExpectedKeys;
+        const TSet<TKey>* SeenKeys = nullptr;
+        ui64 NextLsn = 1;
+        ui64 NextLevel0Id = 0;
+        ui32 NextLateFreshStep = 1'500;
+        ui32 NextLevel0Step = 10'000;
+        ui32 NextSortedStep = 20'000;
+        ui32 FreshKeysAdded = 0;
+        ui32 SstsAdded = 0;
+        ui32 SstsRemoved = 0;
+        ui32 SstKeysAdded = 0;
+        ui32 SstKeysRemoved = 0;
+    };
+
+    struct TCollectingAggregator {
+        TSet<TKey>& SeenKeys;
+        TManualMonotonicTimeProviderForTraverse& TimeProvider;
+        bool Finished = false;
+
+        void UpdateFresh(const char*, const TKey& key, const TMemRec&) {
+            Update(key);
+        }
+
+        void UpdateLevel(const TLogoBlobsLevelSegment::TLevelSstPtr&, const TKey& key, const TMemRec&) {
+            Update(key);
+        }
+
+        void Finish() {
+            Finished = true;
+        }
+
+    private:
+        void Update(const TKey& key) {
+            UNIT_ASSERT_C(SeenKeys.insert(key).second,
+                TStringBuilder() << "duplicate key during resumed traversal: " << key.ToString());
+            TimeProvider.Advance(TDuration::MilliSeconds(1));
+        }
+    };
+
+    Y_UNIT_TEST_SUITE(TTraverseDbWithoutMergeTest) {
+        Y_UNIT_TEST(RandomizedMutationDuringTraversal) {
+            constexpr ui32 Seed = 0x51a7e;
+            constexpr ui32 MaxQuanta = 500;
+            TRandomizedLogoBlobsBase database;
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProviderForTraverse>();
+            TSet<TKey> seenKeys;
+            database.SetSeenKeys(seenKeys);
+            TCollectingAggregator aggregator{seenKeys, *timeProvider};
+            std::optional<TYieldedState> yieldedState;
+            TReallyFastRng32 rng(Seed);
+            ui32 quanta = 0;
+            ui32 yields = 0;
+
+            for (; quanta < MaxQuanta;) {
+                ++quanta;
+                auto snapshot = database.GetSnapshot();
+                yieldedState = TraverseDbWithoutMerge(
+                    database.GetHullCtx(),
+                    &aggregator,
+                    snapshot,
+                    std::move(yieldedState),
+                    TDbStatYieldPolicy{
+                        .StepsBeforeMeasures = 4,
+                        .QuantDuration = TDuration::MilliSeconds(3),
+                        .DelayBetweenQuants = TDuration::Zero(),
+                    },
+                    timeProvider);
+                snapshot.Destroy();
+
+                if (!yieldedState) {
+                    break;
+                }
+
+                ++yields;
+                if (yields <= 80) {
+                    database.Mutate(*yieldedState, rng);
+                }
+            }
+
+            database.PrintStatistics(Seed, quanta, yields, seenKeys.size());
+            UNIT_ASSERT_C(!yieldedState, "traversal did not finish");
+            UNIT_ASSERT_C(aggregator.Finished, "aggregator was not finished");
+            UNIT_ASSERT_C(yields > 10, "traversal did not yield often enough");
+            UNIT_ASSERT(seenKeys == database.GetExpectedKeys());
+            database.AssertAllMutationKindsWereUsed();
+        }
+    }
+
+#undef Ctest
+
+} // anonymous namespace
+} // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -428,8 +428,9 @@ namespace {
             AddSst(1, 0, {2'100, 2'110});
             AddSst(2, 0, {3'000, 3'010});
             AddSst(2, 0, {3'100, 3'110});
-            AddSst(3, 0, {4'000, 4'010});
-            AddSst(3, 0, {4'100, 4'110});
+            // Singleton SSTs ensure yielding also works at an SST boundary.
+            AddSst(3, 0, {4'000});
+            AddSst(3, 0, {4'100});
         }
 
         TIntrusivePtr<THullCtx> GetHullCtx() {
@@ -442,7 +443,7 @@ namespace {
 
         static TVector<ui32> GetExpectedSteps() {
             return {
-                4'110, 4'100, 4'010, 4'000,
+                4'100, 4'000,
                 3'110, 3'100, 3'010, 3'000,
                 2'110, 2'100, 2'010, 2'000,
                 1'110, 1'100, 1'010, 1'000,

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -20,7 +20,7 @@ namespace {
     using TMemRec = TMemRecLogoBlob;
     using TLogoBlobsLevelIndex = ::NKikimr::TLevelIndex<TKey, TMemRec>;
     using TLogoBlobsLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
-    using TYieldedState = TDbStatYeildedState<TKey, TMemRec>;
+    using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
 
     TKey MakeKey(ui32 step) {
         return TKey(TLogoBlobID(1, 1, step, 0, 0, 0));

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -417,8 +417,8 @@ namespace {
                     std::move(yieldedState),
                     TDbStatYieldPolicy{
                         .StepsBeforeMeasures = 4,
-                        .QuantDuration = TDuration::MilliSeconds(3),
-                        .DelayBetweenQuants = TDuration::Zero(),
+                        .QuantumDuration = TDuration::MilliSeconds(3),
+                        .DelayBetweenQuanta = TDuration::Zero(),
                     },
                     timeProvider);
                 snapshot.Destroy();

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -204,7 +204,7 @@ namespace {
             const auto* freshPosition =
                 std::get_if<typename TYieldedState::TFreshPosition>(&yieldedState.Position);
             ui32 step = NextLateFreshStep++;
-            bool expected = false;
+            bool expected = true;
             if (freshPosition) {
                 const ui32 resumeStep = freshPosition->Key.LogoBlobID().Step();
                 const bool addAfterResumePosition = rng() % 2;
@@ -212,7 +212,8 @@ namespace {
                 while (AllKeys.contains(MakeKey(step))) {
                     step += addAfterResumePosition ? 1 : -1;
                 }
-                expected = !(MakeKey(step) < freshPosition->Key);
+                expected = freshPosition->Segment != TYieldedState::EFreshSegment::Cur ||
+                    !(freshPosition->Key < MakeKey(step));
             }
             PutFresh(MakeKey(step), expected);
             ++FreshKeysAdded;
@@ -229,20 +230,19 @@ namespace {
                 NextSortedStep += 100;
             }
 
-            bool expected = std::holds_alternative<typename TYieldedState::TFreshPosition>(
-                yieldedState.Position);
+            bool expected = false;
             if (const auto* levelPosition =
                     std::get_if<typename TYieldedState::TLevelPosition>(&yieldedState.Position)) {
                 if (addToLevel0) {
-                    expected = levelPosition->Level == 0 &&
-                        spec.Id > std::get<typename TYieldedState::TLevelPosition::
-                            TUnsortedLevelDiscriminator>(levelPosition->Discriminator);
-                } else if (levelPosition->Level == 0) {
-                    expected = true;
+                    expected = levelPosition->Level > 0 ||
+                        (levelPosition->Level == 0 &&
+                            spec.Id < std::get<typename TYieldedState::TLevelPosition::
+                                TUnsortedLevelDiscriminator>(levelPosition->Discriminator));
                 } else {
-                    expected = std::get<typename TYieldedState::TLevelPosition::
-                        TSortedLevelDiscriminator>(levelPosition->Discriminator) <
-                        spec.Keys.front();
+                    expected = levelPosition->Level > 1 ||
+                        (levelPosition->Level == 1 &&
+                            spec.Keys.front() < std::get<typename TYieldedState::TLevelPosition::
+                                TSortedLevelDiscriminator>(levelPosition->Discriminator));
                 }
             }
 
@@ -393,7 +393,194 @@ namespace {
         }
     };
 
+    class TReverseTraversalLogoBlobsBase {
+    public:
+        TReverseTraversalLogoBlobsBase()
+            : Contexts(1)
+            , Settings(
+                Contexts.GetHullCtx(),
+                8,
+                64u << 20u,
+                FreshCompactionThreshold(),
+                TDuration::Minutes(10),
+                10,
+                true,
+                false)
+            , Arena(std::make_shared<TRopeArena>(&TRopeArenaBackend::Allocate))
+            , Index(MakeIntrusive<TLogoBlobsLevelIndex>(Settings, Arena))
+        {
+            for (ui32 level = 1; level <= 3; ++level) {
+                Index->CurSlice->SortedLevels.emplace_back(TKey());
+            }
+            Index->LoadCompleted();
+
+            // The low fresh-compaction threshold moves these first two records to
+            // Dreg. Starting a compaction then moves them to Old and the next two
+            // records to Dreg, leaving a new Cur for the final pair.
+            PutFresh({100, 110});
+            PutFresh({200, 210});
+            Index->FindFreshSegmentForCompaction();
+            PutFresh({300, 310});
+
+            AddSst(0, 1, {1'000, 1'010});
+            AddSst(0, 2, {1'100, 1'110});
+            AddSst(1, 0, {2'000, 2'010});
+            AddSst(1, 0, {2'100, 2'110});
+            AddSst(2, 0, {3'000, 3'010});
+            AddSst(2, 0, {3'100, 3'110});
+            AddSst(3, 0, {4'000, 4'010});
+            AddSst(3, 0, {4'100, 4'110});
+        }
+
+        TIntrusivePtr<THullCtx> GetHullCtx() {
+            return Contexts.GetHullCtx();
+        }
+
+        TLevelIndexSnapshot<TKey, TMemRec> GetSnapshot() {
+            return Index->GetIndexSnapshot();
+        }
+
+        static TVector<ui32> GetExpectedSteps() {
+            return {
+                4'110, 4'100, 4'010, 4'000,
+                3'110, 3'100, 3'010, 3'000,
+                2'110, 2'100, 2'010, 2'000,
+                1'110, 1'100, 1'010, 1'000,
+                110, 100,
+                210, 200,
+                310, 300,
+            };
+        }
+
+    private:
+        static constexpr ui64 FreshCompactionThreshold() {
+            constexpr ui64 recordSize = sizeof(TKey) + sizeof(TMemRec);
+            return sizeof(TIdxDiskPlaceHolder) + recordSize + recordSize / 2;
+        }
+
+        void PutFresh(std::initializer_list<ui32> steps) {
+            for (ui32 step : steps) {
+                Index->PutToFresh(NextLsn++, MakeKey(step), TMemRec());
+            }
+        }
+
+        void AddSst(ui32 level, ui64 id, std::initializer_list<ui32> steps) {
+            TTrackableVector<TLogoBlobsLevelSegment::TRec> records(
+                TMemoryConsumer(Contexts.GetVCtx()->SstIndex));
+            for (ui32 step : steps) {
+                records.emplace_back(MakeKey(step), TMemRec());
+            }
+
+            auto sst = MakeIntrusive<TLogoBlobsLevelSegment>(Contexts.GetVCtx());
+            sst->LoadLinearIndex(records);
+            sst->VolatileOrderId = id;
+            if (level == 0) {
+                Index->CurSlice->Level0.Put(sst);
+            } else {
+                Index->CurSlice->SortedLevels[level - 1].Put(sst);
+            }
+        }
+
+    private:
+        TTestContexts Contexts;
+        TLevelIndexSettings Settings;
+        std::shared_ptr<TRopeArena> Arena;
+        TIntrusivePtr<TLogoBlobsLevelIndex> Index;
+        ui64 NextLsn = 1;
+    };
+
+    struct TOrderedCollectingAggregator {
+        TVector<ui32>& SeenSteps;
+        TSet<TKey>& SeenKeys;
+        TSet<TString>& SeenSources;
+        TManualMonotonicTimeProviderForTraverse& TimeProvider;
+        bool Finished = false;
+
+        void UpdateFresh(const char* segmentName, const TKey& key, const TMemRec&) {
+            SeenSources.insert(segmentName);
+            Update(key);
+        }
+
+        void UpdateLevel(const TLogoBlobsLevelSegment::TLevelSstPtr& levelSstPtr,
+                const TKey& key, const TMemRec&) {
+            SeenSources.insert(TStringBuilder() << "L" << levelSstPtr.Level);
+            Update(key);
+        }
+
+        void Finish() {
+            Finished = true;
+        }
+
+    private:
+        void Update(const TKey& key) {
+            UNIT_ASSERT_C(SeenKeys.insert(key).second,
+                TStringBuilder() << "duplicate key during resumed traversal: " << key.ToString());
+            SeenSteps.push_back(key.LogoBlobID().Step());
+            TimeProvider.Advance(TDuration::MilliSeconds(1));
+        }
+    };
+
     Y_UNIT_TEST_SUITE(TTraverseDbWithoutMergeTest) {
+        Y_UNIT_TEST(ReverseTraversalWithYieldsVisitsEveryKeyOnce) {
+            constexpr ui32 MaxQuanta = 100;
+            TReverseTraversalLogoBlobsBase database;
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProviderForTraverse>();
+            TVector<ui32> seenSteps;
+            TSet<TKey> seenKeys;
+            TSet<TString> seenSources;
+            TSet<TString> yieldedSources;
+            TOrderedCollectingAggregator aggregator{
+                seenSteps,
+                seenKeys,
+                seenSources,
+                *timeProvider,
+            };
+            std::optional<TYieldedState> yieldedState;
+            ui32 yields = 0;
+
+            for (ui32 quantum = 0; quantum < MaxQuanta; ++quantum) {
+                auto snapshot = database.GetSnapshot();
+                yieldedState = TraverseDbWithoutMerge(
+                    database.GetHullCtx(),
+                    &aggregator,
+                    snapshot,
+                    std::move(yieldedState),
+                    TDbStatYieldPolicy{
+                        .StepsBeforeMeasures = 1,
+                        .QuantumDuration = TDuration::Zero(),
+                        .DelayBetweenQuanta = TDuration::Zero(),
+                    },
+                    timeProvider);
+                snapshot.Destroy();
+
+                if (!yieldedState) {
+                    break;
+                }
+                if (const auto* freshPosition =
+                        std::get_if<TYieldedState::TFreshPosition>(&yieldedState->Position)) {
+                    const char* freshNames[] = {"FCur", "FDreg", "FOld"};
+                    yieldedSources.insert(freshNames[static_cast<size_t>(freshPosition->Segment)]);
+                } else {
+                    const auto& levelPosition =
+                        std::get<TYieldedState::TLevelPosition>(yieldedState->Position);
+                    yieldedSources.insert(TStringBuilder() << "L" << levelPosition.Level);
+                }
+                ++yields;
+            }
+
+            const TVector<ui32> expectedSteps = database.GetExpectedSteps();
+            const TSet<TString> expectedSources = {
+                "FCur", "FDreg", "FOld", "L0", "L1", "L2", "L3",
+            };
+            UNIT_ASSERT_C(!yieldedState, "traversal did not finish");
+            UNIT_ASSERT_C(aggregator.Finished, "aggregator was not finished");
+            UNIT_ASSERT_C(yields > 0, "traversal did not yield");
+            UNIT_ASSERT_C(seenSteps == expectedSteps, "keys were not visited in reverse order");
+            UNIT_ASSERT_VALUES_EQUAL(seenKeys.size(), expectedSteps.size());
+            UNIT_ASSERT(seenSources == expectedSources);
+            UNIT_ASSERT(yieldedSources == expectedSources);
+        }
+
         Y_UNIT_TEST(RandomizedMutationDuringTraversal) {
             constexpr ui32 Seed = 0x51a7e;
             constexpr ui32 MaxQuanta = 500;

--- a/ydb/core/blobstorage/vdisk/query/ut/ya.make
+++ b/ydb/core/blobstorage/vdisk/query/ut/ya.make
@@ -10,6 +10,8 @@ PEERDIR(
 
 SRCS(
     query_spacetracker_ut.cpp
+    query_statalgo_ut.cpp
+    query_stat_yield_ut.cpp
 )
 
 END()

--- a/ydb/core/blobstorage/vdisk/query/ya.make
+++ b/ydb/core/blobstorage/vdisk/query/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     ydb/core/blobstorage/base
     ydb/core/blobstorage/vdisk/hulldb/barriers
     ydb/core/blobstorage/vdisk/hulldb/base
+    ydb/core/util
 )
 
 SRCS(
@@ -25,6 +26,7 @@ SRCS(
     query_readbatch.h
     query_spacetracker.h
     query_statalgo.h
+    query_stat_yield.h
     query_statdb.cpp
     query_statdb.h
     query_stathuge.cpp

--- a/ydb/core/blobstorage/vdisk/repl/blobstorage_hullrepljob.cpp
+++ b/ydb/core/blobstorage/vdisk/repl/blobstorage_hullrepljob.cpp
@@ -5,7 +5,7 @@
 #include <ydb/core/blobstorage/vdisk/hulldb/bulksst_add/hulldb_bulksst_add.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_partlayout.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <util/datetime/cputimer.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT BS_REPL

--- a/ydb/core/blobstorage/vdisk/scrub/defs.h
+++ b/ydb/core/blobstorage/vdisk/scrub/defs.h
@@ -6,7 +6,7 @@
 #include <ydb/core/blobstorage/vdisk/common/vdisk_pdiskctx.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_lsnmngr.h>
 #include <ydb/core/blobstorage/vdisk/common/blobstorage_dblogcutter.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <ydb/core/blobstorage/base/blobstorage_events.h>
 #include <ydb/core/blobstorage/groupinfo/blobstorage_groupinfo_sets.h>
 #include <ydb/core/blobstorage/backpressure/queue_backpressure_client.h>

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_monactors.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_monactors.cpp
@@ -883,7 +883,7 @@ namespace NKikimr {
         }
 
         struct TMessage {
-            bool Error;                 // was an error?
+            bool Error;                         // was an error?
             std::unique_ptr<IEventBase> Msg;    // in case of error contains reply, or a request to VDisk otherwise
         };
 

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -1442,7 +1442,7 @@ namespace NKikimr {
                 IActor *actor = CreateDbStatActor(HullCtx, HugeBlobCtx, ctx, std::move(fullSnap),
                         ctx.SelfID, ev, std::move(result));
                 if (actor) {
-                    auto aid = ctx.Register(actor);
+                    auto aid = RunInBatchPool(ctx, actor);
                     ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
                 }
                 // CreateDbStatActor is responsible for sending result to the recipient
@@ -1460,7 +1460,7 @@ namespace NKikimr {
             IActor *actor = CreateDbStatActor(HullCtx, HugeBlobCtx, ctx, std::move(fullSnap),
                     ctx.SelfID, ev, std::move(result));
             if (actor) {
-                auto aid = ctx.Register(actor);
+                auto aid = RunInBatchPool(ctx, actor);
                 ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
             }
         }

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -4,7 +4,7 @@
 #include "blobstorage_db.h"
 #include "blobstorage_syncfullhandler.h"
 #include "blobstorage_monactors.h"
-#include "blobstorage_takedbsnap.h"
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include "skeleton_loggedrec.h"
 #include "skeleton_vmultiput_actor.h"
 #include "skeleton_vmovedpatch_actor.h"

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h
@@ -1,36 +1,3 @@
 #pragma once
 
-#include "defs.h"
-#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
-
-namespace NKikimr {
-
-
-    ////////////////////////////////////////////////////////////////////////////
-    // TEvTakeHullSnapshot
-    // Take snapshot of local (Hull) database
-    ////////////////////////////////////////////////////////////////////////////
-    struct TEvTakeHullSnapshot :
-        public TEventLocal<TEvTakeHullSnapshot, TEvBlobStorage::EvTakeHullSnapshot>
-    {
-        const bool Index;
-
-        TEvTakeHullSnapshot(bool index)
-            : Index(index)
-        {}
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    // TEvTakeHullSnapshotResult
-    ////////////////////////////////////////////////////////////////////////////
-    struct TEvTakeHullSnapshotResult :
-        public TEventLocal<TEvTakeHullSnapshotResult, TEvBlobStorage::EvTakeHullSnapshot>
-    {
-        THullDsSnap Snap;
-
-        TEvTakeHullSnapshotResult(THullDsSnap &&snap)
-            : Snap(std::move(snap))
-        {}
-    };
-
-} // NKikimr
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>

--- a/ydb/core/blobstorage/vdisk/skeleton/skeleton_shred.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/skeleton_shred.cpp
@@ -2,7 +2,7 @@
 #include <ydb/core/blobstorage/vdisk/common/vdisk_private_events.h>
 #include <ydb/core/blobstorage/vdisk/huge/blobstorage_hullhuge.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/generic/hullds_idxsnap.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT BS_SHRED
 

--- a/ydb/core/blobstorage/vdisk/skeleton/ya.make
+++ b/ydb/core/blobstorage/vdisk/skeleton/ya.make
@@ -25,7 +25,6 @@ SRCS(
     blobstorage_syncfull.h
     blobstorage_syncfullhandler.cpp
     blobstorage_syncfullhandler.h
-    blobstorage_takedbsnap.h
     skeleton_block_and_get.cpp
     skeleton_block_and_get.h
     skeleton_capturevdisklayout.h

--- a/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_builder.cpp
+++ b/ydb/core/blobstorage/vdisk/synclog/phantom_flag_storage/phantom_flag_storage_builder.cpp
@@ -3,7 +3,7 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <ydb/core/blobstorage/pdisk/blobstorage_pdisk.h>
-#include <ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_context.h>
 #include <ydb/core/blobstorage/vdisk/synclog/blobstorage_synclog_private_events.h>
 

--- a/ydb/core/util/actor_monotonic_time_provider.cpp
+++ b/ydb/core/util/actor_monotonic_time_provider.cpp
@@ -14,6 +14,9 @@ namespace NKikimr {
     }
 
     TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> CreateActorSystemMonotonicTimeProvider() {
+        if (!NActors::TlsActivationContext) {
+            return NMonotonic::CreateDefaultMonotonicTimeProvider();
+        }
         return MakeIntrusive<TActorSystemMonotonicTimeProvider>();
     }
 

--- a/ydb/core/util/actor_monotonic_time_provider.cpp
+++ b/ydb/core/util/actor_monotonic_time_provider.cpp
@@ -1,0 +1,20 @@
+#include "actor_monotonic_time_provider.h"
+
+#include <ydb/library/actors/core/actor.h>
+
+namespace NKikimr {
+
+    namespace {
+        class TActorSystemMonotonicTimeProvider: public NMonotonic::IMonotonicTimeProvider {
+        public:
+            TMonotonic Now() override {
+                return NActors::TActivationContext::Monotonic();
+            }
+        };
+    }
+
+    TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> CreateActorSystemMonotonicTimeProvider() {
+        return MakeIntrusive<TActorSystemMonotonicTimeProvider>();
+    }
+
+} // namespace NKikimr

--- a/ydb/core/util/actor_monotonic_time_provider.h
+++ b/ydb/core/util/actor_monotonic_time_provider.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/library/actors/core/monotonic_provider.h>
+
+namespace NKikimr {
+
+    TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> CreateActorSystemMonotonicTimeProvider();
+
+} // namespace NKikimr

--- a/ydb/core/util/ya.make
+++ b/ydb/core/util/ya.make
@@ -3,6 +3,8 @@ LIBRARY()
 SRCS(
     activeactors.h
     address_classifier.cpp
+    actor_monotonic_time_provider.cpp
+    actor_monotonic_time_provider.h
     backoff.cpp
     cache.cpp
     cache.h


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Traverse VDisk DB with periodic yielding and recapturing snapshots for statistic calculation

### Changelog category <!-- remove all except one -->

* Improvement