### PR TITLE
Fix flacky test

### DIFF
--- a/ydb/core/base/kmeans_clusters.cpp
+++ b/ydb/core/base/kmeans_clusters.cpp
@@ -341,13 +341,16 @@ public:
     }
 
     void FindClusters(const TStringBuf embedding, std::vector<std::pair<ui32, double>>& clusters, size_t n, double skipRatio) override {
+        clusters.clear();
         if (!IsExpectedFormat(embedding)) {
             return;
         }
-        clusters.clear();
         for (ui32 i = 0; const auto& cluster : Clusters) {
             auto cl = std::make_pair(i, (double)TMetric::Distance(cluster, embedding));
-            auto it = std::lower_bound(clusters.begin(), clusters.end(), cl, [](const std::pair<ui32, double>& a, const std::pair<ui32, double>& b) {
+            // upper_bound, not lower_bound: on equal distances the cluster with the lower number wins,
+            // the same way as in FindCluster(). Otherwise rows may be assigned to different clusters
+            // during the K-means and the upload passes of the index build.
+            auto it = std::upper_bound(clusters.begin(), clusters.end(), cl, [](const std::pair<ui32, double>& a, const std::pair<ui32, double>& b) {
                 return a.second < b.second;
             });
             if (clusters.size() < n) {

--- a/ydb/core/base/ut/kmeans_ut.cpp
+++ b/ydb/core/base/ut/kmeans_ut.cpp
@@ -216,6 +216,73 @@ Y_UNIT_TEST_SUITE(NKMeans) {
         UNIT_ASSERT(!centroid[4]);
     }
 
+    Y_UNIT_TEST(FindClustersPrefersLowerClusterNumberOnEqualDistance) {
+        TString error;
+        auto clusters = CreateClusters(
+            MakeCosineSettings(Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT, 2),
+            1,
+            error);
+
+        UNIT_ASSERT_C(clusters, error);
+        // 3 equal centroids and 1 different
+        UNIT_ASSERT(clusters->SetClusters(TVector<TString>{
+            SerializeVector<float>({1.0f, 0.0f}),
+            SerializeVector<float>({1.0f, 0.0f}),
+            SerializeVector<float>({1.0f, 0.0f}),
+            SerializeVector<float>({0.0f, 1.0f}),
+        }));
+
+        const auto embedding = SerializeVector<float>({2.0f, 0.0f});
+
+        // FindCluster() picks the first of the equally distant clusters,
+        // FindClusters() must pick the same one, otherwise rows are distributed
+        // between clusters differently during the K-means and the upload passes
+        // of the vector index build, which leaves clusters without any rows
+        auto single = clusters->FindCluster(embedding);
+        UNIT_ASSERT(single);
+        UNIT_ASSERT_VALUES_EQUAL(*single, 0u);
+
+        std::vector<std::pair<ui32, double>> found;
+        clusters->FindClusters(embedding, found, 1, 0);
+        UNIT_ASSERT_VALUES_EQUAL(found.size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(found[0].first, 0u);
+
+        clusters->FindClusters(embedding, found, 2, 0);
+        UNIT_ASSERT_VALUES_EQUAL(found.size(), 2u);
+        UNIT_ASSERT_VALUES_EQUAL(found[0].first, 0u);
+        UNIT_ASSERT_VALUES_EQUAL(found[1].first, 1u);
+
+        // The farthest cluster must still be the last one
+        clusters->FindClusters(embedding, found, 4, 0);
+        UNIT_ASSERT_VALUES_EQUAL(found.size(), 4u);
+        UNIT_ASSERT_VALUES_EQUAL(found[3].first, 3u);
+    }
+
+    Y_UNIT_TEST(FindClustersClearsResultForInvalidEmbedding) {
+        TString error;
+        auto clusters = CreateClusters(
+            MakeCosineSettings(Ydb::Table::VectorIndexSettings::VECTOR_TYPE_FLOAT, 2),
+            1,
+            error);
+
+        UNIT_ASSERT_C(clusters, error);
+        UNIT_ASSERT(clusters->SetClusters(TVector<TString>{
+            SerializeVector<float>({1.0f, 0.0f}),
+            SerializeVector<float>({0.0f, 1.0f}),
+        }));
+
+        std::vector<std::pair<ui32, double>> found;
+        const auto embedding = SerializeVector<float>({1.0f, 0.0f});
+        clusters->FindClusters(embedding, found, 2, 0);
+        UNIT_ASSERT_VALUES_EQUAL(found.size(), 2u);
+
+        // A vector of a wrong dimension must not be assigned to the clusters
+        // found for the previously checked vector
+        const auto invalid = SerializeVector<float>({1.0f, 0.0f, 1.0f});
+        clusters->FindClusters(invalid, found, 2, 0);
+        UNIT_ASSERT_VALUES_EQUAL(found.size(), 0u);
+    }
+
     Y_UNIT_TEST(ComputeOptimalClustersBasic) {
         // L=1: C = sqrt(T * P * N) = sqrt(10 * 1 * 10000) = sqrt(100000) ≈ 316
         UNIT_ASSERT_VALUES_EQUAL(ComputeOptimalClusters(1, 10, 10000, 1.0), 316);

--- a/ydb/core/kqp/runtime/kqp_vector_actor.cpp
+++ b/ydb/core/kqp/runtime/kqp_vector_actor.cpp
@@ -417,9 +417,23 @@ private:
             RuntimeError(error, NYql::NDqProto::StatusIds::INTERNAL_ERROR);
             return;
         }
-        if (!ReadingChildClustersOf && !FetchedClusters.size()) {
-            // Index is empty
-            EmptyIndex = true;
+        if (!FetchedClusters.size()) {
+            if (!ReadingChildClustersOf) {
+                // Index is empty
+                EmptyIndex = true;
+            } else {
+                // The cluster has no children in the level table, i.e. its subtree is empty.
+                // It's possible when the cluster didn't get any rows during the index build,
+                // for example when two clusters of the same level got equal centroids.
+                // Just skip such clusters instead of failing the query - the row is either
+                // resolved into other (overlapping) clusters or isn't added to the index at all,
+                // which is the same as what the read path does for such clusters.
+                YDB_LOG_NOTICE("Cluster has no child clusters, skipping it",
+                    {"logPrefix", this->LogPrefix},
+                    {"parent", ReadingChildClustersOf});
+                CurClusters = std::move(clusters);
+                CurClusterIds.clear();
+            }
             ContinueResolveClusters();
             return;
         }

--- a/ydb/tests/stress/oltp_workload/tests/test_workload.py
+++ b/ydb/tests/stress/oltp_workload/tests/test_workload.py
@@ -15,6 +15,7 @@ class TestYdbWorkload(StressFixture):
             "enable_table_datetime64": True,
             "enable_vector_index": True,
             "enable_fulltext_index": True,
+            "enable_fulltext_index_prefix": True,
             "enable_json_index": True,
         }
 

--- a/ydb/tests/stress/oltp_workload/workload/type/fulltext_index.py
+++ b/ydb/tests/stress/oltp_workload/workload/type/fulltext_index.py
@@ -17,6 +17,11 @@ class WorkloadFulltextIndex(WorkloadBase):
         self.row_count = 50
         self.limit = 10
         self.query_count = 10
+        # Number of distinct prefix (user_id) values in the prefixed tables.
+        # Every prefixed query matches only one of these groups, so the number of
+        # groups is kept small to leave enough rows in each of them - otherwise
+        # random word queries return nothing too often.
+        self.user_count = 2
 
     def _create_table(self, table_path, utf8, with_prefix=False):
         logger.info(f"Create table {table_path}")
@@ -96,7 +101,7 @@ class WorkloadFulltextIndex(WorkloadBase):
         for key in range(min_key, max_key):
             text = fulltext.get_random_text()
             if with_prefix:
-                user_id = (key % 10) + 1  # Distribute across 10 users
+                user_id = (key % self.user_count) + 1
                 values.append(f'({key}, {user_id}, "{text}")')
             else:
                 values.append(f'({key}, "{text}")')
@@ -127,7 +132,7 @@ class WorkloadFulltextIndex(WorkloadBase):
     def _select_contains(self, index_name, table_path, with_prefix=False):
         query = ' '.join(fulltext.get_random_words(3))
         if with_prefix:
-            user_id = random.randint(1, 10)
+            user_id = random.randint(1, self.user_count)
             select_sql = f"""
                 SELECT `pk`, `text`
                 FROM `{table_path}`
@@ -153,7 +158,7 @@ class WorkloadFulltextIndex(WorkloadBase):
     def _select_relevance(self, index_name, table_path, with_prefix=False):
         query = ' '.join(fulltext.get_random_words(3))
         if with_prefix:
-            user_id = random.randint(1, 10)
+            user_id = random.randint(1, self.user_count)
             select_sql = f"""
                 SELECT `pk`, `text`, FulltextScore(`text`, "{query}") as `rel`
                 FROM `{table_path}`
@@ -184,7 +189,7 @@ class WorkloadFulltextIndex(WorkloadBase):
             prev = rel
         return n
 
-    def _wait_index_ready(self, index_name, table_path):
+    def _wait_index_ready(self, index_name, table_path, with_prefix=False):
         start_time = time.time()
         while time.time() - start_time < 60:
             time.sleep(5)
@@ -192,6 +197,7 @@ class WorkloadFulltextIndex(WorkloadBase):
                 res = self._select_contains(
                     index_name=index_name,
                     table_path=table_path,
+                    with_prefix=with_prefix,
                 )
                 if res == 0:
                     continue
@@ -220,6 +226,7 @@ class WorkloadFulltextIndex(WorkloadBase):
         self._wait_index_ready(
             table_path=table_path,
             index_name=index_name,
+            with_prefix=with_prefix,
         )
         n = 0
         for i in range(0, self.query_count):


### PR DESCRIPTION
### Changelog entry 
Fix test ydb/tests/stress/oltp_workload/tests/test_workload.py.TestYdbWorkload.test
### Changelog category
* Not for changelog
### Description for reviewers
 Three separate defects, all in the same test

  1. Server: Child clusters of 1 are invalid (the failure quoted in the ticket)

  ydb/core/kqp/runtime/kqp_vector_actor.cpp:412 — when the vector-resolve actor descended the kmeans tree and found a cluster with no children in the level table, it raised INTERNAL_ERROR and killed the INSERT.

  That state is reachable from a normal index build: TLocalKMeansScan decides which centroids survive using ClusterSizes, which come from the K-means pass (FindCluster, with the previous round's centroids), but rows are actually placed during
  the upload pass using FindClusters with the recomputed centroids. When two centroids collide on the last round — very likely with bit/int8 vectors of dimension 5, as the workload uses — one of them gets zero rows, so it has no children at the
  next level. With overlap_clusters=2 the resolve actor always picks both root clusters, hits the childless one, and fails. Cluster id 1 in the message is the first root cluster, matching exactly.

  Fix: treat a childless cluster as an empty subtree and skip it (same as the existing empty-index path and as the read path already behaves) instead of failing.

  2. FindClusters bugs (ydb/core/base/kmeans_clusters.cpp:343)
  - tie-break used lower_bound, so on equal distances the last cluster won, while FindCluster keeps the first — the two passes of a build could disagree. Now upper_bound.
  - on an invalid-format embedding it returned without clearing the output, so the row inherited the previous row's cluster list. Now cleared first.

  Unit tests added in ydb/core/base/ut/kmeans_ut.cpp.

  3. The test was failing 100%, not flakily, on current main

  PR #44291 (2026-06-25) added prefixed fulltext indexes to this workload but never enabled the feature flag, and it went unnoticed because the test is muted:
  - test_workload.py: added enable_fulltext_index_prefix.
  - fulltext_index.py: _wait_index_ready issued a prefixed-index query without the required prefix equality predicate.
  - fulltext_index.py: prefixed rows were spread over 10 user_id groups (~5 rows each), so the "10 random queries must return something" check failed ~10% of the time. Reduced to 2 groups; observed once in my runs before the change.

  Verification

  - ydb/core/base/ut -F NKMeans::* — 39/39
  - ydb/core/kqp/ut/indexes/vector, .../prefixed_vector, ydb/core/tx/datashard/build_index/ut — 366/366
  - stress test: 8 runs before the fulltext-selectivity fix (1 failure), then 10/10 clean after

  Two things I deliberately left alone: I did not edit .github/config/muted_ya.txt — per mute_rules.md the unmute happens when a human closes the issue as Completed. And the build side can still write a dead cluster into the level table; I
  fixed the tie-break inconsistency but not the deeper issue that FormLevelRows emits centroids before the upload pass knows which ones get rows. That's a riskier scan-restructuring change, and the actor fix makes the state harmless.

