### PR TITLE
[NBS-7486] Notify when config persisted

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.cpp
@@ -297,6 +297,15 @@ bool TBaseFixture::WaitEraseRequests(size_t count, TDuration timeout)
     return Wait(ErasePromises, count, timeout);
 }
 
+size_t TBaseFixture::ReplyUpdateRequests()
+{
+    auto requests = std::move(PartitionDirectService->UpdateConfigRequests);
+    for (auto& r: requests) {
+        r.Promise.SetValue();
+    }
+    return requests.size();
+}
+
 template <typename T>
 void TBaseFixture::SetResult(
     TVector<NThreading::TPromise<T>>& promises,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/base_test_fixture.h
@@ -97,6 +97,8 @@ struct TBaseFixture: public NUnitTest::TBaseFixture
     void SetEraseResult(TDBGEraseResponse response, bool async);
     bool WaitEraseRequests(size_t count, TDuration timeout);
 
+    size_t ReplyUpdateRequests();
+
     static auto& AccessBlocksDirtyMap(TVChunk& vchunk)
     {
         return vchunk.BlocksDirtyMap;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group.h
@@ -211,12 +211,6 @@ public:
     virtual NThreading::TFuture<TListPBufferResponse> ListPBuffers(
         THostIndex hostIndex) = 0;
 
-    // Translate host index to NodeId
-    virtual ui32 GetNodeId(THostIndex host) = 0;
-
-    // Query dump for DirectBlockGroup and VChunks.
-    virtual NThreading::TFuture<TDBGDumpResponse> Dump() = 0;
-
     // Result of the DBG's AddHost request. On success (empty error) applies the
     // new host; on failure (e.g. rejected at MaxHostCount) logs the reason.
     virtual void OnAddHostResult(
@@ -224,6 +218,12 @@ public:
         THostIndex newHostIndex,
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) = 0;
+
+    // Translate host index to NodeId.
+    [[nodiscard]] virtual ui32 GetNodeId(THostIndex host) const = 0;
+
+    // Query dump for DirectBlockGroup and VChunks.
+    virtual NThreading::TFuture<TDBGDumpResponse> Dump() = 0;
 
     // Builds this DBG's monitoring snapshot on the executor thread (like Dump).
     virtual NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() const = 0;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -37,11 +37,11 @@ constexpr size_t MinLockedDDiskSessionsToStart =
 
 NProto::TError MakeSessionError(ui32 nodeId, THostIndex host)
 {
-    TStringBuilder resut;
-    resut << "DDisk " << PrintHostAndNode(host, nodeId)
-          << " session is not established";
+    TStringBuilder result;
+    result << "DDisk " << PrintHostAndNodeId(host, nodeId)
+           << " session is not established";
 
-    return MakeError(E_REJECTED, resut);
+    return MakeError(E_REJECTED, result);
 }
 
 TListPBufferResponse MakeListPBufferResponse(
@@ -1277,36 +1277,6 @@ NThreading::TFuture<TListPBufferResponse> TDirectBlockGroup::ListPBuffers(
     return result;
 }
 
-ui32 TDirectBlockGroup::GetNodeId(THostIndex host)
-{
-    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
-
-    if (DDiskConnections.size() <= host) {
-        return Max<ui32>();
-    }
-    return DDiskConnections[host].HostConnection.DDiskId.NodeId;
-}
-
-NThreading::TFuture<TDBGDumpResponse> TDirectBlockGroup::Dump()
-{
-    auto promise = NewPromise<TDBGDumpResponse>();
-    auto future = promise.GetFuture();
-    Executor->ExecuteSimple(
-        [weakSelf = weak_from_this(),
-         index = DirectBlockGroupIndex,
-         promise = std::move(promise)]   //
-        () mutable
-        {
-            if (auto self = weakSelf.lock()) {
-                promise.SetValue(self->DoDebugPrintDirtyMap());
-            } else {
-                promise.SetValue({.DirectBlockGroupIndex = index});
-            }
-        });
-
-    return future;
-}
-
 void TDirectBlockGroup::OnAddHostResult(
     const NProto::TError& error,
     THostIndex newHostIndex,
@@ -1345,10 +1315,40 @@ void TDirectBlockGroup::OnAddHostResult(
         NKikimrServices::NBS_PARTITION,
         "%s AddHost %s request OK",
         LogTitle.GetWithTime().c_str(),
-        PrintHostAndNode(newHostIndex, GetNodeId(newHostIndex)).c_str());
+        PrintHostAndNode(newHostIndex).c_str());
 
     DoEstablishConnection(newHostIndex, EConnectionType::DDisk);
     DoEstablishConnection(newHostIndex, EConnectionType::PBuffer);
+}
+
+ui32 TDirectBlockGroup::GetNodeId(THostIndex host) const
+{
+    Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
+
+    if (DDiskConnections.size() <= host) {
+        return Max<ui32>();
+    }
+    return DDiskConnections[host].HostConnection.DDiskId.NodeId;
+}
+
+NThreading::TFuture<TDBGDumpResponse> TDirectBlockGroup::Dump()
+{
+    auto promise = NewPromise<TDBGDumpResponse>();
+    auto future = promise.GetFuture();
+    Executor->ExecuteSimple(
+        [weakSelf = weak_from_this(),
+         index = DirectBlockGroupIndex,
+         promise = std::move(promise)]   //
+        () mutable
+        {
+            if (auto self = weakSelf.lock()) {
+                promise.SetValue(self->DoDebugPrintDirtyMap());
+            } else {
+                promise.SetValue({.DirectBlockGroupIndex = index});
+            }
+        });
+
+    return future;
 }
 
 NThreading::TFuture<TDbgSnapshot> TDirectBlockGroup::BuildMonSnapshot() const
@@ -1383,7 +1383,7 @@ void TDirectBlockGroup::SetHostState(
         NKikimrServices::NBS_PARTITION,
         "%s %s state changed: %s -> %s",
         LogTitle.GetWithTime().c_str(),
-        PrintHostAndNode(hostIndex, GetNodeId(hostIndex)).c_str(),
+        PrintHostAndNode(hostIndex).c_str(),
         ToString(oldState).c_str(),
         ToString(newState).c_str());
 
@@ -1499,7 +1499,7 @@ void TDirectBlockGroup::DoEstablishConnection(
             NKikimrServices::NBS_PARTITION,
             "%s %s starting session: new seq_no: %lu",
             LogTitle.GetWithTime().c_str(),
-            PrintHostAndNode(hostIndex, GetNodeId(hostIndex)).c_str(),
+            PrintHostAndNode(hostIndex).c_str(),
             actualSeqNo);
     }
 
@@ -1573,7 +1573,7 @@ void TDirectBlockGroup::OnConnectionEstablished(
                     "%s %s attempt to establish a session with an old "
                     "seq_no: %lu while actual seq_no: %lu",
                     LogTitle.GetWithTime().c_str(),
-                    PrintHostAndNode(hostIndex, GetNodeId(hostIndex)).c_str(),
+                    PrintHostAndNode(hostIndex).c_str(),
                     seqNo,
                     connection.ConfirmedSessionSeqNo);
                 return;
@@ -1595,7 +1595,7 @@ void TDirectBlockGroup::OnConnectionEstablished(
             NKikimrServices::NBS_PARTITION,
             "%s connection failed %s: %s",
             LogTitle.GetWithTime().c_str(),
-            PrintHostAndNode(hostIndex, GetNodeId(hostIndex)).c_str(),
+            PrintHostAndNode(hostIndex).c_str(),
             FormatError(error).c_str());
         ReEstablishConnection(connectionType, hostIndex);
         return;
@@ -1633,7 +1633,7 @@ void TDirectBlockGroup::ReEstablishConnection(
             "%s reconnect %s suppressed: blocked generation, suicide in "
             "progress",
             LogTitle.GetWithTime().c_str(),
-            PrintHostAndNode(hostIndex, GetNodeId(hostIndex)).c_str());
+            PrintHostAndNode(hostIndex).c_str());
         return;
     }
 
