### PR TITLE
Switch to pathId instead of topic name for partition mapping / controlled by flag for zero-loss migration and safe rollback

### DIFF
--- a/ydb/core/persqueue/ut/partition_chooser_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_chooser_ut.cpp
@@ -348,6 +348,85 @@ void AssertTable(NPersQueue::TTestServer& server, const TString& sourceId, ui32 
     UNIT_ASSERT_VALUES_EQUAL(s.GetOptionalUint64().value(), seqNo);
 }
 
+// --- Helpers for LOGBROKER-10398 PathId migration tests ---
+// These operate on the same table but let the caller specify the exact Topic column value,
+// so the test can distinguish the legacy plain-name row from the PathId-encoded row.
+
+// Writes a single row using an explicit Topic column value.
+void WriteToTableWithTopic(NPersQueue::TTestServer& server, const TString& sourceId,
+                           const TString& topicValue, ui32 partitionId, ui64 seqNo = 0) {
+    InitTable(server);
+
+    const auto& pqConfig = server.CleverServer->GetRuntime()->GetAppData().PQConfig;
+    auto tableGeneration = pqConfig.GetTopicsAreFirstClassCitizen() ? ESourceIdTableGeneration::PartitionMapping
+                                                               : ESourceIdTableGeneration::SrcIdMeta2;
+
+    NPersQueue::TTopicConverterPtr fullConverter = CreateTopicConverter();
+    NKikimr::NPQ::NSourceIdEncoding::TEncodedSourceId encoded = NSourceIdEncoding::EncodeSrcId(
+                fullConverter->GetTopicForSrcIdHash(), sourceId, tableGeneration
+        );
+
+    TString query = TStringBuilder() << "--!syntax_v1\n"
+        "UPSERT INTO `//Root/.metadata/TopicPartitionsMapping` (Hash, Topic, ProducerId, CreateTime, AccessTime, Partition, SeqNo) VALUES "
+                                          "(" << encoded.KeysHash << ", \"" << topicValue << "\", \""
+                                          << encoded.EscapedSourceId << "\", " << TInstant::Now().MilliSeconds() << ", "
+                                          << TInstant::Now().MilliSeconds() << ", " << partitionId << ", " << seqNo << ");";
+    Cerr << "Run query:\n" << query << Endl;
+    server.AnnoyingClient->RunYqlDataQuery(query);
+}
+
+// Selects the row for an explicit Topic column value.
+TMaybe<NYdb::TResultSet> SelectTableWithTopic(NPersQueue::TTestServer& server, const TString& sourceId,
+                                              const TString& topicValue) {
+    const auto& pqConfig = server.CleverServer->GetRuntime()->GetAppData().PQConfig;
+    auto tableGeneration = pqConfig.GetTopicsAreFirstClassCitizen() ? ESourceIdTableGeneration::PartitionMapping
+                                                               : ESourceIdTableGeneration::SrcIdMeta2;
+
+    NPersQueue::TTopicConverterPtr fullConverter = CreateTopicConverter();
+    NKikimr::NPQ::NSourceIdEncoding::TEncodedSourceId encoded = NSourceIdEncoding::EncodeSrcId(
+                fullConverter->GetTopicForSrcIdHash(), sourceId, tableGeneration
+        );
+
+    TString query = TStringBuilder() << "--!syntax_v1\n"
+        "SELECT Partition, SeqNo "
+        "FROM  `//Root/.metadata/TopicPartitionsMapping` "
+        "WHERE Hash = " << encoded.KeysHash <<
+        "  AND Topic = \"" << topicValue << "\"" <<
+        "  AND ProducerId = \"" << encoded.EscapedSourceId << "\"";
+    Cerr << "Run query:\n" << query << Endl;
+    return server.AnnoyingClient->RunYqlDataQuery(query);
+}
+
+void AssertTableTopic(NPersQueue::TTestServer& server, const TString& sourceId,
+                      const TString& topicValue, ui32 partitionId, ui64 seqNo) {
+    auto result = SelectTableWithTopic(server, sourceId, topicValue);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->RowsCount(), 1,
+        "Table must contain row for SourceId='" << sourceId << "' Topic='" << topicValue << "'");
+
+    NYdb::TResultSetParser parser(*result);
+    UNIT_ASSERT(parser.TryNextRow());
+    NYdb::TValueParser p(parser.GetValue(0));
+    NYdb::TValueParser s(parser.GetValue(1));
+    UNIT_ASSERT_VALUES_EQUAL(p.GetOptionalUint32().value(), partitionId);
+    UNIT_ASSERT_VALUES_EQUAL(s.GetOptionalUint64().value(), seqNo);
+}
+
+void AssertTableTopicEmpty(NPersQueue::TTestServer& server, const TString& sourceId, const TString& topicValue) {
+    auto result = SelectTableWithTopic(server, sourceId, topicValue);
+
+    UNIT_ASSERT(result);
+    UNIT_ASSERT_VALUES_EQUAL_C(result->RowsCount(), 0,
+        "Table must not contain row for SourceId='" << sourceId << "' Topic='" << topicValue << "'");
+}
+
+// The PathId-encoded Topic value used by the chooser during/after migration.
+TString PathIdTopic(ui64 pathId) {
+    NPersQueue::TTopicConverterPtr fullConverter = CreateTopicConverter();
+    return NKikimr::NPQ::EncodeTopicWithPathId(pathId, fullConverter->GetClientsideName());
+}
+
 class TPQTabletMock: public TActor<TPQTabletMock> {
 public:
     TPQTabletMock(ETopicPartitionStatus status, std::optional<ui64> seqNo)
@@ -707,6 +786,110 @@ Y_UNIT_TEST(TPartitionChooserActor_SplitMergeDisabled_BadSourceId_Test) {
     auto r = ChoosePartition(server, config, "base64:a***");
 
     UNIT_ASSERT(r->Error);
+}
+
+// --- LOGBROKER-10398: PathId migration tests (SplitMergeEnabled) ---
+
+Y_UNIT_TEST(TPartitionChooserActor_SplitMergeEnabled_PathIdMigration_NewSourceId_DualWrites) {
+    // Migration phase (flag = false): choosing a partition for a brand new SourceId must write
+    // BOTH the PathId-encoded row and the legacy plain-name row so that old code can still read it.
+    NPersQueue::TTestServer server = CreateServer();
+    const ui64 pathId = 100500;
+
+    auto config = CreateConfig0(true);
+    config.SetPathId(pathId);
+    AddPartition(config, 0, {}, {});
+    CreatePQTabletMock(server, 0, ETopicPartitionStatus::Active);
+
+    auto r = ChoosePartition(server, config, "A_Source_PathId_New");
+
+    UNIT_ASSERT(r->Result);
+    UNIT_ASSERT_VALUES_EQUAL(r->Result->Get()->PartitionId, 0);
+
+    NPersQueue::TTopicConverterPtr fullConverter = CreateTopicConverter();
+    // Legacy plain-name row is present for rollback safety.
+    AssertTableTopic(server, "A_Source_PathId_New", fullConverter->GetClientsideName(), 0, 0);
+    // PathId-encoded row is present as the primary key.
+    AssertTableTopic(server, "A_Source_PathId_New", PathIdTopic(pathId), 0, 0);
+}
+
+Y_UNIT_TEST(TPartitionChooserActor_SplitMergeEnabled_PathIdMigration_LegacyRowFound_FallbackRead) {
+    // Migration phase: only the legacy plain-name row exists (written by old code). The chooser must
+    // find it via the fallback read and reuse the stored partition, then re-persist the PathId row.
+    NPersQueue::TTestServer server = CreateServer();
+    const ui64 pathId = 100501;
+
+    auto config = CreateConfig0(true);
+    config.SetPathId(pathId);
+    AddPartition(config, 0, {}, "F");
+    AddPartition(config, 1, "F", {});
+    CreatePQTabletMock(server, 0, ETopicPartitionStatus::Active);
+    CreatePQTabletMock(server, 1, ETopicPartitionStatus::Active);
+
+    NPersQueue::TTopicConverterPtr fullConverter = CreateTopicConverter();
+    // Simulate a mapping written by the old (pre-migration) code: legacy plain-name row only.
+    WriteToTableWithTopic(server, "A_Source_PathId_Legacy", fullConverter->GetClientsideName(), 0, 42);
+
+    auto r = ChoosePartition(server, config, "A_Source_PathId_Legacy");
+
+    UNIT_ASSERT(r->Result);
+    // Existing partition is reused via fallback read of the legacy row.
+    UNIT_ASSERT_VALUES_EQUAL(r->Result->Get()->PartitionId, 0);
+    // After choosing, the PathId-encoded row is now populated as well (dual write).
+    AssertTableTopic(server, "A_Source_PathId_Legacy", PathIdTopic(pathId), 0, 42);
+}
+
+Y_UNIT_TEST(TPartitionChooserActor_SplitMergeEnabled_PathIdMigration_RecreatedTopic_OldMappingIgnored) {
+    // A topic was recreated with the same name but a different PathId. A stale row exists under the
+    // OLD PathId-encoded Topic value pointing at an old partition with a non-zero SeqNo. With the new
+    // PathId, the lookup must miss that stale mapping and its SeqNo must NOT leak into the new topic.
+    NPersQueue::TTestServer server = CreateServer();
+    const ui64 oldPathId = 111;
+    const ui64 newPathId = 222;
+
+    auto config = CreateConfig0(true);
+    config.SetPathId(newPathId);
+    AddPartition(config, 0, {}, "F");
+    AddPartition(config, 1, "F", {});
+    CreatePQTabletMock(server, 0, ETopicPartitionStatus::Active);
+    CreatePQTabletMock(server, 1, ETopicPartitionStatus::Active);
+
+    // Stale row from the previous incarnation, stored under the OLD PathId-encoded Topic value.
+    WriteToTableWithTopic(server, "A_Source_Recreated", PathIdTopic(oldPathId), 0, 777);
+
+    auto r = ChoosePartition(server, config, "A_Source_Recreated");
+
+    UNIT_ASSERT(r->Result);
+    // The stale SeqNo=777 from the old PathId row must not be reused for the new topic.
+    UNIT_ASSERT_VALUES_EQUAL(r->Result->Get()->SeqNo.value_or(0), 0);
+    // The new PathId-encoded row is written with a clean SeqNo.
+    AssertTableTopic(server, "A_Source_Recreated", PathIdTopic(newPathId), r->Result->Get()->PartitionId, 0);
+    // The stale old-PathId row is left untouched.
+    AssertTableTopic(server, "A_Source_Recreated", PathIdTopic(oldPathId), 0, 777);
+}
+
+Y_UNIT_TEST(TPartitionChooserActor_SplitMergeEnabled_PathIdCutover_NoLegacyWrite) {
+    // Cutover phase (flag = true): only the PathId-encoded row is written; no legacy plain-name row.
+    NPersQueue::TTestServer server = CreateServer();
+    server.CleverServer->GetRuntime()->GetAppData().FeatureFlags
+        .SetTopicPartitionMappingByPathIdMigrationComplete(true);
+    const ui64 pathId = 100502;
+
+    auto config = CreateConfig0(true);
+    config.SetPathId(pathId);
+    AddPartition(config, 0, {}, {});
+    CreatePQTabletMock(server, 0, ETopicPartitionStatus::Active);
+
+    auto r = ChoosePartition(server, config, "A_Source_Cutover");
+
+    UNIT_ASSERT(r->Result);
+    UNIT_ASSERT_VALUES_EQUAL(r->Result->Get()->PartitionId, 0);
+
+    NPersQueue::TTopicConverterPtr fullConverter = CreateTopicConverter();
+    // PathId-encoded row is written.
+    AssertTableTopic(server, "A_Source_Cutover", PathIdTopic(pathId), 0, 0);
+    // Legacy plain-name row is NOT written after cutover.
+    AssertTableTopicEmpty(server, "A_Source_Cutover", fullConverter->GetClientsideName());
 }
 
 

--- a/ydb/core/persqueue/writer/partition_chooser_impl.cpp
+++ b/ydb/core/persqueue/writer/partition_chooser_impl.cpp
@@ -51,7 +51,7 @@ IActor* CreatePartitionChooserActor(TActorId parentId,
                                     std::optional<ui32> preferedPartition,
                                     NWilson::TTraceId traceId) {
     if (SplitMergeEnabled(config.GetPQTabletConfig())) {
-        return new NPartitionChooser::TSMPartitionChooserActor<TPipeHelper>(parentId, chooser, graph, fullConverter, sourceId, preferedPartition, std::move(traceId));
+        return new NPartitionChooser::TSMPartitionChooserActor<TPipeHelper>(parentId, chooser, graph, fullConverter, sourceId, preferedPartition, std::move(traceId), config.GetPathId());
     } else {
         return new NPartitionChooser::TPartitionChooserActor<TPipeHelper>(parentId, config, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId));
     }

--- a/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__abstract_chooser_actor.h
@@ -39,13 +39,14 @@ public:
                                    NPersQueue::TTopicConverterPtr& fullConverter,
                                    const TString& sourceId,
                                    std::optional<ui32> preferedPartition,
-                                   NWilson::TTraceId traceId)
+                                   NWilson::TTraceId traceId,
+                                   ui64 pathId = 0)
         : Parent(parentId)
         , SourceId(sourceId)
         , PreferedPartition(preferedPartition)
         , Chooser(chooser)
         , Span(TWilsonTopic::TopicDetailed, std::move(traceId), "Topic.ChoosePartition")
