### PR TITLE
ci(docs): keep PR build-docs check when rebuild_docs fires

### DIFF
--- a/.github/workflows/docs_build.yaml
+++ b/.github/workflows/docs_build.yaml
@@ -24,8 +24,11 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.state == 'open'
+    # Include event_name so rebuild_docs workflow_dispatch does not cancel the
+    # pull_request build. Dispatch runs on main and its check attaches to main
+    # SHA; only the pull_request run updates the PR's build-docs status (#48409).
     concurrency:
-      group: docs-build-${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}
+      group: docs-build-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && inputs.pull_number || github.event.pull_request.number }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ydbdoc-review.yml
+++ b/.github/workflows/ydbdoc-review.yml
@@ -61,7 +61,7 @@ jobs:
     if: ${{ !cancelled() && needs.ydbdoc-review.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger PR-check and docs rebuild on translation PR
+      - name: Trigger PR-check (ok-to-test) on translation PR
         uses: actions/github-script@v8
         with:
           # PAT only here (no checkout): cascades into PR-check/docs rebuild without
@@ -101,13 +101,17 @@ jobs:
               return;
             }
 
+            // ok-to-test only. Do NOT add rebuild_docs here: pull_request already
+            // starts Build documentation on the translation PR, and rebuild's
+            // workflow_dispatch cancels that run (shared concurrency) while
+            // attaching its own success check to main — PR stays red (#48409).
             await github.rest.issues.addLabels({
               owner,
               repo,
               issue_number: translationPr.number,
-              labels: ['rebuild_docs', 'ok-to-test'],
+              labels: ['ok-to-test'],
             });
 
             core.info(
-              `Added rebuild_docs and ok-to-test to translation PR #${translationPr.number}`
+              `Added ok-to-test to translation PR #${translationPr.number}`
             );


### PR DESCRIPTION
## Summary
- After translation PRs, `trigger-translation-ci` added `rebuild_docs`, which `workflow_dispatch`es `docs_build.yaml` from **main**.
- Shared concurrency `docs-build-<PR>` + `cancel-in-progress` **cancels** the in-flight `pull_request` build.
- The successful dispatch check attaches to **main's SHA**, not the PR head, so the PR Checks tab keeps showing cancelled/failed `build-docs` even when content built fine (see #48409, #48422).

## Changes
- Scope concurrency by `event_name` so dispatch does not cancel PR builds.
- Auto-label only `ok-to-test` after `doc_translate` (manual `rebuild_docs` still works for preview/rebuild).

## Test plan
- [ ] Open/push a docs PR: `pull_request` Build documentation goes green on the PR
- [ ] Add `rebuild_docs`: Rebuild succeeds; existing or new PR `build-docs` check is not left cancelled-only
- [ ] `doc_translate` → translation PR gets `ok-to-test` only; PR `build-docs` completes without cancel race


Made with [Cursor](https://cursor.com)