### PR TITLE
[NBS-7510, NBS-7512] Implement DbsController DDiskMap API, part 1

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_actor.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_actor.cpp
@@ -153,6 +153,15 @@ STFUNC(TDbsControllerActor::StateWork)
         HFunc(TEvTabletPipe::TEvServerConnected, HandleServerConnected);
         HFunc(TEvTabletPipe::TEvServerDisconnected, HandleServerDisconnected);
         HFunc(TEvTabletPipe::TEvServerDestroyed, HandleServerDestroyed);
+        HFunc(
+            TEvDbsControllerPrivate::TEvUpdateDDiskMapRequest,
+            HandleUpdateDDiskMapRequest);
+        HFunc(
+            TEvDbsControllerPrivate::TEvGetNodesForPartitionRequest,
+            HandleGetNodesForPartitionRequest);
+        HFunc(
+            TEvDbsControllerPrivate::TEvGetPartitionsForNodeRequest,
+            HandleGetPartitionsForNodeRequest);
 
         default:
             if (!HandleDefaultEvents(ev, SelfId())) {

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_actor.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_actor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dbs_controller_counters.h"
+#include "dbs_controller_events_private.h"
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/core/tablet.h>
 
@@ -61,6 +62,18 @@ private:
         const NActors::TActorContext& ctx);
 
     void ReportTabletState(const NActors::TActorContext& ctx);
