### PR TITLE
Prevent PQ TxInFly growth from stuck DELETING and silent RS acks

### DIFF
--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4285,11 +4285,18 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
     const NKikimrTx::TEvMediatorPlanStep& event = ev->Record;
     const ui64 step = event.GetStep();
     TMaybe<ui64> lastPlannedTxId;
+    ui32 knownTxCount = 0;
+    ui32 unknownTxCount = 0;
+    TStringBuilder transactionsDiag;
 
     for (const auto& tx : event.GetTransactions()) {
         PQ_ENSURE(tx.HasTxId());
         const ui64 txId = tx.GetTxId();
         PQ_ENSURE(!lastPlannedTxId.Defined() || (*lastPlannedTxId < txId));
+
+        if (!transactionsDiag.empty()) {
+            transactionsDiag << ',';
+        }
 
         if (auto p = Txs.find(txId); p != Txs.end()) {
             TDistributedTransaction& tx = p->second;
@@ -4307,33 +4314,53 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
 
                 tx.OnPlanStep(step);
                 TryExecuteTxs(ctx, tx);
+                transactionsDiag << txId << ":known:new";
             } else {
                 YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Transaction already planned for step",
                     {"logPrefix", LogPrefix()},
                     {"txStep", tx.Step},
                     {"step", step},
                     {"txId", txId});
+                transactionsDiag << txId << ":known:already_planned:" << tx.Step;
             }
 
+            ++knownTxCount;
             lastPlannedTxId = txId;
         } else {
             YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown transaction TxId Step",
                 {"logPrefix", LogPrefix()},
                 {"txId", txId},
                 {"step", step});
+            ++unknownTxCount;
+            transactionsDiag << txId << ":unknown";
         }
     }
 
-    // All-unknown PlanStep is allowed only for step <= PlanStep (retransmit after we already
-    // planned, executed and deleted the txs of this step; PlanStep was advanced then).
-    // All-unknown with step > PlanStep must not happen on the KQP path: a TxId reaches the
-    // coordinator only after PREPARED is persisted and is in Txs; cancel-before-plan is not
-    // sent to PQ; expire-before-own-PlanStep is blocked by MediatorTimeCast SafeStep.
-    // Hitting this means durable tx state / PlanStep is inconsistent with the mediator —
-    // fail the tablet rather than ack a future empty plan and silently move on.
+    // ENSURE(step <= PlanStep || lastPlannedTxId) fails only when step > PlanStep and no TxId
+    // from this PlanStep is in Txs (including an empty Transactions list). Paths:
+    //
+    // | Path | How | Prod KQP? |
+    // |---|---|---|
+    // | Empty Transactions, step > PlanStep | Mediator anomaly / unexpected empty plan | Should not |
+    // | All TxIds unknown, step > PlanStep | Durable Txs/PlanStep lost or never restored; mediator retries | Disaster |
+    // | All TxIds unknown, step > PlanStep | Coordinator/mediator listed this tablet for txs never prepared here | Bug |
+    // | All TxIds unknown, step > PlanStep | UT CancelTransactionProposal deleted PREPARED before PlanStep | UT only |
+    // | All TxIds unknown, step > PlanStep | All PREPAREDs EXPIRED+deleted before own PlanStep | Blocked by SafeStep |
+    //
+    // Allowed: all unknown with step <= PlanStep (retransmit after planned/executed/deleted;
+    // PlanStep was advanced then). Mixed known+unknown does not fail (lastPlannedTxId set).
     PQ_ENSURE(step <= PlanStep || lastPlannedTxId.Defined())
         ("step", step)
-        ("planStep", PlanStep);
+        ("planStep", PlanStep)
+        ("planTxId", PlanTxId)
+        ("execStep", ExecStep)
+        ("execTxId", ExecTxId)
+        ("sender", sender.ToString())
+        ("txCount", event.TransactionsSize())
+        ("knownTxCount", knownTxCount)
+        ("unknownTxCount", unknownTxCount)
+        ("hasKnownTx", lastPlannedTxId.Defined())
+        ("transactions", transactionsDiag);
 
     if ((step > PlanStep) && lastPlannedTxId.Defined()) {
         // если это план из будущего, то надо запомнить, последнюю запланированную транзакцию

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4324,6 +4324,17 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         }
     }
 
