### PR TITLE
Add code coverage via codecov to C++ YDB SDK and YDB CLI

### DIFF
--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -1,0 +1,184 @@
+name: Run Clang Codecov Suite
+description: Build/test with clang coverage, upload LCOV to Codecov, publish HTML to S3
+inputs:
+  suite:
+    description: "Suite name: cpp_sdk | cli | cli_workload"
+    required: true
+  codecov_token:
+    description: Codecov upload token
+    required: true
+  aws_access_key_id:
+    description: Yandex Object Storage access key
+    required: false
+    default: ""
+  aws_secret_access_key:
+    description: Yandex Object Storage secret key
+    required: false
+    default: ""
+  bazel_remote_uri:
+    description: Remote cache URI
+    required: false
+    default: ""
+  bazel_remote_username:
+    description: Remote cache username
+    required: false
+    default: ""
+  bazel_remote_password:
+    description: Remote cache password
+    required: false
+    default: ""
+  test_threads:
+    description: ya --test-threads
+    required: false
+    default: "28"
+  link_threads:
+    description: ya --link-threads
+    required: false
+    default: "12"
+  pr_number:
+    description: PR number (empty on push/schedule)
+    required: false
+    default: ""
+  commit_sha:
+    description: Commit SHA for meta/links
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Resolve suite config
+      id: suite
+      shell: bash
+      run: |
+        set -euo pipefail
+        CFG_FILE=$(mktemp)
+        python3 .github/scripts/tests/codecov_suites.py json-suite "${{ inputs.suite }}" > "$CFG_FILE"
+        EXCL=$(python3 .github/scripts/tests/codecov_suites.py exclude-regexp)
+        echo "exclude_regexp=${EXCL}" >> "$GITHUB_OUTPUT"
+        python3 -c 'import json,os,sys; cfg=json.load(open(sys.argv[1],encoding="utf-8")); open(os.environ["GITHUB_OUTPUT"],"a",encoding="utf-8").write("regexp="+cfg["regexp"]+"\nflag="+cfg["flag"]+"\ntargets="+" ".join(cfg["targets"])+"\n")' "$CFG_FILE"
+        rm -f "$CFG_FILE"
+
+    - name: Ya make with clang coverage
+      id: ya
+      shell: bash
+      env:
+        BUILD_PRESET: profile
+      run: |
+        set -euxo pipefail
+        OUT="$(pwd)/coverage_workspace/${{ inputs.suite }}"
+        mkdir -p "$OUT"
+        echo "out_dir=$OUT" >> "$GITHUB_OUTPUT"
+
+        BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
+        echo -n "${{ inputs.bazel_remote_password }}" > "$BAZEL_REMOTE_PASSWORD_FILE"
+
+        REGEXP='${{ steps.suite.outputs.regexp }}'
+        EXCL='${{ steps.suite.outputs.exclude_regexp }}'
+        # shellcheck disable=SC2206
+        TARGETS=( ${{ steps.suite.outputs.targets }} )
+
+        params=(
+          -tA --build profile
+          --clang-coverage --coverage-report --keep-temps
+          "-DCOVERAGE_TARGET_REGEXP=${REGEXP}"
+          "--coverage-exclude-regexp=${EXCL}"
+          --test-threads "${{ inputs.test_threads }}"
+          --link-threads "${{ inputs.link_threads }}"
+          --output "$OUT"
+          --no-dir-outputs
+        )
+        if [ -n "${{ inputs.bazel_remote_uri }}" ]; then
+          params+=(--bazel-remote-store --bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
+          params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
+          params+=(--bazel-remote-password-file "$BAZEL_REMOTE_PASSWORD_FILE")
+          params+=(
+            --bazel-remote-put
+            --dist-cache-max-file-size=209715200
+            --dist-cache-evict-test-runs
+            --dist-cache-evict-bins
+          )
+        fi
+
+        ./ya make "${params[@]}" "${TARGETS[@]}"
+
+    - name: Export filtered LCOV
+      shell: bash
+      run: |
+        set -euxo pipefail
+        OUT="${{ steps.ya.outputs.out_dir }}"
+        python3 .github/scripts/tests/export_coverage_lcov.py \
+          --suite "${{ inputs.suite }}" \
+          --ya-output "$OUT" \
+          --output "$OUT/coverage.lcov"
+
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ inputs.codecov_token }}
+        files: ${{ steps.ya.outputs.out_dir }}/coverage.lcov
+        flags: ${{ steps.suite.outputs.flag }}
+        fail_ci_if_error: false
+        name: ${{ inputs.suite }}
+
+    - name: Publish HTML report to Object Storage
+      continue-on-error: true
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws_access_key_id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws_secret_access_key }}
+        AWS_DEFAULT_REGION: ru-central1
+        SUITE: ${{ inputs.suite }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euxo pipefail
+        if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+          echo "AWS credentials empty; skip S3 upload"
+          exit 0
+        fi
+        if ! command -v aws >/dev/null 2>&1; then
+          pip3 install --user awscli
+          export PATH="$HOME/.local/bin:$PATH"
+        fi
+
+        bucket=ydb-appteam-sdk-reports
+        endpoint=https://storage.yandexcloud.net
+
+        if [ -n "${PR_NUMBER}" ]; then
+          prefix="ydb/pr-${PR_NUMBER}/coverage"
+        else
+          prefix="ydb/coverage"
+        fi
+
+        report_dir="${OUT}/coverage.report"
+        if [ ! -d "${report_dir}" ]; then
+          echo "No coverage.report directory; skip object storage upload"
+          exit 0
+        fi
+
+        python3 -c 'import json,os; from datetime import datetime,timezone; meta={"suite":os.environ["SUITE"],"sha":os.environ["COMMIT_SHA"],"commit":os.environ["COMMIT_SHA"][:12],"event":os.environ.get("GITHUB_EVENT_NAME",""),"run_url":os.environ["RUN_URL"],"generated_at":datetime.now(timezone.utc).isoformat(),"pr":os.environ.get("PR_NUMBER") or None}; open(os.environ["OUT"]+"/meta.json","w",encoding="utf-8").write(json.dumps(meta,indent=2)+"\n")'
+        meta="${OUT}/meta.json"
+
+        aws --endpoint-url "$endpoint" s3 sync \
+          "${report_dir}/" \
+          "s3://${bucket}/${prefix}/${SUITE}/" \
+          --delete
+        aws --endpoint-url "$endpoint" s3 cp \
+          "$meta" \
+          "s3://${bucket}/${prefix}/${SUITE}/meta.json"
+
+        land_dir="${OUT}/landing"
+        mkdir -p "$land_dir"
+        python3 .github/scripts/tests/generate_coverage_landing.py \
+          --output "${land_dir}/index.html" \
+          --title "YDB C++ coverage" \
+          --meta-json "$meta" \
+          --suite "cpp_sdk=./cpp_sdk/index.html" \
+          --suite "cli=./cli/index.html" \
+          --suite "cli_workload=./cli_workload/index.html"
+        aws --endpoint-url "$endpoint" s3 cp \
+          "${land_dir}/index.html" \
+          "s3://${bucket}/${prefix}/index.html"
+
+        echo "Uploaded coverage HTML for ${SUITE} to object storage (prefix ${prefix}/${SUITE}/)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -42,6 +42,10 @@ inputs:
   commit_sha:
     description: Commit SHA for meta/links
     required: true
+  branch:
+    description: Branch name for Codecov (ref_name / head_ref)
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -118,8 +122,15 @@ runs:
         flags: ${{ steps.suite.outputs.flag }}
         fail_ci_if_error: true
         name: ${{ inputs.suite }}
+        # Self-hosted runners often cannot download cli.codecov.io (get HTML); use PyPI instead.
+        use_pypi: true
+        disable_search: true
+        override_commit: ${{ inputs.commit_sha }}
+        override_branch: ${{ inputs.branch }}
 
     - name: Publish HTML report to Object Storage
+      # Still publish HTML if Codecov upload fails (e.g. CDN blocked on runner).
+      if: ${{ always() && steps.ya.outcome == 'success' }}
       continue-on-error: true
       shell: bash
       env:

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -54,12 +54,16 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        case "${{ inputs.suite }}" in
+          cpp_sdk|cli|cli_workload) ;;
+          *) echo "Unknown suite: ${{ inputs.suite }}" >&2; exit 1 ;;
+        esac
         CFG_FILE=$(mktemp)
+        trap 'rm -f "$CFG_FILE"' EXIT
         python3 .github/scripts/tests/codecov_suites.py json-suite "${{ inputs.suite }}" > "$CFG_FILE"
         EXCL=$(python3 .github/scripts/tests/codecov_suites.py exclude-regexp)
         echo "exclude_regexp=${EXCL}" >> "$GITHUB_OUTPUT"
         python3 -c 'import json,os,sys; cfg=json.load(open(sys.argv[1],encoding="utf-8")); open(os.environ["GITHUB_OUTPUT"],"a",encoding="utf-8").write("regexp="+cfg["regexp"]+"\nflag="+cfg["flag"]+"\ntargets="+" ".join(cfg["targets"])+"\n")' "$CFG_FILE"
