### PR TITLE
[WIP] Add Topic write-tx injection tests under tablet reboots and pipe resets

### DIFF
--- a/ydb/core/persqueue/ut/injection/distributed_three_pq_tx_ut.cpp
+++ b/ydb/core/persqueue/ut/injection/distributed_three_pq_tx_ut.cpp
@@ -20,6 +20,7 @@ namespace {
 
 // Edge waits under injection: keep short so a dead dispatch fails into retry quickly.
 constexpr TDuration kDistThreePqEdgeTimeout = TDuration::Seconds(1);
+constexpr ui32 kDistThreePqMsgCount = 2;
 
 class TDistThreePqRetry : public yexception {
 };
@@ -31,6 +32,7 @@ struct TThreeRealPqEnv {
     TActorId Edge;
     TVector<ui64> TabletIds;
     THashMap<ui64, TActorId> Pipes;
+    THashMap<ui64, ui32> MsgSeqNo;
 
     TThreeRealPqEnv() {
         // Keep id=2 free (balancer id in TTestContext); use 1/3/4 for real PQ tablets.
@@ -66,6 +68,7 @@ struct TThreeRealPqEnv {
     {
         activeZone = false;
         ResetAllPipes();
+        MsgSeqNo.clear();
         Runtime.Reset(new TTestBasicRuntime());
         Runtime->SetScheduledLimit(5'000);
         TTestContext::SetupLogging(*Runtime, /*enableDetailedPQLog=*/false);
@@ -98,6 +101,7 @@ struct TThreeRealPqEnv {
                 *Runtime,
                 tabletId,
                 Edge);
+            MsgSeqNo[tabletId] = 0;
         }
     }
 
@@ -178,15 +182,77 @@ struct TThreeRealPqEnv {
         }
         ythrow TDistThreePqRetry() << "tablets not ready after reboot";
     }
+
+    ui64 GetEndOffset(ui64 tabletId) {
+        for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+            try {
+                Runtime->ResetScheduledCount();
+                ResetPipe(tabletId);
+                auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
+                SendToTablet(tabletId, request.Release());
+                auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(
+                    kDistThreePqEdgeTimeout);
+                if (!result || result->Record.PartResultSize() == 0) {
+                    continue;
+                }
+                if (result->Record.GetPartResult(0).GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                    Runtime->DispatchEvents();
+                    retriesLeft = 5;
+                    continue;
+                }
+                return result->Record.GetPartResult(0).GetEndOffset();
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+            } catch (const NActors::TEmptyEventQueueException&) {
+            }
+        }
+        ythrow TDistThreePqRetry() << "GetEndOffset failed for tablet " << tabletId;
+    }
+
+    i64 GetClientOffset(ui64 tabletId, const TString& user) {
+        for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+            try {
+                Runtime->ResetScheduledCount();
+                ResetPipe(tabletId);
+                auto request = MakeHolder<TEvPersQueue::TEvRequest>();
+                auto* req = request->Record.MutablePartitionRequest();
+                req->SetPartition(0);
+                req->MutableCmdGetClientOffset()->SetClientId(user);
+                SendToTablet(tabletId, request.Release());
+                auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(kDistThreePqEdgeTimeout);
+                if (!result) {
+                    continue;
+                }
+                if (result->Record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                    Runtime->DispatchEvents();
+                    retriesLeft = 5;
+                    continue;
+                }
+                UNIT_ASSERT_VALUES_EQUAL(
+                    (int)result->Record.GetErrorCode(), (int)NPersQueue::NErrorCode::OK);
+                UNIT_ASSERT(result->Record.GetPartitionResponse().HasCmdGetClientOffsetResult());
+                return result->Record.GetPartitionResponse().GetCmdGetClientOffsetResult().GetOffset();
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+            } catch (const NActors::TEmptyEventQueueException&) {
+            }
+        }
+        ythrow TDistThreePqRetry() << "GetClientOffset failed for tablet " << tabletId;
+    }
 };
 
