### PR TITLE
[detailed-metrics] propagate METRICS_LEVEL to DataShard via subdomain subscription

### DIFF
--- a/ydb/core/protos/counters_datashard.proto
+++ b/ydb/core/protos/counters_datashard.proto
@@ -538,4 +538,5 @@ enum ETxTypes {
     TXTYPE_COMPLETE_VACUUM = 86                           [(TxTypeOpts) = {Name: "TxCompleteVacuum"}];
     TXTYPE_LOCK_ROWS = 87                                 [(TxTypeOpts) = {Name: "TxLockRows"}];
     TXTYPE_S3_DIRECT_WRITE_FINISH = 88                    [(TxTypeOpts) = {Name: "TxS3DirectWriteFinish"}];
+    TXTYPE_PERSIST_SUBDOMAIN_TABLES_METRICS_LEVEL = 89    [(TxTypeOpts) = {Name: "TxPersistSubDomainTablesMetricsLevel"}];
 }

--- a/ydb/core/protos/flat_scheme_op.proto
+++ b/ydb/core/protos/flat_scheme_op.proto
@@ -13,6 +13,7 @@ import "ydb/core/protos/s3_settings.proto";
 import "ydb/core/protos/schemeshard/operations.proto";
 import "ydb/core/protos/subdomains.proto";
 import "ydb/core/protos/sys_view_types.proto";
+import "ydb/core/protos/table_metrics_settings.proto";
 import "ydb/core/protos/table_stats.proto";
 import "ydb/core/protos/tablet.proto";
 import "ydb/core/protos/test_shard_control.proto";
@@ -292,69 +293,6 @@ message TTTLSettings {
     }
 
     reserved 3;
