### PR TITLE
Add support for io_uring_register_buffers in ICv2

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -599,12 +599,20 @@ static TInterconnectSettings GetInterconnectSettings(const NKikimrConfig::TInter
         result.V2.ChecksumEvents = v2.GetChecksumEvents();
         result.V2.EnableSQPOLL = v2.GetEnableSQPOLL();
         result.V2.EnablePreserializeEvents = v2.GetEnablePreserializeEvents();
-        result.V2.UringEngineThreads = v2.GetUringEngineThreads();
-        result.V2.UringEngineRingsPerShard = v2.GetUringEngineRingsPerShard();
-        result.V2.UringEngineSqThreadIdleMs = v2.GetUringEngineSqThreadIdleMs();
+        result.V2.Threads = v2.GetThreads();
+        result.V2.RingsPerShard = v2.GetRingsPerShard();
+        result.V2.SqThreadIdleMs = v2.GetSqThreadIdleMs();
         result.V2.ShareRingsAmongThreads = v2.GetShareRingsAmongThreads();
         result.V2.EnableFixedFiles = v2.GetEnableFixedFiles();
-        result.V2.UringEngineFixedFilesPerRing = v2.GetUringEngineFixedFilesPerRing();
+        result.V2.FixedFilesPerRing = v2.GetFixedFilesPerRing();
+        result.V2.EnableProvidedBuffers = v2.GetEnableProvidedBuffers();
+        result.V2.PoolBufCount = v2.GetPoolBufCount();
+        result.V2.MinWriteBufferSize = v2.GetMinWriteBufferSizeKB() << 10;
+        result.V2.MaxWriteBufferSize = v2.GetMaxWriteBufferSizeKB() << 10;
+        result.V2.MinReadBufferSize = v2.GetMinReadBufferSizeKB() << 10;
+        result.V2.MaxReadBufferSize = v2.GetMaxReadBufferSizeKB() << 10;
+        result.V2.MinSerializeWindowSize = v2.GetMinSerializeWindowSizeKB() << 10;
+        result.V2.MaxSerializeWindowSize = v2.GetMaxSerializeWindowSizeKB() << 10;
     }
 
     return result;

