### PR TITLE
Make VDisk DB stats actor interruptable

### DIFF
--- a/ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "hull_ds_all_snap.h"
+
+namespace NKikimr {
+
+    struct TEvTakeHullSnapshot :
+        public TEventLocal<TEvTakeHullSnapshot, TEvBlobStorage::EvTakeHullSnapshot>
+    {
+        const bool Index;
+
+        explicit TEvTakeHullSnapshot(bool index)
+            : Index(index)
+        {}
+    };
+
+    struct TEvTakeHullSnapshotResult :
+        public TEventLocal<TEvTakeHullSnapshotResult, TEvBlobStorage::EvTakeHullSnapshot>
+    {
+        THullDsSnap Snap;
+
+        explicit TEvTakeHullSnapshotResult(THullDsSnap&& snap)
+            : Snap(std::move(snap))
+        {}
+    };
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h
+++ b/ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h
@@ -15,7 +15,7 @@ namespace NKikimr {
     };
 
     struct TEvTakeHullSnapshotResult :
-        public TEventLocal<TEvTakeHullSnapshotResult, TEvBlobStorage::EvTakeHullSnapshot>
+        public TEventLocal<TEvTakeHullSnapshotResult, TEvBlobStorage::EvTakeHullSnapshotResult>
     {
         THullDsSnap Snap;
 

--- a/ydb/core/blobstorage/vdisk/hulldb/ya.make
+++ b/ydb/core/blobstorage/vdisk/hulldb/ya.make
@@ -17,6 +17,7 @@ SRCS(
     blobstorage_hullgcmap.h
     hull_ds_all.h
     hull_ds_all_snap.h
+    hull_ds_all_snap_events.h
 )
 
 END()

--- a/ydb/core/blobstorage/vdisk/query/query_public.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_public.cpp
@@ -180,8 +180,7 @@ namespace NKikimr {
                 return new TDumpActor(hullCtx, parentId, std::move(levelSnap), ev, std::move(result));
             }
             case NKikimrBlobStorage::StatDb: {
-                using TStatActor = TLevelIndexStatActor<TKey, TMemRec>;
-                return new TStatActor(hullCtx, parentId, std::move(levelSnap), ev, std::move(result));
+                return CreateLevelIndexStatActor(hullCtx, parentId, std::move(levelSnap), ev, std::move(result));
             }
             default: {
                 DbStatError(hullCtx->VCtx, ctx, ev, std::move(result));
@@ -199,9 +198,7 @@ namespace NKikimr {
             TEvGetLogoBlobIndexStatRequest::TPtr &ev,
             std::unique_ptr<TEvGetLogoBlobIndexStatResponse> result)
     {
-        using TStatActorEx = TLevelIndexStatActor<TKey, TMemRec,
-                TEvGetLogoBlobIndexStatRequest, TEvGetLogoBlobIndexStatResponse>;
-        return new TStatActorEx(hullCtx, parentId, std::move(levelSnap), ev, std::move(result));
+        return CreateLevelIndexStatActor(hullCtx, parentId, std::move(levelSnap), ev, std::move(result));
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
+++ b/ydb/core/blobstorage/vdisk/query/query_stat_yield.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "defs.h"
+
+#include <ydb/core/util/actor_monotonic_time_provider.h>
+
+#include <optional>
+
+namespace NKikimr {
+
+    struct TDbStatYieldPolicy {
+        ui64 StepsBeforeMeasures = 100'000;
+        TDuration QuantumDuration = TDuration::MilliSeconds(50);
+        TDuration DelayBetweenQuanta = TDuration::MilliSeconds(100);
+    };
+
+    class TDbStatYieldChecker {
+    public:
+        TDbStatYieldChecker(
+                std::optional<TDbStatYieldPolicy> policy,
+                TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
+            : Policy(std::move(policy))
+            , MonotonicTimeProvider(std::move(monotonicTimeProvider))
+        {
+            if (Policy) {
+                if (!MonotonicTimeProvider) {
+                    MonotonicTimeProvider = CreateActorSystemMonotonicTimeProvider();
+                }
+                QuantumStart = MonotonicTimeProvider->Now();
+            }
+        }
+
+        bool StepAndCheckForYield() {
+            if (!Policy || !Policy->StepsBeforeMeasures || ++Steps < Policy->StepsBeforeMeasures) {
+                return false;
+            }
+
+            Steps = 0;
+            const TMonotonic now = MonotonicTimeProvider->Now();
+            if (now - QuantumStart > Policy->QuantumDuration) {
+                QuantumStart = now;
+                return true;
+            }
+            return false;
+        }
+
+    private:
+        std::optional<TDbStatYieldPolicy> Policy;
+        TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> MonotonicTimeProvider;
+        TMonotonic QuantumStart = TMonotonic::Zero();
+        ui64 Steps = 0;
+    };
+
+    template <class TKey, class TMemRec>
+    struct TDbStatYieldedState {
+        // The last key fully processed by the previous quantum. TMemRec remains
+        // a template parameter to keep the traversal interface tied to a DB type.
+        TKey LastProcessedKey;
+    };
+
+} // namespace NKikimr

--- a/ydb/core/blobstorage/vdisk/query/query_statalgo.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statalgo.h
@@ -1,11 +1,41 @@
 #pragma once
 
 #include "defs.h"
+#include "query_stat_yield.h"
+
+#include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_heap_it.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
 
 #include <util/stream/length.h>
 
 namespace NKikimr {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TDbStatRecordMerger
+    // Passes every physical record for the current key to a DB-stat aggregator.
+    ////////////////////////////////////////////////////////////////////////////
+    template <class TAggr, class TKey, class TMemRec>
+    class TDbStatRecordMerger {
+    public:
+        explicit TDbStatRecordMerger(TAggr* aggr)
+            : Aggr(aggr)
+        {}
+
+        void AddFromFresh(const TMemRec& memRec, const TRope*, const TKey& key, ui64) {
+            Aggr->Update(key, memRec);
+        }
+
+        void AddFromSegment(const TMemRec& memRec, const TDiskPart*, const TKey& key, ui64, const void*) {
+            Aggr->Update(key, memRec);
+        }
+
+        static constexpr bool HaveToMergeData() {
+            return false;
+        }
+
+    private:
+        TAggr* Aggr;
+    };
 
     ////////////////////////////////////////////////////////////////////////////
     // TraverseDbWithoutMerge
@@ -57,6 +87,54 @@ namespace NKikimr {
         }
 
         aggr->Finish();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TraverseDbWithoutMerge with yielding
+    //
+    // Traverses all physical records in reverse key order. Every quantum
+    // processes at least one complete key before checking whether to yield.
+    // The returned key is independent of a snapshot and can therefore be used
+    // to resume after the old snapshot is released and a new one is acquired.
+    ////////////////////////////////////////////////////////////////////////////
+    template <class TAggr, class TKey, class TMemRec>
+    std::optional<TDbStatYieldedState<TKey, TMemRec>> TraverseDbWithoutMerge(
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            TAggr* aggr,
+            const ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>& snap,
+            std::optional<TDbStatYieldedState<TKey, TMemRec>> yieldedState,
+            std::optional<TDbStatYieldPolicy> yieldPolicy,
+            TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> monotonicTimeProvider = {})
+    {
+        using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
+        using TBackwardIterator = typename TLevelIndexSnapshot<TKey, TMemRec>::TBackwardIterator;
+
+        TBackwardIterator iterator(hullCtx, &snap);
+        THeapIterator<TKey, TMemRec, false> heap(&iterator);
+        if (yieldedState) {
+            heap.Seek(yieldedState->LastProcessedKey);
+            // The saved key was completely processed in the previous quantum.
+            if (heap.Valid() && heap.GetCurKey() == yieldedState->LastProcessedKey) {
+                heap.Prev();
+            }
+        } else {
+            heap.SeekToLast();
+        }
+
+        TDbStatRecordMerger<TAggr, TKey, TMemRec> merger(aggr);
+        TDbStatYieldChecker yieldChecker(std::move(yieldPolicy), std::move(monotonicTimeProvider));
+        while (heap.Valid()) {
+            const TKey key = heap.GetCurKey();
+            heap.PutToMergerAndAdvance(&merger);
+
+            // Do not yield after the final key; finish in the current quantum.
+            if (heap.Valid() && yieldChecker.StepAndCheckForYield()) {
+                return TYieldedState{key};
+            }
+        }
+
+        aggr->Finish();
+        return std::nullopt;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.cpp
@@ -253,40 +253,36 @@ namespace NKikimr {
     }
 
     template <class TKey, class TMemRec>
-    concept CLogoBlobsDb = std::same_as<TKey, TKeyLogoBlob> && std::same_as<TMemRec, TMemRecLogoBlob>;
+    concept CStatDb =
+        (std::same_as<TKey, TKeyLogoBlob> && std::same_as<TMemRec, TMemRecLogoBlob>) ||
+        (std::same_as<TKey, TKeyBlock> && std::same_as<TMemRec, TMemRecBlock>) ||
+        (std::same_as<TKey, TKeyBarrier> && std::same_as<TMemRec, TMemRecBarrier>);
 
     template <class TKey, class TMemRec>
-    concept CBlocksDb = std::same_as<TKey, TKeyBlock> && std::same_as<TMemRec, TMemRecBlock>;
-
-    template <class TKey, class TMemRec>
-    concept CBarriersDb = std::same_as<TKey, TKeyBarrier> && std::same_as<TMemRec, TMemRecBarrier>;
-
-    template <class TKey, class TMemRec>
-    concept CStatDb = CLogoBlobsDb<TKey, TMemRec> || CBlocksDb<TKey, TMemRec> || CBarriersDb<TKey, TMemRec>;
-
-    template <class TKey, class TMemRec>
-        requires CLogoBlobsDb<TKey, TMemRec>
     void EmplaceSnapshot(
             std::optional<TLevelIndexSnapshot<TKey, TMemRec>>& snapshot,
-            THullDsSnap& fullSnapshot)
+            THullDsSnap&& fullSnapshot);
+
+    template <>
+    void EmplaceSnapshot<TKeyLogoBlob, TMemRecLogoBlob>(
+            std::optional<TLevelIndexSnapshot<TKeyLogoBlob, TMemRecLogoBlob>>& snapshot,
+            THullDsSnap&& fullSnapshot)
     {
         snapshot.emplace(std::move(fullSnapshot.LogoBlobsSnap));
     }
 
-    template <class TKey, class TMemRec>
-        requires CBlocksDb<TKey, TMemRec>
-    void EmplaceSnapshot(
-            std::optional<TLevelIndexSnapshot<TKey, TMemRec>>& snapshot,
-            THullDsSnap& fullSnapshot)
+    template <>
+    void EmplaceSnapshot<TKeyBlock, TMemRecBlock>(
+            std::optional<TLevelIndexSnapshot<TKeyBlock, TMemRecBlock>>& snapshot,
+            THullDsSnap&& fullSnapshot)
     {
         snapshot.emplace(std::move(fullSnapshot.BlocksSnap));
     }
 
-    template <class TKey, class TMemRec>
-        requires CBarriersDb<TKey, TMemRec>
-    void EmplaceSnapshot(
-            std::optional<TLevelIndexSnapshot<TKey, TMemRec>>& snapshot,
-            THullDsSnap& fullSnapshot)
+    template <>
+    void EmplaceSnapshot<TKeyBarrier, TMemRecBarrier>(
+            std::optional<TLevelIndexSnapshot<TKeyBarrier, TMemRecBarrier>>& snapshot,
+            THullDsSnap&& fullSnapshot)
     {
         snapshot.emplace(std::move(fullSnapshot.BarriersSnap));
     }
@@ -361,7 +357,7 @@ namespace NKikimr {
         }
 
         void Handle(TEvTakeHullSnapshotResult::TPtr& ev) {
-            EmplaceSnapshot<TKey, TMemRec>(Snapshot, ev->Get()->Snap);
+            EmplaceSnapshot<TKey, TMemRec>(Snapshot, std::move(ev->Get()->Snap));
             ContinueTraversal();
         }
 
@@ -371,12 +367,12 @@ namespace NKikimr {
             }
             SendVDiskResponse(TActivationContext::AsActorContext(), Ev->Sender, Result.release(),
                     Ev->Cookie, HullCtx->VCtx, {});
-            TThis::Send(ParentId, new TEvents::TEvGone);
             TThis::PassAway();
         }
 
         void PassAway() override {
             ReleaseSnapshot();
+            TThis::Send(ParentId, new TEvents::TEvGone);
             TBase::PassAway();
         }
 

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.cpp
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.cpp
@@ -1,7 +1,10 @@
 #include "query_statdb.h"
 #include "query_statalgo.h"
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>
 #include <ydb/core/util/format.h>
+
+#include <concepts>
 
 using namespace NKikimrServices;
 
@@ -249,9 +252,173 @@ namespace NKikimr {
         };
     }
 
+    template <class TKey, class TMemRec>
+    concept CLogoBlobsDb = std::same_as<TKey, TKeyLogoBlob> && std::same_as<TMemRec, TMemRecLogoBlob>;
+
+    template <class TKey, class TMemRec>
+    concept CBlocksDb = std::same_as<TKey, TKeyBlock> && std::same_as<TMemRec, TMemRecBlock>;
+
+    template <class TKey, class TMemRec>
+    concept CBarriersDb = std::same_as<TKey, TKeyBarrier> && std::same_as<TMemRec, TMemRecBarrier>;
+
+    template <class TKey, class TMemRec>
+    concept CStatDb = CLogoBlobsDb<TKey, TMemRec> || CBlocksDb<TKey, TMemRec> || CBarriersDb<TKey, TMemRec>;
+
+    template <class TKey, class TMemRec>
+        requires CLogoBlobsDb<TKey, TMemRec>
+    void EmplaceSnapshot(
+            std::optional<TLevelIndexSnapshot<TKey, TMemRec>>& snapshot,
+            THullDsSnap& fullSnapshot)
+    {
+        snapshot.emplace(std::move(fullSnapshot.LogoBlobsSnap));
+    }
+
+    template <class TKey, class TMemRec>
+        requires CBlocksDb<TKey, TMemRec>
+    void EmplaceSnapshot(
+            std::optional<TLevelIndexSnapshot<TKey, TMemRec>>& snapshot,
+            THullDsSnap& fullSnapshot)
+    {
+        snapshot.emplace(std::move(fullSnapshot.BlocksSnap));
+    }
+
+    template <class TKey, class TMemRec>
+        requires CBarriersDb<TKey, TMemRec>
+    void EmplaceSnapshot(
+            std::optional<TLevelIndexSnapshot<TKey, TMemRec>>& snapshot,
+            THullDsSnap& fullSnapshot)
+    {
+        snapshot.emplace(std::move(fullSnapshot.BarriersSnap));
+    }
+
+    template <
+        class TKey,
+        class TMemRec,
+        class TRequest = TEvBlobStorage::TEvVDbStat,
+        class TResponse = TEvBlobStorage::TEvVDbStatResult>
+        requires CStatDb<TKey, TMemRec>
+    class TLevelIndexStatActor
+        : public TActorBootstrapped<TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>>
+    {
+        using TThis = TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>;
+        using TBase = TActorBootstrapped<TThis>;
+        using TLevelIndexSnapshot = ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>;
+        using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
+        using TTraversal = std::function<std::optional<TYieldedState>(
+            const TLevelIndexSnapshot&, std::optional<TYieldedState>)>;
+
+        friend class TActorBootstrapped<TThis>;
+
+        void Bootstrap() {
+            if constexpr (std::same_as<TRequest, TEvBlobStorage::TEvVDbStat>) {
+                PrepareStat(Output, Ev->Get()->Record.GetPrettyPrint());
+            } else {
+                PrepareStat(Result);
+            }
+            TThis::Become(&TThis::StateFunc);
+            ContinueTraversal();
+        }
+
+        void PrepareStat(IOutputStream& str, bool pretty);
+
+        void PrepareStat(std::unique_ptr<TResponse>& result);
+
+        template <class TAggr>
+        void SetAggregator(std::shared_ptr<TAggr> aggr) {
+            Traversal = [this, aggr = std::move(aggr)](
+                    const TLevelIndexSnapshot& snapshot,
+                    std::optional<TYieldedState> yieldedState) {
+                return TraverseDbWithoutMerge(
+                    HullCtx,
+                    aggr.get(),
+                    snapshot,
+                    std::move(yieldedState),
+                    YieldPolicy);
+            };
+        }
+
+        void ContinueTraversal() {
+            Y_ABORT_UNLESS(Snapshot);
+            YieldedState = Traversal(*Snapshot, std::move(YieldedState));
+            ReleaseSnapshot();
+
+            if (YieldedState) {
+                TThis::Schedule(YieldPolicy.DelayBetweenQuanta, new TEvents::TEvWakeup);
+            } else {
+                ReplyAndDie();
+            }
+        }
+
+        void ReleaseSnapshot() {
+            if (Snapshot) {
+                Snapshot->Destroy();
+                Snapshot.reset();
+            }
+        }
+
+        void HandleWakeup() {
+            TThis::Send(ParentId, new TEvTakeHullSnapshot(true));
+        }
+
+        void Handle(TEvTakeHullSnapshotResult::TPtr& ev) {
+            EmplaceSnapshot<TKey, TMemRec>(Snapshot, ev->Get()->Snap);
+            ContinueTraversal();
+        }
+
+        void ReplyAndDie() {
+            if constexpr (std::same_as<TRequest, TEvBlobStorage::TEvVDbStat>) {
+                Result->SetResult(Output.Str());
+            }
+            SendVDiskResponse(TActivationContext::AsActorContext(), Ev->Sender, Result.release(),
+                    Ev->Cookie, HullCtx->VCtx, {});
+            TThis::Send(ParentId, new TEvents::TEvGone);
+            TThis::PassAway();
+        }
+
+        void PassAway() override {
+            ReleaseSnapshot();
+            TBase::PassAway();
+        }
+
+        STRICT_STFUNC(StateFunc, {
+            cFunc(TEvents::TSystem::Wakeup, HandleWakeup);
+            cFunc(TEvents::TSystem::PoisonPill, PassAway);
+            hFunc(TEvTakeHullSnapshotResult, Handle);
+        })
+
+    public:
+        static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
+            return NKikimrServices::TActivity::BS_LEVEL_INDEX_STAT_QUERY;
+        }
+
+        TLevelIndexStatActor(
+                const TIntrusivePtr<THullCtx>& hullCtx,
+                const TActorId& parentId,
+                TLevelIndexSnapshot&& snapshot,
+                typename TRequest::TPtr& ev,
+                std::unique_ptr<TResponse> result)
+            : HullCtx(hullCtx)
+            , ParentId(parentId)
+            , Snapshot(std::in_place, std::move(snapshot))
+            , Ev(ev)
+            , Result(std::move(result))
+        {}
+
+    private:
+        TIntrusivePtr<THullCtx> HullCtx;
+        const TActorId ParentId;
+        std::optional<TLevelIndexSnapshot> Snapshot;
+        typename TRequest::TPtr Ev;
+        std::unique_ptr<TResponse> Result;
+        const TDbStatYieldPolicy YieldPolicy;
+        TStringStream Output;
+        TTraversal Traversal;
+        std::optional<TYieldedState> YieldedState;
+    };
+
     template <>
-    void TLevelIndexStatActor<TKeyLogoBlob, TMemRecLogoBlob>::CalculateStat(IOutputStream &str,
-                                                                            bool pretty) {
+    void TLevelIndexStatActor<TKeyLogoBlob, TMemRecLogoBlob>::PrepareStat(IOutputStream& str,
+                                                                          bool pretty) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyLogoBlob, TMemRecLogoBlob>;
@@ -266,13 +433,17 @@ namespace NKikimr {
                              const TKeyLogoBlob &key,
                              const TMemRecLogoBlob &memRec) {
                 Y_UNUSED(segName);
-                Tablets.Update(key.LogoBlobID(), memRec);
+                Update(key, memRec);
             }
 
             void UpdateLevel(const TLevelSstPtr &sstPtr,
                              const TKeyLogoBlob &key,
                              const TMemRecLogoBlob &memRec) {
                 Y_UNUSED(sstPtr);
+                Update(key, memRec);
+            }
+
+            void Update(const TKeyLogoBlob& key, const TMemRecLogoBlob& memRec) {
                 Tablets.Update(key.LogoBlobID(), memRec);
             }
 
@@ -285,15 +456,13 @@ namespace NKikimr {
             bool Pretty;
         };
 
-        // run aggregation
-        TAggr aggr(str, pretty);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(str, pretty));
     }
 
     template <>
     void TLevelIndexStatActor<TKeyLogoBlob, TMemRecLogoBlob,
             TEvGetLogoBlobIndexStatRequest, TEvGetLogoBlobIndexStatResponse
-    >::CalculateStat(std::unique_ptr<TEvGetLogoBlobIndexStatResponse> &result) {
+    >::PrepareStat(std::unique_ptr<TEvGetLogoBlobIndexStatResponse>& result) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyLogoBlob, TMemRecLogoBlob>;
@@ -307,13 +476,17 @@ namespace NKikimr {
                              const TKeyLogoBlob &key,
                              const TMemRecLogoBlob &memRec) {
                 Y_UNUSED(segName);
-                Tablets.Update(key.LogoBlobID(), memRec);
+                Update(key, memRec);
             }
 
             void UpdateLevel(const TLevelSstPtr &sstPtr,
                              const TKeyLogoBlob &key,
                              const TMemRecLogoBlob &memRec) {
                 Y_UNUSED(sstPtr);
+                Update(key, memRec);
+            }
+
+            void Update(const TKeyLogoBlob& key, const TMemRecLogoBlob& memRec) {
                 Tablets.Update(key.LogoBlobID(), memRec);
             }
 
@@ -326,14 +499,12 @@ namespace NKikimr {
             std::unique_ptr<TEvGetLogoBlobIndexStatResponse> &Result;
         };
 
-        // run aggregation
-        TAggr aggr(result);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(result));
     }
 
     template <>
-    void TLevelIndexStatActor<TKeyBlock, TMemRecBlock>::CalculateStat(IOutputStream &str,
-                                                                      bool pretty) {
+    void TLevelIndexStatActor<TKeyBlock, TMemRecBlock>::PrepareStat(IOutputStream& str,
+                                                                    bool pretty) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyBlock, TMemRecBlock>;
@@ -412,14 +583,12 @@ namespace NKikimr {
         };
 
 
-        // run aggregation
-        TAggr aggr(str, pretty);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(str, pretty));
     }
 
     template <>
