### PR TITLE
Add RDMA send receive main channel support NBYDB-2295

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -751,9 +751,10 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                             break;
                     }
                 }
+                const int rdmaMaxWr = static_cast<int>(icConfig.GetRdmaMaxWr());
                 setup->LocalServices.emplace_back(NInterconnect::NRdma::MakeCqActorId(),
                     TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(
-                        NInterconnect::NRdma::TRdmaRuntimeParams{-1, static_cast<int>(icConfig.GetRdmaMaxWr()), 0, 0},
+                        CreateRdmaRuntimeParams(rdmaMaxWr, icConfig.GetEnableRdmaSendReceive()),
                         rdmaCqMode,
                         interconectCounters.Get()),
                         TMailboxType::ReadAsFilled, interconnectPoolId));

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -751,10 +751,9 @@ void TBasicServicesInitializer::InitializeServices(NActors::TActorSystemSetup* s
                             break;
                     }
                 }
-                const int rdmaMaxWr = static_cast<int>(icConfig.GetRdmaMaxWr());
                 setup->LocalServices.emplace_back(NInterconnect::NRdma::MakeCqActorId(),
                     TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(
-                        CreateRdmaRuntimeParams(rdmaMaxWr, icConfig.GetEnableRdmaSendReceive()),
+                        CreateRdmaRuntimeParams(static_cast<int>(icConfig.GetRdmaMaxWr()), icConfig.GetEnableRdmaSendReceive()),
                         rdmaCqMode,
                         interconectCounters.Get()),
                         TMailboxType::ReadAsFilled, interconnectPoolId));

--- a/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
+++ b/ydb/library/actors/core/ut/event_pb_payload_ut.cpp
@@ -2,6 +2,7 @@
 #include "events.h"
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <ydb/library/actors/interconnect/rdma/mem_pool.h>
 #include <ydb/library/actors/protos/unittests.pb.h>
 
 using namespace NActors;
@@ -106,6 +107,131 @@ Y_UNIT_TEST_SUITE(TEventProtoWithPayload) {
             UNIT_ASSERT(chunker.IsSuccessfull());
             UNIT_ASSERT_VALUES_EQUAL_C(actual, expected, "chunkSize# " << chunkSize);
         }
+    }
+
+    Y_UNIT_TEST(CoroutineSerializerCopiesAliasedDataToBuffer) {
+        TEvMessageWithPayload msg;
+        msg.Record.SetMeta("hello, world!");
+        msg.Record.AddPayloadId(msg.AddPayload(MakeStringRope(TString(1024, 'x'))));
+
+        auto serializer = MakeHolder<TAllocChunkSerializer>();
+        UNIT_ASSERT(msg.SerializeToArcadiaStream(serializer.Get()));
+        const TString expected = serializer->Release(msg.CreateSerializationInfo(false))->GetString();
+
+        TCoroutineChunkSerializer chunker;
+        chunker.SetSerializingEvent(&msg, true, false);
+
+        TString actual;
+        char buffer[4096];
+        while (!chunker.IsComplete()) {
+            for (const auto& chunk : chunker.FeedBuf(buffer, sizeof(buffer),
+                    TCoroutineChunkSerializer::EAliasedMode::CopyToBuffer)) {
+                UNIT_ASSERT(!chunk.MemRegion);
+                UNIT_ASSERT(buffer <= chunk.Buf);
+                UNIT_ASSERT(chunk.Buf + chunk.Size <= std::end(buffer));
+                actual.append(chunk.Buf, chunk.Size);
+            }
+        }
+
+        UNIT_ASSERT(chunker.IsSuccessfull());
+        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
+    }
+
+    Y_UNIT_TEST(CoroutineSerializerPreservesRdmaAliasedData) {
+        constexpr size_t payloadSize = 1024;
+
+        const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+        auto rdmaBuffer = memPool->AllocRcBuf(payloadSize, 0).value();
+        memset(rdmaBuffer.GetDataMut(), 'x', payloadSize);
+
+        const char* payloadData = rdmaBuffer.GetData();
+        const auto memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(rdmaBuffer);
+        UNIT_ASSERT(!memRegion.Empty());
+
+        TEvMessageWithPayload msg;
+        msg.Record.SetMeta("hello, world!");
+        msg.Record.AddPayloadId(msg.AddPayload(TRope(std::move(rdmaBuffer))));
+
+        auto serializer = MakeHolder<TAllocChunkSerializer>();
+        UNIT_ASSERT(msg.SerializeToArcadiaStream(serializer.Get()));
+        const TString expected = serializer->Release(msg.CreateSerializationInfo(false))->GetString();
+
+        TCoroutineChunkSerializer chunker;
+        chunker.SetSerializingEvent(&msg, true, false);
+
+        TString actual;
+        bool foundRdmaPayload = false;
+        char buffer[4096];
+        while (!chunker.IsComplete()) {
+            for (const auto& chunk : chunker.FeedBuf(buffer, sizeof(buffer),
+                    TCoroutineChunkSerializer::EAliasedMode::CopyToBuffer)) {
+                if (chunk.MemRegion) {
+                    UNIT_ASSERT(!foundRdmaPayload);
+                    UNIT_ASSERT(chunk.MemRegion == memRegion.GetMemRegion());
+                    UNIT_ASSERT(chunk.Buf == payloadData);
+                    UNIT_ASSERT_VALUES_EQUAL(chunk.Size, payloadSize);
+                    foundRdmaPayload = true;
+                } else {
+                    UNIT_ASSERT(buffer <= chunk.Buf);
+                    UNIT_ASSERT(chunk.Buf + chunk.Size <= std::end(buffer));
+                }
+                actual.append(chunk.Buf, chunk.Size);
+            }
+        }
+
+        UNIT_ASSERT(chunker.IsSuccessfull());
+        UNIT_ASSERT(foundRdmaPayload);
+        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
+    }
+
+    // Verifies that an RDMA-backed aliased payload remains zero-copy while a regular
+    // aliased payload is copied into the serializer's RDMA buffer.
+    Y_UNIT_TEST(CoroutineSerializerHandlesMixedAliasedData) {
+        constexpr size_t payloadSize = 1024;
+
+        const auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
+        auto rdmaBuffer = memPool->AllocRcBuf(payloadSize, 0).value();
+        memset(rdmaBuffer.GetDataMut(), 'r', payloadSize);
+
+        const char* rdmaPayloadData = rdmaBuffer.GetData();
+        const auto memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(rdmaBuffer);
+        UNIT_ASSERT(!memRegion.Empty());
+
+        TEvMessageWithPayload msg;
+        msg.Record.SetMeta("hello, world!");
+        msg.Record.AddPayloadId(msg.AddPayload(MakeStringRope(TString(payloadSize, 't'))));
+        msg.Record.AddPayloadId(msg.AddPayload(TRope(std::move(rdmaBuffer))));
+
+        auto serializer = MakeHolder<TAllocChunkSerializer>();
+        UNIT_ASSERT(msg.SerializeToArcadiaStream(serializer.Get()));
+        const TString expected = serializer->Release(msg.CreateSerializationInfo(false))->GetString();
+
+        TCoroutineChunkSerializer chunker;
+        chunker.SetSerializingEvent(&msg, true, false);
+
+        TString actual;
+        bool foundRdmaPayload = false;
+        char buffer[4096];
+        while (!chunker.IsComplete()) {
+            for (const auto& chunk : chunker.FeedBuf(buffer, sizeof(buffer),
+                    TCoroutineChunkSerializer::EAliasedMode::CopyToBuffer)) {
+                if (chunk.MemRegion) {
+                    UNIT_ASSERT(!foundRdmaPayload);
+                    UNIT_ASSERT(chunk.MemRegion == memRegion.GetMemRegion());
+                    UNIT_ASSERT(chunk.Buf == rdmaPayloadData);
+                    UNIT_ASSERT_VALUES_EQUAL(chunk.Size, payloadSize);
+                    foundRdmaPayload = true;
+                } else {
+                    UNIT_ASSERT(buffer <= chunk.Buf);
+                    UNIT_ASSERT(chunk.Buf + chunk.Size <= std::end(buffer));
+                }
+                actual.append(chunk.Buf, chunk.Size);
+            }
+        }
+
+        UNIT_ASSERT(chunker.IsSuccessfull());
+        UNIT_ASSERT(foundRdmaPayload);
+        UNIT_ASSERT_VALUES_EQUAL(actual, expected);
     }
 
 #if (!defined(_tsan_enabled_))

