### PR TITLE
Move topic settings to table.h and make CDC topic settings readable

### DIFF
--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -50,6 +50,13 @@ class LocalBloomFilterIndex;
 class LocalBloomNgramFilterIndex;
 
 } // namespace Table
+
+namespace Topic {
+
+class PartitioningSettings;
+class AutoPartitioningSettings;
+
+} // namespace Topic
 } // namespace Ydb
 
 namespace NYdb::inline Dev {
@@ -645,6 +652,90 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Auto partitioning settings of a topic (e.g. a changefeed's underlying topic).
+//! This type lives in the table client library (instead of the topic client library)
+//! because the topic client library depends on the table client library, and reusing the
+//! topic type here would introduce a reverse (circular) dependency. The topic client
+//! re-exports it as NTopic::TAutoPartitioningSettings.
+struct TTopicAutoPartitioningSettings {
+public:
+    TTopicAutoPartitioningSettings()
+        : Strategy_(ETopicAutoPartitioningStrategy::Disabled)
+        , StabilizationWindow_(TDuration::Seconds(0))
+        , DownUtilizationPercent_(0)
+        , UpUtilizationPercent_(0) {
+    }
+    explicit TTopicAutoPartitioningSettings(const Ydb::Topic::AutoPartitioningSettings& settings);
+    TTopicAutoPartitioningSettings(ETopicAutoPartitioningStrategy strategy, TDuration stabilizationWindow,
+        uint64_t downUtilizationPercent, uint64_t upUtilizationPercent)
+        : Strategy_(strategy)
+        , StabilizationWindow_(stabilizationWindow)
+        , DownUtilizationPercent_(downUtilizationPercent)
+        , UpUtilizationPercent_(upUtilizationPercent) {}
+
+    void SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const;
+
+    ETopicAutoPartitioningStrategy GetStrategy() const;
+    TDuration GetStabilizationWindow() const;
+    uint32_t GetDownUtilizationPercent() const;
+    uint32_t GetUpUtilizationPercent() const;
+
+    void SetStrategy(ETopicAutoPartitioningStrategy value) { Strategy_ = value; }
+    void SetStabilizationWindow(TDuration value) { StabilizationWindow_ = value; }
+    void SetDownUtilizationPercent(uint32_t value) { DownUtilizationPercent_ = value; }
+    void SetUpUtilizationPercent(uint32_t value) { UpUtilizationPercent_ = value; }
+
+    bool operator==(const TTopicAutoPartitioningSettings& other) const = default;
+
+private:
+    ETopicAutoPartitioningStrategy Strategy_;
+    TDuration StabilizationWindow_;
+    uint32_t DownUtilizationPercent_;
+    uint32_t UpUtilizationPercent_;
+};
+
+//! Partitioning settings of a topic (e.g. a changefeed's underlying topic).
+//! Lives in the table client library for the same dependency reason as
+//! TTopicAutoPartitioningSettings. The topic client re-exports it as
+//! NTopic::TPartitioningSettings.
+class TTopicPartitioningSettings {
+public:
+    TTopicPartitioningSettings()
+        : MinActivePartitions_(0)
+        , MaxActivePartitions_(0)
+        , PartitionCountLimit_(0)
+        , AutoPartitioningSettings_() {}
+    explicit TTopicPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings);
+    TTopicPartitioningSettings(uint64_t minActivePartitions, uint64_t maxActivePartitions,
+        TTopicAutoPartitioningSettings autoPartitioning = {})
+        : MinActivePartitions_(minActivePartitions)
+        , MaxActivePartitions_(maxActivePartitions)
+        , PartitionCountLimit_(0)
+        , AutoPartitioningSettings_(autoPartitioning) {}
+
+    void SerializeTo(Ydb::Topic::PartitioningSettings& proto) const;
+
+    uint64_t GetMinActivePartitions() const;
+    uint64_t GetMaxActivePartitions() const;
+    uint64_t GetPartitionCountLimit() const;
+    TTopicAutoPartitioningSettings GetAutoPartitioningSettings() const;
+
+    void SetMinActivePartitions(uint64_t value) { MinActivePartitions_ = value; }
+    void SetMaxActivePartitions(uint64_t value) { MaxActivePartitions_ = value; }
+    void SetPartitionCountLimit(uint64_t value) { PartitionCountLimit_ = value; }
+    TTopicAutoPartitioningSettings& MutableAutoPartitioningSettings() { return AutoPartitioningSettings_; }
+
+    bool operator==(const TTopicPartitioningSettings& other) const = default;
+
+private:
+    uint64_t MinActivePartitions_;
+    uint64_t MaxActivePartitions_;
+    uint64_t PartitionCountLimit_;
+    TTopicAutoPartitioningSettings AutoPartitioningSettings_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 //! Represents changefeed description
 class TChangefeedDescription {
     friend class NYdb::TProtoAccessor;
@@ -689,6 +780,8 @@ public:
     TChangefeedDescription& SetAttributes(std::unordered_map<std::string, std::string>&& attrs);
     // Value that will be emitted in the `awsRegion` field of the record in DynamoDBStreamsJson format
     TChangefeedDescription& WithAwsRegion(const std::string& value);
+    // Partitioning settings of the underlying topic (including auto partitioning strategy).
+    TChangefeedDescription& WithTopicPartitioningSettings(const TTopicPartitioningSettings& value);
 
     const std::string& GetName() const;
     EChangefeedMode GetMode() const;
@@ -703,6 +796,7 @@ public:
     const std::unordered_map<std::string, std::string>& GetAttributes() const;
     const std::string& GetAwsRegion() const;
     const std::optional<TInitialScanProgress>& GetInitialScanProgress() const;
+    const std::optional<TTopicPartitioningSettings>& GetTopicPartitioningSettings() const;
 
     void SerializeTo(Ydb::Table::Changefeed& proto) const;
     void SerializeTo(Ydb::Table::ChangefeedDescription& proto) const;
@@ -734,6 +828,7 @@ private:
     std::unordered_map<std::string, std::string> Attributes_;
     std::string AwsRegion_;
     std::optional<TInitialScanProgress> InitialScanProgress_;
+    std::optional<TTopicPartitioningSettings> TopicPartitioningSettings_;
 };
 
 bool operator==(const TChangefeedDescription& lhs, const TChangefeedDescription& rhs);

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table_enum.h
@@ -96,5 +96,16 @@ enum class EChangefeedState {
     Unknown = std::numeric_limits<int>::max()
 };
 
+//! Auto partitioning strategy of a changefeed's underlying topic
+enum class ETopicAutoPartitioningStrategy {
+    Unspecified /* "UNSPECIFIED" */,
+    Disabled /* "DISABLED" */,
+    ScaleUp /* "SCALE_UP" */,
+    ScaleUpAndDown /* "SCALE_UP_AND_DOWN" */,
+    Paused /* "PAUSED" */,
+
+    Unknown = std::numeric_limits<int>::max()
+};
+
 } // namespace NTable
 } // namespace NYdb

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
@@ -3,6 +3,7 @@
 #include "codecs.h"
 
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h>
 
 #include <ydb/public/api/protos/ydb_topic.pb.h>
 
