### PR TITLE
Fix dstool cluster balance to respect BSC Ready flag

### DIFF
--- a/ydb/apps/dstool/lib/common.py
+++ b/ydb/apps/dstool/lib/common.py
@@ -1245,6 +1245,12 @@ def vdisk_is_ok(vslot):
     return metrics.Replicated and metrics.State == whiteboard_disk_states.EVDiskState.OK
 
 
+def vslot_is_bsc_ready(vslot):
+    # BSC treats a VDisk as ready only after Status=READY is stable for ReadyStablePeriod.
+    # Degraded/fail-model checks use IsReady (BaseConfig.TVSlot.Ready), not Status alone.
+    return vslot.Status == 'READY' and vslot.Ready and vdisk_is_ok(vslot)
+
+
 def filter_healthy_groups(groups, base_config, vslot_map):
     healthy = set()
     for group in base_config.Group:
@@ -1253,9 +1259,7 @@ def filter_healthy_groups(groups, base_config, vslot_map):
         vslots = list(vslots_of_group(group, vslot_map))
         if not vslots:
             continue
-        if not all(vslot.Status == 'READY' for vslot in vslots):
-            continue
-        if all(vdisk_is_ok(vslot) for vslot in vslots):
+        if all(vslot_is_bsc_ready(vslot) for vslot in vslots):
             healthy.add(group.GroupId)
     return healthy
 

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -214,9 +214,9 @@ class BalancingStrategy(IBalancingStrategy):
 
     def check_waiting_conditions(self):
         if any(k < -1 for k in self.cluster_info.vdisks_groups_count_map.keys()):
-            common.print_if_not_quiet(self.args, 'There are groups with more than one non READY vslot, waiting...', sys.stdout)
+            common.print_if_not_quiet(self.args, 'There are groups with more than one non-ready (BSC) vslot, waiting...', sys.stdout)
             groups_count_str = ', '.join(f'{k}: {v}' for k, v in sorted(self.cluster_info.vdisks_groups_count_map.items()))
-            common.print_if_verbose(self.args, f'Number of non READY vdisks -> number of groups: {groups_count_str}', file=sys.stdout)
+            common.print_if_verbose(self.args, f'Number of non-ready (BSC) vdisks -> number of groups: {groups_count_str}', file=sys.stdout)
             return True
 
         if self.args.max_replicating_pdisks is not None:

--- a/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
+++ b/ydb/apps/dstool/lib/dstool_cmd_cluster_balance.py
@@ -95,7 +95,7 @@ class ClusterInfo:
 
         info.vdisks_groups_count_map = defaultdict(int)
         for group in info.base_config.Group:
-            num = sum(vslot.Status == 'READY' for vslot in common.vslots_of_group(group, info.vslot_map)) - len(group.VSlotId)
+            num = sum(common.vslot_is_bsc_ready(vslot) for vslot in common.vslots_of_group(group, info.vslot_map)) - len(group.VSlotId)
             info.vdisks_groups_count_map[num] += 1
         return info
 
@@ -340,17 +340,17 @@ class BalancingStrategy(IBalancingStrategy):
         request.Rollback = self.args.dry_run
         response = common.invoke_bsc_request(request)
 
-        if response.Status[index].Success:
+        if not common.is_successful_bsc_response(response):
+            common.print_request_result(self.args, request, response)
+            sys.exit(1)
+
+        if response.Status[index].Success and response.Status[index].ReassignedItem:
             from_pdisk_id = common.get_pdisk_id(response.Status[index].ReassignedItem[0].From)
             to_pdisk_id = common.get_pdisk_id(response.Status[index].ReassignedItem[0].To)
             common.print_if_not_quiet(
                 self.args,
                 'Relocated vdisk from pdisk [%d:%d] to pdisk [%d:%d] with slot usages (%d -> %d)' % (*from_pdisk_id, *to_pdisk_id, pdisk_usage[from_pdisk_id], pdisk_usage[to_pdisk_id]),
                 file=sys.stdout)
