### PR TITLE
[tests] Fix viewer waiting after cluster restart for secret tests

### DIFF
--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -15,9 +15,7 @@ logger = logging.getLogger(__name__)
 
 DATABASE = "/Root"
 OLD_SECRETS_CREATION_DISABLED_MESSAGE = "Old secrets creation syntax is disabled now. Please use the new one"
-CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE = (
-    "Old secrets are disabled for creating new objects. Please use new secrets"
-)
+CREATION_WITH_OLD_SECRETS_DISABLED_MESSAGE = "Old secrets are disabled for creating new objects. Please use new secrets"
 OLD_SECRETS_USAGE_DISABLED_MESSAGE = "Usage of old secrets is disabled now. Please use new secrets"
 
 
@@ -106,20 +104,15 @@ class Utils:
 
         def viewer_ready():
             try:
-                response = requests.get(
-                    f"{self.mon_endpoint()}/viewer/json/describe",
-                    params={"database": DATABASE, "path": DATABASE},
-                    timeout=10,
-                )
-            except requests.exceptions.RequestException as exc:
+                description = self.viewer_describe(DATABASE)
+            except Exception as exc:
                 logger.info("Viewer not ready yet after cluster restart: %s", exc)
                 return False
-            if response.status_code != 200:
-                logger.info(
-                    "Viewer not ready yet after cluster restart: status=%s body=%s",
-                    response.status_code,
-                    response.text,
-                )
+            if description.get("Status") != "StatusSuccess":
+                logger.info("Viewer not ready yet after cluster restart: %s", description)
+                return False
+            if description.get("PathDescription", {}).get("Self", {}).get("CreateFinished") is not True:
+                logger.info("Viewer not ready yet after cluster restart: %s", description)
                 return False
             return True
 

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -43,6 +43,7 @@ class Utils:
     def __init__(self):
         self.config = KikimrConfigGenerator(use_in_memory_pdisks=False)
         self.config.yaml_config["feature_flags"]["enable_external_data_sources"] = True
+        self.config.yaml_config["feature_flags"]["enable_replace_if_exists_for_external_entities"] = True
 
         self.cluster = KiKiMR(self.config)
         self.cluster.start()

--- a/ydb/tests/functional/secrets/test_old_secrets_usage.py
+++ b/ydb/tests/functional/secrets/test_old_secrets_usage.py
@@ -104,6 +104,28 @@ class Utils:
         if not wait_for(driver_ready, timeout_seconds=120, step_seconds=1):
             raise AssertionError("Driver didn't become ready after cluster restart")
 
+        def viewer_ready():
+            try:
+                response = requests.get(
+                    f"{self.mon_endpoint()}/viewer/json/describe",
+                    params={"database": DATABASE, "path": DATABASE},
+                    timeout=10,
+                )
+            except requests.exceptions.RequestException as exc:
+                logger.info("Viewer not ready yet after cluster restart: %s", exc)
+                return False
+            if response.status_code != 200:
+                logger.info(
+                    "Viewer not ready yet after cluster restart: status=%s body=%s",
+                    response.status_code,
+                    response.text,
+                )
+                return False
+            return True
+
+        if not wait_for(viewer_ready, timeout_seconds=120, step_seconds=1):
+            raise AssertionError("Viewer didn't become ready after cluster restart")
+
         self.driver = driver_holder["driver"]
         self.session_pool = ydb.SessionPool(self.driver)
         self.query_session_pool = ydb.QuerySessionPool(self.driver)


### PR DESCRIPTION
### Changelog category
* Not for changelog (changelog entry is not required)

### Description for reviewers
Меняется только один тестовый файл
1. Явно фиксирую `enable_replace_if_exists_for_external_entities`. Пришлось это делать в stable-26-3. Чтобы потом снова не натыкаться на это, установил в тесте явно
2. Почему-то в 26-3 вьюер не готов быстро принимать запросы после рестарта. Добавил ожидание после рестарта