### PR TITLE
YDB_LOG quotes and escapes text values in text log

### DIFF
--- a/ydb/core/kqp/ut/query/kqp_query_event_log_ut.cpp
+++ b/ydb/core/kqp/ut/query/kqp_query_event_log_ut.cpp
@@ -22,41 +22,6 @@ struct TReqJsonEntry {
     TString Priority;  // "DEBUG" | "WARN" | ...
 };
 
-// The test backend writes records into one continuous blob without `\n`
-// separators, so we extract each [REQ_JSON] object by tracking brace balance
-// with proper string-escape handling.
-size_t FindJsonObjectEnd(TStringBuf data, size_t start) {
-    int depth = 0;
-    bool inStr = false;
-    bool esc = false;
-    for (size_t i = start; i < data.size(); ++i) {
-        const char c = data[i];
-        if (esc) {
-            esc = false;
-            continue;
-        }
-        if (inStr) {
-            if (c == '\\') {
-                esc = true;
-            } else if (c == '"') {
-                inStr = false;
-            }
-            continue;
-        }
-        if (c == '"') {
-            inStr = true;
-        } else if (c == '{') {
-            ++depth;
-        } else if (c == '}') {
-            --depth;
-            if (depth == 0) {
-                return i + 1;
-            }
-        }
-    }
-    return TStringBuf::npos;
-}
-
 // Scan back from `markerPos` to the preceding ":KQP_REQUEST <PRIO>:" token.
 TString ExtractPriority(TStringBuf blob, size_t markerPos) {
     constexpr size_t WINDOW = 256;
@@ -83,20 +48,20 @@ TVector<TReqJsonEntry> CollectReqJson(TStringBuf blob) {
         if (markerPos == TStringBuf::npos) {
             break;
         }
-        const size_t jsonStart = blob.find('{', markerPos + REQ_JSON_MARKER.size());
+        size_t jsonStart = blob.find("=\"{", markerPos + REQ_JSON_MARKER.size());
         if (jsonStart == TStringBuf::npos) {
             break;
         }
-        const size_t jsonEnd = FindJsonObjectEnd(blob, jsonStart);
-        if (jsonEnd == TStringBuf::npos) {
+        jsonStart++;
+        auto extractedJsonStr = NActors::NStructuredLog::TTextWriter::UnescapeFieldValue(TString(blob), jsonStart);
+        if (extractedJsonStr.Empty()) {
             break;
         }
+        pos = jsonStart + 1;
 
         TReqJsonEntry entry;
-        const TStringBuf jsonView = blob.SubStr(jsonStart, jsonEnd - jsonStart);
-        const TString jsonStr(jsonView);
-        if (NJson::ReadJsonTree(jsonStr, &entry.Json, /*throwOnError=*/false)) {
-            entry.RawLine = TString(blob.SubStr(markerPos, jsonEnd - markerPos));
+        if (NJson::ReadJsonTree(extractedJsonStr.GetRef(), &entry.Json, /*throwOnError=*/false)) {
+            entry.RawLine = TString(blob.SubStr(markerPos, jsonStart - markerPos));
             entry.Priority = ExtractPriority(blob, markerPos);
             const auto& req = entry.Json["request"];
             entry.Event = req["event"].GetStringSafe("");
@@ -105,7 +70,6 @@ TVector<TReqJsonEntry> CollectReqJson(TStringBuf blob) {
             entry.Total = entry.Json["total"].GetIntegerSafe(0);
             entries.push_back(std::move(entry));
         }
-        pos = jsonEnd;
     }
     return entries;
 }

--- a/ydb/library/actors/core/ut/log_ut.cpp
+++ b/ydb/library/actors/core/ut/log_ut.cpp
@@ -678,13 +678,13 @@ Y_UNIT_TEST_SUITE(TWriteTextLogTest) {
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", 1});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", 1}, {"value2", 2});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text"});
-        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text\nnew line"}, {"value2", 2});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text\nnew\nline"}, {"value2", 2});
 
         env.FetchMessage("1970-01-01T23:59:50.000000Z :FAKE DEBUG: log_ut.cpp:677: Test message ");
         env.FetchMessage("1970-01-01T23:59:50.000000Z :FAKE DEBUG: log_ut.cpp:678: Test message with data value=1");
         env.FetchMessage("1970-01-01T23:59:50.000000Z :FAKE DEBUG: log_ut.cpp:679: Test message with data value=1 value2=2");
         env.FetchMessage("1970-01-01T23:59:50.000000Z :FAKE DEBUG: log_ut.cpp:680: Test message with data value=text");
