### PR TITLE
Retry GetQueueUrl in SQS workload to tolerate transient http-proxy co…

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_json/sqs_json_client.cpp
+++ b/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_json/sqs_json_client.cpp
@@ -1,8 +1,10 @@
 #include "sqs_json_client.h"
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/client/CoreErrors.h>
 #include <aws/core/http/HttpClient.h>
 #include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/HttpResponse.h>
 #include <aws/core/utils/Array.h>
 #include <aws/core/utils/HashingUtils.h>
 #include <aws/core/utils/memory/stl/SimpleStringStream.h>
@@ -540,11 +542,28 @@ namespace NYdb::NConsoleClient {
             oss << response->GetClientErrorType() << " " << response->GetResponseCode()
                 << " " << response->GetClientErrorMessage() << " " << responseBody;
             Cerr << "got error response: " << oss.str() << Endl;
-            Aws::SQS::SQSError error;
-            error.SetResponseHeaders(response->GetHeaders());
-            error.SetResponseCode(response->GetResponseCode());
-            error.SetMessage(response->GetClientErrorMessage());
-            return GetQueueUrlOutcome(error);
+
+            // Match AWSJsonClient::BuildAWSError / CoreErrorsMapper::GetErrorForHttpResponseCode.
+            const auto responseCode = response->GetResponseCode();
+            Aws::Client::AWSError<Aws::Client::CoreErrors> coreError;
+            if (response->HasClientError()) {
+                const bool retryable =
+                    response->GetClientErrorType() == Aws::Client::CoreErrors::NETWORK_CONNECTION;
+                coreError = Aws::Client::AWSError<Aws::Client::CoreErrors>(
+                    response->GetClientErrorType(),
+                    "",
+                    response->GetClientErrorMessage(),
+                    retryable);
+            } else if (responseCode == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE) {
+                coreError = Aws::Client::AWSError<Aws::Client::CoreErrors>(
+                    Aws::Client::CoreErrors::NETWORK_CONNECTION, true);
+            } else {
+                coreError = Aws::Client::CoreErrorsMapper::GetErrorForHttpResponseCode(responseCode);
+            }
+            coreError.SetResponseHeaders(response->GetHeaders());
+            coreError.SetResponseCode(responseCode);
+            coreError.SetMessage(oss.str());
+            return GetQueueUrlOutcome(Aws::SQS::SQSError(std::move(coreError)));
         }
 
         auto responseJson = ReadResponseBody(*response);

