### PR TITLE
Avoid uninitialized bridge sync stage on missing pile

### DIFF
--- a/ydb/core/mind/bscontroller/bridge.cpp
+++ b/ydb/core/mind/bscontroller/bridge.cpp
@@ -397,13 +397,16 @@ void TBlobStorageController::ApplySyncerState(TNodeId nodeId, const NKikimrBlobS
             updateNodeWarden = true;
 
             if (syncer.HasErrorReason()) {
-                NKikimrBridge::TGroupState::EStage stage;
+                NKikimrBridge::TGroupState::EStage stage = NKikimrBridge::TGroupState::BLOCKS;
+                bool found = false;
                 for (const auto& pile : bridgeGroupInfo.GetBridgeGroupState().GetPile()) {
                     if (TGroupId::FromProto(&pile, &NKikimrBridge::TGroupState::TPile::GetGroupId) == targetGroupId) {
                         stage = pile.GetStage();
+                        found = true;
                         break;
                     }
                 }
+                Y_DEBUG_ABORT_UNLESS(found);
                 updates.emplace_back(targetGroupId, TTxUpdateBridgeSyncState::TRegisterError{
                     .Stage = stage,
                     .Error = syncer.GetErrorReason(),


### PR DESCRIPTION
## Summary
- In `ApplySyncerState`, `stage` was declared without initialization and assigned only when a pile matching `targetGroupId` was found; on a miss it was read for `TRegisterError` (UB).
- `targetGroupId` comes from the NodeWarden syncer report, while `bridgeGroupInfo` is the current BSC/static group state — the match is not expressed as a code invariant. The adjacent stage-advance loop already uses `found` + `Y_DEBUG_ABORT_UNLESS(found)`.
- Initialize `stage` to `BLOCKS`, track `found`, and abort in debug if the pile is missing; keep `emplace_back` + `continue` behavior unchanged.

## Test plan
- [ ] `./ya make --build relwithdebinfo -tA ydb/core/mind/bscontroller` (or existing BSC bridge/syncer coverage)
- [ ] Sanity-check that a finished syncer with `ErrorReason` still registers the pile stage when the target pile exists
- [ ] In debug builds, missing pile hits `Y_DEBUG_ABORT_UNLESS(found)` instead of silent UB


Made with [Cursor](https://cursor.com)