### PR TITLE
ci(docs): restore dispatch-only rebuild_docs workflow

### DIFF
--- a/.github/workflows/docs_build_rebuild.yaml
+++ b/.github/workflows/docs_build_rebuild.yaml
@@ -62,38 +62,6 @@ jobs:
 
       - name: Dispatch docs build
         if: steps.docs-changes.outputs.has_docs == 'true'
-        run: echo "value=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Build
-        if: steps.docs-changes.outputs.has_docs == 'true'
-        uses: diplodoc-platform/docs-build-action@v3
-        with:
-          revision: "pr-${{ github.event.pull_request.number }}-${{ steps.sha.outputs.value }}"
-          src-root: "./ydb/docs"
-          cli-version: "4.59.12"
-          use-ya-opensource: true
-
-      - name: Fail on documentation build issues
-        if: steps.docs-changes.outputs.has_docs == 'true'
-        run: |
-          set -euo pipefail
-          if [[ ! -f build-html.log ]]; then
-            echo "::error::Documentation build log (build-html.log) not found"
-            exit 1
-          fi
-          issue_count=$(grep -cE '^(ERR|WARN)' build-html.log || true)
-          if [[ "$issue_count" -gt 0 ]]; then
-            echo "::error::Documentation build has ${issue_count} error(s)/warning(s)"
-            grep -E '^(ERR|WARN)' build-html.log | sort -u | head -20
-            if [[ "$issue_count" -gt 20 ]]; then
-              echo "... and $((issue_count - 20)) more (see PR comment for full log)"
-            fi
-            exit 1
-          fi
-          echo "No documentation build warnings or errors"
-
-      - name: Remove rebuild_docs label
-        if: always()
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Summary
- `#48223` accidentally replaced `.github/workflows/docs_build_rebuild.yaml` with a hybrid that runs Diplodoc **without checkout** (ENOENT `ydb/docs`) and only `workflow_dispatch`es `docs_build.yaml` from a misnamed final step.
- That cancels the in-flight `pull_request` docs build (`concurrency: cancel-in-progress`) and leaves translation PRs red even when content/QA are fine.
- Restore the `#43222` design: remove `rebuild_docs` → check `ydb/docs/**` → `createWorkflowDispatch(docs_build.yaml)` only. Keep `trigger-translation-ci` adding `rebuild_docs` + `ok-to-test` (GITHUB_TOKEN does not cascade CI).

## Test plan
- [ ] Merge this PR
- [ ] On an open translation PR (or any docs PR), add label `rebuild_docs`
- [ ] Confirm **Rebuild documentation** succeeds quickly (no local Build / no ENOENT)
- [ ] Confirm **Build documentation** runs via `workflow_dispatch` and goes green
- [ ] Optional: run `doc_translate` on a small source PR and confirm post-translate labels trigger a successful docs build without a red Rebuild check


Made with [Cursor](https://cursor.com)