### PR TITLE
[NBS-7510] Add non-hive bootstrap for dbs controller

### DIFF
--- a/ydb/core/base/tabletid.h
+++ b/ydb/core/base/tabletid.h
@@ -77,6 +77,12 @@ namespace NKikimr {
         return MakeTabletID(false, 0x2003);
     }
 
+    // DbsControler tablet (exactly one per domain in default state storage group)
+    // TODO This is a dummy value, actual value is yet to be approved
+    inline ui64 MakeDbsControllerID() {
+        return MakeTabletID(false, 0x2004);
+    }
+
     // TODO: think about encoding scheme for sibling group hive
 
     inline TActorId MakeStateStorageProxyID() {

--- a/ydb/core/base/tabletid.h
+++ b/ydb/core/base/tabletid.h
@@ -77,7 +77,7 @@ namespace NKikimr {
         return MakeTabletID(false, 0x2003);
     }
 
-    // DbsControler tablet (exactly one per domain in default state storage group)
+    // DbsController tablet (exactly one per domain in default state storage group)
     // TODO This is a dummy value, actual value is yet to be approved
     inline ui64 MakeDbsControllerID() {
         return MakeTabletID(false, 0x2004);

--- a/ydb/core/base/tabletid.h
+++ b/ydb/core/base/tabletid.h
@@ -78,7 +78,6 @@ namespace NKikimr {
     }
 
     // DbsController tablet (exactly one per domain in default state storage group)
-    // TODO This is a dummy value, actual value is yet to be approved
     inline ui64 MakeDbsControllerID() {
         return MakeTabletID(false, 0x2004);
     }

--- a/ydb/core/base/tabletid.h
+++ b/ydb/core/base/tabletid.h
@@ -77,6 +77,12 @@ namespace NKikimr {
         return MakeTabletID(false, 0x2003);
     }
 
+    // DbsController tablet (exactly one per domain in default state storage group)
+    // TODO This is a dummy value, actual value is yet to be approved
+    inline ui64 MakeDbsControllerID() {
+        return MakeTabletID(false, 0x2004);
+    }
+
     // TODO: think about encoding scheme for sibling group hive
 
     inline TActorId MakeStateStorageProxyID() {

--- a/ydb/core/cms/console/validators/validator_bootstrap.cpp
+++ b/ydb/core/cms/console/validators/validator_bootstrap.cpp
@@ -70,6 +70,10 @@ bool TBootstrapConfigValidator::CheckTablets(const NKikimrConfig::TAppConfig &co
         NKikimrConfig::TBootstrap::TENANT_SLOT_BROKER,
     };
 
+    if (config.HasNbsConfig() && config.GetNbsConfig().GetEnabled()) {
+        importantTablets.insert(NKikimrConfig::TBootstrap::DBS_CONTROLLER);
+    }
+
     auto &cfg = config.GetBootstrapConfig();
     auto &nsCfg = config.GetNameserviceConfig();
     THashSet<ui32> nodeIds;

--- a/ydb/core/cms/console/validators/validator_bootstrap.cpp
+++ b/ydb/core/cms/console/validators/validator_bootstrap.cpp
@@ -67,9 +67,12 @@ bool TBootstrapConfigValidator::CheckTablets(const NKikimrConfig::TAppConfig &co
     THashSet<NKikimrConfig::TBootstrap::ETabletType> importantTablets = {
         NKikimrConfig::TBootstrap::CMS,
         NKikimrConfig::TBootstrap::NODE_BROKER,
-        NKikimrConfig::TBootstrap::TENANT_SLOT_BROKER,
-        NKikimrConfig::TBootstrap::DBS_CONTROLLER,
+        NKikimrConfig::TBootstrap::TENANT_SLOT_BROKER
     };
+
+    if (config.HasNbsConfig() && config.GetNbsConfig().GetEnabled()) {
+        importantTablets.insert(NKikimrConfig::TBootstrap::DBS_CONTROLLER);
+    }
 
     auto &cfg = config.GetBootstrapConfig();
     auto &nsCfg = config.GetNameserviceConfig();

--- a/ydb/core/cms/console/validators/validator_bootstrap.cpp
+++ b/ydb/core/cms/console/validators/validator_bootstrap.cpp
@@ -68,6 +68,7 @@ bool TBootstrapConfigValidator::CheckTablets(const NKikimrConfig::TAppConfig &co
         NKikimrConfig::TBootstrap::CMS,
         NKikimrConfig::TBootstrap::NODE_BROKER,
         NKikimrConfig::TBootstrap::TENANT_SLOT_BROKER,
+        NKikimrConfig::TBootstrap::DBS_CONTROLLER,
     };
 
     auto &cfg = config.GetBootstrapConfig();

--- a/ydb/core/cms/console/validators/validator_bootstrap.cpp
+++ b/ydb/core/cms/console/validators/validator_bootstrap.cpp
@@ -67,7 +67,7 @@ bool TBootstrapConfigValidator::CheckTablets(const NKikimrConfig::TAppConfig &co
     THashSet<NKikimrConfig::TBootstrap::ETabletType> importantTablets = {
         NKikimrConfig::TBootstrap::CMS,
         NKikimrConfig::TBootstrap::NODE_BROKER,
-        NKikimrConfig::TBootstrap::TENANT_SLOT_BROKER
+        NKikimrConfig::TBootstrap::TENANT_SLOT_BROKER,
     };
 
     if (config.HasNbsConfig() && config.GetNbsConfig().GetEnabled()) {

--- a/ydb/core/mind/configured_tablet_bootstrapper.cpp
+++ b/ydb/core/mind/configured_tablet_bootstrapper.cpp
@@ -31,6 +31,7 @@
 #include <ydb/core/blob_depot/blob_depot.h>
 #include <ydb/core/statistics/aggregator/aggregator.h>
 #include <ydb/core/tablet_flat/flat_executor_recovery.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller.h>
 
 #include <ydb/library/actors/core/hfunc.h>
 #include <library/cpp/monlib/service/pages/templates.h>
@@ -701,6 +702,8 @@ TTabletTypes::EType BootstrapperTypeToTabletType(ui32 type) {
         return TTabletTypes::TenantSlotBroker;
     case NKikimrConfig::TBootstrap::CONSOLE:
         return TTabletTypes::Console;
+    case NKikimrConfig::TBootstrap::DBS_CONTROLLER:
+        return TTabletTypes::DbsController;
     default:
         Y_ABORT("unknown tablet type");
     }
@@ -778,6 +781,11 @@ TIntrusivePtr<TTabletSetupInfo> MakeTabletSetupInfo(
     case TTabletTypes::Dummy:
         createFunc = &CreateSimpleTablet;
         break;
+#if defined(YDB_EMBEDDED_NBS_ENABLED)
+    case TTabletTypes::DbsController:
+        createFunc = &NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet;
+        break;
+#endif
     default:
         return nullptr;
     }

--- a/ydb/core/mind/configured_tablet_bootstrapper.cpp
+++ b/ydb/core/mind/configured_tablet_bootstrapper.cpp
@@ -31,6 +31,7 @@
 #include <ydb/core/blob_depot/blob_depot.h>
 #include <ydb/core/statistics/aggregator/aggregator.h>
 #include <ydb/core/tablet_flat/flat_executor_recovery.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller.h>
 
 #include <ydb/library/actors/core/hfunc.h>
 #include <library/cpp/monlib/service/pages/templates.h>
@@ -701,6 +702,8 @@ TTabletTypes::EType BootstrapperTypeToTabletType(ui32 type) {
         return TTabletTypes::TenantSlotBroker;
     case NKikimrConfig::TBootstrap::CONSOLE:
         return TTabletTypes::Console;
+    case NKikimrConfig::TBootstrap::DBS_CONTROLLER:
+        return TTabletTypes::DbsController;
     default:
         Y_ABORT("unknown tablet type");
     }
@@ -777,6 +780,9 @@ TIntrusivePtr<TTabletSetupInfo> MakeTabletSetupInfo(
         break;
     case TTabletTypes::Dummy:
         createFunc = &CreateSimpleTablet;
+        break;
+    case TTabletTypes::DbsController:
+        createFunc = &NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet;
         break;
     default:
         return nullptr;

--- a/ydb/core/mind/configured_tablet_bootstrapper.cpp
+++ b/ydb/core/mind/configured_tablet_bootstrapper.cpp
@@ -781,11 +781,9 @@ TIntrusivePtr<TTabletSetupInfo> MakeTabletSetupInfo(
     case TTabletTypes::Dummy:
         createFunc = &CreateSimpleTablet;
         break;
-#if defined(YDB_EMBEDDED_NBS_ENABLED)
     case TTabletTypes::DbsController:
         createFunc = &NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet;
         break;
-#endif
     default:
         return nullptr;
     }

--- a/ydb/core/nbs/scripts/dynamic/Configure-Root.txt
+++ b/ydb/core/nbs/scripts/dynamic/Configure-Root.txt
@@ -540,6 +540,37 @@ ConfigureRequest {
                 }
               }
             }
+            Tablet {
+              Type: DBS_CONTROLLER
+              Node: 1
+              Info {
+                TabletID: 72057594037936132
+                Channels {
+                  Channel: 0
+                  History {
+                    FromGeneration: 0
+                    GroupID: 0
+                  }
+                  ChannelErasureName: "none"
+                }
+                Channels {
+                  Channel: 1
+                  History {
+                    FromGeneration: 0
+                    GroupID: 0
+                  }
+                  ChannelErasureName: "none"
+                }
+                Channels {
+                  Channel: 2
+                  History {
+                    FromGeneration: 0
+                    GroupID: 0
+                  }
+                  ChannelErasureName: "none"
+                }
+              }
+            }
           }
           VDiskConfig {
             VDiskKinds {

--- a/ydb/core/nbs/scripts/static/config.yaml
+++ b/ydb/core/nbs/scripts/static/config.yaml
@@ -150,6 +150,11 @@ system_tablets:
       tablet_id: 72057594037936131
     node:
     - 1
+  dbs_controller:
+  - info:
+      tablet_id: 72057594037936132
+    node:
+    - 1
 blob_storage_config:
   service_set:
     pdisks:

--- a/ydb/core/protos/bootstrap.proto
+++ b/ydb/core/protos/bootstrap.proto
@@ -40,6 +40,8 @@ message TBootstrap {
         TENANT_SLOT_BROKER = 53;
         CONSOLE = 54;
 
+        DBS_CONTROLLER = 60;
+
         FAKE_DATASHARD = 700;
     }
 

--- a/ydb/core/tablet/tablet_monitoring_proxy.cpp
+++ b/ydb/core/tablet/tablet_monitoring_proxy.cpp
@@ -430,6 +430,17 @@ TTabletMonitoringProxyActor::Handle(NMon::TEvHttpInfo::TPtr &ev, const TActorCon
                                     << "</a>";}
                         TABLED() {str << "<a href='tablets?RestartTabletID=" << tabletId << "'><span class='glyphicon glyphicon-remove' title='Restart Tablet'/></a>";}
                     }
+                    tabletId = NKikimr::MakeDbsControllerID();
+                    TABLER() {
+                        TABLED() {str << "<a href=\"tablets?TabletID=" << tabletId << "\">DBS_CONTROLLER</a>";}
+                        TABLED() {str << tabletId;}
+                        TABLED() {str << " <a href=\"tablets?SsId="
+                                    << tabletId << "\">"
+                                    << "<span class=\"glyphicon glyphicon-tasks\""
+                                    << " title=\"State Storage\" />"
+                                    << "</a>";}
+                        TABLED() {str << "<a href='tablets?RestartTabletID=" << tabletId << "'><span class='glyphicon glyphicon-remove' title='Restart Tablet'/></a>";}
+                    }
                     for (auto tabletId : domain->Coordinators) {
                         TABLER() {
                             TABLED() {str << "<a href=\"tablets?TabletID=" << tabletId << "\">TX_COORDINATOR</a>";}

--- a/ydb/core/testlib/tenant_runtime.cpp
+++ b/ydb/core/testlib/tenant_runtime.cpp
@@ -9,7 +9,6 @@
 #include <ydb/core/mind/labels_maintainer.h>
 #include <ydb/core/mind/tenant_pool.h>
 #include <ydb/core/mind/tenant_slot_broker.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/persqueue/pq.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
@@ -1158,16 +1157,6 @@ void TTenantTestRuntime::Setup(bool createTenantPools)
             DispatchEvents(options);
         }
     }
-#if defined(YDB_EMBEDDED_NBS_ENABLED)
-    // Create DBS Controller
-    {
-        auto info = CreateTestTabletInfo(MakeDbsControllerID(), TTabletTypes::DbsController, TErasureType::ErasureNone);
-        TActorId actorId = CreateTestBootstrapper(*this, info, [&config=this->Config](const TActorId &tablet, TTabletStorageInfo *info) -> IActor* {
-                    return NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet(tablet, info);
-            });
-        EnableScheduleForActor(actorId, true);
-    }
-#endif
 }
 
 TTenantTestRuntime::TTenantTestRuntime(const TTenantTestConfig &config,

--- a/ydb/core/testlib/tenant_runtime.cpp
+++ b/ydb/core/testlib/tenant_runtime.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/mind/labels_maintainer.h>
 #include <ydb/core/mind/tenant_pool.h>
 #include <ydb/core/mind/tenant_slot_broker.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller.h>
 #include <ydb/core/node_whiteboard/node_whiteboard.h>
 #include <ydb/core/persqueue/pq.h>
 #include <ydb/core/protos/schemeshard/operations.pb.h>
@@ -1157,6 +1158,16 @@ void TTenantTestRuntime::Setup(bool createTenantPools)
             DispatchEvents(options);
         }
     }
+#if defined(YDB_EMBEDDED_NBS_ENABLED)
+    // Create DBS Controller
+    {
+        auto info = CreateTestTabletInfo(MakeDbsControllerID(), TTabletTypes::DbsController, TErasureType::ErasureNone);
+        TActorId actorId = CreateTestBootstrapper(*this, info, [&config=this->Config](const TActorId &tablet, TTabletStorageInfo *info) -> IActor* {
+                    return NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet(tablet, info);
+            });
+        EnableScheduleForActor(actorId, true);
+    }
+#endif
 }
 
 TTenantTestRuntime::TTenantTestRuntime(const TTenantTestConfig &config,

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -962,6 +962,7 @@ namespace Tests {
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(ChangeStateStorage(Hive, domainId), TTabletTypes::Hive), &CreateDefaultHive);
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController), &CreateFlatBsController);
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeTenantSlotBrokerID(), TTabletTypes::TenantSlotBroker), &NTenantSlotBroker::CreateTenantSlotBroker);
+        CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeTenantSlotBrokerID(), TTabletTypes::TenantSlotBroker), &NTenantSlotBroker::CreateTenantSlotBroker);
         if (Settings->EnableConsole) {
             CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeConsoleID(), TTabletTypes::Console), &NConsole::CreateConsole);
         }

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -115,6 +115,7 @@
 #include <ydb/library/yql/providers/pq/gateway/dummy/yql_pq_dummy_gateway_factory.h>
 #include <ydb/library/yql/utils/actor_log/log.h>
 #include <ydb/core/engine/mkql_engine_flat.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/core/kesus/proxy/proxy.h>
