### PR TITLE
Fix use-after-move in S3Fetcher::StartDownload

### DIFF
--- a/ydb/core/external_sources/object_storage/s3_fetcher.cpp
+++ b/ydb/core/external_sources/object_storage/s3_fetcher.cpp
@@ -71,8 +71,10 @@ public:
             authInfo.GetAwsSigV4()
         );
 
+        const TString path = request->Path;
+        const ui64 start = request->Start;
         Gateway_->Download(
-            NYql::NS3Util::UrlEscapeRet(Url_ + request->Path), std::move(headers), request->Start, length,
+            NYql::NS3Util::UrlEscapeRet(Url_ + path), std::move(headers), start, length,
             [actorSystem, selfId = SelfId(), request = std::move(request)](NYql::IHTTPGateway::TResult&& result) mutable {
                 actorSystem->Send(selfId, new TEvS3DownloadResponse(std::move(request), std::move(result)));
             }, {}, RetryPolicy_);


### PR DESCRIPTION
## Summary
- In `S3Fetcher::StartDownload`, `Gateway_->Download` read `request->Path` / `request->Start` in the same call where the lambda captured `request = std::move(request)`.
- Argument evaluation order is unspecified in C++, so this was use-after-move / undefined behavior.
- Copy `Path` and `Start` into locals before the `Download` call so the moved-from `request` is only used inside the callback.

## Test plan
- [ ] Code review of `StartDownload` argument evaluation
- [ ] Existing external source / S3 fetcher tests still pass if run in CI


Made with [Cursor](https://cursor.com)