+
+    void HandleUpdateDDiskMapRequest(
+        const TEvDbsControllerPrivate::TEvUpdateDDiskMapRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleGetNodesForPartitionRequest(
+        const TEvDbsControllerPrivate::TEvGetNodesForPartitionRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
+
+    void HandleGetPartitionsForNodeRequest(
+        const TEvDbsControllerPrivate::TEvGetPartitionsForNodeRequest::TPtr& ev,
+        const NActors::TActorContext& ctx);
 
     BLOCKSTORE_DBS_CONTROLLER_TRANSACTIONS(
         BLOCKSTORE_IMPLEMENT_TRANSACTION,

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_database.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_database.h
@@ -12,9 +12,6 @@ namespace NYdb::NBS::NBlockStore::NStorage::NDbsController {
 
 class TDbsControllerDatabase: public NKikimr::NIceDb::TNiceDb
 {
-    using TDbsControllerState =
-        ::NYdb::NBS::DbsController::NProto::TDbsControllerState;
-
 public:
     TDbsControllerDatabase(NKikimr::NTable::TDatabase& database)
         : NKikimr::NIceDb::TNiceDb(database)

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_events_private.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_events_private.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <ydb/core/nbs/cloud/blockstore/libs/kikimr/events.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/dbs_controller.pb.h>
+
+#include <ydb/core/base/events.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NDbsController {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Offset for the DbsController tablet's private events within
+// ES_NBS_V2_SERVICE, kept clear of the public TEvService event IDs.
+constexpr ui32 PrivateEventsOffset = 2000;
+
+struct TEvDbsControllerPrivate
+{
+    enum EEvents
+    {
+        EvBegin = EventSpaceBegin(NKikimr::TKikimrEvents::ES_NBS_V2_SERVICE) +
+                  PrivateEventsOffset,
+
+        EvUpdateDDiskMapRequest,
+        EvUpdateDDiskMapResponse,
+
+        EvGetPartitionsForNodeRequest,
+        EvGetPartitionsForNodeResponse,
+
+        EvGetNodesForPartitionRequest,
+        EvGetNodesForPartitionResponse,
+
+        EvEnd,
+    };
+
+    BLOCKSTORE_DECLARE_PROTO_EVENTS(UpdateDDiskMap)
+    BLOCKSTORE_DECLARE_PROTO_EVENTS(GetPartitionsForNode)
+    BLOCKSTORE_DECLARE_PROTO_EVENTS(GetNodesForPartition)
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NDbsController

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_query.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_query.cpp
@@ -1,0 +1,49 @@
+#include "dbs_controller_actor.h"
+
+#include <ydb/core/nbs/cloud/storage/core/libs/actors/helpers.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NDbsController {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDbsControllerActor::HandleGetNodesForPartitionRequest(
+    const TEvDbsControllerPrivate::TEvGetNodesForPartitionRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO_S(
+        ctx,
+        NKikimrServices::DBS_CONTROLLER,
+        "Handle GetNodesForPartition request"
+            << ", tabletId: " << ev->Get()->Record.GetPartitionTabletId());
+
+    // TODO Dummy
+    Reply(
+        ctx,
+        *ev,
+        std::make_unique<
+            TEvDbsControllerPrivate::TEvGetNodesForPartitionResponse>(
+            MakeError(S_OK)));
+}
+
+void TDbsControllerActor::HandleGetPartitionsForNodeRequest(
+    const TEvDbsControllerPrivate::TEvGetPartitionsForNodeRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO_S(
+        ctx,
+        NKikimrServices::DBS_CONTROLLER,
+        "Handle GetPartitionsForNode request" << ", tabletId: "
+                                              << ev->Get()->Record.GetNodeId());
+
+    // TODO Dummy
+    Reply(
+        ctx,
+        *ev,
+        std::make_unique<
+            TEvDbsControllerPrivate::TEvGetPartitionsForNodeResponse>(
+            MakeError(S_OK)));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NDbsController

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_query.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_query.cpp
@@ -32,7 +32,7 @@ void TDbsControllerActor::HandleGetPartitionsForNodeRequest(
     LOG_INFO_S(
         ctx,
         NKikimrServices::DBS_CONTROLLER,
-        "Handle GetPartitionsForNode request" << ", tabletId: "
+        "Handle GetPartitionsForNode request" << ", nodeId: "
                                               << ev->Get()->Record.GetNodeId());
 
     // TODO Dummy

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_schema.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_schema.h
@@ -11,21 +11,23 @@ namespace NYdb::NBS::NBlockStore::NStorage::NDbsController {
 
 struct TDbsControllerSchema: public NKikimr::NIceDb::Schema
 {
-    struct Dummy: public TTableSchema<1>
-    {
-        struct DummyA: public Column<1, NKikimr::NScheme::NTypeIds::Uint32>
-        {
-        };
+    struct DDiskMap : Table<1> {
+        struct TabletId : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
 
-        struct DummyB: public Column<2, NKikimr::NScheme::NTypeIds::Uint32>
-        {
-        };
+        // DDiskId.NodeId
+        struct NodeId : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
 
-        using TKey = TableKey<DummyA>;
-        using TColumns = TableColumns<DummyA, DummyB>;
+        // DDiskId.PDiskId
+        struct PDiskId : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
+
+        // DDiskId.DDiskSlotId
+        struct DDiskSlotId : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
+
+        using TKey = TableKey<TabletId, NodeId, PDiskId, DDiskSlotId>;
+        using TColumns = TableColumns<TabletId, NodeId, PDiskId, DDiskSlotId>;
     };
 
-    using TTables = SchemaTables<Dummy>;
+    using TTables = SchemaTables<DDiskMap>;
 
     using TSettings =
         SchemaSettings<ExecutorLogBatching<true>, ExecutorLogFlushPeriod<0>>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_schema.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_schema.h
@@ -52,7 +52,8 @@ struct TDbsControllerSchema: public NKikimr::NIceDb::Schema
             DirectBlockGroupId,
             NodeId,
             PDiskId,
-            DDiskSlotId>;
+            DDiskSlotId,
+            IsPBuffer>;
     };
 
     struct InverseDDiskMap: TTableSchema<2>
@@ -81,7 +82,7 @@ struct TDbsControllerSchema: public NKikimr::NIceDb::Schema
         using TColumns = TableColumns<NodeId, PDiskId, DDiskSlotId, TabletId>;
     };
 
-    using TTables = SchemaTables<DDiskMap>;
+    using TTables = SchemaTables<DDiskMap, InverseDDiskMap>;
 
     using TSettings =
         SchemaSettings<ExecutorLogBatching<true>, ExecutorLogFlushPeriod<0>>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_schema.h
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_schema.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ydb/core/nbs/cloud/blockstore/libs/storage/core/tablet_schema.h>
-#include <ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/dbs_controller.pb.h>
 
 #include <ydb/core/tablet_flat/flat_cxx_database.h>
 
@@ -11,20 +10,75 @@ namespace NYdb::NBS::NBlockStore::NStorage::NDbsController {
 
 struct TDbsControllerSchema: public NKikimr::NIceDb::Schema
 {
-    struct DDiskMap : Table<1> {
-        struct TabletId : Column<1, NKikimr::NScheme::NTypeIds::Uint64> {};
+    struct DDiskMap: TTableSchema<1>
+    {
+        struct TabletId: Column<1, NKikimr::NScheme::NTypeIds::Uint64>
+        {
+        };
+
+        // Unique within TabletId
+        struct DirectBlockGroupId: Column<2, NKikimr::NScheme::NTypeIds::Uint64>
+        {
+        };
 
         // DDiskId.NodeId
-        struct NodeId : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct NodeId: Column<3, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
 
         // DDiskId.PDiskId
-        struct PDiskId : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct PDiskId: Column<4, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
 
         // DDiskId.DDiskSlotId
-        struct DDiskSlotId : Column<1, NKikimr::NScheme::NTypeIds::Uint32> {};
+        struct DDiskSlotId: Column<5, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
 
-        using TKey = TableKey<TabletId, NodeId, PDiskId, DDiskSlotId>;
-        using TColumns = TableColumns<TabletId, NodeId, PDiskId, DDiskSlotId>;
+        struct IsPBuffer: Column<6, NKikimr::NScheme::NTypeIds::Bool>
+        {
+        };
+
+        using TKey = TableKey<
+            TabletId,
+            DirectBlockGroupId,
+            NodeId,
+            PDiskId,
+            DDiskSlotId>;
+
+        using TColumns = TableColumns<
+            TabletId,
+            DirectBlockGroupId,
+            NodeId,
+            PDiskId,
+            DDiskSlotId>;
+    };
+
+    struct InverseDDiskMap: TTableSchema<2>
+    {
+        // DDiskId.NodeId
+        struct NodeId: Column<1, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
+
+        // DDiskId.PDiskId
+        struct PDiskId: Column<2, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
+
+        // DDiskId.DDiskSlotId
+        struct DDiskSlotId: Column<3, NKikimr::NScheme::NTypeIds::Uint32>
+        {
+        };
+
+        struct TabletId: Column<4, NKikimr::NScheme::NTypeIds::Uint64>
+        {
+        };
+
+        using TKey = TableKey<NodeId, PDiskId, DDiskSlotId, TabletId>;
+
+        using TColumns = TableColumns<NodeId, PDiskId, DDiskSlotId, TabletId>;
     };
 
     using TTables = SchemaTables<DDiskMap>;

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_update_ddisk_map.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/dbs_controller_update_ddisk_map.cpp
@@ -1,0 +1,29 @@
+#include "dbs_controller_actor.h"
+
+#include <ydb/core/nbs/cloud/storage/core/libs/actors/helpers.h>
+
+namespace NYdb::NBS::NBlockStore::NStorage::NDbsController {
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TDbsControllerActor::HandleUpdateDDiskMapRequest(
+    const TEvDbsControllerPrivate::TEvUpdateDDiskMapRequest::TPtr& ev,
+    const NActors::TActorContext& ctx)
+{
+    LOG_INFO_S(
+        ctx,
+        NKikimrServices::DBS_CONTROLLER,
+        "Handle UpdateDDiskMap request" << ", tabletId: "
+                                        << ev->Get()->Record.GetTabletId());
+
+    // TODO Dummy
+    Reply(
+        ctx,
+        *ev,
+        std::make_unique<TEvDbsControllerPrivate::TEvUpdateDDiskMapResponse>(
+            MakeError(S_OK)));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+}   // namespace NYdb::NBS::NBlockStore::NStorage::NDbsController

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/dbs_controller.proto
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/dbs_controller.proto
@@ -1,10 +1,72 @@
 syntax = "proto3";
 
-package NYdb.NBS.DbsController.NProto;
+import "ydb/core/protos/blobstorage_ddisk.proto";
+
+import "ydb/core/nbs/cloud/storage/core/protos/error.proto";
+
+package NYdb.NBS.NBlockStore.NStorage.NDbsController.NProto;
 option java_package = "ru.yandex.ydb.core.nbs.dbs_controller.proto";
 
-// Persisted controller state. Placeholder for now - fill with real fields as
-// the tablet gains functionality.
-message TDbsControllerState {
-  uint64 Version = 1;
+
+//
+// Структура с описанием зависимостей Partition от DDisk-ов (включая PBuffer-ы)
+// Уважает DirectBlockGroup-ы
+//
+message TDirectBlockGroupDDisks {
+  message TDDiskIds {
+    NKikimrBlobStorage.NDDisk.TDDiskId DDisk = 1;
+    NKikimrBlobStorage.NDDisk.TDDiskId PersistentBuffer = 2;
+  }
+  repeated TDDiskIds DDiskIds = 1;
 }
+
+message TPartitionDDisks {
+  repeated TDirectBlockGroupDDisks DirectBlockGroupsDDisks = 1;
+}
+
+//
+// Запрос на обновление отношений в Rel(DDiskId, TabletId)
+// для данной таблетки.
+// Все тройки (TabletId, DirectBlockGroupId, DDiskId), содержащиеся в PartitionDDisks запроса,
+// добавляются в отношение с сохранением информации о типе DDisk (обычный или PBuffer).
+// Все тройки (TabletId, DirectBlockGroupId, DDiskId) с TabletId запроса,
+// не содержащиеся в PartitionDDisks запроса, удаляются из отношения.
+//
+message TUpdateDDiskMapRequest {
+  uint64 TabletId = 1;                  // Id таблетки partition
+  TPartitionDDisks PartitionDDisks = 2; // Список DDisk-ов, от которых зависит partition
+}
+
+message TUpdateDDiskMapResponse {
+  NYdb.NBS.NProto.TError Error = 1;
+}
+
+//
+// GetPartitionsForNode
+//
+message TGetPartitionsForNodeRequest
+{
+  uint32 NodeId = 1;
+}
+
+message TGetPartitionsForNodeResponse
+{
+  NYdb.NBS.NProto.TError Error = 1;
+
+  repeated uint64 Partitions = 2;
+};
+
+//
+// GetNodesForPartition
+//
+message TGetNodesForPartitionRequest
+{
+  uint64 PartitionTabletId = 1;
+};
+
+message TGetNodesForPartitionResponse
+{
+  NYdb.NBS.NProto.TError Error = 1;
+
+  repeated uint32 Nodes = 2;
+};

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/dbs_controller.proto
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/dbs_controller.proto
@@ -54,7 +54,7 @@ message TGetPartitionsForNodeResponse
   NYdb.NBS.NProto.TError Error = 1;
 
   repeated uint64 Partitions = 2;
-};
+}
 
 //
 // GetNodesForPartition
@@ -62,11 +62,11 @@ message TGetPartitionsForNodeResponse
 message TGetNodesForPartitionRequest
 {
   uint64 PartitionTabletId = 1;
-};
+}
 
 message TGetNodesForPartitionResponse
 {
   NYdb.NBS.NProto.TError Error = 1;
 
   repeated uint32 Nodes = 2;
-};
+}

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/protos/ya.make
@@ -9,4 +9,9 @@ SRCS(
     dbs_controller.proto
 )
 
+PEERDIR(
+    ydb/core/nbs/cloud/storage/core/protos
+    ydb/core/protos
+)
+
 END()

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/ut/dbs_controller_ut.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/ut/dbs_controller_ut.cpp
@@ -30,6 +30,111 @@ Y_UNIT_TEST_SUITE(TDbsControllerTest)
         options.FinalEvents.emplace_back(TEvTablet::EvBoot, 1);
         runtime.DispatchEvents(options);
     }
+
+    Y_UNIT_TEST(ShouldHandleUpdateDDiskMapRequest)
+    {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        const ui64 tabletId = MakeTabletID(0, 0, 1);
+
+        {
+            CreateTestBootstrapper(
+                runtime,
+                CreateTestTabletInfo(tabletId, TTabletTypes::DbsController),
+                [](const TActorId& tablet, TTabletStorageInfo* info) -> IActor*
+                { return new TDbsControllerActor(tablet, info); });
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvTablet::EvBoot, 1);
+            runtime.DispatchEvents(options);
+        }
+
+        {
+            auto request = std::make_unique<
+                TEvDbsControllerPrivate::TEvUpdateDDiskMapRequest>();
+            request->Record.SetTabletId(1);
+
+            const TActorId& edge = runtime.AllocateEdgeActor();
+
+            runtime.SendToPipe(tabletId, edge, request.release());
+
+            auto response = runtime.GrabEdgeEvent<
+                TEvDbsControllerPrivate::TEvUpdateDDiskMapResponse>();
+
+            UNIT_ASSERT(!HasError(response->GetError()));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleGetNodesForPartitionRequest)
+    {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        const ui64 tabletId = MakeTabletID(0, 0, 1);
+
+        {
+            CreateTestBootstrapper(
+                runtime,
+                CreateTestTabletInfo(tabletId, TTabletTypes::DbsController),
+                [](const TActorId& tablet, TTabletStorageInfo* info) -> IActor*
+                { return new TDbsControllerActor(tablet, info); });
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvTablet::EvBoot, 1);
+            runtime.DispatchEvents(options);
+        }
+
+        {
+            auto request = std::make_unique<
+                TEvDbsControllerPrivate::TEvGetNodesForPartitionRequest>();
+            request->Record.SetPartitionTabletId(1);
+
+            const TActorId& edge = runtime.AllocateEdgeActor();
+
+            runtime.SendToPipe(tabletId, edge, request.release());
+
+            auto response = runtime.GrabEdgeEvent<
+                TEvDbsControllerPrivate::TEvGetNodesForPartitionResponse>();
+
+            UNIT_ASSERT(!HasError(response->GetError()));
+        }
+    }
+
+    Y_UNIT_TEST(ShouldHandleGetPartitionsForNodeRequest)
+    {
+        TTestBasicRuntime runtime;
+        SetupTabletServices(runtime);
+
+        const ui64 tabletId = MakeTabletID(0, 0, 1);
+
+        {
+            CreateTestBootstrapper(
+                runtime,
+                CreateTestTabletInfo(tabletId, TTabletTypes::DbsController),
+                [](const TActorId& tablet, TTabletStorageInfo* info) -> IActor*
+                { return new TDbsControllerActor(tablet, info); });
+
+            TDispatchOptions options;
+            options.FinalEvents.emplace_back(TEvTablet::EvBoot, 1);
+            runtime.DispatchEvents(options);
+        }
+
+        {
+            auto request = std::make_unique<
+                TEvDbsControllerPrivate::TEvGetPartitionsForNodeRequest>();
+            request->Record.SetNodeId(1);
+
+            const TActorId& edge = runtime.AllocateEdgeActor();
+
+            runtime.SendToPipe(tabletId, edge, request.release());
+
+            auto response = runtime.GrabEdgeEvent<
+                TEvDbsControllerPrivate::TEvGetPartitionsForNodeResponse>();
+
+            UNIT_ASSERT(!HasError(response->GetError()));
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/dbs_controller/ya.make
@@ -4,6 +4,8 @@ SRCS(
     dbs_controller.cpp
     dbs_controller_actor.cpp
     dbs_controller_database.cpp
+    dbs_controller_query.cpp
+    dbs_controller_update_ddisk_map.cpp
     dbs_initschema.cpp
     dbs_loadstate.cpp
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- Созданы таблицы локальной базы DbsController для прямого и обратного отображения DDiskMap
- Созданы Protobuf сообщения + ивенты:
   - TUpdateDDiskMap* -- обновление DDiskMap -- для Partition
   - TGetPartitionsForNode*/TGetNodesForPartition -- query отношения по TabletId и NodeId  -- техническое API
- Созданы заглушки обработчиков этих инвентов

### Description for reviewers <!-- (optional) description for those who read this PR -->

Реализация DbsController API по DDiskMap: API, по которому Partition будет уведомлять DbsController о своих отношениях с DDisk-ами и PBuffer-ами

Часть 1, изменения разделены на несколько PR для упрощения процесса ревью