+    // All-unknown PlanStep is allowed only for step <= PlanStep (retransmit after we already
+    // planned, executed and deleted the txs of this step; PlanStep was advanced then).
+    // All-unknown with step > PlanStep must not happen on the KQP path: a TxId reaches the
+    // coordinator only after PREPARED is persisted and is in Txs; cancel-before-plan is not
+    // sent to PQ; expire-before-own-PlanStep is blocked by MediatorTimeCast SafeStep.
+    // Hitting this means durable tx state / PlanStep is inconsistent with the mediator —
+    // fail the tablet rather than ack a future empty plan and silently move on.
+    PQ_ENSURE(step <= PlanStep || lastPlannedTxId.Defined())
+        ("step", step)
+        ("planStep", PlanStep);
+
     if ((step > PlanStep) && lastPlannedTxId.Defined()) {
         // если это план из будущего, то надо запомнить, последнюю запланированную транзакцию
         PlanStep = step;

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4139,7 +4139,7 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
         CanProcessWriteTxs() ||
         CanProcessTxWrites() ||
         TxWritesChanged ||
-        DeleteTxsContainsKafkaTxs
+        !DeleteTxs.empty()
         ;
     if (!canProcess) {
         return;
@@ -4217,7 +4217,7 @@ void TPersQueue::ProcessProposeTransactionQueue(const TActorContext& ctx,
 {
     PQ_ENSURE(!WriteTxsInProgress);
 
-    if (CanProcessProposeTransactionQueue() || DeleteTxsContainsKafkaTxs) {
+    if (!DeleteTxs.empty()) {
         ProcessDeleteTxs(ctx, request);
     }
 
@@ -4460,7 +4460,6 @@ void TPersQueue::ProcessDeleteTxs(const TActorContext& ctx,
     }
 
     DeleteTxs.clear();
-    DeleteTxsContainsKafkaTxs = false;
 }
 
 void TPersQueue::AddCmdDeleteTx(NKikimrClient::TKeyValueRequest& request,
@@ -5327,7 +5326,6 @@ void TPersQueue::DeleteTx(TDistributedTransaction& tx)
         {"txId", tx.TxId});
 
     DeleteTxs.insert(tx.TxId);
-    DeleteTxsContainsKafkaTxs |= (tx.WriteId.Defined() && tx.WriteId->IsKafkaApiTransaction());
 
     if (auto traceId = tx.GetExecuteSpanTraceId(); traceId) {
         HasTxDeleteSpan = true;

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4285,18 +4285,11 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
     const NKikimrTx::TEvMediatorPlanStep& event = ev->Record;
     const ui64 step = event.GetStep();
     TMaybe<ui64> lastPlannedTxId;
-    ui32 knownTxCount = 0;
-    ui32 unknownTxCount = 0;
-    TStringBuilder transactionsDiag;
 
     for (const auto& tx : event.GetTransactions()) {
         PQ_ENSURE(tx.HasTxId());
         const ui64 txId = tx.GetTxId();
         PQ_ENSURE(!lastPlannedTxId.Defined() || (*lastPlannedTxId < txId));
-
-        if (!transactionsDiag.empty()) {
-            transactionsDiag << ',';
-        }
 
         if (auto p = Txs.find(txId); p != Txs.end()) {
             TDistributedTransaction& tx = p->second;
@@ -4314,53 +4307,34 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
 
                 tx.OnPlanStep(step);
                 TryExecuteTxs(ctx, tx);
-                transactionsDiag << txId << ":known:new";
             } else {
                 YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Transaction already planned for step",
                     {"logPrefix", LogPrefix()},
                     {"txStep", tx.Step},
                     {"step", step},
                     {"txId", txId});
-                transactionsDiag << txId << ":known:already_planned:" << tx.Step;
             }
 
-            ++knownTxCount;
             lastPlannedTxId = txId;
         } else {
             YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX, "Unknown transaction TxId Step",
                 {"logPrefix", LogPrefix()},
                 {"txId", txId},
                 {"step", step});
-            ++unknownTxCount;
-            transactionsDiag << txId << ":unknown";
         }
     }
 
-    // ENSURE(step <= PlanStep || lastPlannedTxId) fails only when step > PlanStep and no TxId
-    // from this PlanStep is in Txs (including an empty Transactions list). Paths:
-    //
-    // | Path | How | Prod KQP? |
-    // |---|---|---|
-    // | Empty Transactions, step > PlanStep | Mediator anomaly / unexpected empty plan | Should not |
-    // | All TxIds unknown, step > PlanStep | Durable Txs/PlanStep lost or never restored; mediator retries | Disaster |
-    // | All TxIds unknown, step > PlanStep | Coordinator/mediator listed this tablet for txs never prepared here | Bug |
-    // | All TxIds unknown, step > PlanStep | UT CancelTransactionProposal deleted PREPARED before PlanStep | UT only |
-    // | All TxIds unknown, step > PlanStep | All PREPAREDs EXPIRED+deleted before own PlanStep | Blocked by SafeStep |
-    //
-    // Allowed: all unknown with step <= PlanStep (retransmit after planned/executed/deleted;
-    // PlanStep was advanced then). Mixed known+unknown does not fail (lastPlannedTxId set).
+    // All-unknown PlanStep is allowed only for step <= PlanStep (retransmit after we already
+    // planned, executed and deleted the txs of this step; PlanStep was advanced then).
+    // All-unknown with step > PlanStep must not happen on the KQP path: a TxId reaches the
+    // coordinator only after PREPARED is persisted and is in Txs; cancel-before-plan is not
+    // sent to PQ; expire-before-own-PlanStep is blocked by MediatorTimeCast SafeStep.
+    // Hitting this means durable tx state / PlanStep is inconsistent with the mediator —
+    // fail the tablet rather than ack a future empty plan and silently move on.
     PQ_ENSURE(step <= PlanStep || lastPlannedTxId.Defined())
         ("step", step)
         ("planStep", PlanStep)
-        ("planTxId", PlanTxId)
-        ("execStep", ExecStep)
-        ("execTxId", ExecTxId)
-        ("sender", sender.ToString())
-        ("txCount", event.TransactionsSize())
-        ("knownTxCount", knownTxCount)
-        ("unknownTxCount", unknownTxCount)
-        ("hasKnownTx", lastPlannedTxId.Defined())
-        ("transactions", transactionsDiag);
+        ("txCount", event.TransactionsSize());
 
     if ((step > PlanStep) && lastPlannedTxId.Defined()) {
         // если это план из будущего, то надо запомнить, последнюю запланированную транзакцию

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3986,6 +3986,31 @@ void TPersQueue::SendDeferredReadSetAcks(const TActorContext& ctx)
     DeferredReadSetAcks.clear();
 }
 
+void TPersQueue::MovePendingDeferredPlanStepAcks()
+{
+    AFL_ENSURE(DeferredPlanStepAcks.empty())("DeferredPlanStepAcks", DeferredPlanStepAcks.size());
+    DeferredPlanStepAcks = std::move(PendingDeferredPlanStepAcks);
+    PendingDeferredPlanStepAcks.clear();
+}
+
+void TPersQueue::AddPendingDeferredPlanStepAck(TDeferredPlanStepAck&& ack)
+{
+    PendingDeferredPlanStepAcks.push_back(std::move(ack));
+}
+
+void TPersQueue::SendDeferredPlanStepAcks(const TActorContext& ctx)
+{
+    for (auto& e : DeferredPlanStepAcks) {
+        YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "Send deferred TEvPlanStep acks",
+            {"logPrefix", LogPrefix()},
+            {"step", e.Event->Record.GetStep()},
+            {"txCount", e.Event->Record.TransactionsSize()});
+        SendPlanStepAcks(ctx, e.Sender, *e.Event);
+    }
+
+    DeferredPlanStepAcks.clear();
+}
+
 void TPersQueue::Handle(TEvTxProcessing::TEvReadSetAck::TPtr& ev, const TActorContext& ctx)
 {
     YDB_LOG_INFO_COMP(NKikimrServices::PQ_TX, "Handle TEvTxProcessing::TEvReadSetAck",
@@ -4141,7 +4166,8 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
         CanProcessTxWrites() ||
         TxWritesChanged ||
         !DeleteTxs.empty() ||
-        !PendingDeferredReadSetAcks.empty()
+        !PendingDeferredReadSetAcks.empty() ||
+        !PendingDeferredPlanStepAcks.empty()
         ;
     if (!canProcess) {
         return;
@@ -4155,6 +4181,7 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
     AddCmdWriteTabletTxInfo(request->Record);
 
     MovePendingDeferredReadSetAcks();
+    MovePendingDeferredPlanStepAcks();
 
     WriteTxsInProgress = true;
 
@@ -4201,6 +4228,7 @@ void TPersQueue::EndWriteTxs(const NKikimrClient::TResponse& resp,
     CheckChangedTxStates(ctx);
     CreateSupportivePartitionActors(ctx);
     SendDeferredReadSetAcks(ctx);
+    SendDeferredPlanStepAcks(ctx);
 
     WriteTxsInProgress = false;
 
@@ -4324,23 +4352,7 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         }
     }
 
-    // All-unknown PlanStep with step <= PlanStep: retransmit after we already planned,
-    // executed and deleted the txs of this step (PlanStep was advanced then) — ack below.
-    //
-    // All-unknown with step > PlanStep is also possible and must be acked, not ENSURE'd:
-    // SchemeShard CreatePQ/AlterPQ after SS reboot Attach→NODATA still re-proposes to the
-    // coordinator with PQ in the affected set; coordinator assigns a new step S2 > PlanStep
-    // for a TxId PQ already forgot. See CollectPQConfigChanged (NODATA) and TPropose::ProgressState.
-    // (KQP write path does not normally produce this; CDC/import reboot UT does.)
-    if (step > PlanStep && !lastPlannedTxId.Defined()) {
-        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX,
-            "All-unknown future PlanStep; acking (likely SchemeShard re-plan after NODATA)",
-            {"logPrefix", LogPrefix()},
-            {"step", step},
-            {"planStep", PlanStep},
-            {"txCount", event.TransactionsSize()});
-    }
-
+    // PlanStep / PlanTxId advance only when at least one TxId from this message is in Txs.
     if ((step > PlanStep) && lastPlannedTxId.Defined()) {
         // если это план из будущего, то надо запомнить, последнюю запланированную транзакцию
         PlanStep = step;
@@ -4360,8 +4372,23 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
             SendPlanStepAcks(ctx, tx);
         }
     } else {
-        // таблетка PQ успела выполнить и удалить все транзакции этого шага. надо отправить подтверждение
-        SendPlanStepAcks(ctx, sender, *ev);
+        // No known TxId in this PlanStep (including an empty Transactions list).
+        //
+        // Do not ack immediately: PlanStep is advanced in memory before _txinfo is persisted.
+        // A stale leader can keep that inflated PlanStep after losing generation while the new
+        // leader still has the older durable watermark. Immediate ack on step <= PlanStep
+        // (retransmit of an already-handled step) or on step > PlanStep (e.g. SchemeShard
+        // CreatePQ re-plan after Attach→NODATA) would let the stale tablet confirm the step
+        // without a successful KV write. Defer ack until WRITE_TX succeeds — same fence as
+        // deferred TEvReadSetAck for unknown txs. Watermark is not moved on this path.
+        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX,
+            "All-unknown PlanStep; deferring ack until WRITE_TX completes",
+            {"logPrefix", LogPrefix()},
+            {"step", step},
+            {"planStep", PlanStep},
+            {"txCount", event.TransactionsSize()});
+        AddPendingDeferredPlanStepAck({.Sender = sender, .Event = std::move(ev)});
+        TryWriteTxs(ctx);
     }
 
     YDB_LOG_DEBUG_COMP(NKikimrServices::PQ_TX, "PlanStep PlanTxId",

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -3957,6 +3957,7 @@ void TPersQueue::Handle(TEvTxProcessing::TEvReadSet::TPtr& ev, const TActorConte
             {"txId", event.GetTxId()});
 
         AddPendingDeferredReadSetAck({.Sender = ev->Sender, .Ack = std::move(ack)});
+        TryWriteTxs(ctx);
     }
 }
 
