### PR TITLE
[YQ-4623, YQ-4871] fix FQ retry policy timeout, scope DNS retry to 10s

### DIFF
--- a/ydb/library/yql/providers/common/http_gateway/ut/ya.make
+++ b/ydb/library/yql/providers/common/http_gateway/ut/ya.make
@@ -5,6 +5,7 @@ FORK_SUBTESTS()
 SRCS(
     yql_aws_signature_ut.cpp
     yql_dns_gateway_ut.cpp
+    yql_http_default_retry_policy_ut.cpp
 )
 
 PEERDIR(

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -40,83 +40,25 @@ std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
     };
 }
 
-// Custom retry policy for FQ that applies a shorter time budget for DNS resolution errors
-class TFqRetryPolicy : public IHTTPGateway::TRetryPolicy {
-public:
-    explicit TFqRetryPolicy(std::unordered_set<CURLcode> retriedCurlCodes)
-        : RetriedCurlCodes(std::move(retriedCurlCodes))
-    {}
-
-    struct TFqRetryState : IRetryState {
-        explicit TFqRetryState(std::unordered_set<CURLcode> retriedCurlCodes)
-            : RetriedCurlCodes(std::move(retriedCurlCodes))
-        {}
-
-        TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
-            if (!StartTime) {
-                StartTime = TInstant::Now();
-            }
-
-            auto elapsed = TInstant::Now() - *StartTime;
-
-            auto retryClass = GetRetryClass(curlCode, httpCode);
-            if (retryClass == ERetryErrorClass::NoRetry) {
-                return Nothing();
-            }
-
-            // DNS errors get a much shorter retry window
-            TDuration effectiveMaxTime = (curlCode == CURLE_COULDNT_RESOLVE_HOST)
-                ? DNS_ERROR_MAX_TIME
-                : DEFAULT_MAX_TIME;
-
-            if (elapsed >= effectiveMaxTime) {
-                return Nothing();
-            }
-
-            TDuration delay = CurrentDelay;
-            if (retryClass == ERetryErrorClass::LongRetry) {
-                delay = Max(delay, TDuration::MilliSeconds(200));
-            }
-            CurrentDelay = Min(CurrentDelay * 2.0, TDuration::Seconds(30));
-            return delay;
-        }
-
-    private:
-        ERetryErrorClass GetRetryClass(CURLcode curlCode, long httpCode) const {
-            if (curlCode != CURLE_OK) {
-                return RetriedCurlCodes.contains(curlCode)
-                    ? ERetryErrorClass::ShortRetry
-                    : ERetryErrorClass::NoRetry;
-            }
-
-            switch (httpCode) {
-                case 0:
-                    return ERetryErrorClass::NoRetry;
-                case 408: // Request Timeout
-                case 425: // Too Early
-                case 429: // Too Many Requests
-                case 500: // Internal Server Error
-                case 502: // Bad Gateway
-                case 503: // Service Unavailable
-                case 504: // Gateway Timeout
-                    return ERetryErrorClass::LongRetry;
-                default:
-                    return ERetryErrorClass::NoRetry;
-            }
-        }
-
-        const std::unordered_set<CURLcode> RetriedCurlCodes;
-        std::optional<TInstant> StartTime;
-        TDuration CurrentDelay = TDuration::MilliSeconds(10);
-    };
-
-    IRetryState::TPtr CreateRetryState() const override {
-        return std::make_unique<TFqRetryState>(RetriedCurlCodes);
+// Returns the retry error class for a curl/http error pair, shared by both policies.
+ERetryErrorClass ClassifyError(CURLcode curlCode, long httpCode, const std::unordered_set<CURLcode>& retriedCurlCodes) {
+    if (curlCode != CURLE_OK) {
+        return retriedCurlCodes.contains(curlCode) ? ERetryErrorClass::ShortRetry : ERetryErrorClass::NoRetry;
     }
-
-private:
-    std::unordered_set<CURLcode> RetriedCurlCodes;
-};
+    switch (httpCode) {
+        case 0:   return ERetryErrorClass::NoRetry; // manual cancelling
+        case 408: // Request Timeout
+        case 425: // Too Early
+        case 429: // Too Many Requests
+        case 500: // Internal Server Error
+        case 502: // Bad Gateway
+        case 503: // Service Unavailable
+        case 504: // Gateway Timeout
+            return ERetryErrorClass::LongRetry;
+        default:
+            return ERetryErrorClass::NoRetry;
+    }
+}
 
 } // namespace
 
@@ -133,44 +75,61 @@ THttpRetryPolicyOptions::THttpRetryPolicyOptions(std::optional<TDuration> maxTim
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options) {
     auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
     auto maxRetries = options.MaxRetries;
-    return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy([options = std::move(options)](CURLcode curlCode, long httpCode) {
-        if (curlCode == CURLE_OK) {
-            // pass
-        } else if (options.RetriedCurlCodes.contains(curlCode)) {
-            return ERetryErrorClass::ShortRetry;
-        } else {
-            return ERetryErrorClass::NoRetry;
-        }
-
-        switch (httpCode) {
-            case 0:
-                // rare case when curl code is not available like manual cancelling, not retriable anymore
-                return ERetryErrorClass::NoRetry;
-            case 408: // Request Timeout
-            case 425: // Too Early
-            case 429: // Too Many Requests
-            case 500: // Internal Server Error
-            case 502: // Bad Gateway
-            case 503: // Service Unavailable
-            case 504: // Gateway Timeout
-                return ERetryErrorClass::LongRetry;
-            default:
-                return ERetryErrorClass::NoRetry;
-        }
-    },
-    TDuration::MilliSeconds(10), // minDelay
-    TDuration::MilliSeconds(200), // minLongRetryDelay
-    TDuration::Seconds(30), // maxDelay
-    maxRetries, // maxRetries
-    maxTime); // maxTime
+    return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
+        [options = std::move(options)](CURLcode curlCode, long httpCode) {
+            return ClassifyError(curlCode, httpCode, options.RetriedCurlCodes);
+        },
+        TDuration::MilliSeconds(10),  // minDelay
+        TDuration::MilliSeconds(200), // minLongRetryDelay
+        TDuration::Seconds(30),       // maxDelay
+        maxRetries,
+        maxTime);
 }
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries) {
     return GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{maxTime ? std::make_optional(maxTime) : std::nullopt, maxRetries});
 }
 
+// Custom policy for FQ: applies a shorter 10-second time budget for DNS resolution errors,
+// while other retriable errors use the default 5-minute budget.
+// A plain lambda in GetExponentialBackoffPolicy cannot do this because maxTime is a single
+// value fixed at construction time — it cannot vary per error code within one retry session.
 IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
+    struct TFqRetryState : IHTTPGateway::TRetryPolicy::IRetryState {
+        explicit TFqRetryState(std::unordered_set<CURLcode> codes) : RetriedCurlCodes(std::move(codes)) {}
+
+        TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
+            if (!StartTime) {
+                StartTime = TInstant::Now();
+            }
+            auto retryClass = ClassifyError(curlCode, httpCode, RetriedCurlCodes);
+            if (retryClass == ERetryErrorClass::NoRetry) {
+                return Nothing();
+            }
+            TDuration maxTime = (curlCode == CURLE_COULDNT_RESOLVE_HOST) ? DNS_ERROR_MAX_TIME : DEFAULT_MAX_TIME;
+            if (TInstant::Now() - *StartTime >= maxTime) {
+                return Nothing();
+            }
+            TDuration delay = (retryClass == ERetryErrorClass::LongRetry) ? Max(CurrentDelay, TDuration::MilliSeconds(200)) : CurrentDelay;
+            CurrentDelay = Min(CurrentDelay * 2.0, TDuration::Seconds(30));
+            return delay;
+        }
+
+        const std::unordered_set<CURLcode> RetriedCurlCodes;
+        std::optional<TInstant> StartTime;
+        TDuration CurrentDelay = TDuration::MilliSeconds(10);
+    };
+
+    struct TFqRetryPolicy : IHTTPGateway::TRetryPolicy {
+        explicit TFqRetryPolicy(std::unordered_set<CURLcode> codes) : RetriedCurlCodes(std::move(codes)) {}
+        IRetryState::TPtr CreateRetryState() const override {
+            return std::make_unique<TFqRetryState>(RetriedCurlCodes);
+        }
+        std::unordered_set<CURLcode> RetriedCurlCodes;
+    };
+
     return std::make_shared<TFqRetryPolicy>(FqRetriedCurlCodes());
 }
 
 }
