### PR TITLE
Fix cleanup after oversized event serialization [NBYDB-2295]

### DIFF
--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -310,7 +310,14 @@ namespace NActors {
         bool complete = false;
         if (event.Event) {
             while (!complete) {
-                TMutableContiguousSpan out = task.AcquireSpanForWriting<External>().SubSpan(0, PartLenRemain);
+                Y_ABORT_UNLESS(event.EventActuallySerialized <= MaxSerializedEventSize);
+                const size_t limitRemain = MaxSerializedEventSize - event.EventActuallySerialized;
+                if (!limitRemain) {
+                    throw TExSerializedEventTooLarge(event.Descr.Type);
+                }
+
+                TMutableContiguousSpan out = task.AcquireSpanForWriting<External>()
+                    .SubSpan(0, Min(PartLenRemain, limitRemain));
                 if (!out.size()) {
                     break;
                 }
@@ -638,13 +645,12 @@ namespace NActors {
     void TEventOutputChannel::ProcessUndelivered(TEventHolderPool& pool, NInterconnect::IZcGuard* zg) {
         LOG_DEBUG_IC_SESSION("ICOCH89", "Notyfying about Undelivered messages! NotYetConfirmed size: %zu, Queue size: %zu", NotYetConfirmed.size(), Queue.size());
         if (State == EState::BODY && Queue.front().Event) {
-            if (!Chunker.IsComplete()) {
-                Y_ABORT_UNLESS(!Queue.empty()); // this event must be the first event in queue
-                TEventHolder& event = Queue.front();
-                Y_ABORT_UNLESS(Chunker.GetCurrentEvent() == event.Event.Get()); // ensure the event is valid
-                Chunker.Abort(); // stop serializing current event
-                Y_ABORT_UNLESS(Chunker.IsComplete());
-            }
+            Y_ABORT_UNLESS(!Chunker.IsComplete()); // chunk must have an event being serialized
+            Y_ABORT_UNLESS(!Queue.empty()); // this event must be the first event in queue
+            TEventHolder& event = Queue.front();
+            Y_ABORT_UNLESS(Chunker.GetCurrentEvent() == event.Event.Get()); // ensure the event is valid
+            Chunker.Abort(); // stop serializing current event
+            Y_ABORT_UNLESS(Chunker.IsComplete());
         }
         for (auto& item : NotYetConfirmed) {
             if (item.Descr.Flags & IEventHandle::FlagGenerateUnsureUndelivered) { // notify only when unsure flag is set

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -638,12 +638,13 @@ namespace NActors {
     void TEventOutputChannel::ProcessUndelivered(TEventHolderPool& pool, NInterconnect::IZcGuard* zg) {
         LOG_DEBUG_IC_SESSION("ICOCH89", "Notyfying about Undelivered messages! NotYetConfirmed size: %zu, Queue size: %zu", NotYetConfirmed.size(), Queue.size());
         if (State == EState::BODY && Queue.front().Event) {
-            Y_ABORT_UNLESS(!Chunker.IsComplete()); // chunk must have an event being serialized
-            Y_ABORT_UNLESS(!Queue.empty()); // this event must be the first event in queue
-            TEventHolder& event = Queue.front();
-            Y_ABORT_UNLESS(Chunker.GetCurrentEvent() == event.Event.Get()); // ensure the event is valid
-            Chunker.Abort(); // stop serializing current event
-            Y_ABORT_UNLESS(Chunker.IsComplete());
+            if (!Chunker.IsComplete()) {
+                Y_ABORT_UNLESS(!Queue.empty()); // this event must be the first event in queue
+                TEventHolder& event = Queue.front();
+                Y_ABORT_UNLESS(Chunker.GetCurrentEvent() == event.Event.Get()); // ensure the event is valid
+                Chunker.Abort(); // stop serializing current event
+                Y_ABORT_UNLESS(Chunker.IsComplete());
+            }
         }
         for (auto& item : NotYetConfirmed) {
             if (item.Descr.Flags & IEventHandle::FlagGenerateUnsureUndelivered) { // notify only when unsure flag is set

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -222,6 +222,68 @@ struct TEvXdcCatchReplay
     : TEventPB<TEvXdcCatchReplay, NInterconnectTest::TEvTestSerialization, EventSpaceBegin(TEvents::ES_PRIVATE) + 100>
 {};
 
+struct TEvOversizedTcpEvent
+    : TEventPB<TEvOversizedTcpEvent, NInterconnectTest::TEvTestSerialization, EventSpaceBegin(TEvents::ES_PRIVATE) + 101>
+{};
+
+struct TOversizedTcpEventContext {
+    std::atomic<bool> Undelivered = false;
+    std::atomic<bool> Received = false;
+};
+
+class TOversizedTcpEventSenderActor : public TActorBootstrapped<TOversizedTcpEventSenderActor> {
+public:
+    TOversizedTcpEventSenderActor(TActorId recipient, std::unique_ptr<IEventBase> event,
+            std::shared_ptr<TOversizedTcpEventContext> context)
+        : Recipient(recipient)
+        , Event(std::move(event))
+        , Context(std::move(context))
+    {}
+
+    void Bootstrap() {
+        Send(Recipient, std::move(Event), IEventHandle::FlagTrackDelivery);
+        Become(&TThis::StateFunc);
+    }
+
+private:
+    void Handle(TEvents::TEvUndelivered::TPtr&) {
+        Context->Undelivered.store(true, std::memory_order_release);
+        PassAway();
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvents::TEvUndelivered, Handle);
+    )
+
+private:
+    const TActorId Recipient;
+    std::unique_ptr<IEventBase> Event;
+    const std::shared_ptr<TOversizedTcpEventContext> Context;
+};
+
+class TOversizedTcpEventReceiverActor : public TActorBootstrapped<TOversizedTcpEventReceiverActor> {
+public:
+    explicit TOversizedTcpEventReceiverActor(std::shared_ptr<TOversizedTcpEventContext> context)
+        : Context(std::move(context))
+    {}
+
+    void Bootstrap() {
+        Become(&TThis::StateFunc);
+    }
+
+private:
+    void Handle(TEvOversizedTcpEvent::TPtr&) {
+        Context->Received.store(true, std::memory_order_release);
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvOversizedTcpEvent, Handle);
+    )
+
+private:
+    const std::shared_ptr<TOversizedTcpEventContext> Context;
+};
+
 class TXdcCatchReplaySenderActor : public TActorBootstrapped<TXdcCatchReplaySenderActor> {
 public:
     TXdcCatchReplaySenderActor(TActorId recipient, IEventBase* event)
@@ -1219,6 +1281,43 @@ void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
 } // namespace
 
 Y_UNIT_TEST_SUITE(Interconnect) {
+
+    Y_UNIT_TEST(ProcessUndeliveredAfterCompletedOversizedTcpEvent) {
+        TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, TTestICCluster::DISABLE_RDMA);
+
+        auto context = std::make_shared<TOversizedTcpEventContext>();
+        const TActorId recipient = cluster.RegisterActor(new TOversizedTcpEventReceiverActor(context), 1);
+
+        auto event = std::make_unique<TEvOversizedTcpEvent>();
+        // TEvTestSerialization.Buffer is encoded as a one-byte field tag, a four-byte varint length at
+        // this payload size, and the payload itself. Therefore its serialized size is:
+        //
+        //   1 + 4 + (EventMaxByteSize - 4) = EventMaxByteSize + 1.
+        //
+        // Exceeding the limit by exactly one byte guarantees that no FeedBuf boundary can occur between
+        // crossing the limit and completing serialization. The size check thus throws after the coroutine
+        // serializer has completed, reproducing the ProcessUndelivered failure independently of packet layout.
+        event->Record.SetBuffer(TString(EventMaxByteSize - 4, 'x'));
+        UNIT_ASSERT_VALUES_EQUAL(event->CalculateSerializedSize(), EventMaxByteSize + 1);
+
+        cluster.RegisterActor(new TOversizedTcpEventSenderActor(recipient, std::move(event), context), 2);
+
+        WaitForCondition(TDuration::Seconds(60), [&] {
+            return context->Undelivered.load(std::memory_order_acquire)
+                || context->Received.load(std::memory_order_acquire);
+        }, "oversized TCP event result");
+
+        UNIT_ASSERT(context->Undelivered.load(std::memory_order_acquire));
+        UNIT_ASSERT(!context->Received.load(std::memory_order_acquire));
+
+        auto regular = std::make_unique<TEvOversizedTcpEvent>();
+        regular->Record.SetBuffer("after oversized event");
+        cluster.RegisterActor(new TSingleEventSenderActor(recipient, regular.release()), 2);
+
+        WaitForCondition(TDuration::Seconds(60), [&] {
+            return context->Received.load(std::memory_order_acquire);
+        }, "regular TCP event delivery after oversized event");
+    }
 
     Y_UNIT_TEST(ScopeClassCountersRebindPeerLabel) {
         RunScopeClassCounterRebindTest(TScopeId(0, 1), "system");

--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -1282,7 +1282,7 @@ void RunSubscriberLivenessCheck(bool useSessionV2, TDuration checkInterval) {
 
 Y_UNIT_TEST_SUITE(Interconnect) {
 
-    Y_UNIT_TEST(ProcessUndeliveredAfterCompletedOversizedTcpEvent) {
+    Y_UNIT_TEST(ProcessUndeliveredAfterOversizedTcpEvent) {
         TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr, TTestICCluster::DISABLE_RDMA);
 
         auto context = std::make_shared<TOversizedTcpEventContext>();
@@ -1294,9 +1294,9 @@ Y_UNIT_TEST_SUITE(Interconnect) {
         //
         //   1 + 4 + (EventMaxByteSize - 4) = EventMaxByteSize + 1.
         //
-        // Exceeding the limit by exactly one byte guarantees that no FeedBuf boundary can occur between
-        // crossing the limit and completing serialization. The size check thus throws after the coroutine
-        // serializer has completed, reproducing the ProcessUndelivered failure independently of packet layout.
+        // Exceeding the limit by exactly one byte makes the coroutine request more output after consuming
+        // the complete serialization budget. The size check must terminate the session while the coroutine
+        // is suspended and ProcessUndelivered must abort the pending serialization.
         event->Record.SetBuffer(TString(EventMaxByteSize - 4, 'x'));
         UNIT_ASSERT_VALUES_EQUAL(event->CalculateSerializedSize(), EventMaxByteSize + 1);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->


Limit each coroutine serializer FeedBuf() call to the remaining MaxSerializedEventSize budget.
Keep the serializer suspended when an event exceeds the limit, preserving the BODY state invariant required by ProcessUndelivered().
Terminate the session with EventTooLarge while allowing ProcessUndelivered() to abort the active serialization safely.
Add a full TCP interconnect regression test using the default size limit.
Verify that the oversized event is reported as undelivered and that a subsequent normal event is delivered after session reestablishment.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
