### PR TITLE
Remove dead ReplaceIfExists fields from TExternalTableDescription and TExternalDataSourceDescription

### DIFF
--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -2474,7 +2474,7 @@ message TExternalTableDescription {
     optional string Location = 6;
     repeated TColumnDescription Columns = 7;
     optional bytes Content = 8;
-    optional bool ReplaceIfExists = 9; // Only applicable for `create external table` operation
+    reserved 9; // ReplaceIfExists
 }
 
 // Access without authorization
@@ -2547,7 +2547,7 @@ message TExternalDataSourceDescription {
     optional string Installation = 6;
     optional TAuth Auth = 7;
     optional TExternalDataSourceProperties Properties = 8;
-    optional bool ReplaceIfExists = 9;
+    reserved 9; // ReplaceIfExists
     optional TExternalTableReferences References = 10;
 }
 


### PR DESCRIPTION
These fields were never set or read anywhere in the codebase. All CREATE OR REPLACE operations (external table, EDS, streaming query, and secret) use TModifyScheme.ReplaceIfExists (field 91) instead.