### PR TITLE
Fix incorrect shard id in ReadTable ignore-new-shard trace log

### DIFF
--- a/ydb/core/tx/tx_proxy/read_table_impl.cpp
+++ b/ydb/core/tx/tx_proxy/read_table_impl.cpp
@@ -2686,7 +2686,7 @@ private:
                     shardRange.To.GetCells(), shardRange.ToInclusive,
                     oldShard->Ranges.front().From.GetCells(), oldShard->Ranges.front().FromInclusive))
             {
-                TXLOG_T("Ignoring new shard ShardId# " << (oldShard ? oldShard->ShardId : 0) << " (nothing to read)");
+                TXLOG_T("Ignoring new shard ShardId# " << state.ShardId << " (nothing to read)");
 
                 // We don't want to read anything from current shard
                 state.ShardPosition = ShardList.end();


### PR DESCRIPTION
## Summary
- In `ResolveShards`, the branch that ignores a newly resolved shard (`oldShard == nullptr || !RangeEndBeginHasIntersection(...)`) logged `oldShard->ShardId` (later softened to a null-safe ternary that prints `0`).
- That branch is specifically about the **new** shard in `state`, and `oldShard` can be null after `oldShardNext()` exhausts the previous shard list — so the logged id was either a crash risk historically, or a misleading `0` / wrong old shard id.
- Log `state.ShardId`, matching the sibling `"Ignoring new shard"` message a few lines below.

## Test plan
- [ ] Code review of the log message against neighboring `TXLOG_T` calls in the same method
- [ ] Optional: run ReadTable / resolve-after-split tests under `ydb/core/tx/tx_proxy` if convenient (change is trace-log only)


Made with [Cursor](https://cursor.com)