### PR TITLE
always run callbacks on the completion queue to awoid re-entrant lock…

### DIFF
--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -206,7 +206,15 @@ void TGRpcConnectionsImpl::DeferUntilCredentialsReady(
     }
 
     auto scheduleContext = context;
-    auto scheduleCallback = [this, scheduleContext](TDeadline deadline, std::function<void(bool)> callback) {
+    auto scheduleCallback = [this, scheduleContext, stopState = StopState_]
+        (TDeadline deadline, std::function<void(bool)> callback) {
+        // Future continuations may outlive TGRpcConnectionsImpl. Acquire the guard before
+        // dereferencing this, so destruction either waits for scheduling or prevents it.
+        TSdkCallbackGuard guard(stopState);
+        if (!guard.IsEntered()) {
+            callback(false);
+            return;
+        }
         const auto now = TDeadline::Clock::now();
         const auto timeout = deadline.GetTimePoint() <= now
             ? TDuration::Zero()

--- a/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
+++ b/ydb/public/sdk/cpp/src/client/impl/internal/grpc_connections/grpc_connections.cpp
@@ -112,14 +112,6 @@ TCredentialsWaitResult ReadyResult(const NThreading::TFuture<void>& future) {
     }
 }
 
-bool ScheduledSuccessfully(const NThreading::TFuture<bool>& future) {
-    try {
-        return future.GetValue();
-    } catch (...) {
-        return false;
-    }
-}
-
 } // anonymous namespace
 
 bool TDriverStopState::TryEnterCallback() noexcept {
@@ -199,32 +191,30 @@ void TGRpcConnectionsImpl::DeferUntilCredentialsReady(
     NThreading::TFuture<void> credentialsReady,
     TCredentialsCallback callback)
 {
+    if (!TryCreateContext(context)) {
+        callback(InitCancelledStatus());
+        return;
+    }
+
     auto cancelled = NThreading::NewPromise<void>();
     if (!credentialsReady.IsReady()) {
-        TryCreateContext(context);
-        if (context) {
-            context->SubscribeCancel([cancelled]() mutable {
-                cancelled.TrySetValue();
-            });
-        } else {
-            cancelled.SetValue();
-        }
-    } else if (context && context->IsCancelled()) {
+        context->SubscribeCancel([cancelled]() mutable {
+            cancelled.TrySetValue();
+        });
+    } else if (context->IsCancelled()) {
         cancelled.SetValue();
     }
 
     auto scheduleContext = context;
-    auto schedule = [this, scheduleContext, stopState = StopState_](TDeadline deadline) {
-        TSdkCallbackGuard guard(stopState);
-        if (!guard.IsEntered()) {
-            return NThreading::MakeFuture(false);
-        }
+    auto scheduleCallback = [this, scheduleContext](TDeadline deadline, std::function<void(bool)> callback) {
         const auto now = TDeadline::Clock::now();
         const auto timeout = deadline.GetTimePoint() <= now
             ? TDuration::Zero()
             : TDuration::MicroSeconds(std::chrono::duration_cast<std::chrono::microseconds>(
                 deadline.GetTimePoint() - now).count());
-        return ScheduleFuture(timeout, scheduleContext);
+        // Register the callback directly on the alarm. ScheduleFuture(timeout).Subscribe(...)
+        // may run the callback inline when the future becomes ready before Subscribe().
+        ScheduleCallback(timeout, std::move(callback), scheduleContext);
     };
 
     NThreading::TFuture<TCredentialsWaitResult> wait;
@@ -243,35 +233,25 @@ void TGRpcConnectionsImpl::DeferUntilCredentialsReady(
             result.TrySetValue(InitCancelledStatus());
         });
         if (requestSettings.Deadline != TDeadline::Max()) {
-            try {
-                schedule(requestSettings.Deadline).Subscribe(
-                    [result](const NThreading::TFuture<bool>& future) mutable {
-                        result.TrySetValue(ScheduledSuccessfully(future)
-                            ? TPlainStatus(EStatus::CLIENT_DEADLINE_EXCEEDED,
-                                "Request deadline exceeded while waiting for credentials")
-                            : InitCancelledStatus());
-                    });
-            } catch (...) {
-                result.TrySetValue(InitCancelledStatus());
-            }
+            scheduleCallback(requestSettings.Deadline,
+                [result](bool scheduledSuccessfully) mutable {
+                    result.TrySetValue(scheduledSuccessfully
+                        ? TPlainStatus(EStatus::CLIENT_DEADLINE_EXCEEDED,
+                            "Request deadline exceeded while waiting for credentials")
+                        : InitCancelledStatus());
+                });
         }
     }
 
-    wait.Subscribe([callback = std::move(callback), schedule = std::move(schedule)]
+    wait.Subscribe([callback = std::move(callback), scheduleCallback = std::move(scheduleCallback)]
         (const NThreading::TFuture<TCredentialsWaitResult>& future) mutable {
-        NThreading::TFuture<bool> scheduled;
-        try {
-            scheduled = schedule(TDeadline::Now());
-        } catch (...) {
-            callback(InitCancelledStatus());
-            return;
-        }
-        scheduled.Subscribe([callback = std::move(callback), status = future.GetValue()]
-            (const NThreading::TFuture<bool>& future) mutable {
-            callback(ScheduledSuccessfully(future)
-                ? std::move(status)
-                : TCredentialsWaitResult(InitCancelledStatus()));
-        });
+        scheduleCallback(TDeadline::Now(),
+            [callback = std::move(callback), status = future.GetValue()]
+            (bool scheduledSuccessfully) mutable {
+                callback(scheduledSuccessfully
+                    ? std::move(status)
+                    : TCredentialsWaitResult(InitCancelledStatus()));
+            });
     });
 }
 

--- a/ydb/public/sdk/cpp/src/client/topic/ut/read_session_credentials_ut.cpp
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/read_session_credentials_ut.cpp
@@ -1,0 +1,95 @@
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/credentials/credentials.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+#include <util/datetime/base.h>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace NYdb::inline Dev::NTopic::NTests {
+namespace {
+
+class TPendingCredentialsProvider final : public ICredentialsProvider {
+public:
+    TPendingCredentialsProvider()
+        : AuthInfo_(NThreading::NewPromise<std::string>())
+    {}
+
+    std::string GetAuthInfo() const override {
+        return AuthInfo_.GetFuture().GetValueSync();
+    }
+
+    NThreading::TFuture<std::string> GetAuthInfoAsync() const override {
+        return AuthInfo_.GetFuture();
+    }
+
+    bool IsValid() const override {
+        return true;
+    }
+
+private:
+    NThreading::TPromise<std::string> AuthInfo_;
+};
+
+class TPendingCredentialsFactory final : public ICredentialsProviderFactory {
+public:
+    TPendingCredentialsFactory()
+        : Provider_(std::make_shared<TPendingCredentialsProvider>())
+    {}
+
+    TCredentialsProviderPtr CreateProvider() const override {
+        return Provider_;
+    }
+
+private:
+    std::shared_ptr<TPendingCredentialsProvider> Provider_;
+};
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(TReadSessionCredentialsTest) {
+    Y_UNIT_TEST(CloseWhileCredentialsPendingDoesNotDeadlock) {
+        auto driver = TDriver(TDriverConfig()
+            .SetEndpoint("localhost:100")
+            .SetDatabase("/Root")
+            .SetDiscoveryMode(EDiscoveryMode::Off)
+            .SetCredentialsProviderFactory(std::make_shared<TPendingCredentialsFactory>()));
+        auto client = TTopicClient(driver);
+
+        constexpr size_t ThreadCount = 4;
+        constexpr size_t IterationCount = 1'000;
+        std::atomic_size_t finishedThreads = 0;
+        std::vector<std::thread> threads;
+        threads.reserve(ThreadCount);
+
+        for (size_t threadIndex = 0; threadIndex < ThreadCount; ++threadIndex) {
+            threads.emplace_back([&] {
+                for (size_t iteration = 0; iteration < IterationCount; ++iteration) {
+                    auto session = client.CreateReadSession(
+                        TReadSessionSettings()
+                            .ConsumerName("consumer")
+                            .AppendTopics(TTopicReadSettings("/Root/topic")));
+                    session->Close(TDuration::Zero());
+                }
+                ++finishedThreads;
+            });
+        }
+
+        const TInstant deadline = TInstant::Now() + TDuration::Seconds(30);
+        while (finishedThreads.load() != ThreadCount && TInstant::Now() < deadline) {
+            Sleep(TDuration::MilliSeconds(10));
+        }
+        Y_ABORT_UNLESS(finishedThreads.load() == ThreadCount,
+            "Topic read session Close(0) deadlocked while credentials were pending");
+
+        for (auto& thread : threads) {
+            thread.join();
+        }
+    }
+}
+
+} // namespace NYdb::NTopic::NTests

--- a/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
+++ b/ydb/public/sdk/cpp/src/client/topic/ut/ya.make
@@ -25,6 +25,7 @@ SRCS(
     deferred_publication_ack_state_ut.cpp
     local_partition_ut.cpp
     producer_deferred_publication_ut.cpp
+    read_session_credentials_ut.cpp
     topic_deferred_publish_ut.cpp
     topic_to_table_ut.cpp
     topic_tx_skip_conflict_ut.cpp

--- a/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
+++ b/ydb/public/sdk/cpp/tests/unit/client/driver/driver_ut.cpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <vector>
 
 #include <google/protobuf/text_format.h>
 
@@ -218,6 +219,7 @@ Y_UNIT_TEST_SUITE(DeferredCredentialsTest) {
         UNIT_ASSERT(result.Wait(TDuration::Seconds(10)));
         UNIT_ASSERT_VALUES_EQUAL(result.GetValue().GetStatus(), EStatus::CLIENT_CANCELLED);
     }
+
 }
 
 Y_UNIT_TEST_SUITE(CppGrpcClientSimpleTest) {


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