-    void TLevelIndexStatActor<TKeyBarrier, TMemRecBarrier>::CalculateStat(IOutputStream &str,
-                                                                          bool pretty) {
+    void TLevelIndexStatActor<TKeyBarrier, TMemRecBarrier>::PrepareStat(IOutputStream& str,
+                                                                        bool pretty) {
         // aggregation class
         struct TAggr {
             using TLevelSegment = ::NKikimr::TLevelSegment<TKeyBarrier, TMemRecBarrier>;
@@ -513,9 +682,80 @@ namespace NKikimr {
         };
 
 
-        // run aggregation
-        TAggr aggr(str, pretty);
-        TraverseDbWithoutMerge(HullCtx, &aggr, Snapshot);
+        SetAggregator(std::make_shared<TAggr>(str, pretty));
+    }
+
+    template <class TKey, class TMemRec, class TRequest, class TResponse>
+        requires CStatDb<TKey, TMemRec>
+    IActor* CreateLevelIndexStatActorImpl(
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            const TActorId& parentId,
+            TLevelIndexSnapshot<TKey, TMemRec>&& snapshot,
+            typename TRequest::TPtr& ev,
+            std::unique_ptr<TResponse> result)
+    {
+        using TActor = TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>;
+        return new TActor(hullCtx, parentId, std::move(snapshot), ev, std::move(result));
+    }
+
+    IActor* CreateLevelIndexStatActor(
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            const TActorId& parentId,
+            TLogoBlobsSnapshot&& snapshot,
+            TEvBlobStorage::TEvVDbStat::TPtr& ev,
+            std::unique_ptr<TEvBlobStorage::TEvVDbStatResult> result)
+    {
+        return CreateLevelIndexStatActorImpl<
+            TKeyLogoBlob,
+            TMemRecLogoBlob,
+            TEvBlobStorage::TEvVDbStat,
+            TEvBlobStorage::TEvVDbStatResult>(
+            hullCtx, parentId, std::move(snapshot), ev, std::move(result));
+    }
+
+    IActor* CreateLevelIndexStatActor(
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            const TActorId& parentId,
+            TBlocksSnapshot&& snapshot,
+            TEvBlobStorage::TEvVDbStat::TPtr& ev,
+            std::unique_ptr<TEvBlobStorage::TEvVDbStatResult> result)
+    {
+        return CreateLevelIndexStatActorImpl<
+            TKeyBlock,
+            TMemRecBlock,
+            TEvBlobStorage::TEvVDbStat,
+            TEvBlobStorage::TEvVDbStatResult>(
+            hullCtx, parentId, std::move(snapshot), ev, std::move(result));
+    }
+
+    IActor* CreateLevelIndexStatActor(
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            const TActorId& parentId,
+            TLevelIndexSnapshot<TKeyBarrier, TMemRecBarrier>&& snapshot,
+            TEvBlobStorage::TEvVDbStat::TPtr& ev,
+            std::unique_ptr<TEvBlobStorage::TEvVDbStatResult> result)
+    {
+        return CreateLevelIndexStatActorImpl<
+            TKeyBarrier,
+            TMemRecBarrier,
+            TEvBlobStorage::TEvVDbStat,
+            TEvBlobStorage::TEvVDbStatResult>(
+            hullCtx, parentId, std::move(snapshot), ev, std::move(result));
+    }
+
+    IActor* CreateLevelIndexStatActor(
+            const TIntrusivePtr<THullCtx>& hullCtx,
+            const TActorId& parentId,
+            TLogoBlobsSnapshot&& snapshot,
+            TEvGetLogoBlobIndexStatRequest::TPtr& ev,
+            std::unique_ptr<TEvGetLogoBlobIndexStatResponse> result)
+    {
+        return CreateLevelIndexStatActorImpl<
+            TKeyLogoBlob,
+            TMemRecLogoBlob,
+            TEvGetLogoBlobIndexStatRequest,
+            TEvGetLogoBlobIndexStatResponse>(
+                hullCtx, parentId, std::move(snapshot), ev, std::move(result));
     }
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/query_statdb.h
+++ b/ydb/core/blobstorage/vdisk/query/query_statdb.h
@@ -1,72 +1,38 @@
 #pragma once
 
 #include "defs.h"
+
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
 #include <ydb/core/blobstorage/vdisk/common/vdisk_response.h>
 
 namespace NKikimr {
 
-    ////////////////////////////////////////////////////////////////////////////
-    // TLevelIndexStatActor
-    ////////////////////////////////////////////////////////////////////////////
-    template <class TKey, class TMemRec, class TRequest = TEvBlobStorage::TEvVDbStat, class TResponse = TEvBlobStorage::TEvVDbStatResult>
-    class TLevelIndexStatActor : public TActorBootstrapped<TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>> {
+    IActor* CreateLevelIndexStatActor(
+        const TIntrusivePtr<THullCtx>& hullCtx,
+        const TActorId& parentId,
+        TLogoBlobsSnapshot&& snapshot,
+        TEvBlobStorage::TEvVDbStat::TPtr& ev,
+        std::unique_ptr<TEvBlobStorage::TEvVDbStatResult> result);
 
-        using TThis = ::NKikimr::TLevelIndexStatActor<TKey, TMemRec, TRequest, TResponse>;
-        using TLevelIndex = ::NKikimr::TLevelIndex<TKey, TMemRec>;
-        using TLevelIndexSnapshot = ::NKikimr::TLevelIndexSnapshot<TKey, TMemRec>;
-        using TLevelSliceSnapshot = ::NKikimr::TLevelSliceSnapshot<TKey, TMemRec>;
-        using TSstIterator = typename TLevelSliceSnapshot::TSstIterator;
-        using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
-        using TMemIterator = typename TLevelSegment::TMemIterator;
-        using TLevelSstPtr = typename TLevelSegment::TLevelSstPtr;
+    IActor* CreateLevelIndexStatActor(
+        const TIntrusivePtr<THullCtx>& hullCtx,
+        const TActorId& parentId,
+        TBlocksSnapshot&& snapshot,
+        TEvBlobStorage::TEvVDbStat::TPtr& ev,
+        std::unique_ptr<TEvBlobStorage::TEvVDbStatResult> result);
 
-        friend class TActorBootstrapped<TThis>;
+    IActor* CreateLevelIndexStatActor(
+        const TIntrusivePtr<THullCtx>& hullCtx,
+        const TActorId& parentId,
+        TLevelIndexSnapshot<TKeyBarrier, TMemRecBarrier>&& snapshot,
+        TEvBlobStorage::TEvVDbStat::TPtr& ev,
+        std::unique_ptr<TEvBlobStorage::TEvVDbStatResult> result);
 
-        void Bootstrap(const TActorContext &ctx) {
-            TStringStream str;
-            if constexpr (std::is_same_v<TRequest, TEvBlobStorage::TEvVDbStat>) {
-                const bool prettyPrint = Ev->Get()->Record.GetPrettyPrint();
-                CalculateStat(str, prettyPrint);
-                Result->SetResult(str.Str());
-                SendVDiskResponse(ctx, Ev->Sender, Result.release(), Ev->Cookie, HullCtx->VCtx, {});
-            } else {
-                CalculateStat(Result);
-                SendVDiskResponse(ctx, Ev->Sender, Result.release(), Ev->Cookie, HullCtx->VCtx, {});
-            }
-            ctx.Send(ParentId, new TEvents::TEvGone);
-            TThis::Die(ctx);
-        }
-
-        void CalculateStat(IOutputStream &str, bool pretty);
-
-        void CalculateStat(std::unique_ptr<TResponse> &result);
-
-    public:
-        static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
-            return NKikimrServices::TActivity::BS_LEVEL_INDEX_STAT_QUERY;
-        }
-
-        TLevelIndexStatActor(
-                const TIntrusivePtr<THullCtx> &hullCtx,
-                const TActorId &parentId,
-                TLevelIndexSnapshot &&snapshot,
-                typename TRequest::TPtr &ev,
-                std::unique_ptr<TResponse> result)
-            : TActorBootstrapped<TThis>()
-            , HullCtx(hullCtx)
-            , ParentId(parentId)
-            , Snapshot(std::move(snapshot))
-            , Ev(ev)
-            , Result(std::move(result))
-        {}
-
-    private:
-        TIntrusivePtr<THullCtx> HullCtx;
-        const TActorId ParentId;
-        TLevelIndexSnapshot Snapshot;
-        typename TRequest::TPtr Ev;
-        std::unique_ptr<TResponse> Result;
-    };
+    IActor* CreateLevelIndexStatActor(
+        const TIntrusivePtr<THullCtx>& hullCtx,
+        const TActorId& parentId,
+        TLogoBlobsSnapshot&& snapshot,
+        TEvGetLogoBlobIndexStatRequest::TPtr& ev,
+        std::unique_ptr<TEvGetLogoBlobIndexStatResponse> result);
 
 } // NKikimr

--- a/ydb/core/blobstorage/vdisk/query/ut/query_stat_test_utils.h
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_stat_test_utils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ydb/library/actors/core/monotonic_provider.h>
+
+namespace NKikimr::NDbStatTest {
+
+    class TManualMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
+    public:
+        TMonotonic Now() override {
+            ++Calls;
+            return CurrentTime;
+        }
+
+        void Advance(TDuration duration) {
+            CurrentTime += duration;
+        }
+
+        ui32 GetCalls() const {
+            return Calls;
+        }
+
+    private:
+        TMonotonic CurrentTime = TMonotonic::Zero();
+        ui32 Calls = 0;
+    };
+
+} // namespace NKikimr::NDbStatTest

