### PR TITLE
docs: remove root .ruler symlink

### DIFF
--- a/.ruler
+++ b/.ruler
@@ -1,1 +1,0 @@
-ydb/docs/.ruler

--- a/ydb/docs/README.md
+++ b/ydb/docs/README.md
@@ -25,9 +25,10 @@ YDB provides an AI-powered documentation writing skill that helps developers cre
    - Limitations and constraints
    - Links to PR/Issue where it was implemented
 
-2. **Run `ruler apply`** to generate agent configurations:
+2. **From `ydb/docs`, run `ruler apply`** to generate agent configurations:
 
 ```bash
+cd ydb/docs
 npm install -g @intellectronica/ruler
 ruler apply
 ```


### PR DESCRIPTION
## Summary
- Remove the repository-root `.ruler` symlink that pointed to `ydb/docs/.ruler`.
- Document that `ruler apply` should be run from `ydb/docs`.

Follow-up to #45272 review feedback: documentation agent config must not live in the monorepo root.

## Test plan
- [ ] Confirm `.ruler` is gone from repo root on this branch
- [ ] Confirm `ydb/docs/.ruler/` still present
- [ ] `cd ydb/docs && ruler apply` works for docs contributors


Made with [Cursor](https://cursor.com)