### PR TITLE
IC v2: configure uring engine from Common, add dead-peer detection

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -759,26 +759,22 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
             icCommon->MonCounters = interconectCounters;
             icCommon->ChannelsConfig = channels;
             icCommon->Settings = settings;
+            icCommon->DestructorId = GetDestructActorID();
 
             if (settings.V2.Enable) {
                 // Create the shared v2 io_uring data-plane engine once, at startup, and publish it in Common.
                 // The actor system does not exist yet, so the engine is bound to it later (once it is up,
                 // TInterconnectProxyTCP::Registered calls SetActorSystem). CreateUringEngine returns null when
                 // io_uring is unavailable, in which case v2 is simply never negotiated during the handshake.
-                icCommon->UringEngineV2 = CreateUringEngine(settings.V2.UringEngineThreads,
-                    interconectCounters->GetSubgroup("subsystem", "uring"),
-                    settings.V2.EnableSQPOLL,
-                    settings.V2.UringEngineRingsPerShard,
-                    settings.V2.UringEngineSqThreadIdleMs,
-                    settings.V2.ShareRingsAmongThreads,
-                    GetDestructActorID());
+                // The engine takes its parameters from Common, so Settings/MonCounters/DestructorId must
+                // already be filled in by this point.
+                icCommon->UringEngineV2 = CreateUringEngine(icCommon);
                 setup->OnActorSystemCreated.push_back([engine = icCommon->UringEngineV2](TActorSystem *actorSystem) {
                     if (engine) {
                         engine->SetActorSystem(actorSystem);
                     }
                 });
             }
-            icCommon->DestructorId = GetDestructActorID();
             icCommon->DestructorQueueSize = destructorQueueSize;
             icCommon->HandshakeBallastSize = icConfig.GetHandshakeBallastSize();
             icCommon->LocalScopeId = ScopeId.GetInterconnectScopeId();

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -33,6 +33,9 @@ namespace NActors {
         IC_MSG_ZEROCOPY,
     };
 
