### PR TITLE
docs: add LLM discovery hub (llms.txt) for locales and versions

### DIFF
--- a/ydb/docs/.yfm
+++ b/ydb/docs/.yfm
@@ -1,6 +1,12 @@
 allowHTML: true
-llms: 
+llms:
   enabled: true
+  description: >-
+    YDB is an open-source distributed SQL database. This file indexes Markdown
+    documentation pages for LLM agents. For a hub of all locales and release
+    versions, see https://ydb.tech/docs/llms.txt (when published) or the
+    repository file ydb/docs/llms.txt. Prefer ?version= matching the server
+    release; use llms-full.txt for a single-file full-text dump.
 langs: ['en','ru']
 pdf:
   enabled: true

--- a/ydb/docs/.yfm
+++ b/ydb/docs/.yfm
@@ -1,12 +1,6 @@
 allowHTML: true
-llms:
+llms: 
   enabled: true
-  description: >-
-    YDB is an open-source distributed SQL database. This file indexes Markdown
-    documentation pages for LLM agents. For a hub of all locales and release
-    versions, see https://ydb.tech/docs/llms.txt (when published) or the
-    repository file ydb/docs/llms.txt. Prefer ?version= matching the server
-    release; use llms-full.txt for a single-file full-text dump.
 langs: ['en','ru']
 pdf:
   enabled: true

--- a/ydb/docs/README.md
+++ b/ydb/docs/README.md
@@ -99,12 +99,7 @@ Press `Ctrl+C` to stop the server.
 
 ## LLM indexes (`llms.txt`)
 
-Diplodoc generates per-locale indexes when `llms.enabled` is set in `.yfm`:
-
-- Published: `https://ydb.tech/docs/{en|ru}/llms.txt` and `llms-full.txt` (optional `?version=vX.Y` or `?version=main`)
-- Hub (source of truth in this repo): [`llms.txt`](./llms.txt) — curated links to every locale/version index for agents
-
-After changing `llms.txt`, keep the version list in sync with stables that actually publish LLM indexes (backfill CI on older `stable-*` as needed). Serving the hub at `https://ydb.tech/docs/llms.txt` and the site-root `https://ydb.tech/llms.txt` may require a small publish/CDN follow-up; the per-locale files are already live.
+Diplodoc generates per-locale indexes (`/docs/{en|ru}/llms.txt` and `llms-full.txt`, optional `?version=`). The hub [`llms.txt`](./llms.txt) in this directory links agents to those indexes across locales and release versions. Keep the version list in sync with stables that publish LLM indexes.
 
 ## File Structure
 

--- a/ydb/docs/README.md
+++ b/ydb/docs/README.md
@@ -97,6 +97,15 @@ Builds the documentation and starts a local HTTP server to preview the results.
 
 Press `Ctrl+C` to stop the server.
 
+## LLM indexes (`llms.txt`)
+
+Diplodoc generates per-locale indexes when `llms.enabled` is set in `.yfm`:
+
+- Published: `https://ydb.tech/docs/{en|ru}/llms.txt` and `llms-full.txt` (optional `?version=vX.Y` or `?version=main`)
+- Hub (source of truth in this repo): [`llms.txt`](./llms.txt) — curated links to every locale/version index for agents
+
+After changing `llms.txt`, keep the version list in sync with stables that actually publish LLM indexes (backfill CI on older `stable-*` as needed). Serving the hub at `https://ydb.tech/docs/llms.txt` and the site-root `https://ydb.tech/llms.txt` may require a small publish/CDN follow-up; the per-locale files are already live.
+
 ## File Structure
 
 The documentation source files are organized as Markdown files with YAML configuration, following the Diplodoc documentation format. The built documentation includes both English (`en`) and Russian (`ru`) versions.

--- a/ydb/docs/README.md
+++ b/ydb/docs/README.md
@@ -99,7 +99,7 @@ Press `Ctrl+C` to stop the server.
 
 ## LLM indexes (`llms.txt`)
 
