### PR TITLE
[detailed-metrics] node-level per-database detailed metrics aggregator

### DIFF
--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -1,0 +1,473 @@
+#include "node_database_metrics_aggregator.h"
+
+#include <ydb/core/tablet/private/aggregated_tablet_counters.h>
+
+#include <util/generic/algorithm.h>
+#include <util/generic/hash.h>
+#include <util/generic/vector.h>
+#include <util/string/cast.h>
+
+namespace NKikimr {
+
+namespace {
+
+// Labels of the detailed metrics counter tree
+const TString DATABASE_LABEL = "database";
+const TString TABLE_LABEL = "table";
+const TString DETAILED_METRICS_LABEL = "detailed_metrics";
+const TString TABLET_ID_LABEL = "tablet_id";
+const TString FOLLOWER_ID_LABEL = "follower_id";
+
+const TString PER_PARTITION_VALUE = "per_partition";
+
+// Labels of the low level tablet counters (the same as in the "tablets" group)
+const TString TYPE_LABEL = "type";
+const TString CATEGORY_LABEL = "category";
+
+const TString EXECUTOR_CATEGORY = "executor";
+const TString APP_CATEGORY = "app";
+
+/**
+ * A single tablet (a leader or a follower) within a table.
+ */
+using TTabletKey = std::pair<ui64, ui32>;
+
+/**
+ * Strip the database path prefix from the full path of the table.
+ */
+TString MakeRelativeTablePath(const TString& databasePath, const TString& tablePath) {
+    TStringBuf database(databasePath);
+    database.ChopSuffix("/");
+
+    TStringBuf relativePath(tablePath);
+
+    // The "/" is required, so that /Root/db10/table is NOT stripped down to "0/table"
+    // within the database /Root/db1
+    if (relativePath.SkipPrefix(database) && relativePath.SkipPrefix("/") && !relativePath.empty()) {
+        return TString(relativePath);
+    }
+
+    return tablePath;
+}
+
+/**
+ * A single bucket of the detailed metrics counter tree: the low level counters
+ * of one or more tablets of the same type.
+ *
+ * @note The bucket of a table level table holds many tablets, while a leaf group
+ *       of a partition level table holds exactly one. Both cases are handled by
+ *       the very same code: aggregating a single tablet is a passthrough
+ *       (SUM(x) == MAX(x) == x).
+ */
+class TCountersBucket {
+public:
+    TCountersBucket(NMonitoring::TDynamicCounterPtr bucketGroup, TTabletTypes::EType tabletType)
+        : TabletType(tabletType)
+        , TypeGroup(bucketGroup->GetSubgroup(TYPE_LABEL, TString(TTabletTypes::TypeToStr(tabletType))))
+        , ExecutorCounters(TypeGroup->GetSubgroup(CATEGORY_LABEL, EXECUTOR_CATEGORY))
+        , AppCounters(TypeGroup->GetSubgroup(CATEGORY_LABEL, APP_CATEGORY))
+    {}
+
+    void Apply(
+        const TTabletKey& tablet,
+        const TTabletCountersBase& executorCounters,
+        const TTabletCountersBase& appCounters,
+        TInstant now
+    ) {
+        // The aggregates identify their sources by a single ui64, while a bucket may hold
+        // several followers of the same tablet, hence the synthetic source IDs
+        auto [it, inserted] = SourceIds.try_emplace(tablet, NextSourceId);
+        if (inserted) {
+            ++NextSourceId;
+        }
+
+        // TODO(djant) restrict the counter set
+        // do NOT enable the Partition level in production.
+        if (!ExecutorCounters.IsInitialized) {
+            ExecutorCounters.Initialize(&executorCounters);
+        }
+        if (!AppCounters.IsInitialized) {
+            AppCounters.Initialize(&appCounters);
+        }
+
+        ExecutorCounters.Apply(it->second, &executorCounters, TabletType, now);
+        AppCounters.Apply(it->second, &appCounters, TabletType, now);
+    }
+
+    void Forget(const TTabletKey& tablet) {
+        auto it = SourceIds.find(tablet);
+        if (it == SourceIds.end()) {
+            return;
+        }
+
+        if (ExecutorCounters.IsInitialized) {
+            ExecutorCounters.Forget(it->second);
+        }
+        if (AppCounters.IsInitialized) {
+            AppCounters.Forget(it->second);
+        }
+
+        SourceIds.erase(it);
+    }
+
+    bool IsEmpty() const {
+        return SourceIds.empty();
+    }
+
+    void RecalcAll() {
+        if (ExecutorCounters.IsInitialized) {
+            ExecutorCounters.RecalcAll();
+        }
+        if (AppCounters.IsInitialized) {
+            AppCounters.RecalcAll();
+        }
+    }
+
+private:
+    TTabletTypes::EType TabletType;
+
+    NMonitoring::TDynamicCounterPtr TypeGroup;
+
+    NPrivate::TAggregatedTabletCounters ExecutorCounters;
+    NPrivate::TAggregatedTabletCounters AppCounters;
+
+    THashMap<TTabletKey, ui64> SourceIds;
+    ui64 NextSourceId = 0;
+};
+
+/**
+ * Everything the aggregator keeps for a single table.
+ *
+ * @note Only one of the two shapes is ever populated, the one chosen by
+ *       the effective metrics level of the table.
+ */
+struct TTableEntry {
+    TDetailedMetricsTableInfo Info;
+
+    /**
+     * The path of the table relative to the database (the "table" label).
+     */
+    TString RelativePath;
+
+    NMonitoring::TDynamicCounterPtr TableGroup;
+
+    /**
+     * The tablet type of the first tablet of this table that was registered.
+     * All subsequent tablets of the same table must report the same type.
+     */
+    TTabletTypes::EType RegisteredTabletType = TTabletTypes::TypeInvalid;
+
+    /**
+     * Table level, created on demand: all same-node tablets of the table collapsed
+     * into a single bucket, which lives directly in the table group.
+     */
+    THolder<TCountersBucket> TableBucket;
+
+    // Partition level, created on demand
+    NMonitoring::TDynamicCounterPtr PerPartitionGroup;
+    THashMap<TTabletKey, THolder<TCountersBucket>> Leaves;
+
+    bool IsEmpty() const {
+        return !TableBucket && Leaves.empty();
+    }
+};
+
+class TNodeDatabaseMetricsAggregatorImpl : public TNodeDatabaseMetricsAggregator {
+public:
+    TNodeDatabaseMetricsAggregatorImpl(
+        NMonitoring::TDynamicCounterPtr targetCounterGroup,
+        const TString& databasePath,
+        bool isFollowerRole
+    )
+        : TargetCounterGroup(targetCounterGroup)
+        , DatabasePath(databasePath)
+        , IsFollowerRole(isFollowerRole)
+    {}
+
+    void AddCounters(
+        const TDetailedMetricsTableInfo& table,
+        ui64 tabletId,
+        ui32 followerId,
+        TTabletTypes::EType tabletType,
+        const TTabletCountersBase& executorCounters,
+        const TTabletCountersBase& appCounters,
+        TInstant now
+    ) override {
+        CheckSingleRole(followerId);
+
+        auto* entry = GetOrCreateTable(table);
+        if (!entry) {
+            return;
+        }
+
+        const TTabletKey tablet(tabletId, followerId);
+
+        // Reject tablet type drift: all tablets of the same table must report the same type
+        if (entry->RegisteredTabletType == TTabletTypes::TypeInvalid) {
+            entry->RegisteredTabletType = tabletType;
+        } else {
+            Y_DEBUG_ABORT_UNLESS(
+                entry->RegisteredTabletType == tabletType,
+                "tablet %" PRIu64 " of table %s reports type %s but the table expects %s",
+                tabletId,
+                entry->Info.TablePath.c_str(),
+                TTabletTypes::TypeToStr(tabletType),
+                TTabletTypes::TypeToStr(entry->RegisteredTabletType)
+            );
+        }
+
+        // Record the reverse mapping from tablet key to table for ForgetTablet
+        TabletToTableMap[tablet] = table.TableId;
+
+        if (IsTableLevel(entry->Info)) {
+            auto& bucket = entry->TableBucket;
+            if (!bucket) {
+                bucket = MakeHolder<TCountersBucket>(entry->TableGroup, tabletType);
+            }
+            bucket->Apply(tablet, executorCounters, appCounters, now);
+        } else {
+            auto& leaf = entry->Leaves[tablet];
+            if (!leaf) {
+                leaf = MakeHolder<TCountersBucket>(
+                    GetOrCreatePerPartitionGroup(*entry)
+                        ->GetSubgroup(TABLET_ID_LABEL, ToString(tabletId))
+                        ->GetSubgroup(FOLLOWER_ID_LABEL, ToString(followerId)),
+                    tabletType
+                );
+            }
+            leaf->Apply(tablet, executorCounters, appCounters, now);
+        }
+    }
+
+    void ForgetTablet(ui64 tabletId, ui32 followerId) override {
+        const TTabletKey tablet(tabletId, followerId);
+
+        auto mapIt = TabletToTableMap.find(tablet);
+        if (mapIt == TabletToTableMap.end()) {
+            // Unknown tablet: silent no-op, as per the contract
+            return;
+        }
+
+        const TPathId tableId = mapIt->second;
+        TabletToTableMap.erase(mapIt);
+
+        auto it = Tables.find(tableId);
+        if (it == Tables.end()) {
+            // The table entry is already gone (should not happen, but safe)
+            return;
+        }
+
+        auto& entry = it->second;
+
+        if (IsTableLevel(entry.Info)) {
+            ForgetTableBucketTablet(entry, tablet);
+        } else {
+            ForgetLeaf(entry, tablet);
+        }
+
+        if (entry.IsEmpty()) {
+            DatabaseGroup->RemoveSubgroup(TABLE_LABEL, entry.RelativePath);
+            Tables.erase(it);
+        }
+
+        // The database node is not kept around after its last table is gone: a node
+        // stops hosting a database far more often than the process is restarted
+        if (Tables.empty()) {
+            RemoveDatabaseGroup();
+        }
+    }
+
+    void RecalculateAllCounters() override {
+        for (auto& [_, entry] : Tables) {
+            if (entry.TableBucket) {
+                entry.TableBucket->RecalcAll();
+            }
+            for (auto& [_, leaf] : entry.Leaves) {
+                leaf->RecalcAll();
+            }
+        }
+    }
+
+private:
+    /**
+     * Assert that this instance is only ever handed the tablets of its own role.
+     *
+     * @note Both senders route by role
+     *       (MakeTabletCountersAggregatorID(node, IsFollower()) in flat_executor.cpp
+     *       and datashard.cpp), so a tablet of the other role means the wiring is
+     *       broken. The Table level collapse cannot survive it: the leader-only public
+     *       metrics are filtered by the mapper downstream, and once the roles are
+     *       summed into one bucket there is nothing left to filter on.
+     */
+    void CheckSingleRole(ui32 followerId) const {
+        Y_DEBUG_ABORT_UNLESS(
+            IsFollowerRole == (followerId != 0),
+            "the aggregator of the %s tablets got a follower ID of %" PRIu32,
+            IsFollowerRole ? "follower" : "leader",
+            followerId
+        );
+    }
+
+    static bool IsTableLevel(const TDetailedMetricsTableInfo& table) {
+        return table.MetricsLevel == TDetailedMetricsSettings::MetricsLevelTable;
+    }
+
+    static bool IsPartitionLevel(const TDetailedMetricsTableInfo& table) {
+        return table.MetricsLevel == TDetailedMetricsSettings::MetricsLevelPartition;
+    }
+
+    NMonitoring::TDynamicCounterPtr GetOrCreateDatabaseGroup() {
+        if (!DatabaseGroup) {
+            DatabaseGroup = TargetCounterGroup->GetSubgroup(DATABASE_LABEL, DatabasePath);
+        }
+
+        return DatabaseGroup;
+    }
+
+    /**
+     * Remove the database node from the target group. The next table recreates it.
+     */
+    void RemoveDatabaseGroup() {
+        if (!DatabaseGroup) {
+            return;
+        }
+
+        TargetCounterGroup->RemoveSubgroup(DATABASE_LABEL, DatabasePath);
+
+        DatabaseGroup = nullptr;
+    }
+
+    NMonitoring::TDynamicCounterPtr GetOrCreatePerPartitionGroup(TTableEntry& entry) {
+        if (!entry.PerPartitionGroup) {
+            entry.PerPartitionGroup = entry.TableGroup->GetSubgroup(
+                DETAILED_METRICS_LABEL,
+                PER_PARTITION_VALUE
+            );
+        }
+
+        return entry.PerPartitionGroup;
+    }
+
+    /**
+     * @return The per-table state, or nullptr if the table collects no detailed metrics
+     */
+    TTableEntry* GetOrCreateTable(const TDetailedMetricsTableInfo& table) {
+        if (!IsTableLevel(table) && !IsPartitionLevel(table)) {
+            return nullptr;
+        }
+
+        if (!table.TableId || !table.TablePath) {
+            return nullptr;
+        }
+
+        auto it = Tables.find(table.TableId);
+        if (it != Tables.end()) {
+            return &it->second;
+        }
+
+        // NOTE: Reconciling an existing entry on a schema version or a metrics level
+        //       change is implemented in a separate step
+
+        auto& entry = Tables[table.TableId];
+        entry.Info = table;
+        entry.RelativePath = MakeRelativeTablePath(DatabasePath, table.TablePath);
+        entry.TableGroup = GetOrCreateDatabaseGroup()->GetSubgroup(TABLE_LABEL, entry.RelativePath);
+
+        return &entry;
+    }
+
+    void ForgetTableBucketTablet(TTableEntry& entry, const TTabletKey& tablet) {
+        auto& bucket = entry.TableBucket;
+        if (!bucket) {
+            return;
+        }
+
+        bucket->Forget(tablet);
+
+        // The bucket lives directly in the table group, so its own counter groups are
+        // dropped together with the table group by the caller, for which the emptied
+        // entry is now IsEmpty()
+        if (bucket->IsEmpty()) {
+            bucket.Reset();
+        }
+    }
+
+    void ForgetLeaf(TTableEntry& entry, const TTabletKey& tablet) {
+        auto it = entry.Leaves.find(tablet);
+        if (it == entry.Leaves.end()) {
+            return;
+        }
+
+        // A leaf holds exactly this one tablet, so it is empty right afterwards. Dropping
+        // the contribution first keeps this symmetric with the table bucket path and holds
+        // even if a leaf ever comes to hold more than one tablet
+        it->second->Forget(tablet);
+        Y_DEBUG_ABORT_UNLESS(it->second->IsEmpty());
+
+        entry.Leaves.erase(it);
+
+        const auto& [tabletId, followerId] = tablet;
+
+        const TString tabletIdValue = ToString(tabletId);
+
+        auto tabletGroup = entry.PerPartitionGroup->FindSubgroup(TABLET_ID_LABEL, tabletIdValue);
+        if (tabletGroup) {
+            tabletGroup->RemoveSubgroup(FOLLOWER_ID_LABEL, ToString(followerId));
+        }
+
+        // The tablet group is removed as soon as its last follower is gone
+        const bool hasOtherFollowers = AnyOf(entry.Leaves, [tabletId = tabletId](const auto& leaf) {
+            return leaf.first.first == tabletId;
+        });
+
+        if (!hasOtherFollowers) {
+            entry.PerPartitionGroup->RemoveSubgroup(TABLET_ID_LABEL, tabletIdValue);
+        }
+
+        if (entry.Leaves.empty()) {
+            entry.PerPartitionGroup = nullptr;
+            entry.TableGroup->RemoveSubgroup(DETAILED_METRICS_LABEL, PER_PARTITION_VALUE);
+        }
+    }
+
+private:
+    NMonitoring::TDynamicCounterPtr TargetCounterGroup;
+
+    const TString DatabasePath;
+
+    /**
+     * The role of the tablets this instance serves. A validation input only: it never
+     * reaches the counter tree, both roles build the very same shape.
+     */
+    const bool IsFollowerRole;
+
+    /**
+     * The database= node, where the table= nodes are created. Created together with
+     * the very first table.
+     */
+    NMonitoring::TDynamicCounterPtr DatabaseGroup;
+
+    /**
+     * Reverse map from (tabletId, followerId) to tableId, used to satisfy ForgetTablet
+     * when the forget event carries no table identity.
+     */
+    THashMap<TTabletKey, TPathId> TabletToTableMap;
+
+    THashMap<TPathId, TTableEntry> Tables;
+};
+
+} // namespace <anonymous>
+
+TNodeDatabaseMetricsAggregatorPtr CreateNodeDatabaseMetricsAggregator(
+    NMonitoring::TDynamicCounterPtr targetCounterGroup,
+    const TString& databasePath,
+    bool isFollowerRole
+) {
+    return MakeIntrusive<TNodeDatabaseMetricsAggregatorImpl>(
+        targetCounterGroup,
+        databasePath,
+        isFollowerRole
+    );
+}
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -33,21 +33,34 @@ const TString APP_CATEGORY = "app";
 using TTabletKey = std::pair<ui64, ui32>;
 
 /**
- * Strip the database path prefix from the full path of the table.
+ * @return path with any trailing "/" chopped, as a view into path.
  */
-TString MakeRelativeTablePath(const TString& databasePath, const TString& tablePath) {
-    TStringBuf database(databasePath);
-    database.ChopSuffix("/");
+TStringBuf ChopTrailingSlash(const TStringBuf path) {
+    TStringBuf chopped(path);
+    chopped.ChopSuffix("/");
+    return chopped;
+}
 
+/**
+ * Strip the database path prefix from the full path of the table.
+ *
+ * @param[in] databasePrefix The database path with the trailing "/" already chopped
+ *                            (see TNodeDatabaseMetricsAggregatorImpl::DatabasePrefix)
+ * @param[in] tablePath The full path of the table, which outlives the returned view
+ *
+ * @return A view into tablePath: either the stripped suffix, or tablePath itself
+ *         when it does not start with the database. No allocation either way.
+ */
+TStringBuf MakeRelativeTablePath(const TStringBuf databasePrefix, const TString& tablePath) {
     TStringBuf relativePath(tablePath);
 
     // The "/" is required, so that /Root/db10/table is NOT stripped down to "0/table"
     // within the database /Root/db1
-    if (relativePath.SkipPrefix(database) && relativePath.SkipPrefix("/") && !relativePath.empty()) {
-        return TString(relativePath);
+    if (relativePath.SkipPrefix(databasePrefix) && relativePath.SkipPrefix("/") && !relativePath.empty()) {
+        return relativePath;
     }
 
-    return tablePath;
+    return TStringBuf(tablePath);
 }
 
 /**
@@ -144,11 +157,6 @@ private:
 struct TTableEntry {
     TDetailedMetricsTableInfo Info;
 
-    /**
-     * The path of the table relative to the database (the "table" label).
-     */
-    TString RelativePath;
-
     NMonitoring::TDynamicCounterPtr TableGroup;
 
     /**
@@ -181,6 +189,7 @@ public:
     )
         : TargetCounterGroup(targetCounterGroup)
         , DatabasePath(databasePath)
+        , DatabasePrefix(ChopTrailingSlash(databasePath))
         , IsFollowerRole(isFollowerRole)
     {}
 
@@ -196,18 +205,20 @@ public:
         CheckSingleRole(followerId);
 
         const TTabletKey tablet(tabletId, followerId);
+        const TStringBuf relativePath = MakeRelativeTablePath(DatabasePrefix, table.TablePath);
 
         // A tablet reports exactly one table, so a tablet, which is re-reported under
         // another one, leaves behind a contribution to the old table, which ForgetTablet
         // can no longer reach. Drop it here, BEFORE the group of the new table is created,
         // because dropping the last table of the database removes the database group too
         auto mapIt = TabletToTableMap.find(tablet);
-        if (mapIt != TabletToTableMap.end() && mapIt->second != table.TableId) {
+        if (mapIt != TabletToTableMap.end() && mapIt->second != relativePath) {
             RemoveTabletFromTable(mapIt->second, tablet);
             TabletToTableMap.erase(mapIt);
+            mapIt = TabletToTableMap.end();
         }
 
-        auto* entry = GetOrCreateTable(table);
+        auto* entry = GetOrCreateTable(table, relativePath);
         if (!entry) {
             return;
         }
@@ -230,8 +241,13 @@ public:
             return;
         }
 
-        // Record the reverse mapping from tablet key to table for ForgetTablet
-        TabletToTableMap[tablet] = table.TableId;
+        // Record the reverse mapping from tablet key to table for ForgetTablet. mapIt
+        // still points at an up to date entry (found above and not the-erased-because-
+        // stale case), so the steady state — every report but the first of a tablet —
+        // writes nothing and copies no string.
+        if (mapIt == TabletToTableMap.end()) {
+            TabletToTableMap.emplace(tablet, TString(relativePath));
+        }
 
         if (IsTableLevel(entry->Info)) {
             auto& bucket = entry->TableBucket;
@@ -262,10 +278,12 @@ public:
             return;
         }
 
-        const TPathId tableId = mapIt->second;
+        // RemoveTabletFromTable takes relativePath as a view rather than copying it, so
+        // it MUST run before the reverse map entry it points into is erased below, or the
+        // view dangles. RemoveTabletFromTable is documented not to touch the reverse map,
+        // so calling it first before this function's own erase is safe.
+        RemoveTabletFromTable(mapIt->second, tablet);
         TabletToTableMap.erase(mapIt);
-
-        RemoveTabletFromTable(tableId, tablet);
     }
 
     void RecalculateAllCounters() override {
@@ -342,7 +360,7 @@ private:
     /**
      * @return The per-table state, or nullptr if the table collects no detailed metrics
      */
-    TTableEntry* GetOrCreateTable(const TDetailedMetricsTableInfo& table) {
+    TTableEntry* GetOrCreateTable(const TDetailedMetricsTableInfo& table, const TStringBuf relativePath) {
         if (!IsTableLevel(table) && !IsPartitionLevel(table)) {
             return nullptr;
         }
@@ -351,7 +369,9 @@ private:
             return nullptr;
         }
 
-        auto it = Tables.find(table.TableId);
+        // THash<TString>/TEqualTo<TString> are transparent, so lookup on a TStringBuf
+        // needs no temporary TString
+        auto it = Tables.find(relativePath);
         if (it != Tables.end()) {
             return &it->second;
         }
@@ -362,10 +382,12 @@ private:
         //       the very first report, which MetricsLevelChangeIsIgnoredUntilReconciliation
         //       pins, so that the step has to flip an explicit assertion
 
-        auto& entry = Tables[table.TableId];
+        // A new entry: this is the one place the key is actually materialized into a
+        // TString, once, shared between the map key and the GetSubgroup() call
+        const TString newKey(relativePath);
+        auto& entry = Tables[newKey];
         entry.Info = table;
-        entry.RelativePath = MakeRelativeTablePath(DatabasePath, table.TablePath);
-        entry.TableGroup = GetOrCreateDatabaseGroup()->GetSubgroup(TABLE_LABEL, entry.RelativePath);
+        entry.TableGroup = GetOrCreateDatabaseGroup()->GetSubgroup(TABLE_LABEL, newKey);
 
         return &entry;
     }
@@ -376,8 +398,8 @@ private:
      *
      * @note The caller owns the reverse map entry: this function does not touch it.
      */
-    void RemoveTabletFromTable(const TPathId& tableId, const TTabletKey& tablet) {
-        auto it = Tables.find(tableId);
+    void RemoveTabletFromTable(const TStringBuf relativePath, const TTabletKey& tablet) {
+        auto it = Tables.find(relativePath);
         if (it == Tables.end()) {
             // The table collects no detailed metrics, or its entry is already gone
             return;
@@ -392,7 +414,9 @@ private:
         }
 
         if (entry.IsEmpty()) {
-            DatabaseGroup->RemoveSubgroup(TABLE_LABEL, entry.RelativePath);
+            // it->first is the real TString key, so removal builds nothing from the
+            // (possibly borrowed) relativePath parameter
+            DatabaseGroup->RemoveSubgroup(TABLE_LABEL, it->first);
             Tables.erase(it);
         }
 
@@ -463,6 +487,14 @@ private:
     const TString DatabasePath;
 
     /**
+     * DatabasePath with the trailing "/" chopped, own storage (not a view into
+     * DatabasePath): the impl is copy-constructible (TThrRefBase), and a view member
+     * would alias the SOURCE's DatabasePath after a copy. Precomputed once so that
+     * MakeRelativeTablePath() needs no allocation on every AddCounters call.
+     */
+    const TString DatabasePrefix;
+
+    /**
      * The role of the tablets this instance serves. A validation input only: it never
      * reaches the counter tree, both roles build the very same shape.
      */
@@ -475,12 +507,27 @@ private:
     NMonitoring::TDynamicCounterPtr DatabaseGroup;
 
     /**
-     * Reverse map from (tabletId, followerId) to tableId, used to satisfy ForgetTablet
-     * when the forget event carries no table identity.
+     * Reverse map from (tabletId, followerId) to the table's relative path, used to
+     * satisfy ForgetTablet when the forget event carries no table identity.
      */
-    THashMap<TTabletKey, TPathId> TabletToTableMap;
+    THashMap<TTabletKey, TString> TabletToTableMap;
 
-    THashMap<TPathId, TTableEntry> Tables;
+    /**
+     * Keyed by the table's relative path (the same value the "table" label of the
+     * counter tree carries) rather than by TPathId.
+     *
+     * The counter group is created by GetSubgroup(TABLE_LABEL, relativePath), which
+     * returns the SAME group for any two calls with the same path. If the state were
+     * keyed by TPathId instead, two PathIds sharing one path — a table dropped and
+     * recreated at the same path, or an ESchemeOpMoveTable rename that moves a table
+     * away and a new one is created at the vacated path — would get two entries
+     * silently aliasing one TDynamicCounters group and one implicit source-ID space.
+     * Emptying either entry would then remove the group out from under the other, and
+     * their independent TAggregatedTabletCounters would keep overwriting each other's
+     * sums. Keying by path instead makes the two reports collapse into the very same
+     * entry, which is exactly what the shared group already does.
+     */
+    THashMap<TString, TTableEntry> Tables;
 };
 
 } // namespace <anonymous>

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.cpp
@@ -195,25 +195,39 @@ public:
     ) override {
         CheckSingleRole(followerId);
 
+        const TTabletKey tablet(tabletId, followerId);
+
+        // A tablet reports exactly one table, so a tablet, which is re-reported under
+        // another one, leaves behind a contribution to the old table, which ForgetTablet
+        // can no longer reach. Drop it here, BEFORE the group of the new table is created,
+        // because dropping the last table of the database removes the database group too
+        auto mapIt = TabletToTableMap.find(tablet);
+        if (mapIt != TabletToTableMap.end() && mapIt->second != table.TableId) {
+            RemoveTabletFromTable(mapIt->second, tablet);
+            TabletToTableMap.erase(mapIt);
+        }
+
         auto* entry = GetOrCreateTable(table);
         if (!entry) {
             return;
         }
 
-        const TTabletKey tablet(tabletId, followerId);
-
         // Reject tablet type drift: all tablets of the same table must report the same type
         if (entry->RegisteredTabletType == TTabletTypes::TypeInvalid) {
             entry->RegisteredTabletType = tabletType;
-        } else {
+        } else if (entry->RegisteredTabletType != tabletType) {
             Y_DEBUG_ABORT_UNLESS(
-                entry->RegisteredTabletType == tabletType,
+                false,
                 "tablet %" PRIu64 " of table %s reports type %s but the table expects %s",
                 tabletId,
                 entry->Info.TablePath.c_str(),
                 TTabletTypes::TypeToStr(tabletType),
                 TTabletTypes::TypeToStr(entry->RegisteredTabletType)
             );
+
+            // The aggregates of the bucket are built for the counter set of the registered
+            // type, so feeding another layout into them aborts in TAggregatedTabletCounters
+            return;
         }
 
         // Record the reverse mapping from tablet key to table for ForgetTablet
@@ -251,30 +265,7 @@ public:
         const TPathId tableId = mapIt->second;
         TabletToTableMap.erase(mapIt);
 
-        auto it = Tables.find(tableId);
-        if (it == Tables.end()) {
-            // The table entry is already gone (should not happen, but safe)
-            return;
-        }
-
-        auto& entry = it->second;
-
-        if (IsTableLevel(entry.Info)) {
-            ForgetTableBucketTablet(entry, tablet);
-        } else {
-            ForgetLeaf(entry, tablet);
-        }
-
-        if (entry.IsEmpty()) {
-            DatabaseGroup->RemoveSubgroup(TABLE_LABEL, entry.RelativePath);
-            Tables.erase(it);
-        }
-
-        // The database node is not kept around after its last table is gone: a node
-        // stops hosting a database far more often than the process is restarted
-        if (Tables.empty()) {
-            RemoveDatabaseGroup();
-        }
+        RemoveTabletFromTable(tableId, tablet);
     }
 
     void RecalculateAllCounters() override {
@@ -366,7 +357,10 @@ private:
         }
 
         // NOTE: Reconciling an existing entry on a schema version or a metrics level
-        //       change is implemented in a separate step
+        //       change is implemented in a separate step (the level and rename step of
+        //       the detailed metrics plan). Until then the level of a table is frozen at
+        //       the very first report, which MetricsLevelChangeIsIgnoredUntilReconciliation
+        //       pins, so that the step has to flip an explicit assertion
 
         auto& entry = Tables[table.TableId];
         entry.Info = table;
@@ -374,6 +368,39 @@ private:
         entry.TableGroup = GetOrCreateDatabaseGroup()->GetSubgroup(TABLE_LABEL, entry.RelativePath);
 
         return &entry;
+    }
+
+    /**
+     * Drop the contribution of a single tablet to the given table, removing the groups,
+     * which are left empty.
+     *
+     * @note The caller owns the reverse map entry: this function does not touch it.
+     */
+    void RemoveTabletFromTable(const TPathId& tableId, const TTabletKey& tablet) {
+        auto it = Tables.find(tableId);
+        if (it == Tables.end()) {
+            // The table collects no detailed metrics, or its entry is already gone
+            return;
+        }
+
+        auto& entry = it->second;
+
+        if (IsTableLevel(entry.Info)) {
+            ForgetTableBucketTablet(entry, tablet);
+        } else {
+            ForgetLeaf(entry, tablet);
+        }
+
+        if (entry.IsEmpty()) {
+            DatabaseGroup->RemoveSubgroup(TABLE_LABEL, entry.RelativePath);
+            Tables.erase(it);
+        }
+
+        // The database node is not kept around after its last table is gone: a node
+        // stops hosting a database far more often than the process is restarted
+        if (Tables.empty()) {
+            RemoveDatabaseGroup();
+        }
     }
 
     void ForgetTableBucketTablet(TTableEntry& entry, const TTabletKey& tablet) {

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -85,9 +85,10 @@ public:
      * which are left empty.
      *
      * @param[in] tabletId The tablet ID and its role are sufficient: this class owns
-     *                      the reverse map from (tabletId, followerId) -> tableId,
-     *                      because the forget event from the Tablet Counters Aggregator
-     *                      carries no table identity.
+     *                      the reverse map from (tabletId, followerId) -> the table's
+     *                      relative path (the same key the table entries and their
+     *                      counter groups are addressed by), because the forget event
+     *                      from the Tablet Counters Aggregator carries no table identity.
      *
      * @note A tablet of an unknown table is silently ignored, and forgetting a tablet
      *       twice is not an error.

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -91,6 +91,11 @@ public:
      *
      * @note A tablet of an unknown table is silently ignored, and forgetting a tablet
      *       twice is not an error.
+     *
+     * @note A tablet reports exactly one table, so the reverse map holds one table per
+     *       tablet. A tablet, which is re-reported under another table, is moved: its
+     *       contribution to the previous table is dropped by AddCounters, because
+     *       nothing but the reverse map could reach it afterwards.
      */
     virtual void ForgetTablet(ui64 tabletId, ui32 followerId) = 0;
 

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <ydb/core/base/tablet_types.h>
+#include <ydb/core/protos/table_metrics_settings.pb.h>
+#include <ydb/core/scheme/scheme_pathid.h>
+#include <ydb/core/tablet/tablet_counters.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+
+#include <util/datetime/base.h>
+#include <util/generic/ptr.h>
+#include <util/generic/string.h>
+
+namespace NKikimr {
+
+/**
+ * The per-table detailed metrics settings, as stored in the schema.
+ */
+using TDetailedMetricsSettings = NKikimrSchemeOp::TTableDetailedMetricsSettings;
+
+/**
+ * The effective level at which detailed metrics are collected for a single table.
+ */
+using EDetailedMetricsLevel = TDetailedMetricsSettings::EMetricsLevel;
+
+/**
+ * The identity of the user table, whose tablet reports the low level counters.
+ */
+struct TDetailedMetricsTableInfo {
+    TPathId TableId;
+
+    /**
+     * The full path of the table, for example, /Root/db/dir/table. The database path
+     * prefix is stripped before the path is used as the value of the "table" label.
+     */
+    TString TablePath;
+
+    ui64 SchemaVersion = 0;
+
+    EDetailedMetricsLevel MetricsLevel = TDetailedMetricsSettings::MetricsLevelUnspecified;
+};
+
+/**
+ * The per-node, per-database, per-role builder of the detailed metrics counter tree.
+ *
+ * The instance fills the counter group it is handed, which the caller has already
+ * scoped to the role of its Tablet Counters Aggregator actor:
+ *
+ *     ydb_detailed_raw                        (private, created by the caller)
+ *       role=leader | role=follower           (created by the caller)
+ *         |
+ *         +-- the target group of this instance
+ *             database=<database path>
+ *               table=<table path relative to the database>
+ *                 Table level:     the collapsed counters of the table
+ *                 Partition level: detailed_metrics=per_partition
+ *                                    tablet_id=<id>
+ *                                      follower_id=<n>
+ *
+ * Every group, which holds counters above, holds them as a
+ * type=<tablet type>/category=executor|app subtree of low level counter aggregates,
+ * the very same layout as the node wide "tablets" group.
+ *
+ */
+class TNodeDatabaseMetricsAggregator : public TThrRefBase {
+public:
+    /**
+     * @param[in] now Used to differentiate the cumulative counters into per second rates
+     *
+     * @warning Every named counter of the two counter sets is published as its own
+     *          series in every bucket, so the caller decides the cardinality
+     */
+    virtual void AddCounters(
+        const TDetailedMetricsTableInfo& table,
+        ui64 tabletId,
+        ui32 followerId,
+        TTabletTypes::EType tabletType,
+        const TTabletCountersBase& executorCounters,
+        const TTabletCountersBase& appCounters,
+        TInstant now
+    ) = 0;
+
+    /**
+     * Drop everything this tablet contributed to the tree, removing the groups,
+     * which are left empty.
+     *
+     * @param[in] tabletId The tablet ID and its role are sufficient: this class owns
+     *                      the reverse map from (tabletId, followerId) -> tableId,
+     *                      because the forget event from the Tablet Counters Aggregator
+     *                      carries no table identity.
+     *
+     * @note A tablet of an unknown table is silently ignored, and forgetting a tablet
+     *       twice is not an error.
+     */
+    virtual void ForgetTablet(ui64 tabletId, ui32 followerId) = 0;
+
+    virtual void RecalculateAllCounters() = 0;
+};
+
+using TNodeDatabaseMetricsAggregatorPtr = TIntrusivePtr<TNodeDatabaseMetricsAggregator>;
+
+/**
+ * @param[in] targetCounterGroup The group to fill, already scoped to the role
+ * @param[in] isFollowerRole The role of the tablets this instance is fed
+ */
+TNodeDatabaseMetricsAggregatorPtr CreateNodeDatabaseMetricsAggregator(
+    NMonitoring::TDynamicCounterPtr targetCounterGroup,
+    const TString& databasePath,
+    bool isFollowerRole
+);
+
+} // namespace NKikimr

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -22,6 +22,12 @@ const TString RELATIVE_TABLE_PATH = "dir/table";
 
 const TPathId TABLE_ID(72057594046644480ull, 42);
 
+// The same schemeshard owner as TABLE_ID, but a different local id, reporting under
+// the very same TABLE_PATH: models a table dropped and recreated at the same path,
+// or an ESchemeOpMoveTable rename that moves the old table away and a new one is
+// created at the vacated path.
+const TPathId RECREATED_TABLE_ID(72057594046644480ull, 44);
+
 // Another table of the very same database
 const TString OTHER_TABLE_PATH = "/Root/db/dir/other_table";
 const TString OTHER_RELATIVE_TABLE_PATH = "dir/other_table";
@@ -1174,6 +1180,135 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
             aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
 
             UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+        }
+    }
+
+    /**
+     * Verify that two different TPathIds, which report the very same table path, share
+     * ONE counter group and ONE aggregate rather than fragmenting the tree between them.
+     *
+     * @note In production this happens whenever a table is dropped and a new one is
+     *       created at the same path, or when an ESchemeOpMoveTable rename moves the
+     *       old table away and a new table is created at the vacated old path: the
+     *       schemeshard hands out a fresh PathId, but the "table" label of the counter
+     *       tree is keyed by path, not by PathId. Before this fix, the state map was
+     *       keyed by PathId, so the two reports created two TTableEntry-s aliasing one
+     *       GetSubgroup() result: their TAggregatedTabletCounters overwrote each other's
+     *       sums, and forgetting the last tablet of the OLDER entry unconditionally
+     *       removed the shared group, detaching the counters the SURVIVING entry still
+     *       wrote into.
+     */
+    Y_UNIT_TEST(SamePathUnderDifferentPathIdsSharesOneTable) {
+        const TInstant now = TInstant::Seconds(100);
+
+        // TEST 1: The table level, where both tablets contribute to a shared bucket
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet oldTablet(1000, 0);
+            TFakeTablet newTablet(1001, 0);
+
+            oldTablet.SetSimple(UNIQUE_ROWS, 5);
+            oldTablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now, TABLE_ID, TABLE_PATH);
+
+            newTablet.SetSimple(UNIQUE_ROWS, 7);
+            newTablet.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelTable,
+                now,
+                RECREATED_TABLE_ID,
+                TABLE_PATH
+            );
+
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Table level counters of two PathIds at one path", rootGroup);
+
+            // Exactly one table= group holds the sum of both PathIds' contributions:
+            // under the bug this would read 5 or 7 (whichever entry recalculated last),
+            // never their sum
+            UNIT_ASSERT(FindTableGroup(rootGroup));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                5 + 7
+            );
+
+            // The tablet of the OLDER PathId is forgotten: the group must stay reachable,
+            // because the surviving PathId's entry still owns it
+            aggregator->ForgetTablet(oldTablet.TabletId, oldTablet.FollowerId);
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Table level counters after forgetting the older PathId's tablet", rootGroup);
+
+            UNIT_ASSERT(FindTableGroup(rootGroup));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                7
+            );
+        }
+
+        // TEST 2: The partition level, where both tablets own a leaf of their own
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet oldTablet(1000, 0);
+            TFakeTablet newTablet(1001, 0);
+
+            oldTablet.SetSimple(UNIQUE_ROWS, 5);
+            oldTablet.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelPartition,
+                now,
+                TABLE_ID,
+                TABLE_PATH
+            );
+
+            newTablet.SetSimple(UNIQUE_ROWS, 7);
+            newTablet.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelPartition,
+                now,
+                RECREATED_TABLE_ID,
+                TABLE_PATH
+            );
+
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Partition level leaves of two PathIds at one path", rootGroup);
+
+            // Both leaves live under the very same table= group
+            UNIT_ASSERT(FindTableGroup(rootGroup));
+
+            auto oldLeaf = FindLeafCounters(rootGroup, oldTablet.TabletId, oldTablet.FollowerId);
+            UNIT_ASSERT(oldLeaf);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(oldLeaf, "SUM(UniqueRows)"), 5);
+
+            auto newLeaf = FindLeafCounters(rootGroup, newTablet.TabletId, newTablet.FollowerId);
+            UNIT_ASSERT(newLeaf);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(newLeaf, "SUM(UniqueRows)"), 7);
+
+            // Forgetting the OLDER PathId's tablet must not detach the surviving leaf
+            aggregator->ForgetTablet(oldTablet.TabletId, oldTablet.FollowerId);
+
+            DumpCounters("Partition level leaves after forgetting the older PathId's tablet", rootGroup);
+
+            UNIT_ASSERT(!FindLeafCounters(rootGroup, oldTablet.TabletId, oldTablet.FollowerId));
+
+            auto survivingLeaf = FindLeafCounters(rootGroup, newTablet.TabletId, newTablet.FollowerId);
+            UNIT_ASSERT(survivingLeaf);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(survivingLeaf, "SUM(UniqueRows)"), 7);
         }
     }
 

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -1,0 +1,1052 @@
+#include "node_database_metrics_aggregator.h"
+#include "ut_helpers.h"
+
+#include <library/cpp/monlib/dynamic_counters/encode.h>
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/generic/array_size.h>
+#include <util/string/builder.h>
+#include <util/string/cast.h>
+
+using namespace NKikimr;
+using namespace NKikimr::NDetailedMetricsTests;
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+const TString DATABASE_PATH = "/Root/db";
+
+const TString TABLE_PATH = "/Root/db/dir/table";
+const TString RELATIVE_TABLE_PATH = "dir/table";
+
+const TPathId TABLE_ID(72057594046644480ull, 42);
+
+constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
+
+////////////////////////////////////////////////////////////////////////////////
+// A small stand-in for the low level counters of Data Shard. The real counter set
+// has hundreds of counters, which would make the assertions unreadable without
+// covering anything, which is not covered by these few counters.
+
+constexpr const char* SIMPLE_COUNTER_NAMES[] = {
+    "UniqueRows",
+    "UniqueBytes",
+};
+
+constexpr const char* CUMULATIVE_COUNTER_NAMES[] = {
+    "ConsumedCPU",
+};
+
+constexpr const char* PERCENTILE_COUNTER_NAMES[] = {
+    // A histogram aggregate: it is NOT filled by the tablet, it collects
+    // one observation per tablet from the "ConsumedCPU" cumulative counter
+    "HIST(ConsumedCPU)",
+
+    // An ordinary percentile counter, which the tablet fills itself
+    "TxLatency",
+};
+
+constexpr TTabletPercentileCounter::TRangeDef PERCENTILE_RANGES[] = {
+    {  0,   "0"},
+    { 10,  "10"},
+    {100, "100"},
+};
+
+enum ESimpleCounter : ui32 {
+    UNIQUE_ROWS = 0,
+    UNIQUE_BYTES = 1,
+};
+
+enum ECumulativeCounter : ui32 {
+    CONSUMED_CPU = 0,
+};
+
+enum EPercentileCounter : ui32 {
+    HIST_CONSUMED_CPU = 0,
+    TX_LATENCY = 1,
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A single tablet, which reports the low level counters above.
+ *
+ * @note Reporting goes through MakeDiffForAggr()/RememberCurrentStateAsBaseline(),
+ *       exactly like the Executor does it, so what the aggregator sees is what it
+ *       sees in production: the simple counters are absolute, the cumulative ones
+ *       are the delta since the previous report of THIS tablet, and the integral
+ *       percentile counters are absolute.
+ */
+struct TFakeTablet {
+    TFakeTablet(ui64 tabletId, ui32 followerId)
+        : TabletId(tabletId)
+        , FollowerId(followerId)
+        , AppCounters(
+            Y_ARRAY_SIZE(SIMPLE_COUNTER_NAMES),
+            Y_ARRAY_SIZE(CUMULATIVE_COUNTER_NAMES),
+            Y_ARRAY_SIZE(PERCENTILE_COUNTER_NAMES),
+            SIMPLE_COUNTER_NAMES,
+            CUMULATIVE_COUNTER_NAMES,
+            PERCENTILE_COUNTER_NAMES
+        )
+    {
+        for (ui32 i = 0; i < Y_ARRAY_SIZE(PERCENTILE_COUNTER_NAMES); ++i) {
+            AppCounters.Percentile()[i].Initialize(PERCENTILE_RANGES, true /* integral */);
+        }
+    }
+
+    TFakeTablet& SetSimple(ESimpleCounter counter, ui64 value) {
+        AppCounters.Simple()[counter].Set(value);
+        return *this;
+    }
+
+    TFakeTablet& AddCumulative(ECumulativeCounter counter, ui64 delta) {
+        AppCounters.Cumulative()[counter] += delta;
+        return *this;
+    }
+
+    TFakeTablet& IncrementPercentile(EPercentileCounter counter, ui64 value) {
+        AppCounters.Percentile()[counter].IncrementFor(value);
+        return *this;
+    }
+
+    /**
+     * Send everything accumulated since the previous report, the way the Executor does.
+     */
+    void Report(
+        const TNodeDatabaseMetricsAggregatorPtr& aggregator,
+        EDetailedMetricsLevel level,
+        TInstant now
+    ) {
+        TDetailedMetricsTableInfo table;
+        table.TableId = TABLE_ID;
+        table.TablePath = TABLE_PATH;
+        table.SchemaVersion = 1;
+        table.MetricsLevel = level;
+
+        // An empty baseline (the very first report) makes the diff a plain copy
+        auto appDiff = AppCounters.MakeDiffForAggr(AppBaseline);
+        auto executorDiff = ExecutorCounters.MakeDiffForAggr(ExecutorBaseline);
+
+        aggregator->AddCounters(
+            table,
+            TabletId,
+            FollowerId,
+            TABLET_TYPE,
+            *executorDiff,
+            *appDiff,
+            now
+        );
+
+        AppCounters.RememberCurrentStateAsBaseline(AppBaseline);
+        ExecutorCounters.RememberCurrentStateAsBaseline(ExecutorBaseline);
+    }
+
+    const ui64 TabletId;
+    const ui32 FollowerId;
+
+    TTabletCountersBase ExecutorCounters;
+    TTabletCountersBase AppCounters;
+
+    // The state as of the previous report, subtracted from the cumulative counters
+    TTabletCountersBase ExecutorBaseline;
+    TTabletCountersBase AppBaseline;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @return The counter group of the table (or nullptr if there is none)
+ */
+NMonitoring::TDynamicCounterPtr FindTableGroup(NMonitoring::TDynamicCounterPtr rootGroup) {
+    auto databaseGroup = rootGroup->FindSubgroup("database", DATABASE_PATH);
+    if (!databaseGroup) {
+        return nullptr;
+    }
+
+    return databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH);
+}
+
+/**
+ * @param[in] bucketGroup The counter group of a table bucket or of a leaf
+ *
+ * @return The counter group of the application counters (or nullptr if there is none)
+ */
+NMonitoring::TDynamicCounterPtr FindAppCountersGroup(NMonitoring::TDynamicCounterPtr bucketGroup) {
+    if (!bucketGroup) {
+        return nullptr;
+    }
+
+    auto typeGroup = bucketGroup->FindSubgroup("type", TTabletTypes::TypeToStr(TABLET_TYPE));
+    if (!typeGroup) {
+        return nullptr;
+    }
+
+    return typeGroup->FindSubgroup("category", "app");
+}
+
+/**
+ * @param[in] rootGroup The counter group where the whole tree is created
+ *
+ * @return The application counters of the table bucket (or nullptr if there is none)
+ *
+ * @note At the table level the collapsed counters live directly in the table group:
+ *       the role is the caller's partition of the tree, not a label within it.
+ */
+NMonitoring::TDynamicCounterPtr FindTableBucketCounters(NMonitoring::TDynamicCounterPtr rootGroup) {
+    return FindAppCountersGroup(FindTableGroup(rootGroup));
+}
+
+/**
+ * @param[in] rootGroup The counter group where the whole tree is created
+ * @param[in] tabletId The ID of the tablet
+ * @param[in] followerId The follower ID of the tablet (0 for the leader)
+ *
+ * @return The application counters of the leaf (or nullptr if there is none)
+ */
+NMonitoring::TDynamicCounterPtr FindLeafCounters(
+    NMonitoring::TDynamicCounterPtr rootGroup,
+    ui64 tabletId,
+    ui32 followerId
+) {
+    auto tableGroup = FindTableGroup(rootGroup);
+    if (!tableGroup) {
+        return nullptr;
+    }
+
+    auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
+    if (!perPartitionGroup) {
+        return nullptr;
+    }
+
+    auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
+    if (!tabletGroup) {
+        return nullptr;
+    }
+
+    return FindAppCountersGroup(tabletGroup->FindSubgroup("follower_id", ToString(followerId)));
+}
+
+/**
+ * @param[in] countersGroup The counter group to read the counter from
+ * @param[in] name The name of the counter
+ *
+ * @return The value of the corresponding counter
+ */
+ui64 GetCounterValue(NMonitoring::TDynamicCounterPtr countersGroup, const TString& name) {
+    UNIT_ASSERT_C(countersGroup, "no counter group for the counter " << name);
+
+    auto counter = countersGroup->FindNamedCounter("sensor", name);
+    UNIT_ASSERT_C(counter, "no counter " << name);
+
+    return counter->Val();
+}
+
+/**
+ * @param[in] countersGroup The counter group to read the histogram from
+ * @param[in] name The name of the histogram
+ *
+ * @return The total number of the observations in all the buckets of the histogram
+ */
+ui64 GetHistogramTotal(NMonitoring::TDynamicCounterPtr countersGroup, const TString& name) {
+    UNIT_ASSERT_C(countersGroup, "no counter group for the histogram " << name);
+
+    auto histogram = countersGroup->FindHistogram(name);
+    UNIT_ASSERT_C(histogram, "no histogram " << name);
+
+    auto snapshot = histogram->Snapshot();
+
+    ui64 total = 0;
+    for (ui32 i = 0; i < snapshot->Count(); ++i) {
+        total += snapshot->Value(i);
+    }
+
+    return total;
+}
+
+/**
+ * @param[in] countersGroup The counter group to read the histogram from
+ * @param[in] name The name of the histogram
+ *
+ * @return The value of every bucket of the histogram, comma separated
+ *
+ * @note A string rather than a vector, so that a failed assertion prints
+ *       both the expected and the actual buckets.
+ */
+TString GetHistogramBuckets(NMonitoring::TDynamicCounterPtr countersGroup, const TString& name) {
+    UNIT_ASSERT_C(countersGroup, "no counter group for the histogram " << name);
+
+    auto histogram = countersGroup->FindHistogram(name);
+    UNIT_ASSERT_C(histogram, "no histogram " << name);
+
+    auto snapshot = histogram->Snapshot();
+
+    TStringBuilder buckets;
+    for (ui32 i = 0; i < snapshot->Count(); ++i) {
+        if (i > 0) {
+            buckets << ",";
+        }
+        buckets << snapshot->Value(i);
+    }
+
+    return buckets;
+}
+
+void DumpCounters(const TString& title, NMonitoring::TDynamicCounterPtr rootGroup) {
+    Cerr << "TEST " << title << ":" << Endl
+         << NormalizeJson(NMonitoring::ToJson(*rootGroup)) << Endl;
+}
+
+/**
+ * The two role subtrees of the private "ydb_detailed_raw" group, built the way the two
+ * Tablet Counters Aggregator actors of a node build them: one aggregator per role,
+ * each owning everything below its own role= node, both hanging off one shared root.
+ */
+struct TRoleTrees {
+    NMonitoring::TDynamicCounterPtr Root = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+    NMonitoring::TDynamicCounterPtr LeaderRoot = Root->GetSubgroup("role", "leader");
+    NMonitoring::TDynamicCounterPtr FollowerRoot = Root->GetSubgroup("role", "follower");
+
+    TNodeDatabaseMetricsAggregatorPtr Leaders = CreateNodeDatabaseMetricsAggregator(
+        LeaderRoot,
+        DATABASE_PATH,
+        false /* isFollowerRole */
+    );
+
+    TNodeDatabaseMetricsAggregatorPtr Followers = CreateNodeDatabaseMetricsAggregator(
+        FollowerRoot,
+        DATABASE_PATH,
+        true /* isFollowerRole */
+    );
+
+    void RecalculateAllCounters() {
+        Leaders->RecalculateAllCounters();
+        Followers->RecalculateAllCounters();
+    }
+};
+
+} // namespace <anonymous>
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Unit tests for the node database metrics aggregator (TNodeDatabaseMetricsAggregator).
+ */
+Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
+    /**
+     * Verify that at the table level all same-node partitions of the table are collapsed
+     * into a single bucket per role tree, and no per-partition counters are created.
+     */
+    Y_UNIT_TEST(TableLevelCollapsesPartitions) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // 3 leader partitions of the same table on this node
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+        TFakeTablet leader3(3000, 0);
+
+        leader1.SetSimple(UNIQUE_ROWS, 1).SetSimple(UNIQUE_BYTES, 10).AddCumulative(CONSUMED_CPU, 100);
+        leader2.SetSimple(UNIQUE_ROWS, 2).SetSimple(UNIQUE_BYTES, 20).AddCumulative(CONSUMED_CPU, 200);
+        leader3.SetSimple(UNIQUE_ROWS, 4).SetSimple(UNIQUE_BYTES, 40).AddCumulative(CONSUMED_CPU, 400);
+
+        // 2 followers of the very same partition: they must NOT collide with each other
+        TFakeTablet follower1(1000, 1);
+        TFakeTablet follower2(1000, 2);
+
+        follower1.SetSimple(UNIQUE_ROWS, 8).AddCumulative(CONSUMED_CPU, 800);
+        follower2.SetSimple(UNIQUE_ROWS, 16).AddCumulative(CONSUMED_CPU, 1600);
+
+        for (auto* tablet : {&leader1, &leader2, &leader3}) {
+            tablet->Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        for (auto* tablet : {&follower1, &follower2}) {
+            tablet->Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Table level counters", trees.Root);
+
+        // The bucket of the leader tree holds the 3 leader partitions
+        auto leaderCounters = FindTableBucketCounters(trees.LeaderRoot);
+        UNIT_ASSERT(leaderCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(UniqueRows)"), 1 + 2 + 4);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(UniqueRows)"), 4);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(UniqueBytes)"), 10 + 20 + 40);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(UniqueBytes)"), 40);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200 + 400);
+
+        // The bucket of the follower tree holds the 2 followers
+        auto followerCounters = FindTableBucketCounters(trees.FollowerRoot);
+        UNIT_ASSERT(followerCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "SUM(UniqueRows)"), 8 + 16);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "MAX(UniqueRows)"), 16);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "ConsumedCPU"), 800 + 1600);
+
+        // No per-partition counters at the table level, in either tree
+        for (auto roleRoot : {trees.LeaderRoot, trees.FollowerRoot}) {
+            auto tableGroup = FindTableGroup(roleRoot);
+            UNIT_ASSERT(tableGroup);
+            UNIT_ASSERT(!tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+        }
+    }
+
+    /**
+     * Verify that at the partition level every (tablet_id, follower_id) leaf is kept
+     * verbatim and no on-node rollup of any kind is created.
+     */
+    Y_UNIT_TEST(PartitionLevelKeepsLeaves) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // 2 partitions of the same table, a leader and 2 followers each. The leader goes
+        // to the leader tree and both followers to the follower one, exactly the way
+        // the two Tablet Counters Aggregator actors of a node are fed.
+        const TVector<ui64> tabletIds = {1000, 2000};
+        const TVector<ui32> followerIds = {0, 1, 2};
+
+        ui64 value = 0;
+        THashMap<std::pair<ui64, ui32>, ui64> expectedValues;
+
+        for (ui64 tabletId : tabletIds) {
+            for (ui32 followerId : followerIds) {
+                value += 1;
+                expectedValues[std::make_pair(tabletId, followerId)] = value;
+
+                TFakeTablet tablet(tabletId, followerId);
+                tablet.SetSimple(UNIQUE_ROWS, value).AddCumulative(CONSUMED_CPU, value * 100);
+                tablet.Report(
+                    followerId == 0 ? trees.Leaders : trees.Followers,
+                    TDetailedMetricsSettings::MetricsLevelPartition,
+                    now
+                );
+            }
+        }
+
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Partition level counters", trees.Root);
+
+        // Every leaf holds exactly what its tablet has reported, in the tree of its role
+        for (const auto& [tablet, expectedValue] : expectedValues) {
+            const auto& [tabletId, followerId] = tablet;
+
+            auto roleRoot = followerId == 0 ? trees.LeaderRoot : trees.FollowerRoot;
+
+            auto leafCounters = FindLeafCounters(roleRoot, tabletId, followerId);
+            UNIT_ASSERT_C(leafCounters, "no leaf for " << tabletId << ":" << followerId);
+
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(UniqueRows)"), expectedValue);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "MAX(UniqueRows)"), expectedValue);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "ConsumedCPU"), expectedValue * 100);
+        }
+
+        // A leaf of one role never lands in the tree of the other one
+        UNIT_ASSERT(!FindLeafCounters(trees.LeaderRoot, 1000, 1));
+        UNIT_ASSERT(!FindLeafCounters(trees.FollowerRoot, 1000, 0));
+
+        // No table bucket and no on-node rollup at the partition level, in either tree
+        for (auto roleRoot : {trees.LeaderRoot, trees.FollowerRoot}) {
+            auto tableGroup = FindTableGroup(roleRoot);
+            UNIT_ASSERT(tableGroup);
+            UNIT_ASSERT(!FindAppCountersGroup(tableGroup));
+
+            auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
+            UNIT_ASSERT(perPartitionGroup);
+            UNIT_ASSERT(!FindAppCountersGroup(perPartitionGroup));
+
+            for (ui64 tabletId : tabletIds) {
+                auto tabletGroup = perPartitionGroup->FindSubgroup("tablet_id", ToString(tabletId));
+                UNIT_ASSERT(tabletGroup);
+                UNIT_ASSERT(!FindAppCountersGroup(tabletGroup));
+            }
+        }
+    }
+
+    /**
+     * Verify that the cumulative counters, which the Executor sends as the delta since
+     * the previous report, are ACCUMULATED rather than replaced, and that the derived
+     * per second rate is recomputed from the delta of the latest report only.
+     *
+     * @note This is the whole point of the cumulative counters: a monotonically growing
+     *       series. Replacing the accumulated value with the latest delta would look
+     *       like a counter reset to the consumer.
+     */
+    Y_UNIT_TEST(CumulativeCountersAccumulateAcrossReports) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+
+        // TICK 1: both partitions report a non-zero delta
+        TInstant now = TInstant::Seconds(100);
+
+        leader1.AddCumulative(CONSUMED_CPU, 100);
+        leader2.AddCumulative(CONSUMED_CPU, 200);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        auto leaderCounters = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200);
+
+        // TICK 2: 10 seconds later only the first partition does any work
+        now += TDuration::Seconds(10);
+
+        leader1.AddCumulative(CONSUMED_CPU, 300);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Table level counters after the second report", rootGroup);
+
+        // The accumulated value keeps growing and never goes backwards
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200 + 300);
+
+        // MAX() of a cumulative counter is the maximum per second rate over the bucket:
+        // 300 over the 10 seconds since the previous report of that very tablet
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(ConsumedCPU)"), 300 / 10);
+
+        // TICK 3: nobody does any work at all
+        now += TDuration::Seconds(10);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200 + 300);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "MAX(ConsumedCPU)"), 0);
+    }
+
+    /**
+     * Verify that both kinds of the percentile counters end up in the counter tree:
+     * the ordinary ones, which the tablet fills itself, and the histogram aggregates
+     * named HIST(x), which are filled here from the counter named x.
+     */
+    Y_UNIT_TEST(PercentileCountersAreAggregated) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+
+        // 3 transactions on the first partition, 2 on the second one
+        leader1
+            .IncrementPercentile(TX_LATENCY, 5)
+            .IncrementPercentile(TX_LATENCY, 50)
+            .IncrementPercentile(TX_LATENCY, 500)
+            .AddCumulative(CONSUMED_CPU, 100);
+
+        leader2
+            .IncrementPercentile(TX_LATENCY, 5)
+            .IncrementPercentile(TX_LATENCY, 5)
+            .AddCumulative(CONSUMED_CPU, 200);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Table level counters with the percentile counters", rootGroup);
+
+        auto leaderCounters = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT(leaderCounters);
+
+        // The ordinary percentile counter holds the observations of both partitions
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "TxLatency"), 3 + 2);
+
+        // The histogram aggregate holds one observation per partition, taken from
+        // the "ConsumedCPU" cumulative counter. The tablets do NOT fill it themselves,
+        // so an empty histogram here would mean the aggregate is never fed.
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "HIST(ConsumedCPU)"), 2);
+    }
+
+    /**
+     * Verify that forgetting a tablet drops its observations from the percentile
+     * counters of the table bucket, while the accumulated cumulative counters keep
+     * the work the tablet had already done.
+     *
+     * @note The two kinds of the percentile counters are dropped by two different
+     *       mechanisms: an ordinary one is subtracted bucket by bucket right away,
+     *       while a HIST(x) aggregate is rebuilt from scratch on the next recalculation.
+     */
+    Y_UNIT_TEST(ForgetTabletDropsPercentileObservations) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+
+        // The observations of the two partitions land in DIFFERENT buckets, so that
+        // a misaligned subtraction is not mistaken for a correct one
+        leader1
+            .IncrementPercentile(TX_LATENCY, 5)
+            .IncrementPercentile(TX_LATENCY, 5)
+            .AddCumulative(CONSUMED_CPU, 100);
+
+        leader2
+            .IncrementPercentile(TX_LATENCY, 500)
+            .IncrementPercentile(TX_LATENCY, 500)
+            .IncrementPercentile(TX_LATENCY, 500)
+            .AddCumulative(CONSUMED_CPU, 200);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        auto leaderCounters = FindTableBucketCounters(rootGroup);
+        UNIT_ASSERT(leaderCounters);
+
+        // The ranges {0, 10, 100} become the 4 buckets <=0, (0;10], (10;100], (100;inf],
+        // so the 2 observations of the first partition land in the second bucket and
+        // the 3 observations of the second one in the last
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramBuckets(leaderCounters, "TxLatency"), "0,2,0,3");
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "HIST(ConsumedCPU)"), 2);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200);
+
+        // The second partition is gone
+        aggregator->ForgetTablet(leader2.TabletId, leader2.FollowerId);
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Table level counters after forgetting the second partition", rootGroup);
+
+        // Only the observations of the forgotten partition are subtracted, and only
+        // from its own bucket
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramBuckets(leaderCounters, "TxLatency"), "0,2,0,0");
+
+        // The histogram aggregate is rebuilt from the surviving partitions only
+        UNIT_ASSERT_VALUES_EQUAL(GetHistogramTotal(leaderCounters, "HIST(ConsumedCPU)"), 1);
+
+        // The accumulated cumulative counter is NOT reduced: the CPU the forgotten
+        // partition had burnt has still been burnt, and the series must not go backwards
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 100 + 200);
+
+        // The last partition is gone too, so the whole table leaves the tree
+        aggregator->ForgetTablet(leader1.TabletId, leader1.FollowerId);
+
+        UNIT_ASSERT(!FindTableGroup(rootGroup));
+    }
+
+    /**
+     * Verify that forgetting a tablet of a table level table drops its contribution
+     * from the table bucket and removes the counter groups, which become empty.
+     *
+     * @note The two role trees are torn down independently. That is the whole reason
+     *       the role is the caller's partition of the tree rather than a label within
+     *       it: an aggregator only ever removes groups it exclusively owns, so emptying
+     *       one role tree can never detach the live counters of the other one from
+     *       the shared root.
+     */
+    Y_UNIT_TEST(ForgetTabletAtTableLevel) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader1(1000, 0);
+        TFakeTablet leader2(2000, 0);
+        TFakeTablet follower(1000, 1);
+
+        leader1.SetSimple(UNIQUE_ROWS, 1);
+        leader2.SetSimple(UNIQUE_ROWS, 2);
+        follower.SetSimple(UNIQUE_ROWS, 8);
+
+        for (auto* tablet : {&leader1, &leader2}) {
+            tablet->Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
+        }
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        trees.RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.LeaderRoot), "SUM(UniqueRows)"),
+            1 + 2
+        );
+
+        // TEST 1: The table bucket is recomputed from the surviving partitions
+        trees.Leaders->ForgetTablet(leader2.TabletId, leader2.FollowerId);
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Table level counters after forgetting one leader", trees.Root);
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.LeaderRoot), "SUM(UniqueRows)"),
+            1
+        );
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(trees.LeaderRoot), "MAX(UniqueRows)"),
+            1
+        );
+
+        // TEST 2: The table leaves the leader tree as soon as its last leader is gone,
+        //         and the follower tree keeps its own counters, still reachable from
+        //         the shared root
+        trees.Leaders->ForgetTablet(leader1.TabletId, leader1.FollowerId);
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Counters after forgetting the last leader", trees.Root);
+
+        UNIT_ASSERT(!FindTableGroup(trees.LeaderRoot));
+        UNIT_ASSERT(!trees.Root->FindSubgroup("role", "leader")->FindSubgroup("database", DATABASE_PATH));
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(
+                FindTableBucketCounters(trees.Root->FindSubgroup("role", "follower")),
+                "SUM(UniqueRows)"
+            ),
+            8
+        );
+
+        // TEST 3: The table is removed as soon as its last tablet is gone
+        trees.Followers->ForgetTablet(follower.TabletId, follower.FollowerId);
+
+        UNIT_ASSERT(!FindTableGroup(trees.FollowerRoot));
+
+        // TEST 4: Forgetting an unknown tablet is not an error
+        trees.Leaders->ForgetTablet(leader1.TabletId, leader1.FollowerId);
+    }
+
+    /**
+     * Verify that forgetting a tablet of a partition level table removes its leaf
+     * and all the counter groups, which become empty.
+     */
+    Y_UNIT_TEST(ForgetTabletAtPartitionLevel) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // Two followers of the same partition plus one of another partition, so that
+        // the tablet group is only removed once its LAST follower is gone
+        TFakeTablet follower1(1000, 1);
+        TFakeTablet follower2(1000, 2);
+        TFakeTablet follower3(2000, 1);
+
+        for (auto* tablet : {&follower1, &follower2, &follower3}) {
+            tablet->SetSimple(UNIQUE_ROWS, 1);
+            tablet->Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        }
+
+        trees.RecalculateAllCounters();
+
+        auto rootGroup = trees.FollowerRoot;
+
+        auto tableGroup = FindTableGroup(rootGroup);
+        UNIT_ASSERT(tableGroup);
+
+        auto perPartitionGroup = tableGroup->FindSubgroup("detailed_metrics", "per_partition");
+        UNIT_ASSERT(perPartitionGroup);
+
+        // TEST 1: Only the leaf of the forgotten tablet is removed, its sibling survives
+        trees.Followers->ForgetTablet(follower1.TabletId, follower1.FollowerId);
+
+        DumpCounters("Partition level counters after forgetting one follower", trees.Root);
+
+        UNIT_ASSERT(!FindLeafCounters(rootGroup, follower1.TabletId, follower1.FollowerId));
+        UNIT_ASSERT(FindLeafCounters(rootGroup, follower2.TabletId, follower2.FollowerId));
+        UNIT_ASSERT(perPartitionGroup->FindSubgroup("tablet_id", ToString(follower2.TabletId)));
+
+        // TEST 2: The tablet group is removed as soon as its last follower is gone
+        trees.Followers->ForgetTablet(follower2.TabletId, follower2.FollowerId);
+
+        UNIT_ASSERT(!perPartitionGroup->FindSubgroup("tablet_id", ToString(follower2.TabletId)));
+        UNIT_ASSERT(tableGroup->FindSubgroup("detailed_metrics", "per_partition"));
+
+        // TEST 3: The table is removed as soon as its last tablet is gone
+        trees.Followers->ForgetTablet(follower3.TabletId, follower3.FollowerId);
+
+        UNIT_ASSERT(!FindTableGroup(rootGroup));
+    }
+
+    /**
+     * Verify that the database counter groups do not pile up empty: the database node
+     * is removed together with the last table of the database and recreated on demand.
+     */
+    Y_UNIT_TEST(DatabaseGroupIsRemovedWithTheLastTable) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet leader(1000, 0);
+        leader.SetSimple(UNIQUE_ROWS, 1);
+        leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        auto databaseGroup = rootGroup->FindSubgroup("database", DATABASE_PATH);
+        UNIT_ASSERT(databaseGroup);
+        UNIT_ASSERT(databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH));
+
+        // TEST 1: Nothing of the database is left behind once its last table is gone
+        aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
+
+        DumpCounters("Counters after forgetting the last table", rootGroup);
+
+        UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+        UNIT_ASSERT(!databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH));
+
+        // TEST 2: The database node is recreated by the next table
+        leader.SetSimple(UNIQUE_ROWS, 2);
+        leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+        aggregator->RecalculateAllCounters();
+
+        UNIT_ASSERT_VALUES_EQUAL(
+            GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+            2
+        );
+    }
+
+    /**
+     * Verify that the tables, which do not collect detailed metrics, are ignored.
+     */
+    Y_UNIT_TEST(IgnoresTablesWithoutDetailedMetrics) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            DATABASE_PATH,
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        TFakeTablet tablet(1000, 0);
+        tablet.SetSimple(UNIQUE_ROWS, 1);
+
+        tablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelUnspecified, now);
+        tablet.Report(aggregator, TDetailedMetricsSettings::MetricsLevelDisabled, now);
+
+        aggregator->RecalculateAllCounters();
+
+        // Not a single counter group is created for such tables
+        UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+    }
+
+    /**
+     * Verify that splitting the counters across two role trees prevents the
+     * double-counting of leader-only metrics at the table level.
+     *
+     * A follower's executor counters are real and equal its leader's (the rows
+     * are physically the same), which is why the corresponding public metric
+     * (table.datashard.row_count) must be leader-only. If the roles were
+     * aggregated into one bucket, the collapsed metric would read the follower's
+     * value twice: once from the leader (100) and once from the follower (100),
+     * yielding 200 against the true 100. This is unrecoverable downstream, because
+     * the raw DataShard counters carry no leader-only marking, and the filter
+     * runs on the processor after aggregation (decision S4).
+     *
+     * The role split ensures that the true 100 is preserved in the separate trees
+     * and never summed with itself. A legitimate multi-role metric (one that
+     * counts all copies of the work, not just the leaders) is undamaged: the
+     * consumer adds the two streams and gets the correct total.
+     *
+     * @note Two independent mechanisms defend this, and this test pins the second.
+     *       Feeding both roles to ONE instance, which is what a merged bucket would
+     *       mean in production, never reaches the arithmetic at all: CheckSingleRole()
+     *       aborts first. What this test guards is the shape — that the two trees stay
+     *       separate and each reads the truth — so that a change that aliases them onto
+     *       a shared counter group, which the invariant cannot see, still fails here.
+     *
+     * Reference: exchange/review-response-issue1.md (Tree B vs Tree C).
+     */
+    Y_UNIT_TEST(RoleSplitKeepsLeaderOnlyMetricsUninflated) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // One partition: the leader reports a row count of 100, which is the truth.
+        // The follower's executor counters hold the same value (the rows are the same),
+        // and that is precisely why the corresponding public metric is leader-only.
+        TFakeTablet leader(1000, 0);
+        leader.SetSimple(UNIQUE_ROWS, 100).AddCumulative(CONSUMED_CPU, 7);
+
+        TFakeTablet follower(1000, 1);
+        follower.SetSimple(UNIQUE_ROWS, 100).AddCumulative(CONSUMED_CPU, 3);
+
+        leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelTable, now);
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Role split and leader-only metrics", trees.Root);
+
+        // The leader tree's table bucket reads 100: the true row count
+        auto leaderCounters = FindTableBucketCounters(trees.LeaderRoot);
+        UNIT_ASSERT(leaderCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "SUM(UniqueRows)"), 100);
+
+        // The follower tree's table bucket also reads 100: separate aggregation
+        auto followerCounters = FindTableBucketCounters(trees.FollowerRoot);
+        UNIT_ASSERT(followerCounters);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "SUM(UniqueRows)"), 100);
+
+        // Cumulative counters (non-leader-only) are undamaged by the split: they are
+        // legitimately counted in both roles, and the consumer adds them: 7 + 3 = 10
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderCounters, "ConsumedCPU"), 7);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerCounters, "ConsumedCPU"), 3);
+    }
+
+    /**
+     * Verify that at the partition level, leaves of both roles are kept in their
+     * respective trees and never merged, even on the same node.
+     *
+     * This is deliberate on the node: a leaf is single-owner and passes through
+     * verbatim, and there is no on-node rollup at partition granularity. However,
+     * the leader-only filter for leaf series is an open decision owned by steps 09/13,
+     * not by this class. The rectified plans state the per-metric role selection only
+     * at the table level.
+     *
+     * Consequence: until that decision is made, a consumer summing published leaves
+     * across roles will double-count the eight leader-only metrics (the raw DataShard
+     * subset), exactly as in the role-split test above. The difference is that here
+     * the arithmetic is unavoidable on the consumer side, because the leaves are the
+     * published units and have no aggregation on the node to apply the filter to.
+     *
+     * This test documents the boundary rather than asserting a behaviour we have not
+     * chosen.
+     */
+    Y_UNIT_TEST(PartitionLeavesCarryBothRolesByDesign) {
+        TRoleTrees trees;
+
+        const TInstant now = TInstant::Seconds(100);
+
+        // The leader holds one value, the follower another, so we can verify they
+        // land in their own trees and not in the other's
+        TFakeTablet leader(1000, 0);
+        leader.SetSimple(UNIQUE_ROWS, 42);
+
+        TFakeTablet follower(1000, 1);
+        follower.SetSimple(UNIQUE_ROWS, 99);
+
+        leader.Report(trees.Leaders, TDetailedMetricsSettings::MetricsLevelPartition, now);
+        follower.Report(trees.Followers, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+        trees.RecalculateAllCounters();
+
+        DumpCounters("Partition level leaves, both roles", trees.Root);
+
+        // The leader's leaf is in the leader tree only, carrying the leader's value
+        auto leaderLeaf = FindLeafCounters(trees.LeaderRoot, 1000, 0);
+        UNIT_ASSERT(leaderLeaf);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leaderLeaf, "SUM(UniqueRows)"), 42);
+
+        // The follower's leaf is in the follower tree only, carrying the follower's value
+        auto followerLeaf = FindLeafCounters(trees.FollowerRoot, 1000, 1);
+        UNIT_ASSERT(followerLeaf);
+        UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(followerLeaf, "SUM(UniqueRows)"), 99);
+
+        // Cross-tree lookup finds nothing: the roles are split at the tree root
+        UNIT_ASSERT(!FindLeafCounters(trees.LeaderRoot, 1000, 1));
+        UNIT_ASSERT(!FindLeafCounters(trees.FollowerRoot, 1000, 0));
+    }
+
+    /**
+     * Verify that the "table" label holds the path of the table relative to
+     * the database, and that only a whole path component is ever stripped.
+     */
+    Y_UNIT_TEST(TablePathIsRelativeToTheDatabase) {
+        NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        // NOTE: /Root/db1 is a PREFIX of /Root/db10, but not a parent of it
+        auto aggregator = CreateNodeDatabaseMetricsAggregator(
+            rootGroup,
+            "/Root/db1",
+            false /* isFollowerRole */
+        );
+
+        const TInstant now = TInstant::Seconds(100);
+
+        struct TCase {
+            TPathId TableId;
+            TString TablePath;
+            TString ExpectedLabel;
+        };
+
+        const TVector<TCase> cases = {
+            // Within the database: the database path and the separator are stripped
+            {TPathId(1, 1), "/Root/db1/dir/table", "dir/table"},
+            {TPathId(1, 2), "/Root/db1/table",     "table"},
+
+            // NOT within the database: the path is reported as is, so that the odd
+            // looking label is noticed instead of the counters being silently misplaced
+            {TPathId(1, 3), "/Root/db10/table",    "/Root/db10/table"},
+            {TPathId(1, 4), "/Root/other/table",   "/Root/other/table"},
+        };
+
+        ui64 tabletId = 1000;
+
+        for (const auto& testCase : cases) {
+            TDetailedMetricsTableInfo table;
+            table.TableId = testCase.TableId;
+            table.TablePath = testCase.TablePath;
+            table.SchemaVersion = 1;
+            table.MetricsLevel = TDetailedMetricsSettings::MetricsLevelTable;
+
+            TFakeTablet tablet(tabletId++, 0);
+            tablet.SetSimple(UNIQUE_ROWS, 1);
+
+            aggregator->AddCounters(
+                table,
+                tablet.TabletId,
+                tablet.FollowerId,
+                TABLET_TYPE,
+                tablet.ExecutorCounters,
+                tablet.AppCounters,
+                now
+            );
+        }
+
+        aggregator->RecalculateAllCounters();
+
+        DumpCounters("Table level counters of several tables", rootGroup);
+
+        auto databaseGroup = rootGroup->FindSubgroup("database", "/Root/db1");
+        UNIT_ASSERT(databaseGroup);
+
+        for (const auto& testCase : cases) {
+            UNIT_ASSERT_C(
+                databaseGroup->FindSubgroup("table", testCase.ExpectedLabel),
+                "no table group " << testCase.ExpectedLabel << " for " << testCase.TablePath
+            );
+        }
+    }
+}

