### PR TITLE
[detailed-metrics] report DataShard table identity and FollowerId to the TCA

### DIFF
--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -1230,6 +1230,7 @@ private:
     void HandleWork(NMon::TEvHttpInfo::TPtr& ev, const TActorContext &ctx);
     void HandleWakeup(const TActorContext &ctx);
     void HandleWork(TEvTabletCounters::TEvRemoveDatabase::TPtr& ev);
+    void HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev);
 
     TString RenderSearch(const TStringBuf relPath, const TString& name) const;
 
@@ -1465,6 +1466,12 @@ void TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvRemoveData
 }
 
 ////////////////////////////////////////////
+void TTabletCountersAggregatorActor::HandleWork(TEvTabletCounters::TEvTabletSetTableInfo::TPtr& ev) {
+    // TODO(djant) join incoming metrics with it later
+    Y_UNUSED(ev);
+}
+
+////////////////////////////////////////////
 TString TTabletCountersAggregatorActor::RenderSearch(const TStringBuf relPath, const TString& name) const {
     TStringStream str;
 
@@ -1588,6 +1595,7 @@ STFUNC(TTabletCountersAggregatorActor::StateWork) {
         HFunc(TEvTabletCounters::TEvTabletLabeledCountersRequest, HandleWork);
         HFunc(TEvTabletCounters::TEvTabletLabeledCountersResponse, HandleWork); //from cluster aggregator, for http requests
         hFunc(TEvTabletCounters::TEvRemoveDatabase, HandleWork);
+        hFunc(TEvTabletCounters::TEvTabletSetTableInfo, HandleWork);
         HFunc(NMon::TEvHttpInfo, HandleWork);
         CFunc(TEvents::TSystem::Wakeup, HandleWakeup);
 

--- a/ydb/core/tablet/tablet_counters_aggregator.h
+++ b/ydb/core/tablet/tablet_counters_aggregator.h
@@ -34,6 +34,7 @@ struct TEvTabletCounters {
         EvTabletLabeledCountersRequest,
         EvTabletLabeledCountersResponse,
         EvRemoveDatabase,
+        EvTabletSetTableInfo,
         EvEnd
     };
 
@@ -50,15 +51,38 @@ struct TEvTabletCounters {
         TAutoPtr<TTabletCountersBase> ExecutorCounters;
         TAutoPtr<TTabletCountersBase> AppCounters;
         TIntrusivePtr<TInFlightCookie> InFlightCounter;     // Used to detect when previous event has been consumed by the aggregator
+        const ui32 FollowerId; // 0 = leader, >0 = replica
 
         TEvTabletAddCounters(TIntrusivePtr<TInFlightCookie> inFlightCounter, ui64 tabletID, NKikimrTabletBase::TTabletTypes::EType tabletType, TPathId tenantPathId,
-            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters)
+            TAutoPtr<TTabletCountersBase> executorCounters, TAutoPtr<TTabletCountersBase> appCounters,
+            ui32 followerId = 0)
             : TabletID(tabletID)
             , TabletType(tabletType)
             , TenantPathId(tenantPathId)
             , ExecutorCounters(executorCounters)
             , AppCounters(appCounters)
             , InFlightCounter(inFlightCounter)
+            , FollowerId(followerId)
+        {}
+    };
+
+    // primary user table served by a tablet
+    struct TEvTabletSetTableInfo : public TEventLocal<TEvTabletSetTableInfo, EvTabletSetTableInfo> {
+        const ui64 TabletID;
+        const TPathId TenantPathId;
+        const ui32 FollowerId; // 0 = leader, >0 = replica
+        const TPathId TableId;
+        const TString TablePath;
+        const ui64 SchemaVersion;
+
+        TEvTabletSetTableInfo(ui64 tabletID, TPathId tenantPathId,
+            ui32 followerId, TPathId tableId, const TString& tablePath, ui64 schemaVersion)
+            : TabletID(tabletID)
+            , TenantPathId(tenantPathId)
+            , FollowerId(followerId)
+            , TableId(tableId)
+            , TablePath(tablePath)
+            , SchemaVersion(schemaVersion)
         {}
     };
 

--- a/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator_ut.cpp
@@ -953,4 +953,23 @@ Y_UNIT_TEST_SUITE(TTabletLabeledCountersAggregator) {
     }
 }
 
