### PR TITLE
Support queue overflow tracking in v2

### DIFF
--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -503,6 +503,7 @@ namespace NActors {
                 copy.MergeFrom(base);
                 base.Swap(&copy);
                 PreSerializedData.clear();
+                TBase::InvalidateCachedByteSize(); // cached size may be incorrect now
             }
             return TBase::Record;
         }
@@ -540,14 +541,6 @@ namespace NActors {
 
         ui32 CalculateSerializedSize() const override {
             return PreSerializedData.size() + TBase::CalculateSerializedSize();
-        }
-
-        size_t GetCachedByteSize() const {
-            return PreSerializedData.size() + TBase::GetCachedByteSize();
-        }
-
-        ui32 CalculateSerializedSizeCached() const override {
-            return GetCachedByteSize();
         }
 
         TEventSerializationInfo CreateSerializationInfo(bool allowExternalDataChannel) const override {

--- a/ydb/library/actors/interconnect/events/events.h
+++ b/ydb/library/actors/interconnect/events/events.h
@@ -67,6 +67,8 @@ namespace NActors {
         EvUnregisterSession,
         EvStop,
         EvUringMonRequest,
+        EvUringQueueOverload,
+        EvUringEventTooLarge,
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // nonlocal messages; their indices must be preserved in order to work properly while doing rolling update

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.cpp
@@ -96,6 +96,15 @@ namespace NActors {
     void TInterconnectSessionTCPv2::Terminate(TDisconnectReason reason) {
         LOG_INFO_IC_SESSION("ICS92", "v2 session terminated reason# %s", reason.ToString().data());
 
+        if (const TString& s = reason.ToString()) {
+            Proxy->Metrics->IncDisconnectByReason(s);
+        }
+
+        Proxy->UpdateErrorStateLog(TActivationContext::Now(), "close_socket", reason.ToString().data());
+        Proxy->Metrics->IncDisconnections();
+        Proxy->Metrics->SetConnected(0);
+        Proxy->RegisterDisconnect();
+
         IActor::InvokeOtherActor(*Proxy, &TInterconnectProxyTCP::UnregisterSession, this);
 
         // atomically disconnect the direct interface so racing user threads observe a clean shutdown
@@ -115,8 +124,6 @@ namespace NActors {
             Send(actorId, new TEvInterconnect::TEvNodeDisconnected(Proxy->PeerNodeId), 0, info.Cookie);
         }
         Subscribers.clear();
-
-        Proxy->Metrics->SetConnected(0);
 
         Proxy->Common->UringEngineV2->Unregister(EngineHandle);
 
@@ -207,6 +214,10 @@ namespace NActors {
 
     void TInterconnectSessionTCPv2::HandlePoison() {
         Terminate(TDisconnectReason::UserRequest());
+    }
+
+    ui64 TInterconnectSessionTCPv2::GetTotalOutputQueueSize() const {
+        return Proxy->Common->UringEngineV2->GetTotalOutputQueueSize(EngineHandle);
     }
 
     void TInterconnectSessionTCPv2::GenerateHttpInfo(NMon::TEvHttpInfoRes::TPtr& ev) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
@@ -60,7 +60,7 @@ namespace NActors {
 
         const TSessionParams& GetParams() const override { return Params; }
         const TIntrusivePtr<NInterconnect::TStreamSocket>& GetSocket() const override { return Socket; }
-        ui64 GetTotalOutputQueueSize() const override { return 0; }
+        ui64 GetTotalOutputQueueSize() const override;
         std::optional<ui8> GetXDCFlags() const override { return std::nullopt; }
         TDuration GetPingRTT() const override { return TDuration::FromValue(PingRTT->load()); }
         i64 GetClockSkew() const override { return ClockSkew->load(); }

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
@@ -87,6 +87,25 @@ namespace NActors {
     struct TEvDestroyEvents : TEventLocal<TEvDestroyEvents, 0> {
         std::vector<std::unique_ptr<IEventBase>> Events;
         std::vector<TIntrusivePtr<TEventSerializedData>> Buffers;
+        size_t Bytes = 0;
+        std::shared_ptr<std::atomic<TAtomicBase>> Counter;
+
+        ~TEvDestroyEvents() {
+            if (Counter) {
+                Counter->fetch_sub(Bytes, std::memory_order_relaxed);
+            }
+        }
+
+        size_t CalculateTotalSize() const {
+            size_t bytes = 0;
+            for (const auto& ev : Events) {
+                bytes += ev->CalculateSerializedSizeCached();
+            }
+            for (const auto& buffer : Buffers) {
+                bytes += buffer->GetSize();
+            }
+            return bytes;
+        }
     };
 
     class TUringEngine final : public IUringEngine {
@@ -157,6 +176,8 @@ namespace NActors {
             ui64 ReceiveCycles = 0;
             ui64 EventsReceivedCallback = 0;
             ui64 EventsReceivedActorSystem = 0;
+
+            std::atomic_uint64_t TotalOutputQueueSize{0};
 
             TSession(ui32 shardIdx, TIntrusivePtr<NInterconnect::TStreamSocket> socket,
                     TActorId sessionId, bool checksumming, TScopeId peerScopeId,
@@ -291,7 +312,17 @@ namespace NActors {
                 Y_ABORT_UNLESS(num <= UnsentBytes, "num# %zu UnsentBytes# %zu", num, UnsentBytes);
                 UnsentBytes -= num;
 
+                size_t numEvents = events->size();
+                size_t numBuffers = buffers->size();
+                size_t bytes = 0;
                 Serializer.CommitProducedBytes(num, eventToWireTime, events, buffers);
+                for (size_t i = numEvents, count = events->size(); i < count; ++i) {
+                    bytes += (*events)[i]->CalculateSerializedSizeCached();
+                }
+                for (size_t i = numBuffers, count = buffers->size(); i < count; ++i) {
+                    bytes += (*buffers)[i]->GetSize();
+                }
+                TotalOutputQueueSize.fetch_sub(bytes, std::memory_order_relaxed);
             }
 
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -759,6 +790,18 @@ namespace NActors {
             void Send(ui64 conn, std::unique_ptr<IEventHandle> ev, TIntrusivePtr<IReceiveCallback> replyCallback) {
                 ++*EventsSent;
 
+                // handle output queue size here
+                const size_t size = ev->HasBuffer() ? ev->GetChainBuffer()->GetSize() :
+                    ev->HasEvent() ? ev->GetBase()->CalculateSerializedSizeCached() : 0;
+                if (size > Engine.Common->Settings.MaxSerializedEventSize) {
+                    return SendInternal(conn, static_cast<ui32>(ENetwork::EvUringEventTooLarge), {}, nullptr, true);
+                }
+                auto& session = *reinterpret_cast<TSession*>(conn);
+                const ui64 newQueueSize = size + session.TotalOutputQueueSize.fetch_add(size, std::memory_order_relaxed);
+                if (const ui64 limit = Engine.Common->Settings.SendBufferDieLimitInMB; limit && newQueueSize > limit * 1_MB) {
+                    return SendInternal(conn, static_cast<ui32>(ENetwork::EvUringQueueOverload), {}, nullptr, true);
+                }
+
                 // this event is strictly sequenced
                 SendImpl(conn, std::move(ev), std::move(replyCallback), true);
             }
@@ -959,7 +1002,14 @@ namespace NActors {
 
                     // discard pending events/buffers, if any
                     if (!EvDestroyEvents->Events.empty() || !EvDestroyEvents->Buffers.empty()) {
-                        Engine.ActorSystem->Send(new IEventHandle(Engine.DestructorActorId, {}, EvDestroyEvents.release()));
+                        const size_t bytes = EvDestroyEvents->CalculateTotalSize();
+                        const auto& counter = Engine.Common->DestructorQueueSize;
+                        const size_t max = Engine.Common->MaxDestructorQueueSize;
+                        EvDestroyEvents->Counter = counter;
+                        EvDestroyEvents->Bytes = bytes;
+                        if (Y_LIKELY(!counter || counter->fetch_add(bytes, std::memory_order_relaxed) + bytes <= max)) {
+                            Engine.ActorSystem->Send(new IEventHandle(Engine.DestructorActorId, {}, EvDestroyEvents.release()));
+                        }
                         EvDestroyEvents = std::make_unique<TEvDestroyEvents>();
                     }
 
@@ -1100,6 +1150,18 @@ namespace NActors {
                     case static_cast<ui32>(ENetwork::EvUringMonRequest):
                         ProcessMonRequest(GetSession(record), std::move(record->Ev->Get<TEvUringMonRequest>()->Ev));
                         break;
+
+                    case static_cast<ui32>(ENetwork::EvUringQueueOverload): {
+                        TSession& session = GetSession(record);
+                        session.Disconnect(TDisconnectReason::QueueOverload());
+                        break;
+                    }
+
+                    case static_cast<ui32>(ENetwork::EvUringEventTooLarge): {
+                        TSession& session = GetSession(record);
+                        session.Disconnect(TDisconnectReason::EventTooLarge());
+                        break;
+                    }
 
                     default: {
                         TSession& session = GetSession(record);
@@ -1532,6 +1594,10 @@ namespace NActors {
 
         void IssueMonRequest(ui64 conn, NMon::TEvHttpInfoRes::TPtr ev) override {
             GetShard(conn).IssueMonRequest(conn, std::move(ev));
+        }
+
+        ui64 GetTotalOutputQueueSize(ui64 conn) override {
+            return reinterpret_cast<TSession*>(conn)->TotalOutputQueueSize.load(std::memory_order_relaxed);
         }
     };
 

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.h
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.h
@@ -49,6 +49,9 @@ namespace NActors {
 
         // Issue monitoring request.
         virtual void IssueMonRequest(ui64 conn, NMon::TEvHttpInfoRes::TPtr ev) = 0;
+
+        // Get total output queue size (in bytes).
+        virtual ui64 GetTotalOutputQueueSize(ui64 conn) = 0;
     };
 
     using TUringEnginePtr = TIntrusivePtr<IUringEngine>;

--- a/ydb/library/actors/interconnect/v2_event_serializer.cpp
+++ b/ydb/library/actors/interconnect/v2_event_serializer.cpp
@@ -243,16 +243,19 @@ namespace NActors {
                         queue.Buffer = ev.ReleaseChainBuffer();
                         queue.Iter = queue.Buffer->GetBeginIter();
                         queue.EvSerInfo = &queue.Buffer->GetSerializationInfo();
+                        queue.SerializedBytesPending = queue.Buffer->GetSize();
                     } else if (ev.HasEvent()) {
                         IEventBase *event = ev.GetBase();
                         queue.SerializeStage = ESerializeStage::kChunkSerializer;
                         queue.CoroutineChunkSerializer.SetSerializingEvent(event, /*withCachedSizes=*/ false);
                         queue.EvSerInfoHolder = event->CreateSerializationInfo(true);
                         queue.EvSerInfo = &queue.EvSerInfoHolder;
+                        queue.SerializedBytesPending = event->CalculateSerializedSizeCached();
                     } else {
                         queue.SerializeStage = ESerializeStage::kHeader;
                         queue.EvSerInfoHolder = {};
                         queue.EvSerInfo = &queue.EvSerInfoHolder;
+                        queue.SerializedBytesPending = 0;
                     }
                     if (Checksumming) {
                         XXH3_64bits_reset(&queue.ChecksumState);
@@ -276,9 +279,12 @@ namespace NActors {
                             queue.Iter.ContiguousSize());
                         addEventChunkBytes(queue.Iter.ContiguousData(), numBytes);
                         queue.Iter += numBytes;
+                        Y_ABORT_UNLESS(numBytes <= queue.SerializedBytesPending);
+                        queue.SerializedBytesPending -= numBytes;
                     }
                     if (!queue.Iter.Valid()) {
                         queue.SerializeStage = ESerializeStage::kHeader;
+                        Y_ABORT_UNLESS(queue.SerializedBytesPending == 0);
                     }
 
                     break;
@@ -292,6 +298,8 @@ namespace NActors {
                     for (const auto& chunk : queue.CoroutineChunkSerializer.FeedBuf(&span,
                             maxBytesToProduce - sizeof(TChunkHeader))) {
                         addEventChunkBytes(chunk.Buf, chunk.Size);
+                        Y_ABORT_UNLESS(chunk.Size <= queue.SerializedBytesPending);
+                        queue.SerializedBytesPending -= chunk.Size;
                     }
                     Y_DEBUG_ABORT_UNLESS(buffer.data() + buffer.size() == span.data() + span.size());
                     Y_DEBUG_ABORT_UNLESS(span.size() <= buffer.size()); // ensure span did not reduce
@@ -302,6 +310,10 @@ namespace NActors {
                     // check if we have finished serializing this event
                     if (queue.CoroutineChunkSerializer.IsComplete()) {
                         queue.SerializeStage = ESerializeStage::kHeader;
+                        Y_ABORT_UNLESS(queue.SerializedBytesPending == 0, "Type# 0x%08" PRIx32 " SerializedBytesPending# %zu"
+                            " CalculateSerializedSize# %zu CalculateSerializedSizeCached# %zu", ev.Type,
+                            queue.SerializedBytesPending, ev.GetBase()->CalculateSerializedSize(),
+                            ev.GetBase()->CalculateSerializedSizeCached());
                     }
 
                     SerializeEventTime += UpdateTimestamp();

--- a/ydb/library/actors/interconnect/v2_event_serializer.h
+++ b/ydb/library/actors/interconnect/v2_event_serializer.h
@@ -120,6 +120,7 @@ namespace NActors {
             TEventQueue Events;
             std::deque<TRcBuf> SystemRequests;
             TEventHeader EventHeader;
+            size_t SerializedBytesPending = 0;
             size_t EventHeaderOffset = 0;
             TIntrusivePtr<TEventSerializedData> Buffer;
             TRope::TConstIterator Iter;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Support queue overflow tracking in v2

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch returns queue overflow tracking functionality into v2 as it works in v1.