-Diplodoc generates per-locale indexes (`/docs/{en|ru}/llms.txt` and `llms-full.txt`, optional `?version=`). The hub [`llms.txt`](./llms.txt) in this directory links agents to those indexes across locales and release versions. Keep the version list in sync with stables that publish LLM indexes.
+Diplodoc generates per-locale indexes (`/docs/{en|ru}/llms.txt` and `llms-full.txt`). The hub [`llms.txt`](./llms.txt) links agents to those indexes for the **default stable** (no `?version=`; currently `v26.1`), the **`main` trunk**, and each **stable** (`?version=vX.Y`). Keep the stable list in the hub up to date when new release lines appear.
 
 ## File Structure
 

--- a/ydb/docs/build.sh
+++ b/ydb/docs/build.sh
@@ -30,6 +30,13 @@ if ! yfm -s -i . -o $DIR --allowHTML --apply-presets; then
   exit 1
 fi
 
+# Hub index for agents (locale/version discovery). Diplodoc generates
+# en/llms.txt and ru/llms.txt separately; this file links them together.
+if [[ -f llms.txt ]]; then
+  cp -f llms.txt "$DIR/llms.txt"
+  echo "Copied docs hub llms.txt to $DIR/llms.txt"
+fi
+
 echo
 echo "Build completed successfully!"
 echo "Output directory: $DIR"

--- a/ydb/docs/build.sh
+++ b/ydb/docs/build.sh
@@ -30,13 +30,6 @@ if ! yfm -s -i . -o $DIR --allowHTML --apply-presets; then
   exit 1
 fi
 
-# Hub index for agents (locale/version discovery). Diplodoc generates
-# en/llms.txt and ru/llms.txt separately; this file links them together.
-if [[ -f llms.txt ]]; then
-  cp -f llms.txt "$DIR/llms.txt"
-  echo "Copied docs hub llms.txt to $DIR/llms.txt"
-fi
-
 echo
 echo "Build completed successfully!"
 echo "Output directory: $DIR"