+

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -2,10 +2,23 @@
 
 namespace NYql {
 
-namespace {
-
 constexpr TDuration DEFAULT_MAX_TIME = TDuration::Minutes(5);
 constexpr TDuration DNS_ERROR_MAX_TIME = TDuration::Seconds(10);
+
+std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
+    return {
+        CURLE_COULDNT_CONNECT,
+        CURLE_WEIRD_SERVER_REPLY,
+        CURLE_WRITE_ERROR,
+        CURLE_READ_ERROR,
+        CURLE_OPERATION_TIMEDOUT,
+        CURLE_SSL_CONNECT_ERROR,
+        CURLE_BAD_DOWNLOAD_RESUME,
+        CURLE_SEND_ERROR,
+        CURLE_RECV_ERROR,
+        CURLE_NO_CONNECTION_AVAILABLE
+    };
+}
 
 std::unordered_set<CURLcode> FqRetriedCurlCodes() {
     return {
@@ -25,28 +38,15 @@ std::unordered_set<CURLcode> FqRetriedCurlCodes() {
     };
 }
 
-std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
-    return {
-        CURLE_COULDNT_CONNECT,
-        CURLE_WEIRD_SERVER_REPLY,
-        CURLE_WRITE_ERROR,
-        CURLE_READ_ERROR,
-        CURLE_OPERATION_TIMEDOUT,
-        CURLE_SSL_CONNECT_ERROR,
-        CURLE_BAD_DOWNLOAD_RESUME,
-        CURLE_SEND_ERROR,
-        CURLE_RECV_ERROR,
-        CURLE_NO_CONNECTION_AVAILABLE
-    };
-}
-
-// Returns the retry error class for a curl/http error pair, shared by both policies.
 ERetryErrorClass ClassifyError(CURLcode curlCode, long httpCode, const std::unordered_set<CURLcode>& retriedCurlCodes) {
     if (curlCode != CURLE_OK) {
         return retriedCurlCodes.contains(curlCode) ? ERetryErrorClass::ShortRetry : ERetryErrorClass::NoRetry;
     }
+
     switch (httpCode) {
-        case 0:   return ERetryErrorClass::NoRetry; // manual cancelling
+        case 0:
+            // rare case when curl code is not available like manual cancelling, not retriable anymore
+            return ERetryErrorClass::NoRetry;
         case 408: // Request Timeout
         case 425: // Too Early
         case 429: // Too Many Requests
@@ -60,100 +60,66 @@ ERetryErrorClass ClassifyError(CURLcode curlCode, long httpCode, const std::unor
     }
 }
 
-} // namespace
+IHTTPGateway::TRetryPolicy::TPtr MakeRetryPolicy(std::unordered_set<CURLcode> retriedCurlCodes, TDuration maxTime, size_t maxRetries) {
+    return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
+        [retriedCurlCodes = std::move(retriedCurlCodes)](CURLcode curlCode, long httpCode) {
+            return ClassifyError(curlCode, httpCode, retriedCurlCodes);
+        },
+        TDuration::MilliSeconds(10), // minDelay
+        TDuration::MilliSeconds(200), // minLongRetryDelay
+        TDuration::Seconds(30), // maxDelay
+        maxRetries, // maxRetries
+        maxTime); // maxTime
+}
 
-THttpRetryPolicyOptions::THttpRetryPolicyOptions()
-    : RetriedCurlCodes(YqlRetriedCurlCodes())
-{}
+// Wraps a standard policy to cut DNS resolution retries short: a host that does not resolve
+// is unlikely to start resolving within the full retry budget. Other errors keep the shared
+// backoff and the full budget of the wrapped policy.
+class TFqRetryPolicy final: public IHTTPGateway::TRetryPolicy {
+public:
+    explicit TFqRetryPolicy(IHTTPGateway::TRetryPolicy::TPtr policy)
+        : Policy(std::move(policy))
+    {
+    }
 
-THttpRetryPolicyOptions::THttpRetryPolicyOptions(std::optional<TDuration> maxTime, size_t maxRetries)
-    : MaxTime(maxTime)
-    , MaxRetries(maxRetries)
-    , RetriedCurlCodes(YqlRetriedCurlCodes())
-{}
+    IRetryState::TPtr CreateRetryState() const override {
+        return std::make_unique<TFqRetryState>(Policy->CreateRetryState());
+    }
+
+private:
+    struct TFqRetryState final: IRetryState {
+        explicit TFqRetryState(IRetryState::TPtr state)
+            : State(std::move(state))
+        {
+        }
+
+        TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
+            if (curlCode == CURLE_COULDNT_RESOLVE_HOST && TInstant::Now() - StartTime >= DNS_ERROR_MAX_TIME) {
+                return Nothing();
+            }
+            return State->GetNextRetryDelay(curlCode, httpCode);
+        }
+
+        const IRetryState::TPtr State;
+        const TInstant StartTime = TInstant::Now();
+    };
+
+    const IHTTPGateway::TRetryPolicy::TPtr Policy;
+};
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options) {
-    auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
-    auto maxRetries = options.MaxRetries;
-    return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
-        [options = std::move(options)](CURLcode curlCode, long httpCode) {
-            return ClassifyError(curlCode, httpCode, options.RetriedCurlCodes);
-        },
-        TDuration::MilliSeconds(10),  // minDelay
-        TDuration::MilliSeconds(200), // minLongRetryDelay
-        TDuration::Seconds(30),       // maxDelay
-        maxRetries,
-        maxTime);
+    return MakeRetryPolicy(std::move(options.RetriedCurlCodes), options.MaxTime.value_or(DEFAULT_MAX_TIME), options.MaxRetries);
 }
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries) {
-    return GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{maxTime ? std::make_optional(maxTime) : std::nullopt, maxRetries});
+    return GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{
+        .MaxTime = maxTime ? std::make_optional(maxTime) : std::nullopt,
+        .MaxRetries = maxRetries,
+    });
 }
 
