### PR TITLE
Optimize std::variant visits in executor pool

### DIFF
--- a/ydb/library/actors/core/executor_pool_base.cpp
+++ b/ydb/library/actors/core/executor_pool_base.cpp
@@ -65,8 +65,10 @@ namespace NActors {
     }
 
     TExecutorPoolBase::~TExecutorPoolBase() {
-        while (std::visit([](auto &x){return x.Pop(0);}, Activations))
-            ;
+        VisitActivations([](auto &x) {
+            while (x.Pop(0))
+                ;
+        });
     }
 
     TMailbox* TExecutorPoolBaseMailboxed::ResolveMailbox(ui32 hint) {

--- a/ydb/library/actors/core/executor_pool_base.h
+++ b/ydb/library/actors/core/executor_pool_base.h
@@ -59,6 +59,26 @@ namespace NActors {
         alignas(64) std::variant<TUnorderedCacheActivationQueue, TRingActivationQueueV4> Activations;
         TAtomic ActivationsRevolvingCounter = 0;
         std::atomic_bool StopFlag = false;
+
+        // Checked access that keeps Push/Pop statically dispatched and inlineable. Select TQueue from
+        // this pool's UseRingQueueValue; shared threads may serve pools with different queue types.
+        template <typename TQueue>
+        TQueue& GetActivations() {
+            TQueue* queue = std::get_if<TQueue>(&Activations);
+            Y_ABORT_UNLESS(queue, "activation queue kind mismatch; UseRingQueueValue# %d",
+                static_cast<int>(UseRingQueueValue));
+            return *queue;
+        }
+
+        // Same dispatch, when the caller does not care which alternative is active (cold paths).
+        template <typename TCallback>
+        decltype(auto) VisitActivations(TCallback&& callback) {
+            if (UseRingQueueValue) {
+                return callback(GetActivations<TRingActivationQueueV4>());
+            }
+            return callback(GetActivations<TUnorderedCacheActivationQueue>());
+        }
+
     public:
         TExecutorPoolBase(ui32 poolId, ui32 threads, TAffinity* affinity, bool useRingQueue);
         ~TExecutorPoolBase();

--- a/ydb/library/actors/core/executor_pool_basic.cpp
+++ b/ydb/library/actors/core/executor_pool_basic.cpp
@@ -254,7 +254,8 @@ namespace NActors {
         } while (true);
     }
 
-    TMailbox* TBasicExecutorPool::GetReadyActivationCommon(ui64 revolvingCounter) {
+    template <typename TQueue>
+    TMailbox* TBasicExecutorPool::GetReadyActivationCommonImpl(ui64 revolvingCounter) {
         TWorkerId workerId = TlsThreadContext->WorkerId();
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "");
         NHPTimer::STime hpnow = GetCycleCountFast();
@@ -293,7 +294,7 @@ namespace NActors {
                 }
             } else {
                 TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> activityGuard;
-                if (const ui32 activation = std::visit([&revolvingCounter](auto &x) {return x.Pop(revolvingCounter++);}, Activations)) {
+                if (const ui32 activation = GetActivations<TQueue>().Pop(revolvingCounter++)) {
                     EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "activation found");
                     Threads[workerId].SetWork();
                     AtomicDecrement(Semaphore);
@@ -309,7 +310,17 @@ namespace NActors {
         return nullptr;
     }
 
+    TMailbox* TBasicExecutorPool::GetReadyActivationCommon(ui64 revolvingCounter) {
+        if (UseRingQueueValue) {
+            return GetReadyActivationCommonImpl<TRingActivationQueueV4>(revolvingCounter);
+        }
+        return GetReadyActivationCommonImpl<TUnorderedCacheActivationQueue>(revolvingCounter);
+    }
+
     TMailbox* TBasicExecutorPool::GetReadyActivationRingQueue(ui64 revolvingCounter) {
+        // Only reachable when this pool was built with a ring queue -- see GetReadyActivation below.
+        Y_DEBUG_ABORT_UNLESS(UseRingQueueValue);
+
         if (StopFlag.load(std::memory_order_acquire)) {
             return nullptr;
         }
@@ -337,7 +348,7 @@ namespace NActors {
                     CheckToSleepWorkers.compare_exchange_weak(checkToSleepWorkers, checkToSleepWorkers - 1, std::memory_order_release, std::memory_order_relaxed);
                 } else { // otherwise we ready to get activation
                     TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> activityGuard;
-                    if (const ui32 activation = std::visit([&revolvingCounter](auto &x) {return x.Pop(++revolvingCounter);}, Activations)) {
+                    if (const ui32 activation = GetActivations<TRingActivationQueueV4>().Pop(++revolvingCounter)) {
                         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "activation found");
                         Threads[workerId].SetWork();
                         AtomicDecrement(Semaphore);
@@ -386,7 +397,7 @@ namespace NActors {
             TlsThreadContext->LocalQueueContext.LocalQueueSize = LocalQueueSize.load(std::memory_order_relaxed);
         }
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue done; moving to common");
-        if (TlsThreadContext->UseRingQueue()) {
+        if (UseRingQueueValue) {
             return GetReadyActivationRingQueue(revolvingCounter);
         }
         return GetReadyActivationCommon(revolvingCounter);
@@ -396,7 +407,7 @@ namespace NActors {
         if (MaxLocalQueueSize) {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "local queue");
             return GetReadyActivationLocalQueue(revolvingCounter);
-        } else if (TlsThreadContext->UseRingQueue()) {
+        } else if (UseRingQueueValue) {
             EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "ring queue");
             return GetReadyActivationRingQueue(revolvingCounter);
         } else {
@@ -420,9 +431,11 @@ namespace NActors {
     }
 
     void TBasicExecutorPool::ScheduleActivationExCommon(TMailbox* mailbox, ui64 revolvingCounter, std::optional<TAtomic> initSemaphore) {
-        std::visit([mailbox, revolvingCounter](auto &queue) {
-            queue.Push(mailbox->Hint, revolvingCounter);
-        }, Activations);
+        if (UseRingQueueValue) {
+            GetActivations<TRingActivationQueueV4>().Push(mailbox->Hint, revolvingCounter);
+        } else {
+            GetActivations<TUnorderedCacheActivationQueue>().Push(mailbox->Hint, revolvingCounter);
+        }
         bool needToWakeUp = false;
         bool needToChangeOldSemaphore = true;
 
@@ -835,7 +848,8 @@ namespace NActors {
         SharedPool = pool;
     }
 
-    TMailbox* TBasicExecutorPool::GetReadyActivationShared(ui64 revolvingCounter) {
+    template <typename TQueue>
+    TMailbox* TBasicExecutorPool::GetReadyActivationSharedImpl(ui64 revolvingCounter) {
         TWorkerId workerId = TlsThreadContext->WorkerId();
         NHPTimer::STime hpnow = GetCycleCountFast();
         TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION, false> activityGuard(hpnow);
@@ -854,7 +868,7 @@ namespace NActors {
                 return nullptr;
             } else {
                 TInternalActorTypeGuard<EInternalActorSystemActivity::ACTOR_SYSTEM_GET_ACTIVATION_FROM_QUEUE, false> activityGuard;
-                if (const ui32 activation = std::visit([&revolvingCounter](auto &x) {return x.Pop(revolvingCounter++);}, Activations)) {
+                if (const ui32 activation = GetActivations<TQueue>().Pop(revolvingCounter++)) {
                     SharedPool->Threads[workerId].SetWork();
                     AtomicDecrement(Semaphore);
                     EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Activation, "activation == ", activation, " semaphore == ", semaphore.OldSemaphore);
@@ -868,6 +882,13 @@ namespace NActors {
         }
         EXECUTOR_POOL_BASIC_DEBUG(EDebugLevel::Executor, "stop");
         return nullptr;
+    }
+
+    TMailbox* TBasicExecutorPool::GetReadyActivationShared(ui64 revolvingCounter) {
+        if (UseRingQueueValue) {
+            return GetReadyActivationSharedImpl<TRingActivationQueueV4>(revolvingCounter);
+        }
+        return GetReadyActivationSharedImpl<TUnorderedCacheActivationQueue>(revolvingCounter);
     }
 
     void TBasicExecutorPool::SetSharedCpuQuota(float quota) {

--- a/ydb/library/actors/core/executor_pool_basic.h
+++ b/ydb/library/actors/core/executor_pool_basic.h
@@ -293,6 +293,14 @@ namespace NActors {
 
         bool IsSharedOnly() const;
     private:
+        // Instantiated once per activation queue kind so that Pop() inlines into the spin loop;
+        // GetReadyActivationCommon/Shared pick the instantiation from UseRingQueueValue.
+        template <typename TQueue>
+        TMailbox* GetReadyActivationCommonImpl(ui64 revolvingReadCounter);
+
+        template <typename TQueue>
+        TMailbox* GetReadyActivationSharedImpl(ui64 revolvingReadCounter);
+
         void AskToGoToSleep(bool *needToWait, bool *needToBlock);
 
         void WakeUpLoop(i16 currentThreadCount);

--- a/ydb/library/actors/core/executor_pool_io.cpp
+++ b/ydb/library/actors/core/executor_pool_io.cpp
@@ -31,7 +31,8 @@ namespace NActors {
             ;
     }
 
-    TMailbox* TIOExecutorPool::GetReadyActivation(ui64 revolvingCounter) {
+    template <typename TQueue>
+    TMailbox* TIOExecutorPool::GetReadyActivationImpl(ui64 revolvingCounter) {
         Y_ABORT_UNLESS(TlsThreadContext, "TlsThreadContext is nullptr");
         i16 workerId = TlsThreadContext->WorkerId();
         Y_DEBUG_ABORT_UNLESS(workerId < PoolThreads);
@@ -59,13 +60,20 @@ namespace NActors {
         }
 
         while (!StopFlag.load(std::memory_order_acquire)) {
-            if (const ui32 activation = std::visit([&revolvingCounter](auto &queue){return queue.Pop(++revolvingCounter);}, Activations)) {
+            if (const ui32 activation = GetActivations<TQueue>().Pop(++revolvingCounter)) {
                 return MailboxTable->Get(activation);
             }
             SpinLockPause();
         }
 
         return 0;
+    }
+
+    TMailbox* TIOExecutorPool::GetReadyActivation(ui64 revolvingCounter) {
+        if (UseRingQueueValue) {
+            return GetReadyActivationImpl<TRingActivationQueueV4>(revolvingCounter);
+        }
+        return GetReadyActivationImpl<TUnorderedCacheActivationQueue>(revolvingCounter);
     }
 
     void TIOExecutorPool::Schedule(TInstant deadline, TAutoPtr<IEventHandle> ev, ISchedulerCookie* cookie, TWorkerId workerId) {
@@ -92,9 +100,11 @@ namespace NActors {
     }
 
     void TIOExecutorPool::ScheduleActivationEx(TMailbox* mailbox, ui64 revolvingWriteCounter) {
-        std::visit([mailbox, revolvingWriteCounter](auto &queue) {
-            queue.Push(mailbox->Hint, revolvingWriteCounter);
-        }, Activations);
+        if (UseRingQueueValue) {
+            GetActivations<TRingActivationQueueV4>().Push(mailbox->Hint, revolvingWriteCounter);
+        } else {
+            GetActivations<TUnorderedCacheActivationQueue>().Push(mailbox->Hint, revolvingWriteCounter);
+        }
         const TAtomic semaphoreRaw = AtomicIncrement(Semaphore);
         if (semaphoreRaw <= 0) {
             for (;; ++revolvingWriteCounter) {

--- a/ydb/library/actors/core/executor_pool_io.h
+++ b/ydb/library/actors/core/executor_pool_io.h
@@ -25,6 +25,12 @@ namespace NActors {
 
         const TString PoolName;
         const ui32 ActorSystemIndex = NActors::TActorTypeOperator::GetActorSystemIndex();
+
+        // Instantiated once per activation queue kind so that Pop() inlines into the spin loop;
+        // GetReadyActivation picks the instantiation from UseRingQueueValue.
+        template <typename TQueue>
+        TMailbox* GetReadyActivationImpl(ui64 revolvingCounter);
+
     public:
         TIOExecutorPool(ui32 poolId, ui32 threads, const TString& poolName = "", TAffinity* affinity = nullptr, bool useRingQueue = false);
         explicit TIOExecutorPool(const TIOExecutorPoolConfig& cfg, IHarmonizer *harmonizer = nullptr);

--- a/ydb/library/actors/core/thread_context.cpp
+++ b/ydb/library/actors/core/thread_context.cpp
@@ -1,23 +1,15 @@
 #include "thread_context.h"
 
+#include "config.h"
 #include "executor_pool.h"
-#include "executor_pool_base.h"
 
 namespace NActors {
-
-    bool UseRingQueue(IExecutorPool* pool) {
-        if (auto* basePool = dynamic_cast<TExecutorPoolBase*>(pool)) {
-            return basePool->UseRingQueue();
-        }
-        return false;
-    }
 
     TWorkerContext::TWorkerContext(TWorkerId workerId, IExecutorPool* pool, IExecutorPool* sharedPool)
         : WorkerId(workerId)
         , Pool(pool)
         , OwnerPool(pool)
         , SharedPool(sharedPool)
-        , UseRingQueueValue(::NActors::UseRingQueue(pool))
     {
         AssignPool(pool);
     }
@@ -44,10 +36,6 @@ namespace NActors {
 
     bool TWorkerContext::IsShared() const {
         return SharedPool != nullptr;
-    }
-
-    bool TWorkerContext::UseRingQueue() const {
-        return UseRingQueueValue;
     }
 
     void TWorkerContext::AssignPool(IExecutorPool* pool, ui64 softDeadlineTs) {
@@ -89,10 +77,6 @@ namespace NActors {
 
     bool TThreadContext::IsShared() const {
         return WorkerContext.IsShared();
-    }
-
-    bool TThreadContext::UseRingQueue() const {
-        return WorkerContext.UseRingQueue();
     }
 
     ui64 TThreadContext::TimePerMailboxTs() const {

--- a/ydb/library/actors/core/thread_context.h
+++ b/ydb/library/actors/core/thread_context.h
@@ -50,7 +50,6 @@ namespace NActors {
         ui64 TimePerMailboxTs = 0;
         ui32 EventsPerMailbox = 0;
         ui64 SoftDeadlineTs = ui64(-1);
-        bool UseRingQueueValue = false;
 
         TWorkerContext(TWorkerId workerId, IExecutorPool* pool, IExecutorPool* sharedPool);
 
@@ -58,7 +57,6 @@ namespace NActors {
         TString PoolName() const;
         ui32 OwnerPoolId() const;
         bool IsShared() const;
-        bool UseRingQueue() const;
         void AssignPool(IExecutorPool* pool, ui64 softDeadlineTs = -1);
         void FreeMailbox(TMailbox* mailbox);
     };
@@ -126,7 +124,6 @@ namespace NActors {
         ui32 EventsPerMailbox() const;
         ui64 SoftDeadlineTs() const;
         void FreeMailbox(TMailbox* mailbox);
-        bool UseRingQueue() const;
         void AssignPool(IExecutorPool* pool, ui64 softDeadlineTs = Max<ui64>());
 
         bool CheckSendingType(ESendingType type) const;

--- a/ydb/library/actors/core/ut/executor_pools_ut.cpp
+++ b/ydb/library/actors/core/ut/executor_pools_ut.cpp
@@ -457,6 +457,56 @@ Y_UNIT_TEST_SUITE(ExecutorPoolsTests) {
         }
     }
 
+    Y_UNIT_TEST(SharedThreadSwitchesBetweenActivationQueueTypes) {
+        std::unique_ptr<TSharedExecutorPool> sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
+            .Threads = 1
+        }, std::vector<TPoolShortInfo>{
+            TPoolShortInfo{
+                .PoolId = 0,
+                .SharedThreadCount = 1,
+                .InPriorityOrder = true,
+                .PoolName = "UnorderedPool",
+                .AdjacentPools = {1},
+            },
+            TPoolShortInfo{
+                .PoolId = 1,
+                .SharedThreadCount = 0,
+                .InPriorityOrder = true,
+                .PoolName = "RingPool",
+            }
+        });
+
+        std::vector<std::unique_ptr<TBasicExecutorPool>> pools;
+        for (ui32 poolId = 0; poolId < 2; ++poolId) {
+            pools.push_back(std::make_unique<TBasicExecutorPool>(TBasicExecutorPoolConfig{
+                .PoolId = poolId,
+                .PoolName = poolId == 0 ? "UnorderedPool" : "RingPool",
+                .Threads = 1,
+                .HasSharedThread = poolId == 0,
+                .UseRingQueue = poolId == 1,
+                .MinLocalQueueSize = 0,
+                .MaxLocalQueueSize = 0,
+            }, nullptr));
+        }
+
+        TieBasicPoolsAndSharedPool(pools, sharedPool.get());
+        PreparePools(pools);
+        PreparePool(sharedPool.get());
+
+        std::vector<IExecutorPool*> poolsForEmulator = {pools[0].get(), pools[1].get()};
+        TThreadEmulator emulator(poolsForEmulator, sharedPool.get());
+        TWorkerIdentity workerIdentity{sharedPool.get(), 0};
+
+        TMailbox* unorderedMailbox = pools[0]->GetMailboxTable()->Allocate();
+        TMailbox* ringMailbox = pools[1]->GetMailboxTable()->Allocate();
+
+        emulator.ScheduleActivation(workerIdentity, pools[1].get(), ringMailbox, 0);
+        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workerIdentity, 0), ringMailbox);
+
+        emulator.ScheduleActivation(workerIdentity, pools[0].get(), unorderedMailbox, 0);
+        UNIT_ASSERT_EQUAL(emulator.GetReadyActivation(workerIdentity, 0), unorderedMailbox);
+    }
+
     Y_UNIT_TEST(SharedPoolWithMultiplePools) {
         std::unique_ptr<TSharedExecutorPool> sharedPool = std::make_unique<TSharedExecutorPool>(TSharedExecutorPoolConfig{
             .Threads = 3


### PR DESCRIPTION
### Description for reviewers 

Replace std::visit in executor-pool Push and Pop hot paths with queue-specific template instantiations selected from each pool's immutable queue configuration. This allows queue operations to inline while retaining checked std::variant access and lifetime management.

Use the target pool's queue type when shared threads switch pools, remove the obsolete queue-type cache from thread context, and add a unit test covering switches between unordered and ring queues.

Related to #49294