### PR TITLE
Initialize resultScanData/resultPosition in DrainToControlPoint

### DIFF
--- a/ydb/core/formats/arrow/reader/merger.h
+++ b/ydb/core/formats/arrow/reader/merger.h
@@ -205,8 +205,8 @@ public:
         AFL_VERIFY(ControlPoints == 1);
         builder.ValidateDataSchema(DataSchema);
         bool cpReachedFlag = false;
-        std::shared_ptr<TSortableScanData> resultScanData;
-        ui64 resultPosition;
+        std::shared_ptr<TSortableScanData> resultScanData = nullptr;
+        ui64 resultPosition = 0;
         while (SortHeap.Size() && !cpReachedFlag && !builder.IsBufferExhausted()) {
             if (SortHeap.Current().IsControlPoint()) {
                 auto keyColumns = SortHeap.Current().GetKeyColumns().BuildSortingCursor();


### PR DESCRIPTION
## Summary
- Initialize `resultScanData` to `nullptr` and `resultPosition` to `0` in `DrainToControlPoint` to avoid reading uninitialized locals.
- Existing `if (lastResultPosition && resultScanData)` guards already skip cursor updates until `DrainCurrentPosition` assigns both values.

## Test plan
- [ ] Build/headers check for `ydb/core/formats/arrow/reader`
- [ ] Review control-point-first and empty-heap paths: `lastResultPosition` is left unchanged when no drain has happened


Made with [Cursor](https://cursor.com)