### PR TITLE
[Backport stable-26-2-1] spilling service: fail on bad config + retry directory creation

### DIFF
--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -239,9 +239,9 @@ public:
             Root_.ForceDelete();
             Root_.MkDirs(DIR_MODE);
         } catch (...) {
-            LOG_E(CurrentExceptionMessage());
-            Become(&TDqLocalFileSpillingService::BrokenState);
-            return;
+            const TString root = Root_.GetPath();
+            const TString error = CurrentExceptionMessage();
+            Y_ABORT("Cannot start DQ local file spilling service at %s: %s", root.c_str(), error.c_str());
         }
         
         Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(rootToRemoveOldTmp, nodeId, sessionId));
@@ -258,32 +258,6 @@ protected:
         if (Config_.CleanupOnShutdown) {
             Root_.ForceDelete();
         }
-    }
-
-private:
-    STATEFN(BrokenState) {
-        switch (ev->GetTypeRewrite()) {
-            case TEvDqSpillingLocalFile::TEvOpenFile::EventType:
-            case TEvDqSpillingLocalFile::TEvCloseFile::EventType:
-            case TEvDqSpilling::TEvWrite::EventType:
-            case TEvDqSpilling::TEvRead::EventType: {
-                HandleBroken(ev->Sender);
-                break;
-            }
-            hFunc(NMon::TEvHttpInfo, HandleBroken);
-            cFunc(TEvents::TEvPoison::EventType, PassAway);
-            default:
-                Y_DEBUG_ABORT_UNLESS(false, "%s: unexpected message type 0x%08" PRIx32, __func__, ev->GetTypeRewrite());
-        }
-    }
-
-    void HandleBroken(const TActorId& from) {
-        LOG_E("Service is broken, send error to client " << from);
-        Send(from, new TEvDqSpilling::TEvError("Service not started"));
-    }
-
-    void HandleBroken(NMon::TEvHttpInfo::TPtr& ev) {
-        Send(ev->Sender, new NMon::TEvHttpInfoRes("<html><h2>Service is not started due to IO error</h2></html>"));
     }
 
 private:

--- a/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file.cpp
@@ -169,6 +169,7 @@ private:
             EvWriteFileResponse,
             EvReadFileResponse,
             EvRemoveOldTmp,
+            EvRetryStart,
 
             LastEvent
         };
@@ -208,6 +209,13 @@ private:
             TEvRemoveOldTmp(TFsPath tmpRoot, ui32 nodeId, TString spillingSessionId) 
                 : TmpRoot(std::move(tmpRoot)), NodeId(nodeId), SpillingSessionId(std::move(spillingSessionId)) {}
         };
+
+        struct TEvRetryStart : public TEventLocal<TEvRetryStart, EvRetryStart> {
+            ui32 RetriesLeft;
+
+            explicit TEvRetryStart(ui32 retriesLeft)
+                : RetriesLeft(retriesLeft) {}
+        };
     };
 
     struct TFileDesc;
@@ -225,28 +233,10 @@ public:
 
     void Bootstrap() {
         Root_ = Config_.Root;
-        const auto rootToRemoveOldTmp = Root_;
-        const auto sessionId = Config_.SpillingSessionId;
-        const auto nodeId = SelfId().NodeId();
-
-        Root_ /= (TStringBuilder() << NodePrefix_ << "_" << nodeId << "_" << sessionId);
+        Root_ /= (TStringBuilder() << NodePrefix_ << "_" << SelfId().NodeId() << "_" << Config_.SpillingSessionId);
         LOG_I("Init DQ local file spilling service at " << Root_ << ", actor: " << SelfId());
 
-        try {
-            if (Root_.IsSymlink()) {
-                throw TIoException() << Root_ << " is a symlink, can not start Spilling Service";
-            }
-            Root_.ForceDelete();
-            Root_.MkDirs(DIR_MODE);
-        } catch (...) {
-            const TString root = Root_.GetPath();
-            const TString error = CurrentExceptionMessage();
-            Y_ABORT("Cannot start DQ local file spilling service at %s: %s", root.c_str(), error.c_str());
-        }
-        
-        Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(rootToRemoveOldTmp, nodeId, sessionId));
-
-        Become(&TDqLocalFileSpillingService::WorkState);
+        CreateRoot(MaxStartupRetries);
     }
 
     static constexpr char ActorName[] = "DQ_LOCAL_FILE_SPILLING_SERVICE";