--- a/ydb/docs/llms.txt
+++ b/ydb/docs/llms.txt
@@ -1,0 +1,61 @@
+# YDB Documentation
+> YDB is an open-source distributed SQL database. This file is the discovery hub for LLM-friendly documentation indexes. Prefer a version that matches the YDB server you are working with.
+
+How to use these indexes:
+- Start here, then open one locale/version `llms.txt` for a curated page list, or `llms-full.txt` for a single-file full-text dump (several MB).
+- Links without `?version=` point at the site default documentation version (see `default-branch.txt` in this repository; currently `stable-26-1` → `v26.1`).
+- Use `?version=main` for the latest docs from the `main` branch.
+- Individual pages are also available as Markdown by using the `.md` URL from the index (Diplodoc).
+- English and Russian docs are separate trees. Do not mix locales in one answer unless the user asks.
+
+## Default documentation (no version query)
+
+- [English index](https://ydb.tech/docs/en/llms.txt): Page index for the site default docs version (EN)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt): Page index for the site default docs version (RU)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt): Full Markdown dump for the site default docs version (EN)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt): Full Markdown dump for the site default docs version (RU)
+
+## Latest (main)
+
+- [English index (main)](https://ydb.tech/docs/en/llms.txt?version=main): Unreleased / tip-of-main documentation index (EN)
+- [Russian index (main)](https://ydb.tech/docs/ru/llms.txt?version=main): Unreleased / tip-of-main documentation index (RU)
+- [English full text (main)](https://ydb.tech/docs/en/llms-full.txt?version=main): Full Markdown dump for main (EN)
+- [Russian full text (main)](https://ydb.tech/docs/ru/llms-full.txt?version=main): Full Markdown dump for main (RU)
+
+## Released versions with LLM indexes
+
+Only versions that currently publish `llms.txt` are listed. After enabling Diplodoc `llms` generation on an older `stable-*` branch, add that version here.
+
+### v26.2
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v26.2)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v26.2)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.2)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.2)
+
+### v26.1
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v26.1)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v26.1)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.1)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.1)
+
+### v25.3
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.3)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.3)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.3)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.3)
+
+### v25.2
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.2)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.2)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.2)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.2)
+
+## Optional
+
+- [Human docs entry (EN)](https://ydb.tech/docs/en/): HTML documentation site (English)
+- [Human docs entry (RU)](https://ydb.tech/docs/ru/): HTML documentation site (Russian)
+- [llms.txt specification](https://llmstxt.org/): Format used by this hub and by Diplodoc-generated indexes

--- a/ydb/docs/llms.txt
+++ b/ydb/docs/llms.txt
@@ -1,30 +1,40 @@
 # YDB Documentation
-> YDB is an open-source distributed SQL database. This file is the discovery hub for LLM-friendly documentation indexes. Prefer a version that matches the YDB server you are working with.
+> YDB is an open-source distributed SQL database. This file is the discovery hub for LLM-friendly documentation indexes. Prefer a documentation version that matches the YDB server you are working with.
 
-How to use these indexes:
-- Start here, then open one locale/version `llms.txt` for a curated page list, or `llms-full.txt` for a single-file full-text dump (several MB).
-- Links without `?version=` point at the site default documentation version (see `default-branch.txt` in this repository; currently `stable-26-1` → `v26.1`).
-- Use `?version=main` for the latest docs from the `main` branch.
-- Individual pages are also available as Markdown by using the `.md` URL from the index (Diplodoc).
-- English and Russian docs are separate trees. Do not mix locales in one answer unless the user asks.
+How YDB documentation versions work (trunk-based development):
+- **Default** (URLs without `?version=`): the current default **stable** release docs. That stable is selected by `default-branch.txt` in this repository (currently `stable-26-1` → `v26.1`). Default is **not** `main`.
+- **`main`**: the development trunk. Separate from any stable. Use `?version=main` for tip-of-trunk docs.
+- **Stables**: release lines such as `v25.1`, `v25.2`, `v25.3`, `v25.4`, `v26.1`, `v26.2`, `v26.3`, and later `v26.4`, `v27.1`, … Select with `?version=vX.Y`.
+- Open one locale/version `llms.txt` for a page index, or `llms-full.txt` for a single-file full-text dump (several MB).
+- Individual pages are also available as Markdown via the `.md` URLs from those indexes (Diplodoc).
+- English and Russian are separate trees. Do not mix locales unless the user asks.
 
-## Default documentation (no version query)
+## Default stable (no `?version=`)
 
-- [English index](https://ydb.tech/docs/en/llms.txt): Page index for the site default docs version (EN)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt): Page index for the site default docs version (RU)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt): Full Markdown dump for the site default docs version (EN)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt): Full Markdown dump for the site default docs version (RU)
+Same content as `v26.1` while `default-branch.txt` points at `stable-26-1`.
 
-## Latest (main)
+- [English index](https://ydb.tech/docs/en/llms.txt): Default stable page index (EN)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt): Default stable page index (RU)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt): Default stable full Markdown dump (EN)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt): Default stable full Markdown dump (RU)
 
-- [English index (main)](https://ydb.tech/docs/en/llms.txt?version=main): Unreleased / tip-of-main documentation index (EN)
-- [Russian index (main)](https://ydb.tech/docs/ru/llms.txt?version=main): Unreleased / tip-of-main documentation index (RU)
-- [English full text (main)](https://ydb.tech/docs/en/llms-full.txt?version=main): Full Markdown dump for main (EN)
-- [Russian full text (main)](https://ydb.tech/docs/ru/llms-full.txt?version=main): Full Markdown dump for main (RU)
+## Development trunk (`main`)
 
-## Released versions with LLM indexes
+- [English index (main)](https://ydb.tech/docs/en/llms.txt?version=main): Trunk documentation index (EN)
+- [Russian index (main)](https://ydb.tech/docs/ru/llms.txt?version=main): Trunk documentation index (RU)
+- [English full text (main)](https://ydb.tech/docs/en/llms-full.txt?version=main): Trunk full Markdown dump (EN)
+- [Russian full text (main)](https://ydb.tech/docs/ru/llms-full.txt?version=main): Trunk full Markdown dump (RU)
 
-Only versions that currently publish `llms.txt` are listed. After enabling Diplodoc `llms` generation on an older `stable-*` branch, add that version here.
+## Stable release versions
+
+Add new stables here when they are published (`v26.4`, `v27.1`, …). URL pattern: `?version=vX.Y`.
+
+### v26.3
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v26.3)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v26.3)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.3)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.3)
 
 ### v26.2
 
@@ -40,6 +50,13 @@ Only versions that currently publish `llms.txt` are listed. After enabling Diplo
 - [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.1)
 - [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.1)
 
+### v25.4
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.4)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.4)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.4)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.4)
+
 ### v25.3
 
 - [English index](https://ydb.tech/docs/en/llms.txt?version=v25.3)
@@ -53,6 +70,13 @@ Only versions that currently publish `llms.txt` are listed. After enabling Diplo
 - [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.2)
 - [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.2)
 - [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.2)
+
+### v25.1
+
+- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.1)
+- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.1)
+- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.1)
+- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.1)
 
 ## Optional
 

--- a/ydb/docs/llms.txt
+++ b/ydb/docs/llms.txt
@@ -1,17 +1,29 @@
 # YDB Documentation
 > YDB is an open-source distributed SQL database. This file is the discovery hub for LLM-friendly documentation indexes. Prefer a documentation version that matches the YDB server you are working with.
 
-How YDB documentation versions work (trunk-based development):
-- **Default** (URLs without `?version=`): the current default **stable** release docs. That stable is selected by `default-branch.txt` in this repository (currently `stable-26-1` → `v26.1`). Default is **not** `main`.
-- **`main`**: the development trunk. Separate from any stable. Use `?version=main` for tip-of-trunk docs.
-- **Stables**: release lines such as `v25.1`, `v25.2`, `v25.3`, `v25.4`, `v26.1`, `v26.2`, `v26.3`, and later `v26.4`, `v27.1`, … Select with `?version=vX.Y`.
-- Open one locale/version `llms.txt` for a page index, or `llms-full.txt` for a single-file full-text dump (several MB).
-- Individual pages are also available as Markdown via the `.md` URLs from those indexes (Diplodoc).
-- English and Russian are separate trees. Do not mix locales unless the user asks.
+## How to choose a version
+
+- **Default stable** (no `?version=`): use when the user does not specify a server version. This is the current default **stable** release, not the development trunk. Today that is `v26.1` (`default-branch.txt` → `stable-26-1`).
+- **`vX.Y` (stable release)**: use when the user names a release (for example `26.2` → `?version=v26.2`).
+- **`main` (development trunk)**: use only for tip-of-trunk / unreleased docs. Always pass `?version=main`. Do **not** treat URLs without `?version=` as `main`.
+
+Do **not** mix locales. Choose English **or** Russian, not both.
+
+Each version has two index formats:
+- `llms.txt`: page-by-page index (recommended; on the order of ~100 KB).
+- `llms-full.txt`: single-file Markdown dump of all pages (several MB).
+
+## Version strategy
+
+YDB uses trunk-based development:
+
+- **Default stable**: selected by `default-branch.txt` (currently `stable-26-1` → `v26.1`). Served at URLs **without** `?version=`.
+- **`main`**: development trunk with unreleased features. Served only as `?version=main`.
+- **Stables**: release lines `v25.1`, `v25.2`, `v25.3`, `v25.4`, `v26.1`, `v26.2`, `v26.3`, later `v26.4`, `v27.1`, … Served as `?version=vX.Y`.
 
 ## Default stable (no `?version=`)
 
-Same content as `v26.1` while `default-branch.txt` points at `stable-26-1`.
+Same page set as `v26.1` while `default-branch.txt` points at `stable-26-1`.
 
 - [English index](https://ydb.tech/docs/en/llms.txt): Default stable page index (EN)
 - [Russian index](https://ydb.tech/docs/ru/llms.txt): Default stable page index (RU)
@@ -20,66 +32,66 @@ Same content as `v26.1` while `default-branch.txt` points at `stable-26-1`.
 
 ## Development trunk (`main`)
 
-- [English index (main)](https://ydb.tech/docs/en/llms.txt?version=main): Trunk documentation index (EN)
-- [Russian index (main)](https://ydb.tech/docs/ru/llms.txt?version=main): Trunk documentation index (RU)
+- [English index (main)](https://ydb.tech/docs/en/llms.txt?version=main): Trunk page index (EN)
+- [Russian index (main)](https://ydb.tech/docs/ru/llms.txt?version=main): Trunk page index (RU)
 - [English full text (main)](https://ydb.tech/docs/en/llms-full.txt?version=main): Trunk full Markdown dump (EN)
 - [Russian full text (main)](https://ydb.tech/docs/ru/llms-full.txt?version=main): Trunk full Markdown dump (RU)
 
-## Stable release versions
+## Stable releases
 
-Add new stables here when they are published (`v26.4`, `v27.1`, …). URL pattern: `?version=vX.Y`.
+Add new stables here when published (`v26.4`, `v27.1`, …).
 
 ### v26.3
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v26.3)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v26.3)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.3)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.3)
+- [English index (v26.3)](https://ydb.tech/docs/en/llms.txt?version=v26.3)
+- [Russian index (v26.3)](https://ydb.tech/docs/ru/llms.txt?version=v26.3)
+- [English full text (v26.3)](https://ydb.tech/docs/en/llms-full.txt?version=v26.3)
+- [Russian full text (v26.3)](https://ydb.tech/docs/ru/llms-full.txt?version=v26.3)
 
 ### v26.2
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v26.2)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v26.2)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.2)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.2)
+- [English index (v26.2)](https://ydb.tech/docs/en/llms.txt?version=v26.2)
+- [Russian index (v26.2)](https://ydb.tech/docs/ru/llms.txt?version=v26.2)
+- [English full text (v26.2)](https://ydb.tech/docs/en/llms-full.txt?version=v26.2)
+- [Russian full text (v26.2)](https://ydb.tech/docs/ru/llms-full.txt?version=v26.2)
 
 ### v26.1
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v26.1)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v26.1)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v26.1)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v26.1)
+- [English index (v26.1)](https://ydb.tech/docs/en/llms.txt?version=v26.1)
+- [Russian index (v26.1)](https://ydb.tech/docs/ru/llms.txt?version=v26.1)
+- [English full text (v26.1)](https://ydb.tech/docs/en/llms-full.txt?version=v26.1)
+- [Russian full text (v26.1)](https://ydb.tech/docs/ru/llms-full.txt?version=v26.1)
 
 ### v25.4
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.4)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.4)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.4)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.4)
+- [English index (v25.4)](https://ydb.tech/docs/en/llms.txt?version=v25.4)
+- [Russian index (v25.4)](https://ydb.tech/docs/ru/llms.txt?version=v25.4)
+- [English full text (v25.4)](https://ydb.tech/docs/en/llms-full.txt?version=v25.4)
+- [Russian full text (v25.4)](https://ydb.tech/docs/ru/llms-full.txt?version=v25.4)
 
 ### v25.3
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.3)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.3)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.3)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.3)
+- [English index (v25.3)](https://ydb.tech/docs/en/llms.txt?version=v25.3)
+- [Russian index (v25.3)](https://ydb.tech/docs/ru/llms.txt?version=v25.3)
+- [English full text (v25.3)](https://ydb.tech/docs/en/llms-full.txt?version=v25.3)
+- [Russian full text (v25.3)](https://ydb.tech/docs/ru/llms-full.txt?version=v25.3)
 
 ### v25.2
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.2)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.2)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.2)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.2)
+- [English index (v25.2)](https://ydb.tech/docs/en/llms.txt?version=v25.2)
+- [Russian index (v25.2)](https://ydb.tech/docs/ru/llms.txt?version=v25.2)
+- [English full text (v25.2)](https://ydb.tech/docs/en/llms-full.txt?version=v25.2)
+- [Russian full text (v25.2)](https://ydb.tech/docs/ru/llms-full.txt?version=v25.2)
 
 ### v25.1
 
-- [English index](https://ydb.tech/docs/en/llms.txt?version=v25.1)
-- [Russian index](https://ydb.tech/docs/ru/llms.txt?version=v25.1)
-- [English full text](https://ydb.tech/docs/en/llms-full.txt?version=v25.1)
-- [Russian full text](https://ydb.tech/docs/ru/llms-full.txt?version=v25.1)
+- [English index (v25.1)](https://ydb.tech/docs/en/llms.txt?version=v25.1)
+- [Russian index (v25.1)](https://ydb.tech/docs/ru/llms.txt?version=v25.1)
+- [English full text (v25.1)](https://ydb.tech/docs/en/llms-full.txt?version=v25.1)
+- [Russian full text (v25.1)](https://ydb.tech/docs/ru/llms-full.txt?version=v25.1)
 
 ## Optional
 
-- [Human docs entry (EN)](https://ydb.tech/docs/en/): HTML documentation site (English)
-- [Human docs entry (RU)](https://ydb.tech/docs/ru/): HTML documentation site (Russian)
+- [HTML docs (EN)](https://ydb.tech/docs/en/): Human-readable English documentation
+- [HTML docs (RU)](https://ydb.tech/docs/ru/): Human-readable Russian documentation
 - [llms.txt specification](https://llmstxt.org/): Format used by this hub and by Diplodoc-generated indexes


### PR DESCRIPTION
## Summary
- Add curated hub [`ydb/docs/llms.txt`](ydb/docs/llms.txt) (Cloudflare-style discovery file): one English index that links to EN/RU `llms.txt` + `llms-full.txt` for default docs, `main`, and release versions that already return HTTP 200 (`v26.2`, `v26.1`, `v25.3`, `v25.2`).
- Set `llms.description` in `.yfm` so Diplodoc-generated `/docs/{en,ru}/llms.txt` get a proper blockquote (spec expects this).
- Copy the hub into local `./build.sh` output as `$OUT/llms.txt`.
- Document the layout in `ydb/docs/README.md`.

## Design (why not 2 root files)
- Spec discovery is **one** entrypoint (`/llms.txt`), not per-locale roots.
- Locale/version catalogs already exist: `/docs/{en|ru}/llms.txt` (+ `llms-full.txt`, `?version=`).
- Hub = map of those catalogs (like [Cloudflare’s product hub](https://developers.cloudflare.com/llms.txt)). Do **not** put a giant `llms-full` at the hub level.

## Follow-up (publish / discovery)
- Today `https://ydb.tech/docs/llms.txt` is 404 (Diplodoc release may not upload this source file yet).
- `https://ydb.tech/llms.txt` returns marketing HTML, not text — site-root discovery needs a website/CDN change (redirect or thin copy → docs hub).
- Older stables without LLM indexes (`v25.4`, `v26.3`, …) need the usual CI backfill; then add them to the hub list.

## Test plan
- [ ] Review hub Markdown against [llmstxt.org](https://llmstxt.org/) (H1, blockquote, H2 lists, absolute URLs)
- [ ] After merge + docs release: confirm locale indexes still build; check whether `$OUT/llms.txt` appears in the published bundle
- [ ] Spot-check linked `?version=` URLs still 200
- [ ] Track website task for `https://ydb.tech/llms.txt` → docs hub


Made with [Cursor](https://cursor.com)