### PR TITLE
Improve ICv2 metrics and perf

### DIFF
--- a/ydb/library/actors/interconnect/benchmark/b_v2_event_serializer.cpp
+++ b/ydb/library/actors/interconnect/benchmark/b_v2_event_serializer.cpp
@@ -94,7 +94,7 @@ namespace {
 
         TEventSerializer Serializer;
         TRcBuf Scratch;
-        std::deque<TContiguousSpan> Spans;
+        std::vector<TContiguousSpan> Spans;
     };
 
     struct TDroppingProcessor: TEventDeserializer::IEventProcessor {
@@ -117,7 +117,7 @@ namespace {
 
         TString stream;
         std::vector<TRcBuf> buffers;
-        std::deque<TContiguousSpan> spans;
+        std::vector<TContiguousSpan> spans;
         for (;;) {
             if (buffers.empty() || buffers.back().size() < 1024) {
                 buffers.push_back(TRcBuf::Uninitialized(256 << 10));

--- a/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
+++ b/ydb/library/actors/interconnect/interconnect_uring_engine.cpp
@@ -158,7 +158,7 @@ namespace NActors {
             const bool SendPings;
             TRcBuf WriteBuffer;
             size_t WriteBufferSize = 0;
-            std::deque<TContiguousSpan> OutgoingSpans;
+            std::vector<TContiguousSpan> OutgoingSpans;
             iovec Iov[MaxSpansPerWrite];
             size_t IovLen = 0;
             size_t UnsentBytes = 0;
@@ -342,15 +342,17 @@ namespace NActors {
                         NSan::CheckMemIsInitialized(span.data(), span.size());
                     }
                 }
-                for (size_t remaining = num; remaining; OutgoingSpans.pop_front()) {
-                    Y_DEBUG_ABORT_UNLESS(!OutgoingSpans.empty());
-                    if (TContiguousSpan& front = OutgoingSpans.front(); front.size() <= remaining) {
+                size_t index = 0;
+                for (size_t remaining = num; remaining; ++index) {
+                    Y_DEBUG_ABORT_UNLESS(index < OutgoingSpans.size());
+                    if (TContiguousSpan& front = OutgoingSpans[index]; front.size() <= remaining) {
                         remaining -= front.size();
                     } else {
                         front = TContiguousSpan(front.data() + remaining, front.size() - remaining);
                         break;
                     }
                 }
+                OutgoingSpans.erase(OutgoingSpans.begin(), OutgoingSpans.begin() + index);
 
                 Y_ABORT_UNLESS(num <= UnsentBytes, "num# %zu UnsentBytes# %zu", num, UnsentBytes);
                 UnsentBytes -= num;
@@ -624,17 +626,20 @@ namespace NActors {
             NMonitoring::TDynamicCounters::TCounterPtr OutOfOrderProcessed;
             NMonitoring::TDynamicCounters::TCounterPtr DeadPeersDetected;
 
-            NMonitoring::TDynamicCounters::TCounterPtr OtherTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr CompleteWaitTotalTime;
-            NMonitoring::TDynamicCounters::TCounterPtr SubmitWaitTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr SubmitTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr ApplyBytesReadTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr ApplyBytesWrittenTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr SerializeEventTotalTime;
             NMonitoring::TDynamicCounters::TCounterPtr ReceiveCallbackTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr ProcessCompletionsTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr ProcessPendingCommandsTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr ProcessTouchedSessionsTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr SerializeTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr DestroyEventsTotalTime;
 
             NMonitoring::THistogramPtr CommandDeliveryTime;
             NMonitoring::THistogramPtr EventToWireTime;
-            NMonitoring::THistogramPtr CompletionWaitTime;
             NMonitoring::THistogramPtr CommandExecTime;
             NMonitoring::THistogramPtr SubmitExecTime;
             NMonitoring::THistogramPtr SerializeTime;
@@ -642,7 +647,7 @@ namespace NActors {
             NMonitoring::THistogramPtr SubmissionsProcessedAtOnce;
 
             ui64 LastActivitySwitchTimestamp = 0;
-            NMonitoring::TDynamicCounters::TCounterPtr *CurrentActivityTime = &OtherTotalTime;
+            NMonitoring::TDynamicCounters::TCounterPtr *CurrentActivityTime = nullptr;
 
             const double Freq = 1e9 * NHPTimer::GetSeconds(1); // nanoseconds per cycle
 
@@ -660,6 +665,22 @@ namespace NActors {
             const ui32 MaxSerializeWindowSize;
 
         private:
+            NMonitoring::TDynamicCounters::TCounterPtr *SwitchActivity(
+                    NMonitoring::TDynamicCounters::TCounterPtr *newActivity, ui64 currentTimestamp) {
+                if (CurrentActivityTime != newActivity) {
+                    const ui64 timestamp = std::exchange(LastActivitySwitchTimestamp, currentTimestamp);
+                    if (CurrentActivityTime) {
+                        **CurrentActivityTime += (LastActivitySwitchTimestamp - timestamp) * Freq;
+                    }
+                }
+                return std::exchange(CurrentActivityTime, newActivity);
+            }
+
+            NMonitoring::TDynamicCounters::TCounterPtr *SwitchActivity(
+                    NMonitoring::TDynamicCounters::TCounterPtr *newActivity) {
+                return SwitchActivity(newActivity, GetCycleCountFast());
+            }
+
             class TActivityMeasure {
                 TShard& Shard;
                 NMonitoring::TDynamicCounters::TCounterPtr *PrevActivityTime;
@@ -667,22 +688,11 @@ namespace NActors {
             public:
                 TActivityMeasure(TShard& shard, NMonitoring::TDynamicCounters::TCounterPtr *activityTime)
                     : Shard(shard)
-                    , PrevActivityTime(std::exchange(shard.CurrentActivityTime, activityTime))
-                {
-                    **PrevActivityTime += UpdateTimestamp();
-                }
+                    , PrevActivityTime(Shard.SwitchActivity(activityTime))
+                {}
 
                 ~TActivityMeasure() {
-                    const ui64 delta = UpdateTimestamp();
-                    if (Shard.CurrentActivityTime) {
-                        **Shard.CurrentActivityTime += delta;
-                    }
-                    Shard.CurrentActivityTime = PrevActivityTime;
-                }
-
-                ui64 UpdateTimestamp() {
-                    const ui64 prevTimestamp = std::exchange(Shard.LastActivitySwitchTimestamp, GetCycleCountFast());
-                    return (Shard.LastActivitySwitchTimestamp - prevTimestamp) * Shard.Freq;
+                    Shard.SwitchActivity(PrevActivityTime);
                 }
             };
 
@@ -842,16 +852,19 @@ namespace NActors {
                 , COUNTER(OutOfOrderProcessed, true)
                 , COUNTER(DeadPeersDetected, true)
 #define TOTAL_TIME(NAME) NAME(shardCounters->GetCounter("TotalTime/" #NAME, true))
-                , TOTAL_TIME(OtherTotalTime)
                 , TOTAL_TIME(CompleteWaitTotalTime)
-                , TOTAL_TIME(SubmitWaitTotalTime)
+                , TOTAL_TIME(SubmitTotalTime)
                 , TOTAL_TIME(ApplyBytesReadTotalTime)
                 , TOTAL_TIME(ApplyBytesWrittenTotalTime)
                 , TOTAL_TIME(SerializeEventTotalTime)
                 , TOTAL_TIME(ReceiveCallbackTotalTime)
+                , TOTAL_TIME(ProcessCompletionsTotalTime)
+                , TOTAL_TIME(ProcessPendingCommandsTotalTime)
+                , TOTAL_TIME(ProcessTouchedSessionsTotalTime)
+                , TOTAL_TIME(SerializeTotalTime)
+                , TOTAL_TIME(DestroyEventsTotalTime)
                 , CommandDeliveryTime(shardCounters->GetNamedHistogram("sensor", "CommandDeliveryTime", TimeCollector()))
                 , EventToWireTime(shardCounters->GetNamedHistogram("sensor", "EventToWireTime", TimeCollector()))
-                , CompletionWaitTime(shardCounters->GetNamedHistogram("sensor", "CompletionWaitTime", TimeCollector()))
                 , CommandExecTime(shardCounters->GetNamedHistogram("sensor", "CommandExecTime", TimeCollector()))
                 , SubmitExecTime(shardCounters->GetNamedHistogram("sensor", "SubmitExecTime", TimeCollector()))
                 , SerializeTime(shardCounters->GetNamedHistogram("sensor", "SerializeTime", TimeCollector()))
@@ -1131,7 +1144,7 @@ namespace NActors {
             void DoSubmit(TRingSlot& slot) {
                 ui64 enterTimestamp;
 
-                ACTIVITY(&SubmitWaitTotalTime) {
+                ACTIVITY(&SubmitTotalTime) {
                     enterTimestamp = LastActivitySwitchTimestamp;
 
                     for (;;) {
@@ -1155,15 +1168,16 @@ namespace NActors {
             void WorkerThread() {
                 pthread_setname_np(pthread_self(), "IC_uring");
 
-                LastActivitySwitchTimestamp = GetCycleCountFast();
-                ui64 loopStartTimestamp = LastActivitySwitchTimestamp;
-
                 // Arm pipe + timer
                 PutEventReadRequest();
                 PutTimer();
 
+                LastActivitySwitchTimestamp = GetCycleCountFast();
+                ui64 loopStartTimestamp = LastActivitySwitchTimestamp;
+
                 for (;;) {
                     // submit any pending SQ's (if we have any)
+                    SwitchActivity(&SubmitTotalTime, loopStartTimestamp);
                     for (auto& slot : Rings) {
                         if (slot.ItemsToSubmit) {
                             DoSubmit(slot);
@@ -1171,9 +1185,11 @@ namespace NActors {
                     }
 
                     // process pending CQ events from every ring
+                    SwitchActivity(&ProcessCompletionsTotalTime);
                     bool progress = ProcessCompletions();
 
                     // process pending events and commands
+                    SwitchActivity(&ProcessPendingCommandsTotalTime);
                     bool stopping = false;
                     progress |= ProcessPendingCommands(&stopping);
                     if (stopping) {
@@ -1181,6 +1197,7 @@ namespace NActors {
                     }
 
                     // process touched sessions
+                    SwitchActivity(&ProcessTouchedSessionsTotalTime);
                     while (!TouchedSessions.Empty()) {
                         TSession *session = TouchedSessions.PopFront();
                         MaybeIssueReadForSession(*session);
@@ -1192,6 +1209,7 @@ namespace NActors {
                     }
 
                     // discard pending events/buffers, if any
+                    SwitchActivity(&DestroyEventsTotalTime);
                     if (!EvDestroyEvents->Events.empty() || !EvDestroyEvents->Buffers.empty()) {
                         const size_t bytes = EvDestroyEvents->CalculateTotalSize();
                         const auto& counter = Engine.Common->DestructorQueueSize;
@@ -1204,22 +1222,19 @@ namespace NActors {
                         EvDestroyEvents = std::make_unique<TEvDestroyEvents>();
                     }
 
-                    ui64 waitStartTimestamp = 0;
-                    if (!progress) { // wait for something to happen -- no progress were made in this loop
+                    // wait for CQ in there is no progress
+                    SwitchActivity(&CompleteWaitTotalTime);
+                    const ui64 waitStartTimestamp = LastActivitySwitchTimestamp;
+                    if (!progress) {
                         WaitingForCQ.store(true, std::memory_order_release);
 
                         // it is critical we first set WaitingForCQ, and then rechecking the queue
                         if (IncomingEventQueue.IsEmpty()) {
+                            // wait for the ring waiting for EventFd
                             io_uring_cqe *cqe;
-                            ui64 enterTimestamp;
-                            ACTIVITY(&CompleteWaitTotalTime) {
-                                waitStartTimestamp = enterTimestamp = LastActivitySwitchTimestamp;
-                                // wait for the ring waiting for EventFd
-                                if (int res = io_uring_wait_cqe(&Rings.front().Ring, &cqe); res && res != -EINTR) {
-                                    Y_ABORT("io_uring_wait_cqe() failed: %s", strerror(-res));
-                                }
+                            if (int res = io_uring_wait_cqe(&Rings.front().Ring, &cqe); res && res != -EINTR) {
+                                Y_ABORT("io_uring_wait_cqe() failed: %s", strerror(-res));
                             }
-                            CompletionWaitTime->Collect((LastActivitySwitchTimestamp - enterTimestamp) * Freq);
                         }
 
                         WaitingForCQ.store(false, std::memory_order_relaxed);
@@ -1227,7 +1242,7 @@ namespace NActors {
 
                     const ui64 loopEndTimestamp = GetCycleCountFast();
                     const ui64 total = loopEndTimestamp - loopStartTimestamp;
-                    const ui64 wait = waitStartTimestamp ? loopEndTimestamp - waitStartTimestamp : 0;
+                    const ui64 wait = loopEndTimestamp - waitStartTimestamp;
                     const ui64 work = wait < total ? total - wait : 0;
                     PublishLoadSample(work, total);
                     loopStartTimestamp = loopEndTimestamp;
@@ -1685,13 +1700,14 @@ namespace NActors {
                     return;
                 }
                 if (session.Serializer.IsTrafficPending()) {
-                    session.Serialize(MinWriteBufferSize, MaxWriteBufferSize);
-                    const ui64 serializeEventTime = session.Serializer.GetSerializeEventTime();
-                    const ui64 prevTimestamp = std::exchange(LastActivitySwitchTimestamp, GetCycleCountFast());
-                    **CurrentActivityTime += (LastActivitySwitchTimestamp - prevTimestamp - serializeEventTime) * Freq;
-                    *SerializeEventTotalTime += serializeEventTime * Freq;
-                    *BytesCopied += session.Serializer.GetBytesCopied();
-                    *BytesAliased += session.Serializer.GetBytesAliased();
+                    ACTIVITY(&SerializeTotalTime) {
+                        session.Serialize(MinWriteBufferSize, MaxWriteBufferSize);
+                        const ui64 serializeEventTime = session.Serializer.GetSerializeEventTime();
+                        LastActivitySwitchTimestamp += serializeEventTime;
+                        *SerializeEventTotalTime += serializeEventTime * Freq;
+                        *BytesCopied += session.Serializer.GetBytesCopied();
+                        *BytesAliased += session.Serializer.GetBytesAliased();
+                    }
                 }
                 if (session.PrepareIovec()) {
                     io_uring_sqe *sqe = GetSQE(&session, kOpWrite, session.PreferredRingIdx);

--- a/ydb/library/actors/interconnect/ut/v2_event_serializer_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/v2_event_serializer_ut.cpp
@@ -69,8 +69,8 @@ void CheckIndexedEvent(IEventHandle& outEv, ui16 channel, size_t dataLen, bool w
     }
 }
 
-std::deque<TContiguousSpan> Serialize(TEventSerializer& ser, std::vector<TRcBuf>& bufs) {
-    std::deque<TContiguousSpan> spans;
+std::vector<TContiguousSpan> Serialize(TEventSerializer& ser, std::vector<TRcBuf>& bufs) {
+    std::vector<TContiguousSpan> spans;
 
     for (;;) {
         if (bufs.empty() || bufs.back().size() < 1024) {
@@ -105,7 +105,7 @@ void CheckSerializeThenDeserialize(bool withPayload, bool buffer, ui32 metaLengt
     ser.Push(std::move(h));
 
     std::vector<TRcBuf> bufs;
-    std::deque<TContiguousSpan> spans = Serialize(ser, bufs);
+    std::vector<TContiguousSpan> spans = Serialize(ser, bufs);
 
     TEventDeserializer deser(TScopeId{});
     TEventProcessor processor;
@@ -181,7 +181,7 @@ Y_UNIT_TEST_SUITE(EventSerializerV2) {
         }
 
         std::vector<TRcBuf> bufs;
-        std::deque<TContiguousSpan> spans = Serialize(ser, bufs);
+        std::vector<TContiguousSpan> spans = Serialize(ser, bufs);
 
         TString stream;
         for (const TContiguousSpan& s : spans) {
@@ -235,13 +235,13 @@ Y_UNIT_TEST_SUITE(EventSerializerV2) {
 
         struct TBatch {
             TRcBuf Scratch;
-            std::deque<TContiguousSpan> Spans;
+            std::vector<TContiguousSpan> Spans;
             size_t Bytes;
         };
         std::vector<TBatch> batches;
         for (;;) {
             TRcBuf scratch = TRcBuf::Uninitialized(4096); // small scratch -> many pipelined batches
-            std::deque<TContiguousSpan> spans;
+            std::vector<TContiguousSpan> spans;
             size_t total = 0;
             for (;;) {
                 const size_t produced = ser.ProduceOutputStream(scratch, &spans);
@@ -315,7 +315,7 @@ Y_UNIT_TEST_SUITE(EventSerializerV2) {
         }
 
         std::vector<TRcBuf> bufs;
-        std::deque<TContiguousSpan> spans = Serialize(ser, bufs);
+        std::vector<TContiguousSpan> spans = Serialize(ser, bufs);
 
         // feed the produced stream to the deserializer chunk by chunk and record the exact delivery order
         TEventDeserializer deser(TScopeId{});
@@ -445,7 +445,7 @@ Y_UNIT_TEST_SUITE(EventSerializerV2) {
         ser.Push(MakeCordEventHandle(/*channel=*/1, /*cookie=*/7, /*fill=*/'Z', /*size=*/cordSize));
 
         std::vector<TRcBuf> bufs;
-        std::deque<TContiguousSpan> spans = Serialize(ser, bufs);
+        std::vector<TContiguousSpan> spans = Serialize(ser, bufs);
 
         TString stream;
         for (const TContiguousSpan& s : spans) {
@@ -482,7 +482,7 @@ Y_UNIT_TEST_SUITE(EventSerializerV2) {
 
         struct TBatch {
             TRcBuf Scratch;
-            std::deque<TContiguousSpan> Spans;
+            std::vector<TContiguousSpan> Spans;
             size_t Bytes;
         };
         // One ProduceOutputStream call per batch: Cord aliasing barely consumes scratch, so draining
@@ -490,7 +490,7 @@ Y_UNIT_TEST_SUITE(EventSerializerV2) {
         std::vector<TBatch> batches;
         for (;;) {
             TRcBuf scratch = TRcBuf::Uninitialized(512);
-            std::deque<TContiguousSpan> spans;
+            std::vector<TContiguousSpan> spans;
             const size_t produced = ser.ProduceOutputStream(scratch, &spans);
             if (!produced) {
                 break;

--- a/ydb/library/actors/interconnect/v2_event_serializer.cpp
+++ b/ydb/library/actors/interconnect/v2_event_serializer.cpp
@@ -40,7 +40,7 @@ namespace NActors {
         }
     }
 
-    size_t TEventSerializer::ProduceOutputStream(TRcBuf& buffer, std::deque<TContiguousSpan> *out, size_t maxBytesToProduce) {
+    size_t TEventSerializer::ProduceOutputStream(TRcBuf& buffer, std::vector<TContiguousSpan> *out, size_t maxBytesToProduce) {
         size_t totalBytesProduced = 0;
         ui64 bufferProduced = 0;
 
@@ -48,6 +48,8 @@ namespace NActors {
 
         const ui64 bytesProducedOnEntry = CumulativeProduced;
         const size_t bufferSizeOnEntry = buffer.size();
+
+        TMutableContiguousSpan bufferSpan = buffer.UnsafeGetContiguousSpanMut();
 
         // we can't emit anything useful once the output buffer can't hold at least a chunk header along with a whole
         // some useful data, so we stop here to avoid spinning without making any progress
@@ -69,7 +71,7 @@ namespace NActors {
             TPerChannelQueue& queue = GetQueue(q.Channel);
             const bool isSystemChannel = q.Channel == TChunkHeader::SystemChannel;
             const size_t numBytesProduced = ProduceOutputStreamForQueue(q.Channel, queue,
-                Min<size_t>(maxBytesToProduce, q.Quota), buffer, out, &bufferProduced);
+                Min<size_t>(maxBytesToProduce, q.Quota), bufferSpan, out, &bufferProduced);
             if (!numBytesProduced) { // in case we did not make any progress (not enough space in buffer)
                 break;
             }
@@ -91,7 +93,7 @@ namespace NActors {
 
         Y_DEBUG_ABORT_UNLESS(bytesProducedOnEntry + totalBytesProduced == CumulativeProduced);
 
-        buffer.TrimFront(buffer.size() - buffer.size() % 64); // align buffer on 64-byte boundary
+        buffer.TrimFront(bufferSpan.size() - bufferSpan.size() % 64); // align buffer on 64-byte boundary
         const size_t bufferSizeOnExit = buffer.size();
         Y_DEBUG_ABORT_UNLESS(bufferSizeOnExit <= bufferSizeOnEntry);
 
@@ -135,8 +137,8 @@ namespace NActors {
     }
 
     size_t TEventSerializer::ProduceOutputStreamForQueue(ui16 channel, TPerChannelQueue& queue, size_t maxBytesToProduce,
-            TRcBuf& buffer, std::deque<TContiguousSpan> *out, ui64 *bufferProduced) {
-        const TContiguousSpan bufferSpan = buffer.GetContiguousSpan(); // remember original buffer span
+            TMutableContiguousSpan& buffer, std::vector<TContiguousSpan> *out, ui64 *bufferProduced) {
+        const TContiguousSpan bufferSpan = buffer; // remember original buffer span
         size_t numBytesProduced = 0;
         const char *lastSpanEnd = out->empty() ? nullptr : [s = out->back()]{ return s.data() + s.size(); }();
 
@@ -151,9 +153,9 @@ namespace NActors {
             if (!fromBuffer && (reinterpret_cast<uintptr_t>(span.data()) & 63) + span.size() <= 64 && buffer.size() >= span.size()) {
                 // we got span referenced outside original buffer; check if we can copy it into the buffer, if it is
                 // small enough and buffer has the space to do it
-                memcpy(buffer.UnsafeGetDataMut(), span.data(), span.size());
+                memcpy(buffer.data(), span.data(), span.size());
                 span = {buffer.data(), span.size()};
-                buffer.TrimFront(buffer.size() - span.size());
+                buffer = buffer.SubSpan(span.size(), Max<size_t>());
                 fromBuffer = true;
             }
 
@@ -183,8 +185,8 @@ namespace NActors {
         auto takeInBuffer = [&](size_t numBytes) -> void* {
             Y_ABORT_UNLESS(numBytes <= maxBytesToProduce);
             Y_ABORT_UNLESS(numBytes <= buffer.size());
-            TMutableContiguousSpan res(buffer.UnsafeGetDataMut(), numBytes);
-            buffer.TrimFront(buffer.size() - numBytes);
+            TMutableContiguousSpan res(buffer.data(), numBytes);
+            buffer = buffer.SubSpan(numBytes, Max<size_t>());
             produceOutputSpan(res, false);
             return res.data();
         };
@@ -291,15 +293,14 @@ namespace NActors {
                 case ESerializeStage::kChunkSerializer: {
                     UpdateTimestamp();
 
-                    // serialize as much as we can
-                    TMutableContiguousSpan span = buffer.UnsafeGetContiguousSpanMut().SubSpan(sizeof(TChunkHeader),
-                        Max<size_t>()); // reserve space for TChunkHeader which we write first thing if we have some data
+                    // reserve space for TChunkHeader which we write first thing if we have some data
+                    TMutableContiguousSpan span = buffer.SubSpan(sizeof(TChunkHeader), Max<size_t>());
                     auto chunks = queue.CoroutineChunkSerializer.FeedBuf(&span, maxBytesToProduce - sizeof(TChunkHeader));
                     Y_DEBUG_ABORT_UNLESS(buffer.data() + buffer.size() == span.data() + span.size());
                     Y_DEBUG_ABORT_UNLESS(span.size() <= buffer.size()); // ensure span did not reduce
                     if (!chunks.empty()) {
                         ensureHeader();
-                        buffer.TrimFront(span.size());
+                        buffer = buffer.SubSpan(buffer.size() - span.size(), Max<size_t>());
                     }
                     for (const auto& chunk : chunks) {
                         addEventChunkBytes(chunk.Buf, chunk.Size);

--- a/ydb/library/actors/interconnect/v2_event_serializer.h
+++ b/ydb/library/actors/interconnect/v2_event_serializer.h
@@ -172,7 +172,8 @@ namespace NActors {
         bool HasOutOfBandTraffic() const { return !SystemChannelQueue.SystemRequests.empty(); }
 
         // this function generates output stream for transmission; it returns number of bytes added to output spans
-        size_t ProduceOutputStream(TRcBuf& buffer, std::deque<TContiguousSpan> *out, size_t maxBytesToProduce = Max<size_t>());
+        size_t ProduceOutputStream(TRcBuf& buffer, std::vector<TContiguousSpan> *out,
+            size_t maxBytesToProduce = Max<size_t>());
 
         // notification issued when N produced bytes have been sent to the other party
         void CommitProducedBytes(size_t numBytes, std::vector<ui64> *eventToWireTime = nullptr,
@@ -197,8 +198,8 @@ namespace NActors {
                 channel == TChunkHeader::SystemChannel ? SystemChannelQueue : PerChannelQueueMap[channel];
         }
 
-        size_t ProduceOutputStreamForQueue(ui16 channel, TPerChannelQueue& queue, size_t maxBytesToProduce, TRcBuf& buffer,
-            std::deque<TContiguousSpan> *out, ui64 *bufferProduced);
+        size_t ProduceOutputStreamForQueue(ui16 channel, TPerChannelQueue& queue, size_t maxBytesToProduce,
+            TMutableContiguousSpan& buffer, std::vector<TContiguousSpan> *out, ui64 *bufferProduced);
 
         ui64 UpdateTimestamp();
     };


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Improve ICv2 metrics and perf

### Description for reviewers <!-- (optional) description for those who read this PR -->

This patch adds more discrete timing metrics for ICv2 and also increases performance a little bit by changing deque to vector.
