### PR TITLE
Avoid signed overflow in CalcCV std::accumulate

### DIFF
--- a/ydb/public/sdk/cpp/src/client/table/impl/request_migrator.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/impl/request_migrator.cpp
@@ -15,7 +15,7 @@ TStats CalcCV(const std::vector<size_t>& in) {
     if (in.size() == 1)
         return {0, static_cast<float>(in[0])};
 
-    const size_t sum = std::accumulate(in.begin(), in.end(), 0);
+    const size_t sum = std::accumulate(in.begin(), in.end(), size_t{0});
     if (!sum)
         return {0, 0.0};
 


### PR DESCRIPTION
## Summary
- `std::accumulate` in `CalcCV` used a `0` literal, so the accumulator type was `int`.
- Summing `size_t` elements past `INT_MAX` is signed overflow (UB); initialize with `size_t{0}` instead.

## Test plan
- [ ] Build/check `ydb/public/sdk/cpp/src/client/table`
- [ ] Confirm no behavioral change for typical small latency samples


Made with [Cursor](https://cursor.com)