-
-        if not common.is_successful_bsc_response(response):
-            common.print_request_result(self.args, request, response)
-            sys.exit(1)
 
         return True
 

--- a/ydb/tests/functional/dstool/canondata/result.json
+++ b/ydb/tests/functional/dstool/canondata/result.json
@@ -27,6 +27,9 @@
             "uri": "file://test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0"
         }
     ],
+    "test_canonical_requests.Test.test_cluster_balance_skips_not_bsc_ready": {
+        "uri": "file://test_canonical_requests.Test.test_cluster_balance_skips_not_bsc_ready/results.txt"
+    },
     "test_canonical_requests.Test.test_cluster_get_set": [
         {
             "uri": "file://test_canonical_requests.Test.test_cluster_get_set/results.txt"

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt
@@ -60,6 +60,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -76,6 +77,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance/results.txt.0
@@ -114,6 +114,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -130,6 +131,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt
@@ -86,6 +86,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -102,6 +103,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -118,6 +120,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -134,6 +137,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -150,6 +154,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -166,6 +171,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -182,6 +188,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -198,6 +205,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_mismatching_size_in_units/results.txt.0
@@ -86,6 +86,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -102,6 +103,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -118,6 +120,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -134,6 +137,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -150,6 +154,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -166,6 +171,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -182,6 +188,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -198,6 +205,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 VSlot {
   VSlotId {
@@ -214,6 +222,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_skips_not_bsc_ready/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_cluster_balance_skips_not_bsc_ready/results.txt
@@ -1,0 +1,149 @@
+dstool -e <endpoint> --mon-port <mon_port> --verbose cluster balance --only-from-overpopulated-pdisks --storage-pool=test-pool --max-iterations=1 --waiting-time=0
+Exit Status: 0
+===== stdout =====
+
+Start balancing iteration 1
+Skipping vdisks from unhealthy groups: {2147483649}
+Number of used slots -> number pdisks: 0=>1 2=>1
+Found 1 candidate vslots, 1 groups to reassign
+Checking to relocate vdisk from vslot (1, 1001, 1001) on pdisk (1, 1001) with slot usage 2, try_blocking=False
+Relocated vdisk from pdisk [1:1001] to pdisk [1:1002] with slot usages (2 -> 0)
+
+===== stderr =====
+INFO: using random hosts
+INFO: using random hosts
+
+===== grpc_calls =====
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483650
+      GroupGeneration: 1
+    }
+  }
+  Rollback: true
+}
+
+=== Invoke BlobStorageConfig ===
+Domain: 1
+Request {
+  Command {
+    ReassignGroupDisk {
+      GroupId: 2147483650
+      GroupGeneration: 1
+    }
+  }
+}
+
+===== mock_base_config =====
+
+TBaseConfig {
+PDisk {
+  NodeId: 1
+  PDiskId: 1001
+  PDiskConfig {
+    ExpectedSlotCount: 1
+    SlotSizeInUnits: 0
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 1
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 1
+    SlotSizeInUnits: 0
+  }
+}
+PDisk {
+  NodeId: 1
+  PDiskId: 1002
+  PDiskConfig {
+    ExpectedSlotCount: 4
+    SlotSizeInUnits: 0
+  }
+  BoxId: 1
+  DriveStatus: ACTIVE
+  ExpectedSlotCount: 4
+  PDiskMetrics {
+    EnforcedDynamicSlotSize: 0
+    SlotCount: 4
+    SlotSizeInUnits: 0
+  }
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1000
+  }
+  GroupId: 2147483649
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+    State: OK
+    Replicated: true
+  }
+  Status: "READY"
+}
+VSlot {
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  GroupId: 2147483650
+  GroupGeneration: 1
+  VDiskMetrics {
+    AvailableSize: 0
+    AllocatedSize: 0
+    State: OK
+    Replicated: true
+  }
+  Status: "READY"
+  Ready: true
+}
+Group {
+  GroupId: 2147483649
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1000
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Group {
+  GroupId: 2147483650
+  GroupGeneration: 1
+  ErasureSpecies: "none"
+  VSlotId {
+    NodeId: 1
+    PDiskId: 1001
+    VSlotId: 1001
+  }
+  BoxId: 1
+  StoragePoolId: 1
+  GroupSizeInUnits: 1
+}
+Node {
+  NodeId: 1
+  HostKey {
+    Fqdn: "localhost"
+    IcPort: 19001
+  }
+}
+}
+
+DefineStoragePool {
+BoxId: 1
+StoragePoolId: 1
+Name: "test-pool"
+ErasureSpecies: "none"
+Kind: "hdd"
+}

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt
@@ -50,6 +50,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.0
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.0
@@ -50,6 +50,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.1
+++ b/ydb/tests/functional/dstool/canondata/test_canonical_requests.Test.test_pool_estimated_usage/results.txt.1
@@ -50,6 +50,7 @@ VSlot {
     Replicated: true
   }
   Status: "READY"