-}
-
-/**
- * The parameters for the detailed metrics for the given table.
- */
-message TTableDetailedMetricsSettings {
-    /**
-     * The level at which detailed metrics are aggregated and reported.
-     */
-    enum EMetricsLevel {
-        /**
-         * The detailed metrics level is not specified.
-         */
-        MetricsLevelUnspecified = 0;
-
-        /**
-         * All detailed metrics are disabled for the given table.
-         */
-        MetricsLevelDisabled = 1;
-
-        /**
-         * Detailed metrics are aggregated and reported for the entire table.
-         */
-        MetricsLevelTable = 2;
-
-        /**
-         * Detailed metrics are aggregated and reported for individual partitions.
-         */
-        MetricsLevelPartition = 3;
-    }
-
-    /**
-     * The container for the detailed metrics settings, which are explicitly configured.
-     */
-    message TConfigured {
-        /**
-         * The level at which detailed metrics are aggregated and reported.
-         */
-        optional EMetricsLevel MetricsLevel = 1;
-    }
-
-    /**
-     * The container for the detailed metrics settings, which are explicitly removed.
-     */
-    message TNotConfigured {
-    }
-
-    oneof Status {
-        /**
-         * Set, if the detailed metrics settings are explicitly configured.
-         */
-        TConfigured Configured = 1;
-
-        /**
-         * Set, if the detailed metrics settings are explicitly removed.
-         *
-         * @note This is used in ALTER TABLE requests to remove the detailed metrics settings,
-         *       which are currently configured for the given table. If the detailed metrics
-         *       settings are not configured, the corresponding DetailedMetricsSettings field
-         *       in the table description will not be set.
-         */
-        TNotConfigured NotConfigured = 2;
-    }
 }
 
 message TTableReplicationConfig {

--- a/ydb/core/protos/flat_tx_scheme.proto
+++ b/ydb/core/protos/flat_tx_scheme.proto
@@ -6,6 +6,7 @@ import "ydb/core/scheme/protos/type_info.proto";
 import "ydb/core/protos/subdomains.proto";
 import "ydb/core/protos/bind_channel_storage_pool.proto";
 import "ydb/core/protos/flat_scheme_op.proto";
+import "ydb/core/protos/table_metrics_settings.proto";
 import "ydb/public/api/protos/ydb_cms.proto";
 import "ydb/public/api/protos/ydb_issue_message.proto";
 import "ydb/public/api/protos/annotations/sensitive.proto";
@@ -232,6 +233,8 @@ message TEvInitTenantSchemeShard {
     optional Ydb.Cms.DatabaseQuotas DatabaseQuotas = 17;
     optional NKikimrSubDomains.TAuditSettings AuditSettings = 18;
     optional NKikimrSubDomains.EServerlessComputeResourcesMode ServerlessComputeResourcesMode = 19;
+
+    optional NKikimrSchemeOp.TTableDetailedMetricsSettings.EMetricsLevel TablesMetricsLevel = 20;
 }
 
 message TEvInitTenantSchemeShardResult {
@@ -411,6 +414,8 @@ message TEvUpdateTenantSchemeShard {
 
     optional NKikimrSubDomains.TAuditSettings AuditSettings = 15;
     optional NKikimrSubDomains.EServerlessComputeResourcesMode ServerlessComputeResourcesMode = 17;
+
+    optional NKikimrSchemeOp.TTableDetailedMetricsSettings.EMetricsLevel TablesMetricsLevel = 21;
 }
 
 message TEvFindTabletSubDomainPathId {

--- a/ydb/core/protos/subdomains.proto
+++ b/ydb/core/protos/subdomains.proto
@@ -1,4 +1,5 @@
 import "ydb/core/protos/bind_channel_storage_pool.proto";
+import "ydb/core/protos/table_metrics_settings.proto";
 import "ydb/public/api/protos/ydb_cms.proto";
 import "ydb/library/login/protos/login.proto";
 
@@ -54,6 +55,8 @@ message TSubDomainSettings {
     optional bool ExternalStatisticsAggregator = 14 [default = false];
     optional bool GraphShard = 16 [default = false];
     optional bool ExternalBackupController = 17 [default = false];
+
+    optional NKikimrSchemeOp.TTableDetailedMetricsSettings.EMetricsLevel TablesMetricsLevel = 19;
 }
 
 message TProcessingParams {
@@ -144,6 +147,8 @@ message TDomainDescription {
     optional NLoginProto.TSecurityState SecurityState = 20;
 
     optional TAuditSettings AuditSettings = 21;
+
+    optional NKikimrSchemeOp.TTableDetailedMetricsSettings.EMetricsLevel TablesMetricsLevel = 26;
 }
 
 message TSchemeQuotas {

--- a/ydb/core/protos/table_metrics_settings.proto
+++ b/ydb/core/protos/table_metrics_settings.proto
@@ -1,0 +1,24 @@
+package NKikimrSchemeOp;
+option java_package = "ru.yandex.kikimr.proto";
+
+message TTableDetailedMetricsSettings {
+    enum EMetricsLevel {
+        MetricsLevelUnspecified = 0;
+        MetricsLevelDisabled = 1;
+        MetricsLevelTable = 2;
+        MetricsLevelPartition = 3;
+    }
+
+    message TConfigured {
+        optional EMetricsLevel MetricsLevel = 1;
+    }
+
+    // Helps clear table level override to stick to database defaults
+    message TNotConfigured {
+    }
+
+    oneof Status {
+        TConfigured Configured = 1;
+        TNotConfigured NotConfigured = 2;
+    }
+}

--- a/ydb/core/protos/ya.make
+++ b/ydb/core/protos/ya.make
@@ -154,6 +154,7 @@ SRCS(
     subdomains.proto
     sys_view.proto
     sys_view_types.proto
+    table_metrics_settings.proto
     table_service_config.proto
     table_stats.proto
     tablet.proto

--- a/ydb/core/tablet/tablet_counters_aggregator.h
+++ b/ydb/core/tablet/tablet_counters_aggregator.h
@@ -74,15 +74,19 @@ struct TEvTabletCounters {
         const TPathId TableId;
         const TString TablePath;
         const ui64 SchemaVersion;
+        // plain to keep this free of the schemeshard proto header
+        const ui32 MetricsLevel;
 
         TEvTabletSetTableInfo(ui64 tabletID, TPathId tenantPathId,
-            ui32 followerId, TPathId tableId, const TString& tablePath, ui64 schemaVersion)
+            ui32 followerId, TPathId tableId, const TString& tablePath, ui64 schemaVersion,
+            ui32 metricsLevel)
             : TabletID(tabletID)
             , TenantPathId(tenantPathId)
             , FollowerId(followerId)
             , TableId(tableId)
             , TablePath(tablePath)
             , SchemaVersion(schemaVersion)
+            , MetricsLevel(metricsLevel)
         {}
     };
 

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -4091,7 +4091,8 @@ void TDataShard::SendTableInfoToCountersAggregator(const TActorContext &ctx) {
             FollowerId(),
             TPathId(GetPathOwnerId(), localPathId),
             table->Path,
-            table->GetTableSchemaVersion()));
+            table->GetTableSchemaVersion(),
+            static_cast<ui32>(GetEffectiveMetricsLevel(*table))));
 }
 
 void TDataShard::DoPeriodicTasks(const TActorContext &ctx) {

--- a/ydb/core/tx/datashard/datashard__init.cpp
+++ b/ydb/core/tx/datashard/datashard__init.cpp
@@ -371,6 +371,13 @@ bool TDataShard::TTxInit::ReadEverything(TTransactionContext &txc) {
     LOAD_SYS_BOOL(db, Schema::Sys_SubDomainOutOfSpace, Self->SubDomainOutOfSpace);
 
     {
+        ui64 subDomainTablesMetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
+        LOAD_SYS_UI64(db, Schema::Sys_SubDomainTablesMetricsLevel, subDomainTablesMetricsLevel);
+        Self->SubDomainTablesMetricsLevel =
+            static_cast<NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel>(subDomainTablesMetricsLevel);
+    }
+
+    {
         TString rawProcessingParams;
         LOAD_SYS_BYTES(db, Schema::Sys_SubDomainInfo, rawProcessingParams);
         if (!rawProcessingParams.empty()) {

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -326,6 +326,7 @@ class TDataShard
 
     class TTxPersistSubDomainPathId;
     class TTxPersistSubDomainOutOfSpace;
+    class TTxPersistSubDomainTablesMetricsLevel;
 
     class TTxRequestChangeRecords;
     class TTxRemoveChangeRecords;
@@ -1227,6 +1228,8 @@ class TDataShard
 
             Sys_VacuumCompletedGeneration = 47,
 
+            Sys_SubDomainTablesMetricsLevel = 48,
+
             // reserved
             SysPipeline_Flags = 1000,
             SysPipeline_LimitActiveTx,
@@ -1240,6 +1243,7 @@ class TDataShard
         static_assert(ESysTableKeys::SysMvcc_ImmediateWriteEdgeStep == 39, "SysMvcc_ImmediateWriteEdgeStep changed its value");
         static_assert(ESysTableKeys::SysMvcc_ImmediateWriteEdgeTxId == 40, "SysMvcc_ImmediateWriteEdgeTxId changed its value");
         static_assert(ESysTableKeys::Sys_LastLoanTableTid == 41, "Sys_LastLoanTableTid changed its value");
+        static_assert(ESysTableKeys::Sys_SubDomainTablesMetricsLevel == 48, "Sys_SubDomainTablesMetricsLevel changed its value");
 
         static constexpr ui64 MinLocalTid = TSysTables::SysTableMAX + 1; // 1000
 
@@ -2008,6 +2012,19 @@ public:
     bool IsSubDomainOutOfSpace() const
     {
         return SubDomainOutOfSpace;
+    }
+
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel GetSubDomainTablesMetricsLevel() const
+    {
+        return SubDomainTablesMetricsLevel;
+    }
+
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel GetEffectiveMetricsLevel(const TUserTable& table) const
+    {
+        const auto tableLevel = table.GetDetailedMetricsLevel();
+        return tableLevel != NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+            ? tableLevel
+            : SubDomainTablesMetricsLevel;
     }
 
     ui64 GetExecutorStep() const
@@ -2840,6 +2857,8 @@ private:
     std::optional<TPathId> SubDomainPathId;
     std::optional<TPathId> WatchingSubDomainPathId;
     bool SubDomainOutOfSpace = false;
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel SubDomainTablesMetricsLevel =
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
 
     THashSet<TActorId> Actors;
     TLoanReturnTracker LoanReturnTracker;

--- a/ydb/core/tx/datashard/datashard_subdomain_path_id.cpp
+++ b/ydb/core/tx/datashard/datashard_subdomain_path_id.cpp
@@ -167,19 +167,59 @@ private:
     const bool OutOfSpace;
 };
 
+class TDataShard::TTxPersistSubDomainTablesMetricsLevel : public NTabletFlatExecutor::TTransactionBase<TDataShard> {
+public:
+    TTxPersistSubDomainTablesMetricsLevel(TDataShard* self, NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level)
+        : TTransactionBase(self)
+        , Level(level)
+    { }
+
+    TTxType GetTxType() const override { return TXTYPE_PERSIST_SUBDOMAIN_TABLES_METRICS_LEVEL; }
+
+    bool Execute(TTransactionContext& txc, const TActorContext&) override {
+        NIceDb::TNiceDb db(txc.DB);
+
+        if (Self->SubDomainTablesMetricsLevel != Level) {
+            Self->PersistSys(db, Schema::Sys_SubDomainTablesMetricsLevel, ui64(Level));
+            Self->SubDomainTablesMetricsLevel = Level;
+        }
+
+        return true;
+    }
+
+    void Complete(const TActorContext&) override {
+        // nothing
+    }
+
+private:
+    const NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel Level;
+};
+
 void TDataShard::Handle(TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr& ev, const TActorContext& ctx) {
     const auto* msg = ev->Get();
     if (SubDomainPathId && msg->PathId == *SubDomainPathId) {
-        const bool outOfSpace = msg->Result->GetPathDescription()
-            .GetDomainDescription()
-            .GetDomainState()
-            .GetDiskQuotaExceeded();
+        const auto& domainDescription = msg->Result->GetPathDescription().GetDomainDescription();
+
+        const bool outOfSpace = domainDescription.GetDomainState().GetDiskQuotaExceeded();
 
         LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD,
             "Discovered subdomain " << msg->PathId << " state, outOfSpace = " << outOfSpace
             << " at datashard " << TabletID());
 
         Execute(new TTxPersistSubDomainOutOfSpace(this, outOfSpace), ctx);
+
+        // Persisted so that a restart keeps emitting detailed metrics without
+        // waiting for the next subdomain publish.
+        const auto tablesMetricsLevel = domainDescription.GetTablesMetricsLevel();
+
+        if (tablesMetricsLevel != SubDomainTablesMetricsLevel) {
+            LOG_DEBUG_S(ctx, NKikimrServices::TX_DATASHARD,
+                "Discovered subdomain " << msg->PathId << " tablesMetricsLevel = "
+                << NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel_Name(tablesMetricsLevel)
+                << " at datashard " << TabletID());
+
+            Execute(new TTxPersistSubDomainTablesMetricsLevel(this, tablesMetricsLevel), ctx);
+        }
     }
 }
 

--- a/ydb/core/tx/datashard/datashard_user_table.cpp
+++ b/ydb/core/tx/datashard/datashard_user_table.cpp
@@ -325,6 +325,12 @@ void TUserTable::ParseProto(const NKikimrSchemeOp::TTableDescription& descr)
 
     TableSchemaVersion = descr.GetTableSchemaVersion();
     IsBackup = descr.GetIsBackup();
+    // On the alter path descr is a delta, but the schemeshard always resends the
+    // current detailed metrics settings in it, so an absent Configured status
+    // means the override was never set or was dropped.
+    DetailedMetricsLevel = descr.GetDetailedMetricsSettings().HasConfigured()
+        ? descr.GetDetailedMetricsSettings().GetConfigured().GetMetricsLevel()
+        : NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
     ReplicationConfig = TReplicationConfig(descr.GetReplicationConfig());
     IncrementalBackupConfig = TIncrementalBackupConfig(descr.GetIncrementalBackupConfig());
     if (descr.GetPartitionConfig().HasUniqueIndexKeySize()) {
@@ -421,6 +427,15 @@ void TUserTable::AlterSchema() {
 
     ReplicationConfig.Serialize(*schema.MutableReplicationConfig());
     IncrementalBackupConfig.Serialize(*schema.MutableIncrementalBackupConfig());
+
+    // Keep the persisted schema in sync with the parsed level, so that a restart
+    // does not resurrect an override, which an alter has just dropped
+    if (DetailedMetricsLevel != NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified) {
+        schema.MutableDetailedMetricsSettings()->MutableConfigured()
+            ->SetMetricsLevel(DetailedMetricsLevel);
+    } else {
+        schema.ClearDetailedMetricsSettings();
+    }
 
     schema.SetName(Name);
     schema.SetPath(Path);

--- a/ydb/core/tx/datashard/datashard_user_table.h
+++ b/ydb/core/tx/datashard/datashard_user_table.h
@@ -7,6 +7,7 @@
 #include <ydb/core/tablet_flat/flat_stat_table.h>
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 
 #include <util/generic/ptr.h>
 #include <util/generic/hash.h>
@@ -464,6 +465,10 @@ struct TUserTable : public TThrRefBase {
     TReplicationConfig ReplicationConfig;
     TIncrementalBackupConfig IncrementalBackupConfig;
     bool IsBackup = false;
+    // Per-table METRICS_LEVEL override (Unspecified = falls back to the
+    // database-wide TABLES_METRICS_LEVEL default).
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel DetailedMetricsLevel =
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
     ui32 UniqueIndexKeySize = 0;
     NKikimrSchemeOp::ESpecialTableType SpecialTableType = NKikimrSchemeOp::ESpecialTableType::ESpecialTableTypeNone;
 
@@ -541,6 +546,10 @@ struct TUserTable : public TThrRefBase {
     ui64 GetTableSchemaVersion() const { return TableSchemaVersion; }
     void SetTableSchemaVersion(ui64 schemaVersion);
     bool ResetTableSchemaVersion();
+
+    NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel GetDetailedMetricsLevel() const {
+        return DetailedMetricsLevel;
+    }
 
     void AddIndex(const NKikimrSchemeOp::TIndexDescription& indexDesc);
     void SwitchIndexState(const TPathId& indexPathId, TTableIndex::EState state);

--- a/ydb/core/tx/datashard/datashard_ut_init.cpp
+++ b/ydb/core/tx/datashard/datashard_ut_init.cpp
@@ -4,6 +4,7 @@
 #include <ydb/core/scheme/scheme_types_defs.h>
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/testlib/test_client.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/core/tx/schemeshard/schemeshard.h>
 #include <ydb/core/util/pb.h>
 #include <ydb/public/lib/deprecated/kicli/kicli.h>
@@ -25,6 +26,7 @@ struct TReportedTableInfo {
     TPathId TableId;
     TString TablePath;
     ui64 SchemaVersion;
+    ui32 MetricsLevel;
 
     explicit TReportedTableInfo(const TEvTabletCounters::TEvTabletSetTableInfo &ev)
         : TabletID(ev.TabletID)
@@ -32,6 +34,7 @@ struct TReportedTableInfo {
         , TableId(ev.TableId)
         , TablePath(ev.TablePath)
         , SchemaVersion(ev.SchemaVersion)
+        , MetricsLevel(ev.MetricsLevel)
     {}
 };
 
@@ -238,6 +241,161 @@ Y_UNIT_TEST_SUITE(TTxDataShardTestInit) {
         SimulateSleep(server, TDuration::Seconds(6));
 
         UNIT_ASSERT(reported.empty());
+    }
+
+    Y_UNIT_TEST(TestSetTableInfoReflectsTableMetricsLevel) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardDetailedMetrics(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        TVector<TReportedTableInfo> reported;
+        auto observer = runtime.AddObserver<TEvTabletCounters::TEvTabletSetTableInfo>(
+            [&](TEvTabletCounters::TEvTabletSetTableInfo::TPtr &ev) {
+                reported.push_back(TReportedTableInfo(*ev->Get()));
+            });
+
+        // No per-table override and no database default => nothing to report.
+        SimulateSleep(server, TDuration::Seconds(6));
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified));
+
+        WaitTxNotification(server, sender, AsyncAlterSetMetricsLevel(server, "/Root", "table-1",
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable));
+
+        reported.clear();
+        SimulateSleep(server, TDuration::Seconds(6));
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable));
+
+        WaitTxNotification(server, sender, AsyncAlterSetMetricsLevel(server, "/Root", "table-1",
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+
+        reported.clear();
+        SimulateSleep(server, TDuration::Seconds(6));
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+    }
+
+    // The database-wide TABLES_METRICS_LEVEL reaches DataShard on the subdomain
+    // publish, which bumps no table SchemaVersion. Patch the published subdomain
+    // description on the wire so the DataShard-side handling can be exercised
+    // without a control-plane surface for the database attribute.
+    Y_UNIT_TEST(TestSetTableInfoUsesSubDomainMetricsLevel) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardDetailedMetrics(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+
+        // Installed before the shard exists, so the very first subdomain
+        // notification it gets already carries the database default.
+        auto patcher = runtime.AddObserver<TEvTxProxySchemeCache::TEvWatchNotifyUpdated>(
+            [&](TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr &ev) {
+                auto *msg = ev->Get();
+                NKikimrScheme::TEvDescribeSchemeResult record = *msg->Result;
+                record.MutablePathDescription()->MutableDomainDescription()->SetTablesMetricsLevel(
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable);
+                msg->Result = NSchemeCache::TDescribeResult::Create(record);
+            });
+
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        TVector<TReportedTableInfo> reported;
+        auto observer = runtime.AddObserver<TEvTabletCounters::TEvTabletSetTableInfo>(
+            [&](TEvTabletCounters::TEvTabletSetTableInfo::TPtr &ev) {
+                reported.push_back(TReportedTableInfo(*ev->Get()));
+            });
+
+        SimulateSleep(server, TDuration::Seconds(6));
+
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable));
+
+        // A per-table override wins over the database default.
+        WaitTxNotification(server, sender, AsyncAlterSetMetricsLevel(server, "/Root", "table-1",
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+
+        reported.clear();
+        SimulateSleep(server, TDuration::Seconds(6));
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+    }
+
+    // The database-wide default is persisted, so a restarted shard keeps
+    // reporting it instead of falling back to Unspecified until the next
+    // subdomain publish arrives.
+    Y_UNIT_TEST(TestSubDomainMetricsLevelSurvivesRestart) {
+        TPortManager pm;
+        TServerSettings serverSettings(pm.GetPort(2134));
+        serverSettings.SetDomainName("Root")
+            .SetUseRealThreads(false)
+            .SetEnableDataShardDetailedMetrics(true);
+
+        Tests::TServer::TPtr server = new TServer(serverSettings);
+        auto &runtime = *server->GetRuntime();
+        auto sender = runtime.AllocateEdgeActor();
+
+        InitRoot(server, sender);
+
+        auto patcher = runtime.AddObserver<TEvTxProxySchemeCache::TEvWatchNotifyUpdated>(
+            [&](TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr &ev) {
+                auto *msg = ev->Get();
+                NKikimrScheme::TEvDescribeSchemeResult record = *msg->Result;
+                record.MutablePathDescription()->MutableDomainDescription()->SetTablesMetricsLevel(
+                    NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition);
+                msg->Result = NSchemeCache::TDescribeResult::Create(record);
+            });
+
+        CreateShardedTable(server, sender, "/Root", "table-1", 1);
+
+        auto shard = GetTableShards(server, sender, "/Root/table-1")[0];
+
+        TVector<TReportedTableInfo> reported;
+        auto observer = runtime.AddObserver<TEvTabletCounters::TEvTabletSetTableInfo>(
+            [&](TEvTabletCounters::TEvTabletSetTableInfo::TPtr &ev) {
+                reported.push_back(TReportedTableInfo(*ev->Get()));
+            });
+
+        SimulateSleep(server, TDuration::Seconds(6));
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
+
+        // Cut the subscription off entirely, so the restarted shard can only
+        // know the database default from its own local database.
+        patcher.Remove();
+        auto blocker = runtime.AddObserver<TEvTxProxySchemeCache::TEvWatchNotifyUpdated>(
+            [](TEvTxProxySchemeCache::TEvWatchNotifyUpdated::TPtr &ev) {
+                ev.Reset();
+            });
+
+        RebootTablet(runtime, shard, sender);
+
+        reported.clear();
+        SimulateSleep(server, TDuration::Seconds(6));
+        UNIT_ASSERT(!reported.empty());
+        UNIT_ASSERT_VALUES_EQUAL(reported.back().MetricsLevel,
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition));
     }
 }
 

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.cpp
@@ -1705,6 +1705,20 @@ ui64 AsyncAlterDropColumn(
     return RunSchemeTx(*server->GetRuntime(), std::move(request));
 }
 
+ui64 AsyncAlterSetMetricsLevel(
+        Tests::TServer::TPtr server,
+        const TString& workingDir,
+        const TString& name,
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level)
+{
+    auto request = SchemeTxTemplate(NKikimrSchemeOp::ESchemeOpAlterTable, workingDir);
+    auto& desc = *request->Record.MutableTransaction()->MutableModifyScheme()->MutableAlterTable();
+    desc.SetName(name);
+    desc.MutableDetailedMetricsSettings()->MutableConfigured()->SetMetricsLevel(level);
+
+    return RunSchemeTx(*server->GetRuntime(), std::move(request));
+}
+
 ui64 AsyncSetEnableFilterByKey(
         Tests::TServer::TPtr server,
         const TString& workingDir,

--- a/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
+++ b/ydb/core/tx/datashard/ut_common/datashard_ut_common.h
@@ -651,6 +651,12 @@ ui64 AsyncAlterDropColumn(
         const TString& name,
         const TString& colName);
 
+ui64 AsyncAlterSetMetricsLevel(
+        Tests::TServer::TPtr server,
+        const TString& workingDir,
+        const TString& name,
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level);
+
 ui64 AsyncSetEnableFilterByKey(
         Tests::TServer::TPtr server,
         const TString& workingDir,

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -1790,11 +1790,13 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                         );
                     }
 
-                    alter->SetTablesMetricsLevel(
-                        rowset.GetValueOrDefault<Schema::SubDomainsAlterData::TablesMetricsLevel>(
-                            subdomainInfo->GetTablesMetricsLevel()
-                        )
-                    );
+                    if (!path->IsRoot() || !Self->IsDomainSchemeShard) {
+                        alter->SetTablesMetricsLevel(
+                            rowset.GetValueOrDefault<Schema::SubDomainsAlterData::TablesMetricsLevel>(
+                                subdomainInfo->GetTablesMetricsLevel()
+                            )
+                        );
+                    }
 
                     subdomainInfo->SetAlter(alter);
 

--- a/ydb/core/tx/schemeshard/schemeshard__init.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init.cpp
@@ -5,6 +5,7 @@
 #include "schemeshard_pq_helpers.h"  // for PQGroupReserve
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/protos/fs_settings.pb.h>
 #include <ydb/core/tx/schemeshard/olap/operations/local_index_helpers.h>
 #include <ydb/core/protos/s3_settings.pb.h>
@@ -1710,6 +1711,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             NKikimrSubDomains::EServerlessComputeResourcesModeShared
                         );
                     }
+
+                    domainInfo->SetTablesMetricsLevel(
+                        rowset.GetValueOrDefault<Schema::SubDomains::TablesMetricsLevel>(
+                            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+                        )
+                    );
                 }
 
                 if (!rowset.Next())
@@ -1782,6 +1789,12 @@ struct TSchemeShard::TTxInit : public TTransactionBase<TSchemeShard> {
                             NKikimrSubDomains::EServerlessComputeResourcesModeShared
                         );
                     }
