### PR TITLE
[NBS-7153] ddisk sessions: subscribe on IC session only for connect request

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -1510,7 +1510,7 @@ void TDirectBlockGroup::DoEstablishConnection(
     if (connectionType == EConnectionType::DDisk) {
         actualSeqNo++;
 
-        LOG_INFO(
+        LOG_WARN(
             *ActorSystem,
             NKikimrServices::NBS_PARTITION,
             "%s %s starting session: new seq_no: %lu",
@@ -1581,7 +1581,7 @@ void TDirectBlockGroup::OnConnectionEstablished(
 
     LOG_LOG(
         *ActorSystem,
-        HasError(error) ? NActors::NLog::PRI_WARN : NActors::NLog::PRI_TRACE,
+        HasError(error) ? NActors::NLog::PRI_WARN : NActors::NLog::PRI_NOTICE,
         NKikimrServices::NBS_PARTITION,
         "%s OnConnectionEstablished: %s %s",
         LogTitle.GetWithTime().c_str(),

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.cpp
@@ -1510,7 +1510,7 @@ void TDirectBlockGroup::DoEstablishConnection(
     if (connectionType == EConnectionType::DDisk) {
         actualSeqNo++;
 
-        LOG_WARN(
+        LOG_INFO(
             *ActorSystem,
             NKikimrServices::NBS_PARTITION,
             "%s %s starting session: new seq_no: %lu",
@@ -1555,7 +1555,7 @@ void TDirectBlockGroup::DoEstablishConnection(
                 () mutable
                 {
                     if (auto self = weakSelf.lock()) {
-                        self->OnConnectionEstablished(
+                        self->OnConnectResponse(
                             connectionType,
                             hostIndex,
                             actualSeqNo,
@@ -1565,7 +1565,7 @@ void TDirectBlockGroup::DoEstablishConnection(
         });
 }
 
-void TDirectBlockGroup::OnConnectionEstablished(
+void TDirectBlockGroup::OnConnectResponse(
     EConnectionType connectionType,
     THostIndex hostIndex,
     ui64 seqNo,
@@ -1581,9 +1581,9 @@ void TDirectBlockGroup::OnConnectionEstablished(
 
     LOG_LOG(
         *ActorSystem,
-        HasError(error) ? NActors::NLog::PRI_WARN : NActors::NLog::PRI_NOTICE,
+        HasError(error) ? NActors::NLog::PRI_WARN : NActors::NLog::PRI_INFO,
         NKikimrServices::NBS_PARTITION,
-        "%s OnConnectionEstablished: %s %s",
+        "%s OnConnectResponse: %s %s",
         LogTitle.GetWithTime().c_str(),
         PrintHostAndNode(hostIndex).c_str(),
         FormatError(error).Quote().c_str());

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl.h
@@ -195,7 +195,7 @@ private:
     void DoEstablishConnection(
         THostIndex hostIndex,
         EConnectionType connectionType);
-    void OnConnectionEstablished(
+    void OnConnectResponse(
         EConnectionType connectionType,
         THostIndex hostIndex,
         ui64 seqNo,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/direct_block_group_impl_ut.cpp
@@ -1015,7 +1015,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             1,
             NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR));
 
-        // Drain OnConnectionEstablished (queues the reconnect) then the
+        // Drain OnConnectResponse (queues the reconnect) then the
         // reconnect itself (issues a fresh Connect).
         DrainExecutor(executor);
         DrainExecutor(executor);
@@ -1084,7 +1084,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
             1,
             NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR));
 
-        // Drain OnConnectionEstablished (queues the reconnect) then the
+        // Drain OnConnectResponse (queues the reconnect) then the
         // reconnect itself (issues a fresh Connect).
         DrainExecutor(executor);
         DrainExecutor(executor);
@@ -1147,7 +1147,7 @@ Y_UNIT_TEST_SUITE(TDirectBlockGroupTest)
                 1,
                 NKikimrBlobStorage::NDDisk::TReplyStatus::ERROR));
         }
-        // Drain OnConnectionEstablished + queued reconnects, then the
+        // Drain OnConnectResponse + queued reconnects, then the
         // reconnects.
         DrainExecutor(executor);
         DrainExecutor(executor);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/ic_storage_transport_actor.cpp
@@ -210,7 +210,8 @@ void TICStorageTransportActor::HandleConnect(
         request.ServiceId,
         std::make_unique<NDDisk::TEvConnect>(request.Credentials),
         requestId,
-        NWilson::TTraceId());
+        NWilson::TTraceId(),
+        ESubscribeOnSession::Yes);
 }
 
 void TICStorageTransportActor::HandleConnectUndelivery(
@@ -234,7 +235,7 @@ void TICStorageTransportActor::HandleConnectUndelivery(
         ConnectRequests.erase(requestId);
     } else {
         // That means that request is already completed
-        LOG_ERROR(
+        LOG_WARN(
             ctx,
             NKikimrServices::NBS_PARTITION,
             "%s ConnectEvent with requestId# %lu not found",
@@ -265,7 +266,7 @@ void TICStorageTransportActor::HandleConnectResult(
         ConnectRequests.erase(requestId);
     } else {
         // That means that request is already completed
-        LOG_ERROR(
+        LOG_WARN(
             ctx,
             NKikimrServices::NBS_PARTITION,
             "%s ConnectEvent with requestId# %lu not found",
@@ -313,7 +314,8 @@ void TICStorageTransportActor::HandleWritePersistentBuffer(
             msg->ServiceId,
             std::move(request),
             requestId,
-            std::move(msg->TraceId));
+            std::move(msg->TraceId),
+            ESubscribeOnSession::No);
 
         return;
     }
@@ -454,7 +456,8 @@ void TICStorageTransportActor::HandleWriteToManyPersistentBuffers(
             msg->ServiceId,
             std::move(request),
             requestId,
-            std::move(msg->TraceId));
+            std::move(msg->TraceId),
+            ESubscribeOnSession::No);
         return;
     }
 
@@ -591,7 +594,8 @@ void TICStorageTransportActor::HandleWriteToDDisk(
             msg->ServiceId,
             std::move(request),
             requestId,
-            std::move(msg->TraceId));
+            std::move(msg->TraceId),
+            ESubscribeOnSession::No);
         return;
     }
 
@@ -738,7 +742,8 @@ void TICStorageTransportActor::HandleBarrierErasePersistentBuffer(
         msg->ServiceId,
         std::move(request),
         requestId,
-        std::move(msg->TraceId));
+        std::move(msg->TraceId),
+        ESubscribeOnSession::No);
 }
 
 void TICStorageTransportActor::HandleBatchErasePersistentBufferUndelivery(
@@ -870,7 +875,8 @@ void TICStorageTransportActor::HandleReadPersistentBuffer(
         msg->ServiceId,
         std::move(request),
         requestId,
-        std::move(msg->TraceId));
+        std::move(msg->TraceId),
+        ESubscribeOnSession::No);
 }
 
 void TICStorageTransportActor::HandleReadPersistentBufferUndelivery(
@@ -978,7 +984,8 @@ void TICStorageTransportActor::HandleRead(
         msg->ServiceId,
         std::move(request),
         requestId,
-        std::move(msg->TraceId));
+        std::move(msg->TraceId),
+        ESubscribeOnSession::No);
 }
 
 void TICStorageTransportActor::HandleReadUndelivery(
@@ -1100,7 +1107,8 @@ void TICStorageTransportActor::HandleSyncWithPersistentBuffer(
         msg->ServiceId,
         std::move(request),
         requestId,
-        std::move(msg->TraceId));
+        std::move(msg->TraceId),
+        ESubscribeOnSession::No);
 }
 
 void TICStorageTransportActor::HandleSyncWithPersistentBufferUndelivery(
@@ -1179,7 +1187,8 @@ void TICStorageTransportActor::HandleListPersistentBuffer(
         msg->ServiceId,
         std::move(request),
         requestId,
-        NWilson::TTraceId());
+        NWilson::TTraceId(),
+        ESubscribeOnSession::No);
 }
 
 void TICStorageTransportActor::HandleListPersistentBufferUndelivery(

--- a/ydb/core/nbs/cloud/storage/core/libs/actors/helpers.h
+++ b/ydb/core/nbs/cloud/storage/core/libs/actors/helpers.h
@@ -71,15 +71,24 @@ inline void Send(
         cookie);
 }
 
+enum class ESubscribeOnSession
+{
+    No,
+    Yes,
+};
+
 inline void SendWithUndeliveryTracking(
     const NActors::TActorContext& ctx,
     const NActors::TActorId& recipient,
     NActors::IEventBasePtr event,
     ui64 cookie,
-    NWilson::TTraceId traceId)
+    NWilson::TTraceId traceId,
+    ESubscribeOnSession subscribeOnSession)
 {
-    int flags = NActors::IEventHandle::FlagForwardOnNondelivery |
-                NActors::IEventHandle::FlagSubscribeOnSession;
+    ui32 flags = NActors::IEventHandle::FlagForwardOnNondelivery;
+    if (subscribeOnSession == ESubscribeOnSession::Yes) {
+        flags |= NActors::IEventHandle::FlagSubscribeOnSession;
+    }
     auto ev = std::make_unique<NActors::IEventHandle>(
         recipient,
         ctx.SelfID,


### PR DESCRIPTION

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->
NBS2: subscribe on IC session only for connect request

### Description for reviewers <!-- (optional) description for those who read this PR -->
Подписываемся на разыв IC сессий только для Connect запросов. 
Ранее подписка была на каждый запрос, что избыточно. В частности, при походах в пбуффер (взаимодействие с которым ведется без установленных ddisk сессий) и недоступности хоста мы получали node disconnected, что приводило к повторной логике обработки потери соединения.