-        rm -f "$CFG_FILE"
 
     - name: Ya make with clang coverage
       id: ya
@@ -124,21 +128,28 @@ runs:
         SUITE: ${{ inputs.suite }}
         COMMIT_SHA: ${{ inputs.commit_sha }}
         BRANCH: ${{ inputs.branch }}
+        PR_NUMBER: ${{ inputs.pr_number }}
       run: |
         set -euxo pipefail
         # Prefer PyPI: self-hosted runners often cannot download cli.codecov.io (HTML instead of binary).
         pip3 install --user 'codecov-cli'
         export PATH="${HOME}/.local/bin:${PATH}"
-        codecovcli upload-coverage \
-          -t "${CODECOV_TOKEN}" \
-          --fail-on-error \
-          --git-service github \
-          --sha "${COMMIT_SHA}" \
-          --branch "${BRANCH}" \
-          --disable-search \
-          --file "${OUT}/coverage.lcov" \
-          --flag "${FLAG}" \
+        upload_args=(
+          -t "${CODECOV_TOKEN}"
+          --fail-on-error
+          --git-service github
+          --sha "${COMMIT_SHA}"
+          --branch "${BRANCH}"
+          --disable-search
+          --file "${OUT}/coverage.lcov"
+          --flag "${FLAG}"
           --name "${SUITE}"
+        )
+        # Needed so Codecov attaches the upload to the PR (statuses / comment), not only the commit.
+        if [ -n "${PR_NUMBER}" ]; then
+          upload_args+=(--pull-request-number "${PR_NUMBER}")
+        fi
+        codecovcli upload-coverage "${upload_args[@]}"
 
     - name: Publish HTML report to Object Storage
       # Still publish HTML if Codecov upload fails.
@@ -190,12 +201,13 @@ runs:
           "s3://${bucket}/${prefix}/${SUITE}/" \
           --delete
 
+        # Landing links are static (no per-suite meta) so parallel matrix jobs can
+        # overwrite the same key without racing on content.
         land_dir="${OUT}/landing"
         mkdir -p "$land_dir"
         python3 .github/scripts/tests/generate_coverage_landing.py \
           --output "${land_dir}/index.html" \
           --title "YDB C++ coverage" \
-          --meta-json "$meta" \
           --suite "cpp_sdk=./cpp_sdk/index.html" \
           --suite "cli=./cli/index.html" \
           --suite "cli_workload=./cli_workload/index.html"

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -115,21 +115,32 @@ runs:
           --output "$OUT/coverage.lcov"
 
     - name: Upload to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ inputs.codecov_token }}
-        files: ${{ steps.ya.outputs.out_dir }}/coverage.lcov
-        flags: ${{ steps.suite.outputs.flag }}
-        fail_ci_if_error: true
-        name: ${{ inputs.suite }}
-        # Self-hosted runners often cannot download cli.codecov.io (get HTML); use PyPI instead.
-        use_pypi: true
-        disable_search: true
-        override_commit: ${{ inputs.commit_sha }}
-        override_branch: ${{ inputs.branch }}
+      shell: bash
+      env:
+        CODECOV_TOKEN: ${{ inputs.codecov_token }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
+        FLAG: ${{ steps.suite.outputs.flag }}
+        SUITE: ${{ inputs.suite }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
+        BRANCH: ${{ inputs.branch }}
+      run: |
+        set -euxo pipefail
+        # Prefer PyPI: self-hosted runners often cannot download cli.codecov.io (HTML instead of binary).
+        pip3 install --user 'codecov-cli'
+        export PATH="${HOME}/.local/bin:${PATH}"
+        codecovcli upload-coverage \
+          -t "${CODECOV_TOKEN}" \
+          --fail-on-error \
+          --git-service github \
+          --sha "${COMMIT_SHA}" \
+          --branch "${BRANCH}" \
+          --disable-search \
+          --file "${OUT}/coverage.lcov" \
+          --flag "${FLAG}" \
+          --name "${SUITE}"
 
     - name: Publish HTML report to Object Storage
-      # Still publish HTML if Codecov upload fails (e.g. CDN blocked on runner).
+      # Still publish HTML if Codecov upload fails.
       if: ${{ always() && steps.ya.outcome == 'success' }}
       continue-on-error: true
       shell: bash

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -116,7 +116,7 @@ runs:
         token: ${{ inputs.codecov_token }}
         files: ${{ steps.ya.outputs.out_dir }}/coverage.lcov
         flags: ${{ steps.suite.outputs.flag }}
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         name: ${{ inputs.suite }}
 
     - name: Publish HTML report to Object Storage

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -73,6 +73,7 @@ runs:
         echo "out_dir=$OUT" >> "$GITHUB_OUTPUT"
 
         BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
+        trap 'rm -f "$BAZEL_REMOTE_PASSWORD_FILE"' EXIT
         echo -n "${{ inputs.bazel_remote_password }}" > "$BAZEL_REMOTE_PASSWORD_FILE"
 
         REGEXP='${{ steps.suite.outputs.regexp }}'

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -36,7 +36,7 @@ inputs:
     required: false
     default: "12"
   pr_number:
-    description: PR number (empty on push/schedule)
+    description: PR number (empty on push/manual)
     required: false
     default: ""
   commit_sha:
@@ -179,16 +179,15 @@ runs:
           exit 0
         fi
 
-        python3 -c 'import json,os; from datetime import datetime,timezone; meta={"suite":os.environ["SUITE"],"sha":os.environ["COMMIT_SHA"],"commit":os.environ["COMMIT_SHA"][:12],"event":os.environ.get("GITHUB_EVENT_NAME",""),"run_url":os.environ["RUN_URL"],"generated_at":datetime.now(timezone.utc).isoformat(),"pr":os.environ.get("PR_NUMBER") or None}; open(os.environ["OUT"]+"/meta.json","w",encoding="utf-8").write(json.dumps(meta,indent=2)+"\n")'
-        meta="${OUT}/meta.json"
+        # Keep meta.json inside report_dir so sync --delete does not try to remove
+        # a separately uploaded key (Yandex Object Storage returned AccessDenied).
+        meta="${report_dir}/meta.json"
+        META="$meta" python3 -c 'import json,os; from datetime import datetime,timezone; meta={"suite":os.environ["SUITE"],"sha":os.environ["COMMIT_SHA"],"commit":os.environ["COMMIT_SHA"][:12],"event":os.environ.get("GITHUB_EVENT_NAME",""),"run_url":os.environ["RUN_URL"],"generated_at":datetime.now(timezone.utc).isoformat(),"pr":os.environ.get("PR_NUMBER") or None}; open(os.environ["META"],"w",encoding="utf-8").write(json.dumps(meta,indent=2)+"\n")'
 
         aws --endpoint-url "$endpoint" s3 sync \
           "${report_dir}/" \
           "s3://${bucket}/${prefix}/${SUITE}/" \
           --delete
-        aws --endpoint-url "$endpoint" s3 cp \
-          "$meta" \
-          "s3://${bucket}/${prefix}/${SUITE}/meta.json"
 
         land_dir="${OUT}/landing"
         mkdir -p "$land_dir"

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -52,52 +52,72 @@ runs:
     - name: Resolve suite config
       id: suite
       shell: bash
+      env:
+        SUITE: ${{ inputs.suite }}
       run: |
         set -euo pipefail
-        case "${{ inputs.suite }}" in
+        case "${SUITE}" in
           cpp_sdk|cli|cli_workload) ;;
-          *) echo "Unknown suite: ${{ inputs.suite }}" >&2; exit 1 ;;
+          *) echo "Unknown suite: ${SUITE}" >&2; exit 1 ;;
         esac
         CFG_FILE=$(mktemp)
         trap 'rm -f "$CFG_FILE"' EXIT
-        python3 .github/scripts/tests/codecov_suites.py json-suite "${{ inputs.suite }}" > "$CFG_FILE"
+        python3 .github/scripts/tests/codecov_suites.py json-suite "${SUITE}" > "$CFG_FILE"
         EXCL=$(python3 .github/scripts/tests/codecov_suites.py exclude-regexp)
         echo "exclude_regexp=${EXCL}" >> "$GITHUB_OUTPUT"
-        python3 -c 'import json,os,sys; cfg=json.load(open(sys.argv[1],encoding="utf-8")); open(os.environ["GITHUB_OUTPUT"],"a",encoding="utf-8").write("regexp="+cfg["regexp"]+"\nflag="+cfg["flag"]+"\ntargets="+" ".join(cfg["targets"])+"\n")' "$CFG_FILE"
+        python3 -c '
+import json, os, sys
+cfg = json.load(open(sys.argv[1], encoding="utf-8"))
+out = os.environ["GITHUB_OUTPUT"]
+with open(out, "a", encoding="utf-8") as fh:
+    fh.write("regexp=" + cfg["regexp"] + "\n")
+    fh.write("flag=" + cfg["flag"] + "\n")
+    fh.write("targets_json=" + json.dumps(cfg["targets"]) + "\n")
+' "$CFG_FILE"
 
     - name: Ya make with clang coverage
       id: ya
       shell: bash
       env:
         BUILD_PRESET: profile