-// Custom policy for FQ: applies a shorter 10-second time budget for DNS resolution errors,
-// while other retriable errors use the default 5-minute budget.
-// A plain lambda in GetExponentialBackoffPolicy cannot do this because maxTime is a single
-// value fixed at construction time — it cannot vary per error code within one retry session.
-// TFqRetryState delegates to two standard exponential-backoff states, selecting by curl code.
-IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy(THttpRetryPolicyOptions&& options) {
-    auto dnsMaxTime = options.DnsMaxTime.value_or(DNS_ERROR_MAX_TIME);
-    auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
-
-    auto makeDnsPolicy = [dnsMaxTime]() {
-        return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
-            [](CURLcode curlCode, long httpCode) {
-                return curlCode == CURLE_COULDNT_RESOLVE_HOST ? ERetryErrorClass::ShortRetry : ERetryErrorClass::NoRetry;
-            },
-            TDuration::MilliSeconds(10),  // minDelay
-            TDuration::MilliSeconds(200), // minLongRetryDelay
-            TDuration::Seconds(30),       // maxDelay
-            std::numeric_limits<size_t>::max(),
-            dnsMaxTime);
-    };
-
-    auto makeOtherPolicy = [maxTime](std::unordered_set<CURLcode> codes) {
-        return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
-            [codes = std::move(codes)](CURLcode curlCode, long httpCode) {
-                return ClassifyError(curlCode, httpCode, codes);
-            },
-            TDuration::MilliSeconds(10),  // minDelay
-            TDuration::MilliSeconds(200), // minLongRetryDelay
-            TDuration::Seconds(30),       // maxDelay
-            std::numeric_limits<size_t>::max(),
-            maxTime);
-    };
-
-    struct TFqRetryState : IHTTPGateway::TRetryPolicy::IRetryState {
-        TFqRetryState(IHTTPGateway::TRetryPolicy::TPtr dnsPolicy, IHTTPGateway::TRetryPolicy::TPtr otherPolicy)
-            : DnsState(dnsPolicy->CreateRetryState())
-            , OtherState(otherPolicy->CreateRetryState())
-        {}
-
-        TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
-            return curlCode == CURLE_COULDNT_RESOLVE_HOST
-                ? DnsState->GetNextRetryDelay(curlCode, httpCode)
-                : OtherState->GetNextRetryDelay(curlCode, httpCode);
-        }
-
-        IHTTPGateway::TRetryPolicy::IRetryState::TPtr DnsState;
-        IHTTPGateway::TRetryPolicy::IRetryState::TPtr OtherState;
-    };
-
-    struct TFqRetryPolicy : IHTTPGateway::TRetryPolicy {
-        TFqRetryPolicy(IHTTPGateway::TRetryPolicy::TPtr dnsPolicy, IHTTPGateway::TRetryPolicy::TPtr otherPolicy)
-            : DnsPolicy(std::move(dnsPolicy))
-            , OtherPolicy(std::move(otherPolicy))
-        {}
-        IRetryState::TPtr CreateRetryState() const override {
-            return std::make_unique<TFqRetryState>(DnsPolicy, OtherPolicy);
-        }
-        IHTTPGateway::TRetryPolicy::TPtr DnsPolicy;
-        IHTTPGateway::TRetryPolicy::TPtr OtherPolicy;
-    };
-
-    auto fqCodes = options.RetriedCurlCodes.empty() ? FqRetriedCurlCodes() : std::move(options.RetriedCurlCodes);
-    return std::make_shared<TFqRetryPolicy>(makeDnsPolicy(), makeOtherPolicy(std::move(fqCodes)));
+IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
+    return std::make_shared<TFqRetryPolicy>(MakeRetryPolicy(FqRetriedCurlCodes(), DEFAULT_MAX_TIME, std::numeric_limits<size_t>::max()));
 }
 
 }
-

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -7,21 +7,6 @@ namespace {
 constexpr TDuration DEFAULT_MAX_TIME = TDuration::Minutes(5);
 constexpr TDuration DNS_ERROR_MAX_TIME = TDuration::Seconds(10);
 
-std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
-    return {
-        CURLE_COULDNT_CONNECT,
-        CURLE_WEIRD_SERVER_REPLY,
-        CURLE_WRITE_ERROR,
-        CURLE_READ_ERROR,
-        CURLE_OPERATION_TIMEDOUT,
-        CURLE_SSL_CONNECT_ERROR,
-        CURLE_BAD_DOWNLOAD_RESUME,
-        CURLE_SEND_ERROR,
-        CURLE_RECV_ERROR,
-        CURLE_NO_CONNECTION_AVAILABLE
-    };
-}
-
 std::unordered_set<CURLcode> FqRetriedCurlCodes() {
     return {
         CURLE_COULDNT_CONNECT,
@@ -37,6 +22,21 @@ std::unordered_set<CURLcode> FqRetriedCurlCodes() {
         CURLE_NO_CONNECTION_AVAILABLE,
         CURLE_GOT_NOTHING,
         CURLE_COULDNT_RESOLVE_HOST
+    };
+}
+
+std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
+    return {
+        CURLE_COULDNT_CONNECT,
+        CURLE_WEIRD_SERVER_REPLY,
+        CURLE_WRITE_ERROR,
+        CURLE_READ_ERROR,
+        CURLE_OPERATION_TIMEDOUT,
+        CURLE_SSL_CONNECT_ERROR,
+        CURLE_BAD_DOWNLOAD_RESUME,
+        CURLE_SEND_ERROR,
+        CURLE_RECV_ERROR,
+        CURLE_NO_CONNECTION_AVAILABLE
     };
 }
 
@@ -130,7 +130,7 @@ THttpRetryPolicyOptions::THttpRetryPolicyOptions(std::optional<TDuration> maxTim
     , RetriedCurlCodes(YqlRetriedCurlCodes())
 {}
 
-IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions options) {
+IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options) {
     auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
     auto maxRetries = options.MaxRetries;
     return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy([options = std::move(options)](CURLcode curlCode, long httpCode) {

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -94,41 +94,62 @@ IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, si
 // while other retriable errors use the default 5-minute budget.
 // A plain lambda in GetExponentialBackoffPolicy cannot do this because maxTime is a single
 // value fixed at construction time — it cannot vary per error code within one retry session.
+// TFqRetryState delegates to two standard exponential-backoff states, selecting by curl code.
 IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
+    auto makeDnsPolicy = []() {
+        return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
+            [](CURLcode curlCode, long httpCode) {
+                return curlCode == CURLE_COULDNT_RESOLVE_HOST ? ERetryErrorClass::ShortRetry : ERetryErrorClass::NoRetry;
+            },
+            TDuration::MilliSeconds(10),  // minDelay
+            TDuration::MilliSeconds(200), // minLongRetryDelay
+            TDuration::Seconds(30),       // maxDelay
+            std::numeric_limits<size_t>::max(),
+            DNS_ERROR_MAX_TIME);
+    };
+
+    auto makeOtherPolicy = [](std::unordered_set<CURLcode> codes) {
+        return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
+            [codes = std::move(codes)](CURLcode curlCode, long httpCode) {
+                return ClassifyError(curlCode, httpCode, codes);
+            },
+            TDuration::MilliSeconds(10),  // minDelay
+            TDuration::MilliSeconds(200), // minLongRetryDelay
+            TDuration::Seconds(30),       // maxDelay
+            std::numeric_limits<size_t>::max(),
+            DEFAULT_MAX_TIME);
+    };
+
     struct TFqRetryState : IHTTPGateway::TRetryPolicy::IRetryState {
-        explicit TFqRetryState(std::unordered_set<CURLcode> codes) : RetriedCurlCodes(std::move(codes)) {}
+        TFqRetryState(IHTTPGateway::TRetryPolicy::TPtr dnsPolicy, IHTTPGateway::TRetryPolicy::TPtr otherPolicy)
+            : DnsState(dnsPolicy->CreateRetryState())
+            , OtherState(otherPolicy->CreateRetryState())
+        {}
 
         TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
-            if (!StartTime) {
-                StartTime = TInstant::Now();
-            }
-            auto retryClass = ClassifyError(curlCode, httpCode, RetriedCurlCodes);
-            if (retryClass == ERetryErrorClass::NoRetry) {
-                return Nothing();
-            }
-            TDuration maxTime = (curlCode == CURLE_COULDNT_RESOLVE_HOST) ? DNS_ERROR_MAX_TIME : DEFAULT_MAX_TIME;
-            if (TInstant::Now() - *StartTime >= maxTime) {
-                return Nothing();
-            }
-            TDuration delay = (retryClass == ERetryErrorClass::LongRetry) ? Max(CurrentDelay, TDuration::MilliSeconds(200)) : CurrentDelay;
-            CurrentDelay = Min(CurrentDelay * 2.0, TDuration::Seconds(30));
-            return delay;
+            return curlCode == CURLE_COULDNT_RESOLVE_HOST
+                ? DnsState->GetNextRetryDelay(curlCode, httpCode)
+                : OtherState->GetNextRetryDelay(curlCode, httpCode);
         }
 
-        const std::unordered_set<CURLcode> RetriedCurlCodes;
-        std::optional<TInstant> StartTime;
-        TDuration CurrentDelay = TDuration::MilliSeconds(10);
+        IHTTPGateway::TRetryPolicy::IRetryState::TPtr DnsState;
+        IHTTPGateway::TRetryPolicy::IRetryState::TPtr OtherState;
     };
 
     struct TFqRetryPolicy : IHTTPGateway::TRetryPolicy {
-        explicit TFqRetryPolicy(std::unordered_set<CURLcode> codes) : RetriedCurlCodes(std::move(codes)) {}
+        TFqRetryPolicy(IHTTPGateway::TRetryPolicy::TPtr dnsPolicy, IHTTPGateway::TRetryPolicy::TPtr otherPolicy)
+            : DnsPolicy(std::move(dnsPolicy))
+            , OtherPolicy(std::move(otherPolicy))
+        {}
         IRetryState::TPtr CreateRetryState() const override {
-            return std::make_unique<TFqRetryState>(RetriedCurlCodes);
+            return std::make_unique<TFqRetryState>(DnsPolicy, OtherPolicy);
         }
-        std::unordered_set<CURLcode> RetriedCurlCodes;
+        IHTTPGateway::TRetryPolicy::TPtr DnsPolicy;
+        IHTTPGateway::TRetryPolicy::TPtr OtherPolicy;
     };
 
