### PR TITLE
Fix use-after-dtor in TWorkerThread ut

### DIFF
--- a/ydb/core/util/ut_common.h
+++ b/ydb/core/util/ut_common.h
@@ -21,6 +21,12 @@ namespace NKikimr {
             : Func(std::move(func))
         { }
 
+        ~TWorkerThread() override {
+            // It is essential to join here, because the spawned thread may access Func
+            // after the destructor of this object if not joined.
+            Join();
+        }
+
         double GetTime() const {
             return Time;
         }


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->
In `TFastTlsTest::ManyConcurrentKeys`, a few threads are spawned but not joined. It may happen that a thread object may be destructed BEFORE the spawned OS thread reached its `func`, so we have usage after destructor. Join the thread in `~TWorkerThread()`, as the base `~TThread()` does. The operation is idempotent, so no problem in calling `Join()` twice from both base and derived destructors.