-        env.FetchMessage("1970-01-01T23:59:50.000000Z :FAKE DEBUG: log_ut.cpp:681: Test message with data value=text new line value2=2");
+        env.FetchMessage("1970-01-01T23:59:50.000000Z :FAKE DEBUG: log_ut.cpp:681: Test message with data value=\"text\\nnew\\nline\" value2=2");
     }
 }
 
@@ -718,5 +718,22 @@ Y_UNIT_TEST_SUITE(TWriteShortTextLogTest) {
         env.FetchMessage("FAKE: Test message ");
         env.FetchMessage("FAKE: Test message with data value=1");
         env.FetchMessage("FAKE: Test message with data value=1 value2=2");
+    }
+
+    Y_UNIT_TEST(WriteEscaped) {
+        TFixture env{NoBufferSettings()};
+        env.StartAccumulateMessages(TSettings::ELogFormat::PLAIN_SHORT_FORMAT);
+
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text"});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text with space"});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_new_line\n"});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_quotation\""});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_equal="});
+
+        env.FetchMessage("FAKE: Test message with data value=text");
+        env.FetchMessage("FAKE: Test message with data value=\"text with space\"");
+        env.FetchMessage("FAKE: Test message with data value=\"text_with_new_line\\n\"");
+        env.FetchMessage("FAKE: Test message with data value=\"text_with_quotation\\\"\"");
+        env.FetchMessage("FAKE: Test message with data value=\"text_with_equal=\"");
     }
 }

--- a/ydb/library/actors/core/ut/log_ut.cpp
+++ b/ydb/library/actors/core/ut/log_ut.cpp
@@ -727,13 +727,15 @@ Y_UNIT_TEST_SUITE(TWriteShortTextLogTest) {
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text"});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text with space"});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_new_line\n"});
-        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_quotation\""});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_quotation'"});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_double_quotation\""});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_equal="});
 
         env.FetchMessage("FAKE: Test message with data value=text");
         env.FetchMessage("FAKE: Test message with data value=\"text with space\"");
         env.FetchMessage("FAKE: Test message with data value=\"text_with_new_line\\n\"");
-        env.FetchMessage("FAKE: Test message with data value=\"text_with_quotation\\\"\"");
+        env.FetchMessage("FAKE: Test message with data value=\"text_with_quotation'\"");
+        env.FetchMessage("FAKE: Test message with data value=\"text_with_double_quotation\\\"\"");
         env.FetchMessage("FAKE: Test message with data value=\"text_with_equal=\"");
     }
 }

--- a/ydb/library/actors/core/ut/log_ut.cpp
+++ b/ydb/library/actors/core/ut/log_ut.cpp
@@ -730,12 +730,16 @@ Y_UNIT_TEST_SUITE(TWriteShortTextLogTest) {
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_quotation'"});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_double_quotation\""});
         YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", "text_with_equal="});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", R"("QuotedValue")"});
+        YDB_LOG_CTX_COMP(env, PRI_DEBUG, 1, "Test message with data", {"value", R"(\"EscapedQuotedValue\")"});
 
