### PR TITLE
Fix file is corrupted & stream finished during encrypted restore

### DIFF
--- a/ydb/core/backup/common/encryption.cpp
+++ b/ydb/core/backup/common/encryption.cpp
@@ -823,6 +823,10 @@ public:
         }
     }
 
+    void ResumeStream() {
+        Finished = false;
+    }
+
     TEncryptionIV GetIV() const {
         return IV;
     }
@@ -883,6 +887,10 @@ TEncryptedFileDeserializer TEncryptedFileDeserializer::RestoreFromState(const TS
     TEncryptedFileDeserializer deserializer;
     deserializer.Impl->RestoreFromState(state);
     return deserializer;
+}
+
+void TEncryptedFileDeserializer::ResumeStream() {
+    Impl->ResumeStream();
 }
 
 std::pair<TBuffer, TEncryptionIV> TEncryptedFileDeserializer::DecryptFullFile(TEncryptionKey key, TBuffer data) {

--- a/ydb/core/backup/common/encryption.cpp
+++ b/ydb/core/backup/common/encryption.cpp
@@ -823,10 +823,6 @@ public:
         }
     }
 
-    void ResumeStream() {
-        Finished = false;
-    }
-
     TEncryptionIV GetIV() const {
         return IV;
     }
@@ -887,10 +883,6 @@ TEncryptedFileDeserializer TEncryptedFileDeserializer::RestoreFromState(const TS
     TEncryptedFileDeserializer deserializer;
     deserializer.Impl->RestoreFromState(state);
     return deserializer;
-}
-
-void TEncryptedFileDeserializer::ResumeStream() {
-    Impl->ResumeStream();
 }
 
 std::pair<TBuffer, TEncryptionIV> TEncryptedFileDeserializer::DecryptFullFile(TEncryptionKey key, TBuffer data) {

--- a/ydb/core/backup/common/encryption.h
+++ b/ydb/core/backup/common/encryption.h
@@ -231,6 +231,9 @@ public:
     // State includes secret key
     static TEncryptedFileDeserializer RestoreFromState(const TString& state);
 
+    // Prepares a state restored deserializer to accept input data again.
+    void ResumeStream();
+
     // Get file IV.
     // Must be called after data added enough for the file header.
     TEncryptionIV GetIV() const;

--- a/ydb/core/backup/common/encryption.h
+++ b/ydb/core/backup/common/encryption.h
@@ -231,9 +231,6 @@ public:
     // State includes secret key
     static TEncryptedFileDeserializer RestoreFromState(const TString& state);
 
-    // Prepares a state restored deserializer to accept input data again.
-    void ResumeStream();
-
     // Get file IV.
     // Must be called after data added enough for the file header.
     TEncryptionIV GetIV() const;

--- a/ydb/core/backup/common/encryption_ut.cpp
+++ b/ydb/core/backup/common/encryption_ut.cpp
@@ -310,6 +310,32 @@ Y_UNIT_TEST_SUITE(EncryptedFileSerializerTest) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(restored.AddData(TBuffer("data", 4), true), yexception, "Stream finished");
     }
 