+
+                    alter->SetTablesMetricsLevel(
+                        rowset.GetValueOrDefault<Schema::SubDomainsAlterData::TablesMetricsLevel>(
+                            subdomainInfo->GetTablesMetricsLevel()
+                        )
+                    );
 
                     subdomainInfo->SetAlter(alter);
 

--- a/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__init_root.cpp
@@ -415,6 +415,10 @@ struct TSchemeShard::TTxInitTenantSchemeShard : public TSchemeShard::TRwTxBase {
             subdomain->SetServerlessComputeResourcesMode(record.GetServerlessComputeResourcesMode());
         }
 
+        if (record.HasTablesMetricsLevel()) {
+            subdomain->SetTablesMetricsLevel(record.GetTablesMetricsLevel());
+        }
+
         RegisterShard(db, subdomain, processingParams.GetCoordinators(), TTabletTypes::Coordinator);
         RegisterShard(db, subdomain, processingParams.GetMediators(), TTabletTypes::Mediator);
         RegisterShard(db, subdomain, TVector<ui64>{processingParams.GetSchemeShard()}, TTabletTypes::SchemeShard);

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -318,6 +318,13 @@ VerifyParams(TParamsDelta* delta, const TPathId pathId, const TSubDomainInfo::TP
         serverlessComputeResourcesModeChanged = current->GetServerlessComputeResourcesMode() != input.GetServerlessComputeResourcesMode();
     }
 