--- a/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
+++ b/ydb/core/tablet/detailed_metrics/node_database_metrics_aggregator_ut.cpp
@@ -22,6 +22,12 @@ const TString RELATIVE_TABLE_PATH = "dir/table";
 
 const TPathId TABLE_ID(72057594046644480ull, 42);
 
+// Another table of the very same database
+const TString OTHER_TABLE_PATH = "/Root/db/dir/other_table";
+const TString OTHER_RELATIVE_TABLE_PATH = "dir/other_table";
+
+const TPathId OTHER_TABLE_ID(72057594046644480ull, 43);
+
 constexpr TTabletTypes::EType TABLET_TYPE = TTabletTypes::DataShard;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -117,11 +123,13 @@ struct TFakeTablet {
     void Report(
         const TNodeDatabaseMetricsAggregatorPtr& aggregator,
         EDetailedMetricsLevel level,
-        TInstant now
+        TInstant now,
+        const TPathId& tableId = TABLE_ID,
+        const TString& tablePath = TABLE_PATH
     ) {
         TDetailedMetricsTableInfo table;
-        table.TableId = TABLE_ID;
-        table.TablePath = TABLE_PATH;
+        table.TableId = tableId;
+        table.TablePath = tablePath;
         table.SchemaVersion = 1;
         table.MetricsLevel = level;
 
@@ -159,13 +167,16 @@ struct TFakeTablet {
 /**
  * @return The counter group of the table (or nullptr if there is none)
  */
-NMonitoring::TDynamicCounterPtr FindTableGroup(NMonitoring::TDynamicCounterPtr rootGroup) {
+NMonitoring::TDynamicCounterPtr FindTableGroup(
+    NMonitoring::TDynamicCounterPtr rootGroup,
+    const TString& relativeTablePath = RELATIVE_TABLE_PATH
+) {
     auto databaseGroup = rootGroup->FindSubgroup("database", DATABASE_PATH);
     if (!databaseGroup) {
         return nullptr;
     }
 
-    return databaseGroup->FindSubgroup("table", RELATIVE_TABLE_PATH);
+    return databaseGroup->FindSubgroup("table", relativeTablePath);
 }
 
 /**
@@ -194,8 +205,11 @@ NMonitoring::TDynamicCounterPtr FindAppCountersGroup(NMonitoring::TDynamicCounte
  * @note At the table level the collapsed counters live directly in the table group:
  *       the role is the caller's partition of the tree, not a label within it.
  */
-NMonitoring::TDynamicCounterPtr FindTableBucketCounters(NMonitoring::TDynamicCounterPtr rootGroup) {
-    return FindAppCountersGroup(FindTableGroup(rootGroup));
+NMonitoring::TDynamicCounterPtr FindTableBucketCounters(
+    NMonitoring::TDynamicCounterPtr rootGroup,
+    const TString& relativeTablePath = RELATIVE_TABLE_PATH
+) {
+    return FindAppCountersGroup(FindTableGroup(rootGroup, relativeTablePath));
 }
 
 /**
@@ -208,9 +222,10 @@ NMonitoring::TDynamicCounterPtr FindTableBucketCounters(NMonitoring::TDynamicCou
 NMonitoring::TDynamicCounterPtr FindLeafCounters(
     NMonitoring::TDynamicCounterPtr rootGroup,
     ui64 tabletId,
-    ui32 followerId
+    ui32 followerId,
+    const TString& relativeTablePath = RELATIVE_TABLE_PATH
 ) {
-    auto tableGroup = FindTableGroup(rootGroup);
+    auto tableGroup = FindTableGroup(rootGroup, relativeTablePath);
     if (!tableGroup) {
         return nullptr;
     }
@@ -1047,6 +1062,195 @@ Y_UNIT_TEST_SUITE(TNodeDatabaseMetricsAggregatorTest) {
                 databaseGroup->FindSubgroup("table", testCase.ExpectedLabel),
                 "no table group " << testCase.ExpectedLabel << " for " << testCase.TablePath
             );
+        }
+    }
+
+    /**
+     * Verify that a tablet, which is re-reported under another table, is MOVED rather than
+     * copied: its contribution to the previous table is dropped together with the counter
+     * groups, which become empty.
+     *
+     * @note The reverse map holds one table per tablet, because the forget event carries no
+     *       table identity. Overwriting the entry without cleaning up would leave the old
+     *       table's contribution in the tree with nothing left able to reach it: neither
+     *       ForgetTablet, which now routes to the new table, nor the next report.
+     */
+    Y_UNIT_TEST(TabletReportedUnderAnotherTableIsMoved) {
+        const TInstant now = TInstant::Seconds(100);
+
+        // TEST 1: The table level, where the tablet contributes to a shared bucket
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet leader(1000, 0);
+
+            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+            aggregator->RecalculateAllCounters();
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                5
+            );
+
+            // The very same tablet now reports another table of the same database
+            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelTable,
+                now,
+                OTHER_TABLE_ID,
+                OTHER_TABLE_PATH
+            );
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Counters after the tablet moved to another table", rootGroup);
+
+            // Nothing of the old table is left behind, and the new one holds the counters
+            UNIT_ASSERT(!FindTableGroup(rootGroup));
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(
+                    FindTableBucketCounters(rootGroup, OTHER_RELATIVE_TABLE_PATH),
+                    "SUM(UniqueRows)"
+                ),
+                7
+            );
+
+            // The reverse map points at the new table, so forgetting the tablet empties
+            // the whole tree rather than the table it no longer belongs to
+            aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
+
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+        }
+
+        // TEST 2: The partition level, where the tablet owns a leaf of its own
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet leader(1000, 0);
+
+            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+            aggregator->RecalculateAllCounters();
+
+            UNIT_ASSERT(FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId));
+
+            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.Report(
+                aggregator,
+                TDetailedMetricsSettings::MetricsLevelPartition,
+                now,
+                OTHER_TABLE_ID,
+                OTHER_TABLE_PATH
+            );
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Leaves after the tablet moved to another table", rootGroup);
+
+            // The old leaf and its whole table are gone, the new leaf holds the counters
+            UNIT_ASSERT(!FindTableGroup(rootGroup));
+
+            auto leafCounters = FindLeafCounters(
+                rootGroup,
+                leader.TabletId,
+                leader.FollowerId,
+                OTHER_RELATIVE_TABLE_PATH
+            );
+            UNIT_ASSERT(leafCounters);
+            UNIT_ASSERT_VALUES_EQUAL(GetCounterValue(leafCounters, "SUM(UniqueRows)"), 7);
+
+            aggregator->ForgetTablet(leader.TabletId, leader.FollowerId);
+
+            UNIT_ASSERT(!rootGroup->FindSubgroup("database", DATABASE_PATH));
+        }
+    }
+
+    /**
+     * Pin the CURRENT behaviour of a metrics level change: the level of a table is frozen
+     * at its very first report, so a changed level does not re-route the counters.
+     *
+     * @note This is a deliberate deferral, not the target behaviour: reconciling a table
+     *       entry on a schema version or a metrics level change is the scope of the level
+     *       and rename step, which is expected to REPLACE the assertions below with
+     *       the transition ones (drop the leaves on PARTITION -> TABLE, drop the bucket on
+     *       TABLE -> PARTITION, drop the table on -> DISABLED). The test exists so that
+     *       the step has to flip an explicit assertion instead of silently changing
+     *       behaviour, which nothing pins.
+     */
+    Y_UNIT_TEST(MetricsLevelChangeIsIgnoredUntilReconciliation) {
+        const TInstant now = TInstant::Seconds(100);
+
+        // TEST 1: A table, which was first seen at the table level, keeps collapsing
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet leader(1000, 0);
+
+            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Counters after the level changed to the partition one", rootGroup);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(FindTableBucketCounters(rootGroup), "SUM(UniqueRows)"),
+                7
+            );
+            UNIT_ASSERT(!FindTableGroup(rootGroup)->FindSubgroup("detailed_metrics", "per_partition"));
+        }
+
+        // TEST 2: A table, which was first seen at the partition level, keeps its leaves
+        {
+            NMonitoring::TDynamicCounterPtr rootGroup = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+            auto aggregator = CreateNodeDatabaseMetricsAggregator(
+                rootGroup,
+                DATABASE_PATH,
+                false /* isFollowerRole */
+            );
+
+            TFakeTablet leader(1000, 0);
+
+            leader.SetSimple(UNIQUE_ROWS, 5);
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelPartition, now);
+
+            leader.SetSimple(UNIQUE_ROWS, 7);
+            leader.Report(aggregator, TDetailedMetricsSettings::MetricsLevelTable, now);
+
+            aggregator->RecalculateAllCounters();
+
+            DumpCounters("Counters after the level changed to the table one", rootGroup);
+
+            UNIT_ASSERT_VALUES_EQUAL(
+                GetCounterValue(
+                    FindLeafCounters(rootGroup, leader.TabletId, leader.FollowerId),
+                    "SUM(UniqueRows)"
+                ),
+                7
+            );
+            UNIT_ASSERT(!FindAppCountersGroup(FindTableGroup(rootGroup)));
         }
     }
 }

