### PR TITLE
Experimental CLI for topic deferred publish

### DIFF
--- a/ydb/apps/ydb/experimental/ydb/README.md
+++ b/ydb/apps/ydb/experimental/ydb/README.md
@@ -24,6 +24,26 @@ and adds the `experimental` (alias `exp`) command tree on top of it. The rest
 of the behaviour (authentication options, profiles, output formats, etc.)
 largely matches the official `ydb` client.
 
+### Deferred topic publication
+
+Under `experimental topic`:
+
+```bash
+./ydb/apps/ydb/experimental/ydb/ydb experimental topic deferred-publication --help
+./ydb/apps/ydb/experimental/ydb/ydb experimental topic write --help
+```
+
+Typical flow:
+
+```bash
+INT_ID=$(ydb experimental topic deferred-publication begin --ext-id order-42)
+echo "payload" | ydb experimental topic write /Root/my-topic --deferred-int-id "$INT_ID"
+ydb experimental topic deferred-publication publish --int-id "$INT_ID"
+```
+
+Commands: `begin`, `publish`, `cancel`, `list`, `describe`.
+`write` accepts `--deferred-int-id` and optional `--deferred-ext-id`.
+
 ## Building
 
 ```bash

--- a/ydb/apps/ydb/experimental/ydb/README.md
+++ b/ydb/apps/ydb/experimental/ydb/README.md
@@ -36,13 +36,13 @@ Under `experimental topic`:
 Typical flow:
 
 ```bash
