### PR TITLE
PR1: TPageLocation plumbing, TPageOffset tag inversion, shared-cache …

### DIFF
--- a/ydb/core/tablet_flat/flat_bio_actor.cpp
+++ b/ydb/core/tablet_flat/flat_bio_actor.cpp
@@ -208,7 +208,7 @@ void TBlockIO::Terminate(EStatus code)
         auto data = (code == NKikimrProto::OK)
             ? std::move(BlockStates.at(index).Data)
             : TSharedData{};
-        ev->Pages.emplace_back(Pages[index], std::move(data));
+        ev->Pages.emplace_back(Pages[index].Offset, std::move(data));
     }
 
     if (StatActorId)

--- a/ydb/core/tablet_flat/flat_bio_events.h
+++ b/ydb/core/tablet_flat/flat_bio_events.h
@@ -60,7 +60,7 @@ namespace NBlockIO {
 
         const EStatus Status;
         TIntrusiveConstPtr<NPageCollection::IPageCollection> PageCollection;
-        TVector<NPageCollection::TLoadedPage> Pages;
+        TVector<NPageCollection::TLoadedPageData> Pages;
         const ui64 Cookie;
     };
 

--- a/ydb/core/tablet_flat/flat_dbase_sz_env.h
+++ b/ydb/core/tablet_flat/flat_dbase_sz_env.h
@@ -26,25 +26,27 @@ namespace NTable {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
             auto *info = partStore->Locate(lob, ref);
-            AddPageSize(info->PageCollection.Get(), info->PageCollection->GetLocation(ref));
+            AddPageSize(info, info->GetLocation(ref));
 
             return { true, nullptr };
         }
 
-        const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override
         {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
             auto *collection = partStore->PageCollections.at(groupId.Index).Get();
 
+            // index pages must be loaded for traversal; data pages counted from metadata
             switch (location.Type) {
                 case EPage::FlatIndex:
                 case EPage::BTreeIndex:
+                case EPage::BTreeIndexV2:
                     // need index pages to continue counting
                     // do not count index
                     // if these pages are not in memory, data won't be counted in precharge
                     return Env->TryGetPage(part, location, groupId);
                 default:
-                    AddPageSize(collection->PageCollection.Get(), location);
+                    AddPageSize(collection, location);
                     return nullptr;
             }
         }
@@ -54,7 +56,7 @@ namespace NTable {
         }
 
     private:
