### PR TITLE
Add missing RECURSE for Arcadia import (hash_test / cbo_latency_dataset / udf_store)

### DIFF
--- a/ydb/core/kqp/ya.make
+++ b/ydb/core/kqp/ya.make
@@ -79,6 +79,7 @@ RECURSE(
 RECURSE_FOR_TESTS(
     ut
     common/result_set_format/ut
+    tools/cbo_latency_dataset
     tools/hash_test
 )
 

--- a/ydb/tests/functional/udf_store/ya.make
+++ b/ydb/tests/functional/udf_store/ya.make
@@ -1,3 +1,7 @@
+RECURSE(
+    upload_udf
+)
+
 PY3TEST()
 
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)

--- a/ydb/tests/functional/ya.make
+++ b/ydb/tests/functional/ya.make
@@ -42,6 +42,7 @@ RECURSE(
     tpcc
     tenants
     ttl
+    udf_store
     wardens
     ydb_cli
 )

--- a/ydb/tests/ya.make
+++ b/ydb/tests/ya.make
@@ -4,6 +4,7 @@ RECURSE(
     example
     fq
     functional
+    hash_test
     library
     library/sqs
     olap


### PR DESCRIPTION
## Summary
Fixes GitHub→Arcadia **Missing Recurse** gaps from import [Arcanum 14480830](https://a.yandex-team.ru/review/14480830) (import tip `b5e035f41f`).

Parent `ya.make` is overwritten from GitHub on import — these must land on GH:
- `ydb/tests/hash_test` ← `ydb/tests/ya.make` (#45966 / @eivanov89)
- `ydb/core/kqp/tools/cbo_latency_dataset` ← `ydb/core/kqp/ya.make` (#30969 / @alexpaniman)
- `ydb/tests/functional/udf_store` + `upload_udf` (#46270 / @zverevgeny; overlaps open #47985)

## Out of scope
- `BlobStorageRetroTracing.DistributedDemandTrace` — broken test timing after #43755; leave to owner (@serbel324), not this PR.
- `HasPathDatastreams.ExternalTableMatches` — already fixed in #47585 (next import).

## Please review
- @eivanov89 — `hash_test` (#45966)
- @alexpaniman — `cbo_latency_dataset` (#30969)
- @zverevgeny — `udf_store` (#46270 / #47985)

## Test plan
- [ ] After merge, next Arcadia import common-checks drops these Missing Recurse rows
- [ ] Coordinate with #47985 (`udf_store`): close as superseded or drop overlapping hunk if it merges first