-        , TableHelper(fullConverter->GetClientsideName(), fullConverter->GetTopicForSrcIdHash())
+        , TableHelper(fullConverter->GetClientsideName(), fullConverter->GetTopicForSrcIdHash(), pathId)
         , PartitionHelper(Span.GetTraceId())
     {
     }

--- a/ydb/core/persqueue/writer/partition_chooser_impl__old_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__old_chooser_actor.h
@@ -29,7 +29,7 @@ public:
                            const TString& sourceId,
                            std::optional<ui32> preferedPartition,
                            NWilson::TTraceId traceId)
-        : TAbstractPartitionChooserActor<TPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId))
+        : TAbstractPartitionChooserActor<TPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId), config.GetPathId())
         , PQRBHelper(config.GetBalancerTabletID()) {
     }
 

--- a/ydb/core/persqueue/writer/partition_chooser_impl__sm_chooser_actor.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__sm_chooser_actor.h
@@ -29,8 +29,9 @@ public:
                            NPersQueue::TTopicConverterPtr& fullConverter,
                            const TString& sourceId,
                            std::optional<ui32> preferedPartition,
-                           NWilson::TTraceId traceId)
-        : TAbstractPartitionChooserActor<TSMPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId))
+                           NWilson::TTraceId traceId,
+                           ui64 pathId = 0)
+        : TAbstractPartitionChooserActor<TSMPartitionChooserActor<TPipeCreator>, TPipeCreator>(parentId, chooser, fullConverter, sourceId, preferedPartition, std::move(traceId), pathId)
         , Graph(graph) {
     }
 