-        env.FetchMessage("FAKE: Test message with data value=text");
-        env.FetchMessage("FAKE: Test message with data value=\"text with space\"");
-        env.FetchMessage("FAKE: Test message with data value=\"text_with_new_line\\n\"");
-        env.FetchMessage("FAKE: Test message with data value=\"text_with_quotation'\"");
-        env.FetchMessage("FAKE: Test message with data value=\"text_with_double_quotation\\\"\"");
-        env.FetchMessage("FAKE: Test message with data value=\"text_with_equal=\"");
+        env.FetchMessage(R"(FAKE: Test message with data value=text)");
+        env.FetchMessage(R"(FAKE: Test message with data value="text with space")");
+        env.FetchMessage(R"(FAKE: Test message with data value="text_with_new_line\n")");
+        env.FetchMessage(R"(FAKE: Test message with data value="text_with_quotation'")");
+        env.FetchMessage(R"(FAKE: Test message with data value="text_with_double_quotation\"")");
+        env.FetchMessage(R"(FAKE: Test message with data value="text_with_equal=")");
+        env.FetchMessage(R"(FAKE: Test message with data value="\"QuotedValue\"")");
+        env.FetchMessage(R"(FAKE: Test message with data value="\\\"EscapedQuotedValue\\\"")");
     }
 }

--- a/ydb/library/actors/core/ut/log_ut.cpp
+++ b/ydb/library/actors/core/ut/log_ut.cpp
@@ -743,3 +743,58 @@ Y_UNIT_TEST_SUITE(TWriteShortTextLogTest) {
         env.FetchMessage(R"(FAKE: Test message with data value="\\\"EscapedQuotedValue\\\"")");
     }
 }
+
+Y_UNIT_TEST_SUITE(TLogEscaping) {
+
+    Y_UNIT_TEST(Escape) {
+        std::vector<std::pair<TString, TString>> samples = {
+            {"text", "text"},
+            {"text with space", "\"text with space\""},
+            {"text with new line\n", "\"text with new line\\n\""},
+            {"text with slash\\", "\"text with slash\\\\\""},
+            {"text with double quote\"", "\"text with double quote\\\"\""}
+        };
+
+        for(const auto& sample: samples) {
+            auto escaped = TTextWriter::EscapeFieldValue(sample.first);
+            UNIT_ASSERT_STRINGS_EQUAL(sample.second, escaped);
+        }
+    }
+
+    Y_UNIT_TEST(Unescape) {
+        struct TSample {
+            TString Escaped;
+            std::string::size_type StartPos;
+            TMaybe<TString> Unescaped;
+            std::string::size_type FinishPos{0};
+        };
+        std::vector<TSample> samples = {
+            {"text", 0, "text", 4},
+            {"text next", 0, "text", 4},
+            {"\"text with space\"", 0, "text with space", 17},
+            {"\"text with space", 0, {}},
+            {"\"unknown escape char\\q", 0, {}},
+            {"\"text with new line\\n\"", 0, "text with new line\n", 22},
+            {"\"text with slash\\\\\"", 0, "text with slash\\", 19},
+            {"\"text with double quote\\\"\"", 0, "text with double quote\"", 26},
+            {"abcd text", 5, "text", 9},
+            {"abcd text next", 5, "text", 9},
+            {"abcd \"text with space\"", 5, "text with space", 22},
+            {"abcd \"text with space", 5, {}},
+            {"abcd \"unknown escape char\\q", 5, {}},
+            {"abcd \"text with new line\\n\"", 5, "text with new line\n", 27},
+            {"abcd \"text with slash\\\\\"", 5, "text with slash\\", 24},
+            {"abcd \"text with double quote\\\"\"", 5, "text with double quote\"", 31}
+        };
+
+        for(const auto& sample: samples) {
+            auto pos = sample.StartPos;
+            auto unescaped = TTextWriter::UnescapeFieldValue(sample.Escaped, pos);
+            UNIT_ASSERT_EQUAL(sample.Unescaped, unescaped);
+            if (unescaped.Defined()) {
+                UNIT_ASSERT_EQUAL(sample.FinishPos, pos);
+            }
+
+        }
+    }
+}

