### PR TITLE
Add dynamic function registry

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -3431,7 +3431,7 @@ void TNbsServiceInitializer::InitializeServices(NActors::TActorSystemSetup *setu
 
 TUdfStoreInitializer::TUdfStoreInitializer(const TKikimrRunConfig& runConfig, TIntrusivePtr<NMiniKQL::IMutableFunctionRegistry> functionRegistry)
     : IKikimrServicesInitializer(runConfig)
-    , FunctionRegistry(functionRegistry) {
+    , FunctionRegistry(std::move(functionRegistry)) {
 }
 
 void TUdfStoreInitializer::InitializeServices(NActors::TActorSystemSetup* setup, const NKikimr::TAppData* appData) {

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.h
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.h
@@ -19,6 +19,8 @@
 
 #include <ydb/core/fq/libs/shared_resources/interface/shared_resources.h>
 
+#include <ydb/core/kqp/common/dynamic_function_registry.h>
+
 #include <ydb/library/actors/core/defs.h>
 #include <ydb/library/actors/core/log_settings.h>
 #include <ydb/library/actors/core/scheduler_actor.h>

--- a/ydb/core/driver_lib/run/kikimr_services_initializers.h
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.h
@@ -19,8 +19,6 @@
 
 #include <ydb/core/fq/libs/shared_resources/interface/shared_resources.h>
 
-#include <ydb/core/kqp/common/dynamic_function_registry.h>
-
 #include <ydb/library/actors/core/defs.h>
 #include <ydb/library/actors/core/log_settings.h>
 #include <ydb/library/actors/core/scheduler_actor.h>

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -2283,6 +2283,8 @@ TIntrusivePtr<TServiceInitializersList> TKikimrRunner::CreateServiceInitializers
 #endif
 
     if (serviceMask.EnableUdfStore) {
+        Y_ABORT_UNLESS(NKqp::AsDynamicFunctionRegistry(FunctionRegistry.Get()),
+            "FunctionRegistry must implement NKqp::IDynamicFunctionRegistry for UDF store");
         sil->AddServiceInitializer(new TUdfStoreInitializer(runConfig, FunctionRegistry));
     }
 
@@ -2495,7 +2497,7 @@ void TKikimrRunner::InitializeRegistries(const TKikimrRunConfig& runConfig) {
     TypeRegistry.Reset(new NScheme::TKikimrTypeRegistry());
     TypeRegistry->CalculateMetadataEtag();
 
-    FunctionRegistry.Reset(NMiniKQL::CreateFunctionRegistry(NMiniKQL::CreateBuiltinRegistry())->Clone());
+    FunctionRegistry = NKqp::CreateDynamicFunctionRegistry(NMiniKQL::CreateBuiltinRegistry());
     FormatFactory.Reset(new TFormatFactory);
 
     const TString& udfsDir = runConfig.AppConfig.GetUDFsDir();

--- a/ydb/core/driver_lib/run/run.cpp
+++ b/ydb/core/driver_lib/run/run.cpp
@@ -5,6 +5,7 @@
 #include "kikimr_services_initializers.h"
 
 #include <ydb/core/kqp/compile_service/kqp_warmup_compile_actor.h>
+#include <ydb/core/kqp/common/dynamic_function_registry.h>
 #include <ydb/core/kqp/common/simple/services.h>
 #include <ydb/core/kqp/runtime/scheduler/kqp_compute_scheduler_service.h>
 #include <ydb/core/memory_controller/memory_controller.h>

--- a/ydb/core/kqp/common/dynamic_function_registry.cpp
+++ b/ydb/core/kqp/common/dynamic_function_registry.cpp
@@ -209,10 +209,9 @@ public:
         NUdf::TUniquePtr<NUdf::IUdfModule> module) override
     {
         TString libraryPathStr(libraryPath);
-        auto inserted = LoadedLibraries_.insert({libraryPathStr, nullptr});
-        if (!inserted.second) {
-            return;
-        }
+        // Track the path for RemoveModule cleanup; multiple in-memory modules may
+        // share one synthetic path (unlike LoadUdfs which opens a real .so once).
+        LoadedLibraries_.emplace(libraryPathStr, nullptr);
 
         TUdfModuleRemappings remappings;
         TUdfModuleLoader loader(
@@ -224,6 +223,8 @@ public:
     }
 
     void RemoveModule(const TStringBuf& moduleName) override {
+        // Only UdfModules_ / LoadedLibraries_. SystemModulePaths_ is a separate
+        // catalog and must survive unload so FindUdfPath can still resolve it.
         auto it = UdfModules_.find(TString(moduleName));
         if (it == UdfModules_.end()) {
             return;

--- a/ydb/core/kqp/common/dynamic_function_registry.cpp
+++ b/ydb/core/kqp/common/dynamic_function_registry.cpp
@@ -1,0 +1,447 @@
+#include "dynamic_function_registry.h"
+
+#include <yql/essentials/minikql/mkql_type_builder.h>
+#include <yql/essentials/minikql/mkql_utils.h>
+#include <yql/essentials/public/udf/udf_static_registry.h>
+
+#include <util/folder/path.h>
+#include <util/stream/str.h>
+#include <util/string/builder.h>
+#include <util/system/dynlib.h>
+
+#include <utility>
+
+namespace NKikimr::NKqp {
+namespace {
+
+using namespace NMiniKQL;
+
+const char MODULE_NAME_DELIMITER = '.';
+const char* RegisterFuncName = "Register";
+const char* AbiVersionFuncName = "AbiVersion";
+#if defined(_win_) || defined(_darwin_)
+const char* BindSymbolsFuncName = "BindSymbols";
+#endif
+const char* SetBackTraceCallbackName = "SetBackTraceCallback";
+
+class TDynamicFunctionRegistry: public IDynamicFunctionRegistry {
+    struct TUdfModule {
+        TString LibraryPath;
+        std::shared_ptr<NUdf::IUdfModule> Impl;
+    };
+
+    using TUdfModulesMap = THashMap<TString, TUdfModule>;
+
+    struct TUdfLibrary: public TThrRefBase {
+        ui32 AbiVersion = 0;
+        TDynamicLibrary Lib;
+    };
+    using TUdfLibraryPtr = TIntrusivePtr<TUdfLibrary>;
+
+    class TUdfModuleLoader: public NUdf::IRegistrator {
+    public:
+        TUdfModuleLoader(
+            TUdfModulesMap& modulesMap,
+            THashSet<TString>* newModules,
+            TString libraryPath,
+            const TUdfModuleRemappings& remappings,
+            ui32 abiVersion,
+            TString customUdfPrefix = {})
+            : ModulesMap_(modulesMap)
+            , NewModules_(newModules)
+            , LibraryPath_(std::move(libraryPath))
+            , Remappings_(remappings)
+            , AbiVersion_(NUdf::AbiVersionToStr(abiVersion))
+            , CustomUdfPrefix_(std::move(customUdfPrefix))
+        {
+        }
+
+        void AddModule(
+            const NUdf::TStringRef& name,
+            NUdf::TUniquePtr<NUdf::IUdfModule> module) override
+        {
+            Y_DEBUG_ABORT_UNLESS(module, "Module is empty");
+
+            if (!HasError()) {
+                TUdfModule m;
+                m.LibraryPath = LibraryPath_;
+                m.Impl.reset(module.Release());
+
+                auto it = Remappings_.find(name);
+                const TString& newName = CustomUdfPrefix_ + ((it == Remappings_.end())
+                                                                 ? TString(name)
+                                                                 : it->second);
+
+                auto i = ModulesMap_.insert({newName, std::move(m)});
+                if (!i.second) {
+                    TUdfModule* oldModule = ModulesMap_.FindPtr(newName);
+                    Y_DEBUG_ABORT_UNLESS(oldModule != nullptr);
+                    Error_ = (TStringBuilder()
+                              << "UDF module duplication: name " << TStringBuf(name)
+                              << ", already loaded from " << oldModule->LibraryPath
+                              << ", trying to load from " << LibraryPath_);
+                } else if (NewModules_) {
+                    NewModules_->insert(newName);
+                }
+            }
+        }
+
+        const TString& GetError() const {
+            return Error_;
+        }
+        bool HasError() const {
+            return !Error_.empty();
+        }
+
+    private:
+        TUdfModulesMap& ModulesMap_;
+        THashSet<TString>* NewModules_;
+        const TString LibraryPath_;
+        const TUdfModuleRemappings& Remappings_;
+        const TString AbiVersion_;
+        TString Error_;
+        const TString CustomUdfPrefix_;
+    };
+
+public:
+    explicit TDynamicFunctionRegistry(IBuiltinFunctionRegistry::TPtr builtins)
+        : Builtins_(std::move(builtins))
+    {
+    }
+
+    TDynamicFunctionRegistry(const TDynamicFunctionRegistry& rhs)
+        : IDynamicFunctionRegistry()
+        , Builtins_(rhs.Builtins_)
+        , LoadedLibraries_(rhs.LoadedLibraries_)
+        , UdfModules_(rhs.UdfModules_)
+        , SystemModulePaths_(rhs.SystemModulePaths_)
+        , BackTraceCallback_(rhs.BackTraceCallback_)
+        , SupportsSizedAllocators_(rhs.SupportsSizedAllocators_)
+    {
+    }
+
+    void AllowUdfPatch() override {
+    }
+
+    void LoadUdfs(
+        const TString& libraryPath,
+        const TUdfModuleRemappings& remmapings,
+        ui32 flags = 0,
+        const TString& customUdfPrefix = {},
+        THashSet<TString>* modules = nullptr) override
+    {
+        TUdfLibraryPtr lib;
+
+        auto libIt = LoadedLibraries_.find(libraryPath);
+        if (libIt == LoadedLibraries_.end()) {
+            lib = MakeIntrusive<TUdfLibrary>();
+#ifdef _win32_
+            ui32 loadFlags = 0;
+#else
+            ui32 loadFlags = RTLD_GLOBAL | ((flags & NUdf::IRegistrator::TFlags::TypesOnly) ? RTLD_LAZY : RTLD_NOW);
+#endif
+            TPathSplit absPathSplit(libraryPath);
+            TString absPath = libraryPath;
+            if (!absPathSplit.IsAbsolute) {
+                absPath = JoinPaths(TFsPath::Cwd().PathSplit(), absPathSplit);
+            }
+
+            lib->Lib.Open(absPath.data(), loadFlags);
+            lib->Lib.SetUnloadable(false);
+
+            auto abiVersionFunc = reinterpret_cast<NUdf::TAbiVersionFunctionPtr>(
+                lib->Lib.SymOptional(AbiVersionFuncName));
+            if (!abiVersionFunc) {
+                return;
+            }
+
+            ui32 version = abiVersionFunc();
+            Y_ENSURE(NUdf::IsAbiCompatible(version) && version >= NUdf::MakeAbiVersion(2, 8, 0),
+                     "Non compatible ABI version of UDF library " << libraryPath
+                                                                  << ", expected up to " << NUdf::AbiVersionToStr(NUdf::CurrentCompatibilityAbiVersion() * 100)
+                                                                  << ", got " << NUdf::AbiVersionToStr(version)
+                                                                  << "; try to re-compile library using "
+                                                                  << "YQL_ABI_VERSION(" << UDF_ABI_VERSION_MAJOR
+                                                                  << " " << UDF_ABI_VERSION_MINOR << " 0) macro in ya.make");
+            lib->AbiVersion = version;
+            if (version < NUdf::MakeAbiVersion(2, 8, 0)) {
+                SupportsSizedAllocators_ = false;
+            }
+
+#if defined(_win_) || defined(_darwin_)
+            auto bindSymbolsFunc = reinterpret_cast<NUdf::TBindSymbolsFunctionPtr>(lib->Lib.Sym(BindSymbolsFuncName));
+            bindSymbolsFunc(NUdf::GetStaticSymbols());
+#endif
+
+            if (BackTraceCallback_) {
+                auto setter = reinterpret_cast<NUdf::TSetBackTraceCallbackPtr>(lib->Lib.SymOptional(SetBackTraceCallbackName));
+                if (setter) {
+                    setter(BackTraceCallback_);
+                }
+            }
+
+            libIt = LoadedLibraries_.insert({libraryPath, lib}).first;
+        } else {
+            lib = libIt->second;
+        }
+
+        auto registerFunc = reinterpret_cast<NUdf::TRegisterFunctionPtr>(
+            lib->Lib.Sym(RegisterFuncName));
+
+        THashSet<TString> newModules;
+        TUdfModuleLoader loader(
+            UdfModules_,
+            &newModules,
+            libraryPath,
+            remmapings,
+            lib->AbiVersion, customUdfPrefix);
+        registerFunc(loader, flags);
+        Y_ENSURE(!loader.HasError(), loader.GetError());
+
+        if (modules) {
+            *modules = std::move(newModules);
+        }
+    }
+
+    void AddModule(
+        const TStringBuf& libraryPath,
+        const TStringBuf& moduleName,
+        NUdf::TUniquePtr<NUdf::IUdfModule> module) override
+    {
+        TString libraryPathStr(libraryPath);
+        auto inserted = LoadedLibraries_.insert({libraryPathStr, nullptr});
+        if (!inserted.second) {
+            return;
+        }
+
+        TUdfModuleRemappings remappings;
+        TUdfModuleLoader loader(
+            UdfModules_, /*newModules=*/nullptr, libraryPathStr,
+            remappings, NUdf::CurrentAbiVersion());
+        loader.AddModule(moduleName, std::move(module));
+
+        Y_ENSURE(!loader.HasError(), loader.GetError());
+    }
+
+    void RemoveModule(const TStringBuf& moduleName) override {
+        auto it = UdfModules_.find(TString(moduleName));
+        if (it == UdfModules_.end()) {
+            return;
+        }
+        const TString libraryPath = it->second.LibraryPath;
+        UdfModules_.erase(it);
+        bool pathStillUsed = false;
+        for (const auto& [name, module] : UdfModules_) {
+            Y_UNUSED(name);
+            if (module.LibraryPath == libraryPath) {
+                pathStillUsed = true;
+                break;
+            }
+        }
+        if (!pathStillUsed) {
+            LoadedLibraries_.erase(libraryPath);
+        }
+    }
+
+    void SetSystemModulePaths(const TUdfModulePathsMap& paths) override {
+        SystemModulePaths_ = paths;
+    }
+
+    const IBuiltinFunctionRegistry::TPtr& GetBuiltins() const override {
+        return Builtins_;
+    }
+
+    TStatus FindFunctionTypeInfo(
+        NYql::TLangVersion langver,
+        const NYql::TRuntimeSettings& runtimeSettings,
+        const TTypeEnvironment& env,
+        NUdf::ITypeInfoHelper::TPtr typeInfoHelper,
+        NUdf::ICountersProvider* countersProvider,
+        const TStringBuf& name,
+        TType* userType,
+        const TStringBuf& typeConfig,
+        ui32 flags,
+        const NUdf::TSourcePosition& pos,
+        const NUdf::ISecureParamsProvider* secureParamsProvider,
+        const NUdf::ILogProvider* logProvider,
+        TFunctionTypeInfo* funcInfo) const override
+    {
+        TStringBuf moduleName;
+        TStringBuf funcName;
+        if (name.TrySplit(MODULE_NAME_DELIMITER, moduleName, funcName)) {
+            auto it = UdfModules_.find(moduleName);
+            if (it != UdfModules_.end()) {
+                TFunctionTypeInfoBuilder typeInfoBuilder(langver, runtimeSettings, env, typeInfoHelper, moduleName,
+                                                         (flags & NUdf::IUdfModule::TFlags::TypesOnly) ? nullptr : countersProvider, pos,
+                                                         secureParamsProvider, logProvider);
+                const auto& module = *it->second.Impl;
+                module.BuildFunctionTypeInfo(
+                    funcName, userType, typeConfig, flags, typeInfoBuilder);
+
+                if (typeInfoBuilder.HasError()) {
+                    return TStatus::Error()
+                           << "Module: " << moduleName
+                           << ", function: " << funcName
+                           << ", error: " << typeInfoBuilder.GetError();
+                }
+
+                try {
+                    typeInfoBuilder.Build(funcInfo);
+                } catch (yexception& e) {
+                    return TStatus::Error()
+                           << "Module: " << moduleName
+                           << ", function: " << funcName
+                           << ", error: " << e.what();
+                }
+
+                if ((flags & NUdf::IRegistrator::TFlags::TypesOnly) &&
+                    !funcInfo->FunctionType)
+                {
+                    return TStatus::Error()
+                           << "Module: " << moduleName
+                           << ", function: " << funcName
+                           << ", function not found";
+                }
+
+                if (funcInfo->ModuleIRUniqID) {
+                    funcInfo->ModuleIRUniqID.prepend(moduleName);
+                }
+
+                return TStatus::Ok();
+            }
+
+            return TStatus::Error()
+                   << "Module " << moduleName << " is not registered";
+        }
+
+        return TStatus::Error()
+               << "Function name must be in <module>.<func_name> scheme. "
+               << "But get " << name;
+    }
+
+    TMaybe<TString> FindUdfPath(const TStringBuf& moduleName) const override {
+        if (const TUdfModule* udf = UdfModules_.FindPtr(moduleName)) {
+            return udf->LibraryPath;
+        }
+
+        if (const TString* path = SystemModulePaths_.FindPtr(moduleName)) {
+            return *path;
+        }
+
+        return Nothing();
+    }
+
+    bool IsLoadedUdfModule(const TStringBuf& moduleName) const override {
+        return UdfModules_.contains(moduleName);
+    }
+
+    THashSet<TString> GetAllModuleNames() const override {
+        THashSet<TString> names;
+        names.reserve(UdfModules_.size());
+        for (const auto& module : UdfModules_) {
+            names.insert(module.first);
+        }
+        return names;
+    }
+
+    TFunctionsMap GetModuleFunctions(const TStringBuf& moduleName) const override {
+        struct TFunctionNamesSink: public NUdf::IFunctionNamesSink {
+            TFunctionsMap Functions;
+            class TFuncDescriptor: public NUdf::IFunctionDescriptor {
+            public:
+                explicit TFuncDescriptor(TFunctionProperties& properties)
+                    : Properties_(properties)
+                {
+                }
+
+            private:
+                void SetTypeAwareness() final {
+                    Properties_.IsTypeAwareness = true;
+                }
+
+                void SetPolyArgs(const NUdf::TStringRef& config) final {
+                    Properties_.PolyArgs = config;
+                }
+
+                TFunctionProperties& Properties_;
+            };
+
+            NUdf::IFunctionDescriptor::TPtr Add(const NUdf::TStringRef& name) final {
+                const auto it = Functions.emplace(name, TFunctionProperties{});
+                return new TFuncDescriptor(it.first->second);
+            }
+        } sink;
+
+        const auto it = UdfModules_.find(moduleName);
+        if (UdfModules_.cend() == it) {
+            return TFunctionsMap();
+        }
+        it->second.Impl->GetAllFunctions(sink);
+        return sink.Functions;
+    }
+
+    bool SupportsSizedAllocators() const override {
+        return SupportsSizedAllocators_;
+    }
+
+    void PrintInfoTo(IOutputStream& out) const override {
+        Builtins_->PrintInfoTo(out);
+    }
+
+    void CleanupModulesOnTerminate() const override {
+        for (const auto& module : UdfModules_) {
+            module.second.Impl->CleanupOnTerminate();
+        }
+    }
+
+    TIntrusivePtr<IMutableFunctionRegistry> Clone() const override {
+        return new TDynamicFunctionRegistry(*this);
+    }
+
+    void SetBackTraceCallback(NUdf::TBackTraceCallback callback) override {
+        BackTraceCallback_ = callback;
+    }
+
+private:
+    const IBuiltinFunctionRegistry::TPtr Builtins_;
+
+    THashMap<TString, TUdfLibraryPtr> LoadedLibraries_;
+    TUdfModulesMap UdfModules_;
+    TUdfModulePathsMap SystemModulePaths_;
+    NUdf::TBackTraceCallback BackTraceCallback_ = nullptr;
+    bool SupportsSizedAllocators_ = true;
+};
+
+} // namespace
+
+TIntrusivePtr<NMiniKQL::IMutableFunctionRegistry> CreateDynamicFunctionRegistry(
+    NMiniKQL::IBuiltinFunctionRegistry::TPtr&& builtins)
+{
+    return new TDynamicFunctionRegistry(std::move(builtins));
+}
+
+TIntrusivePtr<NMiniKQL::IMutableFunctionRegistry> CreateDynamicFunctionRegistry(
+    NKikimr::NUdf::TBackTraceCallback backtraceCallback,
+    NMiniKQL::IBuiltinFunctionRegistry::TPtr&& builtins,
+    bool allowUdfPatch,
+    const TVector<TString>& udfsPaths,
+    ui32 flags)
+{
+    auto registry = MakeHolder<TDynamicFunctionRegistry>(std::move(builtins));
+    if (allowUdfPatch) {
+        registry->AllowUdfPatch();
+    }
+    registry->SetBackTraceCallback(backtraceCallback);
+
+    NMiniKQL::TUdfModuleRemappings remappings;
+    THashSet<TString> usedUdfPaths;
+    for (const TString& udfPath : udfsPaths) {
+        if (usedUdfPaths.insert(udfPath).second) {
+            registry->LoadUdfs(udfPath, remappings, flags);
+        }
+    }
+
+    return registry.Release();
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/dynamic_function_registry.h
+++ b/ydb/core/kqp/common/dynamic_function_registry.h
@@ -8,8 +8,10 @@ class IDynamicFunctionRegistry: public NMiniKQL::IMutableFunctionRegistry {
 public:
     using TPtr = TIntrusivePtr<IDynamicFunctionRegistry>;
 
-    //! Removes a previously registered module by YQL module name. No-op if missing.
-    //! Also drops the libraryPath entry when no modules from that path remain.
+    //! Unloads a dynamically registered module by YQL module name. No-op if missing.
+    //! Drops the LoadedLibraries_ entry when no modules from that path remain.
+    //! Does not modify SystemModulePaths_: FindUdfPath may still return a system
+    //! catalog path after unload (same as for never-loaded system modules).
     virtual void RemoveModule(const TStringBuf& moduleName) = 0;
 };
 

--- a/ydb/core/kqp/common/dynamic_function_registry.h
+++ b/ydb/core/kqp/common/dynamic_function_registry.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <yql/essentials/minikql/mkql_function_registry.h>
+
+namespace NKikimr::NKqp {
+
+class IDynamicFunctionRegistry: public NMiniKQL::IMutableFunctionRegistry {
+public:
+    using TPtr = TIntrusivePtr<IDynamicFunctionRegistry>;
+
+    //! Removes a previously registered module by YQL module name. No-op if missing.
+    //! Also drops the libraryPath entry when no modules from that path remain.
+    virtual void RemoveModule(const TStringBuf& moduleName) = 0;
+};
+
+//! Creates a dynamic registry (full mutable UDF registry + RemoveModule).
+//! Returned as IMutableFunctionRegistry; cast to IDynamicFunctionRegistry for RemoveModule.
+TIntrusivePtr<NMiniKQL::IMutableFunctionRegistry> CreateDynamicFunctionRegistry(
+    NMiniKQL::IBuiltinFunctionRegistry::TPtr&& builtins);
+
+TIntrusivePtr<NMiniKQL::IMutableFunctionRegistry> CreateDynamicFunctionRegistry(
+    NKikimr::NUdf::TBackTraceCallback backtraceCallback,
+    NMiniKQL::IBuiltinFunctionRegistry::TPtr&& builtins,
+    bool allowUdfPatch,
+    const TVector<TString>& udfsPaths,
+    ui32 flags = 0);
+
+inline IDynamicFunctionRegistry* AsDynamicFunctionRegistry(
+    NMiniKQL::IMutableFunctionRegistry* registry)
+{
+    return dynamic_cast<IDynamicFunctionRegistry*>(registry);
+}
+
+} // namespace NKikimr::NKqp

--- a/ydb/core/kqp/common/ut/dynamic_function_registry_ut.cpp
+++ b/ydb/core/kqp/common/ut/dynamic_function_registry_ut.cpp
@@ -1,0 +1,323 @@
+#include <ydb/core/kqp/common/dynamic_function_registry.h>
+
+#include <yql/essentials/minikql/invoke_builtins/mkql_builtins.h>
+#include <yql/essentials/minikql/mkql_alloc.h>
+#include <yql/essentials/minikql/mkql_function_registry.h>
+#include <yql/essentials/minikql/mkql_node.h>
+#include <yql/essentials/minikql/mkql_type_builder.h>
+#include <yql/essentials/minikql/mkql_utils.h>
+#include <yql/essentials/minikql/runtime_settings/runtime_settings.h>
+#include <yql/essentials/public/udf/udf_registrator.h>
+#include <yql/essentials/public/udf/udf_type_builder.h>
+#include <yql/essentials/public/udf/udf_value.h>
+
+#include <util/stream/str.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NKikimr;
+using namespace NKikimr::NMiniKQL;
+using namespace NKikimr::NKqp;
+
+namespace {
+
+class TStubUdfModule: public NUdf::IUdfModule {
+public:
+    explicit TStubUdfModule(
+        TString functionName = "Func",
+        bool typeAwareness = false,
+        TMaybe<TString> polyArgs = Nothing(),
+        ui32* cleanupCounter = nullptr)
+        : FunctionName_(std::move(functionName))
+        , TypeAwareness_(typeAwareness)
+        , PolyArgs_(std::move(polyArgs))
+        , CleanupCounter_(cleanupCounter)
+    {
+    }
+
+    void GetAllFunctions(NUdf::IFunctionsSink& sink) const override {
+        auto desc = sink.Add(FunctionName_);
+        if (TypeAwareness_) {
+            desc->SetTypeAwareness();
+        }
+        if (PolyArgs_) {
+            desc->SetPolyArgs(*PolyArgs_);
+        }
+    }
+
+    void BuildFunctionTypeInfo(
+        const NUdf::TStringRef& name,
+        NUdf::TType* /*userType*/,
+        const NUdf::TStringRef& /*typeConfig*/,
+        ui32 /*flags*/,
+        NUdf::IFunctionTypeInfoBuilder& builder) const override
+    {
+        if (name == NUdf::TStringRef(FunctionName_)) {
+            builder.SimpleSignature<i32(i32)>();
+        }
+    }
+
+    void CleanupOnTerminate() const override {
+        if (CleanupCounter_) {
+            ++(*CleanupCounter_);
+        }
+    }
+
+private:
+    const TString FunctionName_;
+    const bool TypeAwareness_;
+    const TMaybe<TString> PolyArgs_;
+    ui32* CleanupCounter_;
+};
+
+TIntrusivePtr<IMutableFunctionRegistry> MakeRegistry() {
+    auto registry = CreateDynamicFunctionRegistry(CreateBuiltinRegistry());
+    UNIT_ASSERT(AsDynamicFunctionRegistry(registry.Get()));
+    return registry;
+}
+
+IDynamicFunctionRegistry* Dyn(IMutableFunctionRegistry* registry) {
+    auto* dyn = AsDynamicFunctionRegistry(registry);
+    UNIT_ASSERT(dyn);
+    return dyn;
+}
+
+TStatus LookupTypeInfo(
+    const IFunctionRegistry& registry,
+    const TTypeEnvironment& env,
+    NUdf::ITypeInfoHelper::TPtr typeInfoHelper,
+    const NYql::TRuntimeSettings& runtimeSettings,
+    const TStringBuf& name,
+    TFunctionTypeInfo* funcInfo)
+{
+    return registry.FindFunctionTypeInfo(
+        NYql::UnknownLangVersion,
+        runtimeSettings,
+        env,
+        typeInfoHelper,
+        /*countersProvider=*/nullptr,
+        name,
+        /*userType=*/nullptr,
+        /*typeConfig=*/TStringBuf(),
+        NUdf::IUdfModule::TFlags::TypesOnly,
+        NUdf::TSourcePosition(),
+        /*secureParamsProvider=*/nullptr,
+        /*logProvider=*/nullptr,
+        funcInfo);
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TDynamicFunctionRegistryTest) {
+
+Y_UNIT_TEST(RemoveModuleRemovesKnownModule) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule());
+
+    UNIT_ASSERT(registry->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT(registry->GetAllModuleNames().contains("Foo"));
+    UNIT_ASSERT(registry->FindUdfPath("Foo").Defined());
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("Foo"), "/lib/foo");
+
+    Dyn(registry.Get())->RemoveModule("Foo");
+
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT(!registry->GetAllModuleNames().contains("Foo"));
+    UNIT_ASSERT(!registry->FindUdfPath("Foo").Defined());
+}
+
+Y_UNIT_TEST(RemoveModuleMissingIsNoOp) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule());
+
+    Dyn(registry.Get())->RemoveModule("Missing");
+    Dyn(registry.Get())->RemoveModule("Missing");
+
+    UNIT_ASSERT(registry->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("Foo"), "/lib/foo");
+}
+
+Y_UNIT_TEST(RemoveModuleDropsLibraryEntryWhenLastModule) {
+    auto registry = MakeRegistry();
+    const TString path = "/lib/shared";
+    registry->AddModule(path, "Only", new TStubUdfModule());
+
+    Dyn(registry.Get())->RemoveModule("Only");
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Only"));
+
+    // Path must have been dropped from LoadedLibraries_: re-add under the same
+    // path must succeed and reappear in FindUdfPath.
+    registry->AddModule(path, "Again", new TStubUdfModule("AgainFunc"));
+    UNIT_ASSERT(registry->IsLoadedUdfModule("Again"));
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("Again"), path);
+}
+
+Y_UNIT_TEST(RemoveModuleKeepsLibraryEntryWhenOtherModulesRemain) {
+    auto registry = MakeRegistry();
+    const TString path = "/lib/shared";
+    registry->AddModule(path, "ModA", new TStubUdfModule("A"));
+    registry->AddModule(path, "ModB", new TStubUdfModule("B"));
+
+    Dyn(registry.Get())->RemoveModule("ModA");
+
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("ModA"));
+    UNIT_ASSERT(registry->IsLoadedUdfModule("ModB"));
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("ModB"), path);
+
+    // Path still tracked: can register another module under the same path.
+    registry->AddModule(path, "ModC", new TStubUdfModule("C"));
+    UNIT_ASSERT(registry->IsLoadedUdfModule("ModC"));
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("ModC"), path);
+}
+
+Y_UNIT_TEST(CloneIsIndependent) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule());
+
+    auto clone = registry->Clone();
+    UNIT_ASSERT(AsDynamicFunctionRegistry(clone.Get()));
+
+    UNIT_ASSERT(clone->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT_VALUES_EQUAL(*clone->FindUdfPath("Foo"), "/lib/foo");
+
+    Dyn(registry.Get())->RemoveModule("Foo");
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT(clone->IsLoadedUdfModule("Foo"));
+    UNIT_ASSERT_VALUES_EQUAL(*clone->FindUdfPath("Foo"), "/lib/foo");
+
+    Dyn(clone.Get())->RemoveModule("Foo");
+    UNIT_ASSERT(!clone->IsLoadedUdfModule("Foo"));
+}
+
+Y_UNIT_TEST(FindFunctionTypeInfoResolvesRegisteredUdf) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule("Bar"));
+
+    TScopedAlloc alloc(__LOCATION__);
+    TTypeEnvironment env(alloc);
+    NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+    auto runtimeSettings = NYql::MakeRuntimeSettings();
+
+    TFunctionTypeInfo funcInfo;
+    auto ok = LookupTypeInfo(*registry, env, typeInfoHelper, *runtimeSettings, "Foo.Bar", &funcInfo);
+    UNIT_ASSERT_C(ok.IsOk(), ok.GetError());
+    UNIT_ASSERT(funcInfo.FunctionType != nullptr);
+
+    TFunctionTypeInfo missingInfo;
+    auto missing = LookupTypeInfo(*registry, env, typeInfoHelper, *runtimeSettings, "Foo.Missing", &missingInfo);
+    UNIT_ASSERT(!missing.IsOk());
+
+    TFunctionTypeInfo noModuleInfo;
+    auto noModule = LookupTypeInfo(*registry, env, typeInfoHelper, *runtimeSettings, "Unknown.Bar", &noModuleInfo);
+    UNIT_ASSERT(!noModule.IsOk());
+}
+
+// --- IMutableFunctionRegistry surface (parity with TMutableFunctionRegistry usage) ---
+
+Y_UNIT_TEST(GetBuiltinsAndSupportsSizedAllocators) {
+    auto builtins = CreateBuiltinRegistry();
+    auto* builtinsRaw = builtins.Get();
+    auto registry = CreateDynamicFunctionRegistry(std::move(builtins));
+
+    UNIT_ASSERT(registry->GetBuiltins().Get() == builtinsRaw);
+    UNIT_ASSERT(registry->SupportsSizedAllocators());
+}
+
+Y_UNIT_TEST(GetModuleFunctionsExposesRegisteredMetadata) {
+    auto registry = MakeRegistry();
+    registry->AddModule(
+        "/lib/foo",
+        "Foo",
+        new TStubUdfModule("Bar", /*typeAwareness=*/true, TString("poly")));
+
+    auto funcs = registry->GetModuleFunctions("Foo");
+    UNIT_ASSERT_VALUES_EQUAL(funcs.size(), 1u);
+    UNIT_ASSERT(funcs.contains("Bar"));
+    UNIT_ASSERT(funcs.at("Bar").IsTypeAwareness);
+    UNIT_ASSERT(funcs.at("Bar").PolyArgs.Defined());
+    UNIT_ASSERT_VALUES_EQUAL(*funcs.at("Bar").PolyArgs, "poly");
+
+    UNIT_ASSERT(registry->GetModuleFunctions("Missing").empty());
+}
+
+Y_UNIT_TEST(SetSystemModulePathsUsedByFindUdfPath) {
+    auto registry = MakeRegistry();
+    registry->SetSystemModulePaths({{"Sys", "/system/sys.so"}});
+
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Sys"));
+    UNIT_ASSERT(registry->FindUdfPath("Sys").Defined());
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("Sys"), "/system/sys.so");
+
+    // Loaded module path takes precedence over system path.
+    registry->AddModule("/lib/sys", "Sys", new TStubUdfModule());
+    UNIT_ASSERT(registry->IsLoadedUdfModule("Sys"));
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("Sys"), "/lib/sys");
+
+    // RemoveModule unloads the dynamic module but keeps the system catalog entry.
+    Dyn(registry.Get())->RemoveModule("Sys");
+    UNIT_ASSERT(!registry->IsLoadedUdfModule("Sys"));
+    UNIT_ASSERT_VALUES_EQUAL(*registry->FindUdfPath("Sys"), "/system/sys.so");
+}
+
+Y_UNIT_TEST(CleanupModulesOnTerminateInvokesModules) {
+    ui32 cleanups = 0;
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/a", "A", new TStubUdfModule("Fa", false, Nothing(), &cleanups));
+    registry->AddModule("/lib/b", "B", new TStubUdfModule("Fb", false, Nothing(), &cleanups));
+
+    registry->CleanupModulesOnTerminate();
+    UNIT_ASSERT_VALUES_EQUAL(cleanups, 2u);
+
+    registry->CleanupModulesOnTerminate();
+    UNIT_ASSERT_VALUES_EQUAL(cleanups, 4u);
+}
+
+Y_UNIT_TEST(AddModuleDuplicateNameFails) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/a", "Foo", new TStubUdfModule("A"));
+    UNIT_ASSERT_EXCEPTION(
+        registry->AddModule("/lib/b", "Foo", new TStubUdfModule("B")),
+        yexception);
+}
+
+Y_UNIT_TEST(FindFunctionTypeInfoRejectsInvalidName) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule("Bar"));
+
+    TScopedAlloc alloc(__LOCATION__);
+    TTypeEnvironment env(alloc);
+    NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+    auto runtimeSettings = NYql::MakeRuntimeSettings();
+
+    TFunctionTypeInfo info;
+    auto status = LookupTypeInfo(*registry, env, typeInfoHelper, *runtimeSettings, "NoDelimiter", &info);
+    UNIT_ASSERT(!status.IsOk());
+}
+
+Y_UNIT_TEST(ClonePreservesFindFunctionTypeInfo) {
+    auto registry = MakeRegistry();
+    registry->AddModule("/lib/foo", "Foo", new TStubUdfModule("Bar"));
+
+    auto clone = registry->Clone();
+
+    TScopedAlloc alloc(__LOCATION__);
+    TTypeEnvironment env(alloc);
+    NUdf::ITypeInfoHelper::TPtr typeInfoHelper(new TTypeInfoHelper);
+    auto runtimeSettings = NYql::MakeRuntimeSettings();
+
+    TFunctionTypeInfo info;
+    auto status = LookupTypeInfo(*clone, env, typeInfoHelper, *runtimeSettings, "Foo.Bar", &info);
+    UNIT_ASSERT_C(status.IsOk(), status.GetError());
+    UNIT_ASSERT(info.FunctionType != nullptr);
+
+    auto funcs = clone->GetModuleFunctions("Foo");
+    UNIT_ASSERT(funcs.contains("Bar"));
+}
+
+Y_UNIT_TEST(PrintInfoToDoesNotCrash) {
+    auto registry = MakeRegistry();
+    TStringStream out;
+    registry->PrintInfoTo(out);
+}
+
+} // Y_UNIT_TEST_SUITE(TDynamicFunctionRegistryTest)