-    return std::make_shared<TFqRetryPolicy>(FqRetriedCurlCodes());
+    auto fqCodes = FqRetriedCurlCodes();
+    return std::make_shared<TFqRetryPolicy>(makeDnsPolicy(), makeOtherPolicy(std::move(fqCodes)));
 }
 
 }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -5,21 +5,6 @@ namespace NYql {
 constexpr TDuration DEFAULT_MAX_TIME = TDuration::Minutes(5);
 constexpr TDuration DNS_ERROR_MAX_TIME = TDuration::Seconds(10);
 
-std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
-    return {
-        CURLE_COULDNT_CONNECT,
-        CURLE_WEIRD_SERVER_REPLY,
-        CURLE_WRITE_ERROR,
-        CURLE_READ_ERROR,
-        CURLE_OPERATION_TIMEDOUT,
-        CURLE_SSL_CONNECT_ERROR,
-        CURLE_BAD_DOWNLOAD_RESUME,
-        CURLE_SEND_ERROR,
-        CURLE_RECV_ERROR,
-        CURLE_NO_CONNECTION_AVAILABLE
-    };
-}
-
 std::unordered_set<CURLcode> FqRetriedCurlCodes() {
     return {
         CURLE_COULDNT_CONNECT,
@@ -38,38 +23,19 @@ std::unordered_set<CURLcode> FqRetriedCurlCodes() {
     };
 }
 
-ERetryErrorClass ClassifyError(CURLcode curlCode, long httpCode, const std::unordered_set<CURLcode>& retriedCurlCodes) {
-    if (curlCode != CURLE_OK) {
-        return retriedCurlCodes.contains(curlCode) ? ERetryErrorClass::ShortRetry : ERetryErrorClass::NoRetry;
-    }
-
-    switch (httpCode) {
-        case 0:
-            // rare case when curl code is not available like manual cancelling, not retriable anymore
-            return ERetryErrorClass::NoRetry;
-        case 408: // Request Timeout
-        case 425: // Too Early
-        case 429: // Too Many Requests
-        case 500: // Internal Server Error
-        case 502: // Bad Gateway
-        case 503: // Service Unavailable
-        case 504: // Gateway Timeout
-            return ERetryErrorClass::LongRetry;
-        default:
-            return ERetryErrorClass::NoRetry;
-    }
-}
-
-IHTTPGateway::TRetryPolicy::TPtr MakeRetryPolicy(std::unordered_set<CURLcode> retriedCurlCodes, TDuration maxTime, size_t maxRetries) {
-    return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
-        [retriedCurlCodes = std::move(retriedCurlCodes)](CURLcode curlCode, long httpCode) {
-            return ClassifyError(curlCode, httpCode, retriedCurlCodes);
-        },
-        TDuration::MilliSeconds(10), // minDelay
-        TDuration::MilliSeconds(200), // minLongRetryDelay
-        TDuration::Seconds(30), // maxDelay
-        maxRetries, // maxRetries
-        maxTime); // maxTime
+std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
+    return {
+        CURLE_COULDNT_CONNECT,
+        CURLE_WEIRD_SERVER_REPLY,
+        CURLE_WRITE_ERROR,
+        CURLE_READ_ERROR,
+        CURLE_OPERATION_TIMEDOUT,
+        CURLE_SSL_CONNECT_ERROR,
+        CURLE_BAD_DOWNLOAD_RESUME,
+        CURLE_SEND_ERROR,
+        CURLE_RECV_ERROR,
+        CURLE_NO_CONNECTION_AVAILABLE
+    };
 }
 
 // Wraps a standard policy to cut DNS resolution retries short: a host that does not resolve
@@ -108,7 +74,38 @@ private:
 };
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options) {
-    return MakeRetryPolicy(std::move(options.RetriedCurlCodes), options.MaxTime.value_or(DEFAULT_MAX_TIME), options.MaxRetries);
+    auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
+    auto maxRetries = options.MaxRetries;
+    return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy([options = std::move(options)](CURLcode curlCode, long httpCode) {
+        if (curlCode == CURLE_OK) {
+            // pass
+        } else if (options.RetriedCurlCodes.contains(curlCode)) {
+            return ERetryErrorClass::ShortRetry;
+        } else {
+            return ERetryErrorClass::NoRetry;
+        }
+
+        switch (httpCode) {
+            case 0:
+                // rare case when curl code is not available like manual cancelling, not retriable anymore
+                return ERetryErrorClass::NoRetry;
+            case 408: // Request Timeout
+            case 425: // Too Early
+            case 429: // Too Many Requests
+            case 500: // Internal Server Error
+            case 502: // Bad Gateway
+            case 503: // Service Unavailable
+            case 504: // Gateway Timeout
+                return ERetryErrorClass::LongRetry;
+            default:
+                return ERetryErrorClass::NoRetry;
+        }
+    },
+    TDuration::MilliSeconds(10), // minDelay
+    TDuration::MilliSeconds(200), // minLongRetryDelay
+    TDuration::Seconds(30), // maxDelay
+    maxRetries, // maxRetries
+    maxTime); // maxTime
 }
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries) {
@@ -119,7 +116,9 @@ IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, si
 }
 
 IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
-    return std::make_shared<TFqRetryPolicy>(MakeRetryPolicy(FqRetriedCurlCodes(), DEFAULT_MAX_TIME, std::numeric_limits<size_t>::max()));
+    return std::make_shared<TFqRetryPolicy>(GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{
+        .RetriedCurlCodes = FqRetriedCurlCodes(),
+    }));
 }
 
 }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -95,8 +95,11 @@ IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, si
 // A plain lambda in GetExponentialBackoffPolicy cannot do this because maxTime is a single
 // value fixed at construction time — it cannot vary per error code within one retry session.
 // TFqRetryState delegates to two standard exponential-backoff states, selecting by curl code.
-IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
-    auto makeDnsPolicy = []() {
+IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy(THttpRetryPolicyOptions&& options) {
+    auto dnsMaxTime = options.DnsMaxTime.value_or(DNS_ERROR_MAX_TIME);
+    auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
+
+    auto makeDnsPolicy = [dnsMaxTime]() {
         return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
             [](CURLcode curlCode, long httpCode) {
                 return curlCode == CURLE_COULDNT_RESOLVE_HOST ? ERetryErrorClass::ShortRetry : ERetryErrorClass::NoRetry;
@@ -105,10 +108,10 @@ IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
             TDuration::MilliSeconds(200), // minLongRetryDelay
             TDuration::Seconds(30),       // maxDelay
             std::numeric_limits<size_t>::max(),
-            DNS_ERROR_MAX_TIME);
+            dnsMaxTime);
     };
 
-    auto makeOtherPolicy = [](std::unordered_set<CURLcode> codes) {
+    auto makeOtherPolicy = [maxTime](std::unordered_set<CURLcode> codes) {
         return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy(
             [codes = std::move(codes)](CURLcode curlCode, long httpCode) {
                 return ClassifyError(curlCode, httpCode, codes);
@@ -117,7 +120,7 @@ IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
             TDuration::MilliSeconds(200), // minLongRetryDelay
             TDuration::Seconds(30),       // maxDelay
             std::numeric_limits<size_t>::max(),
-            DEFAULT_MAX_TIME);
+            maxTime);
     };
 
     struct TFqRetryState : IHTTPGateway::TRetryPolicy::IRetryState {
@@ -148,7 +151,7 @@ IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
         IHTTPGateway::TRetryPolicy::TPtr OtherPolicy;
     };
 
-    auto fqCodes = FqRetriedCurlCodes();
+    auto fqCodes = options.RetriedCurlCodes.empty() ? FqRetriedCurlCodes() : std::move(options.RetriedCurlCodes);
     return std::make_shared<TFqRetryPolicy>(makeDnsPolicy(), makeOtherPolicy(std::move(fqCodes)));
 }
 

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -4,6 +4,24 @@ namespace NYql {
 
 namespace {
 
+constexpr TDuration DEFAULT_MAX_TIME = TDuration::Minutes(5);
+constexpr TDuration DNS_ERROR_MAX_TIME = TDuration::Seconds(10);
+
+std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
+    return {
+        CURLE_COULDNT_CONNECT,
+        CURLE_WEIRD_SERVER_REPLY,
+        CURLE_WRITE_ERROR,
+        CURLE_READ_ERROR,
+        CURLE_OPERATION_TIMEDOUT,
+        CURLE_SSL_CONNECT_ERROR,
+        CURLE_BAD_DOWNLOAD_RESUME,
+        CURLE_SEND_ERROR,
+        CURLE_RECV_ERROR,
+        CURLE_NO_CONNECTION_AVAILABLE
+    };
+}
+
 std::unordered_set<CURLcode> FqRetriedCurlCodes() {
     return {
         CURLE_COULDNT_CONNECT,
@@ -21,30 +39,100 @@ std::unordered_set<CURLcode> FqRetriedCurlCodes() {
         CURLE_COULDNT_RESOLVE_HOST
     };
 }
-        
-}
 
-std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
-    return {
-        CURLE_COULDNT_CONNECT,
-        CURLE_WEIRD_SERVER_REPLY,
-        CURLE_WRITE_ERROR,
-        CURLE_READ_ERROR,
-        CURLE_OPERATION_TIMEDOUT,
-        CURLE_SSL_CONNECT_ERROR,
-        CURLE_BAD_DOWNLOAD_RESUME,
-        CURLE_SEND_ERROR,
-        CURLE_RECV_ERROR,
-        CURLE_NO_CONNECTION_AVAILABLE
+// Custom retry policy for FQ that applies a shorter time budget for DNS resolution errors
+class TFqRetryPolicy : public IHTTPGateway::TRetryPolicy {
+public:
+    explicit TFqRetryPolicy(std::unordered_set<CURLcode> retriedCurlCodes)
+        : RetriedCurlCodes(std::move(retriedCurlCodes))
+    {}
+
+    struct TFqRetryState : IRetryState {
+        explicit TFqRetryState(std::unordered_set<CURLcode> retriedCurlCodes)
+            : RetriedCurlCodes(std::move(retriedCurlCodes))
+        {}
+
+        TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
+            if (!StartTime) {
+                StartTime = TInstant::Now();
+            }
+
+            auto elapsed = TInstant::Now() - *StartTime;
+
+            auto retryClass = GetRetryClass(curlCode, httpCode);
+            if (retryClass == ERetryErrorClass::NoRetry) {
+                return Nothing();
+            }
+
+            // DNS errors get a much shorter retry window
+            TDuration effectiveMaxTime = (curlCode == CURLE_COULDNT_RESOLVE_HOST)
+                ? DNS_ERROR_MAX_TIME
+                : DEFAULT_MAX_TIME;
+
+            if (elapsed >= effectiveMaxTime) {
+                return Nothing();
+            }
+
+            TDuration delay = CurrentDelay;
+            if (retryClass == ERetryErrorClass::LongRetry) {
+                delay = Max(delay, TDuration::MilliSeconds(200));
+            }
+            CurrentDelay = Min(CurrentDelay * 2.0, TDuration::Seconds(30));
+            return delay;
+        }
+
+    private:
+        ERetryErrorClass GetRetryClass(CURLcode curlCode, long httpCode) const {
+            if (curlCode != CURLE_OK) {
+                return RetriedCurlCodes.contains(curlCode)
+                    ? ERetryErrorClass::ShortRetry
+                    : ERetryErrorClass::NoRetry;
+            }
+
+            switch (httpCode) {
+                case 0:
+                    return ERetryErrorClass::NoRetry;
+                case 408: // Request Timeout
+                case 425: // Too Early
+                case 429: // Too Many Requests
+                case 500: // Internal Server Error
+                case 502: // Bad Gateway
+                case 503: // Service Unavailable
+                case 504: // Gateway Timeout
+                    return ERetryErrorClass::LongRetry;
+                default:
+                    return ERetryErrorClass::NoRetry;
+            }
+        }
+
+        const std::unordered_set<CURLcode> RetriedCurlCodes;
+        std::optional<TInstant> StartTime;
+        TDuration CurrentDelay = TDuration::MilliSeconds(10);
     };
-}
 
-IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options) {
-    auto maxTime = options.MaxTime;
-    auto maxRetries = options.MaxRetries;
-    if (!maxTime) {
-        maxTime = TDuration::Minutes(5);
+    IRetryState::TPtr CreateRetryState() const override {
+        return std::make_unique<TFqRetryState>(RetriedCurlCodes);
     }
+
+private:
+    std::unordered_set<CURLcode> RetriedCurlCodes;
+};
+
+} // namespace
+
+THttpRetryPolicyOptions::THttpRetryPolicyOptions()
+    : RetriedCurlCodes(YqlRetriedCurlCodes())
+{}
+
+THttpRetryPolicyOptions::THttpRetryPolicyOptions(std::optional<TDuration> maxTime, size_t maxRetries)
+    : MaxTime(maxTime)
+    , MaxRetries(maxRetries)
+    , RetriedCurlCodes(YqlRetriedCurlCodes())
+{}
+
+IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions options) {
+    auto maxTime = options.MaxTime.value_or(DEFAULT_MAX_TIME);
+    auto maxRetries = options.MaxRetries;
     return IHTTPGateway::TRetryPolicy::GetExponentialBackoffPolicy([options = std::move(options)](CURLcode curlCode, long httpCode) {
         if (curlCode == CURLE_OK) {
             // pass
@@ -78,14 +166,11 @@ IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptio
 }
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries) {
-    return GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{.MaxTime = maxTime, .MaxRetries = maxRetries});
+    return GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{maxTime ? std::make_optional(maxTime) : std::nullopt, maxRetries});
 }
 
 IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy() {
-    return GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{
-        .MaxTime = TDuration::MilliSeconds(1000),
-        .RetriedCurlCodes = FqRetriedCurlCodes(),
-    });
+    return std::make_shared<TFqRetryPolicy>(FqRetriedCurlCodes());
 }
 
 }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -2,6 +2,8 @@
 
 namespace NYql {
 
+namespace {
+
 constexpr TDuration DEFAULT_MAX_TIME = TDuration::Minutes(5);
 constexpr TDuration DNS_ERROR_MAX_TIME = TDuration::Seconds(10);
 
@@ -21,6 +23,8 @@ std::unordered_set<CURLcode> FqRetriedCurlCodes() {
         CURLE_GOT_NOTHING,
         CURLE_COULDNT_RESOLVE_HOST
     };
+}
+
 }
 
 std::unordered_set<CURLcode> YqlRetriedCurlCodes() {

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.cpp
@@ -43,8 +43,9 @@ std::unordered_set<CURLcode> YqlRetriedCurlCodes() {
 }
 
 // Wraps a standard policy to cut DNS resolution retries short: a host that does not resolve
-// is unlikely to start resolving within the full retry budget. Other errors keep the shared
-// backoff and the full budget of the wrapped policy.
+// is unlikely to start resolving within the full retry budget. The dns budget is counted from
+// the first dns error, so a dns error late in the session still gets its own retries. Other
+// errors keep the shared backoff and the full budget of the wrapped policy.
 class TFqRetryPolicy final: public IHTTPGateway::TRetryPolicy {
 public:
     explicit TFqRetryPolicy(IHTTPGateway::TRetryPolicy::TPtr policy)
@@ -64,14 +65,22 @@ private:
         }
 
         TMaybe<TDuration> GetNextRetryDelay(CURLcode curlCode, long httpCode) override {
-            if (curlCode == CURLE_COULDNT_RESOLVE_HOST && TInstant::Now() - StartTime >= DNS_ERROR_MAX_TIME) {
-                return Nothing();
+            if (curlCode != CURLE_COULDNT_RESOLVE_HOST) {
+                // The host has been resolved, so a later dns error starts a new budget
+                DnsErrorsStartTime.reset();
+            } else {
+                const TInstant now = TInstant::Now();
+                if (!DnsErrorsStartTime) {
+                    DnsErrorsStartTime = now;
+                } else if (now - *DnsErrorsStartTime >= DNS_ERROR_MAX_TIME) {
+                    return Nothing();
+                }
             }
             return State->GetNextRetryDelay(curlCode, httpCode);
         }
 
         const IRetryState::TPtr State;
-        const TInstant StartTime = TInstant::Now();
+        std::optional<TInstant> DnsErrorsStartTime; // start of the current run of dns errors
     };
 
     const IHTTPGateway::TRetryPolicy::TPtr Policy;

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
@@ -8,22 +8,18 @@
 
 namespace NYql {
 
-struct THttpRetryPolicyOptions {
-    // If not set, default maxTime (5 minutes) is used
-    std::optional<TDuration> MaxTime;
-    // If not set, default DNS error maxTime (10 seconds) is used (only for GetFqHTTPRetryPolicy)
-    std::optional<TDuration> DnsMaxTime;
-    size_t MaxRetries = std::numeric_limits<size_t>::max();
-    std::unordered_set<CURLcode> RetriedCurlCodes;
+std::unordered_set<CURLcode> YqlRetriedCurlCodes();
 
-    THttpRetryPolicyOptions();
-    THttpRetryPolicyOptions(std::optional<TDuration> maxTime, size_t maxRetries = std::numeric_limits<size_t>::max());
+struct THttpRetryPolicyOptions {
+    std::optional<TDuration> MaxTime; // Not set means default maxTime
+    size_t MaxRetries = std::numeric_limits<size_t>::max();
+    std::unordered_set<CURLcode> RetriedCurlCodes = YqlRetriedCurlCodes();
 };
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options = {});
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries = std::numeric_limits<size_t>::max()); // Zero means default maxTime
 
-IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy(THttpRetryPolicyOptions&& options = {});
+IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy();
 
 }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
