### PR TITLE
Remove unused PEERDIRs from ydb/core/formats/arrow/hash

### DIFF
--- a/ydb/core/formats/arrow/hash/ya.make
+++ b/ydb/core/formats/arrow/hash/ya.make
@@ -6,10 +6,7 @@ PEERDIR(
     ydb/core/formats/arrow/switch
     ydb/library/actors/core
     ydb/library/services
-    ydb/library/actors/protos
     ydb/library/formats/arrow/hash
-    ydb/library/formats/arrow/common
-    ydb/library/formats/arrow/simple_builder
 )
 
 SRCS(


### PR DESCRIPTION
Removed 3 PEERDIRs with no corresponding includes in calcer.h/calcer.cpp: `ydb/library/actors/protos`, `ydb/library/formats/arrow/common`, `ydb/library/formats/arrow/simple_builder`.