+    if (input.HasTablesMetricsLevel()) {
+        TString error;
+        if (!CheckTablesMetricsLevel(input.GetTablesMetricsLevel(), error)) {
+            return paramError(error);
+        }
+    }
+
     delta->CoordinatorsAdded = coordinatorsAdded;
     delta->MediatorsAdded = mediatorsAdded;
     delta->TimeCastBucketsPerMediatorAdded = timeCastBucketsPerMediatorAdded;
@@ -950,6 +957,13 @@ public:
 
         if (inputSettings.HasServerlessComputeResourcesMode()) {
             alter->SetServerlessComputeResourcesMode(inputSettings.GetServerlessComputeResourcesMode());
+        }
+
+        // alter is copy-constructed from the current subdomain info, so the
+        // current level is already carried over; only an explicit request
+        // changes it (already validated in VerifyParams).
+        if (inputSettings.HasTablesMetricsLevel()) {
+            alter->SetTablesMetricsLevel(inputSettings.GetTablesMetricsLevel());
         }
 
         LOG_D("TAlterExtSubDomain Propose"

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_extsubdomain.cpp
@@ -320,7 +320,7 @@ VerifyParams(TParamsDelta* delta, const TPathId pathId, const TSubDomainInfo::TP
 
     if (input.HasTablesMetricsLevel()) {
         TString error;
-        if (!CheckTablesMetricsLevel(input.GetTablesMetricsLevel(), error)) {
+        if (!CheckTablesMetricsLevel(input.GetTablesMetricsLevel(), /* isRootDomain */ false, error)) {
             return paramError(error);
         }
     }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
@@ -308,6 +308,16 @@ public:
             alterData->ApplyAuditSettings(settings.GetAuditSettings());
         }
 
+        // alterData is copy-constructed from subDomainInfo, so the current
+        // level is already carried over; only an explicit request changes it.
+        if (settings.HasTablesMetricsLevel()) {
+            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), errStr)) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                return result;
+            }
+            alterData->SetTablesMetricsLevel(settings.GetTablesMetricsLevel());
+        }
+
         NIceDb::TNiceDb db(context.GetDB());
 
         subDomain->LastTxId = OperationId.GetTxId();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_subdomain.cpp
