### PR TITLE
Fix initial token refresh in write sessions

### DIFF
--- a/ydb/public/sdk/cpp/src/client/persqueue_public/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/persqueue_public/impl/write_session_impl.cpp
@@ -37,6 +37,16 @@ TWriteSessionImpl::TWriteSessionImpl(
                 TDuration::MilliSeconds(100)
     )
 {
+    // Avoid sending the token used to open the session as a token refresh.
+    if (auto credentialsProvider = DbDriverState->GetCredentialsProvider()) {
+        try {
+            auto authInfo = credentialsProvider->GetAuthInfoAsync();
+            if (authInfo.IsReady()) {
+                PrevToken = authInfo.GetValue();
+            }
+        } catch (...) {
+        }
+    }
     if (!Settings.RetryPolicy_) {
         Settings.RetryPolicy_ = IRetryPolicy::GetDefaultPolicy();
     }

--- a/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/write_session_impl.cpp
@@ -194,6 +194,16 @@ TWriteSessionImpl::TWriteSessionImpl(
                 TDuration::MilliSeconds(100)
     )
 {
+    // Avoid sending the token used to open the session as a token refresh.
+    if (auto credentialsProvider = DbDriverState->GetCredentialsProvider()) {
+        try {
+            auto authInfo = credentialsProvider->GetAuthInfoAsync();
+            if (authInfo.IsReady()) {
+                PrevToken = authInfo.GetValue();
+            }
+        } catch (...) {
+        }
+    }
     if (!Settings.RetryPolicy_) {
         Settings.RetryPolicy_ = IRetryPolicy::GetDefaultPolicy();
     }


### PR DESCRIPTION
### Changelog entry

Prevent Topic and legacy PersQueue write sessions from sending the initial authentication token as a token refresh.

### Changelog category

* Bugfix

### Description for reviewers

