### PR TITLE
Add mailbox processing started notifications

### DIFF
--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -574,15 +574,15 @@ namespace NActors {
             // Request a notification after an activation that processed one
             // of this actor's events, or immediately before destruction if it
             // passes away during processing.
-            RequestedMailboxProcessingFinished = 1ull << 0,
+            NotifyOnMailboxProcessingFinished = 1ull << 0,
             // Request a notification before this actor's first non-bootstrap
             // event in a mailbox activation. Enabling this flag while handling
             // an event takes effect starting with the next activation.
-            RequestedMailboxProcessingStarted = 1ull << 1,
-            // Executor-owned marker indicating that this actor has processed
-            // at least one non-bootstrap event in the current mailbox
-            // activation.
-            ActorProcessed = 1ull << 2,
+            NotifyOnMailboxProcessingStarted = 1ull << 1,
+            // Executor-owned marker indicating that an actor requesting
+            // mailbox processing notifications has processed at least one
+            // non-bootstrap event in the current mailbox activation.
+            ProcessedEventInCurrentMailboxActivation = 1ull << 2,
         };
 
     private:

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -571,10 +571,15 @@ namespace NActors {
     public:
         using TReceiveFunc = void (IActor::*)(TAutoPtr<IEventHandle>& ev);
         enum class ESystemFlag : ui64 {
-            // Notify this actor only after an activation that processed one of
-            // its events. Activations of other actors in the same mailbox are
-            // not reported.
+            // Notify this actor after an activation that processed one of its
+            // events, or immediately before destruction if it passes away
+            // during processing. Activations of other actors in the same
+            // mailbox are not reported.
             MailboxProcessingFinished = 1ull << 0,
+            // Notify this actor before its first non-bootstrap event in a
+            // mailbox activation. Enabling this flag while handling an event
+            // takes effect starting with the next activation.
+            MailboxProcessingStarted = 1ull << 1,
         };
 
     private:

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -571,15 +571,18 @@ namespace NActors {
     public:
         using TReceiveFunc = void (IActor::*)(TAutoPtr<IEventHandle>& ev);
         enum class ESystemFlag : ui64 {
-            // Notify this actor after an activation that processed one of its
-            // events, or immediately before destruction if it passes away
-            // during processing. Activations of other actors in the same
-            // mailbox are not reported.
-            MailboxProcessingFinished = 1ull << 0,
-            // Notify this actor before its first non-bootstrap event in a
-            // mailbox activation. Enabling this flag while handling an event
-            // takes effect starting with the next activation.
-            MailboxProcessingStarted = 1ull << 1,
+            // Request a notification after an activation that processed one
+            // of this actor's events, or immediately before destruction if it
+            // passes away during processing.
+            RequestedMailboxProcessingFinished = 1ull << 0,
+            // Request a notification before this actor's first non-bootstrap
+            // event in a mailbox activation. Enabling this flag while handling
+            // an event takes effect starting with the next activation.
+            RequestedMailboxProcessingStarted = 1ull << 1,
+            // Executor-owned marker indicating that this actor has processed
+            // at least one non-bootstrap event in the current mailbox
+            // activation.
+            ActorProcessed = 1ull << 2,
         };
 
     private:

--- a/ydb/library/actors/core/actor.h
+++ b/ydb/library/actors/core/actor.h
@@ -576,12 +576,14 @@ namespace NActors {
             // passes away during processing.
             NotifyOnMailboxProcessingFinished = 1ull << 0,
             // Request a notification before this actor's first non-bootstrap
-            // event in a mailbox activation. Enabling this flag while handling
-            // an event takes effect starting with the next activation.
+            // event in a mailbox activation. Do not set this flag before
+            // Bootstrap() is called. Enabling it while handling an event,
+            // including Bootstrap(), takes effect starting with the next
+            // activation.
             NotifyOnMailboxProcessingStarted = 1ull << 1,
             // Executor-owned marker indicating that an actor requesting
             // mailbox processing notifications has processed at least one
-            // non-bootstrap event in the current mailbox activation.
+            // event in the current mailbox activation.
             ProcessedEventInCurrentMailboxActivation = 1ull << 2,
         };
 

--- a/ydb/library/actors/core/actor_bootstrapped.h
+++ b/ydb/library/actors/core/actor_bootstrapped.h
@@ -7,6 +7,7 @@
 namespace NActors {
     template<typename T> struct dependent_false : std::false_type {};
 
+    // NotifyOnMailboxProcessingStarted must not be set before Bootstrap().
     template<typename TDerived>
     class TActorBootstrapped: public TActor<TDerived> {
     protected:

--- a/ydb/library/actors/core/events.h
+++ b/ydb/library/actors/core/events.h
@@ -117,6 +117,7 @@ namespace NActors {
                 ActorAlive,
                 ActorDead,
                 ActorLivenessUnsure,
+                MailboxProcessingStarted,
                 End,
 
                 // Compatibility section
@@ -147,6 +148,9 @@ namespace NActors {
                 TimeLimitReached,
                 SoftDeadlineReached,
                 TailSend,
+                // The actor passed away during mailbox processing. The
+                // notification is delivered before physical destruction.
+                ActorDied,
             };
 
             const EReason Reason;
@@ -158,6 +162,10 @@ namespace NActors {
                 , ExecutedEvents(executedEvents)
                 , ElapsedCycles(elapsedCycles)
             {}
+        };
+
+        struct TEvMailboxProcessingStarted
+            : public TEventLocal<TEvMailboxProcessingStarted, TSystem::MailboxProcessingStarted> {
         };
 
         struct TEvSubscribe: public TEventLocal<TEvSubscribe, TSystem::Subscribe> {

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -205,11 +205,14 @@ namespace NActors {
         TActorId recipient;
         bool firstEvent = true;
         using EFinishReason = TEvents::TEvMailboxProcessingFinished::EReason;
+        constexpr ui64 mailboxProcessingNotificationFlags =
+            static_cast<ui64>(IActor::ESystemFlag::NotifyOnMailboxProcessingFinished) |
+            static_cast<ui64>(IActor::ESystemFlag::NotifyOnMailboxProcessingStarted);
         EFinishReason finishReason = EFinishReason::EventCountLimitReached;
         ui32 finishedExecutedEvents = execCtx.ExecutedEvents;
         bool isPreempted = false;
         bool wasWorking = false;
-        TStackVec<TActorId, 1> actorProcessedActors;
+        TStackVec<TActorId, 1> actorsWithProcessedEventInCurrentMailboxActivation;
         TStackVec<TActorId, 1> mailboxProcessingFinishedActors;
         NHPTimer::STime hpnow = execCtx.HPStart;
         NHPTimer::STime hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
@@ -267,8 +270,12 @@ namespace NActors {
             if (notifyMailboxProcessingFinished) {
                 for (size_t i = 0; i < DyingActors.size(); ++i) {
                     IActor* dyingActor = DyingActors[i].Get();
-                    if (!(dyingActor->GetSystemFlags() & static_cast<ui64>(
-                            IActor::ESystemFlag::RequestedMailboxProcessingFinished))) {
+                    const ui64 systemFlags = dyingActor->GetSystemFlags();
+                    if (Y_LIKELY(systemFlags == 0)) {
+                        continue;
+                    }
+                    if (!(systemFlags & static_cast<ui64>(
+                            IActor::ESystemFlag::NotifyOnMailboxProcessingFinished))) {
                         continue;
                     }
 
@@ -375,33 +382,35 @@ namespace NActors {
                         ev->GetTypeRewrite() == TEvents::TSystem::Bootstrap;
                     const TActorId actorId = actor->SelfId();
                     const ui64 systemFlagsBefore = actor->GetSystemFlags();
-                    if (!isBootstrapEvent &&
-                            (systemFlagsBefore & static_cast<ui64>(
-                                IActor::ESystemFlag::RequestedMailboxProcessingStarted)) &&
-                            !(systemFlagsBefore & static_cast<ui64>(
-                                IActor::ESystemFlag::ActorProcessed))) {
-                        TActorContext startedCtx(*mailbox, *this, eventStart, recipient);
-                        TlsActivationContext = &startedCtx;
-                        TAutoPtr<IEventHandle> startedEv = new IEventHandle(
-                            actorId,
-                            TActorId(),
-                            new TEvents::TEvMailboxProcessingStarted());
-                        CurrentRecipient = recipient;
-                        CurrentActorScheduledEventsCounter = 0;
+                    if (Y_UNLIKELY(systemFlagsBefore != 0)) {
+                        if (!isBootstrapEvent &&
+                                (systemFlagsBefore & static_cast<ui64>(
+                                    IActor::ESystemFlag::NotifyOnMailboxProcessingStarted)) &&
+                                !(systemFlagsBefore & static_cast<ui64>(
+                                    IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation))) {
+                            TActorContext startedCtx(*mailbox, *this, eventStart, recipient);
+                            TlsActivationContext = &startedCtx;
+                            TAutoPtr<IEventHandle> startedEv = new IEventHandle(
+                                actorId,
+                                TActorId(),
+                                new TEvents::TEvMailboxProcessingStarted());
+                            CurrentRecipient = recipient;
+                            CurrentActorScheduledEventsCounter = 0;
 
-                        actor->Receive(startedEv);
+                            actor->Receive(startedEv);
 
-                        finishActorEvent(
-                            actor,
-                            startedEv.Get(),
-                            TEvents::TSystem::MailboxProcessingStarted,
-                            actorType,
-                            activityType,
-                            true,
-                            false);
-                        dropUnregistered(actor, execCtx.ExecutedEvents);
-                        actorRemovedBeforeEvent = !actor;
-                        eventStart = hpnow;
+                            finishActorEvent(
+                                actor,
+                                startedEv.Get(),
+                                TEvents::TSystem::MailboxProcessingStarted,
+                                actorType,
+                                activityType,
+                                true,
+                                false);
+                            dropUnregistered(actor, execCtx.ExecutedEvents);
+                            actorRemovedBeforeEvent = !actor;
+                            eventStart = hpnow;
+                        }
                     }
 
                     if (actor) {
@@ -413,20 +422,24 @@ namespace NActors {
 
                         actor->Receive(ev);
 
-                        if (!isBootstrapEvent && !actor->HasSystemFlag(
-                                IActor::ESystemFlag::ActorProcessed)) {
-                            actor->SetSystemFlag(IActor::ESystemFlag::ActorProcessed);
-                            actorProcessedActors.push_back(actorId);
-                        }
-
                         const ui64 systemFlags = actor->GetSystemFlags();
-                        if (Y_UNLIKELY(systemFlags & static_cast<ui64>(
-                                IActor::ESystemFlag::RequestedMailboxProcessingFinished))) {
-                            if (std::find(
-                                    mailboxProcessingFinishedActors.begin(),
-                                    mailboxProcessingFinishedActors.end(),
-                                    actorId) == mailboxProcessingFinishedActors.end()) {
-                                mailboxProcessingFinishedActors.push_back(actorId);
+                        if (Y_UNLIKELY(systemFlags != 0)) {
+                            if (!isBootstrapEvent &&
+                                    (systemFlags & mailboxProcessingNotificationFlags) &&
+                                    !(systemFlags & static_cast<ui64>(
+                                        IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation))) {
+                                actor->SetSystemFlag(
+                                    IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation);
+                                actorsWithProcessedEventInCurrentMailboxActivation.push_back(actorId);
+                            }
+                            if (systemFlags & static_cast<ui64>(
+                                    IActor::ESystemFlag::NotifyOnMailboxProcessingFinished)) {
+                                if (std::find(
+                                        mailboxProcessingFinishedActors.begin(),
+                                        mailboxProcessingFinishedActors.end(),
+                                        actorId) == mailboxProcessingFinishedActors.end()) {
+                                    mailboxProcessingFinishedActors.push_back(actorId);
+                                }
                             }
                         }
 
@@ -540,44 +553,58 @@ namespace NActors {
         // Deliver notifications directly so they do not enter the mailbox
         // queue or consume its event processing budget.
         for (const TActorId& actorId : mailboxProcessingFinishedActors) {
-            if (IActor* actor = mailbox->FindActor(actorId.LocalId());
-                    actor && (actor->GetSystemFlags() & static_cast<ui64>(
-                        IActor::ESystemFlag::RequestedMailboxProcessingFinished))) {
-                const TActorId recipient = actor->SelfId();
-                TActorContext ctx(*mailbox, *this, eventStart, recipient);
-                TlsActivationContext = &ctx;
-                TAutoPtr<IEventHandle> ev = new IEventHandle(
-                    actor->SelfId(),
-                    TActorId(),
-                    new TEvents::TEvMailboxProcessingFinished(
-                        finishReason,
-                        finishedExecutedEvents,
-                        finishedElapsedCycles));
-
-                const std::type_info* notificationActorType = &typeid(*actor);
-                const ui32 activityType = actor->GetActivityType().GetIndex();
-                NProfiling::TMemoryTagScope::Reset(activityType);
-                TlsThreadContext->ActivityContext.ElapsingActorActivity.store(activityType, std::memory_order_release);
-                CurrentRecipient = recipient;
-                CurrentActorScheduledEventsCounter = 0;
-
-                actor->Receive(ev);
-
-                finishActorEvent(
-                    actor,
-                    ev.Get(),
-                    TEvents::TSystem::MailboxProcessingFinished,
-                    notificationActorType,
-                    activityType);
-                // The actor has already received its finish notification, so
-                // do not send a second one if it passes away while handling it.
-                dropUnregistered(actor, finishedExecutedEvents, false);
-                eventStart = hpnow;
+            IActor* actor = mailbox->FindActor(actorId.LocalId());
+            if (!actor) {
+                continue;
             }
+            const ui64 systemFlags = actor->GetSystemFlags();
+            if (systemFlags == 0) {
+                continue;
+            }
+            if (!(systemFlags & static_cast<ui64>(
+                    IActor::ESystemFlag::NotifyOnMailboxProcessingFinished))) {
+                continue;
+            }
+
+            const TActorId recipient = actor->SelfId();
+            TActorContext ctx(*mailbox, *this, eventStart, recipient);
+            TlsActivationContext = &ctx;
+            TAutoPtr<IEventHandle> ev = new IEventHandle(
+                actor->SelfId(),
+                TActorId(),
+                new TEvents::TEvMailboxProcessingFinished(
+                    finishReason,
+                    finishedExecutedEvents,
+                    finishedElapsedCycles));
+
+            const std::type_info* notificationActorType = &typeid(*actor);
+            const ui32 activityType = actor->GetActivityType().GetIndex();
+            NProfiling::TMemoryTagScope::Reset(activityType);
+            TlsThreadContext->ActivityContext.ElapsingActorActivity.store(activityType, std::memory_order_release);
+            CurrentRecipient = recipient;
+            CurrentActorScheduledEventsCounter = 0;
+
+            actor->Receive(ev);
+
+            finishActorEvent(
+                actor,
+                ev.Get(),
+                TEvents::TSystem::MailboxProcessingFinished,
+                notificationActorType,
+                activityType);
+            // The actor has already received its finish notification, so
+            // do not send a second one if it passes away while handling it.
+            dropUnregistered(actor, finishedExecutedEvents, false);
+            eventStart = hpnow;
         }
-        for (const TActorId& actorId : actorProcessedActors) {
+        for (const TActorId& actorId : actorsWithProcessedEventInCurrentMailboxActivation) {
             if (IActor* actor = mailbox->FindActor(actorId.LocalId())) {
-                actor->ClearSystemFlag(IActor::ESystemFlag::ActorProcessed);
+                const ui64 systemFlags = actor->GetSystemFlags();
+                if (systemFlags != 0 && (systemFlags & static_cast<ui64>(
+                        IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation))) {
+                    actor->ClearSystemFlag(
+                        IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation);
+                }
             }
         }
         TlsThreadContext->ActivityContext.ActivationStartTS.store(hpnow, std::memory_order_release);

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -340,9 +340,10 @@ namespace NActors {
                         recipient = evExt->GetRecipientRewrite();
                     }
                 }
-                TAutoPtr<IEventHandle> ev = evExt.release();
                 bool eventDelivered = false;
                 bool actorRemovedBeforeEvent = false;
+                const ui32 evTypeForTracing = evExt->Type;
+                ui32 activityType = ActorSystemIndex;
                 if (actor) {
                     EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is not null");
                     wasWorking = true;
@@ -350,7 +351,7 @@ namespace NActors {
                     actorType = &typeid(*actor);
 
 #ifdef USE_ACTOR_CALLSTACK
-                    TCallstack::GetTlsCallstack() = ev->Callstack;
+                    TCallstack::GetTlsCallstack() = evExt->Callstack;
                     TCallstack::GetTlsCallstack().SetLinesToSkip();
 #endif
                     CurrentRecipient = recipient;
@@ -363,28 +364,23 @@ namespace NActors {
                         firstEvent = false;
                     }
 
-                    i64 usecDeliv = ExecutionStats.AddEventDeliveryStats(ev->SendTime, hpprev);
+                    i64 usecDeliv = ExecutionStats.AddEventDeliveryStats(evExt->SendTime, hpprev);
                     if (usecDeliv > 5000) {
                         double sinceActivationMs = NHPTimer::GetSeconds(hpprev - execCtx.HPStart) * 1000.0;
-                        LwTraceSlowDelivery(ev.Get(), actorType, ThreadCtx.PoolId(), CurrentRecipient, NHPTimer::GetSeconds(hpprev - ev->SendTime) * 1000.0, sinceActivationMs, execCtx.ExecutedEvents);
+                        LwTraceSlowDelivery(evExt.get(), actorType, ThreadCtx.PoolId(), CurrentRecipient, NHPTimer::GetSeconds(hpprev - evExt->SendTime) * 1000.0, sinceActivationMs, execCtx.ExecutedEvents);
                     }
 
-                    ui32 evTypeForTracing = ev->Type;
-
-                    ui32 activityType = actor->GetActivityType().GetIndex();
+                    activityType = actor->GetActivityType().GetIndex();
                     if (activityType != prevActivityType) {
                         prevActivityType = activityType;
                         NProfiling::TMemoryTagScope::Reset(activityType);
                         TlsThreadContext->ActivityContext.ElapsingActorActivity.store(activityType, std::memory_order_release);
                     }
 
-                    const bool isBootstrapEvent =
-                        ev->GetTypeRewrite() == TEvents::TSystem::Bootstrap;
                     const TActorId actorId = actor->SelfId();
                     const ui64 systemFlagsBefore = actor->GetSystemFlags();
                     if (Y_UNLIKELY(systemFlagsBefore != 0)) {
-                        if (!isBootstrapEvent &&
-                                (systemFlagsBefore & static_cast<ui64>(
+                        if ((systemFlagsBefore & static_cast<ui64>(
                                     IActor::ESystemFlag::NotifyOnMailboxProcessingStarted)) &&
                                 !(systemFlagsBefore & static_cast<ui64>(
                                     IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation))) {
@@ -412,10 +408,14 @@ namespace NActors {
                             eventStart = hpnow;
                         }
                     }
+                }
 
+                TActorContext ctx(*mailbox, *this, eventStart, recipient);
+                TlsActivationContext = &ctx; // ensure dtor (if any) is called within actor system
+                // move for destruct before ctx;
+                {
+                    TAutoPtr<IEventHandle> ev = evExt.release();
                     if (actor) {
-                        TActorContext ctx(*mailbox, *this, eventStart, recipient);
-                        TlsActivationContext = &ctx; // ensure dtor (if any) is called within actor system
                         CurrentRecipient = recipient;
                         CurrentActorScheduledEventsCounter = 0;
                         eventDelivered = true;
@@ -424,16 +424,16 @@ namespace NActors {
 
                         const ui64 systemFlags = actor->GetSystemFlags();
                         if (Y_UNLIKELY(systemFlags != 0)) {
-                            if (!isBootstrapEvent &&
-                                    (systemFlags & mailboxProcessingNotificationFlags) &&
+                            if ((systemFlags & mailboxProcessingNotificationFlags) &&
                                     !(systemFlags & static_cast<ui64>(
                                         IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation))) {
                                 actor->SetSystemFlag(
                                     IActor::ESystemFlag::ProcessedEventInCurrentMailboxActivation);
-                                actorsWithProcessedEventInCurrentMailboxActivation.push_back(actorId);
+                                actorsWithProcessedEventInCurrentMailboxActivation.push_back(actor->SelfId());
                             }
                             if (systemFlags & static_cast<ui64>(
                                     IActor::ESystemFlag::NotifyOnMailboxProcessingFinished)) {
+                                const TActorId actorId = actor->SelfId();
                                 if (std::find(
                                         mailboxProcessingFinishedActors.begin(),
                                         mailboxProcessingFinishedActors.end(),
@@ -446,26 +446,25 @@ namespace NActors {
                         finishActorEvent(actor, ev.Get(), evTypeForTracing, actorType, activityType);
                         dropUnregistered(actor, execCtx.ExecutedEvents + 1);
                     }
-                    TlsActivationContext = nullptr;
-                }
-                if (!eventDelivered) {
-                    EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is null");
-                    actorType = nullptr;
-                    TlsActivationContext = nullptr;
+                    if (!eventDelivered) {
+                        EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is null");
+                        actorType = nullptr;
 
-                    TAutoPtr<IEventHandle> nonDelivered = IEventHandle::ForwardOnNondelivery(std::move(ev), TEvents::TEvUndelivered::ReasonActorUnknown);
-                    if (nonDelivered.Get()) {
-                        ActorSystem->Send(nonDelivered);
-                    } else {
-                        ExecutionStats.IncrementNonDeliveredEvents();
+                        TAutoPtr<IEventHandle> nonDelivered = IEventHandle::ForwardOnNondelivery(std::move(ev), TEvents::TEvUndelivered::ReasonActorUnknown);
+                        if (nonDelivered.Get()) {
+                            ActorSystem->Send(nonDelivered);
+                        } else {
+                            ExecutionStats.IncrementNonDeliveredEvents();
+                        }
+                        if (actorRemovedBeforeEvent && mailbox->IsEmpty()) {
+                            mailbox->LockToFree();
+                        }
+                        hpnow = GetCycleCountFast();
+                        hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
+                        ExecutionStats.AddElapsedCycles(ActorSystemIndex, hpnow - hpprev);
                     }
-                    if (actorRemovedBeforeEvent && mailbox->IsEmpty()) {
-                        mailbox->LockToFree();
-                    }
-                    hpnow = GetCycleCountFast();
-                    hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
-                    ExecutionStats.AddElapsedCycles(ActorSystemIndex, hpnow - hpprev);
                 }
+                TlsActivationContext = nullptr;
                 eventStart = hpnow;
                 finishedExecutedEvents = execCtx.ExecutedEvents + 1;
 

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -209,6 +209,7 @@ namespace NActors {
         ui32 finishedExecutedEvents = execCtx.ExecutedEvents;
         bool isPreempted = false;
         bool wasWorking = false;
+        TStackVec<TActorId, 1> mailboxProcessingStartedActors;
         TStackVec<TActorId, 1> mailboxProcessingFinishedActors;
         NHPTimer::STime hpnow = execCtx.HPStart;
         NHPTimer::STime hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
@@ -216,20 +217,20 @@ namespace NActors {
         NHPTimer::STime eventStart = execCtx.HPStart;
         TlsThreadContext->ActivityContext.ActivationStartTS.store(execCtx.HPStart, std::memory_order_release);
 
-        auto finishActorEvent = [&](IActor*& currentActor, IEventHandle* ev, ui32 eventType,
-                const std::type_info* currentActorType, ui32 activityType) {
+        auto finishActorEvent = [&](IActor* currentActor, IEventHandle* ev, ui32 eventType,
+                const std::type_info* currentActorType, ui32 activityType,
+                bool updateActorsStats = true,
+                bool lockEmptyMailbox = true) {
             hpnow = GetCycleCountFast();
             hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
 
             const size_t dyingActorsCnt = DyingActors.size();
             EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "dyingActorsCnt ", dyingActorsCnt);
-            ExecutionStats.UpdateActorsStats(dyingActorsCnt, ThreadCtx.Pool());
-            if (dyingActorsCnt) {
-                DropUnregistered();
-                currentActor = nullptr;
+            if (updateActorsStats) {
+                ExecutionStats.UpdateActorsStats(dyingActorsCnt, ThreadCtx.Pool());
             }
 
-            if (mailbox->IsEmpty()) {
+            if (lockEmptyMailbox && mailbox->IsEmpty()) {
                 // had actors and became empty, prepare to reclaim mailbox
                 mailbox->LockToFree();
             }
@@ -256,6 +257,61 @@ namespace NActors {
             CurrentRecipient = TActorId();
         };
 
+        auto dropUnregistered = [&](IActor*& currentActor, ui32 executedEvents,
+                bool notifyMailboxProcessingFinished = true) {
+            if (DyingActors.empty()) {
+                return;
+            }
+
+            if (notifyMailboxProcessingFinished) {
+                for (size_t i = 0; i < DyingActors.size(); ++i) {
+                    IActor* dyingActor = DyingActors[i].Get();
+                    if (!(dyingActor->GetSystemFlags() & static_cast<ui64>(
+                            IActor::ESystemFlag::MailboxProcessingFinished))) {
+                        continue;
+                    }
+
+                    const TActorId recipient = dyingActor->SelfId();
+                    TActorContext ctx(*mailbox, *this, eventStart, recipient);
+                    TlsActivationContext = &ctx;
+                    TAutoPtr<IEventHandle> ev = new IEventHandle(
+                        recipient,
+                        TActorId(),
+                        new TEvents::TEvMailboxProcessingFinished(
+                            EFinishReason::ActorDied,
+                            executedEvents,
+                            hpnow - execCtx.HPStart));
+
+                    const std::type_info* notificationActorType = &typeid(*dyingActor);
+                    const ui32 activityType = dyingActor->GetActivityType().GetIndex();
+                    NProfiling::TMemoryTagScope::Reset(activityType);
+                    TlsThreadContext->ActivityContext.ElapsingActorActivity.store(
+                        activityType,
+                        std::memory_order_release);
+                    CurrentRecipient = recipient;
+                    CurrentActorScheduledEventsCounter = 0;
+
+                    dyingActor->Receive(ev);
+
+                    finishActorEvent(
+                        dyingActor,
+                        ev.Get(),
+                        TEvents::TSystem::MailboxProcessingFinished,
+                        notificationActorType,
+                        activityType,
+                        false,
+                        false);
+                    eventStart = hpnow;
+                }
+            }
+
+            const TActorId currentActorId = currentActor ? currentActor->SelfId() : TActorId();
+            DropUnregistered();
+            currentActor = currentActorId
+                ? mailbox->FindActor(currentActorId.LocalId())
+                : nullptr;
+        };
+
         ThreadCtx.ResetOverwrittenEventsPerMailbox();
         ThreadCtx.ResetOverwrittenTimePerMailboxTs();
         Y_ABORT_UNLESS(mailboxScheduledTimestampTs, "mailbox scheduled timestamp must be set");
@@ -275,10 +331,9 @@ namespace NActors {
                         recipient = evExt->GetRecipientRewrite();
                     }
                 }
-                TActorContext ctx(*mailbox, *this, eventStart, recipient);
-                TlsActivationContext = &ctx; // ensure dtor (if any) is called within actor system
-                // move for destruct before ctx;
                 TAutoPtr<IEventHandle> ev = evExt.release();
+                bool eventDelivered = false;
+                bool actorRemovedBeforeEvent = false;
                 if (actor) {
                     EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is not null");
                     wasWorking = true;
@@ -290,8 +345,6 @@ namespace NActors {
                     TCallstack::GetTlsCallstack().SetLinesToSkip();
 #endif
                     CurrentRecipient = recipient;
-                    CurrentActorScheduledEventsCounter = 0;
-
                     if (firstEvent) {
                         ThreadCtx.SetActivationTimeUs(CalculateWaitingTimeUs(mailboxScheduledTimestampTs, hpprev));
                         double usec = ExecutionStats.AddActivationStats(mailboxScheduledTimestampTs, hpprev);
@@ -316,32 +369,95 @@ namespace NActors {
                         TlsThreadContext->ActivityContext.ElapsingActorActivity.store(activityType, std::memory_order_release);
                     }
 
-                    actor->Receive(ev);
+                    const bool isBootstrapEvent =
+                        ev->GetTypeRewrite() == TEvents::TSystem::Bootstrap;
+                    const TActorId actorId = actor->SelfId();
+                    const ui64 systemFlagsBefore = actor->GetSystemFlags();
+                    if (!isBootstrapEvent &&
+                            (systemFlagsBefore & static_cast<ui64>(
+                                IActor::ESystemFlag::MailboxProcessingStarted)) &&
+                            std::find(
+                                mailboxProcessingStartedActors.begin(),
+                                mailboxProcessingStartedActors.end(),
+                                actorId) == mailboxProcessingStartedActors.end()) {
+                        mailboxProcessingStartedActors.push_back(actorId);
 
-                    const ui64 systemFlags = actor->GetSystemFlags();
-                    if (Y_UNLIKELY(systemFlags != 0)) {
-                        if (systemFlags & static_cast<ui64>(
-                                IActor::ESystemFlag::MailboxProcessingFinished)) {
-                            const TActorId actorId = actor->SelfId();
-                            if (std::find(
-                                    mailboxProcessingFinishedActors.begin(),
-                                    mailboxProcessingFinishedActors.end(),
-                                    actorId) == mailboxProcessingFinishedActors.end()) {
-                                mailboxProcessingFinishedActors.push_back(actorId);
-                            }
-                        }
+                        TActorContext startedCtx(*mailbox, *this, eventStart, recipient);
+                        TlsActivationContext = &startedCtx;
+                        TAutoPtr<IEventHandle> startedEv = new IEventHandle(
+                            actorId,
+                            TActorId(),
+                            new TEvents::TEvMailboxProcessingStarted());
+                        CurrentRecipient = recipient;
+                        CurrentActorScheduledEventsCounter = 0;
+
+                        actor->Receive(startedEv);
+
+                        finishActorEvent(
+                            actor,
+                            startedEv.Get(),
+                            TEvents::TSystem::MailboxProcessingStarted,
+                            actorType,
+                            activityType,
+                            true,
+                            false);
+                        dropUnregistered(actor, execCtx.ExecutedEvents);
+                        actorRemovedBeforeEvent = !actor;
+                        eventStart = hpnow;
                     }
 
-                    finishActorEvent(actor, ev.Get(), evTypeForTracing, actorType, activityType);
-                } else {
+                    if (actor) {
+                        TActorContext ctx(*mailbox, *this, eventStart, recipient);
+                        TlsActivationContext = &ctx; // ensure dtor (if any) is called within actor system
+                        CurrentRecipient = recipient;
+                        CurrentActorScheduledEventsCounter = 0;
+                        eventDelivered = true;
+
+                        actor->Receive(ev);
+
+                        const ui64 systemFlags = actor->GetSystemFlags();
+                        if (Y_UNLIKELY(systemFlags != 0)) {
+                            if (!isBootstrapEvent &&
+                                    (systemFlags & static_cast<ui64>(
+                                        IActor::ESystemFlag::MailboxProcessingStarted)) &&
+                                    std::find(
+                                        mailboxProcessingStartedActors.begin(),
+                                        mailboxProcessingStartedActors.end(),
+                                        actorId) == mailboxProcessingStartedActors.end()) {
+                                // The flag was enabled by the event being handled.
+                                // Remember this actor so the notification starts
+                                // with the next mailbox activation.
+                                mailboxProcessingStartedActors.push_back(actorId);
+                            }
+                            if (systemFlags & static_cast<ui64>(
+                                    IActor::ESystemFlag::MailboxProcessingFinished)) {
+                                if (std::find(
+                                        mailboxProcessingFinishedActors.begin(),
+                                        mailboxProcessingFinishedActors.end(),
+                                        actorId) == mailboxProcessingFinishedActors.end()) {
+                                    mailboxProcessingFinishedActors.push_back(actorId);
+                                }
+                            }
+                        }
+
+                        finishActorEvent(actor, ev.Get(), evTypeForTracing, actorType, activityType);
+                        dropUnregistered(actor, execCtx.ExecutedEvents + 1);
+                    }
+                    TlsActivationContext = nullptr;
+                }
+                if (!eventDelivered) {
                     EXECUTOR_THREAD_DEBUG(EDebugLevel::Event, "actor is null");
                     actorType = nullptr;
+                    TlsActivationContext = nullptr;
 
                     TAutoPtr<IEventHandle> nonDelivered = IEventHandle::ForwardOnNondelivery(std::move(ev), TEvents::TEvUndelivered::ReasonActorUnknown);
                     if (nonDelivered.Get()) {
                         ActorSystem->Send(nonDelivered);
                     } else {
                         ExecutionStats.IncrementNonDeliveredEvents();
+                    }
+                    if (actorRemovedBeforeEvent && mailbox->IsEmpty()) {
+                        mailbox->LockToFree();
                     }
                     hpnow = GetCycleCountFast();
                     hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
@@ -463,6 +579,9 @@ namespace NActors {
                     TEvents::TSystem::MailboxProcessingFinished,
                     notificationActorType,
                     activityType);
+                // The actor has already received its finish notification, so
+                // do not send a second one if it passes away while handling it.
+                dropUnregistered(actor, finishedExecutedEvents, false);
                 eventStart = hpnow;
             }
         }

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -263,6 +263,7 @@ namespace NActors {
                 return;
             }
 
+            TActivationContext* const previousActivationContext = TlsActivationContext;
             if (notifyMailboxProcessingFinished) {
                 for (size_t i = 0; i < DyingActors.size(); ++i) {
                     IActor* dyingActor = DyingActors[i].Get();
@@ -302,6 +303,7 @@ namespace NActors {
                         false,
                         false);
                     eventStart = hpnow;
+                    TlsActivationContext = previousActivationContext;
                 }
             }
 

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -223,7 +223,7 @@ namespace NActors {
         auto finishActorEvent = [&](IActor* currentActor, IEventHandle* ev, ui32 eventType,
                 const std::type_info* currentActorType, ui32 activityType,
                 bool updateActorsStats = true,
-                bool lockEmptyMailbox = true) {
+                bool reclaimEmptyMailbox = true) {
             hpnow = GetCycleCountFast();
             hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
 
@@ -233,8 +233,10 @@ namespace NActors {
                 ExecutionStats.UpdateActorsStats(dyingActorsCnt, ThreadCtx.Pool());
             }
 
-            if (lockEmptyMailbox && mailbox->IsEmpty()) {
-                // had actors and became empty, prepare to reclaim mailbox
+            if (reclaimEmptyMailbox && mailbox->IsEmpty()) {
+                // The last actor has been detached. Mark the mailbox as free so new
+                // events cannot be enqueued and move already queued events to the local
+                // queue. Nested lifecycle notifications defer this to the enclosing event.
                 mailbox->LockToFree();
             }
 
@@ -612,6 +614,7 @@ namespace NActors {
         NProfiling::TMemoryTagScope::Reset(0);
         TlsActivationContext = nullptr;
         ThreadCtx.ResetMailboxContext();
+        // A free mailbox can be reclaimed after its local event queue is drained.
         if (mailbox->IsEmpty() && mailbox->CanReclaim()) {
             ThreadCtx.FreeMailbox(mailbox);
         } else {

--- a/ydb/library/actors/core/executor_thread.cpp
+++ b/ydb/library/actors/core/executor_thread.cpp
@@ -209,7 +209,7 @@ namespace NActors {
         ui32 finishedExecutedEvents = execCtx.ExecutedEvents;
         bool isPreempted = false;
         bool wasWorking = false;
-        TStackVec<TActorId, 1> mailboxProcessingStartedActors;
+        TStackVec<TActorId, 1> actorProcessedActors;
         TStackVec<TActorId, 1> mailboxProcessingFinishedActors;
         NHPTimer::STime hpnow = execCtx.HPStart;
         NHPTimer::STime hpprev = TlsThreadContext->UpdateStartOfProcessingEventTS(hpnow);
@@ -267,7 +267,7 @@ namespace NActors {
                 for (size_t i = 0; i < DyingActors.size(); ++i) {
                     IActor* dyingActor = DyingActors[i].Get();
                     if (!(dyingActor->GetSystemFlags() & static_cast<ui64>(
-                            IActor::ESystemFlag::MailboxProcessingFinished))) {
+                            IActor::ESystemFlag::RequestedMailboxProcessingFinished))) {
                         continue;
                     }
 
@@ -375,13 +375,9 @@ namespace NActors {
                     const ui64 systemFlagsBefore = actor->GetSystemFlags();
                     if (!isBootstrapEvent &&
                             (systemFlagsBefore & static_cast<ui64>(
-                                IActor::ESystemFlag::MailboxProcessingStarted)) &&
-                            std::find(
-                                mailboxProcessingStartedActors.begin(),
-                                mailboxProcessingStartedActors.end(),
-                                actorId) == mailboxProcessingStartedActors.end()) {
-                        mailboxProcessingStartedActors.push_back(actorId);
-
+                                IActor::ESystemFlag::RequestedMailboxProcessingStarted)) &&
+                            !(systemFlagsBefore & static_cast<ui64>(
+                                IActor::ESystemFlag::ActorProcessed))) {
                         TActorContext startedCtx(*mailbox, *this, eventStart, recipient);
                         TlsActivationContext = &startedCtx;
                         TAutoPtr<IEventHandle> startedEv = new IEventHandle(
@@ -415,28 +411,20 @@ namespace NActors {
 
                         actor->Receive(ev);
 
+                        if (!isBootstrapEvent && !actor->HasSystemFlag(
+                                IActor::ESystemFlag::ActorProcessed)) {
+                            actor->SetSystemFlag(IActor::ESystemFlag::ActorProcessed);
+                            actorProcessedActors.push_back(actorId);
+                        }
+
                         const ui64 systemFlags = actor->GetSystemFlags();
-                        if (Y_UNLIKELY(systemFlags != 0)) {
-                            if (!isBootstrapEvent &&
-                                    (systemFlags & static_cast<ui64>(
-                                        IActor::ESystemFlag::MailboxProcessingStarted)) &&
-                                    std::find(
-                                        mailboxProcessingStartedActors.begin(),
-                                        mailboxProcessingStartedActors.end(),
-                                        actorId) == mailboxProcessingStartedActors.end()) {
-                                // The flag was enabled by the event being handled.
-                                // Remember this actor so the notification starts
-                                // with the next mailbox activation.
-                                mailboxProcessingStartedActors.push_back(actorId);
-                            }
-                            if (systemFlags & static_cast<ui64>(
-                                    IActor::ESystemFlag::MailboxProcessingFinished)) {
-                                if (std::find(
-                                        mailboxProcessingFinishedActors.begin(),
-                                        mailboxProcessingFinishedActors.end(),
-                                        actorId) == mailboxProcessingFinishedActors.end()) {
-                                    mailboxProcessingFinishedActors.push_back(actorId);
-                                }
+                        if (Y_UNLIKELY(systemFlags & static_cast<ui64>(
+                                IActor::ESystemFlag::RequestedMailboxProcessingFinished))) {
+                            if (std::find(
+                                    mailboxProcessingFinishedActors.begin(),
+                                    mailboxProcessingFinishedActors.end(),
+                                    actorId) == mailboxProcessingFinishedActors.end()) {
+                                mailboxProcessingFinishedActors.push_back(actorId);
                             }
                         }
 
@@ -552,7 +540,7 @@ namespace NActors {
         for (const TActorId& actorId : mailboxProcessingFinishedActors) {
             if (IActor* actor = mailbox->FindActor(actorId.LocalId());
                     actor && (actor->GetSystemFlags() & static_cast<ui64>(
-                        IActor::ESystemFlag::MailboxProcessingFinished))) {
+                        IActor::ESystemFlag::RequestedMailboxProcessingFinished))) {
                 const TActorId recipient = actor->SelfId();
                 TActorContext ctx(*mailbox, *this, eventStart, recipient);
                 TlsActivationContext = &ctx;
@@ -583,6 +571,11 @@ namespace NActors {
                 // do not send a second one if it passes away while handling it.
                 dropUnregistered(actor, finishedExecutedEvents, false);
                 eventStart = hpnow;
+            }
+        }
+        for (const TActorId& actorId : actorProcessedActors) {
+            if (IActor* actor = mailbox->FindActor(actorId.LocalId())) {
+                actor->ClearSystemFlag(IActor::ESystemFlag::ActorProcessed);
             }
         }
         TlsThreadContext->ActivityContext.ActivationStartTS.store(hpnow, std::memory_order_release);

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -972,6 +972,8 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
                     TlsThreadContext->ExecutionContext.CapturedActivation.SendingType =
                         ESendingType::Tail;
                     break;
+                case EFinishReason::ActorDied:
+                    Y_ABORT("ActorDied cannot be forced for a live actor");
             }
         }
 
@@ -1095,6 +1097,410 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         actorSystem.Stop();
 
         UNIT_ASSERT_VALUES_EQUAL(notifications, 2);
+    }
+}
+
+Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
+    enum class EStep : ui8 {
+        Bootstrap,
+        Started,
+        Event1,
+        Event2,
+        Event3,
+        Finished,
+        Destroyed,
+    };
+
+    class TOrderedObserverActor : public TActorBootstrapped<TOrderedObserverActor> {
+    public:
+        TOrderedObserverActor(TVector<EStep>& steps, TThreadParkPad& done)
+            : Steps(steps)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            Steps.push_back(EStep::Bootstrap);
+            SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            Send(SelfId(), new TEvents::TEvWakeup(1));
+            Send(SelfId(), new TEvents::TEvWakeup(2));
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingStarted, Handle);
+                hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
+            Steps.push_back(EStep::Started);
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
+            Steps.push_back(EStep::Finished);
+            if (++Activations == 1) {
+                Send(SelfId(), new TEvents::TEvWakeup(3));
+            } else {
+                ClearSystemFlag(ESystemFlag::MailboxProcessingStarted);
+                ClearSystemFlag(ESystemFlag::MailboxProcessingFinished);
+                Done.Unpark();
+                PassAway();
+            }
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr& ev) {
+            switch (ev->Get()->Tag) {
+                case 1:
+                    Steps.push_back(EStep::Event1);
+                    break;
+                case 2:
+                    Steps.push_back(EStep::Event2);
+                    break;
+                case 3:
+                    Steps.push_back(EStep::Event3);
+                    break;
+            }
+        }
+
+    private:
+        TVector<EStep>& Steps;
+        TThreadParkPad& Done;
+        ui32 Activations = 0;
+    };
+
+    class TDeferredOptInActor : public TActorBootstrapped<TDeferredOptInActor> {
+    public:
+        TDeferredOptInActor(TVector<EStep>& steps, TThreadParkPad& done)
+            : Steps(steps)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            Steps.push_back(EStep::Bootstrap);
+            Send(SelfId(), new TEvents::TEvWakeup(1));
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingStarted, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
+            Steps.push_back(EStep::Started);
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr& ev) {
+            switch (ev->Get()->Tag) {
+                case 1:
+                    Steps.push_back(EStep::Event1);
+                    SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+                    Send(SelfId(), new TEvents::TEvWakeup(2));
+                    break;
+                case 2:
+                    Steps.push_back(EStep::Event2);
+                    Schedule(TDuration::MilliSeconds(1), new TEvents::TEvWakeup(3));
+                    break;
+                case 3:
+                    Steps.push_back(EStep::Event3);
+                    ClearSystemFlag(ESystemFlag::MailboxProcessingStarted);
+                    Done.Unpark();
+                    PassAway();
+                    break;
+            }
+        }
+
+    private:
+        TVector<EStep>& Steps;
+        TThreadParkPad& Done;
+    };
+
+    class TPassAwayObserverActor : public TActorBootstrapped<TPassAwayObserverActor> {
+    public:
+        TPassAwayObserverActor(
+                TVector<EStep>& steps,
+                TEvents::TEvMailboxProcessingFinished::EReason& reason,
+                ui32& handledEvents,
+                TThreadParkPad& done,
+                bool passAwayOnStarted = false)
+            : Steps(steps)
+            , Reason(reason)
+            , HandledEvents(handledEvents)
+            , Done(done)
+            , PassAwayOnStarted(passAwayOnStarted)
+        {}
+
+        ~TPassAwayObserverActor() {
+            Steps.push_back(EStep::Destroyed);
+            Done.Unpark();
+        }
+
+        void Bootstrap() {
+            Steps.push_back(EStep::Bootstrap);
+            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            if (PassAwayOnStarted) {
+                SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+            }
+            Send(SelfId(), new TEvents::TEvWakeup());
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingStarted, Handle);
+                hFunc(TEvents::TEvMailboxProcessingFinished, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
+            Steps.push_back(EStep::Started);
+            PassAway();
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingFinished::TPtr& ev) {
+            Steps.push_back(EStep::Finished);
+            Reason = ev->Get()->Reason;
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr&) {
+            ++HandledEvents;
+            Steps.push_back(EStep::Event1);
+            PassAway();
+        }
+
+    private:
+        TVector<EStep>& Steps;
+        TEvents::TEvMailboxProcessingFinished::EReason& Reason;
+        ui32& HandledEvents;
+        TThreadParkPad& Done;
+        const bool PassAwayOnStarted;
+    };
+
+    struct TSharedMailboxResult {
+        ui32 Started[2] = {};
+        ui32 Events[2] = {};
+        ui32 FinishedActors = 0;
+        TVector<ui32> Order;
+    };
+
+    class TSharedMailboxChild : public TActorBootstrapped<TSharedMailboxChild> {
+    public:
+        TSharedMailboxChild(
+                ui32 index,
+                TSharedMailboxResult& result,
+                TThreadParkPad& done)
+            : Index(index)
+            , Result(result)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+            Send(SelfId(), new TEvents::TEvWakeup());
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingStarted, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
+            ++Result.Started[Index];
+            Result.Order.push_back(10 + Index);
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr&) {
+            ++Result.Events[Index];
+            Result.Order.push_back(20 + Index);
+            ClearSystemFlag(ESystemFlag::MailboxProcessingStarted);
+            if (++Result.FinishedActors == 2) {
+                Done.Unpark();
+            }
+            PassAway();
+        }
+
+    private:
+        const ui32 Index;
+        TSharedMailboxResult& Result;
+        TThreadParkPad& Done;
+    };
+
+    class TSharedMailboxParent : public TActorBootstrapped<TSharedMailboxParent> {
+    public:
+        TSharedMailboxParent(TSharedMailboxResult& result, TThreadParkPad& done)
+            : Result(result)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            RegisterWithSameMailbox(new TSharedMailboxChild(0, Result, Done));
+            RegisterWithSameMailbox(new TSharedMailboxChild(1, Result, Done));
+            PassAway();
+        }
+
+    private:
+        TSharedMailboxResult& Result;
+        TThreadParkPad& Done;
+    };
+
+    THolder<TActorSystemSetup> MakeSetup() {
+        auto setup = NActors::NTests::TActorBenchmark<>::GetActorSystemSetup();
+        NActors::NTests::TActorBenchmark<>::AddBasicPool(setup, 1, false, false);
+        return setup;
+    }
+
+    Y_UNIT_TEST(NotifiesBeforeFirstEventOfEveryActivation) {
+        auto setup = MakeSetup();
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TVector<EStep> steps;
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TOrderedObserverActor(steps, done),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        const TVector<EStep> expected = {
+            EStep::Bootstrap,
+            EStep::Started,
+            EStep::Event1,
+            EStep::Event2,
+            EStep::Finished,
+            EStep::Started,
+            EStep::Event3,
+            EStep::Finished,
+        };
+        UNIT_ASSERT(steps == expected);
+    }
+
+    Y_UNIT_TEST(EnablingFlagDuringEventTakesEffectNextActivation) {
+        auto setup = MakeSetup();
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TVector<EStep> steps;
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TDeferredOptInActor(steps, done),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        const TVector<EStep> expected = {
+            EStep::Bootstrap,
+            EStep::Event1,
+            EStep::Event2,
+            EStep::Started,
+            EStep::Event3,
+        };
+        UNIT_ASSERT(steps == expected);
+    }
+
+    Y_UNIT_TEST(NotifiesBeforeActorDestruction) {
+        using EReason = TEvents::TEvMailboxProcessingFinished::EReason;
+
+        auto setup = MakeSetup();
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TVector<EStep> steps;
+        EReason reason = EReason::QueueEmpty;
+        ui32 handledEvents = 0;
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TPassAwayObserverActor(steps, reason, handledEvents, done),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        const TVector<EStep> expected = {
+            EStep::Bootstrap,
+            EStep::Event1,
+            EStep::Finished,
+            EStep::Destroyed,
+        };
+        UNIT_ASSERT(steps == expected);
+        UNIT_ASSERT_VALUES_EQUAL(handledEvents, 1);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui8>(reason),
+            static_cast<ui8>(EReason::ActorDied));
+    }
+
+    Y_UNIT_TEST(NotifiesEveryActorInSharedMailbox) {
+        auto setup = MakeSetup();
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TSharedMailboxResult result;
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TSharedMailboxParent(result, done),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        UNIT_ASSERT_VALUES_EQUAL(result.Started[0], 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.Started[1], 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.Events[0], 1);
+        UNIT_ASSERT_VALUES_EQUAL(result.Events[1], 1);
+
+        const auto started0 = std::find(result.Order.begin(), result.Order.end(), 10);
+        const auto event0 = std::find(result.Order.begin(), result.Order.end(), 20);
+        const auto started1 = std::find(result.Order.begin(), result.Order.end(), 11);
+        const auto event1 = std::find(result.Order.begin(), result.Order.end(), 21);
+        UNIT_ASSERT(started0 < event0);
+        UNIT_ASSERT(started1 < event1);
+    }
+
+    Y_UNIT_TEST(DoesNotDeliverOriginalEventAfterActorDiesInStartedNotification) {
+        using EReason = TEvents::TEvMailboxProcessingFinished::EReason;
+
+        auto setup = MakeSetup();
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TVector<EStep> steps;
+        EReason reason = EReason::QueueEmpty;
+        ui32 handledEvents = 0;
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TPassAwayObserverActor(steps, reason, handledEvents, done, true),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        const TVector<EStep> expected = {
+            EStep::Bootstrap,
+            EStep::Started,
+            EStep::Finished,
+            EStep::Destroyed,
+        };
+        UNIT_ASSERT(steps == expected);
+        UNIT_ASSERT_VALUES_EQUAL(handledEvents, 0);
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<ui8>(reason),
+            static_cast<ui8>(EReason::ActorDied));
     }
 }
 

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -928,7 +928,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         {}
 
         void Bootstrap() {
-            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
             ForceFinishReason();
             Become(&TThis::StateWork);
         }
@@ -1003,7 +1003,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         {}
 
         void Bootstrap() {
-            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
             Become(&TThis::StateWork);
         }
 
@@ -1019,7 +1019,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
             if (Notifications == 1) {
                 Send(SelfId(), new TEvents::TEvWakeup(1));
             } else if (Notifications == 2) {
-                ClearSystemFlag(ESystemFlag::MailboxProcessingFinished);
+                ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
                 Send(SelfId(), new TEvents::TEvWakeup(2));
             } else {
                 Done.Unpark();
@@ -1120,8 +1120,8 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Bootstrap() {
             Steps.push_back(EStep::Bootstrap);
-            SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
-            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
             Send(SelfId(), new TEvents::TEvWakeup(1));
             Send(SelfId(), new TEvents::TEvWakeup(2));
             Become(&TThis::StateWork);
@@ -1144,8 +1144,8 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
             if (++Activations == 1) {
                 Send(SelfId(), new TEvents::TEvWakeup(3));
             } else {
-                ClearSystemFlag(ESystemFlag::MailboxProcessingStarted);
-                ClearSystemFlag(ESystemFlag::MailboxProcessingFinished);
+                ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+                ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
                 Done.Unpark();
                 PassAway();
             }
@@ -1199,7 +1199,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
             switch (ev->Get()->Tag) {
                 case 1:
                     Steps.push_back(EStep::Event1);
-                    SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+                    SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
                     Send(SelfId(), new TEvents::TEvWakeup(2));
                     break;
                 case 2:
@@ -1208,7 +1208,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
                     break;
                 case 3:
                     Steps.push_back(EStep::Event3);
-                    ClearSystemFlag(ESystemFlag::MailboxProcessingStarted);
+                    ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
                     Done.Unpark();
                     PassAway();
                     break;
@@ -1242,9 +1242,9 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Bootstrap() {
             Steps.push_back(EStep::Bootstrap);
-            SetSystemFlag(ESystemFlag::MailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
             if (PassAwayOnStarted) {
-                SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+                SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
             }
             Send(SelfId(), new TEvents::TEvWakeup());
             Become(&TThis::StateWork);
@@ -1301,7 +1301,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
         {}
 
         void Bootstrap() {
-            SetSystemFlag(ESystemFlag::MailboxProcessingStarted);
+            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
             Send(SelfId(), new TEvents::TEvWakeup());
             Become(&TThis::StateWork);
         }
@@ -1321,7 +1321,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
         void Handle(TEvents::TEvWakeup::TPtr&) {
             ++Result.Events[Index];
             Result.Order.push_back(20 + Index);
-            ClearSystemFlag(ESystemFlag::MailboxProcessingStarted);
+            ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
             if (++Result.FinishedActors == 2) {
                 Done.Unpark();
             }

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -973,7 +973,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
                         ESendingType::Tail;
                     break;
                 case EFinishReason::ActorDied:
-                    Y_ABORT("ActorDied cannot be forced for a live actor");
+                    break; // Rejected by Run() before the actor starts.
             }
         }
 
@@ -1042,6 +1042,10 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
     };
 
     TResult Run(EFinishReason expectedReason) {
+        UNIT_ASSERT_C(
+            expectedReason != EFinishReason::ActorDied,
+            "ActorDied cannot be forced for a live actor");
+
         auto setup = TActorBenchmark::GetActorSystemSetup();
         TActorBenchmark::AddBasicPool(setup, 1, false, false);
 

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -928,7 +928,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         {}
 
         void Bootstrap() {
-            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
             ForceFinishReason();
             Become(&TThis::StateWork);
         }
@@ -1003,7 +1003,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
         {}
 
         void Bootstrap() {
-            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
             Become(&TThis::StateWork);
         }
 
@@ -1019,7 +1019,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingFinished) {
             if (Notifications == 1) {
                 Send(SelfId(), new TEvents::TEvWakeup(1));
             } else if (Notifications == 2) {
-                ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
+                ClearSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
                 Send(SelfId(), new TEvents::TEvWakeup(2));
             } else {
                 Done.Unpark();
@@ -1124,8 +1124,8 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Bootstrap() {
             Steps.push_back(EStep::Bootstrap);
-            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
-            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
             Send(SelfId(), new TEvents::TEvWakeup(1));
             Send(SelfId(), new TEvents::TEvWakeup(2));
             Become(&TThis::StateWork);
@@ -1148,8 +1148,8 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
             if (++Activations == 1) {
                 Send(SelfId(), new TEvents::TEvWakeup(3));
             } else {
-                ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
-                ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
+                ClearSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
+                ClearSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
                 Done.Unpark();
                 PassAway();
             }
@@ -1203,7 +1203,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
             switch (ev->Get()->Tag) {
                 case 1:
                     Steps.push_back(EStep::Event1);
-                    SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+                    SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
                     Send(SelfId(), new TEvents::TEvWakeup(2));
                     break;
                 case 2:
@@ -1212,7 +1212,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
                     break;
                 case 3:
                     Steps.push_back(EStep::Event3);
-                    ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+                    ClearSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
                     Done.Unpark();
                     PassAway();
                     break;
@@ -1246,9 +1246,9 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Bootstrap() {
             Steps.push_back(EStep::Bootstrap);
-            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingFinished);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
             if (PassAwayOnStarted) {
-                SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+                SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
             }
             Send(SelfId(), new TEvents::TEvWakeup());
             Become(&TThis::StateWork);
@@ -1305,7 +1305,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
         {}
 
         void Bootstrap() {
-            SetSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
             Send(SelfId(), new TEvents::TEvWakeup());
             Become(&TThis::StateWork);
         }
@@ -1325,7 +1325,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
         void Handle(TEvents::TEvWakeup::TPtr&) {
             ++Result.Events[Index];
             Result.Order.push_back(20 + Index);
-            ClearSystemFlag(ESystemFlag::RequestedMailboxProcessingStarted);
+            ClearSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
             if (++Result.FinishedActors == 2) {
                 Done.Unpark();
             }

--- a/ydb/library/actors/core/ut/actor_ut.cpp
+++ b/ydb/library/actors/core/ut/actor_ut.cpp
@@ -1125,9 +1125,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
         void Bootstrap() {
             Steps.push_back(EStep::Bootstrap);
             SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
-            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
-            Send(SelfId(), new TEvents::TEvWakeup(1));
-            Send(SelfId(), new TEvents::TEvWakeup(2));
+            Schedule(TDuration::MilliSeconds(1), new TEvents::TEvWakeup(1));
             Become(&TThis::StateWork);
         }
 
@@ -1141,6 +1139,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
             Steps.push_back(EStep::Started);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
         }
 
         void Handle(TEvents::TEvMailboxProcessingFinished::TPtr&) {
@@ -1159,6 +1158,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
             switch (ev->Get()->Tag) {
                 case 1:
                     Steps.push_back(EStep::Event1);
+                    Send(SelfId(), new TEvents::TEvWakeup(2));
                     break;
                 case 2:
                     Steps.push_back(EStep::Event2);
@@ -1246,11 +1246,13 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Bootstrap() {
             Steps.push_back(EStep::Bootstrap);
-            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
             if (PassAwayOnStarted) {
                 SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
+                Schedule(TDuration::MilliSeconds(1), new TEvents::TEvWakeup());
+            } else {
+                SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
+                Send(SelfId(), new TEvents::TEvWakeup());
             }
-            Send(SelfId(), new TEvents::TEvWakeup());
             Become(&TThis::StateWork);
         }
 
@@ -1264,6 +1266,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
             Steps.push_back(EStep::Started);
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingFinished);
             PassAway();
         }
 
@@ -1306,7 +1309,7 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
         void Bootstrap() {
             SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
-            Send(SelfId(), new TEvents::TEvWakeup());
+            Schedule(TDuration::MilliSeconds(1), new TEvents::TEvWakeup());
             Become(&TThis::StateWork);
         }
 
@@ -1353,6 +1356,63 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
 
     private:
         TSharedMailboxResult& Result;
+        TThreadParkPad& Done;
+    };
+
+    class TContextCheckingWakeup : public TEvents::TEvWakeup {
+    public:
+        TContextCheckingWakeup(
+                std::atomic<bool>& hadActivationContext,
+                TThreadParkPad& done)
+            : HadActivationContext(hadActivationContext)
+            , Done(done)
+        {}
+
+        ~TContextCheckingWakeup() override {
+            HadActivationContext.store(!!TlsActivationContext, std::memory_order_release);
+            Done.Unpark();
+        }
+
+    private:
+        std::atomic<bool>& HadActivationContext;
+        TThreadParkPad& Done;
+    };
+
+    class TEventDestructorContextActor
+        : public TActorBootstrapped<TEventDestructorContextActor> {
+    public:
+        TEventDestructorContextActor(
+                std::atomic<bool>& hadActivationContext,
+                TThreadParkPad& done)
+            : HadActivationContext(hadActivationContext)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            SetSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
+            Schedule(
+                TDuration::MilliSeconds(1),
+                new TContextCheckingWakeup(HadActivationContext, Done));
+            Become(&TThis::StateWork);
+        }
+
+        STFUNC(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvMailboxProcessingStarted, Handle);
+                hFunc(TEvents::TEvWakeup, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvMailboxProcessingStarted::TPtr&) {
+        }
+
+        void Handle(TEvents::TEvWakeup::TPtr&) {
+            ClearSystemFlag(ESystemFlag::NotifyOnMailboxProcessingStarted);
+            PassAway();
+        }
+
+    private:
+        std::atomic<bool>& HadActivationContext;
         TThreadParkPad& Done;
     };
 
@@ -1473,6 +1533,24 @@ Y_UNIT_TEST_SUITE(MailboxProcessingStarted) {
         const auto event1 = std::find(result.Order.begin(), result.Order.end(), 21);
         UNIT_ASSERT(started0 < event0);
         UNIT_ASSERT(started1 < event1);
+    }
+
+    Y_UNIT_TEST(DestroysEventWithinActivationContext) {
+        auto setup = MakeSetup();
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        std::atomic<bool> hadActivationContext = false;
+        TThreadParkPad done;
+        actorSystem.Register(
+            new TEventDestructorContextActor(hadActivationContext, done),
+            TMailboxType::HTSwap,
+            0);
+
+        done.Park();
+        actorSystem.Stop();
+
+        UNIT_ASSERT(hadActivationContext.load(std::memory_order_acquire));
     }
 
     Y_UNIT_TEST(DoesNotDeliverOriginalEventAfterActorDiesInStartedNotification) {


### PR DESCRIPTION
### Changelog entry


### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Adds `TEvMailboxProcessingStarted`, delivered directly before an opted-in actor's first non-bootstrap event in each mailbox activation without entering the mailbox queue or consuming the event budget.

Opt-in during event handling takes effect on the next activation, and actors sharing a mailbox are tracked independently.

Also adds `TEvMailboxProcessingFinished::EReason::ActorDied`: an opted-in actor receives a final finish notification after `PassAway()` but before physical destruction. If an actor dies while handling the started notification, the original event is not delivered and the mailbox remains reclaimable.