### PR TITLE
LOGBROKER-10554 support content based deduplication in pqv1

### DIFF
--- a/ydb/public/api/protos/ydb_persqueue_v1.proto
+++ b/ydb/public/api/protos/ydb_persqueue_v1.proto
@@ -1242,6 +1242,9 @@ message TopicSettings {
     int64 max_partition_write_messages_speed = 17 [(value) = ">= 0"];
     // Max partition write messages burst in messages. Must be less than database limit. Default burst size - 1 Mi messages.
     int64 max_partition_write_messages_burst = 18 [(value) = ">= 0"];
+
+    // Enable content-based deduplication for the topic.
+    bool content_based_deduplication = 19;
 }
 
 message AutoPartitioningSettings {

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/common.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/common.cpp
@@ -324,6 +324,7 @@ TResult ApplyChangesInt( // create and alter
         return {Ydb::StatusIds::BAD_REQUEST, std::move(error)};
     }
     pqTabletConfig->SetFormatVersion(settings.supported_format() - 1);
+    pqTabletConfig->SetContentBasedDeduplication(settings.content_based_deduplication());
 
     auto ct = pqTabletConfig->MutableCodecs();
     if (settings.supported_codecs().size() > NPQ::MAX_SUPPORTED_CODECS_COUNT) {

--- a/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/pqv1/create_topic_ut.cpp
@@ -177,6 +177,37 @@ Y_UNIT_TEST(CreateTopicWithNameEqDB) {
     UNIT_ASSERT_VALUES_EQUAL_C(*status, Ydb::StatusIds::SCHEME_ERROR, result->Issues.ToString());
 }
 
+Y_UNIT_TEST(ContentBasedDeduplication) {
+    auto setup = CreateSetup();
+    auto& runtime = setup->GetRuntime();
+    runtime.GetAppData().PQConfig.SetTopicsAreFirstClassCitizen(true);
+
+    Ydb::PersQueue::V1::CreateTopicRequest request;
+    request.set_path("/Root/test_db/topic1");
+
+    auto& settings = *request.mutable_settings();
+    settings.set_partitions_count(1);
+    settings.set_supported_format(Ydb::PersQueue::V1::TopicSettings::FORMAT_BASE);
+    settings.set_retention_period_ms(TDuration::Days(1).MilliSeconds());
+    settings.set_content_based_deduplication(true);
+
+    auto result = DoRequest<Ydb::PersQueue::V1::CreateTopicRequest, Ydb::PersQueue::V1::CreateTopicResponse>(runtime, request);
+
+    auto status = result->ResultStatus;
+    UNIT_ASSERT(status);
+    UNIT_ASSERT_VALUES_EQUAL_C(*status, Ydb::StatusIds::SUCCESS, result->Issues.ToString());
+
+    runtime.Register(NPQ::NDescriber::CreateDescriberActor(runtime.AllocateEdgeActor(), "/Root/test_db", {"/Root/test_db/topic1"}));
+    auto response = runtime.GrabEdgeEvent<NPQ::NDescriber::TEvDescribeTopicsResponse>(TDuration::Seconds(5));
+
+    UNIT_ASSERT_VALUES_EQUAL(response->Topics.size(), 1);
+    auto topic = response->Topics.begin()->second;
+    UNIT_ASSERT_VALUES_EQUAL(topic.Status, NPQ::NDescriber::EStatus::SUCCESS);
+
+    auto config = topic.Info->Description.GetPQTabletConfig();
+    UNIT_ASSERT_VALUES_EQUAL(config.GetContentBasedDeduplication(), true);
+}
+
 };
 
 } // namespace NKikimr::NGRpcProxy::V1::NPQv1

--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -82,6 +82,7 @@ void TPQDescribeTopicActor::HandleCacheNavigateResponse(TEvTxProxySchemeCache::T
         }
         bool local = config.GetLocalDC();
         settings->set_client_write_disabled(!local);
+        settings->set_content_based_deduplication(config.GetContentBasedDeduplication());
         const auto &partConfig = config.GetPartitionConfig();
         i64 msip = partConfig.GetMaxSizeInPartition();
         if (msip != Max<i64>())


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Added field content_based-deduplication (bool) to public pqv1 API

### Changelog category <!-- remove all except one -->

* Improvement

### Description for reviewers <!-- (optional) description for those who read this PR -->

logbroker/config-manager is based on pqv1 API. Hence to support content based deduplication in CM it needs to be in pqv1