### PR TITLE
Fix build with -DCXXFLAGS=-DMKQL_DISABLE_CODEGEN

### DIFF
--- a/yt/yql/providers/yt/comp_nodes/dq/dq_yt_reader_impl.h
+++ b/yt/yql/providers/yt/comp_nodes/dq/dq_yt_reader_impl.h
@@ -37,7 +37,7 @@ public:
         const TVector<ui32>& inputGroups,
         TType* itemType, const TVector<TString>& tableNames, TVector<std::pair<NYT::TRichYPath, NYT::TFormat>>&& tables,
         NKikimr::NMiniKQL::IStatsRegistry* jobStats, size_t inflight, size_t timeout, const TVector<ui64>& tableOffsets)
-        : TBaseComputation(ctx.Mutables, this, EValueRepresentation::Boxed, EValueRepresentation::Boxed)
+        : TBaseComputation(ctx.Mutables, this, EValueRepresentation::Boxed)
         , Width(AS_TYPE(TStructType, itemType)->GetMembersCount())
         , CodecCtx(ctx.Env, ctx.FunctionRegistry, &ctx.HolderFactory)
         , ClusterName(clusterName)


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fix build with -DCXXFLAGS=-DMKQL_DISABLE_CODEGEN

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

```
ya make -vvv  -r --target-platform=DEFAULT-LINUX-ARMV8A_CORTEX_A53 -DALLOCATOR=TCMALLOC_256K -DCXXFLAGS=-DMKQL_DISABLE_CODEGEN ydb/apps/ydbd
```

Error without fix:
```
In file included from .ya/build/build_root/5qvr/0001e6/yt/yql/providers/yt/comp_nodes/dq/llvm16/dq_yt_reader.cpp:3:
ydb/yt/yql/providers/yt/comp_nodes/dq/dq_yt_reader_impl.h:37:11: error: no matching constructor for initialization of 'TStatefulWideFlowCodegeneratorNode<TDqYtReadWrapperBase<TDqYtReadWrapperRPC, TParallelFileInputState>>' (aka 'TStatefulWideFlowComputationNode<NYql::NDqs::TDqYtReadWrapperBase<NYql::NDqs::TDqYtReadWrapperRPC, NYql::NDqs::TParallelFileInputState>, false>')
   37 |         : TBaseComputation(ctx.Mutables, this, EValueRepresentation::Boxed, EValueRepresentation::Boxed)
      |           ^                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ydb/yt/yql/providers/yt/comp_nodes/dq/dq_yt_rpc_reader.h:99:15: note: in instantiation of member function 'NYql::NDqs::TDqYtReadWrapperBase<NYql::NDqs::TDqYtReadWrapperRPC, NYql::NDqs::TParallelFileInputState>::TDqYtReadWrapperBase' requested here
   99 |             : TDqYtReadWrapperBase<TDqYtReadWrapperRPC, TParallelFileInputState>(ctx, clusterName, token,
      |               ^
ydb/yql/essentials/minikql/computation/mkql_computation_node_impl.h:665:5: note: candidate constructor not viable: requires 3 arguments, but 4 were provided
  665 |     TStatefulWideFlowComputationNode(TComputationMutables& mutables, const IComputationNode* source, EValueRepresentation stateKind)
      |     ^                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ydb/yql/essentials/minikql/computation/mkql_computation_node_impl.h:662:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 4 were provided
  662 | class TStatefulWideFlowComputationNode: public TWideFlowBaseComputationNode<TDerived>, protected TStatefulWideFlowComputationNodeBase
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ydb/yql/essentials/minikql/computation/mkql_computation_node_impl.h:662:7: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 4 were provided
  662 | class TStatefulWideFlowComputationNode: public TWideFlowBaseComputationNode<TDerived>, protected TStatefulWideFlowComputationNodeBase
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from .ya/build/build_root/5qvr/0001e6/yt/yql/providers/yt/comp_nodes/dq/llvm16/dq_yt_reader.cpp:3:
ydb/yt/yql/providers/yt/comp_nodes/dq/dq_yt_reader_impl.h:37:11: error: no matching constructor for initialization of 'TStatefulWideFlowCodegeneratorNode<TDqYtReadWrapperBase<TDqYtReadWrapperHttp, TFileInputState>>' (aka 'TStatefulWideFlowComputationNode<NYql::NDqs::TDqYtReadWrapperBase<NYql::NDqs::TDqYtReadWrapperHttp, NYql::TFileInputState>, false>')
   37 |         : TBaseComputation(ctx.Mutables, this, EValueRepresentation::Boxed, EValueRepresentation::Boxed)
      |           ^                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.ya/build/build_root/5qvr/0001e6/yt/yql/providers/yt/comp_nodes/dq/llvm16/dq_yt_reader.cpp:20:15: note: in instantiation of member function 'NYql::NDqs::TDqYtReadWrapperBase<NYql::NDqs::TDqYtReadWrapperHttp, NYql::TFileInputState>::TDqYtReadWrapperBase' requested here
   20 |             : TDqYtReadWrapperBase<TDqYtReadWrapperHttp, TFileInputState>(ctx, clusterName, token,
      |               ^
ydb/yql/essentials/minikql/computation/mkql_computation_node_impl.h:665:5: note: candidate constructor not viable: requires 3 arguments, but 4 were provided
  665 |     TStatefulWideFlowComputationNode(TComputationMutables& mutables, const IComputationNode* source, EValueRepresentation stateKind)
      |     ^                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ydb/yql/essentials/minikql/computation/mkql_computation_node_impl.h:662:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 4 were provided
  662 | class TStatefulWideFlowComputationNode: public TWideFlowBaseComputationNode<TDerived>, protected TStatefulWideFlowComputationNodeBase
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ydb/yql/essentials/minikql/computation/mkql_computation_node_impl.h:662:7: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 4 were provided
  662 | class TStatefulWideFlowComputationNode: public TWideFlowBaseComputationNode<TDerived>, protected TStatefulWideFlowComputationNodeBase
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
Failed

```