--- a/ydb/core/protos/config.proto
+++ b/ydb/core/protos/config.proto
@@ -562,18 +562,18 @@ message TInterconnectConfig {
         optional bool EnablePreserializeEvents = 4 [default = false];
 
         // Number of worker threads of ICv2 thread pool (not counting uring internal ones).
-        optional uint32 UringEngineThreads = 5 [default = 4];
+        optional uint32 Threads = 5 [default = 4];
 
         // io_uring rings per v2 shard worker (each ring may own a SQPOLL thread). Default 1 preserves legacy
-        // 1:1 ring/worker topology. Raise this when poller-bound; raise UringEngineThreads when serializer-bound.
-        optional uint32 UringEngineRingsPerShard = 6 [default = 1];
+        // 1:1 ring/worker topology. Raise this when poller-bound; raise Threads when serializer-bound.
+        optional uint32 RingsPerShard = 6 [default = 1];
 
         // SQPOLL kernel-thread idle timeout (ms) for v2 rings before the poller sleeps. Only effective when
         // EnableSQPOLLv2 is set. Lower values save idle CPU; higher values keep the poller warm for latency.
-        optional uint32 UringEngineSqThreadIdleMs = 7 [default = 2000];
+        optional uint32 SqThreadIdleMs = 7 [default = 2000];
 
         // If enabled, rings of different threads share same kernel thread pools and SQ pollers (effectively creating
-        // UringEngineRingsPerShard threads instead of UringEngineRingsPerShard * UringEngineThreads).
+        // RingsPerShard threads instead of RingsPerShard * Threads).
         optional bool ShareRingsAmongThreads = 8 [default = false];
 
         // Register session sockets into each ring's fixed-file table (IOSQE_FIXED_FILE) to avoid
@@ -582,7 +582,26 @@ message TInterconnectConfig {
         optional bool EnableFixedFiles = 9 [default = true];
 
         // Size of the fixed-file table reserved per ring when EnableFixedFiles is on.
-        optional uint32 UringEngineFixedFilesPerRing = 10 [default = 4096];
+        optional uint32 FixedFilesPerRing = 10 [default = 4096];
+
+        // Shared provided-buffer pool (buf_ring or provide_buffers) for sessions whose receive
+        // target is still at the minimum size. Falls back to per-session plain buffers.
+        optional bool EnableProvidedBuffers = 11 [default = true];
+
+        // Number of shared-pool buffers reserved per ring.
+        optional uint32 PoolBufCount = 12 [default = 128];
+
+        // Minimum and maximum write buffer size.
+        optional uint32 MinWriteBufferSizeKB = 13 [default = 4];
+        optional uint32 MaxWriteBufferSizeKB = 14 [default = 256];
+
+        // Minimum and maximum read buffer size.
+        optional uint32 MinReadBufferSizeKB = 15 [default = 4];
+        optional uint32 MaxReadBufferSizeKB = 16 [default = 256];
+
+        // Minimum and maximum serialization window size.
+        optional uint32 MinSerializeWindowSizeKB = 17 [default = 4];
+        optional uint32 MaxSerializeWindowSizeKB = 18 [default = 256];
     }
 
     optional TV2Config V2Config = 70;

--- a/ydb/library/actors/interconnect/bench/main.cpp
+++ b/ydb/library/actors/interconnect/bench/main.cpp
@@ -627,8 +627,8 @@ namespace {
             settings.V2.ChecksumEvents = cfg.Checksum;
             settings.V2.EnableSQPOLL = cfg.SqPoll;
             settings.V2.EnablePreserializeEvents = cfg.Preserialize;
-            settings.V2.UringEngineThreads = cfg.UringShards;
-            settings.V2.UringEngineRingsPerShard = cfg.RingsPerShard;
+            settings.V2.Threads = cfg.UringShards;
+            settings.V2.RingsPerShard = cfg.RingsPerShard;
             if (cfg.TcpSocketBufferSize) {
                 settings.TCPSocketBufferSize = cfg.TcpSocketBufferSize;
             }

--- a/ydb/library/actors/interconnect/interconnect_common.h
+++ b/ydb/library/actors/interconnect/interconnect_common.h
@@ -89,7 +89,7 @@ namespace NActors {
         bool CollectSubscriptionStackTrace = false;
         TDuration SubscriberLivenessCheckInterval = TDuration::Hours(1);
 
-        struct {
+        struct TV2 {
             // Enables negotiation and usage of TInterconnectSessionTCPv2 (no session continuation, no encryption).
             // v2 is used only when both peers have this enabled and encryption is not in effect.
             bool Enable = false;
@@ -102,13 +102,13 @@ namespace NActors {
             // serialization cost off the engine's shard worker thread).
             bool EnablePreserializeEvents = false;
             // Number of worker threads.
-            ui32 UringEngineThreads = 4;
+            ui32 Threads = 4;
             // io_uring rings per v2 shard worker (default 1). Each ring may have its own SQPOLL thread, so this
             // scales kernel submission-polling independently of the number of serialization workers.
-            ui32 UringEngineRingsPerShard = 1;
+            ui32 RingsPerShard = 1;
             // SQPOLL kernel-thread idle window (ms) for v2 rings before it sleeps. Only used when EnableSQPOLLv2
             // is on. Matches TUringContext::SqThreadIdleMs by default.
-            ui32 UringEngineSqThreadIdleMs = 2000;
+            ui32 SqThreadIdleMs = 2000;
             // Enable kernel threads sharing among different worker threads.
             bool ShareRingsAmongThreads = false;
             // Register session sockets into each ring's fixed-file table (IOSQE_FIXED_FILE) to avoid
@@ -116,7 +116,21 @@ namespace NActors {
             // the table or a ring runs out of slots. Requires sparse/update support (kernel >= 5.5; target 5.13+).
             bool EnableFixedFiles = true;
             // Size of the fixed-file table reserved per ring when EnableFixedFiles is on.
-            ui32 UringEngineFixedFilesPerRing = 4096;
+            ui32 FixedFilesPerRing = 4096;
+            // Shared provided-buffer pool (buf_ring or provide_buffers) for sessions whose receive
+            // target is still at the minimum size. Falls back to per-session plain buffers.
+            bool EnableProvidedBuffers = true;
+            // Number of shared-pool buffers reserved per ring.
+            ui32 PoolBufCount = 128;
+            // Minimum and maximum write buffer size.
+            ui32 MinWriteBufferSize = 4_KB;
+            ui32 MaxWriteBufferSize = 256_KB;
+            // Minimum and maximum read buffer size.
+            ui32 MinReadBufferSize = 4_KB;
+            ui32 MaxReadBufferSize = 256_KB;
+            // Minimum and maximum serialization window size.
+            ui32 MinSerializeWindowSize = 4_KB;
+            ui32 MaxSerializeWindowSize = 256_KB;
         } V2;
     };
 

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
@@ -40,16 +40,11 @@ namespace NActors {
     namespace {
         constexpr ui32 RingQueueDepth = 4096;
         constexpr unsigned CqeBatchSize = 64;
-        constexpr size_t ReadBufferSize = 262144;
-        constexpr size_t MinReadBufferSize = 65536;
-        constexpr size_t MinWriteBufferSize = 4096;
-        constexpr size_t MaxWriteBufferSize = 262144;
         constexpr size_t MaxSpansPerWrite = 64;
-        constexpr size_t MinSerializeWindowSize = 4096;
-        constexpr size_t MaxSerializeWindowSize = 262144;
         constexpr TDuration RebalancePeriod = TDuration::MilliSeconds(500); // how often MaybeOffload runs
         constexpr ui32 OffloadBusyThreshold = 700000; // ppm
         constexpr ui32 StealBusyThreshold = 300000; // ppm
+        constexpr int ProvidedBufGroupId = 0;
 
         // The shard timer is the only timing source for pings and dead-peer detection, so its period caps
         // how late either of them can be. Keep it at or below this bound to limit the jitter.
@@ -58,6 +53,19 @@ namespace NActors {
         // Number of ping opportunities that must fit into the dead-peer window, so that a single lost or
         // late ping cannot bring a healthy link down.
         constexpr ui32 PingsPerDeadPeerTimeout = 4;
+
+        ui32 NextPowerOfTwo(ui32 n) {
+            if (n <= 1) {
+                return 1;
+            }
+            --n;
+            n |= n >> 1;
+            n |= n >> 2;
+            n |= n >> 4;
+            n |= n >> 8;
+            n |= n >> 16;
+            return n + 1;
+        }
 
         TDuration CalculateDeadPeerTimeout(const TInterconnectSettings& settings) {
             return settings.DeadPeer ? settings.DeadPeer : DEFAULT_DEADPEER_TIMEOUT;
@@ -142,13 +150,14 @@ namespace NActors {
             TEventSerializer Serializer;
             TEventDeserializer Deserializer;
             TRcBuf ReadBuffer;
+            size_t ReadBufferSize = 0;
             bool Terminated = false;
             bool ReadPending = false;
             bool WritePending = false;
             bool UnregisterRequested = false;
             const bool SendPings;
             TRcBuf WriteBuffer;
-            size_t WriteBufferSize = MinWriteBufferSize;
+            size_t WriteBufferSize = 0;
             std::deque<TContiguousSpan> OutgoingSpans;
             iovec Iov[MaxSpansPerWrite];
             size_t IovLen = 0;
@@ -170,7 +179,7 @@ namespace NActors {
 
             std::vector<TIncomingEventQueue::TRecord> PendingRecordsHeap;
 
-            size_t SerializeWindowSize = MinSerializeWindowSize;
+            size_t SerializeWindowSize = 0;
 
             ui64 BytesSent = 0;
             ui64 BytesReceived = 0;
@@ -207,17 +216,16 @@ namespace NActors {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // deserialization/receiving
 
-            TMutableContiguousSpan GetReadSpan() {
-                if (ReadBuffer.size() < MinReadBufferSize) {
+            TMutableContiguousSpan GetReadSpan(size_t minReadBufferSize) {
+                if (ReadBuffer.size() < minReadBufferSize) {
                     ReadBuffer = TRcBuf::Uninitialized(ReadBufferSize);
                     NSan::Poison(ReadBuffer.data(), ReadBuffer.size());
                 }
                 return ReadBuffer.UnsafeGetContiguousSpanMut();
             }
 
-            void ApplyBytesRead(size_t num) {
+            void ApplyBytesRead(size_t num, size_t minReadBufferSize, size_t maxReadBufferSize) {
                 BytesReceived += num;
-                LastInputActivityTimestamp = GetCycleCountFast();
                 Y_DEBUG_ABORT_UNLESS(num <= ReadBuffer.size());
                 NSan::Unpoison(ReadBuffer.data(), num);
                 Deserializer.Push(num == ReadBuffer.size()
@@ -225,9 +233,34 @@ namespace NActors {
                         : TRcBuf(TRcBuf::Piece, ReadBuffer.data(), num, ReadBuffer),
                     this,
                     SessionId);
-                Y_ABORT_UNLESS(num <= ReadBuffer.size());
-                const size_t remain = ReadBuffer.size() - num;
+                const size_t readSpanSize = ReadBuffer.size();
+                const size_t remain = readSpanSize - num;
                 ReadBuffer.TrimFront(remain - remain % 64); // make only this number of bytes remaining in buffer
+
+                if (num == readSpanSize && num >= ReadBufferSize / 2 && ReadBufferSize < maxReadBufferSize) {
+                    // we have read all the provided buffer and it's more than a half of original read buffer
+                    ReadBufferSize *= 2;
+                } else if (num < readSpanSize && readSpanSize >= ReadBufferSize / 2 && ReadBufferSize > minReadBufferSize) {
+                    // we haven't read all the provided buffer and we have asked for more than its half
+                    ReadBufferSize /= 2;
+                    if (ReadBufferSize == minReadBufferSize) {
+                        // reset read buffer so the reads go into the pool
+                        ReadBuffer = {};
+                    }
+                }
+            }
+
+            // Copy-out path for shared-pool completions: pool memory cannot be moved into the deserializer.
+            void ApplyBytesReadCopy(const char *data, size_t num, size_t minReadBufferSize, size_t maxReadBufferSize) {
+                BytesReceived += num;
+                NSan::Unpoison(data, num);
+                Deserializer.Push(TRcBuf::Copy({data, num}), this, SessionId);
+
+                Y_DEBUG_ABORT_UNLESS(num <= minReadBufferSize);
+                if (num == minReadBufferSize && ReadBufferSize < maxReadBufferSize) {
+                    // we have read all the provided buffer and probably have more, so double it
+                    ReadBufferSize *= 2;
+                }
             }
 
             void PushEvent(std::unique_ptr<IEventHandle> ev) override {
@@ -245,11 +278,11 @@ namespace NActors {
             ////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // serialization/sending
 
-            void Serialize() {
+            void Serialize(size_t minWriteBufferSize, size_t maxWriteBufferSize) {
                 Serializer.ResetCounters();
 
                 while (UnsentBytes < SerializeWindowSize && OutgoingSpans.size() < MaxSpansPerWrite) {
-                    if (WriteBuffer.size() < MinWriteBufferSize) { // (re)allocate write buffer
+                    if (WriteBuffer.size() < minWriteBufferSize) { // (re)allocate write buffer
                         WriteBuffer = TRcBuf::Uninitialized(WriteBufferSize);
                     }
                     const size_t numBytesProduced = Serializer.ProduceOutputStream(WriteBuffer, &OutgoingSpans,
@@ -262,9 +295,9 @@ namespace NActors {
                 }
 
                 const size_t numb = Serializer.GetNumBytesInScratchBuffers();
-                if (numb >= WriteBufferSize * 2 && WriteBufferSize < MaxWriteBufferSize) {
+                if (numb >= WriteBufferSize * 2 && WriteBufferSize < maxWriteBufferSize) {
                     WriteBufferSize *= 2;
-                } else if (numb < WriteBufferSize / 2 && WriteBufferSize > MinWriteBufferSize) {
+                } else if (numb < WriteBufferSize / 2 && WriteBufferSize > minWriteBufferSize) {
                     WriteBufferSize /= 2;
                 }
             }
@@ -287,8 +320,8 @@ namespace NActors {
                 return IovLen != 0;
             }
 
-            void ApplyBytesWritten(size_t num, std::vector<ui64> *eventToWireTime,
-                    std::vector<std::unique_ptr<IEventBase>> *events,
+            void ApplyBytesWritten(size_t num, size_t minSerializeWindowSize, size_t maxSerializeWindowSize,
+                    std::vector<ui64> *eventToWireTime, std::vector<std::unique_ptr<IEventBase>> *events,
                     std::vector<TIntrusivePtr<TEventSerializedData>> *buffers) {
                 BytesSent += num;
 
@@ -296,9 +329,9 @@ namespace NActors {
                 // successfully written, and it was limited by serialization window, we can increase it. If we have
                 // serialized less than the window, we can decrease the window.
                 if (num == BytesToWriteLastTime && BytesToWriteLastTime == SerializeWindowSize) {
-                    SerializeWindowSize = Min(SerializeWindowSize + MinSerializeWindowSize, MaxSerializeWindowSize);
+                    SerializeWindowSize = Min(SerializeWindowSize + minSerializeWindowSize, maxSerializeWindowSize);
                 }  else if (UnsentBytes < SerializeWindowSize) {
-                    SerializeWindowSize = Max(SerializeWindowSize - MinSerializeWindowSize, MinSerializeWindowSize);
+                    SerializeWindowSize = Max(SerializeWindowSize - minSerializeWindowSize, minSerializeWindowSize);
                 }
 
                 // Advance past exactly the bytes the kernel accepted. A writev can be short (e.g. under
@@ -460,6 +493,8 @@ namespace NActors {
                                     PARAM(ReadPendingRingIdx)
                                     PARAM(PreferredRingIdx)
                                     PARAM(FixedFileIndex)
+                                    PARAM2("ReadBuffer size", ReadBuffer.size())
+                                    PARAM(ReadBufferSize)
                                     PARAM2("IncomingSeqNo", IncomingSeqNo.load())
                                     PARAM(ExpectedSeqNo)
                                     PARAM(MigrateTargetShard)
@@ -504,6 +539,7 @@ namespace NActors {
                 kOpWrite,
                 kOpTimer,
                 kOpCancel,
+                kOpProvideBuffers,
             };
             static const ui64 kOpMask = (1 << 3) - 1;
 
@@ -512,6 +548,19 @@ namespace NActors {
                 i64 ItemsToSubmit = 0;
                 bool FixedFilesEnabled = false;
                 std::vector<int> FreeIndices;
+
+                // Shared provided-buffer pool (buf_ring and/or legacy provide_buffers).
+                bool ProvidedBuffersEnabled = false;
+                bool BufRingEnabled = false;
+                io_uring_buf_ring *BufRing = nullptr;
+                unsigned BufRingEntries = 0;
+                int BufGroupId = ProvidedBufGroupId;
+                ui32 PoolBufCount = 0;
+                char *PoolMemory = nullptr; // PoolBufCount * MinReadBufferSize contiguous slab
+
+                ~TRingSlot() {
+                    free(PoolMemory);
+                }
             };
 
             TUringEngine& Engine;
@@ -566,14 +615,14 @@ namespace NActors {
             NMonitoring::TDynamicCounters::TCounterPtr PushedTotal;
             NMonitoring::TDynamicCounters::TCounterPtr ReadUnavail;
             NMonitoring::TDynamicCounters::TCounterPtr WriteUnavail;
+            NMonitoring::TDynamicCounters::TCounterPtr ReadsToPool;
+            NMonitoring::TDynamicCounters::TCounterPtr ReadsToBuffer;
+            NMonitoring::TDynamicCounters::TCounterPtr ReadsNoBufs;
             NMonitoring::TDynamicCounters::TCounterPtr SessionsMigratedOut;
             NMonitoring::TDynamicCounters::TCounterPtr SessionsMigratedIn;
             NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderCameIn;
             NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderProcessed;
             NMonitoring::TDynamicCounters::TCounterPtr DeadPeersDetected;
-            NMonitoring::TDynamicCounters::TCounterPtr FixedFilesBound;
-            NMonitoring::TDynamicCounters::TCounterPtr FixedFilesUnbound;
-            NMonitoring::TDynamicCounters::TCounterPtr FixedFilesFallback;
 
             NMonitoring::TDynamicCounters::TCounterPtr OtherTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr CompleteWaitTotalTime;
@@ -602,6 +651,13 @@ namespace NActors {
             TShardLoad& Load;
 
             std::unique_ptr<TEvDestroyEvents> EvDestroyEvents = std::make_unique<TEvDestroyEvents>();
+
+            const ui32 MinReadBufferSize;
+            const ui32 MaxReadBufferSize;
+            const ui32 MinWriteBufferSize;
+            const ui32 MaxWriteBufferSize;
+            const ui32 MinSerializeWindowSize;
+            const ui32 MaxSerializeWindowSize;
 
         private:
             class TActivityMeasure {
@@ -658,70 +714,84 @@ namespace NActors {
                 if (!fixedFilesPerRing) {
                     return;
                 }
-                const unsigned n = fixedFilesPerRing;
-                int ret = io_uring_register_files_sparse(&slot.Ring, n);
+                int ret = io_uring_register_files_sparse(&slot.Ring, fixedFilesPerRing);
                 if (ret != 0) {
-                    std::vector<int> minusOnes(n, -1);
-                    ret = io_uring_register_files(&slot.Ring, minusOnes.data(), n);
+                    std::vector<int> minusOnes(fixedFilesPerRing, -1);
+                    ret = io_uring_register_files(&slot.Ring, minusOnes.data(), minusOnes.size());
                 }
                 if (ret != 0) {
                     return;
                 }
                 slot.FixedFilesEnabled = true;
-                slot.FreeIndices.reserve(n);
-                for (int i = static_cast<int>(n) - 1; i >= 0; --i) {
-                    slot.FreeIndices.push_back(i);
-                }
-            }
-
-            // Bind fd into the preferred ring's fixed-file table. Returns the index, or -1 on fallback.
-            // Caller must only invoke this when slot.FixedFilesEnabled is true.
-            int BindFixedFile(TRingSlot& slot, int fd) {
-                Y_DEBUG_ABORT_UNLESS(slot.FixedFilesEnabled);
-                if (slot.FreeIndices.empty()) {
-                    ++*FixedFilesFallback;
-                    return -1;
-                }
-                const int index = slot.FreeIndices.back();
-                slot.FreeIndices.pop_back();
-                const int ret = io_uring_register_files_update(&slot.Ring, index, &fd, 1);
-                if (ret != 1) {
-                    slot.FreeIndices.push_back(index);
-                    ++*FixedFilesFallback;
-                    return -1;
-                }
-                ++*FixedFilesBound;
-                return index;
-            }
-
-            void UnbindFixedFile(TRingSlot& slot, int index) {
-                if (index < 0 || !slot.FixedFilesEnabled) {
-                    return;
-                }
-                const int clear = -1;
-                const int ret = io_uring_register_files_update(&slot.Ring, index, &clear, 1);
-                Y_ABORT_UNLESS(ret == 1, "io_uring_register_files_update(clear) failed: %s", strerror(-ret));
-                slot.FreeIndices.push_back(index);
-                ++*FixedFilesUnbound;
+                slot.FreeIndices.resize(fixedFilesPerRing);
+                std::iota(slot.FreeIndices.rbegin(), slot.FreeIndices.rend(), 0);
             }
 
             void BindSessionFixedFile(TSession& session) {
-                Y_DEBUG_ABORT_UNLESS(session.FixedFileIndex < 0);
+                Y_DEBUG_ABORT_UNLESS(session.FixedFileIndex == -1);
                 Y_DEBUG_ABORT_UNLESS(session.PreferredRingIdx < Rings.size());
                 auto& slot = Rings[session.PreferredRingIdx];
-                if (!slot.FixedFilesEnabled) {
+                if (!slot.FixedFilesEnabled || slot.FreeIndices.empty()) {
                     return;
                 }
-                session.FixedFileIndex = BindFixedFile(slot, *session.Socket);
+                session.FixedFileIndex = slot.FreeIndices.back();
+                const int fd = *session.Socket;
+                const int ret = io_uring_register_files_update(&slot.Ring, session.FixedFileIndex, &fd, 1);
+                if (ret != 1) {
+                    session.FixedFileIndex = -1;
+                } else {
+                    slot.FreeIndices.pop_back();
+                }
             }
 
             void UnbindSessionFixedFile(TSession& session) {
-                if (session.FixedFileIndex < 0) {
+                if (session.FixedFileIndex == -1) {
                     return;
                 }
                 Y_DEBUG_ABORT_UNLESS(session.PreferredRingIdx < Rings.size());
-                UnbindFixedFile(Rings[session.PreferredRingIdx], session.FixedFileIndex);
+                auto& slot = Rings[session.PreferredRingIdx];
+                Y_DEBUG_ABORT_UNLESS(slot.FixedFilesEnabled);
+                const int clear = -1;
+                const int ret = io_uring_register_files_update(&slot.Ring, session.FixedFileIndex, &clear, 1);
+                Y_ABORT_UNLESS(ret == 1, "io_uring_register_files_update(clear) failed: %s", strerror(-ret));
+                slot.FreeIndices.push_back(session.FixedFileIndex);
                 session.FixedFileIndex = -1;
+            }
+
+            // Shared recv pool: prefer buf_ring (5.19+), else legacy provide_buffers (5.7+ / 5.13).
+            void InitProvidedBuffers(ui32 ringIdx, TRingSlot& slot, ui32 poolBufCount, bool allowBufRing) {
+                if (!poolBufCount) {
+                    return;
+                }
+                slot.PoolBufCount = poolBufCount;
+                slot.BufGroupId = ProvidedBufGroupId;
+                size_t numb = static_cast<size_t>(MinReadBufferSize) * poolBufCount;
+                slot.PoolMemory = static_cast<char*>(malloc(numb));
+                NSan::Poison(slot.PoolMemory, numb);
+
+                if (allowBufRing) {
+                    const unsigned entries = NextPowerOfTwo(poolBufCount);
+                    int err = 0;
+                    slot.BufRing = io_uring_setup_buf_ring(&slot.Ring, entries, slot.BufGroupId, 0, &err);
+                    if (slot.BufRing) {
+                        slot.BufRingEntries = entries;
+                        slot.BufRingEnabled = true;
+                        const int mask = io_uring_buf_ring_mask(entries);
+                        for (size_t i = 0; i < poolBufCount; ++i) {
+                            char *addr = slot.PoolMemory + i * MinReadBufferSize;
+                            io_uring_buf_ring_add(slot.BufRing, addr, MinReadBufferSize, i, mask, i);
+                        }
+                        io_uring_buf_ring_advance(slot.BufRing, poolBufCount);
+                        slot.ProvidedBuffersEnabled = true;
+                        return;
+                    }
+                }
+
+                // Legacy provide_buffers: one SQE installs the whole contiguous slab.
+                io_uring_sqe *sqe = GetSQE(nullptr, kOpProvideBuffers, ringIdx);
+                Y_ABORT_UNLESS(sqe);
+                io_uring_prep_provide_buffers(sqe, slot.PoolMemory, MinReadBufferSize, poolBufCount, slot.BufGroupId, 0);
+                slot.ProvidedBuffersEnabled = true;
             }
 
             void PublishLoadSample(ui64 busyDelta, ui64 totalDelta) {
@@ -739,9 +809,8 @@ namespace NActors {
                 return NMonitoring::ExponentialHistogram(22, 2, 1000);
             }
 
-            TShard(TUringEngine& engine, ui32 shardIdx, const NMonitoring::TDynamicCounterPtr& shardCounters, bool sqpoll,
-                    ui32 ringsPerShard, ui32 sqThreadIdleMs, TShardLoad& load, TShard *shareRingsWith,
-                    bool enableFixedFiles, ui32 fixedFilesPerRing)
+            TShard(TUringEngine& engine, ui32 shardIdx, const NMonitoring::TDynamicCounterPtr& shardCounters,
+                    const TInterconnectSettings::TV2& v2, TShardLoad& load, TShard *shareRingsWith)
 #define COUNTER(NAME, DERIV) NAME(shardCounters->GetCounter(#NAME, DERIV))
                 : Engine(engine)
                 , ShardIdx(shardIdx)
@@ -764,14 +833,14 @@ namespace NActors {
                 , COUNTER(PushedTotal, true)
                 , COUNTER(ReadUnavail, true)
                 , COUNTER(WriteUnavail, true)
+                , COUNTER(ReadsToPool, true)
+                , COUNTER(ReadsToBuffer, true)
+                , COUNTER(ReadsNoBufs, true)
                 , COUNTER(SessionsMigratedOut, true)
                 , COUNTER(SessionsMigratedIn, true)
                 , COUNTER(OutOfOrderCameIn, true)
                 , COUNTER(OutOfOrderProcessed, true)
                 , COUNTER(DeadPeersDetected, true)
-                , COUNTER(FixedFilesBound, true)
-                , COUNTER(FixedFilesUnbound, true)
-                , COUNTER(FixedFilesFallback, true)
 #define TOTAL_TIME(NAME) NAME(shardCounters->GetCounter("TotalTime/" #NAME, true))
                 , TOTAL_TIME(OtherTotalTime)
                 , TOTAL_TIME(CompleteWaitTotalTime)
@@ -788,24 +857,43 @@ namespace NActors {
                 , SerializeTime(shardCounters->GetNamedHistogram("sensor", "SerializeTime", TimeCollector()))
                 , CompletionsProcessedAtOnce(shardCounters->GetNamedHistogram("sensor", "CompletionsProcessedAtOnce", NMonitoring::ExponentialHistogram(10, 2)))
                 , SubmissionsProcessedAtOnce(shardCounters->GetNamedHistogram("sensor", "SubmissionsProcessedAtOnce", NMonitoring::ExponentialHistogram(12, 2)))
-                , Load(load)
 #undef TOTAL_TIME
 #undef COUNTER
+                , Load(load)
+                , MinReadBufferSize(v2.MinReadBufferSize)
+                , MaxReadBufferSize(v2.MaxReadBufferSize)
+                , MinWriteBufferSize(v2.MinWriteBufferSize)
+                , MaxWriteBufferSize(v2.MaxWriteBufferSize)
+                , MinSerializeWindowSize(v2.MinSerializeWindowSize)
+                , MaxSerializeWindowSize(v2.MaxSerializeWindowSize)
             {
+                const ui32 sqThreadIdleMs = v2.SqThreadIdleMs
+                    ? v2.SqThreadIdleMs
+                    : TUringContext::SqThreadIdleMs;
+
+                const bool allowBufRing = !GetEnv("YDB_IC_V2_DISABLE_BUF_RING");
+
                 EventFd = eventfd(0, 0);
                 if (EventFd == -1) {
                     Y_ABORT("eventfd() failed: %s", strerror(errno));
                 }
 
-                Rings.resize(ringsPerShard);
+                Rings.resize(v2.RingsPerShard);
                 for (ui32 i = 0; i < Rings.size(); ++i) {
                     auto& slot = Rings[i];
-                    InitRing(slot, sqpoll, sqThreadIdleMs, shareRingsWith ? &shareRingsWith->Rings[i] : nullptr);
+
+                    InitRing(slot, v2.EnableSQPOLL, sqThreadIdleMs, shareRingsWith ? &shareRingsWith->Rings[i] : nullptr);
+
                     // Must run before Start(): io_uring_register waits for the ring to idle, which deadlocks
                     // if a worker/SQPOLL thread already holds a ref inside io_uring_enter.
-                    if (enableFixedFiles) {
-                        InitFixedFiles(slot, fixedFilesPerRing);
+                    if (v2.EnableFixedFiles) {
+                        InitFixedFiles(slot, v2.FixedFilesPerRing);
                     }
+
+                    if (v2.EnableProvidedBuffers) {
+                        InitProvidedBuffers(i, slot, v2.PoolBufCount, allowBufRing);
+                    }
+
                     if (i > 0) {
                         if (int res = io_uring_register_eventfd(&slot.Ring, EventFd); res < 0) {
                             Y_ABORT("failed to register eventfd along with ring: %s", strerror(-res));
@@ -834,6 +922,10 @@ namespace NActors {
             ~TShard() {
                 Stop(); // joins the worker thread, so no completion will be dispatched after this point
                 for (auto& slot : Rings) {
+                    if (slot.BufRing) {
+                        io_uring_free_buf_ring(&slot.Ring, slot.BufRing, slot.BufRingEntries, slot.BufGroupId);
+                        slot.BufRing = nullptr;
+                    }
                     io_uring_queue_exit(&slot.Ring);
                 }
                 DrainQueue(); // free commands that were enqueued after the worker stopped (teardown races)
@@ -1015,7 +1107,9 @@ namespace NActors {
                     uintptr_t sessionId = reinterpret_cast<uintptr_t>(session);
                     Y_ABORT_UNLESS((sessionId & kOpMask) == 0);
                     io_uring_sqe_set_data64(sqe, sessionId | op);
-                    Y_DEBUG_ABORT_UNLESS(op == kOpEvent || op == kOpTimer ? session == nullptr : session != nullptr);
+                    Y_DEBUG_ABORT_UNLESS(op == kOpEvent || op == kOpTimer || op == kOpProvideBuffers
+                        ? session == nullptr
+                        : session != nullptr);
                     ++*SQEAllocated;
                 }
                 return sqe;
@@ -1290,12 +1384,13 @@ namespace NActors {
             bool ProcessCompletions() {
                 bool progress = false;
                 i64 completionsProcessedAtOnce = 0;
-                for (auto& slot : Rings) {
+                for (ui32 ringIdx = 0; ringIdx < Rings.size(); ++ringIdx) {
+                    auto& slot = Rings[ringIdx];
                     io_uring_cqe *cqes[CqeBatchSize];
                     while (const unsigned n = io_uring_peek_batch_cqe(&slot.Ring, cqes, CqeBatchSize)) {
                         progress = true; // we did something with the queues
                         for (unsigned i = 0; i < n; ++i) {
-                            DispatchCompletion(*cqes[i]);
+                            DispatchCompletion(*cqes[i], ringIdx);
                         }
                         io_uring_cq_advance(&slot.Ring, n);
                         completionsProcessedAtOnce += n;
@@ -1310,7 +1405,7 @@ namespace NActors {
                 return progress;
             }
 
-            void DispatchCompletion(io_uring_cqe& cqe) {
+            void DispatchCompletion(io_uring_cqe& cqe, ui32 ringIdx) {
                 auto *session = reinterpret_cast<TSession*>(uintptr_t(cqe.user_data) & ~uintptr_t(kOpMask));
                 Y_ABORT_UNLESS(!(cqe.flags & IORING_CQE_F_MORE)); // not expecting multiple completions
                 const auto op = static_cast<EOperationType>(cqe.user_data & kOpMask);
@@ -1325,7 +1420,7 @@ namespace NActors {
                         Y_DEBUG_ABORT_UNLESS(session != nullptr);
                         Y_DEBUG_ABORT_UNLESS(session->ReadPendingRingIdx != -1);
                         session->ReadPendingRingIdx = -1;
-                        DispatchRead(*session, cqe.res);
+                        DispatchRead(*session, cqe.res, cqe.flags, ringIdx);
                         break;
 
                     case kOpWrite:
@@ -1341,6 +1436,10 @@ namespace NActors {
 
                     case kOpCancel:
                         // Original op completes with -ECANCELED; the cancel SQE itself needs no action.
+                        break;
+
+                    case kOpProvideBuffers:
+                        // Legacy pool recycle completed; nothing else to do (failure just leaks one slot).
                         break;
                 }
                 ++*CQEProcessed;
@@ -1447,9 +1546,19 @@ namespace NActors {
                 return true;
             }
 
-            void DispatchRead(TSession& session, i32 res) {
+            void DispatchRead(TSession& session, i32 res, ui32 cqeFlags, ui32 ringIdx) {
                 Y_DEBUG_ABORT_UNLESS(session.ReadPending);
                 session.ReadPending = false;
+
+                TRingSlot& slot = Rings[ringIdx];
+
+                unsigned poolBid = 0;
+                char *poolData = nullptr;
+                if (cqeFlags & IORING_CQE_F_BUFFER) {
+                    poolBid = cqeFlags >> IORING_CQE_BUFFER_SHIFT;
+                    Y_ABORT_UNLESS(poolBid < slot.PoolBufCount);
+                    poolData = slot.PoolMemory + static_cast<size_t>(poolBid) * MinReadBufferSize;
+                }
 
                 if (session.Terminated) {
                     // teardown in progress: don't retry the read or re-arm; just let the session drain toward erasure below
@@ -1457,6 +1566,10 @@ namespace NActors {
                     // cancelled without migrate (should be rare); re-arm unless terminating
                 } else if (res == -EAGAIN) {
                     ++*ReadUnavail;
+                } else if (res == -ENOBUFS) {
+                    // no pool buffer available: allocate buffer for ordinary read and retry
+                    ++*ReadsNoBufs;
+                    session.GetReadSpan(MinReadBufferSize);
                 } else if (res < 0) {
                     session.Disconnect(TDisconnectReason::FromErrno(-res));
                 } else if (res == 0) {
@@ -1468,7 +1581,17 @@ namespace NActors {
                     session.EventsReceivedCallback = 0;
                     session.EventsReceivedActorSystem = 0;
                     ACTIVITY(&ApplyBytesReadTotalTime) {
-                        session.ApplyBytesRead(res);
+                        // remember the last time when something came -- used for DeadPeer logic
+                        session.LastInputActivityTimestamp = LastActivitySwitchTimestamp;
+
+                        if (poolData) {
+                            session.ApplyBytesReadCopy(poolData, res, MinReadBufferSize, MaxReadBufferSize);
+                            ++*ReadsToPool;
+                        } else {
+                            session.ApplyBytesRead(res, MinReadBufferSize, MaxReadBufferSize);
+                            ++*ReadsToBuffer;
+                        }
+
                         LastActivitySwitchTimestamp += session.ReceiveCycles;
                         *ReceiveCallbackTotalTime += session.ReceiveCycles * Freq;
                         if (const ui64 n = session.EventsReceivedCallback) {
@@ -1480,6 +1603,19 @@ namespace NActors {
                     }
                 }
 
+                if (poolData) { // recycle processed pool entry, if any
+                    if (slot.BufRingEnabled) {
+                        const int mask = io_uring_buf_ring_mask(slot.BufRingEntries);
+                        io_uring_buf_ring_add(slot.BufRing, poolData, MinReadBufferSize, poolBid, mask, 0);
+                        io_uring_buf_ring_advance(slot.BufRing, 1);
+                    } else {
+                        // Legacy path: re-provide via SQE on the owning ring (completed as kOpProvideBuffers).
+                        io_uring_sqe *sqe = GetSQE(nullptr, kOpProvideBuffers, ringIdx);
+                        Y_ABORT_UNLESS(sqe);
+                        io_uring_prep_provide_buffers(sqe, poolData, MinReadBufferSize, 1, slot.BufGroupId, poolBid);
+                    }
+                }
+
                 TouchedSessions.PushBack(&session);
             }
 
@@ -1488,16 +1624,30 @@ namespace NActors {
                     return;
                 }
 
-                TMutableContiguousSpan span = session.GetReadSpan();
+                auto& slot = Rings[session.PreferredRingIdx];
                 io_uring_sqe *sqe = GetSQE(&session, kOpRead, session.PreferredRingIdx);
                 Y_ABORT_UNLESS(sqe);
-                const int fdOrIndex = session.FixedFileIndex >= 0
-                    ? session.FixedFileIndex
-                    : static_cast<int>(*session.Socket);
-                io_uring_prep_read(sqe, fdOrIndex, span.data(), span.size(), -1);
+
+                TMutableContiguousSpan span(nullptr, MinReadBufferSize);
+
+                if (session.ReadBufferSize == MinReadBufferSize && slot.ProvidedBuffersEnabled && session.ReadBuffer.empty()) {
+                    // we're reading into automatically located pool buffer
+                    sqe->flags |= IOSQE_BUFFER_SELECT;
+                    sqe->buf_group = slot.BufGroupId;
+                } else {
+                    // we're reading into session's ReadBuffer, so we need to possibly allocate buffer and get its read span
+                    span = session.GetReadSpan(MinReadBufferSize);
+                }
+
+                Y_DEBUG_ABORT_UNLESS(span.size());
+
+                io_uring_prep_read(sqe, *session.Socket, span.data(), span.size(), -1);
+
                 if (session.FixedFileIndex >= 0) {
+                    sqe->fd = session.FixedFileIndex;
                     sqe->flags |= IOSQE_FIXED_FILE;
                 }
+
                 session.ReadPending = true;
             }
 
@@ -1518,8 +1668,8 @@ namespace NActors {
                 } else {
                     *BytesSent += res;
                     ACTIVITY(&ApplyBytesWrittenTotalTime) {
-                        session.ApplyBytesWritten(res, &EventToWireTimeVec, &EvDestroyEvents->Events,
-                            &EvDestroyEvents->Buffers);
+                        session.ApplyBytesWritten(res, MinSerializeWindowSize, MaxSerializeWindowSize,
+                            &EventToWireTimeVec, &EvDestroyEvents->Events, &EvDestroyEvents->Buffers);
                         for (const ui64 time : EventToWireTimeVec) {
                             EventToWireTime->Collect(time * Freq, 1u);
                         }
@@ -1535,7 +1685,7 @@ namespace NActors {
                     return;
                 }
                 if (session.Serializer.IsTrafficPending()) {
-                    session.Serialize();
+                    session.Serialize(MinWriteBufferSize, MaxWriteBufferSize);
                     const ui64 serializeEventTime = session.Serializer.GetSerializeEventTime();
                     const ui64 prevTimestamp = std::exchange(LastActivitySwitchTimestamp, GetCycleCountFast());
                     **CurrentActivityTime += (LastActivitySwitchTimestamp - prevTimestamp - serializeEventTime) * Freq;
@@ -1599,26 +1749,15 @@ namespace NActors {
             , UringCounters(Common->MonCounters->GetSubgroup("subsystem", "uring"))
         {
             const auto& v2 = Common->Settings.V2;
-            const ui32 numShards = Max<ui32>(1, v2.UringEngineThreads);
-            const ui32 ringsPerShard = Max<ui32>(1, v2.UringEngineRingsPerShard);
-            const ui32 sqThreadIdleMs = v2.UringEngineSqThreadIdleMs
-                ? v2.UringEngineSqThreadIdleMs
-                : TUringContext::SqThreadIdleMs;
-            const ui32 fixedFilesPerRing = v2.EnableFixedFiles ? Max<ui32>(1, v2.UringEngineFixedFilesPerRing) : 0;
-
-            ShardLoads = std::vector<TShardLoad>(numShards);
-            Shards.reserve(numShards);
-            for (ui32 i = 0; i < numShards; ++i) {
+            ShardLoads = std::vector<TShardLoad>(v2.Threads);
+            Shards.reserve(v2.Threads);
+            for (ui32 i = 0; i < v2.Threads; ++i) {
                 Shards.push_back(std::make_unique<TShard>(*this,
                     i, // shardIdx
                     UringCounters->GetSubgroup("shard", "0" /*ToString(i)*/),
-                    v2.EnableSQPOLL,
-                    ringsPerShard,
-                    sqThreadIdleMs,
+                    v2,
                     ShardLoads[i],
-                    v2.ShareRingsAmongThreads && !Shards.empty() ? Shards.front().get() : nullptr,
-                    v2.EnableFixedFiles,
-                    fixedFilesPerRing));
+                    v2.ShareRingsAmongThreads && !Shards.empty() ? Shards.front().get() : nullptr));
             }
             for (auto& shard : Shards) {
                 shard->Start();
@@ -1660,9 +1799,14 @@ namespace NActors {
                 }
             }
 
+            const auto& v2 = Common->Settings.V2;
+
             auto session = std::make_unique<TSession>(shardIdx, std::move(socket), sessionActorId,
                 ChecksumEvents, peerScopeId, std::move(onDisconnectCallback), ActorSystem, sendPings,
                 std::move(clockSkew), std::move(pingRTT));
+            session->ReadBufferSize = v2.MinReadBufferSize;
+            session->WriteBufferSize = v2.MinWriteBufferSize;
+            session->SerializeWindowSize = v2.MinSerializeWindowSize;
             const ui64 conn = reinterpret_cast<ui64>(session.get());
             Shards[shardIdx]->Register(std::move(session));
             return conn;

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.h
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.h
@@ -71,6 +71,9 @@ namespace NActors {
     // With EnableFixedFiles, each ring reserves UringEngineFixedFilesPerRing slots via
     // io_uring_register_files (sparse); session sockets are bound with register_files_update and
     // submitted with IOSQE_FIXED_FILE. Unsupported kernels or a full table fall back to plain fds.
+    // With EnableProvidedBuffers, idle/min-size sessions recv via BUFFER_SELECT from a shared pool
+    // (buf_ring when available, else provide_buffers). YDB_IC_V2_DISABLE_BUF_RING forces the non-buf_ring
+    // pool path for testing.
     //
     // Common holds the engine via an intrusive pointer too; the resulting cycle is broken by Stop().
     TUringEnginePtr CreateUringEngine(TIntrusivePtr<TInterconnectProxyCommon> common);

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -79,10 +79,10 @@ public:
             // proxy binds it to the actor system on start (SetActorSystem). Shard count is overridable via
             // YDB_IC_V2_SHARDS so tests can force many connections onto a single ring.
             if (const TString s = GetEnv("YDB_IC_V2_SHARDS"); !s.empty()) {
-                common->Settings.V2.UringEngineThreads = FromString<ui32>(s);
+                common->Settings.V2.Threads = FromString<ui32>(s);
             }
             if (const TString s = GetEnv("YDB_IC_V2_RINGS_PER_SHARD"); !s.empty()) {
-                common->Settings.V2.UringEngineRingsPerShard = FromString<ui32>(s);
+                common->Settings.V2.RingsPerShard = FromString<ui32>(s);
             }
             common->UringEngineV2 = CreateUringEngine(common);
             setup.OnActorSystemCreated.push_back([engine = common->UringEngineV2](TActorSystem *actorSystem) {

--- a/ydb/library/actors/interconnect/v2_event_serializer.h
+++ b/ydb/library/actors/interconnect/v2_event_serializer.h
@@ -156,7 +156,7 @@ namespace NActors {
         ui64 CumulativeProduced = 0; // total bytes ever produced into the output stream
         ui64 CumulativeCommitted = 0; // total bytes ever reported as sent via CommitProducedBytes
 
-        ui64 Timestamp;
+        ui64 Timestamp = 0;
         ui64 SerializeEventTime = 0;
         ui64 BytesCopied = 0;
         ui64 BytesAliased = 0;


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add support for io\_uring\_register\_buffers in ICv2

### Description for reviewers <!-- (optional) description for those who read this PR -->

This adds support for buffer pools to improve memory consumption of almost-empty sessions.
