### PR TITLE
Fix use-after-move when returning folder list from ExecGetFolder

### DIFF
--- a/yt/yql/providers/yt/gateway/native/yql_yt_native_folders.cpp
+++ b/yt/yql/providers/yt/gateway/native/yql_yt_native_folders.cpp
@@ -96,10 +96,11 @@ IYtGateway::TBatchFolderResult::TFolderItem MakeFolderItem(const NYT::TNode& nod
     return item;
 }
 
-const TTransactionCache::TEntry::TFolderCache::value_type& StoreResInCache(const TTransactionCache::TEntry::TPtr& entry, TVector<IYtGateway::TBatchFolderResult::TFolderItem>&& items, const TString& cacheKey) {
+const TTransactionCache::TEntry::TFolderCache::value_type& StoreResInCache(const TTransactionCache::TEntry::TPtr& entry, const TVector<IYtGateway::TBatchFolderResult::TFolderItem>& items, const TString& cacheKey) {
     std::vector<std::tuple<TString, TString, NYT::TNode>> cache;
+    cache.reserve(items.size());
     for (const auto& item : items) {
-        cache.emplace_back(std::move(item.Type), std::move(item.Path), std::move(item.Attributes));
+        cache.emplace_back(item.Type, item.Path, item.Attributes);
     }
     with_lock(entry->Lock_) {
         const auto [it, _] = entry->FolderCache.insert_or_assign(cacheKey, std::move(cache));
@@ -208,7 +209,7 @@ IYtGateway::TBatchFolderResult ExecGetFolder(const TExecContext<IYtGateway::TBat
                         path << node.AsString();
                         folderItems.push_back(MakeFolderItem(node, path));
                     }
-                    StoreResInCache(entry, std::move(folderItems), cacheKey);
+                    StoreResInCache(entry, folderItems, cacheKey);
                     return MakeFuture(std::move(folderItems));
                 }
                 catch (const NYT::TErrorResponse& e) {

--- a/yt/yql/providers/yt/gateway/native/yql_yt_native_folders.h
+++ b/yt/yql/providers/yt/gateway/native/yql_yt_native_folders.h
@@ -16,7 +16,7 @@ NYT::TAttributeFilter MakeAttrFilter(const TSet<TString>& attributes, bool isRes
 
 IYtGateway::TBatchFolderResult::TFolderItem MakeFolderItem(const NYT::TNode& node, const TString& prefix, const TString& name, const TVector<TString>& reqAttrKeys);
 
-const TTransactionCache::TEntry::TFolderCache::value_type& StoreResInCache(const TTransactionCache::TEntry::TPtr& entry, TVector<IYtGateway::TBatchFolderResult::TFolderItem>&& items, const TString& cacheKey);
+const TTransactionCache::TEntry::TFolderCache::value_type& StoreResInCache(const TTransactionCache::TEntry::TPtr& entry, const TVector<IYtGateway::TBatchFolderResult::TFolderItem>& items, const TString& cacheKey);
 
 TFileLinkPtr SaveItemsToTempFile(const TExecContext<IYtGateway::TBatchFolderOptions>::TPtr& execCtx, const TVector<IYtGateway::TFolderResult::TFolderItem>& folderItems);
 


### PR DESCRIPTION
## Summary
- `ExecGetFolder` moved `folderItems` into `StoreResInCache` and then moved the same vector into `MakeFuture`, which is a use-after-move.
- `StoreResInCache` already copied folder items into the cache representation (`const auto&` + field copy), so its signature now takes `const TVector&` instead of `&&`.
- The caller stores into the cache by const reference, then returns the filled vector via `MakeFuture(std::move(folderItems))` without an extra full-vector copy.

## Test plan
- [ ] Review the `StoreResInCache` / `ExecGetFolder` change for cache vs return semantics
- [ ] CI on the PR


Made with [Cursor](https://cursor.com)