### PR TITLE
Returned back domain deducing in node init

### DIFF
--- a/ydb/core/config/init/init.cpp
+++ b/ydb/core/config/init/init.cpp
@@ -883,11 +883,18 @@ TString DeduceNodeDomain(const NConfig::TCommonAppOptions& cf, const NKikimrConf
     }
 
     if (appConfig.GetTenantPoolConfig().SlotsSize() == 1) {
-        auto &slot = appConfig.GetTenantPoolConfig().GetSlots(0);
+        const auto &slot = appConfig.GetTenantPoolConfig().GetSlots(0);
         if (slot.GetDomainName()) {
             return slot.GetDomainName();
         }
 
+        if (slot.GetTenantName()) {
+            return ToString(ExtractDomain(slot.GetTenantName()));
+        }
+    }
+
+    if (cf.TenantName.GetOrElse("")) {
+        return ToString(ExtractDomain(*cf.TenantName));
     }
 
     return "";


### PR DESCRIPTION
Reverted commit 633c682 because @artgromov convinced me that there is no clusters with a domain name containing '/'.
