### PR TITLE
Add YDB platform benchmark runner

### DIFF
--- a/ydb/library/actors/core/ut_fat/bundle/ya.make
+++ b/ydb/library/actors/core/ut_fat/bundle/ya.make
@@ -1,0 +1,19 @@
+PROGRAM(actors_core_ut_fat)
+
+SRCDIR(
+    ydb/library/actors/core
+    ydb/library/actors/core/ut_fat
+)
+
+ADDINCL(
+    ydb/library/actors/core
+)
+
+PEERDIR(
+    library/cpp/testing/unittest_main
+    ydb/library/actors/core
+)
+
+INCLUDE(${ARCADIA_ROOT}/ydb/library/actors/core/ut_fat/sources.inc)
+
+END()

--- a/ydb/library/actors/core/ut_fat/sources.inc
+++ b/ydb/library/actors/core/ut_fat/sources.inc
@@ -1,0 +1,4 @@
+SRCS(
+    actor_benchmark.cpp
+    waiting_benchs.cpp
+)

--- a/ydb/library/actors/core/ut_fat/ya.make
+++ b/ydb/library/actors/core/ut_fat/ya.make
@@ -20,9 +20,6 @@ PEERDIR(
     ydb/library/actors/core
 )
 
-SRCS(
-    actor_benchmark.cpp
-    waiting_benchs.cpp
-)
+INCLUDE(sources.inc)
 
 END()

--- a/ydb/tools/platform_bench/README.md
+++ b/ydb/tools/platform_bench/README.md
@@ -1,0 +1,44 @@
+# YDB platform benchmark
+
+`platform_bench` packages benchmark executables into a single Python tool and
+runs reproducible scenarios. The initial `actors-core` scenario bundles the
+program variant of `ydb/library/actors/core/ut_fat` and runs only
+`HeavyActorBenchmark::SendActivateReceiveCSVManual`.
+
+Build and inspect the tool:
+
+```bash
+./ya make --build relwithdebinfo ydb/tools/platform_bench
+ydb/tools/platform_bench/platform_bench list
+ydb/tools/platform_bench/platform_bench describe actors-core
+```
+
+Run a short check or the fixed comparison profile:
+
+```bash
+ydb/tools/platform_bench/platform_bench run actors-core \
+    --profile smoke \
+    --output platform-bench-smoke
+
+ydb/tools/platform_bench/platform_bench run actors-core \
+    --profile baseline \
+    --output platform-bench-baseline
+```
+
+Use `--work-dir` when the system temporary directory is mounted with `noexec`.
+The tool extracts the bundled executable atomically into a unique temporary
+subdirectory and removes it after the run.
+
+The output contains:
+
+- `run.json` with the tool revision, binary SHA-256, platform description,
+  command, benchmark parameters, whitelisted environment, and status;
+- `repeat-NNN/stdout.txt` and `stderr.txt` with unmodified process output;
+- `repeat-NNN/metrics.csv` with CSV rows extracted from the unit-test output;
+- `summary.csv` with median, minimum, and maximum throughput across external
+  repetitions.
+
+The run fails if the process exits unsuccessfully, times out, or produces an
+empty or parameter-mismatched CSV result. Timeout and interruption stop the
+whole process group so that scenarios can safely grow to include a server and
+workload processes.

--- a/ydb/tools/platform_bench/__main__.py
+++ b/ydb/tools/platform_bench/__main__.py
@@ -1,0 +1,25 @@
+import sys
+
+from library.python import resource
+from library.python import svn_version
+
+from ydb.tools.platform_bench.lib.cli import main
+
+
+def load_resource(name):
+    data = resource.find(name)
+    if data is None:
+        raise RuntimeError("bundled resource {!r} was not found".format(name))
+    return data
+
+
+def tool_revision():
+    return {
+        "commit_id": svn_version.commit_id(),
+        "hash": svn_version.hash(),
+        "vcs": svn_version.vcs(),
+    }
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:], resource_loader=load_resource, tool_revision=tool_revision()))