-void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId);
+void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId, ui64 begin, ui64 end);
+
+void RecordOrigin(THashSet<ui64>& seenOrigins, const NKikimrPQ::TEvProposeTransactionResult& record) {
+    UNIT_ASSERT_C(record.HasOrigin(), record.ShortDebugString());
+    seenOrigins.insert(record.GetOrigin());
+}
 
 void WaitNProposeResults(
     TThreeRealPqEnv& env,
     ui64 txId,
     NKikimrPQ::TEvProposeTransactionResult::EStatus status,
-    ui32 expectedCount)
+    ui32 expectedCount,
+    ui64 begin,
+    ui64 end)
 {
     THashSet<ui64> seenOrigins;
     for (ui32 round = 0; round < 20 && seenOrigins.size() < expectedCount; ++round) {
@@ -199,7 +265,7 @@ void WaitNProposeResults(
                 env.ResetAllPipes();
                 env.WaitAllTabletsReady();
                 if (status == NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
-                    ProposeDistributedOffsetTx(env, txId);
+                    ProposeDistributedOffsetTx(env, txId, begin, end);
                 }
                 continue;
             }
@@ -212,11 +278,7 @@ void WaitNProposeResults(
                 (gotStatus == NKikimrPQ::TEvProposeTransactionResult::PREPARED ||
                  gotStatus == NKikimrPQ::TEvProposeTransactionResult::COMPLETE))
             {
-                if (event->Record.HasOrigin()) {
-                    seenOrigins.insert(event->Record.GetOrigin());
-                } else {
-                    seenOrigins.insert(seenOrigins.size());
-                }
+                RecordOrigin(seenOrigins, event->Record);
                 continue;
             }
             if (gotStatus != status) {
@@ -225,11 +287,7 @@ void WaitNProposeResults(
                     << static_cast<int>(gotStatus)
                     << " expected=" << static_cast<int>(status);
             }
-            if (event->Record.HasOrigin()) {
-                seenOrigins.insert(event->Record.GetOrigin());
-            } else {
-                seenOrigins.insert(seenOrigins.size());
-            }
+            RecordOrigin(seenOrigins, event->Record);
         } catch (const NActors::TSchedulingLimitReachedException&) {
             env.Runtime->ResetScheduledCount();
         } catch (const NActors::TEmptyEventQueueException&) {
@@ -243,7 +301,7 @@ void WaitNProposeResults(
     }
 }
 
-void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId) {
+void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId, ui64 begin, ui64 end) {
     for (ui64 tabletId : env.TabletIds) {
         env.ResetPipe(tabletId);
         auto event = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
@@ -252,8 +310,8 @@ void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId) {
         auto* body = event->Record.MutableData();
         auto* operation = body->MutableOperations()->Add();
         operation->SetPartitionId(0);
-        operation->SetCommitOffsetsBegin(0);
-        operation->SetCommitOffsetsEnd(0);
+        operation->SetCommitOffsetsBegin(begin);
+        operation->SetCommitOffsetsEnd(end);
         operation->SetConsumer("user");
         operation->SetPath("/topic");
         // Peer shards only — self is the local participant; RS mesh is among the three tablets.
@@ -309,11 +367,7 @@ void WaitAllCompleteAfterPlan(TThreeRealPqEnv& env, ui64 txId, ui64 step) {
                 continue;
             }
             if (event->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::COMPLETE) {
-                if (event->Record.HasOrigin()) {
-                    completedOrigins.insert(event->Record.GetOrigin());
-                } else {
-                    completedOrigins.insert(completedOrigins.size());
-                }
+                RecordOrigin(completedOrigins, event->Record);
                 continue;
             }
             if (event->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
@@ -336,6 +390,57 @@ void WaitAllCompleteAfterPlan(TThreeRealPqEnv& env, ui64 txId, ui64 step) {
     }
 }
 
+bool AllConsumerOffsetsAt(TThreeRealPqEnv& env, i64 expected) {
+    for (ui64 tabletId : env.TabletIds) {
+        if (env.GetClientOffset(tabletId, "user") != expected) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void AssertAllConsumerOffsetsAt(TThreeRealPqEnv& env, i64 expected) {
+    for (ui64 tabletId : env.TabletIds) {
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            env.GetClientOffset(tabletId, "user"), expected,
+            "tabletId=" << tabletId);
+    }
+}
+
+// Seed each tablet partition so the distributed offset-commit has a real [0, msgCount) range.
+void EnsureMessagesWritten(TThreeRealPqEnv& env, ui32 attempt) {
+    for (ui64 tabletId : env.TabletIds) {
+        const ui64 endOffset = env.GetEndOffset(tabletId);
+        if (endOffset >= kDistThreePqMsgCount) {
+            continue;
+        }
+        TVector<std::pair<ui64, TString>> data;
+        data.reserve(kDistThreePqMsgCount - endOffset);
+        for (ui64 i = endOffset; i < kDistThreePqMsgCount; ++i) {
+            data.emplace_back(
+                i + 1,
+                TStringBuilder() << "d3-" << tabletId << "-" << attempt << "-" << i);
+        }
+        CmdWrite(
+            env.Runtime.Get(),
+            tabletId,
+            env.Edge,
+            /*partition=*/0,
+            TStringBuilder() << "src-" << tabletId,
+            env.MsgSeqNo[tabletId],
+            data,
+            /*error=*/false,
+            /*alreadyWrittenSeqNo=*/{},
+            /*isFirst=*/endOffset == 0,
+            /*ownerCookie=*/"",
+            /*msn=*/-1,
+            /*offset=*/-1,
+            /*treatWrongCookieAsError=*/false,
+            /*treatBadOffsetAsError=*/true,
+            /*disableDeduplication=*/true);
+    }
+}
+
 void DistributedThreePqTxScenario(TThreeRealPqEnv& env, bool& activeZone) {
     for (ui32 attempt = 0; attempt < 15; ++attempt) {
         try {
@@ -345,14 +450,23 @@ void DistributedThreePqTxScenario(TThreeRealPqEnv& env, bool& activeZone) {
             env.DrainEdgeProposeResults();
             env.WaitAllTabletsReady();
 
+            // Previous attempt may have committed while a later GrabEdgeEvent failed.
+            if (AllConsumerOffsetsAt(env, kDistThreePqMsgCount)) {
+                return;
+            }
+
+            EnsureMessagesWritten(env, attempt);
+
             const ui64 txId = 9400 + attempt;
             const ui64 step = 100 + txId;
+            constexpr ui64 begin = 0;
+            constexpr ui64 end = kDistThreePqMsgCount;
 
             // Propose outside the injection zone so the reboot/pipe matrix stays small.
-            ProposeDistributedOffsetTx(env, txId);
+            ProposeDistributedOffsetTx(env, txId, begin, end);
             WaitNProposeResults(
                 env, txId, NKikimrPQ::TEvProposeTransactionResult::PREPARED,
-                TThreeRealPqEnv::TabletCount);
+                TThreeRealPqEnv::TabletCount, begin, end);
 
             // Inject through PlanStep delivery and the following RS mesh / COMPLETE wait.
             // PlanDistributedTx only queues pipe sends; tablet events run while we wait.
@@ -363,6 +477,7 @@ void DistributedThreePqTxScenario(TThreeRealPqEnv& env, bool& activeZone) {
             activeZone = false;
 
             DrainPlanStepSideEffects(env);
+            AssertAllConsumerOffsetsAt(env, kDistThreePqMsgCount);
             return;
         } catch (const TDistThreePqRetry&) {
             activeZone = false;

--- a/ydb/core/persqueue/ut/injection/distributed_three_pq_tx_ut.cpp
+++ b/ydb/core/persqueue/ut/injection/distributed_three_pq_tx_ut.cpp
@@ -1,0 +1,438 @@
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/ut/common/pq_ut_common.h>
+#include <ydb/core/tx/tx_processing.h>
+
+#include <ydb/library/actors/core/actorid.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/system/types.h>
+
+#include <unordered_set>
+
+namespace NKikimr::NPQ {
+
+namespace {
+
+// Edge waits under injection: keep short so a dead dispatch fails into retry quickly.
+constexpr TDuration kDistThreePqEdgeTimeout = TDuration::Seconds(1);
+
+class TDistThreePqRetry : public yexception {
+};
+
+struct TThreeRealPqEnv {
+    static constexpr ui32 TabletCount = 3;
+
+    THolder<TTestBasicRuntime> Runtime;
+    TActorId Edge;
+    TVector<ui64> TabletIds;
+    THashMap<ui64, TActorId> Pipes;
+
+    TThreeRealPqEnv() {
+        // Keep id=2 free (balancer id in TTestContext); use 1/3/4 for real PQ tablets.
+        TabletIds = {
+            MakeTabletID(false, 1),
+            MakeTabletID(false, 3),
+            MakeTabletID(false, 4),
+        };
+    }
+
+    ~TThreeRealPqEnv() {
+        ResetAllPipes();
+        Runtime.Reset(nullptr);
+    }
+
+    void ResetAllPipes() {
+        if (!Runtime) {
+            Pipes.clear();
+            return;
+        }
+        for (auto& [tabletId, pipe] : Pipes) {
+            if (pipe) {
+                Runtime->ClosePipe(pipe, Edge, 0);
+            }
+        }
+        Pipes.clear();
+    }
+
+    void Prepare(
+        const TString& /*dispatchName*/,
+        std::function<void(TTestActorRuntime&)> setup,
+        bool& activeZone)
+    {
+        activeZone = false;
+        ResetAllPipes();
+        Runtime.Reset(new TTestBasicRuntime());
+        Runtime->SetScheduledLimit(5'000);
+        TTestContext::SetupLogging(*Runtime, /*enableDetailedPQLog=*/false);
+        SetupTabletServices(*Runtime);
+        setup(*Runtime);
+
+        FillPQConfig(Runtime->GetAppData(0).PQConfig, "/Root/PQ", /*isFirstClass=*/false);
+        Runtime->GetAppData(0).PQConfig.SetEnabled(true);
+
+        for (ui64 tabletId : TabletIds) {
+            CreateTestBootstrapper(
+                *Runtime,
+                CreateTestTabletInfo(tabletId, TTabletTypes::PersQueue, TErasureType::ErasureNone),
+                &CreatePersQueue);
+            TDispatchOptions options;
+            options.FinalEvents.push_back(TDispatchOptions::TFinalEventCondition(TEvTablet::EvBoot));
+            Runtime->DispatchEvents(options);
+        }
+
+        Edge = Runtime->AllocateEdgeActor();
+        Runtime->SetScheduledEventFilter(&TTestContext::RequestTimeoutFilter);
+
+        const TVector<TConsumerPreparationParameters> users{
+            {.Name = "user", .Important = true},
+        };
+        for (ui64 tabletId : TabletIds) {
+            PQTabletPrepare(
+                {.partitions = 1},
+                users,
+                *Runtime,
+                tabletId,
+                Edge);
+        }
+    }
+
+    TActorId& PipeFor(ui64 tabletId) {
+        auto& pipe = Pipes[tabletId];
+        if (!pipe) {
+            pipe = Runtime->ConnectToPipe(tabletId, Edge, 0, GetPipeConfigWithRetries());
+        }
+        Y_ABORT_UNLESS(pipe);
+        return pipe;
+    }
+
+    void SendToTablet(ui64 tabletId, IEventBase* event) {
+        auto& pipe = PipeFor(tabletId);
+        Runtime->SendToPipe(pipe, Edge, event, 0, 0);
+    }
+
+    void ResetPipe(ui64 tabletId) {
+        auto it = Pipes.find(tabletId);
+        if (it != Pipes.end() && it->second) {
+            Runtime->ClosePipe(it->second, Edge, 0);
+            it->second = {};
+        }
+    }
+
+    // Drain leftover propose/plan replies from a previous interrupted attempt.
+    void DrainEdgeProposeResults() {
+        for (;;) {
+            auto event = Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+                TDuration::MilliSeconds(1));
+            if (!event) {
+                break;
+            }
+        }
+        for (ui32 i = 0; i < TabletCount * 4; ++i) {
+            Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(TDuration::MilliSeconds(1));
+            Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(TDuration::MilliSeconds(1));
+        }
+    }
+
+    bool IsTabletReady(ui64 tabletId) {
+        try {
+            Runtime->ResetScheduledCount();
+            ResetPipe(tabletId);
+            auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
+            SendToTablet(tabletId, request.Release());
+            auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(
+                TDuration::MilliSeconds(200));
+            if (!result || result->Record.PartResultSize() == 0) {
+                return false;
+            }
+            return result->Record.GetPartResult(0).GetErrorCode() != NPersQueue::NErrorCode::INITIALIZING;
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            return false;
+        } catch (const NActors::TEmptyEventQueueException&) {
+            return false;
+        }
+    }
+
+    void WaitAllTabletsReady() {
+        for (ui32 round = 0; round < 15; ++round) {
+            bool allReady = true;
+            for (ui64 tabletId : TabletIds) {
+                if (!IsTabletReady(tabletId)) {
+                    allReady = false;
+                    break;
+                }
+            }
+            if (allReady) {
+                return;
+            }
+            try {
+                Runtime->ResetScheduledCount();
+                Runtime->SimulateSleep(TDuration::MilliSeconds(50));
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+            } catch (const NActors::TEmptyEventQueueException&) {
+            }
+        }
+        ythrow TDistThreePqRetry() << "tablets not ready after reboot";
+    }
+};
+
+void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId);
+
+void WaitNProposeResults(
+    TThreeRealPqEnv& env,
+    ui64 txId,
+    NKikimrPQ::TEvProposeTransactionResult::EStatus status,
+    ui32 expectedCount)
+{
+    THashSet<ui64> seenOrigins;
+    for (ui32 round = 0; round < 20 && seenOrigins.size() < expectedCount; ++round) {
+        try {
+            env.Runtime->ResetScheduledCount();
+            auto event = env.Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+                kDistThreePqEdgeTimeout);
+            if (!event) {
+                // Reboot mid-propose: restore pipes and re-send propose to missing tablets.
+                env.ResetAllPipes();
+                env.WaitAllTabletsReady();
+                if (status == NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
+                    ProposeDistributedOffsetTx(env, txId);
+                }
+                continue;
+            }
+            if (event->Record.GetTxId() != txId) {
+                continue;
+            }
+            const auto gotStatus = event->Record.GetStatus();
+            // COMPLETE implies the tablet already passed PREPARED for this tx.
+            if (status == NKikimrPQ::TEvProposeTransactionResult::PREPARED &&
+                (gotStatus == NKikimrPQ::TEvProposeTransactionResult::PREPARED ||
+                 gotStatus == NKikimrPQ::TEvProposeTransactionResult::COMPLETE))
+            {
+                if (event->Record.HasOrigin()) {
+                    seenOrigins.insert(event->Record.GetOrigin());
+                } else {
+                    seenOrigins.insert(seenOrigins.size());
+                }
+                continue;
+            }
+            if (gotStatus != status) {
+                ythrow TDistThreePqRetry()
+                    << "unexpected ProposeResult status="
+                    << static_cast<int>(gotStatus)
+                    << " expected=" << static_cast<int>(status);
+            }
+            if (event->Record.HasOrigin()) {
+                seenOrigins.insert(event->Record.GetOrigin());
+            } else {
+                seenOrigins.insert(seenOrigins.size());
+            }
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            env.Runtime->ResetScheduledCount();
+        } catch (const NActors::TEmptyEventQueueException&) {
+            env.Runtime->ResetScheduledCount();
+        }
+    }
+    if (seenOrigins.size() < expectedCount) {
+        ythrow TDistThreePqRetry()
+            << "timeout waiting ProposeResult status=" << static_cast<int>(status)
+            << " got=" << seenOrigins.size() << "/" << expectedCount;
+    }
+}
+
+void ProposeDistributedOffsetTx(TThreeRealPqEnv& env, ui64 txId) {
+    for (ui64 tabletId : env.TabletIds) {
+        env.ResetPipe(tabletId);
+        auto event = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
+        ActorIdToProto(env.Edge, event->Record.MutableSourceActor());
+        event->Record.SetTxId(txId);
+        auto* body = event->Record.MutableData();
+        auto* operation = body->MutableOperations()->Add();
+        operation->SetPartitionId(0);
+        operation->SetCommitOffsetsBegin(0);
+        operation->SetCommitOffsetsEnd(0);
+        operation->SetConsumer("user");
+        operation->SetPath("/topic");
+        // Peer shards only — self is the local participant; RS mesh is among the three tablets.
+        for (ui64 shard : env.TabletIds) {
+            if (shard == tabletId) {
+                continue;
+            }
+            body->AddSendingShards(shard);
+            body->AddReceivingShards(shard);
+        }
+        body->SetImmediate(false);
+        env.SendToTablet(tabletId, event.Release());
+    }
+}
+
+void PlanDistributedTx(TThreeRealPqEnv& env, ui64 txId, ui64 step) {
+    for (ui64 tabletId : env.TabletIds) {
+        env.ResetPipe(tabletId);
+        auto event = MakeHolder<TEvTxProcessing::TEvPlanStep>();
+        event->Record.SetStep(step);
+        auto* tx = event->Record.AddTransactions();
+        tx->SetTxId(txId);
+        ActorIdToProto(env.Edge, tx->MutableAckTo());
+        env.SendToTablet(tabletId, event.Release());
+    }
+}
+
+void DrainPlanStepSideEffects(TThreeRealPqEnv& env) {
+    // Best-effort: each tablet may emit Ack/Accepted; ignore under injection.
+    for (ui32 i = 0; i < TThreeRealPqEnv::TabletCount * 2; ++i) {
+        env.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(TDuration::MilliSeconds(1));
+        env.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(TDuration::MilliSeconds(1));
+    }
+}
+
+// After PlanStep, a mid-flight reboot must not start a new TxId: peers stay in WAIT_RS for
+// the original tx, and the restarted tablet restores it from KV and continues the RS mesh.
+void WaitAllCompleteAfterPlan(TThreeRealPqEnv& env, ui64 txId, ui64 step) {
+    THashSet<ui64> completedOrigins;
+    for (ui32 round = 0; round < 25 && completedOrigins.size() < TThreeRealPqEnv::TabletCount; ++round) {
+        try {
+            env.Runtime->ResetScheduledCount();
+            auto event = env.Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+                kDistThreePqEdgeTimeout);
+            if (!event) {
+                // Reboot may drop in-flight replies; restore and re-deliver PlanStep.
+                env.ResetAllPipes();
+                env.WaitAllTabletsReady();
+                PlanDistributedTx(env, txId, step);
+                continue;
+            }
+            if (event->Record.GetTxId() != txId) {
+                continue;
+            }
+            if (event->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::COMPLETE) {
+                if (event->Record.HasOrigin()) {
+                    completedOrigins.insert(event->Record.GetOrigin());
+                } else {
+                    completedOrigins.insert(completedOrigins.size());
+                }
+                continue;
+            }
+            if (event->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
+                // Late PREPARED after we already planned — ignore.
+                continue;
+            }
+            ythrow TDistThreePqRetry()
+                << "unexpected status after PlanStep="
+                << static_cast<int>(event->Record.GetStatus());
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            env.Runtime->ResetScheduledCount();
+        } catch (const NActors::TEmptyEventQueueException&) {
+            env.Runtime->ResetScheduledCount();
+        }
+    }
+    if (completedOrigins.size() < TThreeRealPqEnv::TabletCount) {
+        ythrow TDistThreePqRetry()
+            << "timeout waiting COMPLETE after PlanStep got=" << completedOrigins.size()
+            << "/" << TThreeRealPqEnv::TabletCount;
+    }
+}
+
+void DistributedThreePqTxScenario(TThreeRealPqEnv& env, bool& activeZone) {
+    for (ui32 attempt = 0; attempt < 15; ++attempt) {
+        try {
+            env.Runtime->ResetScheduledCount();
+            env.ResetAllPipes();
+            activeZone = false;
+            env.DrainEdgeProposeResults();
+            env.WaitAllTabletsReady();
+
+            const ui64 txId = 9400 + attempt;
+            const ui64 step = 100 + txId;
+
+            // Propose outside the injection zone so the reboot/pipe matrix stays small.
+            ProposeDistributedOffsetTx(env, txId);
+            WaitNProposeResults(
+                env, txId, NKikimrPQ::TEvProposeTransactionResult::PREPARED,
+                TThreeRealPqEnv::TabletCount);
+
+            // Inject through PlanStep delivery and the following RS mesh / COMPLETE wait.
+            // PlanDistributedTx only queues pipe sends; tablet events run while we wait.
+            activeZone = true;
+            PlanDistributedTx(env, txId, step);
+            // Stay on the same TxId through reboot recovery (do not propose a new one).
+            WaitAllCompleteAfterPlan(env, txId, step);
+            activeZone = false;
+
+            DrainPlanStepSideEffects(env);
+            return;
+        } catch (const TDistThreePqRetry&) {
+            activeZone = false;
+            try {
+                env.Runtime->ResetScheduledCount();
+                env.Runtime->SimulateSleep(TDuration::MilliSeconds(50));
+            } catch (...) {
+            }
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            activeZone = false;
+        } catch (const NActors::TEmptyEventQueueException&) {
+            activeZone = false;
+        }
+    }
+    UNIT_FAIL("DistributedThreePqTxScenario: retries exhausted");
+}
+
+void RunDistributedThreePqInjectionTest(
+    std::function<void(
+        const TVector<ui64>&,
+        std::function<TTestActorRuntime::TEventFilter()>,
+        std::function<void(const TString&, std::function<void(TTestActorRuntime&)>, bool&)>)> runner,
+    const std::unordered_set<TString>& extraSkipEventTypes = {})
+{
+    TInitialEventsFilter filter;
+    const TVector<ui64> rebootTablets{
+        MakeTabletID(false, 1),
+        MakeTabletID(false, 3),
+        MakeTabletID(false, 4),
+    };
+    runner(
+        rebootTablets,
+        [&]() {
+            return filter.Prepare(
+                {TabletPipe, NPDisk, KeyValue, PQ},
+                extraSkipEventTypes);
+        },
+        [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+            TThreeRealPqEnv env;
+            activeZone = false;
+            env.Prepare(dispatchName, setup, activeZone);
+            DistributedThreePqTxScenario(env, activeZone);
+        });
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TDistributedThreePqTxInjectionTests) {
+
+// Three real PQ tablets run a distributed offset-commit tx (ReadSet mesh) under tablet reboots.
+Y_UNIT_TEST(DistributedThreePqTxWithTabletReboots) {
+    RunDistributedThreePqInjectionTest([](const auto& tabletIds, auto filterFactory, auto testFunc) {
+        RunTestWithReboots(tabletIds, filterFactory, testFunc);
+    });
+}
+
+// Same distributed 3-tablet tx under pipe client resets.
+// Skip inter-tablet ReadSet pipes: reconnect goes through Hive, which handmade PQ tablets lack.
+Y_UNIT_TEST(DistributedThreePqTxWithPipeResets) {
+    const std::unordered_set<TString> skipInterTabletRs{
+        "NKikimr::TEvTxProcessing::TEvReadSet",
+        "NKikimr::TEvTxProcessing::TEvReadSetAck",
+    };
+    RunDistributedThreePqInjectionTest(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithPipeResets(tabletIds, filterFactory, testFunc);
+        },
+        skipInterTabletRs);
+}
+
+} // Y_UNIT_TEST_SUITE(TDistributedThreePqTxInjectionTests)
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/injection/distributed_three_pq_tx_ut.cpp
+++ b/ydb/core/persqueue/ut/injection/distributed_three_pq_tx_ut.cpp
@@ -142,14 +142,51 @@ struct TThreeRealPqEnv {
         }
     }
 
+    // Shared Edge receives replies from all tablets; match TabletId before accepting.
+    THolder<TEvPersQueue::TEvOffsetsResponse> GrabOffsetsResponseFor(
+        ui64 tabletId, TDuration timeout)
+    {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline) {
+            const TDuration left = deadline - TInstant::Now();
+            auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(left);
+            if (!result) {
+                return {};
+            }
+            if (!result->Record.HasTabletId() || result->Record.GetTabletId() != tabletId) {
+                continue;
+            }
+            return result;
+        }
+        return {};
+    }
+
+    // TEvResponse may lack TabletId; stamp PartitionRequest cookie with tabletId and filter on it.
+    THolder<TEvPersQueue::TEvResponse> GrabResponseForCookie(ui64 cookie, TDuration timeout) {
+        const TInstant deadline = TInstant::Now() + timeout;
+        while (TInstant::Now() < deadline) {
+            const TDuration left = deadline - TInstant::Now();
+            auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(left);
+            if (!result) {
+                return {};
+            }
+            if (!result->Record.HasPartitionResponse() ||
+                result->Record.GetPartitionResponse().GetCookie() != cookie)
+            {
+                continue;
+            }
+            return result;
+        }
+        return {};
+    }
+
     bool IsTabletReady(ui64 tabletId) {
         try {
             Runtime->ResetScheduledCount();
             ResetPipe(tabletId);
             auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
             SendToTablet(tabletId, request.Release());
-            auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(
-                TDuration::MilliSeconds(200));
+            auto result = GrabOffsetsResponseFor(tabletId, TDuration::MilliSeconds(200));
             if (!result || result->Record.PartResultSize() == 0) {
                 return false;
             }
@@ -190,8 +227,7 @@ struct TThreeRealPqEnv {
                 ResetPipe(tabletId);
                 auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
                 SendToTablet(tabletId, request.Release());
-                auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(
-                    kDistThreePqEdgeTimeout);
+                auto result = GrabOffsetsResponseFor(tabletId, kDistThreePqEdgeTimeout);
                 if (!result || result->Record.PartResultSize() == 0) {
                     continue;
                 }
@@ -216,9 +252,11 @@ struct TThreeRealPqEnv {
                 auto request = MakeHolder<TEvPersQueue::TEvRequest>();
                 auto* req = request->Record.MutablePartitionRequest();
                 req->SetPartition(0);
+                // Cookie identifies the target tablet among shared-Edge replies.
+                req->SetCookie(tabletId);
                 req->MutableCmdGetClientOffset()->SetClientId(user);
                 SendToTablet(tabletId, request.Release());
-                auto result = Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(kDistThreePqEdgeTimeout);
+                auto result = GrabResponseForCookie(tabletId, kDistThreePqEdgeTimeout);
                 if (!result) {
                     continue;
                 }

--- a/ydb/core/persqueue/ut/injection/prod/prod_pq_injection_ut.cpp
+++ b/ydb/core/persqueue/ut/injection/prod/prod_pq_injection_ut.cpp
@@ -30,11 +30,18 @@ constexpr TDuration kEdgeTimeout = TDuration::Seconds(2);
 constexpr ui32 kSeedMsgCount = 2;
 constexpr ui32 kTxWriteMsgCount = 2;
 constexpr ui32 kPqTabletCount = 4;
+constexpr ui32 kAlterLifetimeSeconds = 7200;
+constexpr ui32 kCreateLifetimeSeconds = 3600;
 constexpr const char* kTopicName = "TopicTx";
 constexpr const char* kTopicPath = "/MyRoot/DirA/TopicTx";
 constexpr const char* kConsumer = "user";
 constexpr const char* kTxWriteOwner = "prod-tx-write-owner";
 constexpr const char* kTxWriteSourceId = "prod-tx-src";
+
+// Half-range boundary used by schemeshard split UTs (1/2 of ui128 key space).
+const unsigned char kSplitBoundHalf[] = {
+    0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE};
 
 class TProdPqRetry : public yexception {
 };
@@ -44,15 +51,40 @@ struct TPartitionRef {
     ui64 TabletId = 0;
 };
 
-TString TopicCreateScheme(ui32 partitions, ui32 partitionsPerTablet = 1) {
-    return TStringBuilder()
-        << "Name: \"" << kTopicName << "\" "
-        << "TotalGroupCount: " << partitions << " "
-        << "PartitionPerTablet: " << partitionsPerTablet << " "
-        << "PQTabletConfig: {"
-        << "  PartitionConfig { LifetimeSeconds: 3600 }"
-        << "  Consumers { Name: \"" << kConsumer << "\" Important: true }"
-        << "}";
+TString TopicCreateScheme(
+    ui32 partitions,
+    ui32 partitionsPerTablet = 1,
+    ui32 lifetimeSeconds = kCreateLifetimeSeconds,
+    bool canSplitAndMerge = false)
+{
+    TStringBuilder sb;
+    sb << "Name: \"" << kTopicName << "\" "
+       << "TotalGroupCount: " << partitions << " "
+       << "PartitionPerTablet: " << partitionsPerTablet << " "
+       << "PQTabletConfig: {"
+       << "  PartitionConfig { LifetimeSeconds: " << lifetimeSeconds << " }"
+       << "  Consumers { Name: \"" << kConsumer << "\" Important: true }";
+    if (canSplitAndMerge) {
+        sb << "  PartitionStrategy { PartitionStrategyType: CAN_SPLIT_AND_MERGE }";
+    }
+    sb << "}";
+    return sb;
+}
+
+ui32 GetTopicLifetimeSeconds(TTestActorRuntime& runtime) {
+    return DescribePath(runtime, kTopicPath)
+        .GetPathDescription()
+        .GetPersQueueGroup()
+        .GetPQTabletConfig()
+        .GetPartitionConfig()
+        .GetLifetimeSeconds();
+}
+
+ui32 GetTopicPartitionCount(TTestActorRuntime& runtime) {
+    return DescribePath(runtime, kTopicPath, /*returnPartitioning=*/true)
+        .GetPathDescription()
+        .GetPersQueueGroup()
+        .PartitionsSize();
 }
 
 TVector<TPartitionRef> DescribePartitions(TTestActorRuntime& runtime) {
@@ -581,11 +613,26 @@ TTestEnvOptions MakeEnvOptions() {
 }
 
 // Data-plane reboot targets: Hive-owned PQ tablets + FakeCoordinator (plan deliverer).
-// FakeHive assigns PQ ids at FakeHiveTablets..+3; balancer follows at +4.
-TVector<ui64> DataPlaneRebootTablets() {
+// FakeHive assigns PQ ids at FakeHiveTablets..+(N-1); balancer follows.
+TVector<ui64> DataPlaneRebootTablets(ui32 pqTabletCount = kPqTabletCount) {
     TVector<ui64> ids;
-    ids.reserve(kPqTabletCount + 1);
-    for (ui32 i = 0; i < kPqTabletCount; ++i) {
+    ids.reserve(pqTabletCount + 1);
+    for (ui32 i = 0; i < pqTabletCount; ++i) {
+        ids.push_back(TTestTxConfig::FakeHiveTablets + i);
+    }
+    ids.push_back(TTestTxConfig::Coordinator);
+    return ids;
+}
+
+// Control-plane: PQ + FakeCoordinator.
+// SchemeShard is intentionally not in the reboot vector here: SS-only reboots are
+// already covered by schemeshard/ut_pq_reboots, and rebooting SS mid-alter under
+// RunTestWithReboots livelocks the runtime (event storm past SetScheduledLimit).
+// Injection here focuses on PQ config/split propose + plan delivery.
+TVector<ui64> ControlPlaneRebootTablets(ui32 pqTabletCount = kPqTabletCount) {
+    TVector<ui64> ids;
+    ids.reserve(pqTabletCount + 1);
+    for (ui32 i = 0; i < pqTabletCount; ++i) {
         ids.push_back(TTestTxConfig::FakeHiveTablets + i);
     }
     ids.push_back(TTestTxConfig::Coordinator);
@@ -599,14 +646,18 @@ struct TProdPqEnv {
     TActorId Edge;
     TVector<TPartitionRef> Parts;
     THashSet<ui64> PqTabletIds;
+    ui32 ExpectedPqTabletCount = kPqTabletCount;
 
     void Prepare(
         const TString& dispatchName,
         std::function<void(TTestActorRuntime&)> setup,
         bool& activeZone,
-        bool seedMessages = true)
+        bool seedMessages = true,
+        ui32 partitions = kPqTabletCount,
+        bool canSplitAndMerge = false)
     {
         activeZone = false;
+        ExpectedPqTabletCount = partitions;
         Cerr << Endl
              << "====== " << TInstant::Now()
              << " ===== PROD_PQ RUN: " << dispatchName
@@ -621,14 +672,14 @@ struct TProdPqEnv {
         Edge = Runtime->AllocateEdgeActor();
 
         // Topic create (+ optional seed) stay outside the reboot/pipe-reset zone.
-        // One partition per tablet → kPqTabletCount real PQ tablets + RS mesh among them.
+        // One partition per tablet → N real PQ tablets (+ RS mesh when N>1).
         TestCreatePQGroup(
             *Runtime, ++TxId, "/MyRoot/DirA",
-            TopicCreateScheme(/*partitions=*/kPqTabletCount, /*perTablet=*/1));
+            TopicCreateScheme(partitions, /*perTablet=*/1, kCreateLifetimeSeconds, canSplitAndMerge));
         Env->TestWaitNotification(*Runtime, TxId);
         Parts = DescribePartitions(*Runtime);
         PqTabletIds = UniqueTabletIds(Parts);
-        UNIT_ASSERT_VALUES_EQUAL(PqTabletIds.size(), kPqTabletCount);
+        UNIT_ASSERT_VALUES_EQUAL(PqTabletIds.size(), ExpectedPqTabletCount);
         if (seedMessages) {
             SeedAllPartitions(*Runtime, Parts);
         }
@@ -844,6 +895,132 @@ void RunDataPlaneInjection(
         });
 }
 
+void AlterTopicLifetime(TProdPqEnv& env, ui32 lifetimeSeconds) {
+    TestAlterPQGroup(
+        *env.Runtime, ++env.TxId, "/MyRoot/DirA",
+        TStringBuilder()
+            << "Name: \"" << kTopicName << "\" "
+            << "PQTabletConfig: {"
+            << "  PartitionConfig { LifetimeSeconds: " << lifetimeSeconds << " }"
+            << "  Consumers { Name: \"" << kConsumer << "\" Important: true }"
+            << "}");
+    env.Env->TestWaitNotification(*env.Runtime, env.TxId);
+}
+
+void SplitTopicPartition(TProdPqEnv& env, ui32 partitionId, const TString& boundary) {
+    NKikimrSchemeOp::TPersQueueGroupDescription scheme;
+    scheme.SetName(kTopicName);
+    scheme.MutablePQTabletConfig()->MutablePartitionConfig();
+    auto* split = scheme.AddSplit();
+    split->SetPartition(partitionId);
+    split->SetSplitBoundary(boundary);
+
+    TStringBuilder sb;
+    sb << scheme;
+    const TString schemeText = sb.substr(1, sb.size() - 2);
+    Cerr << "====== PROD_PQ split scheme: " << schemeText << " ======" << Endl;
+    TestAlterPQGroup(*env.Runtime, ++env.TxId, "/MyRoot/DirA", schemeText);
+    env.Env->TestWaitNotification(*env.Runtime, env.TxId);
+}
+
+// Active zone: AlterPQGroup → wait notification (SS→PQ config tx through FakeCoordinator).
+void ControlPlaneAlterScenario(TProdPqEnv& env, bool& activeZone) {
+    activeZone = false;
+    UNIT_ASSERT_VALUES_EQUAL(GetTopicLifetimeSeconds(*env.Runtime), kCreateLifetimeSeconds);
+
+    Cerr << "====== PROD_PQ alter enter activeZone ======" << Endl;
+    activeZone = true;
+    AlterTopicLifetime(env, kAlterLifetimeSeconds);
+    activeZone = false;
+
+    UNIT_ASSERT_VALUES_EQUAL(GetTopicLifetimeSeconds(*env.Runtime), kAlterLifetimeSeconds);
+    TestDescribeResult(
+        DescribePath(*env.Runtime, kTopicPath),
+        {NLs::Finished, NLs::RetentionPeriod(TDuration::Seconds(kAlterLifetimeSeconds))});
+    Cerr << "====== PROD_PQ alter COMPLETE ok ======" << Endl;
+}
+
+// Active zone: split partition 0 → wait notification.
+void ControlPlaneSplitScenario(TProdPqEnv& env, bool& activeZone) {
+    activeZone = false;
+    UNIT_ASSERT_VALUES_EQUAL(GetTopicPartitionCount(*env.Runtime), 1u);
+
+    const TString boundary(reinterpret_cast<const char*>(kSplitBoundHalf), sizeof(kSplitBoundHalf));
+    Cerr << "====== PROD_PQ split enter activeZone ======" << Endl;
+    activeZone = true;
+    SplitTopicPartition(env, /*partitionId=*/0, boundary);
+    activeZone = false;
+
+    const ui32 partsAfter = GetTopicPartitionCount(*env.Runtime);
+    UNIT_ASSERT_C(partsAfter >= 3, "expected parent+2 children, got=" << partsAfter);
+    Cerr << "====== PROD_PQ split COMPLETE ok partitions=" << partsAfter << " ======" << Endl;
+}
+
+// DROP mid distributed offset-commit (after PlanStep → WAIT_RS / commit path).
+// Success: topic gone, PQ tablets deleted, no hang.
+void ControlPlaneDropMidCommitScenario(TProdPqEnv& env, bool& activeZone) {
+    activeZone = false;
+    DrainStaleProposeResults(*env.Runtime, env.Edge);
+
+    const ui64 commitTxId = 9600;
+    const auto tablets = env.PqTabletIds;
+    TVector<ui64> tabletIds(tablets.begin(), tablets.end());
+
+    Cerr << "====== PROD_PQ drop-mid prepare propose txId=" << commitTxId << " ======" << Endl;
+    for (const auto& part : env.Parts) {
+        ProposeOffsetCommit(
+            *env.Runtime, env.Edge, commitTxId, part, tablets,
+            /*begin=*/0, /*end=*/kSeedMsgCount);
+    }
+    WaitPreparedFromTablets(*env.Runtime, env.Edge, commitTxId, tablets.size());
+
+    Cerr << "====== PROD_PQ drop-mid enter activeZone (plan+drop) ======" << Endl;
+    activeZone = true;
+    PlanViaFakeCoordinator(*env.Runtime, env.Edge, commitTxId, tablets);
+    // Best-effort: allow plan/RS to start before DROP kills the path.
+    try {
+        env.Runtime->SimulateSleep(TDuration::MilliSeconds(10));
+    } catch (...) {
+    }
+    TestDropPQGroup(*env.Runtime, ++env.TxId, "/MyRoot/DirA", kTopicName);
+    env.Env->TestWaitNotification(*env.Runtime, env.TxId);
+    activeZone = false;
+
+    env.Env->TestWaitTabletDeletion(*env.Runtime, tabletIds);
+    TestDescribeResult(DescribePath(*env.Runtime, kTopicPath), {NLs::PathNotExist});
+    Cerr << "====== PROD_PQ drop-mid COMPLETE ok ======" << Endl;
+}
+
+void RunControlPlaneInjection(
+    std::function<void(
+        const TVector<ui64>&,
+        std::function<TTestActorRuntime::TEventFilter()>,
+        std::function<void(const TString&, std::function<void(TTestActorRuntime&)>, bool&)>)> runner,
+    std::function<void(TProdPqEnv&, bool&)> scenario,
+    ui32 partitions,
+    bool seedMessages,
+    bool canSplitAndMerge = false,
+    const std::unordered_set<TString>& extraSkipEventTypes = {})
+{
+    TInitialEventsFilter filter;
+    runner(
+        ControlPlaneRebootTablets(partitions),
+        [&]() {
+            return filter.Prepare(
+                {TabletPipe, NPDisk, KeyValue, PQ},
+                extraSkipEventTypes);
+        },
+        [&](const TString& dispatchName,
+            std::function<void(TTestActorRuntime&)> setup,
+            bool& activeZone) {
+            TProdPqEnv env;
+            activeZone = false;
+            env.Prepare(
+                dispatchName, setup, activeZone, seedMessages, partitions, canSplitAndMerge);
+            scenario(env, activeZone);
+        });
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TProdPqInjectionTests) {
@@ -973,20 +1150,164 @@ Y_UNIT_TEST(DistributedTopicWriteWithPipeResets) {
         /*seedMessages=*/false);
 }
 
-#if 0 // control plane: enable after data-plane RunTestWithReboots approach is stable
-Y_UNIT_TEST(AlterTopicConfigWithSchemeShardReboot) {
-    // TODO: activeZone from SS→PQ config propose until tx deleted;
-    // reboot targets: PQ + SchemeShard + FakeCoordinator.
+// --- Control plane: SS schema txs under PQ+SchemeShard+Coordinator injection ---
+
+Y_UNIT_TEST(SmokeAlterTopicConfigViaSchemeShard) {
+    TTestBasicRuntime runtime;
+    runtime.SetScheduledLimit(50'000);
+    TTestEnv env(runtime, MakeEnvOptions());
+    env.SetupLogging(runtime);
+    ui64 txId = 1000;
+    TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+    TestCreatePQGroup(
+        runtime, ++txId, "/MyRoot/DirA",
+        TopicCreateScheme(/*partitions=*/2, /*perTablet=*/1));
+    env.TestWaitNotification(runtime, txId);
+    UNIT_ASSERT_VALUES_EQUAL(GetTopicLifetimeSeconds(runtime), kCreateLifetimeSeconds);
+
+    TestAlterPQGroup(
+        runtime, ++txId, "/MyRoot/DirA",
+        TStringBuilder()
+            << "Name: \"" << kTopicName << "\" "
+            << "PQTabletConfig: {"
+            << "  PartitionConfig { LifetimeSeconds: " << kAlterLifetimeSeconds << " }"
+            << "  Consumers { Name: \"" << kConsumer << "\" Important: true }"
+            << "}");
+    env.TestWaitNotification(runtime, txId);
+    TestDescribeResult(
+        DescribePath(runtime, kTopicPath),
+        {NLs::Finished, NLs::RetentionPeriod(TDuration::Seconds(kAlterLifetimeSeconds))});
 }
 
-Y_UNIT_TEST(SplitPartitionOnProdLikeEnv) {
-    // TODO: same control-plane discipline.
+Y_UNIT_TEST(AlterTopicConfigWithTabletReboots) {
+    RunControlPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithReboots(tabletIds, filterFactory, testFunc);
+        },
+        ControlPlaneAlterScenario,
+        /*partitions=*/2,
+        /*seedMessages=*/false);
 }
 
-Y_UNIT_TEST(DropTopicMidDistributedCommit) {
-    // TODO: DROP mid WAIT_RS → Dead path.
+Y_UNIT_TEST(AlterTopicConfigWithPipeResets) {
+    RunControlPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithPipeResets(tabletIds, filterFactory, testFunc);
+        },
+        ControlPlaneAlterScenario,
+        /*partitions=*/2,
+        /*seedMessages=*/false);
 }
-#endif
+
+Y_UNIT_TEST(SmokeSplitPartitionViaSchemeShard) {
+    TTestBasicRuntime runtime;
+    runtime.SetScheduledLimit(50'000);
+    TTestEnv env(runtime, MakeEnvOptions());
+    env.SetupLogging(runtime);
+    ui64 txId = 1000;
+    TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+    TestCreatePQGroup(
+        runtime, ++txId, "/MyRoot/DirA",
+        TopicCreateScheme(
+            /*partitions=*/1, /*perTablet=*/1, kCreateLifetimeSeconds, /*canSplit=*/true));
+    env.TestWaitNotification(runtime, txId);
+    UNIT_ASSERT_VALUES_EQUAL(GetTopicPartitionCount(runtime), 1u);
+
+    NKikimrSchemeOp::TPersQueueGroupDescription scheme;
+    scheme.SetName(kTopicName);
+    scheme.MutablePQTabletConfig()->MutablePartitionConfig();
+    auto* split = scheme.AddSplit();
+    split->SetPartition(0);
+    split->SetSplitBoundary(
+        TString(reinterpret_cast<const char*>(kSplitBoundHalf), sizeof(kSplitBoundHalf)));
+    TStringBuilder sb;
+    sb << scheme;
+    TestAlterPQGroup(runtime, ++txId, "/MyRoot/DirA", sb.substr(1, sb.size() - 2));
+    env.TestWaitNotification(runtime, txId);
+
+    const ui32 partsAfter = GetTopicPartitionCount(runtime);
+    UNIT_ASSERT_C(partsAfter >= 3, "expected parent+2 children, got=" << partsAfter);
+}
+
+Y_UNIT_TEST(SplitPartitionWithTabletReboots) {
+    RunControlPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithReboots(tabletIds, filterFactory, testFunc);
+        },
+        ControlPlaneSplitScenario,
+        /*partitions=*/1,
+        /*seedMessages=*/false,
+        /*canSplitAndMerge=*/true);
+}
+
+Y_UNIT_TEST(SplitPartitionWithPipeResets) {
+    RunControlPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithPipeResets(tabletIds, filterFactory, testFunc);
+        },
+        ControlPlaneSplitScenario,
+        /*partitions=*/1,
+        /*seedMessages=*/false,
+        /*canSplitAndMerge=*/true);
+}
+
+Y_UNIT_TEST(SmokeDropTopicMidDistributedCommit) {
+    TTestBasicRuntime runtime;
+    runtime.SetScheduledLimit(50'000);
+    TTestEnv env(runtime, MakeEnvOptions());
+    env.SetupLogging(runtime);
+    ui64 txId = 1000;
+    TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+    TestCreatePQGroup(
+        runtime, ++txId, "/MyRoot/DirA",
+        TopicCreateScheme(/*partitions=*/kPqTabletCount, /*perTablet=*/1));
+    env.TestWaitNotification(runtime, txId);
+    auto parts = DescribePartitions(runtime);
+    SeedAllPartitions(runtime, parts);
+    const auto tablets = UniqueTabletIds(parts);
+    TVector<ui64> tabletIds(tablets.begin(), tablets.end());
+
+    const TActorId edge = runtime.AllocateEdgeActor();
+    const ui64 commitTxId = 9600;
+    for (const auto& part : parts) {
+        ProposeOffsetCommit(runtime, edge, commitTxId, part, tablets, 0, kSeedMsgCount);
+    }
+    WaitPreparedFromTablets(runtime, edge, commitTxId, tablets.size());
+    PlanViaFakeCoordinator(runtime, edge, commitTxId, tablets);
+    try {
+        runtime.SimulateSleep(TDuration::MilliSeconds(10));
+    } catch (...) {
+    }
+    TestDropPQGroup(runtime, ++txId, "/MyRoot/DirA", kTopicName);
+    env.TestWaitNotification(runtime, txId);
+    env.TestWaitTabletDeletion(runtime, tabletIds);
+    TestDescribeResult(DescribePath(runtime, kTopicPath), {NLs::PathNotExist});
+}
+
+// DROP mid commit under PQ reboots only (Coordinator reboot mid DROP livelocks the event loop).
+// Not under pipe-reset matrix — peer removal / Dead path, not transient pipe breaks.
+Y_UNIT_TEST(DropTopicMidDistributedCommitWithTabletReboots) {
+    TInitialEventsFilter filter;
+    TVector<ui64> pqOnly;
+    for (ui32 i = 0; i < kPqTabletCount; ++i) {
+        pqOnly.push_back(TTestTxConfig::FakeHiveTablets + i);
+    }
+    RunTestWithReboots(
+        pqOnly,
+        [&]() {
+            return filter.Prepare({TabletPipe, NPDisk, KeyValue, PQ});
+        },
+        [&](const TString& dispatchName,
+            std::function<void(TTestActorRuntime&)> setup,
+            bool& activeZone) {
+            TProdPqEnv env;
+            activeZone = false;
+            env.Prepare(
+                dispatchName, setup, activeZone,
+                /*seedMessages=*/true, kPqTabletCount);
+            ControlPlaneDropMidCommitScenario(env, activeZone);
+        });
+}
 
 } // Y_UNIT_TEST_SUITE(TProdPqInjectionTests)
 

--- a/ydb/core/persqueue/ut/injection/prod/prod_pq_injection_ut.cpp
+++ b/ydb/core/persqueue/ut/injection/prod/prod_pq_injection_ut.cpp
@@ -1,0 +1,993 @@
+#include <ydb/core/keyvalue/keyvalue_events.h>
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/persqueue/public/write_id.h>
+#include <ydb/core/persqueue/ut/common/pq_ut_common.h>
+#include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
+#include <ydb/core/tx/tx.h>
+#include <ydb/core/tx/tx_processing.h>
+#include <ydb/public/lib/base/msgbus_status.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/maybe.h>
+#include <util/generic/vector.h>
+#include <util/string/builder.h>
+
+#include <unordered_set>
+
+namespace NKikimr::NPQ {
+namespace {
+
+using namespace NSchemeShard;
+using namespace NSchemeShardUT_Private;
+
+// Stock TTestEnv boots FakeCoordinator (PlanStep → tablet pipe; no Mediator queue).
+// FakeCoordinator is the plan deliverer in reboot/pipe-reset targets.
+
+constexpr TDuration kEdgeTimeout = TDuration::Seconds(2);
+constexpr ui32 kSeedMsgCount = 2;
+constexpr ui32 kTxWriteMsgCount = 2;
+constexpr ui32 kPqTabletCount = 4;
+constexpr const char* kTopicName = "TopicTx";
+constexpr const char* kTopicPath = "/MyRoot/DirA/TopicTx";
+constexpr const char* kConsumer = "user";
+constexpr const char* kTxWriteOwner = "prod-tx-write-owner";
+constexpr const char* kTxWriteSourceId = "prod-tx-src";
+
+class TProdPqRetry : public yexception {
+};
+
+struct TPartitionRef {
+    ui32 PartitionId = 0;
+    ui64 TabletId = 0;
+};
+
+TString TopicCreateScheme(ui32 partitions, ui32 partitionsPerTablet = 1) {
+    return TStringBuilder()
+        << "Name: \"" << kTopicName << "\" "
+        << "TotalGroupCount: " << partitions << " "
+        << "PartitionPerTablet: " << partitionsPerTablet << " "
+        << "PQTabletConfig: {"
+        << "  PartitionConfig { LifetimeSeconds: 3600 }"
+        << "  Consumers { Name: \"" << kConsumer << "\" Important: true }"
+        << "}";
+}
+
+TVector<TPartitionRef> DescribePartitions(TTestActorRuntime& runtime) {
+    auto desc = DescribePath(runtime, kTopicPath, /*returnPartitioning=*/true)
+                    .GetPathDescription()
+                    .GetPersQueueGroup();
+    TVector<TPartitionRef> parts;
+    parts.reserve(desc.PartitionsSize());
+    for (const auto& p : desc.GetPartitions()) {
+        parts.push_back({.PartitionId = p.GetPartitionId(), .TabletId = p.GetTabletId()});
+    }
+    UNIT_ASSERT_C(!parts.empty(), "topic has no partitions");
+    return parts;
+}
+
+THashSet<ui64> UniqueTabletIds(const TVector<TPartitionRef>& parts) {
+    THashSet<ui64> ids;
+    for (const auto& p : parts) {
+        ids.insert(p.TabletId);
+    }
+    return ids;
+}
+
+void WriteToPartition(
+    TTestActorRuntime& runtime,
+    const TPartitionRef& part,
+    ui32& msgNo,
+    ui64 sourceSeqNo,
+    const TString& payload,
+    bool isFirst)
+{
+    const TActorId edge = runtime.AllocateEdgeActor();
+    const TString cookie = CmdSetOwner(
+        &runtime, part.TabletId, edge, part.PartitionId, "default", true).first;
+    TVector<std::pair<ui64, TString>> data{{sourceSeqNo, payload}};
+    CmdWrite(
+        &runtime, part.TabletId, edge, part.PartitionId, "sourceid0", msgNo, data,
+        false, {}, isFirst, cookie, 0);
+}
+
+void SeedAllPartitions(TTestActorRuntime& runtime, const TVector<TPartitionRef>& parts) {
+    for (const auto& part : parts) {
+        ui32 msgNo = 0;
+        for (ui32 i = 0; i < kSeedMsgCount; ++i) {
+            WriteToPartition(
+                runtime, part, msgNo, /*sourceSeqNo=*/i + 1,
+                TStringBuilder() << "seed-" << part.PartitionId << "-" << i,
+                /*isFirst=*/(i == 0));
+        }
+    }
+}
+
+i64 GetClientOffset(TTestActorRuntime& runtime, const TPartitionRef& part) {
+    const TActorId edge = runtime.AllocateEdgeActor();
+    auto request = MakeHolder<TEvPersQueue::TEvRequest>();
+    auto* req = request->Record.MutablePartitionRequest();
+    req->SetPartition(part.PartitionId);
+    req->SetCookie(part.TabletId);
+    req->MutableCmdGetClientOffset()->SetClientId(kConsumer);
+    runtime.SendToPipe(
+        part.TabletId, edge, request.Release(), 0, GetPipeConfigWithRetries());
+    auto handle = runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(edge, kEdgeTimeout);
+    UNIT_ASSERT(handle);
+    const auto& record = handle->Get()->Record;
+    UNIT_ASSERT_VALUES_EQUAL(
+        (int)record.GetErrorCode(), (int)NPersQueue::NErrorCode::OK);
+    UNIT_ASSERT(record.GetPartitionResponse().HasCmdGetClientOffsetResult());
+    return record.GetPartitionResponse().GetCmdGetClientOffsetResult().GetOffset();
+}
+
+bool AllOffsetsAt(TTestActorRuntime& runtime, const TVector<TPartitionRef>& parts, i64 expected) {
+    for (const auto& part : parts) {
+        if (GetClientOffset(runtime, part) != expected) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void AssertAllOffsetsAt(TTestActorRuntime& runtime, const TVector<TPartitionRef>& parts, i64 expected) {
+    for (const auto& part : parts) {
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetClientOffset(runtime, part), expected,
+            "partition=" << part.PartitionId << " tablet=" << part.TabletId);
+    }
+}
+
+void ProposeOffsetCommit(
+    TTestActorRuntime& runtime,
+    const TActorId& edge,
+    ui64 txId,
+    const TPartitionRef& part,
+    const THashSet<ui64>& allTablets,
+    ui64 begin,
+    ui64 end)
+{
+    auto event = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
+    ActorIdToProto(edge, event->Record.MutableSourceActor());
+    event->Record.SetTxId(txId);
+    auto* body = event->Record.MutableData();
+    auto* operation = body->MutableOperations()->Add();
+    operation->SetPartitionId(part.PartitionId);
+    operation->SetCommitOffsetsBegin(begin);
+    operation->SetCommitOffsetsEnd(end);
+    operation->SetConsumer(kConsumer);
+    operation->SetPath(kTopicPath);
+    for (ui64 shard : allTablets) {
+        if (shard == part.TabletId) {
+            continue;
+        }
+        body->AddSendingShards(shard);
+        body->AddReceivingShards(shard);
+    }
+    body->SetImmediate(false);
+    runtime.SendToPipe(
+        part.TabletId, edge, event.Release(), 0, GetPipeConfigWithRetries());
+}
+
+void WaitPreparedFromTablets(
+    TTestActorRuntime& runtime,
+    const TActorId& edge,
+    ui64 txId,
+    ui32 expectedCount)
+{
+    THashSet<ui64> origins;
+    for (ui32 i = 0; i < expectedCount * 8 && origins.size() < expectedCount; ++i) {
+        auto handle = runtime.GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+            edge, kEdgeTimeout);
+        if (!handle) {
+            ythrow TProdPqRetry() << "timeout waiting PREPARED";
+        }
+        const auto& record = handle->Get()->Record;
+        if (record.GetTxId() != txId) {
+            continue;
+        }
+        const auto status = record.GetStatus();
+        if (status != NKikimrPQ::TEvProposeTransactionResult::PREPARED &&
+            status != NKikimrPQ::TEvProposeTransactionResult::COMPLETE)
+        {
+            ythrow TProdPqRetry()
+                << "unexpected propose status=" << static_cast<int>(status);
+        }
+        UNIT_ASSERT(record.HasOrigin());
+        origins.insert(record.GetOrigin());
+    }
+    if (origins.size() < expectedCount) {
+        ythrow TProdPqRetry()
+            << "PREPARED got=" << origins.size() << "/" << expectedCount;
+    }
+}
+
+void PlanViaFakeCoordinator(
+    TTestActorRuntime& runtime,
+    const TActorId& edge,
+    ui64 txId,
+    const THashSet<ui64>& tablets)
+{
+    auto ev = MakeHolder<TEvTxProxy::TEvProposeTransaction>();
+    ev->Record.SetCoordinatorID(TTestTxConfig::Coordinator);
+    auto& tx = *ev->Record.MutableTransaction();
+    tx.SetTxId(txId);
+    for (ui64 tabletId : tablets) {
+        auto& item = *tx.MutableAffectedSet()->Add();
+        item.SetTabletId(tabletId);
+        item.SetFlags(TEvTxProxy::TEvProposeTransaction::AffectedWrite);
+    }
+    runtime.SendToPipe(
+        TTestTxConfig::Coordinator, edge, ev.Release(), 0, GetPipeConfigWithRetries());
+}
+
+void WaitCompleteFromTablets(
+    TTestActorRuntime& runtime,
+    const TActorId& edge,
+    ui64 txId,
+    ui32 expectedCount)
+{
+    THashSet<ui64> origins;
+    for (ui32 i = 0; i < expectedCount * 16 && origins.size() < expectedCount; ++i) {
+        auto handle = runtime.GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+            edge, kEdgeTimeout);
+        if (!handle) {
+            ythrow TProdPqRetry() << "timeout waiting COMPLETE";
+        }
+        const auto& record = handle->Get()->Record;
+        if (record.GetTxId() != txId) {
+            continue;
+        }
+        if (record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
+            continue;
+        }
+        if (record.GetStatus() != NKikimrPQ::TEvProposeTransactionResult::COMPLETE) {
+            ythrow TProdPqRetry()
+                << "unexpected status after plan="
+                << static_cast<int>(record.GetStatus());
+        }
+        UNIT_ASSERT(record.HasOrigin());
+        origins.insert(record.GetOrigin());
+    }
+    if (origins.size() < expectedCount) {
+        ythrow TProdPqRetry()
+            << "COMPLETE got=" << origins.size() << "/" << expectedCount;
+    }
+}
+
+void DrainStaleProposeResults(TTestActorRuntime& runtime, const TActorId& edge) {
+    for (;;) {
+        auto handle = runtime.GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+            edge, TDuration::MilliSeconds(1));
+        if (!handle) {
+            break;
+        }
+    }
+}
+
+struct TPipeSession {
+    TActorId Pipe;
+
+    void Reset(TTestActorRuntime& runtime, const TActorId& edge) {
+        if (Pipe) {
+            runtime.ClosePipe(Pipe, edge, 0);
+            Pipe = {};
+        }
+    }
+
+    void Ensure(TTestActorRuntime& runtime, const TActorId& edge, ui64 tabletId) {
+        if (!Pipe) {
+            Pipe = runtime.ConnectToPipe(tabletId, edge, 0, GetPipeConfigWithRetries());
+        }
+        Y_ABORT_UNLESS(Pipe);
+    }
+
+    void Send(TTestActorRuntime& runtime, const TActorId& edge, IEventBase* event) {
+        runtime.SendToPipe(Pipe, edge, event, 0, 0);
+    }
+};
+
+ui64 GetEndOffset(TTestActorRuntime& runtime, const TPartitionRef& part) {
+    const TActorId edge = runtime.AllocateEdgeActor();
+    auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
+    runtime.SendToPipe(
+        part.TabletId, edge, request.Release(), 0, GetPipeConfigWithRetries());
+    auto handle = runtime.GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(edge, kEdgeTimeout);
+    if (!handle) {
+        ythrow TProdPqRetry() << "timeout GetEndOffset partition=" << part.PartitionId;
+    }
+    for (const auto& pr : handle->Get()->Record.GetPartResult()) {
+        if (static_cast<ui32>(pr.GetPartition()) == part.PartitionId) {
+            if (pr.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                ythrow TProdPqRetry() << "GetEndOffset INITIALIZING";
+            }
+            return pr.GetEndOffset();
+        }
+    }
+    ythrow TProdPqRetry() << "GetEndOffset: partition not found id=" << part.PartitionId;
+}
+
+bool AllEndOffsetsAt(
+    TTestActorRuntime& runtime,
+    const TVector<TPartitionRef>& parts,
+    ui64 expected)
+{
+    for (const auto& part : parts) {
+        if (GetEndOffset(runtime, part) != expected) {
+            return false;
+        }
+    }
+    return true;
+}
+
+NKikimrClient::TCmdReadResult CaptureCmdReadResult(
+    TTestActorRuntime& runtime,
+    const TPartitionRef& part,
+    ui64 offset,
+    ui32 count)
+{
+    const TActorId edge = runtime.AllocateEdgeActor();
+    auto request = MakeHolder<TEvPersQueue::TEvRequest>();
+    auto* req = request->Record.MutablePartitionRequest();
+    req->SetPartition(part.PartitionId);
+    req->SetCookie(part.TabletId);
+    auto* read = req->MutableCmdRead();
+    read->SetClientId(kConsumer);
+    read->SetSessionId("");
+    read->SetOffset(offset);
+    read->SetCount(count);
+    read->SetBytes(16_MB);
+    read->SetReadToBlobEnd(true);
+    runtime.SendToPipe(
+        part.TabletId, edge, request.Release(), 0, GetPipeConfigWithRetries());
+    auto handle = runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(edge, kEdgeTimeout);
+    if (!handle) {
+        ythrow TProdPqRetry() << "timeout CmdRead partition=" << part.PartitionId;
+    }
+    const auto& record = handle->Get()->Record;
+    if (record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+        ythrow TProdPqRetry() << "CmdRead INITIALIZING";
+    }
+    UNIT_ASSERT_VALUES_EQUAL(
+        (int)record.GetErrorCode(), (int)NPersQueue::NErrorCode::OK);
+    UNIT_ASSERT(record.GetPartitionResponse().HasCmdReadResult());
+    return record.GetPartitionResponse().GetCmdReadResult();
+}
+
+TString CreateSupportivePartition(
+    TTestActorRuntime& runtime,
+    TPipeSession& pipe,
+    const TActorId& edge,
+    const TPartitionRef& part,
+    const TWriteId& writeId)
+{
+    for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+        try {
+            runtime.ResetScheduledCount();
+            pipe.Reset(runtime, edge);
+            pipe.Ensure(runtime, edge, part.TabletId);
+
+            auto event = std::make_unique<TEvPersQueue::TEvRequest>();
+            auto* request = event->Record.MutablePartitionRequest();
+            request->SetPartition(part.PartitionId);
+            request->SetCookie(4);
+            request->SetNeedSupportivePartition(true);
+            SetWriteId(*request, writeId);
+            ActorIdToProto(pipe.Pipe, request->MutablePipeClient());
+            auto* cmd = request->MutableCmdGetOwnership();
+            cmd->SetOwner(kTxWriteOwner);
+            cmd->SetForce(true);
+
+            pipe.Send(runtime, edge, event.release());
+            auto response = runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(edge, kEdgeTimeout);
+            if (!response) {
+                continue;
+            }
+            const auto& record = response->Get()->Record;
+            if (record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                runtime.DispatchEvents();
+                retriesLeft = 5;
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(
+                (int)record.GetStatus(), (int)NMsgBusProxy::MSTATUS_OK);
+            return record.GetPartitionResponse().GetCmdGetOwnershipResult().GetOwnerCookie();
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+        } catch (const NActors::TEmptyEventQueueException&) {
+        }
+    }
+    ythrow TProdPqRetry() << "CreateSupportivePartition exhausted partition=" << part.PartitionId;
+}
+
+void WriteToSupportive(
+    TTestActorRuntime& runtime,
+    TPipeSession& pipe,
+    const TActorId& edge,
+    const TPartitionRef& part,
+    const TWriteId& writeId,
+    const TString& ownerCookie,
+    ui64 seqNo,
+    ui64 messageNo,
+    const TString& data,
+    ui64 cookie)
+{
+    for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+        try {
+            runtime.ResetScheduledCount();
+            pipe.Ensure(runtime, edge, part.TabletId);
+
+            auto event = MakeHolder<TEvPersQueue::TEvRequest>();
+            auto* request = event->Record.MutablePartitionRequest();
+            request->SetTopic(kTopicPath);
+            request->SetPartition(part.PartitionId);
+            request->SetCookie(cookie);
+            request->SetOwnerCookie(ownerCookie);
+            request->SetMessageNo(messageNo);
+            SetWriteId(*request, writeId);
+            ActorIdToProto(pipe.Pipe, request->MutablePipeClient());
+
+            auto* cmdWrite = request->AddCmdWrite();
+            cmdWrite->SetSourceId(kTxWriteSourceId);
+            cmdWrite->SetSeqNo(seqNo);
+            cmdWrite->SetData(data);
+            cmdWrite->SetCreateTimeMS(TInstant::Now().MilliSeconds());
+            cmdWrite->SetDisableDeduplication(true);
+            cmdWrite->SetUncompressedSize(data.size());
+            cmdWrite->SetIgnoreQuotaDeadline(true);
+            cmdWrite->SetExternalOperation(true);
+
+            pipe.Send(runtime, edge, event.Release());
+            auto response = runtime.GrabEdgeEvent<TEvPersQueue::TEvResponse>(edge, kEdgeTimeout);
+            if (!response) {
+                pipe.Reset(runtime, edge);
+                continue;
+            }
+            const auto& record = response->Get()->Record;
+            if (record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                pipe.Reset(runtime, edge);
+                runtime.DispatchEvents();
+                retriesLeft = 5;
+                continue;
+            }
+            if (record.GetErrorCode() != NPersQueue::NErrorCode::OK) {
+                ythrow TProdPqRetry()
+                    << "WriteToSupportive error="
+                    << static_cast<int>(record.GetErrorCode());
+            }
+            UNIT_ASSERT_VALUES_EQUAL(
+                record.GetPartitionResponse().GetCookie(), cookie);
+            return;
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            pipe.Reset(runtime, edge);
+        } catch (const NActors::TEmptyEventQueueException&) {
+            pipe.Reset(runtime, edge);
+        }
+    }
+    ythrow TProdPqRetry() << "WriteToSupportive exhausted partition=" << part.PartitionId;
+}
+
+ui32 WaitSupportivePartitionId(
+    TTestActorRuntime& runtime,
+    TPipeSession& pipe,
+    const TActorId& edge,
+    const TPartitionRef& part,
+    const TWriteId& writeId)
+{
+    for (size_t i = 0; i < 40; ++i) {
+        try {
+            runtime.ResetScheduledCount();
+            pipe.Ensure(runtime, edge, part.TabletId);
+            auto request = std::make_unique<TEvKeyValue::TEvRequest>();
+            request->Record.SetCookie(12345);
+            request->Record.AddCmdRead()->SetKey("_txinfo");
+            pipe.Send(runtime, edge, request.release());
+
+            auto response = runtime.GrabEdgeEvent<TEvKeyValue::TEvResponse>(edge, kEdgeTimeout);
+            if (!response) {
+                pipe.Reset(runtime, edge);
+                continue;
+            }
+            const auto& kvRecord = response->Get()->Record;
+            UNIT_ASSERT_VALUES_EQUAL(kvRecord.GetStatus(), NMsgBusProxy::MSTATUS_OK);
+            const auto& result = kvRecord.GetReadResult(0);
+            if (result.GetStatus() == static_cast<ui32>(NKikimrProto::OK)) {
+                NKikimrPQ::TTabletTxInfo info;
+                UNIT_ASSERT(info.ParseFromString(result.GetValue()));
+                for (const auto& txWrite : info.GetTxWrites()) {
+                    if (GetWriteId(txWrite) == writeId) {
+                        return txWrite.GetInternalPartitionId();
+                    }
+                }
+            } else if (result.GetStatus() != NKikimrProto::NODATA) {
+                ythrow TProdPqRetry()
+                    << "WaitSupportivePartitionId KV status=" << result.GetStatus();
+            }
+            runtime.SimulateSleep(TDuration::MilliSeconds(50));
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            ythrow TProdPqRetry() << "WaitSupportivePartitionId scheduling limit";
+        } catch (const NActors::TEmptyEventQueueException&) {
+            ythrow TProdPqRetry() << "WaitSupportivePartitionId empty queue";
+        }
+    }
+    ythrow TProdPqRetry()
+        << "supportive partition id missing in _txinfo partition=" << part.PartitionId;
+}
+
+void ProposeTopicWriteCommit(
+    TTestActorRuntime& runtime,
+    const TActorId& edge,
+    ui64 txId,
+    const TPartitionRef& part,
+    const THashSet<ui64>& allTablets,
+    const TWriteId& writeId,
+    ui32 supportivePartitionId)
+{
+    auto event = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
+    ActorIdToProto(edge, event->Record.MutableSourceActor());
+    event->Record.SetTxId(txId);
+    auto* body = event->Record.MutableData();
+    auto* operation = body->MutableOperations()->Add();
+    operation->SetPartitionId(part.PartitionId);
+    operation->SetPath(kTopicPath);
+    operation->SetSupportivePartition(supportivePartitionId);
+    for (ui64 shard : allTablets) {
+        if (shard == part.TabletId) {
+            continue;
+        }
+        body->AddSendingShards(shard);
+        body->AddReceivingShards(shard);
+    }
+    SetWriteId(*body, writeId);
+    body->SetImmediate(false);
+    runtime.SendToPipe(
+        part.TabletId, edge, event.Release(), 0, GetPipeConfigWithRetries());
+}
+
+void AssertTopicWriteCommitted(
+    TTestActorRuntime& runtime,
+    const TVector<TPartitionRef>& parts,
+    ui64 readFrom,
+    ui32 txCount,
+    TMaybe<ui32> expectedAttempt)
+{
+    for (const auto& part : parts) {
+        UNIT_ASSERT_VALUES_EQUAL_C(
+            GetEndOffset(runtime, part), readFrom + txCount,
+            "partition=" << part.PartitionId);
+        const auto readResult = CaptureCmdReadResult(runtime, part, readFrom, txCount);
+        UNIT_ASSERT_VALUES_EQUAL(readResult.ResultSize(), txCount);
+        for (ui32 i = 0; i < txCount; ++i) {
+            const auto& row = readResult.GetResult(i);
+            UNIT_ASSERT_VALUES_EQUAL(row.GetOffset(), readFrom + i);
+            if (expectedAttempt.Defined()) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    row.GetData(),
+                    TStringBuilder()
+                        << "prod-tx-write-" << *expectedAttempt
+                        << "-" << part.PartitionId << "-" << i);
+            } else {
+                UNIT_ASSERT_C(
+                    row.GetData().StartsWith("prod-tx-write-"),
+                    "unexpected payload=" << row.GetData());
+            }
+        }
+    }
+}
+
+TTestEnvOptions MakeEnvOptions() {
+    return TTestWithReboots::GetDefaultTestEnvOptions().RunFakeConfigDispatcher(true);
+}
+
+// Data-plane reboot targets: Hive-owned PQ tablets + FakeCoordinator (plan deliverer).
+// FakeHive assigns PQ ids at FakeHiveTablets..+3; balancer follows at +4.
+TVector<ui64> DataPlaneRebootTablets() {
+    TVector<ui64> ids;
+    ids.reserve(kPqTabletCount + 1);
+    for (ui32 i = 0; i < kPqTabletCount; ++i) {
+        ids.push_back(TTestTxConfig::FakeHiveTablets + i);
+    }
+    ids.push_back(TTestTxConfig::Coordinator);
+    return ids;
+}
+
+struct TProdPqEnv {
+    THolder<TTestBasicRuntime> Runtime;
+    THolder<TTestEnv> Env;
+    ui64 TxId = 1000;
+    TActorId Edge;
+    TVector<TPartitionRef> Parts;
+    THashSet<ui64> PqTabletIds;
+
+    void Prepare(
+        const TString& dispatchName,
+        std::function<void(TTestActorRuntime&)> setup,
+        bool& activeZone,
+        bool seedMessages = true)
+    {
+        activeZone = false;
+        Cerr << Endl
+             << "====== " << TInstant::Now()
+             << " ===== PROD_PQ RUN: " << dispatchName
+             << " ===========" << Endl;
+        Runtime.Reset(new TTestBasicRuntime());
+        Runtime->SetScheduledLimit(50'000);
+        setup(*Runtime);
+        Env.Reset(new TTestEnv(*Runtime, MakeEnvOptions()));
+        Env->SetupLogging(*Runtime);
+        TxId = 1000;
+        TestMkDir(*Runtime, ++TxId, "/MyRoot", "DirA");
+        Edge = Runtime->AllocateEdgeActor();
+
+        // Topic create (+ optional seed) stay outside the reboot/pipe-reset zone.
+        // One partition per tablet → kPqTabletCount real PQ tablets + RS mesh among them.
+        TestCreatePQGroup(
+            *Runtime, ++TxId, "/MyRoot/DirA",
+            TopicCreateScheme(/*partitions=*/kPqTabletCount, /*perTablet=*/1));
+        Env->TestWaitNotification(*Runtime, TxId);
+        Parts = DescribePartitions(*Runtime);
+        PqTabletIds = UniqueTabletIds(Parts);
+        UNIT_ASSERT_VALUES_EQUAL(PqTabletIds.size(), kPqTabletCount);
+        if (seedMessages) {
+            SeedAllPartitions(*Runtime, Parts);
+        }
+        Cerr << "====== PROD_PQ prepared tablets=";
+        for (ui64 id : PqTabletIds) {
+            Cerr << " " << id;
+        }
+        Cerr << " ======" << Endl;
+    }
+};
+
+// Active zone: first TEvProposeTransaction → COMPLETE (commit durable / offsets applied).
+// Retries re-propose; never recreate the topic.
+void DataPlaneOffsetCommitScenario(TProdPqEnv& env, bool& activeZone) {
+    for (ui32 attempt = 0; attempt < 15; ++attempt) {
+        try {
+            env.Runtime->ResetScheduledCount();
+            activeZone = false;
+            DrainStaleProposeResults(*env.Runtime, env.Edge);
+
+            if (AllOffsetsAt(*env.Runtime, env.Parts, kSeedMsgCount)) {
+                Cerr << "====== PROD_PQ already committed, skip attempt="
+                     << attempt << " ======" << Endl;
+                return;
+            }
+
+            const ui64 commitTxId = 9400 + attempt;
+            const auto& tablets = env.PqTabletIds;
+
+            Cerr << "====== PROD_PQ attempt=" << attempt
+                 << " txId=" << commitTxId
+                 << " enter activeZone ======" << Endl;
+
+            // Injection covers propose → plan → RS mesh → COMPLETE.
+            activeZone = true;
+            for (const auto& part : env.Parts) {
+                ProposeOffsetCommit(
+                    *env.Runtime, env.Edge, commitTxId, part, tablets,
+                    /*begin=*/0, /*end=*/kSeedMsgCount);
+            }
+            WaitPreparedFromTablets(*env.Runtime, env.Edge, commitTxId, tablets.size());
+            PlanViaFakeCoordinator(*env.Runtime, env.Edge, commitTxId, tablets);
+            WaitCompleteFromTablets(*env.Runtime, env.Edge, commitTxId, tablets.size());
+            activeZone = false;
+
+            AssertAllOffsetsAt(*env.Runtime, env.Parts, kSeedMsgCount);
+            Cerr << "====== PROD_PQ attempt=" << attempt
+                 << " txId=" << commitTxId
+                 << " COMPLETE ok ======" << Endl;
+            return;
+        } catch (const TProdPqRetry& ex) {
+            activeZone = false;
+            Cerr << "====== PROD_PQ attempt=" << attempt
+                 << " retry: " << ex.what() << " ======" << Endl;
+            try {
+                env.Runtime->ResetScheduledCount();
+                env.Runtime->SimulateSleep(TDuration::MilliSeconds(50));
+            } catch (...) {
+            }
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            activeZone = false;
+            Cerr << "====== PROD_PQ attempt=" << attempt
+                 << " scheduling limit ======" << Endl;
+        } catch (const NActors::TEmptyEventQueueException&) {
+            activeZone = false;
+            Cerr << "====== PROD_PQ attempt=" << attempt
+                 << " empty event queue ======" << Endl;
+        }
+    }
+    UNIT_FAIL("DataPlaneOffsetCommitScenario: retries exhausted");
+}
+
+// Active zone: ProposeTransaction(write) → COMPLETE (messages published to real partitions).
+// Ownership + supportive writes stay outside the zone (same discipline as L0 TopicTxWrite*).
+void DataPlaneTopicWriteScenario(TProdPqEnv& env, bool& activeZone) {
+    THashMap<ui64, TPipeSession> pipes;
+    for (ui64 tabletId : env.PqTabletIds) {
+        pipes[tabletId] = TPipeSession{};
+    }
+
+    auto resetPipes = [&]() {
+        for (auto& [_, pipe] : pipes) {
+            pipe.Reset(*env.Runtime, env.Edge);
+        }
+    };
+
+    for (ui32 attempt = 0; attempt < 15; ++attempt) {
+        try {
+            env.Runtime->ResetScheduledCount();
+            activeZone = false;
+            resetPipes();
+            DrainStaleProposeResults(*env.Runtime, env.Edge);
+
+            // Previous attempt may have committed while a later GrabEdgeEvent failed.
+            if (AllEndOffsetsAt(*env.Runtime, env.Parts, kTxWriteMsgCount)) {
+                Cerr << "====== PROD_PQ write already committed, skip attempt="
+                     << attempt << " ======" << Endl;
+                AssertTopicWriteCommitted(
+                    *env.Runtime, env.Parts, /*readFrom=*/0,
+                    kTxWriteMsgCount, /*expectedAttempt=*/Nothing());
+                return;
+            }
+
+            const ui64 endBefore = GetEndOffset(*env.Runtime, env.Parts.front());
+            for (const auto& part : env.Parts) {
+                UNIT_ASSERT_VALUES_EQUAL_C(
+                    GetEndOffset(*env.Runtime, part), endBefore,
+                    "partitions diverged before write-tx");
+            }
+
+            const ui64 writeTxId = 9500 + attempt;
+            const auto& tablets = env.PqTabletIds;
+
+            Cerr << "====== PROD_PQ write attempt=" << attempt
+                 << " txId=" << writeTxId
+                 << " endBefore=" << endBefore
+                 << " prepare supportive ======" << Endl;
+
+            struct TPreparedWrite {
+                TPartitionRef Part;
+                TWriteId WriteId;
+                ui32 SupportivePartitionId = 0;
+            };
+            TVector<TPreparedWrite> prepared;
+            prepared.reserve(env.Parts.size());
+
+            for (const auto& part : env.Parts) {
+                const TWriteId writeId(part.TabletId, 1000 + attempt);
+                auto& pipe = pipes[part.TabletId];
+                const TString ownerCookie = CreateSupportivePartition(
+                    *env.Runtime, pipe, env.Edge, part, writeId);
+                for (ui32 i = 0; i < kTxWriteMsgCount; ++i) {
+                    WriteToSupportive(
+                        *env.Runtime, pipe, env.Edge, part, writeId, ownerCookie,
+                        /*seqNo=*/i, /*messageNo=*/i,
+                        TStringBuilder()
+                            << "prod-tx-write-" << attempt
+                            << "-" << part.PartitionId << "-" << i,
+                        /*cookie=*/500 + i);
+                }
+                const ui32 supportiveId = WaitSupportivePartitionId(
+                    *env.Runtime, pipe, env.Edge, part, writeId);
+                prepared.push_back({part, writeId, supportiveId});
+            }
+
+            Cerr << "====== PROD_PQ write attempt=" << attempt
+                 << " txId=" << writeTxId
+                 << " enter activeZone ======" << Endl;
+
+            activeZone = true;
+            for (const auto& item : prepared) {
+                ProposeTopicWriteCommit(
+                    *env.Runtime, env.Edge, writeTxId, item.Part, tablets,
+                    item.WriteId, item.SupportivePartitionId);
+            }
+            WaitPreparedFromTablets(*env.Runtime, env.Edge, writeTxId, tablets.size());
+            PlanViaFakeCoordinator(*env.Runtime, env.Edge, writeTxId, tablets);
+            WaitCompleteFromTablets(*env.Runtime, env.Edge, writeTxId, tablets.size());
+            activeZone = false;
+
+            AssertTopicWriteCommitted(
+                *env.Runtime, env.Parts, endBefore, kTxWriteMsgCount, attempt);
+            Cerr << "====== PROD_PQ write attempt=" << attempt
+                 << " txId=" << writeTxId
+                 << " COMPLETE ok ======" << Endl;
+            return;
+        } catch (const TProdPqRetry& ex) {
+            activeZone = false;
+            Cerr << "====== PROD_PQ write attempt=" << attempt
+                 << " retry: " << ex.what() << " ======" << Endl;
+            try {
+                env.Runtime->ResetScheduledCount();
+                env.Runtime->SimulateSleep(TDuration::MilliSeconds(50));
+            } catch (...) {
+            }
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            activeZone = false;
+            Cerr << "====== PROD_PQ write attempt=" << attempt
+                 << " scheduling limit ======" << Endl;
+        } catch (const NActors::TEmptyEventQueueException&) {
+            activeZone = false;
+            Cerr << "====== PROD_PQ write attempt=" << attempt
+                 << " empty event queue ======" << Endl;
+        }
+    }
+    UNIT_FAIL("DataPlaneTopicWriteScenario: retries exhausted");
+}
+
+void RunDataPlaneInjection(
+    std::function<void(
+        const TVector<ui64>&,
+        std::function<TTestActorRuntime::TEventFilter()>,
+        std::function<void(const TString&, std::function<void(TTestActorRuntime&)>, bool&)>)> runner,
+    std::function<void(TProdPqEnv&, bool&)> scenario,
+    bool seedMessages = true,
+    const std::unordered_set<TString>& extraSkipEventTypes = {})
+{
+    TInitialEventsFilter filter;
+    runner(
+        DataPlaneRebootTablets(),
+        [&]() {
+            return filter.Prepare(
+                {TabletPipe, NPDisk, KeyValue, PQ},
+                extraSkipEventTypes);
+        },
+        [&](const TString& dispatchName,
+            std::function<void(TTestActorRuntime&)> setup,
+            bool& activeZone) {
+            TProdPqEnv env;
+            activeZone = false;
+            env.Prepare(dispatchName, setup, activeZone, seedMessages);
+            scenario(env, activeZone);
+        });
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TProdPqInjectionTests) {
+
+// Baseline without injection matrix: create → propose → FakeCoordinator plan → COMPLETE.
+Y_UNIT_TEST(SmokeDistributedOffsetCommitViaFakeCoordinator) {
+    TTestBasicRuntime runtime;
+    runtime.SetScheduledLimit(50'000);
+    TTestEnv env(runtime, MakeEnvOptions());
+    env.SetupLogging(runtime);
+    ui64 txId = 1000;
+    TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+
+    TestCreatePQGroup(
+        runtime, ++txId, "/MyRoot/DirA",
+        TopicCreateScheme(/*partitions=*/kPqTabletCount, /*perTablet=*/1));
+    env.TestWaitNotification(runtime, txId);
+    auto parts = DescribePartitions(runtime);
+    UNIT_ASSERT_VALUES_EQUAL(UniqueTabletIds(parts).size(), kPqTabletCount);
+    SeedAllPartitions(runtime, parts);
+
+    const TActorId edge = runtime.AllocateEdgeActor();
+    const auto tablets = UniqueTabletIds(parts);
+    const ui64 commitTxId = 9400;
+    for (const auto& part : parts) {
+        ProposeOffsetCommit(runtime, edge, commitTxId, part, tablets, 0, kSeedMsgCount);
+    }
+    WaitPreparedFromTablets(runtime, edge, commitTxId, tablets.size());
+    PlanViaFakeCoordinator(runtime, edge, commitTxId, tablets);
+    WaitCompleteFromTablets(runtime, edge, commitTxId, tablets.size());
+    AssertAllOffsetsAt(runtime, parts, kSeedMsgCount);
+}
+
+// Baseline: supportive write on all partitions → distributed propose/plan → published.
+Y_UNIT_TEST(SmokeDistributedTopicWriteViaFakeCoordinator) {
+    TTestBasicRuntime runtime;
+    runtime.SetScheduledLimit(50'000);
+    TTestEnv env(runtime, MakeEnvOptions());
+    env.SetupLogging(runtime);
+    ui64 txId = 1000;
+    TestMkDir(runtime, ++txId, "/MyRoot", "DirA");
+
+    TestCreatePQGroup(
+        runtime, ++txId, "/MyRoot/DirA",
+        TopicCreateScheme(/*partitions=*/kPqTabletCount, /*perTablet=*/1));
+    env.TestWaitNotification(runtime, txId);
+    auto parts = DescribePartitions(runtime);
+    UNIT_ASSERT_VALUES_EQUAL(UniqueTabletIds(parts).size(), kPqTabletCount);
+
+    const TActorId edge = runtime.AllocateEdgeActor();
+    const auto tablets = UniqueTabletIds(parts);
+    THashMap<ui64, TPipeSession> pipes;
+    for (ui64 tabletId : tablets) {
+        pipes[tabletId] = TPipeSession{};
+    }
+
+    struct TPreparedWrite {
+        TPartitionRef Part;
+        TWriteId WriteId;
+        ui32 SupportivePartitionId = 0;
+    };
+    TVector<TPreparedWrite> prepared;
+    for (const auto& part : parts) {
+        const TWriteId writeId(part.TabletId, 1000);
+        auto& pipe = pipes[part.TabletId];
+        const TString ownerCookie = CreateSupportivePartition(
+            runtime, pipe, edge, part, writeId);
+        for (ui32 i = 0; i < kTxWriteMsgCount; ++i) {
+            WriteToSupportive(
+                runtime, pipe, edge, part, writeId, ownerCookie,
+                /*seqNo=*/i, /*messageNo=*/i,
+                TStringBuilder() << "prod-tx-write-0-" << part.PartitionId << "-" << i,
+                /*cookie=*/500 + i);
+        }
+        prepared.push_back({
+            part, writeId,
+            WaitSupportivePartitionId(runtime, pipe, edge, part, writeId)});
+    }
+
+    const ui64 writeTxId = 9500;
+    for (const auto& item : prepared) {
+        ProposeTopicWriteCommit(
+            runtime, edge, writeTxId, item.Part, tablets,
+            item.WriteId, item.SupportivePartitionId);
+    }
+    WaitPreparedFromTablets(runtime, edge, writeTxId, tablets.size());
+    PlanViaFakeCoordinator(runtime, edge, writeTxId, tablets);
+    WaitCompleteFromTablets(runtime, edge, writeTxId, tablets.size());
+    AssertTopicWriteCommitted(runtime, parts, /*readFrom=*/0, kTxWriteMsgCount, /*attempt=*/0);
+}
+
+// Data plane: PQ + FakeCoordinator under RunTestWithReboots.
+// Topic create/seed are outside activeZone; zone starts at ProposeTransaction.
+Y_UNIT_TEST(DistributedOffsetCommitWithTabletReboots) {
+    RunDataPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithReboots(tabletIds, filterFactory, testFunc);
+        },
+        DataPlaneOffsetCommitScenario);
+}
+
+// Data plane: same scenario under pipe resets (no ReadSet skip — Hive-owned PQ).
+Y_UNIT_TEST(DistributedOffsetCommitWithPipeResets) {
+    RunDataPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithPipeResets(tabletIds, filterFactory, testFunc);
+        },
+        DataPlaneOffsetCommitScenario);
+}
+
+// Topic write-tx: supportive prep outside zone; propose/plan/COMPLETE under reboots.
+Y_UNIT_TEST(DistributedTopicWriteWithTabletReboots) {
+    RunDataPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithReboots(tabletIds, filterFactory, testFunc);
+        },
+        DataPlaneTopicWriteScenario,
+        /*seedMessages=*/false);
+}
+
+Y_UNIT_TEST(DistributedTopicWriteWithPipeResets) {
+    RunDataPlaneInjection(
+        [](const auto& tabletIds, auto filterFactory, auto testFunc) {
+            RunTestWithPipeResets(tabletIds, filterFactory, testFunc);
+        },
+        DataPlaneTopicWriteScenario,
+        /*seedMessages=*/false);
+}
+
+#if 0 // control plane: enable after data-plane RunTestWithReboots approach is stable
+Y_UNIT_TEST(AlterTopicConfigWithSchemeShardReboot) {
+    // TODO: activeZone from SS→PQ config propose until tx deleted;
+    // reboot targets: PQ + SchemeShard + FakeCoordinator.
+}
+
+Y_UNIT_TEST(SplitPartitionOnProdLikeEnv) {
+    // TODO: same control-plane discipline.
+}
+
+Y_UNIT_TEST(DropTopicMidDistributedCommit) {
+    // TODO: DROP mid WAIT_RS → Dead path.
+}
+#endif
+
+} // Y_UNIT_TEST_SUITE(TProdPqInjectionTests)
+
+} // namespace NKikimr::NPQ

--- a/ydb/core/persqueue/ut/injection/prod/ya.make
+++ b/ydb/core/persqueue/ut/injection/prod/ya.make
@@ -5,21 +5,19 @@ YQL_LAST_ABI_VERSION()
 SIZE(MEDIUM)
 
 FORK_SUBTESTS()
-SPLIT_FACTOR(2)
+SPLIT_FACTOR(4)
 REQUIREMENTS(cpu:2)
 
 PEERDIR(
     library/cpp/testing/unittest
     ydb/core/persqueue/ut/common
     ydb/core/testlib/default
+    ydb/core/tx
+    ydb/core/tx/schemeshard/ut_helpers
 )
 
 SRCS(
-    distributed_three_pq_tx_ut.cpp
-)
-
-RECURSE_FOR_TESTS(
-    prod
+    prod_pq_injection_ut.cpp
 )
 
 END()

--- a/ydb/core/persqueue/ut/injection/ya.make
+++ b/ydb/core/persqueue/ut/injection/ya.make
@@ -1,0 +1,21 @@
+UNITTEST_FOR(ydb/core/persqueue)
+
+YQL_LAST_ABI_VERSION()
+
+SIZE(MEDIUM)
+
+FORK_SUBTESTS()
+SPLIT_FACTOR(2)
+REQUIREMENTS(cpu:2)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    ydb/core/persqueue/ut/common
+    ydb/core/testlib/default
+)
+
+SRCS(
+    distributed_three_pq_tx_ut.cpp
+)
+
+END()

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -4417,6 +4417,391 @@ Y_UNIT_TEST_F(DeferredPublicationRenameThenMidCmdReadKeepsParentOffsets, TPQTabl
     }
 }
 