@@ -311,7 +311,8 @@ public:
         // alterData is copy-constructed from subDomainInfo, so the current
         // level is already carried over; only an explicit request changes it.
         if (settings.HasTablesMetricsLevel()) {
-            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), errStr)) {
+            const bool isRootDomain = subDomain->IsRoot() && context.SS->IsDomainSchemeShard;
+            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), isRootDomain, errStr)) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.cpp
@@ -241,6 +241,7 @@ bool TConfigureParts::ProgressState(TOperationContext& context) {
             if (alterData->GetServerlessComputeResourcesMode()) {
                 event->Record.SetServerlessComputeResourcesMode(*alterData->GetServerlessComputeResourcesMode());
             }
+            event->Record.SetTablesMetricsLevel(alterData->GetTablesMetricsLevel());
             LOG_DEBUG_S(context.Ctx, NKikimrServices::FLAT_TX_SCHEMESHARD,
                         "Send configure request to schemeshard: " << tabletID <<
                             " opId: " << OperationId <<

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
@@ -50,9 +50,14 @@ inline bool CheckStoragePoolsInQuotas(
 // (TABLES_METRICS_LEVEL) coming in with a (ext)subdomain create/alter request.
 // MetricsLevelUnspecified is accepted: at the database level it means "no
 // default", so it is also how an existing default is cleared.
-inline bool CheckTablesMetricsLevel(ETablesMetricsLevel level, TString& error) {
+inline bool CheckTablesMetricsLevel(ETablesMetricsLevel level, bool isRootDomain, TString& error) {
     if (!AppData()->FeatureFlags.GetEnableDataShardDetailedMetrics()) {
         error = "Detailed metrics are disabled (EnableDataShardDetailedMetrics feature flag is off)";
+        return false;
+    }
+
+    if (isRootDomain) {
+        error = "TABLES_METRICS_LEVEL cannot be set on the root database";
         return false;
     }
 

--- a/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_common_subdomain.h
@@ -46,6 +46,28 @@ inline bool CheckStoragePoolsInQuotas(
     return true;
 }
 
+// Validates the database-wide default detailed metrics level
+// (TABLES_METRICS_LEVEL) coming in with a (ext)subdomain create/alter request.
+// MetricsLevelUnspecified is accepted: at the database level it means "no
+// default", so it is also how an existing default is cleared.
+inline bool CheckTablesMetricsLevel(ETablesMetricsLevel level, TString& error) {
+    if (!AppData()->FeatureFlags.GetEnableDataShardDetailedMetrics()) {
+        error = "Detailed metrics are disabled (EnableDataShardDetailedMetrics feature flag is off)";
+        return false;
+    }
+
+    switch (level) {
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified:
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled:
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable:
+    case NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition:
+        return true;
+    default:
+        error = TStringBuilder() << "Unknown TABLES_METRICS_LEVEL: " << static_cast<ui32>(level);
+        return false;
+    }
+}
+
 namespace NSubDomainState {
 
 class TConfigureParts: public TSubOperationState {

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_extsubdomain.cpp
@@ -234,7 +234,7 @@ public:
         }
 
         if (settings.HasTablesMetricsLevel()) {
-            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), errStr)) {
+            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), /* isRootDomain */ false, errStr)) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_extsubdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_extsubdomain.cpp
@@ -233,6 +233,14 @@ public:
             alter->SetAuditSettings(settings.GetAuditSettings());
         }
 
+        if (settings.HasTablesMetricsLevel()) {
+            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), errStr)) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                return result;
+            }
+            alter->SetTablesMetricsLevel(settings.GetTablesMetricsLevel());
+        }
+
         Y_ABORT_UNLESS(!context.SS->SubDomains.contains(newNode->PathId));
         auto& subDomainInfo = context.SS->SubDomains[newNode->PathId];
         subDomainInfo = new TSubDomainInfo();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
@@ -310,7 +310,7 @@ public:
         }
 
         if (settings.HasTablesMetricsLevel()) {
-            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), errStr)) {
+            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), /* isRootDomain */ false, errStr)) {
                 result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
                 return result;
             }

--- a/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_create_subdomain.cpp
@@ -309,6 +309,14 @@ public:
             alter->SetAuditSettings(settings.GetAuditSettings());
         }
 