--- a/ydb/core/tablet/private/aggregated_tablet_counters.cpp
+++ b/ydb/core/tablet/private/aggregated_tablet_counters.cpp
@@ -1,0 +1,267 @@
+#include "aggregated_tablet_counters.h"
+
+#include <ydb/core/protos/sys_view.pb.h>
+
+namespace NKikimr::NPrivate {
+
+TAggregatedTabletCounters::TAggregatedTabletCounters(::NMonitoring::TDynamicCounterPtr counterGroup)
+    : IsInitialized(false)
+    , AggregatedSimpleCounters(counterGroup)
+    , AggregatedCumulativeCounters(counterGroup)
+    , AggregatedHistogramCounters(counterGroup)
+    , CounterGroup(counterGroup)
+{}
+
+void TAggregatedTabletCounters::Initialize(const TTabletCountersBase* counters) {
+    Y_ABORT_UNLESS(!IsInitialized);
+
+    if (counters) {
+        THashMap<TString, THolder<THistogramCounter>> histogramAggregates;
+
+        // percentile counters
+        FullSizePercentile = counters->Percentile().Size();
+        AggregatedHistogramCounters.Reserve(FullSizePercentile);
+        for (ui32 i = 0; i < FullSizePercentile; ++i) {
+            if (!counters->PercentileCounterName(i)) {
+                DeprecatedPercentile.insert(i);
+                continue;
+            }
+
+            auto& percentileCounter = counters->Percentile()[i];
+            const char* percentileCounterName = counters->PercentileCounterName(i);
+            AggregatedHistogramCounters.AddCounter(
+                percentileCounterName,
+                percentileCounter,
+                histogramAggregates);
+        }
+
+        // simple counters
+        FullSizeSimple = counters->Simple().Size();
+        AggregatedSimpleCounters.Reserve(FullSizeSimple);
+        for (ui32 i = 0; i < FullSizeSimple; ++i) {
+            const char* name = counters->SimpleCounterName(i);
+            if (!name) {
+                DeprecatedSimple.insert(i);
+                continue;
+            }
+            auto itHistogramAggregate = histogramAggregates.find(name);
+            if (itHistogramAggregate != histogramAggregates.end()) {
+                AggregatedSimpleCounters.AddSimpleCounter(name, std::move(itHistogramAggregate->second));
+            } else {
+                AggregatedSimpleCounters.AddSimpleCounter(name);
+            }
+        }
+
+        // cumulative counters
+        FullSizeCumulative = counters->Cumulative().Size();
+        AggregatedCumulativeCounters.Reserve(FullSizeCumulative);
+        for (ui32 i = 0; i < FullSizeCumulative; ++i) {
+            const char* name = counters->CumulativeCounterName(i);
+            if (!name) {
+                DeprecatedCumulative.insert(i);
+                continue;
+            }
+            auto itHistogramAggregate = histogramAggregates.find(name);
+            if (itHistogramAggregate != histogramAggregates.end()) {
+                AggregatedCumulativeCounters.AddCumulativeCounter(name, std::move(itHistogramAggregate->second));
+            } else {
+                AggregatedCumulativeCounters.AddCumulativeCounter(name);
+            }
+            auto counter = CounterGroup->GetCounter(name, true);
+            CumulativeCounters.push_back(counter);
+        }
+    }
+
+    //
+    IsInitialized = true;
+}
+
+void TAggregatedTabletCounters::Apply(
+    ui64 tabletId,
+    const TTabletCountersBase* counters,
+    TTabletTypes::EType tabletType,
+    TInstant now)
+{
+    Y_ABORT_UNLESS(counters);
+
+    auto it = LastAggregateUpdateTime.find(tabletId);
+    TDuration diff;
+    if (it != LastAggregateUpdateTime.end()) {
+        diff = now - it->second;
+        it->second = now;
+    } else {
+        LastAggregateUpdateTime.emplace(tabletId, now);
+    }
+
+    // simple counters
+    ui32 nextSimpleOffset = 0;
+    TVector<ui64> simpleValues;
+    simpleValues.resize(FullSizeSimple); // more than needed
+    for (ui32 i = 0; i < FullSizeSimple; ++i) {
+        if (!counters->SimpleCounterName(i)) {
+            continue;
+        }
+        const ui32 offset = nextSimpleOffset++;
+        const ui64 value = counters->Simple()[i].Get();
+        simpleValues[offset] = value;
+    }
+    AggregatedSimpleCounters.SetValues(tabletId, simpleValues, tabletType);
+
+    // cumulative counters
+    ui32 nextCumulativeOffset = 0;
+    TVector<ui64> cumulativeValues;
+    cumulativeValues.resize(FullSizeCumulative, 0);
+    for (ui32 i = 0; i < FullSizeCumulative; ++i) {
+        if (!counters->CumulativeCounterName(i)) {
+            continue;
+        }
+        const ui32 offset = nextCumulativeOffset++;
+        const ui64 valueDiff = counters->Cumulative()[i].Get();
+        if (diff) {
+            cumulativeValues[offset] = valueDiff * 1000000 / diff.MicroSeconds(); // differentiate value to per second rate
+        }
+        Y_ABORT_UNLESS(offset < CumulativeCounters.size(), "inconsistent counters for tablet type %s", TTabletTypes::TypeToStr(tabletType));
+        *CumulativeCounters[offset] += valueDiff;
+    }
+    AggregatedCumulativeCounters.SetValues(tabletId, cumulativeValues, tabletType);
+
+    // percentile counters
+    ui32 nextPercentileOffset = 0;
+    for (ui32 i = 0; i < FullSizePercentile; ++i) {
+        if (!counters->PercentileCounterName(i)) {
+            continue;
+        }
+
+        const ui32 offset = nextPercentileOffset++;
+        AggregatedHistogramCounters.SetValue(
+            tabletId,
+            offset,
+            counters->Percentile()[i],
+            counters->PercentileCounterName(i),
+            tabletType);
+    }
+}
+
+void TAggregatedTabletCounters::Forget(ui64 tabletId) {
+    Y_ABORT_UNLESS(IsInitialized);
+
+    AggregatedSimpleCounters.ForgetTablet(tabletId);
+    AggregatedCumulativeCounters.ForgetTablet(tabletId);
+    AggregatedHistogramCounters.ForgetTablet(tabletId);
+    LastAggregateUpdateTime.erase(tabletId);
+}
+
+void TAggregatedTabletCounters::RecalcAll() {
+    AggregatedSimpleCounters.RecalcAll();
+    AggregatedCumulativeCounters.RecalcAll();
+}
+
+template <bool IsSaving>
+void TAggregatedTabletCounters::Convert(
+    NKikimrSysView::TDbCounters& sumCounters,
+    NKikimrSysView::TDbCounters& maxCounters)
+{
+    // simple counters
+    auto* simpleSum = sumCounters.MutableSimple();
+    auto* simpleMax = maxCounters.MutableSimple();
+    simpleSum->Resize(FullSizeSimple, 0);
+    simpleMax->Resize(FullSizeSimple, 0);
+    ui32 nextSimpleOffset = 0;
+    for (ui32 i = 0; i < FullSizeSimple; ++i) {
+        if (DeprecatedSimple.find(i) != DeprecatedSimple.end()) {
+            if constexpr (IsSaving) {
+                (*simpleSum)[i] = 0;
+                (*simpleMax)[i] = 0;
+            }
+            continue;
+        }
+        const ui32 offset = nextSimpleOffset++;
+        if constexpr (IsSaving) {
+            (*simpleSum)[i] = AggregatedSimpleCounters.GetSum(offset);
+            (*simpleMax)[i] = AggregatedSimpleCounters.GetMax(offset);
+        } else {
+            AggregatedSimpleCounters.SetSum(offset, (*simpleSum)[i]);
+            AggregatedSimpleCounters.SetMax(offset, (*simpleMax)[i]);
+        }
+    }
+    // cumulative counters
+    auto* cumulativeSum = sumCounters.MutableCumulative();
+    auto* cumulativeMax = maxCounters.MutableCumulative();
+    cumulativeSum->Resize(FullSizeCumulative, 0);
+    cumulativeMax->Resize(FullSizeCumulative, 0);
+    ui32 nextCumulativeOffset = 0;
+    for (ui32 i = 0; i < FullSizeCumulative; ++i) {
+        if (DeprecatedCumulative.find(i) != DeprecatedCumulative.end()) {
+            if constexpr (IsSaving) {
+                (*cumulativeSum)[i] = 0;
+                (*cumulativeMax)[i] = 0;
+            }
+            continue;
+        }
+        const ui32 offset = nextCumulativeOffset++;
+        Y_ABORT_UNLESS(offset < CumulativeCounters.size(),
+            "inconsistent cumulative counters %u >= %lu", offset, CumulativeCounters.size());
+        if constexpr (IsSaving) {
+            (*cumulativeSum)[i] = *CumulativeCounters[offset];
+            (*cumulativeMax)[i] = AggregatedCumulativeCounters.GetMax(offset);
+        } else {
+            *CumulativeCounters[offset] = (*cumulativeSum)[i];
+            AggregatedCumulativeCounters.SetMax(offset, (*cumulativeMax)[i]);
+        }
+    }
+    // percentile counters
+    auto* histogramSum = sumCounters.MutableHistogram();
+    if (sumCounters.HistogramSize() < FullSizePercentile) {
+        auto missing = FullSizePercentile - sumCounters.HistogramSize();
+        for (; missing > 0; --missing) {
+            sumCounters.AddHistogram();
+        }
+    }
+    ui32 nextPercentileOffset = 0;
+    for (ui32 i = 0; i < FullSizePercentile; ++i) {
+        if (DeprecatedPercentile.find(i) != DeprecatedPercentile.end()) {
+            continue;
+        }
+        auto* buckets = (*histogramSum)[i].MutableBuckets();
+        const ui32 offset = nextPercentileOffset++;
+        auto histogram = AggregatedHistogramCounters.GetHistogram(offset);
+        auto snapshot = histogram->Snapshot();
+        auto count = snapshot->Count();
+        buckets->Resize(count, 0);
+        if constexpr (!IsSaving) {
+            histogram->Reset();
+        }
+        for (ui32 r = 0; r < count; ++r) {
+            if constexpr (IsSaving) {
+                (*buckets)[r] = snapshot->Value(r);
+            } else {
+                histogram->Collect(snapshot->UpperBound(r), (*buckets)[r]);
+            }
+        }
+    }
+}
+
+void TAggregatedTabletCounters::ToProto(
+    NKikimrSysView::TDbCounters& sumCounters,
+    NKikimrSysView::TDbCounters& maxCounters)
+{
+    Convert<true>(sumCounters, maxCounters);
+}
+
+void TAggregatedTabletCounters::FromProto(
+    NKikimrSysView::TDbCounters& sumCounters,
+    NKikimrSysView::TDbCounters& maxCounters)
+{
+    Convert<false>(sumCounters, maxCounters);
+}
+
+bool TAggregatedTabletCounters::Find(const TString& name, TVector<TTabletCounterValue>& results) const {
+    if (!IsInitialized) {
+        return false;
+    }
+
+    return AggregatedSimpleCounters.Find(name, results)
+        || AggregatedCumulativeCounters.Find(name, results);
+}
+
+} // namespace NKikimr::NPrivate

