### PR TITLE
Replace abort to ensure

### DIFF
--- a/ydb/agents/NO_ABORT.md
+++ b/ydb/agents/NO_ABORT.md
@@ -1,17 +1,11 @@
-# Do not crash the node on check failures
+# No abort
 
-Do **not** use:
+Do **not** use `Y_ABORT`, `Y_ABORT_UNLESS`, `Y_VERIFY`, `Y_FAIL` — they kill the process.
 
-- `Y_ABORT`
-- `Y_ABORT_UNLESS`
-- `Y_VERIFY`
+Use `AFL_ENSURE(cond)("key", value)...` (throws; recoverable) or reply with an error.
 
-These terminate the process. Prefer:
+Always attach localization context for the relevant objects: tablet id, path/name, partition/shard, table, datashard, switch value — whatever identifies the failure (same data as nearby logs).
 
-- `Y_ENSURE` — throws; caller can catch and recover
-- return / reply with an error to the user or peer — keep the node running
+`Y_VERIFY_DEBUG` / `AFL_VERIFY_DEBUG` are OK (debug-only). Prefer `AFL_ENSURE` over `Y_ENSURE`.
 
-When writing code, do not introduce these macros.
-
-**PR review:** always check the diff for new `Y_ABORT` / `Y_ABORT_UNLESS` /
-`Y_VERIFY` and request replacing them with `Y_ENSURE` or a non-fatal error reply.
+**Review:** reject new abort/verify; require diagnostic keys on every `AFL_ENSURE`.

--- a/ydb/agents/NO_ABORT.md
+++ b/ydb/agents/NO_ABORT.md
@@ -1,11 +1,11 @@
 # No abort
 
-Do **not** use `Y_ABORT`, `Y_ABORT_UNLESS`, `Y_VERIFY`, `Y_FAIL` — they kill the process.
+Never `Y_ABORT` / `Y_ABORT_UNLESS` / `Y_VERIFY` / `Y_FAIL` (kills process).
 
-Use `AFL_ENSURE(cond)("key", value)...` (throws; recoverable) or reply with an error.
+Use `AFL_ENSURE(cond)("key", value)...` or reply with an error. Always add localization keys (tablet, path, partition/shard, table, switch value, …).
 
-Always attach localization context for the relevant objects: tablet id, path/name, partition/shard, table, datashard, switch value — whatever identifies the failure (same data as nearby logs).
+`Y_VERIFY_DEBUG` / `AFL_VERIFY_DEBUG` OK. Prefer `AFL_ENSURE` over `Y_ENSURE`.
 
-`Y_VERIFY_DEBUG` / `AFL_VERIFY_DEBUG` are OK (debug-only). Prefer `AFL_ENSURE` over `Y_ENSURE`.
+Actors/tablets: inherit `IActorExceptionHandler` (log + recover). `AFL_ENSURE` only if the calling actor has it — otherwise the throw crashes the server.
 
-**Review:** reject new abort/verify; require diagnostic keys on every `AFL_ENSURE`.
+**Review:** no new abort/verify; keys on every `AFL_ENSURE`; `IActorExceptionHandler` on new actors/tablets and anywhere `AFL_ENSURE` is used.

--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -6,10 +6,38 @@
 #include <ydb/core/persqueue/public/pq_rl_helpers.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/events.h>
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/services/services.pb.h>
 #include <ydb/public/api/protos/persqueue_error_codes_v1.pb.h>
 #include <ydb/public/api/protos/draft/persqueue_error_codes.pb.h> // strange
 
+#include <util/system/backtrace.h>
+#include <util/system/type_name.h>
+
 namespace NKafka {
+
+template <typename TDerived>
+class TKafkaExceptionHandler: public NActors::IActorExceptionHandler {
+public:
+    bool OnUnhandledException(const std::exception& exc) override {
+        auto* self = static_cast<TDerived*>(this);
+        const auto& ctx = self->ActorContext();
+        YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::KAFKA_PROXY, "Unhandled exception in kafka actor",
+            {"actor", TypeName<TDerived>()},
+            {"typeName", TypeName(exc)},
+            {"exception", exc.what()},
+            {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+        self->OnKafkaUnhandledException(exc, ctx);
+        return true;
+    }
+
+    void OnKafkaUnhandledException(const std::exception&, const NActors::TActorContext& ctx) {
+        auto* self = static_cast<TDerived*>(this);
+        ctx.Send(self->SelfId(), new NActors::TEvents::TEvPoison);
+    }
+};
 
 static constexpr int ProxyNodeId = 1;
 static constexpr char UnderlayPrefix[] = "u-";

--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -33,8 +33,18 @@ public:
         return true;
     }
 
+    // Default: tear down the TCP connection when available so the client reconnects.
+    // Override GetKafkaConnectionId() in actors that own a TContext.
+    NActors::TActorId GetKafkaConnectionId() const {
+        return {};
+    }
+
     void OnKafkaUnhandledException(const std::exception&, const NActors::TActorContext& ctx) {
         auto* self = static_cast<TDerived*>(this);
+        if (const auto connectionId = self->GetKafkaConnectionId()) {
+            ctx.Send(connectionId, new NActors::TEvents::TEvPoison);
+            return;
+        }
         ctx.Send(self->SelfId(), new NActors::TEvents::TEvPoison);
     }
 };

--- a/ydb/core/kafka_proxy/actors/actors.h
+++ b/ydb/core/kafka_proxy/actors/actors.h
@@ -28,7 +28,7 @@ public:
             {"actor", TypeName<TDerived>()},
             {"typeName", TypeName(exc)},
             {"exception", exc.what()},
-            {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+            {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
         self->OnKafkaUnhandledException(exc, ctx);
         return true;
     }

--- a/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/kafka_proxy/kafka_constants.h>
 #include <ydb/core/ydb_convert/topic_description.h>
 #include <ydb/core/ydb_convert/ydb_convert.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -75,7 +76,7 @@ void TKafkaDescribeTopicActor::Bootstrap(const NActors::TActorContext& ctx) {
 };
 
 void TKafkaDescribeTopicActor::HandleCacheNavigateResponse(NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
-    Y_ABORT_UNLESS(ev->Get()->Request.Get()->ResultSet.size() == 1); // describe for only one topic
+    AFL_ENSURE(ev->Get()->Request.Get()->ResultSet.size() == 1)("result_set_size", ev->Get()->Request.Get()->ResultSet.size())("database", Database)("path", TopicPath); // describe for only one topic
     if (ReplyIfNotTopic(ev)) {
         return;
     }
@@ -182,7 +183,7 @@ void TKafkaDescribeConfigsActor::AddDescribeResponse(
         response->Results.emplace_back(std::move(singleConfig));
         return;
     }
-    Y_ENSURE(ev != nullptr);
+    AFL_ENSURE(ev != nullptr)("database", Context->DatabasePath);
     AddConfigEntry(singleConfig, "compression.type", "producer", EKafkaConfigType::STRING);
 
     // these are default

--- a/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.h
@@ -27,7 +27,8 @@ public:
 
 };
 