@@ -962,7 +963,9 @@ namespace Tests {
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(ChangeStateStorage(Hive, domainId), TTabletTypes::Hive), &CreateDefaultHive);
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController), &CreateFlatBsController);
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeTenantSlotBrokerID(), TTabletTypes::TenantSlotBroker), &NTenantSlotBroker::CreateTenantSlotBroker);
-        CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeTenantSlotBrokerID(), TTabletTypes::TenantSlotBroker), &NTenantSlotBroker::CreateTenantSlotBroker);
+#if defined(YDB_EMBEDDED_NBS_ENABLED)
+        CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeDbsControllerID(), TTabletTypes::DbsController), &NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet);
+#endif
         if (Settings->EnableConsole) {
             CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeConsoleID(), TTabletTypes::Console), &NConsole::CreateConsole);
         }

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -115,7 +115,6 @@
 #include <ydb/library/yql/providers/pq/gateway/dummy/yql_pq_dummy_gateway_factory.h>
 #include <ydb/library/yql/utils/actor_log/log.h>
 #include <ydb/core/engine/mkql_engine_flat.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller.h>
 
 #include <library/cpp/testing/unittest/registar.h>
 #include <ydb/core/kesus/proxy/proxy.h>
@@ -963,9 +962,6 @@ namespace Tests {
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(ChangeStateStorage(Hive, domainId), TTabletTypes::Hive), &CreateDefaultHive);
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeBSControllerID(), TTabletTypes::BSController), &CreateFlatBsController);
         CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeTenantSlotBrokerID(), TTabletTypes::TenantSlotBroker), &NTenantSlotBroker::CreateTenantSlotBroker);