--- a/ydb/core/tablet/private/aggregated_tablet_counters.h
+++ b/ydb/core/tablet/private/aggregated_tablet_counters.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "aggregated_counters.h"
+
+#include <util/datetime/base.h>
+#include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+
+namespace NKikimrSysView {
+class TDbCounters;
+}
+
+namespace NKikimr::NPrivate {
+
+/**
+ * The aggregate of a single category (the Executor counters or the application counters)
+ * of the low level counters of one or more tablets of the same type.
+ *
+ * @note The class knows nothing about where in the counter tree it lives: it just fills
+ *       the counter group it is given. Both the "tablets" counter group and
+ *       the detailed metrics counter tree are built out of these aggregates.
+ *
+ * @note The aggregated counter names are derived from the low level counter names:
+ *
+ *           * a simple counter x     -> SUM(x) and MAX(x)
+ *           * a cumulative counter x -> x (accumulated) and MAX(x) (a per second rate)
+ *           * a percentile counter x -> x (a histogram)
+ *
+ *       A percentile counter named HIST(x) is a histogram aggregate: the tablet does NOT
+ *       fill it, instead one observation per tablet is collected here from the simple
+ *       or the cumulative counter named x.
+ */
+class TAggregatedTabletCounters {
+public:
+    /**
+     * Whether the counter set reported by the tablets is already known.
+     */
+    bool IsInitialized;
+
+    explicit TAggregatedTabletCounters(::NMonitoring::TDynamicCounterPtr counterGroup);
+
+    /**
+     * Create the aggregated counters for the counter set reported by the tablets.
+     *
+     * @note The layout of the counter set is a property of the tablet type,
+     *       so it is defined once and for all by the very first reporting tablet.
+     */
+    void Initialize(const TTabletCountersBase* counters);
+
+    /**
+     * Add the counters of a single tablet to the aggregate.
+     *
+     * @note The cumulative counters are expected to be the delta since the previous call
+     *       for this tablet (this is what the Executor sends).
+     *
+     * @warning The counters are NOT recalculated by this function.
+     *          RecalcAll() must be called explicitly afterwards.
+     *
+     * @param[in] now Used to differentiate the cumulative counters into per second rates
+     */
+    void Apply(
+        ui64 tabletId,
+        const TTabletCountersBase* counters,
+        TTabletTypes::EType tabletType,
+        TInstant now);
+
+    /**
+     * Drop the contribution of a single tablet from the aggregate.
+     */
+    void Forget(ui64 tabletId);
+
+    void RecalcAll();
+
+    void ToProto(NKikimrSysView::TDbCounters& sumCounters, NKikimrSysView::TDbCounters& maxCounters);
+    void FromProto(NKikimrSysView::TDbCounters& sumCounters, NKikimrSysView::TDbCounters& maxCounters);
+
+    bool Find(const TString& name, TVector<TTabletCounterValue>& results) const;
+
+private:
+    template <bool IsSaving>
+    void Convert(NKikimrSysView::TDbCounters& sumCounters, NKikimrSysView::TDbCounters& maxCounters);
+
+private:
+    ui32 FullSizeSimple = 0;
+    THashSet<ui32> DeprecatedSimple;
+    ui32 FullSizeCumulative = 0;
+    THashSet<ui32> DeprecatedCumulative;
+    ui32 FullSizePercentile = 0;
+    THashSet<ui32> DeprecatedPercentile;
+    //
+    TAggregatedSimpleCounters AggregatedSimpleCounters;
+    TCountersVector CumulativeCounters;
+    TAggregatedCumulativeCounters AggregatedCumulativeCounters;
+    TAggregatedHistogramCounters AggregatedHistogramCounters;
+
+    THashMap<ui64, TInstant> LastAggregateUpdateTime;
+
+    ::NMonitoring::TDynamicCounterPtr CounterGroup;
+};
+
+} // namespace NKikimr::NPrivate