@@ -261,6 +251,44 @@ protected:
     }
 
 private:
+    void CreateRoot(ui32 retriesLeft) {
+        try {
+            if (Root_.IsSymlink()) {
+                throw TIoException() << Root_ << " is a symlink, can not start Spilling Service";
+            }
+            Root_.ForceDelete();
+            Root_.MkDirs(DIR_MODE);
+        } catch (const yexception& e) {
+            const TString root = Root_.GetPath();
+            if (retriesLeft > 0) {
+                LOG_E("Cannot start DQ local file spilling service at " << root << ": " << e.what() << ". Retry "
+                    << (MaxStartupRetries - retriesLeft + 1) << "/" << MaxStartupRetries
+                    << " in " << StartupRetryDelay.Seconds() << "s");
+                Schedule(StartupRetryDelay, new TEvPrivate::TEvRetryStart(retriesLeft - 1));
+                Become(&TDqLocalFileSpillingService::BrokenState);
+                return;
+            }
+            Y_ABORT("Cannot start DQ local file spilling service at %s: %s", root.c_str(), e.what());
+        }
+
+        Send(SelfId(), MakeHolder<TEvPrivate::TEvRemoveOldTmp>(Config_.Root, SelfId().NodeId(), Config_.SpillingSessionId));
+
+        Become(&TDqLocalFileSpillingService::WorkState);
+    }
+
+    STFUNC(BrokenState) {
+        switch (ev->GetTypeRewrite()) {
+            hFunc(NMon::TEvHttpInfo, HandleWork);
+            cFunc(TEvents::TEvPoison::EventType, PassAway);
+            case TEvPrivate::TEvRetryStart::EventType:
+                CreateRoot(ev->Get<TEvPrivate::TEvRetryStart>()->RetriesLeft);
+                break;
+            default:
+                LOG_E("DQ local file spilling service is not started, send error to client " << ev->Sender);
+                Send(ev->Sender, new TEvDqSpilling::TEvError("Spilling service is not started"));
+        }
+    }
+
     STRICT_STFUNC(WorkState,
         hFunc(TEvDqSpillingLocalFile::TEvOpenFile, HandleWork)
         hFunc(TEvDqSpillingLocalFile::TEvCloseFile, HandleWork)
@@ -1033,6 +1061,9 @@ private:
     };
 
 private:
+    static constexpr ui32 MaxStartupRetries = 2;
+    static constexpr TDuration StartupRetryDelay = TDuration::Seconds(1);
+
     const TFileSpillingServiceConfig Config_;
     const TString NodePrefix_ = "node";
     TFsPath Root_;

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -9,6 +9,7 @@
 #include <util/system/fs.h>
 #include <util/generic/string.h>
 #include <util/folder/path.h>
+#include <util/stream/file.h>
 
 namespace NYql::NDq {
 
@@ -539,6 +540,63 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         }
 
         runtime.DispatchEvents(options);