--- a/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
+++ b/ydb/core/persqueue/writer/partition_chooser_impl__table_helper.h
@@ -20,9 +20,10 @@ namespace NKikimr::NPQ::NPartitionChooser {
 
 class TTableHelper {
 public:
-    TTableHelper(const TString& topicName, const TString& topicHashName)
+    TTableHelper(const TString& topicName, const TString& topicHashName, ui64 pathId = 0)
         : TopicName(topicName)
-        , TopicHashName(topicHashName) {
+        , TopicHashName(topicHashName)
+        , PathId(pathId) {
     };
 
     std::optional<ui32> PartitionId() const {
@@ -35,6 +36,7 @@ public:
 
     [[nodiscard]] bool Initialize(const TActorContext& ctx, const TString& sourceId) {
         const auto& pqConfig = AppData(ctx)->PQConfig;
+        const auto& featureFlags = AppData(ctx)->FeatureFlags;
 
         TableGeneration = pqConfig.GetTopicsAreFirstClassCitizen() ? ESourceIdTableGeneration::PartitionMapping
                                                                    : ESourceIdTableGeneration::SrcIdMeta2;
@@ -46,9 +48,20 @@ public:
             return false;
         }
 
-        SelectQuery = GetSelectSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
-        UpdateQuery = GetUpdateSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
-        UpdateAccessTimeQuery = GetUpdateAccessTimeQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration);
+        // Primary Topic key value. When PathId is known, use the PathId-encoded value.
+        // WithFallback keeps writing/reading the legacy plain-name row during migration for safe
+        // rollback; it is disabled once TopicPartitionMappingByPathIdMigrationComplete is set.
+        if (PathId != 0) {
+            PrimaryTopic = EncodeTopicWithPathId(PathId, TopicName);
+            WithFallback = !featureFlags.GetTopicPartitionMappingByPathIdMigrationComplete();
+        } else {
+            PrimaryTopic = TopicName;
+            WithFallback = false;
+        }
+
+        SelectQuery = GetSelectSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration, WithFallback);
+        UpdateQuery = GetUpdateSourceIdQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration, WithFallback);
+        UpdateAccessTimeQuery = GetUpdateAccessTimeQueryFromPath(pqConfig.GetSourceIdTablePath(), TableGeneration, WithFallback);
 
         YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_PARTITION_CHOOSER, "TTableHelper",
             {"selectQuery", SelectQuery});