--- a/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
@@ -1,29 +1,13 @@
 #include <ydb/core/blobstorage/vdisk/query/query_stat_yield.h>
 
+#include "query_stat_test_utils.h"
+
 #include <library/cpp/testing/unittest/registar.h>
 
 namespace NKikimr {
 namespace {
 
-    class TManualMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
-    public:
-        TMonotonic Now() override {
-            ++Calls;
-            return CurrentTime;
-        }
-
-        void Advance(TDuration duration) {
-            CurrentTime += duration;
-        }
-
-        ui32 GetCalls() const {
-            return Calls;
-        }
-
-    private:
-        TMonotonic CurrentTime = TMonotonic::Zero();
-        ui32 Calls = 0;
-    };
+    using NDbStatTest::TManualMonotonicTimeProvider;
 
     Y_UNIT_TEST_SUITE(TDbStatYieldCheckerTest) {
         Y_UNIT_TEST(ChecksTimeOnlyAtConfiguredSteps) {

--- a/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_stat_yield_ut.cpp
@@ -1,0 +1,59 @@
+#include <ydb/core/blobstorage/vdisk/query/query_stat_yield.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+namespace {
+
+    class TManualMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
+    public:
+        TMonotonic Now() override {
+            ++Calls;
+            return CurrentTime;
+        }
+
+        void Advance(TDuration duration) {
+            CurrentTime += duration;
+        }
+
+        ui32 GetCalls() const {
+            return Calls;
+        }
+
+    private:
+        TMonotonic CurrentTime = TMonotonic::Zero();
+        ui32 Calls = 0;
+    };
+
+    Y_UNIT_TEST_SUITE(TDbStatYieldCheckerTest) {
+        Y_UNIT_TEST(ChecksTimeOnlyAtConfiguredSteps) {
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TDbStatYieldChecker checker(
+                TDbStatYieldPolicy{
+                    .StepsBeforeMeasures = 3,
+                    .QuantumDuration = TDuration::MilliSeconds(10),
+                    .DelayBetweenQuanta = TDuration::Zero(),
+                },
+                timeProvider);
+
+            timeProvider->Advance(TDuration::MilliSeconds(11));
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(checker.StepAndCheckForYield());
+            UNIT_ASSERT_VALUES_EQUAL(timeProvider->GetCalls(), 2);
+
+            timeProvider->Advance(TDuration::MilliSeconds(10));
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+            UNIT_ASSERT_VALUES_EQUAL(timeProvider->GetCalls(), 3);
+        }
+
+        Y_UNIT_TEST(DisabledPolicyDoesNotNeedTimeProvider) {
+            TDbStatYieldChecker checker(std::nullopt);
+            UNIT_ASSERT(!checker.StepAndCheckForYield());
+        }
+    }
+
+} // anonymous namespace
+} // namespace NKikimr

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -1,5 +1,7 @@
 #include <ydb/core/blobstorage/vdisk/query/query_statalgo.h>
 