@@ -1658,7 +1658,7 @@ void TDirectBlockGroup::OnNodeDisconnected(THostIndex hostIndex, ui32 nodeId)
         NKikimrServices::NBS_PARTITION,
         "%s OnNodeDisconnected %s",
         LogTitle.GetWithTime().c_str(),
-        PrintHostAndNode(hostIndex, nodeId).c_str());
+        PrintHostAndNodeId(hostIndex, nodeId).c_str());
 
     Oracle.OnDDiskDisconnected(hostIndex, TInstant::Now());
 
@@ -1766,7 +1766,7 @@ void TDirectBlockGroup::OnResponse(
             NKikimrServices::NBS_PARTITION,
             "%s OnResponse %s %s %s",
             LogTitle.GetWithTime().c_str(),
-            PrintHostAndNode(hostIndex, GetNodeId(hostIndex)).c_str(),
+            PrintHostAndNode(hostIndex).c_str(),
             ToString(operation).c_str(),
             FormatError(error).c_str());
 
@@ -1986,6 +1986,11 @@ TConnectionSnapshot TDirectBlockGroup::MakeConnectionSnapshot(
         .DDiskSession = ToString(ddisk.SessionState),
         .PBufferConnected = pbuffer && pbuffer->ConnectPromise.HasValue(),
     };