+        if (settings.HasTablesMetricsLevel()) {
+            if (!CheckTablesMetricsLevel(settings.GetTablesMetricsLevel(), errStr)) {
+                result->SetError(NKikimrScheme::StatusInvalidParameter, errStr);
+                return result;
+            }
+            alter->SetTablesMetricsLevel(settings.GetTablesMetricsLevel());
+        }
+
         Y_ABORT_UNLESS(!context.SS->SubDomains.contains(newNode->PathId));
         auto& subDomainInfo = context.SS->SubDomains[newNode->PathId];
         subDomainInfo = new TSubDomainInfo();

--- a/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_side_effects.cpp
@@ -510,6 +510,7 @@ void TSideEffects::DoUpdateTenant(TSchemeShard* ss, NTabletFlatExecutor::TTransa
             if (const auto& serverlessComputeResourcesMode = subDomain->GetServerlessComputeResourcesMode()) {
                 message->Record.SetServerlessComputeResourcesMode(*serverlessComputeResourcesMode);
             }
+            message->Record.SetTablesMetricsLevel(subDomain->GetTablesMetricsLevel());
             hasChanges = true;
         }
 

--- a/ydb/core/tx/schemeshard/schemeshard__sync_update_tenants.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__sync_update_tenants.cpp
@@ -128,6 +128,11 @@ struct TSchemeShard::TTxUpdateTenant : public TSchemeShard::TRwTxBase {
                 Self->PersistSubDomainServerlessComputeResourcesMode(db, Self->RootPathId(), *subdomain);
             }
 
+            if (record.HasTablesMetricsLevel()) {
+                subdomain->SetTablesMetricsLevel(record.GetTablesMetricsLevel());
+                Self->PersistSubDomainTablesMetricsLevel(db, Self->RootPathId(), *subdomain);
+            }
+
             Self->PersistStoragePools(db, Self->RootPathId(), *subdomain);
             SideEffects.PublishToSchemeBoard(InvalidOperationId, Self->RootPathId());
             MakeSync();

--- a/ydb/core/tx/schemeshard/schemeshard_impl.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.cpp
@@ -2562,6 +2562,7 @@ void TSchemeShard::PersistSubDomainAlter(NIceDb::TNiceDb& db, const TPathId& pat
     }
     PersistSubDomainAuditSettingsAlter(db, pathId, subDomain);
     PersistSubDomainServerlessComputeResourcesModeAlter(db, pathId, subDomain);