+#include "query_stat_test_utils.h"
+
 #include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h>
 #include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all.h>
 
@@ -13,24 +15,11 @@ namespace {
     using TLevelIndex = ::NKikimr::TLevelIndex<TKey, TMemRec>;
     using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
     using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
+    using NDbStatTest::TManualMonotonicTimeProvider;
 
     TKey MakeKey(ui32 step) {
         return TKey(TLogoBlobID(1, 1, step, 0, 0, 0));
     }
-
-    class TManualMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
-    public:
-        TMonotonic Now() override {
-            return CurrentTime;
-        }
-
-        void Advance(TDuration duration) {
-            CurrentTime += duration;
-        }
-
-    private:
-        TMonotonic CurrentTime = TMonotonic::Zero();
-    };
 
     class TTestDatabase {
     public:

--- a/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
+++ b/ydb/core/blobstorage/vdisk/query/ut/query_statalgo_ut.cpp
@@ -1,0 +1,269 @@
+#include <ydb/core/blobstorage/vdisk/query/query_statalgo.h>
+
+#include <ydb/core/blobstorage/vdisk/hulldb/base/hullds_ut.h>
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr {
+namespace {
+
+    using TKey = TKeyLogoBlob;
+    using TMemRec = TMemRecLogoBlob;
+    using TLevelIndex = ::NKikimr::TLevelIndex<TKey, TMemRec>;
+    using TLevelSegment = ::NKikimr::TLevelSegment<TKey, TMemRec>;
+    using TYieldedState = TDbStatYieldedState<TKey, TMemRec>;
+
+    TKey MakeKey(ui32 step) {
+        return TKey(TLogoBlobID(1, 1, step, 0, 0, 0));
+    }
+
+    class TManualMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
+    public:
+        TMonotonic Now() override {
+            return CurrentTime;
+        }
+
+        void Advance(TDuration duration) {
+            CurrentTime += duration;
+        }
+
+    private:
+        TMonotonic CurrentTime = TMonotonic::Zero();
+    };
+
+    class TTestDatabase {
+    public:
+        TTestDatabase()
+            : Arena(std::make_shared<TRopeArena>(&TRopeArenaBackend::Allocate))
+            , Index(MakeIntrusive<TLevelIndex>(Contexts.GetLevelIndexSettings(), Arena))
+        {
+            Index->CurSlice->SortedLevels.emplace_back(TKey());
+            Index->LoadCompleted();
+
+            PutFresh(10);
+            PutFresh(20);
+            PutFresh(20); // two physical fresh records for the same key
+            PutFresh(30);
+            AddLevel0Sst({15, 20, 40}); // and another physical record for key 20
+        }
+
+        TIntrusivePtr<THullCtx> GetHullCtx() {
+            return Contexts.GetHullCtx();
+        }
+
+        TLevelIndexSnapshot<TKey, TMemRec> GetSnapshot() {
+            return Index->GetIndexSnapshot();
+        }
+
+        void PutFresh(ui32 step) {
+            Index->PutToFresh(NextLsn++, MakeKey(step), MakeMemRec());
+        }
+
+    private:
+        TMemRec MakeMemRec() {
+            return TMemRec(TIngress(NextRecordId++));
+        }
+
+        void AddLevel0Sst(std::initializer_list<ui32> steps) {
+            TTrackableVector<TLevelSegment::TRec> records(TMemoryConsumer(Contexts.GetVCtx()->SstIndex));
+            for (ui32 step : steps) {
+                records.emplace_back(MakeKey(step), MakeMemRec());
+            }
+
+            auto sst = MakeIntrusive<TLevelSegment>(Contexts.GetVCtx());
+            sst->LoadLinearIndex(records);
+            sst->VolatileOrderId = 1;
+            Index->CurSlice->Level0.Put(sst);
+        }
+
+    private:
+        TTestContexts Contexts;
+        std::shared_ptr<TRopeArena> Arena;
+        TIntrusivePtr<TLevelIndex> Index;
+        ui64 NextLsn = 1;
+        ui32 NextRecordId = 1;
+    };
+
+    struct TCollectingAggregator {
+        TVector<ui32>& SeenSteps;
+        THashMap<ui32, TVector<ui32>>& QuantaByStep;
+        TManualMonotonicTimeProvider& TimeProvider;
+        ui32 CurrentQuantum = 0;
+        bool Finished = false;
+        TVector<std::pair<ui32, ui64>>* SeenRecords = nullptr;
+
+        void Update(const TKey& key, const TMemRec& memRec) {
+            const ui32 step = key.LogoBlobID().Step();
+            SeenSteps.push_back(step);
+            QuantaByStep[step].push_back(CurrentQuantum);
+            if (SeenRecords) {
+                SeenRecords->emplace_back(step, memRec.GetIngress().Raw());
+            }
+            TimeProvider.Advance(TDuration::MilliSeconds(1));
+        }
+
+        void UpdateFresh(const char*, const TKey& key, const TMemRec& memRec) {
+            Update(key, memRec);
+        }
+
+        void UpdateLevel(const TLevelSegment::TLevelSstPtr&, const TKey& key, const TMemRec& memRec) {
+            Update(key, memRec);
+        }
+
+        void Finish() {
+            Finished = true;
+        }
+    };
+
+    Y_UNIT_TEST_SUITE(TTraverseDbWithoutMergeYieldTest) {
+        Y_UNIT_TEST(YieldingAndNonYieldingProcessSameRecords) {
+            TTestDatabase database;
+
+            auto nonYieldingTimeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TVector<ui32> nonYieldingSteps;
+            THashMap<ui32, TVector<ui32>> nonYieldingQuanta;
+            TVector<std::pair<ui32, ui64>> nonYieldingRecords;
+            TCollectingAggregator nonYieldingAggregator{
+                nonYieldingSteps,
+                nonYieldingQuanta,
+                *nonYieldingTimeProvider,
+                0,
+                false,
+                &nonYieldingRecords,
+            };
+            auto snapshot = database.GetSnapshot();
+            TraverseDbWithoutMerge(database.GetHullCtx(), &nonYieldingAggregator, snapshot);
+            snapshot.Destroy();
+
+            auto yieldingTimeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TVector<ui32> yieldingSteps;
+            THashMap<ui32, TVector<ui32>> yieldingQuanta;
+            TVector<std::pair<ui32, ui64>> yieldingRecords;
+            TCollectingAggregator yieldingAggregator{
+                yieldingSteps,
+                yieldingQuanta,
+                *yieldingTimeProvider,
+                0,
+                false,
+                &yieldingRecords,
+            };
+            std::optional<TYieldedState> yieldedState;
+            for (ui32 quantum = 0; quantum < 10; ++quantum) {
+                yieldingAggregator.CurrentQuantum = quantum;
+                auto yieldingSnapshot = database.GetSnapshot();
+                yieldedState = TraverseDbWithoutMerge(
+                    database.GetHullCtx(),
+                    &yieldingAggregator,
+                    yieldingSnapshot,
+                    std::move(yieldedState),
+                    TDbStatYieldPolicy{
+                        .StepsBeforeMeasures = 1,
+                        .QuantumDuration = TDuration::Zero(),
+                        .DelayBetweenQuanta = TDuration::Zero(),
+                    },
+                    yieldingTimeProvider);
+                yieldingSnapshot.Destroy();
+                if (!yieldedState) {
+                    break;
+                }
+            }
+
+            Sort(nonYieldingSteps);
+            Sort(yieldingSteps);
+            Sort(nonYieldingRecords);
+            Sort(yieldingRecords);
+            UNIT_ASSERT(!yieldedState);
+            UNIT_ASSERT(nonYieldingAggregator.Finished);
+            UNIT_ASSERT(yieldingAggregator.Finished);
+            UNIT_ASSERT(nonYieldingSteps == yieldingSteps);
+            UNIT_ASSERT(nonYieldingRecords == yieldingRecords);
+            UNIT_ASSERT_VALUES_EQUAL(nonYieldingRecords.size(), 7);
+            UNIT_ASSERT(nonYieldingSteps == TVector<ui32>({10, 15, 20, 20, 20, 30, 40}));
+        }
+
+        Y_UNIT_TEST(ReverseTraversalYieldsOnlyBetweenCompleteKeys) {
+            TTestDatabase database;
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TVector<ui32> seenSteps;
+            THashMap<ui32, TVector<ui32>> quantaByStep;
+            TCollectingAggregator aggregator{seenSteps, quantaByStep, *timeProvider};
+            std::optional<TYieldedState> yieldedState;
+
+            for (ui32 quantum = 0; quantum < 10; ++quantum) {
+                aggregator.CurrentQuantum = quantum;
+                auto snapshot = database.GetSnapshot();
+                yieldedState = TraverseDbWithoutMerge(
+                    database.GetHullCtx(),
+                    &aggregator,
+                    snapshot,
+                    std::move(yieldedState),
+                    TDbStatYieldPolicy{
+                        .StepsBeforeMeasures = 1,
+                        .QuantumDuration = TDuration::Zero(),
+                        .DelayBetweenQuanta = TDuration::Zero(),
+                    },
+                    timeProvider);
+                snapshot.Destroy();
+                if (!yieldedState) {
+                    break;
+                }
+            }
+
+            UNIT_ASSERT(!yieldedState);
+            UNIT_ASSERT(aggregator.Finished);
+            UNIT_ASSERT(seenSteps == TVector<ui32>({40, 30, 20, 20, 20, 15, 10}));
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[20].size(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[20].front(), quantaByStep[20].back());
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep.size(), 5);
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[40].front(), 0);
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[30].front(), 1);
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[20].front(), 2);
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[15].front(), 3);
+            UNIT_ASSERT_VALUES_EQUAL(quantaByStep[10].front(), 4);
+        }
+
+        Y_UNIT_TEST(ReacquiredSnapshotContinuesBelowLastCompletedKey) {
+            TTestDatabase database;
+            auto timeProvider = MakeIntrusive<TManualMonotonicTimeProvider>();
+            TVector<ui32> seenSteps;
+            THashMap<ui32, TVector<ui32>> quantaByStep;
+            TCollectingAggregator aggregator{seenSteps, quantaByStep, *timeProvider};
+            std::optional<TYieldedState> yieldedState;
+
+            auto runQuantum = [&] {
+                auto snapshot = database.GetSnapshot();
+                yieldedState = TraverseDbWithoutMerge(
+                    database.GetHullCtx(),
+                    &aggregator,
+                    snapshot,
+                    std::move(yieldedState),
+                    TDbStatYieldPolicy{
+                        .StepsBeforeMeasures = 1,
+                        .QuantumDuration = TDuration::Zero(),
+                        .DelayBetweenQuanta = TDuration::Zero(),
+                    },
+                    timeProvider);
+                snapshot.Destroy();
+                ++aggregator.CurrentQuantum;
+            };
+
+            runQuantum();
+            UNIT_ASSERT_VALUES_EQUAL(seenSteps.back(), 40);
+
+            // A lower new key is still pending; a higher one is beyond the
+            // completed reverse-traversal boundary and must not extend the job.
+            database.PutFresh(35);
+            database.PutFresh(45);
+            for (ui32 quantum = 0; yieldedState && quantum < 10; ++quantum) {
+                runQuantum();
+            }
+
+            UNIT_ASSERT(!yieldedState);
+            UNIT_ASSERT(aggregator.Finished);
+            UNIT_ASSERT(seenSteps == TVector<ui32>({40, 35, 30, 20, 20, 20, 15, 10}));
+        }
+    }
+
+} // anonymous namespace
+} // namespace NKikimr