+}
+
+TString TDirectBlockGroup::PrintHostAndNode(THostIndex host) const
+{
+    return PrintHostAndNodeId(host, GetNodeId(host));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -139,15 +139,15 @@ public:
     NThreading::TFuture<TListPBufferResponse> ListPBuffers(
         THostIndex hostIndex) override;
 
-    ui32 GetNodeId(THostIndex host) override;
-
-    NThreading::TFuture<TDBGDumpResponse> Dump() override;
-
     void OnAddHostResult(
         const NProto::TError& error,
         THostIndex newHostIndex,
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) override;
+
+    ui32 GetNodeId(THostIndex host) const override;
+
+    NThreading::TFuture<TDBGDumpResponse> Dump() override;
 
     NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() const override;
 
@@ -262,6 +262,8 @@ private:
 
     [[nodiscard]] TConnectionSnapshot MakeConnectionSnapshot(
         size_t hostIndex) const;
+
+    [[nodiscard]] TString PrintHostAndNode(THostIndex host) const;
 
     NActors::TActorSystem* const ActorSystem = nullptr;
     const TStorageConfigPtr StorageConfig;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -1330,8 +1330,12 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             "Enabled{+++++}",
             configBefore);
 
-        // Wait for DB request completed
-        DrainExecutor(executor);
+        // Reply UpdateConfig request.
+        {
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(executor);
+        }
+
         TString configAfter;
         TString dirtyMapDDiskAfter;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.cpp
@@ -379,11 +379,6 @@ NThreading::TFuture<TListPBufferResponse> TDirectBlockGroupMock::ListPBuffers(
     return ListPBuffersHandler(hostIndex);
 }
 
-NThreading::TFuture<TDBGDumpResponse> TDirectBlockGroupMock::Dump()
-{
-    return DumpHandler();
-}
-
 void TDirectBlockGroupMock::OnAddHostResult(
     const NProto::TError& error,
     THostIndex newHostIndex,
@@ -397,9 +392,14 @@ void TDirectBlockGroupMock::OnAddHostResult(
         std::move(pbufferId));
 }
 
-ui32 TDirectBlockGroupMock::GetNodeId(THostIndex host)
+ui32 TDirectBlockGroupMock::GetNodeId(THostIndex host) const
 {
     return host + 10;
+}
+
+NThreading::TFuture<TDBGDumpResponse> TDirectBlockGroupMock::Dump()
+{
+    return DumpHandler();
 }
 
 NThreading::TFuture<TDbgSnapshot>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_mock.h
@@ -244,15 +244,15 @@ public:
     NThreading::TFuture<TListPBufferResponse> ListPBuffers(
         THostIndex hostIndex) override;
 
-    ui32 GetNodeId(THostIndex host) override;
-
-    NThreading::TFuture<TDBGDumpResponse> Dump() override;
-
     void OnAddHostResult(
         const NProto::TError& error,
         THostIndex newHostIndex,
         NKikimrBlobStorage::NDDisk::TDDiskId ddiskId,
         NKikimrBlobStorage::NDDisk::TDDiskId pbufferId) override;
+
+    ui32 GetNodeId(THostIndex host) const override;
+
+    NThreading::TFuture<TDBGDumpResponse> Dump() override;
 
     NThreading::TFuture<TDbgSnapshot> BuildMonSnapshot() const override;
 };

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.cpp
@@ -219,4 +219,13 @@ void TDBGFixture::WaitReady(
     UNIT_ASSERT(future.HasValue());
 }
 
+size_t TDBGFixture::ReplyUpdateRequests()
+{
+    auto requests = std::move(Service->UpdateConfigRequests);
+    for (auto& r: requests) {
+        r.Promise.SetValue();
+    }
+    return requests.size();
+}
+
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_test_fixture.h
@@ -135,6 +135,10 @@ struct TDBGFixture: public NUnitTest::TBaseFixture
         const TExecutorPtr& executor,
         const NThreading::TFuture<void>& future,
         TDuration timeout = DefaultWaitFutureTimeout);
+
+    // Sets all response Promises for update configs requests. Returns executed
+    // requests count.
+    size_t ReplyUpdateRequests();
 };
 
 }   // namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.cpp
@@ -24,7 +24,7 @@ TEraseRequestExecutor::TEraseRequestExecutor(
     , LogTitle(logTitle.GetChildWithTags(
           GetCycleCount(),
           {{"t", "BatchErase"},
-           {"h", PrintHostAndNode(host, directBlockGroup->GetNodeId(host))}}))
+           {"h", PrintHostAndNodeId(host, directBlockGroup->GetNodeId(host))}}))
     , VChunkConfig(vChunkConfig)
     , DirectBlockGroup(std::move(directBlockGroup))
     , Span(std::move(span))

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.cpp
@@ -405,11 +405,14 @@ void TFastPathService::ScheduleAfterDelay(
         std::move(callback));
 }
 