+        SUITE: ${{ inputs.suite }}
+        REGEXP: ${{ steps.suite.outputs.regexp }}
+        EXCL: ${{ steps.suite.outputs.exclude_regexp }}
+        TARGETS_JSON: ${{ steps.suite.outputs.targets_json }}
+        TEST_THREADS: ${{ inputs.test_threads }}
+        LINK_THREADS: ${{ inputs.link_threads }}
+        BAZEL_REMOTE_URI: ${{ inputs.bazel_remote_uri }}
+        BAZEL_REMOTE_USERNAME: ${{ inputs.bazel_remote_username }}
+        BAZEL_REMOTE_PASSWORD: ${{ inputs.bazel_remote_password }}
       run: |
         set -euxo pipefail
-        OUT="$(pwd)/coverage_workspace/${{ inputs.suite }}"
+        OUT="$(pwd)/coverage_workspace/${SUITE}"
         mkdir -p "$OUT"
         echo "out_dir=$OUT" >> "$GITHUB_OUTPUT"
 
         BAZEL_REMOTE_PASSWORD_FILE=$(mktemp)
         trap 'rm -f "$BAZEL_REMOTE_PASSWORD_FILE"' EXIT
-        echo -n "${{ inputs.bazel_remote_password }}" > "$BAZEL_REMOTE_PASSWORD_FILE"
+        echo -n "${BAZEL_REMOTE_PASSWORD}" > "$BAZEL_REMOTE_PASSWORD_FILE"
 
-        REGEXP='${{ steps.suite.outputs.regexp }}'
-        EXCL='${{ steps.suite.outputs.exclude_regexp }}'
-        # shellcheck disable=SC2206
-        TARGETS=( ${{ steps.suite.outputs.targets }} )
+        mapfile -t TARGETS < <(python3 -c 'import json,sys; print("\n".join(json.loads(sys.argv[1])))' "${TARGETS_JSON}")
+        if [ "${#TARGETS[@]}" -eq 0 ]; then
+          echo "No ya targets resolved for suite ${SUITE}" >&2
+          exit 1
+        fi
 
         params=(
           -tA --build profile
           --clang-coverage --coverage-report --keep-temps
           "-DCOVERAGE_TARGET_REGEXP=${REGEXP}"
           "--coverage-exclude-regexp=${EXCL}"
-          --test-threads "${{ inputs.test_threads }}"
-          --link-threads "${{ inputs.link_threads }}"
+          --test-threads "${TEST_THREADS}"
+          --link-threads "${LINK_THREADS}"
           --output "$OUT"
           --no-dir-outputs
         )