@@ -4139,7 +4140,8 @@ void TPersQueue::BeginWriteTxs(const TActorContext& ctx)
         CanProcessWriteTxs() ||
         CanProcessTxWrites() ||
         TxWritesChanged ||
-        !DeleteTxs.empty()
+        !DeleteTxs.empty() ||
+        !PendingDeferredReadSetAcks.empty()
         ;
     if (!canProcess) {
         return;

--- a/ydb/core/persqueue/pqtablet/pq_impl.cpp
+++ b/ydb/core/persqueue/pqtablet/pq_impl.cpp
@@ -4324,17 +4324,22 @@ void TPersQueue::ProcessPlanStep(const TActorId& sender, std::unique_ptr<TEvTxPr
         }
     }
 
-    // All-unknown PlanStep is allowed only for step <= PlanStep (retransmit after we already
-    // planned, executed and deleted the txs of this step; PlanStep was advanced then).
-    // All-unknown with step > PlanStep must not happen on the KQP path: a TxId reaches the
-    // coordinator only after PREPARED is persisted and is in Txs; cancel-before-plan is not
-    // sent to PQ; expire-before-own-PlanStep is blocked by MediatorTimeCast SafeStep.
-    // Hitting this means durable tx state / PlanStep is inconsistent with the mediator —
-    // fail the tablet rather than ack a future empty plan and silently move on.
-    PQ_ENSURE(step <= PlanStep || lastPlannedTxId.Defined())
-        ("step", step)
-        ("planStep", PlanStep)
-        ("txCount", event.TransactionsSize());
+    // All-unknown PlanStep with step <= PlanStep: retransmit after we already planned,
+    // executed and deleted the txs of this step (PlanStep was advanced then) — ack below.
+    //
+    // All-unknown with step > PlanStep is also possible and must be acked, not ENSURE'd:
+    // SchemeShard CreatePQ/AlterPQ after SS reboot Attach→NODATA still re-proposes to the
+    // coordinator with PQ in the affected set; coordinator assigns a new step S2 > PlanStep
+    // for a TxId PQ already forgot. See CollectPQConfigChanged (NODATA) and TPropose::ProgressState.
+    // (KQP write path does not normally produce this; CDC/import reboot UT does.)
+    if (step > PlanStep && !lastPlannedTxId.Defined()) {
+        YDB_LOG_WARN_COMP(NKikimrServices::PQ_TX,
+            "All-unknown future PlanStep; acking (likely SchemeShard re-plan after NODATA)",
+            {"logPrefix", LogPrefix()},
+            {"step", step},
+            {"planStep", PlanStep},
+            {"txCount", event.TransactionsSize()});
+    }
 
     if ((step > PlanStep) && lastPlannedTxId.Defined()) {
         // если это план из будущего, то надо запомнить, последнюю запланированную транзакцию

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -675,6 +675,19 @@ private:
     void MovePendingDeferredReadSetAcks();
     void AddPendingDeferredReadSetAck(TDeferredReadSetAck&& ack);
     void SendDeferredReadSetAcks(const TActorContext& ctx);
+
+    // All-unknown TEvPlanStep (no TxId in Txs): ack only after a successful WRITE_TX cycle,
+    // so a stale leader cannot confirm a plan step without winning the KV write.
+    struct TDeferredPlanStepAck {
+        TActorId Sender;
+        std::unique_ptr<TEvTxProcessing::TEvPlanStep> Event;
+    };
+    TDeque<TDeferredPlanStepAck> PendingDeferredPlanStepAcks;
+    TDeque<TDeferredPlanStepAck> DeferredPlanStepAcks;
+
+    void MovePendingDeferredPlanStepAcks();
+    void AddPendingDeferredPlanStepAck(TDeferredPlanStepAck&& ack);
+    void SendDeferredPlanStepAcks(const TActorContext& ctx);
 };
 
 }// NPQ

