### PR TITLE
Avoid uninitialized EVDiskStatus after failed Parse in cluster balancing

### DIFF
--- a/ydb/core/mind/bscontroller/cluster_balancing.cpp
+++ b/ydb/core/mind/bscontroller/cluster_balancing.cpp
@@ -265,18 +265,20 @@ namespace NKikimr::NBsController {
                 }
 
                 const auto& statusStr = vslot.GetStatus();
-                NKikimrBlobStorage::EVDiskStatus status;
-                NKikimrBlobStorage::EVDiskStatus_Parse(statusStr, &status);
-
-                switch (status) {
-                    case NKikimrBlobStorage::ERROR:
-                    case NKikimrBlobStorage::READY:
-                        break;
-                    case NKikimrBlobStorage::INIT_PENDING:
-                    case NKikimrBlobStorage::REPLICATING:
-                        pdisksWithReplicatingVDisks.insert(pdiskId);
-                        replicatingVDisks++;
-                        break;
+                // Empty/unknown Status: Parse leaves value untouched; treat as ERROR
+                // (same as TVSlotInfo::GetStatus / value_or(ERROR)).
+                NKikimrBlobStorage::EVDiskStatus status = NKikimrBlobStorage::ERROR;
+                if (NKikimrBlobStorage::EVDiskStatus_Parse(statusStr, &status)) {
+                    switch (status) {
+                        case NKikimrBlobStorage::ERROR:
+                        case NKikimrBlobStorage::READY:
+                            break;
+                        case NKikimrBlobStorage::INIT_PENDING:
+                        case NKikimrBlobStorage::REPLICATING:
+                            pdisksWithReplicatingVDisks.insert(pdiskId);
+                            replicatingVDisks++;
+                            break;
+                    }
                 }
 
                 auto it = storageInfo.PDiskUsageMap.find(pdiskId);


### PR DESCRIPTION
## Summary
- SAST `core.uninitialized.Branch` in `BuildStorageInfo`: `EVDiskStatus status` was used after `EVDiskStatus_Parse` without checking the return value.
- In this protobuf tree `ParseNamedEnum` explicitly leaves `*value` unchanged on failure; `TBaseConfig.TVSlot.Status` may be empty when status is not known/reported — so the branch was a real uninitialized read, not an FP.
- Initialize `status` to `ERROR` and only enter the switch on successful parse (same default as `TVSlotInfo::GetStatus()` / `value_or(ERROR)`). Slot counting is unchanged.

## Test plan
- [ ] Build `ydb/core/mind/bscontroller`
- [ ] Confirm empty/unknown `Status` no longer drives `REPLICATING`/`INIT_PENDING` counters
- [ ] Existing cluster balancing behavior for valid status names (`ERROR`/`READY`/`INIT_PENDING`/`REPLICATING`) unchanged


Made with [Cursor](https://cursor.com)