### PR TITLE
Replaced TStreamLogBackend with TOwningThreadedLogBackend in the multi-node log backend factory

### DIFF
--- a/ydb/core/kqp/ut/common/kqp_ut_common.cpp
+++ b/ydb/core/kqp/ut/common/kqp_ut_common.cpp
@@ -160,7 +160,7 @@ TKikimrRunner::TKikimrRunner(const TKikimrSettings& settings) {
             auto* logStream = settings.LogStream;
             ServerSettings->SetLoggerInitializer([logStream](NActors::TTestActorRuntime& runtime) {
                 runtime.SetLogBackendFactory([logStream]() {
-                    return new TStreamLogBackend(logStream);
+                    return new TOwningThreadedLogBackend(new TStreamLogBackend(logStream));
                 });
             });
         } else {


### PR DESCRIPTION
In multi-node tests  (`if (settings.NodeCount > 1)`) with UseRealThreads=true, concurrent writes from multiple nodes' logger actors cause data races and use-after-free.