+Y_UNIT_TEST_SUITE(TEvTabletAddCountersDetailedMetricsFields) {
+    Y_UNIT_TEST(DefaultsToLeader) {
+        TEvTabletCounters::TEvTabletAddCounters ev(
+            new TEvTabletCounters::TInFlightCookie, 1, TTabletTypes::DataShard, TPathId(1113, 1001),
+            new TTabletCountersBase, new TTabletCountersBase);
+
+        UNIT_ASSERT_VALUES_EQUAL(ev.FollowerId, 0u);
+    }
+
+    Y_UNIT_TEST(StampsFollowerIdWhenProvided) {
+        TEvTabletCounters::TEvTabletAddCounters ev(
+            new TEvTabletCounters::TInFlightCookie, 1, TTabletTypes::DataShard, TPathId(1113, 1001),
+            new TTabletCountersBase, new TTabletCountersBase,
+            7);
+
+        UNIT_ASSERT_VALUES_EQUAL(ev.FollowerId, 7u);
+    }
+}
+
 }

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -4144,7 +4144,8 @@ void TExecutor::UpdateCounters(const TActorContext &ctx) {
 
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters,
+            FollowerId));
 
         if (ResourceMetrics) {
             ResourceMetrics->TryUpdate(ctx);
@@ -4173,7 +4174,8 @@ void TExecutor::ForceSendCounters() {
 
         TActorId countersAggregator = MakeTabletCountersAggregatorID(SelfId().NodeId(), Stats->IsFollower());
         Send(countersAggregator, new TEvTabletCounters::TEvTabletAddCounters(
-            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters));
+            CounterEventsInFlight, tabletId, tabletType, tenantPathId, executorCounters, externalTabletCounters,
+            FollowerId));
     }
 }
 

--- a/ydb/core/tablet_flat/flat_executor_ut.cpp
+++ b/ydb/core/tablet_flat/flat_executor_ut.cpp
@@ -3,6 +3,7 @@
 #include "util_fmt_abort.h"
 #include "shared_cache_counters.h"
 #include <ydb/core/base/counters.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/testlib/actors/block_events.h>
 #include <ydb/core/testlib/actors/wait_events.h>
 
@@ -672,6 +673,78 @@ Y_UNIT_TEST_SUITE(TFlatTableExecutor_CompactionScan) {
     }
 }
 
