### PR TITLE
[NBS-7570] Add benchmark for time predictor

### DIFF
--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/requests_benchmark.cpp
@@ -1,8 +1,8 @@
-#include "../erase_request.h"
-#include "../flush_request.h"
-#include "../read_request_executor.h"
-#include "../restore_request.h"
-#include "../write_request_test_fixture.h"
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/erase_request.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/flush_request.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/read_request_executor.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/restore_request.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/write_request_test_fixture.h>
 
 #include <ydb/library/actors/core/log.h>
 #include <ydb/library/services/services.pb.h>

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/time_predictor_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/time_predictor_benchmark.cpp
@@ -1,0 +1,74 @@
+#include <ydb/core/nbs/cloud/blockstore/libs/common/constants.h>
+#include <ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/model/time_predictor.h>
+
+#include <util/generic/vector.h>
+#include <util/random/fast.h>
+
+#include <benchmark/benchmark.h>
+
+using namespace NYdb::NBS::NBlockStore;
+using namespace NYdb::NBS::NBlockStore::NStorage::NPartitionDirect;
+
+namespace {
+
+constexpr size_t HistorySize = 100;
+constexpr size_t NthFromEnd = 1;
+
+// Power of two so the loop can wrap with a mask instead of a division.
+constexpr size_t SampleCount = 1024;
+
+struct TSample
+{
+    THostIndex Host = 0;
+    TDuration Time;
+};
+
+// Request completion time: a bulk of fast requests plus a heavy tail. The
+// spread is what matters here - it decides where in the multiset the inserted
+// and the evicted values land.
+TDuration MakeLatency(TReallyFastRng32& rng)
+{
+    const ui32 micros = rng.Uniform(100, 1500);
+    const bool tail = rng.Uniform(100) < 2;
+    return TDuration::MicroSeconds(tail ? micros * 30 : micros);
+}
+
+TVector<TSample> MakeSamples(TReallyFastRng32& rng)
+{
+    TVector<TSample> samples(Reserve(SampleCount));
+    for (size_t i = 0; i < SampleCount; ++i) {
+        samples.push_back(TSample{
+            .Host = static_cast<THostIndex>(
+                rng.Uniform(ui32(DirectBlockGroupHostCount))),
+            .Time = MakeLatency(rng)});
+    }
+    return samples;
+}
+
+}   // namespace
+
+// Add() is called on the datapath for every request completion: it inserts
+// into the multiset and erases the value evicted from the ring buffer. Sample
+// generation and history warmup happen before the timed loop, so only Add() is
+// measured.
+static void BM_TimePredictorAdd(benchmark::State& state)
+{
+    TReallyFastRng32 rng(42);
+    const auto samples = MakeSamples(rng);
+
+    TTimePredictor predictor(HistorySize, NthFromEnd);
+    for (size_t host = 0; host < DirectBlockGroupHostCount; ++host) {
+        for (size_t i = 0; i < HistorySize; ++i) {
+            predictor.Add(static_cast<THostIndex>(host), MakeLatency(rng));
+        }
+    }
+
+    size_t index = 0;
+    for (auto _: state) {
+        const auto& sample = samples[index++ & (SampleCount - 1)];
+        predictor.Add(sample.Host, sample.Time);
+        benchmark::ClobberMemory();
+    }
+}
+
+BENCHMARK(BM_TimePredictorAdd)->Unit(benchmark::kNanosecond);

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/time_predictor_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/time_predictor_benchmark.cpp
@@ -67,7 +67,7 @@ static void BM_TimePredictorAdd(benchmark::State& state)
     for (auto _: state) {
         const auto& sample = samples[index++ & (SampleCount - 1)];
         predictor.Add(sample.Host, sample.Time);
-        benchmark::ClobberMemory();
+        benchmark::DoNotOptimize(predictor);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/time_predictor_benchmark.cpp
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/time_predictor_benchmark.cpp
@@ -64,10 +64,11 @@ static void BM_TimePredictorAdd(benchmark::State& state)
     }
 
     size_t index = 0;
+    auto* predictorPtr = &predictor;
     for (auto _: state) {
         const auto& sample = samples[index++ & (SampleCount - 1)];
         predictor.Add(sample.Host, sample.Time);
-        benchmark::DoNotOptimize(predictor);
+        benchmark::DoNotOptimize(predictorPtr);
     }
 }
 

