### PR TITLE
Dq clique v2

### DIFF
--- a/ydb/library/yql/providers/dq/actors/result_actor_base.h
+++ b/ydb/library/yql/providers/dq/actors/result_actor_base.h
@@ -113,11 +113,10 @@ struct TWriteQueue {
             , BlockingActors()
             , QueryResponse()
             , WaitingAckFromFRW(false) {
-            YQL_CLOG(INFO, ProviderDq) << "ResultActor init: FullResultTableEnabled=" << FullResultTableEnabled
+            YQL_CLOG(DEBUG, ProviderDq) << "ResultActor init: FullResultTableEnabled=" << FullResultTableEnabled
                 << " discard=" << Discard
-                << " sizeLimit=" << SizeLimit;
-            YQL_CLOG(DEBUG, ProviderDq) << "_AllResultsBytesLimit = " << SizeLimit;
-            YQL_CLOG(DEBUG, ProviderDq) << "_RowsLimitPerWrite = " << (RowsLimit.Defined() ? ToString(RowsLimit.GetRef()) : "nothing");
+                << " sizeLimit=" << SizeLimit
+                << " rowsLimit=" << (RowsLimit.Defined() ? ToString(RowsLimit.GetRef()) : "nothing");
         }
 
         virtual void FinishFullResultWriter() {
@@ -201,7 +200,7 @@ struct TWriteQueue {
         }
 
         void Finish() {
-            YQL_CLOG(INFO, ProviderDq) << __FUNCTION__ << " truncated=" << Truncated
+            YQL_CLOG(DEBUG, ProviderDq) << __FUNCTION__ << " truncated=" << Truncated
                 << " hasFullResultWriter=" << (bool)FullResultWriterID
                 << " FullResultTableEnabled=" << FullResultTableEnabled;
             YQL_ENSURE(!FinishCalled);
@@ -260,7 +259,7 @@ struct TWriteQueue {
                 FinishFullResultWriter();
             }
 
-            YQL_CLOG(INFO, ProviderDq) << "Waiting for " << BlockingActors.size() << " blocking actors"
+            YQL_CLOG(DEBUG, ProviderDq) << "Waiting for " << BlockingActors.size() << " blocking actors"
                 << " hasFullResultWriter=" << (bool)FullResultWriterID;
 
             QueryResponse.Reset(ev->Release().Release());
@@ -339,7 +338,7 @@ struct TWriteQueue {
         }
 
         void FlushCurrent() {
-            YQL_CLOG(INFO, ProviderDq) << __FUNCTION__ << ": requesting FullResultWriter on worker";
+            YQL_CLOG(DEBUG, ProviderDq) << __FUNCTION__ << ": requesting FullResultWriter on worker";
             YQL_ENSURE(!FullResultWriterID);
             YQL_ENSURE(FullResultTableEnabled);
 

--- a/ydb/library/yql/providers/dq/actors/result_actor_base.h
+++ b/ydb/library/yql/providers/dq/actors/result_actor_base.h
@@ -113,6 +113,9 @@ struct TWriteQueue {
             , BlockingActors()
             , QueryResponse()
             , WaitingAckFromFRW(false) {
+            YQL_CLOG(INFO, ProviderDq) << "ResultActor init: FullResultTableEnabled=" << FullResultTableEnabled
+                << " discard=" << Discard
+                << " sizeLimit=" << SizeLimit;
             YQL_CLOG(DEBUG, ProviderDq) << "_AllResultsBytesLimit = " << SizeLimit;
             YQL_CLOG(DEBUG, ProviderDq) << "_RowsLimitPerWrite = " << (RowsLimit.Defined() ? ToString(RowsLimit.GetRef()) : "nothing");
         }
@@ -198,7 +201,9 @@ struct TWriteQueue {
         }
 
         void Finish() {
-            YQL_CLOG(DEBUG, ProviderDq) << __FUNCTION__ << ", truncated=" << Truncated;
+            YQL_CLOG(INFO, ProviderDq) << __FUNCTION__ << " truncated=" << Truncated
+                << " hasFullResultWriter=" << (bool)FullResultWriterID
+                << " FullResultTableEnabled=" << FullResultTableEnabled;
             YQL_ENSURE(!FinishCalled);
             FinishCalled = true;
 
@@ -255,7 +260,8 @@ struct TWriteQueue {
                 FinishFullResultWriter();
             }
 
-            YQL_CLOG(DEBUG, ProviderDq) << "Waiting for " << BlockingActors.size() << " blocking actors";
+            YQL_CLOG(INFO, ProviderDq) << "Waiting for " << BlockingActors.size() << " blocking actors"
+                << " hasFullResultWriter=" << (bool)FullResultWriterID;
 
             QueryResponse.Reset(ev->Release().Release());
             TBase::Become(&TDerived::ShutdownHandler);
@@ -333,7 +339,7 @@ struct TWriteQueue {
         }
 
         void FlushCurrent() {
-            YQL_CLOG(DEBUG, ProviderDq) << __FUNCTION__;
+            YQL_CLOG(INFO, ProviderDq) << __FUNCTION__ << ": requesting FullResultWriter on worker";
             YQL_ENSURE(!FullResultWriterID);
             YQL_ENSURE(FullResultTableEnabled);
 

--- a/ydb/library/yql/providers/dq/common/ya.make
+++ b/ydb/library/yql/providers/dq/common/ya.make
@@ -5,6 +5,7 @@ PEERDIR(
     yql/essentials/minikql
     yql/essentials/utils
     yql/essentials/core
+    yql/essentials/providers/common/proto
     yql/essentials/utils/log
     ydb/library/yql/dq/actors
     ydb/library/yql/dq/proto

--- a/ydb/library/yql/providers/dq/common/ya.make
+++ b/ydb/library/yql/providers/dq/common/ya.make
@@ -5,7 +5,6 @@ PEERDIR(
     yql/essentials/minikql
     yql/essentials/utils
     yql/essentials/core
-    yql/essentials/providers/common/proto
     yql/essentials/utils/log
     ydb/library/yql/dq/actors
     ydb/library/yql/dq/proto

--- a/ydb/library/yql/providers/dq/common/yql_dq_settings.cpp
+++ b/ydb/library/yql/providers/dq/common/yql_dq_settings.cpp
@@ -124,6 +124,12 @@ TDqConfiguration::TDqConfiguration() {
         });
     REGISTER_SETTING(*this, UseGraceJoinCoreForMap);
     REGISTER_SETTING(*this, Scheduler);
+    REGISTER_SETTING(*this, Clique)
+        .Validator([this](const TString&, const TString& value) {
+            if (CliqueValidator) {
+                CliqueValidator(value);
+            }
+        });
 }
 
 } // namespace NYql

--- a/ydb/library/yql/providers/dq/common/yql_dq_settings.h
+++ b/ydb/library/yql/providers/dq/common/yql_dq_settings.h
@@ -14,6 +14,8 @@
 #include <util/generic/size_literals.h>
 #include <util/random/random.h>
 
+#include <functional>
+
 namespace NYql {
 
 struct TDqSettings {
@@ -161,6 +163,8 @@ public:
     NCommon::TConfSetting<bool, Static> DisableCheckpoints;
     NCommon::TConfSetting<bool, Static> UseGraceJoinCoreForMap;
     NCommon::TConfSetting<TString, Static> Scheduler;
+    // Target DQ clique for remote graph execution (pragma dq.Clique).
+    NCommon::TConfSetting<TString, Static> Clique;
 
     // This options will be passed to executor_actor and worker_actor
     template <typename TProtoConfig>
@@ -281,11 +285,15 @@ public:
     }
 };
 
+using TDqCliqueValidator = std::function<void(const TString& cliqueValue)>;
+
 struct TDqConfiguration: public TDqSettings, public NCommon::TSettingDispatcher {
     using TPtr = TIntrusivePtr<TDqConfiguration>;
 
     TDqConfiguration();
     TDqConfiguration(const TDqConfiguration&) = delete;
+
+    TDqCliqueValidator CliqueValidator;
 
     template <class TProtoConfig, typename TFilter>
     void Init(const TProtoConfig& config, const TFilter& filter) {

--- a/ydb/library/yql/providers/dq/provider/yql_dq_provider.cpp
+++ b/ydb/library/yql/providers/dq/provider/yql_dq_provider.cpp
@@ -25,7 +25,7 @@ TDataProviderInitializer GetDqDataProviderInitializer(
     bool externalUser,
     TDqCliqueValidator cliqueValidator)
 {
-    return [execTransformerFactory, dqGateway, compFactory, metrics, fileStorage, externalUser, cliqueValidator = std::move(cliqueValidator)] (
+    return [execTransformerFactory, dqGateway, compFactory, metrics, fileStorage, externalUser, cliqueValidator] (
         const TString& userName,
         const TString& sessionId,
         const TGatewaysConfig* gatewaysConfig,
@@ -63,9 +63,7 @@ TDataProviderInitializer GetDqDataProviderInitializer(
             std::move(hiddenAborter)
         );
 
-        if (cliqueValidator) {
-            state->Settings->CliqueValidator = cliqueValidator;
-        }
+        state->Settings->CliqueValidator = cliqueValidator;
 
         TDataProviderInfo info;
         info.Names.insert(TString{DqProviderName});

--- a/ydb/library/yql/providers/dq/provider/yql_dq_provider.cpp
+++ b/ydb/library/yql/providers/dq/provider/yql_dq_provider.cpp
@@ -22,9 +22,10 @@ TDataProviderInitializer GetDqDataProviderInitializer(
     NKikimr::NMiniKQL::TComputationNodeFactory compFactory,
     const IMetricsRegistryPtr& metrics,
     const TFileStoragePtr& fileStorage,
-    bool externalUser)
+    bool externalUser,
+    TDqCliqueValidator cliqueValidator)
 {
-    return [execTransformerFactory, dqGateway, compFactory, metrics, fileStorage, externalUser] (
+    return [execTransformerFactory, dqGateway, compFactory, metrics, fileStorage, externalUser, cliqueValidator = std::move(cliqueValidator)] (
         const TString& userName,
         const TString& sessionId,
         const TGatewaysConfig* gatewaysConfig,
@@ -61,6 +62,10 @@ TDataProviderInitializer GetDqDataProviderInitializer(
             externalUser,
             std::move(hiddenAborter)
         );
+
+        if (cliqueValidator) {
+            state->Settings->CliqueValidator = cliqueValidator;
+        }
 
         TDataProviderInfo info;
         info.Names.insert(TString{DqProviderName});

--- a/ydb/library/yql/providers/dq/provider/yql_dq_provider.h
+++ b/ydb/library/yql/providers/dq/provider/yql_dq_provider.h
@@ -8,6 +8,8 @@
 #include <yql/essentials/minikql/computation/mkql_computation_node.h>
 #include <yql/essentials/core/file_storage/file_storage.h>
 
+#include <ydb/library/yql/providers/dq/common/yql_dq_settings.h>
+
 namespace NYql {
 
 struct TDqState;
@@ -21,6 +23,7 @@ TDataProviderInitializer GetDqDataProviderInitializer(
     NKikimr::NMiniKQL::TComputationNodeFactory compFactory,
     const IMetricsRegistryPtr& metrics,
     const TFileStoragePtr& fileStorage,
-    bool externalUser = false);
+    bool externalUser = false,
+    TDqCliqueValidator cliqueValidator = {});
 
 } // namespace NYql

--- a/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
+++ b/ydb/library/yql/providers/dq/task_runner/tasks_runner_pipe.cpp
@@ -2099,20 +2099,20 @@ private:
         task.GetMeta().UnpackTo(&taskMeta);
 
         auto* files = taskMeta.MutableFiles();
-
+        YQL_CLOG(TRACE, ProviderDq) << "PrepareTask: files " << files->size();
         for (auto& file : *files) {
             if (file.GetObjectType() != Yql::DqsProto::TFile::EEXE_FILE) {
                 auto maybeFile = FileCache->AcquireFile(file.GetObjectId());
                 if (!maybeFile) {
-                    throw std::runtime_error("Cannot find object `" + file.GetObjectId() + "' in cache");
+                    throw std::runtime_error("Cannot find object `" + file.GetObjectId() + "` in cache");
                 }
                 filesHolder->Add(file.GetObjectId());
                 auto name = file.GetName();
-
                 switch (file.GetObjectType()) {
                     case Yql::DqsProto::TFile::EUDF_FILE:
                     case Yql::DqsProto::TFile::EUSER_FILE:
                         file.SetLocalPath(InitializeLocalFile(result->ExternalWorkDir(), *maybeFile, name));
+                        YQL_CLOG(TRACE, ProviderDq) << "PrepareTask: Add file.SetLocalPath: " << name << ", local path: " << file.GetLocalPath();
                         break;
                     default:
                         Y_ABORT_UNLESS(false);

--- a/ydb/library/yql/providers/dq/worker_manager/interface/events.h
+++ b/ydb/library/yql/providers/dq/worker_manager/interface/events.h
@@ -157,4 +157,10 @@ using TDqResManEvents = NDq::TBaseDqResManEvents<NActors::TEvents::EEventSpace::
         memcpy(x + 7, &nodeId, sizeof(ui32));
         return NActors::TActorId(nodeId, TStringBuf(x, 12));
     }
+
+    inline NActors::TActorId MakeGlobalWorkerManagerActorID(ui32 nodeId) {
+        char x[12] = {'g', 'l', 'o', 'b', 'm', 'a', 'n'};
+        memcpy(x + 7, &nodeId, sizeof(ui32));
+        return NActors::TActorId(nodeId, TStringBuf(x, 12));
+    }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add `pragma dq.Clique` setting plumbing and related DQ debug helpers.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Successor of #43097 with a narrower scope matching the current Arcadia branch.

- Add `Clique` DQ setting and optional `CliqueValidator` hook in provider init
- Add `MakeGlobalWorkerManagerActorID`
- Enrich ResultActor / PrepareTask logs used while debugging clique execution

YT-side clique discovery/routing stays out of this PR (lives under `yt/yql` in Arcadia).