+namespace {
+
+constexpr TStringBuf kTopicTxInjectionOwner = "-=[ tx-reboot-owner ]=-";
+// Sim-time deadline: after reboot the in-flight response is dropped and pipe is stale;
+// without a timeout GrabEdgeEvent can spin forever on tablet-resolver retries
+// that do not bump ScheduledCount.
+constexpr TDuration kTopicTxInjectionEdgeTimeout = TDuration::Seconds(2);
+
+// Thrown to restart the Topic-tx scenario after a mid-flight reboot/pipe reset.
+class TTopicTxInjectionRetry : public yexception {
+};
+
+class TTopicTxInjectionHelper {
+public:
+    explicit TTopicTxInjectionHelper(TTestContext& tc)
+        : Tc(tc)
+    {}
+
+    ~TTopicTxInjectionHelper() {
+        ResetPipe();
+    }
+
+    void ResetPipe() {
+        if (Pipe) {
+            Tc.Runtime->ClosePipe(Pipe, Tc.Edge, 0);
+            Pipe = {};
+        }
+    }
+
+    void EnsurePipe() {
+        if (!Pipe) {
+            Pipe = Tc.Runtime->ConnectToPipe(Tc.TabletId, Tc.Edge, 0, GetPipeConfigWithRetries());
+        }
+        Y_ABORT_UNLESS(Pipe);
+    }
+
+    void SendToPipe(IEventBase* event) {
+        EnsurePipe();
+        Tc.Runtime->SendToPipe(Pipe, Tc.Edge, event, 0, 0);
+    }
+
+    TString CreateSupportivePartition(const TWriteId& writeId) {
+        for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+            try {
+                Tc.Runtime->ResetScheduledCount();
+                ResetPipe();
+                EnsurePipe();
+
+                auto event = std::make_unique<TEvPersQueue::TEvRequest>();
+                auto* request = event->Record.MutablePartitionRequest();
+                request->SetPartition(0);
+                request->SetCookie(4);
+                request->SetNeedSupportivePartition(true);
+                SetWriteId(*request, writeId);
+                ActorIdToProto(Pipe, request->MutablePipeClient());
+                auto* cmd = request->MutableCmdGetOwnership();
+                cmd->SetOwner(TString{kTopicTxInjectionOwner});
+                cmd->SetForce(true);
+
+                SendToPipe(event.release());
+                auto response = Tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(
+                    kTopicTxInjectionEdgeTimeout);
+                if (!response) {
+                    continue;
+                }
+                if (response->Record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                    Tc.Runtime->DispatchEvents();
+                    retriesLeft = 5;
+                    continue;
+                }
+                UNIT_ASSERT_VALUES_EQUAL((int)response->Record.GetStatus(), (int)NMsgBusProxy::MSTATUS_OK);
+                return response->Record.GetPartitionResponse().GetCmdGetOwnershipResult().GetOwnerCookie();
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+            } catch (const NActors::TEmptyEventQueueException&) {
+            }
+        }
+        ythrow TTopicTxInjectionRetry() << "CreateSupportivePartition: retries exhausted";
+    }
+
+    void WriteToSupportive(
+        const TWriteId& writeId,
+        const TString& ownerCookie,
+        ui64 seqNo,
+        ui64 messageNo,
+        const TString& data,
+        ui64 cookie)
+    {
+        for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+            try {
+                Tc.Runtime->ResetScheduledCount();
+                EnsurePipe();
+
+                auto event = MakeHolder<TEvPersQueue::TEvRequest>();
+                auto* request = event->Record.MutablePartitionRequest();
+                request->SetTopic("/topic");
+                request->SetPartition(0);
+                request->SetCookie(cookie);
+                request->SetOwnerCookie(ownerCookie);
+                request->SetMessageNo(messageNo);
+                SetWriteId(*request, writeId);
+                ActorIdToProto(Pipe, request->MutablePipeClient());
+
+                auto* cmdWrite = request->AddCmdWrite();
+                cmdWrite->SetSourceId("tx-src");
+                cmdWrite->SetSeqNo(seqNo);
+                cmdWrite->SetData(data);
+                cmdWrite->SetCreateTimeMS(TInstant::Now().MilliSeconds());
+                cmdWrite->SetDisableDeduplication(true);
+                cmdWrite->SetUncompressedSize(data.size());
+                cmdWrite->SetIgnoreQuotaDeadline(true);
+                cmdWrite->SetExternalOperation(true);
+
+                SendToPipe(event.Release());
+                auto response = Tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(
+                    kTopicTxInjectionEdgeTimeout);
+                if (!response) {
+                    ResetPipe();
+                    continue;
+                }
+                if (response->Record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                    ResetPipe();
+                    Tc.Runtime->DispatchEvents();
+                    retriesLeft = 5;
+                    continue;
+                }
+                if (response->Record.GetErrorCode() != NPersQueue::NErrorCode::OK) {
+                    ythrow TTopicTxInjectionRetry()
+                        << "WriteToSupportive error="
+                        << static_cast<int>(response->Record.GetErrorCode());
+                }
+                UNIT_ASSERT_VALUES_EQUAL(response->Record.GetPartitionResponse().GetCookie(), cookie);
+                return;
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+                ResetPipe();
+            } catch (const NActors::TEmptyEventQueueException&) {
+                ResetPipe();
+            }
+        }
+        ythrow TTopicTxInjectionRetry() << "WriteToSupportive: retries exhausted";
+    }
+
+    ui32 WaitSupportivePartitionId(const TWriteId& writeId) {
+        for (size_t i = 0; i < 40; ++i) {
+            try {
+                Tc.Runtime->ResetScheduledCount();
+                EnsurePipe();
+                auto request = std::make_unique<TEvKeyValue::TEvRequest>();
+                request->Record.SetCookie(12345);
+                request->Record.AddCmdRead()->SetKey("_txinfo");
+                SendToPipe(request.release());
+
+                auto response = Tc.Runtime->GrabEdgeEvent<TEvKeyValue::TEvResponse>(
+                    kTopicTxInjectionEdgeTimeout);
+                if (!response) {
+                    ResetPipe();
+                    continue;
+                }
+                UNIT_ASSERT_VALUES_EQUAL(response->Record.GetStatus(), NMsgBusProxy::MSTATUS_OK);
+                const auto& result = response->Record.GetReadResult(0);
+                if (result.GetStatus() == static_cast<ui32>(NKikimrProto::OK)) {
+                    NKikimrPQ::TTabletTxInfo info;
+                    UNIT_ASSERT(info.ParseFromString(result.GetValue()));
+                    for (const auto& txWrite : info.GetTxWrites()) {
+                        if (GetWriteId(txWrite) == writeId) {
+                            return txWrite.GetInternalPartitionId();
+                        }
+                    }
+                } else if (result.GetStatus() != NKikimrProto::NODATA) {
+                    ythrow TTopicTxInjectionRetry() << "WaitSupportivePartitionId: KV status "
+                        << result.GetStatus();
+                }
+                Tc.Runtime->SimulateSleep(TDuration::MilliSeconds(50));
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+                ythrow TTopicTxInjectionRetry() << "WaitSupportivePartitionId: scheduling limit";
+            } catch (const NActors::TEmptyEventQueueException&) {
+                ythrow TTopicTxInjectionRetry() << "WaitSupportivePartitionId: empty queue";
+            }
+        }
+        ythrow TTopicTxInjectionRetry() << "supportive partition id did not appear in _txinfo";
+    }
+
+    void CommitTopicTransaction(const TWriteId& writeId, ui32 supportivePartitionId, ui64 txId) {
+        for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+            try {
+                Tc.Runtime->ResetScheduledCount();
+                ResetPipe();
+                EnsurePipe();
+
+                {
+                    auto event = MakeHolder<TEvPersQueue::TEvProposeTransactionBuilder>();
+                    ActorIdToProto(Tc.Edge, event->Record.MutableSourceActor());
+                    event->Record.SetTxId(txId);
+                    auto* body = event->Record.MutableData();
+                    auto* operation = body->MutableOperations()->Add();
+                    operation->SetPartitionId(0);
+                    operation->SetPath("/topic");
+                    operation->SetSupportivePartition(supportivePartitionId);
+                    body->AddSendingShards(Tc.TabletId);
+                    body->AddReceivingShards(Tc.TabletId);
+                    SetWriteId(*body, writeId);
+                    body->SetImmediate(false);
+                    SendToPipe(event.Release());
+                }
+
+                {
+                    auto event = Tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+                        kTopicTxInjectionEdgeTimeout);
+                    if (!event) {
+                        continue;
+                    }
+                    if (event->Record.GetTxId() != txId) {
+                        continue;
+                    }
+                    if (event->Record.GetStatus() != NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
+                        ythrow TTopicTxInjectionRetry()
+                            << "Propose PREPARE status="
+                            << static_cast<int>(event->Record.GetStatus());
+                    }
+                }
+
+                {
+                    auto event = MakeHolder<TEvTxProcessing::TEvPlanStep>();
+                    event->Record.SetStep(100 + txId);
+                    auto* tx = event->Record.AddTransactions();
+                    tx->SetTxId(txId);
+                    ActorIdToProto(Tc.Edge, tx->MutableAckTo());
+                    SendToPipe(event.Release());
+                }
+
+                {
+                    auto event = Tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+                        kTopicTxInjectionEdgeTimeout);
+                    if (!event || event->Record.GetTxId() != txId) {
+                        ythrow TTopicTxInjectionRetry() << "missing COMPLETE after PlanStep";
+                    }
+                    if (event->Record.GetStatus() != NKikimrPQ::TEvProposeTransactionResult::COMPLETE) {
+                        ythrow TTopicTxInjectionRetry()
+                            << "Propose COMPLETE status="
+                            << static_cast<int>(event->Record.GetStatus());
+                    }
+                }
+
+                Tc.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(TDuration::Seconds(1));
+                Tc.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(TDuration::Seconds(1));
+                return;
+            } catch (const NActors::TSchedulingLimitReachedException&) {
+                ResetPipe();
+            } catch (const NActors::TEmptyEventQueueException&) {
+                ResetPipe();
+            }
+        }
+        ythrow TTopicTxInjectionRetry() << "CommitTopicTransaction: retries exhausted";
+    }
+
+private:
+    TTestContext& Tc;
+    TActorId Pipe;
+};
+
+ui64 GetEndOffsetOrZero(TTestContext& tc) {
+    for (i32 retriesLeft = 3; retriesLeft > 0; --retriesLeft) {
+        try {
+            tc.Runtime->ResetScheduledCount();
+            auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
+            tc.Runtime->SendToPipe(tc.TabletId, tc.Edge, request.Release(), 0, GetPipeConfigWithRetries());
+            auto result = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvOffsetsResponse>(
+                kTopicTxInjectionEdgeTimeout);
+            if (!result || result->Record.PartResultSize() == 0) {
+                continue;
+            }
+            if (result->Record.GetPartResult(0).GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                tc.Runtime->DispatchEvents();
+                retriesLeft = 3;
+                continue;
+            }
+            return result->Record.GetPartResult(0).GetEndOffset();
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+        } catch (const NActors::TEmptyEventQueueException&) {
+        }
+    }
+    return 0;
+}
+
+void TopicTxWriteAndCommitScenario(TTestContext& tc, bool& activeZone) {
+    constexpr ui32 txCount = 2;
+
+    PQTabletPrepare({.partitions=1}, {{"user1", true}}, tc);
+
+    TTopicTxInjectionHelper helper(tc);
+    for (ui32 attempt = 0; attempt < 20; ++attempt) {
+        try {
+            tc.Runtime->ResetScheduledCount();
+            helper.ResetPipe();
+            activeZone = false;
+
+            const ui64 endBefore = GetEndOffsetOrZero(tc);
+            // Previous attempt may have committed while a later GrabEdgeEvent failed.
+            if (endBefore >= txCount) {
+                const ui64 readFrom = endBefore - txCount;
+                TVector<i32> expectedOffsets;
+                expectedOffsets.reserve(txCount);
+                for (ui32 i = 0; i < txCount; ++i) {
+                    expectedOffsets.push_back(static_cast<i32>(readFrom + i));
+                }
+                PQGetPartInfo(0, endBefore, tc);
+                CmdRead(/*partition=*/0, /*offset=*/readFrom, /*count=*/txCount, /*size=*/16_MB,
+                        /*resCount=*/txCount, /*timeouted=*/false, tc, expectedOffsets);
+                return;
+            }
+
+            const TWriteId writeId(0, 1000 + attempt);
+            const ui64 txId = 9301 + attempt;
+
+            // Ownership + supportive writes stay outside the injection zone so the reboot/pipe
+            // matrix focuses on propose/plan (where Topic tx durability matters).
+            const TString ownerCookie = helper.CreateSupportivePartition(writeId);
+            for (ui32 i = 0; i < txCount; ++i) {
+                helper.WriteToSupportive(
+                    writeId, ownerCookie, /*seqNo=*/i, /*messageNo=*/i,
+                    TStringBuilder() << "topic-tx-reboot-" << attempt << "-" << i,
+                    /*cookie=*/500 + i);
+            }
+            const ui32 supportivePartitionId = helper.WaitSupportivePartitionId(writeId);
+
+            activeZone = true;
+            helper.CommitTopicTransaction(writeId, supportivePartitionId, txId);
+            activeZone = false;
+
+            PQGetPartInfo(0, endBefore + txCount, tc);
+            TVector<i32> expectedOffsets;
+            expectedOffsets.reserve(txCount);
+            for (ui32 i = 0; i < txCount; ++i) {
+                expectedOffsets.push_back(static_cast<i32>(endBefore + i));
+            }
+            CmdRead(/*partition=*/0, /*offset=*/endBefore, /*count=*/txCount, /*size=*/16_MB,
+                    /*resCount=*/txCount, /*timeouted=*/false, tc, expectedOffsets);
+            return;
+        } catch (const TTopicTxInjectionRetry&) {
+            activeZone = false;
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+            activeZone = false;
+        } catch (const NActors::TEmptyEventQueueException&) {
+            activeZone = false;
+        }
+    }
+    UNIT_FAIL("TopicTxWriteAndCommitScenario: retries exhausted");
+}
+
+void RunTopicTxWriteInjectionTest(
+    std::function<void(
+        const TVector<ui64>&,
+        std::function<TTestActorRuntime::TEventFilter()>,
+        std::function<void(const TString&, std::function<void(TTestActorRuntime&)>, bool&)>)> runner)
+{
+    TTestContext tabletIds;
+    const TVector<ui64> rebootTablets{tabletIds.TabletId};
+    runner(
+        rebootTablets,
+        [&]() { return tabletIds.InitialEventsFilter.Prepare(); },
+        [&](const TString& dispatchName, std::function<void(TTestActorRuntime&)> setup, bool& activeZone) {
+            TTestContext tc;
+            TFinalizer finalizer(tc);
+            activeZone = false;
+            tc.Prepare(dispatchName, setup, activeZone);
+            tc.Runtime->SetScheduledLimit(2'000);
+            TopicTxWriteAndCommitScenario(tc, activeZone);
+        });
+}
+
+} // namespace
+
+// Topic API write-tx commit must survive tablet reboots mid-propose/plan.
+Y_UNIT_TEST(TopicTxWriteWithTabletReboots) {
+    RunTopicTxWriteInjectionTest([](const auto& tabletIds, auto filterFactory, auto testFunc) {
+        RunTestWithReboots(tabletIds, filterFactory, testFunc);
+    });
+}
+
+// Same Topic write-tx commit path under pipe client resets.
+Y_UNIT_TEST(TopicTxWriteWithPipeResets) {
+    RunTopicTxWriteInjectionTest([](const auto& tabletIds, auto filterFactory, auto testFunc) {
+        RunTestWithPipeResets(tabletIds, filterFactory, testFunc);
+    });
+}
+
 Y_UNIT_TEST_F(DeferredPublication_Cancel_Successful_Commit, TPQTabletFixture) {
     using TDeferredPublicationApi = NKikimrPQ::TPartitionOperation::TWriteOp::TDeferredPublicationApi;
     const TWriteId writeId = NHelpers::MakeDeferredWriteId(43, "ext-43");

--- a/ydb/core/persqueue/ut/pqtablet_ut.cpp
+++ b/ydb/core/persqueue/ut/pqtablet_ut.cpp
@@ -4598,6 +4598,25 @@ public:
         ythrow TTopicTxInjectionRetry() << "supportive partition id did not appear in _txinfo";
     }
 