--- a/ydb/library/actors/interconnect/interconnect_channel.cpp
+++ b/ydb/library/actors/interconnect/interconnect_channel.cpp
@@ -197,7 +197,7 @@ namespace NActors {
                         for (const auto& section : SerializationInfo->Sections) {
                             hasRdmaSections |= section.IsRdmaCapable;
                         }
-                        if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdma && RdmaMemPool && rdmaDeviceIndex >= 0) {
+                        if (hasRdmaSections && Params.UseXdcShuffle && Params.UseRdmaRead && RdmaMemPool && rdmaDeviceIndex >= 0) {
                             if (SerializeEventRdma(event)) {
                                 SerializationInfo = &event.Buffer->GetSerializationInfo();
                                 UseRdmaForCurrentEvent = IsRdmaSectionLayoutConsistentWithData(event, rdmaDeviceIndex);
@@ -290,12 +290,23 @@ namespace NActors {
 
     template<bool External>
     bool TEventOutputChannel::SerializeEvent(TTcpPacketOutTask& task, TEventHolder& event, bool disableChecksums, size_t *bytesSerialized) {
-        auto addChunk = [&](const void *data, size_t len, bool allowCopy) {
+        const bool useRdmaForMainChannelPacket = !External && task.UsePreallocatedInternalStream;
+        auto addChunk = [&](const void *data, size_t len, bool allowCopy, const NInterconnect::NRdma::TMemRegion* memRegion = nullptr) {
             event.UpdateChecksum(data, len);
-            if (allowCopy && (reinterpret_cast<uintptr_t>(data) & 63) + len <= 64) {
-                task.Write<External>(data, len);
+            if (useRdmaForMainChannelPacket) {
+                if (memRegion) {
+                    task.AppendRdma(data, len, memRegion, disableChecksums);
+                } else if (allowCopy) {
+                    task.Write<External>(data, len);
+                } else {
+                    task.Append<External>(data, len, &event.ZcTransferId, disableChecksums);
+                }
             } else {
-                task.Append<External>(data, len, &event.ZcTransferId, disableChecksums);
+                if (allowCopy && (reinterpret_cast<uintptr_t>(data) & 63) + len <= 64) {
+                    task.Write<External>(data, len);
+                } else {
+                    task.Append<External>(data, len, &event.ZcTransferId, disableChecksums);
+                }
             }
             *bytesSerialized += len;
             Y_DEBUG_ABORT_UNLESS(len <= PartLenRemain);
@@ -321,8 +332,11 @@ namespace NActors {
                 if (!out.size()) {
                     break;
                 }
-                for (const auto& chunk : Chunker.FeedBuf(out.data(), out.size())) {
-                    addChunk(chunk.Buf, chunk.Size, false);
+                const auto aliasedMode = useRdmaForMainChannelPacket
+                    ? TCoroutineChunkSerializer::EAliasedMode::CopyToBuffer
+                    : TCoroutineChunkSerializer::EAliasedMode::PassThrough;
+                for (const auto& chunk : Chunker.FeedBuf(out.data(), out.size(), aliasedMode)) {
+                    addChunk(chunk.Buf, chunk.Size, false, chunk.MemRegion);
                 }
                 complete = Chunker.IsComplete();
                 if (complete) {
@@ -333,7 +347,11 @@ namespace NActors {
             while (const size_t numb = Min<size_t>(External ? task.GetExternalFreeAmount() : task.GetInternalFreeAmount(),
                     Iter.ContiguousSize(), PartLenRemain)) {
                 const char *obuf = Iter.ContiguousData();
-                addChunk(obuf, numb, true);
+                NInterconnect::NRdma::TMemRegionSlice memRegion;
+                if (useRdmaForMainChannelPacket) {
+                    memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(Iter.GetChunk());
+                }
+                addChunk(obuf, numb, true, memRegion.GetMemRegion());
                 Iter += numb;
             }
             complete = !Iter.Valid();
@@ -368,10 +386,10 @@ namespace NActors {
                 } else {
                     Y_ABORT_UNLESS(SectionIndex < sections.size());
                     IsPartInline = sections[SectionIndex].IsInline;
-                    IsPartRdma = sections[SectionIndex].IsRdmaCapable;
+                    IsPartRdma = UseRdmaForCurrentEvent && sections[SectionIndex].IsRdmaCapable;
                     while (SectionIndex < sections.size()
                             && IsPartInline == sections[SectionIndex].IsInline
-                            && IsPartRdma == sections[SectionIndex].IsRdmaCapable) {
+                            && IsPartRdma == (UseRdmaForCurrentEvent && sections[SectionIndex].IsRdmaCapable)) {
                         PartLenRemain += sections[SectionIndex].Size;
                         ++SectionIndex;
                     }

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -334,6 +334,10 @@ namespace {
             PingTimeHistogram->Collect(value);
         }
 
+        void UpdatePingTimeRdmaHistogram(ui64 value) override {
+            PingTimeRdmaHistogram->Collect(value);
+        }
+
         void UpdateIcQueueTimeHistogram(ui64 value) override {
             InterconnectQueueTimeHistogram->Collect(value);
         }
@@ -433,8 +437,9 @@ namespace {
                 SubscribersCount = AdaptiveCounters->GetCounter("SubscribersCount");
 
                 PingTimeHistogram = AdaptiveCounters->GetHistogram(
-                    "PingTimeUs", NMonitoring::ExponentialHistogram(
-                        18, 2, Common->Settings.EnableRdmaSendReceive ? 1.25 : 125));
+                    "PingTimeUs", NMonitoring::ExponentialHistogram(18, 2, 125));
+                PingTimeRdmaHistogram = AdaptiveCounters->GetHistogram(
+                    "PingTimeRdmaUs", NMonitoring::ExponentialHistogram(18, 2, 1.25));
                 InterconnectQueueTimeHistogram = AdaptiveCounters->GetHistogram(
                     "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 NumEventsInQueueHistogram = AdaptiveCounters->GetHistogram(
@@ -548,6 +553,7 @@ namespace {
         NMonitoring::TDynamicCounters::TCounterPtr UsefulWriteWakeups;
         NMonitoring::TDynamicCounters::TCounterPtr SpuriousWriteWakeups;
         NMonitoring::THistogramPtr PingTimeHistogram;
+        NMonitoring::THistogramPtr PingTimeRdmaHistogram;
         NMonitoring::THistogramPtr InterconnectQueueTimeHistogram;
         NMonitoring::THistogramPtr NumEventsInQueueHistogram;
         NMonitoring::THistogramPtr RdmaReadTimeHistogram;
@@ -822,6 +828,10 @@ namespace {
             PingTimeHistogram_->Record(value);
         }
 
+        void UpdatePingTimeRdmaHistogram(ui64 value) override {
+            PingTimeRdmaHistogram_->Record(value);
+        }
+
         void UpdateIcQueueTimeHistogram(ui64 value) override {
             InterconnectQueueTimeHistogram_->Record(value);
         }
@@ -941,8 +951,10 @@ namespace {
                 SubscribersCount_ = createIntGauge(AdaptiveMetrics_, "interconnect.subscribers_count");
                 PingTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ping_time_us"}}),
-                        NMonitoring::ExponentialHistogram(
-                            18, 2, Common->Settings.EnableRdmaSendReceive ? 1.25 : 125));
+                        NMonitoring::ExponentialHistogram(18, 2, 125));
+                PingTimeRdmaHistogram_ = AdaptiveMetrics_->HistogramRate(
+                        NMonitoring::MakeLabels({{"sensor", "interconnect.ping_time_rdma_us"}}),
+                        NMonitoring::ExponentialHistogram(18, 2, 1.25));
                 InterconnectQueueTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 NumEventsInQueueHistogram_ = AdaptiveMetrics_->HistogramRate(
@@ -1090,6 +1102,7 @@ namespace {
         NMonitoring::IIntGauge* ClockSkewMicrosec_;
 
         NMonitoring::IHistogram* PingTimeHistogram_;
+        NMonitoring::IHistogram* PingTimeRdmaHistogram_;
         NMonitoring::IHistogram* InterconnectQueueTimeHistogram_;
         NMonitoring::IHistogram* NumEventsInQueueHistogram_;
         NMonitoring::IHistogram* RdmaReadTimeHistogram_;

--- a/ydb/library/actors/interconnect/interconnect_counters.cpp
+++ b/ydb/library/actors/interconnect/interconnect_counters.cpp
@@ -350,6 +350,10 @@ namespace {
             ++*RdmaMultipartEvents;
         }
 
+        void IncRdmaSendBufferAllocationFails() override {
+            ++*RdmaSendBufferAllocationFails;
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             *ch.OutgoingTraffic += value;
@@ -429,14 +433,16 @@ namespace {
                 SubscribersCount = AdaptiveCounters->GetCounter("SubscribersCount");
 
                 PingTimeHistogram = AdaptiveCounters->GetHistogram(
-                    "PingTimeUs", NMonitoring::ExponentialHistogram(18, 2, 125));
+                    "PingTimeUs", NMonitoring::ExponentialHistogram(
+                        18, 2, Common->Settings.EnableRdmaSendReceive ? 1.25 : 125));
                 InterconnectQueueTimeHistogram = AdaptiveCounters->GetHistogram(
                     "InterconnectQueueTimeHistogramUs", NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 NumEventsInQueueHistogram = AdaptiveCounters->GetHistogram(
                     "NumEventsInQueue", NMonitoring::ExplicitHistogram({0, 1, 2, 6, 24, 120}));
                 RdmaReadTimeHistogram = AdaptiveCounters->GetHistogram(
-+                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
+                    "RdmaReadTimeUs", NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
                 RdmaMultipartEvents = AdaptiveCounters->GetCounter("RdmaMultipartEvents", true);
+                RdmaSendBufferAllocationFails = AdaptiveCounters->GetCounter("RdmaSendBufferAllocationFails", true);
             }
 
             if (updateGlobal) {
@@ -546,6 +552,7 @@ namespace {
         NMonitoring::THistogramPtr NumEventsInQueueHistogram;
         NMonitoring::THistogramPtr RdmaReadTimeHistogram;
         NMonitoring::TDynamicCounters::TCounterPtr RdmaMultipartEvents;
+        NMonitoring::TDynamicCounters::TCounterPtr RdmaSendBufferAllocationFails;
 
         std::unordered_map<ui16, TOutputChannel> OutputChannels;
         TOutputChannel OtherOutputChannel;
@@ -831,6 +838,10 @@ namespace {
             RdmaMultipartEvents_->Inc();
         }
 
+        void IncRdmaSendBufferAllocationFails() override {
+            RdmaSendBufferAllocationFails_->Inc();
+        }
+
         void UpdateOutputChannelTraffic(ui16 channel, ui64 value) override {
             auto& ch = GetOutputChannel(channel);
             if (ch.OutgoingTraffic) {
@@ -929,7 +940,9 @@ namespace {
                 InflightRdmaDataAmount_ = createRate(AdaptiveMetrics_, "interconnect.inflight_rdma_data");
                 SubscribersCount_ = createIntGauge(AdaptiveMetrics_, "interconnect.subscribers_count");
                 PingTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
-                        NMonitoring::MakeLabels({{"sensor", "interconnect.ping_time_us"}}), NMonitoring::ExponentialHistogram(18, 2, 125));
+                        NMonitoring::MakeLabels({{"sensor", "interconnect.ping_time_us"}}),
+                        NMonitoring::ExponentialHistogram(
+                            18, 2, Common->Settings.EnableRdmaSendReceive ? 1.25 : 125));
                 InterconnectQueueTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.ic_queue_time_us"}}), NMonitoring::ExplicitHistogram({500, 1000, 5000, 10000, 50000, 100000}));
                 NumEventsInQueueHistogram_ = AdaptiveMetrics_->HistogramRate(
@@ -937,6 +950,7 @@ namespace {
                 RdmaReadTimeHistogram_ = AdaptiveMetrics_->HistogramRate(
                         NMonitoring::MakeLabels({{"sensor", "interconnect.rdma_read_time_us"}}), NMonitoring::ExplicitHistogram({0, 5, 10, 20, 50, 100, 200, 1000, 10000}));
                 RdmaMultipartEvents_ = createRate(AdaptiveMetrics_, "interconnect.rdma_multipart_events");
+                RdmaSendBufferAllocationFails_ = createRate(AdaptiveMetrics_, "interconnect.rdma_send_buffer_allocation_fails");
             }
 
             if (updateGlobal) {
@@ -1080,6 +1094,7 @@ namespace {
         NMonitoring::IHistogram* NumEventsInQueueHistogram_;
         NMonitoring::IHistogram* RdmaReadTimeHistogram_;
         NMonitoring::IRate* RdmaMultipartEvents_;
+        NMonitoring::IRate* RdmaSendBufferAllocationFails_;
 
         THashMap<ui16, TOutputChannel> OutputChannels_;
         TOutputChannel OtherOutputChannel_;

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -54,6 +54,7 @@ public:
     virtual void UpdateOutputChannelEvents(ui16 channel) = 0;
     virtual void SetUtilization(ui32 total, ui32 starvation) = 0;
     virtual void IncRdmaMultipartEvents() = 0;
+    virtual void IncRdmaSendBufferAllocationFails() = 0;
     TString GetHumanFriendlyPeerHostName() const {
         return HumanFriendlyPeerHostName.value_or(TString());
     }

--- a/ydb/library/actors/interconnect/interconnect_counters.h
+++ b/ydb/library/actors/interconnect/interconnect_counters.h
@@ -47,6 +47,7 @@ public:
     virtual void IncRecvSyscalls(ui64 ns) = 0;
     virtual void AddTotalBytesRead(ui64 value) = 0;
     virtual void UpdatePingTimeHistogram(ui64 value) = 0;
+    virtual void UpdatePingTimeRdmaHistogram(ui64 value) = 0;
     virtual void UpdateIcQueueTimeHistogram(ui64 value) = 0;
     virtual void UpdateNumEventsInQueueHistogram(ui64 value) = 0;
     virtual void UpdateRdmaReadTimeHistogram(ui64 value) = 0;

--- a/ydb/library/actors/interconnect/interconnect_handshake.cpp
+++ b/ydb/library/actors/interconnect/interconnect_handshake.cpp
@@ -372,6 +372,7 @@ namespace NActors {
         TActorId HandshakeBroker;
         std::optional<TBrokerLeaseHolder> BrokerLeaseHolder;
         std::optional<TString> HandshakeId; // for XDC
+        THolder<TEvReportConnection::THandle> PendingXdcConnection;
         bool SubscribedForConnection = false;
 
         struct {
@@ -492,7 +493,9 @@ namespace NActors {
                     if (Params.UseExternalDataChannel) {
                         if (incoming) {
                             Y_ABORT_UNLESS(SubscribedForConnection);
-                            auto ev = WaitForSpecificEvent<TEvReportConnection>("WaitInboundXdcStream");
+                            auto ev = PendingXdcConnection
+                                ? std::move(PendingXdcConnection)
+                                : WaitForSpecificEvent<TEvReportConnection>("WaitInboundXdcStream");
                             SubscribedForConnection = false;
                             if (ev->Get()->HandshakeId != *HandshakeId) {
                                 Y_DEBUG_ABORT_UNLESS(false);
@@ -504,7 +507,7 @@ namespace NActors {
                                 auto ack = TryRdmaRead(rdmaIncomingRead.value());
                                 SendExBlock(MainChannel, ack, "TRdmaHandshakeReadAck");
                                 if (ack.HasDigest()) {
-                                    Params.UseRdma = true;
+                                    Params.UseRdmaRead = true;
                                 } else {
                                     Rdma.Clear();
                                 }
@@ -523,7 +526,7 @@ namespace NActors {
                                     // session with rdma in a future
                                     RunDelayedRdmaHandshake = true;
                                 } else {
-                                    Params.UseRdma = true;
+                                    Params.UseRdmaRead = true;
                                 }
                             }
                         }
@@ -614,6 +617,10 @@ namespace NActors {
 
                 case TEvPollerReady::EventType:
                    break;
+
+                case TEvReportConnection::EventType:
+                    PendingXdcConnection.Reset(static_cast<TEvReportConnection::THandle*>(ev.Release()));
+                    break;
 
                 case TEvents::TSystem::Poison:
                    throw TExPoison();

--- a/ydb/library/actors/interconnect/interconnect_session_iface.h
+++ b/ydb/library/actors/interconnect/interconnect_session_iface.h
@@ -15,6 +15,12 @@ namespace NActors {
     // synchronous (same-mailbox) calls through it. Implementations are also actors; SessionActor()
     // provides the bridge required by IActor::InvokeOtherActor.
     struct IInterconnectSession {
+        enum class ERdmaState {
+            None,
+            Present,
+            Active,
+        };
+
         virtual ~IInterconnectSession() = default;
 
         // bridge to the underlying actor object (both implementations derive from TActor<>)
@@ -28,8 +34,7 @@ namespace NActors {
         virtual void StartHandshake() = 0;
         virtual void ReestablishConnectionWithHandshake(TDisconnectReason reason) = 0;
         virtual void CloseInputSession() = 0;
-        virtual bool IsRdmaInUse() = 0;
-        virtual bool HasRdmaState() const = 0;
+        virtual ERdmaState GetRdmaState() const = 0;
 
         // Whether this session type supports resuming over consecutive TCP connections (continuation).
         // TInterconnectSessionTCP returns true; TInterconnectSessionTCPv2 returns false.

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -371,7 +371,7 @@ namespace NActors {
 
     void TInputSessionTCP::CloseInputSession() {
         CloseInputSessionRequested = true;
-        ReceiveData();
+        ReceiveData(true);
     }
 
     void TInputSessionTCP::Handle(TEvPollerReady::TPtr ev) {
@@ -394,7 +394,7 @@ namespace NActors {
             Metrics->IncSpuriousReadWakeups();
         }
 
-        ReceiveData();
+        ReceiveData(!UseRdmaSendReceiveTransport() || msg->Socket == Socket);
 
         if (Params.Encryption && writeBlocked && ev->Sender != SessionId) {
             Send(SessionId, ev->Release().Release());
@@ -408,7 +408,7 @@ namespace NActors {
         } else if (msg->Socket == XdcSocket) {
             XdcPollerToken = std::move(msg->PollerToken);
         }
-        ReceiveData();
+        ReceiveData(!UseRdmaSendReceiveTransport() || msg->Socket == Socket);
     }
 
     void TInputSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaReadDone::TPtr& ev) {
@@ -425,10 +425,34 @@ namespace NActors {
         ProcessEvents(GetPerChannelContext(ev->Get()->Channel));
     }
 
-    void TInputSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr&) {
+    void TInputSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr& ev) {
+        if (!ev->Get()->IsSuccess()) {
+            YDB_LOG_ERROR("RDMA RECEIVE failed",
+                {"marker", "ICRDMA"},
+                {"source", ev->Get()->GetErrSource().data()},
+                {"errCode", ev->Get()->GetErrCode()});
+            throw TExDestroySession({TDisconnectReason::RdmaError()});
+        }
+
+        auto& received = std::get<NInterconnect::NRdma::TEvRdmaIoReceiveDone::TSuccess>(ev->Get()->Record).Buf;
+        const size_t bytes = received.GetSize();
+        if (bytes) {
+            IncomingData.Insert(IncomingData.End(), std::move(received));
+            Metrics->AddTotalBytesRead(bytes);
+            BytesRdmaRecieved += bytes;
+            LastReceiveTimestamp = TActivationContext::Monotonic();
+        }
+
+        ReceiveData(false);
     }
 
     void TInputSessionTCP::ReceiveData() {
+        ReceiveData(!UseRdmaSendReceiveTransport());
+    }
+
+    void TInputSessionTCP::ReceiveData(bool readMainChannel) {
+        ReadMainChannelRequested |= readMainChannel;
+
         TTimeLimit limit(GetMaxCyclesPerEvent());
         ui64 numDataBytes = 0;
 
@@ -473,7 +497,13 @@ namespace NActors {
             }
 
             // try to read more data into buffers
-            progress |= ReadMore();
+            if (ReadMainChannelRequested) {
+                if (ReadMore()) {
+                    progress = true;
+                } else {
+                    ReadMainChannelRequested = false;
+                }
+            }
             progress |= ReadXdc(&numDataBytes);
 
             if (!progress) { // no progress was made during this iteration
@@ -802,13 +832,13 @@ namespace NActors {
                     if (!IgnorePayload) { // process command if packet is being applied
                         auto& pendingEvent = context.PendingEvents.back();
                         const bool isInline = cmd == EXdcCommand::DECLARE_SECTION_INLINE;
+                        const bool isRdma = cmd == EXdcCommand::DECLARE_SECTION_RDMA;
                         pendingEvent.SerializationInfo.Sections.push_back(TEventSectionInfo{headroom, size, tailroom,
-                            alignment, isInline});
+                            alignment, isInline, isRdma});
 
                         Y_ABORT_UNLESS(!isInline || Params.UseXdcShuffle);
                         if (!isInline) {
                             // allocate buffer and push it into the payload
-                            const bool isRdma = cmd == EXdcCommand::DECLARE_SECTION_RDMA;
                             auto buffer = AllocateRcBuf(size, headroom, tailroom, alignment, isRdma);
                             if (!buffer) {
                                 YDB_LOG_CRIT("Unable to allocate rcbuf for section",
@@ -947,9 +977,9 @@ namespace NActors {
                     ptr += credsSerializedSize;
 
                     if (cmd == EXdcCommand::RDMA_READ && Params.ChecksumRdmaEvent) {
-                        context.PendingEvents.back().RdmaCumulativeCheckSum = ReadUnaligned<ui32>(ptr);
+                        context.PendingEvents.back().RdmaReadCumulativeCheckSum = ReadUnaligned<ui32>(ptr);
                     } else {
-                        context.PendingEvents.back().RdmaCumulativeCheckSum = std::nullopt;
+                        context.PendingEvents.back().RdmaReadCumulativeCheckSum = std::nullopt;
                     }
 
                     ptr += sizeof(ui32);
@@ -992,6 +1022,33 @@ namespace NActors {
             UpdateInboundPacketQ(z, pendingEvent.RdmaSize);
             if (processPacketQueue) {
                 ProcessInboundPacketQ(0,0);
+            }
+
+            std::optional<ui32> rdmaReadChecksum;
+            if (pendingEvent.RdmaReadCumulativeCheckSum) {
+                XXH3_state_t state;
+                XXH3_64bits_reset(&state);
+
+                auto externalIt = pendingEvent.ExternalPayload.Begin();
+                auto consumeExternal = [&externalIt](size_t size, XXH3_state_t* checksumState) {
+                    while (size) {
+                        Y_ABORT_UNLESS(externalIt.Valid());
+                        const size_t len = Min(size, externalIt.ContiguousSize());
+                        if (checksumState) {
+                            XXH3_64bits_update(checksumState, externalIt.ContiguousData(), len);
+                        }
+                        externalIt += len;
+                        size -= len;
+                    }
+                };
+
+                for (const auto& section : pendingEvent.SerializationInfo.Sections) {
+                    if (!section.IsInline) {
+                        consumeExternal(section.Size, section.IsRdmaCapable ? &state : nullptr);
+                    }
+                }
+
+                rdmaReadChecksum = XXH3_64bits_digest(&state);
             }
 
             // create aggregated payload
@@ -1079,17 +1136,8 @@ namespace NActors {
                     throw TExReestablishConnection{TDisconnectReason::ChecksumError()};
                 }
             }
-            if (pendingEvent.RdmaCumulativeCheckSum) {
-                XXH3_state_t state;
-                XXH3_64bits_reset(&state);
-                for (auto iter = payload.Begin(); iter.Valid(); ++iter) {
-                    auto memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(iter.GetChunk());
-                    if (!memRegion.Empty()) {
-                        XXH3_64bits_update(&state, memRegion.GetAddr(), memRegion.GetSize());
-                    }
-                }
-                checksum = XXH3_64bits_digest(&state);
-                if (checksum != *pendingEvent.RdmaCumulativeCheckSum) {
+            if (rdmaReadChecksum) {
+                if (*rdmaReadChecksum != *pendingEvent.RdmaReadCumulativeCheckSum) {
                     YDB_LOG_CRIT("Event rdma checksum error",
                         {"marker", "ICIS05"},
                         {"descrType", descr.Type});
@@ -1559,6 +1607,7 @@ namespace NActors {
                             MON_VAR(PacketsReadFromSocket)
                             MON_VAR(DataPacketsReadFromSocket)
                             MON_VAR(IgnoredDataPacketsFromSocket)
+                            MON_VAR(BytesRdmaRecieved)
 
                             MON_VAR(BytesReadFromXdcSocket)
                             MON_VAR(XdcSections)

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -371,7 +371,7 @@ namespace NActors {
 
     void TInputSessionTCP::CloseInputSession() {
         CloseInputSessionRequested = true;
-        ReceiveData(true);
+        ReceiveDataTCP(true);
     }
 
     void TInputSessionTCP::Handle(TEvPollerReady::TPtr ev) {
@@ -394,7 +394,7 @@ namespace NActors {
             Metrics->IncSpuriousReadWakeups();
         }
 
-        ReceiveData(!UseRdmaSendReceiveTransport() || msg->Socket == Socket);
+        ReceiveDataTCP(!UseRdmaSendReceiveTransport() || msg->Socket == Socket);
 
         if (Params.Encryption && writeBlocked && ev->Sender != SessionId) {
             Send(SessionId, ev->Release().Release());
@@ -408,7 +408,7 @@ namespace NActors {
         } else if (msg->Socket == XdcSocket) {
             XdcPollerToken = std::move(msg->PollerToken);
         }
-        ReceiveData(!UseRdmaSendReceiveTransport() || msg->Socket == Socket);
+        ReceiveDataTCP(!UseRdmaSendReceiveTransport() || msg->Socket == Socket);
     }
 
     void TInputSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaReadDone::TPtr& ev) {
@@ -425,7 +425,7 @@ namespace NActors {
         ProcessEvents(GetPerChannelContext(ev->Get()->Channel));
     }
 
-    void TInputSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr& ev) {
+    void TInputSessionTCP::ReceiveDataMainChannelRdma(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr& ev) {
         if (!ev->Get()->IsSuccess()) {
             YDB_LOG_ERROR("RDMA RECEIVE failed",
                 {"marker", "ICRDMA"},
@@ -443,14 +443,14 @@ namespace NActors {
             LastReceiveTimestamp = TActivationContext::Monotonic();
         }
 
-        ReceiveData(false);
+        ReceiveDataTCP(false);
     }
 
-    void TInputSessionTCP::ReceiveData() {
-        ReceiveData(!UseRdmaSendReceiveTransport());
+    void TInputSessionTCP::ReceiveDataTCP() {
+        ReceiveDataTCP(!UseRdmaSendReceiveTransport());
     }
 
-    void TInputSessionTCP::ReceiveData(bool readMainChannel) {
+    void TInputSessionTCP::ReceiveDataTCP(bool readMainChannel) {
         ReadMainChannelRequested |= readMainChannel;
 
         TTimeLimit limit(GetMaxCyclesPerEvent());
@@ -1530,7 +1530,7 @@ namespace NActors {
     void TInputSessionTCP::HandleCheckDeadPeer() {
         const TMonotonic now = TActivationContext::Monotonic();
         if (now >= LastReceiveTimestamp + DeadPeerTimeout) {
-            ReceiveData();
+            ReceiveDataTCP();
             if (Socket && now >= LastReceiveTimestamp + DeadPeerTimeout) {
                 // nothing has changed, terminate session
                 throw TExDestroySession{TDisconnectReason::DeadPeer()};

--- a/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_input_session.cpp
@@ -588,7 +588,11 @@ namespace NActors {
                 ui64 sendTime = AtomicGet(Context->ControlPacketSendTimer);
                 TDuration duration = CyclesToDuration(GetCycleCountFast() - sendTime);
                 const auto durationUs = duration.MicroSeconds();
-                Metrics->UpdatePingTimeHistogram(durationUs);
+                if (UseRdmaSendReceiveTransport()) {
+                    Metrics->UpdatePingTimeRdmaHistogram(durationUs);
+                } else {
+                    Metrics->UpdatePingTimeHistogram(durationUs);
+                }
                 PingQ.push_back(duration);
                 if (PingQ.size() > 16) {
                     PingQ.pop_front();
@@ -1544,7 +1548,11 @@ namespace NActors {
         const auto pingUs = ping.MicroSeconds();
         Context->PingRTT_us = pingUs;
         NewPingProtocol = true;
-        Metrics->UpdatePingTimeHistogram(pingUs);
+        if (UseRdmaSendReceiveTransport()) {
+            Metrics->UpdatePingTimeRdmaHistogram(pingUs);
+        } else {
+            Metrics->UpdatePingTimeHistogram(pingUs);
+        }
     }
 
     void TInputSessionTCP::HandleClock(TInstant clock) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -289,7 +289,7 @@ namespace NActors {
                 {"sender", ev->Sender},
                 {"self", msg->Self},
                 {"peer", msg->Peer});
-        } else if (Session->HasRdmaState()) {
+        } else if (Session->GetRdmaState() != IInterconnectSession::ERdmaState::None) {
             YDB_LOG_NOTICE("(actor rejecting graceful reconnect for RDMA session",
                 {"marker", "ICRDMA"},
                 {"sender", ev->Sender},
@@ -864,7 +864,7 @@ namespace NActors {
         if (CurrentStateFunc() == &TThis::StateWork) {
             SetRdmaRetryWatchdogPending(false);
             // There is a chance that session was promouted to use RDMA without us.
-            if (!InvokeSession(&IInterconnectSession::IsRdmaInUse)) {
+            if (InvokeSession(&IInterconnectSession::GetRdmaState) != IInterconnectSession::ERdmaState::Active) {
                 InvokeSession(&IInterconnectSession::Terminate, TDisconnectReason::NewSession());
             }
         } else {

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -12,7 +12,7 @@
 
 namespace NActors {
     NInterconnect::NRdma::TRdmaRuntimeParams CreateRdmaRuntimeParams(int maxWr, bool enableSendReceive) noexcept {
-        const int rdmaReceiveBufSize = sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen;
+        const int rdmaReceiveBufSize = TTcpPacketBuf::FullPacketSize;
         return {
             -1,
             maxWr,

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.cpp
@@ -1,5 +1,6 @@
 #include "interconnect_tcp_proxy.h"
 #include "interconnect_handshake.h"
+#include "packet.h"
 #include "interconnect_tcp_session.h"
 #include "interconnect_tcp_session_v2.h"
 #include <ydb/library/actors/core/log.h>
@@ -10,6 +11,16 @@
 #define YDB_LOG_THIS_FILE_COMPONENT ::NActorsServices::INTERCONNECT
 
 namespace NActors {
+    NInterconnect::NRdma::TRdmaRuntimeParams CreateRdmaRuntimeParams(int maxWr, bool enableSendReceive) noexcept {
+        const int rdmaReceiveBufSize = sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen;
+        return {
+            -1,
+            maxWr,
+            enableSendReceive ? maxWr : 0,
+            enableSendReceive ? rdmaReceiveBufSize : 0,
+        };
+    }
+
     static constexpr TDuration GetNodeRequestTimeout = TDuration::Seconds(5);
     static constexpr TDuration BaseRdmaRetryDelay = TDuration::Seconds(5);
     static constexpr ui32 MaxSafeRdmaRetryBackoffLevel = 30;

--- a/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_proxy.h
@@ -15,6 +15,7 @@
 
 namespace NActors {
 
+    NInterconnect::NRdma::TRdmaRuntimeParams CreateRdmaRuntimeParams(int maxWr, bool enableSendReceive) noexcept;
 
     /* WARNING: all proxy actors should be alive during actorsystem activity */
     class TInterconnectProxyTCP

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -94,11 +94,11 @@ namespace NActors {
         }
     };
 
-    class TInterconnectSessionTCP::TRdmaWriteStrategy final : public IWriteStrategy {
+    class TInterconnectSessionTCP::TRdmaSendStrategy final : public IWriteStrategy {
         TInterconnectSessionTCP& Session;
 
     public:
-        explicit TRdmaWriteStrategy(TInterconnectSessionTCP& session)
+        explicit TRdmaSendStrategy(TInterconnectSessionTCP& session)
             : Session(session)
         {}
 
@@ -767,7 +767,7 @@ namespace NActors {
             const bool useRdmaMain = UseRdmaSendReceiveTransport();
 
             if (useRdmaMain) {
-                TRdmaWriteStrategy writer(*this);
+                TRdmaSendStrategy writer(*this);
                 WriteData(writer);
             } else {
                 TTcpWriteStrategy writer(*this, Socket, PollerToken,

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -42,6 +42,128 @@ namespace NActors {
         return eventTypeName.empty() ? TStringBuf("manual") : TStringBuf(eventTypeName);
     }
 
+    class TInterconnectSessionTCP::TTcpWriteStrategy final : public IWriteStrategy {
+        TInterconnectSessionTCP& Session;
+        const TIntrusivePtr<NInterconnect::TStreamSocket>& Socket;
+        const TPollerToken::TPtr& PollerToken;
+        bool& WriteBlocked;
+        ui64& BytesWritten;
+
+    public:
+        TTcpWriteStrategy(TInterconnectSessionTCP& session,
+                const TIntrusivePtr<NInterconnect::TStreamSocket>& socket,
+                const TPollerToken::TPtr& pollerToken, bool& writeBlocked, ui64& bytesWritten)
+            : Session(session)
+            , Socket(socket)
+            , PollerToken(pollerToken)
+            , WriteBlocked(writeBlocked)
+            , BytesWritten(bytesWritten)
+        {}
+
+        size_t Write(NInterconnect::TOutgoingStream& stream, size_t maxBytes) override {
+            if (!stream || !Socket || WriteBlocked) {
+                return 0;
+            }
+
+            for (;;) {
+                if (const ssize_t res = Session.Write(stream, *Socket, maxBytes); res > 0) {
+                    BytesWritten += res;
+                    return res;
+                } else if (res == -1) {
+                    if (PollerToken && Socket->RequestWriteNotificationAfterWouldBlock(*PollerToken)) {
+                        continue;
+                    }
+                    WriteBlocked = true;
+                } else if (res != 0) {
+                    Y_UNREACHABLE();
+                }
+                return 0;
+            }
+        }
+
+        size_t GetMaxBytesAtOnce() const override {
+            return 256 * 1024;
+        }
+
+        size_t GetExpectedWriteLength() const override {
+            return Socket ? Socket->ExpectedWriteLength() : 0;
+        }
+
+        bool IsWriteBlocked() const override {
+            return WriteBlocked;
+        }
+    };
+
+    class TInterconnectSessionTCP::TRdmaWriteStrategy final : public IWriteStrategy {
+        TInterconnectSessionTCP& Session;
+
+    public:
+        explicit TRdmaWriteStrategy(TInterconnectSessionTCP& session)
+            : Session(session)
+        {}
+
+        size_t Write(NInterconnect::TOutgoingStream& stream, size_t maxBytes) override {
+            static constexpr size_t MaxRdmaSendSge = 16;
+
+            Y_ABORT_UNLESS(Session.RdmaQp);
+            Y_ABORT_UNLESS(Session.RdmaCq);
+
+            TStackVec<NInterconnect::NRdma::TSendSge, MaxRdmaSendSge> sgList;
+            std::array<NInterconnect::NRdma::TMemRegionPtr, MaxRdmaSendSge> regions;
+            const size_t sgeLimit = Min((int)MaxRdmaSendSge,
+                Max<int>(1, Session.RdmaQp->GetCtx()->GetMaxSge()));
+            const size_t totalBytes = stream.ProduceRdmaSendVec(sgList, sgeLimit, maxBytes);
+
+            // The verbs builder does not own send buffers; keep their regions alive until completion.
+            for (size_t i = 0; i < sgList.size(); ++i) {
+                regions[i] = NInterconnect::NRdma::TMemRegionPtr(
+                    const_cast<NInterconnect::NRdma::TMemRegion*>(sgList[i].MemRegion));
+            }
+
+            if (sgList.empty()) {
+                YDB_LOG_ERROR("RDMA main produced empty SG list",
+                    {"marker", "ICRDMA"},
+                    {"isOutOfBand", &stream == &Session.OutOfBandStream},
+                    {"streamSize", stream.CalculateOutgoingSize()},
+                    {"streamUnsent", stream.CalculateUnsentSize()},
+                    {"sendQueueSize", stream.GetSendQueueSize()});
+                Session.ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
+                return 0;
+            }
+
+            auto builder = NInterconnect::NRdma::CreateIbVerbsBuilder(1);
+            const TActorId selfId = Session.SelfId();
+            builder->AddSendVerb(std::span<const NInterconnect::NRdma::TSendSge>(sgList.data(), sgList.size()),
+                [selfId, regions{std::move(regions)}](TActorSystem* as, NInterconnect::NRdma::TEvRdmaIoDone* ioDone) {
+                    as->Send(selfId, ioDone);
+                    Y_UNUSED(regions);
+                });
+
+            if (Session.RdmaCq->DoWrBatchAsync(Session.RdmaQp, std::move(builder))) {
+                YDB_LOG_ERROR("RDMA send post failed",
+                    {"marker", "ICRDMA"});
+                Session.ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
+                return 0;
+            }
+
+            ++Session.RdmaSendWrSubmitted;
+            return totalBytes;
+        }
+
+        size_t GetMaxBytesAtOnce() const override {
+            // One SEND WR consumes one posted SRQ receive buffer of this size on the peer.
+            return TTcpPacketBuf::FullPacketSize;
+        }
+
+        size_t GetExpectedWriteLength() const override {
+            return 0;
+        }
+
+        bool IsWriteBlocked() const override {
+            return false;
+        }
+    };
+
     TInterconnectSessionTCP::TInterconnectSessionTCP(TInterconnectProxyTCP* const proxy)
         : TActor(&TInterconnectSessionTCP::StateFunc)
         , Created(TInstant::Now())
@@ -641,13 +763,14 @@ namespace NActors {
             const bool useRdmaMain = UseRdmaSendReceiveTransport();
 
             if (useRdmaMain) {
-                WriteDataRdma();
-                if (!Socket) {
-                    return;
-                }
+                TRdmaWriteStrategy writer(*this);
+                WriteData(writer);
+            } else {
+                TTcpWriteStrategy writer(*this, Socket, PollerToken,
+                    ReceiveContext->MainWriteBlocked, BytesWrittenToSocket);
+                WriteData(writer);
             }
 
-            WriteDataTcp(!useRdmaMain);
             if (!Socket) {
                 return;
             }
@@ -868,41 +991,12 @@ namespace NActors {
         }
     }
 
-    void TInterconnectSessionTCP::WriteDataTcp(bool writeMainChannel) {
-        // total bytes written during this call
+    void TInterconnectSessionTCP::WriteData(IWriteStrategy& mainWriter) {
         ui64 written = 0;
 
-        auto process = [&](NInterconnect::TOutgoingStream& stream, const TIntrusivePtr<NInterconnect::TStreamSocket>& socket,
-                const TPollerToken::TPtr& token, bool *writeBlocked, size_t maxBytes) {
-            size_t totalWritten = 0;
-
-            if (stream && socket && !*writeBlocked) {
-                for (;;) {
-                    if (const ssize_t r = Write(stream, *socket, maxBytes); r > 0) {
-                        stream.Advance(r);
-                        totalWritten += r;
-                    } else if (r == -1) {
-                        if (token && socket->RequestWriteNotificationAfterWouldBlock(*token)) {
-                            continue; // we can try again
-                        }
-                        *writeBlocked = true;
-                    } else if (r == 0) {
-                        // error condition
-                    } else {
-                        Y_UNREACHABLE();
-                    }
-                    break;
-                }
-            }
-
-            written += totalWritten;
-            return totalWritten;
-        };
-
-        static constexpr size_t maxBytesAtOnce = 256 * 1024;
-        if (writeMainChannel) {
+        if (OutgoingStream || OutOfBandStream) {
             auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
-            size_t bytesToSendInMain = maxBytesAtOnce;
+            size_t bytesToSendInMain = mainWriter.GetMaxBytesAtOnce();
 
             Y_DEBUG_ABORT_UNLESS(OutgoingIndex < SendQueue.size() || (OutgoingIndex == SendQueue.size() && !OutgoingOffset && !OutgoingStream));
 
@@ -923,28 +1017,41 @@ namespace NActors {
             }
 
             if (bytesToSendInMain) {
-                const size_t w = process(OutgoingStream, Socket, PollerToken, &ReceiveContext->MainWriteBlocked, bytesToSendInMain);
+                const size_t w = mainWriter.Write(OutgoingStream, bytesToSendInMain);
+                OutgoingStream.Advance(w);
+                written += w;
 
                 // adjust sending queue iterator
                 for (OutgoingOffset += w; OutgoingOffset && sendQueueIt->PacketSize <= OutgoingOffset; ++sendQueueIt, ++OutgoingIndex) {
                     OutgoingOffset -= sendQueueIt->PacketSize;
                 }
 
-                BytesWrittenToSocket += w;
-
                 if (OutOfBandStream) {
                     BytesAlignedForOutOfBand += w;
                     bytesToSendInMain -= w;
                 }
 
-                ForcedWriteLength = Socket ? Socket->ExpectedWriteLength() : 0;
+                ForcedWriteLength = mainWriter.GetExpectedWriteLength();
+                if (!Socket) {
+                    if (written) {
+                        Proxy->Metrics->AddTotalBytesWritten(written);
+                    }
+                    return;
+                }
             }
 
             if (!bytesToSendInMain && !ForcedWriteLength) {
-                if (const size_t w = process(OutOfBandStream, Socket, PollerToken, &ReceiveContext->MainWriteBlocked, maxBytesAtOnce)) {
+                if (const size_t w = mainWriter.Write(OutOfBandStream, mainWriter.GetMaxBytesAtOnce())) {
+                    OutOfBandStream.Advance(w);
                     OutOfBandStream.DropFront(w);
-                    BytesWrittenToSocket += w;
                     OutOfBandBytesSent += w;
+                    written += w;
+                }
+                if (!Socket) {
+                    if (written) {
+                        Proxy->Metrics->AddTotalBytesWritten(written);
+                    }
+                    return;
                 }
             }
         }
@@ -963,9 +1070,12 @@ namespace NActors {
             }
         }
 
-        if (const size_t w = process(XdcStream, XdcSocket, XdcPollerToken, &ReceiveContext->XdcWriteBlocked, maxBytesAtOnce)) {
-            XdcBytesSent += w;
+        TTcpWriteStrategy xdcWriter(*this, XdcSocket, XdcPollerToken,
+            ReceiveContext->XdcWriteBlocked, XdcBytesSent);
+        if (const size_t w = xdcWriter.Write(XdcStream, xdcWriter.GetMaxBytesAtOnce())) {
+            XdcStream.Advance(w);
             XdcOffset += w;
+            written += w;
         }
 
         if (written) {
@@ -975,7 +1085,7 @@ namespace NActors {
         DropConfirmed(LastConfirmed);
 
         const bool writeBlockedByFullSendBuffer =
-            (writeMainChannel && ReceiveContext->MainWriteBlocked) || ReceiveContext->XdcWriteBlocked;
+            mainWriter.IsWriteBlocked() || ReceiveContext->XdcWriteBlocked;
         if (WriteBlockedByFullSendBuffer < writeBlockedByFullSendBuffer) { // became blocked
             WriteBlockedCycles = GetCycleCountFast();
             YDB_LOG_DEBUG_COMP(::NActorsServices::INTERCONNECT_SESSION, "Hit send buffer limit",
@@ -984,88 +1094,6 @@ namespace NActors {
             WriteBlockedTotal += TDuration::Seconds(NHPTimer::GetSeconds(GetCycleCountFast() - WriteBlockedCycles));
         }
         WriteBlockedByFullSendBuffer = writeBlockedByFullSendBuffer;
-    }
-
-    void TInterconnectSessionTCP::WriteDataRdma() {
-        if (!OutgoingStream && !OutOfBandStream) {
-            return;
-        }
-
-        Y_ABORT_UNLESS(RdmaQp);
-        Y_ABORT_UNLESS(RdmaCq);
-
-        static constexpr size_t maxBytesAtOnce = sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen;
-        static constexpr size_t maxRdmaSendSge = 16;
-        const size_t sgeLimit = Min((int)maxRdmaSendSge, Max<int>(1, RdmaQp->GetCtx()->GetMaxSge()));
-
-        auto submitStream = [&](NInterconnect::TOutgoingStream& stream, bool isOutOfBand) {
-            TStackVec<NInterconnect::NRdma::TSendSge, maxRdmaSendSge> sgList;
-            std::array<NInterconnect::NRdma::TMemRegionPtr, maxRdmaSendSge> regions;
-
-            const size_t totalBytes = stream.ProduceRdmaSendVec(sgList, sgeLimit, maxBytesAtOnce);
-
-            // Keep regions alive until send completion, including after session termination.
-            //TODO: It looks we can make RdmaCq/Verbs builder iface more nice to handle this case.
-            for (size_t i = 0; i < sgList.size(); i++) {
-                regions[i] = NInterconnect::NRdma::TMemRegionPtr(
-                        const_cast<NInterconnect::NRdma::TMemRegion*>(sgList[i].MemRegion));
-            }
-
-            if (sgList.empty()) {
-                YDB_LOG_ERROR("RDMA main produced empty SG list",
-                    {"marker", "ICRDMA"},
-                    {"isOutOfBand", isOutOfBand},
-                    {"streamSize", stream.CalculateOutgoingSize()},
-                    {"streamUnsent", stream.CalculateUnsentSize()},
-                    {"sendQueueSize", stream.GetSendQueueSize()});
-                ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
-                return;
-            }
-
-            auto builder = NInterconnect::NRdma::CreateIbVerbsBuilder(1);
-            const TActorId selfId = SelfId();
-            builder->AddSendVerb(std::span<const NInterconnect::NRdma::TSendSge>(sgList.data(), sgList.size()),
-                [selfId, regions{std::move(regions)}](TActorSystem* as, NInterconnect::NRdma::TEvRdmaIoDone* ioDone) {
-                    as->Send(selfId, ioDone);
-                    Y_UNUSED(regions);
-                });
-
-            if (RdmaCq->DoWrBatchAsync(RdmaQp, std::move(builder))) {
-                YDB_LOG_ERROR("RDMA send post failed",
-                    {"marker", "ICRDMA"});
-                ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
-                return;
-            }
-
-            ++RdmaSendWrSubmitted;
-
-            if (isOutOfBand) {
-                OutOfBandStream.Advance(totalBytes);
-                OutOfBandStream.DropFront(totalBytes);
-                OutOfBandBytesSent += totalBytes;
-            } else {
-                OutgoingStream.Advance(totalBytes);
-                OutgoingOffset += totalBytes;
-
-                auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
-                for (; OutgoingOffset && sendQueueIt != SendQueue.end() && sendQueueIt->PacketSize <= OutgoingOffset;
-                        ++sendQueueIt, ++OutgoingIndex) {
-                    OutgoingOffset -= sendQueueIt->PacketSize;
-                }
-            }
-
-            Proxy->Metrics->AddTotalBytesWritten(totalBytes);
-            DropConfirmed(LastConfirmed);
-            return;
-        };
-
-        if (OutOfBandStream && OutgoingOffset == 0) {
-            submitStream(OutOfBandStream, true);
-        } else if (OutgoingStream) {
-            submitStream(OutgoingStream, false);
-        } else if (OutOfBandStream) {
-            submitStream(OutOfBandStream, true);
-        }
     }
 
     void TInterconnectSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaIoDone::TPtr& ev) {
@@ -1241,7 +1269,7 @@ namespace NActors {
 
         const bool usePreallocatedInternalStream = UseRdmaSendReceiveTransport();
         if (usePreallocatedInternalStream &&
-                !stream.PreallocateForWriting(sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen)) {
+                !stream.PreallocateForWriting(TTcpPacketBuf::FullPacketSize)) {
             Proxy->Metrics->IncRdmaSendBufferAllocationFails();
 
             YDB_LOG_NOTICE("RDMA send buffer preallocation failed",

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -831,18 +831,18 @@ namespace NActors {
                 break;
             }
             try {
-                auto packetSize = MakePacket(true);
-                if (!packetSize) {
+                // Break loop in case of prealocation failure
+                if (ui32 packetSize = MakePacket(true)) {
+                    bytesProduced += packetSize;
+                } else {
                     return;
                 }
-                bytesProduced += *packetSize;
             } catch (const TExSerializedEventTooLarge& ex) {
                 // terminate session if the event can't be serialized properly
                 YDB_LOG_CRIT_COMP(::NActorsServices::INTERCONNECT, "Serialized event is too large",
                     {"marker", "ICS31"},
                     {"exType", ex.Type});
-                Terminate(TDisconnectReason::EventTooLarge());
-                return;
+                return Terminate(TDisconnectReason::EventTooLarge());
             }
         }
     }
@@ -996,6 +996,7 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCP::WriteData(IWriteStrategy& mainWriter) {
+        // total bytes written during this call
         ui64 written = 0;
 
         auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
@@ -1258,7 +1259,7 @@ namespace NActors {
         }
     }
 
-    std::optional<ui32> TInterconnectSessionTCP::MakePacket(bool data, TMaybe<ui64> pingMask) {
+    ui32 TInterconnectSessionTCP::MakePacket(bool data, TMaybe<ui64> pingMask) {
         NInterconnect::TOutgoingStream& stream = data ? OutgoingStream : OutOfBandStream;
 
 #ifndef NDEBUG
@@ -1281,7 +1282,7 @@ namespace NActors {
                 {"streamSize", stream.CalculateOutgoingSize()},
                 {"streamUnsent", stream.CalculateUnsentSize()});
             ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
-            return std::nullopt;
+            return 0;
         }
 
         TTcpPacketOutTask packet(Params, stream, XdcStream, usePreallocatedInternalStream);

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -3,6 +3,7 @@
 #include "interconnect_handshake.h"
 #include "interconnect_zc_processor.h"
 #include "subscriber_liveness_checker.h"
+#include "rdma/ctx.h"
 
 #include <ydb/library/actors/core/probes.h>
 #include <ydb/library/actors/core/log.h>
@@ -78,6 +79,10 @@ namespace NActors {
 
     void TInterconnectSessionTCP::Init(const TSessionParams& params) {
         Params = params;
+        if (Params.AllowRdmaSendReceive) {
+            OutgoingStream = NInterconnect::TOutgoingStream(Proxy->Common->RdmaMemPool);
+            OutOfBandStream = NInterconnect::TOutgoingStream(Proxy->Common->RdmaMemPool);
+        }
         Proxy->Metrics->SetPeerScopeId(Params.PeerScopeId);
         Proxy->Metrics->SetConnected(0);
         DirectSession = std::make_shared<TDirectSessionV1>(TActivationContext::ActorSystem(), SelfId(), Proxy->PeerNodeId);
@@ -143,7 +148,7 @@ namespace NActors {
     }
 
     bool TInterconnectSessionTCP::HasRdmaState() const {
-        return Params.UseRdma || RdmaQp || RdmaInflightDataAmount;
+        return Params.UseRdmaRead || RdmaQp || RdmaInflightDataAmount;
     }
 
     void TInterconnectSessionTCP::Handle(TEvTerminate::TPtr& ev) {
@@ -426,10 +431,10 @@ namespace NActors {
         Socket = std::move(ev->Get()->Socket);
         XdcSocket = std::move(ev->Get()->XdcSocket);
 
-        NInterconnect::NRdma::ICq::TPtr cq;
         RdmaQp.reset();
+        RdmaCq.reset();
         if (auto rdmaSuccess = ev->Get()->RdmaHanshakeResult.GetOk()) {
-            cq = std::move(rdmaSuccess->RdmaCq);
+            RdmaCq = std::move(rdmaSuccess->RdmaCq);
             RdmaQp = std::move(rdmaSuccess->RdmaQp);
         }
 
@@ -471,7 +476,7 @@ namespace NActors {
             inputSession = ev->Get()->RdmaHanshakeResult.ReleasePreinitedSession();
             ReceiverId = IActor::InvokeOtherActor(*inputSession, &TInputSessionTCP::SelfId);
         } else {
-            inputSession = new TInputSessionTCP(Proxy->Common, RdmaQp, std::move(cq));
+            inputSession = new TInputSessionTCP(Proxy->Common, RdmaQp, RdmaCq);
             ReceiverId = RegisterWithSameMailbox(inputSession);
         }
 
@@ -519,7 +524,9 @@ namespace NActors {
         OutgoingIndex = SendQueue.size();
         DropConfirmed(nextPacket);
         OutgoingStream.Rewind();
-        OutOfBandStream = {};
+        OutOfBandStream = UseRdmaSendReceiveTransport()
+            ? NInterconnect::TOutgoingStream(Proxy->Common->RdmaMemPool)
+            : NInterconnect::TOutgoingStream();
         XdcStream.Rewind();
         OutgoingOffset = XdcOffset = 0;
         OutgoingIndex = 0;
@@ -628,14 +635,38 @@ namespace NActors {
         bool notEnoughCpu = false;
 
         while (Socket) {
-            ProducePackets();
+            const bool canProduceMorePackets = ProducePackets();
             if (!Socket) {
                 return;
             }
 
-            WriteData();
+            const bool useRdmaMain = UseRdmaSendReceiveTransport();
+            if (useRdmaMain && !RdmaInitialTrafficStateReported &&
+                    (NumEventsInQueue || OutgoingStream || OutOfBandStream)) {
+                RdmaInitialTrafficStateReported = true;
+                YDB_LOG_NOTICE("RDMA main initial traffic state",
+                    {"marker", "ICRDMA"},
+                    {"queuedEvents", NumEventsInQueue},
+                    {"canProduceMore", canProduceMorePackets},
+                    {"outgoingSize", OutgoingStream.CalculateOutgoingSize()},
+                    {"outgoingUnsent", OutgoingStream.CalculateUnsentSize()},
+                    {"oobSize", OutOfBandStream.CalculateOutgoingSize()},
+                    {"inflightData", InflightDataAmount},
+                    {"inflightRdma", RdmaInflightDataAmount});
+            }
+            if (useRdmaMain) {
+                WriteDataRdma();
+                if (!Socket) {
+                    return;
+                }
+            }
+
+            WriteData(!useRdmaMain);
             if (!Socket) {
                 return;
+            }
+            if (!canProduceMorePackets) {
+                break;
             }
 
             bool canProducePackets;
@@ -644,8 +675,11 @@ namespace NActors {
             canProducePackets = NumEventsInQueue && (InflightDataAmount + RdmaInflightDataAmount) < GetTotalInflightAmountOfData() &&
                 GetUnsentSize() < GetUnsentLimit();
 
-            canWriteData = ((OutgoingStream || OutOfBandStream) && !ReceiveContext->MainWriteBlocked) ||
-                (XdcStream && !ReceiveContext->XdcWriteBlocked);
+            const bool canWriteMain = useRdmaMain
+                ? (OutgoingStream || OutOfBandStream) && !RdmaSendInFlight
+                : (OutgoingStream || OutOfBandStream) && !ReceiveContext->MainWriteBlocked;
+            const bool canWriteXdc = XdcStream && !ReceiveContext->XdcWriteBlocked;
+            canWriteData = canWriteMain || canWriteXdc;
 
             if (!canProducePackets && !canWriteData) {
                 SetEnoughCpu(true); // we do not starve
@@ -672,7 +706,7 @@ namespace NActors {
         UpdateState(finished ? EState::Idle : notEnoughCpu ? EState::WaitingCpu : EState::Utilized);
     }
 
-    void TInterconnectSessionTCP::ProducePackets() {
+    bool TInterconnectSessionTCP::ProducePackets() {
         // first, we create as many data packets as we can generate under certain conditions; they include presence
         // of events in channels queues and in flight fitting into requested limit; after we hit one of these conditions
         // we exit cycle
@@ -687,15 +721,21 @@ namespace NActors {
                 break;
             }
             try {
-                bytesProduced += MakePacket(true);
+                auto packetSize = MakePacket(true);
+                if (!packetSize) {
+                    return false;
+                }
+                bytesProduced += *packetSize;
             } catch (const TExSerializedEventTooLarge& ex) {
                 // terminate session if the event can't be serialized properly
                 YDB_LOG_CRIT_COMP(::NActorsServices::INTERCONNECT, "Serialized event is too large",
                     {"marker", "ICS31"},
                     {"exType", ex.Type});
-                return Terminate(TDisconnectReason::EventTooLarge());
+                Terminate(TDisconnectReason::EventTooLarge());
+                return false;
             }
         }
+        return true;
     }
 
     void TInterconnectSessionTCP::StartHandshake() {
@@ -846,7 +886,7 @@ namespace NActors {
         }
     }
 
-    void TInterconnectSessionTCP::WriteData() {
+    void TInterconnectSessionTCP::WriteData(bool writeMainChannel) {
         // total bytes written during this call
         ui64 written = 0;
 
@@ -877,51 +917,53 @@ namespace NActors {
             return totalWritten;
         };
 
-        auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
         static constexpr size_t maxBytesAtOnce = 256 * 1024;
-        size_t bytesToSendInMain = maxBytesAtOnce;
+        if (writeMainChannel) {
+            auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
+            size_t bytesToSendInMain = maxBytesAtOnce;
 
-        Y_DEBUG_ABORT_UNLESS(OutgoingIndex < SendQueue.size() || (OutgoingIndex == SendQueue.size() && !OutgoingOffset && !OutgoingStream));
-
-        if (OutOfBandStream) {
-            bytesToSendInMain = 0;
-
-            if (!ForcedWriteLength && OutgoingOffset) {
-                ForcedWriteLength = 1; // send at least one byte from current packet
-            }
-
-            // align send up to packet boundary
-            size_t offset = OutgoingOffset;
-            for (auto it = sendQueueIt; ForcedWriteLength; ++it, offset = 0) {
-                Y_DEBUG_ABORT_UNLESS(it != SendQueue.end());
-                bytesToSendInMain += it->PacketSize - offset; // send remainder of current packet
-                ForcedWriteLength -= Min(it->PacketSize - offset, ForcedWriteLength);
-            }
-        }
-
-        if (bytesToSendInMain) {
-            const size_t w = process(OutgoingStream, Socket, PollerToken, &ReceiveContext->MainWriteBlocked, bytesToSendInMain);
-
-            // adjust sending queue iterator
-            for (OutgoingOffset += w; OutgoingOffset && sendQueueIt->PacketSize <= OutgoingOffset; ++sendQueueIt, ++OutgoingIndex) {
-                OutgoingOffset -= sendQueueIt->PacketSize;
-            }
-
-            BytesWrittenToSocket += w;
+            Y_DEBUG_ABORT_UNLESS(OutgoingIndex < SendQueue.size() || (OutgoingIndex == SendQueue.size() && !OutgoingOffset && !OutgoingStream));
 
             if (OutOfBandStream) {
-                BytesAlignedForOutOfBand += w;
-                bytesToSendInMain -= w;
+                bytesToSendInMain = 0;
+
+                if (!ForcedWriteLength && OutgoingOffset) {
+                    ForcedWriteLength = 1; // send at least one byte from current packet
+                }
+
+                // align send up to packet boundary
+                size_t offset = OutgoingOffset;
+                for (auto it = sendQueueIt; ForcedWriteLength; ++it, offset = 0) {
+                    Y_DEBUG_ABORT_UNLESS(it != SendQueue.end());
+                    bytesToSendInMain += it->PacketSize - offset; // send remainder of current packet
+                    ForcedWriteLength -= Min(it->PacketSize - offset, ForcedWriteLength);
+                }
             }
 
-            ForcedWriteLength = Socket ? Socket->ExpectedWriteLength() : 0;
-        }
+            if (bytesToSendInMain) {
+                const size_t w = process(OutgoingStream, Socket, PollerToken, &ReceiveContext->MainWriteBlocked, bytesToSendInMain);
 
-        if (!bytesToSendInMain && !ForcedWriteLength) {
-            if (const size_t w = process(OutOfBandStream, Socket, PollerToken, &ReceiveContext->MainWriteBlocked, maxBytesAtOnce)) {
-                OutOfBandStream.DropFront(w);
+                // adjust sending queue iterator
+                for (OutgoingOffset += w; OutgoingOffset && sendQueueIt->PacketSize <= OutgoingOffset; ++sendQueueIt, ++OutgoingIndex) {
+                    OutgoingOffset -= sendQueueIt->PacketSize;
+                }
+
                 BytesWrittenToSocket += w;
-                OutOfBandBytesSent += w;
+
+                if (OutOfBandStream) {
+                    BytesAlignedForOutOfBand += w;
+                    bytesToSendInMain -= w;
+                }
+
+                ForcedWriteLength = Socket ? Socket->ExpectedWriteLength() : 0;
+            }
+
+            if (!bytesToSendInMain && !ForcedWriteLength) {
+                if (const size_t w = process(OutOfBandStream, Socket, PollerToken, &ReceiveContext->MainWriteBlocked, maxBytesAtOnce)) {
+                    OutOfBandStream.DropFront(w);
+                    BytesWrittenToSocket += w;
+                    OutOfBandBytesSent += w;
+                }
             }
         }
 
@@ -950,7 +992,8 @@ namespace NActors {
 
         DropConfirmed(LastConfirmed);
 
-        const bool writeBlockedByFullSendBuffer = ReceiveContext->MainWriteBlocked || ReceiveContext->XdcWriteBlocked;
+        const bool writeBlockedByFullSendBuffer =
+            (writeMainChannel && ReceiveContext->MainWriteBlocked) || ReceiveContext->XdcWriteBlocked;
         if (WriteBlockedByFullSendBuffer < writeBlockedByFullSendBuffer) { // became blocked
             WriteBlockedCycles = GetCycleCountFast();
             YDB_LOG_DEBUG_COMP(::NActorsServices::INTERCONNECT_SESSION, "Hit send buffer limit",
@@ -959,6 +1002,109 @@ namespace NActors {
             WriteBlockedTotal += TDuration::Seconds(NHPTimer::GetSeconds(GetCycleCountFast() - WriteBlockedCycles));
         }
         WriteBlockedByFullSendBuffer = writeBlockedByFullSendBuffer;
+    }
+
+    void TInterconnectSessionTCP::WriteDataRdma() {
+        if (RdmaSendInFlight || (!OutgoingStream && !OutOfBandStream)) {
+            return;
+        }
+
+        Y_ABORT_UNLESS(RdmaQp);
+        Y_ABORT_UNLESS(RdmaCq);
+
+        static constexpr size_t maxBytesAtOnce = sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen;
+        static constexpr size_t maxRdmaSendSge = 16;
+        const size_t sgeLimit = Min((int)maxRdmaSendSge, Max<int>(1, RdmaQp->GetCtx()->GetMaxSge()));
+
+        auto submitStream = [&](NInterconnect::TOutgoingStream& stream, bool isOutOfBand) {
+            TStackVec<NInterconnect::NRdma::TSendSge, maxRdmaSendSge> sgList;
+            std::array<NInterconnect::NRdma::TMemRegionPtr, maxRdmaSendSge> regions;
+
+            const size_t totalBytes = stream.ProduceRdmaSendVec(sgList, sgeLimit, maxBytesAtOnce);
+
+            //We need to caprure regions to make sure outgoing buffer is allive during rdma send
+            // even in case of session termination.
+            //TODO: It looks we can make RdmaCq/Verbs builder iface more nice to handle this case.
+            for (size_t i = 0; i < sgList.size(); i++) {
+                regions[i] = NInterconnect::NRdma::TMemRegionPtr(
+                        const_cast<NInterconnect::NRdma::TMemRegion*>(sgList[i].MemRegion));
+            }
+
+            if (sgList.empty()) {
+                YDB_LOG_ERROR("RDMA main produced empty SG list",
+                    {"marker", "ICRDMA"},
+                    {"isOutOfBand", isOutOfBand},
+                    {"streamSize", stream.CalculateOutgoingSize()},
+                    {"streamUnsent", stream.CalculateUnsentSize()},
+                    {"sendQueueSize", stream.GetSendQueueSize()});
+                ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
+                return;
+            }
+
+            auto builder = NInterconnect::NRdma::CreateIbVerbsBuilder(1);
+            const TActorId selfId = SelfId();
+            builder->AddSendVerb(std::span<const NInterconnect::NRdma::TSendSge>(sgList.data(), sgList.size()),
+                [selfId, regions{std::move(regions)}](TActorSystem* as, NInterconnect::NRdma::TEvRdmaIoDone* ioDone) {
+                    as->Send(selfId, ioDone);
+                    Y_UNUSED(regions);
+                });
+
+            if (RdmaCq->DoWrBatchAsync(RdmaQp, std::move(builder))) {
+                YDB_LOG_ERROR("RDMA send post failed",
+                    {"marker", "ICRDMA"});
+                ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
+                return;
+            }
+
+            RdmaSendInFlight = TRdmaSendInFlight {
+                .Bytes = totalBytes,
+                .IsOutOfBand = isOutOfBand,
+            };
+            ++RdmaSendWrSubmitted;
+            return;
+        };
+
+        if (OutOfBandStream && OutgoingOffset == 0) {
+            submitStream(OutOfBandStream, true);
+        } else if (OutgoingStream) {
+            submitStream(OutgoingStream, false);
+        } else if (OutOfBandStream) {
+            submitStream(OutOfBandStream, true);
+        }
+    }
+
+    void TInterconnectSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaIoDone::TPtr& ev) {
+        Y_ABORT_UNLESS(RdmaSendInFlight);
+
+        const TRdmaSendInFlight flight = std::exchange(RdmaSendInFlight, std::nullopt).value();
+        ++RdmaSendWrCompleted;
+        if (!ev->Get()->IsSuccess()) {
+            YDB_LOG_NOTICE("RDMA send failed",
+                {"marker", "ICRDMA"},
+                {"source", ev->Get()->GetErrSource().data()},
+                {"errCode", ev->Get()->GetErrCode()});
+            ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
+            return;
+        }
+
+        if (flight.IsOutOfBand) {
+            OutOfBandStream.Advance(flight.Bytes);
+            OutOfBandStream.DropFront(flight.Bytes);
+            OutOfBandBytesSent += flight.Bytes;
+        } else {
+            OutgoingStream.Advance(flight.Bytes);
+            OutgoingOffset += flight.Bytes;
+
+            auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
+            for (; OutgoingOffset && sendQueueIt != SendQueue.end() && sendQueueIt->PacketSize <= OutgoingOffset;
+                    ++sendQueueIt, ++OutgoingIndex) {
+                OutgoingOffset -= sendQueueIt->PacketSize;
+            }
+        }
+
+        Proxy->Metrics->AddTotalBytesWritten(flight.Bytes);
+        DropConfirmed(LastConfirmed);
+        GenerateTraffic();
     }
 
     ssize_t TInterconnectSessionTCP::HandleWriteResult(ssize_t r, const TString& err) {
@@ -1109,7 +1255,7 @@ namespace NActors {
         }
     }
 
-    ui32 TInterconnectSessionTCP::MakePacket(bool data, TMaybe<ui64> pingMask) {
+    std::optional<ui32> TInterconnectSessionTCP::MakePacket(bool data, TMaybe<ui64> pingMask) {
         NInterconnect::TOutgoingStream& stream = data ? OutgoingStream : OutOfBandStream;
 
 #ifndef NDEBUG
@@ -1120,7 +1266,22 @@ namespace NActors {
         stream.Align();
         XdcStream.Align();
 
-        TTcpPacketOutTask packet(Params, stream, XdcStream);
+        const bool usePreallocatedInternalStream = UseRdmaSendReceiveTransport();
+        if (usePreallocatedInternalStream &&
+                !stream.PreallocateForWriting(sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen)) {
+            Proxy->Metrics->IncRdmaSendBufferAllocationFails();
+
+            YDB_LOG_NOTICE("RDMA send buffer preallocation failed",
+                {"marker", "ICRDMA"},
+                {"data", data},
+                {"queuedEvents", NumEventsInQueue},
+                {"streamSize", stream.CalculateOutgoingSize()},
+                {"streamUnsent", stream.CalculateUnsentSize()});
+            ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
+            return std::nullopt;
+        }
+
+        TTcpPacketOutTask packet(Params, stream, XdcStream, usePreallocatedInternalStream);
         ui64 serial = 0;
 
         if (data) {
@@ -1583,7 +1744,19 @@ namespace NActors {
                             }
                             TABLER() {
                                 TABLED() { str << "RdmaMode" ; }
-                                TABLED() { str << (Params.UseRdma ? Params.ChecksumRdmaEvent ? "On | SoftwareChecksum" : "On" : "Off"); }
+                                TABLED() {
+                                    if (Params.UseRdmaRead || Params.AllowRdmaSendReceive) {
+                                        str << "On";
+                                        if (Params.UseRdmaRead && Params.ChecksumRdmaEvent) {
+                                            str << " | SoftwareChecksum";
+                                        }
+                                        if (Params.AllowRdmaSendReceive) {
+                                            str << " | SendReceive";
+                                        }
+                                    } else {
+                                        str << "Off";
+                                    }
+                                }
                             }
 #define MON_VAR(NAME)     \
     TABLER() {            \
@@ -1686,6 +1859,9 @@ namespace NActors {
                             MON_VAR(XdcStream.CalculateUnsentSize())
                             MON_VAR(XdcStream.GetSendQueueSize())
                             MON_VAR(XdcOffset)
+
+                            MON_VAR(RdmaSendWrSubmitted)
+                            MON_VAR(RdmaSendWrCompleted)
 
                             MON_VAR(CpuStarvationEvents)
                             MON_VAR(CpuStarvationEventsOnWriteData)

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -135,20 +135,18 @@ namespace NActors {
         Send(ReceiverId, new TEvInterconnect::TEvCloseInputSession);
     }
 
-    bool TInterconnectSessionTCP::IsRdmaInUse() {
+    IInterconnectSession::ERdmaState TInterconnectSessionTCP::GetRdmaState() const {
         if (RdmaQp) {
             using NInterconnect::NRdma::TQueuePair;
             const TQueuePair::TQpState res = RdmaQp->GetState(false);
             const TQueuePair::TQpS* qpState = std::get_if<TQueuePair::TQpS>(&res);
-            if (qpState) {
-                return TQueuePair::IsRtsState(*qpState);
+            if (qpState && TQueuePair::IsRtsState(*qpState)) {
+                return ERdmaState::Active;
             }
         }
-        return false;
-    }
-
-    bool TInterconnectSessionTCP::HasRdmaState() const {
-        return Params.UseRdmaRead || RdmaQp || RdmaInflightDataAmount;
+        return Params.UseRdmaRead || RdmaQp
+            ? ERdmaState::Present
+            : ERdmaState::None;
     }
 
     void TInterconnectSessionTCP::Handle(TEvTerminate::TPtr& ev) {
@@ -635,25 +633,13 @@ namespace NActors {
         bool notEnoughCpu = false;
 
         while (Socket) {
-            const bool canProduceMorePackets = ProducePackets();
+            ProducePackets();
             if (!Socket) {
                 return;
             }
 
             const bool useRdmaMain = UseRdmaSendReceiveTransport();
-            if (useRdmaMain && !RdmaInitialTrafficStateReported &&
-                    (NumEventsInQueue || OutgoingStream || OutOfBandStream)) {
-                RdmaInitialTrafficStateReported = true;
-                YDB_LOG_NOTICE("RDMA main initial traffic state",
-                    {"marker", "ICRDMA"},
-                    {"queuedEvents", NumEventsInQueue},
-                    {"canProduceMore", canProduceMorePackets},
-                    {"outgoingSize", OutgoingStream.CalculateOutgoingSize()},
-                    {"outgoingUnsent", OutgoingStream.CalculateUnsentSize()},
-                    {"oobSize", OutOfBandStream.CalculateOutgoingSize()},
-                    {"inflightData", InflightDataAmount},
-                    {"inflightRdma", RdmaInflightDataAmount});
-            }
+
             if (useRdmaMain) {
                 WriteDataRdma();
                 if (!Socket) {
@@ -661,12 +647,9 @@ namespace NActors {
                 }
             }
 
-            WriteData(!useRdmaMain);
+            WriteDataTcp(!useRdmaMain);
             if (!Socket) {
                 return;
-            }
-            if (!canProduceMorePackets) {
-                break;
             }
 
             bool canProducePackets;
@@ -706,7 +689,7 @@ namespace NActors {
         UpdateState(finished ? EState::Idle : notEnoughCpu ? EState::WaitingCpu : EState::Utilized);
     }
 
-    bool TInterconnectSessionTCP::ProducePackets() {
+    void TInterconnectSessionTCP::ProducePackets() {
         // first, we create as many data packets as we can generate under certain conditions; they include presence
         // of events in channels queues and in flight fitting into requested limit; after we hit one of these conditions
         // we exit cycle
@@ -723,7 +706,7 @@ namespace NActors {
             try {
                 auto packetSize = MakePacket(true);
                 if (!packetSize) {
-                    return false;
+                    return;
                 }
                 bytesProduced += *packetSize;
             } catch (const TExSerializedEventTooLarge& ex) {
@@ -732,16 +715,15 @@ namespace NActors {
                     {"marker", "ICS31"},
                     {"exType", ex.Type});
                 Terminate(TDisconnectReason::EventTooLarge());
-                return false;
+                return;
             }
         }
-        return true;
     }
 
     void TInterconnectSessionTCP::StartHandshake() {
         YDB_LOG_INFO("Start handshake",
             {"marker", "ICS15"});
-        if (HasRdmaState()) {
+        if (GetRdmaState() != ERdmaState::None) {
             YDB_LOG_NOTICE("Start initial handshake instead of graceful reconnect for RDMA session",
                 {"marker", "ICRDMA"});
             IActor::InvokeOtherActor(*Proxy, &TInterconnectProxyTCP::StartInitialHandshake);
@@ -886,7 +868,7 @@ namespace NActors {
         }
     }
 
-    void TInterconnectSessionTCP::WriteData(bool writeMainChannel) {
+    void TInterconnectSessionTCP::WriteDataTcp(bool writeMainChannel) {
         // total bytes written during this call
         ui64 written = 0;
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -676,7 +676,7 @@ namespace NActors {
                 GetUnsentSize() < GetUnsentLimit();
 
             const bool canWriteMain = useRdmaMain
-                ? (OutgoingStream || OutOfBandStream) && !RdmaSendInFlight
+                ? (OutgoingStream || OutOfBandStream)
                 : (OutgoingStream || OutOfBandStream) && !ReceiveContext->MainWriteBlocked;
             const bool canWriteXdc = XdcStream && !ReceiveContext->XdcWriteBlocked;
             canWriteData = canWriteMain || canWriteXdc;
@@ -1005,7 +1005,7 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCP::WriteDataRdma() {
-        if (RdmaSendInFlight || (!OutgoingStream && !OutOfBandStream)) {
+        if (!OutgoingStream && !OutOfBandStream) {
             return;
         }
 
@@ -1022,8 +1022,7 @@ namespace NActors {
 
             const size_t totalBytes = stream.ProduceRdmaSendVec(sgList, sgeLimit, maxBytesAtOnce);
 
-            //We need to caprure regions to make sure outgoing buffer is allive during rdma send
-            // even in case of session termination.
+            // Keep regions alive until send completion, including after session termination.
             //TODO: It looks we can make RdmaCq/Verbs builder iface more nice to handle this case.
             for (size_t i = 0; i < sgList.size(); i++) {
                 regions[i] = NInterconnect::NRdma::TMemRegionPtr(
@@ -1056,11 +1055,25 @@ namespace NActors {
                 return;
             }
 
-            RdmaSendInFlight = TRdmaSendInFlight {
-                .Bytes = totalBytes,
-                .IsOutOfBand = isOutOfBand,
-            };
             ++RdmaSendWrSubmitted;
+
+            if (isOutOfBand) {
+                OutOfBandStream.Advance(totalBytes);
+                OutOfBandStream.DropFront(totalBytes);
+                OutOfBandBytesSent += totalBytes;
+            } else {
+                OutgoingStream.Advance(totalBytes);
+                OutgoingOffset += totalBytes;
+
+                auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
+                for (; OutgoingOffset && sendQueueIt != SendQueue.end() && sendQueueIt->PacketSize <= OutgoingOffset;
+                        ++sendQueueIt, ++OutgoingIndex) {
+                    OutgoingOffset -= sendQueueIt->PacketSize;
+                }
+            }
+
+            Proxy->Metrics->AddTotalBytesWritten(totalBytes);
+            DropConfirmed(LastConfirmed);
             return;
         };
 
@@ -1074,9 +1087,6 @@ namespace NActors {
     }
 
     void TInterconnectSessionTCP::Handle(NInterconnect::NRdma::TEvRdmaIoDone::TPtr& ev) {
-        Y_ABORT_UNLESS(RdmaSendInFlight);
-
-        const TRdmaSendInFlight flight = std::exchange(RdmaSendInFlight, std::nullopt).value();
         ++RdmaSendWrCompleted;
         if (!ev->Get()->IsSuccess()) {
             YDB_LOG_NOTICE("RDMA send failed",
@@ -1086,25 +1096,6 @@ namespace NActors {
             ReestablishConnectionWithHandshake(TDisconnectReason::RdmaError());
             return;
         }
-
-        if (flight.IsOutOfBand) {
-            OutOfBandStream.Advance(flight.Bytes);
-            OutOfBandStream.DropFront(flight.Bytes);
-            OutOfBandBytesSent += flight.Bytes;
-        } else {
-            OutgoingStream.Advance(flight.Bytes);
-            OutgoingOffset += flight.Bytes;
-
-            auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
-            for (; OutgoingOffset && sendQueueIt != SendQueue.end() && sendQueueIt->PacketSize <= OutgoingOffset;
-                    ++sendQueueIt, ++OutgoingIndex) {
-                OutgoingOffset -= sendQueueIt->PacketSize;
-            }
-        }
-
-        Proxy->Metrics->AddTotalBytesWritten(flight.Bytes);
-        DropConfirmed(LastConfirmed);
-        GenerateTraffic();
     }
 
     ssize_t TInterconnectSessionTCP::HandleWriteResult(ssize_t r, const TString& err) {

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.cpp
@@ -103,6 +103,10 @@ namespace NActors {
         {}
 
         size_t Write(NInterconnect::TOutgoingStream& stream, size_t maxBytes) override {
+            if (!stream) {
+                return 0;
+            }
+
             static constexpr size_t MaxRdmaSendSge = 16;
 
             Y_ABORT_UNLESS(Session.RdmaQp);
@@ -994,65 +998,63 @@ namespace NActors {
     void TInterconnectSessionTCP::WriteData(IWriteStrategy& mainWriter) {
         ui64 written = 0;
 
-        if (OutgoingStream || OutOfBandStream) {
-            auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
-            size_t bytesToSendInMain = mainWriter.GetMaxBytesAtOnce();
+        auto sendQueueIt = SendQueue.begin() + OutgoingIndex;
+        size_t bytesToSendInMain = mainWriter.GetMaxBytesAtOnce();
 
-            Y_DEBUG_ABORT_UNLESS(OutgoingIndex < SendQueue.size() || (OutgoingIndex == SendQueue.size() && !OutgoingOffset && !OutgoingStream));
+        Y_DEBUG_ABORT_UNLESS(OutgoingIndex < SendQueue.size() || (OutgoingIndex == SendQueue.size() && !OutgoingOffset && !OutgoingStream));
+
+        if (OutOfBandStream) {
+            bytesToSendInMain = 0;
+
+            if (!ForcedWriteLength && OutgoingOffset) {
+                ForcedWriteLength = 1; // send at least one byte from current packet
+            }
+
+            // align send up to packet boundary
+            size_t offset = OutgoingOffset;
+            for (auto it = sendQueueIt; ForcedWriteLength; ++it, offset = 0) {
+                Y_DEBUG_ABORT_UNLESS(it != SendQueue.end());
+                bytesToSendInMain += it->PacketSize - offset; // send remainder of current packet
+                ForcedWriteLength -= Min(it->PacketSize - offset, ForcedWriteLength);
+            }
+        }
+
+        if (bytesToSendInMain) {
+            const size_t w = mainWriter.Write(OutgoingStream, bytesToSendInMain);
+            OutgoingStream.Advance(w);
+            written += w;
+
+            // adjust sending queue iterator
+            for (OutgoingOffset += w; OutgoingOffset && sendQueueIt->PacketSize <= OutgoingOffset; ++sendQueueIt, ++OutgoingIndex) {
+                OutgoingOffset -= sendQueueIt->PacketSize;
+            }
 
             if (OutOfBandStream) {
-                bytesToSendInMain = 0;
-
-                if (!ForcedWriteLength && OutgoingOffset) {
-                    ForcedWriteLength = 1; // send at least one byte from current packet
-                }
-
-                // align send up to packet boundary
-                size_t offset = OutgoingOffset;
-                for (auto it = sendQueueIt; ForcedWriteLength; ++it, offset = 0) {
-                    Y_DEBUG_ABORT_UNLESS(it != SendQueue.end());
-                    bytesToSendInMain += it->PacketSize - offset; // send remainder of current packet
-                    ForcedWriteLength -= Min(it->PacketSize - offset, ForcedWriteLength);
-                }
+                BytesAlignedForOutOfBand += w;
+                bytesToSendInMain -= w;
             }
 
-            if (bytesToSendInMain) {
-                const size_t w = mainWriter.Write(OutgoingStream, bytesToSendInMain);
-                OutgoingStream.Advance(w);
+            ForcedWriteLength = mainWriter.GetExpectedWriteLength();
+            if (!Socket) {
+                if (written) {
+                    Proxy->Metrics->AddTotalBytesWritten(written);
+                }
+                return;
+            }
+        }
+
+        if (!bytesToSendInMain && !ForcedWriteLength) {
+            if (const size_t w = mainWriter.Write(OutOfBandStream, mainWriter.GetMaxBytesAtOnce())) {
+                OutOfBandStream.Advance(w);
+                OutOfBandStream.DropFront(w);
+                OutOfBandBytesSent += w;
                 written += w;
-
-                // adjust sending queue iterator
-                for (OutgoingOffset += w; OutgoingOffset && sendQueueIt->PacketSize <= OutgoingOffset; ++sendQueueIt, ++OutgoingIndex) {
-                    OutgoingOffset -= sendQueueIt->PacketSize;
-                }
-
-                if (OutOfBandStream) {
-                    BytesAlignedForOutOfBand += w;
-                    bytesToSendInMain -= w;
-                }
-
-                ForcedWriteLength = mainWriter.GetExpectedWriteLength();
-                if (!Socket) {
-                    if (written) {
-                        Proxy->Metrics->AddTotalBytesWritten(written);
-                    }
-                    return;
-                }
             }
-
-            if (!bytesToSendInMain && !ForcedWriteLength) {
-                if (const size_t w = mainWriter.Write(OutOfBandStream, mainWriter.GetMaxBytesAtOnce())) {
-                    OutOfBandStream.Advance(w);
-                    OutOfBandStream.DropFront(w);
-                    OutOfBandBytesSent += w;
-                    written += w;
+            if (!Socket) {
+                if (written) {
+                    Proxy->Metrics->AddTotalBytesWritten(written);
                 }
-                if (!Socket) {
-                    if (written) {
-                        Proxy->Metrics->AddTotalBytesWritten(written);
-                    }
-                    return;
-                }
+                return;
             }
         }
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -630,7 +630,7 @@ namespace NActors {
         ssize_t HandleWriteResult(ssize_t r, const TString& err);
         ssize_t Write(NInterconnect::TOutgoingStream& stream, NInterconnect::TStreamSocket& socket, size_t maxBytes);
 
-        std::optional<ui32> MakePacket(bool data, TMaybe<ui64> pingMask = {});
+        ui32 MakePacket(bool data, TMaybe<ui64> pingMask = {});
         void FillSendingBuffer(TTcpPacketOutTask& packet, ui64 serial);
         void DropConfirmed(ui64 confirm);
         void ShutdownSocket(TDisconnectReason reason);

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -624,7 +624,7 @@ namespace NActors {
         };
 
         class TTcpWriteStrategy;
-        class TRdmaWriteStrategy;
+        class TRdmaSendStrategy;
 
         void WriteData(IWriteStrategy& mainWriter);
         ssize_t HandleWriteResult(ssize_t r, const TString& err);

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -735,11 +735,6 @@ namespace NActors {
         TPollerToken::TPtr XdcPollerToken;
         ui32 SendBufferSize;
 
-        struct TRdmaSendInFlight {
-            size_t Bytes = 0;
-            bool IsOutOfBand = false;
-        };
-        std::optional<TRdmaSendInFlight> RdmaSendInFlight;
         ui64 RdmaSendWrSubmitted = 0;
         ui64 RdmaSendWrCompleted = 0;
         bool RdmaInitialTrafficStateReported = false;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -42,6 +42,7 @@
 #include <unordered_map>
 #include <tuple>
 #include <functional>
+#include <optional>
 
 namespace NInterconnect {
     class TInterconnectZcProcessor;
@@ -161,7 +162,7 @@ namespace NActors {
                 std::deque<NInterconnect::NRdma::TMemRegionSlice> RdmaBuffers;
                 TRdmaReadContext::TPtr RdmaReadContext = nullptr;
                 size_t RdmaSize = 0;
-                std::optional<ui32> RdmaCumulativeCheckSum;
+                std::optional<ui32> RdmaReadCumulativeCheckSum;
             };
 
             std::deque<TPendingEvent> PendingEvents;
@@ -351,6 +352,8 @@ namespace NActors {
         ui64 StarvingInRow = 0;
 
         bool CloseInputSessionRequested = false;
+        // Preserve main-socket readiness if processing yields before reaching ReadMore().
+        bool ReadMainChannelRequested = false;
 
         void CloseInputSession();
 
@@ -360,6 +363,7 @@ namespace NActors {
         void Handle(NInterconnect::NRdma::TEvRdmaReadDone::TPtr& ev);
         void Handle(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr& ev);
         void ReceiveData();
+        void ReceiveData(bool readMainChannel);
         void ProcessHeader();
         void ProcessPayload(ui64 *numDataBytes);
         void ProcessInboundPacketQ(ui64 numXdcBytesRead, ui64 numRdmaBytesRead);
@@ -374,6 +378,9 @@ namespace NActors {
         bool ReadXdc(ui64 *numDataBytes);
         void HandleXdcChecksum(TContiguousSpan span);
         TRcBuf AllocateRcBuf(ui64 size, ui64 headroom, ui64 tailroom, ui64 alignment, bool isRdma);
+        bool UseRdmaSendReceiveTransport() const {
+            return Params.AllowRdmaSendReceive && RdmaQp && RdmaCq;
+        }
 
         TReceiveContext::TPerChannelContext& GetPerChannelContext(ui16 channel) const;
 
@@ -419,6 +426,7 @@ namespace NActors {
         ui64 PacketsReadFromSocket = 0;
         ui64 DataPacketsReadFromSocket = 0;
         ui64 IgnoredDataPacketsFromSocket = 0;
+        ui64 BytesRdmaRecieved = 0;
 
         ui64 BytesReadFromXdcSocket = 0;
         ui64 XdcSections = 0;
@@ -571,6 +579,7 @@ namespace NActors {
                 hFunc(TEvSocketDisconnect, OnDisconnect)
                 hFunc(TEvTerminate, Handle)
                 hFunc(TEvProcessPingRequest, Handle)
+                hFunc(NInterconnect::NRdma::TEvRdmaIoDone, Handle)
                 cFunc(static_cast<ui32>(ENetwork::EvProcessDirectSessionQueue), HandleProcessDirectSessionQueue)
             )
             UpdateUtilization();
@@ -588,7 +597,7 @@ namespace NActors {
         void IssueRam(bool batching);
         void HandleRam(TEvRam::TPtr& ev);
         void GenerateTraffic();
-        void ProducePackets();
+        bool ProducePackets();
 
         size_t GetUnsentSize() const {
             return OutgoingStream.CalculateUnsentSize() + OutOfBandStream.CalculateUnsentSize() +
@@ -604,11 +613,13 @@ namespace NActors {
 
         void Handle(TEvPollerReady::TPtr& ev);
         void Handle(TEvPollerRegisterResult::TPtr ev);
-        void WriteData();
+        void Handle(NInterconnect::NRdma::TEvRdmaIoDone::TPtr& ev);
+        void WriteData(bool writeMainChannel);
+        void WriteDataRdma();
         ssize_t HandleWriteResult(ssize_t r, const TString& err);
         ssize_t Write(NInterconnect::TOutgoingStream& stream, NInterconnect::TStreamSocket& socket, size_t maxBytes);
 
-        ui32 MakePacket(bool data, TMaybe<ui64> pingMask = {});
+        std::optional<ui32> MakePacket(bool data, TMaybe<ui64> pingMask = {});
         void FillSendingBuffer(TTcpPacketOutTask& packet, ui64 serial);
         void DropConfirmed(ui64 confirm);
         void ShutdownSocket(TDisconnectReason reason);
@@ -630,6 +641,10 @@ namespace NActors {
         bool UseKernelLivenessMode() const {
             // Effective liveness mode for the currently attached transport connection.
             return KernelLivenessMode;
+        }
+
+        bool UseRdmaSendReceiveTransport() const {
+            return Params.AllowRdmaSendReceive && RdmaQp && RdmaCq;
         }
 
 
@@ -719,6 +734,16 @@ namespace NActors {
         TPollerToken::TPtr PollerToken;
         TPollerToken::TPtr XdcPollerToken;
         ui32 SendBufferSize;
+
+        struct TRdmaSendInFlight {
+            size_t Bytes = 0;
+            bool IsOutOfBand = false;
+        };
+        std::optional<TRdmaSendInFlight> RdmaSendInFlight;
+        ui64 RdmaSendWrSubmitted = 0;
+        ui64 RdmaSendWrCompleted = 0;
+        bool RdmaInitialTrafficStateReported = false;
+
         ui64 InflightDataAmount = 0;
         ui64 RdmaInflightDataAmount = 0;
 
@@ -793,6 +818,7 @@ namespace NActors {
             TInterconnectProxyTCP* const proxy,
             NInterconnect::NRdma::TQueuePair::TPtr rdmaQp);
         NInterconnect::NRdma::TQueuePair::TPtr RdmaQp;
+        NInterconnect::NRdma::ICq::TPtr RdmaCq;
 
     private:
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -275,8 +275,8 @@ namespace NActors {
             hFunc(TEvPollerReady, Handle)
             hFunc(TEvPollerRegisterResult, Handle)
             hFunc(NInterconnect::NRdma::TEvRdmaReadDone, Handle)
-            hFunc(NInterconnect::NRdma::TEvRdmaIoReceiveDone, Handle)
-            cFunc(EvResumeReceiveData, ReceiveData)
+            hFunc(NInterconnect::NRdma::TEvRdmaIoReceiveDone, ReceiveDataMainChannelRdma)
+            cFunc(EvResumeReceiveData, ReceiveDataTCP)
             cFunc(TEvInterconnect::TEvCloseInputSession::EventType, CloseInputSession)
             cFunc(EvCheckDeadPeer, HandleCheckDeadPeer)
             cFunc(TEvConfirmUpdate::EventType, HandleConfirmUpdate)
@@ -361,9 +361,9 @@ namespace NActors {
         void Handle(TEvPollerRegisterResult::TPtr ev);
         void HandleConfirmUpdate();
         void Handle(NInterconnect::NRdma::TEvRdmaReadDone::TPtr& ev);
-        void Handle(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr& ev);
-        void ReceiveData();
-        void ReceiveData(bool readMainChannel);
+        void ReceiveDataMainChannelRdma(NInterconnect::NRdma::TEvRdmaIoReceiveDone::TPtr& ev);
+        void ReceiveDataTCP();
+        void ReceiveDataTCP(bool readMainChannel);
         void ProcessHeader();
         void ProcessPayload(ui64 *numDataBytes);
         void ProcessInboundPacketQ(ui64 numXdcBytesRead, ui64 numRdmaBytesRead);
@@ -613,8 +613,20 @@ namespace NActors {
         void Handle(TEvPollerReady::TPtr& ev);
         void Handle(TEvPollerRegisterResult::TPtr ev);
         void Handle(NInterconnect::NRdma::TEvRdmaIoDone::TPtr& ev);
-        void WriteDataTcp(bool writeMainChannel);
-        void WriteDataRdma();
+
+        class IWriteStrategy {
+        public:
+            virtual ~IWriteStrategy() = default;
+            virtual size_t Write(NInterconnect::TOutgoingStream& stream, size_t maxBytes) = 0;
+            virtual size_t GetMaxBytesAtOnce() const = 0;
+            virtual size_t GetExpectedWriteLength() const = 0;
+            virtual bool IsWriteBlocked() const = 0;
+        };
+
+        class TTcpWriteStrategy;
+        class TRdmaWriteStrategy;
+
+        void WriteData(IWriteStrategy& mainWriter);
         ssize_t HandleWriteResult(ssize_t r, const TString& err);
         ssize_t Write(NInterconnect::TOutgoingStream& stream, NInterconnect::TStreamSocket& socket, size_t maxBytes);
 

--- a/ydb/library/actors/interconnect/interconnect_tcp_session.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session.h
@@ -510,8 +510,7 @@ namespace NActors {
 
         void Init(const TSessionParams& params) override;
         void CloseInputSession() override;
-        bool IsRdmaInUse() override;
-        bool HasRdmaState() const override;
+        ERdmaState GetRdmaState() const override;
         bool SupportsContinuation() const override { return true; }
 
         static TEvTerminate* NewEvTerminate(TDisconnectReason reason) {
@@ -597,7 +596,7 @@ namespace NActors {
         void IssueRam(bool batching);
         void HandleRam(TEvRam::TPtr& ev);
         void GenerateTraffic();
-        bool ProducePackets();
+        void ProducePackets();
 
         size_t GetUnsentSize() const {
             return OutgoingStream.CalculateUnsentSize() + OutOfBandStream.CalculateUnsentSize() +
@@ -614,7 +613,7 @@ namespace NActors {
         void Handle(TEvPollerReady::TPtr& ev);
         void Handle(TEvPollerRegisterResult::TPtr ev);
         void Handle(NInterconnect::NRdma::TEvRdmaIoDone::TPtr& ev);
-        void WriteData(bool writeMainChannel);
+        void WriteDataTcp(bool writeMainChannel);
         void WriteDataRdma();
         ssize_t HandleWriteResult(ssize_t r, const TString& err);
         ssize_t Write(NInterconnect::TOutgoingStream& stream, NInterconnect::TStreamSocket& socket, size_t maxBytes);
@@ -737,7 +736,6 @@ namespace NActors {
 
         ui64 RdmaSendWrSubmitted = 0;
         ui64 RdmaSendWrCompleted = 0;
-        bool RdmaInitialTrafficStateReported = false;
 
         ui64 InflightDataAmount = 0;
         ui64 RdmaInflightDataAmount = 0;

--- a/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
+++ b/ydb/library/actors/interconnect/interconnect_tcp_session_v2.h
@@ -54,8 +54,7 @@ namespace NActors {
         void StartHandshake() override;
         void ReestablishConnectionWithHandshake(TDisconnectReason reason) override;
         void CloseInputSession() override;
-        bool IsRdmaInUse() override { return false; }
-        bool HasRdmaState() const override { return false; }
+        ERdmaState GetRdmaState() const override { return ERdmaState::None; }
         bool SupportsContinuation() const override { return false; }
 
         const TSessionParams& GetParams() const override { return Params; }

--- a/ydb/library/actors/interconnect/outgoing_stream.h
+++ b/ydb/library/actors/interconnect/outgoing_stream.h
@@ -3,7 +3,10 @@
 #include <ydb/library/actors/core/event_load.h>
 #include <ydb/library/actors/util/rc_buf.h>
 #include <library/cpp/containers/stack_vector/stack_vec.h>
+#include "rdma/mem_pool.h"
+#include "rdma/rdma.h"
 #include <deque>
+#include <variant>
 
 namespace NInterconnect {
 
@@ -16,22 +19,34 @@ namespace NInterconnect {
             ui32 RefCount;
             ui32 Index;
 
-            struct TDeleter {
-                void operator ()(TBuffer *buffer) const {
-                    free(buffer);
+            struct TBufOwner {
+                TBufOwner() = default;
+
+                TBufOwner(NRdma::TMemRegionPtr region)
+                    : MemRegion(std::move(region))
+                {}
+
+                NRdma::TMemRegionPtr MemRegion;
+                void operator ()(void *buffer) const noexcept {
+                    if (!MemRegion) {
+                        free(buffer);
+                    }
                 }
             };
         };
 
         static_assert(sizeof(TBuffer) == TotalSize);
 
+        using TBufferPtr = std::unique_ptr<TBuffer, typename TBuffer::TBufOwner>;
+
         struct TSendChunk {
             TContiguousSpan Span;
             TBuffer *Buffer;
-            ui32* ZcTransferId = nullptr;
+            std::variant<ui32*, const NRdma::TMemRegion*> AuxData = static_cast<ui32*>(nullptr);
         };
 
-        std::vector<std::unique_ptr<TBuffer, typename TBuffer::TDeleter>> Buffers;
+        std::vector<TBufferPtr> Buffers;
+        std::vector<TBufferPtr> PreallocatedBuffers;
         TBuffer *AppendBuffer = nullptr;
         size_t AppendOffset = BufferSize; // into the last buffer
         std::deque<TSendChunk> SendQueue;
@@ -39,7 +54,14 @@ namespace NInterconnect {
         size_t SendOffset = 0;
         size_t UnsentBytes = 0;
 
+        std::shared_ptr<NRdma::IMemPool> Allocator;
+
     public:
+        explicit TOutgoingStreamT(std::shared_ptr<NRdma::IMemPool> allocator)
+            : Allocator(std::move(allocator))
+        { }
+
+        TOutgoingStreamT() = default;
         /*
          * Allow to share buffer between socket to produce safe zero copy operation
          */
@@ -95,12 +117,52 @@ namespace NInterconnect {
             return SendQueue.size();
         }
 
+        bool PreallocateForWriting(size_t len) {
+            const size_t buffersNeeded = GetBuffersNeededForWriting(len);
+            if (buffersNeeded <= PreallocatedBuffers.size()) {
+                return true;
+            }
+
+            const size_t extraBuffersNeeded = buffersNeeded - PreallocatedBuffers.size();
+            std::vector<TBufferPtr> allocatedBuffers;
+            allocatedBuffers.reserve(extraBuffersNeeded);
+            for (size_t i = 0; i != extraBuffersNeeded; ++i) {
+                TBufferPtr buffer = AllocateBuffer();
+                if (!buffer) {
+                    return false;
+                }
+                allocatedBuffers.emplace_back(std::move(buffer));
+            }
+
+            PreallocatedBuffers.reserve(PreallocatedBuffers.size() + extraBuffersNeeded);
+            for (auto& buffer : allocatedBuffers) {
+                PreallocatedBuffers.emplace_back(std::move(buffer));
+            }
+            return true;
+        }
+
         TMutableContiguousSpan AcquireSpanForWriting(size_t maxLen) {
             if (!maxLen) {
                 return {nullptr, 0};
             }
             if (AppendOffset == BufferSize) { // we have no free buffer, allocate one
-                Buffers.emplace_back(static_cast<TBuffer*>(malloc(sizeof(TBuffer))));
+                auto res = AddBuffer();
+                Y_ABORT_UNLESS(res);
+                AppendBuffer = Buffers.back().get();
+                Y_ABORT_UNLESS(AppendBuffer);
+                AppendOffset = 0;
+            }
+            return {AppendBuffer->Data + AppendOffset, Min(maxLen, BufferSize - AppendOffset)};
+        }
+
+        TMutableContiguousSpan AcquireSpanForWritingNoAlloc(size_t maxLen) {
+            if (!maxLen) {
+                return {nullptr, 0};
+            }
+            if (AppendOffset == BufferSize) {
+                Y_ABORT_UNLESS(!PreallocatedBuffers.empty());
+                Buffers.emplace_back(std::move(PreallocatedBuffers.back()));
+                PreallocatedBuffers.pop_back();
                 AppendBuffer = Buffers.back().get();
                 Y_ABORT_UNLESS(AppendBuffer);
                 AppendBuffer->RefCount = 1; // through AppendBuffer pointer
@@ -121,24 +183,12 @@ namespace NInterconnect {
         }
 
         void Append(TContiguousSpan span, ui32* const zcHandle) {
-            if (AppendBuffer && span.data() == AppendBuffer->Data + AppendOffset) { // the only valid case to use previously acquired span
-                AppendAcquiredSpan(span);
-            } else {
-#ifndef NDEBUG
-                // ensure this span does not point into any existing buffer part
-                const char *begin = span.data();
-                const char *end = span.data() + span.size();
-                for (const auto& buffer : Buffers) {
-                    const char *bufferBegin = buffer->Data;
-                    const char *bufferEnd = bufferBegin + BufferSize;
-                    if (bufferBegin < end && begin < bufferEnd) {
-                        Y_ABORT();
-                    }
-                }
-#endif
-                AppendSpanWithGlueing(span, nullptr);
-            }
-            SendQueue.back().ZcTransferId = zcHandle;
+            AppendImpl(span, zcHandle);
+        }
+
+        void Append(TContiguousSpan span, const NRdma::TMemRegion* memRegion) {
+            Y_ABORT_UNLESS(memRegion);
+            AppendImpl(span, memRegion);
         }
 
         void Write(TContiguousSpan in) {
@@ -195,11 +245,39 @@ namespace NInterconnect {
                 const TContiguousSpan span = it->Span.SubSpan(offset, maxBytes);
                 container.push_back(NActors::TConstIoVec{span.data(), span.size()});
                 if (controllers) {
-                    controllers->push_back(TBufController(it->ZcTransferId));
+                    const auto* zcTransferId = std::get_if<ui32*>(&it->AuxData);
+                    controllers->push_back(TBufController(zcTransferId ? *zcTransferId : nullptr));
                 }
                 offset = 0;
                 maxBytes -= span.size();
             }
+        }
+
+        template<typename T>
+        size_t ProduceRdmaSendVec(T& container, size_t maxItems, size_t maxBytes) const {
+            size_t offset = SendOffset;
+            const size_t totalBytes = maxBytes;
+            for (auto it = SendQueue.begin() + SendQueuePos; it != SendQueue.end() && std::size(container) < maxItems && maxBytes; ++it) {
+                const TContiguousSpan span = it->Span.SubSpan(offset, maxBytes);
+                const NRdma::TMemRegion* memRegion = nullptr;
+                if (const auto* attachedMemRegion = std::get_if<const NRdma::TMemRegion*>(&it->AuxData)) {
+                    memRegion = *attachedMemRegion;
+                } else {
+                    Y_ABORT_UNLESS(it->Buffer);
+                    const auto& holder = Buffers[it->Buffer->Index];
+                    Y_ABORT_UNLESS(holder.get() == it->Buffer);
+                    memRegion = holder.get_deleter().MemRegion.Get();
+                }
+                Y_ABORT_UNLESS(memRegion);
+                container.push_back(NRdma::TSendSge{
+                    .Data = span.data(),
+                    .Size = span.size(),
+                    .MemRegion = memRegion,
+                });
+                offset = 0;
+                maxBytes -= span.size();
+            }
+            return totalBytes - maxBytes;
         }
 
         void Advance(size_t numBytes) { // called when numBytes portion of data has been sent
@@ -256,6 +334,7 @@ namespace NInterconnect {
         }
 
         void CompleteSharedBuffers() {
+            PreallocatedBuffers.clear();
             for (size_t i = 0; i < Buffers.size(); i++) {
                 DropBufferReference(Buffers[i]);
             }
@@ -263,7 +342,63 @@ namespace NInterconnect {
         }
 
     private:
-        void AppendAcquiredSpan(TContiguousSpan span) {
+        void AppendImpl(TContiguousSpan span, std::variant<ui32*, const NRdma::TMemRegion*> auxData) {
+            if (AppendBuffer && span.data() == AppendBuffer->Data + AppendOffset) { // the only valid case to use previously acquired span
+                AppendAcquiredSpan(span, auxData);
+            } else {
+#ifndef NDEBUG
+                // ensure this span does not point into any existing buffer part
+                const char *begin = span.data();
+                const char *end = span.data() + span.size();
+                for (const auto& buffer : Buffers) {
+                    const char *bufferBegin = buffer->Data;
+                    const char *bufferEnd = bufferBegin + BufferSize;
+                    if (bufferBegin < end && begin < bufferEnd) {
+                        Y_ABORT();
+                    }
+                }
+#endif
+                AppendSpanWithGlueing(span, nullptr, auxData);
+            }
+        }
+
+        size_t GetBuffersNeededForWriting(size_t len) const {
+            const size_t freeBytes = AppendOffset == BufferSize ? 0 : BufferSize - AppendOffset;
+            if (len <= freeBytes) {
+                return 0;
+            }
+            return (len - freeBytes + BufferSize - 1) / BufferSize;
+        }
+
+        TBufferPtr AllocateBuffer() noexcept {
+            if (auto memPool = Allocator.get()) {
+                if (NRdma::TMemRegionPtr p = memPool->Alloc(sizeof(TBuffer), NRdma::IMemPool::EMPTY)) {
+                    return TBufferPtr(static_cast<TBuffer*>(p->GetAddr()), typename TBuffer::TBufOwner(std::move(p)));
+                } else {
+                    return nullptr;
+                }
+            } else {
+                void* p = malloc(sizeof(TBuffer));
+                if (Y_UNLIKELY(!p)) {
+                    return nullptr;
+                }
+                return TBufferPtr(static_cast<TBuffer*>(p));
+            }
+        }
+
+        bool AddBuffer() noexcept {
+            TBufferPtr buffer = AllocateBuffer();
+            if (!buffer) {
+                return false;
+            }
+            buffer->RefCount = 1;
+            buffer->Index = Buffers.size();
+            Buffers.emplace_back(std::move(buffer));
+            return true;
+        }
+
+        void AppendAcquiredSpan(TContiguousSpan span,
+                std::variant<ui32*, const NRdma::TMemRegion*> auxData = static_cast<ui32*>(nullptr)) {
             TBuffer *buffer = AppendBuffer;
             Y_DEBUG_ABORT_UNLESS(buffer);
             Y_DEBUG_ABORT_UNLESS(span.data() == AppendBuffer->Data + AppendOffset);
@@ -274,15 +409,17 @@ namespace NInterconnect {
             } else {
                 ++buffer->RefCount;
             }
-            AppendSpanWithGlueing(span, buffer);
+            AppendSpanWithGlueing(span, buffer, auxData);
         }
 
-        void AppendSpanWithGlueing(TContiguousSpan span, TBuffer *buffer) {
+        void AppendSpanWithGlueing(TContiguousSpan span, TBuffer *buffer,
+                std::variant<ui32*, const NRdma::TMemRegion*> auxData = static_cast<ui32*>(nullptr)) {
             UnsentBytes += span.size();
             if (!SendQueue.empty()) {
                 auto& back = SendQueue.back();
-                if (back.Span.data() + back.Span.size() == span.data()) { // check if it is possible just to extend the last span
-                    Y_DEBUG_ABORT_UNLESS(buffer == back.Buffer);
+                if (back.Span.data() + back.Span.size() == span.data()
+                        && buffer == back.Buffer
+                        && auxData == back.AuxData) { // check if it is possible just to extend the last span
                     if (SendQueuePos == SendQueue.size()) {
                         --SendQueuePos;
                         SendOffset = back.Span.size();
@@ -292,7 +429,7 @@ namespace NInterconnect {
                     return;
                 }
             }
-            SendQueue.push_back(TSendChunk{span, buffer});
+            SendQueue.push_back(TSendChunk{span, buffer, auxData});
         }
 
         void DropBufferReference(TBuffer *buffer) {

--- a/ydb/library/actors/interconnect/packet.cpp
+++ b/ydb/library/actors/interconnect/packet.cpp
@@ -8,11 +8,12 @@
 LWTRACE_USING(ACTORLIB_PROVIDER);
 
 TTcpPacketOutTask::TTcpPacketOutTask(const TSessionParams& params, NInterconnect::TOutgoingStream& outgoingStream,
-    NInterconnect::TOutgoingStream& xdcStream)
+    NInterconnect::TOutgoingStream& xdcStream, bool usePreallocatedInternalStream)
     : Params(params)
     , OutgoingStream(outgoingStream)
     , XdcStream(xdcStream)
-    , HeaderBookmark(OutgoingStream.Bookmark(sizeof(TTcpPacketHeader_v2)))
+    , UsePreallocatedInternalStream(usePreallocatedInternalStream)
+    , HeaderBookmark(BookmarkStream(OutgoingStream, sizeof(TTcpPacketHeader_v2), UsePreallocatedInternalStream))
 {}
 
 ui32 TEventHolder::Fill(IEventHandle& ev) {

--- a/ydb/library/actors/interconnect/packet.h
+++ b/ydb/library/actors/interconnect/packet.h
@@ -14,6 +14,8 @@
 #include <util/generic/string.h>
 #include <util/generic/list.h>
 
+#include <cstring>
+
 #define XXH_INLINE_ALL
 #include <contrib/libs/xxhash/xxhash.h>
 
@@ -148,6 +150,7 @@ struct TTcpPacketOutTask : TNonCopyable {
     const TSessionParams& Params;
     NInterconnect::TOutgoingStream& OutgoingStream;
     NInterconnect::TOutgoingStream& XdcStream;
+    const bool UsePreallocatedInternalStream = false;
     NInterconnect::TOutgoingStream::TBookmark HeaderBookmark;
 
     ui32 InternalSize = 0;
@@ -163,7 +166,7 @@ struct TTcpPacketOutTask : TNonCopyable {
     ui32 RdmaPayloadSize = 0;
 
     TTcpPacketOutTask(const TSessionParams& params, NInterconnect::TOutgoingStream& outgoingStream,
-        NInterconnect::TOutgoingStream& xdcStream);
+        NInterconnect::TOutgoingStream& xdcStream, bool usePreallocatedInternalStream = false);
 
     // Preallocate some space to fill it later.
     NInterconnect::TOutgoingStream::TBookmark Bookmark(size_t len) {
@@ -175,7 +178,7 @@ struct TTcpPacketOutTask : TNonCopyable {
         }
         Y_DEBUG_ABORT_UNLESS(len <= GetInternalFreeAmount());
         InternalSize += len;
-        return OutgoingStream.Bookmark(len);
+        return BookmarkStream(OutgoingStream, len, UsePreallocatedInternalStream);
     }
 
     // Write previously bookmarked space.
@@ -192,10 +195,12 @@ struct TTcpPacketOutTask : TNonCopyable {
     // Acquire raw pointer to write some data.
     template<bool External>
     TMutableContiguousSpan AcquireSpanForWriting() {
-        if (External) {
+        if constexpr (External) {
             return XdcStream.AcquireSpanForWriting(GetExternalFreeAmount());
         } else {
-            return OutgoingStream.AcquireSpanForWriting(GetInternalFreeAmount());
+            return UsePreallocatedInternalStream
+                ? OutgoingStream.AcquireSpanForWritingNoAlloc(GetInternalFreeAmount())
+                : OutgoingStream.AcquireSpanForWriting(GetInternalFreeAmount());
         }
     }
 
@@ -210,12 +215,26 @@ struct TTcpPacketOutTask : TNonCopyable {
         }
     }
 
+    void AppendRdma(const void *buffer, size_t len, const NInterconnect::NRdma::TMemRegion* memRegion,
+            bool disableChecksum) {
+        Y_DEBUG_ABORT_UNLESS(len <= GetInternalFreeAmount());
+        InternalSize += len;
+        OutgoingStream.Append({static_cast<const char*>(buffer), len}, memRegion);
+        if (!disableChecksum) {
+            ProcessChecksum<false>(buffer, len);
+        }
+    }
+
     // Write some data with copying.
     template<bool External>
     void Write(const void *buffer, size_t len) {
         Y_DEBUG_ABORT_UNLESS(len <= (External ? GetExternalFreeAmount() : GetInternalFreeAmount()));
         (External ? ExternalSize : InternalSize) += len;
-        (External ? XdcStream : OutgoingStream).Write({static_cast<const char*>(buffer), len});
+        if constexpr (External) {
+            XdcStream.Write({static_cast<const char*>(buffer), len});
+        } else {
+            WriteStream(OutgoingStream, {static_cast<const char*>(buffer), len}, UsePreallocatedInternalStream);
+        }
         ProcessChecksum<External>(buffer, len);
     }
 
@@ -282,6 +301,39 @@ struct TTcpPacketOutTask : TNonCopyable {
     ui32 GetExternalFreeAmount() const { return 16384 - ExternalSize; }
     ui32 GetExternalSize() const { return ExternalSize; }
     ui32 GetRdmaPayloadSize() const { return RdmaPayloadSize; }
+
+private:
+    static NInterconnect::TOutgoingStream::TBookmark BookmarkStream(NInterconnect::TOutgoingStream& stream, size_t len,
+            bool noAlloc) {
+        if (!noAlloc) {
+            return stream.Bookmark(len);
+        }
+
+        NInterconnect::TOutgoingStream::TBookmark bookmark;
+        while (len) {
+            auto span = stream.AcquireSpanForWritingNoAlloc(len);
+            Y_ABORT_UNLESS(span.size());
+            stream.Append({span.data(), span.size()}, static_cast<ui32*>(nullptr));
+            bookmark.push_back(span);
+            len -= span.size();
+        }
+        return bookmark;
+    }
+
+    static void WriteStream(NInterconnect::TOutgoingStream& stream, TContiguousSpan in, bool noAlloc) {
+        if (!noAlloc) {
+            stream.Write(in);
+            return;
+        }
+
+        while (in.size()) {
+            auto out = stream.AcquireSpanForWritingNoAlloc(in.size());
+            Y_ABORT_UNLESS(out.size());
+            memcpy(out.data(), in.data(), out.size());
+            stream.Append({out.data(), out.size()}, static_cast<ui32*>(nullptr));
+            in = in.SubSpan(out.size(), Max<size_t>());
+        }
+    }
 };
 
 namespace NInterconnect::NDetail {

--- a/ydb/library/actors/interconnect/packet.h
+++ b/ydb/library/actors/interconnect/packet.h
@@ -59,7 +59,9 @@ struct TTcpPacketBuf {
     static constexpr ui64 PingResponseMask = 0x4000000000000000ULL;
     static constexpr ui64 ClockMask = 0x2000000000000000ULL;
 
-    static constexpr size_t PacketDataLen = 4096 * 2 - 96 - sizeof(TTcpPacketHeader_v2);
+    // Maximum serialized size of one main-channel IC packet, including its header.
+    static constexpr size_t FullPacketSize = 4096 * 2 - 96;
+    static constexpr size_t PacketDataLen = FullPacketSize - sizeof(TTcpPacketHeader_v2);
 };
 
 struct TEventData {

--- a/ydb/library/actors/interconnect/rdma/cq_actor/cq_actor.cpp
+++ b/ydb/library/actors/interconnect/rdma/cq_actor/cq_actor.cpp
@@ -12,7 +12,7 @@
 
 #include <contrib/libs/ibdrv/include/infiniband/verbs.h>
 
-#define YDB_LOG_THIS_FILE_COMPONENT ::NActorsServices::INTERCONNECT
+#include <cerrno>
 
 #define YDB_LOG_THIS_FILE_COMPONENT ::NActorsServices::INTERCONNECT
 

--- a/ydb/library/actors/interconnect/rdma/ctx.cpp
+++ b/ydb/library/actors/interconnect/rdma/ctx.cpp
@@ -48,6 +48,10 @@ size_t TRdmaCtx::GetDeviceIndex() const noexcept {
     return Impl->DeviceIndex;
 }
 
+int TRdmaCtx::GetMaxSge() const noexcept {
+    return Impl->DevAttr.max_sge;
+}
+
 TDeviceCtx::~TDeviceCtx() {
     ibv_dealloc_pd(ProtDomain);
     ibv_close_device(Context);

--- a/ydb/library/actors/interconnect/rdma/ctx.h
+++ b/ydb/library/actors/interconnect/rdma/ctx.h
@@ -63,6 +63,7 @@ public:
     int GetGidIndex() const noexcept;
     const ibv_gid& GetGid() const noexcept;
     size_t GetDeviceIndex() const noexcept;
+    int GetMaxSge() const noexcept;
 
     void Output(IOutputStream &str) const;
     TString ToString() const;

--- a/ydb/library/actors/interconnect/rdma/rdma.h
+++ b/ydb/library/actors/interconnect/rdma/rdma.h
@@ -28,6 +28,7 @@ namespace NMonitoring {
 
 class IOutputStream;
 class TRcBuf;
+class TContiguousSpan;
 
 namespace NInterconnect::NRdma {
 

--- a/ydb/library/actors/interconnect/rdma/rdma.h
+++ b/ydb/library/actors/interconnect/rdma/rdma.h
@@ -28,7 +28,6 @@ namespace NMonitoring {
 
 class IOutputStream;
 class TRcBuf;
-class TContiguousSpan;
 
 namespace NInterconnect::NRdma {
 

--- a/ydb/library/actors/interconnect/rdma/ut/rdma_low_ut.cpp
+++ b/ydb/library/actors/interconnect/rdma/ut/rdma_low_ut.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <span>
 #include <string.h>
 #include <vector>
 

--- a/ydb/library/actors/interconnect/types.h
+++ b/ydb/library/actors/interconnect/types.h
@@ -60,7 +60,7 @@ namespace NActors {
         bool UseXxhash = {};
         bool UseXdcShuffle = {};
         bool UseKernelLiveness = {};
-        bool UseRdma = {};
+        bool UseRdmaRead = {};
         bool ChecksumRdmaEvent = {};
         bool AllowDisablingPayloadChecksums = {};
         bool UseSessionV2 = {};

--- a/ydb/library/actors/interconnect/ut/event_output_channel_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/event_output_channel_ut.cpp
@@ -304,7 +304,7 @@ public:
         NInterconnect::TOutgoingStream xdcStream;
         if (!CompleteSerializer) {
             Y_ABORT_UNLESS(mainStream.PreallocateForWriting(
-                sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen));
+                TTcpPacketBuf::FullPacketSize));
         }
         TTcpPacketOutTask task(params, mainStream, xdcStream, !CompleteSerializer);
 

--- a/ydb/library/actors/interconnect/ut/event_output_channel_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/event_output_channel_ut.cpp
@@ -3,6 +3,7 @@
 #include <ydb/library/actors/interconnect/interconnect_counters.h>
 #include <ydb/library/actors/interconnect/outgoing_stream.h>
 #include <ydb/library/actors/interconnect/ut/protos/interconnect_test.pb.h>
+#include <ydb/library/actors/testlib/test_runtime.h>
 
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -265,9 +266,124 @@ void AssertChecksumsWhenDisablingIsNotNegotiated(bool useXxhash) {
     UNIT_ASSERT_VALUES_EQUAL(*pushData.Checksum, CalculateExpectedChecksum(event.XdcPayloadData, useXxhash));
 }
 
+class TProcessUndeliveredActor : public TActorBootstrapped<TProcessUndeliveredActor> {
+public:
+    TProcessUndeliveredActor(TActorId replyTo, bool completeSerializer)
+        : ReplyTo(replyTo)
+        , CompleteSerializer(completeSerializer)
+    {}
+
+    void Bootstrap() {
+        auto common = MakeIntrusive<TInterconnectProxyCommon>();
+        common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        std::shared_ptr<IInterconnectMetrics> metrics = CreateInterconnectCounters(common);
+        metrics->SetPeerInfo("peer", "1", "peer");
+
+        auto releaseCallback = [](THolder<IEventBase>) {};
+        TEventHolderPool pool(common, releaseCallback);
+
+        TSessionParams params;
+        params.AllowRdmaSendReceive = !CompleteSerializer;
+
+        auto memPool = CompleteSerializer
+            ? std::shared_ptr<NInterconnect::NRdma::IMemPool>()
+            : NInterconnect::NRdma::CreateDummyMemPool(true);
+        TEventOutputChannel channel(1, 1, CompleteSerializer ? 1 : 64 << 20,
+            metrics, params, memPool);
+
+        auto* ev = new TEvTestSerialization;
+        ev->Record.SetBuffer(CompleteSerializer
+            ? TString("serialized event larger than configured limit")
+            : TString(2 * TTcpPacketBuf::PacketDataLen, 'X'));
+        auto evHandle = MakeHolder<IEventHandle>(
+            SelfId(), ReplyTo, ev, IEventHandle::FlagTrackDelivery);
+        channel.Push(*evHandle, pool, TInstant::Zero());
+
+        NInterconnect::TOutgoingStream mainStream(memPool);
+        NInterconnect::TOutgoingStream xdcStream;
+        if (!CompleteSerializer) {
+            Y_ABORT_UNLESS(mainStream.PreallocateForWriting(
+                sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen));
+        }
+        TTcpPacketOutTask task(params, mainStream, xdcStream, !CompleteSerializer);
+
+        if (CompleteSerializer) {
+            bool eventTooLarge = false;
+            try {
+                channel.FeedBuf(task, 1);
+            } catch (const TExSerializedEventTooLarge&) {
+                eventTooLarge = true;
+            }
+            Y_ABORT_UNLESS(eventTooLarge);
+        } else {
+            Y_ABORT_UNLESS(!channel.FeedBuf(task, 1));
+        }
+        Y_ABORT_UNLESS(channel.State == TEventOutputChannel::EState::BODY);
+        channel.ProcessUndelivered(pool, nullptr);
+
+        PassAway();
+    }
+
+private:
+    const TActorId ReplyTo;
+    const bool CompleteSerializer;
+};
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(EventOutputChannel) {
+    Y_UNIT_TEST(PropagatesSerializedEventTooLargeFromCoroutineSerializer) {
+        auto common = MakeIntrusive<TInterconnectProxyCommon>();
+        common->MonCounters = MakeIntrusive<NMonitoring::TDynamicCounters>();
+
+        std::shared_ptr<IInterconnectMetrics> metrics = CreateInterconnectCounters(common);
+        metrics->SetPeerInfo("peer", "1", "peer");
+
+        auto releaseCallback = [](THolder<IEventBase>) {};
+        TEventHolderPool pool(common, releaseCallback);
+
+        TSessionParams params;
+        TEventOutputChannel channel(1, 1, 1, metrics, params, nullptr);
+
+        auto* ev = new TEvTestSerialization;
+        ev->Record.SetBuffer("serialized event larger than configured limit");
+        auto evHandle = MakeHolder<IEventHandle>(TActorId(), TActorId(), ev);
+        channel.Push(*evHandle, pool, TInstant::Zero());
+
+        NInterconnect::TOutgoingStream mainStream;
+        NInterconnect::TOutgoingStream xdcStream;
+        TTcpPacketOutTask task(params, mainStream, xdcStream);
+
+        UNIT_ASSERT_EXCEPTION(channel.FeedBuf(task, 1), TExSerializedEventTooLarge);
+    }
+
+    Y_UNIT_TEST(AbortsActiveCoroutineSerializerOnUndelivered) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId edge = runtime.AllocateEdgeActor();
+        runtime.Register(new TProcessUndeliveredActor(edge, false));
+
+        TAutoPtr<IEventHandle> handle;
+        const auto* event = runtime.GrabEdgeEvent<TEvents::TEvUndelivered>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(event->SourceType, TEvTestSerialization::EventType);
+        UNIT_ASSERT_VALUES_EQUAL(event->Reason, TEvents::TEvUndelivered::Disconnected);
+    }
+
+    Y_UNIT_TEST(ReleasesCompletedCoroutineSerializerOnUndelivered) {
+        TTestActorRuntimeBase runtime;
+        runtime.Initialize();
+
+        const TActorId edge = runtime.AllocateEdgeActor();
+        runtime.Register(new TProcessUndeliveredActor(edge, true));
+
+        TAutoPtr<IEventHandle> handle;
+        const auto* event = runtime.GrabEdgeEvent<TEvents::TEvUndelivered>(handle);
+        UNIT_ASSERT_VALUES_EQUAL(event->SourceType, TEvTestSerialization::EventType);
+        UNIT_ASSERT_VALUES_EQUAL(event->Reason, TEvents::TEvUndelivered::Disconnected);
+    }
+
     Y_UNIT_TEST(DisabledPayloadChecksums) {
         AssertDisabledPayloadChecksums(false);
         AssertDisabledPayloadChecksums(true);

--- a/ydb/library/actors/interconnect/ut/lib/node.h
+++ b/ydb/library/actors/interconnect/ut/lib/node.h
@@ -95,6 +95,7 @@ public:
         #if !defined(_msan_enabled_)
         if (withRdma) {
             common->RdmaMemPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
+            setup.RcBufAllocator = std::make_shared<TRdmaAllocatorWithFallback>(common->RdmaMemPool);
         }
         #else
             Y_UNUSED(withRdma);
@@ -132,7 +133,8 @@ public:
         setup.LocalServices.emplace_back(MakePollerActorId(), TActorSetupCmd(CreatePollerActor(counters),
             TMailboxType::ReadAsFilled, 0));
         setup.LocalServices.emplace_back(NInterconnect::NRdma::MakeCqActorId(),
-            TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(NInterconnect::NRdma::TRdmaRuntimeParams{-1, 1024, 0, 0}, rdmaCqMode, nullptr),
+            TActorSetupCmd(NInterconnect::NRdma::CreateCqActor(
+                CreateRdmaRuntimeParams(1024, common->Settings.EnableRdmaSendReceive), rdmaCqMode, nullptr),
             TMailboxType::ReadAsFilled, 0));
 
         const TActorId loggerActorId = loggerSettings ? loggerSettings->LoggerActorId : TActorId(0, "logger");

--- a/ydb/library/actors/interconnect/ut/outgoing_stream_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/outgoing_stream_ut.cpp
@@ -1,13 +1,88 @@
-#include <ydb/library/actors/interconnect/outgoing_stream.h>
+#include <ydb/library/actors/interconnect/packet.h>
 #include <library/cpp/testing/unittest/registar.h>
 #include <util/random/entropy.h>
 #include <util/random/fast.h>
 #include <util/stream/null.h>
+#include <util/system/compiler.h>
+#include <util/system/datetime.h>
 
 #define Ctest Cnull
 
 Y_UNIT_TEST_SUITE(OutgoingStream) {
-    void OutgoingTest(bool withExternal) {
+    using TOutStream = NInterconnect::TOutgoingStreamT<4096>;
+
+    std::shared_ptr<NInterconnect::NRdma::IMemPool> CreateWarmedSlotMemPool() {
+        auto memPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
+        for (size_t size = 512; size <= static_cast<size_t>(memPool->GetMaxAllocSz()); size <<= 1) {
+            auto region = memPool->Alloc(size, NInterconnect::NRdma::IMemPool::EMPTY);
+            if (!region) {
+                Cerr << "Skipping RDMA outgoing stream test, SlotMemPool allocation failed" << Endl;
+                return {};
+            }
+            region.Reset();
+        }
+        return memPool;
+    }
+
+    class TTrackingMemPool final : public NInterconnect::NRdma::IMemPool {
+    public:
+        explicit TTrackingMemPool(std::shared_ptr<NInterconnect::NRdma::IMemPool> underlying)
+            : Underlying(std::move(underlying))
+        {
+            UNIT_ASSERT(Underlying);
+        }
+
+        int GetMaxAllocSz() const noexcept override {
+            return Underlying->GetMaxAllocSz();
+        }
+
+        TString GetName() const noexcept override {
+            return Underlying->GetName();
+        }
+
+        bool Contains(const void* ptr, size_t size) const noexcept {
+            const auto* begin = static_cast<const char*>(ptr);
+            const auto* end = begin + size;
+            for (const auto& range : Ranges) {
+                if (range.Begin <= begin && end <= range.End) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    protected:
+        NInterconnect::NRdma::TMemRegionPtr AllocImpl(int size, ui32 flags) noexcept override {
+            auto region = Underlying->Alloc(size, flags);
+            if (region) {
+                const auto* begin = static_cast<const char*>(region->GetAddr());
+                Ranges.push_back(TRange{begin, begin + region->GetSize()});
+            }
+            return region;
+        }
+
+        void Free(NInterconnect::NRdma::TMemRegion&&, NInterconnect::NRdma::TChunk&) noexcept override {
+            Y_ABORT("tracking mem pool does not own chunks");
+        }
+
+        void DealocateMr(NInterconnect::NRdma::TChunk*) noexcept override {
+            Y_ABORT("tracking mem pool does not own chunks");
+        }
+
+    private:
+        void Tick(NMonotonic::TMonotonic) noexcept override {
+        }
+
+        struct TRange {
+            const char* Begin = nullptr;
+            const char* End = nullptr;
+        };
+
+        std::shared_ptr<NInterconnect::NRdma::IMemPool> Underlying;
+        std::vector<TRange> Ranges;
+    };
+
+    void OutgoingTest(bool withExternal, std::shared_ptr<NInterconnect::NRdma::IMemPool> allocator = {}) {
         struct {
             ui32 ZcCounter = 0; // ZcCounter to handle zero copy async transfer from some event queue
             std::vector<char> Buffer;
@@ -26,8 +101,7 @@ Y_UNIT_TEST_SUITE(OutgoingStream) {
             size_t sendOffset = 0; // offset to base
             size_t pending = 0; // number of bytes in queue
 
-            using TOutStream = NInterconnect::TOutgoingStreamT<4096>;
-            TOutStream stream;
+            TOutStream stream(allocator);
             bool zcSync = false;
 
             size_t numRewindsRemain = 10;
@@ -114,7 +188,7 @@ Y_UNIT_TEST_SUITE(OutgoingStream) {
                         auto span = stream.AcquireSpanForWriting(nextDataLen);
                         UNIT_ASSERT(span.size() != 0);
                         memcpy(span.data(), nextData, span.size());
-                        stream.Append(span, nullptr);
+                        stream.Append(span, static_cast<ui32*>(nullptr));
                         pending += span.size();
                         break;
                     }
@@ -185,5 +259,217 @@ Y_UNIT_TEST_SUITE(OutgoingStream) {
 
     Y_UNIT_TEST(WithExternalLife) {
         OutgoingTest(true);
+    }
+
+    Y_UNIT_TEST(RdmaMemory) {
+        auto memPool = CreateWarmedSlotMemPool();
+        if (!memPool) {
+            return;
+        }
+        OutgoingTest(false, std::move(memPool));
+    }
+
+    Y_UNIT_TEST(RdmaMemoryPreallocateNoAlloc) {
+        auto memPool = CreateWarmedSlotMemPool();
+        if (!memPool) {
+            return;
+        }
+        TOutStream stream(memPool);
+
+        std::vector<char> data(128 * 1024);
+        TReallyFastRng32 rng(EntropyPool());
+        for (char *p = data.data(); p != data.data() + data.size(); p += sizeof(ui32)) {
+            *reinterpret_cast<ui32*>(p) = rng();
+        }
+
+        UNIT_ASSERT(stream.PreallocateForWriting(data.size()));
+
+        size_t offset = 0;
+        while (offset != data.size()) {
+            auto span = stream.AcquireSpanForWritingNoAlloc(data.size() - offset);
+            UNIT_ASSERT(span.size());
+            memcpy(span.data(), data.data() + offset, span.size());
+            stream.Append(span, static_cast<ui32*>(nullptr));
+            offset += span.size();
+        }
+
+        UNIT_ASSERT_VALUES_EQUAL(stream.CalculateOutgoingSize(), data.size());
+        UNIT_ASSERT_VALUES_EQUAL(stream.CalculateUnsentSize(), data.size());
+
+        std::vector<NActors::TConstIoVec> iov;
+        stream.ProduceIoVec(iov, Max<size_t>(), Max<size_t>());
+
+        offset = 0;
+        for (const auto& [ptr, len] : iov) {
+            UNIT_ASSERT(memcmp(data.data() + offset, ptr, len) == 0);
+            offset += len;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(offset, data.size());
+
+        stream.Advance(data.size());
+        stream.DropFront(data.size());
+        UNIT_ASSERT_VALUES_EQUAL(stream.CalculateOutgoingSize(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(stream.CalculateUnsentSize(), 0);
+    }
+
+    Y_UNIT_TEST(PacketBuilderUsesPreallocatedRdmaMemoryForInternalStream) {
+        auto slotMemPool = CreateWarmedSlotMemPool();
+        if (!slotMemPool) {
+            return;
+        }
+        auto memPool = std::make_shared<TTrackingMemPool>(std::move(slotMemPool));
+        NInterconnect::TOutgoingStream mainStream(memPool);
+        NInterconnect::TOutgoingStream xdcStream;
+
+        UNIT_ASSERT(mainStream.PreallocateForWriting(sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen));
+
+        TSessionParams params;
+        params.AllowRdmaSendReceive = true;
+        TTcpPacketOutTask packet(params, mainStream, xdcStream, true);
+
+        const ui64 bookmarked = 42;
+        auto bookmark = packet.Bookmark(sizeof(bookmarked));
+        packet.WriteBookmark(std::move(bookmark), &bookmarked, sizeof(bookmarked));
+
+        const TString payload(TTcpPacketBuf::PacketDataLen / 2, 'X');
+        packet.Write<false>(payload.data(), payload.size());
+        const TString appendedPayload(128, 'A');
+        auto appendSpan = packet.AcquireSpanForWriting<false>().SubSpan(0, appendedPayload.size());
+        memcpy(appendSpan.data(), appendedPayload.data(), appendSpan.size());
+        packet.Append<false>(appendSpan.data(), appendSpan.size(), nullptr, false);
+        auto rdmaBuf = memPool->AllocRcBuf(128, NInterconnect::NRdma::IMemPool::EMPTY);
+        UNIT_ASSERT(rdmaBuf);
+        memset(rdmaBuf->UnsafeGetDataMut(), 'R', rdmaBuf->GetSize());
+        const auto rdmaBufRegion = NInterconnect::NRdma::TryExtractFromRcBuf(*rdmaBuf);
+        UNIT_ASSERT(!rdmaBufRegion.Empty());
+        packet.AppendRdma(rdmaBuf->GetData(), rdmaBuf->GetSize(), rdmaBufRegion.GetMemRegion(), false);
+        packet.Finish(1, 0);
+
+        std::vector<NActors::TConstIoVec> iov;
+        mainStream.ProduceIoVec(iov, Max<size_t>(), Max<size_t>());
+        UNIT_ASSERT(!iov.empty());
+
+        size_t total = 0;
+        for (const auto& [ptr, len] : iov) {
+            UNIT_ASSERT_C(memPool->Contains(ptr, len),
+                TStringBuilder() << "iovec ptr# " << ptr << " len# " << len << " is not backed by RDMA memory");
+            total += len;
+        }
+        UNIT_ASSERT_VALUES_EQUAL(total, packet.GetPacketSize());
+        UNIT_ASSERT_VALUES_EQUAL(xdcStream.CalculateOutgoingSize(), 0);
+
+        std::vector<NInterconnect::NRdma::TSendSge> rdmaChunks;
+        const size_t rdmaBytes = mainStream.ProduceRdmaSendVec(rdmaChunks, Max<size_t>(), Max<size_t>());
+        UNIT_ASSERT(!rdmaChunks.empty());
+        UNIT_ASSERT_VALUES_EQUAL(rdmaBytes, packet.GetPacketSize());
+        for (const auto& chunk : rdmaChunks) {
+            UNIT_ASSERT(chunk.MemRegion);
+            UNIT_ASSERT(chunk.Data);
+            UNIT_ASSERT(chunk.Size);
+        }
+    }
+
+    template <typename TCallback>
+    void ReportLatency(const char* allocatorName, const char* name, size_t iterations, TCallback&& callback) {
+        const TInstant start = TInstant::Now();
+        for (size_t i = 0; i != iterations; ++i) {
+            callback(i);
+        }
+        const TDuration elapsed = TInstant::Now() - start;
+        Cerr << "OutgoingStreamLatency " << allocatorName << "." << name
+            << " iterations# " << iterations
+            << " ns/op# " << static_cast<double>(elapsed.NanoSeconds()) / iterations
+            << Endl;
+    }
+
+    void PublicMethodsLatencyBenchmarkImpl(const char* allocatorName, std::shared_ptr<NInterconnect::NRdma::IMemPool> allocator) {
+        constexpr size_t iterations = 100000;
+        char payload[64];
+        memset(payload, 7, sizeof(payload));
+
+        TOutStream acquireStream(allocator);
+        ReportLatency(allocatorName, "AcquireSpanForWriting+Append", iterations, [&](size_t) {
+            auto& stream = acquireStream;
+            auto span = stream.AcquireSpanForWriting(sizeof(payload));
+            memcpy(span.data(), payload, span.size());
+            stream.Append(span, static_cast<ui32*>(nullptr));
+            Y_DO_NOT_OPTIMIZE_AWAY(stream.GetSendQueueSize());
+        });
+
+        TOutStream writeStream(allocator);
+        ReportLatency(allocatorName, "Write", iterations, [&](size_t) {
+            auto& stream = writeStream;
+            stream.Write({payload, sizeof(payload)});
+            Y_DO_NOT_OPTIMIZE_AWAY(stream.GetSendQueueSize());
+        });
+
+        TOutStream bookmarkStream(allocator);
+        ReportLatency(allocatorName, "Bookmark+WriteBookmark", iterations, [&](size_t) {
+            auto& stream = bookmarkStream;
+            auto bookmark = stream.Bookmark(sizeof(payload));
+            stream.WriteBookmark(std::move(bookmark), {payload, sizeof(payload)});
+            Y_DO_NOT_OPTIMIZE_AWAY(stream.GetSendQueueSize());
+        });
+
+        TOutStream noAllocStream(allocator);
+        ReportLatency(allocatorName, "Preallocate+AcquireNoAlloc+Append", iterations, [&](size_t) {
+            auto& stream = noAllocStream;
+            Y_ABORT_UNLESS(stream.PreallocateForWriting(sizeof(payload)));
+            auto span = stream.AcquireSpanForWritingNoAlloc(sizeof(payload));
+            memcpy(span.data(), payload, span.size());
+            stream.Append(span, static_cast<ui32*>(nullptr));
+            Y_DO_NOT_OPTIMIZE_AWAY(stream.GetSendQueueSize());
+        });
+
+        TOutStream stream(allocator);
+        for (size_t i = 0; i != 256; ++i) {
+            stream.Append({payload, sizeof(payload)}, static_cast<ui32*>(nullptr));
+        }
+
+        ReportLatency(allocatorName, "ProduceIoVec", iterations, [&](size_t) {
+            //std::vector<NActors::TConstIoVec> iov;
+            //iov.reserve(16);
+            //???? StackVes slow ????
+            TStackVec<NActors::TConstIoVec, 16, false> iov;
+            stream.ProduceIoVec(iov, 16, 1024);
+            Y_DO_NOT_OPTIMIZE_AWAY(iov.size());
+        });
+
+        ReportLatency(allocatorName, "ScanLastBytes", iterations, [&](size_t) {
+            size_t bytes = 0;
+            stream.ScanLastBytes(sizeof(payload), [&](TContiguousSpan span) {
+                bytes += span.size();
+            });
+            Y_DO_NOT_OPTIMIZE_AWAY(bytes);
+        });
+
+        ReportLatency(allocatorName, "CalculateSizes", iterations, [&](size_t) {
+            size_t value = stream.CalculateOutgoingSize() + stream.CalculateUnsentSize() + stream.GetSendQueueSize();
+            Y_DO_NOT_OPTIMIZE_AWAY(value);
+        });
+
+        ReportLatency(allocatorName, "Rewind", iterations, [&](size_t) {
+            stream.RewindToEnd();
+            stream.Rewind();
+            Y_DO_NOT_OPTIMIZE_AWAY(stream.CalculateUnsentSize());
+        });
+
+        TOutStream dropStream(allocator);
+        for (size_t i = 0; i != iterations; ++i) {
+            dropStream.Write({payload, sizeof(payload)});
+        }
+
+        ReportLatency(allocatorName, "Advance+DropFront", iterations, [&](size_t) {
+            dropStream.Advance(sizeof(payload));
+            dropStream.DropFront(sizeof(payload));
+            Y_DO_NOT_OPTIMIZE_AWAY(dropStream.GetSendQueueSize());
+        });
+    }
+
+    Y_UNIT_TEST(PublicMethodsLatencyBenchmark) {
+        PublicMethodsLatencyBenchmarkImpl("malloc", {});
+        if (auto memPool = CreateWarmedSlotMemPool()) {
+            PublicMethodsLatencyBenchmarkImpl("rdma", std::move(memPool));
+        }
     }
 }

--- a/ydb/library/actors/interconnect/ut/outgoing_stream_ut.cpp
+++ b/ydb/library/actors/interconnect/ut/outgoing_stream_ut.cpp
@@ -321,7 +321,7 @@ Y_UNIT_TEST_SUITE(OutgoingStream) {
         NInterconnect::TOutgoingStream mainStream(memPool);
         NInterconnect::TOutgoingStream xdcStream;
 
-        UNIT_ASSERT(mainStream.PreallocateForWriting(sizeof(TTcpPacketHeader_v2) + TTcpPacketBuf::PacketDataLen));
+        UNIT_ASSERT(mainStream.PreallocateForWriting(TTcpPacketBuf::FullPacketSize));
 
         TSessionParams params;
         params.AllowRdmaSendReceive = true;

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_send_receive_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_send_receive_ut.cpp
@@ -1,0 +1,708 @@
+#include "rdma_xdc_test_common.h"
+
+namespace {
+
+class THistogramSampleCountConsumer : public NMonitoring::ICountableConsumer {
+public:
+    explicit THistogramSampleCountConsumer(TStringBuf histogramName)
+        : HistogramName(histogramName)
+    {}
+
+    void OnCounter(const TString&, const TString&, const NMonitoring::TCounterForPtr*) override {
+    }
+
+    void OnHistogram(const TString&, const TString& labelValue,
+            NMonitoring::IHistogramSnapshotPtr snapshot, bool) override {
+        if (labelValue == HistogramName) {
+            for (ui32 i = 0; i != snapshot->Count(); ++i) {
+                SampleCount += snapshot->Value(i);
+            }
+        }
+    }
+
+    void OnGroupBegin(const TString&, const TString&, const NMonitoring::TDynamicCounters*) override {
+    }
+
+    void OnGroupEnd(const TString&, const TString&, const NMonitoring::TDynamicCounters*) override {
+    }
+
+    const TString HistogramName;
+    ui64 SampleCount = 0;
+};
+
+ui64 GetNodeHistogramSampleCount(TTestICCluster& cluster, ui32 nodeId, TStringBuf histogramName) {
+    const auto nodeCounters = cluster.GetCounters()->FindSubgroup("nodeId", ToString(nodeId));
+    if (!nodeCounters) {
+        return 0;
+    }
+
+    THistogramSampleCountConsumer consumer(histogramName);
+    nodeCounters->Accept({}, {}, consumer);
+    return consumer.SampleCount;
+}
+
+} // namespace
+
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelTraffic) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    ui32 index = 0;
+    auto receiverPtr = new TReceiveActor([&index](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), index);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TStringBuilder{} << "send receive " << index);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 0u);
+        ++index;
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    constexpr ui32 numEvents = 16;
+    for (ui32 i = 0; i < numEvents; ++i) {
+        auto ev = std::make_unique<TEvTestSerialization>();
+        ev->Record.SetBlobID(i);
+        ev->Record.SetBuffer(TStringBuilder{} << "send receive " << i);
+        cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+    }
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(numEvents, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelAliasedPayload) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr size_t payloadSize = 1024;
+    auto receiverPtr = new TReceiveActor([payloadSize](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].GetSize(), payloadSize);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), TString(payloadSize, 'X'));
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->AddPayload(TRope(TString(payloadSize, 'X')));
+    UNIT_ASSERT(!ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelAliasedProtobuf) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr size_t bufferSize = 1024;
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TString(bufferSize, 'X'));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 0u);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer(TString(bufferSize, 'X'));
+    UNIT_ASSERT(!ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+// Verifies that a pre-serialized event backed by ordinary memory is copied into
+// RDMA memory and delivered through the RDMA main channel.
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelPreSerializedBuffer) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr size_t bufferSize = 1024;
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TString(bufferSize, 'X'));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 0u);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer(TString(bufferSize, 'X'));
+    auto serializedRope = ev->SerializeToRope(GetDefaultRcBufAllocator());
+    UNIT_ASSERT(serializedRope);
+
+    auto serialized = MakeIntrusive<TEventSerializedData>(
+        std::move(*serializedRope), ev->CreateSerializationInfo(false));
+    for (auto iter = serialized->GetBeginIter(); iter.Valid(); iter += iter.ContiguousSize()) {
+        UNIT_ASSERT(NInterconnect::NRdma::TryExtractFromRcBuf(iter.GetChunk()).Empty());
+    }
+
+    UNIT_ASSERT(cluster.GetNode(2)->GetActorSystem()->Send(new IEventHandle(
+        TEvTestSerialization::EventType,
+        0,
+        receiver,
+        TActorId(),
+        std::move(serialized),
+        0)));
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+// Verifies that a pre-serialized event already backed by RDMA memory is
+// delivered through the RDMA main channel.
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelRdmaPreSerializedBuffer) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr size_t bufferSize = 1024;
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TString(bufferSize, 'X'));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 0u);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer(TString(bufferSize, 'X'));
+    auto serializedRope = ev->SerializeToRope(GetDefaultRcBufAllocator());
+    UNIT_ASSERT(serializedRope);
+    const TString serializedData = serializedRope->ConvertToString();
+
+    const auto memPool = cluster.GetNode(2)->GetRdmaMemPool();
+    auto rdmaBuffer = memPool->AllocRcBuf(serializedData.size(), 0).value();
+    memcpy(rdmaBuffer.GetDataMut(), serializedData.data(), serializedData.size());
+    const auto memRegion = NInterconnect::NRdma::TryExtractFromRcBuf(rdmaBuffer);
+    UNIT_ASSERT(!memRegion.Empty());
+
+    auto serialized = MakeIntrusive<TEventSerializedData>(
+        TRope(std::move(rdmaBuffer)), ev->CreateSerializationInfo(false));
+    auto iter = serialized->GetBeginIter();
+    UNIT_ASSERT(iter.Valid());
+    UNIT_ASSERT(iter.ContiguousData() == memRegion.GetAddr());
+    UNIT_ASSERT(NInterconnect::NRdma::TryExtractFromRcBuf(iter.GetChunk()).GetMemRegion() == memRegion.GetMemRegion());
+    iter += iter.ContiguousSize();
+    UNIT_ASSERT(!iter.Valid());
+
+    UNIT_ASSERT(cluster.GetNode(2)->GetActorSystem()->Send(new IEventHandle(
+        TEvTestSerialization::EventType,
+        0,
+        receiver,
+        TActorId(),
+        std::move(serialized),
+        0)));
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+// Verifies successful serialization and reassembly of one event spanning
+// multiple RDMA main-channel packets.
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelMultiPacketEvent) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr size_t bufferSize = 2 * TTcpPacketBuf::PacketDataLen + 1;
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TString(bufferSize, 'X'));
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 0u);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer(TString(bufferSize, 'X'));
+    UNIT_ASSERT(!ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+// Verifies that one main-channel packet split at the 16-SGE SEND limit is
+// reassembled from multiple RDMA receives without changing payload order.
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelSgListBoundary) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr size_t chunkCount = 17;
+    constexpr size_t chunkSize = 64;
+    constexpr size_t chunkStride = 2 * chunkSize;
+
+    TString expectedPayload;
+    for (size_t i = 0; i != chunkCount; ++i) {
+        expectedPayload.append(chunkSize, 'A' + i);
+    }
+
+    auto receiverPtr = new TReceiveActor([expectedPayload](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), expectedPayload);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    const auto memPool = cluster.GetNode(2)->GetRdmaMemPool();
+    auto storage = memPool->AllocRcBuf(chunkCount * chunkStride, 0).value();
+    TRope payload;
+    for (size_t i = 0; i != chunkCount; ++i) {
+        char* data = storage.GetDataMut() + i * chunkStride;
+        memset(data, 'A' + i, chunkSize);
+        payload.Insert(payload.End(), TRope(TRcBuf(TRcBuf::Piece, data, chunkSize, storage)));
+    }
+
+    size_t contiguousBlocks = 0;
+    for (auto iter = payload.Begin(); iter.Valid(); iter.AdvanceToNextContiguousBlock()) {
+        ++contiguousBlocks;
+        UNIT_ASSERT(!NInterconnect::NRdma::TryExtractFromRcBuf(iter.GetChunk()).Empty());
+    }
+    UNIT_ASSERT_VALUES_EQUAL(contiguousBlocks, chunkCount);
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->AddPayload(std::move(payload));
+    UNIT_ASSERT(!ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+// Verifies that a standalone main-channel ACK is delivered over RDMA and
+// releases the sender's in-flight data without writing in either TCP direction.
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelAck) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    const ui64 packetsConfirmedBefore = WaitForSessionCounter(cluster, 2, 1, "PacketsConfirmed");
+    const ui64 senderBytesWrittenToSocketBefore = GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+    const ui64 receiverBytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 1, 2, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer("acknowledge this event");
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+
+    bool confirmed = false;
+    ui64 packetsConfirmed = packetsConfirmedBefore;
+    ui64 inflightDataAmount = 0;
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(20);
+    while (TInstant::Now() < deadline) {
+        packetsConfirmed = GetSessionCounter(cluster, 2, 1, "PacketsConfirmed");
+        inflightDataAmount = GetSessionCounter(cluster, 2, 1, "InflightDataAmount");
+        if (packetsConfirmed > packetsConfirmedBefore && inflightDataAmount == 0) {
+            confirmed = true;
+            break;
+        }
+        Sleep(TDuration::MilliSeconds(10));
+    }
+
+    UNIT_ASSERT_C(confirmed, "packetsConfirmedBefore# " << packetsConfirmedBefore
+        << " packetsConfirmed# " << packetsConfirmed << " inflightDataAmount# " << inflightDataAmount);
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), senderBytesWrittenToSocketBefore);
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 1, 2, "BytesWrittenToSocket"), receiverBytesWrittenToSocketBefore);
+}
+
+// Verifies that a ping request and response update the RTT histogram while
+// both directions of the main channel remain on RDMA.
+TEST_P(RdmaSendReceiveTestCqMode, MainChannelPing) {
+    auto settingsCustomizer = [](ui32 nodeId, TInterconnectSettings& settings) {
+        EnableRdmaSendReceive(nodeId, settings);
+        settings.PingPeriod = TDuration::MilliSeconds(100);
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    const ui64 pingSamplesBefore = GetNodeHistogramSampleCount(cluster, 2, "PingTimeUs");
+    const ui64 senderBytesWrittenToSocketBefore = GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+    const ui64 receiverBytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 1, 2, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+
+    ui64 pingSamples = pingSamplesBefore;
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(20);
+    while (TInstant::Now() < deadline) {
+        pingSamples = GetNodeHistogramSampleCount(cluster, 2, "PingTimeUs");
+        if (pingSamples > pingSamplesBefore) {
+            break;
+        }
+        Sleep(TDuration::MilliSeconds(10));
+    }
+
+    UNIT_ASSERT_C(pingSamples > pingSamplesBefore,
+        "pingSamplesBefore# " << pingSamplesBefore << " pingSamples# " << pingSamples);
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), senderBytesWrittenToSocketBefore);
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 1, 2, "BytesWrittenToSocket"), receiverBytesWrittenToSocketBefore);
+}
+
+// Verifies simultaneous application traffic over the RDMA main channel in
+// both directions without falling back to either TCP main channel.
+TEST_P(RdmaSendReceiveTestCqMode, BidirectionalMainChannelTraffic) {
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), EnableRdmaSendReceive);
+
+    constexpr ui32 numEvents = 16;
+    auto node1ReceiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        const ui32 index = ev->Get()->Record.GetBlobID();
+        UNIT_ASSERT(index < numEvents);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TStringBuilder{} << "2 to 1 " << index);
+    });
+    const TActorId node1Receiver = cluster.RegisterActor(node1ReceiverPtr, 1);
+
+    auto node2ReceiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        const ui32 index = ev->Get()->Record.GetBlobID();
+        UNIT_ASSERT(index < numEvents);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TStringBuilder{} << "1 to 2 " << index);
+    });
+    const TActorId node2Receiver = cluster.RegisterActor(node2ReceiverPtr, 2);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    WaitForInterconnectConnection(cluster, 1, 2);
+    TString node2RdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, node2RdmaStatus),
+        "last node 2 RDMA status: " << FormatLastRdmaStatus(node2RdmaStatus));
+    TString node1RdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 1, 2, "On | SoftwareChecksum | SendReceive", 20, node1RdmaStatus),
+        "last node 1 RDMA status: " << FormatLastRdmaStatus(node1RdmaStatus));
+
+    const ui64 node2BytesWrittenToSocketBefore = GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+    const ui64 node1BytesWrittenToSocketBefore = GetSessionCounter(cluster, 1, 2, "BytesWrittenToSocket");
+
+    for (ui32 i = 0; i != numEvents; ++i) {
+        auto node2Event = std::make_unique<TEvTestSerialization>();
+        node2Event->Record.SetBlobID(i);
+        node2Event->Record.SetBuffer(TStringBuilder{} << "2 to 1 " << i);
+        cluster.RegisterActor(new TSendActor(node1Receiver, std::move(node2Event)), 2);
+
+        auto node1Event = std::make_unique<TEvTestSerialization>();
+        node1Event->Record.SetBlobID(i);
+        node1Event->Record.SetBuffer(TStringBuilder{} << "1 to 2 " << i);
+        cluster.RegisterActor(new TSendActor(node2Receiver, std::move(node1Event)), 1);
+    }
+
+    UNIT_ASSERT(node1ReceiverPtr->WaitForReceive(numEvents, 20));
+    UNIT_ASSERT(node2ReceiverPtr->WaitForReceive(numEvents, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), node2BytesWrittenToSocketBefore);
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 1, 2, "BytesWrittenToSocket"), node1BytesWrittenToSocketBefore);
+}
+
+// Verifies that MaxSerializedEventSize is inclusive for the RDMA main-channel
+// serializer: an event whose serialized size equals the limit is delivered.
+TEST_P(RdmaSendReceiveTestCqMode, MaxSizedMainChannelEvent) {
+    constexpr size_t bufferSize = 1024;
+    auto sizeProbe = std::make_unique<TEvTestSerialization>();
+    sizeProbe->Record.SetBlobID(1);
+    sizeProbe->Record.SetBuffer(TString(bufferSize, 'X'));
+    const ui32 maxSerializedEventSize = sizeProbe->CalculateSerializedSize();
+
+    auto settingsCustomizer = [maxSerializedEventSize](ui32 nodeId, TInterconnectSettings& settings) {
+        EnableRdmaSendReceive(nodeId, settings);
+        settings.MaxSerializedEventSize = maxSerializedEventSize;
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), TString(bufferSize, 'X'));
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer(TString(bufferSize, 'X'));
+    UNIT_ASSERT_VALUES_EQUAL(ev->CalculateSerializedSize(), maxSerializedEventSize);
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT_VALUES_EQUAL(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket"), bytesWrittenToSocketBefore);
+}
+
+namespace {
+
+void RunOversizedMainChannelEventTest(NInterconnect::NRdma::ECqMode cqMode,
+        ui32 maxSerializedEventSize, size_t payloadSize) {
+    auto settingsCustomizer = [maxSerializedEventSize](ui32 nodeId, TInterconnectSettings& settings) {
+        EnableRdmaSendReceive(nodeId, settings);
+        settings.MaxSerializedEventSize = maxSerializedEventSize;
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(cqMode),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr) {});
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    auto extCtx = std::make_shared<TSendActor::TExtCtx>();
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBuffer(TString(payloadSize, 'X'));
+    UNIT_ASSERT(!ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev), extCtx), 2);
+
+    UNIT_ASSERT(extCtx->WaitForUndelivered(20));
+    UNIT_ASSERT_VALUES_EQUAL(receiverPtr->ReceivedEvents.load(std::memory_order_relaxed), 0u);
+}
+
+} // namespace
+
+TEST_P(RdmaSendReceiveTestCqMode, OversizedMainChannelEventDoesNotCrash) {
+    constexpr ui32 maxSerializedEventSize = 1024;
+    RunOversizedMainChannelEventTest(GetParam(), maxSerializedEventSize, 2 * maxSerializedEventSize);
+}
+
+TEST_P(RdmaSendReceiveTestCqMode, OversizedMultiPacketMainChannelEventDoesNotCrash) {
+    constexpr ui32 maxSerializedEventSize = 2 * TTcpPacketBuf::PacketDataLen;
+    RunOversizedMainChannelEventTest(GetParam(), maxSerializedEventSize, 3 * TTcpPacketBuf::PacketDataLen);
+}
+
+// Verifies that an oversized external payload terminates the session and is
+// reported as undelivered instead of crashing in the external chunk consumer.
+TEST_P(RdmaSendReceiveTestCqMode, OversizedExternalChannelEventDoesNotCrash) {
+    constexpr ui32 maxSerializedEventSize = 1024;
+    auto settingsCustomizer = [](ui32 nodeId, TInterconnectSettings& settings) {
+        EnableRdmaSendReceive(nodeId, settings);
+        settings.MaxSerializedEventSize = maxSerializedEventSize;
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr) {});
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    auto extCtx = std::make_shared<TSendActor::TExtCtx>();
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->AddPayload(TRope(TString(5000, 'X')));
+    UNIT_ASSERT_VALUES_EQUAL(ev->Record.ByteSize(), 0);
+    UNIT_ASSERT(ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev), extCtx), 2);
+
+    UNIT_ASSERT(extCtx->WaitForUndelivered(20));
+    UNIT_ASSERT_VALUES_EQUAL(receiverPtr->ReceivedEvents.load(std::memory_order_relaxed), 0u);
+}
+
+// Verifies that terminating an RDMA session because of an oversized event does
+// not prevent a subsequent session from delivering regular traffic.
+TEST_P(RdmaSendReceiveTestCqMode, RecoversAfterOversizedMainChannelEvent) {
+    constexpr ui32 maxSerializedEventSize = 1024;
+    auto settingsCustomizer = [](ui32 nodeId, TInterconnectSettings& settings) {
+        EnableRdmaSendReceive(nodeId, settings);
+        settings.MaxSerializedEventSize = maxSerializedEventSize;
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "after oversized event");
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    auto extCtx = std::make_shared<TSendActor::TExtCtx>();
+    auto oversized = std::make_unique<TEvTestSerialization>();
+    oversized->Record.SetBuffer(TString(2 * maxSerializedEventSize, 'X'));
+    UNIT_ASSERT(!oversized->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(oversized), extCtx), 2);
+
+    UNIT_ASSERT(extCtx->WaitForUndelivered(20));
+    UNIT_ASSERT_VALUES_EQUAL(receiverPtr->ReceivedEvents.load(std::memory_order_relaxed), 0u);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    lastRdmaStatus.clear();
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
+        "last RDMA status after reconnect: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer("after oversized event");
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+}
+
+// Verifies that Send/Receive is not enabled unless both peers advertise it:
+// the main channel stays on TCP while an RDMA-capable payload still uses RDMA READ.
+TEST_P(RdmaSendReceiveTestCqMode, FallsBackToTcpMainWhenPeerDoesNotSupportSendReceive) {
+    auto settingsCustomizer = [](ui32 nodeId, TInterconnectSettings& settings) {
+        if (nodeId == 2) {
+            EnableRdmaSendReceive(nodeId, settings);
+        }
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    constexpr size_t payloadSize = 5000;
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "asymmetric send receive support");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), TString(payloadSize, 'X'));
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 1);
+
+    WaitForInterconnectConnection(cluster, 2, 1);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
+    const ui64 rdmaBytesReadScheduledBefore = WaitForSessionCounter(cluster, 1, 2, "RdmaBytesReadScheduled");
+
+    auto payload = cluster.GetNode(2)->GetRdmaMemPool()->AllocRcBuf(payloadSize, 0).value();
+    memset(payload.GetDataMut(), 'X', payloadSize);
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer("asymmetric send receive support");
+    ev->AddPayload(TRope(std::move(payload)));
+    UNIT_ASSERT(ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 2);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT(GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket") > bytesWrittenToSocketBefore);
+    UNIT_ASSERT(GetSessionCounter(cluster, 1, 2, "RdmaBytesReadScheduled") > rdmaBytesReadScheduledBefore);
+}
+
+// Verifies the opposite asymmetric handshake direction: a sender without
+// Send/Receive support keeps TCP main while the receiver still uses RDMA READ.
+TEST_P(RdmaSendReceiveTestCqMode, FallsBackToTcpMainWhenSenderDoesNotSupportSendReceive) {
+    auto settingsCustomizer = [](ui32 nodeId, TInterconnectSettings& settings) {
+        if (nodeId == 2) {
+            EnableRdmaSendReceive(nodeId, settings);
+        }
+    };
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(GetParam()),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(30), TNode::DefaultInflight(), settingsCustomizer);
+
+    constexpr size_t payloadSize = 5000;
+    auto receiverPtr = new TReceiveActor([](TEvTestSerialization::TPtr ev) {
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBlobID(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->Record.GetBuffer(), "sender without send receive support");
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload().size(), 1u);
+        UNIT_ASSERT_VALUES_EQUAL(ev->Get()->GetPayload()[0].ConvertToString(), TString(payloadSize, 'X'));
+    });
+    const TActorId receiver = cluster.RegisterActor(receiverPtr, 2);
+
+    WaitForInterconnectConnection(cluster, 1, 2);
+    TString lastRdmaStatus;
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 1, 2, "On | SoftwareChecksum", 20, lastRdmaStatus),
+        "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
+
+    const ui64 bytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 1, 2, "BytesWrittenToSocket");
+    const ui64 rdmaBytesReadScheduledBefore = WaitForSessionCounter(cluster, 2, 1, "RdmaBytesReadScheduled");
+
+    auto payload = cluster.GetNode(1)->GetRdmaMemPool()->AllocRcBuf(payloadSize, 0).value();
+    memset(payload.GetDataMut(), 'X', payloadSize);
+
+    auto ev = std::make_unique<TEvTestSerialization>();
+    ev->Record.SetBlobID(1);
+    ev->Record.SetBuffer("sender without send receive support");
+    ev->AddPayload(TRope(std::move(payload)));
+    UNIT_ASSERT(ev->AllowExternalDataChannel());
+    cluster.RegisterActor(new TSendActor(receiver, std::move(ev)), 1);
+
+    UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
+    UNIT_ASSERT(GetSessionCounter(cluster, 1, 2, "BytesWrittenToSocket") > bytesWrittenToSocketBefore);
+    UNIT_ASSERT(GetSessionCounter(cluster, 2, 1, "RdmaBytesReadScheduled") > rdmaBytesReadScheduledBefore);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RdmaSendReceive,
+    RdmaSendReceiveTestCqMode,
+    ::testing::Values(
+        NInterconnect::NRdma::ECqMode::POLLING,
+        NInterconnect::NRdma::ECqMode::EVENT
+    ),
+    [](const testing::TestParamInfo<NInterconnect::NRdma::ECqMode>& info) {
+        return FormatRdmaCqMode(info.param);
+    }
+);

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_send_receive_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_send_receive_ut.cpp
@@ -380,7 +380,7 @@ TEST_P(RdmaSendReceiveTestCqMode, MainChannelPing) {
     UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum | SendReceive", 20, lastRdmaStatus),
         "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
 
-    const ui64 pingSamplesBefore = GetNodeHistogramSampleCount(cluster, 2, "PingTimeUs");
+    const ui64 pingSamplesBefore = GetNodeHistogramSampleCount(cluster, 2, "PingTimeRdmaUs");
     const ui64 senderBytesWrittenToSocketBefore = GetSessionCounter(cluster, 2, 1, "BytesWrittenToSocket");
     const ui64 receiverBytesWrittenToSocketBefore = WaitForSessionCounter(cluster, 1, 2, "BytesWrittenToSocket");
 
@@ -392,7 +392,7 @@ TEST_P(RdmaSendReceiveTestCqMode, MainChannelPing) {
     ui64 pingSamples = pingSamplesBefore;
     const TInstant deadline = TInstant::Now() + TDuration::Seconds(20);
     while (TInstant::Now() < deadline) {
-        pingSamples = GetNodeHistogramSampleCount(cluster, 2, "PingTimeUs");
+        pingSamples = GetNodeHistogramSampleCount(cluster, 2, "PingTimeRdmaUs");
         if (pingSamples > pingSamplesBefore) {
             break;
         }

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_test_common.h
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_test_common.h
@@ -1,0 +1,549 @@
+#pragma once
+
+#include <ydb/library/actors/core/event_pb.h>
+#include <ydb/library/actors/core/actorsystem.h>
+#include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
+#include <ydb/library/actors/interconnect/rdma/mem_pool.h>
+
+#include <library/cpp/monlib/dynamic_counters/counters.h>
+#include <library/cpp/testing/gtest/gtest.h>
+
+#include <ydb/library/actors/interconnect/ut/protos/interconnect_test.pb.h>
+#include <ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h>
+#include <ydb/library/actors/interconnect/channel_scheduler.h>
+#include <ydb/library/actors/interconnect/events_local.h>
+
+#include <ydb/library/testlib/unittest_gtest_macro_subst.h>
+
+#include <util/string/cast.h>
+
+using namespace NActors;
+
+struct TEvTestSerialization : public TEventPB<TEvTestSerialization, NInterconnectTest::TEvTestSerialization, 123> {};
+
+struct TEvSerializeToRopeFailure : public TEventBase<TEvSerializeToRopeFailure, 124> {
+    TString Payload;
+    mutable ui32 SerializeToRopeCallCount = 0;
+
+    explicit TEvSerializeToRopeFailure(size_t payloadSize = 5000)
+        : Payload(payloadSize, 'R')
+    {}
+
+    TString ToStringHeader() const override {
+        return "TEvSerializeToRopeFailure";
+    }
+
+    bool SerializeToArcadiaStream(TChunkSerializer* serializer) const override {
+        return serializer->WriteString(&Payload);
+    }
+
+    std::optional<TRope> SerializeToRope(IRcBufAllocator*) const override {
+        ++SerializeToRopeCallCount;
+        return std::nullopt;
+    }
+
+    TEventSerializationInfo CreateSerializationInfo(bool allowExternalDataChannel) const override {
+        if (!allowExternalDataChannel) {
+            return {};
+        }
+        TEventSerializationInfo info;
+        info.Sections.push_back(TEventSectionInfo{0, Payload.size(), 0, 0, false, true});
+        return info;
+    }
+
+    ui32 CalculateSerializedSize() const override {
+        return Payload.size();
+    }
+
+    bool IsSerializable() const override {
+        return true;
+    }
+};
+
+inline void GTestSkip() {
+    GTEST_SKIP() << "Skipping all rdma tests for suite, set \""
+                 << NRdmaTest::RdmaTestEnvSwitchName << "\" env if it is RDMA compatible";
+}
+
+class XdcRdmaTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        using namespace NRdmaTest;
+        if (NRdmaTest::IsRdmaTestDisabled()) {
+            GTestSkip();
+        }
+    }
+};
+
+class RdmaSendReceiveTestCqMode : public ::testing::TestWithParam<NInterconnect::NRdma::ECqMode> {
+public:
+    void SetUp() override {
+        using namespace NRdmaTest;
+        if (IsRdmaTestDisabled()) {
+            GTestSkip();
+        }
+    }
+};
+
+struct TRdmaTransportTestParams {
+    NInterconnect::NRdma::ECqMode CqMode = NInterconnect::NRdma::ECqMode::EVENT;
+    bool EnableSendReceive = false;
+};
+
+class XdcRdmaTransportTest : public ::testing::TestWithParam<TRdmaTransportTestParams> {
+public:
+    void SetUp() override {
+        using namespace NRdmaTest;
+        if (IsRdmaTestDisabled()) {
+            GTestSkip();
+        }
+    }
+};
+
+// These tests retain SlotMemPool-backed payloads before main-channel metadata is serialized.
+// Keep them on TCP main until RDMA control-buffer allocation guarantees forward progress under pool pressure.
+class XdcRdmaPoolPressureTest : public XdcRdmaTransportTest {
+};
+
+class TSendActor: public TActorBootstrapped<TSendActor> {
+public:
+    struct TExtCtx {
+        std::atomic<bool> Undelivered = false;
+        bool WaitForUndelivered(ui32 maxAttempt) {
+            while (Undelivered.load(std::memory_order_relaxed) == false && maxAttempt) {
+                Sleep(TDuration::MilliSeconds(1000));
+                maxAttempt--;
+            }
+            return Undelivered.load(std::memory_order_relaxed);
+        }
+    };
+
+    TSendActor(TActorId recipient, std::unique_ptr<IEventBase>&& ev, std::shared_ptr<TExtCtx> ctx = nullptr)
+        : Recipient(recipient)
+        , Event(std::move(ev))
+        , Ctx(ctx)
+    {}
+
+    void Bootstrap() {
+        Send(Recipient, std::move(Event), IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
+        Become(&TSendActor::StateResolve);
+    }
+
+    void HandleUndelivered() {
+        if (Ctx) {
+            Ctx->Undelivered.store(true);
+        }
+    }
+
+    STATEFN(StateResolve) {
+        switch (ev->GetTypeRewrite()) {
+            cFunc(TEvents::TEvUndelivered::EventType, HandleUndelivered);
+            cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, HandleUndelivered);
+        }
+    }
+
+private:
+    TActorId Recipient;
+    std::unique_ptr<IEventBase> Event;
+    std::shared_ptr<TExtCtx> Ctx;
+};
+
+class TReceiveActor: public TActorBootstrapped<TReceiveActor> {
+public:
+    TReceiveActor(std::function<void(TEvTestSerialization::TPtr)> check)
+        : Check(check)
+    {}
+
+    void Bootstrap() {
+        Become(&TReceiveActor::StateFunc);
+    }
+    void Handle(TEvTestSerialization::TPtr& ev) {
+        Check(ev);
+        ReceivedEvents.fetch_add(1, std::memory_order_relaxed);
+    }
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvTestSerialization, Handle);
+    )
+public:
+    std::atomic<ui32> ReceivedEvents = 0;
+    bool WaitForReceive(ui32 expected, ui32 maxAttempt) {
+        while (ReceivedEvents.load(std::memory_order_relaxed) != expected && maxAttempt) {
+            Sleep(TDuration::MilliSeconds(1000));
+            maxAttempt--;
+        }
+        auto received = ReceivedEvents.load(std::memory_order_relaxed);
+        if (received != expected) {
+            Cerr << "received != expected " << received << " " << expected << Endl;
+        }
+        return received == expected;
+    }
+private:
+    std::function<void(TEvTestSerialization::TPtr)> Check;
+};
+
+struct TEventsForTest {
+    std::vector<std::unique_ptr<IEventBase>> Events;
+    std::unordered_map<ui64, std::function<void(TEvTestSerialization*)>> Checks;
+    NMonitoring::TDynamicCounterPtr Counters;
+    std::shared_ptr<NInterconnect::NRdma::IMemPool> MemPool;
+
+    TEventsForTest(ui32 numEvents, bool shuffle = false)
+        : Counters(new NMonitoring::TDynamicCounters())
+        , MemPool(NInterconnect::NRdma::CreateSlotMemPool(Counters.Get(), {}))
+    {
+        Generate(numEvents, MemPool.get(), shuffle);
+    }
+
+    void Generate(ui32 numEvents, NInterconnect::NRdma::IMemPool* memPool, bool shuffle = false) {
+        for (ui32 i = 0; i < numEvents; ++i) {
+            const bool isInline = i % 3 == 0;
+            const bool isXdc = i % 3 == 1;
+            const bool isRdma = i % 3 == 2;
+            ui32 numPayloads = i % 5 + (isXdc || isRdma);
+            ui32 sz = 5000;
+            if (i % 128 == 127) {
+                numPayloads += 500;
+                sz = 512;
+            }
+
+            auto ev = std::make_unique<TEvTestSerialization>();
+            ev->Record.SetBlobID(i);
+            ev->Record.SetBuffer(TStringBuilder{} << "hello world " << i);
+            for (ui32 j = 0; j < numPayloads; ++j) {
+                if (isInline) {
+                    ev->AddPayload(TRope(TString(10 + j, j + i)));
+                } else if (isXdc) {
+                    ev->AddPayload(TRope(TString(sz + j, j + i)));
+                } else if (isRdma) {
+                    auto buf = memPool->AllocRcBuf(sz + j, 0).value();
+                    Y_ABORT_UNLESS(buf);
+                    std::fill(buf.GetDataMut(), buf.GetDataMut() + sz + j, j + i);
+                    ev->AddPayload(TRope(std::move(buf)));
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), sz + j);
+                }
+            }
+            if (shuffle) {
+                for (ui32 j = 0; j < numPayloads; ++j) {
+                    ev->AddPayload(TRope(TString(10 + j, j + i)));
+                    ev->AddPayload(TRope(TString(5000 + j, j + i)));
+                    auto buf = memPool->AllocRcBuf(5000 + j, 0).value();
+                    std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000 + j, j + i);
+                    ev->AddPayload(TRope(std::move(buf)));
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), 5000 + j);
+                }
+            }
+
+            if (isXdc || isRdma) {
+                UNIT_ASSERT(ev->AllowExternalDataChannel());
+            }
+
+            Events.push_back(std::move(ev));
+
+            Checks.emplace(i, [i, numPayloads, isInline, sz, shuffle](TEvTestSerialization* ev) {
+                UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBlobID(), i);
+                UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBuffer(), TStringBuilder{} << "hello world " << i);
+                UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads * (shuffle ? 4 : 1));
+                for (ui32 j = 0; j < numPayloads; ++j) {
+                    ui32 payloadSize = isInline ? 10 + j : sz + j;
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].GetSize(), payloadSize);
+                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].ConvertToString(), TString(payloadSize, j + i));
+                }
+            });
+
+        }
+
+        std::random_shuffle(Events.begin(), Events.end());
+    }
+};
+
+inline TEvTestSerialization* MakeMultiGlueTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool* memPool) {
+    auto ev = new TEvTestSerialization();
+    ev->Record.SetBlobID(blobId);
+    ev->Record.SetBuffer("hello world");
+    auto buf = memPool->AllocRcBuf(5000, 0).value();
+    auto b = buf.data();
+    TRcBuf rcbuf1(TRcBuf::Piece, b, b + 500, buf);
+    std::fill(rcbuf1.UnsafeGetDataMut(), rcbuf1.UnsafeGetDataMut() + 500, 'X');
+    TRcBuf rcbuf2(TRcBuf::Piece, b + 500, b + 2000, buf);
+    std::fill(rcbuf2.UnsafeGetDataMut(), rcbuf2.UnsafeGetDataMut() + 1500, 'Y');
+    TRcBuf rcbuf3(TRcBuf::Piece, b + 2000, b + 5000, buf);
+    std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 3000, 'Z');
+    ev->AddPayload(TRcBuf(std::move(rcbuf1)));
+    ev->AddPayload(TRcBuf(std::move(rcbuf2)));
+    ev->AddPayload(TRcBuf(std::move(rcbuf3)));
+
+    bool done = ev->AllowExternalDataChannel();
+    UNIT_ASSERT_VALUES_EQUAL(done, true);
+    return ev;
+}
+
+inline TEvTestSerialization* MakeTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool* memPool = nullptr, bool withGlue = false, bool withOffset = false) {
+    auto ev = new TEvTestSerialization();
+    ev->Record.SetBlobID(blobId);
+    ev->Record.SetBuffer("hello world");
+    if (!memPool) {
+        TRope tmp(TString(5000, 'X'));
+        if (withOffset) {
+            tmp.Insert(tmp.End(), TRope(TString(999, 'Z')));
+        }
+        ev->AddPayload(std::move(tmp));
+    } else {
+        auto buf = memPool->AllocRcBuf(5000, 0).value();
+        // TRope can "glue" rcbufs if they have the same backend and are placed in contiguous memory regions.
+        if (withGlue) {
+            auto b = buf.data();
+            TRcBuf rcbuf1(TRcBuf::Piece, b, b + 2500, buf);
+            std::fill(rcbuf1.UnsafeGetDataMut(), rcbuf1.UnsafeGetDataMut() + 2500, 'X');
+            TRcBuf rcbuf2(TRcBuf::Piece, b + 2500, b + 5000, buf);
+            std::fill(rcbuf2.UnsafeGetDataMut(), rcbuf2.UnsafeGetDataMut() + 2500, 'X');
+            TRope rope1(std::move(rcbuf1));
+            if (withOffset) {
+                TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
+                std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
+                rope1.Insert(rope1.Begin(), TRope(std::move(rcbuf3)));
+            }
+            ev->AddPayload(std::move(rope1));
+            TRope tmp(std::move(rcbuf2));
+            if (withOffset) {
+                TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
+                std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
+                tmp.Insert(tmp.End(), TRope(std::move(rcbuf3)));
+            }
+            ev->AddPayload(std::move(tmp));
+            {
+                auto it = ev->GetPayload().rbegin();
+                UNIT_ASSERT_VALUES_EQUAL(it->size(), withOffset ? 3499u : 2500u);
+                it++;
+                UNIT_ASSERT_VALUES_EQUAL(it->size(), withOffset ? 3499u : 2500u);
+            }
+        } else {
+            std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000, 'X');
+            TRope tmp(std::move(buf));
+            if (withOffset) {
+                TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
+                std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
+                tmp.Insert(tmp.End(), TRope(std::move(rcbuf3)));
+            }
+            ev->AddPayload(std::move(tmp));
+            UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), withOffset ? 5999u : 5000u);
+        }
+    }
+    bool done = ev->AllowExternalDataChannel();
+    UNIT_ASSERT_VALUES_EQUAL(done, true);
+    return ev;
+}
+
+inline bool WaitForRdmaChecksumStatus(TTestICCluster& cluster, ui32 me, ui32 peer, const TString& expected, ui32 maxAttempt,
+        TString& lastStatus)
+{
+    while (maxAttempt--) {
+        try {
+            lastStatus = GetRdmaChecksumStatus(cluster, me, peer);
+            if (lastStatus == expected) {
+                return true;
+            }
+        } catch (const TPatternNotFound&) {
+            lastStatus.clear();
+        }
+        Sleep(TDuration::Seconds(1));
+    }
+    return false;
+}
+
+inline bool WaitForRdmaSessionDropOrStatus(TTestICCluster& cluster, ui32 me, ui32 peer, const TString& expected, ui32 maxAttempt,
+        TString& lastStatus)
+{
+    ui32 missingAttempts = 0;
+    while (maxAttempt--) {
+        try {
+            lastStatus = GetRdmaChecksumStatus(cluster, me, peer);
+            missingAttempts = 0;
+            if (lastStatus == expected) {
+                return true;
+            }
+        } catch (const TPatternNotFound&) {
+            lastStatus.clear();
+            if (++missingAttempts >= 2) {
+                return true;
+            }
+        }
+        Sleep(TDuration::Seconds(1));
+    }
+    return false;
+}
+
+inline TString FormatLastRdmaStatus(const TString& status) {
+    return status.empty() ? TString("<no session>") : status;
+}
+
+inline ui64 GetSessionCounter(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name) {
+    const TString start = TStringBuilder() << "<tr><td>" << name << "</td><td>";
+    return FromString<ui64>(ExtractPattern(cluster, me, peer, start, "<"));
+}
+
+inline ui64 WaitForSessionCounter(TTestICCluster& cluster, ui32 me, ui32 peer, TStringBuf name,
+        TDuration timeout = TDuration::Seconds(10)) {
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        try {
+            return GetSessionCounter(cluster, me, peer, name);
+        } catch (const TPatternNotFound&) {
+            Sleep(TDuration::MilliSeconds(100));
+        }
+    }
+    return GetSessionCounter(cluster, me, peer, name);
+}
+
+struct TCounterSumConsumer : NMonitoring::ICountableConsumer {
+    const TString CounterName;
+    ui64 Sum = 0;
+
+    explicit TCounterSumConsumer(TStringBuf counterName)
+        : CounterName(counterName)
+    {}
+
+    void OnCounter(const TString& /*labelName*/, const TString& labelValue,
+            const NMonitoring::TCounterForPtr* counter) override {
+        if (labelValue == CounterName) {
+            Sum += counter->Val();
+        }
+    }
+
+    void OnHistogram(const TString& /*labelName*/, const TString& /*labelValue*/,
+            NMonitoring::IHistogramSnapshotPtr /*snapshot*/, bool /*derivative*/) override {
+    }
+
+    void OnGroupBegin(const TString& /*labelName*/, const TString& /*labelValue*/,
+            const NMonitoring::TDynamicCounters* /*group*/) override {
+    }
+
+    void OnGroupEnd(const TString& /*labelName*/, const TString& /*labelValue*/,
+            const NMonitoring::TDynamicCounters* /*group*/) override {
+    }
+};
+
+inline ui64 GetNodeCounterSum(TTestICCluster& cluster, ui32 nodeId, TStringBuf counterName) {
+    const auto nodeCounters = cluster.GetCounters()->FindSubgroup("nodeId", ToString(nodeId));
+    if (!nodeCounters) {
+        return 0;
+    }
+
+    TCounterSumConsumer consumer(counterName);
+    nodeCounters->Accept({}, {}, consumer);
+    return consumer.Sum;
+}
+
+inline bool WaitForNodeCounterSum(TTestICCluster& cluster, ui32 nodeId, TStringBuf counterName, ui64 expected,
+        TDuration timeout, ui64& lastValue) {
+    const TInstant deadline = TInstant::Now() + timeout;
+    while (TInstant::Now() < deadline) {
+        lastValue = GetNodeCounterSum(cluster, nodeId, counterName);
+        if (lastValue == expected) {
+            return true;
+        }
+        Sleep(TDuration::MilliSeconds(100));
+    }
+    return false;
+}
+
+class TWaitForConnectionActor: public TActorBootstrapped<TWaitForConnectionActor> {
+public:
+    TWaitForConnectionActor(ui32 peerNodeId, NThreading::TPromise<bool> promise, ui32 attempts)
+        : PeerNodeId(peerNodeId)
+        , Promise(std::move(promise))
+        , AttemptsLeft(attempts)
+    {}
+
+    void Bootstrap() {
+        Become(&TWaitForConnectionActor::StateFunc);
+        SendConnect();
+    }
+
+private:
+    void SendConnect() {
+        if (!AttemptsLeft) {
+            return Finish(false);
+        }
+        --AttemptsLeft;
+        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvInterconnect::TEvConnectNode);
+    }
+
+    void Finish(bool connected) {
+        Promise.SetValue(connected);
+        PassAway();
+    }
+
+    void Handle(TEvInterconnect::TEvNodeConnected::TPtr&) {
+        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvents::TEvUnsubscribe);
+        Finish(true);
+    }
+
+    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr&) {
+        Schedule(TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
+    }
+
+    void Handle(TEvents::TEvWakeup::TPtr&) {
+        SendConnect();
+    }
+
+    STRICT_STFUNC(StateFunc,
+        hFunc(TEvInterconnect::TEvNodeConnected, Handle);
+        hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
+        hFunc(TEvents::TEvWakeup, Handle);
+    )
+
+private:
+    const ui32 PeerNodeId;
+    NThreading::TPromise<bool> Promise;
+    ui32 AttemptsLeft;
+};
+
+inline void WaitForInterconnectConnection(TTestICCluster& cluster, ui32 fromNode, ui32 toNode) {
+    auto promise = NThreading::NewPromise<bool>();
+    auto future = promise.GetFuture();
+    cluster.RegisterActor(new TWaitForConnectionActor(toNode, std::move(promise), 200), fromNode);
+
+    const bool connected = future.Wait(TDuration::Seconds(30)) && future.GetValueSync();
+    UNIT_ASSERT_C(connected, "failed to establish interconnect session from node " << fromNode << " to node " << toNode);
+}
+
+inline TTestICCluster::Flags GetRdmaCqModeFlags(NInterconnect::NRdma::ECqMode cqMode) {
+    return cqMode == NInterconnect::NRdma::ECqMode::POLLING
+        ? TTestICCluster::RDMA_POLLING_CQ
+        : TTestICCluster::EMPTY;
+}
+
+inline TTestICCluster::Flags GetRdmaCqModeFlags(const TRdmaTransportTestParams& params) {
+    return GetRdmaCqModeFlags(params.CqMode);
+}
+
+inline void EnableRdmaSendReceive(ui32, TInterconnectSettings& settings) {
+    settings.EnableRdmaSendReceive = true;
+}
+
+inline std::function<void(ui32, TInterconnectSettings&)> GetRdmaSettingsCustomizer(
+        const TRdmaTransportTestParams& params) {
+    return params.EnableSendReceive
+        ? std::function<void(ui32, TInterconnectSettings&)>(EnableRdmaSendReceive)
+        : std::function<void(ui32, TInterconnectSettings&)>();
+}
+
+inline std::string FormatRdmaCqMode(NInterconnect::NRdma::ECqMode cqMode) {
+    switch (cqMode) {
+        case NInterconnect::NRdma::ECqMode::POLLING:
+            return "POLLING";
+        case NInterconnect::NRdma::ECqMode::EVENT:
+            return "EVENT";
+    }
+    Y_ABORT("unexpected RDMA CQ mode");
+}
+
+inline std::string FormatRdmaTransportParam(const TRdmaTransportTestParams& params) {
+    return FormatRdmaCqMode(params.CqMode) + (params.EnableSendReceive ? "_SendReceive" : "_TcpMain");
+}
+
+inline TString GetExpectedRdmaStatus(const TRdmaTransportTestParams& params) {
+    return params.EnableSendReceive
+        ? TString("On | SoftwareChecksum | SendReceive")
+        : TString("On | SoftwareChecksum");
+}

--- a/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
+++ b/ydb/library/actors/interconnect/ut_rdma/rdma_xdc_ut.cpp
@@ -1,469 +1,4 @@
-#include <ydb/library/actors/core/event_pb.h>
-#include <ydb/library/actors/core/actorsystem.h>
-#include <ydb/library/actors/interconnect/rdma/ut/utils/utils.h>
-#include <ydb/library/actors/interconnect/rdma/mem_pool.h>
-
-#include <library/cpp/monlib/dynamic_counters/counters.h>
-#include <library/cpp/testing/gtest/gtest.h>
-
-#include <ydb/library/actors/interconnect/ut/protos/interconnect_test.pb.h>
-#include <ydb/library/actors/interconnect/ut/lib/ic_test_cluster.h>
-#include <ydb/library/actors/interconnect/channel_scheduler.h>
-#include <ydb/library/actors/interconnect/events_local.h>
-
-#include <ydb/library/testlib/unittest_gtest_macro_subst.h>
-
-using namespace NActors;
-
-struct TEvTestSerialization : public TEventPB<TEvTestSerialization, NInterconnectTest::TEvTestSerialization, 123> {};
-
-struct TEvSerializeToRopeFailure : public TEventBase<TEvSerializeToRopeFailure, 124> {
-    TString Payload;
-    mutable ui32 SerializeToRopeCallCount = 0;
-
-    explicit TEvSerializeToRopeFailure(size_t payloadSize = 5000)
-        : Payload(payloadSize, 'R')
-    {}
-
-    TString ToStringHeader() const override {
-        return "TEvSerializeToRopeFailure";
-    }
-
-    bool SerializeToArcadiaStream(TChunkSerializer* serializer) const override {
-        return serializer->WriteString(&Payload);
-    }
-
-    std::optional<TRope> SerializeToRope(IRcBufAllocator*) const override {
-        ++SerializeToRopeCallCount;
-        return std::nullopt;
-    }
-
-    TEventSerializationInfo CreateSerializationInfo(bool allowExternalDataChannel) const override {
-        if (!allowExternalDataChannel) {
-            return {};
-        }
-        TEventSerializationInfo info;
-        info.Sections.push_back(TEventSectionInfo{0, Payload.size(), 0, 0, false, true});
-        return info;
-    }
-
-    ui32 CalculateSerializedSize() const override {
-        return Payload.size();
-    }
-
-    bool IsSerializable() const override {
-        return true;
-    }
-};
-
-static void GTestSkip() {
-    GTEST_SKIP() << "Skipping all rdma tests for suite, set \""
-                 << NRdmaTest::RdmaTestEnvSwitchName << "\" env if it is RDMA compatible";
-}
-
-class XdcRdmaTest : public ::testing::Test {
-public:
-    void SetUp() override {
-        using namespace NRdmaTest;
-        if (NRdmaTest::IsRdmaTestDisabled()) {
-            GTestSkip();
-        }
-    }
-};
-
-class XdcRdmaTestCqMode : public ::testing::TestWithParam<NInterconnect::NRdma::ECqMode> {
-public:
-    void SetUp() override {
-        using namespace NRdmaTest;
-        if (IsRdmaTestDisabled()) {
-            GTestSkip();
-        }
-    }
-};
-
-class TSendActor: public TActorBootstrapped<TSendActor> {
-public:
-    struct TExtCtx {
-        std::atomic<bool> Undelivered = false;
-        bool WaitForUndelivered(ui32 maxAttempt) {
-            while (Undelivered.load(std::memory_order_relaxed) == false && maxAttempt) {
-                Sleep(TDuration::MilliSeconds(1000));
-                maxAttempt--;
-            }
-            return Undelivered.load(std::memory_order_relaxed);
-        }
-    };
-
-    TSendActor(TActorId recipient, std::unique_ptr<IEventBase>&& ev, std::shared_ptr<TExtCtx> ctx = nullptr)
-        : Recipient(recipient)
-        , Event(std::move(ev))
-        , Ctx(ctx)
-    {}
-
-    void Bootstrap() {
-        Send(Recipient, std::move(Event), IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
-        Become(&TSendActor::StateResolve);
-    }
-
-    void HandleUndelivered() {
-        if (Ctx) {
-            Ctx->Undelivered.store(true);
-        }
-    }
-
-    STATEFN(StateResolve) {
-        switch (ev->GetTypeRewrite()) {
-            cFunc(TEvents::TEvUndelivered::EventType, HandleUndelivered);
-            cFunc(TEvInterconnect::TEvNodeDisconnected::EventType, HandleUndelivered);
-        }
-    }
-
-private:
-    TActorId Recipient;
-    std::unique_ptr<IEventBase> Event;
-    std::shared_ptr<TExtCtx> Ctx;
-};
-
-class TReceiveActor: public TActorBootstrapped<TReceiveActor> {
-public:
-    TReceiveActor(std::function<void(TEvTestSerialization::TPtr)> check)
-        : Check(check)
-    {}
-
-    void Bootstrap() {
-        Become(&TReceiveActor::StateFunc);
-    }
-    void Handle(TEvTestSerialization::TPtr& ev) {
-        Check(ev);
-        ReceivedEvents.fetch_add(1, std::memory_order_relaxed);
-    }
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvTestSerialization, Handle);
-    )
-public:
-    std::atomic<ui32> ReceivedEvents = 0;
-    bool WaitForReceive(ui32 expected, ui32 maxAttempt) {
-        while (ReceivedEvents.load(std::memory_order_relaxed) != expected && maxAttempt) {
-            Sleep(TDuration::MilliSeconds(1000));
-            maxAttempt--;
-        }
-        auto received = ReceivedEvents.load(std::memory_order_relaxed);
-        if (received != expected) {
-            Cerr << "received != expected " << received << " " << expected << Endl;
-        }
-        return received == expected;
-    }
-private:
-    std::function<void(TEvTestSerialization::TPtr)> Check;
-};
-
-struct TEventsForTest {
-    std::vector<std::unique_ptr<IEventBase>> Events;
-    std::unordered_map<ui64, std::function<void(TEvTestSerialization*)>> Checks;
-    NMonitoring::TDynamicCounterPtr Counters;
-    std::shared_ptr<NInterconnect::NRdma::IMemPool> MemPool;
-
-    TEventsForTest(ui32 numEvents, bool shuffle = false)
-        : Counters(new NMonitoring::TDynamicCounters())
-        , MemPool(NInterconnect::NRdma::CreateSlotMemPool(Counters.Get(), {}))
-    {
-        Generate(numEvents, MemPool.get(), shuffle);
-    }
-
-    void Generate(ui32 numEvents, NInterconnect::NRdma::IMemPool* memPool, bool shuffle = false) {
-        for (ui32 i = 0; i < numEvents; ++i) {
-            const bool isInline = i % 3 == 0;
-            const bool isXdc = i % 3 == 1;
-            const bool isRdma = i % 3 == 2;
-            ui32 numPayloads = i % 5 + (isXdc || isRdma);
-            ui32 sz = 5000;
-            if (i % 128 == 127) {
-                numPayloads += 500;
-                sz = 512;
-            }
-
-            auto ev = std::make_unique<TEvTestSerialization>();
-            ev->Record.SetBlobID(i);
-            ev->Record.SetBuffer(TStringBuilder{} << "hello world " << i);
-            for (ui32 j = 0; j < numPayloads; ++j) {
-                if (isInline) {
-                    ev->AddPayload(TRope(TString(10 + j, j + i)));
-                } else if (isXdc) {
-                    ev->AddPayload(TRope(TString(sz + j, j + i)));
-                } else if (isRdma) {
-                    auto buf = memPool->AllocRcBuf(sz + j, 0).value();
-                    Y_ABORT_UNLESS(buf);
-                    std::fill(buf.GetDataMut(), buf.GetDataMut() + sz + j, j + i);
-                    ev->AddPayload(TRope(std::move(buf)));
-                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), sz + j);
-                }
-            }
-            if (shuffle) {
-                for (ui32 j = 0; j < numPayloads; ++j) {
-                    ev->AddPayload(TRope(TString(10 + j, j + i)));
-                    ev->AddPayload(TRope(TString(5000 + j, j + i)));
-                    auto buf = memPool->AllocRcBuf(5000 + j, 0).value();
-                    std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000 + j, j + i);
-                    ev->AddPayload(TRope(std::move(buf)));
-                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), 5000 + j);
-                }
-            }
-
-            if (isXdc || isRdma) {
-                UNIT_ASSERT(ev->AllowExternalDataChannel());
-            }
-
-            Events.push_back(std::move(ev));
-
-            Checks.emplace(i, [i, numPayloads, isInline, sz, shuffle](TEvTestSerialization* ev) {
-                UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBlobID(), i);
-                UNIT_ASSERT_VALUES_EQUAL(ev->Record.GetBuffer(), TStringBuilder{} << "hello world " << i);
-                UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().size(), numPayloads * (shuffle ? 4 : 1));
-                for (ui32 j = 0; j < numPayloads; ++j) {
-                    ui32 payloadSize = isInline ? 10 + j : sz + j;
-                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].GetSize(), payloadSize);
-                    UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload()[j].ConvertToString(), TString(payloadSize, j + i));
-                }
-            });
-
-        }
-
-        std::random_shuffle(Events.begin(), Events.end());
-    }
-};
-
-TEvTestSerialization* MakeMultiGlueTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool* memPool) {
-    auto ev = new TEvTestSerialization();
-    ev->Record.SetBlobID(blobId);
-    ev->Record.SetBuffer("hello world");
-    auto buf = memPool->AllocRcBuf(5000, 0).value();
-    auto b = buf.data();
-    TRcBuf rcbuf1(TRcBuf::Piece, b, b + 500, buf);
-    std::fill(rcbuf1.UnsafeGetDataMut(), rcbuf1.UnsafeGetDataMut() + 500, 'X');
-    TRcBuf rcbuf2(TRcBuf::Piece, b + 500, b + 2000, buf);
-    std::fill(rcbuf2.UnsafeGetDataMut(), rcbuf2.UnsafeGetDataMut() + 1500, 'Y');
-    TRcBuf rcbuf3(TRcBuf::Piece, b + 2000, b + 5000, buf);
-    std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 3000, 'Z');
-    ev->AddPayload(TRcBuf(std::move(rcbuf1)));
-    ev->AddPayload(TRcBuf(std::move(rcbuf2)));
-    ev->AddPayload(TRcBuf(std::move(rcbuf3)));
-
-    bool done = ev->AllowExternalDataChannel();
-    UNIT_ASSERT_VALUES_EQUAL(done, true); 
-    return ev;
-}
-
-TEvTestSerialization* MakeTestEvent(ui64 blobId, NInterconnect::NRdma::IMemPool* memPool = nullptr, bool withGlue = false, bool withOffset = false) {
-    auto ev = new TEvTestSerialization();
-    ev->Record.SetBlobID(blobId);
-    ev->Record.SetBuffer("hello world");
-    if (!memPool) {
-        TRope tmp(TString(5000, 'X'));
-        if (withOffset) {
-            tmp.Insert(tmp.End(), TRope(TString(999, 'Z')));
-        }
-        ev->AddPayload(std::move(tmp));
-    } else {
-        auto buf = memPool->AllocRcBuf(5000, 0).value();
-        // TRope can "glue" rcbufs if they have the same backend and are placed in contiguous memory regions.
-        if (withGlue) {
-            auto b = buf.data();
-            TRcBuf rcbuf1(TRcBuf::Piece, b, b + 2500, buf);
-            std::fill(rcbuf1.UnsafeGetDataMut(), rcbuf1.UnsafeGetDataMut() + 2500, 'X');
-            TRcBuf rcbuf2(TRcBuf::Piece, b + 2500, b + 5000, buf);
-            std::fill(rcbuf2.UnsafeGetDataMut(), rcbuf2.UnsafeGetDataMut() + 2500, 'X');
-            TRope rope1(std::move(rcbuf1));
-            if (withOffset) {
-                TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
-                std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
-                rope1.Insert(rope1.Begin(), TRope(std::move(rcbuf3)));
-            }
-            ev->AddPayload(std::move(rope1));
-            TRope tmp(std::move(rcbuf2));
-            if (withOffset) {
-                TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
-                std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
-                tmp.Insert(tmp.End(), TRope(std::move(rcbuf3)));
-            }
-            ev->AddPayload(std::move(tmp));
-            {
-                auto it = ev->GetPayload().rbegin();
-                UNIT_ASSERT_VALUES_EQUAL(it->size(), withOffset ? 3499u : 2500u);
-                it++;
-                UNIT_ASSERT_VALUES_EQUAL(it->size(), withOffset ? 3499u : 2500u);
-            }
-        } else {
-            std::fill(buf.GetDataMut(), buf.GetDataMut() + 5000, 'X');
-            TRope tmp(std::move(buf));
-            if (withOffset) {
-                TRcBuf rcbuf3 = memPool->AllocRcBuf(999, 0).value();
-                std::fill(rcbuf3.UnsafeGetDataMut(), rcbuf3.UnsafeGetDataMut() + 999, 'Z');
-                tmp.Insert(tmp.End(), TRope(std::move(rcbuf3)));
-            }
-            ev->AddPayload(std::move(tmp));
-            UNIT_ASSERT_VALUES_EQUAL(ev->GetPayload().back().size(), withOffset ? 5999u : 5000u);
-        }
-    }
-    bool done = ev->AllowExternalDataChannel();
-    UNIT_ASSERT_VALUES_EQUAL(done, true);
-    return ev;
-}
-
-static bool WaitForRdmaChecksumStatus(TTestICCluster& cluster, ui32 me, ui32 peer, const TString& expected, ui32 maxAttempt,
-        TString& lastStatus)
-{
-    while (maxAttempt--) {
-        try {
-            lastStatus = GetRdmaChecksumStatus(cluster, me, peer);
-            if (lastStatus == expected) {
-                return true;
-            }
-        } catch (const TPatternNotFound&) {
-            lastStatus.clear();
-        }
-        Sleep(TDuration::Seconds(1));
-    }
-    return false;
-}
-
-static bool WaitForRdmaSessionDropOrStatus(TTestICCluster& cluster, ui32 me, ui32 peer, const TString& expected, ui32 maxAttempt,
-        TString& lastStatus)
-{
-    ui32 missingAttempts = 0;
-    while (maxAttempt--) {
-        try {
-            lastStatus = GetRdmaChecksumStatus(cluster, me, peer);
-            missingAttempts = 0;
-            if (lastStatus == expected) {
-                return true;
-            }
-        } catch (const TPatternNotFound&) {
-            lastStatus.clear();
-            if (++missingAttempts >= 2) {
-                return true;
-            }
-        }
-        Sleep(TDuration::Seconds(1));
-    }
-    return false;
-}
-
-static TString FormatLastRdmaStatus(const TString& status) {
-    return status.empty() ? TString("<no session>") : status;
-}
-
-struct TCounterSumConsumer : NMonitoring::ICountableConsumer {
-    const TString CounterName;
-    ui64 Sum = 0;
-
-    explicit TCounterSumConsumer(TStringBuf counterName)
-        : CounterName(counterName)
-    {}
-
-    void OnCounter(const TString& /*labelName*/, const TString& labelValue,
-            const NMonitoring::TCounterForPtr* counter) override {
-        if (labelValue == CounterName) {
-            Sum += counter->Val();
-        }
-    }
-
-    void OnHistogram(const TString& /*labelName*/, const TString& /*labelValue*/,
-            NMonitoring::IHistogramSnapshotPtr /*snapshot*/, bool /*derivative*/) override {
-    }
-
-    void OnGroupBegin(const TString& /*labelName*/, const TString& /*labelValue*/,
-            const NMonitoring::TDynamicCounters* /*group*/) override {
-    }
-
-    void OnGroupEnd(const TString& /*labelName*/, const TString& /*labelValue*/,
-            const NMonitoring::TDynamicCounters* /*group*/) override {
-    }
-};
-
-static ui64 GetNodeCounterSum(TTestICCluster& cluster, ui32 nodeId, TStringBuf counterName) {
-    const auto nodeCounters = cluster.GetCounters()->FindSubgroup("nodeId", ToString(nodeId));
-    if (!nodeCounters) {
-        return 0;
-    }
-
-    TCounterSumConsumer consumer(counterName);
-    nodeCounters->Accept({}, {}, consumer);
-    return consumer.Sum;
-}
-
-static bool WaitForNodeCounterSum(TTestICCluster& cluster, ui32 nodeId, TStringBuf counterName, ui64 expected,
-        TDuration timeout, ui64& lastValue) {
-    const TInstant deadline = TInstant::Now() + timeout;
-    while (TInstant::Now() < deadline) {
-        lastValue = GetNodeCounterSum(cluster, nodeId, counterName);
-        if (lastValue == expected) {
-            return true;
-        }
-        Sleep(TDuration::MilliSeconds(100));
-    }
-    return false;
-}
-
-class TWaitForConnectionActor: public TActorBootstrapped<TWaitForConnectionActor> {
-public:
-    TWaitForConnectionActor(ui32 peerNodeId, NThreading::TPromise<bool> promise, ui32 attempts)
-        : PeerNodeId(peerNodeId)
-        , Promise(std::move(promise))
-        , AttemptsLeft(attempts)
-    {}
-
-    void Bootstrap() {
-        Become(&TWaitForConnectionActor::StateFunc);
-        SendConnect();
-    }
-
-private:
-    void SendConnect() {
-        if (!AttemptsLeft) {
-            return Finish(false);
-        }
-        --AttemptsLeft;
-        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvInterconnect::TEvConnectNode);
-    }
-
-    void Finish(bool connected) {
-        Promise.SetValue(connected);
-        PassAway();
-    }
-
-    void Handle(TEvInterconnect::TEvNodeConnected::TPtr&) {
-        Send(TActivationContext::InterconnectProxy(PeerNodeId), new TEvents::TEvUnsubscribe);
-        Finish(true);
-    }
-
-    void Handle(TEvInterconnect::TEvNodeDisconnected::TPtr&) {
-        Schedule(TDuration::MilliSeconds(100), new TEvents::TEvWakeup);
-    }
-
-    void Handle(TEvents::TEvWakeup::TPtr&) {
-        SendConnect();
-    }
-
-    STRICT_STFUNC(StateFunc,
-        hFunc(TEvInterconnect::TEvNodeConnected, Handle);
-        hFunc(TEvInterconnect::TEvNodeDisconnected, Handle);
-        hFunc(TEvents::TEvWakeup, Handle);
-    )
-
-private:
-    const ui32 PeerNodeId;
-    NThreading::TPromise<bool> Promise;
-    ui32 AttemptsLeft;
-};
-
-static void WaitForInterconnectConnection(TTestICCluster& cluster, ui32 fromNode, ui32 toNode) {
-    auto promise = NThreading::NewPromise<bool>();
-    auto future = promise.GetFuture();
-    cluster.RegisterActor(new TWaitForConnectionActor(toNode, std::move(promise), 200), fromNode);
-
-    const bool connected = future.Wait(TDuration::Seconds(30)) && future.GetValueSync();
-    UNIT_ASSERT_C(connected, "failed to establish interconnect session from node " << fromNode << " to node " << toNode);
-}
+#include "rdma_xdc_test_common.h"
 
 TEST_F(XdcRdmaTest, SerializeToRope) {
     auto common = MakeIntrusive<TInterconnectProxyCommon>();
@@ -641,7 +176,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaUsesIteratorOffsetInsideChunk) {
     TSessionParams p;
     p.UseExternalDataChannel = true;
     p.UseXdcShuffle = true;
-    p.UseRdma = true;
+    p.UseRdmaRead = true;
     TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
 
     constexpr size_t prefixSize = 17;
@@ -779,7 +314,7 @@ TEST_P(XdcRdmaPayloadChecksumTest, RdmaPayloadChecksums) {
     TSessionParams p;
     p.UseExternalDataChannel = true;
     p.UseXdcShuffle = true;
-    p.UseRdma = true;
+    p.UseRdmaRead = true;
     p.ChecksumRdmaEvent = true;
     p.AllowDisablingPayloadChecksums = params.AllowDisablingPayloadChecksums;
     TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
@@ -848,7 +383,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenDeviceIndexIsInvalid) {
     TSessionParams p;
     p.UseExternalDataChannel = true;
     p.UseXdcShuffle = true;
-    p.UseRdma = true;
+    p.UseRdmaRead = true;
     TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
 
     constexpr size_t payloadSize = 128;
@@ -896,7 +431,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenSerializeToRopeFails) {
     TSessionParams p;
     p.UseExternalDataChannel = true;
     p.UseXdcShuffle = true;
-    p.UseRdma = true;
+    p.UseRdmaRead = true;
     TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
 
     auto* ev = new TEvSerializeToRopeFailure();
@@ -935,7 +470,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenChunkIsNotRdmaRegistered) 
     TSessionParams p;
     p.UseExternalDataChannel = true;
     p.UseXdcShuffle = true;
-    p.UseRdma = true;
+    p.UseRdmaRead = true;
     TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
 
     constexpr size_t payloadSize = 128;
@@ -986,7 +521,7 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunk
     TSessionParams p;
     p.UseExternalDataChannel = true;
     p.UseXdcShuffle = true;
-    p.UseRdma = true;
+    p.UseRdmaRead = true;
     TEventOutputChannel channel(1, 1, 64 << 20, ctr, p, memPool);
 
     constexpr size_t rdmaChunkSize = 64;
@@ -1034,8 +569,10 @@ TEST_F(XdcRdmaTest, ShuffleRdmaFallsBackToPushDataWhenRdmaPartContainsMixedChunk
 }
 #endif
 
-TEST_F(XdcRdmaTest, SendRdma) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaTransportTest, SendRdma) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
     std::unique_ptr<IEventBase> ev(MakeTestEvent(123, memPool.get()));
 
@@ -1056,8 +593,10 @@ TEST_F(XdcRdmaTest, SendRdma) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, SendRdmaEmptyProtoRecordWithPayload) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaTransportTest, SendRdmaEmptyProtoRecordWithPayload) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
 
     auto buf = memPool->AllocRcBuf(5000, 0).value();
@@ -1083,12 +622,14 @@ TEST_F(XdcRdmaTest, SendRdmaEmptyProtoRecordWithPayload) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 
     TString lastRdmaStatus;
-    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum", 20, lastRdmaStatus),
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, GetExpectedRdmaStatus(params), 20, lastRdmaStatus),
         "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
 }
 
-TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaTransportTest, SendRdmaWithShuffledPayload) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
     auto ev = std::make_unique<TEvTestSerialization>();
     ev->Record.SetBlobID(123);
@@ -1127,8 +668,10 @@ TEST_F(XdcRdmaTest, SendRdmaWithShuffledPayload) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, SendRdmaWithRegionOffset) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaTransportTest, SendRdmaWithRegionOffset) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateDummyMemPool();
     std::unique_ptr<IEventBase> ev(MakeTestEvent(123, memPool.get(), false, true));
 
@@ -1149,8 +692,10 @@ TEST_F(XdcRdmaTest, SendRdmaWithRegionOffset) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, SendRdmaWithGlueWithRegionOffset) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaTransportTest, SendRdmaWithGlueWithRegionOffset) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
     std::unique_ptr<IEventBase> ev(MakeTestEvent(123, memPool.get(), true, true));
 
@@ -1175,8 +720,10 @@ TEST_F(XdcRdmaTest, SendRdmaWithGlueWithRegionOffset) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, SendRdmaWithGlue) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaTransportTest, SendRdmaWithGlue) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
     std::unique_ptr<IEventBase> ev(MakeTestEvent(123, memPool.get(), true, false));
 
@@ -1199,8 +746,10 @@ TEST_F(XdcRdmaTest, SendRdmaWithGlue) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, SendRdmaWithMultiGlue) {
-    TTestICCluster cluster(2);
+TEST_P(XdcRdmaPoolPressureTest, SendRdmaWithMultiGlue) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(), GetRdmaSettingsCustomizer(params));
     auto memPool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, {});
     std::unique_ptr<IEventBase> ev(MakeMultiGlueTestEvent(123, memPool.get()));
 
@@ -1225,15 +774,17 @@ TEST_F(XdcRdmaTest, SendRdmaWithMultiGlue) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, RestoreRdmaSession) {
+TEST_P(XdcRdmaPoolPressureTest, DISABLED_RestoreRdmaSession) {
+    const auto params = GetParam();
     constexpr TStringBuf RdmaRetryWatchdogPendingSessions = "RdmaRetryWatchdogPendingSessions";
 
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(9999)); //Disable dead peer detection to parallel activity
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(9999), TNode::DefaultInflight(),
+        GetRdmaSettingsCustomizer(params)); //Disable dead peer detection to parallel activity
 
     std::vector<TRcBuf> occupiedBuffers;
 
@@ -1314,7 +865,7 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
 
     // Wait until the delayed RDMA retry closes the TCP-only session, or until RDMA
     // is restored by an already pending reconnect.
-    UNIT_ASSERT_C(WaitForRdmaSessionDropOrStatus(cluster, 2, 1, "On | SoftwareChecksum", 45, lastRdmaStatus),
+    UNIT_ASSERT_C(WaitForRdmaSessionDropOrStatus(cluster, 2, 1, GetExpectedRdmaStatus(params), 45, lastRdmaStatus),
         "last RDMA status before reconnect: " << FormatLastRdmaStatus(lastRdmaStatus));
 
     {
@@ -1324,20 +875,19 @@ TEST_F(XdcRdmaTest, RestoreRdmaSession) {
         cluster.RegisterActor(senderPtr, 2);
     }
     UNIT_ASSERT(receiverPtr->WaitForReceive(3, 20));
-    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, "On | SoftwareChecksum", 30, lastRdmaStatus),
+    UNIT_ASSERT_C(WaitForRdmaChecksumStatus(cluster, 2, 1, GetExpectedRdmaStatus(params), 30, lastRdmaStatus),
         "last RDMA status: " << FormatLastRdmaStatus(lastRdmaStatus));
-    UNIT_ASSERT_STRINGS_EQUAL(lastRdmaStatus.c_str(), "On | SoftwareChecksum");
+    UNIT_ASSERT_STRINGS_EQUAL(lastRdmaStatus.c_str(), GetExpectedRdmaStatus(params).c_str());
     UNIT_ASSERT_C(WaitForNodeCounterSum(cluster, 2, RdmaRetryWatchdogPendingSessions, 0,
             TDuration::Seconds(10), lastWatchdogPending),
         "last RDMA retry watchdog pending sessions: " << lastWatchdogPending);
 }
 
-TEST_P(XdcRdmaTestCqMode, SendMix) {
-    TTestICCluster::Flags flags = TTestICCluster::EMPTY;
-    if (GetParam() == NInterconnect::NRdma::ECqMode::POLLING) {
-        flags = TTestICCluster::RDMA_POLLING_CQ;
-    }
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, flags);
+TEST_P(XdcRdmaTransportTest, SendMix) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Seconds(2), TNode::DefaultInflight(),
+        GetRdmaSettingsCustomizer(params));
 
     ui32 index = 0;
     auto receiverPtr = new TReceiveActor([&index](TEvTestSerialization::TPtr ev) {
@@ -1364,15 +914,12 @@ TEST_P(XdcRdmaTestCqMode, SendMix) {
     UNIT_ASSERT(receiverPtr->WaitForReceive(numEvents, 20));
 }
 
-TEST_P(XdcRdmaTestCqMode, SendMixBig) {
-    TTestICCluster::Flags flags = TTestICCluster::EMPTY;
-    if (GetParam() == NInterconnect::NRdma::ECqMode::POLLING) {
-        flags = TTestICCluster::RDMA_POLLING_CQ;
-    }
+TEST_P(XdcRdmaPoolPressureTest, SendMixBig) {
+    const auto params = GetParam();
     // Heavy payload validation in this test may starve progress long enough to trip default DeadPeer=2s.
     // Use the same relaxed connectivity envelope as SendMixBigShuffle.
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, flags,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     std::mutex mtx;
     mtx.lock();
     TEventsForTest events(500);
@@ -1408,9 +955,10 @@ TEST_P(XdcRdmaTestCqMode, SendMixBig) {
     UNIT_ASSERT_VALUES_EQUAL(events.Checks.size(), 0u);
 }
 
-TEST_F(XdcRdmaTest, SendMixBigShuffle) {
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+TEST_P(XdcRdmaPoolPressureTest, SendMixBigShuffle) {
+    const auto params = GetParam();
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     TEventsForTest events(1000, true);
 
     auto receiverPtr = new TReceiveActor([&events](TEvTestSerialization::TPtr ev) {
@@ -1472,105 +1020,113 @@ static void DoSendHugePayloadsNum(const ui32 numPayloads, const size_t payloadSz
     UNIT_ASSERT(receiverPtr->WaitForReceive(1, 20));
 }
 
-TEST_F(XdcRdmaTest, Send1Payload) {
+TEST_P(XdcRdmaPoolPressureTest, Send1Payload) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(1, 8192, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, Send2Payloads) {
+TEST_P(XdcRdmaPoolPressureTest, Send2Payloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(2, 8192, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, Send250Payloads) {
+TEST_P(XdcRdmaPoolPressureTest, Send250Payloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(250, 512, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, Send500Payloads) {
+TEST_P(XdcRdmaPoolPressureTest, Send500Payloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(500, 512, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, Send4000Payloads) {
+TEST_P(XdcRdmaPoolPressureTest, Send4000Payloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(4000, 512, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, Send16000Payloads) {
+TEST_P(XdcRdmaPoolPressureTest, Send16000Payloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(16000, 512, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, Send32000Payloads) {
+TEST_P(XdcRdmaPoolPressureTest, Send32000Payloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     DoSendHugePayloadsNum(32000, 512, cluster, pool);
 }
 
-TEST_F(XdcRdmaTest, SendXPayloads) {
+TEST_P(XdcRdmaPoolPressureTest, SendXPayloads) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     for (size_t i = 640; i < 650; i++) {
@@ -1578,14 +1134,15 @@ TEST_F(XdcRdmaTest, SendXPayloads) {
     }
 }
 
-TEST_F(XdcRdmaTest, SendXPayloadsWithRandSize) {
+TEST_P(XdcRdmaPoolPressureTest, SendXPayloadsWithRandSize) {
+    const auto params = GetParam();
     const NInterconnect::NRdma::TMemPoolSettings settings {
         .SizeLimitMb = 256
     };
     auto pool = NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
 
-    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, TTestICCluster::Flags::EMPTY,
-        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20);
+    TTestICCluster cluster(2, NActors::TChannelsConfig(), nullptr, nullptr, GetRdmaCqModeFlags(params),
+        TTestICCluster::TCheckerFactory(), TDuration::Minutes(1), 50u << 20, GetRdmaSettingsCustomizer(params));
     WaitForInterconnectConnection(cluster, 2, 1);
 
     for (size_t i = 640; i < 650; i++) {
@@ -1595,21 +1152,30 @@ TEST_F(XdcRdmaTest, SendXPayloadsWithRandSize) {
 
 INSTANTIATE_TEST_SUITE_P(
     XdcRdmaTest,
-    XdcRdmaTestCqMode,
+    XdcRdmaTransportTest,
     ::testing::Values(
-        NInterconnect::NRdma::ECqMode::POLLING,
-        NInterconnect::NRdma::ECqMode::EVENT
+        TRdmaTransportTestParams{NInterconnect::NRdma::ECqMode::POLLING, false},
+        TRdmaTransportTestParams{NInterconnect::NRdma::ECqMode::EVENT, false},
+        TRdmaTransportTestParams{NInterconnect::NRdma::ECqMode::POLLING, true},
+        TRdmaTransportTestParams{NInterconnect::NRdma::ECqMode::EVENT, true}
     ),
-    [](const testing::TestParamInfo<NInterconnect::NRdma::ECqMode>& info) {
+    [](const testing::TestParamInfo<TRdmaTransportTestParams>& info) {
         const NInterconnect::NRdma::TMemPoolSettings settings {
             .SizeLimitMb = 256
         };
         NInterconnect::NRdma::CreateSlotMemPool(nullptr, settings);
-        switch (info.param) {
-            case NInterconnect::NRdma::ECqMode::POLLING:
-                return "POLLING";
-            case NInterconnect::NRdma::ECqMode::EVENT:
-                return "EVENT";
-        }
+        return FormatRdmaTransportParam(info.param);
+    }
+);
+
+INSTANTIATE_TEST_SUITE_P(
+    XdcRdmaTest,
+    XdcRdmaPoolPressureTest,
+    ::testing::Values(
+        TRdmaTransportTestParams{NInterconnect::NRdma::ECqMode::POLLING, false},
+        TRdmaTransportTestParams{NInterconnect::NRdma::ECqMode::EVENT, false}
+    ),
+    [](const testing::TestParamInfo<TRdmaTransportTestParams>& info) {
+        return FormatRdmaTransportParam(info.param);
     }
 );

--- a/ydb/library/actors/interconnect/ut_rdma/ya.make
+++ b/ydb/library/actors/interconnect/ut_rdma/ya.make
@@ -11,7 +11,8 @@ ENDIF()
 
 SRCS(
     port_manager.cpp
-    rdma_xdc_ut.cpp    
+    rdma_send_receive_ut.cpp
+    rdma_xdc_ut.cpp
     sync_actor_ut.cpp
 )
 


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add RDMA SEND/RECEIVE transport for IC main channel

Use negotiated RDMA SEND/RECEIVE support as the transport for the
existing v1 main-channel packet stream. Keep packet framing, serials,
checksums, acknowledgements, and flow control unchanged. Continue using
TCP when either peer does not enable the feature.

Back outgoing streams with registered RDMA memory. Preallocate a full IC
packet before serialization, serialize protobuf data directly into RDMA
memory, retain registered aliased payloads as SG entries, and copy
unregistered aliases into registered buffers. Extend outgoing stream
chunks with memory-region metadata and build SEND SG lists within the
device max_sge limit.

Submit SEND work requests asynchronously and retain referenced memory
regions until completion. Feed received SRQ buffers directly into the
existing packet parser. Reestablish the connection on allocation, post,
completion, or receive failures.

Configure SRQ receive buffers using the full IC packet size. Keep RDMA
READ and XDC behavior independent from the main-channel transport,
including RDMA READ checksum calculation. Preserve early XDC connection
reports while the handshake coroutine waits for other events.

Add RDMA send allocation, completion, received-byte, status, and ping
metrics.

Add coverage for RDMA-backed outgoing streams, aliased and pre-serialized
payloads, SG boundaries, bidirectional traffic, ACK and ping packets,
oversized events, TCP fallback, both CQ modes, and RDMA READ/XDC
combinations.

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
