### PR TITLE
Restrict failure model checks for groups with a single PhantomsOnly VDisk

### DIFF
--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -3,6 +3,8 @@
 #include <util/generic/hash_set.h>
 #include <util/system/compiler.h>
 
+#include <numeric>
+
 Y_UNIT_TEST_SUITE(SelfHeal) {
     void ChangeDiskStatus(TEnvironmentSetup& env, TPDiskId pdiskId, NKikimrBlobStorage::EDriveStatus status,
             NKikimrBlobStorage::TMaintenanceStatus::E maintenanceStatus) {
@@ -379,116 +381,293 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
         UNIT_ASSERT(seenParameters);
     }
 
-    TPDiskId GetPDiskIdByVDisk(TEnvironmentSetup& env, ui32 groupId, ui32 ring, ui32 domain, ui32 vdisk) {
-        auto base = env.FetchBaseConfig();
-        UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), 1);
+    struct TVDiskState {
+        NKikimrBlobStorage::EVDiskStatus Status = NKikimrBlobStorage::EVDiskStatus::READY;
+        bool OnlyPhantomsRemain = false;
 
+        bool IsReady() const {
+            return Status == NKikimrBlobStorage::EVDiskStatus::READY;
+        }
+
+        bool IsOperational() const {
+            return Status >= NKikimrBlobStorage::EVDiskStatus::REPLICATING;
+        }
+
+        bool IsReplicatingWithPhantomsOnly() const {
+            return Status == NKikimrBlobStorage::EVDiskStatus::REPLICATING && OnlyPhantomsRemain;
+        }
+    };
+
+    using TVDiskKey = std::tuple<ui32, ui32, ui32, ui32>;
+    using TVDiskStates = std::map<TVDiskKey, TVDiskState>;
+
+    TVDiskKey MakeVDiskKey(ui32 groupId, ui32 ring, ui32 domain, ui32 vdisk) {
+        return {groupId, ring, domain, vdisk};
+    }
+
+    TVDiskKey MakeVDiskKey(const NKikimrBlobStorage::TBaseConfig::TVSlot& slot) {
+        return MakeVDiskKey(slot.GetGroupId(), slot.GetFailRealmIdx(), slot.GetFailDomainIdx(), slot.GetVDiskIdx());
+    }
+
+    NKikimrBlobStorage::TConfigResponse InvokeConfigRequest(TEnvironmentSetup& env,
+            const NKikimrBlobStorage::TConfigRequest& request, bool selfHeal) {
+        const TActorId sender = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId, __FILE__, __LINE__);
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerConfigRequest>();
+        ev->Record.MutableRequest()->CopyFrom(request);
+        ev->SelfHeal = selfHeal;
+        env.Runtime->SendToPipe(env.TabletId, sender, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+        auto response = env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerConfigResponse>(sender);
+        return response->Get()->Record.GetResponse();
+    }
+
+    void ReportVDiskStates(TEnvironmentSetup& env, const NKikimrBlobStorage::TBaseConfig& base,
+            const TVDiskStates& states) {
+        std::map<std::pair<ui32, ui32>, ui64> pdiskGuids;
+        for (const auto& pdisk : base.GetPDisk()) {
+            pdiskGuids.emplace(std::make_pair(pdisk.GetNodeId(), pdisk.GetPDiskId()), pdisk.GetGuid());
+        }
+
+        const TActorId sender = env.Runtime->AllocateEdgeActor(env.Settings.ControllerNodeId, __FILE__, __LINE__);
+        auto ev = std::make_unique<TEvBlobStorage::TEvControllerRegisterNode>();
+        ev->Record.SetNodeID(env.Settings.ControllerNodeId);
         for (const auto& slot : base.GetVSlot()) {
-            if (slot.GetGroupId() != groupId) {
-                continue;
+            const TVDiskState& state = states.at(MakeVDiskKey(slot));
+            const auto& vslotId = slot.GetVSlotId();
+            auto *item = ev->Record.AddVDiskStatus();
+            item->SetNodeId(vslotId.GetNodeId());
+            item->SetPDiskId(vslotId.GetPDiskId());
+            item->SetVSlotId(vslotId.GetVSlotId());
+            item->SetPDiskGuid(pdiskGuids.at(std::make_pair(vslotId.GetNodeId(), vslotId.GetPDiskId())));
+            item->SetStatus(state.Status);
+            item->SetOnlyPhantomsRemain(state.OnlyPhantomsRemain);
+            auto *vdiskId = item->MutableVDiskId();
+            vdiskId->SetGroupID(slot.GetGroupId());
+            vdiskId->SetGroupGeneration(slot.GetGroupGeneration());
+            vdiskId->SetRing(slot.GetFailRealmIdx());
+            vdiskId->SetDomain(slot.GetFailDomainIdx());
+            vdiskId->SetVDisk(slot.GetVDiskIdx());
+        }
+        env.Runtime->SendToPipe(env.TabletId, sender, ev.release(), 0, TTestActorSystem::GetPipeConfigWithRetries());
+        env.WaitForEdgeActorEvent<TEvBlobStorage::TEvControllerNodeServiceSetUpdate>(sender);
+    }
+
+    enum class EExpectedResult {
+        Success,
+        Degraded,
+        Disintegrated,
+        FitDegraded,
+        FitDisintegrated,
+    };
+
+    EExpectedResult EvaluateReassign(const TBlobStorageGroupInfo::TTopology& topology,
+            const TVector<TVDiskState>& states, ui32 targetOrderNumber, bool selfHeal) {
+        const TBlobStorageGroupInfo::IQuorumChecker& checker = topology.GetQuorumChecker();
+        TBlobStorageGroupInfo::TGroupVDisks nonOperational(&topology);
+        for (ui32 orderNumber = 0; orderNumber < states.size(); ++orderNumber) {
+            if (!states[orderNumber].IsOperational()) {
+                nonOperational |= {&topology, topology.GetVDiskId(orderNumber)};
             }
-            ui32 curRing = slot.GetFailRealmIdx();
-            ui32 curDomain = slot.GetFailDomainIdx();
-            ui32 curVDisk = slot.GetVDiskIdx();
-            if (curRing == ring && curDomain == domain && curVDisk == vdisk) {
-                return { slot.GetVSlotId().GetNodeId(), slot.GetVSlotId().GetPDiskId() };
+        }
+        if (!checker.CheckFailModelForGroup(nonOperational)) {
+            return EExpectedResult::FitDisintegrated;
+        } else if (checker.IsDegraded(nonOperational)) {
+            return EExpectedResult::FitDegraded;
+        }
+
+        TBlobStorageGroupInfo::TGroupVDisks failed(&topology);
+        for (ui32 orderNumber = 0; orderNumber < states.size(); ++orderNumber) {
+            if (!states[orderNumber].IsReady()) {
+                failed |= {&topology, topology.GetVDiskId(orderNumber)};
+            }
+        }
+        failed |= {&topology, topology.GetVDiskId(targetOrderNumber)};
+
+        if (!checker.CheckFailModelForGroup(failed)) {
+            return EExpectedResult::Disintegrated;
+        }
+
+        if (selfHeal) {
+            for (ui32 orderNumber = 0; orderNumber < states.size(); ++orderNumber) {
+                if (orderNumber != targetOrderNumber && states[orderNumber].IsReplicatingWithPhantomsOnly()) {
+                    failed = failed - TBlobStorageGroupInfo::TGroupVDisks(&topology, topology.GetVDiskId(orderNumber));
+                    break;
+                }
+            }
+        }
+        return checker.IsDegraded(failed) ? EExpectedResult::Degraded : EExpectedResult::Success;
+    }
+
+    void AssertReassignResult(const NKikimrBlobStorage::TConfigResponse& response, EExpectedResult expected,
+            ui32 groupId, const TString& context) {
+        UNIT_ASSERT_VALUES_EQUAL_C(response.GetSuccess(), expected == EExpectedResult::Success,
+            context << " Response# " << response.DebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDegradedSize(), expected == EExpectedResult::Degraded ? 1 : 0,
+            context << " Response# " << response.DebugString());
+        UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDisintegratedSize(),
+            expected == EExpectedResult::Disintegrated ? 1 : 0, context << " Response# " << response.DebugString());
+        if (expected == EExpectedResult::Degraded) {
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GetGroupsGetDegraded(0), groupId, context);
+        } else if (expected == EExpectedResult::Disintegrated) {
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GetGroupsGetDisintegrated(0), groupId, context);
+        } else if (expected == EExpectedResult::FitDegraded || expected == EExpectedResult::FitDisintegrated) {
+            UNIT_ASSERT_VALUES_EQUAL_C(response.StatusSize(), 1, context << " Response# " << response.DebugString());
+            const auto failReason = expected == EExpectedResult::FitDegraded
+                ? NKikimrBlobStorage::TConfigResponse::TStatus::kMayGetDegraded
+                : NKikimrBlobStorage::TConfigResponse::TStatus::kMayLoseData;
+            UNIT_ASSERT_VALUES_EQUAL_C(static_cast<ui32>(response.GetStatus(0).GetFailReason()),
+                static_cast<ui32>(failReason),
+                context << " Response# " << response.DebugString());
+        }
+    }
+
+    Y_UNIT_TEST(RandomizedVDiskStates) {
+        constexpr ui32 numGroups = 64;
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TBlobStorageGroupInfo::TTopology topology(erasure, 1, erasure.BlobSubgroupSize(), 1, true);
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize() + 4,
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(4, numGroups);
+        env.Sim(TDuration::Minutes(1));
+        env.UpdateSettings(true, true, false);
+
+        const NKikimrBlobStorage::TBaseConfig base = env.FetchBaseConfig();
+        UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), numGroups);
+
+        struct TTestCase {
+            const NKikimrBlobStorage::TBaseConfig::TGroup *Group = nullptr;
+            TVector<const NKikimrBlobStorage::TBaseConfig::TVSlot*> SlotsByOrderNumber;
+            TVector<TVDiskState> States;
+            ui32 TargetOrderNumber = 0;
+        };
+
+        TVDiskStates states;
+        TVector<TTestCase> testCases;
+        testCases.reserve(numGroups);
+        for (const auto& group : base.GetGroup()) {
+            TTestCase& testCase = testCases.emplace_back();
+            testCase.Group = &group;
+            testCase.SlotsByOrderNumber.resize(topology.GetTotalVDisksNum());
+            testCase.States.resize(topology.GetTotalVDisksNum());
+
+            for (const auto& slot : base.GetVSlot()) {
+                if (slot.GetGroupId() == group.GetGroupId()) {
+                    const TVDiskIdShort vdiskId(slot.GetFailRealmIdx(), slot.GetFailDomainIdx(), slot.GetVDiskIdx());
+                    testCase.SlotsByOrderNumber[topology.GetOrderNumber(vdiskId)] = &slot;
+                }
+            }
+
+            TVector<ui32> orderNumbers(topology.GetTotalVDisksNum());
+            std::iota(orderNumbers.begin(), orderNumbers.end(), 0);
+            for (ui32 i = 0; i + 1 < orderNumbers.size(); ++i) {
+                std::swap(orderNumbers[i], orderNumbers[i + RandomNumber<ui32>(orderNumbers.size() - i)]);
+            }
+            testCase.TargetOrderNumber = orderNumbers[0];
+
+            // Keep every important validation outcome covered for every seed while randomizing VDisk positions.
+            // Every fifth case adds a fully randomized mix of the same readiness/operational state classes.
+            switch (testCases.size() % 5) {
+                case 0: // SelfHeal succeeds only because it may ignore the phantoms-only VDisk
+                    testCase.States[orderNumbers[0]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    testCase.States[orderNumbers[1]] = {NKikimrBlobStorage::EVDiskStatus::REPLICATING, true};
+                    break;
+
+                case 1: // evicting a third VDisk disintegrates the group, even for SelfHeal
+                    testCase.States[orderNumbers[1]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    testCase.States[orderNumbers[2]] = {NKikimrBlobStorage::EVDiskStatus::REPLICATING, true};
+                    break;
+
+                case 2: // non-operational VDisks trigger the earlier group fitter check
+                    testCase.States[orderNumbers[0]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    testCase.States[orderNumbers[1]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                    break;
+
+                case 3: // a healthy group accepts an ordinary reassign
+                    break;
+
+                case 4: {
+                    const ui32 numNonReady = RandomNumber<ui32>(5);
+                    for (ui32 i = 0; i < numNonReady; ++i) {
+                        switch (RandomNumber<ui32>(3)) {
+                            case 0:
+                                testCase.States[orderNumbers[i]].Status = NKikimrBlobStorage::EVDiskStatus::ERROR;
+                                break;
+                            case 1:
+                                testCase.States[orderNumbers[i]].Status = NKikimrBlobStorage::EVDiskStatus::REPLICATING;
+                                break;
+                            case 2:
+                                testCase.States[orderNumbers[i]] = {
+                                    NKikimrBlobStorage::EVDiskStatus::REPLICATING, true};
+                                break;
+                        }
+                    }
+                    testCase.TargetOrderNumber = RandomNumber<ui32>(orderNumbers.size());
+                    break;
+                }
+            }
+
+            for (ui32 orderNumber = 0; orderNumber < testCase.States.size(); ++orderNumber) {
+                UNIT_ASSERT(testCase.SlotsByOrderNumber[orderNumber]);
+                states.emplace(MakeVDiskKey(*testCase.SlotsByOrderNumber[orderNumber]), testCase.States[orderNumber]);
             }
         }
 
-        UNIT_FAIL("PDisk for VDisk not found");
-        return {};
-    }
-
-    auto MakeCatchDiskStatuses = [](ui32 groupId, const THashSet<ui32>& phantomOnlyDomains,
-                                    const THashSet<ui32>& faultyDomains) {
-        return [=](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+        env.Runtime->FilterFunction = [&states](ui32, std::unique_ptr<IEventHandle>& ev) {
             if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerUpdateDiskStatus::EventType) {
-                auto* vdiskStatuses = ev->Get<TEvBlobStorage::TEvControllerUpdateDiskStatus>()->Record.MutableVDiskStatus();
-
-                for (auto& status : *vdiskStatuses) {
-                    auto& vdiskId = status.GetVDiskId();
-
-                    if (vdiskId.GetGroupID() != groupId) {
-                        continue;
-                    }
-
-                    const ui32 ring = vdiskId.GetRing();
-                    const ui32 domain = vdiskId.GetDomain();
-                    const ui32 vdisk = vdiskId.GetVDisk();
-
-                    if (ring != 0 || vdisk != 0) {
-                        continue;
-                    }
-
-                    if (phantomOnlyDomains.contains(domain)) {
-                        // this VDisk is REPLICATING with only phantom blobs remaining
-                        status.SetOnlyPhantomsRemain(true);
-                        status.SetStatus(NKikimrBlobStorage::EVDiskStatus::REPLICATING);
-                    } else if (faultyDomains.contains(domain)) {
-                        // this VDisk's PDisk is FAULTY, so it doesn't report its status
-                        return false;
+                auto *statuses = ev->Get<TEvBlobStorage::TEvControllerUpdateDiskStatus>()->Record.MutableVDiskStatus();
+                for (auto& status : *statuses) {
+                    const auto& vdiskId = status.GetVDiskId();
+                    const auto it = states.find(MakeVDiskKey(vdiskId.GetGroupID(), vdiskId.GetRing(),
+                        vdiskId.GetDomain(), vdiskId.GetVDisk()));
+                    if (it != states.end()) {
+                        status.SetStatus(it->second.Status);
+                        status.SetOnlyPhantomsRemain(it->second.OnlyPhantomsRemain);
                     }
                 }
             }
             return true;
         };
-    };
+        ReportVDiskStates(env, base, states);
 
-    Y_UNIT_TEST(SelfHealOnlyPhantom) {
-        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
-        TEnvironmentSetup env({
-            .NodeCount = erasure.BlobSubgroupSize() + 1,
-            .Erasure = erasure,
-        });
+        ui32 selfHealSuccesses = 0;
+        ui32 disintegratedRejections = 0;
+        for (ui32 index = 0; index < testCases.size(); ++index) {
+            const TTestCase& testCase = testCases[index];
+            const auto *target = testCase.SlotsByOrderNumber[testCase.TargetOrderNumber];
 
-        env.CreateBoxAndPool(1, 1);
+            NKikimrBlobStorage::TConfigRequest request;
+            request.SetIgnoreGroupReserve(true);
+            request.SetAllowUnusableDisks(true);
+            request.SetIgnoreDisintegratedGroupsChecks(true);
+            auto *reassign = request.AddCommand()->MutableReassignGroupDisk();
+            reassign->SetGroupId(testCase.Group->GetGroupId());
+            reassign->SetGroupGeneration(testCase.Group->GetGroupGeneration());
+            reassign->SetFailRealmIdx(target->GetFailRealmIdx());
+            reassign->SetFailDomainIdx(target->GetFailDomainIdx());
+            reassign->SetVDiskIdx(target->GetVDiskIdx());
 
-        env.UpdateSettings(false, true, false); // disable self-heal
+            const TString context = TStringBuilder() << "Case# " << index << " GroupId# "
+                << testCase.Group->GetGroupId() << " TargetOrderNumber# " << testCase.TargetOrderNumber;
+            const EExpectedResult regularExpected = EvaluateReassign(topology, testCase.States,
+                testCase.TargetOrderNumber, false);
+            NKikimrBlobStorage::TConfigResponse response = InvokeConfigRequest(env, request, false);
+            AssertReassignResult(response, regularExpected, testCase.Group->GetGroupId(), context + " SelfHeal# false");
 
-        const ui32 groupId = env.GetGroups().at(0);
+            if (regularExpected != EExpectedResult::Success) {
+                const EExpectedResult selfHealExpected = EvaluateReassign(topology, testCase.States,
+                    testCase.TargetOrderNumber, true);
+                response = InvokeConfigRequest(env, request, true);
+                AssertReassignResult(response, selfHealExpected, testCase.Group->GetGroupId(),
+                    context + " SelfHeal# true");
+                selfHealSuccesses += selfHealExpected == EExpectedResult::Success;
+                disintegratedRejections += selfHealExpected == EExpectedResult::Disintegrated;
+            }
+        }
 
-        TPDiskId originalPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
-
-        ChangeDiskStatus(env, originalPDiskId, NKikimrBlobStorage::EDriveStatus::FAULTY, NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
-
-        env.Runtime->FilterFunction = MakeCatchDiskStatuses(groupId, /*phantomOnlyDomains=*/{0}, /*faultyDomains=*/{1});
-
-        env.UpdateSettings(true, true, false); // enable self-heal
-        env.Sim(TDuration::Seconds(30));
-
-        TPDiskId newPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
-
-        UNIT_ASSERT_C(newPDiskId != originalPDiskId, "Expected VDisk (0, 1, 0) to be moved");
-    }
-
-    Y_UNIT_TEST(SelfHealWithTwoFailedDisksAndOnePhantomOnly) {
-        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
-        TEnvironmentSetup env({
-            .NodeCount = erasure.BlobSubgroupSize() + 1,
-            .Erasure = erasure,
-        });
-
-        env.CreateBoxAndPool(1, 1);
-
-        env.UpdateSettings(false, true, false); // disable self-heal
-
-        const ui32 groupId = env.GetGroups().at(0);
-
-        TPDiskId originalPDiskId1 = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
-        TPDiskId originalPDiskId2 = GetPDiskIdByVDisk(env, groupId, 0, 2, 0);
-
-        ChangeDiskStatus(env, originalPDiskId1, NKikimrBlobStorage::EDriveStatus::FAULTY, NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
-        ChangeDiskStatus(env, originalPDiskId2, NKikimrBlobStorage::EDriveStatus::FAULTY, NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
-
-        env.Runtime->FilterFunction = MakeCatchDiskStatuses(groupId, /*phantomOnlyDomains=*/{0}, /*faultyDomains=*/{1, 2});
-
-        env.UpdateSettings(true, true, false); // enable self-heal
-        env.Sim(TDuration::Seconds(30));
-
-        TPDiskId newPDiskId1 = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
-        TPDiskId newPDiskId2 = GetPDiskIdByVDisk(env, groupId, 0, 2, 0);
-
-        UNIT_ASSERT_C(newPDiskId1 == originalPDiskId1, "Expected VDisk (0, 1, 0) not to be moved");
-        UNIT_ASSERT_C(newPDiskId2 == originalPDiskId2, "Expected VDisk (0, 2, 0) not to be moved");
+        UNIT_ASSERT_C(selfHealSuccesses, "Randomized test did not cover a SelfHeal-only successful reassign");
+        UNIT_ASSERT_C(disintegratedRejections,
+            "Randomized test did not cover fail-model rejection with IgnoreDisintegratedGroupsChecks=true");
     }
 }

--- a/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
+++ b/ydb/core/blobstorage/ut_blobstorage/self_heal.cpp
@@ -381,6 +381,119 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
         UNIT_ASSERT(seenParameters);
     }
 
+    TPDiskId GetPDiskIdByVDisk(TEnvironmentSetup& env, ui32 groupId, ui32 ring, ui32 domain, ui32 vdisk) {
+        auto base = env.FetchBaseConfig();
+        UNIT_ASSERT_VALUES_EQUAL(base.GroupSize(), 1);
+
+        for (const auto& slot : base.GetVSlot()) {
+            if (slot.GetGroupId() != groupId) {
+                continue;
+            }
+            ui32 curRing = slot.GetFailRealmIdx();
+            ui32 curDomain = slot.GetFailDomainIdx();
+            ui32 curVDisk = slot.GetVDiskIdx();
+            if (curRing == ring && curDomain == domain && curVDisk == vdisk) {
+                return { slot.GetVSlotId().GetNodeId(), slot.GetVSlotId().GetPDiskId() };
+            }
+        }
+
+        UNIT_FAIL("PDisk for VDisk not found");
+        return {};
+    }
+
+    auto MakeCatchDiskStatuses = [](ui32 groupId, const THashSet<ui32>& phantomOnlyDomains,
+                                    const THashSet<ui32>& faultyDomains) {
+        return [=](ui32 /*nodeId*/, std::unique_ptr<IEventHandle>& ev) {
+            if (ev->GetTypeRewrite() == TEvBlobStorage::TEvControllerUpdateDiskStatus::EventType) {
+                auto* vdiskStatuses = ev->Get<TEvBlobStorage::TEvControllerUpdateDiskStatus>()->Record.MutableVDiskStatus();
+
+                for (auto& status : *vdiskStatuses) {
+                    auto& vdiskId = status.GetVDiskId();
+
+                    if (vdiskId.GetGroupID() != groupId) {
+                        continue;
+                    }
+
+                    const ui32 ring = vdiskId.GetRing();
+                    const ui32 domain = vdiskId.GetDomain();
+                    const ui32 vdisk = vdiskId.GetVDisk();
+
+                    if (ring != 0 || vdisk != 0) {
+                        continue;
+                    }
+
+                    if (phantomOnlyDomains.contains(domain)) {
+                        // this VDisk is REPLICATING with only phantom blobs remaining
+                        status.SetOnlyPhantomsRemain(true);
+                        status.SetStatus(NKikimrBlobStorage::EVDiskStatus::REPLICATING);
+                    } else if (faultyDomains.contains(domain)) {
+                        // this VDisk's PDisk is FAULTY, so it doesn't report its status
+                        return false;
+                    }
+                }
+            }
+            return true;
+        };
+    };
+
+    Y_UNIT_TEST(SelfHealOnlyPhantom) {
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize() + 1,
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(1, 1);
+
+        env.UpdateSettings(false, true, false); // disable self-heal
+
+        const ui32 groupId = env.GetGroups().at(0);
+
+        TPDiskId originalPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
+
+        ChangeDiskStatus(env, originalPDiskId, NKikimrBlobStorage::EDriveStatus::FAULTY, NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
+
+        env.Runtime->FilterFunction = MakeCatchDiskStatuses(groupId, /*phantomOnlyDomains=*/{0}, /*faultyDomains=*/{1});
+
+        env.UpdateSettings(true, true, false); // enable self-heal
+        env.Sim(TDuration::Seconds(30));
+
+        TPDiskId newPDiskId = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
+
+        UNIT_ASSERT_C(newPDiskId != originalPDiskId, "Expected VDisk (0, 1, 0) to be moved");
+    }
+
+    Y_UNIT_TEST(SelfHealWithTwoFailedDisksAndOnePhantomOnly) {
+        const TBlobStorageGroupType erasure = TBlobStorageGroupType::Erasure4Plus2Block;
+        TEnvironmentSetup env({
+            .NodeCount = erasure.BlobSubgroupSize() + 1,
+            .Erasure = erasure,
+        });
+
+        env.CreateBoxAndPool(1, 1);
+
+        env.UpdateSettings(false, true, false); // disable self-heal
+
+        const ui32 groupId = env.GetGroups().at(0);
+
+        TPDiskId originalPDiskId1 = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
+        TPDiskId originalPDiskId2 = GetPDiskIdByVDisk(env, groupId, 0, 2, 0);
+
+        ChangeDiskStatus(env, originalPDiskId1, NKikimrBlobStorage::EDriveStatus::FAULTY, NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
+        ChangeDiskStatus(env, originalPDiskId2, NKikimrBlobStorage::EDriveStatus::FAULTY, NKikimrBlobStorage::TMaintenanceStatus::NOT_SET);
+
+        env.Runtime->FilterFunction = MakeCatchDiskStatuses(groupId, /*phantomOnlyDomains=*/{0}, /*faultyDomains=*/{1, 2});
+
+        env.UpdateSettings(true, true, false); // enable self-heal
+        env.Sim(TDuration::Seconds(30));
+
+        TPDiskId newPDiskId1 = GetPDiskIdByVDisk(env, groupId, 0, 1, 0);
+        TPDiskId newPDiskId2 = GetPDiskIdByVDisk(env, groupId, 0, 2, 0);
+
+        UNIT_ASSERT_C(newPDiskId1 == originalPDiskId1, "Expected VDisk (0, 1, 0) not to be moved");
+        UNIT_ASSERT_C(newPDiskId2 == originalPDiskId2, "Expected VDisk (0, 2, 0) not to be moved");
+    }
+
     struct TVDiskState {
         NKikimrBlobStorage::EVDiskStatus Status = NKikimrBlobStorage::EVDiskStatus::READY;
         bool OnlyPhantomsRemain = false;
@@ -588,7 +701,7 @@ Y_UNIT_TEST_SUITE(SelfHeal) {
                     break;
 
                 case 4: {
-                    const ui32 numNonReady = RandomNumber<ui32>(5);
+                    const ui32 numNonReady = 1 + RandomNumber<ui32>(4);
                     for (ui32 i = 0; i < numNonReady; ++i) {
                         switch (RandomNumber<ui32>(3)) {
                             case 0:

--- a/ydb/core/mind/bscontroller/config.cpp
+++ b/ydb/core/mind/bscontroller/config.cpp
@@ -336,8 +336,7 @@ namespace NKikimr::NBsController {
             }
         };
 
-        bool TBlobStorageController::ValidateConfigUpdates(TConfigState& state, bool suppressFailModelChecking,
-                bool suppressDegradedGroupsChecking, bool suppressDisintegratedGroupsChecking,
+        bool TBlobStorageController::ValidateConfigUpdates(TConfigState& state, TValidateConfigUpdatesParameters parameters,
                 TString *errorDescription, NKikimrBlobStorage::TConfigResponse *response) {
 
             // when bridged non-proxy groups get updated, we update parent group too
@@ -405,7 +404,8 @@ namespace NKikimr::NBsController {
             std::vector<TGroupId> disintegrated;
             std::vector<TGroupId> degraded;
 
-            if (!suppressDisintegratedGroupsChecking) {
+            // Check Disintegrated by ExpectedStatus
+            if (!parameters.SuppressDisintegratedGroupsChecking) {
                 for (auto&& [base, overlay] : state.Groups.Diff()) {
                     if (base && overlay->second) {
                         const TGroupInfo::TGroupStatus& prev = base->second->Status;
@@ -420,7 +420,7 @@ namespace NKikimr::NBsController {
             }
 
             // check that group modification would not degrade failure model
-            if (!suppressFailModelChecking) {
+            if (!parameters.SuppressFailModelChecking) {
                 THashSet<TGroupId> groupsToCheck;
                 for (auto&& [base, overlay] : state.VSlots.Diff()) {
                     if (base && base->second->Group) {
@@ -444,19 +444,22 @@ namespace NKikimr::NBsController {
                     }
                     if (const TGroupInfo *group = state.Groups.Find(groupId); group && group->VDisksInGroup) {
                         // process only groups with changed content; create topology for group
-                        auto& topology = *group->Topology;
+                        TBlobStorageGroupInfo::TTopology& topology = *group->Topology;
                         // fill in vector of failed disks (that are not fully operational)
                         TBlobStorageGroupInfo::TGroupVDisks failed(&topology);
-                        bool alreadySeenReplicatingWithPhantomsOnly = false;
+
+                        // A single non-Ready VDisk that is REPLICATING with only phantoms remaining may be ignored by
+                        // the degraded check when AllowDegradedWithSinglePhantomsOnly is set. The full failure set must
+                        // still pass the disintegrated check.
+                        TBlobStorageGroupInfo::TGroupVDisks allowedNonReady(&topology);
                         for (const TVSlotInfo *slot : group->VDisksInGroup) {
-                            bool replicatingWithPhantomsOnly = slot->IsReplicatingWithPhantomsOnly();
-                            // Allow exactly one VDisk that is REPLICATING with only phantoms remaining to be treated as nearly ready
-                            bool allowedOneReplicatingWithPhantomsOnly = replicatingWithPhantomsOnly && !alreadySeenReplicatingWithPhantomsOnly;
-                            if (!slot->IsReady && !allowedOneReplicatingWithPhantomsOnly) {
+                            if (!slot->IsReady) {
                                 failed |= {&topology, slot->GetShortVDiskId()};
-                            }
-                            if (replicatingWithPhantomsOnly) {
-                                alreadySeenReplicatingWithPhantomsOnly = true;
+
+                                if (parameters.AllowDegradedWithSinglePhantomsOnly &&
+                                        slot->IsReplicatingWithPhantomsOnly() && !allowedNonReady) {
+                                    allowedNonReady |= {&topology, slot->GetShortVDiskId()};
+                                }
                             }
                         }
                         // check the failure model
@@ -464,9 +467,12 @@ namespace NKikimr::NBsController {
                         if (!checker.CheckFailModelForGroup(failed)) {
                             disintegrated.push_back(groupId);
                             errors = true;
-                        } else if (!suppressDegradedGroupsChecking && checker.IsDegraded(failed)) {
-                            degraded.push_back(groupId);
-                            errors = true;
+                        } else {
+                            TBlobStorageGroupInfo::TGroupVDisks failedWithSkip = failed - allowedNonReady;
+                            if (!parameters.SuppressDegradedGroupsChecking && checker.IsDegraded(failedWithSkip)) {
+                                degraded.push_back(groupId);
+                                errors = true;
+                            }
                         }
                     } else {
                         Y_ABORT_UNLESS(group); // group must exist
@@ -531,12 +537,13 @@ namespace NKikimr::NBsController {
             }
 
             TString error;
-            const bool suppressFailModelChecking = flags.SuppressFailModelChecking;
-            const bool suppressDegradedGroupsChecking = flags.SuppressDegradedGroupsChecking;
-            const bool suppressDisintegratedGroupsChecking = flags.SuppressDisintegratedGroupsChecking;
+            const TValidateConfigUpdatesParameters parameters{
+                .SuppressFailModelChecking = flags.SuppressFailModelChecking,
+                .SuppressDegradedGroupsChecking = flags.SuppressDegradedGroupsChecking,
+                .SuppressDisintegratedGroupsChecking = flags.SuppressDisintegratedGroupsChecking,
+            };
 
-            if (!ValidateConfigUpdates(*state, suppressFailModelChecking, suppressDegradedGroupsChecking,
-                    suppressDisintegratedGroupsChecking, &error, response)) {
+            if (!ValidateConfigUpdates(*state, parameters, &error, response)) {
                 RollbackConfigUpdate(state);
                 return error;
             }

--- a/ydb/core/mind/bscontroller/config_cmd.cpp
+++ b/ydb/core/mind/bscontroller/config_cmd.cpp
@@ -297,8 +297,13 @@ namespace NKikimr::NBsController {
                 }
 
                 const bool hasChanges = Success && State->Changed() && !Cmd.GetRollback();
-                Success = Success && Self->ValidateConfigUpdates(*State, Cmd.GetIgnoreGroupFailModelChecks(),
-                    Cmd.GetIgnoreDegradedGroupsChecks(), Cmd.GetIgnoreDisintegratedGroupsChecks(), &Error, Response);
+                const TValidateConfigUpdatesParameters validationParameters{
+                    .SuppressFailModelChecking = Cmd.GetIgnoreGroupFailModelChecks(),
+                    .SuppressDegradedGroupsChecking = Cmd.GetIgnoreDegradedGroupsChecks(),
+                    .SuppressDisintegratedGroupsChecking = Cmd.GetIgnoreDisintegratedGroupsChecks(),
+                    .AllowDegradedWithSinglePhantomsOnly = SelfHeal,
+                };
+                Success = Success && Self->ValidateConfigUpdates(*State, validationParameters, &Error, Response);
 
                 if (Success && Cmd.GetRollback()) {
                     Rollback();

--- a/ydb/core/mind/bscontroller/impl.h
+++ b/ydb/core/mind/bscontroller/impl.h
@@ -1662,9 +1662,15 @@ private:
     IActor* CreateSystemViewsCollector();
     void UpdateSystemViews();
 
-    bool ValidateConfigUpdates(TConfigState& state, bool suppressFailModelChecking, bool suppressDegradedGroupsChecking,
-        bool suppressDisintegratedGroupsChecking, TString *errorDescription,
-        NKikimrBlobStorage::TConfigResponse *response = nullptr);
+    struct TValidateConfigUpdatesParameters {
+        bool SuppressFailModelChecking = false;
+        bool SuppressDegradedGroupsChecking = false;
+        bool SuppressDisintegratedGroupsChecking = false;
+        bool AllowDegradedWithSinglePhantomsOnly = false;
+    };
+
+    bool ValidateConfigUpdates(TConfigState& state, TValidateConfigUpdatesParameters parameters,
+            TString* errorDescription, NKikimrBlobStorage::TConfigResponse* response = nullptr);
 
     std::optional<TString> ValidateAndCommitConfigUpdate(std::optional<TConfigState>& state,
         TConfigTxFlags flags, TTransactionContext& txc,

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -95,13 +95,46 @@ struct TEnvironmentSetup {
         return InitialEventsFilter.Prepare();
     }
 
-    NKikimrBlobStorage::TConfigResponse Invoke(const NKikimrBlobStorage::TConfigRequest& request) {
+    NKikimrBlobStorage::TConfigResponse Invoke(const NKikimrBlobStorage::TConfigRequest& request,
+            bool selfHeal = false) {
         const TActorId self = Runtime->AllocateEdgeActor();
         auto ev = MakeHolder<TEvBlobStorage::TEvControllerConfigRequest>();
         ev->Record.MutableRequest()->CopyFrom(request);
+        ev->SelfHeal = selfHeal;
         Runtime->SendToPipe(TabletId, self, ev.Release(), NodeId, GetPipeConfigWithRetries());
         auto response = Runtime->GrabEdgeEventRethrow<TEvBlobStorage::TEvControllerConfigResponse>(self);
         return response->Get()->Record.GetResponse();
+    }
+
+    void ReportVDiskStatuses(const NKikimrBlobStorage::TBaseConfig& baseConfig,
+            const TVector<std::tuple<size_t, NKikimrBlobStorage::EVDiskStatus, bool>>& updates) {
+        TMap<std::pair<ui32, ui32>, ui64> pdiskGuids;
+        for (const auto& pdisk : baseConfig.GetPDisk()) {
+            pdiskGuids.emplace(std::make_pair(pdisk.GetNodeId(), pdisk.GetPDiskId()), pdisk.GetGuid());
+        }
+
+        const TActorId sender = Runtime->AllocateEdgeActor(0);
+        auto ev = MakeHolder<TEvBlobStorage::TEvControllerRegisterNode>();
+        ev->Record.SetNodeID(Runtime->GetNodeId(0));
+        for (const auto& [slotIndex, status, onlyPhantomsRemain] : updates) {
+            const auto& slot = baseConfig.GetVSlot(slotIndex);
+            const auto& vslotId = slot.GetVSlotId();
+            auto *item = ev->Record.AddVDiskStatus();
+            item->SetNodeId(vslotId.GetNodeId());
+            item->SetPDiskId(vslotId.GetPDiskId());
+            item->SetVSlotId(vslotId.GetVSlotId());
+            item->SetPDiskGuid(pdiskGuids.at(std::make_pair(vslotId.GetNodeId(), vslotId.GetPDiskId())));
+            item->SetStatus(status);
+            item->SetOnlyPhantomsRemain(onlyPhantomsRemain);
+            auto *vdiskId = item->MutableVDiskId();
+            vdiskId->SetGroupID(slot.GetGroupId());
+            vdiskId->SetGroupGeneration(slot.GetGroupGeneration());
+            vdiskId->SetRing(slot.GetFailRealmIdx());
+            vdiskId->SetDomain(slot.GetFailDomainIdx());
+            vdiskId->SetVDisk(slot.GetVDiskIdx());
+        }
+        Runtime->SendToPipe(TabletId, sender, ev.Release(), 0, GetPipeConfigWithRetries());
+        Runtime->GrabEdgeEventRethrow<TEvBlobStorage::TEvControllerNodeServiceSetUpdate>(sender);
     }
 
     void RegisterNode() {
@@ -677,6 +710,148 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
             cmd2->SetGroupId(2147483649);
             cmd2->SetGroupGeneration(1);
             cmd2->SetFailDomainIdx(3);
+        });
+    }
+
+    Y_UNIT_TEST(SelfHealRequestAllowsSinglePhantomsOnlyVDisk) {
+        const ui32 numNodes = 12;
+        TEnvironmentSetup env(numNodes, 1);
+
+        RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName,
+                std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {
+            TFinalizer finalizer(env);
+            env.Prepare(dispatchName, setup, outActiveZone);
+
+            NKikimrBlobStorage::TConfigRequest request;
+            env.DefineBox(1, "box", {{"/dev/disk", NKikimrBlobStorage::ROT, false, false, 0}},
+                env.GetNodes(), request);
+            env.DefineStoragePool(1, 1, "storage pool", 1, NKikimrBlobStorage::ROT, {}, request);
+            const size_t baseConfigIndex = request.CommandSize();
+            request.AddCommand()->MutableQueryBaseConfig();
+
+            NKikimrBlobStorage::TConfigResponse response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+            const auto baseConfig = response.GetStatus(baseConfigIndex).GetBaseConfig();
+            UNIT_ASSERT_VALUES_EQUAL(baseConfig.GroupSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(baseConfig.VSlotSize(), 8);
+
+            TVector<std::tuple<size_t, NKikimrBlobStorage::EVDiskStatus, bool>> readyUpdates;
+            for (size_t i = 0; i < baseConfig.VSlotSize(); ++i) {
+                readyUpdates.emplace_back(i, NKikimrBlobStorage::EVDiskStatus::READY, false);
+            }
+            env.ReportVDiskStatuses(baseConfig, readyUpdates);
+            env.Runtime->SimulateSleep(TDuration::Seconds(16));
+
+            request.Clear();
+            request.AddCommand()->MutableQueryBaseConfig();
+            response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+            for (const auto& slot : response.GetStatus(0).GetBaseConfig().GetVSlot()) {
+                UNIT_ASSERT(slot.GetReady());
+            }
+
+            constexpr size_t phantomSlotIndex = 0;
+            constexpr size_t failedSlotIndex = 1;
+            env.ReportVDiskStatuses(baseConfig, {
+                {phantomSlotIndex, NKikimrBlobStorage::EVDiskStatus::REPLICATING, true},
+                {failedSlotIndex, NKikimrBlobStorage::EVDiskStatus::ERROR, false},
+            });
+
+            request.Clear();
+            request.AddCommand()->MutableEnableSelfHeal()->SetEnable(true);
+            response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+
+            const auto& group = baseConfig.GetGroup(0);
+            const auto& failedSlot = baseConfig.GetVSlot(failedSlotIndex);
+            request.Clear();
+            request.SetIgnoreGroupReserve(true);
+            request.SetAllowUnusableDisks(true);
+            auto *reassign = request.AddCommand()->MutableReassignGroupDisk();
+            reassign->SetGroupId(group.GetGroupId());
+            reassign->SetGroupGeneration(group.GetGroupGeneration());
+            reassign->SetFailRealmIdx(failedSlot.GetFailRealmIdx());
+            reassign->SetFailDomainIdx(failedSlot.GetFailDomainIdx());
+            reassign->SetVDiskIdx(failedSlot.GetVDiskIdx());
+
+            response = env.Invoke(request);
+            UNIT_ASSERT_C(!response.GetSuccess(), response.DebugString());
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDegradedSize(), 1, response.DebugString());
+            UNIT_ASSERT_VALUES_EQUAL(response.GetGroupsGetDegraded(0), group.GetGroupId());
+
+            response = env.Invoke(request, true);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+        });
+    }
+
+    Y_UNIT_TEST(SelfHealRequestRejectsDisintegratedGroupWithPhantomsOnlyVDisk) {
+        const ui32 numNodes = 12;
+        TEnvironmentSetup env(numNodes, 1);
+
+        RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName,
+                std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {
+            TFinalizer finalizer(env);
+            env.Prepare(dispatchName, setup, outActiveZone);
+
+            NKikimrBlobStorage::TConfigRequest request;
+            env.DefineBox(1, "box", {{"/dev/disk", NKikimrBlobStorage::ROT, false, false, 0}},
+                env.GetNodes(), request);
+            env.DefineStoragePool(1, 1, "storage pool", 1, NKikimrBlobStorage::ROT, {}, request);
+            const size_t baseConfigIndex = request.CommandSize();
+            request.AddCommand()->MutableQueryBaseConfig();
+
+            NKikimrBlobStorage::TConfigResponse response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+            const auto baseConfig = response.GetStatus(baseConfigIndex).GetBaseConfig();
+            UNIT_ASSERT_VALUES_EQUAL(baseConfig.GroupSize(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(baseConfig.VSlotSize(), 8);
+
+            TVector<std::tuple<size_t, NKikimrBlobStorage::EVDiskStatus, bool>> readyUpdates;
+            for (size_t i = 0; i < baseConfig.VSlotSize(); ++i) {
+                readyUpdates.emplace_back(i, NKikimrBlobStorage::EVDiskStatus::READY, false);
+            }
+            env.ReportVDiskStatuses(baseConfig, readyUpdates);
+            env.Runtime->SimulateSleep(TDuration::Seconds(16));
+
+            request.Clear();
+            request.AddCommand()->MutableQueryBaseConfig();
+            response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+            for (const auto& slot : response.GetStatus(0).GetBaseConfig().GetVSlot()) {
+                UNIT_ASSERT(slot.GetReady());
+            }
+
+            constexpr size_t phantomSlotIndex = 0;
+            constexpr size_t failedSlotIndex = 1;
+            constexpr size_t readySlotToEvictIndex = 2;
+            env.ReportVDiskStatuses(baseConfig, {
+                {phantomSlotIndex, NKikimrBlobStorage::EVDiskStatus::REPLICATING, true},
+                {failedSlotIndex, NKikimrBlobStorage::EVDiskStatus::ERROR, false},
+            });
+
+            request.Clear();
+            request.AddCommand()->MutableEnableSelfHeal()->SetEnable(true);
+            response = env.Invoke(request);
+            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
+
+            const auto& group = baseConfig.GetGroup(0);
+            const auto& readySlotToEvict = baseConfig.GetVSlot(readySlotToEvictIndex);
+            request.Clear();
+            request.SetIgnoreGroupReserve(true);
+            request.SetAllowUnusableDisks(true);
+            request.SetIgnoreDisintegratedGroupsChecks(true);
+            auto *reassign = request.AddCommand()->MutableReassignGroupDisk();
+            reassign->SetGroupId(group.GetGroupId());
+            reassign->SetGroupGeneration(group.GetGroupGeneration());
+            reassign->SetFailRealmIdx(readySlotToEvict.GetFailRealmIdx());
+            reassign->SetFailDomainIdx(readySlotToEvict.GetFailDomainIdx());
+            reassign->SetVDiskIdx(readySlotToEvict.GetVDiskIdx());
+
+            response = env.Invoke(request, true);
+            UNIT_ASSERT_C(!response.GetSuccess(), response.DebugString());
+            UNIT_ASSERT_VALUES_EQUAL(response.GroupsGetDegradedSize(), 0);
+            UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDisintegratedSize(), 1, response.DebugString());
+            UNIT_ASSERT_VALUES_EQUAL(response.GetGroupsGetDisintegrated(0), group.GetGroupId());
         });
     }
 

--- a/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
+++ b/ydb/core/mind/bscontroller/ut_bscontroller/main.cpp
@@ -95,46 +95,13 @@ struct TEnvironmentSetup {
         return InitialEventsFilter.Prepare();
     }
 
-    NKikimrBlobStorage::TConfigResponse Invoke(const NKikimrBlobStorage::TConfigRequest& request,
-            bool selfHeal = false) {
+    NKikimrBlobStorage::TConfigResponse Invoke(const NKikimrBlobStorage::TConfigRequest& request) {
         const TActorId self = Runtime->AllocateEdgeActor();
         auto ev = MakeHolder<TEvBlobStorage::TEvControllerConfigRequest>();
         ev->Record.MutableRequest()->CopyFrom(request);
-        ev->SelfHeal = selfHeal;
         Runtime->SendToPipe(TabletId, self, ev.Release(), NodeId, GetPipeConfigWithRetries());
         auto response = Runtime->GrabEdgeEventRethrow<TEvBlobStorage::TEvControllerConfigResponse>(self);
         return response->Get()->Record.GetResponse();
-    }
-
-    void ReportVDiskStatuses(const NKikimrBlobStorage::TBaseConfig& baseConfig,
-            const TVector<std::tuple<size_t, NKikimrBlobStorage::EVDiskStatus, bool>>& updates) {
-        TMap<std::pair<ui32, ui32>, ui64> pdiskGuids;
-        for (const auto& pdisk : baseConfig.GetPDisk()) {
-            pdiskGuids.emplace(std::make_pair(pdisk.GetNodeId(), pdisk.GetPDiskId()), pdisk.GetGuid());
-        }
-
-        const TActorId sender = Runtime->AllocateEdgeActor(0);
-        auto ev = MakeHolder<TEvBlobStorage::TEvControllerRegisterNode>();
-        ev->Record.SetNodeID(Runtime->GetNodeId(0));
-        for (const auto& [slotIndex, status, onlyPhantomsRemain] : updates) {
-            const auto& slot = baseConfig.GetVSlot(slotIndex);
-            const auto& vslotId = slot.GetVSlotId();
-            auto *item = ev->Record.AddVDiskStatus();
-            item->SetNodeId(vslotId.GetNodeId());
-            item->SetPDiskId(vslotId.GetPDiskId());
-            item->SetVSlotId(vslotId.GetVSlotId());
-            item->SetPDiskGuid(pdiskGuids.at(std::make_pair(vslotId.GetNodeId(), vslotId.GetPDiskId())));
-            item->SetStatus(status);
-            item->SetOnlyPhantomsRemain(onlyPhantomsRemain);
-            auto *vdiskId = item->MutableVDiskId();
-            vdiskId->SetGroupID(slot.GetGroupId());
-            vdiskId->SetGroupGeneration(slot.GetGroupGeneration());
-            vdiskId->SetRing(slot.GetFailRealmIdx());
-            vdiskId->SetDomain(slot.GetFailDomainIdx());
-            vdiskId->SetVDisk(slot.GetVDiskIdx());
-        }
-        Runtime->SendToPipe(TabletId, sender, ev.Release(), 0, GetPipeConfigWithRetries());
-        Runtime->GrabEdgeEventRethrow<TEvBlobStorage::TEvControllerNodeServiceSetUpdate>(sender);
     }
 
     void RegisterNode() {
@@ -710,148 +677,6 @@ Y_UNIT_TEST_SUITE(BsControllerConfig) {
             cmd2->SetGroupId(2147483649);
             cmd2->SetGroupGeneration(1);
             cmd2->SetFailDomainIdx(3);
-        });
-    }
-
-    Y_UNIT_TEST(SelfHealRequestAllowsSinglePhantomsOnlyVDisk) {
-        const ui32 numNodes = 12;
-        TEnvironmentSetup env(numNodes, 1);
-
-        RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName,
-                std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {
-            TFinalizer finalizer(env);
-            env.Prepare(dispatchName, setup, outActiveZone);
-
-            NKikimrBlobStorage::TConfigRequest request;
-            env.DefineBox(1, "box", {{"/dev/disk", NKikimrBlobStorage::ROT, false, false, 0}},
-                env.GetNodes(), request);
-            env.DefineStoragePool(1, 1, "storage pool", 1, NKikimrBlobStorage::ROT, {}, request);
-            const size_t baseConfigIndex = request.CommandSize();
-            request.AddCommand()->MutableQueryBaseConfig();
-
-            NKikimrBlobStorage::TConfigResponse response = env.Invoke(request);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-            const auto baseConfig = response.GetStatus(baseConfigIndex).GetBaseConfig();
-            UNIT_ASSERT_VALUES_EQUAL(baseConfig.GroupSize(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(baseConfig.VSlotSize(), 8);
-
-            TVector<std::tuple<size_t, NKikimrBlobStorage::EVDiskStatus, bool>> readyUpdates;
-            for (size_t i = 0; i < baseConfig.VSlotSize(); ++i) {
-                readyUpdates.emplace_back(i, NKikimrBlobStorage::EVDiskStatus::READY, false);
-            }
-            env.ReportVDiskStatuses(baseConfig, readyUpdates);
-            env.Runtime->SimulateSleep(TDuration::Seconds(16));
-
-            request.Clear();
-            request.AddCommand()->MutableQueryBaseConfig();
-            response = env.Invoke(request);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-            for (const auto& slot : response.GetStatus(0).GetBaseConfig().GetVSlot()) {
-                UNIT_ASSERT(slot.GetReady());
-            }
-
-            constexpr size_t phantomSlotIndex = 0;
-            constexpr size_t failedSlotIndex = 1;
-            env.ReportVDiskStatuses(baseConfig, {
-                {phantomSlotIndex, NKikimrBlobStorage::EVDiskStatus::REPLICATING, true},
-                {failedSlotIndex, NKikimrBlobStorage::EVDiskStatus::ERROR, false},
-            });
-
-            request.Clear();
-            request.AddCommand()->MutableEnableSelfHeal()->SetEnable(true);
-            response = env.Invoke(request);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-
-            const auto& group = baseConfig.GetGroup(0);
-            const auto& failedSlot = baseConfig.GetVSlot(failedSlotIndex);
-            request.Clear();
-            request.SetIgnoreGroupReserve(true);
-            request.SetAllowUnusableDisks(true);
-            auto *reassign = request.AddCommand()->MutableReassignGroupDisk();
-            reassign->SetGroupId(group.GetGroupId());
-            reassign->SetGroupGeneration(group.GetGroupGeneration());
-            reassign->SetFailRealmIdx(failedSlot.GetFailRealmIdx());
-            reassign->SetFailDomainIdx(failedSlot.GetFailDomainIdx());
-            reassign->SetVDiskIdx(failedSlot.GetVDiskIdx());
-
-            response = env.Invoke(request);
-            UNIT_ASSERT_C(!response.GetSuccess(), response.DebugString());
-            UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDegradedSize(), 1, response.DebugString());
-            UNIT_ASSERT_VALUES_EQUAL(response.GetGroupsGetDegraded(0), group.GetGroupId());
-
-            response = env.Invoke(request, true);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-        });
-    }
-
-    Y_UNIT_TEST(SelfHealRequestRejectsDisintegratedGroupWithPhantomsOnlyVDisk) {
-        const ui32 numNodes = 12;
-        TEnvironmentSetup env(numNodes, 1);
-
-        RunTestWithReboots(env.TabletIds, [&] { return env.PrepareInitialEventsFilter(); }, [&](const TString& dispatchName,
-                std::function<void(TTestActorRuntime&)> setup, bool& outActiveZone) {
-            TFinalizer finalizer(env);
-            env.Prepare(dispatchName, setup, outActiveZone);
-
-            NKikimrBlobStorage::TConfigRequest request;
-            env.DefineBox(1, "box", {{"/dev/disk", NKikimrBlobStorage::ROT, false, false, 0}},
-                env.GetNodes(), request);
-            env.DefineStoragePool(1, 1, "storage pool", 1, NKikimrBlobStorage::ROT, {}, request);
-            const size_t baseConfigIndex = request.CommandSize();
-            request.AddCommand()->MutableQueryBaseConfig();
-
-            NKikimrBlobStorage::TConfigResponse response = env.Invoke(request);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-            const auto baseConfig = response.GetStatus(baseConfigIndex).GetBaseConfig();
-            UNIT_ASSERT_VALUES_EQUAL(baseConfig.GroupSize(), 1);
-            UNIT_ASSERT_VALUES_EQUAL(baseConfig.VSlotSize(), 8);
-
-            TVector<std::tuple<size_t, NKikimrBlobStorage::EVDiskStatus, bool>> readyUpdates;
-            for (size_t i = 0; i < baseConfig.VSlotSize(); ++i) {
-                readyUpdates.emplace_back(i, NKikimrBlobStorage::EVDiskStatus::READY, false);
-            }
-            env.ReportVDiskStatuses(baseConfig, readyUpdates);
-            env.Runtime->SimulateSleep(TDuration::Seconds(16));
-
-            request.Clear();
-            request.AddCommand()->MutableQueryBaseConfig();
-            response = env.Invoke(request);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-            for (const auto& slot : response.GetStatus(0).GetBaseConfig().GetVSlot()) {
-                UNIT_ASSERT(slot.GetReady());
-            }
-
-            constexpr size_t phantomSlotIndex = 0;
-            constexpr size_t failedSlotIndex = 1;
-            constexpr size_t readySlotToEvictIndex = 2;
-            env.ReportVDiskStatuses(baseConfig, {
-                {phantomSlotIndex, NKikimrBlobStorage::EVDiskStatus::REPLICATING, true},
-                {failedSlotIndex, NKikimrBlobStorage::EVDiskStatus::ERROR, false},
-            });
-
-            request.Clear();
-            request.AddCommand()->MutableEnableSelfHeal()->SetEnable(true);
-            response = env.Invoke(request);
-            UNIT_ASSERT_C(response.GetSuccess(), response.GetErrorDescription());
-
-            const auto& group = baseConfig.GetGroup(0);
-            const auto& readySlotToEvict = baseConfig.GetVSlot(readySlotToEvictIndex);
-            request.Clear();
-            request.SetIgnoreGroupReserve(true);
-            request.SetAllowUnusableDisks(true);
-            request.SetIgnoreDisintegratedGroupsChecks(true);
-            auto *reassign = request.AddCommand()->MutableReassignGroupDisk();
-            reassign->SetGroupId(group.GetGroupId());
-            reassign->SetGroupGeneration(group.GetGroupGeneration());
-            reassign->SetFailRealmIdx(readySlotToEvict.GetFailRealmIdx());
-            reassign->SetFailDomainIdx(readySlotToEvict.GetFailDomainIdx());
-            reassign->SetVDiskIdx(readySlotToEvict.GetVDiskIdx());
-
-            response = env.Invoke(request, true);
-            UNIT_ASSERT_C(!response.GetSuccess(), response.DebugString());
-            UNIT_ASSERT_VALUES_EQUAL(response.GroupsGetDegradedSize(), 0);
-            UNIT_ASSERT_VALUES_EQUAL_C(response.GroupsGetDisintegratedSize(), 1, response.DebugString());
-            UNIT_ASSERT_VALUES_EQUAL(response.GetGroupsGetDisintegrated(0), group.GetGroupId());
         });
     }
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Make checks for storage model degradation more strict for groups with VDisks in Phantom-like only replication state

### Changelog category <!-- remove all except one -->

* Improvement