+    }
+
+    Y_UNIT_TEST(RecoverAfterStartError) {
+        TTestActorRuntime runtime;
+        runtime.SetScheduledEventFilter([](
+                TTestActorRuntimeBase& runtime,
+                TAutoPtr<IEventHandle>& event,
+                TDuration delay,
+                TInstant& deadline)
+        {
+            if (runtime.IsScheduleForActorEnabled(event->GetRecipientRewrite())) {
+                deadline = runtime.GetTimeProvider()->Now() + delay;
+                return false;
+            }
+            return true;
+        });
+        runtime.Initialize();
+
+        const TFsPath root = TFsPath::Cwd() / (runtime.GetSpillingPrefix() + "_recover");
+        root.ForceDelete();
+        {
+            TFileOutput output(root.GetPath());
+        }
+
+        runtime.StartSpillingService(1000, 500, 100, 1000, root);
+        runtime.WaitBootstrap();
+
+        // While the root is unusable, requests are rejected instead of killing the service.
+        {
+            auto tester = runtime.AllocateEdgeActor();
+            runtime.StartSpillingActor(tester);
+            runtime.WaitBootstrap();
+
+            auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvError>(tester, TDuration::Seconds(1));
+            UNIT_ASSERT_VALUES_EQUAL("Spilling service is not started", resp->Get()->Message);
+        }
+
+        // Unblock the root and let the scheduled retry start the service.
+        root.ForceDelete();
+
+        TDispatchOptions retryOptions;
+        retryOptions.CustomFinalCondition = [&root]() { return root.IsDirectory(); };
+        UNIT_ASSERT(runtime.DispatchEvents(retryOptions, TDuration::Seconds(5)));
+
+        {
+            auto tester = runtime.AllocateEdgeActor();
+            auto spillingActor = runtime.StartSpillingActor(tester);
+            runtime.WaitBootstrap();
+
+            runtime.Send(new IEventHandle(
+                spillingActor,
+                tester,
+                new TEvDqSpilling::TEvWrite(1, CreateRope(10, 'a'))));
+
+            auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvWriteResult>(tester, TDuration::Seconds(1));
+            UNIT_ASSERT_VALUES_EQUAL(resp->Get()->BlobId, 1);
+        }
     }
 
     Y_UNIT_TEST(NoSpillingService) {

--- a/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
+++ b/ydb/library/yql/dq/actors/spilling/spilling_file_ut.cpp
@@ -541,47 +541,6 @@ Y_UNIT_TEST_SUITE(DqSpillingFileTests) {
         runtime.DispatchEvents(options);
     }
 
-    Y_UNIT_TEST(StartError) {
-        TTestActorRuntime runtime;
-        runtime.Initialize();
-
-        auto spillingService = runtime.StartSpillingService(100, 500, 100, 1000, TFsPath("/nonexistent") / runtime.GetSpillingPrefix());
-        auto tester = runtime.AllocateEdgeActor();
-        auto spillingActor = runtime.StartSpillingActor(tester);
-
-        runtime.WaitBootstrap();
-
-        // put blob 1
-        {
-            auto ev = new TEvDqSpilling::TEvWrite(1, CreateRope(10, 'a'));
-            runtime.Send(new IEventHandle(spillingActor, tester, ev));
-
-            auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvError>(tester, TDuration::Seconds(1));
-            UNIT_ASSERT_EQUAL("Service not started", resp->Get()->Message);
-        }
-
-        // get blob 1
-        {
-            auto ev = new TEvDqSpilling::TEvRead(1);
-            runtime.Send(new IEventHandle(spillingActor, tester, ev));
-
-            auto resp = runtime.GrabEdgeEvent<TEvDqSpilling::TEvError>(tester, TDuration::Seconds(1));
-            UNIT_ASSERT_EQUAL("Service not started", resp->Get()->Message);
-        }
-
-        // mon
-        {
-            THttpRequest httpReq(HTTP_METHOD_GET);
-            NMonitoring::TMonService2HttpRequest monReq(nullptr, &httpReq, nullptr, nullptr, "", nullptr);
-
-            runtime.Send(new IEventHandle(spillingService, tester, new NMon::TEvHttpInfo(monReq)));
-
-            auto resp = runtime.GrabEdgeEvent<NMon::TEvHttpInfoRes>(tester, TDuration::Seconds(1));
-            UNIT_ASSERT_EQUAL("<html><h2>Service is not started due to IO error</h2></html>",
-                            ((NMon::TEvHttpInfoRes*) resp->Get())->Answer);
-        }
-    }
-
     Y_UNIT_TEST(NoSpillingService) {
         TTestActorRuntime runtime;
         runtime.Initialize();


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
- Backport #48533: fail on incorrect spilling service config
- Backport #48753: retry on spilling directory creation

### Changelog category <!-- remove all except one -->


* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