+    PersistSubDomainTablesMetricsLevelAlter(db, pathId, subDomain);
 
     for (auto shardIdx: subDomain.GetPrivateShards()) {
         db.Table<Schema::SubDomainShardsAlterData>().Key(pathId.LocalPathId, shardIdx.GetLocalId()).Update();
@@ -2632,6 +2633,7 @@ void TSchemeShard::PersistSubDomain(NIceDb::TNiceDb& db, const TPathId& pathId, 
 
     PersistSubDomainAuditSettings(db, pathId, subDomain);
     PersistSubDomainServerlessComputeResourcesMode(db, pathId, subDomain);
+    PersistSubDomainTablesMetricsLevel(db, pathId, subDomain);
 
     db.Table<Schema::SubDomainsAlterData>().Key(pathId.LocalPathId).Delete();
 
@@ -2779,6 +2781,22 @@ void TSchemeShard::PersistSubDomainServerlessComputeResourcesModeAlter(NIceDb::T
                                                                        const TSubDomainInfo& subDomain) {
     const auto& serverlessComputeResourcesMode = subDomain.GetServerlessComputeResourcesMode();
     PersistSubDomainServerlessComputeResourcesModeImpl<Schema::SubDomainsAlterData>(db, pathId, serverlessComputeResourcesMode);
+}
+
+template <class Table>
+void PersistSubDomainTablesMetricsLevelImpl(NIceDb::TNiceDb& db, const TPathId& pathId, ETablesMetricsLevel value) {
+    using Field = typename Table::TablesMetricsLevel;
+    db.Table<Table>().Key(pathId.LocalPathId).Update(NIceDb::TUpdate<Field>(value));
+}
+
+void TSchemeShard::PersistSubDomainTablesMetricsLevel(NIceDb::TNiceDb& db, const TPathId& pathId,
+                                                      const TSubDomainInfo& subDomain) {
+    PersistSubDomainTablesMetricsLevelImpl<Schema::SubDomains>(db, pathId, subDomain.GetTablesMetricsLevel());
+}
+
+void TSchemeShard::PersistSubDomainTablesMetricsLevelAlter(NIceDb::TNiceDb& db, const TPathId& pathId,
+                                                           const TSubDomainInfo& subDomain) {
+    PersistSubDomainTablesMetricsLevelImpl<Schema::SubDomainsAlterData>(db, pathId, subDomain.GetTablesMetricsLevel());
 }
 
 void TSchemeShard::PersistACL(NIceDb::TNiceDb& db, const TPathElement::TPtr path) {
@@ -8179,6 +8197,16 @@ TString TSchemeShard::FillAlterTableTxBody(TPathId pathId, TShardIdx shardIdx, T
         proto->MutableIncrementalBackupConfig()->CopyFrom(alterData->TableDescriptionFull->GetIncrementalBackupConfig());
     } else if (tableInfo->HasIncrementalBackupConfig()) {
         proto->MutableIncrementalBackupConfig()->CopyFrom(tableInfo->IncrementalBackupConfig());
+    }
+
+    // The alter body is a delta, but DataShard reads its METRICS_LEVEL override
+    // out of whatever this message carries, so the effective settings have to be
+    // restated on every alter: the pending change if there is one (including an
+    // explicit drop, which arrives as NotConfigured), otherwise the current one.
+    if (alterData->TableDescriptionFull.Defined() && alterData->TableDescriptionFull->HasDetailedMetricsSettings()) {
+        proto->MutableDetailedMetricsSettings()->CopyFrom(alterData->TableDescriptionFull->GetDetailedMetricsSettings());
+    } else if (tableInfo->HasDetailedMetricsSettings()) {
+        proto->MutableDetailedMetricsSettings()->MutableConfigured()->CopyFrom(tableInfo->GetDetailedMetricsSettings());
     }
 
     TString txBody;

--- a/ydb/core/tx/schemeshard/schemeshard_impl.h
+++ b/ydb/core/tx/schemeshard/schemeshard_impl.h
@@ -932,6 +932,8 @@ public:
     void PersistSubDomainAuditSettingsAlter(NIceDb::TNiceDb& db, const TPathId& pathId, const TSubDomainInfo& subDomain);
     void PersistSubDomainServerlessComputeResourcesMode(NIceDb::TNiceDb& db, const TPathId& pathId, const TSubDomainInfo& subDomain);
     void PersistSubDomainServerlessComputeResourcesModeAlter(NIceDb::TNiceDb& db, const TPathId& pathId, const TSubDomainInfo& subDomain);
+    void PersistSubDomainTablesMetricsLevel(NIceDb::TNiceDb& db, const TPathId& pathId, const TSubDomainInfo& subDomain);
+    void PersistSubDomainTablesMetricsLevelAlter(NIceDb::TNiceDb& db, const TPathId& pathId, const TSubDomainInfo& subDomain);
     void PersistKesusInfo(NIceDb::TNiceDb& db, TPathId pathId, const TKesusInfo::TPtr);
     void PersistKesusVersion(NIceDb::TNiceDb& db, TPathId pathId, const TKesusInfo::TPtr);
     void PersistAddKesusAlter(NIceDb::TNiceDb& db, TPathId pathId, const TKesusInfo::TPtr);

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.cpp
@@ -14,6 +14,7 @@
 #include <ydb/core/engine/mkql_proto.h>
 #include <ydb/core/protos/config.pb.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/scheme/scheme_types_proto.h>
 #include <ydb/core/tablet/tablet_counters_aggregator.h>
 #include <ydb/core/tablet/tablet_counters_protobuf.h>

--- a/ydb/core/tx/schemeshard/schemeshard_info_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_info_types.h
@@ -11,6 +11,7 @@
 
 #include <util/generic/yexception.h>
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/public/api/protos/ydb_cms.pb.h>
 #include <ydb/public/api/protos/ydb_coordination.pb.h>
 #include <ydb/public/api/protos/ydb_import.pb.h>
@@ -2754,6 +2755,14 @@ struct TSubDomainInfo: TSimpleRefCount<TSubDomainInfo> {
         ServerlessComputeResourcesMode = serverlessComputeResourcesMode;
     }
 
+    ETablesMetricsLevel GetTablesMetricsLevel() const {
+        return TablesMetricsLevel;
+    }
+
+    void SetTablesMetricsLevel(ETablesMetricsLevel level) {
+        TablesMetricsLevel = level;
+    }
+
 private:
     bool InitiatedAsGlobal = false;
     NKikimrSubDomains::TProcessingParams ProcessingParams;
@@ -2799,6 +2808,8 @@ private:
     ui64 SecurityStateVersion = 0;
 
     TMaybeAuditSettings AuditSettings;
+
+    ETablesMetricsLevel TablesMetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified;
 
     TVector<TTabletId> FilterPrivateTablets(TTabletTypes::EType type, const THashMap<TShardIdx, TShardInfo>& allShards) const {
         TVector<TTabletId> tablets;

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -1006,6 +1006,8 @@ void TPathDescriber::DescribeDomainRoot(TPathElement::TPtr pathEl) {
         entry->MutableAuditSettings()->CopyFrom(*auditSettings);
     }
 
+    entry->SetTablesMetricsLevel(subDomainInfo->GetTablesMetricsLevel());
+
     if (const auto& serverlessComputeResourcesMode = subDomainInfo->GetServerlessComputeResourcesMode()) {
         entry->SetServerlessComputeResourcesMode(*serverlessComputeResourcesMode);
     }

--- a/ydb/core/tx/schemeshard/schemeshard_schema.h
+++ b/ydb/core/tx/schemeshard/schemeshard_schema.h
@@ -841,6 +841,7 @@ struct Schema : NIceDb::Schema {
         struct ServerlessComputeResourcesMode : Column<31, NScheme::NTypeIds::Uint32> { using Type = EServerlessComputeResourcesMode; };
         struct ColumnTableColumnsLimit : Column<32, NScheme::NTypeIds::Uint64> {};
         struct SmallBlobsQuotaExceeded : Column<33, NScheme::NTypeIds::Bool> {};
+        struct TablesMetricsLevel : Column<34, NScheme::NTypeIds::Uint32> { using Type = ETablesMetricsLevel; };
 
         using TKey = TableKey<PathId>;
         using TColumns = TableColumns<
@@ -876,7 +877,8 @@ struct Schema : NIceDb::Schema {
             AuditSettings,
             ServerlessComputeResourcesMode,
             ColumnTableColumnsLimit,
-            SmallBlobsQuotaExceeded
+            SmallBlobsQuotaExceeded,
+            TablesMetricsLevel
         >;
     };
 
@@ -919,6 +921,7 @@ struct Schema : NIceDb::Schema {
         struct ExportsLimit : Column<27, NScheme::NTypeIds::Uint64> {};
         struct ImportsLimit : Column<28, NScheme::NTypeIds::Uint64> {};
         struct ColumnTableColumnsLimit : Column<29, NScheme::NTypeIds::Uint64> {};
+        struct TablesMetricsLevel : Column<30, NScheme::NTypeIds::Uint32> { using Type = ETablesMetricsLevel; };
 
         using TKey = TableKey<PathId>;
         using TColumns = TableColumns<
@@ -950,7 +953,8 @@ struct Schema : NIceDb::Schema {
             TableCdcStreamsLimit,
             ExportsLimit,
             ImportsLimit,
-            ColumnTableColumnsLimit
+            ColumnTableColumnsLimit,
+            TablesMetricsLevel
         >;
     };
 

--- a/ydb/core/tx/schemeshard/schemeshard_types.h
+++ b/ydb/core/tx/schemeshard/schemeshard_types.h
@@ -4,8 +4,10 @@
 
 #include <ydb/core/base/row_version.h>
 #include <ydb/core/base/tablet_types.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
 #include <ydb/core/protos/subdomains.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 
 #include <util/generic/fwd.h>
@@ -141,6 +143,8 @@ enum class EAttachChildResult : ui32 {
 };
 
 using EServerlessComputeResourcesMode = NKikimrSubDomains::EServerlessComputeResourcesMode;
+
+using ETablesMetricsLevel = NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel;
 
 struct TTempDirsState {
 

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -6,6 +6,7 @@
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <ydb/core/protos/flat_scheme_op.pb.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
 
 using namespace NKikimr;
 using namespace NSchemeShard;
@@ -902,5 +903,118 @@ Y_UNIT_TEST_SUITE(TSchemeShardTableDetailedMetricsSettingsTest) {
             true /* sourceHasMetricsLevel */,
             NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
         );
+    }
+}
+
+/**
+ * Unit test for the logic in Scheme Shard, which configures the database-wide default
+ * detailed metrics level (TABLES_METRICS_LEVEL) for row/column tables and publishes it
+ * in the subdomain description, where DataShard picks it up.
+ */
+Y_UNIT_TEST_SUITE(TSchemeShardDatabaseDetailedMetricsSettingsTest) {
+    constexpr const char* SubDomainSettings =
+        "PlanResolution: 50 "
+        "Coordinators: 1 "
+        "Mediators: 1 "
+        "TimeCastBucketsPerMediator: 2 "
+        "Name: \"USER_0\" ";
+
+    ui32 GetPublishedTablesMetricsLevel(TTestBasicRuntime& runtime, const TString& path) {
+        const auto describeResult = DescribePath(runtime, path);
+        UNIT_ASSERT(describeResult.GetPathDescription().HasDomainDescription());
+        return describeResult.GetPathDescription().GetDomainDescription().GetTablesMetricsLevel();
+    }
+
+    void VerifyAlterDatabaseTablesMetricsLevel(
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", SubDomainSettings);
+        env.TestWaitNotification(runtime, txId);
+
+        // No database default configured yet
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot/USER_0"),
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified));
+
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf("%sTablesMetricsLevel: %u", SubDomainSettings, ui32(level)));
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot/USER_0"), ui32(level));
+
+        // The database default is persisted, so it survives a Scheme Shard restart
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot/USER_0"), ui32(level));
+
+        // An ALTER that says nothing about the level keeps the current one
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot", SubDomainSettings);
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot/USER_0"), ui32(level));
+
+        // Setting the level back to Unspecified clears the database default
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf("%sTablesMetricsLevel: %u", SubDomainSettings,
+                ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified)));
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot/USER_0"),
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified));
+    }
+
+    Y_UNIT_TEST(AlterDatabaseTablesMetricsLevelDisabled) {
+        VerifyAlterDatabaseTablesMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    Y_UNIT_TEST(AlterDatabaseTablesMetricsLevelTable) {
+        VerifyAlterDatabaseTablesMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    Y_UNIT_TEST(AlterDatabaseTablesMetricsLevelPartition) {
+        VerifyAlterDatabaseTablesMetricsLevel(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
+        );
+    }
+
+    Y_UNIT_TEST(AlterDatabaseTablesMetricsLevelNotAllowedFeatureFlagDisabled) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(false);
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot", SubDomainSettings);
+        env.TestWaitNotification(runtime, txId);
+
+        TestAlterSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf("%sTablesMetricsLevel: %u", SubDomainSettings,
+                ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable)),
+            {NKikimrScheme::StatusInvalidParameter});
+    }
+
+    Y_UNIT_TEST(CreateDatabaseWithTablesMetricsLevel) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
+
+        TestCreateSubDomain(runtime, ++txId, "/MyRoot",
+            Sprintf("%sTablesMetricsLevel: %u", SubDomainSettings,
+                ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable)));
+        env.TestWaitNotification(runtime, txId);
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot/USER_0"),
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable));
     }
 }