-void TFastPathService::UpdateVChunkConfig(const TVChunkConfig& cfg)
+NThreading::TFuture<void> TFastPathService::UpdateVChunkConfig(
+    const TVChunkConfig& cfg)
 {
     auto event =
         std::make_unique<TEvPartitionDirectPrivate::TEvUpdateVChunkConfig>(cfg);
+    auto result = event->UpdateCompleted.GetFuture();
     ActorSystem->Send(PartitionActorId, event.release());
+    return result;
 }
 
 void TFastPathService::QueryAddHost(

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/fast_path_service.h
@@ -120,7 +120,8 @@ public:
         TDuration delay,
         NYdb::NBS::TCallback callback) override;
 
-    void UpdateVChunkConfig(const TVChunkConfig& cfg) override;
+    NThreading::TFuture<void> UpdateVChunkConfig(
+        const TVChunkConfig& cfg) override;
 
     void QueryAddHost(size_t directBlockGroupId, size_t newHostIndex) override;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.cpp
@@ -25,11 +25,11 @@ TFlushRequestExecutor::TFlushRequestExecutor(
           GetCycleCount(),
           {{"t", "Flush"},
            {"src",
-            PrintHostAndNode(
+            PrintHostAndNodeId(
                 route.SourceHostIndex,
                 directBlockGroup->GetNodeId(route.SourceHostIndex))},
            {"dst",
-            PrintHostAndNode(
+            PrintHostAndNodeId(
                 route.DestinationHostIndex,
                 directBlockGroup->GetNodeId(route.DestinationHostIndex))}}))
     , VChunkConfig(vChunkConfig)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.cpp
@@ -39,7 +39,7 @@ TString PrintNodeId(ui32 nodeId)
     return result;
 }
 
-TString PrintHostAndNode(THostIndex hostIndex, ui32 nodeId)
+TString PrintHostAndNodeId(THostIndex hostIndex, ui32 nodeId)
 {
     TStringBuilder result;
     result << PrintHostIndex(hostIndex) << "#" << nodeId;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/host.h
@@ -73,7 +73,7 @@ struct THostRoute
 
 TString PrintHostIndex(THostIndex hostIndex);
 TString PrintNodeId(ui32 nodeId);
-TString PrintHostAndNode(THostIndex hostIndex, ui32 nodeId);
+TString PrintHostAndNodeId(THostIndex hostIndex, ui32 nodeId);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.cpp
@@ -79,6 +79,11 @@ TVChunkConfig TVChunkConfig::Make(
     return result;
 }
 
+bool TVChunkConfig::Empty() const
+{
+    return HostCount == 0;
+}
+
 size_t TVChunkConfig::GetHostCount() const
 {
     return HostCount;
@@ -294,6 +299,8 @@ bool TVChunkConfig::IsValid() const
     }
     return !PBufferHosts.GetActive().Empty() && !DDiskHosts.GetActive().Empty();
 }
+
+bool TVChunkConfig::operator==(const TVChunkConfig& other) const = default;
 
 TString TVChunkConfig::DebugPrint() const
 {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/vchunk_config.h
@@ -22,6 +22,7 @@ public:
         THostMask enabledHosts,
         TVector<std::optional<ui64>> watermarks);
 
+    [[nodiscard]] bool Empty() const;
     [[nodiscard]] size_t GetHostCount() const;
     [[nodiscard]] ui32 GetVChunkIndex() const;
 
@@ -81,6 +82,8 @@ public:
     [[nodiscard]] THostMask GetDisabledHosts() const;
 
     [[nodiscard]] bool IsValid() const;
+
+    bool operator==(const TVChunkConfig& other) const;
 
     [[nodiscard]] TString DebugPrint() const;
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_tx.h
@@ -9,6 +9,8 @@
 
 #include <ydb/library/actors/core/actorid.h>
 
+#include <library/cpp/threading/future/core/future.h>
+
 #include <util/generic/maybe.h>
 #include <util/generic/vector.h>
 #include <util/system/types.h>