+    Y_UNIT_TEST(ResumeStreamAfterRestoreFromState) {
+        TEncryptionIV iv = TEncryptionIV::Generate();
+        TEncryptedFileSerializer serializer("Chacha20-Poly1305", Key32, iv);
+        TBuffer firstPortion = serializer.AddBlock("Come crawling faster", false);
+        TBuffer lastPortion = serializer.AddBlock("Obey your master", true);
+
+        TEncryptedFileDeserializer deserializer(Key32);
+        deserializer.AddData(TBuffer(firstPortion.Data(), firstPortion.Size()), false);
+        {
+            TMaybe<TBuffer> block = deserializer.GetNextBlock();
+            UNIT_ASSERT(block);
+            UNIT_ASSERT_STRINGS_EQUAL(TStringBuf(block->Data(), block->Size()), "Come crawling faster");
+        }
+
+        // The tail arrives and is marked as the last one, but is not decrypted yet.
+        deserializer.AddData(TBuffer(lastPortion.Data(), lastPortion.Size()), true);
+        const TString state = deserializer.GetState();
+
+        TEncryptedFileDeserializer restored = TEncryptedFileDeserializer::RestoreFromState(state);
+        restored.ResumeStream();
+        restored.AddData(TBuffer(lastPortion.Data(), lastPortion.Size()), true);
+        TMaybe<TBuffer> block = restored.GetNextBlock();
+        UNIT_ASSERT(block);
+        UNIT_ASSERT_STRINGS_EQUAL(TStringBuf(block->Data(), block->Size()), "Obey your master");
+    }
+
     Y_UNIT_TEST(IVSerialization) {
         TEncryptionIV iv = TEncryptionIV::Generate();
         UNIT_ASSERT_STRINGS_EQUAL(TEncryptionIV::FromHexString(iv.GetHexString()).GetHexString(), iv.GetHexString());

--- a/ydb/core/backup/common/encryption_ut.cpp
+++ b/ydb/core/backup/common/encryption_ut.cpp
@@ -310,32 +310,6 @@ Y_UNIT_TEST_SUITE(EncryptedFileSerializerTest) {
         UNIT_ASSERT_EXCEPTION_CONTAINS(restored.AddData(TBuffer("data", 4), true), yexception, "Stream finished");
     }
 
-    Y_UNIT_TEST(ResumeStreamAfterRestoreFromState) {
-        TEncryptionIV iv = TEncryptionIV::Generate();
-        TEncryptedFileSerializer serializer("Chacha20-Poly1305", Key32, iv);
-        TBuffer firstPortion = serializer.AddBlock("Come crawling faster", false);
-        TBuffer lastPortion = serializer.AddBlock("Obey your master", true);
-
-        TEncryptedFileDeserializer deserializer(Key32);
-        deserializer.AddData(TBuffer(firstPortion.Data(), firstPortion.Size()), false);
-        {
-            TMaybe<TBuffer> block = deserializer.GetNextBlock();
-            UNIT_ASSERT(block);
-            UNIT_ASSERT_STRINGS_EQUAL(TStringBuf(block->Data(), block->Size()), "Come crawling faster");
-        }
-
-        // The tail arrives and is marked as the last one, but is not decrypted yet.
-        deserializer.AddData(TBuffer(lastPortion.Data(), lastPortion.Size()), true);
-        const TString state = deserializer.GetState();
-
-        TEncryptedFileDeserializer restored = TEncryptedFileDeserializer::RestoreFromState(state);
-        restored.ResumeStream();
-        restored.AddData(TBuffer(lastPortion.Data(), lastPortion.Size()), true);
-        TMaybe<TBuffer> block = restored.GetNextBlock();
-        UNIT_ASSERT(block);
-        UNIT_ASSERT_STRINGS_EQUAL(TStringBuf(block->Data(), block->Size()), "Obey your master");
-    }
-
     Y_UNIT_TEST(IVSerialization) {
         TEncryptionIV iv = TEncryptionIV::Generate();
         UNIT_ASSERT_STRINGS_EQUAL(TEncryptionIV::FromHexString(iv.GetHexString()).GetHexString(), iv.GetHexString());

--- a/ydb/core/tx/datashard/import_s3.cpp
+++ b/ydb/core/tx/datashard/import_s3.cpp
@@ -549,7 +549,6 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
             if (const TString& deserializerState = state.GetEncryptedDeserializerState()) {
                 try {
                     Deserializer = NBackup::TEncryptedFileDeserializer::RestoreFromState(deserializerState);
-                    Deserializer.ResumeStream();
                     ConfirmedDeserializerState = deserializerState;
                     FeedUnprocessedBytes = 0;
                     ReadyInputBytes = 0;

--- a/ydb/core/tx/datashard/import_s3.cpp
+++ b/ydb/core/tx/datashard/import_s3.cpp
@@ -450,9 +450,9 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
                 NewData = true;
             }
             Last = last;
-            FeedUnprocessedBytes += portion.size();
             try {
                 Deserializer.AddData(TBuffer(portion.data(), portion.size()), last);
+                FeedUnprocessedBytes += portion.size();
             } catch (const std::exception& ex) {
                 FeedError = ex.what();
             }

--- a/ydb/core/tx/datashard/import_s3.cpp
+++ b/ydb/core/tx/datashard/import_s3.cpp
@@ -443,15 +443,26 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
         }
 
         void Feed(TString&& portion, bool last) override {
+            if (FeedError) {
+                return;
+            }
             if (!portion.empty() || last) {
                 NewData = true;
             }
             Last = last;
             FeedUnprocessedBytes += portion.size();
-            Deserializer.AddData(TBuffer(portion.data(), portion.size()), last);
+            try {
+                Deserializer.AddData(TBuffer(portion.data(), portion.size()), last);
+            } catch (const std::exception& ex) {
+                FeedError = ex.what();
+            }
         }
 
         IReadController::EDataStatus TryGetData(TStringBuf& data, TString& error) override {
+            if (FeedError) {
+                error = *FeedError;
+                return IReadController::ERROR;
+            }
             if (BytesFedToChild) {
                 auto status = TryGetDataFromChildController(data, error);
                 if (status != IReadController::NOT_ENOUGH_DATA || !NewData) {
@@ -506,10 +517,13 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
         }
 
         void Confirm(NKikimrBackup::TS3DownloadState& state) override {
-            state.SetEncryptedDeserializerState(Deserializer.GetState());
             if (ui64 readyBytes = ReadyBytes()) {
+                ConfirmedDeserializerState = Deserializer.GetState();
                 FeedUnprocessedBytes -= readyBytes;
                 ReadyInputBytes = 0;
+            }
+            if (ConfirmedDeserializerState) {
+                state.SetEncryptedDeserializerState(ConfirmedDeserializerState);
             }
             DataController->Confirm(state);
         }
@@ -535,8 +549,14 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
             if (const TString& deserializerState = state.GetEncryptedDeserializerState()) {
                 try {
                     Deserializer = NBackup::TEncryptedFileDeserializer::RestoreFromState(deserializerState);
+                    Deserializer.ResumeStream();
+                    ConfirmedDeserializerState = deserializerState;
                     FeedUnprocessedBytes = 0;
                     ReadyInputBytes = 0;
+                    BytesFedToChild = 0;
+                    NewData = false;
+                    Last = false;
+                    FeedError.Clear();
                 } catch (const std::exception& ex) {
                     error = ex.what();
                     return false;
@@ -551,6 +571,8 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
         ui64 ReadyInputBytes = 0;
         bool NewData = false;
         ui64 BytesFedToChild = 0;
+        TString ConfirmedDeserializerState;
+        TMaybe<TString> FeedError;
         NBackup::TEncryptedFileDeserializer Deserializer;
         THolder<IReadController> DataController;
         const ui64 ReadBatchSize;

--- a/ydb/core/tx/datashard/import_s3.cpp
+++ b/ydb/core/tx/datashard/import_s3.cpp
@@ -437,6 +437,7 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
                 THolder<IReadController> deserializedDataController,
                 ui64 readBatchSize)
             : Deserializer(std::move(key), std::move(expectedIV))
+            , ConfirmedDeserializerState(Deserializer.GetState())
             , DataController(std::move(deserializedDataController))
             , ReadBatchSize(readBatchSize)
         {
@@ -522,9 +523,7 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
                 FeedUnprocessedBytes -= readyBytes;
                 ReadyInputBytes = 0;
             }
-            if (ConfirmedDeserializerState) {
-                state.SetEncryptedDeserializerState(ConfirmedDeserializerState);
-            }
+            state.SetEncryptedDeserializerState(ConfirmedDeserializerState);
             DataController->Confirm(state);
         }
 
@@ -570,9 +569,9 @@ class TS3Downloader: public TActorBootstrapped<TS3Downloader<TSettings>> {
         ui64 ReadyInputBytes = 0;
         bool NewData = false;
         ui64 BytesFedToChild = 0;
-        TString ConfirmedDeserializerState;
         TMaybe<TString> FeedError;
         NBackup::TEncryptedFileDeserializer Deserializer;
+        TString ConfirmedDeserializerState;
         THolder<IReadController> DataController;
         const ui64 ReadBatchSize;
     };

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -3048,7 +3048,7 @@ value {
     // - downloaded blocks size
     // - decrypted blocks size
     // - compression blocks size
-    void ImportBigEncryptedFile(size_t encryptedBlockSize, size_t resultFileSize, size_t readBatchSize, bool compressed, bool enableDataShardDirectPartImport) {
+    void ImportBigEncryptedFile(size_t encryptedBlockSize, size_t resultFileSize, size_t readBatchSize, bool compressed, bool enableDataShardDirectPartImport, bool rebootAfterLastPortion = false) {
         TString key = "Cool very very secret rand key!!";
         NBackup::TEncryptionIV iv = NBackup::TEncryptionIV::Generate();
 
@@ -3081,6 +3081,24 @@ value {
         const auto desc = DescribePath(runtime, "/MyRoot/TestTable", true, true);
         UNIT_ASSERT_VALUES_EQUAL(desc.GetStatus(), NKikimrScheme::StatusSuccess);
 
+        bool wholeFileRead = false;
+        bool readyToReboot = false;
+        if (rebootAfterLastPortion) {
+            runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+                switch (ev->GetTypeRewrite()) {
+                case NWrappers::NExternalStorage::EvGetObjectResponse:
+                    if (ev->Get<NWrappers::NExternalStorage::TEvGetObjectResponse>()->Body.size() < readBatchSize) {
+                        wholeFileRead = true;
+                    }
+                    break;
+                case TEvDataShard::EvS3UploadRowsResponse:
+                    readyToReboot = wholeFileRead;
+                    break;
+                }
+                return TTestActorRuntime::EEventAction::PROCESS;
+            });
+        }
+
         NKikimrScheme::EStatus status = (NKikimrScheme::EStatus)TestRestore(runtime, ++txId, "/MyRoot", Sprintf(R"(
             TableName: "TestTable"
             TableDescription {
@@ -3104,10 +3122,29 @@ value {
             }
         )", GenerateTableDescription(desc).data(), s3Port, readBatchSize, PrintInProtoText(iv).c_str(), key.c_str()));
         UNIT_ASSERT_EQUAL(status, NKikimrScheme::StatusAccepted);
+
+        if (rebootAfterLastPortion) {
+            if (!readyToReboot) {
+                TDispatchOptions opts;
+                opts.FinalEvents.emplace_back([&readyToReboot](IEventHandle&) -> bool {
+                    return readyToReboot;
+                });
+                runtime.DispatchEvents(opts);
+            }
+            UNIT_ASSERT(readyToReboot);
+            runtime.SetObserverFunc(&TTestActorRuntime::DefaultObserverFunc);
+            RebootTablet(runtime, TTestTxConfig::FakeHiveTablets, runtime.AllocateEdgeActor());
+        }
+
         env.TestWaitNotification(runtime, txId);
 
         const ui64 rows = CountRows(runtime, "/MyRoot/TestTable");
         UNIT_ASSERT_VALUES_EQUAL(rows, lines);
+    }
+
+    Y_UNIT_TEST(ImportBigEncryptedFileWithRebootAfterLastPortion) {
+        ImportBigEncryptedFile(315_B, 10_KB, 8_KB, false, false, true);
+        ImportBigEncryptedFile(555_B, 10_KB, 8_KB, true, false, true);
     }
 
     Y_UNIT_TEST_FLAG(ImportBigEncryptedFile, EnableDataShardDirectPartImport) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -3044,11 +3044,24 @@ value {
         return result;
     }
 
+    enum class EEncryptedImportRebootMode {
+        None,
+        AfterLastPortion,
+        AfterReadAndAfterStateSave,
+    };
+
     // Test that checks different combinations of:
     // - downloaded blocks size
     // - decrypted blocks size
     // - compression blocks size
-    void ImportBigEncryptedFile(size_t encryptedBlockSize, size_t resultFileSize, size_t readBatchSize, bool compressed, bool enableDataShardDirectPartImport, bool rebootAfterLastPortion = false) {
+    void ImportBigEncryptedFile(
+            size_t encryptedBlockSize,
+            size_t resultFileSize,
+            size_t readBatchSize,
+            bool compressed,
+            bool enableDataShardDirectPartImport,
+            EEncryptedImportRebootMode rebootMode = EEncryptedImportRebootMode::None)
+    {
         TString key = "Cool very very secret rand key!!";
         NBackup::TEncryptionIV iv = NBackup::TEncryptionIV::Generate();
 
@@ -3084,18 +3097,30 @@ value {
 
         bool wholeFileRead = false;
         bool readyToReboot = false;
-        if (rebootAfterLastPortion) {
+        ui32 rebootCount = 0;
+
+        if (rebootMode != EEncryptedImportRebootMode::None) {
             runtime.SetObserverFunc([&, contentLength](TAutoPtr<IEventHandle>& ev) {
+                if (readyToReboot) {
+                    return TTestActorRuntime::EEventAction::PROCESS;
+                }
+                const bool afterRead = rebootCount % 2 == 0;
                 switch (ev->GetTypeRewrite()) {
                 case NWrappers::NExternalStorage::EvGetObjectResponse: {
                     const auto& interval = ev->Get<NWrappers::NExternalStorage::TEvGetObjectResponse>()->GetReadInterval();
-                    if (interval.second + 1 == contentLength) {
-                        wholeFileRead = true;
+                    if (rebootMode == EEncryptedImportRebootMode::AfterLastPortion) {
+                        wholeFileRead |= interval.second + 1 == contentLength;
+                    } else if (afterRead) {
+                        readyToReboot = true;
                     }
                     break;
                 }
                 case TEvDataShard::EvS3UploadRowsResponse:
-                    readyToReboot = wholeFileRead;
+                    if (rebootMode == EEncryptedImportRebootMode::AfterLastPortion) {
+                        readyToReboot = wholeFileRead;
+                    } else if (!afterRead) {
+                        readyToReboot = true;
+                    }
                     break;
                 }
                 return TTestActorRuntime::EEventAction::PROCESS;
@@ -3126,7 +3151,7 @@ value {
         )", GenerateTableDescription(desc).data(), s3Port, readBatchSize, PrintInProtoText(iv).c_str(), key.c_str()));
         UNIT_ASSERT_EQUAL(status, NKikimrScheme::StatusAccepted);
 
-        if (rebootAfterLastPortion) {
+        auto waitReadyToReboot = [&]() {
             if (!readyToReboot) {
                 TDispatchOptions opts;
                 opts.FinalEvents.emplace_back([&readyToReboot](IEventHandle&) -> bool {
@@ -3135,8 +3160,21 @@ value {
                 runtime.DispatchEvents(opts);
             }
             UNIT_ASSERT(readyToReboot);
+        };
+
+        if (rebootMode == EEncryptedImportRebootMode::AfterLastPortion) {
+            waitReadyToReboot();
             runtime.SetObserverFunc(&TTestActorRuntime::DefaultObserverFunc);
             RebootTablet(runtime, TTestTxConfig::FakeHiveTablets, runtime.AllocateEdgeActor());
+        } else if (rebootMode == EEncryptedImportRebootMode::AfterReadAndAfterStateSave) {
+            constexpr ui32 rebootsCount = 4;
+            for (ui32 i = 0; i < rebootsCount; ++i) {
+                waitReadyToReboot();
+                RebootTablet(runtime, TTestTxConfig::FakeHiveTablets, runtime.AllocateEdgeActor());
+                ++rebootCount;
+                readyToReboot = false;
+            }
+            runtime.SetObserverFunc(&TTestActorRuntime::DefaultObserverFunc);
         }
 
         env.TestWaitNotification(runtime, txId);
@@ -3146,8 +3184,13 @@ value {
     }
 
     Y_UNIT_TEST(ImportBigEncryptedFileWithRebootAfterLastPortion) {
-        ImportBigEncryptedFile(315_B, 10_KB, 8_KB, false, false, true);
-        ImportBigEncryptedFile(555_B, 10_KB, 8_KB, true, false, true);
+        ImportBigEncryptedFile(315_B, 10_KB, 8_KB, false, false, EEncryptedImportRebootMode::AfterLastPortion);
+        ImportBigEncryptedFile(555_B, 10_KB, 8_KB, true, false, EEncryptedImportRebootMode::AfterLastPortion);
+    }
+
+    Y_UNIT_TEST(ImportBigEncryptedFileWithRebootsAfterReadAndStateSave) {
+        ImportBigEncryptedFile(315_B, 10_KB, 8_KB, false, false, EEncryptedImportRebootMode::AfterReadAndAfterStateSave);
+        ImportBigEncryptedFile(555_B, 10_KB, 8_KB, true, false, EEncryptedImportRebootMode::AfterReadAndAfterStateSave);
     }
 
     Y_UNIT_TEST_FLAG(ImportBigEncryptedFile, EnableDataShardDirectPartImport) {

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -2936,7 +2936,7 @@ value {
         NKqp::CompareYson(data.YsonStr, content);
     }
 
-    size_t MakeBigEncryptedExport(TS3Mock& s3Mock, const TString& key, const NBackup::TEncryptionIV& iv, size_t encryptedBlockSize, size_t resultFileSize, bool compressed) {
+    std::pair<size_t, size_t> MakeBigEncryptedExport(TS3Mock& s3Mock, const TString& key, const NBackup::TEncryptionIV& iv, size_t encryptedBlockSize, size_t resultFileSize, bool compressed) {
         const TStringBuf exportPrefix = "/test_bucket/Export123/";
         NBackup::TEncryptionKey encryptionKey(key);
 
@@ -3029,7 +3029,7 @@ value {
             UNIT_ASSERT_VALUES_EQUAL(decodedLines, line);
         }
         UNIT_ASSERT(line > 0);
-        return line;
+        return {line, resultEncryptedData.size()};
     }
 
     TString PrintInProtoText(const NBackup::TEncryptionIV& iv) {
@@ -3058,7 +3058,8 @@ value {
         TS3Mock s3Mock(s3Settings);
         s3Mock.Start();
 
-        const size_t lines = MakeBigEncryptedExport(s3Mock, key, iv, encryptedBlockSize, resultFileSize, compressed);
+        const auto [lines, contentLength] = MakeBigEncryptedExport(s3Mock, key, iv, encryptedBlockSize, resultFileSize, compressed);
+        UNIT_ASSERT_GT(contentLength, 0);
 
         TTestBasicRuntime runtime;
         TTestEnv env(runtime, TTestEnvOptions().EnableChecksumsExport(false));
@@ -3084,13 +3085,15 @@ value {
         bool wholeFileRead = false;
         bool readyToReboot = false;
         if (rebootAfterLastPortion) {
-            runtime.SetObserverFunc([&](TAutoPtr<IEventHandle>& ev) {
+            runtime.SetObserverFunc([&, contentLength](TAutoPtr<IEventHandle>& ev) {
                 switch (ev->GetTypeRewrite()) {
-                case NWrappers::NExternalStorage::EvGetObjectResponse:
-                    if (ev->Get<NWrappers::NExternalStorage::TEvGetObjectResponse>()->Body.size() < readBatchSize) {
+                case NWrappers::NExternalStorage::EvGetObjectResponse: {
+                    const auto& interval = ev->Get<NWrappers::NExternalStorage::TEvGetObjectResponse>()->GetReadInterval();
+                    if (interval.second + 1 == contentLength) {
                         wholeFileRead = true;
                     }
                     break;
+                }
                 case TEvDataShard::EvS3UploadRowsResponse:
                     readyToReboot = wholeFileRead;
                     break;

--- a/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
+++ b/ydb/core/tx/schemeshard/ut_restore/ut_restore.cpp
@@ -3157,24 +3157,30 @@ value {
                 opts.FinalEvents.emplace_back([&readyToReboot](IEventHandle&) -> bool {
                     return readyToReboot;
                 });
-                runtime.DispatchEvents(opts);
+                runtime.DispatchEvents(opts, TDuration::Seconds(10));
             }
-            UNIT_ASSERT(readyToReboot);
+            return readyToReboot;
         };
 
         if (rebootMode == EEncryptedImportRebootMode::AfterLastPortion) {
-            waitReadyToReboot();
+            UNIT_ASSERT(waitReadyToReboot());
             runtime.SetObserverFunc(&TTestActorRuntime::DefaultObserverFunc);
             RebootTablet(runtime, TTestTxConfig::FakeHiveTablets, runtime.AllocateEdgeActor());
         } else if (rebootMode == EEncryptedImportRebootMode::AfterReadAndAfterStateSave) {
             constexpr ui32 rebootsCount = 4;
+            ui32 rebootsDone = 0;
             for (ui32 i = 0; i < rebootsCount; ++i) {
-                waitReadyToReboot();
-                RebootTablet(runtime, TTestTxConfig::FakeHiveTablets, runtime.AllocateEdgeActor());
-                ++rebootCount;
+                if (!waitReadyToReboot()) {
+                    break;
+                }
                 readyToReboot = false;
+                ++rebootCount;
+                RebootTablet(runtime, TTestTxConfig::FakeHiveTablets, runtime.AllocateEdgeActor());
+                ++rebootsDone;
             }
             runtime.SetObserverFunc(&TTestActorRuntime::DefaultObserverFunc);
+            Cerr << "Reboots done: " << rebootsDone << Endl;
+            UNIT_ASSERT_GE(rebootsDone, 0);
         }
 
         env.TestWaitNotification(runtime, txId);
@@ -3189,8 +3195,8 @@ value {
     }
 
     Y_UNIT_TEST(ImportBigEncryptedFileWithRebootsAfterReadAndStateSave) {
-        ImportBigEncryptedFile(315_B, 10_KB, 8_KB, false, false, EEncryptedImportRebootMode::AfterReadAndAfterStateSave);
-        ImportBigEncryptedFile(555_B, 10_KB, 8_KB, true, false, EEncryptedImportRebootMode::AfterReadAndAfterStateSave);
+        ImportBigEncryptedFile(315_B, 70_KB, 8_KB, false, false, EEncryptedImportRebootMode::AfterReadAndAfterStateSave);
+        ImportBigEncryptedFile(555_B, 70_KB, 8_KB, true, false, EEncryptedImportRebootMode::AfterReadAndAfterStateSave);
     }
 
     Y_UNIT_TEST_FLAG(ImportBigEncryptedFile, EnableDataShardDirectPartImport) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Исправления в восстановлении из шифрованных бэкапов

### Changelog category <!-- remove all except one -->

* Bugfix 

### Description for reviewers <!-- (optional) description for those who read this PR -->

Исправление проблем в импорте шифрованных бэкапов:
- падение нод из-за не перехваченного исключения  (`Stream finished`): [KIKIMR-26574](st/KIKIMR-26574);
- File is corrupted: [KIKIMR-26574](st/KIKIMR-26574).