### PR TITLE
Remove implicit breaks in truncate_unit

### DIFF
--- a/ydb/core/tx/datashard/truncate_unit.cpp
+++ b/ydb/core/tx/datashard/truncate_unit.cpp
@@ -1,7 +1,6 @@
 #include "datashard_impl.h"
 #include "datashard_pipeline.h"
 #include "execution_unit_ctors.h"
-#include "setup_sys_locks.h"
 #include "datashard_locks_db.h"
 
 #define YDB_LOG_THIS_FILE_COMPONENT NKikimrServices::TX_DATASHARD
@@ -67,12 +66,8 @@ EExecutionStatus TTruncateUnit::Execute(
         {"localTid", localTid},
         {"txId", op->GetTxId()});
 
-    // break locks
     TDataShardLocksDb locksDb(DataShard, txc);
 
-    TSetupSysLocks guardLocks(op, DataShard, &locksDb);
-    const TTableId fullTableId(pathId.OwnerId, tableId);
-    DataShard.SysLocksTable().BreakAllLocks(fullTableId);
     DataShard.GetConflictsCache().GetTableCache(localTid).RemoveAllUncommittedWrites(txc.DB);
 
     txc.DB.Truncate(localTid);
@@ -97,6 +92,7 @@ EExecutionStatus TTruncateUnit::Execute(
     userTable->StatsUpdateInProgress = false;
     userTable->StatsNeedUpdate = true;
 
+    // Passing locksDb invalidates every lock of this shard, like any other schema change does.
     DataShard.AddUserTable(pathId, userTable, &locksDb);
     if (userTable->NeedSchemaSnapshots()) {
         DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, actorCtx);
@@ -105,9 +101,6 @@ EExecutionStatus TTruncateUnit::Execute(
     txc.DB.NoMoreReadsForTx();
     BuildResult(op, NKikimrTxDataShard::TEvProposeTransactionResult::COMPLETE);
     op->Result()->SetStepOrderId(op->GetStepOrder().ToPair());
-
-    DataShard.SysLocksTable().ApplyLocks();
-    DataShard.SubscribeNewLocks(actorCtx);
 
     YDB_LOG_DEBUG_CTX(actorCtx, "TTruncateUnit::Execute: finished successfully",
         {"tableId", tableId},


### PR DESCRIPTION
### Changelog entry

Not for changelog (internal refactoring, no behaviour change)

### Description for reviewers

Removed the explicit lock-breaking block from `TTruncateUnit` (`BreakAllLocks` + `TSetupSysLocks` guard + `ApplyLocks`/`SubscribeNewLocks`).

It was dead weight: `AddUserTable(pathId, userTable, &locksDb)` right below already calls `SysLocks.RemoveSchema`, which drops every lock of the shard. That is how any schema operation invalidates locks — every other schema unit does exactly the same.

Behaviour is unchanged.