### PR TITLE
Quickfix for TWrittenPortionInfo::CommitSnapshot data race.

### DIFF
--- a/ydb/core/tx/columnshard/engines/portions/constructor_portion.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/constructor_portion.cpp
@@ -62,7 +62,7 @@ ISnapshotSchema::TPtr TPortionInfoConstructor::GetSchema(const TVersionedIndex& 
 std::shared_ptr<TPortionInfo> TWrittenPortionInfoConstructor::BuildPortionImpl(TPortionMeta&& meta) {
     auto result = std::make_shared<TWrittenPortionInfo>(std::move(meta));
     if (CommitSnapshot) {
-        result->CommitSnapshot = *CommitSnapshot;
+        result->CommitSnapshot.Set(*CommitSnapshot);
     }
     AFL_VERIFY(InsertWriteId);
     result->InsertWriteId = *InsertWriteId;

--- a/ydb/core/tx/columnshard/engines/portions/written.cpp
+++ b/ydb/core/tx/columnshard/engines/portions/written.cpp
@@ -11,13 +11,14 @@ void TWrittenPortionInfo::DoSaveMetaToDatabase(const std::vector<TUnifiedBlobId>
     auto metaProto = GetMeta().SerializeToProto(blobIds, NPortion::EProduced::INSERTED);
     using IndexPortions = NColumnShard::Schema::IndexPortions;
     const auto removeSnapshot = GetRemoveSnapshotOptional();
+    const auto commitSnapshot = GetCommitSnapshotOptional();
     AFL_VERIFY(InsertWriteId);
     db.Table<IndexPortions>()
         .Key(GetPathId().GetRawValue(), GetPortionId())
         .Update(NIceDb::TUpdate<IndexPortions::SchemaVersion>(GetSchemaVersionVerified()),
             NIceDb::TUpdate<IndexPortions::ShardingVersion>(GetShardingVersionDef(0)),
-            NIceDb::TUpdate<IndexPortions::CommitPlanStep>(CommitSnapshot ? CommitSnapshot->GetPlanStep() : 0),
-            NIceDb::TUpdate<IndexPortions::CommitTxId>(CommitSnapshot ? CommitSnapshot->GetTxId() : 0),
+            NIceDb::TUpdate<IndexPortions::CommitPlanStep>(commitSnapshot ? commitSnapshot->GetPlanStep() : 0),
+            NIceDb::TUpdate<IndexPortions::CommitTxId>(commitSnapshot ? commitSnapshot->GetTxId() : 0),
             NIceDb::TUpdate<IndexPortions::InsertWriteId>((ui64)*InsertWriteId),
             NIceDb::TUpdate<IndexPortions::XPlanStep>(removeSnapshot ? removeSnapshot->GetPlanStep() : 0),
             NIceDb::TUpdate<IndexPortions::XTxId>(removeSnapshot ? removeSnapshot->GetTxId() : 0),
@@ -31,8 +32,8 @@ std::unique_ptr<TPortionInfoConstructor> TWrittenPortionInfo::BuildConstructor(c
 
 void TWrittenPortionInfo::FillDefaultColumn(NAssembling::TColumnAssemblingInfo& column, const std::optional<TSnapshot>& defaultSnapshot) const {
     TSnapshot defaultSnapshotLocal = TSnapshot::Max();
-    if (CommitSnapshot) {
-        defaultSnapshotLocal = *CommitSnapshot;
+    if (CommitSnapshot.Has()) {
+        defaultSnapshotLocal = CommitSnapshot.Get();
     } else if (defaultSnapshot) {
         defaultSnapshotLocal = *defaultSnapshot;
     }
@@ -61,8 +62,8 @@ bool TWrittenPortionInfo::DoIsVisible(const TSnapshot& snapshot, const bool chec
     if (!checkCommitSnapshot) {
         return true;
     }
-    if (CommitSnapshot) {
-        return *CommitSnapshot <= snapshot;
+    if (CommitSnapshot.Has()) {
+        return CommitSnapshot.Get() <= snapshot;
     } else {
         return false;
     }
@@ -70,13 +71,13 @@ bool TWrittenPortionInfo::DoIsVisible(const TSnapshot& snapshot, const bool chec
 
 bool TWrittenPortionInfo::MayGetForScanAt(const TSnapshot& snapshot) const {
     // aborted portion, in fact, never existed, so there is no point to take it for scan
-    bool aborted = HasRemoveSnapshot() && CommitSnapshot.has_value() && GetRemoveSnapshotVerified() <= CommitSnapshot.value();
+    bool aborted = HasRemoveSnapshot() && HasCommitSnapshot() && GetRemoveSnapshotVerified() <= GetCommitSnapshotVerified();
     return !aborted && !IsRemovedFor(snapshot);
 }
 
 void TWrittenPortionInfo::CommitToDatabase(IDbWrapper& wrapper) {
-    AFL_VERIFY(CommitSnapshot);
-    wrapper.CommitPortion(*this, *CommitSnapshot);
+    AFL_VERIFY(HasCommitSnapshot());
+    wrapper.CommitPortion(*this, CommitSnapshot.Get());
 }
 
 }   // namespace NKikimr::NOlap

--- a/ydb/core/tx/columnshard/engines/portions/written.h
+++ b/ydb/core/tx/columnshard/engines/portions/written.h
@@ -11,7 +11,7 @@ class IDbWrapper;
 class TWrittenPortionInfo: public TPortionInfo {
 private:
     using TBase = TPortionInfo;
-    std::optional<TSnapshot> CommitSnapshot;
+    TThreadSafeOptional<TSnapshot> CommitSnapshot;
     std::optional<TInsertWriteId> InsertWriteId;
     friend class TWrittenPortionInfoConstructor;
 
@@ -29,8 +29,8 @@ private:
 
     virtual TString DoDebugString(const bool /*withDetails*/) const override {
         TStringBuilder sb;
-        if (CommitSnapshot) {
-            sb << "cs:" << CommitSnapshot->DebugString() << ";";
+        if (CommitSnapshot.Has()) {
+            sb << "cs:" << CommitSnapshot.Get().DebugString() << ";";
         }
         if (InsertWriteId) {
             sb << "wi:" << (ui64)*InsertWriteId << ";";
@@ -86,20 +86,20 @@ public:
     }
 
     bool HasCommitSnapshot() const {
-        return !!CommitSnapshot;
+        return CommitSnapshot.Has();
     }
 
     virtual bool IsCommitted() const override {
-        return !!CommitSnapshot;
+        return CommitSnapshot.Has();
     }
 
     const TSnapshot& GetCommitSnapshotVerified() const {
-        AFL_VERIFY(!!CommitSnapshot);
-        return *CommitSnapshot;
+        AFL_VERIFY(HasCommitSnapshot());
+        return CommitSnapshot.Get();
     }
 
-    const std::optional<TSnapshot>& GetCommitSnapshotOptional() const {
-        return CommitSnapshot;
+    std::optional<TSnapshot> GetCommitSnapshotOptional() const {
+        return CommitSnapshot.GetOptional();
     }
 
     TInsertWriteId GetInsertWriteId() const {
@@ -109,14 +109,14 @@ public:
 
     void SetCommitSnapshot(const TSnapshot& value) {
         AFL_VERIFY(!!InsertWriteId);
-        AFL_VERIFY(!CommitSnapshot);
+        AFL_VERIFY(!HasCommitSnapshot());
         AFL_VERIFY(value.Valid());
-        CommitSnapshot = value;
+        CommitSnapshot.Set(value);
     }
 
     virtual const TSnapshot& RecordSnapshotMin(const std::optional<TSnapshot>& snapshotDefault = std::nullopt) const override {
-        if (CommitSnapshot) {
-            return *CommitSnapshot;
+        if (CommitSnapshot.Has()) {
+            return CommitSnapshot.Get();
         } else {
             AFL_VERIFY(snapshotDefault);
             return *snapshotDefault;
@@ -124,8 +124,8 @@ public:
     }
 
     virtual const TSnapshot& RecordSnapshotMax(const std::optional<TSnapshot>& snapshotDefault = std::nullopt) const override {
-        if (CommitSnapshot) {
-            return *CommitSnapshot;
+        if (CommitSnapshot.Has()) {
+            return CommitSnapshot.Get();
         } else {
             AFL_VERIFY(snapshotDefault);
             return *snapshotDefault;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fix for thread sanitizer issue #47618. A proper fix would be a much bigger rework described in #27205