-#if defined(YDB_EMBEDDED_NBS_ENABLED)
-        CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeDbsControllerID(), TTabletTypes::DbsController), &NYdb::NBS::NBlockStore::NStorage::NDbsController::CreateDbsControllerTablet);
-#endif
         if (Settings->EnableConsole) {
             CreateTestBootstrapper(*Runtime, CreateTestTabletInfo(MakeConsoleID(), TTabletTypes::Console), &NConsole::CreateConsole);
         }

--- a/ydb/core/viewer/viewer_storage_stats.h
+++ b/ydb/core/viewer/viewer_storage_stats.h
@@ -406,6 +406,8 @@ public:
                     TabletStorageInfo[MakeTenantSlotBrokerID()].Type = NKikimrTabletBase::TTabletTypes::TenantSlotBroker;
                     pathStorageInfo.Tablets.push_back(MakeCmsID());
                     TabletStorageInfo[MakeCmsID()].Type = NKikimrTabletBase::TTabletTypes::Cms;
+                    pathStorageInfo.Tablets.push_back(MakeDbsControllerID());
+                    TabletStorageInfo[MakeDbsControllerID()].Type = NKikimrTabletBase::TTabletTypes::DbsController;
                     for (TTabletId tabletId : domain->Coordinators) {
                         pathStorageInfo.Tablets.push_back(tabletId);
                         TabletStorageInfo[tabletId].Type = NKikimrTabletBase::TTabletTypes::Coordinator;

--- a/ydb/core/viewer/viewer_tabletinfo.h
+++ b/ydb/core/viewer/viewer_tabletinfo.h
@@ -324,6 +324,7 @@ public:
                         Tablets[MakeNodeBrokerID()] = NKikimrTabletBase::TTabletTypes::NodeBroker;
                         Tablets[MakeTenantSlotBrokerID()] = NKikimrTabletBase::TTabletTypes::TenantSlotBroker;
                         Tablets[MakeCmsID()] = NKikimrTabletBase::TTabletTypes::Cms;
+                        Tablets[MakeDbsControllerID()] = NKikimrTabletBase::TTabletTypes::DbsController;
                         for (TTabletId tabletId : domain->Coordinators) {
                             Tablets[tabletId] = NKikimrTabletBase::TTabletTypes::Coordinator;
                         }

--- a/ydb/library/yaml_config/core_constants.h
+++ b/ydb/library/yaml_config/core_constants.h
@@ -22,17 +22,25 @@ constexpr inline TStringBuf EPHEMERAL_POOL_CONFIG_PATH = "/storage_pool_types/*"
 
 constexpr inline TStringBuf ERASURE_SPECIES_FIELD = "erasure_species";
 
-const inline std::array<std::pair<TString, ui32>, 10> DEFAULT_TABLETS{
-    std::pair{TString{"FlatHive"}, 1},
-    std::pair{TString{"FlatBsController"}, 1},
-    std::pair{TString{"FlatSchemeshard"}, 1},
-    std::pair{TString{"FlatTxCoordinator"}, 3},
-    std::pair{TString{"TxMediator"}, 3},
-    std::pair{TString{"TxAllocator"}, 3},
-    std::pair{TString{"Cms"}, 1},
-    std::pair{TString{"NodeBroker"}, 1},
-    std::pair{TString{"TenantSlotBroker"}, 1},
-    std::pair{TString{"Console"}, 1},
+struct TDefaultTabletConfig
+{
+    TString Type;
+    ui32 Count;
+    bool IsOptional = false;
+};
+
+const inline std::array DEFAULT_TABLETS{
+    TDefaultTabletConfig{.Type = TString{"FlatHive"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"FlatBsController"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"FlatSchemeshard"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"FlatTxCoordinator"}, .Count = 3},
+    TDefaultTabletConfig{.Type = TString{"TxMediator"}, .Count = 3},
+    TDefaultTabletConfig{.Type = TString{"TxAllocator"}, .Count = 3},
+    TDefaultTabletConfig{.Type = TString{"Cms"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"NodeBroker"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"TenantSlotBroker"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"Console"}, .Count = 1},
+    TDefaultTabletConfig{.Type = TString{"DbsController"}, .Count = 1, .IsOptional = true},
 };
 
 const inline std::map<TString, ui64> GetTablets(ui64 idx) {
@@ -44,6 +52,7 @@ const inline std::map<TString, ui64> GetTablets(ui64 idx) {
         {TString{"NodeBroker"}, 72057594037936129},
         {TString{"TenantSlotBroker"}, 72057594037936130},
         {TString{"Console"}, 72057594037936131},
+        {TString{"DbsController"}, 72057594037936132},
         {TString{"TxAllocator"}, TDomainsInfo::MakeTxAllocatorIDFixed(idx)},
         {TString{"FlatTxCoordinator"}, TDomainsInfo::MakeTxCoordinatorIDFixed(idx)},
         {TString{"TxMediator"}, TDomainsInfo::MakeTxMediatorIDFixed(idx)},

--- a/ydb/library/yaml_config/core_constants.h
+++ b/ydb/library/yaml_config/core_constants.h
@@ -22,7 +22,7 @@ constexpr inline TStringBuf EPHEMERAL_POOL_CONFIG_PATH = "/storage_pool_types/*"
 
 constexpr inline TStringBuf ERASURE_SPECIES_FIELD = "erasure_species";
 
-const inline std::array<std::pair<TString, ui32>, 10> DEFAULT_TABLETS{
+const inline std::array<std::pair<TString, ui32>, 11> DEFAULT_TABLETS{
     std::pair{TString{"FlatHive"}, 1},
     std::pair{TString{"FlatBsController"}, 1},
     std::pair{TString{"FlatSchemeshard"}, 1},
@@ -33,6 +33,7 @@ const inline std::array<std::pair<TString, ui32>, 10> DEFAULT_TABLETS{
     std::pair{TString{"NodeBroker"}, 1},
     std::pair{TString{"TenantSlotBroker"}, 1},
     std::pair{TString{"Console"}, 1},
+    std::pair{TString{"DbsController"}, 1},
 };
 
 const inline std::map<TString, ui64> GetTablets(ui64 idx) {

--- a/ydb/library/yaml_config/protos/config.proto
+++ b/ydb/library/yaml_config/protos/config.proto
@@ -58,6 +58,7 @@ message TSystemTablets {
     repeated NKikimrConfig.TBootstrap.TTablet FlatTxCoordinator = 9 [(NMarkers.AsMap) = "Tablets"];
     repeated NKikimrConfig.TBootstrap.TTablet TxAllocator = 10 [(NMarkers.AsMap) = "Tablets"];
     repeated NKikimrConfig.TBootstrap.TTablet TxMediator = 11 [(NMarkers.AsMap) = "Tablets"];
+    repeated NKikimrConfig.TBootstrap.TTablet DbsController = 12 [(NMarkers.AsMap) = "Tablets"];
 }
 
 message TExtendedHostConfigDrive {

--- a/ydb/library/yaml_config/yaml_config_parser.cpp
+++ b/ydb/library/yaml_config/yaml_config_parser.cpp
@@ -274,25 +274,24 @@ namespace NKikimr::NYaml {
         }
     }
 
-    ui32 GetDefaultTabletCount(TString& type) {
-        const auto& defaults = DEFAULT_TABLETS;
-        for(const auto& [type_, cnt] : defaults) {
-            if (type == type_) {
-                return cnt;
+    const TDefaultTabletConfig& GetDefaultTabletConfig(const TString& type) {
+        for(const auto& cfg : DEFAULT_TABLETS) {
+            if (type == cfg.Type) {
+                return cfg;
             }
         }
         Y_ENSURE_BT(false, "unknown tablet " << type);
     }
 
-    bool isUnique(TString& type) {
-        return GetDefaultTabletCount(type) == 1;
+    bool isUnique(const TString& type) {
+        return GetDefaultTabletConfig(type).Count == 1;
     }
 
     std::vector<TString> GetTabletTypes() {
         const auto& defaults = DEFAULT_TABLETS;
         std::vector<TString> types;
-        for(const auto& [type, cnt] : defaults) {
-            types.push_back(TString(type));
+        for(const auto& [type, cnt, isOptional] : defaults) {
+            types.emplace_back(type);
         }
         return types;
     }
@@ -1394,7 +1393,7 @@ endDiskTypeCheck:   ;
         enumName = to_upper(enumName);
 
         if (!systemTabletsConfig->TabletsSize(type)) {
-            for(ui32 idx = 0; idx < GetDefaultTabletCount(type); ++idx) {
+            for(ui32 idx = 0; idx < GetDefaultTabletConfig(type).Count; ++idx) {
                 auto* tablet = systemTabletsConfig->AddTablets(type);
                 NKikimrConfig::TBootstrap_ETabletType res;
                 Y_ENSURE_BT(TryFromString<NKikimrConfig::TBootstrap_ETabletType>(enumName, res), "incorrect enum: " << enumName);
@@ -1409,7 +1408,7 @@ endDiskTypeCheck:   ;
             auto* tabletInfo = tablet.MutableInfo();
 
             if (!tabletInfo->HasTabletID()) {
-                Y_ENSURE_BT(idx <= GetDefaultTabletCount(type));
+                Y_ENSURE_BT(idx <= GetDefaultTabletConfig(type).Count);
                 tabletInfo->SetTabletID(GetNextTabletID(type, idx));
             }
         }
@@ -1509,6 +1508,10 @@ endDiskTypeCheck:   ;
     }
 
 
+    bool TabletsEnabledFor(const NKikimrConfig::TEphemeralInputFields& ephemeralConfig, const TString& type) {
+        return !GetDefaultTabletConfig(type).IsOptional || ephemeralConfig.GetSystemTablets().TabletsSize(type);
+    }
+
     const NProtoBuf::RepeatedPtrField<NKikimrConfig::TBootstrap::TTablet>& GetTabletsFor(NKikimrConfig::TEphemeralInputFields& ephemeralConfig, TString type) {
         auto* systemTabletsConfig = ephemeralConfig.MutableSystemTablets();
         TString enumName = type;
@@ -1516,7 +1519,7 @@ endDiskTypeCheck:   ;
         enumName = to_upper(enumName);
 
         if (!systemTabletsConfig->TabletsSize(type)) {
-            for(ui32 idx = 0; idx < GetDefaultTabletCount(type); ++idx) {
+            for(ui32 idx = 0; idx < GetDefaultTabletConfig(type).Count; ++idx) {
                 auto* tablet = systemTabletsConfig->AddTablets(type);
                 NKikimrConfig::TBootstrap_ETabletType res;
                 Y_ENSURE_BT(TryFromString<NKikimrConfig::TBootstrap_ETabletType>(enumName, res), "incorrect enum: " << enumName);
@@ -1543,7 +1546,7 @@ endDiskTypeCheck:   ;
             auto* tabletInfo = tablet.MutableInfo();
 
             if (!tabletInfo->HasTabletID()) {
-                Y_ENSURE_BT(idx <= GetDefaultTabletCount(type));
+                Y_ENSURE_BT(idx <= GetDefaultTabletConfig(type).Count);
                 tabletInfo->SetTabletID(GetNextTabletID(type, idx));
             }
 
@@ -1566,6 +1569,9 @@ endDiskTypeCheck:   ;
 
         auto* bootConfig = config.MutableBootstrapConfig();
         for(const auto& type : GetTabletTypes()) {
+            if (!TabletsEnabledFor(ephemeralConfig, type)) {
+                continue;
+            }
             for(const auto& tablet : GetTabletsFor(ephemeralConfig, type)) {
                 bootConfig->AddTablet()->CopyFrom(tablet);
             }

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -682,7 +682,7 @@ class KikimrConfigGenerator(object):
             # Enable DbsController tablet
             self.yaml_config.setdefault("system_tablets", {})["dbs_controller"] = [
                 {
-                    "info": {"tablet_id": 72057594037936132}
+                    "info": {}
                 }
             ]
 

--- a/ydb/tests/library/harness/kikimr_config.py
+++ b/ydb/tests/library/harness/kikimr_config.py
@@ -678,6 +678,14 @@ class KikimrConfigGenerator(object):
         if self.system_tablets:
             self.yaml_config["system_tablets"] = self.system_tablets
 
+        if enable_nbs:
+            # Enable DbsController tablet
+            self.yaml_config.setdefault("system_tablets", {})["dbs_controller"] = [
+                {
+                    "info": {"tablet_id": 72057594037936132}
+                }
+            ]
+
         if system_tablet_backup_config:
             self.yaml_config["system_tablet_backup_config"] = system_tablet_backup_config
 

--- a/ydb/tests/tools/local_cluster/__main__.py
+++ b/ydb/tests/tools/local_cluster/__main__.py
@@ -87,6 +87,36 @@ class LocalCluster:
         port_allocator = DefaultFirstNodePortAllocator(base_offset=self.port_offset)
 
         nbs_database_name = "/Root/NBS"
+        # Based on ydb/tests/library/harness/resources/default_yaml.yml
+        system_tablets = {
+            "default_node": [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "dbs_controller": [
+                {
+                    "info": {"tablet_id": 72057594037936132},
+                    "node": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                }
+            ],
+            "flat_tx_coordinator": [
+                {
+                    "node": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                }
+            ],
+            "tx_allocator": [
+                {
+                    "node": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                }
+            ],
+            "tx_mediator": [
+                {
+                    "node": [1, 2, 3, 4, 5, 6, 7, 8, 9]
+                }
+            ],
+            "flat_schemeshard": [
+                {
+                    "info": {"tablet_id": 72057594046678944}
+                }
+            ]
+        }
         configurator = kikimr_config.KikimrConfigGenerator(
             erasure=Erasure.MIRROR_3_DC,
             port_allocator=port_allocator,
@@ -94,6 +124,7 @@ class LocalCluster:
             binary_paths=[self.binary_path],
             enable_nbs=self.enable_nbs,
             nbs_database_name=nbs_database_name,
+            system_tablets=system_tablets,
         )
 
         self.cluster = kikimr_runner.KiKiMR(


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Наделяем DbsController таблетку статически бутстрапом.
Чтобы таблетка запускалась, она должна быть явно указана в конфиге в system_tablets (для этого в конфигурацию была добавлена соответствующая возможность).
Таблетка помечается как Important в валидаторе, если в конфиге включен nbs.
Таблетка запускается в локальном кластере, если включен nbs.

### Changelog category <!-- remove all except one -->

* New feature

### Description for reviewers <!-- (optional) description for those who read this PR -->

Таблетке DbsController выдан временный TabletID по принципу "следующий по списку",
окончательный ID необходимо согласовать с эксплуатацией.
Замечания и комментарии крайне приветствуются.