### PR TITLE
Add InterruptInheritance flag to public API and CLI

### DIFF
--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -123,7 +123,7 @@ TMaybe<Ydb::Scheme::ModifyPermissionsRequest> GenYdbPermissions(const NKikimrSch
     permissions.mutable_actions()->Add()->set_change_owner(selfDesc.GetOwner());
 
     NProtoBuf::RepeatedPtrField<Ydb::Scheme::Permissions> toGrant;
-    ConvertAclToYdb(selfDesc.GetOwner(), selfDesc.GetACL(), false, &toGrant);
+    FillPermissionsFromAcl(NACLib::TACL(selfDesc.GetACL()), &toGrant);
     for (const auto& permission : toGrant) {
         *permissions.mutable_actions()->Add()->mutable_grant() = permission;
     }

--- a/ydb/core/tx/datashard/export_common.cpp
+++ b/ydb/core/tx/datashard/export_common.cpp
@@ -121,12 +121,7 @@ TMaybe<Ydb::Scheme::ModifyPermissionsRequest> GenYdbPermissions(const NKikimrSch
 
     const auto& selfDesc = pathDesc.GetSelf();
     permissions.mutable_actions()->Add()->set_change_owner(selfDesc.GetOwner());
-
-    NProtoBuf::RepeatedPtrField<Ydb::Scheme::Permissions> toGrant;
-    FillPermissionsFromAcl(NACLib::TACL(selfDesc.GetACL()), &toGrant);
-    for (const auto& permission : toGrant) {
-        *permissions.mutable_actions()->Add()->mutable_grant() = permission;
-    }
+    FillPermissionsFromAcl(selfDesc, /* withEffectiveAcl */ false, &permissions);
 
     return permissions;
 }

--- a/ydb/core/ydb_convert/ydb_convert.cpp
+++ b/ydb/core/ydb_convert/ydb_convert.cpp
@@ -814,9 +814,12 @@ void ConvertYdbValueToMiniKQLValue(const Ydb::Type& inputType,
     }
 }
 
-void ConvertAclToYdb(const TString& owner, const TString& acl, bool isContainer,
-    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions) {
-    const auto& securityObject = TSecurityObject(owner, acl, isContainer);
+namespace {
+
+void FillPermissionsFromSecurityObject(
+    const NACLib::TSecurityObject& securityObject,
+    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions
+) {
     for (const auto& ace : securityObject.GetACL().GetACE()) {
         auto entry = permissions->Add();
         entry->set_subject(ace.GetSID());
@@ -825,7 +828,15 @@ void ConvertAclToYdb(const TString& owner, const TString& acl, bool isContainer,
             entry->add_permission_names(n);
         }
     }
+}
 
+} // namespace
+
+void ConvertAclToYdb(
+    const TString& owner, const TString& acl, bool isContainer,
+    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions
+) {
+    FillPermissionsFromSecurityObject(TSecurityObject(owner, acl, isContainer), permissions);
 }
 
 using namespace NACLib;
@@ -1012,9 +1023,9 @@ void ConvertDirectoryEntry(const NKikimrSchemeOp::TDirEntry& from, Ydb::Scheme::
     if (processAcl) {
         const bool isDir = from.GetPathType() == NKikimrSchemeOp::EPathTypeDir;
         ConvertAclToYdb(from.GetOwner(), from.GetEffectiveACL(), isDir, to->mutable_effective_permissions());
-        ConvertAclToYdb(from.GetOwner(), from.GetACL(), isDir, to->mutable_permissions());
-        const NACLib::TACL acl(from.GetACL());
-        to->set_interrupt_permissions_inheritance(acl.GetInterruptInheritance());
+        const TSecurityObject securityObject(from.GetOwner(), from.GetACL(), isDir);
+        FillPermissionsFromSecurityObject(securityObject, to->mutable_permissions());
+        to->set_interrupt_permissions_inheritance(securityObject.GetACL().GetInterruptInheritance());
     }
 }
 

--- a/ydb/core/ydb_convert/ydb_convert.cpp
+++ b/ydb/core/ydb_convert/ydb_convert.cpp
@@ -1013,6 +1013,8 @@ void ConvertDirectoryEntry(const NKikimrSchemeOp::TDirEntry& from, Ydb::Scheme::
         const bool isDir = from.GetPathType() == NKikimrSchemeOp::EPathTypeDir;
         ConvertAclToYdb(from.GetOwner(), from.GetEffectiveACL(), isDir, to->mutable_effective_permissions());
         ConvertAclToYdb(from.GetOwner(), from.GetACL(), isDir, to->mutable_permissions());
+        const NACLib::TACL acl(from.GetACL());
+        to->set_interrupt_permissions_inheritance(acl.GetInterruptInheritance());
     }
 }
 