@@ -28,13 +29,9 @@ enum class EMeteringMode : uint32_t {
     Unknown = std::numeric_limits<int>::max(),
 };
 
-enum class EAutoPartitioningStrategy: uint32_t {
-    Unspecified = 0,
-    Disabled = 1,
-    ScaleUp = 2,
-    ScaleUpAndDown = 3,
-    Paused = 4,
-};
+// The auto partitioning strategy enum lives in the table client library (see the note on
+// NTable::TTopicPartitioningSettings). It is re-exported here for backward compatibility.
+using EAutoPartitioningStrategy = ::NYdb::NTable::ETopicAutoPartitioningStrategy;
 
 enum class EConsumerType {
     Unspecified = 0,
@@ -231,34 +228,9 @@ private:
 struct TAlterPartitioningSettings;
 struct TAlterTopicSettings;
 
-struct TAutoPartitioningSettings {
-friend struct TAutoPartitioningSettingsBuilder;
-public:
-    TAutoPartitioningSettings()
-        : Strategy_(EAutoPartitioningStrategy::Disabled)
-        , StabilizationWindow_(TDuration::Seconds(0))
-        , DownUtilizationPercent_(0)
-        , UpUtilizationPercent_(0) {
-    }
-    TAutoPartitioningSettings(const Ydb::Topic::AutoPartitioningSettings& settings);
-    TAutoPartitioningSettings(EAutoPartitioningStrategy strategy, TDuration stabilizationWindow, ui64 downUtilizationPercent, ui64 upUtilizationPercent)
-        : Strategy_(strategy)
-        , StabilizationWindow_(stabilizationWindow)
-        , DownUtilizationPercent_(downUtilizationPercent)
-        , UpUtilizationPercent_(upUtilizationPercent) {}
-
-    void SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const;
-
-    EAutoPartitioningStrategy GetStrategy() const;
-    TDuration GetStabilizationWindow() const;
-    ui32 GetDownUtilizationPercent() const;
-    ui32 GetUpUtilizationPercent() const;
-private:
-    EAutoPartitioningStrategy Strategy_;
-    TDuration StabilizationWindow_;
-    ui32 DownUtilizationPercent_;
-    ui32 UpUtilizationPercent_;
-};
+// TAutoPartitioningSettings lives in the table client library (see the note on
+// NTable::TTopicPartitioningSettings). It is re-exported here for backward compatibility.
+using TAutoPartitioningSettings = ::NYdb::NTable::TTopicAutoPartitioningSettings;
 
 struct TAlterAutoPartitioningSettings {
     using TSelf = TAlterAutoPartitioningSettings;
@@ -276,32 +248,9 @@ private:
     TAlterPartitioningSettings& Parent_;
 };
 
-class TPartitioningSettings {
-    using TSelf = TPartitioningSettings;
-    friend struct TPartitioningSettingsBuilder;
-public:
-    TPartitioningSettings() : MinActivePartitions_(0), MaxActivePartitions_(0), PartitionCountLimit_(0), AutoPartitioningSettings_(){}
-    TPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings);
-    TPartitioningSettings(uint64_t minActivePartitions, uint64_t maxActivePartitions, TAutoPartitioningSettings autoPartitioning = {})
-        : MinActivePartitions_(minActivePartitions)
-        , MaxActivePartitions_(maxActivePartitions)
-        , PartitionCountLimit_(0)
-        , AutoPartitioningSettings_(autoPartitioning)
-    {
-    }
-
-    void SerializeTo(Ydb::Topic::PartitioningSettings& proto) const;
-
-    uint64_t GetMinActivePartitions() const;
-    uint64_t GetMaxActivePartitions() const;
-    uint64_t GetPartitionCountLimit() const;
-    TAutoPartitioningSettings GetAutoPartitioningSettings() const;
-private:
-    uint64_t MinActivePartitions_;
-    uint64_t MaxActivePartitions_;
-    uint64_t PartitionCountLimit_;
-    TAutoPartitioningSettings AutoPartitioningSettings_;
-};
+// TPartitioningSettings lives in the table client library (see the note on
+// NTable::TTopicPartitioningSettings). It is re-exported here for backward compatibility.
+using TPartitioningSettings = ::NYdb::NTable::TTopicPartitioningSettings;
 
 struct TAlterTopicSettings;
 