--- a/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
+++ b/ydb/core/tx/schemeshard/ut_metrics/ut_table_metrics_settings.cpp
@@ -1002,6 +1002,57 @@ Y_UNIT_TEST_SUITE(TSchemeShardDatabaseDetailedMetricsSettingsTest) {
             {NKikimrScheme::StatusInvalidParameter});
     }
 
+    // The root database has no SysView Processor, so detailed metrics can never be
+    // aggregated for it
+    void VerifyAlterRootDatabaseTablesMetricsLevelRejected(
+        NKikimrSchemeOp::TTableDetailedMetricsSettings::EMetricsLevel level
+    ) {
+        TTestBasicRuntime runtime;
+        TTestEnv env(runtime);
+        ui64 txId = 100;
+
+        runtime.GetAppData().FeatureFlags.SetEnableDataShardDetailedMetrics(true);
+        // So that the request is rejected by the root-database check, not by the
+        // ALTER DATABASE gate
+        runtime.GetAppData().FeatureFlags.SetEnableAlterDatabase(true);
+
+        TestAlterSubDomain(runtime, ++txId, "/",
+            Sprintf("Name: \"MyRoot\" TablesMetricsLevel: %u", ui32(level)),
+            {NKikimrScheme::StatusInvalidParameter});
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot"),
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified));
+
+        RebootTablet(runtime, TTestTxConfig::SchemeShard, runtime.AllocateEdgeActor());
+
+        UNIT_ASSERT_VALUES_EQUAL(GetPublishedTablesMetricsLevel(runtime, "/MyRoot"),
+            ui32(NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified));
+    }
+
+    Y_UNIT_TEST(AlterRootDatabaseTablesMetricsLevelUnspecifiedNotAllowed) {
+        VerifyAlterRootDatabaseTablesMetricsLevelRejected(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelUnspecified
+        );
+    }
+
+    Y_UNIT_TEST(AlterRootDatabaseTablesMetricsLevelDisabledNotAllowed) {
+        VerifyAlterRootDatabaseTablesMetricsLevelRejected(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelDisabled
+        );
+    }
+
+    Y_UNIT_TEST(AlterRootDatabaseTablesMetricsLevelTableNotAllowed) {
+        VerifyAlterRootDatabaseTablesMetricsLevelRejected(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelTable
+        );
+    }
+
+    Y_UNIT_TEST(AlterRootDatabaseTablesMetricsLevelPartitionNotAllowed) {
+        VerifyAlterRootDatabaseTablesMetricsLevelRejected(
+            NKikimrSchemeOp::TTableDetailedMetricsSettings::MetricsLevelPartition
+        );
+    }
+
     Y_UNIT_TEST(CreateDatabaseWithTablesMetricsLevel) {
         TTestBasicRuntime runtime;
         TTestEnv env(runtime);

--- a/ydb/core/viewer/tests/canondata/result.json
+++ b/ydb/core/viewer/tests/canondata/result.json
@@ -4134,7 +4134,8 @@
                             "Kind": "hdd",
                             "Name": "dynamic_storage_pool:1"
                         }
-                    ]
+                    ],
+                    "TablesMetricsLevel": 0
                 },
                 "Self": {
                     "ACL": "text",
@@ -4272,7 +4273,8 @@
                             "Kind": "hdd",
                             "Name": "/Root/dedicated_db:hdd"
                         }
-                    ]
+                    ],
+                    "TablesMetricsLevel": 0
                 },
                 "Self": {
                     "ACL": "text",
@@ -4393,7 +4395,8 @@
                             "Kind": "hdd",
                             "Name": "/Root/shared_db:hdd"
                         }
-                    ]
+                    ],
+                    "TablesMetricsLevel": 0
                 },
                 "Self": {
                     "ACL": "",
@@ -4530,7 +4533,8 @@
                             "Kind": "hdd",
                             "Name": "/Root/shared_db:hdd"
                         }
-                    ]
+                    ],
+                    "TablesMetricsLevel": 0
                 },
                 "Self": {
                     "ACL": "",

--- a/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
+++ b/ydb/tests/functional/scheme_tests/canondata/tablet_scheme_tests.TestTabletSchemes.test_tablet_schemes_flat_schemeshard_/flat_schemeshard.schema
@@ -1581,6 +1581,11 @@
                 "ColumnId": 33,
                 "ColumnName": "SmallBlobsQuotaExceeded",
                 "ColumnType": "Bool"
+            },
+            {
+                "ColumnId": 34,
+                "ColumnName": "TablesMetricsLevel",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
@@ -1619,7 +1624,8 @@
                     30,
                     31,
                     32,
-                    33
+                    33,
+                    34
                 ],
                 "RoomID": 0,
                 "Codec": 0,
@@ -2329,11 +2335,6 @@
         ],
         "ColumnsAdded": [
             {
-                "ColumnId": 29,
-                "ColumnName": "ColumnTableColumnsLimit",
-                "ColumnType": "Uint64"
-            },
-            {
                 "ColumnId": 1,
                 "ColumnName": "PathId",
                 "ColumnType": "Uint64"
@@ -2472,13 +2473,22 @@
                 "ColumnId": 28,
                 "ColumnName": "ImportsLimit",
                 "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 29,
+                "ColumnName": "ColumnTableColumnsLimit",
+                "ColumnType": "Uint64"
+            },
+            {
+                "ColumnId": 30,
+                "ColumnName": "TablesMetricsLevel",
+                "ColumnType": "Uint32"
             }
         ],
         "ColumnsDropped": [],
         "ColumnFamilies": {
             "0": {
                 "Columns": [
-                    29,
                     1,
                     2,
                     3,
@@ -2506,7 +2516,9 @@
                     25,
                     26,
                     27,
-                    28
+                    28,
+                    29,
+                    30
                 ],
                 "RoomID": 0,
                 "Codec": 0,


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

To be used later as a gate for a specific row table to report its detailed metrics at a certain level