@@ -18,7 +18,7 @@ struct THttpRetryPolicyOptions {
     THttpRetryPolicyOptions(std::optional<TDuration> maxTime, size_t maxRetries = std::numeric_limits<size_t>::max());
 };
 
-IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions options = {});
+IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options = {});
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries = std::numeric_limits<size_t>::max()); // Zero means default maxTime
 

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
@@ -11,6 +11,8 @@ namespace NYql {
 struct THttpRetryPolicyOptions {
     // If not set, default maxTime (5 minutes) is used
     std::optional<TDuration> MaxTime;
+    // If not set, default DNS error maxTime (10 seconds) is used (only for GetFqHTTPRetryPolicy)
+    std::optional<TDuration> DnsMaxTime;
     size_t MaxRetries = std::numeric_limits<size_t>::max();
     std::unordered_set<CURLcode> RetriedCurlCodes;
 
@@ -22,6 +24,6 @@ IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptio
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries = std::numeric_limits<size_t>::max()); // Zero means default maxTime
 
-IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy();
+IHTTPGateway::TRetryPolicy::TPtr GetFqHTTPRetryPolicy(THttpRetryPolicyOptions&& options = {});
 
 }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy.h
@@ -3,19 +3,22 @@
 #include "yql_http_gateway.h"
 
 #include <curl/curl.h>
+#include <optional>
 #include <unordered_set>
 
 namespace NYql {
 
-std::unordered_set<CURLcode> YqlRetriedCurlCodes();
-
 struct THttpRetryPolicyOptions {
-    TDuration MaxTime = TDuration::Zero(); // Zero means default maxTime
+    // If not set, default maxTime (5 minutes) is used
+    std::optional<TDuration> MaxTime;
     size_t MaxRetries = std::numeric_limits<size_t>::max();
-    std::unordered_set<CURLcode> RetriedCurlCodes = YqlRetriedCurlCodes();
+    std::unordered_set<CURLcode> RetriedCurlCodes;
+
+    THttpRetryPolicyOptions();
+    THttpRetryPolicyOptions(std::optional<TDuration> maxTime, size_t maxRetries = std::numeric_limits<size_t>::max());
 };
 
-IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions&& options = {});
+IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions options = {});
 
 IHTTPGateway::TRetryPolicy::TPtr GetHTTPDefaultRetryPolicy(TDuration maxTime, size_t maxRetries = std::numeric_limits<size_t>::max()); // Zero means default maxTime
 

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
@@ -40,7 +40,7 @@ Y_UNIT_TEST_SUITE(THttpDefaultRetryPolicyTest) {
             // 500 is a long retry, so the delay starts from minLongRetryDelay (200ms) and grows.
             // RandomizeDelay returns half of the current delay plus a random part of the other half.
             UNIT_ASSERT_GE_C(*delay, TDuration::MilliSeconds(100), i);
-            UNIT_ASSERT_LT_C(prevDelay, *delay, i);
+            UNIT_ASSERT_LE_C(prevDelay, *delay, i);
             prevDelay = *delay;
         }
     }

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
@@ -122,6 +122,29 @@ Y_UNIT_TEST_SUITE(THttpDefaultRetryPolicyTest) {
         UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
     }
 