@@ -118,9 +120,13 @@ struct TTxPartition
     struct TUpdateVChunkConfig
     {
         const TVChunkConfig VChunkConfig;
+        NThreading::TPromise<void> UpdateCompleted;
 
-        explicit TUpdateVChunkConfig(TVChunkConfig vChunkConfig)
+        explicit TUpdateVChunkConfig(
+            TVChunkConfig vChunkConfig,
+            NThreading::TPromise<void> updateCompleted)
             : VChunkConfig(std::move(vChunkConfig))
+            , UpdateCompleted(std::move(updateCompleted))
         {}
 
         void Clear()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/part_updatevchunkconfig.cpp
@@ -38,7 +38,8 @@ void TPartitionActor::CompleteUpdateVChunkConfig(
     TTxPartition::TUpdateVChunkConfig& args)
 {
     Y_UNUSED(ctx);
-    Y_UNUSED(args);
+
+    args.UpdateCompleted.SetValue();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_actor.cpp
@@ -585,16 +585,20 @@ void TPartitionActor::HandleUpdateVChunkConfig(
     const TEvPartitionDirectPrivate::TEvUpdateVChunkConfig::TPtr& ev,
     const NActors::TActorContext& ctx)
 {
-    auto& cfg = ev->Get()->VChunkConfig;
+    auto* msg = ev->Get();
 
     LOG_INFO(
         ctx,
         NKikimrServices::NBS_PARTITION,
         "%s Handle UpdateVChunkConfig %s",
         LogTitle.GetWithTime().c_str(),
-        cfg.DebugPrint().c_str());
+        msg->VChunkConfig.DebugPrint().c_str());
 
-    ExecuteTx(ctx, CreateTx<TUpdateVChunkConfig>(std::move(cfg)));
+    ExecuteTx(
+        ctx,
+        CreateTx<TUpdateVChunkConfig>(
+            std::move(msg->VChunkConfig),
+            std::move(msg->UpdateCompleted)));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_events_private.h
@@ -6,6 +6,8 @@
 
 #include <ydb/library/actors/core/event_local.h>
 
+#include <library/cpp/threading/future/core/future.h>
+
 #include <memory>
 
 namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect {
@@ -40,6 +42,7 @@ struct TEvPartitionDirectPrivate
               TEventLocal<TEvUpdateVChunkConfig, EvUpdateVChunkConfig>
     {
         TVChunkConfig VChunkConfig;
+        NThreading::TPromise<void> UpdateCompleted = NThreading::NewPromise();
 
         explicit TEvUpdateVChunkConfig(TVChunkConfig cfg)
             : VChunkConfig(std::move(cfg))

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service.h
@@ -9,6 +9,8 @@
 
 #include <ydb/core/mind/bscontroller/types.h>
 
+#include <library/cpp/threading/future/core/future.h>
+
 #include <util/datetime/base.h>
 #include <util/system/types.h>
 
@@ -29,7 +31,7 @@ struct IPartitionDirectService
 
     // Asynchronously persists the given vchunk config to the partition's
     // local DB. Caller must ensure cfg.IsValid().
-    virtual void UpdateVChunkConfig(
+    virtual NThreading::TFuture<void> UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) = 0;
 
     // Query the addition of a new host to the group. The request is idempotent

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/partition_direct_service_mock.h
@@ -18,6 +18,12 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
         size_t NewHostIndex = 0;
     };
 
+    struct TUpdateConfigRequest
+    {
+        NStorage::NPartitionDirect::TVChunkConfig Config;
+        NThreading::TPromise<void> Promise;
+    };
+
     explicit TPartitionDirectServiceMock(bool dropScheduledCallbacks = false)
         : DropScheduledCallbacks(dropScheduledCallbacks)
     {}
@@ -28,6 +34,7 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
     ui64 LsnGenerator = 0;
     size_t BlockedGenerationCount = 0;
     TString LastBlockedReason;
+    TVector<TUpdateConfigRequest> UpdateConfigRequests;
 
     [[nodiscard]] TVolumeConfigPtr GetVolumeConfig() const override
     {
@@ -46,10 +53,11 @@ struct TPartitionDirectServiceMock: public IPartitionDirectService
         executor->ExecuteSimple(std::move(callback));
     }
 
-    void UpdateVChunkConfig(
+    NThreading::TFuture<void> UpdateVChunkConfig(
         const NStorage::NPartitionDirect::TVChunkConfig& cfg) override
     {
-        Y_UNUSED(cfg);
+        UpdateConfigRequests.emplace_back(cfg, NThreading::NewPromise());
+        return UpdateConfigRequests.back().Promise.GetFuture();
     }
 
     void QueryAddHost(size_t directBlockGroupId, size_t newHostIndex) override

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.cpp
@@ -235,14 +235,10 @@ void TVChunk::SetHostState(THostIndex hostIndex, EHostState state)
         }
         return TVChunkConfig{};
     };
-    auto apply = [weakSelf = weak_from_this()]()
-    {
-        if (auto self = weakSelf.lock()) {
-            self->ApplyConfig();
-        }
-    };
-
-    UpdateConfig(std::move(prepare), std::move(apply));
+    UpdateConfig(
+        std::move(prepare),
+        TStringBuilder() << "state of " << PrintHostAndNode(hostIndex)
+                         << " updated to " << ToString(state));
 }
 
 void TVChunk::UpdateHostCount(size_t newHostCount)
@@ -265,14 +261,7 @@ void TVChunk::UpdateHostCount(size_t newHostCount)
         }
         return TVChunkConfig{};
     };