--- a/ydb/library/actors/struct_log/text_writer.cpp
+++ b/ydb/library/actors/struct_log/text_writer.cpp
@@ -38,11 +38,10 @@ void TTextWriter::TValueWriter::operator()(const TString& value) const {
     }
     outputText << "=";
     auto str = TTypesMapping::ToString(value);
-    if (SubstGlobal(str, "\n", "\\n") !=0 ||
-        SubstGlobal(str, "\"", "\\\"") !=0  ||
-        SubstGlobal(str, "'", "\\'") !=0 ||
-        str.Contains(" ") ||
-        str.Contains("=")) {
+    auto substNewLines = SubstGlobal(str, "\n", "\\n");
+    auto substDoubleQuote = SubstGlobal(str, "\"", "\\\"");
+
+    if ( substNewLines!=0 || substDoubleQuote!=0 || str.Contains(" ") || str.Contains("=") || str.Contains("'")) {
         outputText << "\"";
         outputText << str;
         outputText << "\"";

--- a/ydb/library/actors/struct_log/text_writer.cpp
+++ b/ydb/library/actors/struct_log/text_writer.cpp
@@ -38,8 +38,17 @@ void TTextWriter::TValueWriter::operator()(const TString& value) const {
     }
     outputText << "=";
     auto str = TTypesMapping::ToString(value);
-    SubstGlobal(str, "\n", " ");
-    outputText << str;
+    if (SubstGlobal(str, "\n", "\\n") !=0 ||
+        SubstGlobal(str, "\"", "\\\"") !=0  ||
+        SubstGlobal(str, "'", "\\'") !=0 ||
+        str.Contains(" ") ||
+        str.Contains("=")) {
+        outputText << "\"";
+        outputText << str;
+        outputText << "\"";
+    } else {
+        outputText << str;
+    }
 }
 
 }  // namespace NActors::NStructuredLog

--- a/ydb/library/actors/struct_log/text_writer.cpp
+++ b/ydb/library/actors/struct_log/text_writer.cpp
@@ -38,12 +38,15 @@ void TTextWriter::TValueWriter::operator()(const TString& value) const {
     }
     outputText << "=";
     auto str = TTypesMapping::ToString(value);