--- a/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_json/sqs_json_client.cpp
+++ b/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_json/sqs_json_client.cpp
@@ -537,11 +537,13 @@ namespace NYdb::NConsoleClient {
         if (response->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
             Aws::OStringStream oss;
             auto responseBody = response->GetResponseBody().rdbuf();
-            oss << response->GetClientErrorType() << " " << response->GetResponseCode() << " " << responseBody;
+            oss << response->GetClientErrorType() << " " << response->GetResponseCode()
+                << " " << response->GetClientErrorMessage() << " " << responseBody;
             Cerr << "got error response: " << oss.str() << Endl;
             Aws::SQS::SQSError error;
             error.SetResponseHeaders(response->GetHeaders());
             error.SetResponseCode(response->GetResponseCode());
+            error.SetMessage(response->GetClientErrorMessage());
             return GetQueueUrlOutcome(error);
         }
 

--- a/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_workload_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_workload_scenario.cpp
@@ -8,6 +8,7 @@
 #include <aws/sqs/model/GetQueueUrlRequest.h>
 #include <library/cpp/logger/log.h>
 #include <library/cpp/uri/http_url.h>
+#include <util/datetime/base.h>
 #include <util/string/builder.h>
 #include <ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_json/sqs_json_client.h>
 #include <ydb/public/lib/ydb_cli/common/command.h>
@@ -104,15 +105,33 @@ namespace NYdb::NConsoleClient {
     }
 
     TString TSqsWorkloadScenario::GetQueueUrl(TString topic, TString consumer, TMaybe<TString> queueName) const {
+        constexpr size_t maxAttempts = 10;
+        constexpr TDuration retryDelay = TDuration::MilliSeconds(500);
+
         Aws::SQS::Model::GetQueueUrlRequest request;
         request.SetQueueName(BuildQueueName(topic, consumer, queueName));
-        auto outcome = SqsClient->GetQueueUrl(request);
-        if (outcome.IsSuccess()) {
-            return outcome.GetResult().GetQueueUrl().c_str();
-        } else {
-            Log->Write(ELogPriority::TLOG_ERR, "got error: " + outcome.GetError().GetMessage());
-            return "";
+
+        for (size_t attempt = 1; attempt <= maxAttempts; ++attempt) {
+            auto outcome = SqsClient->GetQueueUrl(request);
+            if (outcome.IsSuccess()) {
+                return outcome.GetResult().GetQueueUrl().c_str();
+            }
+
+            const auto& error = outcome.GetError();
+            Log->Write(
+                ELogPriority::TLOG_ERR,
+                TStringBuilder()
+                    << "GetQueueUrl failed (attempt " << attempt << "/" << maxAttempts
+                    << "): " << error.GetMessage()
+                    << " responseCode=" << static_cast<int>(error.GetResponseCode()));
+
+            if (attempt == maxAttempts) {
+                break;
+            }
+            Sleep(retryDelay);
         }
+
+        return "";
     }
 
     void TSqsWorkloadScenario::DestroySqsClient() {

--- a/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_workload_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/sqs_workload/sqs_workload_scenario.cpp
@@ -3,6 +3,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/http/HttpResponse.h>
 #include <aws/core/utils/ratelimiter/RateLimiterInterface.h>
 #include <aws/core/utils/threading/Executor.h>
 #include <aws/sqs/model/GetQueueUrlRequest.h>
@@ -118,14 +119,21 @@ namespace NYdb::NConsoleClient {
             }
 
             const auto& error = outcome.GetError();
+            const auto responseCode = error.GetResponseCode();
+            const bool retryable =
+                error.ShouldRetry() ||
+                responseCode == Aws::Http::HttpResponseCode::REQUEST_NOT_MADE ||
+                Aws::Http::IsRetryableHttpResponseCode(responseCode);
+            const bool finalFailure = !retryable || attempt == maxAttempts;
+
             Log->Write(
-                ELogPriority::TLOG_ERR,
+                finalFailure ? ELogPriority::TLOG_ERR : ELogPriority::TLOG_WARNING,
                 TStringBuilder()
                     << "GetQueueUrl failed (attempt " << attempt << "/" << maxAttempts
                     << "): " << error.GetMessage()
-                    << " responseCode=" << static_cast<int>(error.GetResponseCode()));
+                    << " responseCode=" << static_cast<int>(responseCode));
 
-            if (attempt == maxAttempts) {
+            if (finalFailure) {
                 break;
             }
             Sleep(retryDelay);

--- a/ydb/tests/stress/topic_sqs/workload/__init__.py
+++ b/ydb/tests/stress/topic_sqs/workload/__init__.py
@@ -101,6 +101,8 @@ class Workload:
             '--percentile', '99',
             '--message-groups-amount', '0',
             '--max-unique-messages', '0',
+            # CLI timeouts are in milliseconds.
+            '--request-timeout', '5000',
         ]
         return self.cmd_run(self.get_command(subcmds=subcmds))
 
@@ -115,8 +117,10 @@ class Workload:
             '--consumer', 'shared_consumer',
             '--percentile', '99',
             '--handle-message-time', '2',
-            '--visibility-timeout', '5',
-            '--keep-error-every', '0'
+            # CLI takes visibility-timeout in milliseconds; reader truncates to whole seconds.
+            '--visibility-timeout', '5000',
+            '--keep-error-every', '0',
+            '--request-timeout', '5000',
         ]
         return self.cmd_run(self.get_command(subcmds=subcmds))
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

`ydb workload sqs` fail-fast'ил на старте, если `GetQueueUrl` ловил транзиентный `NETWORK_CONNECTION` / `REQUEST_NOT_MADE` к локальному http-proxy (типичный сценарий под параллельным write/read stress на CI). Из-за этого падал `TestYdbTopicSqsWorkload`.

Дополнительно stress helper передавал `--visibility-timeout 5`, а CLI интерпретирует это в миллисекундах: reader делает `.Seconds()` и получает 0s. Request timeout по умолчанию (2s) тоже был слишком жёстким под CI-нагрузкой.

Изменения:
- ретраи `GetQueueUrl` (10 попыток, 500 ms)
- прокидывание `ClientErrorMessage` в ошибку/лог, чтобы видеть реальную curl-причину
- в `topic_sqs` workload: `--visibility-timeout 5000` (5s) и `--request-timeout 5000` для write/read

Related to #45711