@@ -876,22 +825,22 @@ public:
     TAutoPartitioningSettingsBuilder(TPartitioningSettingsBuilder& parent, TAutoPartitioningSettings& settings): Parent_(parent), Settings_(settings) {}
 
     TSelf Strategy(EAutoPartitioningStrategy value) {
-        Settings_.Strategy_ = value;
+        Settings_.SetStrategy(value);
         return *this;
     }
 
     TSelf StabilizationWindow(TDuration value) {
-        Settings_.StabilizationWindow_ = value;
+        Settings_.SetStabilizationWindow(value);
         return *this;
     }
 
     TSelf DownUtilizationPercent(ui32 value) {
-        Settings_.DownUtilizationPercent_ = value;
+        Settings_.SetDownUtilizationPercent(value);
         return *this;
     }
 
     TSelf UpUtilizationPercent(ui32 value) {
-        Settings_.UpUtilizationPercent_ = value;
+        Settings_.SetUpUtilizationPercent(value);
         return *this;
     }
 
@@ -910,17 +859,17 @@ public:
     TPartitioningSettingsBuilder(TCreateTopicSettings& parent): Parent_(parent) {}
 
     TSelf MinActivePartitions(uint64_t value) {
-        Parent_.PartitioningSettings_.MinActivePartitions_ = value;
+        Parent_.PartitioningSettings_.SetMinActivePartitions(value);
         return *this;
     }
 
     TSelf MaxActivePartitions(uint64_t value) {
-        Parent_.PartitioningSettings_.MaxActivePartitions_ = value;
+        Parent_.PartitioningSettings_.SetMaxActivePartitions(value);
         return *this;
     }
 
     TAutoPartitioningSettingsBuilder BeginConfigureAutoPartitioningSettings() {
-        return {*this, Parent_.PartitioningSettings_.AutoPartitioningSettings_};
+        return {*this, Parent_.PartitioningSettings_.MutableAutoPartitioningSettings()};
     }
 
     TCreateTopicSettings& EndConfigurePartitioningSettings() {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -3833,12 +3833,6 @@ TChangefeedDescription TChangefeedDescription::FromProto(const TProto& proto) {
         ret.WithAwsRegion(proto.aws_region());
     }
 
-    if constexpr (std::is_same_v<TProto, Ydb::Table::Changefeed>) {
-        if (proto.has_topic_partitioning_settings()) {
-            ret.TopicPartitioningSettings_ = TTopicPartitioningSettings(proto.topic_partitioning_settings());
-        }
-    }
-
     if constexpr (std::is_same_v<TProto, Ydb::Table::ChangefeedDescription>) {
         switch (proto.state()) {
         case Ydb::Table::ChangefeedDescription::STATE_ENABLED:

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -13,6 +13,7 @@
 
 #include <ydb/public/api/grpc/ydb_table_v1.grpc.pb.h>
 #include <ydb/public/api/protos/ydb_table.pb.h>
+#include <ydb/public/api/protos/ydb_topic.pb.h>
 #include <ydb/public/api/protos/ydb_value.pb.h>
 #include <ydb/public/sdk/cpp/src/client/impl/stats/stats.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/proto/accessor.h>
@@ -3561,6 +3562,100 @@ float TChangefeedDescription::TInitialScanProgress::GetProgress() const {
     return 100 * float(PartsCompleted) / float(PartsTotal);
 }
 
+static ETopicAutoPartitioningStrategy AutoPartitioningStrategyFromProto(Ydb::Topic::AutoPartitioningStrategy strategy) {
+    switch (strategy) {
+    case Ydb::Topic::AUTO_PARTITIONING_STRATEGY_DISABLED:
+        return ETopicAutoPartitioningStrategy::Disabled;
+    case Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP:
+        return ETopicAutoPartitioningStrategy::ScaleUp;
+    case Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN:
+        return ETopicAutoPartitioningStrategy::ScaleUpAndDown;
+    case Ydb::Topic::AUTO_PARTITIONING_STRATEGY_PAUSED:
+        return ETopicAutoPartitioningStrategy::Paused;
+    case Ydb::Topic::AUTO_PARTITIONING_STRATEGY_UNSPECIFIED:
+        return ETopicAutoPartitioningStrategy::Unspecified;
+    default:
+        return ETopicAutoPartitioningStrategy::Unknown;
+    }
+}
+
+static Ydb::Topic::AutoPartitioningStrategy AutoPartitioningStrategyToProto(ETopicAutoPartitioningStrategy strategy) {
+    switch (strategy) {
+    case ETopicAutoPartitioningStrategy::Disabled:
+        return Ydb::Topic::AUTO_PARTITIONING_STRATEGY_DISABLED;
+    case ETopicAutoPartitioningStrategy::ScaleUp:
+        return Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP;
+    case ETopicAutoPartitioningStrategy::ScaleUpAndDown:
+        return Ydb::Topic::AUTO_PARTITIONING_STRATEGY_SCALE_UP_AND_DOWN;
+    case ETopicAutoPartitioningStrategy::Paused:
+        return Ydb::Topic::AUTO_PARTITIONING_STRATEGY_PAUSED;
+    case ETopicAutoPartitioningStrategy::Unspecified:
+    case ETopicAutoPartitioningStrategy::Unknown:
+        return Ydb::Topic::AUTO_PARTITIONING_STRATEGY_UNSPECIFIED;
+    }
+}
+
+TTopicAutoPartitioningSettings::TTopicAutoPartitioningSettings(const Ydb::Topic::AutoPartitioningSettings& settings)
+    : Strategy_(AutoPartitioningStrategyFromProto(settings.strategy()))
+    , StabilizationWindow_(TDuration::Seconds(settings.partition_write_speed().stabilization_window().seconds()))
+    , DownUtilizationPercent_(settings.partition_write_speed().down_utilization_percent())
+    , UpUtilizationPercent_(settings.partition_write_speed().up_utilization_percent())
+{}
+
+void TTopicAutoPartitioningSettings::SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const {
+    proto.set_strategy(AutoPartitioningStrategyToProto(Strategy_));
+    auto& writeSpeed = *proto.mutable_partition_write_speed();
+    writeSpeed.mutable_stabilization_window()->set_seconds(StabilizationWindow_.Seconds());
+    writeSpeed.set_down_utilization_percent(DownUtilizationPercent_);
+    writeSpeed.set_up_utilization_percent(UpUtilizationPercent_);
+}
+
+ETopicAutoPartitioningStrategy TTopicAutoPartitioningSettings::GetStrategy() const {
+    return Strategy_;
+}
+
+TDuration TTopicAutoPartitioningSettings::GetStabilizationWindow() const {
+    return StabilizationWindow_;
+}
+
+uint32_t TTopicAutoPartitioningSettings::GetUpUtilizationPercent() const {
+    return UpUtilizationPercent_;
+}
+
+uint32_t TTopicAutoPartitioningSettings::GetDownUtilizationPercent() const {
+    return DownUtilizationPercent_;
+}
+
+TTopicPartitioningSettings::TTopicPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings)
+    : MinActivePartitions_(settings.min_active_partitions())
+    , MaxActivePartitions_(settings.max_active_partitions())
+    , PartitionCountLimit_(settings.partition_count_limit())
+    , AutoPartitioningSettings_(settings.auto_partitioning_settings())
+{}
+
+void TTopicPartitioningSettings::SerializeTo(Ydb::Topic::PartitioningSettings& proto) const {
+    proto.set_min_active_partitions(MinActivePartitions_);
+    proto.set_max_active_partitions(MaxActivePartitions_);
+    proto.set_partition_count_limit(PartitionCountLimit_);
+    AutoPartitioningSettings_.SerializeTo(*proto.mutable_auto_partitioning_settings());
+}
+
+uint64_t TTopicPartitioningSettings::GetMinActivePartitions() const {
+    return MinActivePartitions_;
+}
+
+uint64_t TTopicPartitioningSettings::GetMaxActivePartitions() const {
+    return MaxActivePartitions_;
+}
+
+uint64_t TTopicPartitioningSettings::GetPartitionCountLimit() const {
+    return PartitionCountLimit_;
+}
+
+TTopicAutoPartitioningSettings TTopicPartitioningSettings::GetAutoPartitioningSettings() const {
+    return AutoPartitioningSettings_;
+}
+
 TChangefeedDescription& TChangefeedDescription::WithVirtualTimestamps() {
     VirtualTimestamps_ = true;
     return *this;
@@ -3616,6 +3711,11 @@ TChangefeedDescription& TChangefeedDescription::WithAwsRegion(const std::string&
     return *this;
 }
 
+TChangefeedDescription& TChangefeedDescription::WithTopicPartitioningSettings(const TTopicPartitioningSettings& value) {
+    TopicPartitioningSettings_ = value;
+    return *this;
+}
+
 const std::string& TChangefeedDescription::GetName() const {
     return Name_;
 }
@@ -3666,6 +3766,10 @@ const std::string& TChangefeedDescription::GetAwsRegion() const {
 
 const std::optional<TChangefeedDescription::TInitialScanProgress>& TChangefeedDescription::GetInitialScanProgress() const {
     return InitialScanProgress_;
+}
+
+const std::optional<TTopicPartitioningSettings>& TChangefeedDescription::GetTopicPartitioningSettings() const {
+    return TopicPartitioningSettings_;
 }
 
 template <typename TProto>
@@ -3727,6 +3831,12 @@ TChangefeedDescription TChangefeedDescription::FromProto(const TProto& proto) {
     }
     if (!proto.aws_region().empty()) {
         ret.WithAwsRegion(proto.aws_region());
+    }
+
+    if constexpr (std::is_same_v<TProto, Ydb::Table::Changefeed>) {
+        if (proto.has_topic_partitioning_settings()) {
+            ret.TopicPartitioningSettings_ = TTopicPartitioningSettings(proto.topic_partitioning_settings());
+        }
     }
 
     if constexpr (std::is_same_v<TProto, Ydb::Table::ChangefeedDescription>) {
@@ -3819,6 +3929,10 @@ void TChangefeedDescription::SerializeTo(Ydb::Table::Changefeed& proto) const {
     if (RetentionPeriod_) {
         SetDuration(*RetentionPeriod_, *proto.mutable_retention_period());
     }
+
+    if (TopicPartitioningSettings_) {
+        TopicPartitioningSettings_->SerializeTo(*proto.mutable_topic_partitioning_settings());
+    }
 }
 
 void TChangefeedDescription::SerializeTo(Ydb::Table::ChangefeedDescription& proto) const {
@@ -3869,6 +3983,12 @@ void TChangefeedDescription::Out(IOutputStream& o) const {
         o << ", initial_scan_progress: " << InitialScanProgress_->GetProgress() << "%";
     }
 
+    if (TopicPartitioningSettings_) {
+        o << ", topic_min_active_partitions: " << TopicPartitioningSettings_->GetMinActivePartitions()
+          << ", topic_max_active_partitions: " << TopicPartitioningSettings_->GetMaxActivePartitions()
+          << ", topic_auto_partitioning_strategy: " << TopicPartitioningSettings_->GetAutoPartitioningSettings().GetStrategy();
+    }
+
     o << " }";
 }
 
@@ -3879,7 +3999,8 @@ bool operator==(const TChangefeedDescription& lhs, const TChangefeedDescription&
         && lhs.GetVirtualTimestamps() == rhs.GetVirtualTimestamps()
         && lhs.GetSchemaChanges() == rhs.GetSchemaChanges()
         && lhs.GetResolvedTimestamps() == rhs.GetResolvedTimestamps()
-        && lhs.GetAwsRegion() == rhs.GetAwsRegion();
+        && lhs.GetAwsRegion() == rhs.GetAwsRegion()
+        && lhs.GetTopicPartitioningSettings() == rhs.GetTopicPartitioningSettings();
 }
 
 bool operator!=(const TChangefeedDescription& lhs, const TChangefeedDescription& rhs) {

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -284,67 +284,6 @@ const std::vector<NScheme::TPermissions>& TTopicDescription::GetEffectivePermiss
     return EffectivePermissions_;
 }
 
-TPartitioningSettings::TPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings)
-    : MinActivePartitions_(settings.min_active_partitions())
-    , MaxActivePartitions_(settings.max_active_partitions())
-    , PartitionCountLimit_(settings.partition_count_limit())
-    , AutoPartitioningSettings_(settings.auto_partitioning_settings())
-{}
-
-void TPartitioningSettings::SerializeTo(Ydb::Topic::PartitioningSettings& proto) const {
-    proto.set_min_active_partitions(MinActivePartitions_);
-    proto.set_max_active_partitions(MaxActivePartitions_);
-    proto.set_partition_count_limit(PartitionCountLimit_);
-    AutoPartitioningSettings_.SerializeTo(*proto.mutable_auto_partitioning_settings());
-}
-
-uint64_t TPartitioningSettings::GetMinActivePartitions() const {
-    return MinActivePartitions_;
-}
-
-uint64_t TPartitioningSettings::GetMaxActivePartitions() const {
-    return MaxActivePartitions_;
-}
-
-uint64_t TPartitioningSettings::GetPartitionCountLimit() const {
-    return PartitionCountLimit_;
-}
-
-TAutoPartitioningSettings TPartitioningSettings::GetAutoPartitioningSettings() const {
-    return AutoPartitioningSettings_;
-}
-
-TAutoPartitioningSettings::TAutoPartitioningSettings(const Ydb::Topic::AutoPartitioningSettings& settings)
-    : Strategy_(static_cast<EAutoPartitioningStrategy>(settings.strategy()))
-    , StabilizationWindow_(TDuration::Seconds(settings.partition_write_speed().stabilization_window().seconds()))
-    , DownUtilizationPercent_(settings.partition_write_speed().down_utilization_percent())
-    , UpUtilizationPercent_(settings.partition_write_speed().up_utilization_percent())
-{}
-
-void TAutoPartitioningSettings::SerializeTo(Ydb::Topic::AutoPartitioningSettings& proto) const {
-    proto.set_strategy(static_cast<Ydb::Topic::AutoPartitioningStrategy>(Strategy_));
-    auto& writeSpeed = *proto.mutable_partition_write_speed();
-    writeSpeed.mutable_stabilization_window()->set_seconds(StabilizationWindow_.Seconds());
-    writeSpeed.set_down_utilization_percent(DownUtilizationPercent_);
-    writeSpeed.set_up_utilization_percent(UpUtilizationPercent_);
-}
-
-EAutoPartitioningStrategy TAutoPartitioningSettings::GetStrategy() const {
-    return Strategy_;
-}
-
-TDuration TAutoPartitioningSettings::GetStabilizationWindow() const {
-    return StabilizationWindow_;
-}
-
-uint32_t TAutoPartitioningSettings::GetUpUtilizationPercent() const {
-    return UpUtilizationPercent_;
-}
-
-uint32_t TAutoPartitioningSettings::GetDownUtilizationPercent() const {
-    return DownUtilizationPercent_;
-}
-
 TTopicStats::TTopicStats(const Ydb::Topic::DescribeTopicResult::TopicStats& topicStats)
     : StoreSizeBytes_(topicStats.store_size_bytes())
     , MinLastWriteTime_(TInstant::Seconds(topicStats.min_last_write_time().seconds()))


### PR DESCRIPTION
### Changelog entry 

Introduce `TChangefeedDescription::GetTopicPartitioningSettings()` for accessing CDC partitioning.

### Description for reviewers 

I am creating a new CDC topic and need to dump the result of `ALTER TABLE ADD CHANGEFEED` back from ydb.
Move TTopicSettings from `topic/control_plane.h` to `table/table.h` (where Changefeed settings are described).