-INT_ID=$(ydb experimental topic deferred-publication begin --ext-id order-42)
-echo "payload" | ydb experimental topic write /Root/my-topic --deferred-int-id "$INT_ID"
-ydb experimental topic deferred-publication publish --int-id "$INT_ID"
+INT_ID=$(ydb experimental topic deferred-publication begin --ext-publication-id order-42)
+echo "payload" | ydb experimental topic write /Root/my-topic --deferred-int-publication-id "$INT_ID"
+ydb experimental topic deferred-publication publish --int-publication-id "$INT_ID"
 ```
 
 Commands: `begin`, `publish`, `cancel`, `list`, `describe`.
-`write` accepts `--deferred-int-id` and optional `--deferred-ext-id`.
+`write` accepts `--deferred-int-publication-id` and optional `--deferred-ext-publication-id`.
 Run `publish` / `cancel` only after `write` exits successfully; they do not wait
 for in-flight writes from another process.
 

--- a/ydb/apps/ydb/experimental/ydb/README.md
+++ b/ydb/apps/ydb/experimental/ydb/README.md
@@ -43,6 +43,8 @@ ydb experimental topic deferred-publication publish --int-id "$INT_ID"
 
 Commands: `begin`, `publish`, `cancel`, `list`, `describe`.
 `write` accepts `--deferred-int-id` and optional `--deferred-ext-id`.
+Run `publish` / `cancel` only after `write` exits successfully; they do not wait
+for in-flight writes from another process.
 
 ## Building
 

--- a/ydb/apps/ydb/experimental/ydb/commands/ya.make
+++ b/ydb/apps/ydb/experimental/ydb/commands/ya.make
@@ -6,6 +6,7 @@ SRCS(
     ydb_service_experimental_fq.cpp
     ydb_service_experimental.cpp
     ydb_sql.cpp
+    ydb_topic_deferred_publish.cpp
 )
 
 PEERDIR(

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_service_experimental.cpp
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_service_experimental.cpp
@@ -2,6 +2,7 @@
 #include "generate.h"
 #include "ydb_service_experimental.h"
 #include "ydb_sql.h"
+#include "ydb_topic_deferred_publish.h"
 
 #include <memory>
 #include <ydb/public/lib/ydb_cli/common/plan2svg.h>
@@ -41,6 +42,7 @@ TCommandExperimental::TCommandExperimental()
     AddCommand(std::make_unique<TCommandSqlExperimental>());
     AddCommand(std::make_unique<TCommandSqlOperation>());
     AddCommand(std::make_unique<TCommandDeleteSession>());
+    AddCommand(std::make_unique<TCommandExperimentalTopic>());
 }
 
 TCommandStreamQuery::TCommandStreamQuery()

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
@@ -93,7 +93,10 @@ void TCommandExperimentalTopicWrite::Parse(TConfig& config) {
     if (Delimiter_.Defined() && MessagingFormat != EMessagingFormat::SingleMessage) {
         throw TMisuseException() << "Both mutually exclusive options \"delimiter\" and \"input-format\" were provided.";
     }
-    if (DeferredExtPublicationId_.Defined() && DeferredIntPublicationId_ == 0) {
+    if (DeferredIntPublicationId_.Defined() && *DeferredIntPublicationId_ == 0) {
+        throw TMisuseException() << "--deferred-int-id must be a positive integer";
+    }
+    if (DeferredExtPublicationId_.Defined() && !DeferredIntPublicationId_.Defined()) {
         throw TMisuseException() << "--deferred-ext-id requires --deferred-int-id";
     }
 }
@@ -142,10 +145,10 @@ int TCommandExperimentalTopicWrite::Run(TConfig& config) {
         GetTransform(),
         MessagesWaitTimeout_);
 
-    if (DeferredIntPublicationId_ != 0) {
+    if (DeferredIntPublicationId_.Defined()) {
         NTopic::TDeferredPublication deferred = DeferredExtPublicationId_.Defined()
-            ? NTopic::TDeferredPublication(DeferredIntPublicationId_, std::string(*DeferredExtPublicationId_))
-            : NTopic::TDeferredPublication(DeferredIntPublicationId_);
+            ? NTopic::TDeferredPublication(*DeferredIntPublicationId_, std::string(*DeferredExtPublicationId_))
+            : NTopic::TDeferredPublication(*DeferredIntPublicationId_);
         writerParams.SetDeferredPublication(std::move(deferred));
     }
 

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
@@ -71,11 +71,11 @@ void TCommandExperimentalTopicWrite::Config(TConfig& config) {
         .Hidden()
         .StoreMappedResult(&MessagesWaitTimeout_, &ParseDurationSeconds);
 
-    config.Opts->AddLongOption("deferred-int-id", "Deferred publication int_publication_id from begin")
+    config.Opts->AddLongOption("deferred-int-publication-id", "Deferred publication int_publication_id from begin")
         .Optional()
         .RequiredArgument("UINT64")
         .StoreResult(&DeferredIntPublicationId_);
-    config.Opts->AddLongOption("deferred-ext-id", "Optional deferred publication ext_publication_id")
+    config.Opts->AddLongOption("deferred-ext-publication-id", "Optional deferred publication ext_publication_id")
         .Optional()
         .RequiredArgument("STRING")
         .StoreResult(&DeferredExtPublicationId_);
@@ -94,10 +94,10 @@ void TCommandExperimentalTopicWrite::Parse(TConfig& config) {
         throw TMisuseException() << "Both mutually exclusive options \"delimiter\" and \"input-format\" were provided.";
     }
     if (DeferredIntPublicationId_.Defined() && *DeferredIntPublicationId_ == 0) {
-        throw TMisuseException() << "--deferred-int-id must be a positive integer";
+        throw TMisuseException() << "--deferred-int-publication-id must be a positive integer";
     }
     if (DeferredExtPublicationId_.Defined() && !DeferredIntPublicationId_.Defined()) {
-        throw TMisuseException() << "--deferred-ext-id requires --deferred-int-id";
+        throw TMisuseException() << "--deferred-ext-publication-id requires --deferred-int-publication-id";
     }
 }
 
@@ -192,7 +192,7 @@ TCommandTopicDeferredPublicationBegin::TCommandTopicDeferredPublicationBegin()
 void TCommandTopicDeferredPublicationBegin::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->SetFreeArgsNum(0);
-    config.Opts->AddLongOption("ext-id", "Client-defined publication name (unique among active)")
+    config.Opts->AddLongOption("ext-publication-id", "Client-defined publication name (unique among active)")
         .Required()
         .RequiredArgument("STRING")
         .StoreResult(&ExtPublicationId_);
@@ -246,7 +246,7 @@ TCommandTopicDeferredPublicationPublish::TCommandTopicDeferredPublicationPublish
 void TCommandTopicDeferredPublicationPublish::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->SetFreeArgsNum(0);
-    config.Opts->AddLongOption("int-id", "Server-assigned publication id from begin")
+    config.Opts->AddLongOption("int-publication-id", "Server-assigned publication id from begin")
         .Required()
         .RequiredArgument("UINT64")
         .StoreResult(&IntPublicationId_);
@@ -273,7 +273,7 @@ TCommandTopicDeferredPublicationCancel::TCommandTopicDeferredPublicationCancel()
 void TCommandTopicDeferredPublicationCancel::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->SetFreeArgsNum(0);
-    config.Opts->AddLongOption("int-id", "Server-assigned publication id from begin")
+    config.Opts->AddLongOption("int-publication-id", "Server-assigned publication id from begin")
         .Required()
         .RequiredArgument("UINT64")
         .StoreResult(&IntPublicationId_);
@@ -359,7 +359,7 @@ TCommandTopicDeferredPublicationDescribe::TCommandTopicDeferredPublicationDescri
 void TCommandTopicDeferredPublicationDescribe::Config(TConfig& config) {
     TYdbCommand::Config(config);
     config.Opts->SetFreeArgsNum(0);
-    config.Opts->AddLongOption("int-id", "Server-assigned publication id from begin")
+    config.Opts->AddLongOption("int-publication-id", "Server-assigned publication id from begin")
         .Required()
         .RequiredArgument("UINT64")
         .StoreResult(&IntPublicationId_);

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
@@ -8,6 +8,9 @@
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/deferred_publications.h>
 
+#include <library/cpp/json/json_value.h>
+#include <library/cpp/json/json_writer.h>
+
 #include <openssl/sha.h>
 #include <util/stream/file.h>
 #include <util/string/hex.h>
@@ -15,6 +18,15 @@
 namespace NYdb::NConsoleClient {
 
 using NTopic::TDeferredPublishClient;
+
+namespace {
+
+void WriteJsonLine(const NJson::TJsonValue& value) {
+    NJson::WriteJson(&Cout, &value, /*formatOutput*/ false);
+    Cout << Endl;
+}
+
+} // namespace
 
 TCommandExperimentalTopic::TCommandExperimentalTopic()
     : TClientCommandTree("topic", {}, "Topic commands with experimental deferred publish support")
@@ -208,8 +220,10 @@ int TCommandTopicDeferredPublicationBegin::Run(TConfig& config) {
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
 
     if (OutputFormat == EDataFormat::Json) {
-        Cout << "{\"int_publication_id\":" << result.GetIntPublicationId()
-             << ",\"ext_publication_id\":\"" << ExtPublicationId_ << "\"}" << Endl;
+        NJson::TJsonValue json(NJson::JSON_MAP);
+        json["int_publication_id"] = result.GetIntPublicationId();
+        json["ext_publication_id"] = ExtPublicationId_;
+        WriteJsonLine(json);
     } else {
         Cout << result.GetIntPublicationId() << Endl;
     }
@@ -217,7 +231,12 @@ int TCommandTopicDeferredPublicationBegin::Run(TConfig& config) {
 }
 
 TCommandTopicDeferredPublicationPublish::TCommandTopicDeferredPublicationPublish()
-    : TYdbCommand("publish", {}, "Publish staged messages of a deferred publication")
+    : TYdbCommand(
+          "publish",
+          {},
+          "Publish staged messages of a deferred publication. "
+          "Run only after deferred write exits successfully; this command does not wait "
+          "for in-flight writes from another process.")
 {
 }
 
@@ -239,7 +258,12 @@ int TCommandTopicDeferredPublicationPublish::Run(TConfig& config) {
 }
 
 TCommandTopicDeferredPublicationCancel::TCommandTopicDeferredPublicationCancel()
-    : TYdbCommand("cancel", {}, "Cancel a deferred publication and discard staged messages")
+    : TYdbCommand(
+          "cancel",
+          {},
+          "Cancel a deferred publication and discard staged messages. "
+          "Run only after deferred write exits successfully; this command does not wait "
+          "for in-flight writes from another process.")
 {
 }
 
@@ -295,21 +319,17 @@ int TCommandTopicDeferredPublicationList::Run(TConfig& config) {
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
 
     if (OutputFormat == EDataFormat::Json) {
-        Cout << "[";
-        bool first = true;
+        NJson::TJsonValue json(NJson::JSON_ARRAY);
         for (const auto& publication : result.GetPublications()) {
-            if (!first) {
-                Cout << ",";
-            }
-            first = false;
-            Cout << "{\"int_publication_id\":" << publication.IntPublicationId
-                 << ",\"ext_publication_id\":\"" << publication.ExtPublicationId << "\"";
+            NJson::TJsonValue item(NJson::JSON_MAP);
+            item["int_publication_id"] = publication.IntPublicationId;
+            item["ext_publication_id"] = TString(publication.ExtPublicationId);
             if (publication.WriterIdentity) {
-                Cout << ",\"writer_identity\":\"" << *publication.WriterIdentity << "\"";
+                item["writer_identity"] = TString(*publication.WriterIdentity);
             }
-            Cout << "}";
+            json.AppendValue(std::move(item));
         }
-        Cout << "]" << Endl;
+        WriteJsonLine(json);
         return EXIT_SUCCESS;
     }
 
@@ -359,33 +379,28 @@ int TCommandTopicDeferredPublicationDescribe::Run(TConfig& config) {
 
     const auto& publication = result.GetPublication();
     if (OutputFormat == EDataFormat::Json) {
-        Cout << "{\"ext_publication_id\":\"" << publication.ExtPublicationId << "\"";
+        NJson::TJsonValue json(NJson::JSON_MAP);
+        json["ext_publication_id"] = TString(publication.ExtPublicationId);
         if (publication.WriterIdentity) {
-            Cout << ",\"writer_identity\":\"" << *publication.WriterIdentity << "\"";
+            json["writer_identity"] = TString(*publication.WriterIdentity);
         }
-        Cout << ",\"created_at\":\"" << publication.CreatedAt.ToString() << "\"";
+        json["created_at"] = publication.CreatedAt.ToString();
         if (publication.CreatedBy) {
-            Cout << ",\"created_by\":\"" << *publication.CreatedBy << "\"";
+            json["created_by"] = TString(*publication.CreatedBy);
         }
-        Cout << ",\"destinations\":[";
-        bool firstDest = true;
+        NJson::TJsonValue destinations(NJson::JSON_ARRAY);
         for (const auto& destination : publication.Destinations) {
-            if (!firstDest) {
-                Cout << ",";
-            }
-            firstDest = false;
-            Cout << "{\"topic_path\":\"" << destination.TopicPath << "\",\"partition_ids\":[";
-            bool firstPart = true;
+            NJson::TJsonValue dest(NJson::JSON_MAP);
+            dest["topic_path"] = TString(destination.TopicPath);
+            NJson::TJsonValue partitionIds(NJson::JSON_ARRAY);
             for (const auto partitionId : destination.PartitionIds) {
-                if (!firstPart) {
-                    Cout << ",";
-                }
-                firstPart = false;
-                Cout << partitionId;
+                partitionIds.AppendValue(partitionId);
             }
-            Cout << "]}";
+            dest["partition_ids"] = std::move(partitionIds);
+            destinations.AppendValue(std::move(dest));
         }
-        Cout << "]}" << Endl;
+        json["destinations"] = std::move(destinations);
+        WriteJsonLine(json);
         return EXIT_SUCCESS;
     }
 

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
@@ -383,6 +383,7 @@ int TCommandTopicDeferredPublicationDescribe::Run(TConfig& config) {
     const auto& publication = result.GetPublication();
     if (OutputFormat == EDataFormat::Json) {
         NJson::TJsonValue json(NJson::JSON_MAP);
+        json["int_publication_id"] = IntPublicationId_;
         json["ext_publication_id"] = TString(publication.ExtPublicationId);
         if (publication.WriterIdentity) {
             json["writer_identity"] = TString(*publication.WriterIdentity);
@@ -407,6 +408,7 @@ int TCommandTopicDeferredPublicationDescribe::Run(TConfig& config) {
         return EXIT_SUCCESS;
     }
 
+    Cout << "int_publication_id: " << IntPublicationId_ << Endl;
     Cout << "ext_publication_id: " << publication.ExtPublicationId << Endl;
     if (publication.WriterIdentity) {
         Cout << "writer_identity: " << *publication.WriterIdentity << Endl;

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.cpp
@@ -1,0 +1,416 @@
+#include "ydb_topic_deferred_publish.h"
+
+#include <ydb/public/lib/ydb_cli/commands/ydb_common.h>
+#include <ydb/public/lib/ydb_cli/common/duration.h>
+#include <ydb/public/lib/ydb_cli/common/pretty_table.h>
+#include <ydb/public/lib/ydb_cli/common/scheme_path_completer.h>
+#include <ydb/public/lib/ydb_cli/topic/topic_write.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/deferred_publications.h>
+
+#include <openssl/sha.h>
+#include <util/stream/file.h>
+#include <util/string/hex.h>
+
+namespace NYdb::NConsoleClient {
+
+using NTopic::TDeferredPublishClient;
+
+TCommandExperimentalTopic::TCommandExperimentalTopic()
+    : TClientCommandTree("topic", {}, "Topic commands with experimental deferred publish support")
+{
+    AddCommand(std::make_unique<TCommandExperimentalTopicWrite>());
+    AddCommand(std::make_unique<TCommandTopicDeferredPublication>());
+}
+
+TCommandExperimentalTopicWrite::TCommandExperimentalTopicWrite()
+    : TYdbCommand("write", {}, "Write to topic; supports deferred publication staging")
+{
+}
+
+void TCommandExperimentalTopicWrite::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.Opts->SetFreeArgsNum(1);
+    SetFreeArgTitle(0, "<topic-path>", "Topic path");
+    SetSchemePathCompletionForTopics(config.Opts->GetOpts().GetFreeArgSpec(0));
+
+    AddMessagingFormats(config, {
+        EMessagingFormat::NewlineDelimited,
+        EMessagingFormat::SingleMessage,
+    });
+    AddAllowedCodecs(config, AllowedCodecs);
+
+    config.Opts->AddLongOption('d', "delimiter", "Delimiter to split messages")
+        .Optional()
+        .StoreResult(&Delimiter_);
+    config.Opts->AddLongOption('f', "file", "File to read data from")
+        .Optional()
+        .StoreResult(&File_);
+    config.Opts->AddLongOption("message-group-id", "Message group identifier")
+        .Optional()
+        .StoreResult(&MessageGroupId_);
+    config.Opts->AddLongOption("partition-id", "Write to an exact partition")
+        .Hidden()
+        .Optional()
+        .RequiredArgument("INDEX")
+        .StoreResult(&PartitionId_);
+    config.Opts->AddLongOption("init-seqno-timeout", "Max wait duration for initial seqno")
+        .Optional()
+        .Hidden()
+        .StoreMappedResult(&MessagesWaitTimeout_, &ParseDurationSeconds);
+
+    config.Opts->AddLongOption("deferred-int-id", "Deferred publication int_publication_id from begin")
+        .Optional()
+        .RequiredArgument("UINT64")
+        .StoreResult(&DeferredIntPublicationId_);
+    config.Opts->AddLongOption("deferred-ext-id", "Optional deferred publication ext_publication_id")
+        .Optional()
+        .RequiredArgument("STRING")
+        .StoreResult(&DeferredExtPublicationId_);
+
+    AddTransform(config);
+}
+
+void TCommandExperimentalTopicWrite::Parse(TConfig& config) {
+    TYdbCommand::Parse(config);
+    ParseTopicName(config, 0);
+    ParseMessagingFormats();
+    ParseTransform();
+    ParseCodec();
+
+    if (Delimiter_.Defined() && MessagingFormat != EMessagingFormat::SingleMessage) {
+        throw TMisuseException() << "Both mutually exclusive options \"delimiter\" and \"input-format\" were provided.";
+    }
+    if (DeferredExtPublicationId_.Defined() && DeferredIntPublicationId_ == 0) {
+        throw TMisuseException() << "--deferred-ext-id requires --deferred-int-id";
+    }
+}
+
+NTopic::TWriteSessionSettings TCommandExperimentalTopicWrite::PrepareWriteSessionSettings() {
+    NTopic::TWriteSessionSettings settings;
+    if (auto codec = GetCodec(); codec.Defined()) {
+        settings.Codec(*codec);
+    }
+    settings.Path(TopicName);
+
+    if (PartitionId_.Defined()) {
+        settings.PartitionId(*PartitionId_);
+    }
+    if (!MessageGroupId_.Defined()) {
+        const TString rnd = ToString(TInstant::Now().NanoSeconds());
+        SHA_CTX ctx;
+        SHA1_Init(&ctx);
+        SHA1_Update(&ctx, rnd.data(), rnd.size());
+        unsigned char sha1[SHA_DIGEST_LENGTH];
+        SHA1_Final(sha1, &ctx);
+
+        TString hex = HexEncode(TString(reinterpret_cast<const char*>(sha1), SHA_DIGEST_LENGTH));
+        hex.to_lower();
+        MessageGroupId_ = TString(hex.begin(), hex.begin() + 6);
+    }
+
+    settings.MessageGroupId(*MessageGroupId_);
+    settings.ProducerId(*MessageGroupId_);
+    return settings;
+}
+
+int TCommandExperimentalTopicWrite::Run(TConfig& config) {
+    SetInterruptHandlers();
+
+    auto driver = CreateDriver(config);
+    auto writeSession = NTopic::TTopicClient(driver).CreateWriteSession(PrepareWriteSessionSettings());
+
+    auto writerParams = TTopicWriterParams(
+        MessagingFormat,
+        Delimiter_,
+        MessageSizeLimit_,
+        Nothing(),
+        Nothing(),
+        Nothing(),
+        GetTransform(),
+        MessagesWaitTimeout_);
+
+    if (DeferredIntPublicationId_ != 0) {
+        NTopic::TDeferredPublication deferred = DeferredExtPublicationId_.Defined()
+            ? NTopic::TDeferredPublication(DeferredIntPublicationId_, std::string(*DeferredExtPublicationId_))
+            : NTopic::TDeferredPublication(DeferredIntPublicationId_);
+        writerParams.SetDeferredPublication(std::move(deferred));
+    }
+
+    TTopicWriter writer(writeSession, std::move(writerParams));
+    if (int status = writer.Init(); status) {
+        return status;
+    }
+
+    int status = 0;
+    if (File_.Defined()) {
+        TFileInput input(*File_);
+        status = writer.Run(input);
+    } else {
+        status = writer.Run(Cin);
+    }
+    if (status) {
+        return status;
+    }
+    if (!writer.Close()) {
+        Cerr << "Failed to close session" << Endl;
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}
+
+TCommandTopicDeferredPublication::TCommandTopicDeferredPublication()
+    : TClientCommandTree("deferred-publication", {"publication", "dp"}, "Deferred topic publication operations")
+{
+    AddCommand(std::make_unique<TCommandTopicDeferredPublicationBegin>());
+    AddCommand(std::make_unique<TCommandTopicDeferredPublicationPublish>());
+    AddCommand(std::make_unique<TCommandTopicDeferredPublicationCancel>());
+    AddCommand(std::make_unique<TCommandTopicDeferredPublicationList>());
+    AddCommand(std::make_unique<TCommandTopicDeferredPublicationDescribe>());
+}
+
+TCommandTopicDeferredPublicationBegin::TCommandTopicDeferredPublicationBegin()
+    : TYdbCommand("begin", {}, "Begin a deferred publication")
+{
+}
+
+void TCommandTopicDeferredPublicationBegin::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.Opts->SetFreeArgsNum(0);
+    config.Opts->AddLongOption("ext-id", "Client-defined publication name (unique among active)")
+        .Required()
+        .RequiredArgument("STRING")
+        .StoreResult(&ExtPublicationId_);
+    config.Opts->AddLongOption("writer-identity", "Optional writer identity for List filter")
+        .Optional()
+        .RequiredArgument("STRING")
+        .StoreResult(&WriterIdentity_);
+    AddOutputFormats(config, {
+        EDataFormat::Pretty,
+        EDataFormat::Json,
+    });
+}
+
+void TCommandTopicDeferredPublicationBegin::Parse(TConfig& config) {
+    TYdbCommand::Parse(config);
+    ParseOutputFormats();
+}
+
+int TCommandTopicDeferredPublicationBegin::Run(TConfig& config) {
+    auto driver = CreateDriver(config);
+    TDeferredPublishClient client(driver);
+    NTopic::TBeginPublicationSettings settings;
+    if (WriterIdentity_.Defined()) {
+        settings.WriterIdentity(std::string(*WriterIdentity_));
+    }
+
+    auto result = client.BeginPublication(std::string(ExtPublicationId_), settings).GetValueSync();
+    NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
+
+    if (OutputFormat == EDataFormat::Json) {
+        Cout << "{\"int_publication_id\":" << result.GetIntPublicationId()
+             << ",\"ext_publication_id\":\"" << ExtPublicationId_ << "\"}" << Endl;
+    } else {
+        Cout << result.GetIntPublicationId() << Endl;
+    }
+    return EXIT_SUCCESS;
+}
+
+TCommandTopicDeferredPublicationPublish::TCommandTopicDeferredPublicationPublish()
+    : TYdbCommand("publish", {}, "Publish staged messages of a deferred publication")
+{
+}
+
+void TCommandTopicDeferredPublicationPublish::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.Opts->SetFreeArgsNum(0);
+    config.Opts->AddLongOption("int-id", "Server-assigned publication id from begin")
+        .Required()
+        .RequiredArgument("UINT64")
+        .StoreResult(&IntPublicationId_);
+}
+
+int TCommandTopicDeferredPublicationPublish::Run(TConfig& config) {
+    auto driver = CreateDriver(config);
+    TDeferredPublishClient client(driver);
+    auto result = client.Publish(NTopic::TDeferredPublication(IntPublicationId_)).GetValueSync();
+    NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
+    return EXIT_SUCCESS;
+}
+
+TCommandTopicDeferredPublicationCancel::TCommandTopicDeferredPublicationCancel()
+    : TYdbCommand("cancel", {}, "Cancel a deferred publication and discard staged messages")
+{
+}
+
+void TCommandTopicDeferredPublicationCancel::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.Opts->SetFreeArgsNum(0);
+    config.Opts->AddLongOption("int-id", "Server-assigned publication id from begin")
+        .Required()
+        .RequiredArgument("UINT64")
+        .StoreResult(&IntPublicationId_);
+}
+
+int TCommandTopicDeferredPublicationCancel::Run(TConfig& config) {
+    auto driver = CreateDriver(config);
+    TDeferredPublishClient client(driver);
+    auto result = client.CancelPublication(NTopic::TDeferredPublication(IntPublicationId_)).GetValueSync();
+    NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
+    return EXIT_SUCCESS;
+}
+
+TCommandTopicDeferredPublicationList::TCommandTopicDeferredPublicationList()
+    : TYdbCommand("list", {}, "List active deferred publications")
+{
+}
+
+void TCommandTopicDeferredPublicationList::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.Opts->SetFreeArgsNum(0);
+    config.Opts->AddLongOption("writer-identity", "Filter by writer identity from begin")
+        .Optional()
+        .RequiredArgument("STRING")
+        .StoreResult(&WriterIdentity_);
+    AddOutputFormats(config, {
+        EDataFormat::Pretty,
+        EDataFormat::Json,
+    });
+}
+
+void TCommandTopicDeferredPublicationList::Parse(TConfig& config) {
+    TYdbCommand::Parse(config);
+    ParseOutputFormats();
+}
+
+int TCommandTopicDeferredPublicationList::Run(TConfig& config) {
+    auto driver = CreateDriver(config);
+    TDeferredPublishClient client(driver);
+    NTopic::TListPublicationsSettings settings;
+    if (WriterIdentity_.Defined()) {
+        settings.WriterIdentity(std::string(*WriterIdentity_));
+    }
+
+    auto result = client.ListPublications(settings).GetValueSync();
+    NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
+
+    if (OutputFormat == EDataFormat::Json) {
+        Cout << "[";
+        bool first = true;
+        for (const auto& publication : result.GetPublications()) {
+            if (!first) {
+                Cout << ",";
+            }
+            first = false;
+            Cout << "{\"int_publication_id\":" << publication.IntPublicationId
+                 << ",\"ext_publication_id\":\"" << publication.ExtPublicationId << "\"";
+            if (publication.WriterIdentity) {
+                Cout << ",\"writer_identity\":\"" << *publication.WriterIdentity << "\"";
+            }
+            Cout << "}";
+        }
+        Cout << "]" << Endl;
+        return EXIT_SUCCESS;
+    }
+
+    TPrettyTable table({
+        "int_publication_id",
+        "ext_publication_id",
+        "writer_identity",
+    });
+    for (const auto& publication : result.GetPublications()) {
+        auto& row = table.AddRow();
+        row.Column(0, publication.IntPublicationId);
+        row.Column(1, TString(publication.ExtPublicationId));
+        row.Column(2, publication.WriterIdentity ? TString(*publication.WriterIdentity) : TString("-"));
+    }
+    Cout << table;
+    return EXIT_SUCCESS;
+}
+
+TCommandTopicDeferredPublicationDescribe::TCommandTopicDeferredPublicationDescribe()
+    : TYdbCommand("describe", {}, "Describe an active deferred publication")
+{
+}
+
+void TCommandTopicDeferredPublicationDescribe::Config(TConfig& config) {
+    TYdbCommand::Config(config);
+    config.Opts->SetFreeArgsNum(0);
+    config.Opts->AddLongOption("int-id", "Server-assigned publication id from begin")
+        .Required()
+        .RequiredArgument("UINT64")
+        .StoreResult(&IntPublicationId_);
+    AddOutputFormats(config, {
+        EDataFormat::Pretty,
+        EDataFormat::Json,
+    });
+}
+
+void TCommandTopicDeferredPublicationDescribe::Parse(TConfig& config) {
+    TYdbCommand::Parse(config);
+    ParseOutputFormats();
+}
+
+int TCommandTopicDeferredPublicationDescribe::Run(TConfig& config) {
+    auto driver = CreateDriver(config);
+    TDeferredPublishClient client(driver);
+    auto result = client.DescribePublication(NTopic::TDeferredPublication(IntPublicationId_)).GetValueSync();
+    NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
+
+    const auto& publication = result.GetPublication();
+    if (OutputFormat == EDataFormat::Json) {
+        Cout << "{\"ext_publication_id\":\"" << publication.ExtPublicationId << "\"";
+        if (publication.WriterIdentity) {
+            Cout << ",\"writer_identity\":\"" << *publication.WriterIdentity << "\"";
+        }
+        Cout << ",\"created_at\":\"" << publication.CreatedAt.ToString() << "\"";
+        if (publication.CreatedBy) {
+            Cout << ",\"created_by\":\"" << *publication.CreatedBy << "\"";
+        }
+        Cout << ",\"destinations\":[";
+        bool firstDest = true;
+        for (const auto& destination : publication.Destinations) {
+            if (!firstDest) {
+                Cout << ",";
+            }
+            firstDest = false;
+            Cout << "{\"topic_path\":\"" << destination.TopicPath << "\",\"partition_ids\":[";
+            bool firstPart = true;
+            for (const auto partitionId : destination.PartitionIds) {
+                if (!firstPart) {
+                    Cout << ",";
+                }
+                firstPart = false;
+                Cout << partitionId;
+            }
+            Cout << "]}";
+        }
+        Cout << "]}" << Endl;
+        return EXIT_SUCCESS;
+    }
+
+    Cout << "ext_publication_id: " << publication.ExtPublicationId << Endl;
+    if (publication.WriterIdentity) {
+        Cout << "writer_identity: " << *publication.WriterIdentity << Endl;
+    }
+    Cout << "created_at: " << publication.CreatedAt << Endl;
+    if (publication.CreatedBy) {
+        Cout << "created_by: " << *publication.CreatedBy << Endl;
+    }
+    Cout << "destinations:" << Endl;
+    if (publication.Destinations.empty()) {
+        Cout << "  (none)" << Endl;
+    } else {
+        for (const auto& destination : publication.Destinations) {
+            Cout << "  - topic: " << destination.TopicPath << Endl;
+            Cout << "    partitions:";
+            for (const auto partitionId : destination.PartitionIds) {
+                Cout << " " << partitionId;
+            }
+            Cout << Endl;
+        }
+    }
+    return EXIT_SUCCESS;
+}
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.h
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.h
@@ -35,7 +35,7 @@ private:
     TMaybe<TDuration> MessagesWaitTimeout_;
     ui64 MessageSizeLimit_ = 0;
 
-    ui64 DeferredIntPublicationId_ = 0;
+    TMaybe<ui64> DeferredIntPublicationId_;
     TMaybe<TString> DeferredExtPublicationId_;
 };
 

--- a/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.h
+++ b/ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <ydb/public/lib/ydb_cli/commands/ydb_command.h>
+#include <ydb/public/lib/ydb_cli/common/command.h>
+#include <ydb/public/lib/ydb_cli/common/format.h>
+#include <ydb/public/lib/ydb_cli/common/interruptable.h>
+#include <ydb/public/lib/ydb_cli/commands/ydb_service_topic.h>
+
+namespace NYdb::NConsoleClient {
+
+class TCommandExperimentalTopic : public TClientCommandTree {
+public:
+    TCommandExperimentalTopic();
+};
+
+class TCommandExperimentalTopicWrite : public TYdbCommand,
+                                       public TCommandWithMessagingFormat,
+                                       public TInterruptableCommand,
+                                       public TCommandWithTopicName,
+                                       public TCommandWithCodec,
+                                       public TCommandWithTransformBody {
+public:
+    TCommandExperimentalTopicWrite();
+    void Config(TConfig& config) override;
+    void Parse(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    NTopic::TWriteSessionSettings PrepareWriteSessionSettings();
+
+    TMaybe<TString> File_;
+    TMaybe<TString> Delimiter_;
+    TMaybe<TString> MessageGroupId_;
+    TMaybe<ui32> PartitionId_;
+    TMaybe<TDuration> MessagesWaitTimeout_;
+    ui64 MessageSizeLimit_ = 0;
+
+    ui64 DeferredIntPublicationId_ = 0;
+    TMaybe<TString> DeferredExtPublicationId_;
+};
+
+class TCommandTopicDeferredPublication : public TClientCommandTree {
+public:
+    TCommandTopicDeferredPublication();
+};
+
+class TCommandTopicDeferredPublicationBegin : public TYdbCommand, public TCommandWithOutput {
+public:
+    TCommandTopicDeferredPublicationBegin();
+    void Config(TConfig& config) override;
+    void Parse(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    TString ExtPublicationId_;
+    TMaybe<TString> WriterIdentity_;
+};
+
+class TCommandTopicDeferredPublicationPublish : public TYdbCommand {
+public:
+    TCommandTopicDeferredPublicationPublish();
+    void Config(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    ui64 IntPublicationId_ = 0;
+};
+
+class TCommandTopicDeferredPublicationCancel : public TYdbCommand {
+public:
+    TCommandTopicDeferredPublicationCancel();
+    void Config(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    ui64 IntPublicationId_ = 0;
+};
+
+class TCommandTopicDeferredPublicationList : public TYdbCommand, public TCommandWithOutput {
+public:
+    TCommandTopicDeferredPublicationList();
+    void Config(TConfig& config) override;
+    void Parse(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    TMaybe<TString> WriterIdentity_;
+};
+
+class TCommandTopicDeferredPublicationDescribe : public TYdbCommand, public TCommandWithOutput {
+public:
+    TCommandTopicDeferredPublicationDescribe();
+    void Config(TConfig& config) override;
+    void Parse(TConfig& config) override;
+    int Run(TConfig& config) override;
+
+private:
+    ui64 IntPublicationId_ = 0;
+};
+
+} // namespace NYdb::NConsoleClient

--- a/ydb/public/lib/ydb_cli/topic/topic_write.cpp
+++ b/ydb/public/lib/ydb_cli/topic/topic_write.cpp
@@ -190,7 +190,12 @@ namespace NYdb::NConsoleClient {
                 continue;
             }
 
-            WriteSession_->Write(std::move(*ContinuationToken_), std::move(message.Data), CurrentSeqNo_++);
+            NTopic::TWriteMessage writeMessage(std::move(message.Data));
+            writeMessage.SeqNo(CurrentSeqNo_++);
+            if (WriterParams_.DeferredPublication().Defined()) {
+                writeMessage.DeferredPublication(*WriterParams_.DeferredPublication());
+            }
+            WriteSession_->Write(std::move(*ContinuationToken_), std::move(writeMessage));
             ContinuationToken_ = Nothing();
         }
 

--- a/ydb/public/lib/ydb_cli/topic/topic_write.h
+++ b/ydb/public/lib/ydb_cli/topic/topic_write.h
@@ -32,6 +32,11 @@ namespace NYdb::NConsoleClient {
         GETTER(NTopic::ECodec, Codec);
         GETTER(ETransformBody, Transform);
         GETTER(TMaybe<TDuration>, MessagesWaitTimeout);
+        GETTER(TMaybe<NTopic::TDeferredPublication>, DeferredPublication);
+
+        void SetDeferredPublication(NTopic::TDeferredPublication deferredPublication) {
+            DeferredPublication_ = std::move(deferredPublication);
+        }
 
     private:
         TMaybe<TString> File_;
@@ -45,6 +50,7 @@ namespace NYdb::NConsoleClient {
         NTopic::ECodec Codec_ = NTopic::ECodec::RAW;
         ETransformBody Transform_ = ETransformBody::None;
         TMaybe<TDuration> MessagesWaitTimeout_;
+        TMaybe<NTopic::TDeferredPublication> DeferredPublication_;
 
         ui64 MessageSizeLimit_ = 0;
     };

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -9,6 +9,7 @@ The same suite runs on dedicated (/Root) and serverless databases.
 """
 
 import logging
+import json
 import os
 import tempfile
 import uuid
@@ -166,6 +167,12 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
         describe = self._describe(int_id)
         assert ext_id in describe.stdout
         assert AUTH_TOKEN in describe.stdout
+        assert f"int_publication_id: {int_id}" in describe.stdout
+
+        describe_json = self._describe(int_id, output_format="json")
+        description = json.loads(describe_json.stdout)
+        assert description["int_publication_id"] == int(int_id)
+        assert description["ext_publication_id"] == ext_id
 
         listed = self._list()
         assert ext_id in listed.stdout

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+"""
+Functional smoke tests for deferred topic publish via experimental CLI.
+
+Scenarios mirror the demo happy path / cancel / list-describe flows:
+  begin → write --deferred-int-id → publish|cancel → topic read
+"""
+
+import logging
+import os
+import tempfile
+import uuid
+
+import yatest
+
+from ydb.tests.functional.ydb_cli.ydb_cli_helpers import BaseCliTestWithDatabase, ydb_bin
+from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+
+logger = logging.getLogger(__name__)
+
+AUTH_TOKEN = "root@builtin"
+CONSUMER = "dp-consumer"
+
+
+class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
+    CLI_BINARY_ENV = "YDB_CLI_EXPERIMENTAL_BINARY"
+
+    @classmethod
+    def get_cluster_configurator(cls):
+        return KikimrConfigGenerator(
+            extra_feature_flags=["enable_topic_deferred_publish"],
+        )
+
+    @classmethod
+    def _auth_env(cls, extra=None):
+        env = os.environ.copy()
+        env["YDB_TOKEN"] = AUTH_TOKEN
+        if extra:
+            env.update(extra)
+        return env
+
+    @classmethod
+    def execute_exp(cls, args, stdin=None, check_exit_code=True, with_auth=True):
+        execution = yatest.common.execute(
+            [
+                ydb_bin(cls.CLI_BINARY_ENV),
+                "--endpoint", cls.grpc_endpoint(),
+                "--database", cls.root_dir,
+            ] + args,
+            stdin=stdin,
+            check_exit_code=check_exit_code,
+            env=cls._auth_env() if with_auth else None,
+        )
+        result = cls.ExecutionResult(
+            stdout=execution.std_out.decode("utf-8") if execution.std_out else "",
+            stderr=execution.std_err.decode("utf-8") if execution.std_err else "",
+            exit_code=execution.exit_code,
+        )
+        logger.debug("args: %s", args)
+        logger.debug("stdout:\n%s", result.stdout)
+        logger.debug("stderr:\n%s", result.stderr)
+        logger.debug("exit_code: %d", result.exit_code)
+        return result
+
+    @classmethod
+    def _unique_topic(cls, prefix):
+        return f"{cls.root_dir}/{prefix}-{uuid.uuid4().hex[:8]}"
+
+    @classmethod
+    def _prepare_topic(cls, topic_path):
+        # Scheme/topic DDL in this harness is anonymous-friendly; deferred RPCs require auth.
+        cls.driver.topic_client.create_topic(
+            topic_path,
+            consumers=[CONSUMER],
+            min_active_partitions=1,
+        )
+
+    @classmethod
+    def _begin(cls, ext_id, writer_identity=None):
+        args = ["experimental", "topic", "deferred-publication", "begin", "--ext-id", ext_id]
+        if writer_identity is not None:
+            args.extend(["--writer-identity", writer_identity])
+        result = cls.execute_exp(args)
+        int_id = result.stdout.strip()
+        assert int_id.isdigit(), f"expected int_publication_id, got: {result.stdout!r}"
+        return int_id
+
+    @classmethod
+    def _write_deferred(cls, topic_path, int_id, payload, ext_id=None):
+        args = [
+            "experimental", "topic", "write", topic_path,
+            "--deferred-int-id", int_id,
+            "--format", "single-message",
+        ]
+        if ext_id is not None:
+            args.extend(["--deferred-ext-id", ext_id])
+        with tempfile.NamedTemporaryFile("w+b") as stdin_file:
+            stdin_file.write(payload.encode("utf-8"))
+            stdin_file.flush()
+            stdin_file.seek(0)
+            return cls.execute_exp(args, stdin=stdin_file)
+
+    @classmethod
+    def _publish(cls, int_id, check_exit_code=True):
+        return cls.execute_exp(
+            ["experimental", "topic", "deferred-publication", "publish", "--int-id", int_id],
+            check_exit_code=check_exit_code,
+        )
+
+    @classmethod
+    def _cancel(cls, int_id, check_exit_code=True):
+        return cls.execute_exp(
+            ["experimental", "topic", "deferred-publication", "cancel", "--int-id", int_id],
+            check_exit_code=check_exit_code,
+        )
+
+    @classmethod
+    def _list(cls, writer_identity=None):
+        args = ["experimental", "topic", "deferred-publication", "list"]
+        if writer_identity is not None:
+            args.extend(["--writer-identity", writer_identity])
+        return cls.execute_exp(args)
+
+    @classmethod
+    def _describe(cls, int_id, check_exit_code=True):
+        return cls.execute_exp(
+            ["experimental", "topic", "deferred-publication", "describe", "--int-id", int_id],
+            check_exit_code=check_exit_code,
+        )
+
+    @classmethod
+    def _read(cls, topic_path, limit=10):
+        # Prefer CLI topic read without token: anonymous works for read in this harness.
+        return cls.execute_exp(
+            [
+                "topic", "read", topic_path,
+                "--consumer", CONSUMER,
+                "--limit", str(limit),
+                "--format", "single-message",
+                "--idle-timeout", "2s",
+                "--commit", "1",
+            ],
+            check_exit_code=True,
+            with_auth=False,
+        )
+
+    def test_happy_path_publish(self):
+        topic = self._unique_topic("dp-happy")
+        self._prepare_topic(topic)
+        ext_id = f"order-{uuid.uuid4().hex[:8]}"
+        payload = "hello-deferred-publish"
+
+        int_id = self._begin(ext_id)
+        describe = self._describe(int_id)
+        assert ext_id in describe.stdout
+        assert AUTH_TOKEN in describe.stdout
+
+        listed = self._list()
+        assert ext_id in listed.stdout
+        assert int_id in listed.stdout
+
+        self._write_deferred(topic, int_id, payload, ext_id=ext_id)
+
+        before = self._read(topic)
+        assert payload not in before.stdout
+
+        publish = self._publish(int_id)
+        assert publish.exit_code == 0
+
+        after = self._read(topic)
+        assert payload in after.stdout
+
+        repeat = self._publish(int_id, check_exit_code=False)
+        assert repeat.exit_code != 0
+
+    def test_cancel_discards_staged_data(self):
+        topic = self._unique_topic("dp-cancel")
+        self._prepare_topic(topic)
+        ext_id = f"cancel-{uuid.uuid4().hex[:8]}"
+        payload = "to-be-cancelled"
+
+        int_id = self._begin(ext_id)
+        self._write_deferred(topic, int_id, payload, ext_id=ext_id)
+
+        cancel = self._cancel(int_id)
+        assert cancel.exit_code == 0
+
+        read = self._read(topic)
+        assert payload not in read.stdout
+
+        describe = self._describe(int_id, check_exit_code=False)
+        assert describe.exit_code != 0
+
+    def test_write_without_ext_id(self):
+        topic = self._unique_topic("dp-no-ext")
+        self._prepare_topic(topic)
+        ext_id = f"no-ext-{uuid.uuid4().hex[:8]}"
+        payload = "payload-without-ext"
+
+        int_id = self._begin(ext_id)
+        self._write_deferred(topic, int_id, payload, ext_id=None)
+        self._publish(int_id)
+
+        read = self._read(topic)
+        assert payload in read.stdout
+
+    def test_duplicate_begin_while_active(self):
+        topic = self._unique_topic("dp-dup-begin")
+        self._prepare_topic(topic)
+        ext_id = f"dup-{uuid.uuid4().hex[:8]}"
+
+        int_id = self._begin(ext_id)
+        duplicate = self.execute_exp(
+            ["experimental", "topic", "deferred-publication", "begin", "--ext-id", ext_id],
+            check_exit_code=False,
+        )
+        assert duplicate.exit_code != 0
+
+        self._cancel(int_id)
+        again = self._begin(ext_id)
+        assert again.isdigit()
+
+    def test_list_filter_by_writer_identity(self):
+        writer = f"writer-{uuid.uuid4().hex[:8]}"
+        other = f"other-{uuid.uuid4().hex[:8]}"
+        ext_a = f"list-a-{uuid.uuid4().hex[:8]}"
+        ext_b = f"list-b-{uuid.uuid4().hex[:8]}"
+
+        int_a = self._begin(ext_a, writer_identity=writer)
+        int_b = self._begin(ext_b, writer_identity=other)
+
+        filtered = self._list(writer_identity=writer)
+        assert ext_a in filtered.stdout
+        assert int_a in filtered.stdout
+        assert ext_b not in filtered.stdout
+
+        self._cancel(int_a)
+        self._cancel(int_b)

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -4,6 +4,9 @@ Functional smoke tests for deferred topic publish via experimental CLI.
 
 Scenarios mirror the demo happy path / cancel / list-describe flows:
   begin → write --deferred-int-id → publish|cancel → topic read
+
+Also covers serverless DB: registry tables under the tenant .metadata and
+Publish/Cancel finalize transactions.
 """
 
 import logging
@@ -13,13 +16,20 @@ import uuid
 
 import yatest
 
-from ydb.tests.functional.ydb_cli.ydb_cli_helpers import BaseCliTestWithDatabase, ydb_bin
+from ydb.tests.functional.ydb_cli.ydb_cli_helpers import (
+    BaseCliTestWithDatabase,
+    set_ydb_cli_test_canondata_root,
+    ydb_bin,
+)
 from ydb.tests.library.harness.kikimr_config import KikimrConfigGenerator
+from ydb.tests.oss.ydb_sdk_import import ydb
 
 logger = logging.getLogger(__name__)
 
 AUTH_TOKEN = "root@builtin"
 CONSUMER = "dp-consumer"
+PUBLICATIONS_TABLE = "topic_deferred_publications"
+DESTINATIONS_TABLE = "topic_deferred_publication_destinations"
 
 
 class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
@@ -30,6 +40,11 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
         return KikimrConfigGenerator(
             extra_feature_flags=["enable_topic_deferred_publish"],
         )
+
+    @classmethod
+    def setup_class(cls):
+        super().setup_class()
+        cls.cli_database = cls.root_dir
 
     @classmethod
     def _auth_env(cls, extra=None):
@@ -45,7 +60,7 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
             [
                 ydb_bin(cls.CLI_BINARY_ENV),
                 "--endpoint", cls.grpc_endpoint(),
-                "--database", cls.root_dir,
+                "--database", cls.cli_database,
             ] + args,
             stdin=stdin,
             check_exit_code=check_exit_code,
@@ -64,7 +79,24 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
 
     @classmethod
     def _unique_topic(cls, prefix):
-        return f"{cls.root_dir}/{prefix}-{uuid.uuid4().hex[:8]}"
+        return f"{cls.cli_database}/{prefix}-{uuid.uuid4().hex[:8]}"
+
+    @classmethod
+    def _scheme_path_exists(cls, path, scheme_driver=None):
+        driver = scheme_driver if scheme_driver is not None else cls.driver
+        try:
+            driver.scheme_client.describe_path(path)
+            return True
+        except ydb.SchemeError:
+            return False
+        except ydb.Unauthorized:
+            # System .metadata tables often deny Describe to ordinary SIDs; that still
+            # proves the path exists (missing paths come back as SchemeError).
+            return True
+
+    @classmethod
+    def _metadata_table_path(cls, database, table_name):
+        return f"{database}/.metadata/{table_name}"
 
     @classmethod
     def _prepare_topic(cls, topic_path):
@@ -236,3 +268,131 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
 
         self._cancel(int_a)
         self._cancel(int_b)
+
+
+class TestTopicDeferredPublishCliServerless(TestTopicDeferredPublishCli):
+    """Same CLI flows on a serverless tenant; assert registry tables land in the tenant .metadata."""
+
+    HOSTEL_DB = "/Root/hostel"
+    SERVERLESS_DB = "/Root/serverless"
+
+    @classmethod
+    def setup_class(cls):
+        set_ydb_cli_test_canondata_root()
+        cls.cluster = cls._start_cluster(configurator=cls.get_cluster_configurator())
+        cls.root_dir = "/Root"
+
+        cls.cluster.create_hostel_database(
+            cls.HOSTEL_DB,
+            storage_pool_units_count={"hdd": 1},
+        )
+        cls.cluster.register_and_start_slots(cls.HOSTEL_DB, count=1)
+        cls.cluster.wait_tenant_up(cls.HOSTEL_DB)
+        cls.cluster.create_serverless_database(cls.SERVERLESS_DB, hostel_db=cls.HOSTEL_DB)
+
+        credentials = ydb.AuthTokenCredentials(AUTH_TOKEN)
+        cls.root_driver = cls._start_driver(cls.root_dir, credentials=credentials)
+        cls.hostel_driver = cls._start_driver(cls.HOSTEL_DB, credentials=credentials)
+        cls.driver = cls._start_driver(cls.SERVERLESS_DB, credentials=credentials)
+        cls.cli_database = cls.SERVERLESS_DB
+
+    @classmethod
+    def teardown_class(cls):
+        for attr in ("root_driver", "hostel_driver"):
+            driver = getattr(cls, attr, None)
+            if driver is not None:
+                driver.stop()
+        super().teardown_class()
+
+    @classmethod
+    def _assert_registry_tables_only_under(cls, database):
+        # Tenant paths must be described with a driver bound to that database;
+        # /Root DescribePath cannot see inside a serverless/hostel subdomain.
+        tenant_driver = cls.driver if database == cls.cli_database else cls.root_driver
+        pubs = cls._metadata_table_path(database, PUBLICATIONS_TABLE)
+        dests = cls._metadata_table_path(database, DESTINATIONS_TABLE)
+        assert cls._scheme_path_exists(pubs, tenant_driver), f"missing {pubs}"
+        assert cls._scheme_path_exists(dests, tenant_driver), f"missing {dests}"
+
+        for foreign_db, foreign_driver in (
+            (cls.root_dir, cls.root_driver),
+            (cls.HOSTEL_DB, cls.hostel_driver),
+        ):
+            if foreign_db == database:
+                continue
+            foreign_pubs = cls._metadata_table_path(foreign_db, PUBLICATIONS_TABLE)
+            foreign_dests = cls._metadata_table_path(foreign_db, DESTINATIONS_TABLE)
+            assert not cls._scheme_path_exists(foreign_pubs, foreign_driver), (
+                f"registry leaked to {foreign_pubs}"
+            )
+            assert not cls._scheme_path_exists(foreign_dests, foreign_driver), (
+                f"registry leaked to {foreign_dests}"
+            )
+
+    def test_metadata_tables_created_under_serverless_db(self):
+        assert not self._scheme_path_exists(
+            self._metadata_table_path(self.SERVERLESS_DB, PUBLICATIONS_TABLE),
+            self.driver,
+        )
+
+        ext_id = f"sls-meta-{uuid.uuid4().hex[:8]}"
+        int_id = self._begin(ext_id)
+        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
+
+        describe = self._describe(int_id)
+        assert ext_id in describe.stdout
+
+        self._cancel(int_id)
+        # Tables remain after Cancel; only the publication row is removed.
+        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
+        gone = self._describe(int_id, check_exit_code=False)
+        assert gone.exit_code != 0
+
+    def test_happy_path_publish(self):
+        topic = self._unique_topic("sls-happy")
+        self._prepare_topic(topic)
+        ext_id = f"sls-order-{uuid.uuid4().hex[:8]}"
+        payload = "serverless-deferred-publish"
+
+        int_id = self._begin(ext_id)
+        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
+
+        self._write_deferred(topic, int_id, payload, ext_id=ext_id)
+        describe = self._describe(int_id)
+        assert topic in describe.stdout or topic.rsplit("/", 1)[-1] in describe.stdout
+
+        before = self._read(topic)
+        assert payload not in before.stdout
+
+        publish = self._publish(int_id)
+        assert publish.exit_code == 0
+
+        after = self._read(topic)
+        assert payload in after.stdout
+
+        # Publish deleted the registry row; tables stay in the serverless tenant.
+        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
+        gone = self._describe(int_id, check_exit_code=False)
+        assert gone.exit_code != 0
+
+        repeat = self._publish(int_id, check_exit_code=False)
+        assert repeat.exit_code != 0
+
+    def test_cancel_discards_staged_data(self):
+        topic = self._unique_topic("sls-cancel")
+        self._prepare_topic(topic)
+        ext_id = f"sls-cancel-{uuid.uuid4().hex[:8]}"
+        payload = "serverless-to-be-cancelled"
+
+        int_id = self._begin(ext_id)
+        self._write_deferred(topic, int_id, payload, ext_id=ext_id)
+
+        cancel = self._cancel(int_id)
+        assert cancel.exit_code == 0
+
+        read = self._read(topic)
+        assert payload not in read.stdout
+
+        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
+        describe = self._describe(int_id, check_exit_code=False)
+        assert describe.exit_code != 0

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -232,6 +232,22 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
         again = self._begin(ext_id)
         assert again.isdigit()
 
+    def test_write_rejects_zero_deferred_int_id(self):
+        topic = self._unique_topic("dp-zero-int")
+        self._prepare_topic(topic)
+        result = self.execute_exp(
+            [
+                "experimental", "topic", "write", topic,
+                "--deferred-int-id", "0",
+                "--format", "single-message",
+            ],
+            check_exit_code=False,
+        )
+        assert result.exit_code != 0
+        combined = (result.stdout + result.stderr).lower()
+        assert "deferred-int-id" in combined
+        assert "positive" in combined
+
     def test_list_filter_by_writer_identity(self):
         writer = f"writer-{uuid.uuid4().hex[:8]}"
         other = f"other-{uuid.uuid4().hex[:8]}"

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -236,8 +236,7 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
         assert duplicate.exit_code != 0
 
         self._cancel(int_id)
-        again = self._begin(ext_id)
-        assert again.isdigit()
+        self._begin(ext_id)
 
     def test_write_rejects_zero_deferred_int_id(self):
         topic = self._unique_topic("dp-zero-int")

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -3,7 +3,7 @@
 Functional smoke tests for deferred topic publish via experimental CLI.
 
 Scenarios mirror the demo happy path / cancel / list-describe flows:
-  begin → write --deferred-int-id → publish|cancel → topic read
+  begin → write --deferred-int-publication-id → publish|cancel → topic read
 
 The same suite runs on dedicated (/Root) and serverless databases.
 """
@@ -90,7 +90,7 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
 
     @classmethod
     def _begin(cls, ext_id, writer_identity=None):
-        args = ["experimental", "topic", "deferred-publication", "begin", "--ext-id", ext_id]
+        args = ["experimental", "topic", "deferred-publication", "begin", "--ext-publication-id", ext_id]
         if writer_identity is not None:
             args.extend(["--writer-identity", writer_identity])
         result = cls.execute_exp(args)
@@ -102,11 +102,11 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
     def _write_deferred(cls, topic_path, int_id, payload, ext_id=None):
         args = [
             "experimental", "topic", "write", topic_path,
-            "--deferred-int-id", int_id,
+            "--deferred-int-publication-id", int_id,
             "--format", "single-message",
         ]
         if ext_id is not None:
-            args.extend(["--deferred-ext-id", ext_id])
+            args.extend(["--deferred-ext-publication-id", ext_id])
         with tempfile.NamedTemporaryFile("w+b") as stdin_file:
             stdin_file.write(payload.encode("utf-8"))
             stdin_file.flush()
@@ -116,14 +116,14 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
     @classmethod
     def _publish(cls, int_id, check_exit_code=True):
         return cls.execute_exp(
-            ["experimental", "topic", "deferred-publication", "publish", "--int-id", int_id],
+            ["experimental", "topic", "deferred-publication", "publish", "--int-publication-id", int_id],
             check_exit_code=check_exit_code,
         )
 
     @classmethod
     def _cancel(cls, int_id, check_exit_code=True):
         return cls.execute_exp(
-            ["experimental", "topic", "deferred-publication", "cancel", "--int-id", int_id],
+            ["experimental", "topic", "deferred-publication", "cancel", "--int-publication-id", int_id],
             check_exit_code=check_exit_code,
         )
 
@@ -136,7 +136,7 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
 
     @classmethod
     def _describe(cls, int_id, check_exit_code=True, output_format=None):
-        args = ["experimental", "topic", "deferred-publication", "describe", "--int-id", int_id]
+        args = ["experimental", "topic", "deferred-publication", "describe", "--int-publication-id", int_id]
         if output_format is not None:
             args.extend(["--format", output_format])
         return cls.execute_exp(args, check_exit_code=check_exit_code)
@@ -230,7 +230,7 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
 
         int_id = self._begin(ext_id)
         duplicate = self.execute_exp(
-            ["experimental", "topic", "deferred-publication", "begin", "--ext-id", ext_id],
+            ["experimental", "topic", "deferred-publication", "begin", "--ext-publication-id", ext_id],
             check_exit_code=False,
         )
         assert duplicate.exit_code != 0
@@ -244,14 +244,14 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
         result = self.execute_exp(
             [
                 "experimental", "topic", "write", topic,
-                "--deferred-int-id", "0",
+                "--deferred-int-publication-id", "0",
                 "--format", "single-message",
             ],
             check_exit_code=False,
         )
         assert result.exit_code != 0
         combined = (result.stdout + result.stderr).lower()
-        assert "deferred-int-id" in combined
+        assert "deferred-int-publication-id" in combined
         assert "positive" in combined
 
     def test_list_filter_by_writer_identity(self):

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -5,12 +5,10 @@ Functional smoke tests for deferred topic publish via experimental CLI.
 Scenarios mirror the demo happy path / cancel / list-describe flows:
   begin → write --deferred-int-id → publish|cancel → topic read
 
-Also covers serverless DB: registry tables under the tenant .metadata and
-Publish/Cancel finalize transactions.
+The same suite runs on dedicated (/Root) and serverless databases.
 """
 
 import logging
-import json
 import os
 import tempfile
 import uuid
@@ -29,8 +27,6 @@ logger = logging.getLogger(__name__)
 
 AUTH_TOKEN = "root@builtin"
 CONSUMER = "dp-consumer"
-PUBLICATIONS_TABLE = "topic_deferred_publications"
-DESTINATIONS_TABLE = "topic_deferred_publication_destinations"
 
 
 class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
@@ -81,23 +77,6 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
     @classmethod
     def _unique_topic(cls, prefix):
         return f"{cls.cli_database}/{prefix}-{uuid.uuid4().hex[:8]}"
-
-    @classmethod
-    def _scheme_path_exists(cls, path, scheme_driver=None):
-        driver = scheme_driver if scheme_driver is not None else cls.driver
-        try:
-            driver.scheme_client.describe_path(path)
-            return True
-        except ydb.SchemeError:
-            return False
-        except ydb.Unauthorized:
-            # System .metadata tables often deny Describe to ordinary SIDs; that still
-            # proves the path exists (missing paths come back as SchemeError).
-            return True
-
-    @classmethod
-    def _metadata_table_path(cls, database, table_name):
-        return f"{database}/.metadata/{table_name}"
 
     @classmethod
     def _prepare_topic(cls, topic_path):
@@ -272,7 +251,7 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
 
 
 class TestTopicDeferredPublishCliServerless(TestTopicDeferredPublishCli):
-    """Same CLI flows on a serverless tenant; assert registry tables land in the tenant .metadata."""
+    """Same CLI suite on a serverless tenant over a shared hostel database."""
 
     HOSTEL_DB = "/Root/hostel"
     SERVERLESS_DB = "/Root/serverless"
@@ -291,111 +270,8 @@ class TestTopicDeferredPublishCliServerless(TestTopicDeferredPublishCli):
         cls.cluster.wait_tenant_up(cls.HOSTEL_DB)
         cls.cluster.create_serverless_database(cls.SERVERLESS_DB, hostel_db=cls.HOSTEL_DB)
 
-        credentials = ydb.AuthTokenCredentials(AUTH_TOKEN)
-        cls.root_driver = cls._start_driver(cls.root_dir, credentials=credentials)
-        cls.hostel_driver = cls._start_driver(cls.HOSTEL_DB, credentials=credentials)
-        cls.driver = cls._start_driver(cls.SERVERLESS_DB, credentials=credentials)
-        cls.cli_database = cls.SERVERLESS_DB
-
-    @classmethod
-    def teardown_class(cls):
-        for attr in ("root_driver", "hostel_driver"):
-            driver = getattr(cls, attr, None)
-            if driver is not None:
-                driver.stop()
-        super().teardown_class()
-
-    @classmethod
-    def _assert_registry_tables_only_under(cls, database):
-        # Tenant paths must be described with a driver bound to that database;
-        # /Root DescribePath cannot see inside a serverless/hostel subdomain.
-        tenant_driver = cls.driver if database == cls.cli_database else cls.root_driver
-        pubs = cls._metadata_table_path(database, PUBLICATIONS_TABLE)
-        dests = cls._metadata_table_path(database, DESTINATIONS_TABLE)
-        assert cls._scheme_path_exists(pubs, tenant_driver), f"missing {pubs}"
-        assert cls._scheme_path_exists(dests, tenant_driver), f"missing {dests}"
-
-        for foreign_db, foreign_driver in (
-            (cls.root_dir, cls.root_driver),
-            (cls.HOSTEL_DB, cls.hostel_driver),
-        ):
-            if foreign_db == database:
-                continue
-            foreign_pubs = cls._metadata_table_path(foreign_db, PUBLICATIONS_TABLE)
-            foreign_dests = cls._metadata_table_path(foreign_db, DESTINATIONS_TABLE)
-            assert not cls._scheme_path_exists(foreign_pubs, foreign_driver), (
-                f"registry leaked to {foreign_pubs}"
-            )
-            assert not cls._scheme_path_exists(foreign_dests, foreign_driver), (
-                f"registry leaked to {foreign_dests}"
-            )
-
-    def test_metadata_tables_created_under_serverless_db(self):
-        assert not self._scheme_path_exists(
-            self._metadata_table_path(self.SERVERLESS_DB, PUBLICATIONS_TABLE),
-            self.driver,
+        cls.driver = cls._start_driver(
+            cls.SERVERLESS_DB,
+            credentials=ydb.AuthTokenCredentials(AUTH_TOKEN),
         )
-
-        ext_id = f"sls-meta-{uuid.uuid4().hex[:8]}"
-        int_id = self._begin(ext_id)
-        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
-
-        describe = self._describe(int_id)
-        assert ext_id in describe.stdout
-
-        self._cancel(int_id)
-        # Tables remain after Cancel; only the publication row is removed.
-        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
-        gone = self._describe(int_id, check_exit_code=False)
-        assert gone.exit_code != 0
-
-    def test_happy_path_publish(self):
-        topic = self._unique_topic("sls-happy")
-        self._prepare_topic(topic)
-        ext_id = f"sls-order-{uuid.uuid4().hex[:8]}"
-        payload = "serverless-deferred-publish"
-
-        int_id = self._begin(ext_id)
-        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
-
-        self._write_deferred(topic, int_id, payload, ext_id=ext_id)
-        describe = self._describe(int_id, output_format="json")
-        description = json.loads(describe.stdout)
-        destination_paths = [item["topic_path"] for item in description["destinations"]]
-        assert topic in destination_paths
-
-        before = self._read(topic)
-        assert payload not in before.stdout
-
-        publish = self._publish(int_id)
-        assert publish.exit_code == 0
-
-        after = self._read(topic)
-        assert payload in after.stdout
-
-        # Publish deleted the registry row; tables stay in the serverless tenant.
-        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
-        gone = self._describe(int_id, check_exit_code=False)
-        assert gone.exit_code != 0
-
-        repeat = self._publish(int_id, check_exit_code=False)
-        assert repeat.exit_code != 0
-
-    def test_cancel_discards_staged_data(self):
-        topic = self._unique_topic("sls-cancel")
-        self._prepare_topic(topic)
-        ext_id = f"sls-cancel-{uuid.uuid4().hex[:8]}"
-        payload = "serverless-to-be-cancelled"
-
-        int_id = self._begin(ext_id)
-        self._write_deferred(topic, int_id, payload, ext_id=ext_id)
-
-        cancel = self._cancel(int_id)
-        assert cancel.exit_code == 0
-
-        read = self._read(topic)
-        assert payload not in read.stdout
-
-        self._assert_registry_tables_only_under(self.SERVERLESS_DB)
-        describe = self._describe(int_id, check_exit_code=False)
-        assert describe.exit_code != 0
+        cls.cli_database = cls.SERVERLESS_DB

--- a/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
+++ b/ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py
@@ -10,6 +10,7 @@ Publish/Cancel finalize transactions.
 """
 
 import logging
+import json
 import os
 import tempfile
 import uuid
@@ -154,11 +155,11 @@ class TestTopicDeferredPublishCli(BaseCliTestWithDatabase):
         return cls.execute_exp(args)
 
     @classmethod
-    def _describe(cls, int_id, check_exit_code=True):
-        return cls.execute_exp(
-            ["experimental", "topic", "deferred-publication", "describe", "--int-id", int_id],
-            check_exit_code=check_exit_code,
-        )
+    def _describe(cls, int_id, check_exit_code=True, output_format=None):
+        args = ["experimental", "topic", "deferred-publication", "describe", "--int-id", int_id]
+        if output_format is not None:
+            args.extend(["--format", output_format])
+        return cls.execute_exp(args, check_exit_code=check_exit_code)
 
     @classmethod
     def _read(cls, topic_path, limit=10):
@@ -358,8 +359,10 @@ class TestTopicDeferredPublishCliServerless(TestTopicDeferredPublishCli):
         self._assert_registry_tables_only_under(self.SERVERLESS_DB)
 
         self._write_deferred(topic, int_id, payload, ext_id=ext_id)
-        describe = self._describe(int_id)
-        assert topic in describe.stdout or topic.rsplit("/", 1)[-1] in describe.stdout
+        describe = self._describe(int_id, output_format="json")
+        description = json.loads(describe.stdout)
+        destination_paths = [item["topic_path"] for item in description["destinations"]]
+        assert topic in destination_paths
 
         before = self._read(topic)
         assert payload not in before.stdout

--- a/ydb/tests/functional/ydb_cli/ya.make
+++ b/ydb/tests/functional/ydb_cli/ya.make
@@ -16,6 +16,7 @@ TEST_SRCS(
     test_ydb_sql.py
     test_ydb_table.py
     test_ydb_tools.py
+    test_ydb_topic_deferred_publish.py
 )
 
 INCLUDE(${ARCADIA_ROOT}/ydb/tests/harness_dep.inc)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Add experimental CLI under `experimental topic` for deferred publication lifecycle (begin/publish/cancel/list/describe)
- Wire deferred write via `TTopicWriter` + `TDeferredPublication` / `TDeferredPublishClient`
- Add functional smoke tests covering publish and cancel paths

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

## Контекст PR: experimental CLI для topic deferred publish

### Зачем этот PR

На сервере и в C++ SDK deferred publish уже есть (`TDeferredPublishClient`, `TWriteMessage::DeferredPublication`, feature-flag `enable_topic_deferred_publish`). Нужен **операторский/dev CLI**, чтобы руками и в CI прогонять lifecycle без написания C++:

`begin → write (staged) → publish|cancel → read`

Это **не** новый серверный путь и **не** новый SDK API — тонкая обёртка над уже влитым SDK (#47420) поверх того же gRPC.

### Где живёт код и почему experimental

| Слой | Путь | Роль |
|------|------|------|
| UX (временный) | `ydb/apps/ydb/experimental/ydb/commands/ydb_topic_deferred_publish.*` | Команды `experimental topic …` |
| Shared write infra | `ydb/public/lib/ydb_cli/topic/topic_write.*` | `TTopicWriter` + опциональный `DeferredPublication` |
| SDK (уже в main) | `NTopic::TDeferredPublishClient`, write session | Реальные RPC / StreamWrite |
| Тесты | `ydb/tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py` | E2E через experimental binary |

Команды лежат в **experimental CLI** намеренно: официальный `ydb topic` пока не расширяем (флаг/API ещё не для прод-CLI). После стабилизации те же команды планируется перенести в обычный `topic`; shared `TTopicWriter` — место, куда deferred write «приземлится» без второй копии write-loop.

### Пользовательский контракт (как demo/SDK example)

```text
INT_ID=$(… deferred-publication begin --ext-publication-id …)
echo payload | … topic write <path> --deferred-int-publication-id "$INT_ID" [--deferred-ext-publication-id …]
… deferred-publication publish|cancel --int-publication-id "$INT_ID"
… topic read …   # данные видны только после publish
```

Команды control-plane: `begin`, `publish`, `cancel`, `list`, `describe` → `TDeferredPublishClient`.
`write` → обычный `CreateWriteSession` + `TTopicWriter` с `TWriteMessage::DeferredPublication`.

**Важно про процессы:** CLI `write` и `publish` — **разные процессы**. У `publish`/`cancel` новый `TDeferredPublication(intId)` → пустой AckState → SDK **не** ждёт in-flight writes другого процесса (в отличие от in-process SDK example, где один handle шарится). Контракт: `publish`/`cancel` только после успешного exit `write` (`Close()` дожидается ack’ов). Это в help команд и в README.

### Что меняется в shared `TTopicWriter` и почему это безопасно для `ydb topic write`

Раньше: `Write(token, data, seqNo)`.
Сейчас: явный `TWriteMessage` + `SeqNo`, и **если** задан `DeferredPublication` — проставляем его.

Почему нельзя оставить старый оверлоад: deferred в SDK есть только на `TWriteMessage`; `Write(token, data, seqNo)` внутри собирает message **без** `DeferredPublication`.

Для обычного `ydb topic write` params без deferred → ветка не выполняется. Семантика = тому, что уже делал SDK-оверлоад (`data` + `seqNo`). Отдельного `test_ydb_topic.py` под write в `ydb_cli` нет; non-deferred путь не расширяли тестами в этом PR.

### Тесты

Один behavioral suite, два окружения:

- `TestTopicDeferredPublishCli` — dedicated `/Root`
- `TestTopicDeferredPublishCliServerless` — hostel + serverless, **те же** сценарии (наследование)

Сценарии: happy publish, cancel, write без ext-id, duplicate begin, list filter, reject `--deferred-int-publication-id 0`.
Проверки — по CLI/API-исходам (видимость в topic, describe/list, exit codes), **без** scheme-проб `.metadata` (наличие таблиц реестра — серверный инвариант, не обязанность functional CLI).

Флаг в кластере тестов: `enable_topic_deferred_publish`.

### Что сознательно вне scope

- Перенос команд в официальный `ydb topic`
- Java/Go CLI
- Серверная логика Publish/Cancel / registry DDL
- In-process «write+publish одной командой» с общим AckState

### Карта файлов

```text
experimental/ydb/commands/ydb_topic_deferred_publish.*  — команды + JSON (NJson)
experimental/ydb/commands/ydb_service_experimental.cpp — регистрация experimental topic
experimental/ydb/README.md                             — how-to + инвариант write→publish
public/lib/ydb_cli/topic/topic_write.*                 — крючок DeferredPublication
tests/functional/ydb_cli/test_ydb_topic_deferred_publish.py — E2E dedicated+serverless
```

### Как проверяли

```bash
ya make -r -j16 ydb/apps/ydb/experimental/ydb
ya test -r -j16 ydb/tests/functional/ydb_cli -F '*TopicDeferredPublishCli*'
```