### PR TITLE
Wait for login security state publication

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard__operation_alter_login.cpp
@@ -220,6 +220,9 @@ public:
             domainPtr->IncSecurityStateVersion();
             context.SS->PersistSubDomainSecurityStateVersion(db, subDomainPathId, *domainPtr);
             context.OnComplete.PublishToSchemeBoard(OperationId, subDomainPathId);
+
+            // Wait until the updated security state is observable through SchemeCache.
+            result->SetStatus(NKikimrScheme::StatusAccepted);
         }
 
         context.OnComplete.DoneOperation(OperationId);

--- a/ydb/core/tx/schemeshard/ut_helpers/helpers.h
+++ b/ydb/core/tx/schemeshard/ut_helpers/helpers.h
@@ -661,25 +661,25 @@ namespace NSchemeShardUT_Private {
 
     void CreateAlterLoginCreateUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user, const TString& hashedPassword,
-        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     void CreateAlterLoginRemoveUser(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& user,
-        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     void CreateAlterLoginCreateGroup(TTestActorRuntime& runtime, ui64 txId, const TString& database,
-        const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+        const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     void CreateAlterLoginRemoveGroup(TTestActorRuntime& runtime, ui64 txId, const TString& database,
-        const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+        const TString& group, const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     void AlterLoginAddGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& member, const TString& group,
-        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     void AlterLoginRemoveGroupMembership(TTestActorRuntime& runtime, ui64 txId, const TString& database,
         const TString& member, const TString& group,
-        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusSuccess}});
+        const TVector<TExpectedResult>& expectedResults = {{NKikimrScheme::StatusAccepted}});
 
     NKikimrScheme::TEvLoginResult LoginExternal(TTestActorRuntime& runtime, const TString& user);
 

--- a/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
+++ b/ydb/core/tx/schemeshard/ut_login/ut_login.cpp
@@ -101,6 +101,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
         const auto user1Hashes = MakeTestPasswordHashes("password1");
         CreateAlterLoginCreateUser(runtime, ++txId, "/MyRoot", "user1", user1Hashes.HashedPassword);
+        env.TestWaitNotification(runtime, txId);
 
         {
             auto describe = DescribePath(runtime, TTestTxConfig::SchemeShard, "/MyRoot");
@@ -214,7 +215,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
             AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
             TestModificationResults(runtime, txId, TVector<TExpectedResult>{{
-                missingOk ? NKikimrScheme::StatusSuccess : NKikimrScheme::StatusPreconditionFailed,
+                missingOk ? NKikimrScheme::StatusAccepted : NKikimrScheme::StatusPreconditionFailed,
                 missingOk ? "" : "User not found"
             }});
         }
@@ -423,7 +424,7 @@ Y_UNIT_TEST_SUITE(TSchemeShardLoginTest) {
 
             AsyncSend(runtime, TTestTxConfig::SchemeShard, modifyTx.release());
             TestModificationResults(runtime, txId, TVector<TExpectedResult>{{
-                missingOk ? NKikimrScheme::StatusSuccess : NKikimrScheme::StatusPreconditionFailed,
+                missingOk ? NKikimrScheme::StatusAccepted : NKikimrScheme::StatusPreconditionFailed,
                 missingOk ? "" : "Group not found"
             }});
         }


### PR DESCRIPTION
## Summary

- return `StatusAccepted` for successful AlterLogin operations after scheduling the security state publication
- update SchemeShard login test expectations for the asynchronous completion contract
- wait for transaction completion before checking the published security state in `UserLogin1`

## Root cause

AlterLogin updated the SchemeShard login provider and returned `StatusSuccess` before `PublishToSchemeBoard` completed. KQP treated that response as `ExecComplete`, so an immediate authentication request could resolve the database through SchemeCache while it still contained the previous security state and fail with `Unauthorized`.

Returning `StatusAccepted` makes the scheme operation handler subscribe to transaction completion. The client now observes successful completion only after the updated security state has been published.

This race was observed in the YDB .NET SDK integration test `DisableDiscovery_WhenUserIsCreatedAndPropertyIsTrue_SimpleWorking`:
https://github.com/ydb-platform/ydb-dotnet-sdk/actions/runs/31022179361/job/92361424017

## Impact

This removes the transient authorization failure when a newly created user authenticates immediately after `CREATE USER`. No client-side retry is required.