--- a/ydb/core/tablet/tablet_counters_aggregator.cpp
+++ b/ydb/core/tablet/tablet_counters_aggregator.cpp
@@ -4,6 +4,7 @@
 #include "labeled_db_counters.h"
 #include "detailed_metrics/ydb_metrics_mapper.h"
 #include "private/aggregated_counters.h"
+#include "private/aggregated_tablet_counters.h"
 #include "private/labeled_db_counters.h"
 
 #include <ydb/library/actors/core/log.h>
@@ -368,18 +369,20 @@ private:
         {
             Y_ABORT_UNLESS(executorCounters);
 
+            const TInstant now = NActors::TActivationContext::Now();
+
             if (executorCounters) {
                 if (!TabletExecutorCounters.IsInitialized) {
                     TabletExecutorCounters.Initialize(executorCounters);
                 }
-                TabletExecutorCounters.Apply(tabletId, executorCounters, tabletType);
+                TabletExecutorCounters.Apply(tabletId, executorCounters, tabletType, now);
             }
 
             if (appCounters) {
                 if (!TabletAppCounters.IsInitialized) {
                     TabletAppCounters.Initialize(limitedAppCounters ? limitedAppCounters : appCounters);
                 }
-                TabletAppCounters.Apply(tabletId, appCounters, tabletType);
+                TabletAppCounters.Apply(tabletId, appCounters, tabletType, now);
             }
         }
 