+// MakeTabletCountersAggregatorID(...) is a named-service ActorId: sends to it go through the real
+// ActorSystem, bypassing TTestActorRuntime's mailbox-dispatch loop (so AddObserver never sees them).
+// Register a catcher in its place that forwards the raw message to an edge actor instead.
+class TCountersCatcher : public TActor<TCountersCatcher> {
+public:
+    explicit TCountersCatcher(TActorId forwardTo)
+        : TActor(&TThis::StateWork)
+        , ForwardTo(forwardTo)
+    {}
+
+    STFUNC(StateWork) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(TEvTabletCounters::TEvTabletAddCounters, Handle);
+            hFunc(TEvents::TEvPoison, HandlePoison);
+        default:
+            break;
+        }
+    }
+
+    void Handle(TEvTabletCounters::TEvTabletAddCounters::TPtr &ev) {
+        Send(ForwardTo, ev->Release().Release());
+    }
+
+    void HandlePoison(TEvents::TEvPoison::TPtr &ev) {
+        Send(ev->Sender, new TEvents::TEvGone);
+        PassAway();
+    }
+
+private:
+    TActorId ForwardTo;
+};
+
+Y_UNIT_TEST_SUITE(TFlatTableExecutor_DetailedMetricsCounters) {
+    Y_UNIT_TEST(TestAddCountersStampsLeaderFollowerId) {
+        TMyEnvBase env;
+        env.RunOn(2, MakeTabletCountersAggregatorID(env.NodeId, false), new TCountersCatcher(env.Edge), NFake::EMail::Simple);
+
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        // DetachTablet() (reached via TEvPoison) unconditionally calls ForceSendCounters().
+        env.SendSync(new TEvents::TEvPoison, false, true);
+
+        auto ev = env.GrabEdgeEvent<TEvTabletCounters::TEvTabletAddCounters>();
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->FollowerId, 0u);
+    }
+
+    Y_UNIT_TEST(TestAddCountersStampsFollowerId) {
+        TMyEnvBase env;
+        // Followers report to the *follower* aggregator, so only the follower's messages
+        // land in this catcher and the leader's cannot be mistaken for them.
+        env.RunOn(2, MakeTabletCountersAggregatorID(env.NodeId, true), new TCountersCatcher(env.Edge), NFake::EMail::Simple);
+
+        env.FireTablet(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        });
+        env.WaitForWakeUp();
+
+        env.FireFollower(env.Edge, env.Tablet, [&env](const TActorId &tablet, TTabletStorageInfo *info) {
+            return new TTestFlatTablet(env.Edge, tablet, info);
+        }, /* followerId */ 1);
+        env.WaitForWakeUp();
+
+        // Exercises the periodic path: TExecutor::UpdateCounters() is driven by a 15s timer.
+        env->SimulateSleep(TDuration::Seconds(16));
+
+        auto ev = env.GrabEdgeEvent<TEvTabletCounters::TEvTabletAddCounters>();
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->FollowerId, 1u);
+    }
+}
 
 Y_UNIT_TEST_SUITE(TFlatTableExecutor_ExecutorTxLimit) {
 

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/protos/datashard_config.pb.h>
 #include <ydb/core/protos/query_stats.pb.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/tablet/tablet_counters_protobuf.h>
 #include <ydb/core/tx/long_tx_service/public/events.h>
 #include <ydb/library/aclib/user_context.h>
@@ -4063,11 +4064,40 @@ void TDataShard::CheckChangesQueueNoOverflow(ui64 cookie) {
     }
 }
 