--- a/ydb/core/kqp/common/ut/ya.make
+++ b/ydb/core/kqp/common/ut/ya.make
@@ -6,10 +6,14 @@ SIZE(SMALL)
 
 SRCS(
     kqp_tli_ut.cpp
+    dynamic_function_registry_ut.cpp
 )
 
 PEERDIR(
+    ydb/core/kqp/common
     ydb/core/kqp/ut/common
+    yql/essentials/minikql
+    yql/essentials/minikql/invoke_builtins/llvm16
     yql/essentials/sql/pg_dummy
 )
 

--- a/ydb/core/kqp/common/ya.make
+++ b/ydb/core/kqp/common/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     control.cpp
+    dynamic_function_registry.cpp
     kqp_batch_operations.cpp
     kqp_event_ids.h
     kqp_event_impl.cpp
@@ -53,6 +54,7 @@ PEERDIR(
     yql/essentials/core/dq_integration
     yql/essentials/core/issue
     yql/essentials/core/services
+    yql/essentials/minikql
     yql/essentials/parser/pg_wrapper/interface
     yql/essentials/public/issue
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Add dynamic function registry, for ydb implementation IMutableFunctionRegistry from yql/essentials/minikql/mkql_function_registry.h, 
Add RemoveModule removes a previously registered module by YQL module name.