-        if [ -n "${{ inputs.bazel_remote_uri }}" ]; then
-          params+=(--bazel-remote-store --bazel-remote-base-uri "${{ inputs.bazel_remote_uri }}")
-          params+=(--bazel-remote-username "${{ inputs.bazel_remote_username }}")
+        if [ -n "${BAZEL_REMOTE_URI}" ]; then
+          params+=(--bazel-remote-store --bazel-remote-base-uri "${BAZEL_REMOTE_URI}")
+          params+=(--bazel-remote-username "${BAZEL_REMOTE_USERNAME}")
           params+=(--bazel-remote-password-file "$BAZEL_REMOTE_PASSWORD_FILE")
           params+=(
             --bazel-remote-put
@@ -111,11 +131,13 @@ runs:
 
     - name: Export filtered LCOV
       shell: bash
+      env:
+        SUITE: ${{ inputs.suite }}
+        OUT: ${{ steps.ya.outputs.out_dir }}
       run: |
         set -euxo pipefail
-        OUT="${{ steps.ya.outputs.out_dir }}"
         python3 .github/scripts/tests/export_coverage_lcov.py \
-          --suite "${{ inputs.suite }}" \
+          --suite "${SUITE}" \
           --ya-output "$OUT" \
           --output "$OUT/coverage.lcov"
 
@@ -132,7 +154,7 @@ runs:
       run: |
         set -euxo pipefail
         # Prefer PyPI: self-hosted runners often cannot download cli.codecov.io (HTML instead of binary).
-        pip3 install --user 'codecov-cli'
+        pip3 install --user 'codecov-cli==11.3.1'
         export PATH="${HOME}/.local/bin:${PATH}"
         upload_args=(
           -t "${CODECOV_TOKEN}"
@@ -172,7 +194,8 @@ runs:
           exit 0
         fi
         if ! command -v aws >/dev/null 2>&1; then
-          pip3 install --user awscli
+          # Pin: same version that succeeded in dogfood on self-hosted runners.
+          pip3 install --user 'awscli==1.46.0'
           export PATH="$HOME/.local/bin:$PATH"
         fi
 

--- a/.github/actions/run_clang_codecov/action.yaml
+++ b/.github/actions/run_clang_codecov/action.yaml
@@ -65,15 +65,7 @@ runs:
         python3 .github/scripts/tests/codecov_suites.py json-suite "${SUITE}" > "$CFG_FILE"
         EXCL=$(python3 .github/scripts/tests/codecov_suites.py exclude-regexp)
         echo "exclude_regexp=${EXCL}" >> "$GITHUB_OUTPUT"
-        python3 -c '
-import json, os, sys
-cfg = json.load(open(sys.argv[1], encoding="utf-8"))
-out = os.environ["GITHUB_OUTPUT"]
-with open(out, "a", encoding="utf-8") as fh:
-    fh.write("regexp=" + cfg["regexp"] + "\n")
-    fh.write("flag=" + cfg["flag"] + "\n")
-    fh.write("targets_json=" + json.dumps(cfg["targets"]) + "\n")
-' "$CFG_FILE"
+        python3 -c 'import json,os,sys; cfg=json.load(open(sys.argv[1],encoding="utf-8")); out=os.environ["GITHUB_OUTPUT"]; open(out,"a",encoding="utf-8").write("regexp="+cfg["regexp"]+"\nflag="+cfg["flag"]+"\ntargets_json="+json.dumps(cfg["targets"])+"\n")' "$CFG_FILE"
 
     - name: Ya make with clang coverage
       id: ya

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,73 @@
+# Codecov config for ydb-platform/ydb (C++ SDK + CLI + workload).
+# Separate from per-language SDK repos (java/go/js) and their native-sdk component.
+
+coverage:
+  status:
+    project:
+      default: off
+      cpp_sdk:
+        flags:
+          - cpp_sdk
+        target: auto
+        threshold: 0.1%
+      cli:
+        flags:
+          - cli
+        target: auto
+        threshold: 5%
+      cli_workload:
+        flags:
+          - cli_workload
+        target: auto
+        threshold: 5%
+    patch:
+      default: off
+      cpp_sdk:
+        flags:
+          - cpp_sdk
+        target: 80%
+        informational: true
+      cli:
+        flags:
+          - cli
+        target: 80%
+        informational: true
+      cli_workload:
+        flags:
+          - cli_workload
+        target: 80%
+        informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: cpp_sdk
+      paths:
+        - ydb/public/sdk/cpp/**
+      carryforward: true
+    - name: cli
+      paths:
+        - ydb/apps/ydb/**
+        - ydb/public/lib/ydb_cli/**
+      carryforward: true
+    - name: cli_workload
+      paths:
+        - ydb/library/workload/**
+      carryforward: true
+
+component_management:
+  individual_components:
+    - component_id: cli_app
+      name: apps/ydb
+      paths:
+        - ydb/apps/ydb/**
+    - component_id: cli_core
+      name: ydb_cli lib
+      paths:
+        - ydb/public/lib/ydb_cli/**
+
+comment:
+  layout: "diff, flags, components, files"
+  behavior: default
+  require_changes: false

--- a/.github/scripts/tests/codecov_suites.py
+++ b/.github/scripts/tests/codecov_suites.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Shared suite table for C++ Codecov CI (detect + run_clang_codecov)."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+# Product-only exclude (same idea as SDK --coverage-exclude-regexp).
+COVERAGE_EXCLUDE_REGEXP = r"/(ut|tests)/|_(ut|it)\.(c|cc|cpp|cxx|h|hh|hpp|hxx)"
+
+# Infra changes validate the pipeline for every suite.
+SHARED_PATH_PREFIXES = [
+    ".github/actions/run_clang_codecov/",
+    ".github/scripts/tests/codecov_suites.py",
+    ".github/scripts/tests/detect_codecov_matrix.py",
+    ".github/scripts/tests/export_coverage_lcov.py",
+    ".github/scripts/tests/generate_coverage_landing.py",
+    ".github/workflows/cpp_codecov.yml",
+    ".github/codecov.yml",
+]
+
+SUITES: dict[str, dict] = {
+    "cpp_sdk": {
+        "flag": "cpp_sdk",
+        "regexp": "ydb/public/sdk/cpp",
+        "targets": ["ydb/public/sdk/cpp"],
+        "lcov_prefixes": ["ydb/public/sdk/cpp/"],
+        "path_prefixes": ["ydb/public/sdk/cpp/"],
+        "labels": ["coverage/sdk"],
+    },
+    "cli": {
+        "flag": "cli",
+        "regexp": "ydb/apps/ydb/|ydb/public/lib/ydb_cli",
+        "targets": [
+            "ydb/apps/ydb",
+            "ydb/public/lib/ydb_cli",
+            "ydb/tests/functional/ydb_cli",
+        ],
+        "lcov_prefixes": ["ydb/apps/ydb/", "ydb/public/lib/ydb_cli/"],
+        "path_prefixes": [
+            "ydb/apps/ydb/",
+            "ydb/public/lib/ydb_cli/",
+            "ydb/tests/functional/ydb_cli/",
+        ],
+        "labels": ["coverage/cli"],
+    },
+    "cli_workload": {
+        "flag": "cli_workload",
+        "regexp": "ydb/library/workload",
+        "targets": ["ydb/library/workload"],
+        "lcov_prefixes": ["ydb/library/workload/"],
+        "path_prefixes": ["ydb/library/workload/"],
+        "labels": ["coverage/workload"],
+    },
+}
+
+ALL_COVERAGE_LABELS = {
+    "coverage/sdk",
+    "coverage/cli",
+    "coverage/workload",
+    "coverage/all",
+}
+
+LABEL_TO_SUITES = {
+    "coverage/sdk": ["cpp_sdk"],
+    "coverage/cli": ["cli"],
+    "coverage/workload": ["cli_workload"],
+    "coverage/all": ["cpp_sdk", "cli", "cli_workload"],
+}
+
+
+def _normalize_repo_path(path: str) -> str:
+    while path.startswith("./"):
+        path = path[2:]
+    return path
+
+
+def _matches_prefix(norm: str, prefixes: list[str]) -> bool:
+    return any(norm.startswith(p) or p.rstrip("/") == norm for p in prefixes)
+
+
+def suites_from_paths(changed_files: list[str]) -> list[str]:
+    found: set[str] = set()
+    for path in changed_files:
+        norm = _normalize_repo_path(path)
+        if _matches_prefix(norm, SHARED_PATH_PREFIXES):
+            found.update(SUITES.keys())
+            continue
+        for name, cfg in SUITES.items():
+            if _matches_prefix(norm, cfg["path_prefixes"]):
+                found.add(name)
+    return sorted(found)
+
+
+def suites_from_labels(labels: list[str]) -> list[str]:
+    found: set[str] = set()
+    for lab in labels:
+        found.update(LABEL_TO_SUITES.get(lab, []))
+    return sorted(found)
+
+
+def coverage_labels_present(labels: list[str]) -> list[str]:
+    return sorted({lab for lab in labels if lab in ALL_COVERAGE_LABELS})
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: codecov_suites.py {list|json-suite <name>|exclude-regexp}", file=sys.stderr)
+        return 2
+    cmd = sys.argv[1]
+    if cmd == "list":
+        print("\n".join(SUITES.keys()))
+        return 0
+    if cmd == "exclude-regexp":
+        print(COVERAGE_EXCLUDE_REGEXP)
+        return 0
+    if cmd == "json-suite" and len(sys.argv) == 3:
+        name = sys.argv[2]
+        if name not in SUITES:
+            print(f"unknown suite: {name}", file=sys.stderr)
+            return 1
+        print(json.dumps(SUITES[name]))
+        return 0
+    print(f"unknown command: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/codecov_suites.py
+++ b/.github/scripts/tests/codecov_suites.py
@@ -16,6 +16,7 @@ SHARED_PATH_PREFIXES = [
     ".github/scripts/tests/detect_codecov_matrix.py",
     ".github/scripts/tests/export_coverage_lcov.py",
     ".github/scripts/tests/generate_coverage_landing.py",
+    ".github/scripts/tests/overlay_trusted_codecov_ci.sh",
     ".github/workflows/cpp_codecov.yml",
     ".github/codecov.yml",
 ]

--- a/.github/scripts/tests/detect_codecov_matrix.py
+++ b/.github/scripts/tests/detect_codecov_matrix.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Decide which Codecov suites to run for a PR (paths and/or labels)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from codecov_suites import (
+    ALL_COVERAGE_LABELS,
+    coverage_labels_present,
+    suites_from_labels,
+    suites_from_paths,
+)
+
+
+def write_output(name: str, value: str) -> None:
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        print(f"{name}={value}")
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        if "\n" in value:
+            fh.write(f"{name}<<EOF\n{value}\nEOF\n")
+        else:
+            fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("paths", "labels"),
+        required=True,
+        help="paths: changed-files only; labels: coverage/* labels only",
+    )
+    parser.add_argument(
+        "--changed-files",
+        default="",
+        help="Newline-separated list of changed paths (paths mode)",
+    )
+    parser.add_argument(
+        "--changed-files-file",
+        default="",
+        help="File with newline-separated changed paths",
+    )
+    parser.add_argument(
+        "--labels",
+        default="",
+        help="JSON array or newline-separated PR labels",
+    )
+    args = parser.parse_args()
+
+    files: list[str] = []
+    if args.changed_files_file:
+        with open(args.changed_files_file, encoding="utf-8") as fh:
+            files = [ln.strip() for ln in fh if ln.strip()]
+    elif args.changed_files:
+        files = [ln.strip() for ln in args.changed_files.splitlines() if ln.strip()]
+
+    labels: list[str] = []
+    raw = args.labels.strip()
+    if raw:
+        if raw.startswith("["):
+            labels = list(json.loads(raw))
+        else:
+            labels = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+
+    hanging = coverage_labels_present(labels)
+
+    if args.mode == "labels":
+        suites = suites_from_labels(hanging)
+    else:
+        suites = suites_from_paths(files)
+
+    matrix = json.dumps(suites)
+    should_run = "true" if suites else "false"
+    write_output("matrix", matrix)
+    write_output("should_run", should_run)
+    write_output("hanging_labels", json.dumps(hanging))
+    write_output("all_coverage_labels", json.dumps(sorted(ALL_COVERAGE_LABELS)))
+    print(f"mode={args.mode} suites={suites} hanging_labels={hanging}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/detect_codecov_matrix.py
+++ b/.github/scripts/tests/detect_codecov_matrix.py
@@ -12,7 +12,6 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from codecov_suites import (
-    ALL_COVERAGE_LABELS,
     coverage_labels_present,
     suites_from_labels,
     suites_from_paths,
@@ -83,7 +82,6 @@ def main() -> int:
     write_output("matrix", matrix)
     write_output("should_run", should_run)
     write_output("hanging_labels", json.dumps(hanging))
-    write_output("all_coverage_labels", json.dumps(sorted(ALL_COVERAGE_LABELS)))
     print(f"mode={args.mode} suites={suites} hanging_labels={hanging}", file=sys.stderr)
     return 0
 

--- a/.github/scripts/tests/export_coverage_lcov.py
+++ b/.github/scripts/tests/export_coverage_lcov.py
@@ -23,12 +23,34 @@ EXCLUDE_RE = re.compile(COVERAGE_EXCLUDE_REGEXP)
 # ya logs: Executing: ['.../bin/llvm-cov', 'export', ..., '-object', 'path', ...]
 EXECUTING_RE = re.compile(r"Executing:\s*(\[.*bin/llvm-cov',\s*'export'.*\])")
 
+# llvm-cov options that consume the following argv token (not binaries).
+_LLVM_COV_VALUE_FLAGS = frozenset(
+    {
+        "-instr-profile",
+        "-object",
+        "-format",
+        "-ignore-filename-regex",
+        "-name",
+        "-name-regex",
+        "-name-allowlist",
+        "-path-equivalence",
+        "-j",
+        "-num-threads",
+        "-Xdemangler",
+        "-coverage-watermark",
+    }
+)
+
 
 def parse_ya_llvm_cov_cmd(log_text: str) -> tuple[str, list[str]]:
-    """Return (llvm_cov_path, object_paths) from ya coverage report log."""
+    """Return (llvm_cov_path, object_paths) from ya coverage report log.
+
+    Only real instrumented binaries are returned. Values of flags such as
+    -instr-profile / -ignore-filename-regex must not be treated as -object paths
+    (that bug made llvm-cov export fail with exit 1 in CI).
+    """
     match = EXECUTING_RE.search(log_text)
     if not match:
-        # Fallback: multiline / slightly different quoting
         match = re.search(
             r"(\[[^\]]*bin/llvm-cov',\s*'export'[^\]]*\])",
             log_text,
@@ -47,10 +69,12 @@ def parse_ya_llvm_cov_cmd(log_text: str) -> tuple[str, list[str]]:
 
     llvm_cov = cmd[0]
     objects: list[str] = []
-    # First positional after flags is often the main binary; also collect -object=
     i = 1
     while i < len(cmd):
         arg = cmd[i]
+        if arg in ("export", "show", "report"):
+            i += 1
+            continue
         if arg == "-object" and i + 1 < len(cmd):
             objects.append(cmd[i + 1])
             i += 2
@@ -59,15 +83,18 @@ def parse_ya_llvm_cov_cmd(log_text: str) -> tuple[str, list[str]]:
             objects.append(arg.split("=", 1)[1])
             i += 1
             continue
+        if arg in _LLVM_COV_VALUE_FLAGS:
+            i += 2  # skip flag + its value
+            continue
         if arg.startswith("-"):
+            # -flag=value or boolean flag
             i += 1
             continue
-        # positional binary
-        if "instr-profile" not in arg and arg not in ("export", "show"):
+        # Positional binary (legacy llvm-cov style): path, not .profdata
+        if "/" in arg and not arg.endswith((".profdata", ".profraw")):
             objects.append(arg)
         i += 1
 
-    # Deduplicate preserving order
     seen: set[str] = set()
     uniq: list[str] = []
     for o in objects:
@@ -90,7 +117,6 @@ def path_matches_prefixes(path: str, prefixes: list[str]) -> bool:
             or norm.endswith("/" + p)
             or p in norm
         ):
-            # Prefer startswith-style match on repo-relative segment
             idx = norm.find(p)
             if idx != -1 and (idx == 0 or norm[idx - 1] == "/"):
                 return True
@@ -195,7 +221,11 @@ def main() -> int:
         cmd.append(f"-object={obj}")
 
     print("+", " ".join(cmd[:6]), f"... ({len(objects)} objects)", flush=True)
-    proc = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    if proc.returncode != 0:
+        print(proc.stderr, file=sys.stderr)
+        raise SystemExit(f"llvm-cov export failed with exit {proc.returncode}")
+
     filtered = filter_lcov(proc.stdout, cfg["lcov_prefixes"])
     if not filtered.strip():
         print("Warning: filtered LCOV is empty", file=sys.stderr)

--- a/.github/scripts/tests/export_coverage_lcov.py
+++ b/.github/scripts/tests/export_coverage_lcov.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Export filtered LCOV from a ya --coverage-report output directory.
+
+Uses coverage.report/coverage.profdata and the llvm-cov object list from
+build_clang_coverage_report.log (same sources ya used for the HTML report).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from codecov_suites import COVERAGE_EXCLUDE_REGEXP, SUITES
+
+EXCLUDE_RE = re.compile(COVERAGE_EXCLUDE_REGEXP)
+
+# ya logs: Executing: ['.../bin/llvm-cov', 'export', ..., '-object', 'path', ...]
+EXECUTING_RE = re.compile(r"Executing:\s*(\[.*bin/llvm-cov',\s*'export'.*\])")
+
+
+def parse_ya_llvm_cov_cmd(log_text: str) -> tuple[str, list[str]]:
+    """Return (llvm_cov_path, object_paths) from ya coverage report log."""
+    match = EXECUTING_RE.search(log_text)
+    if not match:
+        # Fallback: multiline / slightly different quoting
+        match = re.search(
+            r"(\[[^\]]*bin/llvm-cov',\s*'export'[^\]]*\])",
+            log_text,
+            re.S,
+        )
+    if not match:
+        raise SystemExit("Could not find llvm-cov export command in coverage log")
+
+    try:
+        cmd = ast.literal_eval(match.group(1))
+    except (SyntaxError, ValueError) as exc:
+        raise SystemExit(f"Failed to parse llvm-cov command: {exc}") from exc
+
+    if not cmd or "llvm-cov" not in cmd[0]:
+        raise SystemExit(f"Unexpected llvm-cov command: {cmd[:3]!r}")
+
+    llvm_cov = cmd[0]
+    objects: list[str] = []
+    # First positional after flags is often the main binary; also collect -object=
+    i = 1
+    while i < len(cmd):
+        arg = cmd[i]
+        if arg == "-object" and i + 1 < len(cmd):
+            objects.append(cmd[i + 1])
+            i += 2
+            continue
+        if arg.startswith("-object="):
+            objects.append(arg.split("=", 1)[1])
+            i += 1
+            continue
+        if arg.startswith("-"):
+            i += 1
+            continue
+        # positional binary
+        if "instr-profile" not in arg and arg not in ("export", "show"):
+            objects.append(arg)
+        i += 1
+
+    # Deduplicate preserving order
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for o in objects:
+        if o not in seen:
+            seen.add(o)
+            uniq.append(o)
+
+    if not uniq:
+        raise SystemExit("No -object binaries found in llvm-cov command")
+    return llvm_cov, uniq
+
+
+def path_matches_prefixes(path: str, prefixes: list[str]) -> bool:
+    norm = path.replace("\\", "/")
+    for pref in prefixes:
+        p = pref.rstrip("/")
+        if (
+            f"/{p}/" in f"/{norm}/"
+            or norm.startswith(pref)
+            or norm.endswith("/" + p)
+            or p in norm
+        ):
+            # Prefer startswith-style match on repo-relative segment
+            idx = norm.find(p)
+            if idx != -1 and (idx == 0 or norm[idx - 1] == "/"):
+                return True
+    return False
+
+
+def filter_lcov(text: str, prefixes: list[str]) -> str:
+    records: list[str] = []
+    current: list[str] = []
+    keep = False
+
+    def flush() -> None:
+        nonlocal current, keep
+        if current and keep:
+            records.append("".join(current))
+        current = []
+        keep = False
+
+    for line in text.splitlines(keepends=True):
+        if line.startswith("TN:"):
+            flush()
+            current = [line]
+            keep = False
+            continue
+        if line.startswith("SF:"):
+            if not current:
+                current = ["TN:\n"]
+            path = line[3:].strip()
+            keep = path_matches_prefixes(path, prefixes) and not EXCLUDE_RE.search(
+                path.replace("\\", "/")
+            )
+            current.append(line)
+            continue
+        if line.startswith("end_of_record"):
+            current.append(line)
+            flush()
+            continue
+        if current:
+            current.append(line)
+    flush()
+    return "".join(records)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", required=True, choices=sorted(SUITES.keys()))
+    parser.add_argument(
+        "--ya-output",
+        required=True,
+        type=Path,
+        help="Directory passed to ya make --output (contains coverage.report/)",
+    )
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=None,
+        help="Override path to build_clang_coverage_report.log",
+    )
+    parser.add_argument(
+        "--profdata",
+        type=Path,
+        default=None,
+        help="Override path to coverage.profdata",
+    )
+    parser.add_argument("--llvm-cov", default="", help="Override llvm-cov binary")
+    args = parser.parse_args()
+
+    cfg = SUITES[args.suite]
+    ya_out = args.ya_output.resolve()
+    report_dir = ya_out / "coverage.report"
+    profdata = args.profdata or (report_dir / "coverage.profdata")
+    log_path = args.log or (ya_out / "build_clang_coverage_report.log")
+
+    if not profdata.is_file():
+        raise SystemExit(f"Missing profdata: {profdata}")
+    if not log_path.is_file():
+        raise SystemExit(f"Missing coverage log: {log_path}")
+
+    log_text = log_path.read_text(encoding="utf-8", errors="replace")
+    llvm_cov, objects = parse_ya_llvm_cov_cmd(log_text)
+    if args.llvm_cov:
+        llvm_cov = args.llvm_cov
+
+    missing = [o for o in objects if not Path(o).is_file()]
+    if missing:
+        print(f"Warning: {len(missing)}/{len(objects)} binaries missing", file=sys.stderr)
+        for m in missing[:10]:
+            print(f"  missing: {m}", file=sys.stderr)
+        objects = [o for o in objects if Path(o).is_file()]
+    if not objects:
+        raise SystemExit("No instrumented binaries available for llvm-cov export")
+
+    cmd = [
+        llvm_cov,
+        "export",
+        "-format=lcov",
+        f"-instr-profile={profdata}",
+        objects[0],
+    ]
+    for obj in objects[1:]:
+        cmd.append(f"-object={obj}")
+
+    print("+", " ".join(cmd[:6]), f"... ({len(objects)} objects)", flush=True)
+    proc = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    filtered = filter_lcov(proc.stdout, cfg["lcov_prefixes"])
+    if not filtered.strip():
+        print("Warning: filtered LCOV is empty", file=sys.stderr)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(filtered, encoding="utf-8")
+    n_rec = filtered.count("end_of_record")
+    print(f"Wrote {args.output} ({len(filtered)} bytes, {n_rec} records)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/export_coverage_lcov.py
+++ b/.github/scripts/tests/export_coverage_lcov.py
@@ -108,18 +108,23 @@ def parse_ya_llvm_cov_cmd(log_text: str) -> tuple[str, list[str]]:
 
 
 def path_matches_prefixes(path: str, prefixes: list[str]) -> bool:
+    """True if path is under any prefix as a path segment (not a mere substring)."""
     norm = path.replace("\\", "/")
     for pref in prefixes:
         p = pref.rstrip("/")
-        if (
-            f"/{p}/" in f"/{norm}/"
-            or norm.startswith(pref)
-            or norm.endswith("/" + p)
-            or p in norm
-        ):
-            idx = norm.find(p)
-            if idx != -1 and (idx == 0 or norm[idx - 1] == "/"):
+        if not p:
+            continue
+        idx = 0
+        while True:
+            idx = norm.find(p, idx)
+            if idx == -1:
+                break
+            end = idx + len(p)
+            left_ok = idx == 0 or norm[idx - 1] == "/"
+            right_ok = end == len(norm) or norm[end] == "/"
+            if left_ok and right_ok:
                 return True
+            idx = end
     return False
 
 

--- a/.github/scripts/tests/generate_coverage_landing.py
+++ b/.github/scripts/tests/generate_coverage_landing.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate a simple HTML landing page linking suite coverage reports."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--title", default="YDB C++ coverage")
+    parser.add_argument(
+        "--suite",
+        action="append",
+        default=[],
+        metavar="NAME=REL_URL",
+        help="Suite entry, e.g. cli=./cli/index.html",
+    )
+    parser.add_argument("--meta-json", type=Path, default=None, help="Optional meta.json to embed summary")
+    args = parser.parse_args()
+
+    rows = []
+    for item in args.suite:
+        if "=" not in item:
+            raise SystemExit(f"bad --suite value: {item}")
+        name, url = item.split("=", 1)
+        rows.append((name, url))
+
+    meta_note = ""
+    if args.meta_json and args.meta_json.is_file():
+        meta = json.loads(args.meta_json.read_text(encoding="utf-8"))
+        meta_note = (
+            f"<p>Generated {html.escape(str(meta.get('generated_at', '')))} "
+            f"sha={html.escape(str(meta.get('sha', '')))} "
+            f"event={html.escape(str(meta.get('event', '')))}</p>"
+        )
+
+    lis = "\n".join(
+        f'  <li><a href="{html.escape(url)}">{html.escape(name)}</a></li>' for name, url in rows
+    )
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>{html.escape(args.title)}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; }}
+    a {{ color: #056; }}
+  </style>
+</head>
+<body>
+  <h1>{html.escape(args.title)}</h1>
+  {meta_note}
+  <ul>
+{lis}
+  </ul>
+  <p><small>Landing built {now}</small></p>
+</body>
+</html>
+"""
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(body, encoding="utf-8")
+    print(f"Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/overlay_trusted_codecov_ci.sh
+++ b/.github/scripts/tests/overlay_trusted_codecov_ci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Overlay coverage CI helpers from a checkout of the PR base (main) into the
+# current workspace. Invoked only from cpp_codecov.yml on pull_request* events;
+# the script itself must come from the trusted base checkout, not the PR tree.
+set -euo pipefail
+
+src="${1:-_trusted_coverage_ci}"
+if [ ! -d "$src/.github/actions/run_clang_codecov" ]; then
+  echo "Trusted coverage CI checkout missing under ${src}" >&2
+  exit 1
+fi
+
+rm -rf .github/actions/run_clang_codecov
+cp -a "$src/.github/actions/run_clang_codecov" .github/actions/
+
+rm -rf .github/actions/setup_ci_ydb_service_account_key_file_credentials
+cp -a "$src/.github/actions/setup_ci_ydb_service_account_key_file_credentials" .github/actions/
+
+mkdir -p .github/scripts/tests
+for f in codecov_suites.py detect_codecov_matrix.py export_coverage_lcov.py generate_coverage_landing.py; do
+  cp "$src/.github/scripts/tests/$f" ".github/scripts/tests/$f"
+done

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -1,8 +1,10 @@
 name: Codecov C++ (SDK / CLI / workload)
 
-# Dogfood: pull_request. Switch to pull_request_target before merging to main.
+# pull_request_target: required for fork → upstream PRs so repo secrets (CODECOV_TOKEN, AWS, …)
+# are available. Same pattern as cpp_sdk_coverage.yml. Workflow file is taken from the
+# base branch (main); checkout of PR code uses refs/pull/<n>/merge below.
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
   push:
@@ -38,7 +40,7 @@ on:
 concurrency:
   group: >-
     ${{
-      github.event_name == 'pull_request' && format('codecov-pr-{0}', github.event.pull_request.number)
+      startsWith(github.event_name, 'pull_request') && format('codecov-pr-{0}', github.event.pull_request.number)
       || github.event_name == 'schedule' && 'codecov-weekly'
       || github.event_name == 'workflow_dispatch' && 'codecov-manual'
       || 'codecov-main'
@@ -56,7 +58,7 @@ jobs:
     # Upstream only; PRs only when targeting main (stable-* etc. skip the whole job).
     if: >-
       github.repository == 'ydb-platform/ydb' &&
-      (github.event_name != 'pull_request' || github.base_ref == 'main')
+      (!startsWith(github.event_name, 'pull_request') || github.base_ref == 'main')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.decide.outputs.matrix || '[]' }}
@@ -66,16 +68,12 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
       pr_number: ${{ github.event.pull_request.number || '' }}
     steps:
-      - name: Collaborator check on labeled
-        if: github.event_name == 'pull_request' && github.event.action == 'labeled'
+      # pull_request_target runs with secrets; only collaborators may trigger (fork PRs included).
+      - name: Collaborator check
+        if: startsWith(github.event_name, 'pull_request')
         uses: actions/github-script@v8
         with:
           script: |
-            const label = context.payload.label?.name || '';
-            if (!label.startsWith('coverage/')) {
-              core.info(`Ignoring non-coverage label: ${label}`);
-              return;
-            }
             const sender = context.payload.sender.login;
             try {
               await github.rest.repos.checkCollaborator({
@@ -86,17 +84,19 @@ jobs:
             } catch (error) {
               if (!error.status || error.status != 404) throw error;
               core.setFailed(
-                `Only repository collaborators can trigger Codecov via labels (sender: @${sender}).`
+                `Only repository collaborators can trigger Codecov (sender: @${sender}).`
               );
             }
 
+      # For PRs: checkout merge ref so detect scripts match the PR (base workflow + PR tree).
       - uses: actions/checkout@v5
         with:
+          ref: ${{ startsWith(github.event_name, 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           fetch-depth: 0
 
       - name: Strip coverage labels on sync/open/reopen
         if: >-
-          github.event_name == 'pull_request' &&
+          startsWith(github.event_name, 'pull_request') &&
           (github.event.action == 'synchronize' ||
            github.event.action == 'opened' ||
            github.event.action == 'reopened')
@@ -124,12 +124,13 @@ jobs:
           CHANGED_FILE=$(mktemp)
           LABELS_FILE=$(mktemp)
           echo '[]' > "$LABELS_FILE"
+          EVENT="${{ github.event_name }}"
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "$EVENT" = "schedule" ]; then
             MODE=labels
             echo '["coverage/all"]' > "$LABELS_FILE"
             : > "$CHANGED_FILE"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
             MODE=labels
             case "${{ inputs.suites }}" in
               all) echo '["coverage/all"]' > "$LABELS_FILE" ;;
@@ -139,7 +140,7 @@ jobs:
               *) echo "Unknown suites input: ${{ inputs.suites }}" >&2; exit 1 ;;
             esac
             : > "$CHANGED_FILE"
-          elif [ "${{ github.event_name }}" = "push" ]; then
+          elif [ "$EVENT" = "push" ]; then
             BEFORE="${{ github.event.before }}"
             AFTER="${{ github.sha }}"
             if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
@@ -147,7 +148,7 @@ jobs:
             else
               git diff --name-only "$BEFORE" "$AFTER" > "$CHANGED_FILE"
             fi
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+          elif [ "$EVENT" = "pull_request" ] || [ "$EVENT" = "pull_request_target" ]; then
             if [ "${{ github.event.action }}" = "labeled" ]; then
               gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
                 --jq '[.[].name]' > "$LABELS_FILE"
@@ -176,7 +177,8 @@ jobs:
         id: decide
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.action }}" = "labeled" ]; then
+          EVENT="${{ github.event_name }}"
+          if { [ "$EVENT" = "pull_request" ] || [ "$EVENT" = "pull_request_target" ]; } && [ "${{ github.event.action }}" = "labeled" ]; then
             LAB="${{ github.event.label.name }}"
             case "$LAB" in
               coverage/*) ;;
@@ -207,7 +209,7 @@ jobs:
         suite: ${{ fromJson(needs.detect.outputs.matrix) }}
     steps:
       - name: Verify PR is mergeable
-        if: github.event_name == 'pull_request'
+        if: startsWith(github.event_name, 'pull_request')
         uses: actions/github-script@v8
         with:
           script: |
@@ -228,7 +230,7 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          ref: ${{ startsWith(github.event_name, 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           fetch-depth: 0
 
       - name: Setup ydb access
@@ -256,7 +258,7 @@ jobs:
     if: >-
       always() &&
       !cancelled() &&
-      github.event_name == 'pull_request' &&
+      startsWith(github.event_name, 'pull_request') &&
       needs.detect.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -250,9 +250,10 @@ jobs:
   finalize:
     name: Finalize PR labels
     needs: [detect, coverage]
+    # Also run when the run is cancelled (cancel-in-progress): one-shot labels must
+    # be cleared so coverage/* can be re-applied.
     if: >-
       always() &&
-      !cancelled() &&
       startsWith(github.event_name, 'pull_request') &&
       needs.detect.outputs.should_run == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -22,9 +22,8 @@ on:
       - ".github/scripts/tests/generate_coverage_landing.py"
       - ".github/workflows/cpp_codecov.yml"
       - ".github/codecov.yml"
-  schedule:
-    # Weekly full refresh for carryforward baselines (Sunday 03:00 UTC).
-    - cron: "0 3 * * 0"
+  # Baselines on main: push + paths above (only changed suites). No weekly cron —
+  # unused flags stay via Codecov carryforward until the next relevant merge.
   workflow_dispatch:
     inputs:
       suites:
@@ -41,7 +40,6 @@ concurrency:
   group: >-
     ${{
       startsWith(github.event_name, 'pull_request') && format('codecov-pr-{0}', github.event.pull_request.number)
-      || github.event_name == 'schedule' && 'codecov-weekly'
       || github.event_name == 'workflow_dispatch' && 'codecov-manual'
       || 'codecov-main'
     }}
@@ -64,7 +62,7 @@ jobs:
       matrix: ${{ steps.decide.outputs.matrix || '[]' }}
       should_run: ${{ steps.decide.outputs.should_run || 'false' }}
       hanging_labels: ${{ steps.decide.outputs.hanging_labels || '[]' }}
-      # Head SHA for Codecov/S3 meta; PR number for S3 prefix (empty on push/schedule/manual).
+      # Head SHA for Codecov/S3 meta; PR number for S3 prefix (empty on push/manual).
       commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
       pr_number: ${{ github.event.pull_request.number || '' }}
     steps:
@@ -126,11 +124,7 @@ jobs:
           echo '[]' > "$LABELS_FILE"
           EVENT="${{ github.event_name }}"
 
-          if [ "$EVENT" = "schedule" ]; then
-            MODE=labels
-            echo '["coverage/all"]' > "$LABELS_FILE"
-            : > "$CHANGED_FILE"
-          elif [ "$EVENT" = "workflow_dispatch" ]; then
+          if [ "$EVENT" = "workflow_dispatch" ]; then
             MODE=labels
             case "${{ inputs.suites }}" in
               all) echo '["coverage/all"]' > "$LABELS_FILE" ;;

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -251,6 +251,7 @@ jobs:
           bazel_remote_password: ${{ secrets.REMOTE_CACHE_PASSWORD }}
           pr_number: ${{ needs.detect.outputs.pr_number }}
           commit_sha: ${{ needs.detect.outputs.commit_sha }}
+          branch: ${{ github.head_ref || github.ref_name }}
 
   finalize:
     name: Finalize PR labels

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -1,8 +1,9 @@
 name: Codecov C++ (SDK / CLI / workload)
 
 # pull_request_target: required for fork → upstream PRs so repo secrets (CODECOV_TOKEN, AWS, …)
-# are available. Same pattern as cpp_sdk_coverage.yml. Workflow file is taken from the
-# base branch (main); checkout of PR code uses refs/pull/<n>/merge below.
+# are available. Workflow YAML is always taken from the base branch (main).
+# Product code is checked out from refs/pull/<n>/merge; coverage actions/scripts are then
+# overlaid from the PR base SHA so an untrusted PR tree cannot replace secret-bearing helpers.
 on:
   pull_request_target:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - ".github/scripts/tests/detect_codecov_matrix.py"
       - ".github/scripts/tests/export_coverage_lcov.py"
       - ".github/scripts/tests/generate_coverage_landing.py"
+      - ".github/scripts/tests/overlay_trusted_codecov_ci.sh"
       - ".github/workflows/cpp_codecov.yml"
       - ".github/codecov.yml"
   # Baselines on main: push + paths above (only changed suites). No weekly cron —
@@ -86,11 +88,33 @@ jobs:
               );
             }
 
-      # For PRs: checkout merge ref so detect scripts match the PR (base workflow + PR tree).
+      # PR product tree (merge ref). push / workflow_dispatch: the event commit.
       - uses: actions/checkout@v5
         with:
           ref: ${{ startsWith(github.event_name, 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           fetch-depth: 0
+
+      # Trusted marketplace action + inline copy (not a local composite): helpers must
+      # come from base, not from the PR tree that was just checked out.
+      - name: Checkout trusted coverage CI helpers from base
+        if: startsWith(github.event_name, 'pull_request')
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            .github/actions/run_clang_codecov
+            .github/actions/setup_ci_ydb_service_account_key_file_credentials
+            .github/scripts/tests/codecov_suites.py
+            .github/scripts/tests/detect_codecov_matrix.py
+            .github/scripts/tests/export_coverage_lcov.py
+            .github/scripts/tests/generate_coverage_landing.py
+            .github/scripts/tests/overlay_trusted_codecov_ci.sh
+          sparse-checkout-cone-mode: false
+          path: _trusted_coverage_ci
+
+      - name: Overlay trusted coverage CI helpers
+        if: startsWith(github.event_name, 'pull_request')
+        run: bash _trusted_coverage_ci/.github/scripts/tests/overlay_trusted_codecov_ci.sh
 
       - name: Strip coverage labels on sync/open/reopen
         if: >-
@@ -226,6 +250,26 @@ jobs:
         with:
           ref: ${{ startsWith(github.event_name, 'pull_request') && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           fetch-depth: 0
+
+      - name: Checkout trusted coverage CI helpers from base
+        if: startsWith(github.event_name, 'pull_request')
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            .github/actions/run_clang_codecov
+            .github/actions/setup_ci_ydb_service_account_key_file_credentials
+            .github/scripts/tests/codecov_suites.py
+            .github/scripts/tests/detect_codecov_matrix.py
+            .github/scripts/tests/export_coverage_lcov.py
+            .github/scripts/tests/generate_coverage_landing.py
+            .github/scripts/tests/overlay_trusted_codecov_ci.sh
+          sparse-checkout-cone-mode: false
+          path: _trusted_coverage_ci
+
+      - name: Overlay trusted coverage CI helpers
+        if: startsWith(github.event_name, 'pull_request')
+        run: bash _trusted_coverage_ci/.github/scripts/tests/overlay_trusted_codecov_ci.sh
 
       - name: Setup ydb access
         uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials

--- a/.github/workflows/cpp_codecov.yml
+++ b/.github/workflows/cpp_codecov.yml
@@ -1,0 +1,276 @@
+name: Codecov C++ (SDK / CLI / workload)
+
+# Dogfood: pull_request. Switch to pull_request_target before merging to main.
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+  push:
+    branches: [main]
+    paths:
+      - "ydb/public/sdk/cpp/**"
+      - "ydb/apps/ydb/**"
+      - "ydb/public/lib/ydb_cli/**"
+      - "ydb/tests/functional/ydb_cli/**"
+      - "ydb/library/workload/**"
+      - ".github/actions/run_clang_codecov/**"
+      - ".github/scripts/tests/codecov_suites.py"
+      - ".github/scripts/tests/detect_codecov_matrix.py"
+      - ".github/scripts/tests/export_coverage_lcov.py"
+      - ".github/scripts/tests/generate_coverage_landing.py"
+      - ".github/workflows/cpp_codecov.yml"
+      - ".github/codecov.yml"
+  schedule:
+    # Weekly full refresh for carryforward baselines (Sunday 03:00 UTC).
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+    inputs:
+      suites:
+        description: Suites to run (use "all" to seed Codecov / S3 baselines on main)
+        type: choice
+        options:
+          - all
+          - cpp_sdk
+          - cli
+          - cli_workload
+        default: all
+
+concurrency:
+  group: >-
+    ${{
+      github.event_name == 'pull_request' && format('codecov-pr-{0}', github.event.pull_request.number)
+      || github.event_name == 'schedule' && 'codecov-weekly'
+      || github.event_name == 'workflow_dispatch' && 'codecov-manual'
+      || 'codecov-main'
+    }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  detect:
+    name: Detect suites
+    # Upstream only; PRs only when targeting main (stable-* etc. skip the whole job).
+    if: >-
+      github.repository == 'ydb-platform/ydb' &&
+      (github.event_name != 'pull_request' || github.base_ref == 'main')
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.decide.outputs.matrix || '[]' }}
+      should_run: ${{ steps.decide.outputs.should_run || 'false' }}
+      hanging_labels: ${{ steps.decide.outputs.hanging_labels || '[]' }}
+      # Head SHA for Codecov/S3 meta; PR number for S3 prefix (empty on push/schedule/manual).
+      commit_sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      pr_number: ${{ github.event.pull_request.number || '' }}
+    steps:
+      - name: Collaborator check on labeled
+        if: github.event_name == 'pull_request' && github.event.action == 'labeled'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const label = context.payload.label?.name || '';
+            if (!label.startsWith('coverage/')) {
+              core.info(`Ignoring non-coverage label: ${label}`);
+              return;
+            }
+            const sender = context.payload.sender.login;
+            try {
+              await github.rest.repos.checkCollaborator({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: sender,
+              });
+            } catch (error) {
+              if (!error.status || error.status != 404) throw error;
+              core.setFailed(
+                `Only repository collaborators can trigger Codecov via labels (sender: @${sender}).`
+              );
+            }
+
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Strip coverage labels on sync/open/reopen
+        if: >-
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'synchronize' ||
+           github.event.action == 'opened' ||
+           github.event.action == 'reopened')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          labels=$(gh api "repos/${{ github.repository }}/issues/${PR}/labels" --jq '.[].name')
+          for lab in coverage/sdk coverage/cli coverage/workload coverage/all; do
+            if printf '%s\n' "$labels" | grep -qx "$lab"; then
+              echo "Removing label $lab (paths-only mode after ${{ github.event.action }})"
+              enc=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$lab")
+              gh api -X DELETE "repos/${{ github.repository }}/issues/${PR}/labels/${enc}" || true
+            fi
+          done
+
+      - name: Collect changed files / labels
+        id: inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          MODE=paths
+          CHANGED_FILE=$(mktemp)
+          LABELS_FILE=$(mktemp)
+          echo '[]' > "$LABELS_FILE"
+
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            MODE=labels
+            echo '["coverage/all"]' > "$LABELS_FILE"
+            : > "$CHANGED_FILE"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            MODE=labels
+            case "${{ inputs.suites }}" in
+              all) echo '["coverage/all"]' > "$LABELS_FILE" ;;
+              cpp_sdk) echo '["coverage/sdk"]' > "$LABELS_FILE" ;;
+              cli) echo '["coverage/cli"]' > "$LABELS_FILE" ;;
+              cli_workload) echo '["coverage/workload"]' > "$LABELS_FILE" ;;
+              *) echo "Unknown suites input: ${{ inputs.suites }}" >&2; exit 1 ;;
+            esac
+            : > "$CHANGED_FILE"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BEFORE="${{ github.event.before }}"
+            AFTER="${{ github.sha }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+              git diff --name-only HEAD~1 HEAD > "$CHANGED_FILE" || git ls-files > "$CHANGED_FILE"
+            else
+              git diff --name-only "$BEFORE" "$AFTER" > "$CHANGED_FILE"
+            fi
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            if [ "${{ github.event.action }}" = "labeled" ]; then
+              gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
+                --jq '[.[].name]' > "$LABELS_FILE"
+              if python3 -c 'import json,sys; labs=json.load(open(sys.argv[1])); sys.exit(0 if any(str(l).startswith("coverage/") for l in labs) else 1)' "$LABELS_FILE"; then
+                MODE=labels
+              else
+                MODE=paths
+                gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                  --paginate --jq '.[].filename' > "$CHANGED_FILE"
+              fi
+            else
+              MODE=paths
+              gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+                --paginate --jq '.[].filename' > "$CHANGED_FILE"
+            fi
+          fi
+
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+          echo "changed_files_file=$CHANGED_FILE" >> "$GITHUB_OUTPUT"
+          echo "labels_file=$LABELS_FILE" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE"
+          echo "changed files:" && head -50 "$CHANGED_FILE" || true
+          echo "labels:" && cat "$LABELS_FILE"
+
+      - name: Decide matrix
+        id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.action }}" = "labeled" ]; then
+            LAB="${{ github.event.label.name }}"
+            case "$LAB" in
+              coverage/*) ;;
+              *)
+                echo "matrix=[]" >> "$GITHUB_OUTPUT"
+                echo "should_run=false" >> "$GITHUB_OUTPUT"
+                echo "hanging_labels=[]" >> "$GITHUB_OUTPUT"
+                exit 0
+                ;;
+            esac
+          fi
+
+          LABELS=$(cat "${{ steps.inputs.outputs.labels_file }}")
+          python3 .github/scripts/tests/detect_codecov_matrix.py \
+            --mode "${{ steps.inputs.outputs.mode }}" \
+            --changed-files-file "${{ steps.inputs.outputs.changed_files_file }}" \
+            --labels "$LABELS"
+
+  coverage:
+    name: Coverage (${{ matrix.suite }})
+    needs: detect
+    if: needs.detect.outputs.should_run == 'true'
+    runs-on: [self-hosted, auto-provisioned, build-preset-relwithdebinfo]
+    timeout-minutes: 480
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJson(needs.detect.outputs.matrix) }}
+    steps:
+      - name: Verify PR is mergeable
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            let pr = context.payload.pull_request;
+            if (pr.mergeable == null || !pr.merge_commit_sha) {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              pr = data;
+            }
+            if (!pr.mergeable || !pr.merge_commit_sha) {
+              core.setFailed(
+                'Unable to merge PR into the base branch. Please rebase or resolve conflicts and re-request coverage.'
+              );
+            }
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          fetch-depth: 0
+
+      - name: Setup ydb access
+        uses: ./.github/actions/setup_ci_ydb_service_account_key_file_credentials
+        with:
+          ci_ydb_service_account_key_file_credentials: ${{ secrets.CI_YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS }}
+          ydb_qa_config: ${{ vars.YDB_QA_CONFIG }}
+
+      - name: Run suite
+        uses: ./.github/actions/run_clang_codecov
+        with:
+          suite: ${{ matrix.suite }}
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+          aws_access_key_id: ${{ secrets.YDB_TECH_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.YDB_TECH_AWS_SECRET_ACCESS_KEY }}
+          bazel_remote_uri: ${{ vars.REMOTE_CACHE_URL_YA }}
+          bazel_remote_username: ${{ secrets.REMOTE_CACHE_USERNAME }}
+          bazel_remote_password: ${{ secrets.REMOTE_CACHE_PASSWORD }}
+          pr_number: ${{ needs.detect.outputs.pr_number }}
+          commit_sha: ${{ needs.detect.outputs.commit_sha }}
+
+  finalize:
+    name: Finalize PR labels
+    needs: [detect, coverage]
+    if: >-
+      always() &&
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      needs.detect.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove coverage labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          labels=$(gh api "repos/${{ github.repository }}/issues/${PR}/labels" --jq '.[].name')
+          for lab in coverage/sdk coverage/cli coverage/workload coverage/all; do
+            if printf '%s\n' "$labels" | grep -qx "$lab"; then
+              echo "Removing label $lab"
+              enc=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$lab")
+              gh api -X DELETE "repos/${{ github.repository }}/issues/${PR}/labels/${enc}" || true
+            fi
+          done


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Adds Clang coverage CI for C++ SDK, YDB CLI and workload libraries, uploading LCOV to Codecov and HTML reports to internal Object Storage.

**What runs**
- Workflow: `.github/workflows/cpp_codecov.yml`
- Suites / Codecov flags: `cpp_sdk`, `cli`, `cli_workload` (CLI components `cli_app` / `cli_core` in Codecov UI)
- PR to `main`: path filter and/or one-shot labels `coverage/sdk`, `coverage/cli`, `coverage/workload`, `coverage/all` (`pull_request_target` + collaborator check)
- Push to `main`: only when relevant paths change; matrix runs only affected suites; other flags use Codecov carryforward (no weekly cron)
- Manual: `workflow_dispatch` to seed/re-run suites

**Config / code**
- `.github/codecov.yml` — project/patch statuses, flags, components, comment layout
- `.github/actions/run_clang_codecov` — ya clang coverage → filtered LCOV → Codecov → S3
- Helpers under `.github/scripts/tests/` (`codecov_suites`, `detect_codecov_matrix`, `export_coverage_lcov`, `generate_coverage_landing`, `overlay_trusted_codecov_ci`)

**Trust model on PRs (`pull_request_target`)**
- Workflow YAML always from base (`main`)
- Product code from `refs/pull/<n>/merge`
- Coverage actions/scripts overlaid from the PR **base SHA** (not from the PR tree), so helpers that see secrets cannot be swapped by a malicious PR
- Consequence: changes to coverage CI in a PR take effect only after merge to `main` (same as the workflow file itself)

**Secrets / vars (already used or needed in the repo)**
- `CODECOV_TOKEN`, `YDB_TECH_AWS_ACCESS_KEY_ID` / `YDB_TECH_AWS_SECRET_ACCESS_KEY`, remote cache + existing YDB CI credentials

**Notes**
- Leaves the old label-triggered `cpp_sdk_coverage.yml` (`sdk-coverage`) untouched
- Prefer squash merge (history has intermediate dogfood commits)