### PR TITLE
Add SVG Plan Format

### DIFF
--- a/ydb/apps/ydb/CHANGELOG.md
+++ b/ydb/apps/ydb/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+* Added support for `--format svg` plan format to `ydb sql` command when used with `--explain` or `--explain-analyze` options
 * Added `--content-based-deduplication` option to `ydb topic create` and `ydb topic alter` commands.
 * Added support for the new `setnotnull` operation in the `ydb operation` subcommands.
 

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -113,6 +113,9 @@ void TCommandSql::Parse(TConfig& config) {
         throw TMisuseException() << "Both mutually exclusive options \"Explain-AST mode\" (\"--explain-ast\") "
             << "and \"Explain-analyze mode\" (\"--explain-analyze\") were provided.";
     }
+    if (OutputFormat == EDataFormat::Svg && !ExecSettings.ExplainMode && !ExecSettings.ExplainAnalyzeMode && !ExecSettings.ExplainAst) {
+        throw TMisuseException() << "SVG output format is only available with --explain or --explain-analyze options";
+    }
     if (ExecSettings.ExplainAnalyzeMode && !CollectStatsMode.empty()) {
         throw TMisuseException() << "Statistics collection mode option \"--stats\" has no effect in explain-analyze mode. "
             "Relevant for execution mode only.";

--- a/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_sql.cpp
@@ -79,6 +79,7 @@ void TCommandSql::Config(TConfig& config) {
         EDataFormat::Csv,
         EDataFormat::Tsv,
         EDataFormat::Parquet,
+        EDataFormat::Svg,
     });
 
     AddParametersOption(config);

--- a/ydb/public/lib/ydb_cli/common/format.cpp
+++ b/ydb/public/lib/ydb_cli/common/format.cpp
@@ -7,6 +7,7 @@
 #include <ydb/public/lib/json_value/ydb_json_value.h>
 #include <ydb/public/lib/ydb_cli/common/colors.h>
 #include <ydb/library/arrow_parquet/result_set_parquet_printer.h>
+#include <ydb/library/plan2svg/plan2svg.h>
 
 #include <iomanip>
 #include <regex>
@@ -54,6 +55,7 @@ namespace {
         { EDataFormat::Csv, "CSV format" },
         { EDataFormat::Tsv, "TSV format" },
         { EDataFormat::Parquet, "Parquet format" },
+        { EDataFormat::Svg, "SVG format" },
     };
 
     THashMap<EMessagingFormat, TString> MessagingFormatDescriptions = {
@@ -456,6 +458,9 @@ void TQueryPlanPrinter::Print(const TString& plan) {
         case EDataFormat::JsonBase64:
             PrintJson(plan);
             break;
+        case EDataFormat::Svg:
+            PrintSvg(plan);
+            break;
         default:
             throw TMisuseException() << "This command doesn't support " << Format << " output format";
     }
@@ -463,6 +468,12 @@ void TQueryPlanPrinter::Print(const TString& plan) {
 
 void TQueryPlanPrinter::PrintJson(const TString& plan) {
     Output << NJson::PrettifyJson(plan, false) << Endl;
+}
+
+void TQueryPlanPrinter::PrintSvg(const TString& plan) {
+    TPlanVisualizer planViz;
+    planViz.LoadPlans(plan);
+    Output << planViz.PrintSvg() << Endl;
 }
 
 void TQueryPlanPrinter::PrintPretty(const NJson::TJsonValue& plan) {

--- a/ydb/public/lib/ydb_cli/common/format.h
+++ b/ydb/public/lib/ydb_cli/common/format.h
@@ -158,6 +158,7 @@ private:
     void PrintPrettyTableImpl(const NJson::TJsonValue& plan, TString& offset, TPrettyTable& table, bool isLast = true, TVector<bool> hasMore = TVector<bool>());
     void PrintJson(const TString& plan);
     void PrintSimplifyJson(const NJson::TJsonValue& plan);
+    void PrintSvg(const TString& plan);
     TString JsonToString(const NJson::TJsonValue& jsonValue);
 
 private:

--- a/ydb/public/lib/ydb_cli/common/formats.h
+++ b/ydb/public/lib/ydb_cli/common/formats.h
@@ -21,7 +21,8 @@ enum class EDataFormat {
     Parquet /* "parquet" */,
     NoFraming /* "no-framing" */,
     NewlineDelimited /* "newline-delimited" */,
-    Raw /* "raw" */
+    Raw /* "raw" */,
+    Svg /* "svg" */
 };
 
 // EMessagingFormat to be used in both input and output when working with files/pipes in operations related to messaging


### PR DESCRIPTION
Add support for `--format svg` plan format to `ydb sql` command when used with `--explain` or `--explain-analyze`