### PR TITLE
Avoid calling virtual CloseImpl from IEventsWriterWrapper destructor

### DIFF
--- a/ydb/core/ymq/actor/yc_search_ut/test_events_writer.h
+++ b/ydb/core/ymq/actor/yc_search_ut/test_events_writer.h
@@ -7,6 +7,9 @@ namespace NKikimr::NSQS {
 class TTestEventsWriter : public IEventsWriterWrapper {
 public:
     TTestEventsWriter() = default;
+    ~TTestEventsWriter() override {
+        Close();
+    }
     void Write(const TString& data) override;
     TVector<TString> GetMessages();
 

--- a/ydb/core/ymq/base/events_writer.cpp
+++ b/ydb/core/ymq/base/events_writer.cpp
@@ -20,6 +20,10 @@ public:
         Session = Client->CreateSession(sessionSettings);
     }
 
+    ~TUaEventsWriter() override {
+        Close();
+    }
+
     void Write(const TString& data) override
     {
         Session->Send(NUnifiedAgent::TClientMessage{data, Nothing(), Nothing()});
@@ -43,6 +47,10 @@ public:
         : OutputFile(TFile(outputFileName, OpenAlways | WrOnly))
         , OutStream(OutputFile)
     {}
+
+    ~TFileEventsWriter() override {
+        Close();
+    }
 
     void Write(const TString& data) override
     {
@@ -68,6 +76,10 @@ class TNullEventsWriter : public IEventsWriterWrapper {
 public:
     TNullEventsWriter()
     {}
+
+    ~TNullEventsWriter() override {
+        Close();
+    }
 
     void Write(const TString&) override
     {}

--- a/ydb/core/ymq/base/events_writer_iface.h
+++ b/ydb/core/ymq/base/events_writer_iface.h
@@ -10,9 +10,8 @@ namespace NKikimr::NSQS {
 class IEventsWriterWrapper : public TAtomicRefCount<IEventsWriterWrapper> {
 public:
     virtual void Write(const TString& data) = 0;
-    virtual ~IEventsWriterWrapper() {
-        Close();
-    };
+    // Do not call Close() here: CloseImpl() is virtual and derived members are already gone.
+    virtual ~IEventsWriterWrapper() = default;
 
     void Close();
 


### PR DESCRIPTION
## Summary
- `IEventsWriterWrapper::~IEventsWriterWrapper()` called `Close()` → pure virtual `CloseImpl()`, which is undefined behavior once the derived object is already destroyed.
- Remove that call from the base destructor and invoke `Close()` from each derived destructor instead (owners may still call `Close()` earlier; the `Closed` guard makes that safe).

## Test plan
- [ ] Existing YMQ search/cloud events paths still close writers via owner destructors (`TSearchEventsProcessor`, `TProcessor`)
- [ ] Dropping a writer without an earlier explicit `Close()` no longer hits a pure-virtual call from the base dtor
- [ ] `./ya make --build relwithdebinfo -tA ydb/core/ymq/actor/yc_search_ut` (optional local check)


Made with [Cursor](https://cursor.com)