### PR TITLE
[NBS-7570] Benchmarks for nbs2 requests creation

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
@@ -71,17 +71,30 @@ void InitFixture(TWriteRequestTestFixture& f)
         NKikimrServices::NBS_PARTITION,
         NActors::NLog::PRI_ERROR);
 
+    // Zero every delay/timeout so hedging/timeout Schedule paths are skipped
+    // (executors early-return on zero) and flush cooldown calls DoRun() inline.
     f.HedgeDelay = TDuration::Zero();
     f.Timeout = TDuration::Zero();
-    f.DirectBlockGroup->Oracle.WriteHedgingDelay = f.HedgeDelay;
-    f.DirectBlockGroup->Oracle.WriteRequestTimeout = f.Timeout;
+    f.PBufferReplyTimeout = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.ReadHedgingDelay = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.ReadRequestTimeout = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.WriteHedgingDelay = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.WriteRequestTimeout = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.PBufferReplyTimeout = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.FlushRequestCooldown = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.FlushRequestTimeout = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.EraseRequestTimeout = TDuration::Zero();
     f.DirectBlockGroup->Oracle.WriteMode = EWriteMode::IndirectWrite;
 
     // Run() must complete synchronously so drained executors can be destroyed.
+    // With the zeros above, Schedule is not used on the happy path. Still run
+    // the callback immediately if something does schedule (e.g. a non-zero
+    // flush cooldown), so previous->Run() cannot leave an unreplied executor.
     f.DirectBlockGroup->ScheduleHandler =
         [](TDuration delay, TCallback callback)
     {
-        Y_UNUSED(delay, callback);
+        Y_UNUSED(delay);
+        callback();
     };
     f.DirectBlockGroup->WriteBlocksToManyPBuffersHandler =
         f.GetManyPBuffersHandlerWithImmediateOkResponse();

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
@@ -1,0 +1,335 @@
+#include "../erase_request.h"
+#include "../flush_request.h"
+#include "../read_request_executor.h"
+#include "../restore_request.h"
+#include "../write_request_test_fixture.h"
+
+#include <ydb/library/actors/core/log.h>
+#include <ydb/library/services/services.pb.h>
+
+#include <benchmark/benchmark.h>
+
+using namespace NKikimr;
+using namespace NThreading;
+using namespace NYdb::NBS;
+using namespace NYdb::NBS::NBlockStore;
+using namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect;
+
+namespace {
+
+const TBlockRange64 BenchRange = TBlockRange64::WithLength(10, 1000);
+
+TRequestHeaders MakeHeaders(const TBlockRange64& range, ui32 blockSize)
+{
+    auto volumeConfig = std::make_shared<TVolumeConfig>(TVolumeConfig{
+        .DiskId = "disk-1",
+        .BlockSize = blockSize,
+        .BlockCount = 65536,
+        .BlocksPerStripe = 1024,
+        .VChunkSize = DefaultVChunkSize});
+
+    return TRequestHeaders{
+        .VolumeConfig = std::move(volumeConfig),
+        .RequestId = 1,
+        .Range = range};
+}
+
+std::shared_ptr<TWriteRequestBundle> MakeWriteBundle(
+    TWriteRequestTestFixture& f)
+{
+    auto originalRequest = std::make_shared<TWriteBlocksLocalRequest>(
+        MakeHeaders(f.Range, f.BlockSize));
+    originalRequest->Sglist = f.MakeSgList();
+
+    auto bundle = std::make_shared<TWriteRequestBundle>(
+        f.Runtime->GetActorSystem(0),
+        f.WriteClient,
+        std::move(originalRequest),
+        NWilson::TTraceId(),
+        MakeIntrusive<TCallContext>(),
+        f.Range);
+    bundle->SetLsn(f.UserLsn);
+    return bundle;
+}
+
+std::shared_ptr<TReadBlocksLocalRequest> MakeReadRequest(
+    TWriteRequestTestFixture& f)
+{
+    auto request = std::make_shared<TReadBlocksLocalRequest>(TRequestHeaders{
+        .VolumeConfig = f.PartitionDirectService->GetVolumeConfig(),
+        .RequestId = 1,
+        .Range = f.Range});
+    request->Sglist = f.MakeSgList();
+    return request;
+}
+
+void InitFixture(TWriteRequestTestFixture& f)
+{
+    f.Range = BenchRange;
+    f.Init();
+    f.Runtime->SetLogPriority(
+        NKikimrServices::NBS_PARTITION,
+        NActors::NLog::PRI_ERROR);
+
+    f.HedgeDelay = TDuration::Zero();
+    f.Timeout = TDuration::Zero();
+    f.DirectBlockGroup->Oracle.WriteHedgingDelay = f.HedgeDelay;
+    f.DirectBlockGroup->Oracle.WriteRequestTimeout = f.Timeout;
+    f.DirectBlockGroup->Oracle.WriteMode = EWriteMode::IndirectWrite;
+
+    // Run() must complete synchronously so drained executors can be destroyed.
+    f.DirectBlockGroup->ScheduleHandler =
+        [](TDuration delay, TCallback callback)
+    {
+        Y_UNUSED(delay, callback);
+    };
+    f.DirectBlockGroup->WriteBlocksToManyPBuffersHandler =
+        f.GetManyPBuffersHandlerWithImmediateOkResponse();
+    // Contiguous reads go to DDisk; dirty-map splits go to PBuffer.
+    auto immediateReadOk = [](auto&&...)
+    {
+        return MakeFuture(TDBGReadBlocksResponse{.Error = MakeError(S_OK)});
+    };
+    f.DirectBlockGroup->ReadBlocksFromDDiskHandler = immediateReadOk;
+    f.DirectBlockGroup->ReadBlocksFromPBufferHandler = immediateReadOk;
+    f.DirectBlockGroup->BatchEraseFromPBufferHandler =
+        [](THostIndex, const TEraseSegments&, const NWilson::TTraceId&)
+    {
+        return MakeFuture(TDBGEraseResponse{.Error = MakeError(S_OK)});
+    };
+    f.DirectBlockGroup->SyncWithPBufferHandler =
+        [](ui32,
+           THostIndex,
+           THostIndex,
+           const TVector<TPBufferSegment>&,
+           const NWilson::TTraceId&)
+    {
+        return MakeFuture(TDBGFlushResponse{.Errors = {MakeError(S_OK)}});
+    };
+    f.DirectBlockGroup->ListPBuffersHandler = [](THostIndex)
+    {
+        return MakeFuture(TListPBufferResponse{.Error = MakeError(S_OK)});
+    };
+
+    // Split the range so CreateReadRequestExecutor picks the multi-location
+    // path when MakeReadHint is called for BM_ReadMultiple*.
+    f.DirtyMap->RegisterInflightWrite(100, TBlockRange64::WithLength(20, 10));
+    f.DirtyMap->WriteFinished(
+        100,
+        TBlockRange64::WithLength(20, 10),
+        f.VChunkConfig.GetDesiredPBuffers(),
+        f.VChunkConfig.GetDesiredPBuffers());
+}
+
+}   // namespace
+
+// Setup (retire previous request, build inputs) is excluded via PauseTiming.
+
+static void BM_WriteRequestExecutorCreation(benchmark::State& state)
+{
+    TWriteRequestTestFixture fixture;
+    InitFixture(fixture);
+
+    TWriteRequestExecutorPtr previous;
+    for (auto _: state) {
+        state.PauseTiming();
+        if (previous) {
+            previous->Run();
+            previous.reset();
+        }
+        auto bundle = MakeWriteBundle(fixture);
+        state.ResumeTiming();
+
+        auto executor = CreateWriteRequestExecutor(
+            fixture.Runtime->GetActorSystem(0),
+            fixture.LogTitle,
+            fixture.VChunkConfig,
+            fixture.DirectBlockGroup,
+            std::move(bundle));
+        auto* executorPtr = &executor;
+        benchmark::DoNotOptimize(executorPtr);
+        previous = std::move(executor);
+    }
+    if (previous) {
+        previous->Run();
+    }
+}
+
+static void BM_ReadSingleLocationRequestExecutorCreation(
+    benchmark::State& state)
+{
+    TWriteRequestTestFixture fixture;
+    InitFixture(fixture);
+
+    // Contiguous hint: a fresh dirty map without the split registered above.
+    auto cleanDirtyMap = std::make_shared<TBlocksDirtyMap>(
+        fixture.VChunkConfig,
+        fixture.BlockSize,
+        fixture.VChunkBlockCount);
+
+    IReadRequestExecutorPtr previous;
+    for (auto _: state) {
+        state.PauseTiming();
+        if (previous) {
+            previous->Run();
+            previous.reset();
+        }
+        auto readHint = cleanDirtyMap->MakeReadHint(fixture.Range);
+        auto request = MakeReadRequest(fixture);
+        state.ResumeTiming();
+
+        auto executor = CreateReadRequestExecutor(
+            fixture.Runtime->GetActorSystem(0),
+            fixture.LogTitle,
+            fixture.VChunkConfig,
+            fixture.DirectBlockGroup,
+            std::move(readHint),
+            MakeIntrusive<TCallContext>(),
+            std::move(request),
+            NWilson::TTraceId());
+        auto* executorPtr = &executor;
+        benchmark::DoNotOptimize(executorPtr);
+        previous = std::move(executor);
+    }
+    if (previous) {
+        previous->Run();
+    }
+}
+
+static void BM_ReadMultipleLocationRequestExecutorCreation(
+    benchmark::State& state)
+{
+    TWriteRequestTestFixture fixture;
+    InitFixture(fixture);
+
+    IReadRequestExecutorPtr previous;
+    for (auto _: state) {
+        state.PauseTiming();
+        if (previous) {
+            previous->Run();
+            previous.reset();
+        }
+        auto readHint = fixture.DirtyMap->MakeReadHint(fixture.Range);
+        auto request = MakeReadRequest(fixture);
+        state.ResumeTiming();
+
+        auto executor = CreateReadRequestExecutor(
+            fixture.Runtime->GetActorSystem(0),
+            fixture.LogTitle,
+            fixture.VChunkConfig,
+            fixture.DirectBlockGroup,
+            std::move(readHint),
+            MakeIntrusive<TCallContext>(),
+            std::move(request),
+            NWilson::TTraceId());
+        auto* executorPtr = &executor;
+        benchmark::DoNotOptimize(executorPtr);
+        previous = std::move(executor);
+    }
+    if (previous) {
+        previous->Run();
+    }
+}
+
+static void BM_EraseRequestExecutorCreation(benchmark::State& state)
+{
+    TWriteRequestTestFixture fixture;
+    InitFixture(fixture);
+
+    std::shared_ptr<TEraseRequestExecutor> previous;
+    for (auto _: state) {
+        state.PauseTiming();
+        if (previous) {
+            previous->Run();
+            previous.reset();
+        }
+        TEraseHint hint;
+        hint.Segments.push_back(TEraseSegment{.Generation = 1, .Lsn = 42});
+        state.ResumeTiming();
+
+        auto executor = std::make_shared<TEraseRequestExecutor>(
+            fixture.Runtime->GetActorSystem(0),
+            fixture.LogTitle,
+            fixture.VChunkConfig,
+            fixture.DirectBlockGroup,
+            THostIndex{1},
+            std::move(hint),
+            NWilson::TSpan());
+        auto* executorPtr = &executor;
+        benchmark::DoNotOptimize(executorPtr);
+        previous = std::move(executor);
+    }
+    if (previous) {
+        previous->Run();
+    }
+}
+
+static void BM_FlushRequestExecutorCreation(benchmark::State& state)
+{
+    TWriteRequestTestFixture fixture;
+    InitFixture(fixture);
+
+    std::shared_ptr<TFlushRequestExecutor> previous;
+    for (auto _: state) {
+        state.PauseTiming();
+        if (previous) {
+            previous->Run();
+            previous.reset();
+        }
+        TFlushHint hint;
+        hint.Segments.push_back(TPBufferSegment{
+            .Lsn = 42,
+            .Range = TBlockRange64::WithLength(10, 3)});
+        state.ResumeTiming();
+
+        auto executor = std::make_shared<TFlushRequestExecutor>(
+            fixture.Runtime->GetActorSystem(0),
+            fixture.LogTitle,
+            fixture.VChunkConfig,
+            fixture.DirectBlockGroup,
+            THostRoute{.SourceHostIndex = 0, .DestinationHostIndex = 1},
+            std::move(hint),
+            NWilson::TSpan());
+        auto* executorPtr = &executor;
+        benchmark::DoNotOptimize(executorPtr);
+        previous = std::move(executor);
+    }
+    if (previous) {
+        previous->Run();
+    }
+}
+
+static void BM_RestoreRequestExecutorCreation(benchmark::State& state)
+{
+    TWriteRequestTestFixture fixture;
+    InitFixture(fixture);
+
+    std::shared_ptr<TRestoreRequestExecutor> previous;
+    for (auto _: state) {
+        state.PauseTiming();
+        if (previous) {
+            previous->Run();
+            previous.reset();
+        }
+        state.ResumeTiming();
+
+        auto executor = std::make_shared<TRestoreRequestExecutor>(
+            fixture.Runtime->GetActorSystem(0),
+            fixture.DirectBlockGroup);
+        auto* executorPtr = &executor;
+        benchmark::DoNotOptimize(executorPtr);
+        previous = std::move(executor);
+    }
+    if (previous) {
+        previous->Run();
+    }
+}
+
+BENCHMARK(BM_WriteRequestExecutorCreation)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_ReadSingleLocationRequestExecutorCreation)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_ReadMultipleLocationRequestExecutorCreation)
+    ->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_EraseRequestExecutorCreation)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_FlushRequestExecutorCreation)->Unit(benchmark::kNanosecond);
+BENCHMARK(BM_RestoreRequestExecutorCreation)->Unit(benchmark::kNanosecond);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/ya.make
@@ -1,0 +1,26 @@
+G_BENCHMARK(nbs_partition_direct_write_request_benchmark)
+
+SIZE(SMALL)
+
+# Keeps the case inside the SMALL test budget. Run the binary directly without
+# this option (or with a larger --benchmark_min_time) when comparing numbers.
+BENCHMARK_OPTS(--benchmark_min_time=0.05s)
+
+SRCS(
+    requests_benchmark.cpp
+    ../base_test_fixture.cpp
+    ../direct_block_group_mock.cpp
+    ../write_request_test_fixture.cpp
+)
+
+PEERDIR(
+    ydb/core/base
+    ydb/core/blobstorage/ut_blobstorage/lib
+    ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct
+    ydb/core/nbs/cloud/blockstore/libs/storage/storage_transport/testlib
+    ydb/core/nbs/cloud/blockstore/libs/storage/testlib
+    ydb/core/protos
+    ydb/core/testlib
+)
+
+END()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/ya.make
@@ -1,4 +1,4 @@
-G_BENCHMARK(nbs_partition_direct_write_request_benchmark)
+G_BENCHMARK(nbs_partition_direct_requests_creation_benchmark)
 
 SIZE(SMALL)
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/ya.make
@@ -64,6 +64,7 @@ RECURSE(
 )
 
 RECURSE_FOR_TESTS(
+    benchmark
     partition_ut
     ut
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Benchmarks for nbs2 requests creation.

```
Run on (96 X 1995.31 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x96)
  L1 Instruction 32 KiB (x96)
  L2 Unified 4096 KiB (x48)
  L3 Unified 16384 KiB (x2)
Load Average: 2.04, 2.18, 1.78
------ sole chunk ran 6 tests (total:2.13s - test:2.11s)
Info: 
-----------------------------------------------------------------------------------------
Benchmark                                               Time             CPU   Iterations
-----------------------------------------------------------------------------------------
BM_WriteRequestExecutorCreation                      1203 ns         1193 ns        57875
BM_ReadSingleLocationRequestExecutorCreation         1324 ns         1322 ns        50202
BM_ReadMultipleLocationRequestExecutorCreation       4480 ns         4477 ns        15198
BM_EraseRequestExecutorCreation                      1001 ns         1005 ns        68672
BM_FlushRequestExecutorCreation                      1137 ns         1140 ns        59202
BM_RestoreRequestExecutorCreation                     375 ns          376 ns       181982
```
