### PR TITLE
Fix S3 data leak on column table drop (#45898)

### DIFF
--- a/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
+++ b/ydb/core/kqp/ut/olap/indexes/indexes_ut.cpp
@@ -167,9 +167,9 @@ Y_UNIT_TEST_SUITE(KqpOlapIndexes) {
                 )");
         ExecQuery(kikimr, UseQueryService,
             TStringBuilder() << "ALTER OBJECT `/Root/olapStore` (TYPE TABLESTORE) SET (ACTION=UPSERT_OPTIONS, SCHEME_NEED_ACTUALIZATION=`true`);");
-        // Make the just-actualized portions (with index data) visible to the following scan.
-        AdvancePlanStep(kikimr);
         csController->WaitActualization(TDuration::Seconds(10));
+        // advance the plan step AFTER the actualization commits, otherwise the scan snapshot may predate the rewritten portions
+        AdvancePlanStep(kikimr);
         {
             auto it = tableClient
                           .StreamExecuteScanQuery(R"(
@@ -2170,9 +2170,9 @@ Y_UNIT_TEST(RenameLocalBloomIndex, EUseQueryService) {
                 )");
         ExecQuery(kikimr, UseQueryService,
             TStringBuilder() << "ALTER OBJECT `/Root/olapStore` (TYPE TABLESTORE) SET (ACTION=UPSERT_OPTIONS, SCHEME_NEED_ACTUALIZATION=`true`);");
-        // Make the just-actualized portions (with index data) visible to the following scan.
-        AdvancePlanStep(kikimr);
         csController->WaitActualization(TDuration::Seconds(10));
+        // advance the plan step AFTER the actualization commits, otherwise the scan snapshot may predate the rewritten portions
+        AdvancePlanStep(kikimr);
         {
             auto it = tableClient
                           .StreamExecuteScanQuery(R"(

--- a/ydb/core/kqp/ut/olap/tiering_ut.cpp
+++ b/ydb/core/kqp/ut/olap/tiering_ut.cpp
@@ -3,6 +3,7 @@
 #include "helpers/query_executor.h"
 #include "helpers/writer.h"
 
+#include <ydb/core/base/tablet_pipecache.h>
 #include <ydb/core/kqp/ut/common/columnshard.h>
 #include <ydb/core/kqp/ut/common/olap_indexes_enums.h>
 #include <ydb/core/tx/columnshard/data_locks/locks/list.h>
@@ -511,6 +512,188 @@ Y_UNIT_TEST_SUITE(KqpOlapTiering) {
         csController->WaitCondition(TDuration::Seconds(60), []() {
             return Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize() == 0;
         });
+    }
+
+    Y_UNIT_TEST(DropTableAndStoreDeletesS3Data) {
+        // shards belong to the store, so the deferred deletion is driven by DROP TABLESTORE
+        Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->Clear();
+        TTieringTestHelper tieringHelper;
+        auto& csController = tieringHelper.GetCsController();
+        csController->SetOverrideMaxReadStaleness(TDuration::Seconds(1));
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+        auto& olapHelper = tieringHelper.GetOlapHelper();
+        auto& testHelper = tieringHelper.GetTestHelper();
+
+        olapHelper.CreateTestOlapTable();
+        testHelper.CreateTier(DEFAULT_TIER_NAME);
+        tieringHelper.WriteSampleData();
+        testHelper.SetTiering(DEFAULT_TABLE_PATH, DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
+
+        {
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(R"(DROP TABLE `/Root/olapStore/olapTable`)").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        {
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(R"(DROP TABLESTORE `/Root/olapStore`)").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // AFL_VERIFYs internally when the condition is not reached in time
+        csController->WaitCondition(TDuration::Seconds(60), []() {
+            return Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize() == 0;
+        });
+    }
+
+    Y_UNIT_TEST(DropStandaloneTableDeletesS3Data) {
+        // https://github.com/ydb-platform/ydb/issues/45898
+        Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->Clear();
+        TTieringTestHelper tieringHelper;
+        auto& csController = tieringHelper.GetCsController();
+        csController->SetOverrideMaxReadStaleness(TDuration::Seconds(1));
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+        auto& olapHelper = tieringHelper.GetOlapHelper();
+        auto& testHelper = tieringHelper.GetTestHelper();
+        testHelper.GetRuntime().GetAppData().ColumnShardConfig.SetBulkUpsertRequireAllColumns(false);
+
+        tieringHelper.SetTablePath("/Root/olapTable");
+        olapHelper.CreateTestOlapStandaloneTable();
+        testHelper.CreateTier(DEFAULT_TIER_NAME);
+        tieringHelper.WriteSampleData();
+        testHelper.SetTiering("/Root/olapTable", DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
+
+        {
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(R"(DROP TABLE `/Root/olapTable`)").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+
+        // AFL_VERIFYs internally when the condition is not reached in time
+        csController->WaitCondition(TDuration::Seconds(60), []() {
+            return Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize() == 0;
+        });
+    }
+
+    Y_UNIT_TEST(DropTableWithUnavailableS3) {
+        // the tier is unreachable at drop time: the shards must stay alive until the data is erased
+        Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->Clear();
+        TTieringTestHelper tieringHelper;
+        auto& csController = tieringHelper.GetCsController();
+        csController->SetOverrideMaxReadStaleness(TDuration::Seconds(1));
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+        auto& olapHelper = tieringHelper.GetOlapHelper();
+        auto& testHelper = tieringHelper.GetTestHelper();
+        testHelper.GetRuntime().GetAppData().ColumnShardConfig.SetBulkUpsertRequireAllColumns(false);
+
+        tieringHelper.SetTablePath("/Root/olapTable");
+        olapHelper.CreateTestOlapStandaloneTable();
+        testHelper.CreateTier(DEFAULT_TIER_NAME);
+        tieringHelper.WriteSampleData();
+        testHelper.SetTiering("/Root/olapTable", DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
+
+        csController->SetExternalStorageUnavailable(true);
+        // the unavailability override is picked up on operator re-initialization
+        testHelper.SetTiering("/Root/olapTable", DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        {
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(R"(DROP TABLE `/Root/olapTable`)").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        Sleep(TDuration::Seconds(15));
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
+
+        UNIT_ASSERT_GT(csController->GetActiveTablets().size(), 0);
+
+        csController->SetExternalStorageUnavailable(false);
+        // on boot the shards must reconstruct the tier configuration from the persisted removal queues
+        for (const auto& [tabletId, unused] : csController->GetActiveTablets()) {
+            testHelper.GetRuntime().Send(MakePipePerNodeCacheID(false), NActors::TActorId(),
+                new TEvPipeCache::TEvForward(new TEvents::TEvPoisonPill(), tabletId, false));
+        }
+        csController->WaitCondition(TDuration::Seconds(120), []() {
+            return Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize() == 0;
+        });
+    }
+
+    Y_UNIT_TEST(DropTableSilentShardNeverDeleted) {
+        // emulates column shards on an older binary: they never answer the cleanup poll
+        Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->Clear();
+        TTieringTestHelper tieringHelper;
+        auto& csController = tieringHelper.GetCsController();
+        csController->SetOverrideMaxReadStaleness(TDuration::Seconds(1));
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+        csController->SetAnswerDropCleanup(false);
+        auto& olapHelper = tieringHelper.GetOlapHelper();
+        auto& testHelper = tieringHelper.GetTestHelper();
+        testHelper.GetRuntime().GetAppData().ColumnShardConfig.SetBulkUpsertRequireAllColumns(false);
+
+        tieringHelper.SetTablePath("/Root/olapTable");
+        olapHelper.CreateTestOlapStandaloneTable();
+        testHelper.CreateTier(DEFAULT_TIER_NAME);
+        tieringHelper.WriteSampleData();
+        testHelper.SetTiering("/Root/olapTable", DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
+        const size_t tabletsBefore = csController->GetActiveTablets().size();
+        UNIT_ASSERT_GT(tabletsBefore, 0);
+
+        {
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(R"(DROP TABLE `/Root/olapTable`)").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        csController->WaitCondition(TDuration::Seconds(120), []() {
+            return Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize() == 0;
+        });
+        Sleep(TDuration::Seconds(70));
+        UNIT_ASSERT_VALUES_EQUAL(csController->GetActiveTablets().size(), tabletsBefore);
+
+        csController->SetAnswerDropCleanup(true);
+        csController->WaitCondition(TDuration::Seconds(180), [&]() {
+            return csController->GetActiveTablets().size() == 0;
+        });
+    }
+
+    Y_UNIT_TEST(DropCleanupKillSwitchDrains) {
+        // disabling the kill-switch deletes the pending tablets without waiting, accepting the leak
+        Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->Clear();
+        TTieringTestHelper tieringHelper;
+        auto& csController = tieringHelper.GetCsController();
+        csController->SetOverrideMaxReadStaleness(TDuration::Seconds(1));
+        csController->SetOverridePeriodicWakeupActivationPeriod(TDuration::Seconds(1));
+        auto& olapHelper = tieringHelper.GetOlapHelper();
+        auto& testHelper = tieringHelper.GetTestHelper();
+        testHelper.GetRuntime().GetAppData().ColumnShardConfig.SetBulkUpsertRequireAllColumns(false);
+
+        tieringHelper.SetTablePath("/Root/olapTable");
+        olapHelper.CreateTestOlapStandaloneTable();
+        testHelper.CreateTier(DEFAULT_TIER_NAME);
+        tieringHelper.WriteSampleData();
+        testHelper.SetTiering("/Root/olapTable", DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        csController->WaitCompactions(TDuration::Seconds(5));
+        csController->WaitActualization(TDuration::Seconds(5));
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
+
+        csController->SetExternalStorageUnavailable(true);
+        testHelper.SetTiering("/Root/olapTable", DEFAULT_TIER_PATH, DEFAULT_COLUMN_NAME);
+        {
+            auto result = testHelper.GetSession().ExecuteSchemeQuery(R"(DROP TABLE `/Root/olapTable`)").GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), NYdb::EStatus::SUCCESS, result.GetIssues().ToString());
+        }
+        Sleep(TDuration::Seconds(10));
+        UNIT_ASSERT_GT(csController->GetActiveTablets().size(), 0);
+
+        testHelper.GetRuntime().GetAppData().FeatureFlags.SetEnableDeferredColumnShardDeletionOnDrop(false);
+        csController->WaitCondition(TDuration::Seconds(180), [&]() {
+            return csController->GetActiveTablets().size() == 0;
+        });
+        UNIT_ASSERT_GT(Singleton<NKikimr::NWrappers::NExternalStorage::TFakeExternalStorage>()->GetBucket("olap-tier1").GetSize(), 0);
     }
 
     Y_UNIT_TEST(NoBackoffUnavailableS3) {

--- a/ydb/core/protos/counters_schemeshard.proto
+++ b/ydb/core/protos/counters_schemeshard.proto
@@ -306,6 +306,11 @@ enum ESimpleCounters {
     COUNTER_TEST_SHARD_COUNT = 236                         [(CounterOpts) = {Name: "TestShardCount"}];
     COUNTER_IN_FLIGHT_OPS_TxCreateTestShardSet = 237      [(CounterOpts) = {Name: "InFlightOps/CreateTestShardSet"}];
     COUNTER_IN_FLIGHT_OPS_TxDropTestShardSet = 238        [(CounterOpts) = {Name: "InFlightOps/DropTestShardSet"}];
+
+    // column shards of dropped tables that are still erasing evicted data from external tiers
+    COUNTER_COLUMN_SHARDS_PENDING_DROP_CLEANUP = 239       [(CounterOpts) = {Name: "ColumnShardsPendingDropCleanup"}];
+    // subset of the above that did not answer several cleanup polls in a row (e.g. an older binary)
+    COUNTER_COLUMN_SHARDS_CLEANUP_SILENT = 240             [(CounterOpts) = {Name: "ColumnShardsCleanupSilent"}];
 }
 
 enum ECumulativeCounters {
@@ -803,4 +808,7 @@ enum ETxTypes {
     TXTYPE_LIST_SET_COLUMN_CONSTRAINT = 127             [(TxTypeOpts) = {Name: "TxListSetColumnConstraint"}];
     TXTYPE_FORGET_SET_COLUMN_CONSTRAINT = 128          [(TxTypeOpts) = {Name: "TxForgetSetColumnConstraint"}];
     TXTYPE_CANCEL_SET_COLUMN_CONSTRAINT = 129             [(TxTypeOpts) = {Name: "TxCancelSetColumnConstraint"}];
+
+    // must be declared last: tablet counters require enum values in ascending declaration order
+    TXTYPE_COLUMN_SHARD_CLEANUP_COMPLETE = 130            [(TxTypeOpts) = {Name: "TxColumnShardCleanupComplete"}];
 }

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -357,4 +357,7 @@ message TFeatureFlags {
     optional bool EnableRejectActionInResourcePoolClassifiers = 304 [default = true];
     optional bool EnableMoveWithColumnTableReplace = 305 [default = false];
     optional bool DisableOldSecrets = 306 [default = false];
+    // Kill-switch: defer column shard deletion on drop until evicted data is erased from external tiers.
+    // Disabling it makes dropped shards be deleted immediately, leaking their evicted data (issue #45898).
+    optional bool EnableDeferredColumnShardDeletionOnDrop = 307 [default = true];
 }

--- a/ydb/core/protos/tx_columnshard.proto
+++ b/ydb/core/protos/tx_columnshard.proto
@@ -387,6 +387,17 @@ message TEvOverloadUnsubscribe {
     optional uint64 SeqNo = 1;
 }
 
+// Schemeshard asks a column shard of a dropped table whether external (S3) cleanup is complete
+message TEvCheckDropCleanup {
+    optional uint64 TabletId = 1;
+}
+
+// Answer to TEvCheckDropCleanup: Ready means the tablet can be deleted without losing external data
+message TEvDropCleanupState {
+    optional uint64 TabletId = 1;
+    optional bool Ready = 2;
+}
+
 message TCompletedBackupTransaction {
     optional uint64 TxId = 1;
     optional TShardOpResult OpResult = 2;

--- a/ydb/core/tx/columnshard/blobs_action/abstract/action.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/action.h
@@ -127,6 +127,14 @@ public:
         return result;
     }
 
+    void OnWritingsAborted() {
+        for (auto&& [_, action] : StorageActions) {
+            if (!!action.GetWritingOptional()) {
+                action.GetWritingOptional()->OnWritingAborted();
+            }
+        }
+    }
+
     std::vector<std::shared_ptr<IBlobsReadingAction>> GetReadingActions() const {
         std::vector<std::shared_ptr<IBlobsReadingAction>> result;
         for (auto&& i : StorageActions) {

--- a/ydb/core/tx/columnshard/blobs_action/abstract/storage.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/storage.h
@@ -151,6 +151,15 @@ public:
         StartGCAction(action);
     }
 
+    bool HasOngoingGC() const {
+        return CurrentGCAction && CurrentGCAction->IsInProgress();
+    }
+
+    // whether removed blobs still must be erased from an external system (e.g. S3)
+    virtual bool HasPendingExternalCleanup() const {
+        return false;
+    }
+
     [[nodiscard]] std::shared_ptr<IBlobsGCAction> CreateGC() {
         YDB_LOG_CREATE_CONTEXT_COMP(NKikimrServices::TX_COLUMNSHARD_BLOBS,
             {"storageId", GetStorageId()},

--- a/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.cpp
@@ -61,6 +61,16 @@ bool IStoragesManager::LoadIdempotency(NTable::TDatabase& database) {
         return false;
     }
     TBlobManagerDb blobsDB(database);
+    {
+        // construct operators for storages that only have persisted removal queues, otherwise the queues are never loaded
+        THashSet<TString> storageIds;
+        if (!blobsDB.LoadTierStorageIds(storageIds)) {
+            return false;
+        }
+        for (const auto& storageId : storageIds) {
+            GetOperatorGuarantee(storageId);
+        }
+    }
     for (auto&& i : GetStorages()) {
         if (!i.second->Load(blobsDB)) {
             return false;
@@ -74,6 +84,15 @@ bool IStoragesManager::LoadIdempotency(NTable::TDatabase& database) {
 bool IStoragesManager::HasBlobsToDelete() const {
     for (auto&& i : Constructed) {
         if (!i.second->GetBlobsToDelete().IsEmpty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool IStoragesManager::HasPendingExternalCleanup() const {
+    for (auto&& i : Constructed) {
+        if (i.second->HasPendingExternalCleanup()) {
             return true;
         }
     }

--- a/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/storages_manager.h
@@ -48,6 +48,7 @@ public:
 
     bool LoadIdempotency(NTable::TDatabase& database);
     bool HasBlobsToDelete() const;
+    bool HasPendingExternalCleanup() const;
     void Stop();
 
     std::shared_ptr<IBlobsStorageOperator> GetDefaultOperator() const {

--- a/ydb/core/tx/columnshard/blobs_action/abstract/write.h
+++ b/ydb/core/tx/columnshard/blobs_action/abstract/write.h
@@ -24,6 +24,7 @@ private:
     THashMap<TUnifiedBlobId, TString> BlobsForWrite;
     THashSet<TUnifiedBlobId> BlobsWaiting;
     bool Aborted = false;
+    bool AfterWriteFinalized = false;
     std::shared_ptr<NBlobOperations::TWriteCounters> Counters;
     YDB_FLAG_ACCESSOR(Bulk, false);
     void AddDataForWrite(const TUnifiedBlobId& blobId, const TString& data);
@@ -37,6 +38,9 @@ protected:
 
     virtual void DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& self, TBlobManagerDb& dbBlobs, const bool blobsWroteSuccessfully) = 0;
     virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, const bool blobsWroteSuccessfully) = 0;
+
+    virtual void DoOnWritingAborted() {
+    }
 
     virtual TUnifiedBlobId AllocateNextBlobId(const TString& data) = 0;
 
@@ -91,11 +95,22 @@ public:
     }
 
     void OnExecuteTxAfterWrite(NColumnShard::TColumnShard& self, TBlobManagerDb& dbBlobs, const bool blobsWroteSuccessfully) {
+        AfterWriteFinalized = true;
         return DoOnExecuteTxAfterWrite(self, dbBlobs, blobsWroteSuccessfully);
     }
 
     void OnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, const bool blobsWroteSuccessfully) {
+        AfterWriteFinalized = true;
         return DoOnCompleteTxAfterWrite(self, blobsWroteSuccessfully);
+    }
+
+    // blobs already written by a dying change are tracked by nothing: schedule their drafts for removal
+    void OnWritingAborted() {
+        if (AfterWriteFinalized) {
+            return;
+        }
+        AfterWriteFinalized = true;
+        DoOnWritingAborted();
     }
 
     void SendWriteBlobRequest(const TString& data, const TUnifiedBlobId& blobId);

--- a/ydb/core/tx/columnshard/blobs_action/blob_manager_db.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/blob_manager_db.cpp
@@ -224,6 +224,53 @@ bool TBlobManagerDb::LoadTierLists(
     return true;
 }
 
+bool TBlobManagerDb::LoadTierStorageIds(THashSet<TString>& storageIds) {
+    THashSet<TString> local;
+    NIceDb::TNiceDb db(Database);
+
+    {
+        auto rowset = db.Table<Schema::TierBlobsToDelete>().Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+        while (!rowset.EndOfSet()) {
+            local.emplace(rowset.GetValue<Schema::TierBlobsToDelete::StorageId>());
+            if (!rowset.Next()) {
+                return false;
+            }
+        }
+    }
+
+    {
+        auto rowset = db.Table<Schema::TierBlobsToDeleteWT>().Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+        while (!rowset.EndOfSet()) {
+            local.emplace(rowset.GetValue<Schema::TierBlobsToDeleteWT::StorageId>());
+            if (!rowset.Next()) {
+                return false;
+            }
+        }
+    }
+
+    {
+        auto rowset = db.Table<Schema::TierBlobsDraft>().Select();
+        if (!rowset.IsReady()) {
+            return false;
+        }
+        while (!rowset.EndOfSet()) {
+            local.emplace(rowset.GetValue<Schema::TierBlobsDraft::StorageId>());
+            if (!rowset.Next()) {
+                return false;
+            }
+        }
+    }
+
+    std::swap(local, storageIds);
+    return true;
+}
+
 void TBlobManagerDb::AddTierBlobToDelete(const TString& storageId, const TUnifiedBlobId& blobId, const TTabletId tabletId) {
     NIceDb::TNiceDb db(Database);
     db.Table<Schema::TierBlobsToDeleteWT>().Key(storageId, blobId.ToStringNew(), (ui64)tabletId).Update();

--- a/ydb/core/tx/columnshard/blobs_action/blob_manager_db.h
+++ b/ydb/core/tx/columnshard/blobs_action/blob_manager_db.h
@@ -36,6 +36,7 @@ public:
 
     [[nodiscard]] virtual bool LoadTierLists(const TString& storageId, TTabletsByBlob& blobsToDelete,
         std::deque<TUnifiedBlobId>& draftBlobsToDelete, const TTabletId selfTabletId) = 0;
+    [[nodiscard]] virtual bool LoadTierStorageIds(THashSet<TString>& storageIds) = 0;
 
     virtual void AddTierBlobToDelete(const TString& storageId, const TUnifiedBlobId& blobId, const TTabletId tabletId) = 0;
     virtual void RemoveTierBlobToDelete(const TString& storageId, const TUnifiedBlobId& blobId, const TTabletId tabletId) = 0;
@@ -73,6 +74,7 @@ public:
 
     [[nodiscard]] bool LoadTierLists(const TString& storageId, TTabletsByBlob& blobsToDelete, std::deque<TUnifiedBlobId>& draftBlobsToDelete,
         const TTabletId selfTabletId) override;
+    [[nodiscard]] bool LoadTierStorageIds(THashSet<TString>& storageIds) override;
 
     void AddTierBlobToDelete(const TString& storageId, const TUnifiedBlobId& blobId, const TTabletId tabletId) override;
     void RemoveTierBlobToDelete(const TString& storageId, const TUnifiedBlobId& blobId, const TTabletId tabletId) override;

--- a/ydb/core/tx/columnshard/blobs_action/tier/storage.h
+++ b/ydb/core/tx/columnshard/blobs_action/tier/storage.h
@@ -60,6 +60,11 @@ public:
         return result;
     }
 
+    virtual bool HasPendingExternalCleanup() const override {
+        return HasOngoingGC() || !GCInfo->GetBlobsToDelete().IsEmpty() || !GCInfo->GetBlobsToDeleteInFuture().IsEmpty() ||
+               !GCInfo->GetDraftBlobIdsToRemove().empty();
+    }
+
     virtual std::shared_ptr<IBlobInUseTracker> GetBlobsTracker() const override {
         return GCInfo;
     }

--- a/ydb/core/tx/columnshard/blobs_action/tier/write.cpp
+++ b/ydb/core/tx/columnshard/blobs_action/tier/write.cpp
@@ -27,8 +27,18 @@ void TWriteAction::DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& /*self*/,
 }
 
 void TWriteAction::DoOnExecuteTxBeforeWrite(NColumnShard::TColumnShard& /*self*/, TBlobManagerDb& dbBlobs) {
+    DraftsPersisted = true;
     for (auto&& i : GetBlobsForWrite()) {
         dbBlobs.AddTierDraftBlobId(GetStorageId(), i.first);
+    }
+}
+
+void TWriteAction::DoOnWritingAborted() {
+    if (!DraftsPersisted) {
+        return;
+    }
+    for (auto&& i : GetBlobsForWrite()) {
+        GCInfo->MutableDraftBlobIdsToRemove().emplace_back(i.first);
     }
 }
 

--- a/ydb/core/tx/columnshard/blobs_action/tier/write.h
+++ b/ydb/core/tx/columnshard/blobs_action/tier/write.h
@@ -17,6 +17,7 @@ private:
     const ui32 Generation;
     const ui32 Step;
     mutable ui32 BlobIdsCounter = 0;
+    bool DraftsPersisted = false;
 
 protected:
     virtual void DoSendWriteBlobRequest(const TString& data, const TUnifiedBlobId& blobId) override;
@@ -33,6 +34,7 @@ protected:
 
     virtual void DoOnExecuteTxAfterWrite(NColumnShard::TColumnShard& self, TBlobManagerDb& dbBlobs, const bool blobsWroteSuccessfully) override;
     virtual void DoOnCompleteTxAfterWrite(NColumnShard::TColumnShard& self, const bool blobsWroteSuccessfully) override;
+    virtual void DoOnWritingAborted() override;
 
 public:
     virtual bool NeedDraftTransaction() const override {

--- a/ydb/core/tx/columnshard/columnshard.cpp
+++ b/ydb/core/tx/columnshard/columnshard.cpp
@@ -96,6 +96,10 @@ void TColumnShard::TrySwitchToWork(const TActorContext& ctx) {
         OnTieringModified();
     }
     Counters.GetCSCounters().OnIndexMetadataLimit(NOlap::IColumnEngine::GetMetadataLimit());
+    for (auto&& postponedEvent : InitializationPostponedEvents) {
+        TActivationContext::Send(postponedEvent.release());
+    }
+    InitializationPostponedEvents.clear();
     EnqueueBackgroundActivities();
     BackgroundSessionsManager->Start();
     ctx.Send(SelfId(), new NActors::TEvents::TEvWakeup());
@@ -564,6 +568,37 @@ void TColumnShard::SendPeriodicStats(bool withExecutor) {
             StatsReportRound++;
         }
     }
+}
+
+bool TColumnShard::IsDropCleanupComplete() const {
+    if (TablesManager.HasAnyAliveTable()) {
+        return false;
+    }
+    if (DataLocksManager->HasProcessLocks()) {
+        // in-flight background task: its blobs may exist in the external storage before the index commit
+        return false;
+    }
+    const auto& portionStats = Counters.GetPortionIndexCounters();
+    for (const auto& [_, pathIds] : TablesManager.GetPathsToDrop()) {
+        for (const auto& pathId : pathIds) {
+            if (portionStats->GetTableStats(pathId, TPortionIndexStats::TNonDefaultTierPortions()).GetCount()) {
+                return false;
+            }
+        }
+    }
+    return !StoragesManager->HasPendingExternalCleanup();
+}
+
+void TColumnShard::Handle(TEvColumnShard::TEvCheckDropCleanup::TPtr& ev, const TActorContext& ctx) {
+    if (!NYDBTest::TControllers::GetColumnShardController()->NeedAnswerDropCleanup()) {
+        // Emulates an old binary that does not know the request (mixed-version tests)
+        return;
+    }
+    const bool ready = IsDropCleanupComplete();
+    YDB_LOG_INFO("Drop cleanup state requested",
+        {"tabletId", TabletID()},
+        {"ready", ready});
+    ctx.Send(ev->Sender, new TEvColumnShard::TEvDropCleanupState(TabletID(), ready));
 }
 
 void TColumnShard::Handle(TEvPrivate::TEvReportBaseStatistics::TPtr& /*ev*/) {

--- a/ydb/core/tx/columnshard/columnshard.h
+++ b/ydb/core/tx/columnshard/columnshard.h
@@ -95,6 +95,9 @@ enum EEv {
     EvOverloadReady,
     EvOverloadUnsubscribe,
 
+    EvCheckDropCleanup,
+    EvDropCleanupState,
+
     EvEnd
 };
 
@@ -246,6 +249,23 @@ struct TEvOverloadUnsubscribe: public TEventPB<TEvOverloadUnsubscribe, NKikimrTx
 
     explicit TEvOverloadUnsubscribe(ui64 seqNo) {
         Record.SetSeqNo(seqNo);
+    }
+};
+
+struct TEvCheckDropCleanup: public TEventPB<TEvCheckDropCleanup, NKikimrTxColumnShard::TEvCheckDropCleanup, EvCheckDropCleanup> {
+    TEvCheckDropCleanup() = default;
+
+    explicit TEvCheckDropCleanup(ui64 tabletId) {
+        Record.SetTabletId(tabletId);
+    }
+};
+
+struct TEvDropCleanupState: public TEventPB<TEvDropCleanupState, NKikimrTxColumnShard::TEvDropCleanupState, EvDropCleanupState> {
+    TEvDropCleanupState() = default;
+
+    TEvDropCleanupState(ui64 tabletId, bool ready) {
+        Record.SetTabletId(tabletId);
+        Record.SetReady(ready);
     }
 };
 };   // namespace TEvColumnShard

--- a/ydb/core/tx/columnshard/columnshard_impl.cpp
+++ b/ydb/core/tx/columnshard/columnshard_impl.cpp
@@ -489,6 +489,8 @@ void TColumnShard::EnqueueBackgroundActivities(const bool periodic) {
     Counters.GetCSCounters().OnStartBackground();
 
     if (!TablesManager.HasPrimaryIndex()) {
+        // GC must run even without an index to drain persisted external-tier removal queues
+        SetupGC();
         YDB_LOG_NOTICE_COMP(NKikimrServices::TX_COLUMNSHARD, "",
             {"problem", "Background activities cannot be started: no index at tablet"});
         return;
@@ -1872,6 +1874,11 @@ void TColumnShard::Enqueue(STFUNC_SIG) {
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUpdated, Handle);
         HFunc(TEvTxProxySchemeCache::TEvWatchNotifyUnavailable, Handle);
         HFunc(TEvColumnShard::TEvNotifyTxCompletion, Handle);
+        case TEvDataShard::TEvKqpScan::EventType:
+            YDB_LOG_WARN_COMP(NKikimrServices::TX_COLUMNSHARD, "",
+                {"event", "postpone scan until initialization is finished"});
+            InitializationPostponedEvents.emplace_back(ev.Release());
+            return;
         default:
             YDB_LOG_WARN_COMP(NKikimrServices::TX_COLUMNSHARD, "",
                 {"event", "unexpected event in enqueue"});

--- a/ydb/core/tx/columnshard/columnshard_impl.h
+++ b/ydb/core/tx/columnshard/columnshard_impl.h
@@ -273,6 +273,7 @@ class TColumnShard: public TActor<TColumnShard>, public NTabletFlatExecutor::TTa
     void Handle(TEvColumnShard::TEvCheckPlannedTransaction::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvCancelTransactionProposal::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvColumnShard::TEvNotifyTxCompletion::TPtr& ev, const TActorContext& ctx);
+    void Handle(TEvColumnShard::TEvCheckDropCleanup::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvTxProcessing::TEvPlanStep::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvDataShard::TEvKqpScan::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvColumnShard::TEvInternalScan::TPtr& ev, const TActorContext& ctx);
@@ -452,6 +453,7 @@ protected:
             HFunc(TEvColumnShard::TEvCheckPlannedTransaction, Handle);
             HFunc(TEvDataShard::TEvCancelTransactionProposal, Handle);
             HFunc(TEvColumnShard::TEvNotifyTxCompletion, Handle);
+            HFunc(TEvColumnShard::TEvCheckDropCleanup, Handle);
             HFunc(TEvDataShard::TEvKqpScan, Handle);
             HFunc(TEvColumnShard::TEvInternalScan, Handle);
             HFunc(TEvTxProcessing::TEvPlanStep, Handle);
@@ -533,6 +535,7 @@ private:
     const TMonotonic CreateInstant = TMonotonic::Now();
     std::optional<TMonotonic> StartInstant;
     bool IsTxInitFinished = false;
+    std::vector<std::unique_ptr<IEventHandle>> InitializationPostponedEvents;
 
     ui64 CurrentSchemeShardId = 0;
     TMessageSeqNo LastSchemaSeqNo;
@@ -685,6 +688,9 @@ public:
     const TTablesManager& GetTablesManager() const {
         return TablesManager;
     }
+
+    // true when the tablet can be deleted without losing external (S3) data; monotonic after drop
+    bool IsDropCleanupComplete() const;
 
     void EnqueueProgressTx(const TActorContext& ctx, const ui64 continueTxId = 0);
 

--- a/ydb/core/tx/columnshard/counters/portion_index.h
+++ b/ydb/core/tx/columnshard/counters/portion_index.h
@@ -129,6 +129,13 @@ public:
             return portionClass.GetProduced() == Type;
         }
     };
+
+    class TNonDefaultTierPortions: public IStatsSelector {
+    public:
+        bool Select(const TPortionClass& portionClass) const override {
+            return !portionClass.GetIsDefaultTier();
+        }
+    };
 };
 
 }   // namespace NKikimr::NColumnShard

--- a/ydb/core/tx/columnshard/data_locks/manager/manager.h
+++ b/ydb/core/tx/columnshard/data_locks/manager/manager.h
@@ -44,6 +44,10 @@ private:
 public:
     TManager() = default;
 
+    bool HasProcessLocks() const {
+        return !ProcessLocks.empty();
+    }
+
     void Stop();
 
     class TGuard {

--- a/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/abstract/abstract.cpp
@@ -91,6 +91,7 @@ void TColumnEngineChanges::Abort(NColumnShard::TColumnShard& self, TChangesFinis
                                               "stage", StateGuard.GetStage())("reason", context.ErrorMessage)("prev_reason", AbortedReason);
     SetStage(NChanges::EStage::Aborted);
     AbortedReason = context.ErrorMessage;
+    MutableBlobsAction().OnWritingsAborted();
     OnFinish(self, context);
 }
 
@@ -124,6 +125,7 @@ void TColumnEngineChanges::AbortEmergency(const TString& reason) {
     } else {
         SetStage(NChanges::EStage::Aborted);
         AbortedReason = reason;
+        MutableBlobsAction().OnWritingsAborted();
         if (!!LockGuard) {
             LockGuard->AbortLock();
         }

--- a/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
+++ b/ydb/core/tx/columnshard/engines/changes/with_appended.cpp
@@ -20,13 +20,18 @@ void TChangesWithAppend::DoWriteIndexOnExecute(NColumnShard::TColumnShard* self,
         PortionsToRemove.ApplyOnExecute(self, context, *FetchedDataAccessors);
         PortionsToMove.ApplyOnExecute(self, context, *FetchedDataAccessors);
     }
-    const auto predRemoveDroppedTable = [self](const TWritePortionInfoWithBlobsResult& item) {
+    const auto predRemoveDroppedTable = [self, this](const TWritePortionInfoWithBlobsResult& item) {
         auto& portionInfo = item.GetPortionResult();
         if (!!self && !self->TablesManager.HasTable(portionInfo.GetPortionInfo().GetPathId(), false)) {
             YDB_LOG_WARN("",
                 {"event", "skip_inserted_data"},
                 {"reason", "table_removed"},
                 {"pathId", portionInfo.GetPortionInfo().GetPathId()});
+            // the portion is discarded: without an explicit removal declaration its blobs leak
+            for (auto&& blob : item.GetBlobs()) {
+                MutableBlobsAction().GetRemoving(blob.GetOperator()->GetStorageId())->DeclareRemove((TTabletId)self->TabletID(),
+                    blob.GetBlobIdVerified());
+            }
             return true;
         } else {
             return false;

--- a/ydb/core/tx/columnshard/hooks/abstract/abstract.h
+++ b/ydb/core/tx/columnshard/hooks/abstract/abstract.h
@@ -278,6 +278,11 @@ public:
         return false;
     }
 
+    // tests only: false emulates an old binary that does not answer TEvCheckDropCleanup
+    virtual bool NeedAnswerDropCleanup() const {
+        return true;
+    }
+
     ui64 GetSmallPortionSizeDetector() const {
         const ui64 defaultValue = GetConfig().GetSmallPortionDetectSizeLimit();
         return DoGetSmallPortionSizeDetector(defaultValue);

--- a/ydb/core/tx/columnshard/loading/stages.cpp
+++ b/ydb/core/tx/columnshard/loading/stages.cpp
@@ -51,7 +51,10 @@ bool TStoragesManagerInitializer::DoPrecharge(NTabletFlatExecutor::TTransactionC
            (int)Schema::Precharge<Schema::BlobsToDelete>(db, txc.DB.GetScheme()) &
            (int)Schema::Precharge<Schema::BlobsToDeleteWT>(db, txc.DB.GetScheme()) &
            (int)Schema::Precharge<Schema::SharedBlobIds>(db, txc.DB.GetScheme()) &
-           (int)Schema::Precharge<Schema::BorrowedBlobIds>(db, txc.DB.GetScheme());
+           (int)Schema::Precharge<Schema::BorrowedBlobIds>(db, txc.DB.GetScheme()) &
+           (int)Schema::Precharge<Schema::TierBlobsDraft>(db, txc.DB.GetScheme()) &
+           (int)Schema::Precharge<Schema::TierBlobsToDelete>(db, txc.DB.GetScheme()) &
+           (int)Schema::Precharge<Schema::TierBlobsToDeleteWT>(db, txc.DB.GetScheme());
 }
 
 bool TDBLocksInitializer::DoExecute(NTabletFlatExecutor::TTransactionContext& txc, const TActorContext& /*ctx*/) {
@@ -247,6 +250,17 @@ bool TTiersManagerInitializer::DoExecute(NTabletFlatExecutor::TTransactionContex
 
         if (!rowset.Next()) {
             return false;
+        }
+    }
+
+    // re-activate tiers for storages with persisted external removal queues (their tables may be already dropped)
+    for (const auto& [storageId, storageOperator] : Self->StoragesManager->GetStorages()) {
+        if (storageId == NOlap::IStoragesManager::DefaultStorageId || storageId == NOlap::IStoragesManager::MemoryStorageId ||
+            storageId == NOlap::IStoragesManager::LocalMetadataStorageId) {
+            continue;
+        }
+        if (storageOperator->HasPendingExternalCleanup()) {
+            Self->Tiers->ActivateTiers({ NTiers::TExternalStorageId(storageId) }, false);
         }
     }
     return true;

--- a/ydb/core/tx/columnshard/tables_manager.h
+++ b/ydb/core/tx/columnshard/tables_manager.h
@@ -517,6 +517,15 @@ public:
         return Tables;
     }
 
+    bool HasAnyAliveTable() const {
+        for (const auto& [_, table] : Tables) {
+            if (!table.IsDropped()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     const THashSet<ui32>& GetSchemaPresets() const {
         return SchemaPresetsIds;
     }

--- a/ydb/core/tx/columnshard/test_helper/controllers.h
+++ b/ydb/core/tx/columnshard/test_helper/controllers.h
@@ -18,6 +18,7 @@ private:
     YDB_READONLY(TAtomicCounter, MaxValueUsageCount, 0);
     YDB_ACCESSOR_DEF(std::optional<ui64>, SmallSizeDetector);
     YDB_ACCESSOR(bool, SkipSpecialCheckForEvict, false);
+    YDB_ACCESSOR(bool, AnswerDropCleanup, true);
 
 protected:
     virtual void OnTieringModified(const std::shared_ptr<NKikimr::NColumnShard::TTiersManager>& /*tiers*/) override;
@@ -51,6 +52,10 @@ protected:
     }
 
 public:
+    virtual bool NeedAnswerDropCleanup() const override {
+        return AnswerDropCleanup;
+    }
+
     virtual bool CheckPortionForEvict(const TPortionInfo& portion) const override {
         if (SkipSpecialCheckForEvict) {
             return true;

--- a/ydb/core/tx/schemeshard/olap/operations/drop_store.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/drop_store.cpp
@@ -241,8 +241,18 @@ public:
         NIceDb::TNiceDb db(context.GetDB());
         context.SS->PersistOlapStoreRemove(db, txState->TargetPathId);
 
+        // defer shard deletion until evicted data is erased from external tiers
+        const bool deferShardDeletion = AppData()->FeatureFlags.GetEnableDeferredColumnShardDeletionOnDrop();
         for (auto& shard : txState->Shards) {
-            context.OnComplete.DeleteShard(shard.Idx);
+            if (deferShardDeletion) {
+                LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                           DebugHint() << " Defer deletion of shard " << shard.Idx
+                                       << " until external data cleanup is complete");
+                context.SS->SchedulePollColumnShardDropCleanup(context.Ctx, TDuration::Seconds(1));
+            } else {
+                context.OnComplete.DeleteShard(shard.Idx);
+            }
+            context.SS->TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_PENDING_DROP_CLEANUP].Add(1);
         }
 
         context.OnComplete.DoneOperation(OperationId);

--- a/ydb/core/tx/schemeshard/olap/operations/drop_table.cpp
+++ b/ydb/core/tx/schemeshard/olap/operations/drop_table.cpp
@@ -317,15 +317,30 @@ private:
         NIceDb::TNiceDb db(context.GetDB());
 
         bool isStandalone = false;
+        bool deferShardDeletion = false;
         {
             Y_ABORT_UNLESS(context.SS->ColumnTables.contains(txState->TargetPathId));
             auto tableInfo = context.SS->ColumnTables.GetVerified(txState->TargetPathId);
             isStandalone = tableInfo->IsStandalone();
+            bool hasOwnedShards = false;
+            for (const auto& shard : txState->Shards) {
+                if (context.SS->ShardInfos.at(shard.Idx).PathId == txState->TargetPathId) {
+                    hasOwnedShards = true;
+                    break;
+                }
+            }
 
-            for (const auto& tier : tableInfo->GetUsedTiers()) {
-                auto tierPath = TPath::Resolve(tier, context.SS);
-                AFL_VERIFY(tierPath.IsResolved())("path", tier);
-                context.SS->PersistRemoveExternalDataSourceReference(db, tierPath->PathId, txState->TargetPathId);
+            // deferred shards need the tier configuration until the cleanup finishes: the references
+            // are removed together with the last shard of the path in TTxDeleteTabletReply
+            deferShardDeletion = isStandalone && hasOwnedShards &&
+                AppData()->FeatureFlags.GetEnableDeferredColumnShardDeletionOnDrop();
+
+            if (!deferShardDeletion) {
+                for (const auto& tier : tableInfo->GetUsedTiers()) {
+                    auto tierPath = TPath::Resolve(tier, context.SS);
+                    AFL_VERIFY(tierPath.IsResolved())("path", tier);
+                    context.SS->PersistRemoveExternalDataSourceReference(db, tierPath->PathId, txState->TargetPathId);
+                }
             }
         }
 
@@ -341,8 +356,17 @@ private:
                     // Not the owner - remove from SharedShards
                     RemoveSharedShard(context, shardIdx, targetPathId);
                 } else if (sharedIt == context.SS->SharedShards.end()) {
-                    // Owner, no one is sharing - delete the shard
-                    context.OnComplete.DeleteShard(shardIdx);
+                    if (deferShardDeletion) {
+                        // the shard is deleted later, upon a Ready answer to the cleanup poll
+                        LOG_INFO_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                                   DebugHint() << " Defer deletion of shard " << shardIdx
+                                               << " until external data cleanup is complete");
+                        context.SS->SchedulePollColumnShardDropCleanup(context.Ctx, TDuration::Seconds(1));
+                    } else {
+                        // Owner, no one is sharing - delete the shard
+                        context.OnComplete.DeleteShard(shardIdx);
+                    }
+                    context.SS->TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_PENDING_DROP_CLEANUP].Add(1);
                 } else {
                     // Owner, there are dependents - transfer ownership
                     AFL_VERIFY(newOwner.has_value());

--- a/ydb/core/tx/schemeshard/schemeshard__column_shard_cleanup_complete.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__column_shard_cleanup_complete.cpp
@@ -1,0 +1,192 @@
+#include "schemeshard_impl.h"
+
+namespace NKikimr {
+namespace NSchemeShard {
+
+using namespace NTabletFlatExecutor;
+
+namespace {
+
+bool IsShardPendingDropCleanup(const TSchemeShard& ss, const TShardIdx shardIdx) {
+    const auto* shardInfo = ss.ShardInfos.FindPtr(shardIdx);
+    if (!shardInfo || shardInfo->TabletType != ETabletType::ColumnShard) {
+        return false;
+    }
+    const auto* path = ss.PathsById.FindPtr(shardInfo->PathId);
+    if (!path || !(*path)->Dropped()) {
+        // e.g. a legitimately empty shard of an alive store
+        return false;
+    }
+    if (ss.Operations.contains((*path)->DropTxId)) {
+        // The drop operation is still in flight and decides the shards' fate itself
+        return false;
+    }
+    return true;
+}
+
+}   // namespace
+
+// A polled column shard of a dropped table reported whether external (S3) cleanup is complete
+struct TSchemeShard::TTxColumnShardDropCleanupState: public TTransactionBase<TSchemeShard> {
+    TEvColumnShard::TEvDropCleanupState::TPtr Ev;
+    TSideEffects SideEffects;
+
+    TTxColumnShardDropCleanupState(TSelf* self, TEvColumnShard::TEvDropCleanupState::TPtr& ev)
+        : TTransactionBase<TSchemeShard>(self)
+        , Ev(ev)
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_COLUMN_SHARD_CLEANUP_COMPLETE;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        const auto tabletId = TTabletId(Ev->Get()->Record.GetTabletId());
+        Self->ColumnShardDropCleanupSilentPolls.erase(tabletId);
+
+        if (!Ev->Get()->Record.GetReady()) {
+            return true;
+        }
+
+        const auto* shardIdxPtr = Self->TabletIdToShardIdx.FindPtr(tabletId);
+        if (!shardIdxPtr) {
+            // Unknown or already deleted tablet; a duplicate of an already processed answer
+            return true;
+        }
+        const auto shardIdx = *shardIdxPtr;
+        if (!IsShardPendingDropCleanup(*Self, shardIdx)) {
+            return true;
+        }
+
+        LOG_INFO_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   "TTxColumnShardDropCleanupState: external data cleanup complete"
+                       << ", delete shard " << shardIdx
+                       << ", tabletId: " << tabletId
+                       << ", at schemeshard: " << Self->TabletID());
+
+        SideEffects.DeleteShard(shardIdx);
+        SideEffects.ApplyOnExecute(Self, txc, ctx);
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        SideEffects.ApplyOnComplete(Self, ctx);
+    }
+};
+
+// Deletes the given shards right away: the feature flag is disabled
+struct TSchemeShard::TTxColumnShardDropCleanupDrain: public TTransactionBase<TSchemeShard> {
+    std::vector<TShardIdx> Shards;
+    TSideEffects SideEffects;
+
+    TTxColumnShardDropCleanupDrain(TSelf* self, std::vector<TShardIdx>&& shards)
+        : TTransactionBase<TSchemeShard>(self)
+        , Shards(std::move(shards))
+    {}
+
+    TTxType GetTxType() const override {
+        return TXTYPE_COLUMN_SHARD_CLEANUP_COMPLETE;
+    }
+
+    bool Execute(TTransactionContext& txc, const TActorContext& ctx) override {
+        for (const auto& shardIdx : Shards) {
+            if (!IsShardPendingDropCleanup(*Self, shardIdx)) {
+                continue;
+            }
+            LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                         "TTxColumnShardDropCleanupDrain: deferred deletion disabled by feature flag"
+                             << ", delete shard " << shardIdx << " without waiting for external data cleanup"
+                             << ", at schemeshard: " << Self->TabletID());
+            SideEffects.DeleteShard(shardIdx);
+        }
+        SideEffects.ApplyOnExecute(Self, txc, ctx);
+        return true;
+    }
+
+    void Complete(const TActorContext& ctx) override {
+        SideEffects.ApplyOnComplete(Self, ctx);
+    }
+};
+
+ITransaction* TSchemeShard::CreateTxColumnShardDropCleanupState(TEvColumnShard::TEvDropCleanupState::TPtr& ev) {
+    return new TTxColumnShardDropCleanupState(this, ev);
+}
+
+ITransaction* TSchemeShard::CreateTxColumnShardDropCleanupDrain(std::vector<TShardIdx>&& shards) {
+    return new TTxColumnShardDropCleanupDrain(this, std::move(shards));
+}
+
+void TSchemeShard::Handle(TEvColumnShard::TEvDropCleanupState::TPtr& ev, const TActorContext& ctx) {
+    Execute(CreateTxColumnShardDropCleanupState(ev), ctx);
+}
+
+THashSet<TShardIdx> TSchemeShard::CollectColumnShardsPendingDropCleanup() const {
+    THashSet<TShardIdx> result;
+    for (const auto& [shardIdx, shardInfo] : ShardInfos) {
+        if (shardInfo.TabletType != ETabletType::ColumnShard) {
+            continue;
+        }
+        if (IsShardPendingDropCleanup(*this, shardIdx)) {
+            result.insert(shardIdx);
+        }
+    }
+    return result;
+}
+
+void TSchemeShard::SchedulePollColumnShardDropCleanup(const TActorContext& ctx, const TDuration delay) {
+    if (ColumnShardDropCleanupPollScheduled) {
+        return;
+    }
+    ColumnShardDropCleanupPollScheduled = true;
+    ctx.Schedule(delay, new TEvPrivate::TEvPollColumnShardDropCleanup());
+}
+
+void TSchemeShard::Handle(TEvPrivate::TEvPollColumnShardDropCleanup::TPtr&, const TActorContext& ctx) {
+    ColumnShardDropCleanupPollScheduled = false;
+
+    const auto pending = CollectColumnShardsPendingDropCleanup();
+    TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_PENDING_DROP_CLEANUP].Set(pending.size());
+    if (pending.empty()) {
+        ColumnShardDropCleanupSilentPolls.clear();
+        TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_CLEANUP_SILENT].Set(0);
+        return;
+    }
+
+    if (!AppData()->FeatureFlags.GetEnableDeferredColumnShardDeletionOnDrop()) {
+        Execute(CreateTxColumnShardDropCleanupDrain(std::vector<TShardIdx>(pending.begin(), pending.end())), ctx);
+        SchedulePollColumnShardDropCleanup(ctx);
+        return;
+    }
+
+    ui32 silent = 0;
+    THashSet<TTabletId> pendingTablets;
+    for (const auto& shardIdx : pending) {
+        const auto tabletId = ShardInfos.at(shardIdx).TabletID;
+        pendingTablets.insert(tabletId);
+        const auto polls = ++ColumnShardDropCleanupSilentPolls[tabletId];
+        if (polls >= 3) {
+            // observational only: acting on silence would silently leak data
+            ++silent;
+        }
+        PipeClientCache->Send(ctx, ui64(tabletId), new TEvColumnShard::TEvCheckDropCleanup(ui64(tabletId)));
+    }
+    for (auto it = ColumnShardDropCleanupSilentPolls.begin(); it != ColumnShardDropCleanupSilentPolls.end();) {
+        if (!pendingTablets.contains(it->first)) {
+            ColumnShardDropCleanupSilentPolls.erase(it++);
+        } else {
+            ++it;
+        }
+    }
+    TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_CLEANUP_SILENT].Set(silent);
+    if (silent) {
+        LOG_WARN_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                   "Column shards pending drop cleanup did not answer " << silent
+                       << " tablets (older binary or unhealthy); waiting indefinitely"
+                       << ", at schemeshard: " << TabletID());
+    }
+
+    SchedulePollColumnShardDropCleanup(ctx);
+}
+
+} // namespace NSchemeShard
+} // namespace NKikimr

--- a/ydb/core/tx/schemeshard/schemeshard__delete_tablet_reply.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__delete_tablet_reply.cpp
@@ -146,6 +146,26 @@ struct TSchemeShard::TTxDeleteTabletReply : public TSchemeShard::TRwTxBase {
             auto path = Self->PathsById.at(pathId);
             path->DecShardsInside();
 
+            if (tabletType == ETabletType::ColumnShard && path->Dropped()) {
+                auto& pendingCleanupCounter = Self->TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_PENDING_DROP_CLEANUP];
+                if (pendingCleanupCounter.Get() > 0) {
+                    pendingCleanupCounter.Sub(1);
+                }
+                // the last shard of the dropped path is gone: release the external data sources
+                // kept for the tier configuration (see olap/operations/drop_table.cpp)
+                if (path->GetShardsInside() == 0) {
+                    for (const auto& [sourcePathId, source] : Self->ExternalDataSources) {
+                        const auto& references = source->ExternalTableReferences.GetReferences();
+                        const bool referenced = AnyOf(references.begin(), references.end(), [&](const auto& reference) {
+                            return TPathId::FromProto(reference.GetPathId()) == pathId;
+                        });
+                        if (referenced) {
+                            Self->PersistRemoveExternalDataSourceReference(db, sourcePathId, pathId);
+                        }
+                    }
+                }
+            }
+
             auto domain = Self->ResolveDomainInfo(path);
             domain->RemoveInternalShard(ShardIdx, Self);
             switch (tabletType) {

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -4514,6 +4514,35 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
             }
         }
 
+        // with the feature disabled, delete the shards deferred earlier right away (rollback path)
+        if (!AppData()->FeatureFlags.GetEnableDeferredColumnShardDeletionOnDrop()) {
+            THashSet<TPathId> pathsUnderOperation;
+            for (const auto& [opId, txState] : Self->TxInFlight) {
+                pathsUnderOperation.insert(txState.TargetPathId);
+            }
+            for (const auto& [shardIdx, shardInfo] : Self->ShardInfos) {
+                if (shardInfo.TabletType != ETabletType::ColumnShard) {
+                    continue;
+                }
+                const auto* path = Self->PathsById.FindPtr(shardInfo.PathId);
+                if (!path || !(*path)->Dropped()) {
+                    continue;
+                }
+                if (Self->SharedShards.contains(shardIdx)) {
+                    continue;
+                }
+                if (pathsUnderOperation.contains(shardInfo.PathId)) {
+                    // The drop operation is still in flight and will decide the shards' fate
+                    continue;
+                }
+                LOG_NOTICE_S(ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
+                             "TTxInit: deferred deletion of column shard " << shardIdx
+                                 << " is disabled by feature flag, deleting the shard"
+                                 << ", at schemeshard: " << Self->TabletID());
+                OnComplete.DeleteShard(shardIdx);
+            }
+        }
+
         // Read backup settings
         {
             TBackupSettingsRows backupSettings;
@@ -4869,6 +4898,9 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                 break;
             case ETabletType::ColumnShard:
                 Self->TabletCounters->Simple()[COUNTER_COLUMN_SHARDS].Add(1);
+                if (path->Dropped()) {
+                    Self->TabletCounters->Simple()[COUNTER_COLUMN_SHARDS_PENDING_DROP_CLEANUP].Add(1);
+                }
                 break;
             case ETabletType::SequenceShard:
                 Self->TabletCounters->Simple()[COUNTER_SEQUENCESHARD_COUNT].Add(1);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_drop_external_data_source.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_drop_external_data_source.cpp
@@ -148,8 +148,22 @@ public:
             result->SetError(NKikimrScheme::StatusSchemeError, "Data source doesn't exist");
             return result;
         }
-        if (externalDataSource->ExternalTableReferences.ReferencesSize()) {
-            result->SetError(NKikimrScheme::StatusSchemeError, "Other entities depend on this data source, please remove them at the beginning: " + externalDataSource->ExternalTableReferences.GetReferences(0).GetPath());
+        for (const auto& reference : externalDataSource->ExternalTableReferences.GetReferences()) {
+            const auto referrerPathId = TPathId::FromProto(reference.GetPathId());
+            const auto* referrerPath = context.SS->PathsById.FindPtr(referrerPathId);
+            if (!referrerPath || ((*referrerPath)->Dropped() && (*referrerPath)->GetShardsInside() == 0)) {
+                // stale reference (e.g. left by an older binary): must not block the drop
+                continue;
+            }
+            if ((*referrerPath)->Dropped()) {
+                // shards of the dropped table still need this data source to erase evicted data
+                result->SetError(NKikimrScheme::StatusSchemeError,
+                    "External data cleanup for dropped table " + reference.GetPath() +
+                        " is still in progress, please retry the drop later");
+                return result;
+            }
+            result->SetError(NKikimrScheme::StatusSchemeError,
+                "Other entities depend on this data source, please remove them at the beginning: " + reference.GetPath());
             return result;
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -365,6 +365,10 @@ void TSchemeShard::ActivateAfterInitialization(const TActorContext& ctx, TActiva
 
     Execute(CreateTxInitPopulator(std::move(opts.DelayPublications)), ctx);
 
+    // Resume waiting for column shards of dropped tables that are still erasing evicted
+    // data from external tiers (the set is derived from persistent state on each poll)
+    SchedulePollColumnShardDropCleanup(ctx);
+
     if (opts.TablesToClean) {
         Execute(CreateTxCleanTables(std::move(opts.TablesToClean)), ctx);
     }
@@ -5932,6 +5936,8 @@ void TSchemeShard::StateWork(STFUNC_SIG) {
         //
         HFuncTraced(TEvColumnShard::TEvProposeTransactionResult, Handle);
         HFuncTraced(TEvColumnShard::TEvNotifyTxCompletionResult, Handle);
+        HFuncTraced(TEvColumnShard::TEvDropCleanupState, Handle);
+        HFuncTraced(TEvPrivate::TEvPollColumnShardDropCleanup, Handle);
 
         // sequence shard
         HFuncTraced(NSequenceShard::TEvSequenceShard::TEvCreateSequenceResult, Handle);

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -1186,6 +1186,18 @@ public:
     struct TTxDeleteTabletReply;
     NTabletFlatExecutor::ITransaction* CreateTxDeleteTabletReply(TEvHive::TEvDeleteTabletReply::TPtr& ev);
 
+    struct TTxColumnShardDropCleanupState;
+    NTabletFlatExecutor::ITransaction* CreateTxColumnShardDropCleanupState(TEvColumnShard::TEvDropCleanupState::TPtr& ev);
+    struct TTxColumnShardDropCleanupDrain;
+    NTabletFlatExecutor::ITransaction* CreateTxColumnShardDropCleanupDrain(std::vector<TShardIdx>&& shards);
+
+    THashSet<TShardIdx> CollectColumnShardsPendingDropCleanup() const;
+    void SchedulePollColumnShardDropCleanup(const TActorContext& ctx, const TDuration delay = TDuration::Seconds(60));
+    void Handle(TEvPrivate::TEvPollColumnShardDropCleanup::TPtr& ev, const TActorContext& ctx);
+    bool ColumnShardDropCleanupPollScheduled = false;
+    // poll rounds without an answer, per tablet: purely observational
+    THashMap<TTabletId, ui32> ColumnShardDropCleanupSilentPolls;
+
     class TTxProgressIncrementalRestore;
     class TTxProgressIncrementalRestoreAllocateResult;
     class TTxIncrementalRestoreShardProgress;
@@ -1494,6 +1506,7 @@ public:
     void Handle(TEvPersQueue::TEvDropTabletReply::TPtr &ev, const TActorContext &ctx);
     void Handle(TEvColumnShard::TEvProposeTransactionResult::TPtr& ev, const TActorContext& ctx);
     void Handle(TEvColumnShard::TEvNotifyTxCompletionResult::TPtr &ev, const TActorContext &ctx);
+    void Handle(TEvColumnShard::TEvDropCleanupState::TPtr& ev, const TActorContext& ctx);
     void Handle(NSequenceShard::TEvSequenceShard::TEvCreateSequenceResult::TPtr &ev, const TActorContext &ctx);
     void Handle(NSequenceShard::TEvSequenceShard::TEvDropSequenceResult::TPtr &ev, const TActorContext &ctx);
     void Handle(NSequenceShard::TEvSequenceShard::TEvUpdateSequenceResult::TPtr &ev, const TActorContext &ctx);

--- a/ydb/core/tx/schemeshard/schemeshard_private.h
+++ b/ydb/core/tx/schemeshard/schemeshard_private.h
@@ -56,6 +56,7 @@ namespace TEvPrivate {
         EvFullBackupItemDone,
         EvProgressForcedCompaction,
         EvMoveShardToStoragePool,
+        EvPollColumnShardDropCleanup,
         EvEnd
     };
 
@@ -63,6 +64,9 @@ namespace TEvPrivate {
 
     // This event is sent by a schemeshard to itself to signal that some tx state has changed
     // and it should run all the actions associated with this state
+    struct TEvPollColumnShardDropCleanup: public TEventLocal<TEvPollColumnShardDropCleanup, EvPollColumnShardDropCleanup> {
+    };
+
     struct TEvProgressOperation: public TEventLocal<TEvProgressOperation, EvProgressOperation> {
         const ui64 TxId;
         const ui32 TxPartId;

--- a/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
+++ b/ydb/core/tx/schemeshard/ut_olap/ut_olap.cpp
@@ -1,4 +1,6 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+
+#include <util/generic/xrange.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/local_indexes.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/olap_helpers.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/schemeshard_counters.h>
@@ -632,6 +634,8 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/MyTable", false, NLs::PathNotExist);
+        // the shards are deleted after external cleanup, only then the path is removed
+        env.TestWaitTabletDeletion(runtime, TTestTxConfig::FakeHiveTablets + 1);
         TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
     }
 
@@ -966,6 +970,8 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/OlapStore", false, NLs::PathNotExist);
+        // the store shards are deleted after external cleanup, only then the path is removed
+        env.TestWaitTabletDeletion(runtime, TTestTxConfig::FakeHiveTablets);
         TestLsPathId(runtime, expectedStorePathId, NLs::PathStringEqual(""));
     }
 
@@ -989,6 +995,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
+        env.TestWaitTabletDeletion(runtime, TTestTxConfig::FakeHiveTablets);
         TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
 
         // PARTITION BY ()
@@ -1034,6 +1041,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
+        env.TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets + 1, TTestTxConfig::FakeHiveTablets + 5));
         TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
     }
 
@@ -1057,6 +1065,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
+        env.TestWaitTabletDeletion(runtime, TTestTxConfig::FakeHiveTablets);
         TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
 
         TString otherSchema = R"(
@@ -1097,6 +1106,7 @@ Y_UNIT_TEST_SUITE(TOlap) {
         env.TestWaitNotification(runtime, txId);
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
+        env.TestWaitTabletDeletion(runtime, xrange(TTestTxConfig::FakeHiveTablets + 1, TTestTxConfig::FakeHiveTablets + 65));
         TestLsPathId(runtime, expectedTablePathId, NLs::PathStringEqual(""));
     }
 
@@ -3391,6 +3401,7 @@ Y_UNIT_TEST_SUITE(TOlapNaming) {
 
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
         UNIT_ASSERT_VALUES_EQUAL(CountSharedShardsRows(runtime), 0u);
+        env.TestWaitTabletDeletion(runtime, tabletIds);
         // Shards rows for the (now deleted) column shards must be gone.
         UNIT_ASSERT_VALUES_EQUAL(GetShardOwnerLocalPathId(runtime, localShardIdx), 0u);
     }
@@ -3438,6 +3449,7 @@ Y_UNIT_TEST_SUITE(TOlapNaming) {
         TestDropColumnTable(runtime, ++txId, "/MyRoot/MyDir", "ColumnTable");
         env.TestWaitNotification(runtime, txId);
         TestLs(runtime, "/MyRoot/MyDir/ColumnTable", false, NLs::PathNotExist);
+        env.TestWaitTabletDeletion(runtime, tabletIds);
         UNIT_ASSERT_VALUES_EQUAL(GetShardOwnerLocalPathId(runtime, localShardIdx), 0u);
     }
 

--- a/ydb/core/tx/schemeshard/ya.make
+++ b/ydb/core/tx/schemeshard/ya.make
@@ -113,6 +113,7 @@ SRCS(
     schemeshard__local_index_migration.cpp
     schemeshard__local_index_migration.h
     schemeshard__login.cpp
+    schemeshard__column_shard_cleanup_complete.cpp
     schemeshard__make_access_database_no_inheritable.cpp
     schemeshard__monitoring.cpp
     schemeshard__monitoring.h

--- a/ydb/tests/olap/ttl_tiering/base.py
+++ b/ydb/tests/olap/ttl_tiering/base.py
@@ -78,7 +78,19 @@ class TllTieringTestBase(object):
         else:
             cls.ydb_client = YdbClient(database=cls.database, endpoint=cls.endpoint)
 
-        cls.ydb_client.wait_connection()
+        # fail_fast inside wait_connection surfaces the very first discovery error, giving the
+        # cluster only a couple of seconds to become ready; retry to tolerate slow schemeshard boot
+        last_error = None
+        for _ in range(12):
+            try:
+                cls.ydb_client.wait_connection()
+                last_error = None
+                break
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                time.sleep(5)
+        if last_error is not None:
+            raise last_error
 
     @classmethod
     def _setup_s3(cls):

--- a/ydb/tests/olap/ttl_tiering/drop_table_s3.py
+++ b/ydb/tests/olap/ttl_tiering/drop_table_s3.py
@@ -1,0 +1,115 @@
+import logging
+
+from .base import TllTieringTestBase
+from ydb.tests.olap.common.column_table_helper import ColumnTableHelper
+from ydb.tests.library.test_meta import link_test_case
+
+logger = logging.getLogger(__name__)
+
+
+class TestDropTableS3(TllTieringTestBase):
+
+    row_count = 10 ** 5
+    rows_in_upsert = 10 ** 4
+    days_to_cool = 1000
+
+    @link_test_case("#45898")
+    def test_drop_table_deletes_data_from_s3(self):
+        ''' Implements https://github.com/ydb-platform/ydb/issues/45898 '''
+        test_name = "drop_table_s3"
+        cold_bucket = "cold_drop"
+        test_dir = f"{self.ydb_client.database}/{test_name}"
+        table_path = f"{test_dir}/table"
+        secret_prefix = test_name
+        access_key_id_secret_name = f"{secret_prefix}_key_id"
+        access_key_secret_secret_name = f"{secret_prefix}_key_secret"
+        cold_eds_path = f"{test_dir}/{cold_bucket}"
+
+        self.s3_client.create_bucket(cold_bucket)
+
+        # Expect empty bucket to avoid unintentional data deletion/modification
+        if self.s3_client.get_bucket_stat(cold_bucket) != (0, 0):
+            raise Exception("Bucket for cold data is not empty")
+
+        self.ydb_client.query(f"""
+            CREATE TABLE `{table_path}` (
+                ts Timestamp NOT NULL,
+                s String,
+                val Uint64,
+                PRIMARY KEY(ts),
+            )
+            WITH (STORE = COLUMN)
+            """)
+
+        logger.info(f"Table {table_path} created")
+
+        self.ydb_client.query(f"CREATE OBJECT {access_key_id_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_id}'")
+        self.ydb_client.query(f"CREATE OBJECT {access_key_secret_secret_name} (TYPE SECRET) WITH value='{self.s3_client.key_secret}'")
+
+        self.ydb_client.query(f"""
+            CREATE EXTERNAL DATA SOURCE `{cold_eds_path}` WITH (
+                SOURCE_TYPE="ObjectStorage",
+                LOCATION="{self.s3_client.endpoint}/{cold_bucket}",
+                AUTH_METHOD="AWS",
+                AWS_ACCESS_KEY_ID_SECRET_NAME="{access_key_id_secret_name}",
+                AWS_SECRET_ACCESS_KEY_SECRET_NAME="{access_key_secret_secret_name}",
+                AWS_REGION="{self.s3_client.region}"
+            )
+        """)
+
+        table = ColumnTableHelper(self.ydb_client, table_path)
+        table.set_fast_compaction()
+
+        cur_rows = 0
+        while cur_rows < self.row_count:
+            self.ydb_client.query("""
+                $row_count = %i;
+                $from_us = CAST(Timestamp('2010-01-01T00:00:00.000000Z') as Uint64);
+                $to_us = CAST(Timestamp('2020-01-01T00:00:00.000000Z') as Uint64);
+                $dt = $to_us - $from_us;
+                $k = ((1ul << 64) - 1) / CAST($dt - 1 as Double);
+                $rows= ListMap(ListFromRange(0, $row_count), ($i)->{
+                    $us = CAST(RandomNumber($i) / $k as Uint64) + $from_us;
+                    $ts = Unwrap(CAST($us as Timestamp));
+                    return <|
+                        ts: $ts,
+                        s: 'some date:' || CAST($ts as String),
+                        val: $us
+                    |>;
+                });
+                upsert into `%s`
+                select * FROM AS_TABLE($rows);
+            """ % (min(self.row_count - cur_rows, self.rows_in_upsert), table_path))
+            cur_rows = table.get_row_count()
+            logger.info(f"{cur_rows} rows inserted in total, portions: {table.get_portion_stat_by_tier()}, blobs: {table.get_blob_stat_by_tier()}")
+
+        assert table.portions_actualized_in_sys(), ".sys reports incorrect data portions"
+
+        stmt = f"""
+            ALTER TABLE `{table_path}` SET (TTL =
+                Interval("P{self.days_to_cool}D") TO EXTERNAL DATA SOURCE `{cold_eds_path}`
+                ON ts
+            )
+        """
+        logger.info(stmt)
+        self.ydb_client.query(stmt)
+
+        def data_evicted_to_s3():
+            bucket_stat = self.s3_client.get_bucket_stat(cold_bucket)
+            logger.info(
+                f"portions: {table.get_portion_stat_by_tier()}, blobs: {table.get_blob_stat_by_tier()}, cold bucket stat: {bucket_stat}")
+            return bucket_stat[0] != 0
+
+        assert self.wait_for(data_evicted_to_s3, 300), "Data eviction has not been started"
+
+        stmt = f"DROP TABLE `{table_path}`"
+        logger.info(stmt)
+        self.ydb_client.query(stmt)
+
+        def data_deleted_from_bucket():
+            bucket_stat = self.s3_client.get_bucket_stat(cold_bucket)
+            logger.info(f"cold bucket stat: {bucket_stat}")
+            return bucket_stat[0] == 0
+
+        assert self.wait_for(data_deleted_from_bucket, 300), \
+            f"Data is not deleted from S3 after DROP TABLE, bucket stat: {self.s3_client.get_bucket_stat(cold_bucket)}"

--- a/ydb/tests/olap/ttl_tiering/ya.make
+++ b/ydb/tests/olap/ttl_tiering/ya.make
@@ -10,6 +10,7 @@ TEST_SRCS(
     base.py
     data_correctness.py
     data_migration_when_alter_ttl.py
+    drop_table_s3.py
     tier_delete.py
     ttl_delete_s3.py
     ttl_unavailable_s3.py


### PR DESCRIPTION

### Changelog entry

Fixed a data leak in S3: evicted data was not erased from external tiers when a column table or table store was dropped. Column shard tablets are now deleted only after they confirm that no data remains in external tiers (kill-switch: `EnableDeferredColumnShardDeletionOnDrop`, enabled by default).

### Changelog category

* Bugfix

### Description for reviewers

**Problem.** On `DROP TABLE`/`DROP TABLESTORE` the schemeshard deletes the ColumnShard tablets immediately. Blobs evicted to an external tier (S3) can only be erased by a living shard's GC, so the objects are orphaned forever (74 objects leaked in the reproducer). Closes #45898, supersedes #8261 (the muted demo test scenario is covered by `KqpOlapTiering::DropTableAndStoreDeletesS3Data`).

**Fix: deferred tablet deletion with a pull protocol.**
- The schemeshard defers `DeleteShard` for column shards bound to a dropped path and polls them (`TEvCheckDropCleanup` → `TEvDropCleanupState`, every 60s via `PipeClientCache`, first poll after 1s). A shard answers `Ready` from a monotonic predicate: no alive tables, no portions outside the default tier, no pending external removals, no in-flight background tasks.
- No new persistent state: the pending set is recomputed from `ShardInfos` + path state; every step is idempotent and crash/restart-safe (poll simply repeats).
- The data itself is erased by the existing shard GC (retries until the storage responds, `NO_SUCH_KEY` = success); the shard just stays alive until it finishes.
- External data source references are kept until the last shard of the path is deleted (removed atomically with `PersistShardDeleted`), so the shards retain the tier configuration (endpoint/credentials). Dropping the EDS during cleanup returns an explicit "cleanup in progress, please retry" error; stale references left by older binaries do not block the drop.
- Mixed versions need no coordination: old shards simply do not answer and stay pending (visible in a counter + WARN log) until their node is upgraded. Old schemeshards never poll, shards get deleted as before.
- Kill-switch `EnableDeferredColumnShardDeletionOnDrop` (default **true**). Disabling it is the only path that accepts the legacy leak: the poller drains the pending shards within one cycle (no restart needed); on restart `TTxInit` also drains. This is also the downgrade path for the schemeshard.
- Observability: `SchemeShard/ColumnShardsPendingDropCleanup` and `.../ColumnShardsCleanupSilent` gauges.

**Also fixed on the way** (found by the new tests): several smaller leaks and stalls on the same path — unscheduled tier removals for portions written into a dropped table, leaked write drafts on abort, GC/tier-config/removal-queue issues on restart of a dropped shard, and a false `Ready` while an eviction write was in flight.

**Tests.**
- `ydb/tests/olap/ttl_tiering/drop_table_s3.py` — e2e reproducer (fails on main, green with the fix).
- `KqpOlapTiering`: `DropStandaloneTableDeletesS3Data`, `DropTableAndStoreDeletesS3Data` (the #8261 scenario), `DropTableWithUnavailableS3` (S3 down at drop → shards survive → S3 back + reboot → bucket empty), `DropTableSilentShardNeverDeleted` (old-binary emulation), `DropCleanupKillSwitchDrains` (runtime flag flip drains, leak accepted).
- `schemeshard ut_olap`: existing drop tests updated for the deferred-deletion semantics.
- `KqpOlapIndexes`: fixed a race in `IndexesActualization`/`MinMaxIndexAppliedToDataAfterCompaction` (`AdvancePlanStep` must run after `WaitActualization`, otherwise the scan snapshot may predate the rewritten portions). The latter test is currently muted as flaky — this likely fixes the flakiness (unmute proposed separately).
