### PR TITLE
Fix flaky MNC viewer operation tab navigation

### DIFF
--- a/ydb/tools/mnc/viewer/main.py
+++ b/ydb/tools/mnc/viewer/main.py
@@ -826,8 +826,14 @@ class Viewer(App):
 
         if tab_id in self._opened_tab_order:
             tabs = self.query_one("#tabs", TabbedContent)
+            tab_index = self._opened_tab_order.index(tab_id)
             self._created_tabs.discard(tab_id)
             self._opened_tab_order.remove(tab_id)
+            if tabs.active == tab_id and self._opened_tab_order:
+                self._bump_navigation_generation()
+                next_tab = self._opened_tab_order[min(tab_index, len(self._opened_tab_order) - 1)]
+                tabs.active = next_tab
+                self._focus_active_tab_content(next_tab)
             await tabs.remove_pane(tab_id)
 
         await self._open_tab(

--- a/ydb/tools/mnc/viewer/ut/test_navigation.py
+++ b/ydb/tools/mnc/viewer/ut/test_navigation.py
@@ -1,5 +1,6 @@
 import unittest
 from dataclasses import dataclass
+from unittest import mock
 
 from textual.widgets import TabPane, TabbedContent
 
@@ -125,6 +126,29 @@ class ViewerTabNavigationTest(unittest.IsolatedAsyncioTestCase):
                             include_agents=True,
                             include_operation=True,
                         )
+
+    async def test_reopening_active_operation_deactivates_pane_before_removal(self):
+        app = Viewer()
+        async with app.run_test() as pilot:
+            await app.run_action("open_operation('install')")
+            tabs = app.query_one("#tabs", TabbedContent)
+            active_during_removal = []
+            pane_active_during_removal = []
+            remove_pane = tabs.remove_pane
+
+            def capture_active_tab(pane_id: str):
+                active_during_removal.append(tabs.active)
+                pane_active_during_removal.append(tabs.get_tab(pane_id).has_class("-active"))
+                return remove_pane(pane_id)
+
+            with mock.patch.object(tabs, "remove_pane", side_effect=capture_active_tab):
+                await app.run_action("open_operation('install')")
+
+            await pilot.pause()
+            self.assertEqual(active_during_removal, ["general"])
+            self.assertEqual(pane_active_during_removal, [False])
+            self.assertEqual(self._actual_tabs(app), ["general", "operation"])
+            self.assertEqual(tabs.active, "operation")
 
     async def _assert_command_sequence(
         self,


### PR DESCRIPTION
### Changelog entry

Fix a race when reopening the active MNC viewer operation tab.

### Changelog category

* Bugfix

### Description for reviewers

Textual may activate the neighboring tab asynchronously after the active operation pane is removed. If the replacement pane has already been mounted, this delayed event can overwrite the intended active tab.

Deactivate the operation pane and invalidate the current navigation generation before removing it, then recreate and activate the pane. This makes the transition deterministic and prevents stale activation events from winning the race.
