### PR TITLE
ci(docs): gate doc_verify with YDBDOC_ALLOWED_ACTORS

### DIFF
--- a/.github/workflows/ydbdoc-verify.yml
+++ b/.github/workflows/ydbdoc-verify.yml
@@ -44,6 +44,11 @@ jobs:
           YANDEX_CLOUD_API_KEY_DOC_REVIEW: ${{ secrets.YANDEX_CLOUD_API_KEY_DOC_REVIEW }}
           YDBDOC_REPO_PATH: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.event.sender.login }}
+          YDBDOC_ALLOWED_ACTORS: ${{ vars.YDBDOC_ALLOWED_ACTORS }}
+          YDBDOC_DAILY_BUDGET_RUB: ${{ vars.YDBDOC_DAILY_BUDGET_RUB }}
+          YDBDOC_TRANSCRIPT_BACKEND: ydb
+          YDB_SA_KEY: ${{ secrets.YDB_SA_KEY }}
 
   trigger-verify-ci:
     needs: ydbdoc-verify


### PR DESCRIPTION
## Summary
- Pass `GITHUB_ACTOR`, `YDBDOC_ALLOWED_ACTORS`, daily budget, and YDB ledger env into `ydbdoc-verify.yml`, matching `doc_translate`.
- Without these, anyone who can add `doc_verify` could burn LLM budget while translate stayed allowlisted.

## Test plan
- [ ] After merge: non-allowlisted user adds `doc_verify` → deny comment, no LLM work
- [ ] Allowlisted actor (`sintjuri`) adds `doc_verify` → job proceeds as before


Made with [Cursor](https://cursor.com)