+    Y_UNIT_TEST(FqPolicyDnsErrorBudgetRestartsAfterOtherError) {
+        auto state = GetFqHTTPRetryPolicy()->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined());
+        Sleep(TDuration::Seconds(11));
+
+        // The host has been resolved in between, so the dns budget starts over and the dns
+        // error is retried even though the first dns error is more than 10 seconds old
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined());
+    }
+
+    Y_UNIT_TEST(FqPolicyDnsErrorAfterOtherErrorsIsRetried) {
+        auto state = GetFqHTTPRetryPolicy()->CreateRetryState();
+        // Other errors use up more than the dns budget before the first dns error arrives
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+        Sleep(TDuration::Seconds(11));
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+
+        // The dns budget is counted from the first dns error, not from the start of the session
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined());
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined());
+    }
+
 }
 
 } // namespace NYql

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
@@ -1,0 +1,113 @@
+#include "yql_http_default_retry_policy.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NYql {
+
+Y_UNIT_TEST_SUITE(THttpDefaultRetryPolicyTest) {
+
+    Y_UNIT_TEST(DefaultOptionsHasDefaultMaxTime) {
+        // Default options should use 5-minute maxTime (not zero, not 1 second)
+        auto policy = GetHTTPDefaultRetryPolicy();
+        UNIT_ASSERT(policy);
+        auto state = policy->CreateRetryState();
+        UNIT_ASSERT(state);
+        // A retriable curl code should get a retry delay
+        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
+        UNIT_ASSERT(delay.Defined());
+    }
+
+    Y_UNIT_TEST(NonRetriableCurlCodeNoRetry) {
+        auto policy = GetHTTPDefaultRetryPolicy();
+        auto state = policy->CreateRetryState();
+        // CURLE_URL_MALFORMAT is not in the retried set
+        auto delay = state->GetNextRetryDelay(CURLE_URL_MALFORMAT, 0);
+        UNIT_ASSERT(!delay.Defined());
+    }
+
+    Y_UNIT_TEST(RetriableHttpCodesGetLongRetry) {
+        auto policy = GetHTTPDefaultRetryPolicy();
+        auto state = policy->CreateRetryState();
+        // HTTP 429 Too Many Requests should be retriable
+        auto delay = state->GetNextRetryDelay(CURLE_OK, 429);
+        UNIT_ASSERT(delay.Defined());
+    }
+
+    Y_UNIT_TEST(NonRetriableHttpCodeNoRetry) {
+        auto policy = GetHTTPDefaultRetryPolicy();
+        auto state = policy->CreateRetryState();
+        // HTTP 400 Bad Request should not be retried
+        auto delay = state->GetNextRetryDelay(CURLE_OK, 400);
+        UNIT_ASSERT(!delay.Defined());
+    }
+
+    Y_UNIT_TEST(Http0NoRetry) {
+        auto policy = GetHTTPDefaultRetryPolicy();
+        auto state = policy->CreateRetryState();
+        // HTTP code 0 with OK curl means cancellation — no retry
+        auto delay = state->GetNextRetryDelay(CURLE_OK, 0);
+        UNIT_ASSERT(!delay.Defined());
+    }
+
+    Y_UNIT_TEST(MaxRetriesIsRespected) {
+        THttpRetryPolicyOptions options;
+        options.MaxRetries = 2;
+        auto policy = GetHTTPDefaultRetryPolicy(std::move(options));
+        auto state = policy->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+        UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+    }
+
+    Y_UNIT_TEST(CustomMaxTimeIsRespected) {
+        THttpRetryPolicyOptions options;
+        options.MaxTime = TDuration::MilliSeconds(1);
+        auto policy = GetHTTPDefaultRetryPolicy(std::move(options));
+        auto state = policy->CreateRetryState();
+        // Sleep long enough so maxTime (1ms) is exceeded before first check
+        Sleep(TDuration::MilliSeconds(50));
+        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
+        UNIT_ASSERT(!delay.Defined());
+    }
+
+    Y_UNIT_TEST(FqPolicyRetriableCodesWork) {
+        auto policy = GetFqHTTPRetryPolicy();
+        UNIT_ASSERT(policy);
+        auto state = policy->CreateRetryState();
+        // CURLE_COULDNT_CONNECT should be retriable in FQ policy
+        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
+        UNIT_ASSERT(delay.Defined());
+    }
+
+    Y_UNIT_TEST(FqPolicyDnsErrorRetriable) {
+        auto policy = GetFqHTTPRetryPolicy();
+        auto state = policy->CreateRetryState();
+        // CURLE_COULDNT_RESOLVE_HOST should be retriable in FQ policy
+        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0);
+        UNIT_ASSERT(delay.Defined());
+    }
+
+    Y_UNIT_TEST(FqPolicyNonDnsErrorNotExpiredBy10Seconds) {
+        auto policy = GetFqHTTPRetryPolicy();
+        auto state = policy->CreateRetryState();
+        // Non-DNS errors should NOT expire after 10 seconds (they use 5 minute budget)
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+        // Immediately check again — should still have budget
+        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
+        UNIT_ASSERT(delay.Defined());
+    }
+
+    Y_UNIT_TEST(OptionalMaxTimeConstructor) {
+        // Test constructor with explicit maxTime
+        THttpRetryPolicyOptions options(TDuration::Seconds(30));
+        UNIT_ASSERT(options.MaxTime.has_value());
+        UNIT_ASSERT_EQUAL(*options.MaxTime, TDuration::Seconds(30));
+
+        // Test constructor with no maxTime (nullopt = default)
+        THttpRetryPolicyOptions defaultOptions(std::nullopt);
+        UNIT_ASSERT(!defaultOptions.MaxTime.has_value());
+    }
+
+}
+
+} // namespace NYql