+    // Effective dead-peer timeout when TInterconnectSettings::DeadPeer is left unset.
+    static constexpr TDuration DEFAULT_DEADPEER_TIMEOUT = TDuration::Seconds(10);
+
     struct TInterconnectSettings {
         TDuration Handshake;
         TDuration DeadPeer;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -100,7 +100,7 @@ namespace NActors {
         const ui64 UpperLimit;
     };
 
-    static constexpr TDuration DEFAULT_DEADPEER_TIMEOUT = TDuration::Seconds(10);
+    // DEFAULT_DEADPEER_TIMEOUT lives in interconnect_common.h -- it is shared with the v2 data plane.
     static constexpr TDuration DEFAULT_LOST_CONNECTION_TIMEOUT = TDuration::Seconds(10);
     static constexpr ui32 DEFAULT_MAX_INFLIGHT_DATA = 10240 * 1024;
     static constexpr ui32 DEFAULT_TOTAL_INFLIGHT_DATA = 4 * 10240 * 1024;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -83,9 +83,8 @@ namespace NActors {
             as->Send(selfId, new TEvPrivate::TEvTerminate(reason));
         };
         SetNonBlock(*Socket, false);
-        EngineHandle = Proxy->Common->UringEngineV2->Register(Socket, SelfId(),
-            Proxy->Common->Settings.V2.ChecksumEvents, Params.PeerScopeId, onDisconnectCallback,
-            SelfId().NodeId() < Proxy->PeerNodeId, ClockSkew, PingRTT);
+        EngineHandle = Proxy->Common->UringEngineV2->Register(Socket, SelfId(), Params.PeerScopeId,
+            onDisconnectCallback, SelfId().NodeId() < Proxy->PeerNodeId, ClockSkew, PingRTT);
         if (!EngineHandle) {
             LOG_ERROR_IC_SESSION("ICS99", "v2 io_uring engine failed to register the connection");
             return Terminate(TDisconnectReason::LostConnection());

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
@@ -3,6 +3,7 @@
 #include "uring_context.h" // for TUringContext::IsAvailable() / SqThreadIdleMs
 
 #include "v2_event_serializer.h"
+#include "interconnect_common.h"
 #include "interconnect_direct_session.h"
 #include "interconnect_uring_event_queue.h"
 
@@ -17,6 +18,7 @@
 
 #include <library/cpp/monlib/service/pages/templates.h>
 
+#include <util/datetime/cputimer.h>
 #include <util/system/env.h>
 #include <util/system/hp_timer.h>
 
@@ -45,9 +47,33 @@ namespace NActors {
         constexpr size_t MaxSpansPerWrite = 64;
         constexpr size_t MinSerializeWindowSize = 4096;
         constexpr size_t MaxSerializeWindowSize = 262144;
-        constexpr ui32 RebalanceTimerMs = 500; // drives MaybeOffload and also issues ping packet
+        constexpr TDuration RebalancePeriod = TDuration::MilliSeconds(500); // how often MaybeOffload runs
         constexpr ui32 OffloadBusyThreshold = 700000; // ppm
         constexpr ui32 StealBusyThreshold = 300000; // ppm
+
+        // The shard timer is the only timing source for pings and dead-peer detection, so its period caps
+        // how late either of them can be. Keep it at or below this bound to limit the jitter.
+        constexpr TDuration MaxTickPeriod = TDuration::Seconds(1);
+        constexpr TDuration MinTickPeriod = TDuration::MilliSeconds(100);
+        // Number of ping opportunities that must fit into the dead-peer window, so that a single lost or
+        // late ping cannot bring a healthy link down.
+        constexpr ui32 PingsPerDeadPeerTimeout = 4;
+
+        TDuration CalculateDeadPeerTimeout(const TInterconnectSettings& settings) {
+            return settings.DeadPeer ? settings.DeadPeer : DEFAULT_DEADPEER_TIMEOUT;
+        }
+
+        TDuration CalculatePingPeriod(const TInterconnectSettings& settings, TDuration deadPeerTimeout) {
+            TDuration period = deadPeerTimeout / PingsPerDeadPeerTimeout;
+            if (settings.PingPeriod) {
+                period = Min(period, settings.PingPeriod);
+            }
+            return Max(period, MinTickPeriod);
+        }
+
+        TDuration CalculateTickPeriod(TDuration pingPeriod) {
+            return Max(Min(pingPeriod, MaxTickPeriod), MinTickPeriod);
+        }
     }
 
     struct TEvUringMonRequest : TEventLocal<TEvUringMonRequest, static_cast<ui32>(ENetwork::EvUringMonRequest)> {
@@ -67,6 +93,21 @@ namespace NActors {
         TActorSystem *ActorSystem = nullptr; // bound after construction via SetActorSystem()
         std::once_flag ActorSystemInitFlag;
         std::atomic_bool Stopping{false};
+
+        // Shared interconnect parameters this engine was created with. Common owns the engine as well, so
+        // the reference cycle is broken in Stop(); everything the data plane needs from Settings is derived
+        // into the const members below at construction time and Common is not dereferenced afterwards.
+        TIntrusivePtr<TInterconnectProxyCommon> Common;
+
+        const bool ChecksumEvents;
+
+        // Liveness timing. TickPeriod is the shard timer period and thus the granularity (and worst-case
+        // lateness) of both ping issuance and the dead-peer verdict.
+        const TDuration DeadPeerTimeout;
+        const TDuration PingPeriod;
+        const TDuration TickPeriod;
+        const ui64 DeadPeerTimeoutCycles;
+        const ui64 PingPeriodCycles;
 
         // Low 3 bits of the session pointer are used as an io_uring user_data op tag; heap allocation
         // alignment of this type is already >= 8 (actually 64 via base/members).
@@ -149,6 +190,7 @@ namespace NActors {
 
             void ApplyBytesRead(size_t num) {
                 BytesReceived += num;
+                LastInputActivityTimestamp = GetCycleCountFast();
                 TRcBuf chunk = {TRcBuf::Piece, ReadBuffer.data(), num, ReadBuffer};
                 Deserializer.Push(std::move(chunk), this, SessionId);
                 Y_ABORT_UNLESS(num <= ReadBuffer.size());
@@ -255,12 +297,20 @@ namespace NActors {
             NHPTimer::STime PingRequestSentTimestamp = 0;
             NHPTimer::STime PingResponseSentTimestamp = 0;
 
-            void SendPingRequest() {
+            // When the last ping request was issued. Unlike PingRequestSentTimestamp (which is reset as soon
+            // as the reply arrives) this one keeps the ping cadence independent of the round-trip time.
+            ui64 LastPingSentTimestamp = 0;
+
+            // When we last got anything at all from the peer; drives dead-peer detection.
+            ui64 LastInputActivityTimestamp = GetCycleCountFast();
+
+            void SendPingRequest(ui64 timestamp) {
                 NActorsInterconnect::TSystemPayloadV2 systemRequest;
                 auto *r = systemRequest.AddRequests();
                 r->MutablePingRequest();
                 Serializer.Push(systemRequest);
-                PingRequestSentTimestamp = GetCycleCountFast();
+                PingRequestSentTimestamp = timestamp;
+                LastPingSentTimestamp = timestamp;
             }
 
             void Process(NActorsInterconnect::TSystemPayloadV2& systemRequest) override {
@@ -335,7 +385,7 @@ namespace NActors {
 
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-            void RenderHtml(IOutputStream& str) const {
+            void RenderHtml(IOutputStream& str, TDuration deadPeerTimeout, TDuration pingPeriod) const {
                 HTML(str) {
                     DIV_CLASS("panel panel-info") {
                         DIV_CLASS("panel-heading") {
@@ -370,6 +420,10 @@ namespace NActors {
                                     PARAM(MigrateTargetShard)
                                     PARAM2("ClockSkew", ClockSkew->load())
                                     PARAM2("PingRTT", PingRTT->load())
+                                    PARAM2("SinceLastInputActivity",
+                                        CyclesToDuration(GetCycleCountFast() - LastInputActivityTimestamp))
+                                    PARAM2("DeadPeerTimeout", deadPeerTimeout)
+                                    PARAM2("PingPeriod", pingPeriod)
                                     PARAM2("ReceiveCallbacks size", ReceiveCallbacks.size())
                                     PARAM2("PendingRecordsHeap size", PendingRecordsHeap.size())
                                     PARAM(SerializeWindowSize)
@@ -424,6 +478,8 @@ namespace NActors {
             int TimerFd = -1;
             ui64 ReadTimerBuffer;
             std::atomic_bool WaitingForCQ{false};
+            ui64 TicksPerRebalance = 1;
+            ui64 TicksSinceRebalance = 0;
 
             size_t OpShift = 0;
 
@@ -466,6 +522,7 @@ namespace NActors {
             NMonitoring::TDynamicCounters::TCounterPtr SessionsMigratedIn;
             NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderCameIn;
             NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderProcessed;
+            NMonitoring::TDynamicCounters::TCounterPtr DeadPeersDetected;
 
             NMonitoring::TDynamicCounters::TCounterPtr OtherTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr CompleteWaitTotalTime;
@@ -587,6 +644,7 @@ namespace NActors {
                 , COUNTER(SessionsMigratedIn, true)
                 , COUNTER(OutOfOrderCameIn, true)
                 , COUNTER(OutOfOrderProcessed, true)
+                , COUNTER(DeadPeersDetected, true)
 #define TOTAL_TIME(NAME) NAME(shardCounters->GetCounter("TotalTime/" #NAME, true))
                 , TOTAL_TIME(OtherTotalTime)
                 , TOTAL_TIME(CompleteWaitTotalTime)
@@ -628,13 +686,17 @@ namespace NActors {
 
                 // Keep the timer armed for the shard lifetime. Disarming while an io_uring read is
                 // outstanding would leave a stuck SQE; idle CPU is controlled via sq_thread_idle instead.
+                const TDuration tickPeriod = Engine.TickPeriod;
                 itimerspec spec{};
-                spec.it_interval.tv_sec = RebalanceTimerMs / 1000;
-                spec.it_interval.tv_nsec = 1'000'000 * (RebalanceTimerMs % 1000);
+                spec.it_interval.tv_sec = tickPeriod.Seconds();
+                spec.it_interval.tv_nsec = tickPeriod.NanoSecondsOfSecond();
                 spec.it_value = spec.it_interval;
                 if (timerfd_settime(TimerFd, 0, &spec, nullptr) < 0) {
                     Y_ABORT("timerfd_settime failed: %s", strerror(errno));
                 }
+
+                // The tick drives liveness, which may be much more frequent than rebalancing needs to be.
+                TicksPerRebalance = Max<ui64>(1, RebalancePeriod.GetValue() / tickPeriod.GetValue());
             }
 
             ~TShard() {
@@ -1041,7 +1103,7 @@ namespace NActors {
 
             void ProcessMonRequest(TSession& session, NMon::TEvHttpInfoRes::TPtr ev) {
                 TStringOutput str(const_cast<TString&>(static_cast<NMon::TEvHttpInfoRes*>(ev->Get())->Answer));
-                session.RenderHtml(str);
+                session.RenderHtml(str, Engine.DeadPeerTimeout, Engine.PingPeriod);
                 Engine.ActorSystem->Send(ev.Release());
             }
 
@@ -1108,16 +1170,36 @@ namespace NActors {
             }
 
             void DispatchTimer() {
+                const ui64 now = GetCycleCountFast();
+
                 for (auto& session : Sessions) {
-                    if (!session->Terminated && session->MigrateTargetShard != ShardIdx && session->SendPings &&
-                            session->PingRequestSentTimestamp == 0) {
-                        session->SendPingRequest();
+                    if (session->Terminated || session->MigrateTargetShard != ShardIdx) {
+                        continue;
+                    }
+
+                    // Anything arriving from the peer -- payload, ping request, ping response -- counts as
+                    // proof of life; when nothing has for the whole timeout, the link is declared dead. The
+                    // peer keeps the stream flowing either by pinging us or by answering our pings, so this
+                    // works on both sides of the connection.
+                    if (now - session->LastInputActivityTimestamp >= Engine.DeadPeerTimeoutCycles) {
+                        ++*DeadPeersDetected;
+                        session->Disconnect(TDisconnectReason::DeadPeer());
+                        continue;
+                    }
+
+                    if (session->SendPings && session->PingRequestSentTimestamp == 0 &&
+                            now - session->LastPingSentTimestamp >= Engine.PingPeriodCycles) {
+                        session->SendPingRequest(now);
                         MaybeIssueWriteForSession(*session);
                     }
                 }
 
-                // Rebalance at most once per ping period to limit churn under short load spikes.
-                MaybeOffload();
+                // Rebalancing is far less urgent than liveness, so it runs on its own, coarser period to
+                // limit churn under short load spikes.
+                if (++TicksSinceRebalance >= TicksPerRebalance) {
+                    TicksSinceRebalance = 0;
+                    MaybeOffload();
+                }
             }
 
             void MaybeOffload() {
@@ -1318,22 +1400,34 @@ namespace NActors {
         TActorId DestructorActorId;
 
     public:
-        TUringEngine(ui32 numShards, NMonitoring::TDynamicCounterPtr counters, bool sqpoll, ui32 ringsPerShard,
-                ui32 sqThreadIdleMs, bool shareRingsAmongThreads, TActorId destructorActorId)
-            : UringCounters(std::move(counters))
-            , DestructorActorId(destructorActorId)
+        TUringEngine(TIntrusivePtr<TInterconnectProxyCommon> common)
+            : Common(std::move(common))
+            , ChecksumEvents(Common->Settings.V2.ChecksumEvents)
+            , DeadPeerTimeout(CalculateDeadPeerTimeout(Common->Settings))
+            , PingPeriod(CalculatePingPeriod(Common->Settings, DeadPeerTimeout))
+            , TickPeriod(CalculateTickPeriod(PingPeriod))
+            , DeadPeerTimeoutCycles(DurationToCycles(DeadPeerTimeout))
+            , PingPeriodCycles(DurationToCycles(PingPeriod))
+            , UringCounters(Common->MonCounters->GetSubgroup("subsystem", "uring"))
         {
+            const auto& v2 = Common->Settings.V2;
+            const ui32 numShards = Max<ui32>(1, v2.UringEngineThreads);
+            const ui32 ringsPerShard = Max<ui32>(1, v2.UringEngineRingsPerShard);
+            const ui32 sqThreadIdleMs = v2.UringEngineSqThreadIdleMs
+                ? v2.UringEngineSqThreadIdleMs
+                : TUringContext::SqThreadIdleMs;
+
             ShardLoads = std::vector<TShardLoad>(numShards);
             Shards.reserve(numShards);
             for (ui32 i = 0; i < numShards; ++i) {
                 Shards.push_back(std::make_unique<TShard>(*this,
                     i, // shardIdx
                     UringCounters->GetSubgroup("shard", "0" /*ToString(i)*/),
-                    sqpoll,
+                    v2.EnableSQPOLL,
                     ringsPerShard,
                     sqThreadIdleMs,
                     ShardLoads[i],
-                    shareRingsAmongThreads && !Shards.empty() ? Shards.front().get() : nullptr));
+                    v2.ShareRingsAmongThreads && !Shards.empty() ? Shards.front().get() : nullptr));
             }
             for (auto& shard : Shards) {
                 shard->Start();
@@ -1346,6 +1440,10 @@ namespace NActors {
 
         void SetActorSystem(TActorSystem* actorSystem) override {
             Y_ABORT_UNLESS(actorSystem);
+            // DestructorId is filled in after the engine is created, so it is picked up here rather than in
+            // the constructor. Published together with ActorSystem, i.e. before the first Register and thus
+            // before any shard worker can reach the code using either of them.
+            DestructorActorId = Common->DestructorId;
             ActorSystem = actorSystem;
             // Stop the reaper threads while the actor system is still up, so no completion is posted to a
             // torn-down system.
@@ -1353,7 +1451,7 @@ namespace NActors {
         }
 
         ui64 Register(TIntrusivePtr<NInterconnect::TStreamSocket> socket, const TActorId& sessionActorId,
-                bool checksumming, TScopeId peerScopeId, std::function<void(TDisconnectReason)> onDisconnectCallback,
+                TScopeId peerScopeId, std::function<void(TDisconnectReason)> onDisconnectCallback,
                 bool sendPings, std::shared_ptr<std::atomic<int64_t>> clockSkew,
                 std::shared_ptr<std::atomic<uint64_t>> pingRTT) override {
             if (Stopping) {
@@ -1372,8 +1470,8 @@ namespace NActors {
             }
 
             auto session = std::make_unique<TSession>(shardIdx, std::move(socket), sessionActorId,
-                checksumming, peerScopeId, std::move(onDisconnectCallback), ActorSystem, sendPings, std::move(clockSkew),
-                std::move(pingRTT));
+                ChecksumEvents, peerScopeId, std::move(onDisconnectCallback), ActorSystem, sendPings,
+                std::move(clockSkew), std::move(pingRTT));
             const ui64 conn = reinterpret_cast<ui64>(session.get());
             Shards[shardIdx]->Register(std::move(session));
             return conn;
@@ -1417,6 +1515,10 @@ namespace NActors {
                 for (auto& shard : Shards) {
                     shard->Stop();
                 }
+                // Common holds this engine, so keeping a reference to it here would make the pair
+                // unreclaimable. The workers are joined by now and nothing dereferences Common past this
+                // point (all of its data the engine needs is cached in const members).
+                Common.Reset();
             }
         }
 
@@ -1425,22 +1527,13 @@ namespace NActors {
         }
     };
 
-    TUringEnginePtr CreateUringEngine(ui32 numShards, NMonitoring::TDynamicCounterPtr counters, bool sqpoll,
-            ui32 ringsPerShard, ui32 sqThreadIdleMs, bool shareRingsAmongThreads, TActorId destructorActorId) {
+    TUringEnginePtr CreateUringEngine(TIntrusivePtr<TInterconnectProxyCommon> common) {
         if (!TUringContext::IsAvailable()) {
             return nullptr;
         }
-        if (numShards < 1) {
-            numShards = 1;
-        }
-        if (ringsPerShard < 1) {
-            ringsPerShard = 1;
-        }
-        if (sqThreadIdleMs < 1) {
-            sqThreadIdleMs = TUringContext::SqThreadIdleMs;
-        }
-        return MakeIntrusive<TUringEngine>(numShards, std::move(counters), sqpoll, ringsPerShard, sqThreadIdleMs,
-            shareRingsAmongThreads, destructorActorId);
+        Y_ABORT_UNLESS(common);
+        Y_ABORT_UNLESS(common->MonCounters);
+        return MakeIntrusive<TUringEngine>(std::move(common));
     }
 
 } // namespace NActors

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.h
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.h
@@ -18,6 +18,7 @@ namespace NActors {
 
     class TActorSystem;
     class IReceiveCallback;
+    struct TInterconnectProxyCommon;
 
     class IUringEngine : public TThrRefBase {
     public:
@@ -30,7 +31,7 @@ namespace NActors {
         // Registers a connected socket, arms receiving, and returns an opaque non-zero handle (0 on
         // failure). The engine holds a reference to the socket until Unregister fully drains. Thread-safe.
         virtual ui64 Register(TIntrusivePtr<NInterconnect::TStreamSocket> socket, const TActorId& sessionActorId,
-            bool checksumming, TScopeId peerScopeId, std::function<void(TDisconnectReason)> onDisconnectCallback,
+            TScopeId peerScopeId, std::function<void(TDisconnectReason)> onDisconnectCallback,
             bool sendPings, std::shared_ptr<std::atomic<int64_t>> clockSkew, std::shared_ptr<std::atomic<uint64_t>> pingRTT) = 0;
 
         // Put a message into outgoing queue. Thread-safe.
@@ -52,19 +53,20 @@ namespace NActors {
 
     using TUringEnginePtr = TIntrusivePtr<IUringEngine>;
 
-    // Creates the engine with `numShards` worker threads (clamped to >= 1), each driving `ringsPerShard`
-    // io_uring rings (clamped to >= 1). With SQPOLL, each ring has its own kernel poll thread, so
-    // rings-per-shard scales submission-polling capacity independently of serialization workers.
+    // Creates the engine, taking every knob it needs from `common` (which it keeps a reference to, so
+    // sessions can read the shared settings): Settings.V2.UringEngineThreads worker threads (clamped to
+    // >= 1), each driving Settings.V2.UringEngineRingsPerShard io_uring rings (clamped to >= 1). With
+    // SQPOLL, each ring has its own kernel poll thread, so rings-per-shard scales submission-polling
+    // capacity independently of serialization workers.
     // The engine is created without an actor system (it does not exist yet at startup); bind it later via
     // SetActorSystem before the first Register. Returns nullptr when io_uring is unavailable (non-Linux or a
     // kernel that cannot create a ring).
     //
     // When the kernel SQPOLL thread is saturated while shard workers still have headroom, try
-    // EnableSQPOLLv2=false (submit from the underutilized worker) or raise ringsPerShard. When workers are
-    // the bottleneck, raise numShards / lower ringsPerShard.
-    // sqThreadIdleMs is the SQPOLL kernel-thread idle timeout in milliseconds (ignored when sqpoll is false).
-    TUringEnginePtr CreateUringEngine(ui32 numShards, NMonitoring::TDynamicCounterPtr counters, bool sqpoll,
-        ui32 ringsPerShard = 1, ui32 sqThreadIdleMs = 2000, bool shareRingsAmongThreads = false,
-        TActorId destructorActorId = {});
+    // EnableSQPOLL=false (submit from the underutilized worker) or raise UringEngineRingsPerShard. When
+    // workers are the bottleneck, raise UringEngineThreads / lower UringEngineRingsPerShard.
+    //
+    // Common holds the engine via an intrusive pointer too; the resulting cycle is broken by Stop().
+    TUringEnginePtr CreateUringEngine(TIntrusivePtr<TInterconnectProxyCommon> common);
 
 }

--- a/ydb/library/actors/interconnect/interconnect_uring_engine_stub.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine_stub.cpp
@@ -1,7 +1,9 @@
 #include "interconnect_uring_engine.h"
 
+#include "interconnect_common.h" // TIntrusivePtr<TInterconnectProxyCommon> must be complete to be destroyed
+
 namespace NActors {
-    TUringEnginePtr CreateUringEngine(ui32, NMonitoring::TDynamicCounterPtr, bool, ui32, ui32) {
+    TUringEnginePtr CreateUringEngine(TIntrusivePtr<TInterconnectProxyCommon>) {
         return nullptr;
     }
 }

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -78,20 +78,13 @@ public:
             // Mirror production: create the shared v2 io_uring engine up front and publish it in Common; the
             // proxy binds it to the actor system on start (SetActorSystem). Shard count is overridable via
             // YDB_IC_V2_SHARDS so tests can force many connections onto a single ring.
-            ui32 uringShards = common->Settings.V2.UringEngineThreads;
             if (const TString s = GetEnv("YDB_IC_V2_SHARDS"); !s.empty()) {
-                uringShards = FromString<ui32>(s);
+                common->Settings.V2.UringEngineThreads = FromString<ui32>(s);
             }
-            ui32 ringsPerShard = common->Settings.V2.UringEngineRingsPerShard;
             if (const TString s = GetEnv("YDB_IC_V2_RINGS_PER_SHARD"); !s.empty()) {
-                ringsPerShard = FromString<ui32>(s);
+                common->Settings.V2.UringEngineRingsPerShard = FromString<ui32>(s);
             }
-            common->UringEngineV2 = CreateUringEngine(uringShards,
-                common->MonCounters->GetSubgroup("subsystem", "uring"),
-                common->Settings.V2.EnableSQPOLL,
-                ringsPerShard,
-                common->Settings.V2.UringEngineSqThreadIdleMs,
-                common->Settings.V2.ShareRingsAmongThreads);
+            common->UringEngineV2 = CreateUringEngine(common);
             setup.OnActorSystemCreated.push_back([engine = common->UringEngineV2](TActorSystem *actorSystem) {
                 if (engine) {
                     engine->SetActorSystem(actorSystem);

--- a/ydb/library/actors/interconnect/ut/v2_session_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/v2_session_ut.cpp
@@ -306,7 +306,9 @@ namespace {
         std::atomic<size_t> DisconnectCount{0};
     };
 
-    std::unique_ptr<TTestICCluster> MakeV2Cluster(ui32 tcpSocketBufferSize = 0) {
+    std::unique_ptr<TTestICCluster> MakeV2Cluster(ui32 tcpSocketBufferSize = 0,
+            TTestICCluster::TTrafficInterrupterSettings *tiSettings = nullptr,
+            TDuration deadPeerTimeout = TDuration::Seconds(2)) {
         auto customizer = [tcpSocketBufferSize](ui32, TInterconnectSettings& settings) {
             settings.V2.Enable = true;
             settings.V2.ChecksumEvents = true;
@@ -315,9 +317,9 @@ namespace {
             }
         };
         return std::make_unique<TTestICCluster>(
-            /*numNodes=*/2, TChannelsConfig(), /*tiSettings=*/nullptr, /*loggerSettings=*/nullptr,
+            /*numNodes=*/2, TChannelsConfig(), tiSettings, /*loggerSettings=*/nullptr,
             TTestICCluster::EMPTY, /*checkerFactory=*/TTestICCluster::TCheckerFactory{},
-            /*deadPeerTimeout=*/TDuration::Seconds(2), /*inflight=*/TNode::DefaultInflight(), customizer);
+            deadPeerTimeout, /*inflight=*/TNode::DefaultInflight(), customizer);
     }
 
     std::shared_ptr<IDirectSession> GrabDirectSession(TTestICCluster& cluster, ui32 fromNode, ui32 peerNode) {
@@ -859,5 +861,66 @@ Y_UNIT_TEST_SUITE(InterconnectSessionV2) {
             /*channel=*/1, promise), 1);
         UNIT_ASSERT_C(future.Wait(TDuration::Seconds(60)), "connection did not recover after disconnect churn");
         UNIT_ASSERT_VALUES_EQUAL(future.GetValueSync(), kTotal);
+    }
+
+    // A link that stops delivering anything while both sockets stay open (blackholed traffic) gives the
+    // engine no error to react to: only the dead-peer watchdog can notice that the peer went silent. The
+    // session must be torn down shortly after the timeout expires -- and not before -- and the connection
+    // must come back once traffic flows again.
+    Y_UNIT_TEST(DeadPeerTimeout) {
+        if (!TUringContext::IsAvailable()) {
+            Cerr << "io_uring not available; skipping" << Endl;
+            return;
+        }
+
+        constexpr TDuration deadPeerTimeout = TDuration::Seconds(2);
+        TTestICCluster::TTrafficInterrupterSettings tiSettings{
+            .RejectingTrafficTimeout = TDuration::Zero(), // no random rejects; the test drives the blackhole
+            .BandWidth = 0.0,
+            .Disconnect = false,
+        };
+        auto cluster = MakeV2Cluster(/*tcpSocketBufferSize=*/0, &tiSettings, deadPeerTimeout);
+
+        const TActorId responder = cluster->RegisterActor(new TLoadEchoActor, 2);
+        auto* monitor = new TConnectionMonitorActor(2);
+        cluster->RegisterActor(monitor, 1);
+
+        auto runLoad = [&](ui32 total, TStringBuf what) {
+            auto promise = NThreading::NewPromise<ui32>();
+            auto future = promise.GetFuture();
+            cluster->RegisterActor(new TLoadDriverActor(responder, total, /*inFlyMax=*/16, /*payloadSize=*/4096,
+                /*channel=*/1, promise), 1);
+            UNIT_ASSERT_C(future.Wait(TDuration::Seconds(60)), what);
+            UNIT_ASSERT_VALUES_EQUAL(future.GetValueSync(), total);
+        };
+
+        runLoad(500, "initial load stalled");
+        AssertV2InUse(*cluster, 1, 2);
+        WaitFor(TDuration::Seconds(20), [&] { return monitor->Connects() >= 1; }, "connection observed");
+
+        // Connecting may take a couple of attempts (handshake races at startup), so count from where we are
+        // rather than from zero.
+        const size_t disconnectsBefore = monitor->Disconnects();
+
+        // From now on nothing gets through in either direction, but the sockets remain open.
+        cluster->StartBlackhole(1);
+        cluster->StartBlackhole(2);
+        const TInstant blackholeStart = TInstant::Now();
+
+        WaitFor(deadPeerTimeout + TDuration::Seconds(20),
+            [&] { return monitor->Disconnects() > disconnectsBefore; },
+            "dead peer detected while traffic is blackholed");
+
+        // Pings keep the stream alive right up to the blackhole, so a disconnect noticeably earlier than the
+        // timeout would mean something other than the dead-peer watchdog tore the session down.
+        const TDuration elapsed = TInstant::Now() - blackholeStart;
+        UNIT_ASSERT_C(elapsed >= deadPeerTimeout / 2, TStringBuilder()
+            << "session died after " << elapsed << ", too early for a dead-peer timeout of " << deadPeerTimeout);
+
+        cluster->StopBlackhole(1);
+        cluster->StopBlackhole(2);
+
+        runLoad(500, "load after dead peer stalled -- reconnect broken");
+        AssertV2InUse(*cluster, 1, 2);
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

IC v2: configure uring engine from Common, add dead-peer detection

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

The engine used to be built from a snapshot of individual V2 settings. It now
holds an intrusive pointer to the TInterconnectProxyCommon shared by every
session and derives its configuration from there; the resulting reference cycle
(Common owns the engine) is broken in Stop() once the workers are joined.

Sessions were also never actually pinged, because the shard timer only
considered sessions being migrated away, so a silently dead link stayed up
forever. Pings now go out on the shard tick, and a session that has received
nothing from its peer for DeadPeer is torn down, as in IC v1. The tick period is
derived from the ping and dead-peer settings and capped at one second so neither
reacts with a noticeable delay, while rebalancing keeps its own coarser period.
