### PR TITLE
Avoid UB in MakeTzDate on MakeTzDatetime failure

### DIFF
--- a/yql/essentials/minikql/mkql_type_ops.cpp
+++ b/yql/essentials/minikql/mkql_type_ops.cpp
@@ -1314,9 +1314,11 @@ bool SplitInterval(i64 value, bool& sign, ui32& day, ui32& hour, ui32& min, ui32
 
 bool MakeTzDate(ui32 year, ui32 month, ui32 day, ui16& value, ui16 tzId) {
     ui32 datetime;
-    auto result = MakeTzDatetime(year, month, day, 0U, 0U, 0U, datetime, tzId);
+    if (!MakeTzDatetime(year, month, day, 0U, 0U, 0U, datetime, tzId)) {
+        return false;
+    }
     value = datetime / 86400U;
-    return result;
+    return true;
 }
 
 bool MakeTzDatetime(ui32 year, ui32 month, ui32 day, ui32 hour, ui32 min, ui32 sec, ui32& value, ui16 tzId) {


### PR DESCRIPTION
## Summary
- `MakeTzDate` used `datetime` after `MakeTzDatetime` without checking the return value.
- On failure (`tzId == 0` and invalid date/time), `datetime` stayed uninitialized, so dividing it by `86400` was undefined behavior.
- Check `MakeTzDatetime` result first and return `false` before touching `datetime`.

## Test plan
- [ ] Existing minikql type ops tests still pass: `./ya make --build relwithdebinfo -tA yql/essentials/minikql -F *SplitMakeTzDate*`
- [ ] Confirm compilers no longer warn about uninitialized `datetime` on this path

Made with [Cursor](https://cursor.com)