### PR TITLE
[WIP][NOT-FOR-MERGE-YET] checkpoint storage: reorder pk to better match most queries

### DIFF
--- a/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
+++ b/ydb/core/fq/libs/checkpoint_storage/ydb_state_storage.cpp
@@ -376,7 +376,7 @@ TFuture<TIssues> TStateStorage::Init(const NACLib::TDiffACL& acl) {
         .AddNullableColumn("blob", EPrimitiveType::String)
         .AddNullableColumn("blob_seq_num", EPrimitiveType::Uint64)
         .AddNullableColumn("type", EPrimitiveType::Uint8)
-        .SetPrimaryKeyColumns({"graph_id", "task_id", "coordinator_generation", "seq_no", "blob_seq_num"})
+        .SetPrimaryKeyColumns({"graph_id", "coordinator_generation", "seq_no", "task_id", "blob_seq_num"})
         .Build();
 
     auto promise = NThreading::NewPromise<TIssues>();
@@ -640,8 +640,8 @@ TFuture<TStatus> TStateStorage::ListStates(const TContextPtr& context) {
                 SELECT task_id, coordinator_generation, seq_no, CAST(COUNT(*) as UINT64) as cnt
                 FROM %s
                 WHERE graph_id = $graph_id AND %s
-                GROUP by task_id, coordinator_generation, seq_no
-                ORDER BY task_id, coordinator_generation DESC, seq_no DESC;
+                GROUP by coordinator_generation, seq_no, task_id
+                ORDER BY coordinator_generation DESC, seq_no DESC, task_id;
             )", prefix.c_str(),
                 context->Tasks.size() == 1 ? "DECLARE $task_id AS Uint64" : "DECLARE $task_ids AS List<Uint64>",
                 StatesTable,


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

INCOMPLETE: migration required (and missing) (we'd need: describe table, check if pk order mismatch, re-create and copy table otherwise - which may temporarily require 2x storage; then again, we normally *use* temporarily at least 2x space anyway -- when checkpoint is being added, so should not be show-stopper)