@@ -143,11 +156,18 @@ public:
 
         paramsBuilder
             .AddParam("$Topic")
-                .Utf8(TopicName)
+                .Utf8(PrimaryTopic)
                 .Build()
             .AddParam("$SourceId")
                 .Utf8(EncodedSourceId.EscapedSourceId)
                 .Build();
+
+        if (WithFallback) {
+            paramsBuilder
+                .AddParam("$TopicName")
+                    .Utf8(TopicName)
+                    .Build();
+        }
 
         NYdb::TParams params = paramsBuilder.Build();
 
@@ -222,7 +242,7 @@ public:
 
         paramsBuilder
             .AddParam("$Topic")
-                .Utf8(TopicName)
+                .Utf8(PrimaryTopic)
                 .Build()
             .AddParam("$SourceId")
                 .Utf8(EncodedSourceId.EscapedSourceId)
@@ -240,6 +260,13 @@ public:
                 .Uint32(partitionId)
                 .Build();
 
+        if (WithFallback) {
+            paramsBuilder
+                .AddParam("$TopicName")
+                    .Utf8(TopicName)
+                    .Build();
+        }
+
         NYdb::TParams params = paramsBuilder.Build();
 
         ev->Record.MutableRequest()->MutableYdbParameters()->swap(*(NYdb::TProtoAccessor::GetProtoMapPtr(params)));