-        void AddPageSize(const NPageCollection::IPageCollection *collection, TPageLocation location)
+        void AddPageSize(const TPageCollection *collection, const TPageLocation& location)
         {
             if (Touched[collection].insert(location.Offset).second) {
                 Pages++;
@@ -64,7 +66,7 @@ namespace NTable {
 
     private:
         IPages* Env;
-        THashMap<const NPageCollection::IPageCollection*, THashSet<TPageOffset>> Touched;
+        THashMap<const TPageCollection*, THashSet<TPageOffset>> Touched;
         ui64 Pages = 0;
         ui64 Bytes = 0;
     };

--- a/ydb/core/tablet_flat/flat_executor.cpp
+++ b/ydb/core/tablet_flat/flat_executor.cpp
@@ -691,7 +691,7 @@ void TExecutor::TryActivateWaitingTransaction(TIntrusivePtr<NPageCollection::TPa
     if (pageCollection) {
         auto &pinnedCollection = transaction.Seat->Pinned[pageCollection->Id];
         for (auto& loaded : loadedPages) {
-            auto inserted = pinnedCollection.insert(std::make_pair(loaded.Location.Offset, TPrivatePageCache::TPinnedPage(std::move(loaded.Page))));
+            auto inserted = pinnedCollection.insert(std::make_pair(loaded.Offset, TPrivatePageCache::TPinnedPage(std::move(loaded.Page))));
             Y_ENSURE(inserted.second);
         }
     }
@@ -3064,11 +3064,11 @@ void TExecutor::Handle(NSharedCache::TEvResult::TPtr &ev) {
 
             if (requestType == ERequestTypeCookie::StickyPages) {
                 for (auto& loaded : msg->Pages) {
-                    PrivatePageCache->AddStickyPage(loaded.Location, std::move(loaded.Page), pageCollection);
+                    PrivatePageCache->AddStickyPage(loaded.Offset, loaded.Size, std::move(loaded.Page), pageCollection);
                 }
             } else { // requestType == ERequestTypeCookie::Transaction or ERequestTypeCookie::TryKeepInMemPages
                 for (auto& loaded : msg->Pages) {
-                    PrivatePageCache->AddPage(loaded.Location, loaded.Page, pageCollection);
+                    PrivatePageCache->AddPage(loaded.Offset, loaded.Size, loaded.Page, pageCollection);
                 }
                 if (requestType == ERequestTypeCookie::Transaction) {
                     TryActivateWaitingTransaction(std::move(msg->WaitPad), std::move(msg->Pages), pageCollection);

--- a/ydb/core/tablet_flat/flat_executor_recovery.cpp
+++ b/ydb/core/tablet_flat/flat_executor_recovery.cpp
@@ -230,7 +230,7 @@ class TDryRunExecutor
     struct TDryRunPages : public NTable::IPages {
         TResult Locate(const NTable::TMemTable*, ui64, ui32) override { Y_TABLET_ERROR("Not supported"); }
         TResult Locate(const NTable::TPart*, ui64, NTable::ELargeObj) override { Y_TABLET_ERROR("Not supported"); }
-        const TSharedData* TryGetPage(const NTable::TPart*, TPageLocation, TGroupId) override { Y_TABLET_ERROR("Not supported"); }
+        const TSharedData* TryGetPage(const NTable::TPart*, const TPageLocation&, TGroupId) override { Y_TABLET_ERROR("Not supported"); }
     };
 
     struct TDryRunStats : public TExecutorStats {};

--- a/ydb/core/tablet_flat/flat_executor_tx_env.h
+++ b/ydb/core/tablet_flat/flat_executor_tx_env.h
@@ -44,7 +44,7 @@ namespace NTabletFlatExecutor {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
             auto *info = partStore->Locate(lob, ref);
-            const TSharedData* page = TryGetPage(info->PageCollection->GetLocation(ref), info);
+            const TSharedData* page = TryGetPage(info->GetLocation(ref), info);
 
             if (!page && ReadMissingReferences) {
                 MissingReferencesSize_ += Max<ui64>(1, part->GetPageSize(lob, ref));
@@ -53,7 +53,7 @@ namespace NTabletFlatExecutor {
             return { !ReadMissingReferences, page };
         }
 
-        const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override
         {
             auto *partStore = CheckedCast<const NTable::TPartStore*>(part);
 
@@ -70,20 +70,25 @@ namespace NTabletFlatExecutor {
         }
 
         ui64 MissingReferencesSize() const
-        { 
+        {
             return MissingReferencesSize_;
         }
 
     private:
-        void ToLoadPage(TPageLocation location, TPageCollection *pageCollection) {
-            if (ToLoad[pageCollection->Id].insert(location).second) {
+        using THashSetOfLocation = THashSet<TPageLocation, NTable::NPage::TPageLocationByOffsetHash>;
+
+        void ToLoadPage(const TPageLocation& location, TPageCollection *pageCollection) {
+            auto res = ToLoad[pageCollection->Id].insert(location);
+            if (res.second) {
                 Stats.ToLoadPages++;
                 Y_ASSERT(!pageCollection->IsStickyPage(location.Offset));
                 Stats.ToLoadBytes += location.Size;
+            } else {
+                Y_ASSERT(res.first->Type == location.Type && res.first->Size == location.Size && res.first->Crc32 == location.Crc32);
             }
         }
 
-        const TSharedData* TryGetPage(TPageLocation location, TPageCollection *pageCollection)
+        const TSharedData* TryGetPage(const TPageLocation& location, TPageCollection *pageCollection)
         {
             auto& pinnedCollection = Seat.Pinned[pageCollection->Id];
             auto* pinnedPage = pinnedCollection.FindPtr(location.Offset);
@@ -125,13 +130,11 @@ namespace NTabletFlatExecutor {
         }
 
     private:
-        using THashSetOfLocation = THashSet<TPageLocation, NTable::NPage::TPageLocationByOffsetHash>;
-
         TPrivatePageCache& Cache;
         TSeat& Seat;
 
         THashMap<TLogoBlobID, THashSetOfLocation> ToLoad;
-    
+
         bool ReadMissingReferences = false;
         ui64 MissingReferencesSize_ = 0;
 

--- a/ydb/core/tablet_flat/flat_fwd_blobs.h
+++ b/ydb/core/tablet_flat/flat_fwd_blobs.h
@@ -39,7 +39,7 @@ namespace NFwd {
 
         TResult Get(IPageLoadingQueue *head, TPageOffset offset, EPage, ui64 lower) override
         {
-            auto pageId = offset.AsPageIndex();
+            auto pageId = offset.AsPageIndex(); // blob pages are always page-index-addressed
 
             Y_ENSURE(pageId >= Lower, "Cannot handle backward blob reads");
 
@@ -73,6 +73,7 @@ namespace NFwd {
 
             Stat.Saved += page.Data.size();
             OnFetch -= page.Data.size();
+            // blob pages are always page-index-addressed
             OnHold += Lookup(page.Location.Offset.AsPageIndex()).Settle(page, std::move(sharedPageRef));
 
             Shrink(false /* do not drop loading pages */);

--- a/ydb/core/tablet_flat/flat_fwd_env.h
+++ b/ydb/core/tablet_flat/flat_fwd_env.h
@@ -131,7 +131,7 @@ namespace NFwd {
             return Pending == 0;
         }
 
-        const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override
         {
             auto type = location.Type;
 
@@ -176,9 +176,9 @@ namespace NFwd {
             Pending -= pages.size();
 
             for (auto& page : pages) {
-                auto type = page.Location.Type;
+                auto type = page.Page.GetType();
                 auto data = NSharedCache::TPinnedPageRef(page.Page).GetData();
-                NPageCollection::TLoadedPage loadedPage{ page.Location, std::move(data) };
+                NPageCollection::TLoadedPage loadedPage{ TPageLocation(page.Offset, data.size(), type), std::move(data) };
                 if (IsIndexPage(type)) {
                     Y_ENSURE(queue.IndexPageCollection->Label() == pageCollection->Label(), "TPart head storage doesn't match with fetch result");
                     queue->Fill(loadedPage, std::move(page.Page), type);

--- a/ydb/core/tablet_flat/flat_ops_compact.h
+++ b/ydb/core/tablet_flat/flat_ops_compact.h
@@ -367,9 +367,9 @@ namespace NTabletFlatExecutor {
                         sharedPage->ProvideBody(std::move(loadedPage.Data));
                         saveCompactedPages->Pages.push_back(sharedPage);
                         if (sticky) {
-                            resultingPageCollection->AddStickyPage(loadedPage.Location, TSharedPageRef::MakeUsed(std::move(sharedPage), gcList));
+                            resultingPageCollection->AddStickyPage(loadedPage.Location.Offset, loadedPage.Location.Size, TSharedPageRef::MakeUsed(std::move(sharedPage), gcList, loadedPage.Location.Type));
                         } else {
-                            resultingPageCollection->AddPage(loadedPage.Location, TSharedPageRef::MakeUsed(std::move(sharedPage), gcList));
+                            resultingPageCollection->AddPage(loadedPage.Location.Offset, loadedPage.Location.Size, TSharedPageRef::MakeUsed(std::move(sharedPage), gcList, loadedPage.Location.Type));
                         }
                     };
                     for (auto &page : pageCollection.StickyPages) {

--- a/ydb/core/tablet_flat/flat_page_blobs.h
+++ b/ydb/core/tablet_flat/flat_page_blobs.h
@@ -90,7 +90,7 @@ namespace NPage {
             return { size, { page, 0 }, { page, size } };
         }
 
-        NPageCollection::TBorder Bounds(TPageLocation location) const override {
+        NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
             return Bounds(location.Offset.AsPageIndex());
         }
 
@@ -104,7 +104,7 @@ namespace NPage {
             return data && data.size() == Array.at(page).Bytes();
         }
 
-        bool Verify(TPageLocation location, TArrayRef<const char> data) const override {
+        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
             return data && data.size() == location.Size;
         }
 

--- a/ydb/core/tablet_flat/flat_page_iface.h
+++ b/ydb/core/tablet_flat/flat_page_iface.h
@@ -17,7 +17,7 @@ namespace NPage {
         ui64 Raw;
 
         static constexpr ui64 MaxRaw = ::Max<ui64>();
-        static constexpr ui64 ByteOffsetTag = ui64(1) << 63;
+        static constexpr ui64 IndexTag = ui64(1) << 63;
 
         explicit constexpr TPageOffset(ui64 raw) noexcept
             : Raw(raw)
@@ -30,16 +30,17 @@ namespace NPage {
         {}
 
         /** Factory: create from a real byte offset (pages in a blob sequence).
-            Sets the MSB to tag this as a byte offset. */
+            Untagged — sorts before IndexTag-addressed pages. */
         static TPageOffset FromByteOffset(ui64 value) {
-            Y_ENSURE(value < ByteOffsetTag,
+            Y_DEBUG_ABORT_UNLESS(value < IndexTag,
                 "Byte offset is too large to be represented as TPageOffset");
-            return TPageOffset(value | ByteOffsetTag);
+            return TPageOffset(value);
         }
 
-        /** Factory: create from a page index (independently addressed pages). */
+        /** Factory: create from a page index (independently addressed pages).
+            Sets the MSB to tag this as an index-addressed entry (sorts after byte offsets). */
         static TPageOffset FromPageIndex(ui32 value) noexcept {
-            return TPageOffset(static_cast<ui64>(value));
+            return TPageOffset(static_cast<ui64>(value) | IndexTag);
         }
 
         /** Max sentinel — all bits set */
@@ -50,22 +51,22 @@ namespace NPage {
         explicit operator bool() const noexcept { return Raw != MaxRaw; }
 
         bool IsMax() const noexcept { return Raw == MaxRaw; }
-        bool IsByteOffset() const noexcept { return !IsMax() && (Raw & ByteOffsetTag); }
-        bool IsPageIndex() const noexcept { return !IsMax() && !(Raw & ByteOffsetTag); }
+        bool IsByteOffset() const noexcept { return !IsMax() && !(Raw & IndexTag); }
+        bool IsPageIndex() const noexcept { return !IsMax() && (Raw & IndexTag); }
 
         /** Access as a real byte offset — asserts ByteOffset kind */
         ui64 AsByteOffset() const {
             Y_ENSURE(IsByteOffset(), "TPageOffset is not a byte offset (raw=" << Raw << ")");
-            return Raw & ~ByteOffsetTag;
+            return Raw;
         }
 
         /** Access as a page index — asserts PageIndex kind */
         ui32 AsPageIndex() const {
             Y_ENSURE(IsPageIndex(), "TPageOffset is not a page index (raw=" << Raw << ")");
-            return static_cast<ui32>(Raw);
+            return static_cast<ui32>(Raw & ~IndexTag);
         }
 
-        /** Natural ui64 ordering: page-index (no MSB) < byte-offset (MSB set) < Max */
+        /** Natural ui64 ordering: byte-offset (no MSB) < page-index (MSB set) < Max */
         friend auto operator<=>(const TPageOffset& a, const TPageOffset& b) noexcept = default;
 
         explicit operator size_t() const noexcept {
@@ -78,7 +79,7 @@ namespace NPage {
             } else if (IsByteOffset()) {
                 out << "bo:" << AsByteOffset();
             } else {
-                out << "pi:" << static_cast<ui32>(Raw);
+                out << "pi:" << AsPageIndex();
             }
         }
 
@@ -150,6 +151,8 @@ namespace NPage {
         TxIdStats = 11, /* Stats for uncommitted TxIds at compaction time */
         TxStatus = 12, /* Status of committed/removed transactions */
         BTreeIndex = 13,
+        BTreeIndexV2 = 14,
+        Skip = 15,     /* Absorbs excluded data/btree pages in TMeta */
     };
 
     struct TPageLocation {
@@ -170,7 +173,7 @@ namespace NPage {
             return {TPageOffset::FromPageIndex(pageId), size, type, crc32};
         }
 
-        TPageLocation(TPageOffset offset, ui64 size, EPage type = EPage::Undef, ui32 crc32 = 0) noexcept
+        TPageLocation(TPageOffset offset, ui64 size = 0, EPage type = EPage::Undef, ui32 crc32 = 0) noexcept
             : Offset(offset), Size(size), Type(type), Crc32(crc32)
         {}
 
@@ -182,14 +185,11 @@ namespace NPage {
         /** Access the offset as a page index — asserts the location was built from FromPageIndex */
         ui32 GetPageIndex() const { return Offset.AsPageIndex(); }
 
-        /** Ordering by Offset only */
-        auto operator<=>(const TPageLocation& rhs) const {
-            // 2 different pages at the same offset is impossible
-            Y_ENSURE(Offset != rhs.Offset || (Size == rhs.Size && Type == rhs.Type && Crc32 == rhs.Crc32),
-                "TPageLocation at same offset but differs (Size: " << Size << " vs " << rhs.Size << ", Type: " << Type
-                                                                   << " vs " << rhs.Type << ", Crc32: " << Crc32
-                                                                   << " vs " << rhs.Crc32 << ")");
-            return Offset <=> rhs.Offset;
+        /** Within a single collection, pages never overlap — Offset alone uniquely identifies a page */
+        auto operator<=>(const TPageLocation& rhs) const noexcept {
+            if (auto cmp = Offset <=> rhs.Offset; cmp != 0) return cmp;
+            Y_DEBUG_ABORT_UNLESS(Type == rhs.Type && Size == rhs.Size && Crc32 == rhs.Crc32);
+            return std::strong_ordering::equal;
         }
 
         bool operator==(const TPageLocation& rhs) const noexcept { return (operator<=>(rhs)) == 0; }

--- a/ydb/core/tablet_flat/flat_part_iface.h
+++ b/ydb/core/tablet_flat/flat_part_iface.h
@@ -73,7 +73,7 @@ namespace NTable {
 
         virtual TResult Locate(const TMemTable*, ui64 ref, ui32 tag) = 0;
         virtual TResult Locate(const TPart*, ui64 ref, ELargeObj lob) = 0;
-        virtual const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) = 0;
+        virtual const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) = 0;
 
         /**
          * Hook for cleaning up env on DB.RollbackChanges()

--- a/ydb/core/tablet_flat/flat_part_iter.h
+++ b/ydb/core/tablet_flat/flat_part_iter.h
@@ -78,7 +78,7 @@ namespace NTable {
         }
 
     protected:
-        bool LoadPage(TPageLocation location, TRowId baseRow)
+        bool LoadPage(const TPageLocation& location, TRowId baseRow)
         {
             if (Offset != location.Offset) {
                 Data = { };

--- a/ydb/core/tablet_flat/flat_part_keys.h
+++ b/ydb/core/tablet_flat/flat_part_keys.h
@@ -125,7 +125,7 @@ namespace NTable {
             return true;
         }
 
-        bool LoadPage(TPageLocation location)
+        bool LoadPage(const TPageLocation& location)
         {
             Y_ENSURE(location.Offset != TPageOffset::Max(), "Unexpected seek to an invalid page id");
             if (Offset != location.Offset) {

--- a/ydb/core/tablet_flat/flat_part_loader.h
+++ b/ydb/core/tablet_flat/flat_part_loader.h
@@ -57,7 +57,7 @@ namespace NTable {
                 Part = part;
             }
 
-            const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override
+            const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override
             {
                 Y_ENSURE(part == Part, "Unsupported part");
                 Y_ENSURE(groupId.IsMain(), "Unsupported column group");
@@ -77,7 +77,8 @@ namespace NTable {
                 if (savedPage != SavedPages.end()) {
                     return &savedPage->second;
                 } else {
-                    NeedPages.insert(location);
+                    auto [it, inserted] = NeedPages.emplace(location);
+                    Y_DEBUG_ABORT_UNLESS(inserted || *it == location);
                     return nullptr;
                 }
             }
@@ -103,17 +104,17 @@ namespace NTable {
 
             void Save(NSharedCache::TEvResult::TLoaded&& loaded)
             {
-                EPage pageType = loaded.Location.Type;
-
-                auto needed = NeedPages.erase(loaded.Location);
-                Y_ENSURE(needed, "Got unknown " << (ui16)pageType << " page at " << loaded.Location.Offset);
+                auto it = NeedPages.find(TPageLocation(loaded.Offset));
+                Y_ENSURE(it != NeedPages.end(), "Got unknown page at " << loaded.Offset);
+                EPage pageType = it->Type;
+                NeedPages.erase(it);
 
                 bool sticky = NeedIn(pageType) || pageType == EPage::FlatIndex;
-                AddSavedPage(loaded.Location.Offset, loaded.Page);
+                AddSavedPage(loaded.Offset, loaded.Page);
                 if (sticky) {
-                    PageCollection->AddStickyPage(loaded.Location, std::move(loaded.Page));
+                    PageCollection->AddStickyPage(loaded.Offset, loaded.Size, std::move(loaded.Page));
                 } else {
-                    PageCollection->AddPage(loaded.Location, std::move(loaded.Page));
+                    PageCollection->AddPage(loaded.Offset, loaded.Size, std::move(loaded.Page));
                 }
             }
 
@@ -124,11 +125,18 @@ namespace NTable {
                 SavedPagesRefs.emplace_back(std::move(page));
             }
 
+            struct TPageLocationByOffsetEq {
+                bool operator()(const TPageLocation& a, const TPageLocation& b) const noexcept {
+                    return a.Offset == b.Offset;
+                }
+            };
+
             const TPart* Part = nullptr;
             TIntrusivePtr<TPageCollection> PageCollection;
             THashMap<TPageOffset, TSharedData> SavedPages;
             TVector<NSharedCache::TSharedPageRef> SavedPagesRefs;
-            THashSet<TPageLocation, NPage::TPageLocationByOffsetHash> NeedPages;
+            // Dedup by offset — keep Size/Type for the fetch request
+            THashSet<TPageLocation, NPage::TPageLocationByOffsetHash, TPageLocationByOffsetEq> NeedPages;
         };
 
         struct TRunOptions {

--- a/ydb/core/tablet_flat/flat_sausage_fetch.h
+++ b/ydb/core/tablet_flat/flat_sausage_fetch.h
@@ -31,5 +31,25 @@ namespace NPageCollection {
         TSharedData Data;
     };
 
+    // Lightweight: offset+data only; Size/Type/Crc32 are authoritative in the cache's PageSet.
+    struct TLoadedPageData {
+        TLoadedPageData() = default;
+
+        TLoadedPageData(TPageOffset offset, TSharedData data)
+            : Offset(offset)
+            , Data(std::move(data))
+        {
+
+        }
+
+        explicit operator bool() const noexcept
+        {
+            return Data && bool(Offset);
+        }
+
+        TPageOffset Offset;
+        TSharedData Data;
+    };
+
 }
 }

--- a/ydb/core/tablet_flat/flat_sausage_gut.h
+++ b/ydb/core/tablet_flat/flat_sausage_gut.h
@@ -17,11 +17,11 @@ namespace NPageCollection {
         virtual TInfo Page(ui32 page) const = 0;
         virtual TBorder Bounds(ui32 page) const = 0;
         /// Maps a page location to the blob storage range containing it
-        virtual TBorder Bounds(TPageLocation) const = 0;
+        virtual TBorder Bounds(const TPageLocation&) const = 0;
         virtual TGlobId Glob(ui32 blob) const = 0;
         virtual bool Verify(ui32 page, TArrayRef<const char>) const = 0;
         /// Verifies page data using the location's size and checksum
-        virtual bool Verify(TPageLocation, TArrayRef<const char>) const = 0;
+        virtual bool Verify(const TPageLocation&, TArrayRef<const char>) const = 0;
         virtual size_t BackingSize() const noexcept = 0;
         virtual NTable::NPage::TPageLocation GetLocation(ui32 pageId) const = 0;
     };

--- a/ydb/core/tablet_flat/flat_sausage_meta.cpp
+++ b/ydb/core/tablet_flat/flat_sausage_meta.cpp
@@ -88,15 +88,21 @@ NTable::NPage::TPageLocation TMeta::GetLocation(ui32 pageId) const
     return NTable::NPage::TPageLocation::FromByteOffset(offset, size, static_cast<NTable::NPage::EPage>(Extra[pageId].Type), Extra[pageId].Crc32);
 }
 
-TBorder TMeta::Bounds(NTable::NPage::TPageLocation location) const
+TBorder TMeta::Bounds(const NTable::NPage::TPageLocation& location) const
 {
     Y_ENSURE(!location.Offset.IsMax());
     if (!location.Offset.IsByteOffset()) {
-        // Accept page-index offsets (from blob forward cache): resolve byte offset from Index
+        // Page-index path (blob forward cache, outer collections):
+        //   resolve byte offset from Index, validate size against metadata.
         const auto pageId = location.Offset.AsPageIndex();
-        Y_ENSURE(pageId < Header->Pages, "Requested page " << pageId << " out of " << Header->Pages << " total pages");
+        Y_ENSURE(pageId < Header->Pages,
+            "Requested page " << pageId << " out of " << Header->Pages << " total pages");
         const ui64 offset = pageId ? Index[pageId - 1].Page : 0;
-        return TAlign(Steps).Lookup(offset, location.Size);
+        const ui64 size = Index[pageId].Page - offset;
+        Y_DEBUG_ABORT_UNLESS(location.Size == size,
+            "Size mismatch at page %" PRIu32 ": location claims %" PRIu64 " but meta has %" PRIu64,
+            pageId, location.Size, size);
+        return TAlign(Steps).Lookup(offset, size);
     }
     return TAlign(Steps).Lookup(location.GetByteOffset(), location.Size);
 }

--- a/ydb/core/tablet_flat/flat_sausage_meta.h
+++ b/ydb/core/tablet_flat/flat_sausage_meta.h
@@ -41,7 +41,7 @@ namespace NPageCollection {
         ui64 GetPageSize(ui32 pageId) const;
         TStringBuf GetPageInplaceData(ui32 pageId) const;
 
-        TBorder Bounds(NTable::NPage::TPageLocation location) const;
+        TBorder Bounds(const NTable::NPage::TPageLocation& location) const;
         TPageLocation GetLocation(ui32 pageId) const;
 
     public:

--- a/ydb/core/tablet_flat/flat_sausage_packet.h
+++ b/ydb/core/tablet_flat/flat_sausage_packet.h
@@ -53,12 +53,12 @@ namespace NPageCollection {
                 && Meta.GetPageChecksum(page) == Checksum(body);
         }
 
-        TBorder Bounds(TPageLocation location) const override
+        TBorder Bounds(const TPageLocation& location) const override
         {
             return Meta.Bounds(location);
         }
 
-        bool Verify(TPageLocation location, TArrayRef<const char> data) const override
+        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override
         {
             return data.size() == location.Size && Checksum(data) == location.Crc32;
         }

--- a/ydb/core/tablet_flat/flat_sausagecache.cpp
+++ b/ydb/core/tablet_flat/flat_sausagecache.cpp
@@ -34,7 +34,7 @@ TPrivatePageCache::TPageCollection::TPageCollection(const TPageCollection &pageC
     PageMap.reserve(pageCollection.PageMap.size());
     for (const auto& page : pageCollection.PageMap) {
         Y_ASSERT(page);
-        AddPage({page->Offset, page->Size}, page->SharedBody);
+        AddPage(page->Offset, page->Size, page->SharedBody);
     }
 }
 
@@ -118,18 +118,18 @@ void TPrivatePageCache::DropPage(TPageOffset offset, TPageCollection* pageCollec
     }
 }
 
-void TPrivatePageCache::AddPage(TPageLocation location, TSharedPageRef sharedBody, TPageCollection *pageCollection)
+void TPrivatePageCache::AddPage(TPageOffset offset, size_t size, const TSharedPageRef& sharedBody, TPageCollection *pageCollection)
 {
-    if (pageCollection->AddPage(location, std::move(sharedBody))) {
-        Stats.SharedBodyBytes += location.Size;
+    if (pageCollection->AddPage(offset, size, sharedBody)) {
+        Stats.SharedBodyBytes += size;
     }
 }
 
-void TPrivatePageCache::AddStickyPage(TPageLocation location, TSharedPageRef sharedBody, TPageCollection *pageCollection)
+void TPrivatePageCache::AddStickyPage(TPageOffset offset, size_t size, TSharedPageRef sharedBody, TPageCollection *pageCollection)
 {
-    AddPage(location, sharedBody, pageCollection);
-    if (pageCollection->AddStickyPage(location, std::move(sharedBody))) {
-        Stats.StickyBytes += location.Size;
+    AddPage(offset, size, sharedBody, pageCollection);
+    if (pageCollection->AddStickyPage(offset, size, std::move(sharedBody))) {
+        Stats.StickyBytes += size;
     }
 }
 

--- a/ydb/core/tablet_flat/flat_sausagecache.h
+++ b/ydb/core/tablet_flat/flat_sausagecache.h
@@ -85,28 +85,15 @@ public:
         // Mutable methods can be only called on a construction stage or from a Private Cache
         // Otherwise stat counters would be out of sync
 
-        bool AddPage(TPageId pageId, TSharedPageRef sharedBody) {
-            auto location = PageCollection->GetLocation(pageId);
-            return AddPage(location, std::move(sharedBody));
-        }
-
-        bool AddPage(TPageLocation location, TSharedPageRef sharedBody) {
+        bool AddPage(TPageOffset offset, size_t size, TSharedPageRef sharedBody) {
             return PageMap.emplace(MakeHolder<TPage>(
-                location.Offset, location.Size, std::move(sharedBody), this)).second;
+                offset, size, std::move(sharedBody), this)).second;
         }
 
-        bool AddStickyPage(TPageId pageId, TSharedPageRef sharedBody) {
-            return AddStickyPage(PageCollection->GetLocation(pageId), std::move(sharedBody));
-        }
-
-        bool AddStickyPage(TPageLocation location, TSharedPageRef sharedBody) {
+        bool AddStickyPage(TPageOffset offset, size_t size, TSharedPageRef sharedBody) {
             Y_ENSURE(sharedBody.IsUsed());
-            AddPage(location, sharedBody);
-            return StickyPages.emplace(location.Offset, std::move(sharedBody)).second;
-        }
-
-        bool DropPage(TPageId pageId) {
-            return DropPage(PageCollection->GetLocation(pageId).Offset);
+            AddPage(offset, size, sharedBody);
+            return StickyPages.emplace(offset, std::move(sharedBody)).second;
         }
 
         bool DropPage(NTable::NPage::TPageOffset offset, ui64 *size = nullptr) {
@@ -124,6 +111,10 @@ public:
 
         void SetCacheMode(ECacheMode cacheMode) {
             CacheMode = cacheMode;
+        }
+
+        NTable::NPage::TPageLocation GetLocation(ui32 pageId) const {
+            return PageCollection->GetLocation(pageId);
         }
 
         const TLogoBlobID Id;
@@ -160,23 +151,11 @@ public:
 
     const TStats& GetStats() const { return Stats; }
 
-    TSharedPageRef TryGetPage(TPageId pageId, TPageCollection *pageCollection) {
-        return TryGetPage(pageCollection->PageCollection->GetLocation(pageId).Offset, pageCollection);
-    }
     TSharedPageRef TryGetPage(TPageOffset offset, TPageCollection *pageCollection);
 
-    void DropPage(TPageId pageId, TPageCollection *pageCollection) {
-        DropPage(pageCollection->PageCollection->GetLocation(pageId).Offset, pageCollection);
-    }
     void DropPage(TPageOffset offset, TPageCollection *pageCollection);
-    void AddPage(TPageId pageId, TSharedPageRef sharedBody, TPageCollection *pageCollection) {
-        AddPage(pageCollection->PageCollection->GetLocation(pageId), std::move(sharedBody), pageCollection);
-    }
-    void AddPage(TPageLocation location, TSharedPageRef sharedBody, TPageCollection *pageCollection);
-    void AddStickyPage(TPageId pageId, TSharedPageRef sharedBody, TPageCollection *pageCollection) {
-        AddStickyPage(pageCollection->PageCollection->GetLocation(pageId), std::move(sharedBody), pageCollection);
-    }
-    void AddStickyPage(TPageLocation location, TSharedPageRef sharedBody, TPageCollection *pageCollection);
+    void AddPage(TPageOffset offset, size_t size, const TSharedPageRef& sharedBody, TPageCollection *pageCollection);
+    void AddStickyPage(TPageOffset offset, size_t size, TSharedPageRef sharedBody, TPageCollection *pageCollection);
     bool UpdateCacheMode(ECacheMode newCacheMode, TPageCollection *pageCollection);
 
     THashMap<TLogoBlobID, TIntrusivePtr<TPageCollection>> DetachPrivatePageCache();

--- a/ydb/core/tablet_flat/shared_cache_events.h
+++ b/ydb/core/tablet_flat/shared_cache_events.h
@@ -133,16 +133,18 @@ namespace NKikimr::NSharedCache {
             return
                 std::accumulate(Pages.begin(), Pages.end(), ui64(0),
                     [](ui64 bytes, const TLoaded& loaded)
-                        { return bytes + TPinnedPageRef(loaded.Page)->size(); });
+                        { return bytes + loaded.Size; });
         }
 
         struct TLoaded {
-            TLoaded(NTable::NPage::TPageLocation location, TSharedPageRef page)
-                : Location(location)
+            TLoaded(NTable::NPage::TPageOffset offset, size_t size, TSharedPageRef page)
+                : Offset(offset)
+                , Size(size)
                 , Page(std::move(page))
             { }
 
-            NTable::NPage::TPageLocation Location;
+            NTable::NPage::TPageOffset Offset;
+            size_t Size;
             TSharedPageRef Page;
         };
 

--- a/ydb/core/tablet_flat/shared_handle.h
+++ b/ydb/core/tablet_flat/shared_handle.h
@@ -326,10 +326,12 @@ public:
 
     TSharedPageRef(
             TIntrusivePtr<TSharedPageHandle> handle,
-            TIntrusivePtr<TSharedPageGCList> gcList) noexcept
+            TIntrusivePtr<TSharedPageGCList> gcList,
+            NTable::NPage::EPage type = NTable::NPage::EPage::Undef) noexcept
         : Handle(std::move(handle))
         , GCList(std::move(gcList))
         , Used(false)
+        , Type(type)
     { }
 
     ~TSharedPageRef() {
@@ -340,6 +342,7 @@ public:
         : Handle(ref.Handle)
         , GCList(ref.GCList)
         , Used(false)
+        , Type(ref.Type)
     {
         if (ref.Used) {
             Y_ENSURE(Use());
@@ -350,6 +353,7 @@ public:
         : Handle(std::move(ref.Handle))
         , GCList(std::move(ref.GCList))
         , Used(std::exchange(ref.Used, false))
+        , Type(ref.Type)
     { }
 
     TSharedPageRef& operator=(const TSharedPageRef& ref) {
@@ -357,6 +361,7 @@ public:
             Drop();
             Handle = ref.Handle;
             GCList = ref.GCList;
+            Type = ref.Type;
             if (ref.Used) {
                 Y_ENSURE(Use());
             }
@@ -371,6 +376,7 @@ public:
             Handle = std::move(ref.Handle);
             GCList = std::move(ref.GCList);
             Used = std::exchange(ref.Used, false);
+            Type = ref.Type;
         }
 
         return *this;
@@ -378,9 +384,10 @@ public:
 
     static TSharedPageRef MakeUsed(
         TIntrusivePtr<TSharedPageHandle> handle,
-        TIntrusivePtr<TSharedPageGCList> gcList) noexcept
+        TIntrusivePtr<TSharedPageGCList> gcList,
+        NTable::NPage::EPage type = NTable::NPage::EPage::Undef) noexcept
     {
-        TSharedPageRef ref(std::move(handle), std::move(gcList));
+        TSharedPageRef ref(std::move(handle), std::move(gcList), type);
         ref.Use();
         return ref;
     }
@@ -399,6 +406,15 @@ public:
 
     bool IsUsed() const {
         return Used;
+    }
+
+    NTable::NPage::EPage GetType() const noexcept {
+        Y_DEBUG_ABORT_UNLESS(Type != NTable::NPage::EPage::Undef);
+        return Type;
+    }
+
+    void SetType(NTable::NPage::EPage type) noexcept {
+        Type = type;
     }
 
     bool Use() noexcept {
@@ -457,6 +473,7 @@ private:
     TIntrusivePtr<TSharedPageHandle> Handle;
     TIntrusivePtr<TSharedPageGCList> GCList;
     bool Used;
+    NTable::NPage::EPage Type = NTable::NPage::EPage::Undef;
 };
 
 /**

--- a/ydb/core/tablet_flat/shared_sausagecache.cpp
+++ b/ydb/core/tablet_flat/shared_sausagecache.cpp
@@ -467,9 +467,9 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
                     page->IncrementFrequency();
                 }
                 if (doTraceLog) {
-                    pagesFromCacheTraceLog.push_back(location.Offset);
+                    pagesFromCacheTraceLog.push_back(page->Offset);
                 }
-                readyPages.emplace_back(location, TSharedPageRef::MakeUsed(page, SharedCachePages->GCList));
+                readyPages.emplace_back(page->Offset, page->Size, TSharedPageRef::MakeUsed(page, SharedCachePages->GCList, page->Type));
                 break;
             case PageStateNo:
                 ++pagesToRequestCount;
@@ -483,8 +483,8 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
                     Counters.CacheMissInMemoryPages->Inc();
                     Counters.CacheMissInMemoryBytes->Add(page->Size);
                 }
-                readyPages.emplace_back(location, TSharedPageRef());
-                pendingPages.emplace_back(location.Offset, reqIdx);
+                readyPages.emplace_back(page->Offset, page->Size, TSharedPageRef());
+                pendingPages.emplace_back(page->Offset, reqIdx);
                 break;
             case PageStateEvicted:
                 Y_TABLET_ERROR("must not happens");
@@ -848,7 +848,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
             bool needNotifyOwners = fetchType == EBlockIOFetchTypeCookie::TryKeepInMemoryPreload && collection->InMemoryOwners;
             auto loadedPages = needNotifyOwners ? TVector<TPage*>(::Reserve(msg->Pages.size())) : TVector<TPage*>();
             for (auto &paged : msg->Pages) {
-                auto* page = collection->PageSet.FindPage(paged.Location.Offset);
+                auto* page = collection->PageSet.FindPage(paged.Offset);
                 if (!page || !page->HasMissingBody()) {
                     continue;
                 }
@@ -875,7 +875,7 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
     }
 
     TPage* EnsurePage(TCollection& collection,
-        TPageLocation location, ECacheMode initialMode) {
+        const TPageLocation& location, ECacheMode initialMode) {
         TPage* page = collection.PageSet.FindPage(location.Offset);
 
         if (!page) {
@@ -1052,8 +1052,8 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
             }
 
             auto &readyPage = request->ReadyPages[index];
-            Y_ENSURE(readyPage.Location.Offset == page->Offset);
-            readyPage.Page = TSharedPageRef::MakeUsed(page, SharedCachePages->GCList);
+            Y_ENSURE(readyPage.Offset == page->Offset);
+            readyPage.Page = TSharedPageRef::MakeUsed(page, SharedCachePages->GCList, page->Type);
 
             if (--request->PendingBlocks == 0) {
                 SendResult(*request);
@@ -1114,8 +1114,8 @@ class TSharedPageCache : public TActorBootstrapped<TSharedPageCache> {
         for (auto* page : readyPages) {
             if (page->State == PageStateLoaded) { // page may be evicted before NotifyInMemOwner call
                 readyLoadedPages.emplace_back(
-                    TPageLocation(page->Offset, page->Size, page->Type, page->Crc32),
-                    TSharedPageRef::MakeUsed(page, SharedCachePages->GCList));
+                    page->Offset, page->Size,
+                    TSharedPageRef::MakeUsed(page, SharedCachePages->GCList, page->Type));
             }
         }
 
@@ -1663,7 +1663,7 @@ template<> inline
 void Out<TVector<NKikimr::NSharedCache::TEvResult::TLoaded>>(IOutputStream& o, const TVector<NKikimr::NSharedCache::TEvResult::TLoaded> &vec) {
     o << "[ ";
     for (const auto &x : vec)
-        o << x.Location << ' ';
+        o << x.Offset << ' ';
     o << "]";
 }
 
@@ -1671,7 +1671,15 @@ template<> inline
 void Out<TVector<NKikimr::NPageCollection::TLoadedPage>>(IOutputStream& o, const TVector<NKikimr::NPageCollection::TLoadedPage> &vec) {
     o << "[ ";
     for (const auto &x : vec)
-        o << x.Location.Offset << ' ';
+        o << x.Location << ' ';
+    o << "]";
+}
+
+template<> inline
+void Out<TVector<NKikimr::NPageCollection::TLoadedPageData>>(IOutputStream& o, const TVector<NKikimr::NPageCollection::TLoadedPageData> &vec) {
+    o << "[ ";
+    for (const auto &x : vec)
+        o << x.Offset << ' ';
     o << "]";
 }
 

--- a/ydb/core/tablet_flat/test/libs/table/test_dummy.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_dummy.h
@@ -19,7 +19,7 @@ namespace NTable {
             Y_TABLET_ERROR("Dummy env cannot deal with storage");
         }
 
-        const TSharedData* TryGetPage(const TPart*, TPageLocation, TGroupId) override
+        const TSharedData* TryGetPage(const TPart*, const TPageLocation&, TGroupId) override
         {
              Y_TABLET_ERROR("Dummy env cannot deal with storage");
         }

--- a/ydb/core/tablet_flat/test/libs/table/test_envs.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_envs.h
@@ -46,7 +46,7 @@ namespace NTest {
                 pass ? TTestEnv::Locate(part, ref, lob) : TResult{need, nullptr };
         }
 
-        const TSharedData* TryGetPage(const TPart *part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
             return Pages ? TTestEnv::TryGetPage(part, location, groupId) : nullptr;
         }
@@ -107,7 +107,7 @@ namespace NTest {
             }
         }
 
-        const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override
         {
             auto pass = ShouldPass((const void*)part,
                 static_cast<ui64>(THash<TPageOffset>()(location.Offset)) ^ (ui64(groupId.Raw()) << 48),
@@ -192,7 +192,7 @@ namespace NTest {
             return { size, { page, 0 }, { page, size } };
         }
 
-        NPageCollection::TBorder Bounds(TPageLocation location) const override {
+        NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
             return Bounds(location.Offset.AsPageIndex());
         }
 
@@ -204,7 +204,7 @@ namespace NTest {
             return true;
         }
 
-        bool Verify(TPageLocation location, TArrayRef<const char> data) const override {
+        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
             return data.size() == location.Size;
         }
 
@@ -336,7 +336,7 @@ namespace NTest {
             return Get(part, room).DoLoad(TPageOffset::FromPageIndex(ref), EPage::Opaque, AheadLo, AheadHi);
         }
 
-        const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override
         {
             InitPart(part);
 

--- a/ydb/core/tablet_flat/test/libs/table/test_part.h
+++ b/ydb/core/tablet_flat/test/libs/table/test_part.h
@@ -116,7 +116,7 @@ namespace NTest {
             return { true, Get(part, room, ref) };
         }
 
-        const TSharedData* TryGetPage(const TPart *part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
             auto pageId = location.GetPageIndex();
             return Get(part, groupId.Index, pageId);

--- a/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_btree_index_iter_charge.cpp
@@ -18,7 +18,7 @@ namespace {
     using TChild = TBtreeIndexNode::TChild;
 
     struct TTouchEnv : public NTest::TTestEnv {
-        const TSharedData* TryGetPage(const TPart *part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
             auto pageId = location.GetPageIndex();
             if (Sticky[groupId].contains(pageId)) {

--- a/ydb/core/tablet_flat/ut/ut_charge.cpp
+++ b/ydb/core/tablet_flat/ut/ut_charge.cpp
@@ -53,7 +53,7 @@ namespace {
             , Sticky(std::move(sticky))
             { }
 
-        const TSharedData* TryGetPage(const TPart *part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
             auto pageId = location.GetPageIndex();
             Touched[groupId].insert(pageId);

--- a/ydb/core/tablet_flat/ut/ut_forward.cpp
+++ b/ydb/core/tablet_flat/ut/ut_forward.cpp
@@ -36,10 +36,10 @@ namespace {
         ui32 Total() const noexcept override { return 0; }
         NPageCollection::TInfo Page(ui32) const override { return {0, 0}; }
         NPageCollection::TBorder Bounds(ui32) const override { Y_TABLET_ERROR("Not implemented"); }
-        NPageCollection::TBorder Bounds(TPageLocation) const override { Y_TABLET_ERROR("Not implemented"); }
+        NPageCollection::TBorder Bounds(const TPageLocation&) const override { Y_TABLET_ERROR("Not implemented"); }
         NPageCollection::TGlobId Glob(ui32) const override { Y_TABLET_ERROR("Not implemented"); }
         bool Verify(ui32, TArrayRef<const char>) const override { return true; }
-        bool Verify(TPageLocation, TArrayRef<const char>) const override { return true; }
+        bool Verify(const TPageLocation&, TArrayRef<const char>) const override { return true; }
         size_t BackingSize() const noexcept override { return 0; }
 
         NTable::NPage::TPageLocation GetLocation(ui32 pageId) const override {
@@ -196,7 +196,7 @@ namespace {
         }
 
         // AsPageIndex: test collection uses FromPageIndex, so the offset encodes a page index
-        NPageCollection::TBorder Bounds(TPageLocation location) const override {
+        NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
             return { location.Size, { 0, location.Offset.AsPageIndex() }, { 0, location.Offset.AsPageIndex() + (ui32)location.Size } };
         }
 
@@ -208,7 +208,7 @@ namespace {
             return true;
         }
 
-        bool Verify(TPageLocation location, TArrayRef<const char> data) const override {
+        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
             return data.size() == location.Size;
         }
 

--- a/ydb/core/tablet_flat/ut/ut_iterator.cpp
+++ b/ydb/core/tablet_flat/ut/ut_iterator.cpp
@@ -182,7 +182,7 @@ Y_UNIT_TEST_SUITE(TIterator) {
             return NTest::TTestEnv::Locate(part, ref, lob);
         }
 
-        const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override {
+        const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override {
             auto pageId = location.GetPageIndex();
             if (AutoLoad) {
                 if (Loaded[groupId].insert(pageId).second) {

--- a/ydb/core/tablet_flat/ut/ut_part.cpp
+++ b/ydb/core/tablet_flat/ut/ut_part.cpp
@@ -58,7 +58,7 @@ namespace {
     }
 
     struct TTouchEnv : public NTest::TTestEnv {
-        const TSharedData* TryGetPage(const TPart *part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
             auto pageId = location.GetPageIndex();
             if (PrechargePhase) {

--- a/ydb/core/tablet_flat/ut/ut_sausage.cpp
+++ b/ydb/core/tablet_flat/ut/ut_sausage.cpp
@@ -652,7 +652,7 @@ Y_UNIT_TEST_SUITE(NPageCollection) {
                 Map[loc.Offset] = std::move(data);
             }
 
-            const TSharedData* TryGetPage(const TPart*, TPageLocation location, TGroupId) override
+            const TSharedData* TryGetPage(const TPart*, const TPageLocation& location, TGroupId) override
             {
                 auto it = Map.find(location.Offset);
                 return it != Map.end() ? &it->second : nullptr;

--- a/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
+++ b/ydb/core/tablet_flat/ut/ut_shared_sausagecache_actor.cpp
@@ -68,7 +68,7 @@ struct TPageCollectionMock : public IPageCollection {
         return { Page(page).Size, { page, 0 }, { page, ui32(Page(page).Size) } };
     }
 
-    TBorder Bounds(TPageLocation location) const override {
+    TBorder Bounds(const TPageLocation& location) const override {
         return Bounds(location.Offset.AsPageIndex());
     }
 
@@ -80,7 +80,7 @@ struct TPageCollectionMock : public IPageCollection {
         Y_TABLET_ERROR("Unexpected Verify(...) call");
     }
 
-    bool Verify(TPageLocation location, TArrayRef<const char> data) const override {
+    bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
         return data.size() == location.Size;
     }
 
@@ -198,7 +198,7 @@ struct TSharedPageCacheMock {
     TSharedPageCacheMock& Provide(TIntrusiveConstPtr<TPageCollectionMock> collection, TVector<TPageLocation> locations, ui64 eventCookie = NO_QUEUE_COOKIE) { // event cookie -> queue type
         auto data = new NBlockIO::TEvData(NKikimrProto::OK, collection, locations.size() * 10); // fetch cookie -> requested size
         for (auto& loc : locations) {
-            data->Pages.emplace_back(loc, TSharedData::Copy(TString(10, 'x')));
+            data->Pages.emplace_back(loc.Offset, TSharedData::Copy(TString(10, 'x')));
         }
         Send(BlockIoSender, data, eventCookie);
 
@@ -275,8 +275,8 @@ struct TSharedPageCacheMock {
             auto& result = *r->Get();
             actual.push_back(TFetch{result.Cookie, result.PageCollection, {}});
             for (auto& p : r->Get()->Pages) {
-                actual.back().Pages.push_back(p.Location);
-                pages.emplace(p.Location.Offset.AsPageIndex(), p.Page);
+                actual.back().Pages.push_back(r->Get()->PageCollection->GetLocation(p.Offset.AsPageIndex()));
+                pages.emplace(p.Offset.AsPageIndex(), p.Page);
             }
         }
         Results.clear();
@@ -386,7 +386,7 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->PageCollectionOwners->Val(), 4);
 
         auto data = new NBlockIO::TEvData(NKikimrProto::ERROR, sharedCache.Collection1, 30);
-        data->Pages = {{_P(1), TSharedData{}}, {_P(2), TSharedData{}}, {_P(3), TSharedData{}}};
+        data->Pages = {TLoadedPageData(_P(1).Offset, TSharedData{}), TLoadedPageData(_P(2).Offset, TSharedData{}), TLoadedPageData(_P(3).Offset, TSharedData{})};
         sharedCache.Send(sharedCache.BlockIoSender, data, NO_QUEUE_COOKIE);
         sharedCache.CheckResults({
             TFetch{1, sharedCache.Collection1, {}},
@@ -496,7 +496,7 @@ Y_UNIT_TEST_SUITE(TSharedPageCache_Actor) {
         UNIT_ASSERT_VALUES_EQUAL(sharedCache.Counters->PageCollectionOwners->Val(), 4);
 
         auto data = new NBlockIO::TEvData(NKikimrProto::ERROR, sharedCache.Collection1, 10);
-        data->Pages = {{_P(1), TSharedData{}}};
+        data->Pages = {TLoadedPageData(_P(1).Offset, TSharedData{})};
         sharedCache.Send(sharedCache.BlockIoSender, data, ASYNC_QUEUE_COOKIE);
         sharedCache.CheckResults({
             TFetch{1, sharedCache.Collection1, {}},

--- a/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
+++ b/ydb/core/tablet_flat/ut/ut_slice_loader.cpp
@@ -91,7 +91,7 @@ namespace {
             return { Page(page).Size, { page, 0 }, { page, ui32(Page(page).Size) } };
         }
 
-        NPageCollection::TBorder Bounds(TPageLocation location) const override {
+        NPageCollection::TBorder Bounds(const TPageLocation& location) const override {
             return Bounds(location.Offset.AsPageIndex());
         }
 
@@ -105,7 +105,7 @@ namespace {
             Y_TABLET_ERROR("Unexpected Verify(...) call");
         }
 
-        bool Verify(TPageLocation location, TArrayRef<const char> data) const override {
+        bool Verify(const TPageLocation& location, TArrayRef<const char> data) const override {
             return data.size() == location.Size;
         }
 
@@ -172,7 +172,7 @@ namespace {
                     auto pageId = location.GetPageIndex();
                     auto* page = part->Store->GetPage(0, pageId);
                     UNIT_ASSERT_C(page, "TLoader wants a missing page " << pageId);
-                    env.Save({ location, NSharedCache::TSharedPageRef::MakePrivate(*page) });
+                    env.Save({ location.Offset, location.Size, NSharedCache::TSharedPageRef::MakePrivate(*page) });
                 }
             } else {
                 UNIT_ASSERT_C(false, "TKeysLoader was stalled");

--- a/ydb/core/tablet_flat/ut/ut_stat.cpp
+++ b/ydb/core/tablet_flat/ut/ut_stat.cpp
@@ -16,7 +16,7 @@ namespace {
     using namespace NTest;
 
     struct TTouchEnv : public NTest::TTestEnv {
-        const TSharedData* TryGetPage(const TPart *part, TPageLocation location, TGroupId groupId) override
+        const TSharedData* TryGetPage(const TPart *part, const TPageLocation& location, TGroupId groupId) override
         {
             auto pageId = location.GetPageIndex();
             auto page = NTest::TTestEnv::TryGetPage(part, location, groupId);

--- a/ydb/core/tx/datashard/datashard__stats.cpp
+++ b/ydb/core/tx/datashard/datashard__stats.cpp
@@ -83,13 +83,13 @@ public:
         Y_ENSURE(false, "IPages::Locate(TPart*, ...) shouldn't be used here");
     }
 
-    const TSharedData* TryGetPage(const TPart* part, TPageLocation location, TGroupId groupId) override {
+    const TSharedData* TryGetPage(const TPart* part, const TPageLocation& location, TGroupId groupId) override {
         Y_ENSURE(groupId.IsMain(), "Unsupported column group");
 
         auto partStore = CheckedCast<const TPartStore*>(part);
         auto info = partStore->PageCollections.at(groupId.Index).Get();
         auto type = location.Type;
-        Y_ENSURE(type == EPage::FlatIndex || type == EPage::BTreeIndex);
+        Y_ENSURE(type == EPage::FlatIndex || type == EPage::BTreeIndex || type == EPage::BTreeIndexV2);
 
         auto& partPages = Pages[part];
         auto page = partPages.FindPtr(location.Offset);
@@ -110,7 +110,7 @@ public:
         Resume();
 
         for (auto& loaded : ev->Get()->Pages) {
-            partPages.emplace(loaded.Location.Offset, TPinnedPageRef(loaded.Page).GetData());
+            partPages.emplace(loaded.Offset, TPinnedPageRef(loaded.Page).GetData());
             PageRefs.emplace_back(std::move(loaded.Page));
         }
 


### PR DESCRIPTION
…interface migration

Foundation for the V2 btree-index work. No V2 feature logic; V1 behavior preserved.

- Invert TPageOffset encoding: byte-offsets untagged (sort first), page-indexes carry the MSB IndexTag. TPageLocation::operator<=> is noexcept/debug-checked.
- Add EPage::BTreeIndexV2 and EPage::Skip enum values (unused yet).
- IPages::TryGetPage takes const TPageLocation& (all implementers migrated).
- Introduce NPageCollection::TLoadedPageData; NSharedCache::TEvResult::TLoaded now carries Offset+Size+Page instead of a full TPageLocation.
- TSharedPageRef carries an EPage type (defaulted; MakeUsed takes type).
- Private/shared page cache keyed by TPageOffset+size; TPageId/TPageLocation overloads of AddPage/AddStickyPage/DropPage removed.
- IPageCollection::Bounds/Verify take const TPageLocation& (all implementers migrated); TMeta::Bounds validates page-index size against metadata.
- TLoaderEnv::NeedPages is a THashSet<TPageLocation, ByOffsetHash, ByOffsetEq> deduped by offset; TPageLocation ctor defaults size = 0 so a probe can be built from an offset; GetFetch builds the request from the set iterators.
- Fix pre-existing double-increment in TBlockIO::Terminate.

### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
