### PR TITLE
Use pathid+topicname for uniqueness / dual write/read during migration

### DIFF
--- a/ydb/core/persqueue/writer/partition_chooser_impl.cpp
+++ b/ydb/core/persqueue/writer/partition_chooser_impl.cpp
@@ -51,7 +51,7 @@ IActor* CreatePartitionChooserActor(TActorId parentId,
                                     std::optional<ui32> preferedPartition,
                                     NWilson::TTraceId traceId) {
     if (SplitMergeEnabled(config.GetPQTabletConfig())) {
-        return new NPartitionChooser::TSMPartitionChooserActor<TPipeHelper>(parentId, chooser, graph, fullConverter, sourceId, preferedPartition, std::move(traceId));
+        return new NPartitionChooser::TSMPartitionChooserActor<TPipeHelper>(parentId, chooser, graph, fullConverter, sourceId, preferedPartition, std::move(traceId), config.GetPathId());
     } else {
         return new NPartitionChooser::TPartitionChooserActor<TPipeHelper>(parentId, config, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId));
     }

--- a/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
@@ -39,13 +39,14 @@ public:
                                    NPersQueue::TTopicConverterPtr& fullConverter,
                                    const TString& sourceId,
                                    std::optional<ui32> preferedPartition,
-                                   NWilson::TTraceId traceId)
+                                   NWilson::TTraceId traceId,
+                                   ui64 pathId = 0)
         : Parent(parentId)
         , SourceId(sourceId)
         , PreferedPartition(preferedPartition)
         , Chooser(chooser)
         , Span(TWilsonTopic::TopicDetailed, std::move(traceId), "Topic.ChoosePartition")
-        , TableHelper(fullConverter->GetClientsideName(), fullConverter->GetTopicForSrcIdHash())
+        , TableHelper(fullConverter->GetClientsideName(), fullConverter->GetTopicForSrcIdHash(), pathId)
         , PartitionHelper(Span.GetTraceId())
     {
     }

--- a/ydb/core/persqueue/writer/partition_chooser_impl__old_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__old_chooser_actor.h
@@ -29,7 +29,7 @@ public:
                            const TString& sourceId,
                            std::optional<ui32> preferedPartition,
                            NWilson::TTraceId traceId)
-        : TAbstractPartitionChooserActor<TPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId))
+        : TAbstractPartitionChooserActor<TPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId), config.GetPathId())
         , PQRBHelper(config.GetBalancerTabletID()) {
     }
 

--- a/ydb/core/persqueue/writer/partition_chooser_impl__sm_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__sm_chooser_actor.h
@@ -29,8 +29,9 @@ public:
                            NPersQueue::TTopicConverterPtr& fullConverter,
                            const TString& sourceId,
                            std::optional<ui32> preferedPartition,
-                           NWilson::TTraceId traceId)
-        : TAbstractPartitionChooserActor<TSMPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId))
+                           NWilson::TTraceId traceId,
+                           ui64 pathId = 0)
+        : TAbstractPartitionChooserActor<TSMPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId), pathId)
         , Graph(graph) {
     }
 