--- a/ydb/core/persqueue/pqtablet/pq_impl.h
+++ b/ydb/core/persqueue/pqtablet/pq_impl.h
@@ -333,7 +333,6 @@ private:
     TDeque<std::unique_ptr<TEvPersQueue::TEvProposeTransaction>> EvProposeTransactionQueue;
     THashMap<ui64, NKikimrPQ::TTransaction::EState> WriteTxs;
     THashSet<ui64> DeleteTxs;
-    bool DeleteTxsContainsKafkaTxs = false;
     TSet<std::pair<ui64, ui64>> ChangedTxs;
     TMaybe<NKikimrPQ::TPQTabletConfig> TabletConfigTx;
     TMaybe<NKikimrPQ::TBootstrapConfig> BootstrapConfigTx;

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -2730,13 +2730,7 @@ Y_UNIT_TEST_F(One_New_Partition_In_Another_Tablet, TPQTabletFixture)
 
     tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
 
-    // PQ отправит запрос в KV, а потом пришлёт ответ на TEvReadSet
-    SendProposeTransactionRequest({.TxId=txId + 1,
-                                  .Configs=NHelpers::TConfigParams{
-                                  .Tablet=tabletConfig,
-                                  .Bootstrap=NHelpers::MakeBootstrapConfig(),
-                                  }});
-
+    // Deferred TEvReadSetAck is flushed by the WRITE_TX cycle without a follow-up ProposeTransaction.
     WaitReadSetAck(*tablet, {.Step=100, .TxId=txId, .Source=mockTabletId, .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
 }
 
@@ -3195,6 +3189,226 @@ Y_UNIT_TEST_F(DeleteTx_With_Concurrent_Propose, TPQTabletFixture)
                                    .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
 
     WaitForTheTransactionToBeDeleted(txId);
+}
+
+Y_UNIT_TEST_F(Deferred_ReadSetAck_For_Unknown_Tx_Without_Propose, TPQTabletFixture)
+{
+    // B1-N1: unknown TEvReadSet is acked after WRITE_TX without a follow-up ProposeTransaction.
+    const ui64 unknownTxId = 424242;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=unknownTxId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitReadSetAck(*tablet, {.Step=100, .TxId=unknownTxId, .Source=mockTabletId,
+                             .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
+}
+
+Y_UNIT_TEST_F(Deferred_ReadSetAck_Waits_For_Successful_WriteTx, TPQTabletFixture)
+{
+    // B1-N2: stale-leader gate — ack is not sent until WRITE_TX succeeds.
+    const ui64 unknownTxId = 424243;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    TVector<TAutoPtr<IEventHandle>> heldRequests;
+    bool holdWriteTx = true;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (holdWriteTx) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+                if (msg->Record.GetCookie() == 5 /* WRITE_TX_COOKIE */) {
+                    heldRequests.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=unknownTxId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldRequests.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    WaitForNoReadSetAck(*tablet);
+
+    holdWriteTx = false;
+    for (auto& held : heldRequests) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldRequests.clear();
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    WaitReadSetAck(*tablet, {.Step=100, .TxId=unknownTxId, .Source=mockTabletId,
+                             .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
+}
+
+Y_UNIT_TEST_F(Deferred_ReadSetAck_While_WriteTx_In_Progress, TPQTabletFixture)
+{
+    // B1-N3: unknown RS during an in-flight WRITE_TX is flushed after that cycle ends.
+    const ui64 txId = 67890;
+    const ui64 unknownTxId = 424244;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+
+    // Catch the propose WRITE_TX and inject an unknown RS while it is in progress.
+    TVector<TAutoPtr<IEventHandle>> heldResponses;
+    bool holdWriteTxResponse = true;
+    bool seenWriteTxRequest = false;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+            if (msg->Record.GetCookie() == 5 /* WRITE_TX_COOKIE */) {
+                seenWriteTxRequest = true;
+            }
+        }
+        if (holdWriteTxResponse && seenWriteTxRequest) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvResponse>()) {
+                if (msg->Record.GetCookie() == 5 /* WRITE_TX_COOKIE */) {
+                    heldResponses.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return seenWriteTxRequest;
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=200, .TxId=unknownTxId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldResponses.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    WaitForNoReadSetAck(*tablet);
+
+    holdWriteTxResponse = false;
+    for (auto& held : heldResponses) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldResponses.clear();
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+    WaitReadSetAck(*tablet, {.Step=200, .TxId=unknownTxId, .Source=mockTabletId,
+                             .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
+}
+
+Y_UNIT_TEST_F(Deferred_ReadSetAck_Multiple_Unknown_Without_Propose, TPQTabletFixture)
+{
+    // B1-N4: several deferred unknown RS acks flush without ProposeTransaction.
+    const ui64 mockTabletId = 22222;
+    const ui64 baseTxId = 424250;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    THashSet<ui64> ackedTxIds;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (auto* msg = event->CastAsLocal<TEvTxProcessing::TEvReadSetAck>()) {
+            if (msg->Record.GetTabletDest() == Ctx->TabletId) {
+                ackedTxIds.insert(msg->Record.GetTxId());
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    for (ui64 i = 0; i < 3; ++i) {
+        tablet->SendReadSet(*Ctx->Runtime, {.Step=100 + i, .TxId=baseTxId + i, .Target=Ctx->TabletId,
+                                            .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+    }
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&]() {
+        return ackedTxIds.size() >= 3;
+    };
+    UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    for (ui64 i = 0; i < 3; ++i) {
+        UNIT_ASSERT(ackedTxIds.contains(baseTxId + i));
+    }
+}
+
+Y_UNIT_TEST_F(Known_ReadSet_Path_Unchanged, TPQTabletFixture)
+{
+    // B1-N5: known-tx TEvReadSet path still completes and deletes without relying on deferred-only flush.
+    const ui64 txId = 67890;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    WaitReadSet(*tablet, {.Step=100, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                          .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=txId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+
+    WaitReadSetAck(*tablet, {.Step=100, .TxId=txId, .Source=mockTabletId,
+                             .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
+
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+    WaitForTheTransactionToBeDeleted(txId);
+}
+
+Y_UNIT_TEST_F(Deferred_ReadSetAck_From_Silent_Peer_Without_Propose, TPQTabletFixture)
+{
+    // B1-N6: simplified PQ↔PQ ring — peer RS for an absent local tx is acked without propose.
+    const ui64 peerTxId = 1412647829058208ull;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=1779169393560ull, .TxId=peerTxId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitReadSetAck(*tablet, {.Step=1779169393560ull, .TxId=peerTxId, .Source=mockTabletId,
+                             .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
 }
 
 Y_UNIT_TEST_F(Kafka_Transaction_Supportive_Partitions_Should_Be_Deleted_After_Timeout, TPQTabletFixture)

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -3152,10 +3152,14 @@ Y_UNIT_TEST_F(DeleteTx_Without_FollowUp_Propose_Kafka, TPQTabletFixture)
 
 Y_UNIT_TEST_F(DeleteTx_With_Concurrent_Propose, TPQTabletFixture)
 {
-    // A1-N6: DeleteTxs flush in the same WRITE_TX cycle as a new ProposeTransaction.
+    // A1-N6: DeleteTxs and a new ProposeTransaction share one WRITE_TX persist.
     const ui64 txId = 67890;
     const ui64 nextTxId = txId + 1;
+    const ui64 unknownTxId = 424299;
     const ui64 mockTabletId = 22222;
+    const TString deleteTxKeyFrom = GetTxKey(txId);
+    const TString deleteTxKeyTo = GetTxKey(txId + 1);
+    const TString proposeTxKey = GetTxKey(nextTxId);
 
     NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
     PQTabletPrepare({.partitions=1}, {}, *Ctx);
@@ -3178,17 +3182,79 @@ Y_UNIT_TEST_F(DeleteTx_With_Concurrent_Propose, TPQTabletFixture)
     WaitProposeTransactionResponse({.TxId=txId,
                                    .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
 
-    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+    // Hold the next WRITE_TX so DeleteTx and the new propose both queue while WriteTxsInProgress.
+    TVector<TAutoPtr<IEventHandle>> heldWriteTxRequests;
+    bool holdWriteTx = true;
+    bool foundCombinedPersist = false;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+            if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                if (holdWriteTx) {
+                    heldWriteTxRequests.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+
+                bool hasDelete = false;
+                bool hasProposeWrite = false;
+                for (const auto& cmd : msg->Record.GetCmdDeleteRange()) {
+                    if (cmd.HasRange() &&
+                        cmd.GetRange().GetFrom() == deleteTxKeyFrom &&
+                        cmd.GetRange().GetTo() == deleteTxKeyTo)
+                    {
+                        hasDelete = true;
+                    }
+                }
+                for (const auto& cmd : msg->Record.GetCmdWrite()) {
+                    if (cmd.GetKey() == proposeTxKey) {
+                        hasProposeWrite = true;
+                    }
+                }
+                if (hasDelete && hasProposeWrite) {
+                    foundCombinedPersist = true;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    // Start a WRITE_TX cycle (deferred RS ack) and keep it in flight.
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=200, .TxId=unknownTxId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldWriteTxRequests.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
 
     SendProposeTransactionRequest({.TxId=nextTxId,
                                   .Senders={mockTabletId}, .Receivers={mockTabletId},
                                   .TxOps={
                                   {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
                                   }});
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+
+    holdWriteTx = false;
+    for (auto& held : heldWriteTxRequests) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldWriteTxRequests.clear();
+
     WaitProposeTransactionResponse({.TxId=nextTxId,
                                    .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
-
     WaitForTheTransactionToBeDeleted(txId);
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return foundCombinedPersist;
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    UNIT_ASSERT(foundCombinedPersist);
 }
 
 Y_UNIT_TEST_F(Deferred_ReadSetAck_For_Unknown_Tx_Without_Propose, TPQTabletFixture)

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -2871,13 +2871,38 @@ Y_UNIT_TEST_F(Duplicate_ReadSetAck_From_Same_Recipient, TPQTabletFixture)
         SendToPipe(Ctx->Edge, event.release());
     };
 
+    const TString deleteTxKeyFrom = GetTxKey(txId);
+    const TString deleteTxKeyTo = GetTxKey(txId + 1);
+    bool sawPrematureDelete = false;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+            if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                for (const auto& cmd : msg->Record.GetCmdDeleteRange()) {
+                    if (cmd.HasRange() &&
+                        cmd.GetRange().GetFrom() == deleteTxKeyFrom &&
+                        cmd.GetRange().GetTo() == deleteTxKeyTo)
+                    {
+                        sawPrematureDelete = true;
+                    }
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
     sendReadSetAck(tabletB);
     sendReadSetAck(tabletB);
 
     // Without dedup, two acks from B would satisfy HaveAllRecipientsReceive (2/2) even though C
-    // has not acked. DeleteTx must not run yet; give the write cycle a chance to flush if it were queued.
-    Ctx->Runtime->SimulateSleep(TDuration::MilliSeconds(300));
+    // has not acked. DeleteTx must not run; give WRITE_TX a chance to flush if it were queued.
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&]() {
+        return sawPrematureDelete;
+    };
+    Ctx->Runtime->DispatchEvents(options, TDuration::Seconds(2));
+    UNIT_ASSERT(!sawPrematureDelete);
     AssertTransactionInKV(txId);
+    Ctx->Runtime->SetObserverFunc(prev);
 
     sendReadSetAck(tabletC);
 

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -3287,7 +3287,7 @@ Y_UNIT_TEST_F(Deferred_ReadSetAck_Waits_For_Successful_WriteTx, TPQTabletFixture
     auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
         if (holdWriteTx) {
             if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
-                if (msg->Record.GetCookie() == 5 /* WRITE_TX_COOKIE */) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
                     heldRequests.push_back(event);
                     return TTestActorRuntimeBase::EEventAction::DROP;
                 }
@@ -3342,13 +3342,13 @@ Y_UNIT_TEST_F(Deferred_ReadSetAck_While_WriteTx_In_Progress, TPQTabletFixture)
     bool seenWriteTxRequest = false;
     auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
         if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
-            if (msg->Record.GetCookie() == 5 /* WRITE_TX_COOKIE */) {
+            if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
                 seenWriteTxRequest = true;
             }
         }
         if (holdWriteTxResponse && seenWriteTxRequest) {
             if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvResponse>()) {
-                if (msg->Record.GetCookie() == 5 /* WRITE_TX_COOKIE */) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
                     heldResponses.push_back(event);
                     return TTestActorRuntimeBase::EEventAction::DROP;
                 }

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -312,6 +312,7 @@ protected:
     void SendPlanStep(const TPlanStepParams& params);
     void WaitPlanStepAck(const TPlanStepAckMatcher& matcher = {});
     void WaitPlanStepAccepted(const TPlanStepAcceptedMatcher& matcher = {});
+    void WaitForNoPlanStepAccepted(TDuration timeout = TDuration::Seconds(2));
 
     void WaitReadSet(NHelpers::TPQTabletMock& tablet, const TReadSetMatcher& matcher);
     void WaitReadSetEx(NHelpers::TPQTabletMock& tablet, const TReadSetMatcher& matcher);
@@ -637,6 +638,26 @@ void TPQTabletFixture::WaitPlanStepAccepted(const TPlanStepAcceptedMatcher& matc
         UNIT_ASSERT(event->Record.HasStep());
         UNIT_ASSERT_VALUES_EQUAL(*matcher.Step, event->Record.GetStep());
     }
+}
+
+void TPQTabletFixture::WaitForNoPlanStepAccepted(TDuration timeout)
+{
+    bool sawAccepted = false;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (event->GetTypeRewrite() == TEvTxProcessing::TEvPlanStepAccepted::EventType) {
+            sawAccepted = true;
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&]() {
+        return sawAccepted;
+    };
+    Ctx->Runtime->DispatchEvents(options, timeout);
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    UNIT_ASSERT(!sawAccepted);
 }
 
 void TPQTabletFixture::WaitReadSet(NHelpers::TPQTabletMock& tablet, const TReadSetMatcher& matcher)
@@ -3500,6 +3521,293 @@ Y_UNIT_TEST_F(Deferred_ReadSetAck_From_Silent_Peer_Without_Propose, TPQTabletFix
 
     WaitReadSetAck(*tablet, {.Step=1779169393560ull, .TxId=peerTxId, .Source=mockTabletId,
                              .Target=Ctx->TabletId, .Consumer=Ctx->TabletId});
+}
+
+Y_UNIT_TEST_F(Deferred_PlanStepAck_Future_Unknown_Waits_WriteTx, TPQTabletFixture)
+{
+    // All-unknown future PlanStep: ack only after successful WRITE_TX; PlanStep not advanced.
+    const ui64 unknownTxId = 424301;
+
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    TVector<TAutoPtr<IEventHandle>> heldRequests;
+    bool holdWriteTx = true;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (holdWriteTx) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                    heldRequests.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    SendPlanStep({.Step=100, .TxIds={unknownTxId}});
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldRequests.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    WaitForNoPlanStepAccepted();
+
+    holdWriteTx = false;
+    for (auto& held : heldRequests) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldRequests.clear();
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    WaitPlanStepAck({.Step=100, .TxIds={unknownTxId}});
+    WaitPlanStepAccepted({.Step=100});
+}
+
+Y_UNIT_TEST_F(Deferred_PlanStepAck_Empty_Future_Waits_WriteTx, TPQTabletFixture)
+{
+    // Empty Transactions + future step: same deferred fence.
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    TVector<TAutoPtr<IEventHandle>> heldRequests;
+    bool holdWriteTx = true;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (holdWriteTx) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                    heldRequests.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    SendPlanStep({.Step=100, .TxIds={}});
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldRequests.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    WaitForNoPlanStepAccepted();
+
+    holdWriteTx = false;
+    for (auto& held : heldRequests) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldRequests.clear();
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    // Empty Transactions list: only TEvPlanStepAccepted is sent (no per-TxId AckTo).
+    WaitPlanStepAccepted({.Step=100});
+}
+
+Y_UNIT_TEST_F(Deferred_PlanStepAck_Past_Retransmit_After_Delete, TPQTabletFixture)
+{
+    // After execute+delete, retransmit of the same step is all-unknown with step <= PlanStep;
+    // ack is still deferred until WRITE_TX (stale-leader fence).
+    const ui64 txId = 67890;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    WaitReadSet(*tablet, {.Step=100, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                          .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=txId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+    WaitForTheTransactionToBeDeleted(txId);
+
+    // Drain PlanStep ack/accepted from the known-tx path (sent at EXECUTED).
+    WaitPlanStepAck({.Step=100, .TxIds={txId}});
+    WaitPlanStepAccepted({.Step=100});
+
+    TVector<TAutoPtr<IEventHandle>> heldRequests;
+    bool holdWriteTx = true;
+    ui32 planStepAcceptedCount = 0;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (event->GetTypeRewrite() == TEvTxProcessing::TEvPlanStepAccepted::EventType) {
+            ++planStepAcceptedCount;
+        }
+        if (holdWriteTx) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                    heldRequests.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    const ui32 acceptedBeforeRetransmit = planStepAcceptedCount;
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldRequests.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    UNIT_ASSERT_VALUES_EQUAL(planStepAcceptedCount, acceptedBeforeRetransmit);
+
+    holdWriteTx = false;
+    for (auto& held : heldRequests) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldRequests.clear();
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    WaitPlanStepAck({.Step=100, .TxIds={txId}});
+    WaitPlanStepAccepted({.Step=100});
+}
+
+Y_UNIT_TEST_F(Deferred_PlanStepAck_Multiple_Unknown_One_WriteTx, TPQTabletFixture)
+{
+    // Several all-unknown PlanSteps while WRITE_TX is held flush together after one cycle.
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    TVector<TAutoPtr<IEventHandle>> heldRequests;
+    bool holdWriteTx = true;
+    THashSet<ui64> acceptedSteps;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (auto* msg = event->CastAsLocal<TEvTxProcessing::TEvPlanStepAccepted>()) {
+            acceptedSteps.insert(msg->Record.GetStep());
+        }
+        if (holdWriteTx) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                    heldRequests.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    for (ui64 i = 0; i < 3; ++i) {
+        SendPlanStep({.Step=100 + i, .TxIds={424310 + i}});
+    }
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldRequests.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    UNIT_ASSERT(acceptedSteps.empty());
+
+    holdWriteTx = false;
+    for (auto& held : heldRequests) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldRequests.clear();
+
+    TDispatchOptions options;
+    options.CustomFinalCondition = [&]() {
+        return acceptedSteps.size() >= 3;
+    };
+    UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    for (ui64 i = 0; i < 3; ++i) {
+        UNIT_ASSERT(acceptedSteps.contains(100 + i));
+    }
+}
+
+Y_UNIT_TEST_F(Deferred_PlanStepAck_While_WriteTx_In_Progress, TPQTabletFixture)
+{
+    // Unknown PlanStep during an in-flight WRITE_TX is flushed after that cycle ends.
+    const ui64 txId = 67890;
+    const ui64 unknownTxId = 424320;
+    const ui64 mockTabletId = 22222;
+
+    CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+
+    TVector<TAutoPtr<IEventHandle>> heldResponses;
+    bool holdWriteTxResponse = true;
+    bool seenWriteTxRequest = false;
+    auto prev = Ctx->Runtime->SetObserverFunc([&](TAutoPtr<IEventHandle>& event) {
+        if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvRequest>()) {
+            if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                seenWriteTxRequest = true;
+            }
+        }
+        if (holdWriteTxResponse && seenWriteTxRequest) {
+            if (auto* msg = event->CastAsLocal<TEvKeyValue::TEvResponse>()) {
+                if (msg->Record.HasCookie() && msg->Record.GetCookie() == WRITE_TX_COOKIE) {
+                    heldResponses.push_back(event);
+                    return TTestActorRuntimeBase::EEventAction::DROP;
+                }
+            }
+        }
+        return TTestActorRuntimeBase::EEventAction::PROCESS;
+    });
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return seenWriteTxRequest;
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    SendPlanStep({.Step=200, .TxIds={unknownTxId}});
+
+    {
+        TDispatchOptions options;
+        options.CustomFinalCondition = [&]() {
+            return !heldResponses.empty();
+        };
+        UNIT_ASSERT(Ctx->Runtime->DispatchEvents(options));
+    }
+
+    WaitForNoPlanStepAccepted();
+
+    holdWriteTxResponse = false;
+    for (auto& held : heldResponses) {
+        Ctx->Runtime->Send(held.Release());
+    }
+    heldResponses.clear();
+    Ctx->Runtime->SetObserverFunc(prev);
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+    WaitPlanStepAck({.Step=200, .TxIds={unknownTxId}});
+    WaitPlanStepAccepted({.Step=200});
 }
 
 Y_UNIT_TEST_F(Kafka_Transaction_Supportive_Partitions_Should_Be_Deleted_After_Timeout, TPQTabletFixture)

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -2880,27 +2880,14 @@ Y_UNIT_TEST_F(Duplicate_ReadSetAck_From_Same_Recipient, TPQTabletFixture)
     sendReadSetAck(tabletB);
     sendReadSetAck(tabletB);
 
-    AssertTransactionInKV(txId);
-
-    // Without dedup, two acks from B satisfy HaveAllRecipientsReceive (2/2) even though C
-    // has not acked. DeleteTx is queued in memory; the next ProposeTransaction persists it.
-    SendProposeTransactionRequest({.TxId=txId + 1,
-                                  .Receivers={tabletB, tabletC},
-                                  .TxOps={
-                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
-                                  }});
-    WaitProposeTransactionResponse({.TxId=txId + 1,
-                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+    // Without dedup, two acks from B would satisfy HaveAllRecipientsReceive (2/2) even though C
+    // has not acked. DeleteTx must not run yet; give the write cycle a chance to flush if it were queued.
+    Ctx->Runtime->SimulateSleep(TDuration::MilliSeconds(300));
     AssertTransactionInKV(txId);
 
     sendReadSetAck(tabletC);
 
-    SendProposeTransactionRequest({.TxId=txId + 2,
-                                  .Receivers={tabletB, tabletC},
-                                  .TxOps={
-                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
-                                  }});
-
+    // Delete is persisted by a WRITE_TX cycle without a follow-up ProposeTransaction.
     WaitForTheTransactionToBeDeleted(txId);
 }
 
@@ -2954,15 +2941,8 @@ Y_UNIT_TEST_F(TEvReadSet_For_A_Non_Existent_Tablet, TPQTabletFixture)
 
     WaitProposeTransactionResponse({.TxId=txId, .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
 
-    // We will send a TEvProposeTransaction to delete the previous transaction
-    SendProposeTransactionRequest({.TxId=txId + 1,
-                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
-                                  .TxOps={
-                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
-                                  }});
-
     // Instead of TEvReadSetAck, the PQ tablet will receive TEvClientConnected with the Dead flag. The transaction
-    // will switch from the WAIT_RS_AKS state to the DELETING state.
+    // will switch from the WAIT_RS_ACKS state to the DELETING state and be deleted without a follow-up propose.
     WaitForTheTransactionToBeDeleted(txId);
 }
 
@@ -3005,6 +2985,216 @@ Y_UNIT_TEST_F(Limit_On_The_Number_Of_Transactons, TPQTabletFixture)
 
     UNIT_ASSERT_EQUAL(preparedCount, 1000);
     UNIT_ASSERT_EQUAL(overloadedCount, 2);
+}
+
+Y_UNIT_TEST_F(DeleteTx_Without_FollowUp_Propose_Complete, TPQTabletFixture)
+{
+    // A1-N1: non-Kafka COMPLETE tx is deleted from KV without a follow-up ProposeTransaction.
+    const ui64 txId = 67890;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    WaitReadSet(*tablet, {.Step=100, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                          .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=txId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+    WaitForTheTransactionToBeDeleted(txId);
+}
+
+Y_UNIT_TEST_F(DeleteTx_Without_FollowUp_Propose_Abort, TPQTabletFixture)
+{
+    // A1-N2: ABORTED tx is deleted from KV without a follow-up ProposeTransaction.
+    const ui64 txId = 67890;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    WaitReadSet(*tablet, {.Step=100, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                          .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=txId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_ABORT});
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::ABORTED});
+
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+    WaitForTheTransactionToBeDeleted(txId);
+}
+
+Y_UNIT_TEST_F(DeleteTx_Without_FollowUp_Propose_Frees_Slot_For_New_Propose, TPQTabletFixture)
+{
+    // A1-N3: completed txs leave DELETING without a propose; slots free so a new propose is PREPARED.
+    const ui64 mockTabletId = 22222;
+    const ui64 baseTxId = 67890;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    for (ui64 i = 0; i < 3; ++i) {
+        const ui64 txId = baseTxId + i;
+        const ui64 step = 100 + i;
+
+        SendProposeTransactionRequest({.TxId=txId,
+                                      .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                      .TxOps={
+                                      {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                      }});
+        WaitProposeTransactionResponse({.TxId=txId,
+                                       .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+        SendPlanStep({.Step=step, .TxIds={txId}});
+
+        WaitReadSet(*tablet, {.Step=step, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                              .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+        tablet->SendReadSet(*Ctx->Runtime, {.Step=step, .TxId=txId, .Target=Ctx->TabletId,
+                                            .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+        WaitProposeTransactionResponse({.TxId=txId,
+                                       .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+
+        tablet->ReadSetAck.Clear();
+        tablet->SendReadSetAck(*Ctx->Runtime, {.Step=step, .TxId=txId, .Source=Ctx->TabletId});
+        WaitForTheTransactionToBeDeleted(txId);
+    }
+
+    const ui64 nextTxId = baseTxId + 3;
+    SendProposeTransactionRequest({.TxId=nextTxId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=nextTxId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+}
+
+Y_UNIT_TEST_F(DeleteTx_Without_FollowUp_Propose_Batch, TPQTabletFixture)
+{
+    // A1-N4: several DeleteTxs flush without a follow-up ProposeTransaction.
+    const ui64 mockTabletId = 22222;
+    const ui64 baseTxId = 67890;
+    constexpr ui64 txCount = 3;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    for (ui64 i = 0; i < txCount; ++i) {
+        const ui64 txId = baseTxId + i;
+        const ui64 step = 100 + i;
+
+        SendProposeTransactionRequest({.TxId=txId,
+                                      .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                      .TxOps={
+                                      {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                      }});
+        WaitProposeTransactionResponse({.TxId=txId,
+                                       .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+        SendPlanStep({.Step=step, .TxIds={txId}});
+
+        WaitReadSet(*tablet, {.Step=step, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                              .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+        tablet->SendReadSet(*Ctx->Runtime, {.Step=step, .TxId=txId, .Target=Ctx->TabletId,
+                                            .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+        WaitProposeTransactionResponse({.TxId=txId,
+                                       .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+    }
+
+    for (ui64 i = 0; i < txCount; ++i) {
+        const ui64 txId = baseTxId + i;
+        const ui64 step = 100 + i;
+        tablet->ReadSetAck.Clear();
+        tablet->SendReadSetAck(*Ctx->Runtime, {.Step=step, .TxId=txId, .Source=Ctx->TabletId});
+    }
+
+    for (ui64 i = 0; i < txCount; ++i) {
+        WaitForTheTransactionToBeDeleted(baseTxId + i);
+    }
+}
+
+Y_UNIT_TEST_F(DeleteTx_Without_FollowUp_Propose_Kafka, TPQTabletFixture)
+{
+    // A1-N5: Kafka commit still deletes the tx without a follow-up ProposeTransaction.
+    NKafka::TProducerInstanceId producerInstanceId = {1, 0};
+    const ui64 txId = 67890;
+
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+    EnsurePipeExist();
+
+    TString ownerCookie = CreateSupportivePartitionForKafka(producerInstanceId);
+    SendKafkaTxnWriteRequest(producerInstanceId, ownerCookie);
+    CommitKafkaTransaction(producerInstanceId, txId);
+
+    WaitForTheTransactionToBeDeleted(txId);
+}
+
+Y_UNIT_TEST_F(DeleteTx_With_Concurrent_Propose, TPQTabletFixture)
+{
+    // A1-N6: DeleteTxs flush in the same WRITE_TX cycle as a new ProposeTransaction.
+    const ui64 txId = 67890;
+    const ui64 nextTxId = txId + 1;
+    const ui64 mockTabletId = 22222;
+
+    NHelpers::TPQTabletMock* tablet = CreatePQTabletMock(mockTabletId);
+    PQTabletPrepare({.partitions=1}, {}, *Ctx);
+
+    SendProposeTransactionRequest({.TxId=txId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    SendPlanStep({.Step=100, .TxIds={txId}});
+
+    WaitReadSet(*tablet, {.Step=100, .TxId=txId, .Source=Ctx->TabletId, .Target=mockTabletId,
+                          .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT, .Producer=Ctx->TabletId});
+    tablet->SendReadSet(*Ctx->Runtime, {.Step=100, .TxId=txId, .Target=Ctx->TabletId,
+                                        .Decision=NKikimrTx::TReadSetData::DECISION_COMMIT});
+
+    WaitProposeTransactionResponse({.TxId=txId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::COMPLETE});
+
+    tablet->SendReadSetAck(*Ctx->Runtime, {.Step=100, .TxId=txId, .Source=Ctx->TabletId});
+
+    SendProposeTransactionRequest({.TxId=nextTxId,
+                                  .Senders={mockTabletId}, .Receivers={mockTabletId},
+                                  .TxOps={
+                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
+                                  }});
+    WaitProposeTransactionResponse({.TxId=nextTxId,
+                                   .Status=NKikimrPQ::TEvProposeTransactionResult::PREPARED});
+
+    WaitForTheTransactionToBeDeleted(txId);
 }
 
 Y_UNIT_TEST_F(Kafka_Transaction_Supportive_Partitions_Should_Be_Deleted_After_Timeout, TPQTabletFixture)
@@ -3218,13 +3408,6 @@ Y_UNIT_TEST_F(Kafka_Transaction_Incoming_Before_Previous_TEvDeletePartitionDone_
                              deleteDoneEvent.Release(),
                              0, 0);
 
-    // We will send a TEvProposeTransaction to delete the previous transaction
-    SendProposeTransactionRequest({.TxId=txId + 1,
-                                  .Senders={Ctx->TabletId}, .Receivers={Ctx->TabletId},
-                                  .TxOps={
-                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
-                                  }});
-
     WaitForTheTransactionToBeDeleted(txId);
 
     // check that information about a transaction with this WriteId has been renewed on disk
@@ -3282,13 +3465,6 @@ Y_UNIT_TEST_F(Kafka_Transaction_Several_Partitions_One_Tablet_Deleting_State, TP
                              deleteDoneEvents[i].Release(),
                              0, i);
     }
-
-    // We will send a TEvProposeTransaction to delete the previous transaction
-    SendProposeTransactionRequest({.TxId=txId + 1,
-                                  .Senders={Ctx->TabletId}, .Receivers={Ctx->TabletId},
-                                  .TxOps={
-                                  {.Partition=0, .Consumer="user", .Begin=0, .End=0, .Path="/topic"},
-                                  }});
 
     WaitForTheTransactionToBeDeleted(txId);
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- After large multi-PQ txs, tablets without the tx could not ack unknown ReadSets without new proposes, leaving peers in WAIT_RS_ACKS.
- Finished txs stuck in DELETING could exhaust the in-fly limit and block new proposes.
- Flush deletes and deferred RS acks via WRITE_TX on their own; keep stale-leader protection for deferred acks.
- Regression UTs for both failure modes and for persist coalescing.

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