-    auto substNewLines = SubstGlobal(str, "\n", "\\n");
-    auto substDoubleQuote = SubstGlobal(str, "\"", "\\\"");
-
-    if ( substNewLines!=0 || substDoubleQuote!=0 || str.Contains(" ") || str.Contains("=") || str.Contains("'")) {
+    if (str.find_first_of(" ='\"\\\n")!=std::string::npos)
+    {
         outputText << "\"";
-        outputText << str;
+        for(std::string::size_type pos = 0;pos < str.size();pos++) {
+            if (str[pos]=='"') outputText << "\\\"";
+            else if (str[pos]=='\\') outputText << "\\\\";
+            else if (str[pos]=='\n') outputText << "\\n";
+            else outputText << str[pos];
+        }
         outputText << "\"";
     } else {
         outputText << str;

--- a/ydb/library/actors/struct_log/text_writer.cpp
+++ b/ydb/library/actors/struct_log/text_writer.cpp
@@ -14,6 +14,78 @@ bool TTextWriter::Write(TStringBuilder& outputText, const TStructuredMessage& me
     return result;
 }
 
+TString TTextWriter::EscapeFieldValue(const TString& value) {
+    if (value.find_first_of(" ='\"\\\n")==std::string::npos) {
+        return value;
+    }
+
+    TStringStream result;
+    result << "\"";
+    for(std::string::size_type pos = 0;pos < value.size();pos++) {
+        if (value[pos]=='"') result << "\\\"";
+        else if (value[pos]=='\\') result << "\\\\";
+        else if (value[pos]=='\n') result << "\\n";
+        else result << value[pos];
+    }
+    result << "\"";
+    return result.Str();
+}
+
+TMaybe<TString> TTextWriter::UnescapeFieldValue(const TString& escapedFieldValue) {
+    std::string::size_type startPos;
+    return UnescapeFieldValue(escapedFieldValue, startPos);
+}
+
+TMaybe<TString> TTextWriter::UnescapeFieldValue(const TString& escapedFieldValue, std::string::size_type& startPos) {
+    if (startPos > escapedFieldValue.size()) {
+        return "";
+    }
+
+    if (escapedFieldValue[startPos]!='"') {
+        auto pos = startPos;
+        auto spacePos = escapedFieldValue.find(' ', startPos);
+        if (spacePos == std::string::npos) {
+            startPos = escapedFieldValue.size();
+            return escapedFieldValue.substr(pos);
+        } else {
+            startPos = spacePos;
+            return escapedFieldValue.substr(pos, spacePos - pos);
+        }
+    }
+
+    TStringStream result;
+    startPos++;
+    while (startPos < escapedFieldValue.size()) {
+        if (escapedFieldValue[startPos]=='"') {
+            // End of escaped string found
+            startPos++;
+            return result.Str();
+        } else if (escapedFieldValue[startPos]=='\\') {
+            startPos++;
+            if (startPos > escapedFieldValue.size()) {
+                // invalid escaped string (\ is last character)
+                return {};
+            } else {
+                if (escapedFieldValue[startPos]=='n') result << '\n';
+                else if (escapedFieldValue[startPos]=='\\') result << '\\';
+                else if (escapedFieldValue[startPos]=='"') result << '"';
+                else {
+                    // invalid escaped string (unknown character after "\")
+                    return {};
+                }
+                startPos++;
+            }
+        } else {
+            result << escapedFieldValue[startPos];
+            startPos++;
+        }
+    }
+
+    // End of escaped string is not found
+    return {};
+}
+
+
 TTextWriter::TValueWriter::TValueWriter(TTextWriter& writer)
     : TBaseValueWriter<TTextWriter>(writer)
 {}
@@ -38,19 +110,7 @@ void TTextWriter::TValueWriter::operator()(const TString& value) const {
     }
     outputText << "=";
     auto str = TTypesMapping::ToString(value);
-    if (str.find_first_of(" ='\"\\\n")!=std::string::npos)
-    {
-        outputText << "\"";
-        for(std::string::size_type pos = 0;pos < str.size();pos++) {
-            if (str[pos]=='"') outputText << "\\\"";
-            else if (str[pos]=='\\') outputText << "\\\\";
-            else if (str[pos]=='\n') outputText << "\\n";
-            else outputText << str[pos];
-        }
-        outputText << "\"";
-    } else {
-        outputText << str;
-    }
+    outputText << EscapeFieldValue(str);
 }
 
 }  // namespace NActors::NStructuredLog

--- a/ydb/library/actors/struct_log/text_writer.h
+++ b/ydb/library/actors/struct_log/text_writer.h
@@ -3,6 +3,7 @@
 #include "base_writer.h"
 
 #include <util/generic/string.h>
+#include <util/generic/maybe.h>
 #include <util/string/builder.h>
 
 namespace NActors::NStructuredLog {
@@ -14,6 +15,10 @@ public:
     TTextWriter() = default;
 
     bool Write(TStringBuilder& outputText, const TStructuredMessage& message);
+
+    static TString EscapeFieldValue(const TString& value);
+    static TMaybe<TString> UnescapeFieldValue(const TString& escapedFieldValue);
+    static TMaybe<TString> UnescapeFieldValue(const TString& escapedFieldValue, std::string::size_type& startPos);
 
 protected:
     TStringBuilder* OutputText{nullptr};


### PR DESCRIPTION
### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Если выводимое в текстовый лог значение содержит пробелы или специальные символы, то текст берётся в кавычки, а символы - экранируются