### PR TITLE
Improve PQ read-proxy diagnostics for invariant violations

### DIFF
--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -18,6 +18,9 @@
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::PQ_READ_PROXY
 
+#define PARTITION_ENSURE(condition) \
+    AFL_ENSURE(condition)("session", Session)("partition", Partition)("tablet_id", TabletID)
+
 namespace NKikimr::NGRpcProxy::V1 {
 
 using namespace PersQueue::V1;
@@ -149,13 +152,16 @@ void TPartitionActor::MakeCommit(const TActorContext& ctx) {
 
     auto jt = Offsets.begin();
     while(jt != Offsets.end() && jt->ReadId != readId) ++jt;
-    AFL_ENSURE(jt != Offsets.end());
+    PARTITION_ENSURE(jt != Offsets.end())
+        ("read_id", readId);
 
     offset = Max(offset, jt->Offset);
 
     Offsets.erase(Offsets.begin(), ++jt);
 
-    AFL_ENSURE(offset > ClientCommitOffset);
+    PARTITION_ENSURE(offset > ClientCommitOffset)
+        ("offset", offset)
+        ("client_commit_offset", ClientCommitOffset);
 
     ClientCommitOffset = offset;
     CommitsInfly.emplace_back(readId, TCommitInfo{startReadId, offset, ctx.Now()});
@@ -206,13 +212,16 @@ void TPartitionActor::SendCommit(const ui64 readId, const ui64 offset, const TAc
         request.MutablePartitionRequest()->SetPartition(Partition.Partition);
         request.MutablePartitionRequest()->SetCookie(readId);
 
-        AFL_ENSURE(PipeClient);
+        PARTITION_ENSURE(PipeClient)
+            ("read_id", readId)
+            ("offset", offset);
 
         ActorIdToProto(PipeClient, request.MutablePartitionRequest()->MutablePipeClient());
         auto commit = request.MutablePartitionRequest()->MutableCmdSetClientOffset();
         commit->SetClientId(ClientId);
         commit->SetOffset(offset);
-        AFL_ENSURE(!Session.empty());
+        PARTITION_ENSURE(!Session.empty())
+            ("read_id", readId);
         commit->SetSessionId(Session);
 
         YDB_LOG_DEBUG_CTX(ctx, "Committing to position prev end by cookie",
@@ -275,12 +284,14 @@ void TPartitionActor::SendPublishDirectRead(const ui64 directReadId, const TActo
     request.MutablePartitionRequest()->SetPartition(Partition.Partition);
     request.MutablePartitionRequest()->SetCookie(ReadOffset);
 
-    AFL_ENSURE(PipeClient);
+    PARTITION_ENSURE(PipeClient)
+        ("direct_read_id", directReadId);
 
     ActorIdToProto(PipeClient, request.MutablePartitionRequest()->MutablePipeClient());
     auto publish = request.MutablePartitionRequest()->MutableCmdPublishRead();
     publish->SetDirectReadId(directReadId);
-    AFL_ENSURE(!Session.empty());
+    PARTITION_ENSURE(!Session.empty())
+        ("direct_read_id", directReadId);
 
     publish->MutableSessionKey()->SetSessionId(Session);
     publish->MutableSessionKey()->SetPartitionSessionId(Partition.AssignId);
@@ -302,12 +313,14 @@ void TPartitionActor::SendForgetDirectRead(const ui64 directReadId, const TActor
     request.MutablePartitionRequest()->SetPartition(Partition.Partition);
     request.MutablePartitionRequest()->SetCookie(ReadOffset);
 
-    AFL_ENSURE(PipeClient);
+    PARTITION_ENSURE(PipeClient)
+        ("direct_read_id", directReadId);
 
     ActorIdToProto(PipeClient, request.MutablePartitionRequest()->MutablePipeClient());
     auto publish = request.MutablePartitionRequest()->MutableCmdForgetRead();
     publish->SetDirectReadId(directReadId);
-    AFL_ENSURE(!Session.empty());
+    PARTITION_ENSURE(!Session.empty())
+        ("direct_read_id", directReadId);
 
     publish->MutableSessionKey()->SetSessionId(Session);
     publish->MutableSessionKey()->SetPartitionSessionId(Partition.AssignId);
@@ -392,7 +405,7 @@ void TPartitionActor::Handle(TEvPQProxy::TEvDirectReadAck::TPtr& ev, const TActo
 
 void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TActorContext& ctx) {
 
-    AFL_ENSURE(!PipeClient);
+    PARTITION_ENSURE(!PipeClient);
 
     NTabletPipe::TClientConfig clientConfig;
     clientConfig.RetryPolicy = {
@@ -403,7 +416,7 @@ void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TAct
         .DoFirstRetryInstantly = true
     };
     PipeClient = ctx.RegisterWithSameMailbox(NTabletPipe::CreateClient(ctx.SelfID, TabletID, clientConfig));
-    AFL_ENSURE(TabletID);
+    PARTITION_ENSURE(TabletID);
 
     YDB_LOG_INFO_CTX(ctx, "Pipe restart attempt RequestInfly ReadOffset EndOffset InitDone WaitForData",
         {"PQLOGPREFIX", PQ_LOG_PREFIX},
@@ -419,7 +432,8 @@ void TPartitionActor::Handle(const TEvPQProxy::TEvRestartPipe::TPtr&, const TAct
     if (InitDone && DirectRead) {
         DirectReadsToRestore = DirectReadResults;
         DirectReadsToPublish = PublishedDirectReads;
-        AFL_ENSURE(!DirectReadsToPublish.contains(DirectReadId));
+        PARTITION_ENSURE(!DirectReadsToPublish.contains(DirectReadId))
+            ("direct_read_id", DirectReadId);
         RestoredDirectReadId = 0;
         RestartDirectReadSession();
         return;
@@ -432,9 +446,9 @@ void TPartitionActor::ResendRecentRequests() {
         return;
     }
 
-    AFL_ENSURE(!DirectRead || DirectReadRestoreStage == EDirectReadRestoreStage::None)
-        ("DirectRead", DirectRead)
-        ("DirectReadRestoreStage", static_cast<int>(DirectReadRestoreStage));
+    PARTITION_ENSURE(!DirectRead || DirectReadRestoreStage == EDirectReadRestoreStage::None)
+        ("direct_read", DirectRead)
+        ("direct_read_restore_stage", static_cast<int>(DirectReadRestoreStage));
 
     const auto& ctx = ActorContext();
     if (RequestInfly) { //got read infly
@@ -485,24 +499,24 @@ void SetBatchWriteTimestampMS(Topic::StreamReadMessage::ReadResponse::Batch* bat
 }
 
 TString GetBatchSourceId(PersQueue::V1::MigrationStreamingReadServerMessage::DataBatch::Batch* batch) {
-    AFL_ENSURE(batch);
+    AFL_ENSURE(batch)("reason", "batch is null");
     return batch->source_id();
 }
 
 TString GetBatchSourceId(Topic::StreamReadMessage::ReadResponse::Batch* batch) {
-    AFL_ENSURE(batch);
+    AFL_ENSURE(batch)("reason", "batch is null");
     return batch->producer_id();
 }
 
 void SetBatchExtraField(PersQueue::V1::MigrationStreamingReadServerMessage::DataBatch::Batch* batch, TString key, TString value) {
-    AFL_ENSURE(batch);
+    AFL_ENSURE(batch)("reason", "batch is null")("key", key);
     auto* item = batch->add_extra_fields();
     item->set_key(std::move(key));
     item->set_value(std::move(value));
 }
 
 void SetBatchExtraField(Topic::StreamReadMessage::ReadResponse::Batch* batch, TString key, TString value) {
-    AFL_ENSURE(batch);
+    AFL_ENSURE(batch)("reason", "batch is null")("key", key);
     (*batch->mutable_write_session_meta())[key] = std::move(value);
 }
 
@@ -545,7 +559,15 @@ bool FillBatchedData(
         const ui64 messageCount = Max<ui64>(1, r.GetLogicalMessageCount());
         // When reading from the middle of a batch, tablet returns the whole blob
         // with base offset below ReadOffset; SDK skips already-committed records.
-        AFL_ENSURE(r.GetOffset() + static_cast<i64>(messageCount) > ReadOffset);
+        AFL_ENSURE(r.GetOffset() + static_cast<i64>(messageCount) > ReadOffset)
+            ("partition", Partition)
+            ("topic", topic->GetPrimaryPath())
+            ("offset", r.GetOffset())
+            ("message_count", messageCount)
+            ("logical_message_count", r.GetLogicalMessageCount())
+            ("read_offset", ReadOffset)
+            ("result_index", i)
+            ("end_offset", EndOffset);
         ReadOffset = r.GetOffset() + messageCount;
         hasOffset = true;
 
@@ -577,7 +599,10 @@ bool FillBatchedData(
             // If write time and source id are the same, the rest fields will be the same too.
             currentBatch = partitionData->add_batches();
             i64 write_ts = static_cast<i64>(r.GetWriteTimestampMS());
-            AFL_ENSURE(write_ts >= 0);
+            AFL_ENSURE(write_ts >= 0)
+                ("partition", Partition)
+                ("write_ts", write_ts)
+                ("offset", r.GetOffset());
             SetBatchWriteTimestampMS(currentBatch, write_ts);
             SetBatchSourceId(currentBatch, std::move(sourceId));
             batchCodec = GetDataChunkCodec(proto);
@@ -656,7 +681,8 @@ void TPartitionActor::Handle(TEvPQProxy::TEvParentCommitedToFinish::TPtr& ev, co
 }
 
 void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionResponse& result, const TActorContext& ctx) {
-    AFL_ENSURE(DirectReadRestoreStage == EDirectReadRestoreStage::None);
+    PARTITION_ENSURE(DirectReadRestoreStage == EDirectReadRestoreStage::None)
+        ("direct_read_restore_stage", static_cast<int>(DirectReadRestoreStage));
     if (result.GetCookie() != InitCookie) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited response in init with cookie",
             {"PQLOGPREFIX", PQ_LOG_PREFIX},
@@ -664,13 +690,15 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
             {"cookie", result.GetCookie()});
         return;
     }
-    AFL_ENSURE(RequestInfly);
+    PARTITION_ENSURE(RequestInfly);
     CurrentRequest.Clear();
     RequestInfly = false;
 
-    AFL_ENSURE(result.HasCmdGetClientOffsetResult());
+    PARTITION_ENSURE(result.HasCmdGetClientOffsetResult())
+        ("result", result.ShortDebugString());
     const auto& resp = result.GetCmdGetClientOffsetResult();
-    AFL_ENSURE(resp.HasEndOffset());
+    PARTITION_ENSURE(resp.HasEndOffset())
+        ("resp", resp.ShortDebugString());
     EndOffset = resp.GetEndOffset();
     SizeLag = resp.GetSizeLag();
     WriteTimestampEstimateMs = resp.GetWriteTimestampEstimateMS();
@@ -678,7 +706,9 @@ void TPartitionActor::HandleInit(const NKikimrClient::TPersQueuePartitionRespons
 
     ClientCommitOffset = ReadOffset = CommittedOffset = resp.HasOffset() ? resp.GetOffset() : 0;
     ClientMaxOffset.Clear();
-    AFL_ENSURE(EndOffset >= CommittedOffset);
+    PARTITION_ENSURE(EndOffset >= CommittedOffset)
+        ("end_offset", EndOffset)
+        ("committed_offset", CommittedOffset);
 
     if (resp.HasWriteTimestampMS())
         WTime = resp.GetWriteTimestampMS();
@@ -723,7 +753,8 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             }
             return;
         case EDirectReadRestoreStage::Prepare:
-            AFL_ENSURE(RestoredDirectReadId != 0);
+            PARTITION_ENSURE(RestoredDirectReadId != 0)
+                ("restored_direct_read_id", RestoredDirectReadId);
             if (!result.HasCmdPrepareReadResult() || DirectReadsToRestore.empty() || DirectReadsToRestore.begin()->first != result.GetCmdPrepareReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
@@ -745,19 +776,27 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             }
             return;
         case EDirectReadRestoreStage::Publish:
-            AFL_ENSURE(RestoredDirectReadId != 0);
+            PARTITION_ENSURE(RestoredDirectReadId != 0)
+                ("restored_direct_read_id", RestoredDirectReadId);
 
-            AFL_ENSURE(result.HasCmdPublishReadResult());
-            AFL_ENSURE(*DirectReadsToPublish.begin() == result.GetCmdPublishReadResult().GetDirectReadId());
+            PARTITION_ENSURE(result.HasCmdPublishReadResult())
+                ("result", result.ShortDebugString());
+            PARTITION_ENSURE(*DirectReadsToPublish.begin() == result.GetCmdPublishReadResult().GetDirectReadId())
+                ("expected_direct_read_id", *DirectReadsToPublish.begin())
+                ("got_direct_read_id", result.GetCmdPublishReadResult().GetDirectReadId());
             DirectReadsToPublish.erase(DirectReadsToPublish.begin());
             if (!SendNextRestorePrepareOrForget()) {
                 OnDirectReadsRestored();
             }
             return;
         case EDirectReadRestoreStage::Forget:
-            AFL_ENSURE(RestoredDirectReadId != 0);
-            AFL_ENSURE(result.HasCmdForgetReadResult());
-            AFL_ENSURE(*DirectReadsToForget.begin() == result.GetCmdForgetReadResult().GetDirectReadId());
+            PARTITION_ENSURE(RestoredDirectReadId != 0)
+                ("restored_direct_read_id", RestoredDirectReadId);
+            PARTITION_ENSURE(result.HasCmdForgetReadResult())
+                ("result", result.ShortDebugString());
+            PARTITION_ENSURE(*DirectReadsToForget.begin() == result.GetCmdForgetReadResult().GetDirectReadId())
+                ("expected_direct_read_id", *DirectReadsToForget.begin())
+                ("got_direct_read_id", result.GetCmdForgetReadResult().GetDirectReadId());
             DirectReadsToForget.erase(DirectReadsToForget.begin());
             if (!SendNextRestorePrepareOrForget()) {
                 OnDirectReadsRestored();
@@ -767,10 +806,13 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
 }
 
 void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::TCmdPrepareDirectReadResult& res, const TActorContext& ctx) {
-    AFL_ENSURE(DirectReadRestoreStage == EDirectReadRestoreStage::None);
+    PARTITION_ENSURE(DirectReadRestoreStage == EDirectReadRestoreStage::None)
+        ("direct_read_restore_stage", static_cast<int>(DirectReadRestoreStage));
 
-    AFL_ENSURE(DirectRead);
-    AFL_ENSURE(res.GetDirectReadId() == DirectReadId);
+    PARTITION_ENSURE(DirectRead);
+    PARTITION_ENSURE(res.GetDirectReadId() == DirectReadId)
+        ("got_direct_read_id", res.GetDirectReadId())
+        ("direct_read_id", DirectReadId);
     if (!PipeClient)
         return; // Pipe was already destroyed, direct read session is being restored. Will resend this request afterwards;
 
@@ -793,7 +835,7 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
 
     SendPublishDirectRead(DirectReadId, ctx);
 
-    AFL_ENSURE(RequestInfly);
+    PARTITION_ENSURE(RequestInfly);
 
     CurrentRequest.Clear();
     RequestInfly = false;
@@ -803,11 +845,14 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     ++ReadIdToResponse;
 
     ReadGuid = TString();
-    AFL_ENSURE(DirectReadResults.find(DirectReadId) != DirectReadResults.end());
-    AFL_ENSURE(res.GetDirectReadId() == DirectReadId);
+    PARTITION_ENSURE(DirectReadResults.find(DirectReadId) != DirectReadResults.end())
+        ("direct_read_id", DirectReadId);
+    PARTITION_ENSURE(res.GetDirectReadId() == DirectReadId)
+        ("got_direct_read_id", res.GetDirectReadId())
+        ("direct_read_id", DirectReadId);
     PublishedDirectReads.insert(DirectReadId);
 
-    AFL_ENSURE(!RequestInfly);
+    PARTITION_ENSURE(!RequestInfly);
 
     const auto& dr = DirectReadResults[DirectReadId];
 
@@ -823,7 +868,8 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
 
     ctx.Send(ParentId, readResponse.Release());
 
-    AFL_ENSURE(!WaitForData);
+    PARTITION_ENSURE(!WaitForData)
+        ("direct_read_id", DirectReadId);
 
     bool isInFlightMemoryOk = PartitionInFlightMemoryController.Add(dr.GetReadOffset(), dr.GetBytesSizeEstimate());
     ReadOffset = dr.GetLastOffset() + 1;
@@ -837,7 +883,8 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
         {"directReadId", DirectReadId},
         {"isInFlightMemoryOk", isInFlightMemoryOk});
 
-    AFL_ENSURE(!RequestInfly);
+    PARTITION_ENSURE(!RequestInfly)
+        ("direct_read_id", DirectReadId);
 
     if (isInFlightMemoryOk && IsPartitionDataReady()) {
         SendPartitionReady(ctx);
@@ -849,7 +896,8 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
 }
 
 void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TActorContext& ctx) {
-    AFL_ENSURE(res.HasMaxOffset());
+    PARTITION_ENSURE(res.HasMaxOffset())
+        ("res", res.ShortDebugString());
     EndOffset = res.GetMaxOffset();
     SizeLag = res.GetSizeLag();
 
@@ -883,7 +931,7 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
     CurrentRequest.Clear();
     RequestInfly = false;
 
-    AFL_ENSURE(!WaitForData);
+    PARTITION_ENSURE(!WaitForData);
 
     for (ui32 i = 0; i < res.ResultSize(); ++i) {
         const auto& resultItem = res.GetResult(i);
@@ -930,7 +978,7 @@ void TPartitionActor::Handle(const NKikimrClient::TCmdReadResult& res, const TAc
         );
         ctx.Send(ParentId, readResponse.Release());
     } else {
-        AFL_ENSURE(!DirectRead);
+        PARTITION_ENSURE(!DirectRead);
         auto readResponse = MakeHolder<TEvPQProxy::TEvReadResponse>(
             std::move(response),
             ReadOffset,
@@ -959,7 +1007,10 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
     }
 
     if (ev->Get()->Record.GetStatus() != NKikimr::NMsgBusProxy::MSTATUS_OK) { //this is incorrect answer, die
-        AFL_ENSURE(!ev->Get()->Record.HasErrorCode());
+        PARTITION_ENSURE(!ev->Get()->Record.HasErrorCode())
+            ("error_code", static_cast<int>(ev->Get()->Record.GetErrorCode()))
+            ("status", static_cast<int>(ev->Get()->Record.GetStatus()))
+            ("error_reason", ev->Get()->Record.GetErrorReason());
         Counters.Errors.Inc();
         // map NMsgBusProxy::EResponseStatus to PersQueue::ErrorCode???
 
@@ -1049,7 +1100,8 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
         return;
     }
 
-    AFL_ENSURE(false)("unexpected response", result.ShortDebugString());
+    PARTITION_ENSURE(false)
+        ("unexpected_response", result.ShortDebugString());
 }
 
 void TPartitionActor::CommitDone(ui64 cookie, const TActorContext& ctx) {
@@ -1183,7 +1235,8 @@ void TPartitionActor::Handle(TEvPQProxy::TEvLockPartition::TPtr& ev, const TActo
     ClientMaxOffset = ev->Get()->MaxOffset;
 
     if (StartReading) {
-        AFL_ENSURE(ev->Get()->StartReading); //otherwise it is signal from actor, this could not be done
+        PARTITION_ENSURE(ev->Get()->StartReading) //otherwise it is signal from actor, this could not be done
+            ("start_reading", StartReading);
         ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession("double partition locking", PersQueue::ErrorCode::BAD_REQUEST));
         return;
     }
@@ -1194,8 +1247,9 @@ void TPartitionActor::Handle(TEvPQProxy::TEvLockPartition::TPtr& ev, const TActo
 
 void TPartitionActor::InitStartReading(const TActorContext& ctx) {
 
-    AFL_ENSURE(AllPrepareInited);
-    AFL_ENSURE(!WaitForData);
+    PARTITION_ENSURE(AllPrepareInited)
+        ("start_reading", StartReading);
+    PARTITION_ENSURE(!WaitForData);
     YDB_LOG_INFO_CTX(ctx, "Start reading EndOffset readOffset committedOffset clientCommitOffset clientReadOffset clientMaxOffset",
         {"PQLOGPREFIX", PQ_LOG_PREFIX},
         {"partition", Partition},
@@ -1275,7 +1329,8 @@ void TPartitionActor::InitStartReading(const TActorContext& ctx) {
                         PersQueue::ErrorCode::BAD_REQUEST));
             return;
         }
-        AFL_ENSURE(CommitsInfly.empty());
+        PARTITION_ENSURE(CommitsInfly.empty())
+            ("commits_infly", CommitsInfly.size());
         CommitsInfly.emplace_back(Max<ui64>(), TCommitInfo{Max<ui64>(), ClientCommitOffset.GetOrElse(0), ctx.Now()});
         if (Counters.SLITotal)
             Counters.SLITotal.Inc();
@@ -1331,7 +1386,7 @@ void TPartitionActor::InitLockPartition(const TActorContext& ctx) {
 
 
     if (FirstInit) {
-        AFL_ENSURE(!PipeClient);
+        PARTITION_ENSURE(!PipeClient);
         FirstInit = false;
         NTabletPipe::TClientConfig clientConfig;
         clientConfig.RetryPolicy = {
@@ -1349,15 +1404,17 @@ void TPartitionActor::InitLockPartition(const TActorContext& ctx) {
             {"partition", Partition});
 
         TAutoPtr<TEvPersQueue::TEvRequest> req(new TEvPersQueue::TEvRequest);
-        AFL_ENSURE(!RequestInfly);
+        PARTITION_ENSURE(!RequestInfly);
         CurrentRequest = request;
         RequestInfly = true;
         req->Record.Swap(&request);
 
         NTabletPipe::SendData(ctx, PipeClient, req.Release());
     } else {
-        AFL_ENSURE(StartReading); //otherwise it is double locking from actor, not client - client makes lock always with StartReading == true
-        AFL_ENSURE(InitDone);
+        PARTITION_ENSURE(StartReading) //otherwise it is double locking from actor, not client - client makes lock always with StartReading == true
+            ("init_done", InitDone);
+        PARTITION_ENSURE(InitDone)
+            ("start_reading", StartReading);
         InitStartReading(ctx);
     }
 }
@@ -1398,15 +1455,24 @@ bool TPartitionActor::SendNextRestorePrepareOrForget() {
             {"prepareId", prepareId},
             {"id", dr.GetDirectReadId()},
             {"partition", Partition});
-        AFL_ENSURE(prepareId != 0);
+        PARTITION_ENSURE(prepareId != 0)
+            ("prepare_id", prepareId)
+            ("forget_id", forgetId);
 
         //Restore;
-        AFL_ENSURE(prepareId == dr.GetDirectReadId());
+        PARTITION_ENSURE(prepareId == dr.GetDirectReadId())
+            ("prepare_id", prepareId)
+            ("direct_read_id", dr.GetDirectReadId());
 
-        AFL_ENSURE(RestoredDirectReadId < dr.GetDirectReadId());
+        PARTITION_ENSURE(RestoredDirectReadId < dr.GetDirectReadId())
+            ("restored_direct_read_id", RestoredDirectReadId)
+            ("direct_read_id", dr.GetDirectReadId());
         RestoredDirectReadId = dr.GetDirectReadId();
         DirectReadRestoreStage = EDirectReadRestoreStage::Prepare;
-        AFL_ENSURE(dr.GetReadOffset() <= dr.GetLastOffset());
+        PARTITION_ENSURE(dr.GetReadOffset() <= dr.GetLastOffset())
+            ("read_offset", dr.GetReadOffset())
+            ("last_offset", dr.GetLastOffset())
+            ("direct_read_id", dr.GetDirectReadId());
 
         auto request = MakeReadRequest(dr.GetReadOffset(), dr.GetLastOffset() + 1, std::numeric_limits<i32>::max(),
                                     std::numeric_limits<i32>::max(), 0, 0, dr.GetDirectReadId(), dr.GetBytesSizeEstimate());
@@ -1424,7 +1490,8 @@ bool TPartitionActor::SendNextRestorePrepareOrForget() {
 bool TPartitionActor::SendNextRestorePublishRequest() {
     const auto& ctx = ActorContext();
     if (DirectReadsToPublish.empty()) {
-        AFL_ENSURE(DirectReadsToRestore.empty());
+        PARTITION_ENSURE(DirectReadsToRestore.empty())
+            ("direct_reads_to_restore", DirectReadsToRestore.size());
         return false;
     }
     auto id = *DirectReadsToPublish.begin();
@@ -1433,7 +1500,9 @@ bool TPartitionActor::SendNextRestorePublishRequest() {
         {"id", id},
         {"partition", Partition});
 
-    AFL_ENSURE(RestoredDirectReadId == id);
+    PARTITION_ENSURE(RestoredDirectReadId == id)
+        ("restored_direct_read_id", RestoredDirectReadId)
+        ("direct_read_id", id);
     DirectReadRestoreStage = EDirectReadRestoreStage::Publish;
 
     if (!PipeClient) //Pipe will be recreated soon
@@ -1444,7 +1513,10 @@ bool TPartitionActor::SendNextRestorePublishRequest() {
 }
 
 void TPartitionActor::OnDirectReadsRestored() {
-    AFL_ENSURE(DirectReadsToRestore.empty() && DirectReadsToPublish.empty() && DirectReadsToForget.empty());
+    PARTITION_ENSURE(DirectReadsToRestore.empty() && DirectReadsToPublish.empty() && DirectReadsToForget.empty())
+        ("direct_reads_to_restore", DirectReadsToRestore.size())
+        ("direct_reads_to_publish", DirectReadsToPublish.size())
+        ("direct_reads_to_forget", DirectReadsToForget.size());
     DirectReadRestoreStage = EDirectReadRestoreStage::None;
 
     const auto& ctx = ActorContext();
@@ -1471,9 +1543,14 @@ void TPartitionActor::WaitDataInPartition(const TActorContext& ctx) {
         return;
     }
 
-    AFL_ENSURE(InitDone);
-    AFL_ENSURE(PipeClient);
-    AFL_ENSURE(MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData());
+    PARTITION_ENSURE(InitDone);
+    PARTITION_ENSURE(PipeClient);
+    PARTITION_ENSURE(MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData())
+        ("max_time_lag_ms", MaxTimeLagMs)
+        ("read_timestamp_ms", ReadTimestampMs)
+        ("wait_for_data", WaitForData)
+        ("read_offset", ReadOffset)
+        ("end_offset", EndOffset);
 
     TAutoPtr<TEvPersQueue::TEvHasDataInfo> event(new TEvPersQueue::TEvHasDataInfo());
     event->Record.SetPartition(Partition.Partition);
@@ -1539,9 +1616,17 @@ void TPartitionActor::Handle(TEvPersQueue::TEvHasDataInfoResponse::TPtr& ev, con
         Counters.WaitsForData.Inc();
     }
 
-    AFL_ENSURE(record.HasEndOffset());
-    AFL_ENSURE(EndOffset <= record.GetEndOffset()); //end offset could not be changed if no data arrived, but signal will be sended anyway after timeout
-    AFL_ENSURE(MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData()); //otherwise no WaitData were needed
+    PARTITION_ENSURE(record.HasEndOffset())
+        ("record", record.ShortDebugString());
+    PARTITION_ENSURE(EndOffset <= record.GetEndOffset()) //end offset could not be changed if no data arrived, but signal will be sended anyway after timeout
+        ("end_offset", EndOffset)
+        ("record_end_offset", record.GetEndOffset());
+    PARTITION_ENSURE(MaxTimeLagMs || ReadTimestampMs || IsNeedMorePartitionData()) //otherwise no WaitData were needed
+        ("max_time_lag_ms", MaxTimeLagMs)
+        ("read_timestamp_ms", ReadTimestampMs)
+        ("wait_for_data", WaitForData)
+        ("read_offset", ReadOffset)
+        ("end_offset", EndOffset);
 
     YDB_LOG_DEBUG_CTX(ctx, "Wait for data done: readOffset EndOffset newEndOffset commitOffset clientCommitOffset clientMaxOffset cookie readingFinished firstRead",
         {"PQLOGPREFIX", PQ_LOG_PREFIX},
@@ -1651,8 +1736,10 @@ void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext&
         {"clientMaxOffset", ClientMaxOffset},
         {"guid", ev->Get()->Guid});
 
-    AFL_ENSURE(ReadGuid.empty());
-    AFL_ENSURE(!RequestInfly);
+    PARTITION_ENSURE(ReadGuid.empty())
+        ("read_guid", ReadGuid);
+    PARTITION_ENSURE(!RequestInfly)
+        ("read_guid", ReadGuid);
 
     ReadGuid = ev->Get()->Guid;
 
@@ -1681,7 +1768,9 @@ void TPartitionActor::Handle(TEvPQProxy::TEvRead::TPtr& ev, const TActorContext&
 
 void TPartitionActor::Handle(TEvPQProxy::TEvCommitCookie::TPtr& ev, const TActorContext& ctx) {
     //TODO: add here processing of cookie == 0 if ReadOffset > ClientCommittedOffset if any
-    AFL_ENSURE(ev->Get()->AssignId == Partition.AssignId);
+    PARTITION_ENSURE(ev->Get()->AssignId == Partition.AssignId)
+        ("assign_id", ev->Get()->AssignId)
+        ("partition_assign_id", Partition.AssignId);
     for (auto& readId : ev->Get()->CommitInfo.Cookies) {
         if (readId == 0) {
             if (ReadIdCommitted > 0) {
@@ -1721,7 +1810,9 @@ void TPartitionActor::Handle(TEvPQProxy::TEvCommitCookie::TPtr& ev, const TActor
 }
 
 void TPartitionActor::Handle(TEvPQProxy::TEvCommitRange::TPtr& ev, const TActorContext& ctx) {
-    AFL_ENSURE(ev->Get()->AssignId == Partition.AssignId);
+    PARTITION_ENSURE(ev->Get()->AssignId == Partition.AssignId)
+        ("assign_id", ev->Get()->AssignId)
+        ("partition_assign_id", Partition.AssignId);
 
     for (auto& c : ev->Get()->CommitInfo.Ranges) {
         NextRanges.InsertInterval(c.first, c.second);
@@ -1790,3 +1881,5 @@ bool TPartitionActor::IsNeedMorePartitionData() const {
 }
 
 }
+
+#undef PARTITION_ENSURE

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -499,24 +499,24 @@ void SetBatchWriteTimestampMS(Topic::StreamReadMessage::ReadResponse::Batch* bat
 }
 
 TString GetBatchSourceId(PersQueue::V1::MigrationStreamingReadServerMessage::DataBatch::Batch* batch) {
-    AFL_ENSURE(batch)("reason", "batch is null");
+    AFL_ENSURE(batch);
     return batch->source_id();
 }
 
 TString GetBatchSourceId(Topic::StreamReadMessage::ReadResponse::Batch* batch) {
-    AFL_ENSURE(batch)("reason", "batch is null");
+    AFL_ENSURE(batch);
     return batch->producer_id();
 }
 
 void SetBatchExtraField(PersQueue::V1::MigrationStreamingReadServerMessage::DataBatch::Batch* batch, TString key, TString value) {
-    AFL_ENSURE(batch)("reason", "batch is null")("key", key);
+    AFL_ENSURE(batch)("key", key);
     auto* item = batch->add_extra_fields();
     item->set_key(std::move(key));
     item->set_value(std::move(value));
 }
 
 void SetBatchExtraField(Topic::StreamReadMessage::ReadResponse::Batch* batch, TString key, TString value) {
-    AFL_ENSURE(batch)("reason", "batch is null")("key", key);
+    AFL_ENSURE(batch)("key", key);
     (*batch->mutable_write_session_meta())[key] = std::move(value);
 }
 
@@ -1008,8 +1008,8 @@ void TPartitionActor::Handle(TEvPersQueue::TEvResponse::TPtr& ev, const TActorCo
 
     if (ev->Get()->Record.GetStatus() != NKikimr::NMsgBusProxy::MSTATUS_OK) { //this is incorrect answer, die
         PARTITION_ENSURE(!ev->Get()->Record.HasErrorCode())
-            ("error_code", static_cast<int>(ev->Get()->Record.GetErrorCode()))
-            ("status", static_cast<int>(ev->Get()->Record.GetStatus()))
+            ("error_code", NPersQueue::NErrorCode::EErrorCode_Name(ev->Get()->Record.GetErrorCode()))
+            ("status", NMsgBusProxy::ToCString(static_cast<NMsgBusProxy::EResponseStatus>(ev->Get()->Record.GetStatus())))
             ("error_reason", ev->Get()->Record.GetErrorReason());
         Counters.Errors.Inc();
         // map NMsgBusProxy::EResponseStatus to PersQueue::ErrorCode???


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Enrich AFL_ENSURE logs in partition_actor with session, partition, tablet_id
- Log concrete values for offset / direct-read / restore / wait-data checks
- Goal: faster incident triage when read-proxy invariants break

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