@@ -450,291 +453,13 @@ private:
 
     private:
         //
-        class TSolomonCounters {
-        public:
-            //
-            bool IsInitialized;
-
-            TSolomonCounters(::NMonitoring::TDynamicCounterPtr counterGroup)
-                : IsInitialized(false)
-                , AggregatedSimpleCounters(counterGroup)
-                , AggregatedCumulativeCounters(counterGroup)
-                , AggregatedHistogramCounters(counterGroup)
-                , CounterGroup(counterGroup)
-            {}
-
-            void Initialize(const TTabletCountersBase* counters) {
-                Y_ABORT_UNLESS(!IsInitialized);
-
-                if (counters) {
-                    THashMap<TString, THolder<NPrivate::THistogramCounter>> histogramAggregates;
-
-                    // percentile counters
-                    FullSizePercentile = counters->Percentile().Size();
-                    AggregatedHistogramCounters.Reserve(FullSizePercentile);
-                    for (ui32 i = 0; i < FullSizePercentile; ++i) {
-                        if (!counters->PercentileCounterName(i)) {
-                            DeprecatedPercentile.insert(i);
-                            continue;
-                        }
-
-                        auto& percentileCounter = counters->Percentile()[i];
-                        const char* percentileCounterName = counters->PercentileCounterName(i);
-                        AggregatedHistogramCounters.AddCounter(
-                            percentileCounterName,
-                            percentileCounter,
-                            histogramAggregates);
-                    }
-
-                    // simple counters
-                    FullSizeSimple = counters->Simple().Size();
-                    AggregatedSimpleCounters.Reserve(FullSizeSimple);
-                    for (ui32 i = 0; i < FullSizeSimple; ++i) {
-                        const char* name = counters->SimpleCounterName(i);
-                        if (!name) {
-                            DeprecatedSimple.insert(i);
-                            continue;
-                        }
-                        auto itHistogramAggregate = histogramAggregates.find(name);
-                        if (itHistogramAggregate != histogramAggregates.end()) {
-                            AggregatedSimpleCounters.AddSimpleCounter(name, std::move(itHistogramAggregate->second));
-                        } else {
-                            AggregatedSimpleCounters.AddSimpleCounter(name);
-                        }
-                    }
-
-                    // cumulative counters
-                    FullSizeCumulative = counters->Cumulative().Size();
-                    AggregatedCumulativeCounters.Reserve(FullSizeCumulative);
-                    for (ui32 i = 0; i < FullSizeCumulative; ++i) {
-                        const char* name = counters->CumulativeCounterName(i);
-                        if (!name) {
-                            DeprecatedCumulative.insert(i);
-                            continue;
-                        }
-                        auto itHistogramAggregate = histogramAggregates.find(name);
-                        if (itHistogramAggregate != histogramAggregates.end()) {
-                            AggregatedCumulativeCounters.AddCumulativeCounter(name, std::move(itHistogramAggregate->second));
-                        } else {
-                            AggregatedCumulativeCounters.AddCumulativeCounter(name);
-                        }
-                        auto counter = CounterGroup->GetCounter(name, true);
-                        CumulativeCounters.push_back(counter);
-                    }
-                }
-
-                //
-                IsInitialized = true;
-            }
-
-            void Apply(ui64 tabletId, const TTabletCountersBase* counters, TTabletTypes::EType tabletType) {
-                Y_ABORT_UNLESS(counters);
-
-                TInstant now = NActors::TActivationContext::Now();
-                auto it = LastAggregateUpdateTime.find(tabletId);
-                TDuration diff;
-                if (it != LastAggregateUpdateTime.end()) {
-                    diff = now - it->second;
-                    it->second = now;
-                } else {
-                    LastAggregateUpdateTime.emplace(tabletId, now);
-                }
-
-                // simple counters
-                ui32 nextSimpleOffset = 0;
-                TVector<ui64> simpleValues;
-                simpleValues.resize(FullSizeSimple); // more than needed
-                for (ui32 i = 0; i < FullSizeSimple; ++i) {
-                    if (!counters->SimpleCounterName(i)) {
-                        continue;
-                    }
-                    const ui32 offset = nextSimpleOffset++;
-                    const ui64 value = counters->Simple()[i].Get();
-                    simpleValues[offset] = value;
-                }
-                AggregatedSimpleCounters.SetValues(tabletId, simpleValues, tabletType);
-
-                // cumulative counters
-                ui32 nextCumulativeOffset = 0;
-                TVector<ui64> cumulativeValues;
-                cumulativeValues.resize(FullSizeCumulative, 0);
-                for (ui32 i = 0; i < FullSizeCumulative; ++i) {
-                    if (!counters->CumulativeCounterName(i)) {
-                        continue;
-                    }
-                    const ui32 offset = nextCumulativeOffset++;
-                    const ui64 valueDiff = counters->Cumulative()[i].Get();
-                    if (diff) {
-                        cumulativeValues[offset] = valueDiff * 1000000 / diff.MicroSeconds(); // differentiate value to per second rate
-                    }
-                    Y_ABORT_UNLESS(offset < CumulativeCounters.size(), "inconsistent counters for tablet type %s", TTabletTypes::TypeToStr(tabletType));
-                    *CumulativeCounters[offset] += valueDiff;
-                }
-                AggregatedCumulativeCounters.SetValues(tabletId, cumulativeValues, tabletType);
-
-                // percentile counters
-                ui32 nextPercentileOffset = 0;
-                for (ui32 i = 0; i < FullSizePercentile; ++i) {
-                    if (!counters->PercentileCounterName(i)) {
-                        continue;
-                    }
-
-                    const ui32 offset = nextPercentileOffset++;
-                    AggregatedHistogramCounters.SetValue(
-                        tabletId,
-                        offset,
-                        counters->Percentile()[i],
-                        counters->PercentileCounterName(i),
-                        tabletType);
-                }
-
-            }
-
-            void Forget(ui64 tabletId) {
-                Y_ABORT_UNLESS(IsInitialized);
-
-                AggregatedSimpleCounters.ForgetTablet(tabletId);
-                AggregatedCumulativeCounters.ForgetTablet(tabletId);
-                AggregatedHistogramCounters.ForgetTablet(tabletId);
-                LastAggregateUpdateTime.erase(tabletId);
-            }
-
-            void RecalcAll() {
-                AggregatedSimpleCounters.RecalcAll();
-                AggregatedCumulativeCounters.RecalcAll();
-            }
-
-            template <bool IsSaving>
-            void Convert(NKikimrSysView::TDbCounters& sumCounters,
-                NKikimrSysView::TDbCounters& maxCounters)
-            {
-                // simple counters
-                auto* simpleSum = sumCounters.MutableSimple();
-                auto* simpleMax = maxCounters.MutableSimple();
-                simpleSum->Resize(FullSizeSimple, 0);
-                simpleMax->Resize(FullSizeSimple, 0);
-                ui32 nextSimpleOffset = 0;
-                for (ui32 i = 0; i < FullSizeSimple; ++i) {
-                    if (DeprecatedSimple.find(i) != DeprecatedSimple.end()) {
-                        if constexpr (IsSaving) {
-                            (*simpleSum)[i] = 0;
-                            (*simpleMax)[i] = 0;
-                        }
-                        continue;
-                    }
-                    const ui32 offset = nextSimpleOffset++;
-                    if constexpr (IsSaving) {
-                        (*simpleSum)[i] = AggregatedSimpleCounters.GetSum(offset);
-                        (*simpleMax)[i] = AggregatedSimpleCounters.GetMax(offset);
-                    } else {
-                        AggregatedSimpleCounters.SetSum(offset, (*simpleSum)[i]);
-                        AggregatedSimpleCounters.SetMax(offset, (*simpleMax)[i]);
-                    }
-                }
-                // cumulative counters
-                auto* cumulativeSum = sumCounters.MutableCumulative();
-                auto* cumulativeMax = maxCounters.MutableCumulative();
-                cumulativeSum->Resize(FullSizeCumulative, 0);
-                cumulativeMax->Resize(FullSizeCumulative, 0);
-                ui32 nextCumulativeOffset = 0;
-                for (ui32 i = 0; i < FullSizeCumulative; ++i) {
-                    if (DeprecatedCumulative.find(i) != DeprecatedCumulative.end()) {
-                        if constexpr (IsSaving) {
-                            (*cumulativeSum)[i] = 0;
-                            (*cumulativeMax)[i] = 0;
-                        }
-                        continue;
-                    }
-                    const ui32 offset = nextCumulativeOffset++;
-                    Y_ABORT_UNLESS(offset < CumulativeCounters.size(),
-                        "inconsistent cumulative counters %u >= %lu", offset, CumulativeCounters.size());
-                    if constexpr (IsSaving) {
-                        (*cumulativeSum)[i] = *CumulativeCounters[offset];
-                        (*cumulativeMax)[i] = AggregatedCumulativeCounters.GetMax(offset);
-                    } else {
-                        *CumulativeCounters[offset] = (*cumulativeSum)[i];
-                        AggregatedCumulativeCounters.SetMax(offset, (*cumulativeMax)[i]);
-                    }
-                }
-                // percentile counters
-                auto* histogramSum = sumCounters.MutableHistogram();
-                if (sumCounters.HistogramSize() < FullSizePercentile) {
-                    auto missing = FullSizePercentile - sumCounters.HistogramSize();
-                    for (; missing > 0; --missing) {
-                        sumCounters.AddHistogram();
-                    }
-                }
-                ui32 nextPercentileOffset = 0;
-                for (ui32 i = 0; i < FullSizePercentile; ++i) {
-                    if (DeprecatedPercentile.find(i) != DeprecatedPercentile.end()) {
-                        continue;
-                    }
-                    auto* buckets = (*histogramSum)[i].MutableBuckets();
-                    const ui32 offset = nextPercentileOffset++;
-                    auto histogram = AggregatedHistogramCounters.GetHistogram(offset);
-                    auto snapshot = histogram->Snapshot();
-                    auto count = snapshot->Count();
-                    buckets->Resize(count, 0);
-                    if constexpr (!IsSaving) {
-                        histogram->Reset();
-                    }
-                    for (ui32 r = 0; r < count; ++r) {
-                        if constexpr (IsSaving) {
-                            (*buckets)[r] = snapshot->Value(r);
-                        } else {
-                            histogram->Collect(snapshot->UpperBound(r), (*buckets)[r]);
-                        }
-                    }
-                }
-            }
-
-            void ToProto(NKikimrSysView::TDbCounters& sumCounters,
-                NKikimrSysView::TDbCounters& maxCounters)
-            {
-                Convert<true>(sumCounters, maxCounters);
-            }
-
-            void FromProto(NKikimrSysView::TDbCounters& sumCounters,
-                NKikimrSysView::TDbCounters& maxCounters)
-            {
-                Convert<false>(sumCounters, maxCounters);
-            }
-
-            bool Find(const TString& name, TVector<NPrivate::TTabletCounterValue>& results) const {
-                if (!IsInitialized) {
-                    return false;
-                }
-
-                return AggregatedSimpleCounters.Find(name, results) 
-                    || AggregatedCumulativeCounters.Find(name, results);
-            }
-
-        private:
-            ui32 FullSizeSimple = 0;
-            THashSet<ui32> DeprecatedSimple;
-            ui32 FullSizeCumulative = 0;
-            THashSet<ui32> DeprecatedCumulative;
-            ui32 FullSizePercentile = 0;
-            THashSet<ui32> DeprecatedPercentile;
-            //
-            NPrivate::TAggregatedSimpleCounters AggregatedSimpleCounters;
-            NPrivate::TCountersVector CumulativeCounters;
-            NPrivate::TAggregatedCumulativeCounters AggregatedCumulativeCounters;
-            NPrivate::TAggregatedHistogramCounters AggregatedHistogramCounters;
-
-            THashMap<ui64, TInstant> LastAggregateUpdateTime;
-
-            ::NMonitoring::TDynamicCounterPtr CounterGroup;
-        };
-
-        //
         ::NMonitoring::TDynamicCounterPtr TabletCountersSection;
 
         ::NMonitoring::TDynamicCounterPtr TabletExecutorCountersSection;
         ::NMonitoring::TDynamicCounterPtr TabletAppCountersSection;
 
