### PR TITLE
Fix racy fetching script publication and null iterator deref in scan diagnostics

### DIFF
--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -590,7 +590,7 @@ void TColumnShardScan::SendScanError(const TString& reason) {
 
 void TColumnShardScan::Finish(const NColumnShard::TScanCounters::EStatusFinish status) {
     if (AppDataVerified().ColumnShardConfig.GetEnableDiagnostics()) {
-        auto scanIteratorDiagnostics = ScanIterator->DebugString(true);
+        auto scanIteratorDiagnostics = ScanIterator ? ScanIterator->DebugString(true) : TString("NO");
         Send(ScanDiagnosticsActorId,
             std::make_unique<NColumnShard::TEvPrivate::TEvReportScanIteratorDiagnostics>(RequestCookie, std::move(scanIteratorDiagnostics)));
     }

--- a/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/actor/actor.cpp
@@ -11,6 +11,8 @@
 
 namespace NKikimr::NOlap::NReader {
 
+constexpr TStringBuf NoScanIteratorDiagnostics = "NO";
+
 NKqp::TScanStatistics TColumnShardScan::GetScanStats() {
     TVector<NKqp::TPerStepScanStatistics> timesPerStep = [&] {
         auto cnt = ScanCountersPool.ReadStepsCounters();
@@ -590,7 +592,7 @@ void TColumnShardScan::SendScanError(const TString& reason) {
 
 void TColumnShardScan::Finish(const NColumnShard::TScanCounters::EStatusFinish status) {
     if (AppDataVerified().ColumnShardConfig.GetEnableDiagnostics()) {
-        auto scanIteratorDiagnostics = ScanIterator ? ScanIterator->DebugString(true) : TString("NO");
+        auto scanIteratorDiagnostics = ScanIterator ? ScanIterator->DebugString(true) : TString(NoScanIteratorDiagnostics);
         Send(ScanDiagnosticsActorId,
             std::make_unique<NColumnShard::TEvPrivate::TEvReportScanIteratorDiagnostics>(RequestCookie, std::move(scanIteratorDiagnostics)));
     }

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/common/script.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/common/script.h
@@ -66,7 +66,7 @@ private:
     YDB_READONLY_DEF(TString, BranchName);
     std::vector<std::shared_ptr<IFetchingStep>> Steps;
     TAtomic StartInstant = 0;
-    TAtomic FinishInstant;
+    TAtomic FinishInstant = 0;
 
 public:
     TFetchingScript(const TString& branchName, std::vector<std::shared_ptr<IFetchingStep>>&& steps)
@@ -102,22 +102,33 @@ public:
 
 class TFetchingScriptOwner: TNonCopyable {
 private:
-    TAtomic InitializationDetector = 0;
+    static constexpr TAtomicBase StateEmpty = 0;
+    static constexpr TAtomicBase StateInitialized = 1;
+    static constexpr TAtomicBase StateInProgress = 2;
+
+    TAtomic InitializationDetector = StateEmpty;
     std::shared_ptr<TFetchingScript> Script;
 
     void FinishInitialization(std::shared_ptr<TFetchingScript>&& script) {
         Script = std::move(script);
-        AFL_VERIFY(AtomicCas(&InitializationDetector, 1, 2));
+        AFL_VERIFY(AtomicCas(&InitializationDetector, StateInitialized, StateInProgress));
+    }
+
+    // Script is published by the release AtomicCas above and may happen on another thread
+    // (conveyor); it must not be read until the acquire load below observes StateInitialized
+    bool IsInitialized() const {
+        return AtomicGet(InitializationDetector) == StateInitialized;
     }
 
 public:
     const std::shared_ptr<TFetchingScript>& GetScriptVerified() const {
+        AFL_VERIFY(IsInitialized());
         AFL_VERIFY(Script);
         return Script;
     }
 
     TString ProfileDebugString() const {
-        if (Script) {
+        if (HasScript()) {
             return TStringBuilder() << Script->ProfileDebugString() << Endl;
         } else {
             return TStringBuilder() << "NO_SCRIPT" << Endl;
@@ -125,11 +136,11 @@ public:
     }
 
     bool HasScript() const {
-        return !!Script;
+        return IsInitialized() && !!Script;
     }
 
     bool NeedInitialization() const {
-        return AtomicGet(InitializationDetector) != 1;
+        return !IsInitialized();
     }
 
     class TInitializationGuard: TNonCopyable {
@@ -153,7 +164,7 @@ public:
     };
 
     std::optional<TInitializationGuard> StartInitialization() {
-        if (AtomicCas(&InitializationDetector, 2, 0)) {
+        if (AtomicCas(&InitializationDetector, StateInProgress, StateEmpty)) {
             return std::optional<TInitializationGuard>(*this);
         } else {
             return std::nullopt;

--- a/ydb/core/tx/columnshard/engines/ut/ut_script.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_script.cpp
@@ -5,6 +5,8 @@
 #include <reader/simple_reader/iterator/fetching.h>
 #include <scheme/versions/snapshot_scheme.h>
 
+#include <thread>
+
 using namespace NKikimr;
 using namespace NKikimr::NOlap;
 using namespace NKikimr::NOlap::NReader;
@@ -49,5 +51,39 @@ Y_UNIT_TEST_SUITE(TestScript) {
             "{name=FETCHING_COLUMNS;details={columns=1,2;};};"
             "{name=ASSEMBLER;details={columns=(column_ids=1,2;column_names=c1,c2;);;};};"
             "{name=DELETION;details={};};]}");
+    }
+
+    // regression for #47943: reading the owner from another thread while the script is being
+    // published must not observe a torn shared_ptr
+    Y_UNIT_TEST(OwnerConcurrentInitialization) {
+        static constexpr ui32 RacesCount = 5000;
+        static constexpr ui32 ReaderAttemptsCount = 100000;
+        auto schema = MakeTestSchema({ { 0, NTable::TColumn("c0", 0, NScheme::TTypeInfo(NScheme::NTypeIds::Int32), "") } });
+        for (ui32 i = 0; i < RacesCount; ++i) {
+            NCommon::TFetchingScriptBuilder acc = NCommon::TFetchingScriptBuilder::MakeForTests(schema);
+            acc.AddFetchingStep(std::vector<ui32>({ 0 }), NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter);
+            acc.AddAssembleStep(std::vector<ui32>({ 0 }), "", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
+            auto script = std::move(acc).Build();
+
+            NCommon::TFetchingScriptOwner owner;
+            std::atomic<bool> readerStarted = false;
+            std::thread reader([&]() {
+                readerStarted = true;
+                for (ui32 j = 0; j < ReaderAttemptsCount; ++j) {
+                    if (owner.HasScript()) {
+                        Y_UNUSED(owner.ProfileDebugString());
+                        break;
+                    }
+                }
+            });
+            while (!readerStarted) {
+            }
+            auto guard = owner.StartInitialization();
+            UNIT_ASSERT(guard);
+            guard->InitializationFinished(std::move(script));
+            reader.join();
+            UNIT_ASSERT(!owner.NeedInitialization());
+            UNIT_ASSERT_STRING_CONTAINS(owner.GetScriptVerified()->DebugString(), "FETCHING_COLUMNS");
+        }
     }
 }

--- a/ydb/core/tx/columnshard/engines/ut/ut_script.cpp
+++ b/ydb/core/tx/columnshard/engines/ut/ut_script.cpp
@@ -65,13 +65,15 @@ Y_UNIT_TEST_SUITE(TestScript) {
             acc.AddAssembleStep(std::vector<ui32>({ 0 }), "", NArrow::NSSA::IMemoryCalculationPolicy::EStage::Filter, false);
             auto script = std::move(acc).Build();
 
+            const NCommon::TFetchingScript* published = script.get();
             NCommon::TFetchingScriptOwner owner;
             std::atomic<bool> readerStarted = false;
+            std::atomic<const NCommon::TFetchingScript*> observed = nullptr;
             std::thread reader([&]() {
                 readerStarted = true;
                 for (ui32 j = 0; j < ReaderAttemptsCount; ++j) {
                     if (owner.HasScript()) {
-                        Y_UNUSED(owner.ProfileDebugString());
+                        observed = owner.GetScriptVerified().get();
                         break;
                     }
                 }
@@ -83,7 +85,11 @@ Y_UNIT_TEST_SUITE(TestScript) {
             guard->InitializationFinished(std::move(script));
             reader.join();
             UNIT_ASSERT(!owner.NeedInitialization());
-            UNIT_ASSERT_STRING_CONTAINS(owner.GetScriptVerified()->DebugString(), "FETCHING_COLUMNS");
+            if (observed) {
+                UNIT_ASSERT_VALUES_EQUAL((const void*)observed.load(), (const void*)published);
+            }
+            UNIT_ASSERT_VALUES_EQUAL((const void*)owner.GetScriptVerified().get(), (const void*)published);
+            UNIT_ASSERT(!owner.GetScriptVerified()->IsFinished(0));
         }
     }
 }


### PR DESCRIPTION
Fixes #47943 (SIGSEGV in `IFetchingStep::DebugString` / `ProfileDebugString` at `TColumnShardScan::Finish`).

This removes all UB found on the crash path.The specific crash  may also be a victim of the systemic scan-pipeline heap corruption investigated under #47942.

### Root cause analysis of the UB

The crash reads a garbage `IFetchingStep::Name` while `Finish` (diagnostics enabled) walks `CacheFetchingScripts`. The debug-string path contains real UB:

* `TFetchingScriptOwner` publishes `Script` (plain `shared_ptr`) without synchronization: `HasScript()` / `ProfileDebugString()` / `GetScriptVerified()` read it while `FinishInitialization()` assigns it. In the plain reader the initialization runs on conveyor worker threads (`TDetectInMem::DoExecuteInplace` → `GetColumnsFetchingPlan`), concurrently with the scan actor — a torn `shared_ptr` read crashes exactly as in the issue. The `InitializationDetector` atomic already exists but reads did not gate on it.
* The iterator-error path in `ContinueProcessing` does `ScanIterator.reset()` and then calls `Finish`, which dereferenced `ScanIterator->DebugString(true)` unguarded — guaranteed null deref whenever a scan fails with `EnableDiagnostics` on.
* `TFetchingScript::FinishInstant` was uninitialized and read by `ProfileDebugString`.

### Fix

* Gate every `Script` read on `AtomicGet(InitializationDetector) == 1` (acquire, paired with the release CAS in `FinishInitialization`). After the CAS the pointer is immutable, so the gated read is safe. Null scripts stored by the plain reader ("FAKE" branch) keep working: `HasScript()` also checks the pointer.
* Guard `ScanIterator` in `Finish` the same way as the other `DebugString` call sites.
* Initialize `FinishInstant`.

### Test

`TestScript::OwnerConcurrentInitialization` — hammers `TFetchingScriptOwner` with a concurrent reader (`HasScript`/`ProfileDebugString`) while another thread publishes the script. Under `--sanitize=thread` it reports the data race on `Script` before the fix and is clean after.