-    auto apply = [weakSelf = weak_from_this()]()
-    {
-        if (auto self = weakSelf.lock()) {
-            self->ApplyConfig();
-        }
-    };
-
-    UpdateConfig(std::move(prepare), std::move(apply));
+    UpdateConfig(std::move(prepare), "Host count increased");
 }
 
 const TVChunkConfig& TVChunk::GetConfig() const
@@ -882,15 +871,13 @@ void TVChunk::UpdatePendingCounters()
         BlocksDirtyMap.GetMinErasePendingLsn());
 }
 
-void TVChunk::UpdateConfig(
-    TPrepareConfigFunc prepareConfig,
-    TApplyPersistedConfigFunc applyPersisted)
+void TVChunk::UpdateConfig(TPrepareConfigFunc prepareConfig, TString message)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
     PendingVChunkConfigs.push_back(TPendingVChunkConfig{
         .PrepareConfig = std::move(prepareConfig),
-        .ApplyPersisted = std::move(applyPersisted)});
+        .Message = std::move(message)});
     PersistNextPendingConfig();
 }
 
@@ -905,19 +892,40 @@ void TVChunk::PersistNextPendingConfig()
     auto& pending = *PendingVChunkConfigs.begin();
 
     pending.Config = std::move(pending.PrepareConfig)();
+
+    if (pending.Config.Empty() || pending.Config == VChunkConfig) {
+        LOG_INFO(
+            *ActorSystem,
+            NKikimrServices::NBS_PARTITION,
+            "%s Skip update config: %s %s",
+            LogTitle.GetWithTime().c_str(),
+            pending.Message.Quote().c_str(),
+            pending.Config.DebugPrint().c_str());
+
+        PendingVChunkConfigs.pop_front();
+        PersistNextPendingConfig();
+        return;
+    }
+
     Y_ABORT_UNLESS(
         pending.Config.GetVChunkIndex() == VChunkConfig.GetVChunkIndex());
     Y_ABORT_UNLESS(pending.Config.IsValid());
 
-    PartitionDirectService->UpdateVChunkConfig(pending.Config);
-
-    DirectBlockGroup->Schedule(
-        TDuration::Seconds(1),
-        [weakSelf = weak_from_this()]()
+    auto onPersisted =
+        PartitionDirectService->UpdateVChunkConfig(pending.Config);
+    onPersisted.Subscribe(
+        [weakSelf = weak_from_this(), executor = Executor]   //
+        (const TFuture<void>& f)
         {
-            if (auto self = weakSelf.lock()) {
-                self->OnConfigPersisted();
-            }
+            Y_UNUSED(f);
+
+            executor->ExecuteSimple(
+                [weakSelf = std::move(weakSelf)]()
+                {
+                    if (auto self = weakSelf.lock()) {
+                        self->OnConfigPersisted();
+                    }
+                });
         });
 }
 
@@ -926,57 +934,27 @@ void TVChunk::OnConfigPersisted()
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
     Y_ABORT_UNLESS(!PendingVChunkConfigs.empty());
 
-    auto& pending = *PendingVChunkConfigs.begin();
-    VChunkConfig = pending.Config;
-    auto apply = std::move(pending.ApplyPersisted);
+    auto persisted = std::move(PendingVChunkConfigs.front());
     PendingVChunkConfigs.pop_front();
+
+    ApplyConfig(std::move(persisted.Config), persisted.Message);
     PersistNextPendingConfig();
-    apply();
 }
 