--- a/ydb/core/blobstorage/vdisk/query/ut/ya.make
+++ b/ydb/core/blobstorage/vdisk/query/ut/ya.make
@@ -10,6 +10,8 @@ PEERDIR(
 
 SRCS(
     query_spacetracker_ut.cpp
+    query_statalgo_ut.cpp
+    query_stat_yield_ut.cpp
 )
 
 END()

--- a/ydb/core/blobstorage/vdisk/query/ya.make
+++ b/ydb/core/blobstorage/vdisk/query/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     ydb/core/blobstorage/base
     ydb/core/blobstorage/vdisk/hulldb/barriers
     ydb/core/blobstorage/vdisk/hulldb/base
+    ydb/core/util
 )
 
 SRCS(
@@ -25,6 +26,7 @@ SRCS(
     query_readbatch.h
     query_spacetracker.h
     query_statalgo.h
+    query_stat_yield.h
     query_statdb.cpp
     query_statdb.h
     query_stathuge.cpp

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_skeleton.cpp
@@ -1472,7 +1472,7 @@ namespace NKikimr {
                 IActor *actor = CreateDbStatActor(HullCtx, HugeBlobCtx, ctx, std::move(fullSnap),
                         ctx.SelfID, ev, std::move(result));
                 if (actor) {
-                    auto aid = ctx.Register(actor);
+                    auto aid = RunInBatchPool(ctx, actor);
                     ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
                 }
                 // CreateDbStatActor is responsible for sending result to the recipient
@@ -1490,7 +1490,7 @@ namespace NKikimr {
             IActor *actor = CreateDbStatActor(HullCtx, HugeBlobCtx, ctx, std::move(fullSnap),
                     ctx.SelfID, ev, std::move(result));
             if (actor) {
-                auto aid = ctx.Register(actor);
+                auto aid = RunInBatchPool(ctx, actor);
                 ActiveActors.Insert(aid, __FILE__, __LINE__, ctx, NKikimrServices::BLOBSTORAGE);
             }
         }

--- a/ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h
+++ b/ydb/core/blobstorage/vdisk/skeleton/blobstorage_takedbsnap.h
@@ -1,36 +1,3 @@
 #pragma once
 
-#include "defs.h"
-#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap.h>
-
-namespace NKikimr {
-
-
-    ////////////////////////////////////////////////////////////////////////////
-    // TEvTakeHullSnapshot
-    // Take snapshot of local (Hull) database
-    ////////////////////////////////////////////////////////////////////////////
-    struct TEvTakeHullSnapshot :
-        public TEventLocal<TEvTakeHullSnapshot, TEvBlobStorage::EvTakeHullSnapshot>
-    {
-        const bool Index;
-
-        TEvTakeHullSnapshot(bool index)
-            : Index(index)
-        {}
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    // TEvTakeHullSnapshotResult
-    ////////////////////////////////////////////////////////////////////////////
-    struct TEvTakeHullSnapshotResult :
-        public TEventLocal<TEvTakeHullSnapshotResult, TEvBlobStorage::EvTakeHullSnapshot>
-    {
-        THullDsSnap Snap;
-
-        TEvTakeHullSnapshotResult(THullDsSnap &&snap)
-            : Snap(std::move(snap))
-        {}
-    };
-
-} // NKikimr
+#include <ydb/core/blobstorage/vdisk/hulldb/hull_ds_all_snap_events.h>

--- a/ydb/core/util/actor_monotonic_time_provider.cpp
+++ b/ydb/core/util/actor_monotonic_time_provider.cpp
@@ -1,0 +1,24 @@
+#include "actor_monotonic_time_provider.h"
+
+#include <ydb/library/actors/core/actor.h>
+
+namespace NKikimr {
+namespace {
+
+    class TActorSystemMonotonicTimeProvider : public NMonotonic::IMonotonicTimeProvider {
+    public:
+        TMonotonic Now() override {
+            return NActors::TActivationContext::Monotonic();
+        }
+    };
+
+} // anonymous namespace
+
+    TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> CreateActorSystemMonotonicTimeProvider() {
+        if (!NActors::TlsActivationContext) {
+            return NMonotonic::CreateDefaultMonotonicTimeProvider();
+        }
+        return MakeIntrusive<TActorSystemMonotonicTimeProvider>();
+    }
+
+} // namespace NKikimr

--- a/ydb/core/util/actor_monotonic_time_provider.h
+++ b/ydb/core/util/actor_monotonic_time_provider.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <ydb/library/actors/core/monotonic_provider.h>
+
+namespace NKikimr {
+
+    TIntrusivePtr<NMonotonic::IMonotonicTimeProvider> CreateActorSystemMonotonicTimeProvider();
+
+} // namespace NKikimr

--- a/ydb/core/util/ya.make
+++ b/ydb/core/util/ya.make
@@ -1,6 +1,8 @@
 LIBRARY()
 
 SRCS(
+    actor_monotonic_time_provider.cpp
+    actor_monotonic_time_provider.h
     activeactors.h
     address_classifier.cpp
     backoff.cpp


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Move VDisk DB statistics actors to Batch pool and make traversal of VDisk DB interruptable with recapturing of the hull snapshot

### Changelog category <!-- remove all except one -->

* Improvement