+  Ready: true
 }
 Group {
   GroupId: 2147483649

--- a/ydb/tests/functional/dstool/conftest.py
+++ b/ydb/tests/functional/dstool/conftest.py
@@ -44,7 +44,7 @@ class BaseConfigBuilder:
 
     def add_vslot(self, node_id, pdisk_id, vslot_id, group_id,
                   group_generation=0, fail_realm_idx=0, fail_domain_idx=0, vdisk_idx=0,
-                  status='READY', allocated_size=0, available_size=0):
+                  status='READY', ready=None, allocated_size=0, available_size=0):
         vslot = self._base_config.VSlot.add()
         vslot.VSlotId.NodeId = node_id
         vslot.VSlotId.PDiskId = pdisk_id
@@ -58,9 +58,12 @@ class BaseConfigBuilder:
         vslot.VDiskMetrics.AllocatedSize = allocated_size
         vslot.VDiskMetrics.AvailableSize = available_size
         if status == 'READY':
-            vslot.Ready = True
+            # Default Ready=True for Status=READY; pass ready=False to model ReadyStablePeriod.
+            vslot.Ready = True if ready is None else ready
             vslot.VDiskMetrics.Replicated = True
             vslot.VDiskMetrics.State = EVDiskState.OK
+        elif ready is not None:
+            vslot.Ready = ready
         return self
 
     def add_group(self, group_id, erasure_species='none',

--- a/ydb/tests/functional/dstool/conftest.py
+++ b/ydb/tests/functional/dstool/conftest.py
@@ -58,6 +58,7 @@ class BaseConfigBuilder:
         vslot.VDiskMetrics.AllocatedSize = allocated_size
         vslot.VDiskMetrics.AvailableSize = available_size
         if status == 'READY':
+            vslot.Ready = True
             vslot.VDiskMetrics.Replicated = True
             vslot.VDiskMetrics.State = EVDiskState.OK
         return self

--- a/ydb/tests/functional/dstool/test_canonical_requests.py
+++ b/ydb/tests/functional/dstool/test_canonical_requests.py
@@ -576,3 +576,72 @@ class Test(TestBase):
                 builder=make_builder(2, [2, 2, 2, 2, 1, 2, 2, 2, 2]),
                 pending_reassigns={0x80000005: (1, 1002, 1000)}),
         ]