--- a/ydb/tools/platform_bench/lib/__init__.py
+++ b/ydb/tools/platform_bench/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable implementation of the YDB platform benchmark runner."""

--- a/ydb/tools/platform_bench/lib/actors_core.py
+++ b/ydb/tools/platform_bench/lib/actors_core.py
@@ -1,0 +1,261 @@
+import csv
+import io
+import statistics
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ydb.tools.platform_bench.lib.common import BenchmarkError, atomic_write_json, atomic_write_text
+from ydb.tools.platform_bench.lib.runner import run_command
+from ydb.tools.platform_bench.lib.system_info import collect_system_info
+
+
+CSV_COLUMNS = (
+    "threads",
+    "actorPairs",
+    "in_flight",
+    "msgs_per_sec",
+    "elapsed_seconds",
+    "min_pair_sent_msgs",
+    "max_pair_sent_msgs",
+)
+CSV_HEADER = ",".join(CSV_COLUMNS)
+TEST_FILTER = "HeavyActorBenchmark::SendActivateReceiveCSVManual"
+ENVIRONMENT_KEYS = (
+    "ACTORSYSTEM_TEST_MODE",
+    "ACTORSYSTEM_THREADS",
+    "ACTORSYSTEM_ACTOR_PAIRS",
+    "ACTORSYSTEM_INFLIGHTS",
+    "ACTORSYSTEM_DURATION",
+)
+
+
+@dataclass(frozen=True)
+class RunConfiguration:
+    profile: str
+    threads: tuple
+    actor_pairs: tuple
+    inflights: tuple
+    duration_seconds: int
+    repetitions: int
+    timeout_seconds: float
+
+
+def parse_metrics(stdout):
+    lines = stdout.splitlines()
+    try:
+        header_index = next(index for index, line in enumerate(lines) if line.strip() == CSV_HEADER)
+    except StopIteration as error:
+        raise BenchmarkError("benchmark output does not contain the expected CSV header") from error
+
+    rows = []
+    for line in lines[header_index + 1 :]:
+        try:
+            values = next(csv.reader([line]))
+        except csv.Error:
+            continue
+        if len(values) != len(CSV_COLUMNS):
+            continue
+        try:
+            row = {
+                "threads": int(values[0]),
+                "actorPairs": int(values[1]),
+                "in_flight": int(values[2]),
+                "msgs_per_sec": float(values[3]),
+                "elapsed_seconds": float(values[4]),
+                "min_pair_sent_msgs": int(values[5]),
+                "max_pair_sent_msgs": int(values[6]),
+            }
+        except ValueError:
+            continue
+        rows.append(row)
+
+    if not rows:
+        raise BenchmarkError("benchmark produced the CSV header but no metric rows")
+    return rows
+
+
+def render_metrics(rows):
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def validate_metrics(rows, configuration):
+    expected = {
+        (threads, actor_pairs, in_flight)
+        for threads in configuration.threads
+        for actor_pairs in configuration.actor_pairs
+        for in_flight in configuration.inflights
+    }
+    actual = {(row["threads"], row["actorPairs"], row["in_flight"]) for row in rows}
+    if len(actual) != len(rows):
+        raise BenchmarkError("benchmark produced duplicate metric rows")
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        raise BenchmarkError(
+            "benchmark metric parameters do not match the request; missing={}, unexpected={}".format(
+                missing, unexpected
+            )
+        )
+
+
+def summarize_metrics(repetition_rows):
+    grouped = {}
+    for rows in repetition_rows:
+        for row in rows:
+            key = (row["threads"], row["actorPairs"], row["in_flight"])
+            grouped.setdefault(key, []).append(row)
+
+    summary = []
+    for key in sorted(grouped):
+        rows = grouped[key]
+        rates = [row["msgs_per_sec"] for row in rows]
+        elapsed = [row["elapsed_seconds"] for row in rows]
+        summary.append(
+            {
+                "threads": key[0],
+                "actorPairs": key[1],
+                "in_flight": key[2],
+                "repetitions": len(rows),
+                "median_msgs_per_sec": statistics.median(rates),
+                "min_msgs_per_sec": min(rates),
+                "max_msgs_per_sec": max(rates),
+                "median_elapsed_seconds": statistics.median(elapsed),
+            }
+        )
+    return summary
+
+
+def render_summary(rows):
+    columns = (
+        "threads",
+        "actorPairs",
+        "in_flight",
+        "repetitions",
+        "median_msgs_per_sec",
+        "min_msgs_per_sec",
+        "max_msgs_per_sec",
+        "median_elapsed_seconds",
+    )
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=columns, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(rows)
+    return output.getvalue()
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _environment(configuration):
+    return {
+        "ACTORSYSTEM_TEST_MODE": "manual",
+        "ACTORSYSTEM_THREADS": ",".join(str(value) for value in configuration.threads),
+        "ACTORSYSTEM_ACTOR_PAIRS": ",".join(str(value) for value in configuration.actor_pairs),
+        "ACTORSYSTEM_INFLIGHTS": ",".join(str(value) for value in configuration.inflights),
+        "ACTORSYSTEM_DURATION": str(configuration.duration_seconds),
+    }
+
+
+def _command_record(binary_path):
+    return [str(binary_path), TEST_FILTER]
+
+
+def run_actors_core(binary, configuration, output_directory, tool_revision, work_dir_hint=None):
+    output_directory = Path(output_directory)
+    environment = _environment(configuration)
+    manifest = {
+        "schema_version": 1,
+        "scenario": "actors-core",
+        "profile": configuration.profile,
+        "status": "running",
+        "started_at": _utc_now(),
+        "tool_revision": tool_revision,
+        "binary": {
+            "name": binary.path.name,
+            "sha256": binary.sha256,
+            "size": binary.size,
+        },
+        "platform": collect_system_info(),
+        "parameters": {
+            "threads": list(configuration.threads),
+            "actor_pairs": list(configuration.actor_pairs),
+            "inflights": list(configuration.inflights),
+            "duration_seconds": configuration.duration_seconds,
+            "repetitions": configuration.repetitions,
+            "timeout_seconds": configuration.timeout_seconds,
+        },
+        "environment": environment,
+        "command": _command_record(binary.path),
+        "runs": [],
+    }
+    manifest_path = output_directory / "run.json"
+    atomic_write_json(manifest_path, manifest)
+    repetition_rows = []
+
+    for index in range(1, configuration.repetitions + 1):
+        repetition_directory = output_directory / "repeat-{:03d}".format(index)
+        repetition_directory.mkdir()
+        result = run_command(
+            _command_record(binary.path),
+            environment,
+            configuration.timeout_seconds,
+            work_dir_hint=work_dir_hint,
+        )
+        atomic_write_text(repetition_directory / "stdout.txt", result.stdout)
+        atomic_write_text(repetition_directory / "stderr.txt", result.stderr)
+        run_record = {
+            "index": index,
+            "command": list(result.command),
+            "started_at": result.started_at,
+            "finished_at": result.finished_at,
+            "duration_seconds": result.duration_seconds,
+            "exit_code": result.exit_code,
+            "timed_out": result.timed_out,
+            "interrupted": result.interrupted,
+            "stdout": str(Path(repetition_directory.name) / "stdout.txt"),
+            "stderr": str(Path(repetition_directory.name) / "stderr.txt"),
+        }
+        manifest["runs"].append(run_record)
+
+        failure = None
+        if result.interrupted:
+            failure = "benchmark was interrupted"
+        elif result.timed_out:
+            failure = "benchmark timed out after {} seconds".format(configuration.timeout_seconds)
+        elif result.exit_code != 0:
+            failure = "benchmark exited with code {}".format(result.exit_code)
+        else:
+            try:
+                metrics = parse_metrics(result.stdout)
+                validate_metrics(metrics, configuration)
+            except BenchmarkError as error:
+                failure = str(error)
+            else:
+                atomic_write_text(repetition_directory / "metrics.csv", render_metrics(metrics))
+                run_record["metrics"] = str(Path(repetition_directory.name) / "metrics.csv")
+                run_record["metric_rows"] = len(metrics)
+                repetition_rows.append(metrics)
+
+        if failure is not None:
+            run_record["error"] = failure
+            manifest["status"] = "interrupted" if result.interrupted else "failed"
+            manifest["finished_at"] = _utc_now()
+            manifest["error"] = failure
+            atomic_write_json(manifest_path, manifest)
+            raise BenchmarkError(failure)
+        atomic_write_json(manifest_path, manifest)
+
+    summary = summarize_metrics(repetition_rows)
+    atomic_write_text(output_directory / "summary.csv", render_summary(summary))
+    manifest["status"] = "completed"
+    manifest["finished_at"] = _utc_now()
+    manifest["summary"] = "summary.csv"
+    manifest["summary_rows"] = len(summary)
+    atomic_write_json(manifest_path, manifest)
+    return manifest

--- a/ydb/tools/platform_bench/lib/actors_core.py
+++ b/ydb/tools/platform_bench/lib/actors_core.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-from ydb.tools.platform_bench.lib.common import BenchmarkError, atomic_write_json, atomic_write_text
+from ydb.tools.platform_bench.lib.common import (
+    BenchmarkError,
+    BenchmarkInterrupted,
+    atomic_write_json,
+    atomic_write_text,
+)
 from ydb.tools.platform_bench.lib.runner import run_command
 from ydb.tools.platform_bench.lib.system_info import collect_system_info
 
@@ -21,13 +26,6 @@ CSV_COLUMNS = (
 )
 CSV_HEADER = ",".join(CSV_COLUMNS)
 TEST_FILTER = "HeavyActorBenchmark::SendActivateReceiveCSVManual"
-ENVIRONMENT_KEYS = (
-    "ACTORSYSTEM_TEST_MODE",
-    "ACTORSYSTEM_THREADS",
-    "ACTORSYSTEM_ACTOR_PAIRS",
-    "ACTORSYSTEM_INFLIGHTS",
-    "ACTORSYSTEM_DURATION",
-)
 
 
 @dataclass(frozen=True)
@@ -272,6 +270,8 @@ def run_actors_core(binary, configuration, output_directory, tool_revision, work
             manifest["finished_at"] = _utc_now()
             manifest["error"] = failure
             atomic_write_json(manifest_path, manifest)
+            if result.interrupted:
+                raise BenchmarkInterrupted(failure)
             raise BenchmarkError(failure)
         atomic_write_json(manifest_path, manifest)
 

--- a/ydb/tools/platform_bench/lib/actors_core.py
+++ b/ydb/tools/platform_bench/lib/actors_core.py
@@ -200,13 +200,37 @@ def run_actors_core(binary, configuration, output_directory, tool_revision, work
 
     for index in range(1, configuration.repetitions + 1):
         repetition_directory = output_directory / "repeat-{:03d}".format(index)
+        command = _command_record(binary.path)
+        started_at = _utc_now()
+        try:
+            result = run_command(
+                command,
+                environment,
+                configuration.timeout_seconds,
+                work_dir_hint=work_dir_hint,
+            )
+        except BenchmarkError as error:
+            failure = str(error)
+            finished_at = _utc_now()
+            manifest["runs"].append(
+                {
+                    "index": index,
+                    "command": command,
+                    "started_at": started_at,
+                    "finished_at": finished_at,
+                    "exit_code": None,
+                    "timed_out": False,
+                    "interrupted": False,
+                    "error": failure,
+                }
+            )
+            manifest["status"] = "failed"
+            manifest["finished_at"] = finished_at
+            manifest["error"] = failure
+            atomic_write_json(manifest_path, manifest)
+            raise
+
         repetition_directory.mkdir()
-        result = run_command(
-            _command_record(binary.path),
-            environment,
-            configuration.timeout_seconds,
-            work_dir_hint=work_dir_hint,
-        )
         atomic_write_text(repetition_directory / "stdout.txt", result.stdout)
         atomic_write_text(repetition_directory / "stderr.txt", result.stderr)
         run_record = {

--- a/ydb/tools/platform_bench/lib/cli.py
+++ b/ydb/tools/platform_bench/lib/cli.py
@@ -1,0 +1,201 @@
+import argparse
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ydb.tools.platform_bench.lib.actors_core import RunConfiguration, run_actors_core
+from ydb.tools.platform_bench.lib.common import BenchmarkError, extract_executable
+
+
+SCENARIO_NAME = "actors-core"
+RESOURCE_NAME = "actors_core_ut_fat"
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    description: str
+    threads: tuple
+    actor_pairs: tuple
+    inflights: tuple
+    duration_seconds: int
+    repetitions: int
+
+
+PROFILES = {
+    "smoke": Profile(
+        name="smoke",
+        description="one short actor-system measurement",
+        threads=(1,),
+        actor_pairs=(32,),
+        inflights=(1,),
+        duration_seconds=1,
+        repetitions=1,
+    ),
+    "baseline": Profile(
+        name="baseline",
+        description="fixed cross-platform comparison at 1, 2, 4, and 8 threads",
+        threads=(1, 2, 4, 8),
+        actor_pairs=(512,),
+        inflights=(1,),
+        duration_seconds=2,
+        repetitions=3,
+    ),
+}
+
+
+def _scale_profile():
+    cpu_count = max(1, os.cpu_count() or 1)
+    threads = []
+    value = 1
+    while value < cpu_count:
+        threads.append(value)
+        value *= 2
+    threads.append(cpu_count)
+    return Profile(
+        name="scale",
+        description="power-of-two thread sweep up to the current CPU count",
+        threads=tuple(threads),
+        actor_pairs=(512,),
+        inflights=(1,),
+        duration_seconds=2,
+        repetitions=3,
+    )
+
+
+def _profile(name):
+    if name == "scale":
+        return _scale_profile()
+    return PROFILES[name]
+
+
+def _positive_integer(value):
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _positive_float(value):
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _positive_integer_list(value):
+    try:
+        parsed = tuple(_positive_integer(part.strip()) for part in value.split(",") if part.strip())
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a comma-separated list of positive integers") from error
+    if not parsed:
+        raise argparse.ArgumentTypeError("must not be empty")
+    return parsed
+
+
+def _default_output_directory():
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return Path("platform-bench-results") / "{}-{}".format(timestamp, SCENARIO_NAME)
+
+
+def _create_parser():
+    parser = argparse.ArgumentParser(prog="platform_bench")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("list", help="list available benchmark scenarios")
+
+    describe = subparsers.add_parser("describe", help="describe a benchmark scenario")
+    describe.add_argument("scenario", choices=(SCENARIO_NAME,))
+
+    run = subparsers.add_parser("run", help="run a benchmark scenario")
+    run.add_argument("scenario", choices=(SCENARIO_NAME,))
+    run.add_argument("--profile", choices=("smoke", "baseline", "scale"), default="baseline")
+    run.add_argument("--output", type=Path)
+    run.add_argument("--work-dir", type=Path)
+    run.add_argument("--threads", type=_positive_integer_list)
+    run.add_argument("--actor-pairs", type=_positive_integer_list)
+    run.add_argument("--inflight", type=_positive_integer_list)
+    run.add_argument("--duration", type=_positive_integer)
+    run.add_argument("--repetitions", type=_positive_integer)
+    run.add_argument("--timeout", type=_positive_float)
+    return parser
+
+
+def _describe():
+    print("{}: bundled ydb/library/actors/core/ut_fat actor-system throughput benchmark".format(SCENARIO_NAME))
+    for name in ("smoke", "baseline", "scale"):
+        profile = _profile(name)
+        print("  {}: {}".format(profile.name, profile.description))
+    print("metrics: threads, actorPairs, in_flight, msgs_per_sec, elapsed_seconds")
+    print("artifacts: run.json, per-repeat stdout/stderr/metrics.csv, summary.csv")
+
+
+def _configuration(arguments):
+    profile = _profile(arguments.profile)
+    threads = arguments.threads or profile.threads
+    actor_pairs = arguments.actor_pairs or profile.actor_pairs
+    inflights = arguments.inflight or profile.inflights
+    duration = arguments.duration or profile.duration_seconds
+    repetitions = arguments.repetitions or profile.repetitions
+    combinations = len(threads) * len(actor_pairs) * len(inflights)
+    default_timeout = combinations * duration * 3 + 30
+    return RunConfiguration(
+        profile=profile.name,
+        threads=threads,
+        actor_pairs=actor_pairs,
+        inflights=inflights,
+        duration_seconds=duration,
+        repetitions=repetitions,
+        timeout_seconds=arguments.timeout or default_timeout,
+    )
+
+
+def _prepare_output(path):
+    path = path or _default_output_directory()
+    try:
+        path.mkdir(parents=True)
+    except FileExistsError as error:
+        raise BenchmarkError("output directory already exists: {}".format(path)) from error
+    return path.resolve()
+
+
+def _run(arguments, resource_loader, tool_revision):
+    if resource_loader is None:
+        raise BenchmarkError("the benchmark executable resource loader is not configured")
+
+    output_directory = _prepare_output(arguments.output)
+    if arguments.work_dir is not None:
+        arguments.work_dir.mkdir(parents=True, exist_ok=True)
+        work_dir_parent = arguments.work_dir.resolve()
+    else:
+        work_dir_parent = None
+
+    with tempfile.TemporaryDirectory(prefix="platform-bench-", dir=work_dir_parent) as temporary_directory:
+        binary = extract_executable(resource_loader(RESOURCE_NAME), temporary_directory, RESOURCE_NAME)
+        manifest = run_actors_core(
+            binary,
+            _configuration(arguments),
+            output_directory,
+            tool_revision=tool_revision,
+            work_dir_hint=temporary_directory,
+        )
+    print("completed {}: {}".format(SCENARIO_NAME, output_directory))
+    print("summary: {}".format(output_directory / manifest["summary"]))
+    return 0
+
+
+def main(argv=None, resource_loader=None, tool_revision=None):
+    arguments = _create_parser().parse_args(argv)
+    try:
+        if arguments.command == "list":
+            print("{}\tbundled actor-system throughput benchmark".format(SCENARIO_NAME))
+            return 0
+        if arguments.command == "describe":
+            _describe()
+            return 0
+        return _run(arguments, resource_loader, tool_revision or {"commit_id": "unknown"})
+    except BenchmarkError as error:
+        print("platform_bench: error: {}".format(error), file=sys.stderr)
+        return 130 if "interrupted" in str(error) else 1

--- a/ydb/tools/platform_bench/lib/cli.py
+++ b/ydb/tools/platform_bench/lib/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 import os
 import sys
 import tempfile
@@ -7,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ydb.tools.platform_bench.lib.actors_core import RunConfiguration, run_actors_core
-from ydb.tools.platform_bench.lib.common import BenchmarkError, extract_executable
+from ydb.tools.platform_bench.lib.common import BenchmarkError, BenchmarkInterrupted, extract_executable
 
 
 SCENARIO_NAME = "actors-core"
@@ -81,8 +82,8 @@ def _positive_integer(value):
 
 def _positive_float(value):
     parsed = float(value)
-    if parsed <= 0:
-        raise argparse.ArgumentTypeError("must be positive")
+    if parsed <= 0 or not math.isfinite(parsed):
+        raise argparse.ArgumentTypeError("must be a finite positive number")
     return parsed
 
 
@@ -196,6 +197,9 @@ def main(argv=None, resource_loader=None, tool_revision=None):
             _describe()
             return 0
         return _run(arguments, resource_loader, tool_revision or {"commit_id": "unknown"})
+    except BenchmarkInterrupted as error:
+        print("platform_bench: error: {}".format(error), file=sys.stderr)
+        return 130
     except BenchmarkError as error:
         print("platform_bench: error: {}".format(error), file=sys.stderr)
-        return 130 if "interrupted" in str(error) else 1
+        return 1

--- a/ydb/tools/platform_bench/lib/common.py
+++ b/ydb/tools/platform_bench/lib/common.py
@@ -1,0 +1,61 @@
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class BenchmarkError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class BinaryArtifact:
+    path: Path
+    sha256: str
+    size: int
+
+
+def atomic_write_bytes(path, data, mode=None):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix="." + path.name + ".", dir=str(path.parent))
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if mode is not None:
+            os.chmod(temporary_path, mode)
+        os.replace(temporary_path, path)
+    except BaseException:
+        try:
+            temporary_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def atomic_write_text(path, text):
+    atomic_write_bytes(path, text.encode("utf-8"))
+
+
+def atomic_write_json(path, value):
+    atomic_write_text(path, json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def extract_executable(data, directory, name):
+    if not data:
+        raise BenchmarkError("bundled executable {!r} is empty".format(name))
+
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    destination = directory / name
+    atomic_write_bytes(destination, data, mode=0o755)
+    return BinaryArtifact(
+        path=destination,
+        sha256=hashlib.sha256(data).hexdigest(),
+        size=len(data),
+    )

--- a/ydb/tools/platform_bench/lib/common.py
+++ b/ydb/tools/platform_bench/lib/common.py
@@ -10,6 +10,10 @@ class BenchmarkError(RuntimeError):
     pass
 
 
+class BenchmarkInterrupted(BenchmarkError):
+    pass
+
+
 @dataclass(frozen=True)
 class BinaryArtifact:
     path: Path

--- a/ydb/tools/platform_bench/lib/runner.py
+++ b/ydb/tools/platform_bench/lib/runner.py
@@ -1,0 +1,104 @@
+import errno
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from ydb.tools.platform_bench.lib.common import BenchmarkError
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: tuple
+    stdout: str
+    stderr: str
+    exit_code: int
+    started_at: str
+    finished_at: str
+    duration_seconds: float
+    timed_out: bool = False
+    interrupted: bool = False
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _signal_process_group(process, sig):
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(process.pid, sig)
+        elif process.poll() is not None:
+            return
+        elif sig == signal.SIGKILL:
+            process.kill()
+        else:
+            process.terminate()
+    except ProcessLookupError:
+        pass
+
+
+def _stop_process_group(process, first_signal, grace_seconds):
+    _signal_process_group(process, first_signal)
+    try:
+        return process.communicate(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        _signal_process_group(process, signal.SIGKILL)
+        return process.communicate()
+
+
+def run_command(command, env_overrides, timeout_seconds, cwd=None, work_dir_hint=None, grace_seconds=2.0):
+    command = tuple(str(part) for part in command)
+    environment = os.environ.copy()
+    environment.update({str(key): str(value) for key, value in env_overrides.items()})
+    started_at = _utc_now()
+    started_monotonic = time.monotonic()
+
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=None if cwd is None else str(cwd),
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            start_new_session=True,
+        )
+    except OSError as error:
+        if error.errno in (errno.EACCES, errno.EPERM):
+            hint = ""
+            if work_dir_hint:
+                hint = " Choose an executable filesystem with --work-dir (current: {}).".format(work_dir_hint)
+            raise BenchmarkError(
+                "cannot execute {}: permission denied; the extraction filesystem may be mounted noexec.{}".format(
+                    command[0], hint
+                )
+            ) from error
+        raise BenchmarkError("cannot start {}: {}".format(command[0], error)) from error
+
+    timed_out = False
+    interrupted = False
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        stdout, stderr = _stop_process_group(process, signal.SIGTERM, grace_seconds)
+    except KeyboardInterrupt:
+        interrupted = True
+        stdout, stderr = _stop_process_group(process, signal.SIGINT, grace_seconds)
+
+    return CommandResult(
+        command=command,
+        stdout=stdout,
+        stderr=stderr,
+        exit_code=process.returncode,
+        started_at=started_at,
+        finished_at=_utc_now(),
+        duration_seconds=time.monotonic() - started_monotonic,
+        timed_out=timed_out,
+        interrupted=interrupted,
+    )

--- a/ydb/tools/platform_bench/lib/system_info.py
+++ b/ydb/tools/platform_bench/lib/system_info.py
@@ -1,0 +1,53 @@
+import os
+import platform
+import subprocess
+
+
+def _physical_memory_bytes():
+    try:
+        return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _cpu_model():
+    try:
+        with open("/proc/cpuinfo", encoding="utf-8") as stream:
+            for line in stream:
+                if line.lower().startswith("model name"):
+                    return line.split(":", 1)[1].strip()
+    except OSError:
+        pass
+
+    try:
+        result = subprocess.run(
+            ["sysctl", "-n", "machdep.cpu.brand_string"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    processor = platform.processor().strip()
+    return processor or None
+
+
+def collect_system_info():
+    uname = platform.uname()
+    return {
+        "architecture": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "cpu_model": _cpu_model(),
+        "physical_memory_bytes": _physical_memory_bytes(),
+        "uname": {
+            "machine": uname.machine,
+            "node": uname.node,
+            "release": uname.release,
+            "system": uname.system,
+            "version": uname.version,
+        },
+    }

--- a/ydb/tools/platform_bench/lib/ya.make
+++ b/ydb/tools/platform_bench/lib/ya.make
@@ -1,0 +1,12 @@
+PY3_LIBRARY()
+
+PY_SRCS(
+    __init__.py
+    actors_core.py
+    cli.py
+    common.py
+    runner.py
+    system_info.py
+)
+
+END()

--- a/ydb/tools/platform_bench/tests/test_platform_bench.py
+++ b/ydb/tools/platform_bench/tests/test_platform_bench.py
@@ -136,6 +136,32 @@ class PlatformBenchTest(unittest.TestCase):
         manifest = json.loads((output / "run.json").read_text())
         self.assertEqual(manifest["status"], "failed")
 
+    def test_start_failure_finalizes_manifest(self):
+        script = self._script("exit 0")
+        binary = self._binary(script)
+        binary.path.chmod(0o644)
+        output = self.root / "start-failure-output"
+        output.mkdir()
+
+        with self.assertRaisesRegex(BenchmarkError, "noexec"):
+            run_actors_core(
+                binary,
+                self._configuration(),
+                output,
+                tool_revision={"commit_id": "test"},
+                work_dir_hint=self.root,
+            )
+
+        manifest = json.loads((output / "run.json").read_text())
+        self.assertEqual(manifest["status"], "failed")
+        self.assertIn("finished_at", manifest)
+        self.assertIn("noexec", manifest["error"])
+        self.assertEqual(len(manifest["runs"]), 1)
+        self.assertIn("finished_at", manifest["runs"][0])
+        self.assertIsNone(manifest["runs"][0]["exit_code"])
+        self.assertEqual(manifest["runs"][0]["error"], manifest["error"])
+        self.assertFalse((output / "repeat-001").exists())
+
     @unittest.skipUnless(hasattr(os, "killpg"), "requires POSIX process groups")
     def test_timeout_signals_the_whole_process_group(self):
         marker = self.root / "child-terminated"

--- a/ydb/tools/platform_bench/tests/test_platform_bench.py
+++ b/ydb/tools/platform_bench/tests/test_platform_bench.py
@@ -7,7 +7,7 @@ import stat
 import tempfile
 import textwrap
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from ydb.tools.platform_bench.lib.actors_core import (
@@ -16,7 +16,7 @@ from ydb.tools.platform_bench.lib.actors_core import (
     parse_metrics,
     run_actors_core,
 )
-from ydb.tools.platform_bench.lib.common import BenchmarkError, extract_executable
+from ydb.tools.platform_bench.lib.common import BenchmarkError, BenchmarkInterrupted, extract_executable
 from ydb.tools.platform_bench.lib.cli import main
 from ydb.tools.platform_bench.lib.runner import run_command
 
@@ -81,6 +81,35 @@ class PlatformBenchTest(unittest.TestCase):
             self.assertEqual(main(["describe", "actors-core"]), 0)
         self.assertIn("actors-core", output.getvalue())
         self.assertIn("summary.csv", output.getvalue())
+
+    def test_timeout_rejects_non_finite_values(self):
+        for value in ("nan", "inf", "-inf"):
+            with self.subTest(value=value):
+                error = io.StringIO()
+                with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+                    main(["run", "actors-core", "--timeout={}".format(value)])
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn("must be a finite positive number", error.getvalue())
+
+    def test_cli_exit_code_uses_interruption_error_type(self):
+        def loader_for(error):
+            def loader(_):
+                raise error
+
+            return loader
+
+        error_output = io.StringIO()
+        with redirect_stderr(error_output):
+            generic_code = main(
+                ["run", "actors-core", "--output", str(self.root / "generic-error")],
+                resource_loader=loader_for(BenchmarkError("benchmark was interrupted by another component")),
+            )
+            interrupted_code = main(
+                ["run", "actors-core", "--output", str(self.root / "interrupted-error")],
+                resource_loader=loader_for(BenchmarkInterrupted("benchmark stopped")),
+            )
+        self.assertEqual(generic_code, 1)
+        self.assertEqual(interrupted_code, 130)
 
     def test_run_writes_manifest_raw_metrics_and_median_summary(self):
         script = self._script(

--- a/ydb/tools/platform_bench/tests/test_platform_bench.py
+++ b/ydb/tools/platform_bench/tests/test_platform_bench.py
@@ -1,0 +1,176 @@
+import hashlib
+import io
+import json
+import os
+import signal
+import stat
+import tempfile
+import textwrap
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from ydb.tools.platform_bench.lib.actors_core import (
+    CSV_HEADER,
+    RunConfiguration,
+    parse_metrics,
+    run_actors_core,
+)
+from ydb.tools.platform_bench.lib.common import BenchmarkError, extract_executable
+from ydb.tools.platform_bench.lib.cli import main
+from ydb.tools.platform_bench.lib.runner import run_command
+
+
+class PlatformBenchTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory(prefix="platform-bench-test-")
+        self.root = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def _script(self, body, name="fake_benchmark.sh"):
+        path = self.root / name
+        path.write_text("#!/bin/sh\n{}".format(textwrap.dedent(body)), encoding="utf-8")
+        path.chmod(0o755)
+        return path
+
+    def _binary(self, path):
+        data = path.read_bytes()
+        return extract_executable(data, self.root / "extracted", "actors_core_ut_fat")
+
+    def _configuration(self, repetitions=1, timeout=5):
+        return RunConfiguration(
+            profile="test",
+            threads=(1, 2),
+            actor_pairs=(32,),
+            inflights=(1,),
+            duration_seconds=1,
+            repetitions=repetitions,
+            timeout_seconds=timeout,
+        )
+
+    def test_extract_executable_is_atomic_executable_and_hashed(self):
+        data = b"#!/bin/sh\nexit 0\n"
+        artifact = extract_executable(data, self.root / "bin", "test-binary")
+        self.assertEqual(artifact.sha256, hashlib.sha256(data).hexdigest())
+        self.assertEqual(artifact.size, len(data))
+        self.assertEqual(artifact.path.read_bytes(), data)
+        self.assertTrue(artifact.path.stat().st_mode & stat.S_IXUSR)
+        self.assertEqual(list(artifact.path.parent.glob(".test-binary.*")), [])
+
+    def test_parse_metrics_ignores_unittest_output(self):
+        stdout = "\n".join(
+            [
+                "[==========] Running 1 test",
+                CSV_HEADER,
+                "1,32,1,1000,1.5,900,1100",
+                "[       OK ] HeavyActorBenchmark::SendActivateReceiveCSVManual",
+            ]
+        )
+        self.assertEqual(parse_metrics(stdout)[0]["msgs_per_sec"], 1000)
+
+    def test_parse_metrics_rejects_header_without_rows(self):
+        with self.assertRaisesRegex(BenchmarkError, "no metric rows"):
+            parse_metrics(CSV_HEADER + "\n[       OK ]")
+
+    def test_list_and_describe_expose_actors_core(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(main(["list"]), 0)
+            self.assertEqual(main(["describe", "actors-core"]), 0)
+        self.assertIn("actors-core", output.getvalue())
+        self.assertIn("summary.csv", output.getvalue())
+
+    def test_run_writes_manifest_raw_metrics_and_median_summary(self):
+        script = self._script(
+            """
+            test "$1" = "HeavyActorBenchmark::SendActivateReceiveCSVManual" || exit 10
+            test "$ACTORSYSTEM_TEST_MODE" = "manual" || exit 11
+            test "$ACTORSYSTEM_THREADS" = "1,2" || exit 12
+            test "$ACTORSYSTEM_ACTOR_PAIRS" = "32" || exit 13
+            test "$ACTORSYSTEM_INFLIGHTS" = "1" || exit 14
+            test "$ACTORSYSTEM_DURATION" = "1" || exit 15
+            echo "[ RUN      ] benchmark"
+            echo "threads,actorPairs,in_flight,msgs_per_sec,elapsed_seconds,min_pair_sent_msgs,max_pair_sent_msgs"
+            echo "1,32,1,1000,1.0,900,1100"
+            echo "2,32,1,2000,1.0,1800,2200"
+            """
+        )
+        output = self.root / "output"
+        output.mkdir()
+        manifest = run_actors_core(
+            self._binary(script),
+            self._configuration(repetitions=3),
+            output,
+            tool_revision={"commit_id": "test"},
+            work_dir_hint=self.root,
+        )
+        self.assertEqual(manifest["status"], "completed")
+        self.assertEqual(len(manifest["runs"]), 3)
+        self.assertTrue((output / "summary.csv").is_file())
+        self.assertIn("1,32,1,3,1000.0,1000.0,1000.0,1.0", (output / "summary.csv").read_text())
+        stored = json.loads((output / "run.json").read_text())
+        self.assertEqual(stored["binary"]["sha256"], self._binary(script).sha256)
+        for index in range(1, 4):
+            repetition = output / "repeat-{:03d}".format(index)
+            self.assertTrue((repetition / "stdout.txt").is_file())
+            self.assertTrue((repetition / "stderr.txt").is_file())
+            self.assertTrue((repetition / "metrics.csv").is_file())
+
+    def test_empty_csv_fails_even_with_zero_exit_code(self):
+        script = self._script(
+            """
+            echo "threads,actorPairs,in_flight,msgs_per_sec,elapsed_seconds,min_pair_sent_msgs,max_pair_sent_msgs"
+            """
+        )
+        output = self.root / "empty-output"
+        output.mkdir()
+        with self.assertRaisesRegex(BenchmarkError, "no metric rows"):
+            run_actors_core(
+                self._binary(script),
+                self._configuration(),
+                output,
+                tool_revision={"commit_id": "test"},
+            )
+        manifest = json.loads((output / "run.json").read_text())
+        self.assertEqual(manifest["status"], "failed")
+
+    @unittest.skipUnless(hasattr(os, "killpg"), "requires POSIX process groups")
+    def test_timeout_signals_the_whole_process_group(self):
+        marker = self.root / "child-terminated"
+        script = self._script(
+            """
+            marker="$1"
+            (
+                trap 'echo 15 > "$marker"; exit 0' TERM
+                while :; do
+                    sleep 1
+                done
+            ) &
+            trap 'wait; exit 0' TERM
+            while :; do
+                sleep 1
+            done
+            """,
+            name="process_tree.sh",
+        )
+        result = run_command(
+            [script, marker],
+            {},
+            timeout_seconds=0.5,
+            grace_seconds=2,
+        )
+        self.assertTrue(result.timed_out)
+        self.assertEqual(marker.read_text().strip(), str(int(signal.SIGTERM)))
+
+    def test_permission_error_mentions_noexec_and_work_dir(self):
+        path = self.root / "not-executable"
+        path.write_text("#!/bin/sh\n")
+        path.chmod(0o644)
+        with self.assertRaisesRegex(BenchmarkError, "noexec.*--work-dir"):
+            run_command([path], {}, timeout_seconds=1, work_dir_hint=self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ydb/tools/platform_bench/tests/ya.make
+++ b/ydb/tools/platform_bench/tests/ya.make
@@ -1,0 +1,11 @@
+PY3TEST()
+
+TEST_SRCS(
+    test_platform_bench.py
+)
+
+PEERDIR(
+    ydb/tools/platform_bench/lib
+)
+
+END()

--- a/ydb/tools/platform_bench/ya.make
+++ b/ydb/tools/platform_bench/ya.make
@@ -1,0 +1,25 @@
+PY3_PROGRAM(platform_bench)
+
+PY_SRCS(
+    __main__.py
+)
+
+BUNDLE(
+    ydb/library/actors/core/ut_fat/bundle NAME actors_core_ut_fat
+)
+
+RESOURCE(
+    actors_core_ut_fat actors_core_ut_fat
+)
+
+PEERDIR(
+    library/python/resource
+    library/python/svn_version
+    ydb/tools/platform_bench/lib
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    tests
+)

--- a/ydb/tools/ya.make
+++ b/ydb/tools/ya.make
@@ -3,6 +3,7 @@ RECURSE(
     cfg
     disk_obliterator
     mnc
+    platform_bench
     include_sanitizer
     partcheck
     query_replay

--- a/ydb/tools/ya.make
+++ b/ydb/tools/ya.make
@@ -3,9 +3,9 @@ RECURSE(
     cfg
     disk_obliterator
     mnc
-    platform_bench
     include_sanitizer
     partcheck
+    platform_bench
     query_replay
     query_replay_yt
     stress_tool


### PR DESCRIPTION
### Changelog entry

Add a platform benchmark runner that bundles YDB benchmark binaries and stores reproducible result artifacts.

### Changelog category

* Experimental feature

### Description for reviewers

This adds the initial `ydb/tools/platform_bench` scenario for `ydb/library/actors/core/ut_fat`. The tool provides `list`, `describe actors-core`, and `run actors-core` commands, with `smoke`, fixed `baseline`, and CPU-derived `scale` profiles as well as explicit parameter overrides.

The bundled executable is extracted atomically into a unique work directory, hashed with SHA-256, and reported clearly when the filesystem is likely mounted with `noexec`. The scenario runs only `HeavyActorBenchmark::SendActivateReceiveCSVManual`, validates the exact requested CSV parameter grid, and rejects successful processes that produce no metrics.

Each run stores `run.json`, raw stdout and stderr, per-repeat CSV data, and a median/min/max summary. Timeout and interruption terminate the full process group so future server/workload scenarios do not leave child processes behind. The original `ut_fat` test and its bundleable program variant share one source list.