--- a/ydb/core/ydb_convert/ydb_convert.cpp
+++ b/ydb/core/ydb_convert/ydb_convert.cpp
@@ -814,13 +814,11 @@ void ConvertYdbValueToMiniKQLValue(const Ydb::Type& inputType,
     }
 }
 
-namespace {
-
-void FillPermissionsFromSecurityObject(
-    const NACLib::TSecurityObject& securityObject,
+void FillPermissionsFromAcl(
+    const NACLib::TACL& acl,
     google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions
 ) {
-    for (const auto& ace : securityObject.GetACL().GetACE()) {
+    for (const auto& ace : acl.GetACE()) {
         auto entry = permissions->Add();
         entry->set_subject(ace.GetSID());
         auto str = ConvertACLMaskToYdbPermissionNames(ace.GetAccessRight());
@@ -828,15 +826,6 @@ void FillPermissionsFromSecurityObject(
             entry->add_permission_names(n);
         }
     }
-}
-
-} // namespace
-
-void ConvertAclToYdb(
-    const TString& owner, const TString& acl, bool isContainer,
-    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions
-) {
-    FillPermissionsFromSecurityObject(TSecurityObject(owner, acl, isContainer), permissions);
 }
 
 using namespace NACLib;
@@ -1021,11 +1010,10 @@ void ConvertDirectoryEntry(const NKikimrSchemeOp::TDirEntry& from, Ydb::Scheme::
     timestamp.set_tx_id(from.GetCreateTxId());
 
     if (processAcl) {
-        const bool isDir = from.GetPathType() == NKikimrSchemeOp::EPathTypeDir;
-        ConvertAclToYdb(from.GetOwner(), from.GetEffectiveACL(), isDir, to->mutable_effective_permissions());
-        const TSecurityObject securityObject(from.GetOwner(), from.GetACL(), isDir);
-        FillPermissionsFromSecurityObject(securityObject, to->mutable_permissions());
-        to->set_interrupt_permissions_inheritance(securityObject.GetACL().GetInterruptInheritance());
+        FillPermissionsFromAcl(NACLib::TACL(from.GetEffectiveACL()), to->mutable_effective_permissions());
+        const NACLib::TACL acl(from.GetACL());
+        FillPermissionsFromAcl(acl, to->mutable_permissions());
+        to->set_interrupt_permissions_inheritance(acl.GetInterruptInheritance());
     }
 }
 

--- a/ydb/core/ydb_convert/ydb_convert.cpp
+++ b/ydb/core/ydb_convert/ydb_convert.cpp
@@ -42,6 +42,20 @@ namespace {
         return true;
     }
 
+    void FillPermissionsField(
+        const NACLib::TACL& acl,
+        google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions
+    ) {
+        Y_ENSURE(permissions);
+        for (const auto& ace : acl.GetACE()) {
+            auto entry = permissions->Add();
+            entry->set_subject(ace.GetSID());
+            for (const auto& name : ConvertACLMaskToYdbPermissionNames(ace.GetAccessRight())) {
+                entry->add_permission_names(name);
+            }
+        }
+    }
+
 } // anonymous namespace
 
 template<typename TOut>
@@ -815,16 +829,34 @@ void ConvertYdbValueToMiniKQLValue(const Ydb::Type& inputType,
 }
 
 void FillPermissionsFromAcl(
-    const NACLib::TACL& acl,
-    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions
+    const NKikimrSchemeOp::TDirEntry& from,
+    const bool withEffectiveAcl,
+    Ydb::Scheme::Entry* to
 ) {
-    for (const auto& ace : acl.GetACE()) {
-        auto entry = permissions->Add();
-        entry->set_subject(ace.GetSID());
-        auto str = ConvertACLMaskToYdbPermissionNames(ace.GetAccessRight());
-        for (auto n : str) {
-            entry->add_permission_names(n);
-        }
+    Y_ENSURE(to);
+    const NACLib::TACL acl(from.GetACL());
+    FillPermissionsField(acl, to->mutable_permissions());
+    to->set_interrupt_permission_inheritance(acl.GetInterruptInheritance());
+
+    if (withEffectiveAcl) {
+        FillPermissionsField(NACLib::TACL(from.GetEffectiveACL()), to->mutable_effective_permissions());
+    }
+}
+
+void FillPermissionsFromAcl(
+    const NKikimrSchemeOp::TDirEntry& from,
+    const bool withEffectiveAcl,
+    Ydb::Scheme::ModifyPermissionsRequest* to
+) {
+    Y_ENSURE(!withEffectiveAcl);
+    const NACLib::TACL acl(from.GetACL());
+    NProtoBuf::RepeatedPtrField<Ydb::Scheme::Permissions> toGrant;
+    FillPermissionsField(acl, &toGrant);
+    for (const auto& permission : toGrant) {
+        *to->mutable_actions()->Add()->mutable_grant() = permission;
+    }
+    if (acl.GetInterruptInheritance()) {
+        to->set_interrupt_inheritance(true);
     }
 }
 
@@ -1010,10 +1042,7 @@ void ConvertDirectoryEntry(const NKikimrSchemeOp::TDirEntry& from, Ydb::Scheme::
     timestamp.set_tx_id(from.GetCreateTxId());
 
     if (processAcl) {
-        FillPermissionsFromAcl(NACLib::TACL(from.GetEffectiveACL()), to->mutable_effective_permissions());
-        const NACLib::TACL acl(from.GetACL());
-        FillPermissionsFromAcl(acl, to->mutable_permissions());
-        to->set_interrupt_permissions_inheritance(acl.GetInterruptInheritance());
+        FillPermissionsFromAcl(from, /* withEffectiveAcl */ true, to);
     }
 }
 

--- a/ydb/core/ydb_convert/ydb_convert.h
+++ b/ydb/core/ydb_convert/ydb_convert.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ydb/library/aclib/aclib.h>
 #include <ydb/library/mkql_proto/protos/minikql.pb.h>
 #include <ydb/core/protos/flat_tx_scheme.pb.h>
 #include <ydb/core/scheme/scheme_tablecell.h>
@@ -31,8 +32,8 @@ void ConvertYdbValueToMiniKQLValue(const Ydb::Type& inputType,
 
 void ConvertYdbResultToKqpResult(const Ydb::ResultSet& input, NKikimrMiniKQL::TResult& output);
 
-void ConvertAclToYdb(const TString& owner, const TString& acl, bool isContainer,
-    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions> *permissions);
+void FillPermissionsFromAcl(const NACLib::TACL& acl,
+    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions);
 
 struct TACLAttrs {
     ui32 AccessMask;

--- a/ydb/core/ydb_convert/ydb_convert.h
+++ b/ydb/core/ydb_convert/ydb_convert.h
@@ -32,8 +32,10 @@ void ConvertYdbValueToMiniKQLValue(const Ydb::Type& inputType,
 
 void ConvertYdbResultToKqpResult(const Ydb::ResultSet& input, NKikimrMiniKQL::TResult& output);
 
-void FillPermissionsFromAcl(const NACLib::TACL& acl,
-    google::protobuf::RepeatedPtrField<Ydb::Scheme::Permissions>* permissions);
+void FillPermissionsFromAcl(const NKikimrSchemeOp::TDirEntry& from, const bool withEffectiveAcl,
+    Ydb::Scheme::Entry* to);
+void FillPermissionsFromAcl(const NKikimrSchemeOp::TDirEntry& from, const bool withEffectiveAcl,
+    Ydb::Scheme::ModifyPermissionsRequest* to);
 
 struct TACLAttrs {
     ui32 AccessMask;

--- a/ydb/core/ydb_convert/ydb_convert_ut.cpp
+++ b/ydb/core/ydb_convert/ydb_convert_ut.cpp
@@ -1210,6 +1210,46 @@ Y_UNIT_TEST(TestEqualGranularAndDeprecatedAcl) {
 
 } // ConvertYdbPermissionNameToACLAttrs
 
+Y_UNIT_TEST_SUITE(ConvertDirectoryEntryTest) {
+    Y_UNIT_TEST(InterruptPermissionsInheritance) {
+        NACLib::TACL acl;
+        acl.SetInterruptInheritance(true);
+        TString aclStr;
+        UNIT_ASSERT(acl.SerializeToString(&aclStr));
+
+        NKikimrSchemeOp::TDirEntry from;
+        from.SetACL(aclStr);
+
+        Ydb::Scheme::Entry to;
+        ConvertDirectoryEntry(from, &to, true);
+
+        UNIT_ASSERT(to.interrupt_permissions_inheritance());
+    }
+
+    Y_UNIT_TEST(DefaultInterruptPermissionsInheritance) {
+        const NKikimrSchemeOp::TDirEntry from;
+        Ydb::Scheme::Entry to;
+        ConvertDirectoryEntry(from, &to, true);
+
+        UNIT_ASSERT(!to.interrupt_permissions_inheritance());
+    }
+
+    Y_UNIT_TEST(SkipAclProcessing) {
+        NACLib::TACL acl;
+        acl.SetInterruptInheritance(true);
+        TString aclStr;
+        UNIT_ASSERT(acl.SerializeToString(&aclStr));
+
+        NKikimrSchemeOp::TDirEntry from;
+        from.SetACL(aclStr);
+
+        Ydb::Scheme::Entry to;
+        ConvertDirectoryEntry(from, &to, false);
+
+        UNIT_ASSERT(!to.interrupt_permissions_inheritance());
+        UNIT_ASSERT_EQUAL(to.permissions_size(), 0);
+    }
+}
 
 Y_UNIT_TEST_SUITE(CellsFromTupleTest) {
 

--- a/ydb/core/ydb_convert/ydb_convert_ut.cpp
+++ b/ydb/core/ydb_convert/ydb_convert_ut.cpp
@@ -1223,7 +1223,7 @@ Y_UNIT_TEST_SUITE(ConvertDirectoryEntryTest) {
         Ydb::Scheme::Entry to;
         ConvertDirectoryEntry(from, &to, true);
 
-        UNIT_ASSERT(to.interrupt_permissions_inheritance());
+        UNIT_ASSERT(to.interrupt_permission_inheritance());
     }
 
     Y_UNIT_TEST(DefaultInterruptPermissionsInheritance) {
@@ -1231,7 +1231,7 @@ Y_UNIT_TEST_SUITE(ConvertDirectoryEntryTest) {
         Ydb::Scheme::Entry to;
         ConvertDirectoryEntry(from, &to, true);
 
-        UNIT_ASSERT(!to.interrupt_permissions_inheritance());
+        UNIT_ASSERT(!to.interrupt_permission_inheritance());
     }
 
     Y_UNIT_TEST(SkipAclProcessing) {
@@ -1246,7 +1246,7 @@ Y_UNIT_TEST_SUITE(ConvertDirectoryEntryTest) {
         Ydb::Scheme::Entry to;
         ConvertDirectoryEntry(from, &to, false);
 
-        UNIT_ASSERT(!to.interrupt_permissions_inheritance());
+        UNIT_ASSERT(!to.interrupt_permission_inheritance());
         UNIT_ASSERT_EQUAL(to.permissions_size(), 0);
     }
 }

--- a/ydb/public/api/protos/ydb_scheme.proto
+++ b/ydb/public/api/protos/ydb_scheme.proto
@@ -89,6 +89,9 @@ message Entry {
 
     // Virtual timestamp when the object was created
     VirtualTimestamp created_at = 9;
+
+    // When true, permissions are not inherited from parent objects
+    bool interrupt_permissions_inheritance = 10;
 }
 
 message ListDirectoryResult {

--- a/ydb/public/api/protos/ydb_scheme.proto
+++ b/ydb/public/api/protos/ydb_scheme.proto
@@ -91,7 +91,7 @@ message Entry {
     VirtualTimestamp created_at = 9;
 
     // When true, permissions are not inherited from parent objects
-    bool interrupt_permissions_inheritance = 10;
+    bool interrupt_permission_inheritance = 10;
 }
 
 message ListDirectoryResult {

--- a/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
+++ b/ydb/public/lib/ydb_cli/commands/ydb_service_scheme.cpp
@@ -542,7 +542,7 @@ int TCommandPermissionList::Run(TConfig& config) {
     NStatusHelpers::ThrowOnErrorOrPrintIssues(result);
     NScheme::TSchemeEntry entry = result.GetEntry();
     Cout << Endl;
-    PrintAllPermissions(entry.Owner, entry.Permissions, entry.EffectivePermissions);
+    PrintAllPermissions(entry.Owner, entry.Permissions, entry.EffectivePermissions, entry.InterruptInheritance);
     return EXIT_SUCCESS;
 }
 

--- a/ydb/public/lib/ydb_cli/common/describe.cpp
+++ b/ydb/public/lib/ydb_cli/common/describe.cpp
@@ -794,7 +794,7 @@ int TDescribeLogic::PrintSecretResponsePretty(const NSecret::TDescribeSecretResu
 int TDescribeLogic::DescribeEntryDefault(NScheme::TSchemeEntry entry, const TDescribeOptions& options) {
     if (options.ShowPermissions) {
         Out << Endl;
-        PrintAllPermissions(entry.Owner, entry.Permissions, entry.EffectivePermissions, Out);
+        PrintAllPermissions(entry.Owner, entry.Permissions, entry.EffectivePermissions, entry.InterruptInheritance, Out);
     }
     WarnAboutTableOptions(TString(entry.Name), options, EDataFormat::Default); // Assuming default format for check
     return EXIT_SUCCESS;
@@ -1311,6 +1311,7 @@ void TDescribeLogic::PrintPermissionsIfNeeded(const TDescriptionType& descriptio
             description.GetOwner(),
             description.GetPermissions(),
             description.GetEffectivePermissions(),
+            description.GetInterruptInheritance(),
             Out
         );
     }

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -279,10 +279,14 @@ void PrintAllPermissions(
     const std::string& owner,
     const std::vector<NScheme::TPermissions>& permissions,
     const std::vector<NScheme::TPermissions>& effectivePermissions,
+    bool interruptInheritance,
     IOutputStream& out
 ) {
     out << "Owner: " << owner << Endl << Endl << "Permissions: " << Endl;
     PrintPermissions(permissions, out);
+    if (interruptInheritance) {
+        out << Endl << "Interrupt permissions inheritance: true" << Endl;
+    }
     out << Endl << "Effective permissions: " << Endl;
     PrintPermissions(effectivePermissions, out);
 }

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -285,7 +285,7 @@ void PrintAllPermissions(
     out << "Owner: " << owner << Endl << Endl << "Permissions: " << Endl;
     PrintPermissions(permissions, out);
     if (interruptInheritance) {
-        out << Endl << "Interrupt permissions inheritance: true" << Endl;
+        out << Endl << "Is permissions inheritance interrupted: true" << Endl;
     }
     out << Endl << "Effective permissions: " << Endl;
     PrintPermissions(effectivePermissions, out);

--- a/ydb/public/lib/ydb_cli/common/print_utils.cpp
+++ b/ydb/public/lib/ydb_cli/common/print_utils.cpp
@@ -285,7 +285,7 @@ void PrintAllPermissions(
     out << "Owner: " << owner << Endl << Endl << "Permissions: " << Endl;
     PrintPermissions(permissions, out);
     if (interruptInheritance) {
-        out << Endl << "Is permissions inheritance interrupted: true" << Endl;
+        out << Endl << "Is permission inheritance interrupted: true" << Endl;
     }
     out << Endl << "Effective permissions: " << Endl;
     PrintPermissions(effectivePermissions, out);

--- a/ydb/public/lib/ydb_cli/common/print_utils.h
+++ b/ydb/public/lib/ydb_cli/common/print_utils.h
@@ -24,6 +24,7 @@ TString EntryTypeToString(NScheme::ESchemeEntryType entry);
         const std::string& owner,
         const std::vector<NScheme::TPermissions>& permissions,
         const std::vector<NScheme::TPermissions>& effectivePermissions,
+        bool interruptInheritance,
         IOutputStream& out = Cout
     );
 

--- a/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
@@ -277,7 +277,7 @@ Y_UNIT_TEST_SUITE(PrintAllPermissionsTests) {
             "Permissions: \n"
             "none\n"
             "\n"
-            "Interrupt permissions inheritance: true\n"
+            "Is permissions inheritance interrupted: true\n"
             "\n"
             "Effective permissions: \n"
             "none\n"

--- a/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
@@ -300,7 +300,7 @@ Y_UNIT_TEST_SUITE(PrintAllPermissionsTests) {
             "Permissions: \n"
             "database:ydb.generic.full\n"
             "\n"
-            "Interrupt permissions inheritance: true\n"
+            "Is permissions inheritance interrupted: true\n"
             "\n"
             "Effective permissions: \n"
             "USERS:ydb.database.connect\n"

--- a/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
@@ -1,5 +1,7 @@
 #include <ydb/public/lib/ydb_cli/common/print_utils.h>
 
+#include <ydb/public/api/protos/ydb_scheme.pb.h>
+
 #include <library/cpp/testing/unittest/registar.h>
 
 #include <util/stream/str.h>
@@ -246,5 +248,79 @@ Y_UNIT_TEST_SUITE(PrintPermissionsTests) {
         permissions.push_back(perm);
         PrintPermissions(permissions, ss);
         UNIT_ASSERT_STRINGS_EQUAL(ss.Str(), "user@domain:read,write\n");
+    }
+}
+
+Y_UNIT_TEST_SUITE(PrintAllPermissionsTests) {
+    Y_UNIT_TEST(InterruptInheritanceOmittedWhenFalse) {
+        TStringStream ss;
+        PrintAllPermissions("root", {}, {}, false, ss);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            ss.Str(),
+            "Owner: root\n"
+            "\n"
+            "Permissions: \n"
+            "none\n"
+            "\n"
+            "Effective permissions: \n"
+            "none\n"
+        );
+    }
+
+    Y_UNIT_TEST(InterruptInheritanceTrue) {
+        TStringStream ss;
+        PrintAllPermissions("root", {}, {}, true, ss);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            ss.Str(),
+            "Owner: root\n"
+            "\n"
+            "Permissions: \n"
+            "none\n"
+            "\n"
+            "Interrupt permissions inheritance: true\n"
+            "\n"
+            "Effective permissions: \n"
+            "none\n"
+        );
+    }
+
+    Y_UNIT_TEST(WithPermissions) {
+        TStringStream ss;
+        const std::vector<NYdb::NScheme::TPermissions> permissions = {
+            NYdb::NScheme::TPermissions("database", {"ydb.generic.full"}),
+        };
+        const std::vector<NYdb::NScheme::TPermissions> effectivePermissions = {
+            NYdb::NScheme::TPermissions("USERS", {"ydb.database.connect"}),
+        };
+        PrintAllPermissions("root", permissions, effectivePermissions, true, ss);
+        UNIT_ASSERT_STRINGS_EQUAL(
+            ss.Str(),
+            "Owner: root\n"
+            "\n"
+            "Permissions: \n"
+            "database:ydb.generic.full\n"
+            "\n"
+            "Interrupt permissions inheritance: true\n"
+            "\n"
+            "Effective permissions: \n"
+            "USERS:ydb.database.connect\n"
+        );
+    }
+}
+
+Y_UNIT_TEST_SUITE(TSchemeEntryInterruptInheritanceTests) {
+    Y_UNIT_TEST(FromProto) {
+        Ydb::Scheme::Entry proto;
+        proto.set_interrupt_permissions_inheritance(true);
+
+        const NYdb::NScheme::TSchemeEntry entry(proto);
+        UNIT_ASSERT_VALUES_EQUAL(entry.InterruptInheritance, true);
+    }
+
+    Y_UNIT_TEST(DefaultFromProto) {
+        Ydb::Scheme::Entry proto;
+
+        const NYdb::NScheme::TSchemeEntry entry(proto);
+        UNIT_ASSERT_VALUES_EQUAL(entry.InterruptInheritance, false);
     }
 }

--- a/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
+++ b/ydb/public/lib/ydb_cli/common/ut/print_utils_ut.cpp
@@ -277,7 +277,7 @@ Y_UNIT_TEST_SUITE(PrintAllPermissionsTests) {
             "Permissions: \n"
             "none\n"
             "\n"
-            "Is permissions inheritance interrupted: true\n"
+            "Is permission inheritance interrupted: true\n"
             "\n"
             "Effective permissions: \n"
             "none\n"
@@ -300,7 +300,7 @@ Y_UNIT_TEST_SUITE(PrintAllPermissionsTests) {
             "Permissions: \n"
             "database:ydb.generic.full\n"
             "\n"
-            "Is permissions inheritance interrupted: true\n"
+            "Is permission inheritance interrupted: true\n"
             "\n"
             "Effective permissions: \n"
             "USERS:ydb.database.connect\n"
@@ -311,7 +311,7 @@ Y_UNIT_TEST_SUITE(PrintAllPermissionsTests) {
 Y_UNIT_TEST_SUITE(TSchemeEntryInterruptInheritanceTests) {
     Y_UNIT_TEST(FromProto) {
         Ydb::Scheme::Entry proto;
-        proto.set_interrupt_permissions_inheritance(true);
+        proto.set_interrupt_permission_inheritance(true);
 
         const NYdb::NScheme::TSchemeEntry entry(proto);
         UNIT_ASSERT_VALUES_EQUAL(entry.InterruptInheritance, true);

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/scheme/scheme.h
@@ -64,6 +64,7 @@ struct TSchemeEntry {
     ESchemeEntryType Type;
     std::vector<TPermissions> EffectivePermissions;
     std::vector<TPermissions> Permissions;
+    bool InterruptInheritance = false;
     uint64_t SizeBytes = 0;
     TVirtualTimestamp CreatedAt;
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/table/table.h
@@ -1100,6 +1100,7 @@ public:
     const std::string& GetOwner() const;
     const std::vector<NScheme::TPermissions>& GetPermissions() const;
     const std::vector<NScheme::TPermissions>& GetEffectivePermissions() const;
+    bool GetInterruptInheritance() const;
 
     const std::vector<TKeyRange>& GetKeyRanges() const;
 

--- a/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
+++ b/ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/control_plane.h
@@ -340,6 +340,8 @@ public:
 
     const std::vector<NScheme::TPermissions>& GetEffectivePermissions() const;
 
+    bool GetInterruptInheritance() const;
+
     const TPartitioningSettings& GetPartitioningSettings() const;
 
     uint32_t GetTotalPartitionsCount() const;
@@ -395,6 +397,7 @@ private:
 
     std::string Owner_;
     NScheme::TVirtualTimestamp CreationTimestamp_;
+    bool InterruptInheritance_ = false;
     std::vector<NScheme::TPermissions> Permissions_;
     std::vector<NScheme::TPermissions> EffectivePermissions_;
     std::optional<EMetricsLevel> MetricsLevel_;

--- a/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
@@ -82,6 +82,7 @@ TSchemeEntry::TSchemeEntry(const ::Ydb::Scheme::Entry& proto)
     : Name(proto.name())
     , Owner(proto.owner())
     , Type(ConvertProtoEntryType(proto.type()))
+    , InterruptInheritance(proto.interrupt_permissions_inheritance())
     , SizeBytes(proto.size_bytes())
     , CreatedAt(proto.created_at())
 {

--- a/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
+++ b/ydb/public/sdk/cpp/src/client/scheme/scheme.cpp
@@ -82,7 +82,7 @@ TSchemeEntry::TSchemeEntry(const ::Ydb::Scheme::Entry& proto)
     : Name(proto.name())
     , Owner(proto.owner())
     , Type(ConvertProtoEntryType(proto.type()))
-    , InterruptInheritance(proto.interrupt_permissions_inheritance())
+    , InterruptInheritance(proto.interrupt_permission_inheritance())
     , SizeBytes(proto.size_bytes())
     , CreatedAt(proto.created_at())
 {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -466,6 +466,7 @@ public:
         Proto_ = std::move(desc);
 
         Owner_ = Proto_.self().owner();
+        InterruptInheritance_ = Proto_.self().interrupt_permissions_inheritance();
         PermissionToSchemeEntry(Proto_.self().permissions(), &Permissions_);
         PermissionToSchemeEntry(Proto_.self().effective_permissions(), &EffectivePermissions_);
 
@@ -681,6 +682,10 @@ public:
         return EffectivePermissions_;
     }
 
+    bool GetInterruptInheritance() const {
+        return InterruptInheritance_;
+    }
+
     const std::vector<TKeyRange>& GetKeyRanges() const {
         return Ranges_;
     }
@@ -756,6 +761,7 @@ private:
     std::vector<TChangefeedDescription> Changefeeds_;
     std::optional<TTtlSettings> TtlSettings_;
     std::string Owner_;
+    bool InterruptInheritance_ = false;
     std::vector<NScheme::TPermissions> Permissions_;
     std::vector<NScheme::TPermissions> EffectivePermissions_;
     std::vector<TKeyRange> Ranges_;
@@ -844,6 +850,10 @@ const std::vector<NScheme::TPermissions>& TTableDescription::GetPermissions() co
 
 const std::vector<NScheme::TPermissions>& TTableDescription::GetEffectivePermissions() const {
     return Impl_->GetEffectivePermissions();
+}
+
+bool TTableDescription::GetInterruptInheritance() const {
+    return Impl_->GetInterruptInheritance();
 }
 
 const std::vector<TKeyRange>& TTableDescription::GetKeyRanges() const {

--- a/ydb/public/sdk/cpp/src/client/table/table.cpp
+++ b/ydb/public/sdk/cpp/src/client/table/table.cpp
@@ -466,7 +466,7 @@ public:
         Proto_ = std::move(desc);
 
         Owner_ = Proto_.self().owner();
-        InterruptInheritance_ = Proto_.self().interrupt_permissions_inheritance();
+        InterruptInheritance_ = Proto_.self().interrupt_permission_inheritance();
         PermissionToSchemeEntry(Proto_.self().permissions(), &Permissions_);
         PermissionToSchemeEntry(Proto_.self().effective_permissions(), &EffectivePermissions_);
 

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -61,6 +61,7 @@ TTopicDescription::TTopicDescription(Ydb::Topic::DescribeTopicResult&& result)
 {
     Owner_ = Proto_.self().owner();
     CreationTimestamp_ = NScheme::TVirtualTimestamp(Proto_.self().created_at());
+    InterruptInheritance_ = Proto_.self().interrupt_permissions_inheritance();
     PermissionToSchemeEntry(Proto_.self().permissions(), &Permissions_);
     PermissionToSchemeEntry(Proto_.self().effective_permissions(), &EffectivePermissions_);
 
@@ -282,6 +283,10 @@ const std::vector<NScheme::TPermissions>& TTopicDescription::GetPermissions() co
 
 const std::vector<NScheme::TPermissions>& TTopicDescription::GetEffectivePermissions() const {
     return EffectivePermissions_;
+}
+
+bool TTopicDescription::GetInterruptInheritance() const {
+    return InterruptInheritance_;
 }
 
 TPartitioningSettings::TPartitioningSettings(const Ydb::Topic::PartitioningSettings& settings)

--- a/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/impl/topic.cpp
@@ -61,7 +61,7 @@ TTopicDescription::TTopicDescription(Ydb::Topic::DescribeTopicResult&& result)
 {
     Owner_ = Proto_.self().owner();
     CreationTimestamp_ = NScheme::TVirtualTimestamp(Proto_.self().created_at());
-    InterruptInheritance_ = Proto_.self().interrupt_permissions_inheritance();
+    InterruptInheritance_ = Proto_.self().interrupt_permission_inheritance();
     PermissionToSchemeEntry(Proto_.self().permissions(), &Permissions_);
     PermissionToSchemeEntry(Proto_.self().effective_permissions(), &EffectivePermissions_);
 


### PR DESCRIPTION
### Description for reviewers
Этот флаг по дефолту выставляется при создании схемных секретов, без него в АПИ сейчас неудобно, т.к. описание объекта получается неполным.