-TVChunkConfig TVChunk::PrepareNewConfig(
-    THostIndex hostIndex,
-    EHostState state) const
-{
-    auto newConfig = VChunkConfig;
-
-    switch (state) {
-        case EHostState::Online: {
-            newConfig.EnableHost(hostIndex);
-            break;
-        }
-        case EHostState::TemporaryOffline: {
-            newConfig.DisableHost(hostIndex);
-            break;
-        }
-        case EHostState::Offline: {
-            const TString message = newConfig.EvacuateHost(hostIndex);
-            if (!message.empty()) {
-                LOG_WARN(
-                    *ActorSystem,
-                    NKikimrServices::NBS_PARTITION,
-                    "%s %s",
-                    LogTitle.GetWithTime().c_str(),
-                    message.c_str());
-            }
-
-            break;
-        }
-    }
-    return newConfig;
-}
-
-void TVChunk::ApplyConfig()
+void TVChunk::ApplyConfig(TVChunkConfig newConfig, const TString& message)
 {
     Y_ABORT_UNLESS(ExecutorThreadChecker.Check());
 
     LOG_INFO(
         *ActorSystem,
         NKikimrServices::NBS_PARTITION,
-        "%s Applying config %s",
+        "%s Applying new config %s %s -> %s",
         LogTitle.GetWithTime().c_str(),
-        VChunkConfig.DebugPrint().c_str());
+        message.Quote().c_str(),
+        VChunkConfig.DebugPrint().c_str(),
+        newConfig.DebugPrint().c_str());
 
+    VChunkConfig = std::move(newConfig);
     BlocksDirtyMap.UpdateConfig(VChunkConfig);
 
     // Remove unnecessary copiers
@@ -995,7 +973,7 @@ void TVChunk::ApplyConfig()
             NKikimrServices::NBS_PARTITION,
             "%s Copier %s stopping",
             LogTitle.GetWithTime().c_str(),
-            PrintHostIndex(hostIndex).c_str());
+            PrintHostAndNode(hostIndex).c_str());
 
         (*copier)->Stop().Subscribe(
             [weakSelf = weak_from_this(), hostIndex]   //
@@ -1037,7 +1015,7 @@ void TVChunk::ApplyConfig()
             NKikimrServices::NBS_PARTITION,
             "%s Copier %s started",
             LogTitle.GetWithTime().c_str(),
-            PrintHostIndex(hostIndex).c_str());
+            PrintHostAndNode(hostIndex).c_str());
 
         newCopier->Start().Subscribe(
             [weakSelf = weak_from_this(), hostIndex]   //
@@ -1048,6 +1026,38 @@ void TVChunk::ApplyConfig()
                 }
             });
     }
+}
+
+TVChunkConfig TVChunk::PrepareNewConfig(
+    THostIndex hostIndex,
+    EHostState state) const
+{
+    auto newConfig = VChunkConfig;
+
+    switch (state) {
+        case EHostState::Online: {
+            newConfig.EnableHost(hostIndex);
+            break;
+        }
+        case EHostState::TemporaryOffline: {
+            newConfig.DisableHost(hostIndex);
+            break;
+        }
+        case EHostState::Offline: {
+            const TString message = newConfig.EvacuateHost(hostIndex);
+            if (!message.empty()) {
+                LOG_WARN(
+                    *ActorSystem,
+                    NKikimrServices::NBS_PARTITION,
+                    "%s %s",
+                    LogTitle.GetWithTime().c_str(),
+                    message.c_str());
+            }
+
+            break;
+        }
+    }
+    return newConfig;
 }
 
 void TVChunk::OnCopierStopped(
@@ -1061,7 +1071,7 @@ void TVChunk::OnCopierStopped(
         NKikimrServices::NBS_PARTITION,
         "%s Copier %s stopped %s",
         LogTitle.GetWithTime().c_str(),
-        PrintHostIndex(hostIndex).c_str(),
+        PrintHostAndNode(hostIndex).c_str(),
         ToString(result).c_str());
 }
 
@@ -1076,7 +1086,7 @@ void TVChunk::OnCopyComplete(
         NKikimrServices::NBS_PARTITION,
         "%s CopyDDisk %s finished: %s",
         LogTitle.GetWithTime().c_str(),
-        PrintHostIndex(hostIndex).c_str(),
+        PrintHostAndNode(hostIndex).c_str(),
         ToString(result).c_str());
 
     auto prepare = [weakSelf = weak_from_this(), hostIndex]()
@@ -1088,14 +1098,9 @@ void TVChunk::OnCopyComplete(
         }
         return TVChunkConfig{};
     };
-    auto apply = [weakSelf = weak_from_this()]()
-    {
-        if (auto self = weakSelf.lock()) {
-            self->ApplyConfig();
-        }
-    };
-
-    UpdateConfig(std::move(prepare), std::move(apply));
+    UpdateConfig(
+        std::move(prepare),
+        TStringBuilder() << PrintHostAndNode(hostIndex) << " copy finished");
 }
 
 void TVChunk::WaitForDirtyMapReady()
@@ -1104,6 +1109,11 @@ void TVChunk::WaitForDirtyMapReady()
         const auto dirtyMapReadyFuture = DirtyMapReady.GetFuture();
         Executor->WaitFor(dirtyMapReadyFuture);
     }
