### PR TITLE
Reduce InFlightWrites to fix PersistentBufferTestWrite CI timeout

### DIFF
--- a/ydb/tools/stress_tool/device_test_tool_ut.cpp
+++ b/ydb/tools/stress_tool/device_test_tool_ut.cpp
@@ -328,7 +328,7 @@ Y_UNIT_TEST(PersistentBufferTestWrite) {
                 }
                 WriteInfos: { Size: 4096 Weight: 1 }
                 DurationSeconds: )___" << TestDurationSec << R"___(
-                InFlightWrites: 64
+                InFlightWrites: 32
                 FillRatio: 10
             }
         }


### PR DESCRIPTION
Fixes #48834 

### Changelog entry 

Lowered `InFlightWrites` in `PersistentBufferTestWrite` from 64 to 32 to eliminate CI timeout flakiness.

### Changelog category 

* Bugfix 

