### PR TITLE
Account for overload metrics increment in TEvWrite pipelining

### DIFF
--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -38,6 +38,7 @@ enum ESimpleCounters {
     COUNTER_VOLATILE_TX_ABORTING_COUNT = 28                        [(CounterOpts) = {Name: "VolatileTxAbortingCount"}];
     COUNTER_LOCK_ROWS_INFLIGHT = 29                                [(CounterOpts) = {Name: "LockRowsInFlight"}];
     COUNTER_LOCK_ROWS_WAITING = 30                                 [(CounterOpts) = {Name: "LockRowsWaiting"}];
+    COUNTER_CHANGE_QUEUE_BYTES = 31                                [(CounterOpts) = {Name: "ChangeQueueBytes"}];
 }
 
 enum ECumulativeCounters {
@@ -157,6 +158,7 @@ enum ECumulativeCounters {
     COUNTER_PREPARE_DATABASE_DISK_SPACE_QUOTA_EXCEEDED = 113 [(CounterOpts) = {Name: "PrepareDatabaseDiskSpaceQuotaExceeded"}];
     COUNTER_REMOVED_COMMITTED_TXS = 114                   [(CounterOpts) = {Name: "RemovedCommittedTxs"}];
     COUNTER_LOCK_ROWS_FINISHED = 115                      [(CounterOpts) = {Name: "LockRowsFinished"}];
+    COUNTER_CHANGE_QUEUE_OVERFLOW_REJECTS = 116           [(CounterOpts) = {Name: "ChangeQueueOverflowRejects"}];
 }
 
 enum EPercentileCounters {

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -1199,6 +1199,7 @@ void TDataShard::RemoveChangeRecord(NIceDb::TNiceDb& db, ui64 order) {
 
     IncCounter(COUNTER_CHANGE_RECORDS_REMOVED);
     SetCounter(COUNTER_CHANGE_QUEUE_SIZE, ChangesQueue.size());
+    SetCounter(COUNTER_CHANGE_QUEUE_BYTES, ChangesQueueBytes);
 
     CheckChangesQueueNoOverflow();
 }
@@ -1257,6 +1258,7 @@ void TDataShard::EnqueueChangeRecords(TVector<IDataShardChangeCollector::TChange
     UpdateChangeExchangeLag(now);
     IncCounter(COUNTER_CHANGE_RECORDS_ENQUEUED, forward.size());
     SetCounter(COUNTER_CHANGE_QUEUE_SIZE, ChangesQueue.size());
+    SetCounter(COUNTER_CHANGE_QUEUE_BYTES, ChangesQueueBytes);
 
     Y_ENSURE(OutChangeSender);
     Send(OutChangeSender, new NChangeExchange::TEvChangeExchange::TEvEnqueueRecords(std::move(forward)));

--- a/ydb/core/tx/datashard/datashard_change_sending.cpp
+++ b/ydb/core/tx/datashard/datashard_change_sending.cpp
@@ -422,7 +422,7 @@ private:
 /// Request
 void TDataShard::Handle(NChangeExchange::TEvChangeExchange::TEvRequestRecords::TPtr& ev, const TActorContext& ctx) {
     ChangeRecordsRequested[ev->Sender].insert(ev->Get()->Records.begin(), ev->Get()->Records.end());
-    SetCounter(COUNTER_CHANGE_QUEUE_SIZE, Accumulate(ChangeRecordsRequested, (size_t)0, [](size_t sum, const auto& kv) {
+    SetCounter(COUNTER_CHANGE_RECORDS_REQUESTED, Accumulate(ChangeRecordsRequested, (size_t)0, [](size_t sum, const auto& kv) {
         return sum + kv.second.size();
     }));
     ScheduleRequestChangeRecords(ctx);

--- a/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_change_exchange.cpp
@@ -7,7 +7,9 @@
 #include <ydb/core/base/path.h>
 #include <ydb/core/change_exchange/change_sender.h>
 #include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/protos/schemeshard/operations.pb.h>
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
 #include <ydb/core/persqueue/public/write_meta/write_meta.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/tx/scheme_board/events.h>
@@ -34,6 +36,68 @@ using namespace NDataShard;
 using namespace NDataShard::NKqpHelpers;
 using namespace Tests;
 using namespace NSchemeShardUT_Private;
+
+NKikimrTabletBase::TTabletCountersBase GetAppCounters(TTestActorRuntime& runtime, ui64 tabletId) {
+    const auto edge = runtime.AllocateEdgeActor();
+    runtime.SendToPipe(tabletId, edge, new TEvTablet::TEvGetCounters(), 0, GetPipeConfigWithRetries());
+    auto ev = runtime.GrabEdgeEventRethrow<TEvTablet::TEvGetCountersResponse>(edge);
+    UNIT_ASSERT(ev);
+    return ev->Get()->Record.GetTabletCounters().GetAppCounters();
+}
+
+ui64 GetSimpleCounter(TTestActorRuntime& runtime, ui64 tabletId, const TString& name) {
+    const auto counters = GetAppCounters(runtime, tabletId);
+    for (const auto& counter : counters.GetSimpleCounters()) {
+        if (counter.GetName() == name) {
+            return counter.GetValue();
+        }
+    }
+    UNIT_ASSERT_C(false, name << " counter not found");
+    return 0;
+}
+
+ui64 GetCumulativeCounter(TTestActorRuntime& runtime, ui64 tabletId, const TString& name) {
+    const auto counters = GetAppCounters(runtime, tabletId);
+    for (const auto& counter : counters.GetCumulativeCounters()) {
+        if (counter.GetName() == name) {
+            return counter.GetValue();
+        }
+    }
+    UNIT_ASSERT_C(false, name << " counter not found");
+    return 0;
+}
+
+// which one is bumped depends on whether the op came as TEvWrite or TEvProposeTransaction
+ui64 GetRejectedByOverloadCount(TTestActorRuntime& runtime, ui64 tabletId) {
+    return GetCumulativeCounter(runtime, tabletId, "DataShard/WriteOverloaded")
+        + GetCumulativeCounter(runtime, tabletId, "DataShard/PrepareOverloaded");
+}
+
+ui64 AsyncAlterFreezeState(TServer::TPtr server, const TString& workingDir, const TString& name,
+        NKikimrSchemeOp::EFreezeState state)
+{
+    auto request = MakeHolder<TEvTxUserProxy::TEvProposeTransaction>();
+    request->Record.SetExecTimeoutPeriod(Max<ui64>());
+
+    auto& tx = *request->Record.MutableTransaction()->MutableModifyScheme();
+    tx.SetOperationType(NKikimrSchemeOp::ESchemeOpAlterTable);
+    tx.SetWorkingDir(workingDir);
+
+    auto& desc = *tx.MutableAlterTable();
+    desc.SetName(name);
+    desc.MutablePartitionConfig()->SetFreezeState(state);
+
+    auto& runtime = *server->GetRuntime();
+    const auto sender = runtime.AllocateEdgeActor();
+    runtime.Send(new IEventHandle(MakeTxProxyID(), sender, request.Release()), 0, false);
+
+    auto ev = runtime.GrabEdgeEventRethrow<TEvTxUserProxy::TEvProposeTransactionStatus>(sender);
+    UNIT_ASSERT_VALUES_EQUAL_C(ev->Get()->Record.GetStatus(),
+        TEvTxUserProxy::TEvProposeTransactionStatus::EStatus::ExecInProgress,
+        "Issues: " << ev->Get()->Record.GetIssues());
+
+    return ev->Get()->Record.GetTxId();
+}
 
 Y_UNIT_TEST_SUITE(AsyncIndexChangeExchange) {
     void SenderShouldBeActivated(const TString& path, const TShardedTableOptions& opts) {
@@ -668,8 +732,23 @@ Y_UNIT_TEST_SUITE(AsyncIndexChangeExchange) {
 
         CreateShardedTable(server, sender, "/Root", "Table", TableWithIndex(SimpleAsyncIndex()));
 
+        const auto tabletIds = GetTableShards(server, sender, "/Root/Table");
+        UNIT_ASSERT_VALUES_EQUAL(tabletIds.size(), 1);
+        const ui64 tabletId = tabletIds.at(0);
+
         ExecSQL(server, sender, "UPSERT INTO `/Root/Table` (pkey, ikey) VALUES (1, 10);");
+
+        // the record is enqueued but never delivered, so the queue stays full
+        UNIT_ASSERT_GT(GetSimpleCounter(runtime, tabletId, "DataShard/ChangeQueueSize"), 0);
+        UNIT_ASSERT_GT(GetSimpleCounter(runtime, tabletId, "DataShard/ChangeQueueBytes"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetCumulativeCounter(runtime, tabletId, "DataShard/ChangeQueueOverflowRejects"), 0);
+
+        const ui64 rejectedBefore = GetRejectedByOverloadCount(runtime, tabletId);
+
         ExecSQL(server, sender, "UPSERT INTO `/Root/Table` (pkey, ikey) VALUES (2, 20);", true, Ydb::StatusIds::TIMEOUT);
+
+        UNIT_ASSERT_GT(GetCumulativeCounter(runtime, tabletId, "DataShard/ChangeQueueOverflowRejects"), 0);
+        UNIT_ASSERT_GT(GetRejectedByOverloadCount(runtime, tabletId), rejectedBefore);
 
         sendEnqueued();
         WaitForContent(server, "/Root/Table/by_ikey/indexImplTable",
@@ -690,6 +769,58 @@ Y_UNIT_TEST_SUITE(AsyncIndexChangeExchange) {
         ShouldRejectChangesOnQueueOverflow([](TServerSettings& opts) {
             opts.SetChangesQueueBytesLimit(1);
         });
+    }
+
+    Y_UNIT_TEST(ShouldNotEnqueueChangesOnFrozenShard) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings
+            .SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataColumnForIndexTable(true);
+
+        TServer::TPtr server = new TServer(serverSettings);
+        auto& runtime = *server->GetRuntime();
+        const TActorId sender = runtime.AllocateEdgeActor();
+
+        runtime.SetLogPriority(NKikimrServices::TX_DATASHARD, NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::CHANGE_EXCHANGE, NLog::PRI_DEBUG);
+        InitRoot(server, sender);
+
+        CreateShardedTable(server, sender, "/Root", "Table", TableWithIndex(SimpleAsyncIndex()));
+
+        const auto tabletIds = GetTableShards(server, sender, "/Root/Table");
+        UNIT_ASSERT_VALUES_EQUAL(tabletIds.size(), 1);
+        const ui64 tabletId = tabletIds.at(0);
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/Table` (pkey, ikey) VALUES (1, 10);");
+        WaitForContent(server, "/Root/Table/by_ikey/indexImplTable",
+            "ikey = 10, pkey = 1");
+        WaitFor(runtime, [&]{
+            return GetSimpleCounter(runtime, tabletId, "DataShard/ChangeQueueSize") == 0;
+        }, "empty change queue");
+
+        WaitTxNotification(server, sender, AsyncAlterFreezeState(server, "/Root", "Table",
+            NKikimrSchemeOp::EFreezeState::Freeze));
+
+        const ui64 rejectedBefore = GetRejectedByOverloadCount(runtime, tabletId);
+
+        // a frozen shard passes admission checks and is rejected by the pipeline instead
+        ExecSQL(server, sender, "UPSERT INTO `/Root/Table` (pkey, ikey) VALUES (2, 20);",
+            true, Ydb::StatusIds::INTERNAL_ERROR);
+
+        UNIT_ASSERT_GT(GetRejectedByOverloadCount(runtime, tabletId), rejectedBefore);
+        // the rejected write must not leave anything behind in the change queue
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, tabletId, "DataShard/ChangeQueueSize"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetSimpleCounter(runtime, tabletId, "DataShard/ChangeQueueBytes"), 0);
+        UNIT_ASSERT_VALUES_EQUAL(GetCumulativeCounter(runtime, tabletId, "DataShard/ChangeQueueOverflowRejects"), 0);
+
+        WaitTxNotification(server, sender, AsyncAlterFreezeState(server, "/Root", "Table",
+            NKikimrSchemeOp::EFreezeState::Unfreeze));
+
+        ExecSQL(server, sender, "UPSERT INTO `/Root/Table` (pkey, ikey) VALUES (2, 20);");
+        WaitForContent(server, "/Root/Table/by_ikey/indexImplTable",
+            "ikey = 10, pkey = 1\nikey = 20, pkey = 2");
     }
 
     Y_UNIT_TEST(ShouldNotReorderChangesOnRace) {

--- a/ydb/core/tx/datashard/execution_unit.cpp
+++ b/ydb/core/tx/datashard/execution_unit.cpp
@@ -172,6 +172,10 @@ THolder<TExecutionUnit> CreateExecutionUnit(EExecutionUnitKind kind,
 bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext& ctx) {
     TWriteOperation* writeOp = TWriteOperation::TryCastWriteOperation(op);
 
+    auto incOverloaded = [this, writeOp]() {
+        DataShard.IncCounter(writeOp ? COUNTER_WRITE_OVERLOADED : COUNTER_PREPARE_OVERLOADED);
+    };
+
     // Reject operations after receiving EvSplit
     // This is to avoid races when split is in progress
     if (DataShard.GetState() == TShardState::SplitSrcWaitForNoTxInFlight ||
@@ -193,6 +197,7 @@ bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext&
         YDB_LOG_NOTICE_CTX(ctx, "Tablet rejecting tx due to split",
             {"tabletId", DataShard.TabletID()});
 
+        incOverloaded();
         op->Abort();
         return true;
     }
@@ -214,6 +219,7 @@ bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext&
 
         YDB_LOG_NOTICE_CTX(ctx, err);
 
+        incOverloaded();
         op->Abort();
         return true;
     }
@@ -231,6 +237,7 @@ bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext&
 
         YDB_LOG_NOTICE_CTX(ctx, err);
 
+        incOverloaded();
         op->Abort();
         return true;
     }
@@ -251,6 +258,8 @@ bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext&
         YDB_LOG_NOTICE_CTX(ctx, "Tablet rejecting tx due to changes queue overflow",
             {"tabletId", DataShard.TabletID()});
 
+        incOverloaded();
+        DataShard.IncCounter(COUNTER_CHANGE_QUEUE_OVERFLOW_REJECTS);
         op->Abort();
         return true;
     }

--- a/ydb/core/tx/datashard/execution_unit.cpp
+++ b/ydb/core/tx/datashard/execution_unit.cpp
@@ -172,6 +172,7 @@ THolder<TExecutionUnit> CreateExecutionUnit(EExecutionUnitKind kind,
 bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext& ctx) {
     TWriteOperation* writeOp = TWriteOperation::TryCastWriteOperation(op);
 
+     // COUNTER_WRITE_COMPLETE / COUNTER_PREPARE_COMPLETE are updated in FinishProposeWrite / FinishPropose respectively
     auto incOverloaded = [this, writeOp]() {
         DataShard.IncCounter(writeOp ? COUNTER_WRITE_OVERLOADED : COUNTER_PREPARE_OVERLOADED);
     };
@@ -278,6 +279,7 @@ bool TExecutionUnit::CheckRejectDataTx(TOperation::TPtr op, const TActorContext&
 
         YDB_LOG_NOTICE_CTX(ctx, err);
 
+        // no incOverloaded here as it's treated as BAD_REQUEST, not OVERLOAD
         op->Abort();
         return true;
     }


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add missing increments from `ydb/core/tx/datashard/datashard.cpp` `TDataShard::CheckDataTxRejectAndReply`

that were done via

```
IncCounter(COUNTER_WRITE_OVERLOADED);
IncCounter(COUNTER_WRITE_COMPLETE);
```