### PR TITLE
Add TLS kernel liveness interconnect test, NBYDB-2413

### DIFF
--- a/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/interconnect_ut.cpp
@@ -894,6 +894,28 @@ void RunKernelLivenessMixedConfigAsymmetric(bool withRdma, ui32 kernelLivenessNo
     UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), node1Expected);
 }
 
+void RunKernelLivenessWithTls() {
+    auto settingsCustomizer = [](ui32, TInterconnectSettings& settings) {
+        settings.EnableKernelLiveness = true;
+        settings.PingPeriod = TDuration::MilliSeconds(200);
+    };
+
+    TTestICCluster cluster(2, TChannelsConfig(), nullptr, nullptr,
+        TTestICCluster::Flags(TTestICCluster::USE_TLS | TTestICCluster::DISABLE_RDMA),
+        {}, TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto* recipientPtr = new TRecipientActor;
+    const TActorId recipient = cluster.RegisterActor(recipientPtr, 1);
+    cluster.RegisterActor(new TSenderActor(recipient, 1), 2);
+
+    WaitForCondition(TDuration::Seconds(10), [&] {
+        return recipientPtr->GetReceived() >= 1;
+    }, "TLS initial message delivery with kernel liveness");
+
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 2, 1, "Params.UseKernelLiveness"), 1ULL);
+    UNIT_ASSERT_VALUES_EQUAL(WaitForSessionCounter(cluster, 1, 2, "Params.UseKernelLiveness"), 1ULL);
+}
+
 void RunKernelLivenessSocketSetupFallback(bool withRdma) {
     if (SkipIfRdmaUnavailable(withRdma, "KernelLivenessSocketSetupFallbackRdma")) {
         return;
@@ -1489,6 +1511,10 @@ Y_UNIT_TEST_SUITE(Interconnect) {
 
     Y_UNIT_TEST(KernelLivenessMixedConfigFallbackReverse) {
         RunKernelLivenessMixedConfigAsymmetric(false, 1);
+    }
+
+    Y_UNIT_TEST(KernelLivenessWithTls) {
+        RunKernelLivenessWithTls();
     }
 
     Y_UNIT_TEST(KernelLivenessSocketSetupFallback) {

--- a/ydb/library/actors/interconnect/ut_kernel_liveness/tcp_user_timeout_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_kernel_liveness/tcp_user_timeout_ut.cpp
@@ -224,11 +224,7 @@ private:
     bool FloodStarted = false;
 };
 
-} // namespace
-
-Y_UNIT_TEST_SUITE(InterconnectKernelLiveness) {
-
-    Y_UNIT_TEST(TcpUserTimeoutBlackholeDisconnectsSession) {
+void RunTcpUserTimeoutBlackholeDisconnectsSession(TTestICCluster::Flags flags) {
         constexpr size_t messages = 512;
         constexpr size_t payloadSize = 64 * 1024;
         constexpr TDuration userTimeout = TDuration::Seconds(3);
@@ -250,7 +246,7 @@ Y_UNIT_TEST_SUITE(InterconnectKernelLiveness) {
             .Disconnect = false,
         };
 
-        TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr, TTestICCluster::DISABLE_RDMA,
+        TTestICCluster cluster(2, TChannelsConfig(), &interrupterSettings, nullptr, flags,
             {}, TDuration::Seconds(30), 128 * 1024 * 1024, settingsCustomizer);
 
         auto* recipient12 = new TDropRecipientActor;
@@ -342,6 +338,19 @@ Y_UNIT_TEST_SUITE(InterconnectKernelLiveness) {
         UNIT_ASSERT_VALUES_EQUAL(sender21->GetObservedUnion(), messages);
         UNIT_ASSERT_C(sender12->GetUndelivered() > 0 || sender21->GetUndelivered() > 0,
             "expected at least one undelivered event after forced termination");
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(InterconnectKernelLiveness) {
+
+    Y_UNIT_TEST(TcpUserTimeoutBlackholeDisconnectsSession) {
+        RunTcpUserTimeoutBlackholeDisconnectsSession(TTestICCluster::DISABLE_RDMA);
+    }
+
+    Y_UNIT_TEST(TcpUserTimeoutBlackholeDisconnectsSessionWithTls) {
+        RunTcpUserTimeoutBlackholeDisconnectsSession(
+            TTestICCluster::Flags(TTestICCluster::USE_TLS | TTestICCluster::DISABLE_RDMA));
     }
 
     Y_UNIT_TEST(TcpUserTimeoutNoReconnectGeneratesUndelivered) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Check kernel keep-alive works with TLS encryption enabled socket

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
