### PR TITLE
Prevent HealthEvents crash on RowsCount=0

### DIFF
--- a/ydb/core/mind/bscontroller/monitoring.cpp
+++ b/ydb/core/mind/bscontroller/monitoring.cpp
@@ -363,7 +363,7 @@ public:
         , RespondTo(sender)
         , Json(cgi.Has("fmt") && cgi.Get("fmt") == "json")
         , Offset(FromStringWithDefault<ui64>(cgi.Get("RowsOffset"), 0))
-        , NumRows(FromStringWithDefault<ui64>(cgi.Get("RowsCount"), 1000))
+        , NumRows(Max<ui64>(1, FromStringWithDefault<ui64>(cgi.Get("RowsCount"), 1000)))
     {}
 
     TTxType GetTxType() const override { return NBlobStorageController::TXTYPE_MON_EVENT_HEALTH_EVENTS; }


### PR DESCRIPTION
## Summary
- `TTxMonEvent_HealthEvents` parsed `RowsCount` via `FromStringWithDefault` with default 1000, but an explicit `RowsCount=0` left `NumRows == 0`.
- Pagination then did `Events.size() % NumRows`, which is undefined for unsigned zero and crashes the BSController tablet mon page.
- Clamp `NumRows` to `Max(1, …)`, matching the existing guard in `OperationLog` in the same file.

## Test plan
- [ ] Open BSController mon page `HealthEvents` with default params — page renders as before
- [ ] Open with `RowsCount=0` — page renders instead of crashing
- [ ] Open with `RowsCount=1` / omitted `RowsCount` — pagination still works


Made with [Cursor](https://cursor.com)