### PR TITLE
Fix serializer in ICv2

### DIFF
--- a/ydb/library/actors/core/event_pb.cpp
+++ b/ydb/library/actors/core/event_pb.cpp
@@ -58,22 +58,29 @@ namespace NActors {
         return true;
     }
 
-    void TCoroutineChunkSerializer::Produce(const void* data, size_t size,
+    void TCoroutineChunkSerializer::Produce(const void* data, ssize_t size,
             const NInterconnect::NRdma::TMemRegion* memRegion) {
-        Y_ABORT_UNLESS(size <= TotalSizeRemain);
+        Y_ABORT_UNLESS(size < 0 || static_cast<size_t>(size) <= TotalSizeRemain);
         TotalSizeRemain -= size;
         TotalSerializedDataSize += size;
 
         if (LastChunk.Buf + LastChunk.Size == data && LastChunk.MemRegion == memRegion) {
-            auto& ref = Chunks.back();
-            ref.Size += size;
+            Y_ABORT_UNLESS(size > 0 || static_cast<size_t>(-size) <= LastChunk.Size);
             LastChunk.Size += size;
+            if (LastChunk.Size == 0) {
+                Chunks.pop_back();
+                LastChunk = Chunks.empty() ? TChunk{nullptr, 0, nullptr} : Chunks.back();
+            } else {
+                Chunks.back().Size += size;
+            }
             return;
         }
 
+        Y_ABORT_UNLESS(size > 0);
+
         LastChunk = Chunks.emplace_back(TChunk{
             .Buf = static_cast<const char*>(data),
-            .Size = size,
+            .Size = static_cast<size_t>(size),
             .MemRegion = memRegion,
         });
     }
@@ -174,25 +181,11 @@ namespace NActors {
         if (!count) {
             return;
         }
-        Y_ABORT_UNLESS(count > 0);
-        Y_ABORT_UNLESS(!Chunks.empty());
-        TChunk& buf = Chunks.back();
-        Y_ABORT_UNLESS((size_t)count <= buf.Size, "count# %d buf.Size# %zu", count, buf.Size);
-        Y_ABORT_UNLESS(buf.Buf + buf.Size == Buffer.data(), "buf# %p:%zu Buffer.data# %p Buffer.size# %zu"
-            " NumChunks# %zu", buf.Buf, buf.Size, Buffer.data(), Buffer.size(), Chunks.size());
-        buf.Size -= count;
-        LastChunk.Size -= count;
-        if (!buf.Size) {
-            Chunks.pop_back();
-            if (!Chunks.empty()) {
-                LastChunk = Chunks.back();
-            } else {
-                LastChunk = {nullptr, 0, nullptr};
-            }
-        }
-        Buffer = {Buffer.data() - count, Buffer.size() + count};
-        TotalSizeRemain += count;
-        TotalSerializedDataSize -= count;
+        Produce(Buffer.data(), -count, nullptr);
+        Buffer = {
+            Buffer.data() - count,
+            Buffer.size() + count,
+        };
     }
 
     void TCoroutineChunkSerializer::Resume() {
@@ -217,6 +210,38 @@ namespace NActors {
         return WriteAliasedRaw(s->data(), s->length());
     }
 
+    bool TCoroutineChunkSerializer::WriteCord(const y_absl::Cord& cord) {
+        if (WithCord) {
+            for (const y_absl::string_view& chunk : cord.Chunks()) {
+                if (!WriteAliasedRawImpl(chunk.data(), chunk.size(), nullptr)) {
+                    return false;
+                }
+            }
+            // retain ownership of the cord
+            Cords.push_back(cord);
+        } else {
+            for (const y_absl::string_view& chunk : cord.Chunks()) {
+                const char *chunkData = chunk.data();
+                size_t chunkSize = chunk.size();
+                while (chunkSize) {
+                    void *buffer;
+                    int bufferSize;
+                    if (!Next(&buffer, &bufferSize)) {
+                        return false;
+                    }
+                    size_t numBytesToCopy = Min<size_t>(chunkSize, bufferSize);
+                    memcpy(buffer, chunkData, numBytesToCopy);
+                    chunkData += numBytesToCopy;
+                    chunkSize -= numBytesToCopy;
+                    buffer = (char*)buffer + numBytesToCopy;
+                    bufferSize -= numBytesToCopy;
+                    BackUp(bufferSize);
+                }
+            }
+        }
+        return true;
+    }
+
     std::span<TCoroutineChunkSerializer::TChunk> TCoroutineChunkSerializer::FeedBuf(void* data, size_t size,
             EAliasedMode aliasedMode) {
         TMutableContiguousSpan buffer(static_cast<char*>(data), size);
@@ -235,6 +260,7 @@ namespace NActors {
         Chunks.clear();
         LastChunk = {nullptr, 0, nullptr};
         AliasedMode = aliasedMode;
+        Y_ABORT_UNLESS(Cords.empty());
         Resume();
 
         Y_DEBUG_ABORT_UNLESS(Buffer.data() >= buffer->data() &&
@@ -243,12 +269,13 @@ namespace NActors {
         return Chunks;
     }
 
-    void TCoroutineChunkSerializer::SetSerializingEvent(const IEventBase *event, bool withCachedSizes) {
+    void TCoroutineChunkSerializer::SetSerializingEvent(const IEventBase *event, bool withCachedSizes, bool withCord) {
         Y_ABORT_UNLESS(Event == nullptr);
         Event = event;
         TotalSerializedDataSize = 0;
         AbortFlag = false;
         WithCachedSizes = withCachedSizes;
+        WithCord = withCord;
     }
 
     void TCoroutineChunkSerializer::Abort() {

--- a/ydb/library/actors/core/event_pb.h
+++ b/ydb/library/actors/core/event_pb.h
@@ -102,7 +102,7 @@ namespace NActors {
         TCoroutineChunkSerializer();
         ~TCoroutineChunkSerializer();
 
-        void SetSerializingEvent(const IEventBase *event, bool withCachedSizes);
+        void SetSerializingEvent(const IEventBase *event, bool withCachedSizes, bool withCord);
         void DiscardEvent() { Event = nullptr; };
         void Abort();
         std::span<TChunk> FeedBuf(void* data, size_t size,
@@ -129,6 +129,7 @@ namespace NActors {
 
         bool WriteRope(const TRope *rope) override;
         bool WriteString(const TString *s) override;
+        bool WriteCord(const y_absl::Cord& cord) override;
 
         NProtoBuf::io::CodedOutputStream *GetCodedOutputStream() override {
             if (!WithCachedSizes) {
@@ -140,10 +141,14 @@ namespace NActors {
             return CodedOutputStream.get();
         }
 
+        std::vector<y_absl::Cord>& GetCords() {
+            return Cords;
+        }
+
     protected:
         void DoRun() override;
         void Resume();
-        void Produce(const void* data, size_t size,
+        void Produce(const void* data, ssize_t size,
             const NInterconnect::NRdma::TMemRegion* memRegion);
         bool WriteAliasedRawImpl(const void* data, int size,
             const NInterconnect::NRdma::TMemRegion* memRegion);
@@ -164,7 +169,9 @@ namespace NActors {
         bool SerializationSuccess;
         bool Finished = false;
         bool WithCachedSizes = false;
+        bool WithCord = false;
         std::unique_ptr<NProtoBuf::io::CodedOutputStream> CodedOutputStream;
+        std::vector<y_absl::Cord> Cords;
     };
 
     struct TProtoArenaHolder : public TAtomicRefCount<TProtoArenaHolder> {

--- a/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
+++ b/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
@@ -56,7 +56,7 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
 
         TString chunkerRes;
         TCoroutineChunkSerializer chunker;
-        chunker.SetSerializingEvent(&msg, true);
+        chunker.SetSerializingEvent(&msg, true, false);
         while (!chunker.IsComplete()) {
             char buffer[4096];
             auto range = chunker.FeedBuf(buffer, sizeof(buffer));
@@ -96,7 +96,7 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
         for (size_t chunkSize = 1; chunkSize <= 32; ++chunkSize) {
             TString actual;
             TCoroutineChunkSerializer chunker;
-            chunker.SetSerializingEvent(&msg, true);
+            chunker.SetSerializingEvent(&msg, true, false);
             while (!chunker.IsComplete()) {
                 TString buffer(chunkSize, '\0');
                 for (const auto& chunk : chunker.FeedBuf(buffer.begin(), buffer.size())) {

--- a/ydb/library/actors/core/ut/event_pb_ut.cpp
+++ b/ydb/library/actors/core/ut/event_pb_ut.cpp
@@ -56,7 +56,7 @@ Y_UNIT_TEST_SUITE(TEventSerialization) {
         for (int i = 0; i < 4; ++i) {
             TMockEvent event;
             event.msg = &bm;
-            chunker.SetSerializingEvent(&event, true);
+            chunker.SetSerializingEvent(&event, true, false);
             char buf1[87];
             TString bmChunkedSerialized;
             while (!chunker.IsComplete()) {

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -174,7 +174,7 @@ namespace NActors {
                         State = EState::BODY;
                         IEventBase *base = event.Event.Get();
                         if (event.EventSerializedSize) {
-                            Chunker.SetSerializingEvent(base, /*withCachedSizes=*/ true);
+                            Chunker.SetSerializingEvent(base, /*withCachedSizes=*/ true, /*withCord=*/ false);
                         }
                         SerializationInfoContainer = base->CreateSerializationInfo(Params.UseExternalDataChannel);
                         SerializationInfo = &SerializationInfoContainer;

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
@@ -208,6 +208,7 @@ namespace NActors {
             TMutableContiguousSpan GetReadSpan() {
                 if (ReadBuffer.size() < MinReadBufferSize) {
                     ReadBuffer = TRcBuf::Uninitialized(ReadBufferSize);
+                    NSan::Poison(ReadBuffer.data(), ReadBuffer.size());
                 }
                 return ReadBuffer.UnsafeGetContiguousSpanMut();
             }
@@ -215,8 +216,13 @@ namespace NActors {
             void ApplyBytesRead(size_t num) {
                 BytesReceived += num;
                 LastInputActivityTimestamp = GetCycleCountFast();
-                TRcBuf chunk = {TRcBuf::Piece, ReadBuffer.data(), num, ReadBuffer};
-                Deserializer.Push(std::move(chunk), this, SessionId);
+                Y_DEBUG_ABORT_UNLESS(num <= ReadBuffer.size());
+                NSan::Unpoison(ReadBuffer.data(), num);
+                Deserializer.Push(num == ReadBuffer.size()
+                        ? std::move(ReadBuffer)
+                        : TRcBuf(TRcBuf::Piece, ReadBuffer.data(), num, ReadBuffer),
+                    this,
+                    SessionId);
                 Y_ABORT_UNLESS(num <= ReadBuffer.size());
                 const size_t remain = ReadBuffer.size() - num;
                 ReadBuffer.TrimFront(remain - remain % 64); // make only this number of bytes remaining in buffer
@@ -296,8 +302,10 @@ namespace NActors {
                 // Advance past exactly the bytes the kernel accepted. A writev can be short (e.g. under
                 // backpressure or on a real network), so drop only fully-sent spans and trim the span that
                 // straddles the boundary; the rest stay queued and are retried by the next writev.
-                for (auto& span : OutgoingSpans) {
-                    NSan::CheckMemIsInitialized(span.data(), span.size());
+                if constexpr (NSan::MSanIsOn()) {
+                    for (auto& span : OutgoingSpans) {
+                        NSan::CheckMemIsInitialized(span.data(), span.size());
+                    }
                 }
                 for (size_t remaining = num; remaining; OutgoingSpans.pop_front()) {
                     Y_DEBUG_ABORT_UNLESS(!OutgoingSpans.empty());
@@ -1361,6 +1369,7 @@ namespace NActors {
                     session.Disconnect(TDisconnectReason::EndOfStream());
                 } else {
                     *BytesReceived += res;
+
                     session.ReceiveCycles = 0;
                     session.EventsReceivedCallback = 0;
                     session.EventsReceivedActorSystem = 0;

--- a/ydb/library/actors/interconnect/ut/xdc_shuffle_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/xdc_shuffle_ut.cpp
@@ -34,7 +34,7 @@ Y_UNIT_TEST_SUITE(InterconnectXdcShuffle) {
         UNIT_ASSERT_VALUES_EQUAL(info.Sections[2].Size, 0u);
 
         TCoroutineChunkSerializer chunker;
-        chunker.SetSerializingEvent(&event, true);
+        chunker.SetSerializingEvent(&event, true, false);
 
         TString headerBuffer(info.Sections[0].Size, '\0');
         auto getSerializedSize = [](std::span<TCoroutineChunkSerializer::TChunk> chunks) {

--- a/ydb/library/actors/interconnect/v2_event_serializer.cpp
+++ b/ydb/library/actors/interconnect/v2_event_serializer.cpp
@@ -148,18 +148,13 @@ namespace NActors {
 
             bool fromBuffer = span.data() >= bufferSpan.data() && span.data() + span.size() <= bufferSpan.data() + bufferSpan.size();
 
-            if (span.size() <= 64 && !fromBuffer) {
+            if (!fromBuffer && (reinterpret_cast<uintptr_t>(span.data()) & 63) + span.size() <= 64 && buffer.size() >= span.size()) {
                 // we got span referenced outside original buffer; check if we can copy it into the buffer, if it is
                 // small enough and buffer has the space to do it
-                const uintptr_t spanBegin = reinterpret_cast<uintptr_t>(span.data());
-                const uintptr_t spanEnd = reinterpret_cast<uintptr_t>(span.data() + span.size() - 1);
-                const uintptr_t mask = ~uintptr_t(63); // check if it fits the same cacheline
-                if (buffer.size() >= span.size() && (spanBegin & mask) == (spanEnd & mask)) {
-                    memcpy(buffer.UnsafeGetDataMut(), span.data(), span.size());
-                    span = {buffer.data(), span.size()};
-                    buffer.TrimFront(buffer.size() - span.size());
-                    fromBuffer = true;
-                }
+                memcpy(buffer.UnsafeGetDataMut(), span.data(), span.size());
+                span = {buffer.data(), span.size()};
+                buffer.TrimFront(buffer.size() - span.size());
+                fromBuffer = true;
             }
 
             Y_ABORT_UNLESS(span.size() <= maxBytesToProduce);
@@ -168,19 +163,14 @@ namespace NActors {
             CumulativeProduced += span.size();
             if (lastSpanEnd != span.data()) {
                 out->push_back(span);
-                lastSpanEnd = span.data() + span.size();
             } else {
                 Y_DEBUG_ABORT_UNLESS(!out->empty());
                 TContiguousSpan& lastSpan = out->back();
                 lastSpan = {lastSpan.data(), lastSpan.size() + span.size()};
-                lastSpanEnd += span.size();
             }
+            lastSpanEnd = span.data() + span.size();
 
-            if (span.data() + span.size() <= bufferSpan.data() || span.data() >= bufferSpan.data() + bufferSpan.size()) {
-                BytesAliased += span.size();
-            } else {
-                BytesCopied += span.size();
-            }
+            (fromBuffer ? BytesCopied : BytesAliased) += span.size();
 
             if (fromBuffer) {
                 Y_DEBUG_ABORT_UNLESS(*bufferProduced < CumulativeProduced);
@@ -221,8 +211,7 @@ namespace NActors {
             IEventHandle& ev = *queue.Events.Peek();
 
             TChunkHeader *header = nullptr;
-            auto addEventChunkBytes = [&](const char *ptr, size_t numBytes) {
-                Y_DEBUG_ABORT_UNLESS(numBytes);
+            auto ensureHeader = [&] {
                 if (!header) {
                     header = static_cast<TChunkHeader*>(takeInBuffer(sizeof(TChunkHeader)));
                     *header = {
@@ -230,9 +219,20 @@ namespace NActors {
                         .TypeChannel = static_cast<ui16>(channel | TChunkHeader::kEventChunk),
                     };
                 }
+            };
+            auto addEventChunkBytes = [&](const char *ptr, size_t numBytes) {
+                ensureHeader();
+                Y_DEBUG_ABORT_UNLESS(numBytes);
                 Y_DEBUG_ABORT_UNLESS(header->Length + numBytes <= Max<ui16>());
                 header->Length += numBytes;
                 produceOutputSpan({ptr, numBytes}, Checksumming);
+
+                Y_ABORT_UNLESS(numBytes <= queue.SerializedBytesPending, "Type# 0x%08" PRIx32
+                    " SerializedBytesPending# %zu CalculateSerializedSize# %zu CalculateSerializedSizeCached# %zu",
+                    ev.Type, queue.SerializedBytesPending, ev.GetBase()->CalculateSerializedSize(),
+                    ev.GetBase()->CalculateSerializedSizeCached());
+
+                queue.SerializedBytesPending -= numBytes;
             };
 
             switch (queue.SerializeStage) {
@@ -247,7 +247,8 @@ namespace NActors {
                     } else if (ev.HasEvent()) {
                         IEventBase *event = ev.GetBase();
                         queue.SerializeStage = ESerializeStage::kChunkSerializer;
-                        queue.CoroutineChunkSerializer.SetSerializingEvent(event, /*withCachedSizes=*/ false);
+                        queue.CoroutineChunkSerializer.SetSerializingEvent(event, /*withCachedSizes=*/ true,
+                            /*withCords=*/ true);
                         queue.EvSerInfoHolder = event->CreateSerializationInfo(true);
                         queue.EvSerInfo = &queue.EvSerInfoHolder;
                         queue.SerializedBytesPending = event->CalculateSerializedSizeCached();
@@ -279,8 +280,6 @@ namespace NActors {
                             queue.Iter.ContiguousSize());
                         addEventChunkBytes(queue.Iter.ContiguousData(), numBytes);
                         queue.Iter += numBytes;
-                        Y_ABORT_UNLESS(numBytes <= queue.SerializedBytesPending);
-                        queue.SerializedBytesPending -= numBytes;
                     }
                     if (!queue.Iter.Valid()) {
                         queue.SerializeStage = ESerializeStage::kHeader;
@@ -295,16 +294,22 @@ namespace NActors {
                     // serialize as much as we can
                     TMutableContiguousSpan span = buffer.UnsafeGetContiguousSpanMut().SubSpan(sizeof(TChunkHeader),
                         Max<size_t>()); // reserve space for TChunkHeader which we write first thing if we have some data
-                    for (const auto& chunk : queue.CoroutineChunkSerializer.FeedBuf(&span,
-                            maxBytesToProduce - sizeof(TChunkHeader))) {
-                        addEventChunkBytes(chunk.Buf, chunk.Size);
-                        Y_ABORT_UNLESS(chunk.Size <= queue.SerializedBytesPending);
-                        queue.SerializedBytesPending -= chunk.Size;
-                    }
+                    auto chunks = queue.CoroutineChunkSerializer.FeedBuf(&span, maxBytesToProduce - sizeof(TChunkHeader));
                     Y_DEBUG_ABORT_UNLESS(buffer.data() + buffer.size() == span.data() + span.size());
                     Y_DEBUG_ABORT_UNLESS(span.size() <= buffer.size()); // ensure span did not reduce
-                    if (header) {
+                    if (!chunks.empty()) {
+                        ensureHeader();
                         buffer.TrimFront(span.size());
+                    }
+                    for (const auto& chunk : chunks) {
+                        addEventChunkBytes(chunk.Buf, chunk.Size);
+                    }
+                    if (auto& cords = queue.CoroutineChunkSerializer.GetCords(); !cords.empty()) {
+                        // retain ownership of cords provided for this serialization
+                        RefcountItems.push_back({
+                            .EndOffset = CumulativeProduced,
+                            .Cords = std::exchange(cords, {}),
+                        });
                     }
 
                     // check if we have finished serializing this event

--- a/ydb/library/actors/interconnect/v2_event_serializer.h
+++ b/ydb/library/actors/interconnect/v2_event_serializer.h
@@ -148,7 +148,8 @@ namespace NActors {
             std::unique_ptr<IEventBase> Event;
             TRcBuf Scratch;
             size_t ScratchBytesUsed = 0;
-            ui64 EventReceivedTimestamp;
+            ui64 EventReceivedTimestamp = 0;
+            std::vector<y_absl::Cord> Cords; // keeping ownership of the following cords referring the data
         };
         std::deque<TRefcountItem> RefcountItems;
         size_t NumBytesInScratchBuffers = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix serializer in ICv2

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch fixes serializer in ICv2 and also adds support for abseil cords in zero-copy output streams.