+}
+
+TString TVChunk::PrintHostAndNode(THostIndex host) const
+{
+    return PrintHostAndNodeId(host, DirectBlockGroup->GetNodeId(host));
 }
 
 TString TVChunk::PrintInflight() const

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk.h
@@ -96,14 +96,12 @@ private:
     friend struct TBaseFixture;
 
     using TPrepareConfigFunc = std::function<TVChunkConfig()>;
-    using TApplyPersistedConfigFunc = std::function<void()>;
 
     struct TPendingVChunkConfig
     {
         TPrepareConfigFunc PrepareConfig;
-        TApplyPersistedConfigFunc ApplyPersisted;
-
         TVChunkConfig Config;
+        TString Message;
     };
 
     void UpdateDirtyMap(const TDBGRestoreResponse& response);
@@ -136,16 +134,14 @@ private:
 
     // Persists newConfig to the partition's local DB. The in-memory config is
     // unchanged; the new value applies after config persisted.
-    void UpdateConfig(
-        TPrepareConfigFunc prepareConfig,
-        TApplyPersistedConfigFunc applyPersisted);
+    void UpdateConfig(TPrepareConfigFunc prepareConfig, TString message);
     void PersistNextPendingConfig();
     void OnConfigPersisted();
+    void ApplyConfig(TVChunkConfig newConfig, const TString& message);
 
     TVChunkConfig PrepareNewConfig(
         THostIndex hostIndex,
         EHostState state) const;
-    void ApplyConfig();
 
     void OnCopierStopped(
         THostIndex hostIndex,
@@ -155,6 +151,7 @@ private:
     // Checks DirtyMap's initial readiness and waits it if need.
     void WaitForDirtyMapReady();
 
+    [[nodiscard]] TString PrintHostAndNode(THostIndex host) const;
     [[nodiscard]] TString PrintInflight() const;
 
     NActors::TActorSystem* const ActorSystem = nullptr;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/vchunk_ut.cpp
@@ -308,12 +308,10 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             "H4+{Disabled,0,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
-        // Scheduled DBResponse.
-        // TODO replace with real DB response.
+        // Reply UpdateConfig request.
         {
-            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
-            auto task = RunScheduledTasks();
-            task.Wait(TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
         }
 
         // Config should be updated.
@@ -348,12 +346,10 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             wait.GetValue(TDuration::Seconds(10));
         }
 
-        // Scheduled DBResponse.
-        // TODO replace with real DB response.
+        // Reply UpdateConfig request.
         {
-            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
-            auto task = RunScheduledTasks();
-            task.Wait(TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
         }
 
         // Config should be updated.
@@ -415,11 +411,10 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             DirectBlockGroupHostCount,
             AccessConfig(*vchunk).GetHostCount());
 
+        // Reply UpdateConfig request.
         {
-            // Response from the database
-            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
-            auto task = RunScheduledTasks();
-            task.Wait(TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
         }
 
         UNIT_ASSERT_VALUES_EQUAL(
@@ -537,13 +532,10 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             "H4+{Disabled,0,0};",
             AccessBlocksDirtyMap(*vchunk).DebugPrintDDiskState());
 
-        // Scheduled DBResponse.
-        // TODO replace with real DB response.
+        // Reply UpdateConfig request.
         {
-            WaitScheduledTasks(1, TDuration::Seconds(10));
-            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
-            auto task = RunScheduledTasks();
-            task.Wait(TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
         }
 
         // Config should be updated.
@@ -578,13 +570,10 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
             wait.GetValue(TDuration::Seconds(10));
         }
 
-        // Scheduled DBResponse.
-        // TODO replace with real DB response.
+        // Reply UpdateConfig request.
         {
-            WaitScheduledTasks(1, TDuration::Seconds(10));
-            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
-            auto task = RunScheduledTasks();
-            task.Wait(TDuration::Seconds(10));
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
         }
 
         // Config should be updated.
@@ -615,10 +604,9 @@ Y_UNIT_TEST_SUITE(TVChunkTest)
 
         // Waiting for the coping to be completed.
         {
-            WaitScheduledTasks(1, TDuration::Seconds(10));
-            UNIT_ASSERT_VALUES_EQUAL(1, ScheduledTasks.size());
-            auto task = RunScheduledTasks();
-            task.Wait(TDuration::Seconds(10));
+            DrainExecutor(DirectBlockGroup->GetExecutor());
+            UNIT_ASSERT_VALUES_EQUAL(1, ReplyUpdateRequests());
+            DrainExecutor(DirectBlockGroup->GetExecutor());
         }
 
         // Config should be updated.


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

1. Future returned for UpdateConfig()
2. NodeId printed in logs

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