+
+    def test_filter_healthy_groups_requires_bsc_ready(self):
+        """Status=READY alone is not enough: BSC ReadyStablePeriod uses TVSlot.Ready."""
+        from ydb.apps.dstool.lib.dstool_cmd_cluster_balance import ClusterInfo, GroupsInfo
+
+        builder = (
+            BaseConfigBuilder()
+            .add_node(node_id=1)
+            .add_pdisk(node_id=1, pdisk_id=1001, expected_slot_count=8)
+            .add_group(group_id=0x80000001, vslot_ids=[(1, 1001, 1000)])
+            .add_group(group_id=0x80000002, vslot_ids=[(1, 1001, 1001)])
+            # Fully BSC-ready
+            .add_vslot(node_id=1, pdisk_id=1001, vslot_id=1000, group_id=0x80000001, group_generation=1)
+            # Status=READY + metrics OK, but Ready=False (still in ReadyStablePeriod)
+            .add_vslot(node_id=1, pdisk_id=1001, vslot_id=1001, group_id=0x80000002, group_generation=1, ready=False)
+            .add_storage_pool(name='test-pool', erasure_species='none', kind='hdd')
+        )
+        mock_config = builder.build()
+        base_config = mock_config['BaseConfig']
+        vslot_map = common.build_vslot_map(base_config)
+        groups = common.select_groups(base_config)
+
+        healthy = common.filter_healthy_groups(groups, base_config, vslot_map)
+        assert healthy == {0x80000001}, healthy
+
+        with patch.object(common, 'fetch_base_config_and_storage_pools', return_value=mock_config):
+            cluster_info = ClusterInfo.collect_cluster_info()
+            groups_info = GroupsInfo.collect_groups_info(cluster_info)
+
+        assert groups_info.healthy_groups == {0x80000001}
+        assert 0x80000002 in groups_info.unhealthy_groups
+        # One group fully ready (diff 0), one group missing BSC-ready (diff -1)
+        assert cluster_info.vdisks_groups_count_map[0] == 1
+        assert cluster_info.vdisks_groups_count_map[-1] == 1
+
+    def test_cluster_balance_skips_not_bsc_ready(self):
+        """Balance must not relocate VDisks from groups still in ReadyStablePeriod."""
+        builder = (
+            BaseConfigBuilder()
+            .add_node(node_id=1)
+            .add_pdisk(node_id=1, pdisk_id=1001, expected_slot_count=1)
+            .add_pdisk(node_id=1, pdisk_id=1002, expected_slot_count=4)
+            .add_group(group_id=0x80000001, vslot_ids=[(1, 1001, 1000)], group_size_in_units=1)
+            .add_group(group_id=0x80000002, vslot_ids=[(1, 1001, 1001)], group_size_in_units=1)
+            # Overpopulated pdisk 1001 has two slots; only group 2 is BSC-ready.
+            .add_vslot(node_id=1, pdisk_id=1001, vslot_id=1000, group_id=0x80000001, group_generation=1, ready=False)
+            .add_vslot(node_id=1, pdisk_id=1001, vslot_id=1001, group_id=0x80000002, group_generation=1)
+            .add_storage_pool(name='test-pool', erasure_species='none', kind='hdd')
+        )
+
+        base_config = builder.build()
+        # Fake handler would succeed for either group; balance must only pick the BSC-ready one.
+        fake_grpc_handler = FakeReassignGroupDiskHandler(
+            {
+                0x80000001: (1, 1002, 1000),
+                0x80000002: (1, 1002, 1001),
+            },
+            base_config,
+        )
+        return self._trace(
+            '--verbose', 'cluster', 'balance',
+            '--only-from-overpopulated-pdisks',
+            '--storage-pool=test-pool',
+            '--max-iterations=1',
+            '--waiting-time=0',
+            with_grpc_calls=True,
+            mock_base_config=base_config,
+            fake_grpc_handler=fake_grpc_handler,
+        )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

filter_healthy_groups treated Status=READY as enough to relocate a VDisk, but BSC degraded checks use IsReady (TVSlot.Ready), which stays false for ReadyStablePeriod after Status becomes READY. That race let balance move a second disk from a group that still had an unstable replica and fail with Degraded GroupIds.

Also avoid printing Relocated when the overall BSC request fails.

Fixes https://github.com/ydb-platform/ydb/issues/48063

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
