### PR TITLE
Silence false-positive string_view::data() SAST in string kernels

### DIFF
--- a/yql/essentials/minikql/invoke_builtins/mkql_builtins_string_kernels.cpp
+++ b/yql/essentials/minikql/invoke_builtins/mkql_builtins_string_kernels.cpp
@@ -53,6 +53,8 @@ Y_NO_INLINE arrow::Status ExecStringScalarArrayImpl(const arrow::compute::ExecBa
         const size_t val1Size = val1.size();
         const auto offsets2 = arr2.buffers[1]->data();
         const auto data2 = arr2.buffers[2]->data();
+        // Length is passed via &val1Size (stringOffsets1); callee builds string_view(data, size).
+        // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
         func(reinterpret_cast<const TOffset1*>(&val1Size), val1.data(),
              reinterpret_cast<const TOffset2*>(offsets2), reinterpret_cast<const char*>(data2),
              reinterpret_cast<TOutput*>(resPtr), length, 0, arr2.offset);
@@ -75,6 +77,8 @@ Y_NO_INLINE arrow::Status ExecStringArrayScalarImpl(const arrow::compute::ExecBa
         const size_t val2Size = val2.size();
         const auto offsets1 = arr1.buffers[1]->data();
         const auto data1 = arr1.buffers[2]->data();
+        // Length is passed via &val2Size (stringOffsets2); callee builds string_view(data, size).
+        // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
         func(reinterpret_cast<const TOffset1*>(offsets1), reinterpret_cast<const char*>(data1),
              reinterpret_cast<const TOffset2*>(&val2Size), val2.data(),
              reinterpret_cast<TOutput*>(resPtr), length, arr1.offset, 0);


### PR DESCRIPTION
## Summary
- SAST `bugprone-suspicious-stringview-data-usage` fires on `val1.data()` / `val2.data()` in `ExecStringScalarArrayImpl` / `ExecStringArrayScalarImpl`.
- This is a false positive: length is passed via `&val1Size` / `&val2Size` as the offsets argument; callees rebuild `std::string_view(data, size)` and never treat the pointer as a C string.
- Add `NOLINTNEXTLINE` with a short comment at both call sites.

## Test plan
- [ ] Confirm clang-tidy / SAST no longer reports these lines
- [ ] Existing string kernel comparison tests still pass


Made with [Cursor](https://cursor.com)