--- a/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
@@ -20,9 +20,10 @@ namespace NKikimr::NPQ::NPartitionChooser {
 
 class TTableHelper {
 public:
-    TTableHelper(const TString& topicName, const TString& topicHashName)
+    TTableHelper(const TString& topicName, const TString& topicHashName, ui64 pathId)
         : TopicName(topicName)
-        , TopicHashName(topicHashName) {
+        , TopicHashName(topicHashName)
+        , PathId(pathId) {
     };
 
     std::optional<ui32> PartitionId() const {
@@ -35,9 +36,20 @@ public:
 
     [[nodiscard]] bool Initialize(const TActorContext& ctx, const TString& sourceId) {
         const auto& pqConfig = AppData(ctx)->PQConfig;
+        const auto& ff = AppData(ctx)->FeatureFlags;
 
-        TableGeneration = pqConfig.GetTopicsAreFirstClassCitizen() ? ESourceIdTableGeneration::PartitionMapping
-                                                                   : ESourceIdTableGeneration::SrcIdMeta2;
+        // flag=false (migration): Primary=V2 (PathId-encoded Topic), Fallback=legacy (plain Topic)
+        // flag=true (cutover):    Primary=V2 (PathId-encoded Topic), no fallback (V2 only)
+        bool migrationComplete = ff.GetTopicPartitionMappingByPathIdMigrationComplete();
+        // Fallback enabled during migration (flag=false); disabled after cutover (flag=true)
+        HasFallback = !migrationComplete;
+
+        if (pqConfig.GetTopicsAreFirstClassCitizen()) {
+            TableGeneration = ESourceIdTableGeneration::PartitionMapping;
+        } else {
+            TableGeneration = ESourceIdTableGeneration::SrcIdMeta2;
+        }
+
         try {
             EncodedSourceId = NSourceIdEncoding::EncodeSrcId(
                         TopicHashName, sourceId, TableGeneration
@@ -49,6 +61,13 @@ public:
         SelectQuery = GetSelectSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
         UpdateQuery = GetUpdateSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
         UpdateAccessTimeQuery = GetUpdateAccessTimeQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
+
+        // Prepare fallback queries if needed (same generation, but with plain Topic name)
+        if (HasFallback) {
+            FallbackSelectQuery = GetSelectSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
+            FallbackUpdateQuery = GetUpdateSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
+            FallbackUpdateAccessTimeQuery = GetUpdateAccessTimeQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
+        }
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "TTableHelper",
             {"selectQuery", SelectQuery});
@@ -117,16 +136,91 @@ public:
     }
 
     void SendSelectRequest(const TActorContext& ctx) {
-        auto ev = MakeSelectQueryRequest(ctx);
-        ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release());
+        // Always try primary (V2 PathId-encoded) first
+        SendSelectRequestWithGeneration(true /* isPrimary */, ctx);
     }
 
     THolder<NKqp::TEvKqp::TEvQueryRequest> MakeSelectQueryRequest(const NActors::TActorContext& ctx) {
+        return MakeSelectQueryRequestWithGeneration(SelectQuery, true /* isPrimary */, ctx);
+    }
+
+    bool HandleSelect(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& ctx) {
+        auto& record = ev->Get()->Record;
+
+        if (record.GetYdbStatus() != Ydb::StatusIds::SUCCESS) {
+            return false;
+        }
+
+        NYdb::TResultSetParser parser(record.GetResponse().GetYdbResults(0));
+        TxId = record.GetResponse().GetTxMeta().id();
+        AFL_ENSURE(!TxId.empty());
+
+        bool found = false;
+        while(parser.TryNextRow()) {
+            auto tt = parser.ColumnParser(0).GetOptionalUint32();
+
+            if (tt.has_value()) { //already got partition
+                auto accessTime = parser.ColumnParser(2).GetOptionalUint64().value_or(0);
+                if (accessTime > AccessTime) { // AccessTime
+                    PartitionId_ = *tt;
+                    CreateTime = parser.ColumnParser(1).GetOptionalUint64().value_or(0);
+                    AccessTime = accessTime;
+                    SeqNo_ = parser.ColumnParser(3).GetOptionalUint64().value_or(0);
+                    found = true;
+                }
+            }
+        }
+
+        if (!found && HasFallback && !FallbackAttempted) {
+            // Primary (V2) returned no rows — fall back to legacy (plain Topic)
+            FallbackAttempted = true;
+            SendSelectRequestWithGeneration(false /* isPrimary */, ctx);
+            return true; // wait for fallback response
+        }
+
+        if (CreateTime == 0) {
+            CreateTime = TAppData::TimeProvider->Now().MilliSeconds();
+        }
+
+        return found;
+    }
+
+    void SendUpdateRequest(ui32 partitionId, std::optional<ui64> seqNo, const TActorContext& ctx) {
+        // Always write primary (V2 PathId-encoded) format
+        SendUpdateRequestWithGeneration(true /* isPrimary */, partitionId, seqNo, ctx);
+
+        // Also write legacy (plain Topic) format for rollback safety during migration
+        if (HasFallback) {
+            SendUpdateRequestWithGeneration(false /* isPrimary */, partitionId, seqNo, ctx);
+        }
+    }
+
+    THolder<NKqp::TEvKqp::TEvQueryRequest> MakeUpdateQueryRequest(ui32 partitionId, std::optional<ui64> seqNo, const NActors::TActorContext& ctx) {
+        return MakeUpdateQueryRequestWithGeneration(UpdateQuery, true /* isPrimary */, partitionId, seqNo, ctx);
+    }
+
+private:
+    TString GetTopicParam(bool isPrimary) const {
+        if (isPrimary) {
+            // Encode PathId into the Topic value for primary (V2)
+            return TStringBuilder() << "\x00PATHID:" << PathId << ":" << TopicName;
+        }
+        return TopicName;
+    }
+
+    void SendSelectRequestWithGeneration(bool isPrimary, const TActorContext& ctx) {
+        auto ev = MakeSelectQueryRequestWithGeneration(
+            isPrimary ? SelectQuery : *FallbackSelectQuery, isPrimary, ctx);
+        ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release());
+    }
+
+    THolder<NKqp::TEvKqp::TEvQueryRequest> MakeSelectQueryRequestWithGeneration(
+        const TString& query, bool isPrimary, const NActors::TActorContext& ctx) {
         auto ev = MakeHolder<NKqp::TEvKqp::TEvQueryRequest>();
 
         ev->Record.MutableRequest()->SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
         ev->Record.MutableRequest()->SetType(NKikimrKqp::QUERY_TYPE_SQL_DML);
-        ev->Record.MutableRequest()->SetQuery(SelectQuery);
+        ev->Record.MutableRequest()->SetQuery(query);
 
         ev->Record.MutableRequest()->SetDatabase(GetDatabaseName(ctx));
         // fill tx settings: set commit tx flag&  begin new serializable tx.
@@ -143,7 +237,7 @@ public:
 
         paramsBuilder
             .AddParam("$Topic")
-                .Utf8(TopicName)
+                .Utf8(GetTopicParam(isPrimary))
                 .Build()
             .AddParam("$SourceId")
                 .Utf8(EncodedSourceId.EscapedSourceId)
@@ -156,49 +250,24 @@ public:
         return ev;
     }
 
-    bool HandleSelect(NKqp::TEvKqp::TEvQueryResponse::TPtr& ev, const TActorContext& /*ctx*/) {
-        auto& record = ev->Get()->Record;
-
-        if (record.GetYdbStatus() != Ydb::StatusIds::SUCCESS) {
-            return false;
-        }
-
-        NYdb::TResultSetParser parser(record.GetResponse().GetYdbResults(0));
-        TxId = record.GetResponse().GetTxMeta().id();
-        AFL_ENSURE(!TxId.empty());
-
-        while(parser.TryNextRow()) {
-            auto tt = parser.ColumnParser(0).GetOptionalUint32();
-
-            if (tt.has_value()) { //already got partition
-                auto accessTime = parser.ColumnParser(2).GetOptionalUint64().value_or(0);
-                if (accessTime > AccessTime) { // AccessTime
-                    PartitionId_ = *tt;
-                    CreateTime = parser.ColumnParser(1).GetOptionalUint64().value_or(0);
-                    AccessTime = accessTime;
-                    SeqNo_ = parser.ColumnParser(3).GetOptionalUint64().value_or(0);
-                }
-            }
-        }
-
-        if (CreateTime == 0) {
-            CreateTime = TAppData::TimeProvider->Now().MilliSeconds();
-        }
-
-        return true;
-    }
-
-    void SendUpdateRequest(ui32 partitionId, std::optional<ui64> seqNo, const TActorContext& ctx) {
-        auto ev = MakeUpdateQueryRequest(partitionId, seqNo, ctx);
+    void SendUpdateRequestWithGeneration(bool isPrimary, ui32 partitionId,
+                                          std::optional<ui64> seqNo, const TActorContext& ctx) {
+        // Choose query: full UPSERT when TxId is set (after SELECT), otherwise lighter AccessTime UPDATE
+        const TString& query = TxId
+            ? (isPrimary ? UpdateQuery : *FallbackUpdateQuery)
+            : (isPrimary ? UpdateAccessTimeQuery : *FallbackUpdateAccessTimeQuery);
+        auto ev = MakeUpdateQueryRequestWithGeneration(query, isPrimary, partitionId, seqNo, ctx);
         ctx.Send(NKqp::MakeKqpProxyID(ctx.SelfID.NodeId()), ev.Release());
     }
 
-    THolder<NKqp::TEvKqp::TEvQueryRequest> MakeUpdateQueryRequest(ui32 partitionId, std::optional<ui64> seqNo, const NActors::TActorContext& ctx) {
+    THolder<NKqp::TEvKqp::TEvQueryRequest> MakeUpdateQueryRequestWithGeneration(
+        const TString& query, bool isPrimary,
+        ui32 partitionId, std::optional<ui64> seqNo, const NActors::TActorContext& ctx) {
         auto ev = MakeHolder<NKqp::TEvKqp::TEvQueryRequest>();
 
         ev->Record.MutableRequest()->SetAction(NKikimrKqp::QUERY_ACTION_EXECUTE);
         ev->Record.MutableRequest()->SetType(NKikimrKqp::QUERY_TYPE_SQL_DML);
-        ev->Record.MutableRequest()->SetQuery(TxId ? UpdateQuery : UpdateAccessTimeQuery);
+        ev->Record.MutableRequest()->SetQuery(query);
         ev->Record.MutableRequest()->SetDatabase(GetDatabaseName(ctx));
         // fill tx settings: set commit tx flag&  begin new serializable tx.
         ev->Record.MutableRequest()->MutableTxControl()->set_commit_tx(true);
@@ -222,7 +291,7 @@ public:
 
         paramsBuilder
             .AddParam("$Topic")
-                .Utf8(TopicName)
+                .Utf8(GetTopicParam(isPrimary))
                 .Build()
             .AddParam("$SourceId")
                 .Utf8(EncodedSourceId.EscapedSourceId)
@@ -250,13 +319,18 @@ public:
 private:
     const TString TopicName;
     const TString TopicHashName;
+    const ui64 PathId;
 
     NPQ::NSourceIdEncoding::TEncodedSourceId EncodedSourceId;
 
     NPQ::ESourceIdTableGeneration TableGeneration;
+    bool HasFallback = false;
     TString SelectQuery;
     TString UpdateQuery;
     TString UpdateAccessTimeQuery;
+    std::optional<TString> FallbackSelectQuery;
+    std::optional<TString> FallbackUpdateQuery;
+    std::optional<TString> FallbackUpdateAccessTimeQuery;
 
     TString KqpSessionId;
     TString TxId;
@@ -266,6 +340,8 @@ private:
 
     std::optional<ui32> PartitionId_;
     std::optional<ui64> SeqNo_;
+
+    bool FallbackAttempted = false;
 };
 
 #undef LOG_PREFIX

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -360,4 +360,5 @@ message TFeatureFlags {
     optional bool EnableKafkaServerlessTransactions = 307 [default = false];
     optional bool EnableGeneratedStored = 308 [default = false];
     optional bool EnableGeneratedVirtual = 309 [default = false];
+    optional bool TopicPartitionMappingByPathIdMigrationComplete = 310 [default = false];
 }


### PR DESCRIPTION
Fix possible issues while deleting and then recreating topic with the same name due to rows in TopicPartitioningMapping  table referencing metadata by topic name.
Use unique combination from pathId and topic name to make unique key.
Keeps backward compatibility by maintaining both new and old format during migration phase (controlled by feature flag).

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

# Миграция: хранение producerId→PartitionId по PathId

## Проблема

Таблица `TopicPartitionsMapping` индексирует строки по `(Hash, Topic, ProducerId)`, где `Topic` — обычное имя топика. Если топик удаляется и создаётся заново с тем же именем, но другим `PathId`, старая маппинг-запись остаётся доступной, так как ключ совпадает. Это приводит к тому, что продюсеры назначаются на партиции нового топика, хотя данные в старой записи относятся к старому топика.

## Решение

Кодировать `PathId` в значение колонки `Topic` с помощью специального формата:

```
\x00PATHID:<owner>:<local>:<topic>
```

Это делает ключ таблицы уникальным для каждой инкарнации топика. Хеш (вычисляется от `TopicHashName`) остаётся неизменным, поэтому существующие строки остаются находимыми.

## Фазы миграции

Миграция управляется флагом `TopicPartitionMappingByPathIdMigrationComplete`.

### Фаза 1: Миграция (flag = `false`, по умолчанию)

- **Запись**: Dual-write — каждый upsert записывает **обе** строки: V2 (с PathId в Topic) и legacy (обычный Topic)
- **Чтение**: Первичное чтение из V2, с **fallback** на legacy, если V2 не вернула строк
- **Цель**: Постепенное заполнение V2-строк при сохранении обратной совместимости

### Фаза 2: Cutover (flag = `true`)

- **Запись**: Только V2 — legacy строки не записываются
- **Чтение**: Только V2 — fallback на legacy отключён
- **Цель**: Миграция завершена; legacy строки будут удалены при следующей перезаписи

## Откат

Откат **безопасен и поддерживается** в любой момент во время Фазы 1:

1. Флаг остаётся `false` (по умолчанию) — система продолжает dual-write legacy строк
2. Если новый код откатывается (rollback к прежнему коду), legacy строки продолжают существовать и полностью функциональны
3. Потери данных не происходит, так как legacy строки поддерживаются на протяжении всей фазы миграции

**После Фазы 2 (flag = `true`)** откат требует возврата флага в `false`, что повторно включает fallback-чтение. Однако к этому моменту V2-only запись уже прекратила писать legacy строки, поэтому новые продюсеры будут иметь только V2 строки. Если разворачивается прежний код после Фазы 2, он не найдёт V2 строки (разное кодирование Topic) и назначит новые партиции — это допустимо, так как эквивалентно начальному состоянию для затронутых продюсеров.

## Оценка накладных расходов

### Dual-write (Фаза 1)

Каждая операция записи producerId→PartitionId выполняет **два** UPSERT-запроса вместо одного:
- V2 строка (PathId-encoded Topic)
- Legacy строка (plain Topic)

**Нагрузка**: удвоение количества write-операций в таблицу `TopicPartitionsMapping` на время фазы миграции. Таблица используется редко (только при выборе партиции для продюсера), поэтому абсолютное количество операций невелико.

Оценка: при N активных продюсерах и частоте выбора партиции F раз/сек на продюсера:
- До миграции: N × F write-операций/сек
- Во время миграции: 2 × N × F write-операций/сек
- После миграции: N × F write-операций/сек

### Fallback read (Фаза 1)

Fallback-чтение происходит **только** в случае, когда V2-запрос не вернул строк. Это происходит в двух сценариях:

1. **Первое обращение продюсера после деплоя** — V2 строки ещё не созданы, требуется fallback на legacy. После успешного fallback выполняется dual-write, и последующие чтения находят V2 строку без fallback.
2. **Топик только что создан** — ни V2, ни legacy строк нет.

**Нагрузка**: один дополнительный SELECT-запрос на первое обращение каждого продюсера после начала миграции. Это разовая операция, которая не повторяется.

### Хранение (Фаза 1)

Во время миграции таблица содержит **обе** версии строк для каждого продюсера:
- V2 строка с Topic = `\x00PATHID:<owner>:<local>:<topic>` (~50-100 байт дополнительно на строку)
- Legacy строка с Topic = `<topic>`

**Нагрузка**: удвоение количества строк в таблице на время миграции. После Фазы 2 legacy строки постепенно заменяются V2 при каждой перезаписи.

### После миграции (Фаза 2)

- Запись: 1 операция (только V2)
- Чтение: 1 операция (только V2)
- Хранение: 1 строка на продюсера (V2)

Накладные расходы после завершения миграции: **~50-100 байт на строку** из-за увеличенного размера колонки Topic.
