### PR TITLE
A test reproducing stale read for writes with same PK.

### DIFF
--- a/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
+++ b/ydb/core/kqp/ut/tx/kqp_sink_mvcc_ut.cpp
@@ -82,7 +82,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             auto client = Kikimr->GetQueryClient();
 
             auto session1 = client.GetSession().GetValueSync().GetSession();
-    
+
             // tx1 writes (1, 1) and commits
             auto result = session1.ExecuteQuery(Q1_(R"(
                 upsert into KV2 (Key, Value) values (1u, "1");
@@ -95,7 +95,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
                 )"), TTxControl::BeginTx().CommitTx()).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             CompareYson(R"([[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
-    
+
             // tx3 reads (1, 1)
             result = session1.ExecuteQuery(Q1_(R"(
                 select * from KV2;
@@ -104,7 +104,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             CompareYson(R"([[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
         }
     };
-    
+
     Y_UNIT_TEST_TWIN(TxReadsCommitted, IsOlap) {
         TTxReadsCommitted tester;
         tester.SetIsOlap(IsOlap);
@@ -117,7 +117,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             auto client = Kikimr->GetQueryClient();
 
             auto session1 = client.GetSession().GetValueSync().GetSession();
-    
+
             // tx1 writes (1, 1)
             auto result = session1.ExecuteQuery(Q1_(R"(
                 upsert into KV2 (Key, Value) values (1u, "1");
@@ -131,7 +131,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
                 )"), TTxControl::Tx(*tx1)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             CompareYson(R"([[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
-    
+
             // tx1 reads (1, 1)
             result = session1.ExecuteQuery(Q1_(R"(
                 select * from KV2;
@@ -140,7 +140,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             CompareYson(R"([[1u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
         }
     };
-    
+
     Y_UNIT_TEST_TWIN(TxReadsItsOwnWrites, IsOlap) {
         TTxReadsItsOwnWrites tester;
         tester.SetIsOlap(IsOlap);
@@ -154,7 +154,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             auto client = Kikimr->GetQueryClient();
 
             auto session1 = client.GetSession().GetValueSync().GetSession();
-    
+
             // tx1 writes (1, 1)
             auto result = session1.ExecuteQuery(Q1_(R"(
                 upsert into KV2 (Key, Value) values (1u, "1");
@@ -209,7 +209,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             CompareYson("[]", FormatResultSetYson(result.GetResultSet(0)));
         }
     };
-    
+
     Y_UNIT_TEST_TWIN(TxDeleteOwnUncommitted, IsOlap) {
         if (IsOlap) {
             // muted until this is fixed: https://github.com/ydb-platform/ydb/issues/28447
@@ -265,7 +265,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             tx2 = result.GetTransaction();
 
             // bonus checks 1: tx1's reads do not affect the visibility of its writes to other concurrent txs
-            
+
             // tx1 sees (0, 1), (1, 1)
             result = session1.ExecuteQuery(Q1_(R"(
                 select * from KV2 order by Key;
@@ -370,7 +370,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         tester.SetIsOlap(IsOlap);
         tester.Execute();
     }
-    
+
     class TLostUpdate : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
@@ -522,7 +522,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
             CompareYson(R"([[1u;["1"]];[2u;["1"]]])", FormatResultSetYson(result.GetResultSet(0)));
             auto tx1 = result.GetTransaction();
-            
+
             // tx1 writes (3, 1), so the sum = 3, which is ok
             result = session1.ExecuteQuery(
                 GetWriteOp() + " into KV2 (Key, Value) values (3u, \"1\");",
@@ -588,7 +588,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         tester.SetWriteOp("replace");
         tester.Execute();
     }
-    
+
     class TReadOnlyTxCommitsOnConcurrentWrite : public TTableDataModificationTester {
     protected:
         void DoExecute() override {
@@ -888,6 +888,40 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
         tester.Execute();
     }
 
+    class TMultiSinksCompacted: public TTableDataModificationTester {
+    protected:
+        void DoExecute() override {
+            auto client = Kikimr->GetQueryClient();
+
+            auto session1 = client.GetSession().GetValueSync().GetSession();
+
+            {
+                auto result = session1.ExecuteQuery(Q_(R"(
+                    UPSERT INTO `/Root/KV` (Key, Value) VALUES (1u, "1");
+                    UPSERT INTO `/Root/KV` (Key, Value) VALUES (1u, "2");
+                )"), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+            }
+            // wait for general compaction of the inserted portions
+            Sleep(TDuration::Seconds(5));
+            {
+                auto result = session1.ExecuteQuery(Q_(R"(
+                    SELECT Value FROM `/Root/KV` WHERE Key = 1u;
+                )"), TTxControl::BeginTx(TTxSettings::SerializableRW()).CommitTx()).ExtractValueSync();
+                UNIT_ASSERT_VALUES_EQUAL_C(result.GetStatus(), EStatus::SUCCESS, result.GetIssues().ToString());
+                // For now the assertion is disabled because CS cannot order the two writes without their WriteID
+                // may return "1"
+                // CompareYson(R"([[["2"]]])", FormatResultSetYson(result.GetResultSet(0)));
+            }
+        }
+    };
+
+    Y_UNIT_TEST(OlapMultiSinksAfterCompaction) {
+        TMultiSinksCompacted tester;
+        tester.SetIsOlap(true);
+        tester.Execute();
+    }
+
     class TInsertConflictingKey: public TTableDataModificationTester {
         YDB_ACCESSOR(bool, CommitOnInsert, false);
     protected:
@@ -971,7 +1005,7 @@ Y_UNIT_TEST_SUITE(KqpSinkMvcc) {
             auto client = Kikimr->GetQueryClient();
             auto session1 = client.GetSession().GetValueSync().GetSession();
             auto session2 = client.GetSession().GetValueSync().GetSession();
-            
+
             auto insertResult1 = session1.ExecuteQuery(R"(
                         UPSERT INTO `/Root/Test` (Group, Name, Amount) VALUES (1u, "Anna", 7000ul)
                 )", NQuery::TTxControl::BeginTx()) .GetValueSync();


### PR DESCRIPTION
A multi-statement transaction writing one key several times produces
committed rows distinguished only by the WRITE_ID version column.
General compaction drops that column from its outputs, and same-snapshot
rows can end up in different merge groups (memory-budget chunking inside
one task re-merges intermediates that already lost WRITE_ID; the optimizer
can also split such portions across tasks). After that, the versions tie
on (PLAN_STEP, TX_ID) and reads resolve the tie arbitrarily, returning a
stale value: UPSERT (1,"1"); UPSERT (1,"2") in one transaction followed
by SELECT may return "1" once compaction ran between write and read.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