-class TKafkaDescribeConfigsActor: public NActors::TActorBootstrapped<TKafkaDescribeConfigsActor> {
+class TKafkaDescribeConfigsActor: public NActors::TActorBootstrapped<TKafkaDescribeConfigsActor>
+                                , public TKafkaExceptionHandler<TKafkaDescribeConfigsActor> {
 public:
     TKafkaDescribeConfigsActor(
             const TContext::TPtr context,

--- a/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_describe_configs_actor.h
@@ -43,6 +43,10 @@ public:
     void Handle(const TEvKafka::TEvTopicDescribeResponse::TPtr& ev);
     void Reply();
 
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
+    }
+
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             hFunc(TEvKafka::TEvTopicDescribeResponse, Handle);

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.cpp
@@ -8,6 +8,7 @@
 #include <ydb/core/kafka_proxy/kafka_messages.h>
 #include <ydb/core/persqueue/public/list_topics/list_all_topics_actor.h>
 #include <ydb/services/persqueue_v1/actors/schema_actors.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -123,7 +124,7 @@ void TKafkaMetadataActor::ProcessTopicsFromRequest() {
 }
 
 void TKafkaMetadataActor::HandleListTopics(NKikimr::TEvPQ::TEvListAllTopicsResponse::TPtr& ev) {
-    Y_ABORT_UNLESS(PendingResponses > 0);
+    AFL_ENSURE(PendingResponses > 0)("pending", PendingResponses)("database", Context->DatabasePath);
     PendingResponses--;
     auto topics = std::move(ev->Get()->Topics);
     Response->Topics.resize(topics.size());

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -34,6 +34,10 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
+    }
+
 private:
     using TEvLocationResponse = NKikimr::NGRpcProxy::V1::TEvPQProxy::TEvPartitionLocationResponse;
 

--- a/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_metadata_actor.h
@@ -19,7 +19,8 @@ namespace NKafka {
 
 TActorId MakeKafkaDiscoveryCacheID();
 
-class TKafkaMetadataActor: public NActors::TActorBootstrapped<TKafkaMetadataActor> {
+class TKafkaMetadataActor: public NActors::TActorBootstrapped<TKafkaMetadataActor>
+                         , public TKafkaExceptionHandler<TKafkaMetadataActor> {
 public:
     TKafkaMetadataActor(const TContext::TPtr context, const ui64 correlationId, const TMessagePtr<TMetadataRequestData>& message,
                         const TActorId& discoveryCacheActor)

--- a/ydb/core/kafka_proxy/actors/kafka_metrics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metrics_actor.cpp
@@ -1,4 +1,5 @@
 #include "kafka_metrics_actor.h"
+#include "actors.h"
 
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/events.h>
@@ -12,7 +13,8 @@ namespace NKafka {
 
     using namespace NActors;
 
-    class TKafkaMetricsActor : public NActors::TActorBootstrapped<TKafkaMetricsActor> {
+    class TKafkaMetricsActor : public NActors::TActorBootstrapped<TKafkaMetricsActor>
+                             , public TKafkaExceptionHandler<TKafkaMetricsActor> {
         using TBase = NActors::TActorBootstrapped<TKafkaMetricsActor>;
     public:
         explicit TKafkaMetricsActor(const TKafkaMetricsSettings& settings)

--- a/ydb/core/kafka_proxy/actors/kafka_metrics_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_metrics_actor.cpp
@@ -49,7 +49,7 @@ namespace NKafka {
     };
 
     TIntrusivePtr<NMonitoring::TDynamicCounters> TKafkaMetricsActor::GetGroupFromLabels(const TVector<std::pair<TString, TString>>& labels) {
-        Y_ABORT_UNLESS(labels.size() > 1);
+        AFL_ENSURE(labels.size() > 1)("labels_size", labels.size());
         auto group = Settings.Counters->GetSubgroup(labels[0].first, labels[0].second);
         for (ui32 i = 1; i + 1 < labels.size(); ++i) {
             if (labels[i].second.empty())

--- a/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.cpp
@@ -1,4 +1,5 @@
 #include "kafka_offset_commit_actor.h"
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -134,11 +135,11 @@ void TKafkaOffsetCommitActor::Handle(TEvTabletPipe::TEvClientDestroyed::TPtr& ev
 
 void TKafkaOffsetCommitActor::ProcessPipeProblem(ui64 tabletId, const TActorContext& ctx) {
     auto cookiesIt = TabletIdToCookies.find(tabletId);
-    Y_ABORT_UNLESS(cookiesIt != TabletIdToCookies.end());
+    AFL_ENSURE(cookiesIt != TabletIdToCookies.end())("tablet_id", tabletId)("group", Message->GroupId.value())("database", Context->DatabasePath);
 
     for (auto cookie: cookiesIt->second) {
         auto requestInfoIt = CookieToRequestInfo.find(cookie);
-        Y_ABORT_UNLESS(requestInfoIt != CookieToRequestInfo.end());
+        AFL_ENSURE(requestInfoIt != CookieToRequestInfo.end())("tablet_id", tabletId)("cookie", cookie)("database", Context->DatabasePath);
 
         if (!requestInfoIt->second.Done) {
             requestInfoIt->second.Done = true;
@@ -300,7 +301,7 @@ void TKafkaOffsetCommitActor::SendCommits(const TActorContext& ctx) {
 void TKafkaOffsetCommitActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorContext& ctx) {
     const auto& partitionResult = ev->Get()->Record.GetPartitionResponse();
     auto requestInfo = CookieToRequestInfo.find(partitionResult.GetCookie());
-    Y_ABORT_UNLESS(requestInfo != CookieToRequestInfo.end());
+    AFL_ENSURE(requestInfo != CookieToRequestInfo.end())("cookie", partitionResult.GetCookie())("database", Context->DatabasePath);
 
     requestInfo->second.Done = true;
     if (ev->Get()->Record.GetErrorCode() != NPersQueue::NErrorCode::OK) {

--- a/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.h
@@ -30,7 +30,8 @@ using namespace NKikimr;
 
 extern const TString CHECK_GROUP_GENERATION;
 
-class TKafkaOffsetCommitActor: public NActors::TActorBootstrapped<TKafkaOffsetCommitActor> {
+class TKafkaOffsetCommitActor: public NActors::TActorBootstrapped<TKafkaOffsetCommitActor>
+                             , public TKafkaExceptionHandler<TKafkaOffsetCommitActor> {
 
 struct TRequestInfo {
     TString TopicName = "";

--- a/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_commit_actor.h
@@ -53,6 +53,10 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
+    }
+
 private:
     NActors::NStructuredLog::TStructuredMessage LogPrefix();
     void Die(const TActorContext& ctx) override;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -35,7 +35,8 @@ class TTopicOffsetActor: public NKikimr::NGRpcProxy::V1::TPQInternalSchemaActor<
                                                        NKikimr::NGRpcProxy::V1::TLocalRequestBase,
                                                        NKikimr::NGRpcProxy::V1::TEvPQProxy::TEvPartitionLocationResponse>,
                          public NKikimr::NGRpcProxy::V1::TDescribeTopicActorImpl,
-                         public NKikimr::NGRpcProxy::V1::TCdcStreamCompatible {
+                         public NKikimr::NGRpcProxy::V1::TCdcStreamCompatible,
+                         public TKafkaExceptionHandler<TTopicOffsetActor> {
     using TBase = NKikimr::NGRpcProxy::V1::TPQInternalSchemaActor<TTopicOffsetActor,
         NKikimr::NGRpcProxy::V1::TLocalRequestBase,
         NKikimr::NGRpcProxy::V1::TEvPQProxy::TEvPartitionLocationResponse>;

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/kafka_proxy/kafka_events.h>
 
 #include "ydb/services/persqueue_v1/actors/schema_actors.h"
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -145,7 +146,7 @@ class TTopicOffsetActor: public NKikimr::NGRpcProxy::V1::TPQInternalSchemaActor<
                        const TActorContext& ctx) override {
         Y_UNUSED(ctx);
         Y_UNUSED(ev);
-        Y_ABORT();
+        AFL_ENSURE(false)("reason", "TOffsetFetchActor: unexpected TEvGetPartitionsLocationResponse")("database", Database)("path", TopicPath);
     };
 
     void HandleCacheNavigateResponse(NKikimr::TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) override {

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -65,6 +65,10 @@ public:
 
     void Bootstrap(const NActors::TActorContext& ctx);
 
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
+    }
+
     STATEFN(StateWork) {
         switch (ev->GetTypeRewrite()) {
             HFunc(TEvKafka::TEvCommitedOffsetsResponse, Handle);

--- a/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_offset_fetch_actor.h
@@ -49,7 +49,8 @@ struct TTopicGroupRequest {
 };
 
 
-class TKafkaOffsetFetchActor: public NActors::TActorBootstrapped<TKafkaOffsetFetchActor> {
+class TKafkaOffsetFetchActor: public NActors::TActorBootstrapped<TKafkaOffsetFetchActor>
+                            , public TKafkaExceptionHandler<TKafkaOffsetFetchActor> {
 
     using TBase = NActors::TActor<TKafkaOffsetFetchActor>;
     using TOffsetFetchResponsePartitions = NKafka::TOffsetFetchResponseData::TOffsetFetchResponseGroup::TOffsetFetchResponseTopics::TOffsetFetchResponsePartitions;

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.cpp
@@ -12,6 +12,7 @@
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <limits>
 #include <util/string/join.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -530,7 +531,7 @@ std::pair<EKafkaErrors, THolder<TEvPartitionWriter::TEvWriteRequest>> Convert(
 
             TString str;
             bool res = proto.SerializeToString(&str);
-            Y_ABORT_UNLESS(res);
+            AFL_ENSURE(res)("reason", "failed to serialize TDataChunk");
 
             auto w = partitionRequest->AddCmdWrite();
             w->SetSourceId(NPQ::NSourceIdEncoding::EncodeSimple(sourceId));

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
@@ -44,6 +44,10 @@ public:
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::KAFKA_PRODUCE_ACTOR; }
 
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
+    }
+
 private:
     void PassAway() override;
 

--- a/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_produce_actor.h
@@ -24,7 +24,8 @@ using namespace NKikimrClient;
 // Requests are processed in parallel, but it is guaranteed that the recording order will be preserved.
 // The order of responses to requests is also guaranteed.
 //
-class TKafkaProduceActor: public NActors::TActorBootstrapped<TKafkaProduceActor> {
+class TKafkaProduceActor: public NActors::TActorBootstrapped<TKafkaProduceActor>
+                        , public TKafkaExceptionHandler<TKafkaProduceActor> {
     struct TPendingRequest;
 
     enum ETopicStatus {

--- a/ydb/core/kafka_proxy/actors/kafka_read_session_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_actor.cpp
@@ -1,5 +1,6 @@
 #include "kafka_read_session_actor.h"
 #include "kafka_read_session_utils.h"
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -373,7 +374,7 @@ TConsumerProtocolAssignment TKafkaReadSessionActor::BuildAssignmentAndInformBala
     for (auto& [topicName, partitions] : TopicPartitions) {
         auto topicInfoIt = TopicsInfo.find(topicName);
 
-        Y_ABORT_UNLESS(topicInfoIt != TopicsInfo.end());
+        AFL_ENSURE(topicInfoIt != TopicsInfo.end())("topic", topicName)("session", Session)("group", GroupId)("database", Context->DatabasePath);
 
         THashSet<ui64> finalPartitionsToRead;
 
@@ -554,9 +555,9 @@ void TKafkaReadSessionActor::HandleLockPartition(TEvPersQueue::TEvLockPartition:
         {"topic", record.GetTopic()},
         {"partition", record.GetPartition()});
 
-    Y_ABORT_UNLESS(record.GetSession() == Session);
-    Y_ABORT_UNLESS(record.GetClientId() == GroupId);
-    Y_ABORT_UNLESS(record.GetGeneration() > 0);
+    AFL_ENSURE(record.GetSession() == Session)("expected", Session)("actual", record.GetSession())("topic", record.GetTopic())("database", Context->DatabasePath);
+    AFL_ENSURE(record.GetClientId() == GroupId)("expected", GroupId)("actual", record.GetClientId())("topic", record.GetTopic())("database", Context->DatabasePath);
+    AFL_ENSURE(record.GetGeneration() > 0)("topic", record.GetTopic())("partition", record.GetPartition())("database", Context->DatabasePath);
 
     auto path = record.GetPath();
     if (path.empty()) {
@@ -597,14 +598,14 @@ void TKafkaReadSessionActor::HandleReleasePartition(TEvPersQueue::TEvReleasePart
         {"topic", record.GetTopic()},
         {"group", group});
 
-    Y_ABORT_UNLESS(record.GetSession() == Session);
-    Y_ABORT_UNLESS(record.GetClientId() == GroupId);
+    AFL_ENSURE(record.GetSession() == Session)("expected", Session)("actual", record.GetSession())("topic", record.GetTopic())("database", Context->DatabasePath);
+    AFL_ENSURE(record.GetClientId() == GroupId)("expected", GroupId)("actual", record.GetClientId())("topic", record.GetTopic())("database", Context->DatabasePath);
 
     auto pathIt = FullPathToConverter.find(NPersQueue::NormalizeFullPath(record.GetPath()));
-    Y_ABORT_UNLESS(pathIt != FullPathToConverter.end());
+    AFL_ENSURE(pathIt != FullPathToConverter.end())("path", record.GetPath())("topic", record.GetTopic())("database", Context->DatabasePath);
 
     auto topicInfoIt = TopicsInfo.find(pathIt->second->GetInternalName());
-    Y_ABORT_UNLESS(topicInfoIt != TopicsInfo.end());
+    AFL_ENSURE(topicInfoIt != TopicsInfo.end())("topic", pathIt->second->GetInternalName())("path", record.GetPath())("database", Context->DatabasePath);
 
     if (topicInfoIt->second.PipeClient != ActorIdFromProto(record.GetPipeClient())) {
         YDB_LOG_INFO("Ignored ev release topic is unknown",
@@ -617,7 +618,7 @@ void TKafkaReadSessionActor::HandleReleasePartition(TEvPersQueue::TEvReleasePart
     auto newPartitionsToLockCount = newPartitionsToLockIt == NewPartitionsToLockOnTime.end() ? 0 : newPartitionsToLockIt->second.size();
 
     auto topicPartitionsIt = TopicPartitions.find(pathIt->second->GetInternalName());
-    Y_ABORT_UNLESS(1 <= (topicPartitionsIt.IsEnd() ? 0 : topicPartitionsIt->second.ToLock.size() + topicPartitionsIt->second.ReadingNow.size()) + newPartitionsToLockCount);
+    AFL_ENSURE(1 <= (topicPartitionsIt.IsEnd() ? 0 : topicPartitionsIt->second.ToLock.size() + topicPartitionsIt->second.ReadingNow.size()) + newPartitionsToLockCount)("topic", record.GetTopic())("path", record.GetPath())("database", Context->DatabasePath);
 
     auto partitionToRelease = record.GetGroup() - 1;
 
@@ -670,7 +671,7 @@ void TKafkaReadSessionActor::InformBalancerAboutPartitionRelease(const TString& 
     auto request = MakeHolder<TEvPersQueue::TEvPartitionReleased>();
 
     auto topicIt = TopicsInfo.find(topic);
-    Y_ABORT_UNLESS(topicIt != TopicsInfo.end());
+    AFL_ENSURE(topicIt != TopicsInfo.end())("topic", topic)("partition", partition)("session", Session)("database", Context->DatabasePath);
 
     auto& req = request->Record;
     req.SetSession(Session);

--- a/ydb/core/kafka_proxy/actors/kafka_read_session_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_actor.h
@@ -90,9 +90,8 @@ public:
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::KAFKA_READ_SESSION_ACTOR; }
 
-    void OnKafkaUnhandledException(const std::exception&, const NActors::TActorContext& ctx) {
-        CloseReadSession(ctx);
-        ctx.Send(SelfId(), new NActors::TEvents::TEvPoison);
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
     }
 
 private:

--- a/ydb/core/kafka_proxy/actors/kafka_read_session_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_read_session_actor.h
@@ -54,7 +54,8 @@ namespace NKafka {
      *           <----------------
      */
 
-class TKafkaReadSessionActor: public NActors::TActorBootstrapped<TKafkaReadSessionActor> {
+class TKafkaReadSessionActor: public NActors::TActorBootstrapped<TKafkaReadSessionActor>
+                            , public TKafkaExceptionHandler<TKafkaReadSessionActor> {
 
 enum EReadSessionSteps {
     WAIT_JOIN_GROUP,
@@ -88,6 +89,11 @@ public:
     void Bootstrap(const NActors::TActorContext& ctx);
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::KAFKA_READ_SESSION_ACTOR; }
+
+    void OnKafkaUnhandledException(const std::exception&, const NActors::TActorContext& ctx) {
+        CloseReadSession(ctx);
+        ctx.Send(SelfId(), new NActors::TEvents::TEvPoison);
+    }
 
 private:
     using TActorContext = NActors::TActorContext;

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.cpp
@@ -11,6 +11,7 @@
 #include <ydb/core/security/sasl/scram_auth_actor.h>
 #include <ydb/library/login/sasl/scram.h>
 #include <ydb/services/persqueue_v1/actors/persqueue_utils.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -415,7 +416,7 @@ void TKafkaSaslAuthActor::HandleNavigate(TEvTxProxySchemeCache::TEvNavigateKeySe
     }
 
     if (CurrentStateFunc() == &TThis::StateResolveDatabase) {
-        Y_ABORT_UNLESS(navigate->ResultSet.size() == 1);
+        AFL_ENSURE(navigate->ResultSet.size() == 1)("result_set_size", navigate->ResultSet.size())("database", DatabasePath);
         IsServerless = navigate->ResultSet.front().DomainInfo->IsServerless();
 
         for (const auto& attr : navigate->ResultSet.front().Attributes) {

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.h
@@ -17,7 +17,8 @@ namespace NKafka {
 
 using namespace NKikimr;
 
-class TKafkaSaslAuthActor: public NActors::TActorBootstrapped<TKafkaSaslAuthActor> {
+class TKafkaSaslAuthActor: public NActors::TActorBootstrapped<TKafkaSaslAuthActor>
+                         , public TKafkaExceptionHandler<TKafkaSaslAuthActor> {
 
 struct TAuthData {
     TString UserName;

--- a/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_sasl_auth_actor.h
@@ -33,6 +33,10 @@ public:
 
     void Bootstrap();
 
+    NActors::TActorId GetKafkaConnectionId() const {
+        return Context ? Context->ConnectionId : NActors::TActorId{};
+    }
+
 private:
     STATEFN(StateWork) {
         YDB_LOG_TRACE_COMP(NKikimrServices::KAFKA_PROXY, "Received",

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.h
@@ -16,7 +16,8 @@ class TTopicOffsetsActor : public NKikimr::NGRpcProxy::V1::TPQInternalSchemaActo
                                                                TEvKafka::TGetOffsetsRequest,
                                                                TEvKafka::TEvTopicOffsetsResponse>
                                , public NKikimr::NGRpcProxy::V1::TDescribeTopicActorImpl
-                               , public NKikimr::NGRpcProxy::V1::TCdcStreamCompatible {
+                               , public NKikimr::NGRpcProxy::V1::TCdcStreamCompatible
+                               , public TKafkaExceptionHandler<TTopicOffsetsActor> {
 
 using TBase = TPQInternalSchemaActor<TTopicOffsetsActor,
                                                                TEvKafka::TGetOffsetsRequest,

--- a/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_topic_offsets_actor.h
@@ -8,6 +8,7 @@
 #include <ydb/services/persqueue_v1/actors/schema_actors.h>
 #include <ydb/services/lib/actors/pq_schema_actor.h>
 #include <ydb/core/kafka_proxy/kafka_events.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKafka {
 
@@ -34,11 +35,11 @@ public:
 
     virtual void ApplyResponse(TTabletInfo&, NKikimr::TEvPersQueue::TEvReadSessionsInfoResponse::TPtr&,
                                const TActorContext&) override {
-        Y_ABORT();
+        AFL_ENSURE(false)("reason", "TTopicOffsetsActor: unexpected TEvReadSessionsInfoResponse")("database", Database)("path", TopicPath);
     }
 
     bool ApplyResponse(NKikimr::TEvPersQueue::TEvGetPartitionsLocationResponse::TPtr&, const TActorContext&) override {
-        Y_ABORT();
+        AFL_ENSURE(false)("reason", "TTopicOffsetsActor: unexpected TEvGetPartitionsLocationResponse")("database", Database)("path", TopicPath);
     }
 
     void ApplyResponse(TTabletInfo& tabletInfo, NKikimr::TEvPersQueue::TEvStatusResponse::TPtr& ev, const TActorContext& ctx) override;

--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.cpp
@@ -7,6 +7,7 @@
 #include <ydb/core/kqp/common/simple/services.h>
 #include <util/generic/cast.h>
 #include <regex>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::KAFKA_PROXY
 
@@ -146,7 +147,7 @@ namespace NKafka {
                 HandleCommitResponse(ctx);
                 break;
             default:
-                Y_FAIL("Unexpected KQP request");
+                AFL_ENSURE(false)("reason", "Unexpected KQP request")("request", GetAsStr(LastSentToKqpRequest))("database", DatabasePath);
         }
     }
 

--- a/ydb/core/kafka_proxy/actors/kafka_transaction_actor.h
+++ b/ydb/core/kafka_proxy/actors/kafka_transaction_actor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "actors.h"
 #include "kafka_init_producer_id_actor.h"
 #include <ydb/core/kafka_proxy/kafka_log_impl.h>
 #include <ydb/core/kafka_proxy/kafka_topic_partition.h>
@@ -14,7 +15,8 @@ namespace NKafka {
 
     It accumulates transaction state (partitions in tx, offsets) and on commit submits transaction to KQP
     */
-    class TTransactionActor : public NActors::TActor<TTransactionActor> {
+    class TTransactionActor : public NActors::TActor<TTransactionActor>
+                            , public TKafkaExceptionHandler<TTransactionActor> {
 
         using TBase = NActors::TActor<TTransactionActor>;
 

--- a/ydb/core/kafka_proxy/kqp_helper.cpp
+++ b/ydb/core/kafka_proxy/kqp_helper.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/services/metadata/service.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKafka {
 
@@ -33,7 +34,7 @@ bool TKqpTxHelper::HandleCreateSessionResponse(TEvKqp::TEvCreateSessionResponse:
     }
 
     KqpSessionId = record.GetResponse().GetSessionId();
-    Y_ABORT_UNLESS(!KqpSessionId.empty());
+    AFL_ENSURE(!KqpSessionId.empty())("reason", "KqpSessionId is empty")("database", DataBase);
 
     return true;
 }

--- a/ydb/core/persqueue/common/key.cpp
+++ b/ydb/core/persqueue/common/key.cpp
@@ -1,4 +1,5 @@
 #include "key.h"
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -103,7 +104,7 @@ void TKeyPrefix::SetTypeImpl(EType type, bool isServicePartition)
             c = ServiceTypeTxMeta;
             break;
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("type", static_cast<int>(type))("type_char", c);
         }
     }
 

--- a/ydb/core/persqueue/common/key.h
+++ b/ydb/core/persqueue/common/key.h
@@ -105,7 +105,7 @@ public:
             case ServiceTypeTxMeta:
                 return TypeTxMeta;
         }
-        Y_ABORT();
+        AFL_ENSURE(false)("type_char", *PtrType());
         return TypeNone;
     }
 

--- a/ydb/core/persqueue/common/partitioning_keys_manager.cpp
+++ b/ydb/core/persqueue/common/partitioning_keys_manager.cpp
@@ -3,6 +3,7 @@
 #include <util/generic/vector.h>
 
 #include <random>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -11,7 +12,7 @@ TPartitioningKeysManager::TPartitioningKeysManager(size_t numSketches, TDuration
       Rng(std::random_device{}()),
       InitialWeight(initialWeight)
 {
-    Y_ENSURE(numSketches > 0, "numSketches must be greater than 0");
+    AFL_ENSURE(numSketches > 0)("reason", "numSketches must be greater than 0");
     SketchWindowSize = Max(Min(TDuration::Seconds(1), windowSize), windowSize / numSketches);
 }
 

--- a/ydb/core/persqueue/deferred_publish/destination_blob.cpp
+++ b/ydb/core/persqueue/deferred_publish/destination_blob.cpp
@@ -1,4 +1,5 @@
 #include "destination_blob.h"
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ::NDeferredPublish {
 
@@ -9,7 +10,7 @@ TString SerializeDestinationBlob(const NKikimrPQ::TDeferredPublishDestinationBlo
 }
 
 bool ParseDestinationBlob(TStringBuf bytes, NKikimrPQ::TDeferredPublishDestinationBlob* blob) {
-    Y_ABORT_UNLESS(blob != nullptr);
+    AFL_ENSURE(blob != nullptr)("reason", "destination blob is null");
     return blob->ParseFromArray(bytes.data(), bytes.size());
 }
 
@@ -37,7 +38,7 @@ void AddOrUpdateTopicPartition(
     ui32 partitionId,
     ui64 tabletId)
 {
-    Y_ABORT_UNLESS(blob != nullptr);
+    AFL_ENSURE(blob != nullptr)("reason", "destination blob is null");
 
     for (auto& partition : *blob->MutablePartitions()) {
         if (partition.GetPartitionId() == partitionId) {

--- a/ydb/core/persqueue/deferred_publish/finalize_publication_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/finalize_publication_actor.cpp
@@ -58,8 +58,8 @@ bool BuildDeferredPublicationRequest(
     NKikimrKqp::TTopicDeferredPublicationRequest* request,
     NYql::TIssues* issues)
 {
-    AFL_ENSURE(request != nullptr);
-    AFL_ENSURE(issues != nullptr);
+    AFL_ENSURE(request != nullptr)("op", static_cast<int>(op))("int_publication_id", intPublicationId);
+    AFL_ENSURE(issues != nullptr)("op", static_cast<int>(op))("int_publication_id", intPublicationId);
 
     request->Clear();
     request->SetOp(MapFinalizeOp(op));
@@ -251,7 +251,8 @@ private:
             return ReplyAndPassAway(response.Status, response.Issues);
         }
 
-        AFL_ENSURE(response.Data.Defined());
+        AFL_ENSURE(response.Data.Defined())
+            ("database", Database)("int_publication_id", IntPublicationId)("op", static_cast<int>(Op));
         ListDestinationsData = *response.Data;
 
         if (!IsPublicationOwnedByCaller(CallerSid, ListDestinationsData->CreatedBy)) {
@@ -296,7 +297,8 @@ private:
         }
 
         KqpSessionId = record.GetResponse().GetSessionId();
-        AFL_ENSURE(!KqpSessionId.empty());
+        AFL_ENSURE(!KqpSessionId.empty())
+            ("database", Database)("int_publication_id", IntPublicationId)("op", static_cast<int>(Op));
         SendKqpBeginTx();
     }
 
@@ -309,7 +311,9 @@ private:
         switch (Step) {
             case EStep::KqpBeginTx: {
                 TxId = record.GetResponse().GetTxMeta().id();
-                AFL_ENSURE(!TxId.empty());
+                AFL_ENSURE(!TxId.empty())
+                    ("database", Database)("int_publication_id", IntPublicationId)
+                    ("op", static_cast<int>(Op))("kqp_session", KqpSessionId);
                 SendKqpDelete();
                 return;
             }

--- a/ydb/core/persqueue/deferred_publish/finalize_publication_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/finalize_publication_actor.cpp
@@ -14,6 +14,7 @@
 #include <ydb/library/actors/core/hfunc.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
 #include <yql/essentials/public/issue/yql_issue.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ::NDeferredPublish {
 
@@ -46,7 +47,7 @@ NKikimrKqp::TTopicDeferredPublicationRequest::EOp MapFinalizeOp(EFinalizePublica
         case EFinalizePublicationOp::Cancel:
             return NKikimrKqp::TTopicDeferredPublicationRequest::Cancel;
         default:
-            Y_ABORT("unexpected EFinalizePublicationOp");
+            AFL_ENSURE(false)("reason", "unexpected EFinalizePublicationOp")("op", static_cast<int>(op));
     }
 }
 
@@ -57,8 +58,8 @@ bool BuildDeferredPublicationRequest(
     NKikimrKqp::TTopicDeferredPublicationRequest* request,
     NYql::TIssues* issues)
 {
-    Y_ABORT_UNLESS(request != nullptr);
-    Y_ABORT_UNLESS(issues != nullptr);
+    AFL_ENSURE(request != nullptr);
+    AFL_ENSURE(issues != nullptr);
 
     request->Clear();
     request->SetOp(MapFinalizeOp(op));
@@ -250,7 +251,7 @@ private:
             return ReplyAndPassAway(response.Status, response.Issues);
         }
 
-        Y_ABORT_UNLESS(response.Data.Defined());
+        AFL_ENSURE(response.Data.Defined());
         ListDestinationsData = *response.Data;
 
         if (!IsPublicationOwnedByCaller(CallerSid, ListDestinationsData->CreatedBy)) {
@@ -295,7 +296,7 @@ private:
         }
 
         KqpSessionId = record.GetResponse().GetSessionId();
-        Y_ABORT_UNLESS(!KqpSessionId.empty());
+        AFL_ENSURE(!KqpSessionId.empty());
         SendKqpBeginTx();
     }
 
@@ -308,7 +309,7 @@ private:
         switch (Step) {
             case EStep::KqpBeginTx: {
                 TxId = record.GetResponse().GetTxMeta().id();
-                Y_ABORT_UNLESS(!TxId.empty());
+                AFL_ENSURE(!TxId.empty());
                 SendKqpDelete();
                 return;
             }

--- a/ydb/core/persqueue/deferred_publish/registry_actor.cpp
+++ b/ydb/core/persqueue/deferred_publish/registry_actor.cpp
@@ -6,6 +6,7 @@
 #include <ydb/core/base/appdata.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ::NDeferredPublish {
 
@@ -225,7 +226,7 @@ private:
         const TString& createdBy,
         const NActors::TActorId& replyTo)
     {
-        Y_ABORT_UNLESS(!ShuttingDown);
+        AFL_ENSURE(!ShuttingDown)("reason", "registry is shutting down");
         ++InFlightInserts;
         Register(CreateInsertPublicationQueryActor(replyTo, database, extPublicationId, writerIdentity, createdBy));
     }

--- a/ydb/core/persqueue/deferred_publish/ut/ya.make
+++ b/ydb/core/persqueue/deferred_publish/ut/ya.make
@@ -4,6 +4,7 @@ SIZE(SMALL)
 
 PEERDIR(
     ydb/core/protos
+    ydb/library/actors/core
 )
 
 SRCS(

--- a/ydb/core/persqueue/events/internal.cpp
+++ b/ydb/core/persqueue/events/internal.cpp
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -48,7 +49,7 @@ namespace NKikimr::NPQ {
 namespace NKikimr {
 
     TEvPQ::TEvMLPChangeMessageDeadlineRequest::TEvMLPChangeMessageDeadlineRequest(const TString& topic, const TString& consumer, ui32 partitionId, const std::span<const ui64> offsets, const std::span<const TInstant> deadlineTimestamps) {
-        Y_ENSURE(deadlineTimestamps.size() == offsets.size());
+        AFL_ENSURE(deadlineTimestamps.size() == offsets.size())("deadlines", deadlineTimestamps.size())("offsets", offsets.size());
         Record.SetTopic(topic);
         Record.SetConsumer(consumer);
         Record.SetPartitionId(partitionId);

--- a/ydb/core/persqueue/pqrb/read_balancer.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer.cpp
@@ -15,6 +15,7 @@
 #include <library/cpp/monlib/service/pages/templates.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <library/cpp/random_provider/random_provider.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE_READ_BALANCER
 
@@ -116,7 +117,7 @@ void TPersQueueReadBalancer::OnActivateExecutor(const TActorContext &ctx) {
     ResourceMetrics = Executor()->GetResourceMetrics();
     Become(&TThis::StateWork);
     if (Executor()->GetStats().IsFollower())
-        Y_ABORT("is follower works well with Balancer?");
+        PQ_ENSURE(false)("reason", "is follower works well with Balancer?");
     else
         Execute(new TTxPreInit(this), ctx);
 }
@@ -370,7 +371,7 @@ void TPersQueueReadBalancer::Handle(TEvPersQueue::TEvUpdateBalancerConfig::TPtr 
     std::vector<ui32> deletedPartitions;
     for (auto& p : PartitionsInfo) {
         if (partitionsInfo.find(p.first) == partitionsInfo.end()) {
-            Y_ABORT("deleting of partitions is not fully supported yet");
+            PQ_ENSURE(false)("reason", "deleting of partitions is not fully supported yet")("partition_id", p.first);
             deletedPartitions.push_back(p.first);
         }
     }

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -433,7 +433,9 @@ void TPartitionFamily::Merge(TPartitionFamily* other) {
         {"logPrefix", LogPrefix()},
         {"debug", other->DebugStr()});
 
-    AFL_ENSURE(this != other);
+    AFL_ENSURE(this != other)
+        ("this_id", Id)("other_id", other->Id)
+        ("this_partitions", Partitions.size())("other_partitions", other->Partitions.size());
 
     Partitions.insert(Partitions.end(), other->Partitions.begin(), other->Partitions.end());
     UpdatePartitionMapping(other->Partitions);
@@ -846,7 +848,9 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
 }
 
 std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lhs, TPartitionFamily* rhs, const TActorContext& ctx) {
-    AFL_ENSURE(lhs != rhs);
+    AFL_ENSURE(lhs != rhs)
+        ("lhs_id", lhs->Id)("rhs_id", rhs->Id)
+        ("lhs_partitions", lhs->Partitions.size())("rhs_partitions", rhs->Partitions.size());
 
     if (lhs->IsFree() && rhs->IsFree() ||
         lhs->IsActive() && rhs->IsActive() && lhs->Session == rhs->Session ||

--- a/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__balancing.cpp
@@ -2,6 +2,7 @@
 #include "read_balancer_log.h"
 
 #include <ydb/core/persqueue/public/utils.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE_READ_BALANCER
 
@@ -432,7 +433,7 @@ void TPartitionFamily::Merge(TPartitionFamily* other) {
         {"logPrefix", LogPrefix()},
         {"debug", other->DebugStr()});
 
-    Y_VERIFY(this != other);
+    AFL_ENSURE(this != other);
 
     Partitions.insert(Partitions.end(), other->Partitions.begin(), other->Partitions.end());
     UpdatePartitionMapping(other->Partitions);
@@ -845,7 +846,7 @@ bool TConsumer::BreakUpFamily(TPartitionFamily* family, ui32 partitionId, bool d
 }
 
 std::pair<TPartitionFamily*, bool> TConsumer::MergeFamilies(TPartitionFamily* lhs, TPartitionFamily* rhs, const TActorContext& ctx) {
-    Y_VERIFY(lhs != rhs);
+    AFL_ENSURE(lhs != rhs);
 
     if (lhs->IsFree() && rhs->IsFree() ||
         lhs->IsActive() && rhs->IsActive() && lhs->Session == rhs->Session ||

--- a/ydb/core/persqueue/pqrb/read_balancer__sqs_metrics.cpp
+++ b/ydb/core/persqueue/pqrb/read_balancer__sqs_metrics.cpp
@@ -10,6 +10,7 @@
 
 #include <util/generic/array_ref.h>
 #include <util/string/builder.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -302,7 +303,9 @@ bool TTopicSqsMetricsHandler::IsApplicable(const NKikimrPQ::TPQTabletConfig& tab
 }
 
 TTopicSqsMetricsHandler::TTopicSqsMetricsHandler(const NKikimrPQ::TPQTabletConfig& tabletConfig, const NActors::TActorContext& ctx) {
-    Y_ABORT_UNLESS(IsApplicable(tabletConfig));
+    AFL_ENSURE(IsApplicable(tabletConfig))
+        ("sqs_queue", tabletConfig.GetSqsQueueName())
+        ("sqs_export_metrics", tabletConfig.GetSqsExportMetrics());
 
     const TString& account = tabletConfig.GetSqsAccountName();
     const TString& queueName = tabletConfig.GetSqsQueueName();

--- a/ydb/core/persqueue/pqrb/read_balancer__txinit.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__txinit.h
@@ -115,7 +115,9 @@ struct TPersQueueReadBalancer::TTxInit : public ITransaction {
         } catch (const TNotReadyTabletException&) {
             return false;
         } catch (...) {
-        AFL_ENSURE(false)("reason", "there must be no leaked exceptions")("tablet_id", Self->TabletID())("path", Self->Path)("topic", Self->Topic);
+            AFL_ENSURE(false)("reason", "there must be no leaked exceptions")
+                ("exception", CurrentExceptionMessage())
+                ("tablet_id", Self->TabletID())("path", Self->Path)("topic", Self->Topic);
         }
         return true;
     }

--- a/ydb/core/persqueue/pqrb/read_balancer__txinit.h
+++ b/ydb/core/persqueue/pqrb/read_balancer__txinit.h
@@ -6,6 +6,7 @@
 
 #include <ydb/core/tablet/tablet_exception.h>
 #include <ydb/core/tablet_flat/tablet_flat_executed.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 namespace NPQ {
@@ -114,7 +115,7 @@ struct TPersQueueReadBalancer::TTxInit : public ITransaction {
         } catch (const TNotReadyTabletException&) {
             return false;
         } catch (...) {
-        Y_ABORT("there must be no leaked exceptions");
+        AFL_ENSURE(false)("reason", "there must be no leaked exceptions")("tablet_id", Self->TabletID())("path", Self->Path)("topic", Self->Topic);
         }
         return true;
     }

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -64,7 +64,11 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
         return {data.ReadResult};
     }
 
-    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec());
+    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec())
+        ("has_codec", dataChunk.HasCodec())
+        ("codec", dataChunk.HasCodec() ? dataChunk.GetCodec() : -1)
+        ("expected_codec", KafkaBatchCodec())
+        ("offset", data.ReadResult.GetOffset());
 
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     if (batch.Records.empty()) {
@@ -101,7 +105,8 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
             itemChunk.ClearData();
         }
         TString serializedChunk;
-        AFL_ENSURE(itemChunk.SerializeToString(&serializedChunk));
+        AFL_ENSURE(itemChunk.SerializeToString(&serializedChunk))
+            ("offset", offset)("seq_no", seqNo)("codec", codec);
         item.SetData(std::move(serializedChunk));
 
         if (record.Key) {
@@ -125,7 +130,11 @@ THashMap<TString, ui64> TKafkaBatchCutter::GetKeys(const TBatchCutterData& data,
         return result;
     }
 
-    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec());
+    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec())
+        ("has_codec", dataChunk.HasCodec())
+        ("codec", dataChunk.HasCodec() ? dataChunk.GetCodec() : -1)
+        ("expected_codec", KafkaBatchCodec())
+        ("offset", data.ReadResult.GetOffset());
 
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     const ui64 baseOffset = data.ReadResult.GetOffset();

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -13,6 +13,7 @@
 #include <util/stream/mem.h>
 #include <util/stream/output.h>
 #include <util/stream/zlib.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ::NBatching {
 namespace {
@@ -63,7 +64,7 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
         return {data.ReadResult};
     }
 
-    Y_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec());
+    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec());
 
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     if (batch.Records.empty()) {
@@ -100,7 +101,7 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
             itemChunk.ClearData();
         }
         TString serializedChunk;
-        Y_ENSURE(itemChunk.SerializeToString(&serializedChunk));
+        AFL_ENSURE(itemChunk.SerializeToString(&serializedChunk));
         item.SetData(std::move(serializedChunk));
 
         if (record.Key) {
@@ -124,7 +125,7 @@ THashMap<TString, ui64> TKafkaBatchCutter::GetKeys(const TBatchCutterData& data,
         return result;
     }
 
-    Y_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec());
+    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec());
 
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     const ui64 baseOffset = data.ReadResult.GetOffset();

--- a/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
+++ b/ydb/core/persqueue/pqtablet/batching/batch_cutter.cpp
@@ -13,7 +13,6 @@
 #include <util/stream/mem.h>
 #include <util/stream/output.h>
 #include <util/stream/zlib.h>
-#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ::NBatching {
 namespace {
@@ -64,11 +63,14 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
         return {data.ReadResult};
     }
 
-    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec())
-        ("has_codec", dataChunk.HasCodec())
-        ("codec", dataChunk.HasCodec() ? dataChunk.GetCodec() : -1)
-        ("expected_codec", KafkaBatchCodec())
-        ("offset", data.ReadResult.GetOffset());
+    // Bad on-disk/client data: throw yexception (catchable in UT and callers), not AFL_ENSURE
+    // which aborts outside an actor activation context.
+    Y_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec(),
+        "unexpected data chunk codec for kafka batch cutter"
+        << " has_codec=" << dataChunk.HasCodec()
+        << " codec=" << (dataChunk.HasCodec() ? static_cast<int>(dataChunk.GetCodec()) : -1)
+        << " expected_codec=" << static_cast<int>(KafkaBatchCodec())
+        << " offset=" << data.ReadResult.GetOffset());
 
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     if (batch.Records.empty()) {
@@ -105,8 +107,11 @@ TVector<TReadResult> TKafkaBatchCutter::Cut(const TBatchCutterData& data, const 
             itemChunk.ClearData();
         }
         TString serializedChunk;
-        AFL_ENSURE(itemChunk.SerializeToString(&serializedChunk))
-            ("offset", offset)("seq_no", seqNo)("codec", codec);
+        Y_ENSURE(itemChunk.SerializeToString(&serializedChunk),
+            "failed to serialize data chunk"
+            << " offset=" << offset
+            << " seq_no=" << seqNo
+            << " codec=" << static_cast<int>(codec));
         item.SetData(std::move(serializedChunk));
 
         if (record.Key) {
@@ -130,11 +135,12 @@ THashMap<TString, ui64> TKafkaBatchCutter::GetKeys(const TBatchCutterData& data,
         return result;
     }
 
-    AFL_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec())
-        ("has_codec", dataChunk.HasCodec())
-        ("codec", dataChunk.HasCodec() ? dataChunk.GetCodec() : -1)
-        ("expected_codec", KafkaBatchCodec())
-        ("offset", data.ReadResult.GetOffset());
+    Y_ENSURE(dataChunk.HasCodec() && dataChunk.GetCodec() == KafkaBatchCodec(),
+        "unexpected data chunk codec for kafka batch cutter"
+        << " has_codec=" << dataChunk.HasCodec()
+        << " codec=" << (dataChunk.HasCodec() ? static_cast<int>(dataChunk.GetCodec()) : -1)
+        << " expected_codec=" << static_cast<int>(KafkaBatchCodec())
+        << " offset=" << data.ReadResult.GetOffset());
 
     const auto batch = NKafka::ReadKafkaRecordBatch(dataChunk.GetData());
     const ui64 baseOffset = data.ReadResult.GetOffset();

--- a/ydb/core/persqueue/pqtablet/blob/blob.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob.cpp
@@ -56,8 +56,8 @@ TClientBlob::TClientBlob(TString&& sourceId, ui64 seqNo, TString&& data, const T
         , ExplicitHashKey(std::move(explicitHashKey))
         , LogicalMessageCount(logicalMessageCount)
         , IsBatch(isBatch) {
-    Y_ENSURE(PartitionKey.size() <= 256);
-    Y_ENSURE(LogicalMessageCount >= 1 && LogicalMessageCount <= MAX_LOGICAL_MESSAGE_COUNT);
+    AFL_ENSURE(PartitionKey.size() <= 256);
+    AFL_ENSURE(LogicalMessageCount >= 1 && LogicalMessageCount <= MAX_LOGICAL_MESSAGE_COUNT);
 }
 
 

--- a/ydb/core/persqueue/pqtablet/blob/blob.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob.cpp
@@ -56,8 +56,10 @@ TClientBlob::TClientBlob(TString&& sourceId, ui64 seqNo, TString&& data, const T
         , ExplicitHashKey(std::move(explicitHashKey))
         , LogicalMessageCount(logicalMessageCount)
         , IsBatch(isBatch) {
-    AFL_ENSURE(PartitionKey.size() <= 256);
-    AFL_ENSURE(LogicalMessageCount >= 1 && LogicalMessageCount <= MAX_LOGICAL_MESSAGE_COUNT);
+    AFL_ENSURE(PartitionKey.size() <= 256)("partition_key_size", PartitionKey.size());
+    AFL_ENSURE(LogicalMessageCount >= 1 && LogicalMessageCount <= MAX_LOGICAL_MESSAGE_COUNT)
+        ("logical_message_count", LogicalMessageCount)
+        ("max_logical_message_count", MAX_LOGICAL_MESSAGE_COUNT);
 }
 
 

--- a/ydb/core/persqueue/pqtablet/blob/blob_serialization.cpp
+++ b/ydb/core/persqueue/pqtablet/blob/blob_serialization.cpp
@@ -631,7 +631,7 @@ void TBatch::UnpackTo(TVector<TClientBlob> *blobs) const
             TBatchDeserializer<NKikimrPQ::TBatchHeader::ECompressed>(*this).Unpack(blobs);
             break;
         default:
-            Y_ABORT("uknown type");
+            AFL_ENSURE(false)("reason", "unknown type")("format", static_cast<int>(type));
     };
 }
 

--- a/ydb/core/persqueue/pqtablet/blob/type_coders.h
+++ b/ydb/core/persqueue/pqtablet/blob/type_coders.h
@@ -8,6 +8,7 @@
 
 #include <util/generic/typetraits.h>
 #include <util/generic/buffer.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 namespace NScheme {
@@ -61,7 +62,7 @@ template <>
 class TCoderMask<false> {
 public:
     inline size_t MaxSize() const { return 0; }
-    inline void AddNull() { Y_ABORT("Null values are not supported."); }
+    inline void AddNull() { AFL_ENSURE(false)("reason", "Null values are not supported."); }
     inline void AddNonNull() { }
     inline void Seal(TBuffer&) { }
 };

--- a/ydb/core/persqueue/pqtablet/common/logging.h
+++ b/ydb/core/persqueue/pqtablet/common/logging.h
@@ -7,6 +7,4 @@ namespace NKikimr::NPQ {
 
 inline TString LogPrefix() { return {}; }
 
-#define Y_ABORT_UNLESS_S(expr, msg) Y_ABORT_UNLESS(expr, "%s", (TStringBuilder() << msg).data())
-
 } // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/pqtablet/fix_transaction_states.cpp
+++ b/ydb/core/persqueue/pqtablet/fix_transaction_states.cpp
@@ -1,6 +1,7 @@
 #include "fix_transaction_states.h"
 #include <ydb/core/persqueue/common/key.h>
 #include <util/generic/maybe.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -8,7 +9,7 @@ static const size_t TX_KEY_LENGTH = GetTxKey(0).size();
 
 bool IsMainContextOfTransaction(const TString& key)
 {
-    Y_ENSURE(key.size() >= TX_KEY_LENGTH);
+    AFL_ENSURE(key.size() >= TX_KEY_LENGTH);
     return key.size() == TX_KEY_LENGTH;
 }
 

--- a/ydb/core/persqueue/pqtablet/metering_sink.cpp
+++ b/ydb/core/persqueue/pqtablet/metering_sink.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/metering/metering.h>
 #include <library/cpp/json/json_writer.h>
 #include <util/generic/size_literals.h>
+#include <ydb/library/actors/core/log.h>
 
 
 namespace NKikimr::NPQ {
@@ -232,7 +233,7 @@ TMeteringSink::FlushParameters TMeteringSink::GetFlushParameters(const EMetering
     }
 
     default:
-        Y_ENSURE(false);
+        AFL_ENSURE(false)("type", static_cast<int>(type))("tablet_id", Parameters_.TabletId)("stream", Parameters_.StreamName);
     };
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -5253,8 +5253,10 @@ void TPartition::AttachPersistRequestSpan(NWilson::TSpan& span)
 }
 
 void TPartition::SendCompacterWriteRequest(THolder<TEvKeyValue::TEvRequest>&& request) {
-    AFL_ENSURE(!CompacterKvRequestInflight);
-    AFL_ENSURE(!CompacterKvRequest);
+    AFL_ENSURE(!CompacterKvRequestInflight)
+        ("tablet_id", TabletId)("partition_id", Partition)("topic", TopicName());
+    AFL_ENSURE(!CompacterKvRequest)
+        ("tablet_id", TabletId)("partition_id", Partition)("topic", TopicName());
     YDB_LOG_DEBUG_COMP(Service, "Topic partition Acquire RW Lock",
         {"logPrefix", NPQ_LOG_PREFIX},
         {"clientSideName", TopicConverter->GetClientsideName()},

--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -29,6 +29,7 @@
 #include <util/string/escape.h>
 #include <util/system/byteorder.h>
 #include <util/generic/overloaded.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_TX
 
@@ -575,7 +576,7 @@ bool TPartition::CleanUpBlobsInEncoder(TPartitionBlobEncoder& encoder, bool isCo
                 return false;
             }
         } else {
-            Y_ABORT_UNLESS(nextKey);
+            PQ_ENSURE(nextKey)("topic", TopicName());
             if (ImportantConsumersNeedToKeepCurrentKey(firstKey, *nextKey, now)) {
                 return false;
             }
@@ -2571,7 +2572,7 @@ bool TPartition::UpdateCounters(const TActorContext& ctx, bool force) {
         SET_METRIC(PartitionCountersLabeled, METRIC_READ_QUOTA_PARTITION_TOTAL_USAGE, quotaUsage);
     }
     if (PartitionKeyCompactionCounters) {
-        Y_ENSURE(Compacter);
+        PQ_ENSURE(Compacter)("topic", TopicName());
         auto counters = Compacter->GetCounters();
         SET_METRIC(PartitionKeyCompactionCounters, METRIC_UNCOMPACTED_SIZE_MAX, counters.UncompactedSize);
         SET_METRIC(PartitionKeyCompactionCounters, METRIC_UNCOMPACTED_SIZE_SUM, counters.UncompactedSize);
@@ -3407,7 +3408,7 @@ TPartition::EProcessResult TPartition::PreProcessUserActionOrTransaction(TSimple
         t->State = ECommitState::Committed;
         return EProcessResult::Break;
     }
-    Y_ABORT();
+    AFL_ENSURE(false)("reason", "unreachable transaction kind")("tablet_id", TabletId)("partition_id", Partition)("topic", TopicName());
     return result;
 }
 
@@ -5176,17 +5177,17 @@ void TPartition::AddCmdDeleteRangeForAllKeys(TEvKeyValue::TEvRequest& request)
 
 void TPartition::ScheduleNegativeReply(const TEvPQ::TEvSetClientInfo&)
 {
-    Y_ABORT("The supportive partition does not accept read operations");
+    PQ_ENSURE(false)("reason", "The supportive partition does not accept read operations")("topic", TopicName());
 }
 
 void TPartition::ScheduleNegativeReply(const TEvPersQueue::TEvProposeTransaction&)
 {
-    Y_ABORT("The supportive partition does not accept immediate transactions");
+    PQ_ENSURE(false)("reason", "The supportive partition does not accept immediate transactions")("topic", TopicName());
 }
 
 void TPartition::ScheduleNegativeReply(const TTransaction&)
 {
-    Y_ABORT("The supportive partition does not accept distribute transactions");
+    PQ_ENSURE(false)("reason", "The supportive partition does not accept distribute transactions")("topic", TopicName());
 }
 
 void TPartition::ScheduleNegativeReply(const TMessage& msg)
@@ -5252,8 +5253,8 @@ void TPartition::AttachPersistRequestSpan(NWilson::TSpan& span)
 }
 
 void TPartition::SendCompacterWriteRequest(THolder<TEvKeyValue::TEvRequest>&& request) {
-    Y_ENSURE(!CompacterKvRequestInflight);
-    Y_ENSURE(!CompacterKvRequest);
+    AFL_ENSURE(!CompacterKvRequestInflight);
+    AFL_ENSURE(!CompacterKvRequest);
     YDB_LOG_DEBUG_COMP(Service, "Topic partition Acquire RW Lock",
         {"logPrefix", NPQ_LOG_PREFIX},
         {"clientSideName", TopicConverter->GetClientsideName()},

--- a/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_blob_encoder.cpp
@@ -2,6 +2,7 @@
 #include "partition_util.h"
 
 #include <ydb/core/base/appdata.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -353,7 +354,7 @@ TString TPartitionBlobEncoder::SerializeForKey(const TKey& key, ui32 size,
     AFL_ENSURE(size >= valueD.size());
 
     if (size > valueD.size() && key.HasSuffix()) { //change to real size if real packed size is smaller
-        Y_ABORT("Can't be here right now, only after merging of small batches");
+        AFL_ENSURE(false)("reason", "Can't be here right now, only after merging of small batches")("key", key.ToString())("size", size)("value_size", valueD.size());
 
         //for (auto it = DataKeysHead.rbegin(); it != DataKeysHead.rend(); ++it) {
         //    if (it->KeysCount() > 0 ) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -2,6 +2,7 @@
 #include <ydb/core/persqueue/pqtablet/common/logging.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include "partition_util.h"
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE
 
@@ -37,7 +38,7 @@ TPartitionCompaction::TPartitionCompaction(ui64 firstUncompactedOffset, ui64 par
 }
 
 void TPartitionCompaction::TryCompactionIfPossible() {
-    Y_ENSURE(PartitionActor->Config.GetEnableCompactification());
+    AFL_ENSURE(PartitionActor->Config.GetEnableCompactification())("tablet_id", PartitionActor->TabletId)("partition_id", PartitionActor->Partition)("topic", PartitionActor->TopicName());
     if (PartitionActor->CompacterPartitionRequestInflight || PartitionActor->CompacterKvRequestInflight) {
         return;
     }
@@ -58,7 +59,7 @@ void TPartitionCompaction::TryCompactionIfPossible() {
         } else if (step == EStep::COMPACTING) {
             Step = EStep::COMPACTING;
             CompactState.ConstructInPlace(std::move(ReadState->GetData()), FirstUncompactedOffset, ReadState->GetLastOffset(), PartitionActor, &Counters);
-            Y_ENSURE(FirstUncompactedOffset < ReadState->GetLastOffset());
+            AFL_ENSURE(FirstUncompactedOffset < ReadState->GetLastOffset());
             FirstUncompactedOffset = ReadState->GetLastOffset();
             Counters.CurrentReadCycleKeys = CompactState->TopicData.size();
             Counters.ReadCyclesCount += 1;
@@ -117,7 +118,11 @@ void TPartitionCompaction::ProcessResponse(TEvPQ::TEvProxyResponse::TPtr& ev) {
         case EStep::PENDING:
             break;
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)
+                ("step", static_cast<int>(Step))
+                ("tablet_id", PartitionActor->TabletId)
+                ("partition_id", PartitionActor->Partition)
+                ("topic", PartitionActor->TopicName());
     }
     if (!processResponseResult) {
         PartitionActor->Send(PartitionActor->TabletActorId, new TEvents::TEvPoison());
@@ -639,7 +644,13 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
         if (haveTruncatedMessage && isNewMsg) {
             // Probably previous message was deleted (do we really expect this to happen though?)
             // Drop it anyway.
-            Y_ABORT();
+            AFL_ENSURE(false)
+                ("reason", "truncated message before new message")
+                ("tablet_id", PartitionActor->TabletId)
+                ("partition_id", PartitionActor->Partition)
+                ("topic", PartitionActor->TopicName())
+                ("offset", res.GetOffset())
+                ("seqNo", res.GetSeqNo());
             CurrentMessage = Nothing();
         }
         AFL_ENSURE(res.GetData().size() != 0);
@@ -697,7 +708,12 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
                 auto proto(GetDeserializedData(CurrentMessage->GetData()));
                 if (proto.GetChunkType() != NKikimrPQClient::TDataChunk::REGULAR) {
                     CurrentMessage = Nothing();
-                    Y_ABORT();
+                    AFL_ENSURE(false)
+                        ("reason", "unexpected chunk type")
+                        ("chunk_type", static_cast<int>(proto.GetChunkType()))
+                        ("tablet_id", PartitionActor->TabletId)
+                        ("partition_id", PartitionActor->Partition)
+                        ("topic", PartitionActor->TopicName());
                     continue; //no such chunks must be on prod - ?
                 }
                 TString key;
@@ -761,8 +777,8 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
         {"hasNonZeroParts", hasNonZeroParts},
         {"isMiddlePartOfMessage", isMiddlePartOfMessage});
 
-    Y_ENSURE(KeysIter->Key.GetInternalPartsCount() == internalPartsCount);
-    Y_ENSURE(KeysIter->Key.GetCount() == offsetSpan);
+    AFL_ENSURE(KeysIter->Key.GetInternalPartsCount() == internalPartsCount);
+    AFL_ENSURE(KeysIter->Key.GetCount() == offsetSpan);
     if (!hasNonZeroParts) {
         EmptyBlobs.emplace(isTruncatedBlob ? lastExpectedOffset : lastExpectedOffset - 1, KeysIter->Key);
     }
@@ -933,8 +949,8 @@ void TPartitionCompaction::TCompactState::UpdateDataKeysBody() {
         itExisting++;
     }
 
-    Y_ENSURE(PartitionActor->CompactionBlobEncoder.DataKeysBody.size() == oldDataKeys.size() - zeroedKeys);
-    Y_ENSURE(currCumulSize == PartitionActor->CompactionBlobEncoder.BodySize - sizeDiff);
+    AFL_ENSURE(PartitionActor->CompactionBlobEncoder.DataKeysBody.size() == oldDataKeys.size() - zeroedKeys);
+    AFL_ENSURE(currCumulSize == PartitionActor->CompactionBlobEncoder.BodySize - sizeDiff);
     PartitionActor->CompactionBlobEncoder.BodySize = currCumulSize;
     if (PartitionActor->IsTopicRetentionDeleteLastBlobEnabled()) {
         if (PartitionActor->CompactionBlobEncoder.DataKeysBody.empty()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compactification.cpp
@@ -59,7 +59,12 @@ void TPartitionCompaction::TryCompactionIfPossible() {
         } else if (step == EStep::COMPACTING) {
             Step = EStep::COMPACTING;
             CompactState.ConstructInPlace(std::move(ReadState->GetData()), FirstUncompactedOffset, ReadState->GetLastOffset(), PartitionActor, &Counters);
-            AFL_ENSURE(FirstUncompactedOffset < ReadState->GetLastOffset());
+            AFL_ENSURE(FirstUncompactedOffset < ReadState->GetLastOffset())
+                ("first_uncompacted_offset", FirstUncompactedOffset)
+                ("last_offset", ReadState->GetLastOffset())
+                ("tablet_id", PartitionActor->TabletId)
+                ("partition_id", PartitionActor->Partition)
+                ("topic", PartitionActor->TopicName());
             FirstUncompactedOffset = ReadState->GetLastOffset();
             Counters.CurrentReadCycleKeys = CompactState->TopicData.size();
             Counters.ReadCyclesCount += 1;
@@ -777,8 +782,18 @@ bool TPartitionCompaction::TCompactState::ProcessReadResult(NKikimrClient::TCmdR
         {"hasNonZeroParts", hasNonZeroParts},
         {"isMiddlePartOfMessage", isMiddlePartOfMessage});
 
-    AFL_ENSURE(KeysIter->Key.GetInternalPartsCount() == internalPartsCount);
-    AFL_ENSURE(KeysIter->Key.GetCount() == offsetSpan);
+    AFL_ENSURE(KeysIter->Key.GetInternalPartsCount() == internalPartsCount)
+        ("key_internal_parts", KeysIter->Key.GetInternalPartsCount())
+        ("internal_parts_count", internalPartsCount)
+        ("key", KeysIter->Key.ToString())
+        ("tablet_id", PartitionActor->TabletId)
+        ("partition_id", PartitionActor->Partition);
+    AFL_ENSURE(KeysIter->Key.GetCount() == offsetSpan)
+        ("key_count", KeysIter->Key.GetCount())
+        ("offset_span", offsetSpan)
+        ("key", KeysIter->Key.ToString())
+        ("tablet_id", PartitionActor->TabletId)
+        ("partition_id", PartitionActor->Partition);
     if (!hasNonZeroParts) {
         EmptyBlobs.emplace(isTruncatedBlob ? lastExpectedOffset : lastExpectedOffset - 1, KeysIter->Key);
     }
@@ -949,8 +964,18 @@ void TPartitionCompaction::TCompactState::UpdateDataKeysBody() {
         itExisting++;
     }
 
-    AFL_ENSURE(PartitionActor->CompactionBlobEncoder.DataKeysBody.size() == oldDataKeys.size() - zeroedKeys);
-    AFL_ENSURE(currCumulSize == PartitionActor->CompactionBlobEncoder.BodySize - sizeDiff);
+    AFL_ENSURE(PartitionActor->CompactionBlobEncoder.DataKeysBody.size() == oldDataKeys.size() - zeroedKeys)
+        ("data_keys_body_size", PartitionActor->CompactionBlobEncoder.DataKeysBody.size())
+        ("old_data_keys_size", oldDataKeys.size())
+        ("zeroed_keys", zeroedKeys)
+        ("tablet_id", PartitionActor->TabletId)
+        ("partition_id", PartitionActor->Partition);
+    AFL_ENSURE(currCumulSize == PartitionActor->CompactionBlobEncoder.BodySize - sizeDiff)
+        ("curr_cumul_size", currCumulSize)
+        ("body_size", PartitionActor->CompactionBlobEncoder.BodySize)
+        ("size_diff", sizeDiff)
+        ("tablet_id", PartitionActor->TabletId)
+        ("partition_id", PartitionActor->Partition);
     PartitionActor->CompactionBlobEncoder.BodySize = currCumulSize;
     if (PartitionActor->IsTopicRetentionDeleteLastBlobEnabled()) {
         if (PartitionActor->CompactionBlobEncoder.DataKeysBody.empty()) {

--- a/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_compaction.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/persqueue/pqtablet/common/logging.h>
 #include "partition_util.h"
 #include <util/string/escape.h>
+#include <ydb/library/actors/core/log.h>
 
 #define LOG_PREFIX_INT TStringBuilder() << "[" << TabletId << "]" << GetLogPrefix()
 
@@ -582,7 +583,7 @@ void TPartition::BlobsForCompactionWereRead(const TVector<NPQ::TRequestedBlob>& 
                 YDB_LOG_DEBUG_COMP(Service, "Can't append blob for key",
                     {"logPrefix", NPQ_LOG_PREFIX},
                     {"key", k.Key});
-                Y_FAIL("Something went wrong");
+                PQ_ENSURE(false)("reason", "Something went wrong")("topic", TopicName())("key", k.Key.ToString());
                 return;
             }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_types.h
+++ b/ydb/core/persqueue/pqtablet/partition/partition_types.h
@@ -6,6 +6,7 @@
 #include <util/generic/maybe.h>
 
 #include <variant>
+#include <ydb/library/actors/core/log.h>
 
 
 namespace NKikimr::NPQ {
@@ -99,7 +100,7 @@ struct TMessage {
         case 4:
             return std::get<4>(Body).Cookie;
         default:
-            Y_ABORT("unreachable");
+            AFL_ENSURE(false)("reason", "unreachable")("index", Body.index());
         }
     }
 

--- a/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition_write.cpp
@@ -27,6 +27,7 @@
 #include <util/folder/path.h>
 #include <util/string/escape.h>
 #include <util/system/byteorder.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
@@ -443,7 +444,7 @@ void TPartition::AnswerCurrentWrites(const TActorContext& ctx) {
 
             ReplyOk(ctx, response.GetCookie(), response.Span);
         } else {
-            Y_ABORT("Unexpected message");
+            PQ_ENSURE(false)("reason", "Unexpected message")("topic", TopicName())("cookie", response.GetCookie())("index", response.Body.index());
         }
         Responses.pop_front();
     }
@@ -1352,7 +1353,7 @@ bool TPartition::ExecRequest(TWriteMsg& p, ProcessParameters& parameters, TEvKey
                 {"endOffset", BlobEncoder.EndOffset},
                 {"curOffset", curOffset},
                 {"offset", poffset});
-            Y_ENSURE(!p.Internal); // No Already for transactions;
+            PQ_ENSURE(!p.Internal)("topic", TopicName()); // No Already for transactions;
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_ALREADY].Increment(1);
             MsgsDiscarded.Inc();
             TabletCounters.Cumulative()[COUNTER_PQ_WRITE_BYTES_ALREADY].Increment(p.Msg.Data.size());

--- a/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/sourceid.cpp
@@ -1,6 +1,7 @@
 #include "sourceid.h"
 
 #include <util/generic/size_literals.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PERSQUEUE
 
@@ -365,7 +366,7 @@ void TSourceIdStorage::LoadSourceIdInfo(const TString& key, const TString& data,
     case TKeyPrefix::MarkProtoSourceId:
         return LoadProtoSourceIdInfo(key, data);
     default:
-        Y_FAIL_S("Unexpected mark: " << (char)mark);
+        AFL_ENSURE(false)("reason", "Unexpected mark")("mark", (char)mark);
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/partition/user_info.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/user_info.cpp
@@ -6,6 +6,7 @@
 
 #include <library/cpp/containers/absl/flat_hash_map.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 namespace NPQ {
@@ -169,7 +170,7 @@ void TUserInfo::ReadDone(const TActorContext& ctx, const TInstant& now, ui64 rea
 }
 
 static TUserInfo::TPerPartitionCounters CreateDetailedMetricsForSubgroup(const TActorContext& ctx, const TString& user, NMonitoring::TDynamicCounterPtr subgroup) {
-    Y_ABORT_UNLESS(subgroup);
+    AFL_ENSURE(subgroup);
 
     bool fcc = AppData()->PQConfig.GetTopicsAreFirstClassCitizen();
 

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -111,7 +111,7 @@ TEvPQ::TMessageGroupsPtr CreateExplicitMessageGroups(const NKikimrPQ::TBootstrap
 
     if (graph) {
         auto* node = graph.GetPartition(partitionId);
-        Y_VERIFY_S(node, "Partition " << partitionId << " not found. Known partitions " << graph.DebugString());
+        AFL_ENSURE(node)("partition_id", partitionId)("graph", graph.DebugString());
         for (const auto& p : partitionsData.GetPartition()) {
             if (node->IsParent(p.GetPartitionId())) {
                 for (const auto& g : p.GetMessageGroup()) {
@@ -441,7 +441,7 @@ void TPersQueue::ApplyNewConfig(const NKikimrPQ::TPQTabletConfig& newConfig,
         PQ_ENSURE(TopicName.size())("description", "Need topic name here");
         ctx.Send(CacheActor, new TEvPQ::TEvChangeCacheConfig(TopicName, cacheSize));
     } else {
-        //AFL_ENSURE(TopicName == Config.GetTopicName(), "Changing topic name is not supported");
+        //AFL_ENSURE(TopicName == Config.GetTopicName())("reason", "Changing topic name is not supported");
         TopicPath = Config.GetTopicPath();
         ctx.Send(CacheActor, new TEvPQ::TEvChangeCacheConfig(cacheSize));
     }
@@ -5581,7 +5581,7 @@ void TPersQueue::EnsurePartitionsAreNotDeleted(const NKikimrPQ::TPQTabletConfig&
     }
 
     for (const auto& partition : Config.GetPartitions()) {
-        Y_VERIFY_S(was.contains(partition.GetPartitionId()), "New config is bad, missing partition " << partition.GetPartitionId());
+        PQ_ENSURE(was.contains(partition.GetPartitionId()))("partition_id", partition.GetPartitionId());
     }
 }
 

--- a/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
+++ b/ydb/core/persqueue/pqtablet/quota/read_quoter.cpp
@@ -1,6 +1,7 @@
 #include "read_quoter.h"
 
 #include <ydb/core/persqueue/public/constants.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -155,7 +156,7 @@ THolder<TAccountQuoterHolder> TReadQuoter::CreateAccountQuotaTracker(const TStri
     const auto& quotingConfig = AppData()->PQConfig.GetQuotingConfig();
     TActorId actorId;
     if (GetTabletActor() && quotingConfig.GetEnableQuoting()) {
-        Y_ENSURE(TopicConverter);
+        AFL_ENSURE(TopicConverter)("tablet_id", TabletId)("partition_id", Partition);
         if (quotingConfig.GetEnableReadQuoting()) {
             actorId = TActivationContext::RegisterWithSameMailbox(
                 new TAccountReadQuoter(

--- a/ydb/core/persqueue/public/list_topics/list_all_topics_actor.cpp
+++ b/ydb/core/persqueue/public/list_topics/list_all_topics_actor.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/persqueue/events/internal.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -69,7 +70,7 @@ class TListAllTopicsActor : public NActors::TActorBootstrapped<TListAllTopicsAct
     }
 
     void TListAllTopicsActor::SendResponse() {
-        Y_ENSURE(WaitingList.size() == 0 && RequestsInFlight == 0);
+        AFL_ENSURE(WaitingList.size() == 0 && RequestsInFlight == 0);
 
         for (TString& topic : Topics) {
             topic = TFsPath(topic).RelativePath(DatabasePath).GetPath();
@@ -127,7 +128,7 @@ class TListAllTopicsActor : public NActors::TActorBootstrapped<TListAllTopicsAct
             } else if (entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindPath
                 || entry.Kind == NSchemeCache::TSchemeCacheNavigate::EKind::KindSubdomain)
             {
-                Y_ENSURE(entry.ListNodeEntry, "ListNodeEntry is zero");
+                AFL_ENSURE(entry.ListNodeEntry)("reason", "ListNodeEntry is zero");
                 for (const auto& child : entry.ListNodeEntry->Children) {
                     TString childFullPath = JoinPath({JoinPath(entry.Path), child.Name});
                     switch (child.Kind) {

--- a/ydb/core/persqueue/public/mlp/mlp_writer.cpp
+++ b/ydb/core/persqueue/public/mlp/mlp_writer.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/protos/grpc_pq_old.pb.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/codecs.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT Service
 
@@ -113,7 +114,7 @@ size_t SerializeTo(TWriterSettings::TMessage& item, ::NKikimrClient::TPersQueueP
 
     TString dataStr;
     bool res = proto.SerializeToString(&dataStr);
-    Y_ABORT_UNLESS(res);
+    AFL_ENSURE(res);
     cmdWrite.SetData(dataStr);
 
     return totalSize;

--- a/ydb/core/persqueue/public/pq_rl_helpers.cpp
+++ b/ydb/core/persqueue/public/pq_rl_helpers.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/tx/scheme_board/subscriber.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -36,7 +37,7 @@ bool TRlHelpers::IsQuotaInflight() const {
 }
 
 bool TRlHelpers::IsQuotaRequired() const {
-    Y_ENSURE(MeteringMode.Defined());
+    AFL_ENSURE(MeteringMode.Defined());
     return MeteringMode == NKikimrPQ::TPQTabletConfig::METERING_MODE_REQUEST_UNITS && Ctx;
 }
 

--- a/ydb/core/persqueue/public/schema/common.cpp
+++ b/ydb/core/persqueue/public/schema/common.cpp
@@ -385,9 +385,11 @@ TResult AddConsumer(
         return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "service type cannot be empty for consumer '" << consumerConfig.name() << "'"};
     }
 
-    AFL_ENSURE(supportedClientServiceTypes.find(serviceType) != supportedClientServiceTypes.end());
+    auto serviceTypeIt = supportedClientServiceTypes.find(serviceType);
+    AFL_ENSURE(serviceTypeIt != supportedClientServiceTypes.end())
+        ("service_type", serviceType)("consumer", consumerConfig.name());
 
-    const TClientServiceType& clientServiceType = supportedClientServiceTypes.find(serviceType)->second;
+    const TClientServiceType& clientServiceType = serviceTypeIt->second;
 
     if (checkServiceType) {
         bool found = clientServiceType.PasswordHashes.empty() && !hasPassword;

--- a/ydb/core/persqueue/public/schema/common.cpp
+++ b/ydb/core/persqueue/public/schema/common.cpp
@@ -10,6 +10,7 @@
 #include <ydb/library/persqueue/topic_parser/topic_parser.h>
 
 #include <library/cpp/digest/md5/md5.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ::NSchema {
 
@@ -384,7 +385,7 @@ TResult AddConsumer(
         return {Ydb::StatusIds::BAD_REQUEST, TStringBuilder() << "service type cannot be empty for consumer '" << consumerConfig.name() << "'"};
     }
 
-    Y_ABORT_UNLESS(supportedClientServiceTypes.find(serviceType) != supportedClientServiceTypes.end());
+    AFL_ENSURE(supportedClientServiceTypes.find(serviceType) != supportedClientServiceTypes.end());
 
     const TClientServiceType& clientServiceType = supportedClientServiceTypes.find(serviceType)->second;
 

--- a/ydb/core/persqueue/public/write_meta/write_meta.h
+++ b/ydb/core/persqueue/public/write_meta/write_meta.h
@@ -5,6 +5,7 @@
 #include <ydb/public/sdk/cpp/src/client/persqueue_public/persqueue.h>
 
 #include <util/string/vector.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr {
 
@@ -62,7 +63,7 @@ TString GetSerializedData(const NKikimrPQClient::TDataChunk& init, TArgs&...args
 
     TString str;
     bool res = proto.SerializeToString(&str);
-    Y_ENSURE(res);
+    AFL_ENSURE(res);
     return str;
 }
 

--- a/ydb/core/persqueue/writer/partition_chooser_impl__pqrb_helper.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__pqrb_helper.h
@@ -3,6 +3,7 @@
 #include "pipe_utils.h"
 
 #include <ydb/core/persqueue/events/global.h>
+#include <ydb/library/actors/core/log.h>
 
 
 namespace NKikimr::NPQ::NPartitionChooser {
@@ -19,7 +20,7 @@ public:
     }
 
     void SendRequest(const NActors::TActorContext& ctx) {
-        Y_ENSURE(BalancerTabletId);
+        AFL_ENSURE(BalancerTabletId);
 
         if (!Pipe) {
             NTabletPipe::TClientConfig clientConfig;

--- a/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
@@ -13,6 +13,7 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/result/result.h>
 
 #include <library/cpp/time_provider/time_provider.h>
+#include <ydb/library/actors/core/log.h>
 
 
 namespace NKikimr::NPQ::NPartitionChooser {
@@ -95,7 +96,7 @@ public:
         }
 
         KqpSessionId = record.GetResponse().GetSessionId();
-        Y_ENSURE(!KqpSessionId.empty());
+        AFL_ENSURE(!KqpSessionId.empty());
 
         return true;
     }
@@ -164,7 +165,7 @@ public:
 
         NYdb::TResultSetParser parser(record.GetResponse().GetYdbResults(0));
         TxId = record.GetResponse().GetTxMeta().id();
-        Y_ENSURE(!TxId.empty());
+        AFL_ENSURE(!TxId.empty());
 
         while(parser.TryNextRow()) {
             auto tt = parser.ColumnParser(0).GetOptionalUint32();

--- a/ydb/core/persqueue/writer/source_id_encoding.cpp
+++ b/ydb/core/persqueue/writer/source_id_encoding.cpp
@@ -13,6 +13,7 @@
 #include <util/string/hex.h>
 #include <util/string/join.h>
 #include <util/string/strip.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NPQ {
 
@@ -34,7 +35,7 @@ TString GetSelectSourceIdQueryFromPath(const TString& path, ESourceIdTableGenera
                    << NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath()
                    << "` WHERE Hash == $Hash AND Topic == $Topic AND ProducerId == $SourceId;";
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
@@ -48,7 +49,7 @@ TString GetSelectSourceIdQuery(const TString& root, ESourceIdTableGeneration gen
                     generation
             );
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
@@ -78,7 +79,7 @@ TString GetUpdateSourceIdQueryFromPath(const TString& path, ESourceIdTableGenera
                     << "` (Hash, Topic, ProducerId, CreateTime, AccessTime, Partition, SeqNo) VALUES "
                                               "($Hash, $Topic, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo);";
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
@@ -107,7 +108,7 @@ TString GetUpdateAccessTimeQueryFromPath(const TString& path, ESourceIdTableGene
                    "SET AccessTime = $AccessTime "
                    "WHERE Hash = $Hash AND Topic = $Topic AND ProducerId = $SourceId AND Partition = $Partition;";
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
@@ -121,7 +122,7 @@ TString GetUpdateSourceIdQuery(const TString& root, ESourceIdTableGeneration gen
                     generation
             );
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
@@ -135,7 +136,7 @@ TString GetUpdateAccessTimeQuery(const TString& root, ESourceIdTableGeneration g
                     generation
             );
         default:
-            Y_ABORT();
+            AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
@@ -155,7 +156,7 @@ TString EncodeSimple(const TString& sourceId) {
 }
 
 TString DecodeSimple(const TString& sourceId) {
-    Y_ENSURE(!sourceId.empty() && sourceId[0] == TTags::Simple);
+    AFL_ENSURE(!sourceId.empty() && sourceId[0] == TTags::Simple);
     return sourceId.substr(1);
 }
 
@@ -179,7 +180,7 @@ TString EncodeBase64(const TString& sourceId) {
 }
 
 TString DecodeBase64(const TString& sourceId) {
-    Y_ENSURE(!sourceId.empty() && sourceId[0] == TTags::Base64);
+    AFL_ENSURE(!sourceId.empty() && sourceId[0] == TTags::Base64);
     return Base64Prefix + StripStringRight(Base64EncodeUrl(sourceId.substr(1)), EqualsStripAdapter(','));
 }
 
@@ -192,7 +193,7 @@ TString Encode(const TString& sourceId) {
 }
 
 TString Decode(const TString& sourceId) {
-    Y_ENSURE(!sourceId.empty());
+    AFL_ENSURE(!sourceId.empty());
 
     switch (sourceId[0]) {
     case TTags::Simple:

--- a/ydb/core/persqueue/writer/writer.cpp
+++ b/ydb/core/persqueue/writer/writer.cpp
@@ -79,7 +79,7 @@ TString TEvPartitionWriter::TEvWriteAccepted::ToString() const {
 }
 
 TString TEvPartitionWriter::TEvWriteResponse::DumpError() const {
-    Y_ENSURE(!IsSuccess());
+    AFL_ENSURE(!IsSuccess());
 
     return TStringBuilder() << "Error {"
         << " SessionId: " << SessionId
@@ -174,7 +174,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     TWriteId MakeDeferredWriteIdFromOpts() const {
-        Y_ENSURE(Opts.DeferredPublish);
+        AFL_ENSURE(Opts.DeferredPublish)("topic", Opts.TopicPath)("tablet_id", TabletId);
         NKikimrPQ::TWriteId proto;
         auto* deferred = proto.MutableDeferredPublicationApi();
         deferred->SetIntPublicationId(Opts.DeferredPublish->IntPublicationId);
@@ -401,7 +401,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     void AbortDeferredStaging() {
-        Y_ENSURE(HasWriteId());
+        AFL_ENSURE(HasWriteId())("topic", Opts.TopicPath)("tablet_id", TabletId);
 
         auto ev = MakeRequest(PartitionId, PipeClient);
         auto& request = *ev->Record.MutablePartitionRequest();
@@ -500,8 +500,8 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     void StartUpsertDestination() {
-        Y_ENSURE(IsDeferredPublishWriter());
-        Y_ENSURE(!Opts.Database.empty());
+        AFL_ENSURE(IsDeferredPublishWriter())("topic", Opts.TopicPath)("tablet_id", TabletId);
+        AFL_ENSURE(!Opts.Database.empty())("topic", Opts.TopicPath)("tablet_id", TabletId);
 
         auto* event = new TEvPartitionWriter::TEvRequestDeferredDestinationUpsert;
         event->IntPublicationId = Opts.DeferredPublish->IntPublicationId;
@@ -541,8 +541,8 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
     }
 
     void SavePartitionIdToKqpTxn(const TActorContext& ctx) {
-        Y_ENSURE(HasWriteId());
-        Y_ENSURE(HasSupportivePartitionId());
+        AFL_ENSURE(HasWriteId())("topic", Opts.TopicPath)("tablet_id", TabletId);
+        AFL_ENSURE(HasSupportivePartitionId())("topic", Opts.TopicPath)("tablet_id", TabletId);
 
         YDB_LOG_DEBUG("Start of a request to KQP to save PartitionId",
             {"logPrefix", LOG_PREFIX},
@@ -633,7 +633,7 @@ class TPartitionWriter : public TActorBootstrapped<TPartitionWriter>, public TPa
             }
         }
 
-        Y_VERIFY(sourceIdInfo.GetSeqNo() >= 0);
+        AFL_ENSURE(sourceIdInfo.GetSeqNo() >= 0)("topic", Opts.TopicPath)("tablet_id", TabletId)("source_id", SourceId)("seq_no", sourceIdInfo.GetSeqNo());
         if (Opts.InitialSeqNo && (ui64)sourceIdInfo.GetSeqNo() < Opts.InitialSeqNo.value()) {
             sourceIdInfo.SetSeqNo(Opts.InitialSeqNo.value());
         }

--- a/ydb/services/datastreams/datastreams_proxy.cpp
+++ b/ydb/services/datastreams/datastreams_proxy.cpp
@@ -24,6 +24,7 @@
 #include <util/folder/path.h>
 
 #include <iterator>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
@@ -791,7 +792,7 @@ namespace NKikimr::NDataStreams::V1 {
 
     void TDescribeStreamActor::HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-        Y_ABORT_UNLESS(result->ResultSet.size() == 1); // describe only one topic
+        AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size()); // describe only one topic
         const auto& response = result->ResultSet.front();
         const TString path = JoinSeq("/", response.Path);
 
@@ -799,7 +800,7 @@ namespace NKikimr::NDataStreams::V1 {
             return;
         }
 
-        Y_ABORT_UNLESS(response.PQGroupInfo);
+        AFL_ENSURE(response.PQGroupInfo)("path", path);
 
         PQGroup = response.PQGroupInfo->Description;
         SelfInfo = response.Self->Info;
@@ -1070,7 +1071,7 @@ namespace NKikimr::NDataStreams::V1 {
 
     void TListStreamConsumersActor::HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
         const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-        Y_ABORT_UNLESS(result->ResultSet.size() == 1); // describe only one topic
+        AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size()); // describe only one topic
 
         if (ReplyIfNotTopic(ev)) {
             return;
@@ -1569,7 +1570,7 @@ namespace NKikimr::NDataStreams::V1 {
                         Result.set_millis_behind_latest(0);
 
                         if (IsQuotaRequired()) {
-                            Y_ABORT_UNLESS(MaybeRequestQuota(1, EWakeupTag::RlAllowed, ctx));
+                            AFL_ENSURE(MaybeRequestQuota(1, EWakeupTag::RlAllowed, ctx));
                         } else {
                             SendResponse(ctx);
                         }
@@ -1638,7 +1639,7 @@ namespace NKikimr::NDataStreams::V1 {
 
         if (IsQuotaRequired()) {
             const auto ru = 1 + CalcRuConsumption(GetPayloadSize());
-            Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
+            AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
         } else {
             SendResponse(ctx);
         }
@@ -2014,9 +2015,9 @@ namespace NKikimr::NDataStreams::V1 {
         }
 
         const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-        Y_ABORT_UNLESS(result->ResultSet.size() == 1); // describe only one topic
+        AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size()); // describe only one topic
         const auto& response = result->ResultSet.front();
-        Y_ABORT_UNLESS(response.PQGroupInfo);
+        AFL_ENSURE(response.PQGroupInfo)("path", JoinSeq("/", response.Path));
         const TString path = JoinSeq("/", response.Path);
 
         PQGroup = response.PQGroupInfo->Description;
@@ -2127,7 +2128,7 @@ DECLARE_RPC_NI(StopStreamEncryption);
 
 void DoDataStreamsDecreaseStreamRetentionPeriodRequest(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
     auto* req = dynamic_cast<TEvDataStreamsDecreaseStreamRetentionPeriodRequest*>(p.release());
-    Y_ABORT_UNLESS(req != nullptr, "Wrong using of TGRpcRequestWrapper");
+    AFL_ENSURE(req != nullptr)("reason", "Wrong using of TGRpcRequestWrapper");
     TActivationContext::AsActorContext().Register(new TSetStreamRetentionPeriodActor<TEvDataStreamsDecreaseStreamRetentionPeriodRequest>(req, false));
 }
 template<>
@@ -2137,7 +2138,7 @@ IActor* TEvDataStreamsDecreaseStreamRetentionPeriodRequest::CreateRpcActor(NKiki
 
 void DoDataStreamsIncreaseStreamRetentionPeriodRequest(std::unique_ptr<IRequestOpCtx> p, const IFacilityProvider&) {
     auto* req = dynamic_cast<TEvDataStreamsIncreaseStreamRetentionPeriodRequest*>(p.release());
-    Y_ABORT_UNLESS(req != nullptr, "Wrong using of TGRpcRequestWrapper");
+    AFL_ENSURE(req != nullptr)("reason", "Wrong using of TGRpcRequestWrapper");
     TActivationContext::AsActorContext().Register(new TSetStreamRetentionPeriodActor<TEvDataStreamsIncreaseStreamRetentionPeriodRequest>(req, true));
 }
 template<>

--- a/ydb/services/datastreams/next_token.h
+++ b/ydb/services/datastreams/next_token.h
@@ -3,6 +3,7 @@
 #include <ydb/core/protos/pqconfig.pb.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <util/datetime/base.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NDataStreams::V1 {
 
@@ -33,7 +34,7 @@ TNextToken(const TString& streamArn, ui32 alreadyRead, ui32 maxResults, ui64 cre
 TString Serialize() const {
     TString data;
     bool result = Proto.SerializeToString(&data);
-    Y_ABORT_UNLESS(result);
+    AFL_ENSURE(result);
     TString encoded;
     Base64Encode(data, encoded);
     return encoded;

--- a/ydb/services/datastreams/put_records_actor.h
+++ b/ydb/services/datastreams/put_records_actor.h
@@ -16,6 +16,7 @@
 #include <ydb/services/lib/sharding/sharding.h>
 
 #include <library/cpp/digest/md5/md5.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NDataStreams::V1 {
 
@@ -38,7 +39,7 @@ namespace NKikimr::NDataStreams::V1 {
 
         TString str;
         bool res = proto.SerializeToString(&str);
-        Y_ABORT_UNLESS(res);
+        AFL_ENSURE(res);
         return str;
     }
 
@@ -132,8 +133,8 @@ namespace NKikimr::NDataStreams::V1 {
                 return;
             }
 
-            Y_ABORT_UNLESS(ev->Get()->Record.HasPartitionResponse());
-            Y_ENSURE(ev->Get()->Record.GetPartitionResponse().GetCmdWriteResult().size() > 0, "Wrong number of cmd write commands");
+            AFL_ENSURE(ev->Get()->Record.HasPartitionResponse());
+            AFL_ENSURE(ev->Get()->Record.GetPartitionResponse().GetCmdWriteResult().size() > 0)("reason", "Wrong number of cmd write commands");
             auto offset = ev->Get()->Record.GetPartitionResponse().GetCmdWriteResult(0).GetOffset();
             ReplySuccessAndDie(ctx, offset);
         }
@@ -274,7 +275,7 @@ namespace NKikimr::NDataStreams::V1 {
             , TRlHelpers({}, request, 4_KB, false, TDuration::Seconds(1))
             , Ip(request->GetPeerName())
     {
-        Y_ENSURE(request);
+        AFL_ENSURE(request);
     }
 
     template<class TDerived, class TProto>
@@ -355,7 +356,7 @@ namespace NKikimr::NDataStreams::V1 {
 
         if (IsQuotaRequired()) {
             const auto ru = 1 + CalcRuConsumption(GetPayloadSize());
-            Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, this->ActorContext()));
+            AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, this->ActorContext()));
         } else {
             Write(this->ActorContext());
         }
@@ -400,7 +401,7 @@ namespace NKikimr::NDataStreams::V1 {
     template<class TDerived, class TProto>
     void TPutRecordsActorBase<TDerived, TProto>::Handle(NDataStreams::V1::TEvDataStreams::TEvPartitionActorResult::TPtr& ev, const TActorContext& ctx) {
         auto it = PartitionToActor.find(ev->Get()->PartitionId);
-        Y_ENSURE(it != PartitionToActor.end());
+        AFL_ENSURE(it != PartitionToActor.end());
         if (ev->Get()->ErrorText.Defined()) {
             PutRecordsResult.set_failed_record_count(
                     PutRecordsResult.failed_record_count() + it->second.RecordIndexes.size());

--- a/ydb/services/datastreams/shard_iterator.h
+++ b/ydb/services/datastreams/shard_iterator.h
@@ -4,6 +4,7 @@
 #include <ydb/core/protos/msgbus_pq.pb.h>
 #include <library/cpp/string_utils/base64/base64.h>
 #include <util/datetime/base.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NDataStreams::V1 {
 
@@ -78,7 +79,7 @@ static TShardIterator Cdc(const TString& streamName, const TString& streamArn,
 TString Serialize() const {
     TString data;
     bool result = Proto.SerializeToString(&data);
-    Y_ABORT_UNLESS(result);
+    AFL_ENSURE(result);
     TString encoded;
     Base64Encode(data, encoded);
     return encoded;

--- a/ydb/services/lib/actors/pq_schema_actor.h
+++ b/ydb/services/lib/actors/pq_schema_actor.h
@@ -309,7 +309,7 @@ namespace NKikimr::NGRpcProxy::V1 {
             YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::PERSQUEUE, "Unhandled exception",
                 {"typeName", TypeName(exc)},
                 {"exception", exc.what()},
-                {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+                {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
 
             ReplyWithError(Ydb::StatusIds::INTERNAL_ERROR, Ydb::PersQueue::ErrorCode::ERROR, "Internal error");
 

--- a/ydb/services/lib/actors/pq_schema_actor.h
+++ b/ydb/services/lib/actors/pq_schema_actor.h
@@ -13,6 +13,7 @@
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/event_local.h>
 #include <ydb/library/actors/core/hfunc.h>
+#include <ydb/library/actors/core/log.h>
 
 
 struct TMsgPqCodes {
@@ -367,7 +368,11 @@ namespace NKikimr::NGRpcProxy::V1 {
         bool ProcessCdc(const NSchemeCache::TSchemeCacheNavigate::TEntry& response) override {
             if constexpr (THasCdcStreamCompatibility<TDerived>::Value) {
                 if (static_cast<TDerived*>(this)->IsCdcStreamCompatible()) {
-                    Y_ABORT_UNLESS(response.ListNodeEntry->Children.size() == 1);
+                    AFL_ENSURE(response.ListNodeEntry)
+                        ("path", GetTopicPath())("database", TActorBase::Database);
+                    AFL_ENSURE(response.ListNodeEntry->Children.size() == 1)
+                        ("path", GetTopicPath())("database", TActorBase::Database)
+                        ("children", response.ListNodeEntry->Children.size());
                     PrivateTopicName = response.ListNodeEntry->Children.at(0).Name;
 
                     if (response.Self) {

--- a/ydb/services/persqueue_v1/actors/codecs.cpp
+++ b/ydb/services/persqueue_v1/actors/codecs.cpp
@@ -15,7 +15,7 @@ namespace NKikimr::NGRpcProxy {
             const auto& ids = pqTabletConfig.codecs().ids();
             if (!ids.empty() && Find(ids, codecID) == ids.end()) {
                 const auto& names = pqTabletConfig.codecs().codecs();
-                AFL_ENSURE(ids.size() == names.size())("reason", "PQ tabled supported codecs configuration is invalid");
+                AFL_ENSURE(ids.size() == names.size())("reason", "PQ tablet supported codecs configuration is invalid");
                 TStringBuilder errorBuilder;
                 errorBuilder << "given codec (id " << static_cast<i32>(codecID) << ") is not configured for the topic. Configured codecs are " << names[0] << " (id " << ids[0] << ")";
                 for (i32 i = 1; i != ids.size(); ++i) {

--- a/ydb/services/persqueue_v1/actors/codecs.cpp
+++ b/ydb/services/persqueue_v1/actors/codecs.cpp
@@ -5,6 +5,7 @@
 
 #include <util/generic/algorithm.h>
 #include <util/string/builder.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NGRpcProxy {
     bool ValidateWriteWithCodec(const NKikimrPQ::TPQTabletConfig& pqTabletConfig, const ui32 codecID, TString& error) {
@@ -14,7 +15,7 @@ namespace NKikimr::NGRpcProxy {
             const auto& ids = pqTabletConfig.codecs().ids();
             if (!ids.empty() && Find(ids, codecID) == ids.end()) {
                 const auto& names = pqTabletConfig.codecs().codecs();
-                Y_ABORT_UNLESS(ids.size() == names.size(), "PQ tabled supported codecs configuration is invalid");
+                AFL_ENSURE(ids.size() == names.size())("reason", "PQ tabled supported codecs configuration is invalid");
                 TStringBuilder errorBuilder;
                 errorBuilder << "given codec (id " << static_cast<i32>(codecID) << ") is not configured for the topic. Configured codecs are " << names[0] << " (id " << ids[0] << ")";
                 for (i32 i = 1; i != ids.size(); ++i) {

--- a/ydb/services/persqueue_v1/actors/distributed_commit_helper.cpp
+++ b/ydb/services/persqueue_v1/actors/distributed_commit_helper.cpp
@@ -1,5 +1,6 @@
 #include "distributed_commit_helper.h"
 #include "ydb/core/kqp/common/simple/services.h"
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -56,7 +57,7 @@ bool TDistributedCommitHelper::Handle(NKqp::TEvKqp::TEvCreateSessionResponse::TP
     }
 
     KqpSessionId = record.GetResponse().GetSessionId();
-    Y_ABORT_UNLESS(!KqpSessionId.empty());
+    AFL_ENSURE(!KqpSessionId.empty());
     BeginTransaction(ctx);
     return true;
 }
@@ -84,7 +85,7 @@ THolder<NKqp::TEvKqp::TEvCloseSessionRequest> TDistributedCommitHelper::MakeClos
 void TDistributedCommitHelper::SendCommits(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const NActors::TActorContext& ctx) {
     auto& record = ev->Get()->Record;
     TxId = record.GetResponse().GetTxMeta().id();
-    Y_ABORT_UNLESS(!TxId.empty());
+    AFL_ENSURE(!TxId.empty());
 
     auto offsets = MakeHolder<NKqp::TEvKqp::TEvQueryRequest>();
     offsets->Record.MutableRequest()->SetDatabase(DataBase);

--- a/ydb/services/persqueue_v1/actors/persqueue_utils.cpp
+++ b/ydb/services/persqueue_v1/actors/persqueue_utils.cpp
@@ -9,19 +9,20 @@
 
 #include <library/cpp/string_utils/base64/base64.h>
 #include <util/charset/utf8.h>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NGRpcProxy::V1 {
 
 TAclWrapper::TAclWrapper(THolder<NACLib::TSecurityObject> acl)
     : AclOldSchemeCache(std::move(acl))
 {
-    Y_ABORT_UNLESS(AclOldSchemeCache);
+    AFL_ENSURE(AclOldSchemeCache);
 }
 
 TAclWrapper::TAclWrapper(TIntrusivePtr<TSecurityObject> acl)
     : AclNewSchemeCache(std::move(acl))
 {
-    Y_ABORT_UNLESS(AclNewSchemeCache);
+    AFL_ENSURE(AclNewSchemeCache);
 }
 
 bool TAclWrapper::CheckAccess(NACLib::EAccessRights rights, const NACLib::TUserToken& userToken) {

--- a/ydb/services/persqueue_v1/actors/read_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.cpp
@@ -699,7 +699,7 @@ void TReadSessionActor<Protocol>::Handle(TEvPQProxy::TEvCommitDone::TPtr& ev, co
                 partition.ReadIdCommitted = i;
             }
         } else { // commit on cookies not supported in this case
-            AFL_ENSURE(false);
+            AFL_ENSURE(false)("reason", "cookie commits not supported")("protocol", static_cast<int>(Protocol));
         }
     } else {
         if constexpr (Protocol == EProtocol::PQv1) {

--- a/ydb/services/persqueue_v1/actors/read_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.h
@@ -90,7 +90,8 @@ struct TPartitionActorInfo {
         , NodeId(0)
         , ReadingFinished(false)
     {
-        AFL_ENSURE(partition.DiscoveryConverter != nullptr);
+        AFL_ENSURE(partition.DiscoveryConverter != nullptr)
+            ("partition", partition.Partition)("assign_id", partition.AssignId);
     }
 
     bool IsLastOffsetCommitted() const {

--- a/ydb/services/persqueue_v1/actors/read_session_actor.h
+++ b/ydb/services/persqueue_v1/actors/read_session_actor.h
@@ -22,6 +22,7 @@
 #include <google/protobuf/util/time_util.h>
 
 #include <type_traits>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -89,7 +90,7 @@ struct TPartitionActorInfo {
         , NodeId(0)
         , ReadingFinished(false)
     {
-        Y_ABORT_UNLESS(partition.DiscoveryConverter != nullptr);
+        AFL_ENSURE(partition.DiscoveryConverter != nullptr);
     }
 
     bool IsLastOffsetCommitted() const {

--- a/ydb/services/persqueue_v1/actors/schema_actors.cpp
+++ b/ydb/services/persqueue_v1/actors/schema_actors.cpp
@@ -9,6 +9,7 @@
 #include <ydb/public/sdk/cpp/src/library/persqueue/obfuscate/obfuscate.h>
 
 #include <library/cpp/json/json_writer.h>
+#include <ydb/library/actors/core/log.h>
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
@@ -642,7 +643,7 @@ void TDescribeTopicActor::ApplyResponse(TTabletInfo& tabletInfo, NKikimr::TEvPer
     Y_UNUSED(ctx);
     Y_UNUSED(tabletInfo);
     Y_UNUSED(ev);
-    Y_ABORT("");
+    AFL_ENSURE(false)("reason", "TDescribeTopicActor: unexpected TEvReadSessionsInfoResponse");
 }
 
 

--- a/ydb/services/persqueue_v1/actors/schema_actors.h
+++ b/ydb/services/persqueue_v1/actors/schema_actors.h
@@ -7,6 +7,7 @@
 #include <ydb/core/client/server/ic_nodes_cache_service.h>
 
 #include <optional>
+#include <ydb/library/actors/core/log.h>
 
 namespace NKikimr::NGRpcProxy::V1 {
 
@@ -207,11 +208,11 @@ public:
     void ApplyResponse(TTabletInfo&,
                       NKikimr::TEvPersQueue::TEvStatusResponse::TPtr&,
                       const TActorContext&) override {
-        Y_ABORT();
+        AFL_ENSURE(false)("reason", "TPartitionsLocationActor: unexpected TEvStatusResponse");
     }
     virtual void ApplyResponse(TTabletInfo&, TEvPersQueue::TEvReadSessionsInfoResponse::TPtr&,
                                const TActorContext&) override {
-        Y_ABORT();
+        AFL_ENSURE(false)("reason", "TPartitionsLocationActor: unexpected TEvReadSessionsInfoResponse");
     }
 
     void Finalize();

--- a/ydb/services/persqueue_v1/actors/write_session_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/write_session_actor.cpp
@@ -77,7 +77,7 @@ ECodec<Protocol> CodecByName(const TString& codec) {
         if constexpr (Protocol == EProtocol::Topic) {
             return (i32)Ydb::Topic::CODEC_UNSPECIFIED;
         }
-        Y_ABORT("Unsupported codec enum");
+        AFL_ENSURE(false)("reason", "Unsupported codec enum")("codec", codec);
     }
     return codecIt->second;
 }

--- a/ydb/services/persqueue_v1/grpc_pq_read.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_read.cpp
@@ -104,9 +104,11 @@ void TPQReadService::Handle(NNetClassifier::TEvNetClassifier::TEvClassifierUpdat
 }
 
 void TPQReadService::Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvClustersUpdate::TPtr& ev, const TActorContext& ctx) {
-    AFL_ENSURE(ev->Get()->ClustersList);
+    AFL_ENSURE(ev->Get()->ClustersList)("local_cluster", LocalCluster);
 
-    AFL_ENSURE(ev->Get()->ClustersList->Clusters.size());
+    AFL_ENSURE(ev->Get()->ClustersList->Clusters.size())
+        ("clusters", ev->Get()->ClustersList->Clusters.size())
+        ("local_cluster", LocalCluster);
 
     const auto& clusters = ev->Get()->ClustersList->Clusters;
 
@@ -161,7 +163,7 @@ void TPQReadService::Handle(NGRpcService::TEvStreamTopicDirectReadRequest::TPtr&
         // TODO: Inc SLI Errors
         return;
     } else {
-        AFL_ENSURE(TopicsHandler != nullptr);
+        AFL_ENSURE(TopicsHandler != nullptr)("local_cluster", LocalCluster)("have_clusters", HaveClusters);
         auto ip = ev->Get()->GetPeerName();
 
         const ui64 cookie = NextCookie();

--- a/ydb/services/persqueue_v1/grpc_pq_read.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_read.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/tx/scheme_board/cache.h>
 
 #include <algorithm>
+#include <ydb/library/actors/core/log.h>
 
 using namespace NActors;
 using namespace NKikimrClient;
@@ -80,14 +81,14 @@ void TPQReadService::Handle(NGRpcService::TEvCommitOffsetRequest::TPtr& ev, cons
         YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New commit offset request failed - cluster is not known yet");
 
         auto e = dynamic_cast<TEvCommitOffsetRequest*>(ev->Get());
-        Y_ENSURE(e);
+        AFL_ENSURE(e);
         e->RaiseIssue(FillIssue("cluster initializing", PersQueue::ErrorCode::INITIALIZING));
         e->ReplyWithYdbStatus(ConvertPersQueueInternalCodeToStatus(PersQueue::ErrorCode::INITIALIZING));
         return;
     } else {
         std::unique_ptr<TEvCommitOffsetRequest> e;
         e.reset(dynamic_cast<TEvCommitOffsetRequest*>(ev->Release().Release()));
-        Y_ENSURE(e);
+        AFL_ENSURE(e);
         ctx.Register(new TCommitOffsetActor(e.release(), *TopicsHandler, SchemeCache, NewSchemeCache, Counters));
     }
 }
@@ -103,9 +104,9 @@ void TPQReadService::Handle(NNetClassifier::TEvNetClassifier::TEvClassifierUpdat
 }
 
 void TPQReadService::Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvClustersUpdate::TPtr& ev, const TActorContext& ctx) {
-    Y_ABORT_UNLESS(ev->Get()->ClustersList);
+    AFL_ENSURE(ev->Get()->ClustersList);
 
-    Y_ABORT_UNLESS(ev->Get()->ClustersList->Clusters.size());
+    AFL_ENSURE(ev->Get()->ClustersList->Clusters.size());
 
     const auto& clusters = ev->Get()->ClustersList->Clusters;
 
@@ -160,7 +161,7 @@ void TPQReadService::Handle(NGRpcService::TEvStreamTopicDirectReadRequest::TPtr&
         // TODO: Inc SLI Errors
         return;
     } else {
-        Y_ABORT_UNLESS(TopicsHandler != nullptr);
+        AFL_ENSURE(TopicsHandler != nullptr);
         auto ip = ev->Get()->GetPeerName();
 
         const ui64 cookie = NextCookie();
@@ -212,7 +213,7 @@ namespace NGRpcService {
 
 void DoPQReadInfoRequest(std::unique_ptr<IRequestOpCtx> ctx, const NKikimr::NGRpcService::IFacilityProvider&) {
     auto ev = dynamic_cast<TEvPQReadInfoRequest*>(ctx.release());
-    Y_ENSURE(ev);
+    AFL_ENSURE(ev);
 
     auto evHandle = std::make_unique<NActors::IEventHandle>(
         NGRpcProxy::V1::GetPQReadServiceActorID(),

--- a/ydb/services/persqueue_v1/grpc_pq_read.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_read.cpp
@@ -81,14 +81,14 @@ void TPQReadService::Handle(NGRpcService::TEvCommitOffsetRequest::TPtr& ev, cons
         YDB_LOG_INFO_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New commit offset request failed - cluster is not known yet");
 
         auto e = dynamic_cast<TEvCommitOffsetRequest*>(ev->Get());
-        AFL_ENSURE(e);
+        AFL_ENSURE(e)("reason", "unexpected event type for commit offset")("local_cluster", LocalCluster);
         e->RaiseIssue(FillIssue("cluster initializing", PersQueue::ErrorCode::INITIALIZING));
         e->ReplyWithYdbStatus(ConvertPersQueueInternalCodeToStatus(PersQueue::ErrorCode::INITIALIZING));
         return;
     } else {
         std::unique_ptr<TEvCommitOffsetRequest> e;
         e.reset(dynamic_cast<TEvCommitOffsetRequest*>(ev->Release().Release()));
-        AFL_ENSURE(e);
+        AFL_ENSURE(e)("reason", "unexpected event type for commit offset")("local_cluster", LocalCluster);
         ctx.Register(new TCommitOffsetActor(e.release(), *TopicsHandler, SchemeCache, NewSchemeCache, Counters));
     }
 }
@@ -215,7 +215,7 @@ namespace NGRpcService {
 
 void DoPQReadInfoRequest(std::unique_ptr<IRequestOpCtx> ctx, const NKikimr::NGRpcService::IFacilityProvider&) {
     auto ev = dynamic_cast<TEvPQReadInfoRequest*>(ctx.release());
-    AFL_ENSURE(ev);
+    AFL_ENSURE(ev)("reason", "unexpected request type for PQ read info");
 
     auto evHandle = std::make_unique<NActors::IEventHandle>(
         NGRpcProxy::V1::GetPQReadServiceActorID(),

--- a/ydb/services/persqueue_v1/grpc_pq_read.h
+++ b/ydb/services/persqueue_v1/grpc_pq_read.h
@@ -127,7 +127,7 @@ void TPQReadService::HandleStreamPQReadRequest(typename ReadRequest::TPtr& ev, c
         return;
     } else {
 
-        AFL_ENSURE(TopicsHandler != nullptr);
+        AFL_ENSURE(TopicsHandler != nullptr)("local_cluster", LocalCluster)("have_clusters", HaveClusters);
         const ui64 cookie = NextCookie();
 
         YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New session created cookie",

--- a/ydb/services/persqueue_v1/grpc_pq_read.h
+++ b/ydb/services/persqueue_v1/grpc_pq_read.h
@@ -13,6 +13,7 @@
 #include <util/system/mutex.h>
 
 #include <type_traits>
+#include <ydb/library/actors/core/log.h>
 
 
 namespace NKikimr {
@@ -126,7 +127,7 @@ void TPQReadService::HandleStreamPQReadRequest(typename ReadRequest::TPtr& ev, c
         return;
     } else {
 
-        Y_ABORT_UNLESS(TopicsHandler != nullptr);
+        AFL_ENSURE(TopicsHandler != nullptr);
         const ui64 cookie = NextCookie();
 
         YDB_LOG_DEBUG_CTX_COMP(ctx, NKikimrServices::PQ_READ_PROXY, "New session created cookie",

--- a/ydb/services/persqueue_v1/grpc_pq_write.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_write.cpp
@@ -64,8 +64,11 @@ void TPQWriteService::Handle(NNetClassifier::TEvNetClassifier::TEvClassifierUpda
 
 
 void TPQWriteService::Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvClustersUpdate::TPtr& ev, const TActorContext& ctx) {
-    AFL_ENSURE(ev->Get()->ClustersList);
-    AFL_ENSURE(ev->Get()->ClustersList->Clusters.size());
+    AFL_ENSURE(ev->Get()->ClustersList)("local_cluster", LocalCluster)("enabled", Enabled);
+    AFL_ENSURE(ev->Get()->ClustersList->Clusters.size())
+        ("clusters", ev->Get()->ClustersList->Clusters.size())
+        ("local_cluster", LocalCluster)
+        ("enabled", Enabled);
 
     const auto& clusters = ev->Get()->ClustersList->Clusters;
 

--- a/ydb/services/persqueue_v1/grpc_pq_write.cpp
+++ b/ydb/services/persqueue_v1/grpc_pq_write.cpp
@@ -3,6 +3,7 @@
 #include <ydb/core/tx/scheme_board/cache.h>
 #include <ydb/core/base/appdata.h>
 #include <util/generic/queue.h>
+#include <ydb/library/actors/core/log.h>
 
 using namespace NActors;
 using namespace NKikimrClient;
@@ -63,8 +64,8 @@ void TPQWriteService::Handle(NNetClassifier::TEvNetClassifier::TEvClassifierUpda
 
 
 void TPQWriteService::Handle(NPQ::NClusterTracker::TEvClusterTracker::TEvClustersUpdate::TPtr& ev, const TActorContext& ctx) {
-    Y_ABORT_UNLESS(ev->Get()->ClustersList);
-    Y_ABORT_UNLESS(ev->Get()->ClustersList->Clusters.size());
+    AFL_ENSURE(ev->Get()->ClustersList);
+    AFL_ENSURE(ev->Get()->ClustersList->Clusters.size());
 
     const auto& clusters = ev->Get()->ClustersList->Clusters;
 

--- a/ydb/services/sqs_topic/actor.h
+++ b/ydb/services/sqs_topic/actor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "error.h"
+
 #include <ydb/core/base/appdata.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/persqueue/public/describer/describer.h>
@@ -7,8 +9,13 @@
 #include <ydb/core/protos/sqs.pb.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/aclib/aclib.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/http_proxy/error/error.h>
+#include <ydb/library/services/services.pb.h>
 #include <ydb/services/lib/actors/pq_schema_actor.h>
+
+#include <util/system/type_name.h>
+#include <util/system/backtrace.h>
 
 namespace NKikimr::NSqsTopic::V1 {
 
@@ -40,6 +47,19 @@ namespace NKikimr::NSqsTopic::V1 {
             this->Request_->ReplyWithYdbStatus(Ydb::StatusIds_StatusCode_STATUS_CODE_UNSPECIFIED);
             this->Die(this->ActorContext());
             TBase::IsDead = true;
+        }
+
+        bool OnUnhandledException(const std::exception& exc) override {
+            const auto& ctx = this->ActorContext();
+            YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::SQS, "Unhandled exception in SQS topic actor",
+                {"typeName", TypeName(exc)},
+                {"exception", exc.what()},
+                {"path", this->GetTopicPath()},
+                {"database", this->Database},
+                {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+
+            ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE, "Internal error"));
+            return true;
         }
 
         void DescribeTopic(NACLib::EAccessRights accessRights) {

--- a/ydb/services/sqs_topic/actor.h
+++ b/ydb/services/sqs_topic/actor.h
@@ -56,7 +56,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 {"exception", exc.what()},
                 {"path", this->GetTopicPath()},
                 {"database", this->Database},
-                {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+                {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
 
             ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE, "Internal error"));
             return true;

--- a/ydb/services/sqs_topic/change_message_visibility.cpp
+++ b/ydb/services/sqs_topic/change_message_visibility.cpp
@@ -36,7 +36,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 using namespace NActors;

--- a/ydb/services/sqs_topic/create_queue.cpp
+++ b/ydb/services/sqs_topic/create_queue.cpp
@@ -42,7 +42,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/json/json_writer.h>
 
@@ -117,11 +117,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            if (result->Topics.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
-            }
+            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size())("path", TopicPath);
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/create_queue.cpp
+++ b/ydb/services/sqs_topic/create_queue.cpp
@@ -116,7 +116,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            Y_ABORT_UNLESS(result->Topics.size() == 1);
+            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size());
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/create_queue.cpp
+++ b/ydb/services/sqs_topic/create_queue.cpp
@@ -42,6 +42,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 #include <library/cpp/json/json_writer.h>
 
 
@@ -116,6 +118,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
             if (result->Topics.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
             }

--- a/ydb/services/sqs_topic/create_queue.cpp
+++ b/ydb/services/sqs_topic/create_queue.cpp
@@ -40,7 +40,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 #include <library/cpp/json/json_writer.h>
@@ -116,7 +115,10 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size());
+            if (result->Topics.size() != 1) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
+            }
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -253,7 +253,7 @@ namespace NKikimr::NSqsTopic::V1 {
                     SetRlContext(*rlContext);
                     if (IsQuotaRequired()) {
                         const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
-                        Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
+                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
                         return;
                     }
                 }
@@ -262,7 +262,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -38,7 +38,6 @@
 
 #include <ydb/services/sqs_topic/billing.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 using namespace NActors;
@@ -253,8 +252,10 @@ namespace NKikimr::NSqsTopic::V1 {
                     SetRlContext(*rlContext);
                     if (IsQuotaRequired()) {
                         const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
-                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
-                            ("ru", ru)("path", FullTopicPath_);
+                        if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext())) {
+                            return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                                "Rate limiter request already in progress"));
+                        }
                         return;
                     }
                 }
@@ -263,7 +264,10 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
+            if (result->ResultSet.size() != 1) {
+                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
+            }
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -40,7 +40,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 using namespace NActors;
 using namespace NKikimrClient;
@@ -254,11 +254,8 @@ namespace NKikimr::NSqsTopic::V1 {
                     SetRlContext(*rlContext);
                     if (IsQuotaRequired()) {
                         const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
-                        if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext())) {
-                            Y_VERIFY_DEBUG(false);
-                            return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                                "Rate limiter request already in progress"));
-                        }
+                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
+                            ("ru", ru)("path", FullTopicPath_);
                         return;
                     }
                 }
@@ -267,11 +264,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            if (result->ResultSet.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
-            }
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size())("path", FullTopicPath_);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -40,6 +40,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 using namespace NActors;
 using namespace NKikimrClient;
 
@@ -253,6 +255,7 @@ namespace NKikimr::NSqsTopic::V1 {
                     if (IsQuotaRequired()) {
                         const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
                         if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext())) {
+                            Y_VERIFY_DEBUG(false);
                             return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                 "Rate limiter request already in progress"));
                         }
@@ -265,6 +268,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
             if (result->ResultSet.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
             }

--- a/ydb/services/sqs_topic/delete_message.cpp
+++ b/ydb/services/sqs_topic/delete_message.cpp
@@ -253,7 +253,8 @@ namespace NKikimr::NSqsTopic::V1 {
                     SetRlContext(*rlContext);
                     if (IsQuotaRequired()) {
                         const ui64 ru = NBilling::CalcRu(0, NBilling::DELETE_BASE_COST, 0, false, false);
-                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
+                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
+                            ("ru", ru)("path", FullTopicPath_);
                         return;
                     }
                 }

--- a/ydb/services/sqs_topic/delete_queue.cpp
+++ b/ydb/services/sqs_topic/delete_queue.cpp
@@ -98,7 +98,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            Y_ABORT_UNLESS(result->Topics.size() == 1);
+            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size());
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/delete_queue.cpp
+++ b/ydb/services/sqs_topic/delete_queue.cpp
@@ -37,6 +37,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 #include <library/cpp/json/json_writer.h>
 
 using namespace NActors;
@@ -98,6 +100,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
             if (result->Topics.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
             }

--- a/ydb/services/sqs_topic/delete_queue.cpp
+++ b/ydb/services/sqs_topic/delete_queue.cpp
@@ -35,7 +35,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 #include <library/cpp/json/json_writer.h>
@@ -98,7 +97,10 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size());
+            if (result->Topics.size() != 1) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
+            }
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/delete_queue.cpp
+++ b/ydb/services/sqs_topic/delete_queue.cpp
@@ -37,7 +37,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/json/json_writer.h>
 
@@ -99,11 +99,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            if (result->Topics.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
-            }
+            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size())("path", FullTopicPath_);
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/get_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/get_queue_attributes.cpp
@@ -38,7 +38,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/json/json_writer.h>
 
@@ -193,11 +193,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            if (result->ResultSet.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
-            }
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size())("path", FullTopicPath_);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -216,11 +212,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
-            if (!response.PQGroupInfo) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Failed to describe topic: missing PQ group info for " << FullTopicPath_));
-            }
+            AFL_ENSURE(response.PQGroupInfo)("path", FullTopicPath_);
             PQGroup = response.PQGroupInfo->Description;
             SelfInfo = response.Self->Info;
             ConsumerConfig = GetConsumerConfig(PQGroup.GetPQTabletConfig(), QueueUrl_->Consumer, ActorContext());

--- a/ydb/services/sqs_topic/get_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/get_queue_attributes.cpp
@@ -36,7 +36,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 #include <library/cpp/json/json_writer.h>
@@ -192,7 +191,10 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
+            if (result->ResultSet.size() != 1) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
+            }
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -211,7 +213,10 @@ namespace NKikimr::NSqsTopic::V1 {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
-            AFL_ENSURE(response.PQGroupInfo)("path", FullTopicPath_);
+            if (!response.PQGroupInfo) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Failed to describe topic: missing PQ group info for " << FullTopicPath_));
+            }
             PQGroup = response.PQGroupInfo->Description;
             SelfInfo = response.Self->Info;
             ConsumerConfig = GetConsumerConfig(PQGroup.GetPQTabletConfig(), QueueUrl_->Consumer, ActorContext());

--- a/ydb/services/sqs_topic/get_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/get_queue_attributes.cpp
@@ -38,6 +38,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 #include <library/cpp/json/json_writer.h>
 
 #include <concepts>
@@ -192,6 +194,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
             if (result->ResultSet.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
             }
@@ -214,6 +217,7 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
             if (!response.PQGroupInfo) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Failed to describe topic: missing PQ group info for " << FullTopicPath_));
             }

--- a/ydb/services/sqs_topic/get_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/get_queue_attributes.cpp
@@ -192,7 +192,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -211,7 +211,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
-            Y_ABORT_UNLESS(response.PQGroupInfo);
+            AFL_ENSURE(response.PQGroupInfo)("path", FullTopicPath_);
             PQGroup = response.PQGroupInfo->Description;
             SelfInfo = response.Self->Info;
             ConsumerConfig = GetConsumerConfig(PQGroup.GetPQTabletConfig(), QueueUrl_->Consumer, ActorContext());

--- a/ydb/services/sqs_topic/get_queue_url.cpp
+++ b/ydb/services/sqs_topic/get_queue_url.cpp
@@ -39,7 +39,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 #include <library/cpp/json/json_writer.h>
@@ -99,7 +98,10 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
+            if (result->ResultSet.size() != 1) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
+            }
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -117,7 +119,10 @@ namespace NKikimr::NSqsTopic::V1 {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
-            AFL_ENSURE(response.PQGroupInfo)("path", this->TopicPath);
+            if (!response.PQGroupInfo) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Failed to describe topic: missing PQ group info for " << this->TopicPath));
+            }
             PQGroup = response.PQGroupInfo->Description;
             SelfInfo = response.Self->Info;
             ConsumerConfig = GetConsumerConfig(PQGroup.GetPQTabletConfig(), ConsumerName, ActorContext());

--- a/ydb/services/sqs_topic/get_queue_url.cpp
+++ b/ydb/services/sqs_topic/get_queue_url.cpp
@@ -99,7 +99,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -117,7 +117,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
-            Y_ABORT_UNLESS(response.PQGroupInfo);
+            AFL_ENSURE(response.PQGroupInfo)("path", this->TopicPath);
             PQGroup = response.PQGroupInfo->Description;
             SelfInfo = response.Self->Info;
             ConsumerConfig = GetConsumerConfig(PQGroup.GetPQTabletConfig(), ConsumerName, ActorContext());

--- a/ydb/services/sqs_topic/get_queue_url.cpp
+++ b/ydb/services/sqs_topic/get_queue_url.cpp
@@ -41,6 +41,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 #include <library/cpp/json/json_writer.h>
 
 
@@ -99,6 +101,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
             if (result->ResultSet.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
             }
@@ -120,6 +123,7 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
             if (!response.PQGroupInfo) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Failed to describe topic: missing PQ group info for " << this->TopicPath));
             }

--- a/ydb/services/sqs_topic/get_queue_url.cpp
+++ b/ydb/services/sqs_topic/get_queue_url.cpp
@@ -41,7 +41,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/json/json_writer.h>
 
@@ -100,11 +100,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void HandleCacheNavigateResponse(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev) {
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            if (result->ResultSet.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
-            }
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size())("path", this->TopicPath);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -122,11 +118,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
-            if (!response.PQGroupInfo) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Failed to describe topic: missing PQ group info for " << this->TopicPath));
-            }
+            AFL_ENSURE(response.PQGroupInfo)("path", this->TopicPath);
             PQGroup = response.PQGroupInfo->Description;
             SelfInfo = response.Self->Info;
             ConsumerConfig = GetConsumerConfig(PQGroup.GetPQTabletConfig(), ConsumerName, ActorContext());

--- a/ydb/services/sqs_topic/list_queues.cpp
+++ b/ydb/services/sqs_topic/list_queues.cpp
@@ -35,7 +35,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 namespace NKikimr::NSqsTopic::V1 {

--- a/ydb/services/sqs_topic/purge_queue.cpp
+++ b/ydb/services/sqs_topic/purge_queue.cpp
@@ -31,7 +31,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 
 using namespace NActors;
 using namespace NKikimrClient;

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -44,6 +44,7 @@
 #include <ydb/services/sqs_topic/billing.h>
 
 #include <ydb/library/actors/core/log.h>
+#include <ydb/library/yverify_stream/yverify_stream.h>
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
@@ -301,6 +302,7 @@ namespace NKikimr::NSqsTopic::V1 {
                 const ui64 ru = NBilling::CalcRu(
                     CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
                 if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx)) {
+                    Y_VERIFY_DEBUG(false);
                     return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                         "Rate limiter request already in progress"));
                 }
@@ -335,6 +337,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
             if (result->ResultSet.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
             }

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -300,7 +300,7 @@ namespace NKikimr::NSqsTopic::V1 {
             if (ShouldBeCharged_ && IsQuotaRequired()) {
                 const ui64 ru = NBilling::CalcRu(
                     CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
-                Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
+                AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
                 return;
             }
 
@@ -331,7 +331,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -300,7 +300,7 @@ namespace NKikimr::NSqsTopic::V1 {
             if (ShouldBeCharged_ && IsQuotaRequired()) {
                 const ui64 ru = NBilling::CalcRu(
                     CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
-                AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx));
+                AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx))("ru", ru)("path", FullTopicPath_);
                 return;
             }
 

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -44,7 +44,6 @@
 #include <ydb/services/sqs_topic/billing.h>
 
 #include <ydb/library/actors/core/log.h>
-#include <ydb/library/yverify_stream/yverify_stream.h>
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/string_utils/base64/base64.h>
 
@@ -301,11 +300,7 @@ namespace NKikimr::NSqsTopic::V1 {
             if (ShouldBeCharged_ && IsQuotaRequired()) {
                 const ui64 ru = NBilling::CalcRu(
                     CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
-                if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx)) {
-                    Y_VERIFY_DEBUG(false);
-                    return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                        "Rate limiter request already in progress"));
-                }
+                AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx))("ru", ru)("path", FullTopicPath_);
                 return;
             }
 
@@ -336,11 +331,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            if (result->ResultSet.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
-            }
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size())("path", FullTopicPath_);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {

--- a/ydb/services/sqs_topic/receive_message.cpp
+++ b/ydb/services/sqs_topic/receive_message.cpp
@@ -300,7 +300,10 @@ namespace NKikimr::NSqsTopic::V1 {
             if (ShouldBeCharged_ && IsQuotaRequired()) {
                 const ui64 ru = NBilling::CalcRu(
                     CalcRuConsumption(payloadSize), NBilling::READ_BASE_COST, NBilling::READ_COST_PER_BLOCK, Fifo_, false);
-                AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx))("ru", ru)("path", FullTopicPath_);
+                if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, ctx)) {
+                    return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                        "Rate limiter request already in progress"));
+                }
                 return;
             }
 
@@ -331,7 +334,10 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
+            if (result->ResultSet.size() != 1) {
+                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
+            }
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -326,7 +326,7 @@ namespace NKikimr::NSqsTopic::V1 {
                             NBilling::WRITE_COST_PER_BLOCK,
                             Fifo_,
                             ContentBasedDeduplication_);
-                        Y_ABORT_UNLESS(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
+                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
                         return;
                     }
                 }
@@ -335,7 +335,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            Y_ABORT_UNLESS(result->ResultSet.size() == 1);
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -352,7 +352,7 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
 
-            Y_ABORT_UNLESS(response.PQGroupInfo);
+            AFL_ENSURE(response.PQGroupInfo)("path", FullTopicPath_);
             Fifo_ = QueueUrl_->Fifo;
             ApplyContentBasedDeduplication(
                 Fifo_ && response.PQGroupInfo->Description.GetPQTabletConfig().GetContentBasedDeduplication());

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -43,7 +43,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/openssl/crypto/sha.h>
@@ -327,11 +327,8 @@ namespace NKikimr::NSqsTopic::V1 {
                             NBilling::WRITE_COST_PER_BLOCK,
                             Fifo_,
                             ContentBasedDeduplication_);
-                        if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext())) {
-                            Y_VERIFY_DEBUG(false);
-                            return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                                "Rate limiter request already in progress"));
-                        }
+                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
+                            ("ru", ru)("path", FullTopicPath_);
                         return;
                     }
                 }
@@ -340,11 +337,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            if (result->ResultSet.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
-            }
+            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size())("path", FullTopicPath_);
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -361,11 +354,7 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
 
-            if (!response.PQGroupInfo) {
-                Y_VERIFY_DEBUG(false);
-                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Failed to describe topic: missing PQ group info for " << FullTopicPath_));
-            }
+            AFL_ENSURE(response.PQGroupInfo)("path", FullTopicPath_);
             Fifo_ = QueueUrl_->Fifo;
             ApplyContentBasedDeduplication(
                 Fifo_ && response.PQGroupInfo->Description.GetPQTabletConfig().GetContentBasedDeduplication());

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -43,6 +43,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 #include <library/cpp/digest/md5/md5.h>
 #include <library/cpp/openssl/crypto/sha.h>
 #include <util/generic/guid.h>
@@ -326,6 +328,7 @@ namespace NKikimr::NSqsTopic::V1 {
                             Fifo_,
                             ContentBasedDeduplication_);
                         if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext())) {
+                            Y_VERIFY_DEBUG(false);
                             return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                                 "Rate limiter request already in progress"));
                         }
@@ -338,6 +341,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
             if (result->ResultSet.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
             }
@@ -358,6 +362,7 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             if (!response.PQGroupInfo) {
+                Y_VERIFY_DEBUG(false);
                 return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Failed to describe topic: missing PQ group info for " << FullTopicPath_));
             }

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -326,7 +326,8 @@ namespace NKikimr::NSqsTopic::V1 {
                             NBilling::WRITE_COST_PER_BLOCK,
                             Fifo_,
                             ContentBasedDeduplication_);
-                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()));
+                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
+                            ("ru", ru)("path", FullTopicPath_);
                         return;
                     }
                 }

--- a/ydb/services/sqs_topic/send_message.cpp
+++ b/ydb/services/sqs_topic/send_message.cpp
@@ -41,7 +41,6 @@
 
 #include <ydb/services/sqs_topic/billing.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 #include <library/cpp/digest/md5/md5.h>
@@ -326,8 +325,10 @@ namespace NKikimr::NSqsTopic::V1 {
                             NBilling::WRITE_COST_PER_BLOCK,
                             Fifo_,
                             ContentBasedDeduplication_);
-                        AFL_ENSURE(MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext()))
-                            ("ru", ru)("path", FullTopicPath_);
+                        if (!MaybeRequestQuota(ru, EWakeupTag::RlAllowed, TlsActivationContext->AsActorContext())) {
+                            return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                                "Rate limiter request already in progress"));
+                        }
                         return;
                     }
                 }
@@ -336,7 +337,10 @@ namespace NKikimr::NSqsTopic::V1 {
             }
 
             const NSchemeCache::TSchemeCacheNavigate* result = ev->Get()->Request.Get();
-            AFL_ENSURE(result->ResultSet.size() == 1)("result_set_size", result->ResultSet.size());
+            if (result->ResultSet.size() != 1) {
+                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected scheme cache result size: " << result->ResultSet.size()));
+            }
             const auto& response = result->ResultSet.front();
             if (response.Status == NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
                 if (response.Kind == NSchemeCache::TSchemeCacheNavigate::KindCdcStream) {
@@ -353,7 +357,10 @@ namespace NKikimr::NSqsTopic::V1 {
                                                 TStringBuilder() << "Failed to describe topic: " << response.Status));
             }
 
-            AFL_ENSURE(response.PQGroupInfo)("path", FullTopicPath_);
+            if (!response.PQGroupInfo) {
+                return this->ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Failed to describe topic: missing PQ group info for " << FullTopicPath_));
+            }
             Fifo_ = QueueUrl_->Fifo;
             ApplyContentBasedDeduplication(
                 Fifo_ && response.PQGroupInfo->Description.GetPQTabletConfig().GetContentBasedDeduplication());

--- a/ydb/services/sqs_topic/set_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/set_queue_attributes.cpp
@@ -38,7 +38,7 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
-#include <ydb/library/yverify_stream/yverify_stream.h>
+#include <ydb/library/actors/core/log.h>
 
 #include <library/cpp/json/json_writer.h>
 
@@ -109,11 +109,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            if (result->Topics.size() != 1) {
-                Y_VERIFY_DEBUG(false);
-                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
-                    TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
-            }
+            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size())("path", FullTopicPath_);
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/set_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/set_queue_attributes.cpp
@@ -38,6 +38,8 @@
 
 #include <ydb/services/sqs_topic/statuses.h>
 
+#include <ydb/library/yverify_stream/yverify_stream.h>
+
 #include <library/cpp/json/json_writer.h>
 
 using namespace NActors;
@@ -108,6 +110,7 @@ namespace NKikimr::NSqsTopic::V1 {
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
             if (result->Topics.size() != 1) {
+                Y_VERIFY_DEBUG(false);
                 return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
                     TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
             }

--- a/ydb/services/sqs_topic/set_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/set_queue_attributes.cpp
@@ -36,7 +36,6 @@
 
 #include <ydb/core/persqueue/public/mlp/mlp.h>
 
-#include <ydb/library/actors/core/log.h>
 #include <ydb/services/sqs_topic/statuses.h>
 
 #include <library/cpp/json/json_writer.h>
@@ -108,7 +107,10 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size());
+            if (result->Topics.size() != 1) {
+                return ReplyWithError(MakeError(NSQS::NErrors::INTERNAL_FAILURE,
+                    TStringBuilder() << "Unexpected describe topics result size: " << result->Topics.size()));
+            }
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/set_queue_attributes.cpp
+++ b/ydb/services/sqs_topic/set_queue_attributes.cpp
@@ -108,7 +108,7 @@ namespace NKikimr::NSqsTopic::V1 {
 
         void Handle(NDescriber::TEvDescribeTopicsResponse::TPtr& ev) {
             const auto* result = ev->Get();
-            Y_ABORT_UNLESS(result->Topics.size() == 1);
+            AFL_ENSURE(result->Topics.size() == 1)("topics_size", result->Topics.size());
             const auto& topicInfo = result->Topics.begin()->second;
 
             switch(topicInfo.Status) {

--- a/ydb/services/sqs_topic/sqs_topic_proxy.cpp
+++ b/ydb/services/sqs_topic/sqs_topic_proxy.cpp
@@ -66,7 +66,7 @@ namespace NKikimr::NSqsTopic::V1 {
             YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::SQS, "Unhandled exception in SQS topic actor",
                 {"typeName", TypeName(exc)},
                 {"exception", exc.what()},
-                {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+                {"backTrace", TBackTrace::FromCurrentException().PrintToString()});
 
             const auto error = MakeError(NSQS::NErrors::INTERNAL_FAILURE, "Internal error");
             NYql::TIssue issue(error.GetMessage());

--- a/ydb/services/sqs_topic/sqs_topic_proxy.cpp
+++ b/ydb/services/sqs_topic/sqs_topic_proxy.cpp
@@ -41,7 +41,10 @@ namespace NKikimr::NSqsTopic::V1 {
     using namespace NGRpcProxy::V1;
 
     template <class TEvRequest>
-    class TNotImplementedRequestActor: public TRpcSchemeRequestActor<TNotImplementedRequestActor<TEvRequest>, TEvRequest> {
+    class TNotImplementedRequestActor
+        : public TRpcSchemeRequestActor<TNotImplementedRequestActor<TEvRequest>, TEvRequest>
+        , public NActors::IActorExceptionHandler
+    {
         using TBase = TRpcSchemeRequestActor<TNotImplementedRequestActor, TEvRequest>;
 
     public:
@@ -56,6 +59,24 @@ namespace NKikimr::NSqsTopic::V1 {
             this->Request_->RaiseIssue(FillIssue("Method is not implemented yet", static_cast<size_t>(NYds::EErrorCodes::ERROR)));
             this->Request_->ReplyWithYdbStatus(Ydb::StatusIds::UNSUPPORTED);
             this->Die(ctx);
+        }
+
+        bool OnUnhandledException(const std::exception& exc) override {
+            const auto& ctx = this->ActorContext();
+            YDB_LOG_CRIT_CTX_COMP(ctx, NKikimrServices::SQS, "Unhandled exception in SQS topic actor",
+                {"typeName", TypeName(exc)},
+                {"exception", exc.what()},
+                {"currentException", TBackTrace::FromCurrentException().PrintToString()});
+
+            const auto error = MakeError(NSQS::NErrors::INTERNAL_FAILURE, "Internal error");
+            NYql::TIssue issue(error.GetMessage());
+            issue.SetCode(
+                NSQS::TErrorClass::GetId(error.GetErrorCode()),
+                NYql::ESeverity::TSeverityIds_ESeverityId_S_ERROR);
+            this->Request_->RaiseIssue(issue);
+            this->Request_->ReplyWithYdbStatus(Ydb::StatusIds_StatusCode_STATUS_CODE_UNSPECIFIED);
+            this->Die(ctx);
+            return true;
         }
     };
 } // namespace NKikimr::NSqsTopic::V1


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Replace process-killing asserts with recoverable AFL_ENSURE in Topics-related code and document no-abort guidelines for agents.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Replace `Y_ABORT` / `Y_ABORT_UNLESS` / `Y_VERIFY` / `Y_FAIL` with `AFL_ENSURE` (throws, recoverable) in Topics production code:

* `ydb/core/persqueue`
* `ydb/services/persqueue_v1`
* `ydb/core/kafka_proxy`
* `ydb/services/sqs_topic`
* `ydb/services/datastreams`

Key points:
* Diagnostic context on ensures (tablet/path/partition/database/switch value, etc.)
* `ydb/agents/NO_ABORT.md` — no abort macros; prefer `AFL_ENSURE` with localization keys; new actors/tablets must inherit `IActorExceptionHandler`; review checklist
* `sqs_topic`: `TGrpcActorBase::OnUnhandledException` logs and replies `INTERNAL_FAILURE` so `AFL_ENSURE` does not kill the server
* `ProcessCdc`: `Y_ABORT_UNLESS` → `AFL_ENSURE`
* Left alone: `Y_VERIFY_DEBUG*` / `AFL_VERIFY_DEBUG`, most `ut/` asserts