--- a/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
+++ b/ydb/library/yql/providers/common/http_gateway/yql_http_default_retry_policy_ut.cpp
@@ -6,106 +6,120 @@ namespace NYql {
 
 Y_UNIT_TEST_SUITE(THttpDefaultRetryPolicyTest) {
 
-    Y_UNIT_TEST(DefaultOptionsHasDefaultMaxTime) {
-        // Default options should use 5-minute maxTime (not zero, not 1 second)
-        auto policy = GetHTTPDefaultRetryPolicy();
-        UNIT_ASSERT(policy);
-        auto state = policy->CreateRetryState();
-        UNIT_ASSERT(state);
-        // A retriable curl code should get a retry delay
-        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
-        UNIT_ASSERT(delay.Defined());
+    Y_UNIT_TEST(RetriableCurlCode) {
+        auto state = GetHTTPDefaultRetryPolicy()->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
     }
 
-    Y_UNIT_TEST(NonRetriableCurlCodeNoRetry) {
-        auto policy = GetHTTPDefaultRetryPolicy();
-        auto state = policy->CreateRetryState();
-        // CURLE_URL_MALFORMAT is not in the retried set
-        auto delay = state->GetNextRetryDelay(CURLE_URL_MALFORMAT, 0);
-        UNIT_ASSERT(!delay.Defined());
+    Y_UNIT_TEST(NonRetriableCurlCode) {
+        auto state = GetHTTPDefaultRetryPolicy()->CreateRetryState();
+        UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_URL_MALFORMAT, 0).Defined());
     }
 
-    Y_UNIT_TEST(RetriableHttpCodesGetLongRetry) {
-        auto policy = GetHTTPDefaultRetryPolicy();
-        auto state = policy->CreateRetryState();
-        // HTTP 429 Too Many Requests should be retriable
-        auto delay = state->GetNextRetryDelay(CURLE_OK, 429);
-        UNIT_ASSERT(delay.Defined());
+    Y_UNIT_TEST(RetriableHttpCodes) {
+        for (long httpCode : {408, 425, 429, 500, 502, 503, 504}) {
+            auto state = GetHTTPDefaultRetryPolicy()->CreateRetryState();
+            UNIT_ASSERT_C(state->GetNextRetryDelay(CURLE_OK, httpCode).Defined(), httpCode);
+        }
     }
 
-    Y_UNIT_TEST(NonRetriableHttpCodeNoRetry) {
-        auto policy = GetHTTPDefaultRetryPolicy();
-        auto state = policy->CreateRetryState();
-        // HTTP 400 Bad Request should not be retried
-        auto delay = state->GetNextRetryDelay(CURLE_OK, 400);
-        UNIT_ASSERT(!delay.Defined());
+    Y_UNIT_TEST(NonRetriableHttpCodes) {
+        // 0 is the rare case when curl code is not available, e.g. manual cancelling
+        for (long httpCode : {0, 200, 400, 403, 404, 501}) {
+            auto state = GetHTTPDefaultRetryPolicy()->CreateRetryState();
+            UNIT_ASSERT_C(!state->GetNextRetryDelay(CURLE_OK, httpCode).Defined(), httpCode);
+        }
     }
 
-    Y_UNIT_TEST(Http0NoRetry) {
-        auto policy = GetHTTPDefaultRetryPolicy();
-        auto state = policy->CreateRetryState();
-        // HTTP code 0 with OK curl means cancellation — no retry
-        auto delay = state->GetNextRetryDelay(CURLE_OK, 0);
-        UNIT_ASSERT(!delay.Defined());
+    Y_UNIT_TEST(RetriesInternalServerError) {
+        auto state = GetHTTPDefaultRetryPolicy()->CreateRetryState();
+        TDuration prevDelay;
+        for (size_t i = 0; i < 5; ++i) {
+            auto delay = state->GetNextRetryDelay(CURLE_OK, 500);
+            UNIT_ASSERT_C(delay.Defined(), i);
+            // 500 is a long retry, so the delay starts from minLongRetryDelay (200ms) and grows.
+            // RandomizeDelay returns half of the current delay plus a random part of the other half.
+            UNIT_ASSERT_GE_C(*delay, TDuration::MilliSeconds(100), i);
+            UNIT_ASSERT_LT_C(prevDelay, *delay, i);
+            prevDelay = *delay;
+        }
     }
 
-    Y_UNIT_TEST(MaxRetriesIsRespected) {
-        THttpRetryPolicyOptions options;
-        options.MaxRetries = 2;
-        auto policy = GetHTTPDefaultRetryPolicy(std::move(options));
-        auto state = policy->CreateRetryState();
+    Y_UNIT_TEST(FqPolicyRetriesInternalServerError) {
+        auto state = GetFqHTTPRetryPolicy()->CreateRetryState();
+        for (size_t i = 0; i < 5; ++i) {
+            auto delay = state->GetNextRetryDelay(CURLE_OK, 500);
+            UNIT_ASSERT_C(delay.Defined(), i);
+            UNIT_ASSERT_GE_C(*delay, TDuration::MilliSeconds(100), i);
+        }
+    }
+
+    Y_UNIT_TEST(MaxRetries) {
+        auto state = GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{.MaxRetries = 2})->CreateRetryState();
         UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
         UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
         UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
     }
 
-    Y_UNIT_TEST(CustomMaxTimeIsRespected) {
-        THttpRetryPolicyOptions options;
-        options.MaxTime = TDuration::MilliSeconds(1);
-        auto policy = GetHTTPDefaultRetryPolicy(std::move(options));
-        auto state = policy->CreateRetryState();
-        // Sleep long enough so maxTime (1ms) is exceeded before first check
-        Sleep(TDuration::MilliSeconds(50));
-        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
-        UNIT_ASSERT(!delay.Defined());
-    }
-
-    Y_UNIT_TEST(FqPolicyRetriableCodesWork) {
-        auto policy = GetFqHTTPRetryPolicy();
-        UNIT_ASSERT(policy);
-        auto state = policy->CreateRetryState();
-        // CURLE_COULDNT_CONNECT should be retriable in FQ policy
-        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
-        UNIT_ASSERT(delay.Defined());
-    }
-
-    Y_UNIT_TEST(FqPolicyDnsErrorRetriable) {
-        auto policy = GetFqHTTPRetryPolicy();
-        auto state = policy->CreateRetryState();
-        // CURLE_COULDNT_RESOLVE_HOST should be retriable in FQ policy
-        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0);
-        UNIT_ASSERT(delay.Defined());
-    }
-
-    Y_UNIT_TEST(FqPolicyNonDnsErrorNotExpiredBy10Seconds) {
-        auto policy = GetFqHTTPRetryPolicy();
-        auto state = policy->CreateRetryState();
-        // Non-DNS errors should NOT expire after 10 seconds (they use 5 minute budget)
+    Y_UNIT_TEST(MaxTime) {
+        // maxTime has to stay above minDelay (10ms), see Y_ASSERT in TExponentialBackoffPolicy
+        auto state = GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{.MaxTime = TDuration::MilliSeconds(50)})->CreateRetryState();
         UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
-        // Immediately check again — should still have budget
-        auto delay = state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0);
-        UNIT_ASSERT(delay.Defined());
+        Sleep(TDuration::MilliSeconds(150));
+        UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
     }
 
-    Y_UNIT_TEST(OptionalMaxTimeConstructor) {
-        // Test constructor with explicit maxTime
-        THttpRetryPolicyOptions options(TDuration::Seconds(30));
-        UNIT_ASSERT(options.MaxTime.has_value());
-        UNIT_ASSERT_EQUAL(*options.MaxTime, TDuration::Seconds(30));
+    Y_UNIT_TEST(ZeroMaxTimeMeansDefaultMaxTime) {
+        // Zero has to be translated to the default maxTime, not passed through as an expired budget
+        auto state = GetHTTPDefaultRetryPolicy(TDuration::Zero())->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+    }
 
-        // Test constructor with no maxTime (nullopt = default)
-        THttpRetryPolicyOptions defaultOptions(std::nullopt);
-        UNIT_ASSERT(!defaultOptions.MaxTime.has_value());
+    Y_UNIT_TEST(DefaultOptionsUseYqlRetriedCurlCodes) {
+        UNIT_ASSERT(THttpRetryPolicyOptions{}.RetriedCurlCodes == YqlRetriedCurlCodes());
+    }
+
+    Y_UNIT_TEST(CustomRetriedCurlCodes) {
+        auto state = GetHTTPDefaultRetryPolicy(THttpRetryPolicyOptions{.RetriedCurlCodes = {CURLE_URL_MALFORMAT}})->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_URL_MALFORMAT, 0).Defined());
+        UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
+    }
+
+    Y_UNIT_TEST(FqPolicyUsesFqRetriedCurlCodes) {
+        // These codes are retried by the Fq policy only
+        for (CURLcode curlCode : {CURLE_PARTIAL_FILE, CURLE_GOT_NOTHING, CURLE_COULDNT_RESOLVE_HOST}) {
+            auto fqState = GetFqHTTPRetryPolicy()->CreateRetryState();
+            UNIT_ASSERT_C(fqState->GetNextRetryDelay(curlCode, 0).Defined(), int(curlCode));
+
+            auto defaultState = GetHTTPDefaultRetryPolicy()->CreateRetryState();
+            UNIT_ASSERT_C(!defaultState->GetNextRetryDelay(curlCode, 0).Defined(), int(curlCode));
+        }
+    }
+
+    Y_UNIT_TEST(FqPolicyRetriableHttpCodes) {
+        auto state = GetFqHTTPRetryPolicy()->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_OK, 503).Defined());
+        UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_OK, 404).Defined());
+    }
+
+    Y_UNIT_TEST(FqPolicySharesRetryBudgetBetweenDnsAndOtherErrors) {
+        // Dns errors are not retried on their own schedule, they consume the shared budget
+        auto state = GetFqHTTPRetryPolicy()->CreateRetryState();
+        for (size_t i = 0; i < 10; ++i) {
+            UNIT_ASSERT_C(state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined(), i);
+        }
+        // Backoff has grown past minDelay for the non dns error as well
+        UNIT_ASSERT_GT(*state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0), TDuration::MilliSeconds(10));
+    }
+
+    Y_UNIT_TEST(FqPolicyDnsErrorsAreGivenUpEarly) {
+        auto state = GetFqHTTPRetryPolicy()->CreateRetryState();
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined());
+
+        // Dns errors get 10 seconds, everything else keeps the default 5 minutes
+        Sleep(TDuration::Seconds(11));
+        UNIT_ASSERT(!state->GetNextRetryDelay(CURLE_COULDNT_RESOLVE_HOST, 0).Defined());
+        UNIT_ASSERT(state->GetNextRetryDelay(CURLE_COULDNT_CONNECT, 0).Defined());
     }
 
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

- Replaced single-policy approach with a custom `TFqRetryPolicy` / `TFqRetryState` that tracks elapsed time per retry session
- Non-DNS retriable errors: full **5-minute** budget (restored from the 1s regression)
- `CURLE_COULDNT_RESOLVE_HOST`: **10-second** budget (DNS failures are fast-fail or fast-recover)