+void TDataShard::SendTableInfoToCountersAggregator(const TActorContext &ctx) {
+    if (!AppData(ctx)->FeatureFlags.GetEnableDataShardDetailedMetrics()) {
+        return;
+    }
+
+    // No user table means there is nothing to attribute counters to. Not sending the event
+    // is how that is expressed; the aggregator keeps whatever it last learned until the
+    // tablet is forgotten.
+    if (TableInfos.empty()) {
+        return;
+    }
+
+    // Expected that it's almost always one table here, hence only TableInfos.begin()
+    // IsBackup can be filtered out though
+    const auto& [localPathId, table] = *TableInfos.begin();
+
+    // Read straight from TableInfos on every tick: a rename or a schema bump is picked up
+    // on the next tick with no cache to invalidate.
+    ctx.Send(MakeTabletCountersAggregatorID(ctx.SelfID.NodeId(), IsFollower()),
+        new TEvTabletCounters::TEvTabletSetTableInfo(
+            TabletID(),
+            Info()->TenantPathId,
+            FollowerId(),
+            TPathId(GetPathOwnerId(), localPathId),
+            table->Path,
+            table->GetTableSchemaVersion()));
+}
+
 void TDataShard::DoPeriodicTasks(const TActorContext &ctx) {
     UpdateLagCounters(ctx);
     UpdateChangeExchangeLag(ctx.Now());
     UpdateTableStats(ctx);
     SendPeriodicTableStats(ctx);
+    SendTableInfoToCountersAggregator(ctx);
     CollectCpuUsage(ctx);
 
     if (CurrentKeySampler == EnabledKeySampler && ctx.Now() > StopKeyAccessSamplingAt) {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1491,6 +1491,10 @@ class TDataShard
     void DoPeriodicTasks(const TActorContext &ctx);
     void DoPeriodicTasks(TEvPrivate::TEvPeriodicWakeup::TPtr&, const TActorContext &ctx);
 
+    // Reports the identity of this shard's primary user table to the node's tablet counters
+    // aggregator, so detailed metrics can attribute the executor's counter deltas to a table.
+    void SendTableInfoToCountersAggregator(const TActorContext &ctx);
+
     TDuration GetTxCompleteLag()
     {
         ui64 mediatorTime = MediatorTimeCastEntry ? MediatorTimeCastEntry->Get(TabletID()) : 0;

--- a/ydb/core/tx/datashard/datashard_ut_init.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_init.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/core/base/tablet.h>
 #include <ydb/core/scheme/scheme_types_defs.h>
+#include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/testlib/test_client.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/util/pb.h>
@@ -16,6 +17,23 @@ using namespace Tests;
 using NClient::TValue;
 
 namespace {
+
+// TEvTabletSetTableInfo is not copyable (all-const members), so observers snapshot it.
+struct TReportedTableInfo {
+    ui64 TabletID;
+    ui32 FollowerId;
+    TPathId TableId;
+    TString TablePath;
+    ui64 SchemaVersion;
+
+    explicit TReportedTableInfo(const TEvTabletCounters::TEvTabletSetTableInfo &ev)
+        : TabletID(ev.TabletID)
+        , FollowerId(ev.FollowerId)
+        , TableId(ev.TableId)
+        , TablePath(ev.TablePath)
+        , SchemaVersion(ev.SchemaVersion)
+    {}
+};
 
 TString GetTablePath(TTestActorRuntime &runtime,
                      TActorId sender,
@@ -154,6 +172,72 @@ Y_UNIT_TEST_SUITE(TTxDataShardTestInit) {
 
     Y_UNIT_TEST(TestResolvePathAfterRestart) {
         TestTablePath(true, true);
+    }
+
+    Y_UNIT_TEST(TestSetTableInfoReflectsRename) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardDetailedMetrics(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        auto shard = GetTableShards(server, sender, "/Root/table-1")[0];
+
+        TVector<TReportedTableInfo> reported;
+        auto observer = runtime.AddObserver<TEvTabletCounters::TEvTabletSetTableInfo>(
+            [&](TEvTabletCounters::TEvTabletSetTableInfo::TPtr &ev) {
+                reported.push_back(TReportedTableInfo(*ev->Get()));
+            });
+
+        // DataShard reports its identity from DoPeriodicTasks(), which reschedules every 5s.
+        SimulateSleep(server, TDuration::Seconds(6));
+
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().TabletID, shard);
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().FollowerId, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().TablePath, "/Root/table-1");
+        auto prevTableId = reported.back().TableId;
+
+        WaitTxNotification(server, sender, AsyncMoveTable(server, "/Root/table-1", "/Root/table-1-moved"));
+
+        // No cache to invalidate: the very next tick reads the renamed table out of TableInfos.
+        reported.clear();
+        SimulateSleep(server, TDuration::Seconds(6));
+
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().TablePath, "/Root/table-1-moved");
+        UNIT_ASSERT_UNEQUAL(reported.back().TableId, prevTableId);
+    }
+
+    Y_UNIT_TEST(TestSetTableInfoNotSentWithoutFeatureFlag) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        // EnableDataShardDetailedMetrics defaults to false
+        serverSettings.SetDomainName("Root").SetUseRealThreads(false);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        TVector<TReportedTableInfo> reported;
+        auto observer = runtime.AddObserver<TEvTabletCounters::TEvTabletSetTableInfo>(
+            [&](TEvTabletCounters::TEvTabletSetTableInfo::TPtr &ev) {
+                reported.push_back(TReportedTableInfo(*ev->Get()));
+            });
+
+        SimulateSleep(server, TDuration::Seconds(6));
+
+        UNIT_ASSERT(reported.empty());
     }
 }
 


### PR DESCRIPTION

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Detailed metrics need to attribute a tablet's counter deltas to a user table, per follower. The aggregator will later join on (TabletID, FollowerId) to produce detailed metrics per table. This way nothing leaks through the ITablet and Executor