--- a/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/ya.make
+++ b/ydb/core/nbs/cloud/blockstore/libs/storage/partition_direct/benchmark/ya.make
@@ -8,6 +8,7 @@ BENCHMARK_OPTS(--benchmark_min_time=0.05s)
 
 SRCS(
     requests_benchmark.cpp
+    time_predictor_benchmark.cpp
     ../base_test_fixture.cpp
     ../direct_block_group_mock.cpp
     ../write_request_test_fixture.cpp

--- a/ydb/core/nbs/flamegraph_analysis/README.md
+++ b/ydb/core/nbs/flamegraph_analysis/README.md
@@ -1,0 +1,115 @@
+# Profiling an nbs2 partition dyn node with perf + FlameGraph
+
+## Prerequisites
+
+`FlameGraph` must be checked out next to the work dir:
+
+```bash
+ssh <host>
+mkdir -p ~/flamegraphs && cd ~/flamegraphs
+git clone https://github.com/brendangregg/FlameGraph.git ../FlameGraph   # -> ~/FlameGraph
+mkdir -p work && cd work
+```
+
+Only `flamegraph.pl` and `stackcollapse-perf.pl` are actually used.
+
+## 1. Find the process
+
+```bash
+ps aux | grep -E 'kikimr.*NBS' | grep -v grep
+# sanity-check it is the right one and see how busy it is:
+ps -p <pid> -o pid,etime,nlwp,pcpu,rss,cmd --no-headers
+top -b -n1 -H -p <pid> | head -25      # per-thread CPU — tells you which pools are hot
+```
+
+## 2. Record
+
+```bash
+cd ~/flamegraphs/work
+sudo perf record -F 99 -g -p <pid> -o perf_analysis.data sleep 30
+```
+
+* `-F 99` — 99 Hz, deliberately not 100 to avoid beating against periodic timers.
+* `-g` — call graphs. The binary is built with frame pointers, so the default
+  fp unwinding works; if stacks come out truncated add `--call-graph dwarf`
+  (much larger `perf.data`, ~10x).
+* `-p <pid>` samples **all threads** of the process. That is what you want here —
+  the interesting question is how work splits across the actor pools.
+* Bump `sleep` to 60–120 s if the load is bursty. 30 s at 99 Hz across ~3 busy
+  threads gives ~8 k samples, which is enough to resolve anything above ~0.5 %.
+
+## 3. Fold the stacks (this is the artifact you actually analyse)
+
+```bash
+sudo perf script --no-demangle -i perf_analysis.data > perf_analysis.script
+sudo chown $USER perf_analysis.script
+
+c++filt -n < perf_analysis.script \
+  | ~/FlameGraph/stackcollapse-perf.pl \
+  > folded.txt
+```
+
+`--no-demangle` + external `c++filt -n` is much faster and more reliable than
+perf's built-in demangler for Arcadia's very long template symbols.
+
+`folded.txt` is one line per unique stack: `frame;frame;...;leaf <count>`.
+It is small (a few thousand lines), greppable, and is the input to everything below.
+
+## 4a. SVG flamegraph
+
+```bash
+~/FlameGraph/flamegraph.pl \
+  --title "nbs2 partition dyn node (pid <pid>) 30s @99Hz" \
+  folded.txt > nbs2_analysis.svg
+```
+
+## 4b. Text summary (preferred for analysis)
+
+The SVG is good for exploring, bad for answering "where does the time go".
+[analyze_folded.py](analyze_folded.py) turns `folded.txt` into ranked tables:
+
+```bash
+python3 analyze_folded.py folded.txt --top 30
+```
+
+Prints, each as a percentage with a bar:
+
+* **threads** — samples grouped by root frame (= thread comm = actor pool)
+* **self time** — leaf frames, i.e. where cycles are actually burnt
+* **inclusive time** — every frame anywhere in a stack
+* **hottest full stacks** — the top complete stacks, indented
+
+Useful flags:
+
+```bash
+# Drop blocked/idle time. Every stack that went to sleep has finish_task_switch
+# in it, so excluding it leaves a pure on-CPU profile. Do this first — otherwise
+# futex_wait/epoll_wait/__schedule dominate and hide the real work.
+python3 analyze_folded.py folded.txt --exclude finish_task_switch
+
+# One actor pool at a time (root frame match)
+python3 analyze_folded.py folded.txt --exclude finish_task_switch --thread kikimr.NBS_0
+
+# Everything touching one symbol, with the call paths that reach it
+python3 analyze_folded.py folded.txt --grep TTimePredictor --exclude finish_task_switch
+```
+
+Inclusive samples for an arbitrary pattern, straight from `folded.txt`:
+
+```bash
+grep -v finish_task_switch folded.txt \
+  | awk -F' ' '/TTimePredictor/ { s += $NF } END { print s }'
+```
+
+## Reading the numbers
+
+* **Always exclude `finish_task_switch` first.** In the raw profile ~27 % of
+  samples are stacks caught going to sleep, and `perf_ctx_enable` /
+  `__perf_event_task_sched_in` / `_raw_spin_unlock` (perf's own
+  context-switch bookkeeping, ~25 % of raw self time) sit on top of them.
+  Those are measurement artefacts, not the workload.
+* **`__nss_database_lookup` is a lie.** glibc ifunc'd `memcpy`/`strlen` resolve
+  to that symbol. Its callers here are tcmalloc refill and string append —
+  read it as "libc mem/string ops".
+* Percentages in the per-pool reports are relative to that pool, not the process.
+

--- a/ydb/core/nbs/flamegraph_analysis/analyze_folded.py
+++ b/ydb/core/nbs/flamegraph_analysis/analyze_folded.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Summarize a FlameGraph folded-stacks file as text.
+
+Usage: analyze_folded.py folded.txt [--top N] [--grep SUBSTR] [--thread COMM]
+
+Prints:
+  * total samples and per-thread (comm) breakdown
+  * top leaf frames by self time
+  * top frames by inclusive time
+  * hottest full stacks
+"""
+import sys
+import argparse
+from collections import Counter
+
+
+def load(path):
+    stacks = []
+    with open(path) as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            stack, _, cnt = line.rpartition(" ")
+            try:
+                cnt = int(cnt)
+            except ValueError:
+                continue
+            stacks.append((stack.split(";"), cnt))
+    return stacks
+
+
+def bar(frac, width=40):
+    n = int(round(frac * width))
+    return "#" * n + "." * (width - n)
+
+
+def report(title, counter, total, top):
+    print(f"\n=== {title} ===")
+    for name, cnt in counter.most_common(top):
+        print(f"{100.0*cnt/total:6.2f}%  {cnt:6d}  {bar(cnt/total, 24)}  {name}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("path")
+    ap.add_argument("--top", type=int, default=30)
+    ap.add_argument("--grep", default=None, help="only stacks containing this substring")
+    ap.add_argument("--exclude", action="append", default=[],
+                    help="drop stacks containing this substring (repeatable)")
+    ap.add_argument("--thread", default=None, help="only stacks whose root frame matches")
+    args = ap.parse_args()
+
+    stacks = load(args.path)
+    if args.grep:
+        stacks = [(s, c) for s, c in stacks if any(args.grep in f for f in s)]
+    for ex in args.exclude:
+        stacks = [(s, c) for s, c in stacks if not any(ex in f for f in s)]
+    if args.thread:
+        stacks = [(s, c) for s, c in stacks if args.thread in s[0]]
+
+    total = sum(c for _, c in stacks)
+    if not total:
+        print("no samples matched")
+        return
+    print(f"total samples: {total}")
+
+    threads = Counter()
+    leaves = Counter()
+    inclusive = Counter()
+    whole = Counter()
+    for frames, cnt in stacks:
+        threads[frames[0]] += cnt
+        leaves[frames[-1]] += cnt
+        whole[";".join(frames)] += cnt
+        for f in set(frames):
+            inclusive[f] += cnt
+
+    report("threads (root frame = comm)", threads, total, args.top)
+    report("self time (leaf frames)", leaves, total, args.top)
+    report("inclusive time (any frame)", inclusive, total, args.top)
+
+    print(f"\n=== hottest full stacks (top {min(args.top, 15)}) ===")
+    for stack, cnt in whole.most_common(min(args.top, 15)):
+        print(f"\n-- {100.0*cnt/total:.2f}%  {cnt} samples")
+        for i, f in enumerate(stack.split(";")):
+            print("   " + "  " * min(i, 20) + f)
+
+
+if __name__ == "__main__":
+    main()

--- a/ydb/core/nbs/flamegraph_analysis/analyze_folded.py
+++ b/ydb/core/nbs/flamegraph_analysis/analyze_folded.py
@@ -48,7 +48,8 @@ def main():
     ap.add_argument("--grep", default=None, help="only stacks containing this substring")
     ap.add_argument("--exclude", action="append", default=[],
                     help="drop stacks containing this substring (repeatable)")
-    ap.add_argument("--thread", default=None, help="only stacks whose root frame matches")
+    ap.add_argument("--thread", default=None,
+                    help="only stacks whose root frame equals this value exactly")
     args = ap.parse_args()
 
     stacks = load(args.path)
@@ -57,7 +58,7 @@ def main():
     for ex in args.exclude:
         stacks = [(s, c) for s, c in stacks if not any(ex in f for f in s)]
     if args.thread:
-        stacks = [(s, c) for s, c in stacks if args.thread in s[0]]
+        stacks = [(s, c) for s, c in stacks if s[0] == args.thread]
 
     total = sum(c for _, c in stacks)
     if not total:


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

Add benchmark for time predictor

```
Info: 
-----------------------------------------------------------------------------------------
Benchmark                                               Time             CPU   Iterations
-----------------------------------------------------------------------------------------
BM_WriteRequestExecutorCreation                      1244 ns         1265 ns        48842
BM_ReadSingleLocationRequestExecutorCreation         1381 ns         1403 ns        47219
BM_ReadMultipleLocationRequestExecutorCreation       4155 ns         4173 ns        16341
BM_EraseRequestExecutorCreation                       979 ns          990 ns        68362
BM_FlushRequestExecutorCreation                      1215 ns         1227 ns        59214
BM_RestoreRequestExecutorCreation                     387 ns          383 ns       169004
BM_TimePredictorAdd                                   140 ns          140 ns       449719
```