+    void DrainEdgeProposeAndPlanResults() {
+        for (;;) {
+            auto event = Tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
+                TDuration::MilliSeconds(1));
+            if (!event) {
+                break;
+            }
+        }
+        DrainPlanStepSideEffects();
+    }
+
+    // Best-effort: PlanStep may emit Ack/Accepted; under injection they can be dropped.
+    void DrainPlanStepSideEffects() {
+        for (ui32 i = 0; i < 4; ++i) {
+            Tc.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(TDuration::MilliSeconds(1));
+            Tc.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(TDuration::MilliSeconds(1));
+        }
+    }
+
     void CommitTopicTransaction(const TWriteId& writeId, ui32 supportivePartitionId, ui64 txId) {
         for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
             try {
@@ -4646,21 +4665,32 @@ public:
                     SendToPipe(event.Release());
                 }
 
-                {
+                bool gotComplete = false;
+                for (ui32 waitRound = 0; waitRound < 8 && !gotComplete; ++waitRound) {
                     auto event = Tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvProposeTransactionResult>(
                         kTopicTxInjectionEdgeTimeout);
-                    if (!event || event->Record.GetTxId() != txId) {
-                        ythrow TTopicTxInjectionRetry() << "missing COMPLETE after PlanStep";
+                    if (!event) {
+                        break;
+                    }
+                    if (event->Record.GetTxId() != txId) {
+                        continue;
+                    }
+                    if (event->Record.GetStatus() == NKikimrPQ::TEvProposeTransactionResult::PREPARED) {
+                        // Late PREPARED after PlanStep — ignore and keep waiting for COMPLETE.
+                        continue;
                     }
                     if (event->Record.GetStatus() != NKikimrPQ::TEvProposeTransactionResult::COMPLETE) {
                         ythrow TTopicTxInjectionRetry()
                             << "Propose COMPLETE status="
                             << static_cast<int>(event->Record.GetStatus());
                     }
+                    gotComplete = true;
+                }
+                if (!gotComplete) {
+                    ythrow TTopicTxInjectionRetry() << "missing COMPLETE after PlanStep";
                 }
 
-                Tc.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAck>(TDuration::Seconds(1));
-                Tc.Runtime->GrabEdgeEvent<TEvTxProcessing::TEvPlanStepAccepted>(TDuration::Seconds(1));
+                DrainPlanStepSideEffects();
                 return;
             } catch (const NActors::TSchedulingLimitReachedException&) {
                 ResetPipe();
@@ -4676,8 +4706,8 @@ private:
     TActorId Pipe;
 };
 
-ui64 GetEndOffsetOrZero(TTestContext& tc) {
-    for (i32 retriesLeft = 3; retriesLeft > 0; --retriesLeft) {
+ui64 GetEndOffset(TTestContext& tc) {
+    for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
         try {
             tc.Runtime->ResetScheduledCount();
             auto request = MakeHolder<TEvPersQueue::TEvOffsets>();
@@ -4689,7 +4719,7 @@ ui64 GetEndOffsetOrZero(TTestContext& tc) {
             }
             if (result->Record.GetPartResult(0).GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
                 tc.Runtime->DispatchEvents();
-                retriesLeft = 3;
+                retriesLeft = 5;
                 continue;
             }
             return result->Record.GetPartResult(0).GetEndOffset();
@@ -4697,7 +4727,71 @@ ui64 GetEndOffsetOrZero(TTestContext& tc) {
         } catch (const NActors::TEmptyEventQueueException&) {
         }
     }
-    return 0;
+    ythrow TTopicTxInjectionRetry() << "GetEndOffset failed";
+}
+
+NKikimrClient::TCmdReadResult CaptureCmdReadResult(
+    TTestContext& tc, ui64 offset, ui32 count)
+{
+    for (i32 retriesLeft = 5; retriesLeft > 0; --retriesLeft) {
+        try {
+            tc.Runtime->ResetScheduledCount();
+            auto request = MakeHolder<TEvPersQueue::TEvRequest>();
+            auto* req = request->Record.MutablePartitionRequest();
+            req->SetPartition(0);
+            req->SetCookie(123);
+            auto* read = req->MutableCmdRead();
+            read->SetClientId("user");
+            read->SetSessionId("");
+            read->SetOffset(offset);
+            read->SetCount(count);
+            read->SetBytes(16_MB);
+            read->SetReadToBlobEnd(true);
+            tc.Runtime->SendToPipe(tc.TabletId, tc.Edge, request.Release(), 0, GetPipeConfigWithRetries());
+
+            auto response = tc.Runtime->GrabEdgeEvent<TEvPersQueue::TEvResponse>(
+                kTopicTxInjectionEdgeTimeout);
+            if (!response) {
+                continue;
+            }
+            if (response->Record.GetErrorCode() == NPersQueue::NErrorCode::INITIALIZING) {
+                tc.Runtime->DispatchEvents();
+                retriesLeft = 5;
+                continue;
+            }
+            UNIT_ASSERT_VALUES_EQUAL(
+                (int)response->Record.GetErrorCode(), (int)NPersQueue::NErrorCode::OK);
+            UNIT_ASSERT(response->Record.GetPartitionResponse().HasCmdReadResult());
+            return response->Record.GetPartitionResponse().GetCmdReadResult();
+        } catch (const NActors::TSchedulingLimitReachedException&) {
+        } catch (const NActors::TEmptyEventQueueException&) {
+        }
+    }
+    ythrow TTopicTxInjectionRetry() << "CaptureCmdReadResult failed";
+}
+
+void AssertTopicTxCommittedPayloads(
+    TTestContext& tc,
+    ui64 readFrom,
+    ui32 txCount,
+    TMaybe<ui32> expectedAttempt)
+{
+    PQGetPartInfo(0, readFrom + txCount, tc);
+    const auto readResult = CaptureCmdReadResult(tc, readFrom, txCount);
+    UNIT_ASSERT_VALUES_EQUAL(readResult.ResultSize(), txCount);
+    for (ui32 i = 0; i < txCount; ++i) {
+        const auto& row = readResult.GetResult(i);
+        UNIT_ASSERT_VALUES_EQUAL(row.GetOffset(), readFrom + i);
+        if (expectedAttempt.Defined()) {
+            UNIT_ASSERT_VALUES_EQUAL(
+                row.GetData(),
+                TStringBuilder() << "topic-tx-reboot-" << *expectedAttempt << "-" << i);
+        } else {
+            UNIT_ASSERT_C(
+                row.GetData().StartsWith("topic-tx-reboot-"),
+                "unexpected payload=" << row.GetData());
+        }
+    }
 }
 
 void TopicTxWriteAndCommitScenario(TTestContext& tc, bool& activeZone) {
@@ -4710,20 +4804,14 @@ void TopicTxWriteAndCommitScenario(TTestContext& tc, bool& activeZone) {
         try {
             tc.Runtime->ResetScheduledCount();
             helper.ResetPipe();
+            helper.DrainEdgeProposeAndPlanResults();
             activeZone = false;
 
-            const ui64 endBefore = GetEndOffsetOrZero(tc);
+            const ui64 endBefore = GetEndOffset(tc);
             // Previous attempt may have committed while a later GrabEdgeEvent failed.
             if (endBefore >= txCount) {
-                const ui64 readFrom = endBefore - txCount;
-                TVector<i32> expectedOffsets;
-                expectedOffsets.reserve(txCount);
-                for (ui32 i = 0; i < txCount; ++i) {
-                    expectedOffsets.push_back(static_cast<i32>(readFrom + i));
-                }
-                PQGetPartInfo(0, endBefore, tc);
-                CmdRead(/*partition=*/0, /*offset=*/readFrom, /*count=*/txCount, /*size=*/16_MB,
-                        /*resCount=*/txCount, /*timeouted=*/false, tc, expectedOffsets);
+                AssertTopicTxCommittedPayloads(
+                    tc, endBefore - txCount, txCount, /*expectedAttempt=*/Nothing());
                 return;
             }
 
@@ -4745,14 +4833,7 @@ void TopicTxWriteAndCommitScenario(TTestContext& tc, bool& activeZone) {
             helper.CommitTopicTransaction(writeId, supportivePartitionId, txId);
             activeZone = false;
 
-            PQGetPartInfo(0, endBefore + txCount, tc);
-            TVector<i32> expectedOffsets;
-            expectedOffsets.reserve(txCount);
-            for (ui32 i = 0; i < txCount; ++i) {
-                expectedOffsets.push_back(static_cast<i32>(endBefore + i));
-            }
-            CmdRead(/*partition=*/0, /*offset=*/endBefore, /*count=*/txCount, /*size=*/16_MB,
-                    /*resCount=*/txCount, /*timeouted=*/false, tc, expectedOffsets);
+            AssertTopicTxCommittedPayloads(tc, endBefore, txCount, attempt);
             return;
         } catch (const TTopicTxInjectionRetry&) {
             activeZone = false;

--- a/ydb/core/persqueue/ya.make
+++ b/ydb/core/persqueue/ya.make
@@ -31,6 +31,7 @@ RECURSE_FOR_TESTS(
     ut
     deferred_publish/ut
     dread_cache_service/ut
+    ut/injection
     ut/slow
     ut/ut_with_sdk
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Cover single-tablet Topic write-tx durability under `RunTestWithReboots` / `RunTestWithPipeResets` (`TopicTxWriteWithTabletReboots`, `TopicTxWriteWithPipeResets`)
- Cover distributed 3-PQ offset-commit durability the same way (`DistributedThreePqTxWithTabletReboots`, `DistributedThreePqTxWithPipeResets`)
- Add `ydb/core/persqueue/ut/injection` suite for the multi-tablet scenario
- Scenario retries mid-flight injection via pipe reset / scheduling-limit recovery and asserts committed offsets after completion

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Stacked on LOGBROKER-10584 after Key≠Header mid-blob read regressions (#48844).

**Topic write-tx** (`pqtablet_ut`): propose/plan a write transaction under tablet reboots and pipe resets; assert committed payloads via CmdRead.

**Distributed 3-PQ offset-commit** (`ut/injection`): three real PQ tablets + RS mesh; seed writes, commit `[0, 2)`, assert `user.Offset == 2` on all tablets under the same injection. Shared Edge replies are filtered by `TabletId` / stamped cookie so readiness and offset queries cannot accept another tablet's response.