@@ -250,6 +277,12 @@ public:
 private:
     const TString TopicName;
     const TString TopicHashName;
+    const ui64 PathId;
+
+    // Primary Topic column value: PathId-encoded when PathId is known, otherwise the plain name.
+    TString PrimaryTopic;
+    // When true, queries also handle the legacy plain-name row (migration phase, safe rollback).
+    bool WithFallback = false;
 
     NPQ::NSourceIdEncoding::TEncodedSourceId EncodedSourceId;
 

--- a/ydb/core/persqueue/writer/source_id_encoding.cpp
+++ b/ydb/core/persqueue/writer/source_id_encoding.cpp
@@ -17,127 +17,187 @@
 
 namespace NKikimr::NPQ {
 
-TString GetSelectSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration generation) {
+// During migration (withFallback == true) queries handle two Topic values in a single request:
+//   $Topic     - primary, PathId-encoded value ("pathId:<pathId>:<topicName>")
+//   $TopicName - legacy plain topic name
+// This keeps the one-response-per-phase contract of the partition chooser state machine intact.
+TString GetSelectSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration generation, bool withFallback) {
     switch (generation) {
-        case ESourceIdTableGeneration::SrcIdMeta2:
-            return TStringBuilder() << "--!syntax_v1\n"
+        case ESourceIdTableGeneration::SrcIdMeta2: {
+            TStringBuilder query;
+            query << "--!syntax_v1\n"
                    "DECLARE $Hash AS Uint32; "
-                   "DECLARE $Topic AS Utf8; "
-                   "DECLARE $SourceId AS Utf8;\n"
+                   "DECLARE $Topic AS Utf8; ";
+            if (withFallback) {
+                query << "DECLARE $TopicName AS Utf8; ";
+            }
+            query << "DECLARE $SourceId AS Utf8;\n"
                    "SELECT Partition, CreateTime, AccessTime, SeqNo FROM `" << path << "` "
-                   "WHERE Hash == $Hash AND Topic == $Topic AND SourceId == $SourceId;";
-        case ESourceIdTableGeneration::PartitionMapping:
-            return TStringBuilder() << "--!syntax_v1\n"
+                   "WHERE Hash == $Hash AND "
+                   << (withFallback ? "(Topic == $Topic OR Topic == $TopicName)" : "Topic == $Topic")
+                   << " AND SourceId == $SourceId;";
+            return query;
+        }
+        case ESourceIdTableGeneration::PartitionMapping: {
+            TStringBuilder query;
+            query << "--!syntax_v1\n"
                    "DECLARE $Hash AS Uint64; "
-                   "DECLARE $Topic AS Utf8; "
-                   "DECLARE $SourceId AS Utf8;\n"
+                   "DECLARE $Topic AS Utf8; ";
+            if (withFallback) {
+                query << "DECLARE $TopicName AS Utf8; ";
+            }
+            query << "DECLARE $SourceId AS Utf8;\n"
                    "SELECT Partition, CreateTime, AccessTime, SeqNo FROM `"
                    << NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath()
-                   << "` WHERE Hash == $Hash AND Topic == $Topic AND ProducerId == $SourceId;";
+                   << "` WHERE Hash == $Hash AND "
+                   << (withFallback ? "(Topic == $Topic OR Topic == $TopicName)" : "Topic == $Topic")
+                   << " AND ProducerId == $SourceId;";
+            return query;
+        }
         default:
             AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
-TString GetSelectSourceIdQuery(const TString& root, ESourceIdTableGeneration generation) {
+TString GetSelectSourceIdQuery(const TString& root, ESourceIdTableGeneration generation, bool withFallback) {
     switch (generation) {
         case ESourceIdTableGeneration::SrcIdMeta2:
-            return GetSelectSourceIdQueryFromPath(root + "/SourceIdMeta2", generation);
+            return GetSelectSourceIdQueryFromPath(root + "/SourceIdMeta2", generation, withFallback);
         case ESourceIdTableGeneration::PartitionMapping:
             return GetSelectSourceIdQueryFromPath(
                     NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath(),
-                    generation
+                    generation, withFallback
             );
         default:
             AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
-TString GetUpdateSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration generation) {
+TString GetUpdateSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration generation, bool withFallback) {
     switch (generation) {
-        case ESourceIdTableGeneration::SrcIdMeta2:
-            return TStringBuilder() << "--!syntax_v1\n"
+        case ESourceIdTableGeneration::SrcIdMeta2: {
+            TStringBuilder query;
+            query << "--!syntax_v1\n"
                    "DECLARE $SourceId AS Utf8; "
-                   "DECLARE $Topic AS Utf8; "
-                   "DECLARE $Hash AS Uint32; "
+                   "DECLARE $Topic AS Utf8; ";
+            if (withFallback) {
+                query << "DECLARE $TopicName AS Utf8; ";
+            }
+            query << "DECLARE $Hash AS Uint32; "
                    "DECLARE $Partition AS Uint32; "
                    "DECLARE $CreateTime AS Uint64; "
                    "DECLARE $AccessTime AS Uint64;"
                    "DECLARE $SeqNo AS Uint64;\n"
                    "UPSERT INTO `" << path << "` (Hash, Topic, SourceId, CreateTime, AccessTime, Partition, SeqNo) VALUES "
-                                              "($Hash, $Topic, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo);";
-        case ESourceIdTableGeneration::PartitionMapping:
-            return TStringBuilder() << "--!syntax_v1\n"
+                   "($Hash, $Topic, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo)";
+            if (withFallback) {
+                query << ", ($Hash, $TopicName, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo)";
+            }
+            query << ";";
+            return query;
+        }
+        case ESourceIdTableGeneration::PartitionMapping: {
+            TStringBuilder query;
+            query << "--!syntax_v1\n"
                    "DECLARE $SourceId AS Utf8; "
-                   "DECLARE $Topic AS Utf8; "
-                   "DECLARE $Hash AS Uint64; "
+                   "DECLARE $Topic AS Utf8; ";
+            if (withFallback) {
+                query << "DECLARE $TopicName AS Utf8; ";
+            }
+            query << "DECLARE $Hash AS Uint64; "
                    "DECLARE $Partition AS Uint32; "
                    "DECLARE $CreateTime AS Uint64; "
                    "DECLARE $AccessTime AS Uint64; "
                    "DECLARE $SeqNo AS Uint64;\n"
                    "UPSERT INTO `" << NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath()
                     << "` (Hash, Topic, ProducerId, CreateTime, AccessTime, Partition, SeqNo) VALUES "
-                                              "($Hash, $Topic, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo);";
+                   "($Hash, $Topic, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo)";
+            if (withFallback) {
+                query << ", ($Hash, $TopicName, $SourceId, $CreateTime, $AccessTime, $Partition, $SeqNo)";
+            }
+            query << ";";
+            return query;
+        }
         default:
             AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
-TString GetUpdateAccessTimeQueryFromPath(const TString& path, ESourceIdTableGeneration generation) {
+TString GetUpdateAccessTimeQueryFromPath(const TString& path, ESourceIdTableGeneration generation, bool withFallback) {
     switch (generation) {
-        case ESourceIdTableGeneration::SrcIdMeta2:
-            return TStringBuilder() << "--!syntax_v1\n"
+        case ESourceIdTableGeneration::SrcIdMeta2: {
+            TStringBuilder query;
+            query << "--!syntax_v1\n"
                    "DECLARE $SourceId AS Utf8; "
-                   "DECLARE $Topic AS Utf8; "
-                   "DECLARE $Hash AS Uint32; "
+                   "DECLARE $Topic AS Utf8; ";
+            if (withFallback) {
+                query << "DECLARE $TopicName AS Utf8; ";
+            }
+            query << "DECLARE $Hash AS Uint32; "
                    "DECLARE $Partition AS Uint32; "
                    "DECLARE $CreateTime AS Uint64; "
                    "DECLARE $AccessTime AS Uint64;\n"
                    "UPDATE `" << path << "` "
                    "SET AccessTime = $AccessTime "
-                   "WHERE Hash = $Hash AND Topic = $Topic AND SourceId = $SourceId AND Partition = $Partition;";
-        case ESourceIdTableGeneration::PartitionMapping:
-            return TStringBuilder() << "--!syntax_v1\n"
+                   "WHERE Hash = $Hash AND "
+                   << (withFallback ? "(Topic = $Topic OR Topic = $TopicName)" : "Topic = $Topic")
+                   << " AND SourceId = $SourceId AND Partition = $Partition;";
+            return query;
+        }
+        case ESourceIdTableGeneration::PartitionMapping: {
+            TStringBuilder query;
+            query << "--!syntax_v1\n"
                    "DECLARE $SourceId AS Utf8; "
-                   "DECLARE $Topic AS Utf8; "
-                   "DECLARE $Hash AS Uint64; "
+                   "DECLARE $Topic AS Utf8; ";
+            if (withFallback) {
+                query << "DECLARE $TopicName AS Utf8; ";
+            }
+            query << "DECLARE $Hash AS Uint64; "
                    "DECLARE $Partition AS Uint32; "
                    "DECLARE $CreateTime AS Uint64; "
                    "DECLARE $AccessTime AS Uint64;\n"
                    "UPDATE `" << NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath() << "` "
                    "SET AccessTime = $AccessTime "
-                   "WHERE Hash = $Hash AND Topic = $Topic AND ProducerId = $SourceId AND Partition = $Partition;";
+                   "WHERE Hash = $Hash AND "
+                   << (withFallback ? "(Topic = $Topic OR Topic = $TopicName)" : "Topic = $Topic")
+                   << " AND ProducerId = $SourceId AND Partition = $Partition;";
+            return query;
+        }
         default:
             AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
-TString GetUpdateSourceIdQuery(const TString& root, ESourceIdTableGeneration generation) {
+TString GetUpdateSourceIdQuery(const TString& root, ESourceIdTableGeneration generation, bool withFallback) {
     switch (generation) {
         case ESourceIdTableGeneration::SrcIdMeta2:
-            return GetUpdateSourceIdQueryFromPath(root + "/SourceIdMeta2", generation);
+            return GetUpdateSourceIdQueryFromPath(root + "/SourceIdMeta2", generation, withFallback);
         case ESourceIdTableGeneration::PartitionMapping:
             return GetUpdateSourceIdQueryFromPath(
                     NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath(),
-                    generation
+                    generation, withFallback
             );
         default:
             AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
 }
 
-TString GetUpdateAccessTimeQuery(const TString& root, ESourceIdTableGeneration generation) {
+TString GetUpdateAccessTimeQuery(const TString& root, ESourceIdTableGeneration generation, bool withFallback) {
     switch (generation) {
         case ESourceIdTableGeneration::SrcIdMeta2:
-            return GetUpdateAccessTimeQueryFromPath(root + "/SourceIdMeta2", generation);
+            return GetUpdateAccessTimeQueryFromPath(root + "/SourceIdMeta2", generation, withFallback);
         case ESourceIdTableGeneration::PartitionMapping:
             return GetUpdateAccessTimeQueryFromPath(
                     NGRpcProxy::V1::TSrcIdMetaInitManager::GetInstant()->GetStorageTablePath(),
-                    generation
+                    generation, withFallback
             );
         default:
             AFL_ENSURE(false)("generation", static_cast<int>(generation));
     }
+}
+
+TString EncodeTopicWithPathId(ui64 pathId, const TString& topicName) {
+    return TStringBuilder() << "pathId:" << pathId << ":" << topicName;
 }
 
 namespace NSourceIdEncoding {

--- a/ydb/core/persqueue/writer/source_id_encoding.h
+++ b/ydb/core/persqueue/writer/source_id_encoding.h
@@ -16,13 +16,17 @@ enum class ESourceIdTableGeneration {
     PartitionMapping
 };
 
-TString GetSelectSourceIdQuery(const TString& root, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2);
-TString GetUpdateSourceIdQuery(const TString& root, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2);
-TString GetUpdateAccessTimeQuery(const TString& root, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2);
+// When withFallback is true, the query additionally reads/writes a second (legacy) Topic value
+TString GetSelectSourceIdQuery(const TString& root, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2, bool withFallback = false);
+TString GetUpdateSourceIdQuery(const TString& root, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2, bool withFallback = false);
+TString GetUpdateAccessTimeQuery(const TString& root, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2, bool withFallback = false);
 
-TString GetSelectSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2);
-TString GetUpdateSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2);
-TString GetUpdateAccessTimeQueryFromPath(const TString& path, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2);
+TString GetSelectSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2, bool withFallback = false);
+TString GetUpdateSourceIdQueryFromPath(const TString& path, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2, bool withFallback = false);
+TString GetUpdateAccessTimeQueryFromPath(const TString& path, ESourceIdTableGeneration = ESourceIdTableGeneration::SrcIdMeta2, bool withFallback = false);
+
+// Builds the PathId-encoded Topic column value.
+TString EncodeTopicWithPathId(ui64 pathId, const TString& topicName);
 
 namespace NSourceIdEncoding {
 

--- a/ydb/core/protos/feature_flags.proto
+++ b/ydb/core/protos/feature_flags.proto
@@ -360,4 +360,7 @@ message TFeatureFlags {
     optional bool EnableKafkaServerlessTransactions = 307 [default = false];
     optional bool EnableGeneratedStored = 308 [default = false];
     optional bool EnableGeneratedVirtual = 309 [default = false];
+    // false (default) = migration phase: write+read both PathId-encoded and legacy Topic rows (safe rollback)
+    // true            = cutover: use only PathId-encoded Topic rows
+    optional bool TopicPartitionMappingByPathIdMigrationComplete = 310 [default = false];
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Use pathId:<pathId>:topicName for topic key in partition mapping table instead of just topic name to avoid issues with topic deleted and re-created with the same name but old mapping still exists.

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Feature flag: TopicPartitionMappingByPathIdMigrationComplete to control migration.
While the flag is false (default) mappings are selected, created and updated using both new and old topic key, hence providing zero-loss migration and safe code rollback.
Once flag set only new mapping will be used.
Table structure has not changed
