### PR TITLE
persqueue: AI rules for topic message test coverage

### DIFF
--- a/ydb/core/persqueue/RULES.md
+++ b/ydb/core/persqueue/RULES.md
@@ -6,6 +6,13 @@
 * `*_fwd.h` for forwards; `.pb.h` only when needed; config: [`public/config.h`](public/config.h).
 * Implement methods in `.cpp`, not headers (except templates).
 
+## Tests
+
+Cover cases:
+* small and large messages
+* kafka batch message format with single and multiple messages
+* holes in the offset (mirroring)
+
 ## Review
 
 * Flag redundant or unreachable branches.

--- a/ydb/core/persqueue/RULES.md
+++ b/ydb/core/persqueue/RULES.md
@@ -8,13 +8,16 @@
 
 ## Tests
 
-Cover cases:
-* small and large messages
-* kafka batch message format with single and multiple messages
-* holes in the offset (mirroring)
+When changing topic read/write/offset/blob logic, cover:
+
+* **Small and large messages.** Large = >512 KiB (split into parts).
+* **Large-message layout:** all parts in one blob; parts across different blobs.
+* **Formats:** at least native and Kafka (single and multi-message batch).
+* **Offset gaps:** missing offsets / holes (e.g. mirroring).
 
 ## Review
 
+* Flag missing coverage for the cases above when the change touches message/blob/offset handling.
 * Flag redundant or unreachable branches.
 * [`agents/BACKWARD_COMPATIBILITY.md`](../../agents/BACKWARD_COMPATIBILITY.md)
 * [`agents/NO_ABORT.md`](../../agents/NO_ABORT.md)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds Tests/Review guidance to `ydb/core/persqueue/RULES.md` for AI agents:

* small and large messages (>512 KiB, split into parts)
* large-message parts in one blob vs across blobs
* native and Kafka formats (single/multi-message batch)
* offset gaps / holes

Reviewers should flag missing coverage of these cases when message/blob/offset handling changes.