-        TSolomonCounters TabletExecutorCounters;
-        TSolomonCounters TabletAppCounters;
+        NPrivate::TAggregatedTabletCounters TabletExecutorCounters;
+        NPrivate::TAggregatedTabletCounters TabletAppCounters;
     };
 
     using TTabletCountersForTabletTypePtr = TIntrusivePtr<TTabletCountersForTabletType>;

--- a/ydb/core/tablet/ut/ya.make
+++ b/ydb/core/tablet/ut/ya.make
@@ -29,6 +29,7 @@ SRCS(
     tablet_state_ut.cpp
     detailed_metrics/ut_helpers.cpp
     detailed_metrics/ut_helpers.h
+    detailed_metrics/node_database_metrics_aggregator_ut.cpp
     detailed_metrics/ydb_metrics_aggregator_ut.cpp
     detailed_metrics/ydb_metrics_ut.cpp
 )

--- a/ydb/core/tablet/ya.make
+++ b/ydb/core/tablet/ya.make
@@ -56,6 +56,8 @@ SRCS(
     tablet_tracing_signals.h
     detailed_metrics/metric_value_aggregator.cpp
     detailed_metrics/metric_value_aggregator.h
+    detailed_metrics/node_database_metrics_aggregator.cpp
+    detailed_metrics/node_database_metrics_aggregator.h
     detailed_metrics/ydb_metrics_aggregator.cpp
     detailed_metrics/ydb_metrics_aggregator.h
     detailed_metrics/ydb_metrics_mapper.cpp

--- a/ydb/core/tablet/ya.make
+++ b/ydb/core/tablet/ya.make
@@ -63,6 +63,8 @@ SRCS(
     detailed_metrics/ydb_metrics_target_counters_base.h
     private/aggregated_counters.cpp
     private/aggregated_counters.h
+    private/aggregated_tablet_counters.cpp
+    private/aggregated_tablet_counters.h
     private/labeled_db_counters.cpp
     private/labeled_db_counters.h
 )


### PR DESCRIPTION
### Description for reviewers <!-- (optional) description for those who read this PR -->

- Extracted NPrivate::TAggregatedTabletCounters from TSolomonCounters.
- Added TNodeDatabaseMetricsAggregator: two role buckets per table at TABLE level, one verbatim leaf per (tablet, follower) at PARTITION level.
- Counter aggregation delegated to the extracted class, so cumulative deltas accumulate and HIST(x) aggregates get fed.
- Empty groups removed on forget; Unspecified/Disabled create nothing.