### PR TITLE
Defer BS queue event serialization until send

### DIFF
--- a/ydb/core/blobstorage/backpressure/event.cpp
+++ b/ydb/core/blobstorage/backpressure/event.cpp
@@ -1,5 +1,7 @@
 #include "event.h"
 
+#include <ydb/library/actors/core/event_pb.h>
+
 namespace NKikimr::NBsQueue {
 
 IEventBase *TEventHolder::MakeErrorReply(NKikimrProto::EReplyStatus status, const TString& errorReason,
@@ -27,7 +29,8 @@ IEventBase *TEventHolder::MakeErrorReply(NKikimrProto::EReplyStatus status, cons
 
 void TEventHolder::SendToVDisk(const TActorContext& ctx, const TActorId& remoteVDisk, ui64 queueCookie, ui64 msgId,
         ui64 sequenceId, bool sendMeCostSettings, NWilson::TTraceId traceId, const NBackpressure::TQueueClientId& clientId,
-        const TBSQueueTimer& processingTimer) {
+        const TBSQueueTimer& processingTimer, const ::NMonitoring::TDynamicCounters::TCounterPtr& serItems,
+        const ::NMonitoring::TDynamicCounters::TCounterPtr& serBytes) {
     // check that we are not discarded yet
     Y_ABORT_UNLESS(Type != 0);
 
@@ -51,7 +54,7 @@ void TEventHolder::SendToVDisk(const TActorContext& ctx, const TActorId& remoteV
 
     const ui32 flags = IEventHandle::MakeFlags(InterconnectChannel, IEventHandle::FlagTrackDelivery);
 
-    if (LocalEvent) {
+    if (Local && Event) {
         auto callback = [&](auto *ev) -> std::unique_ptr<IEventBase> {
             using T = std::remove_pointer_t<decltype(ev)>;
             auto clone = std::make_unique<T>();
@@ -63,27 +66,48 @@ void TEventHolder::SendToVDisk(const TActorContext& ctx, const TActorId& remoteV
             return clone;
         };
         ctx.Send(remoteVDisk, Apply(callback).release(), flags, queueCookie, std::move(traceId));
-    } else {
-        // FIXME: ensure that MsgQoS has the same field identifier in all structures
-        NKikimrBlobStorage::TEvVPut record;
-        processMsgQoS(record);
-
-        // serialize that extra buffer
-        TString buf;
-        const bool status = record.SerializeToString(&buf);
-        Y_ABORT_UNLESS(status);
-
-        // send it to disk
-        ctx.Send(new IEventHandle(Type, flags, remoteVDisk, ctx.SelfID,
-            MakeIntrusive<TEventSerializedData>(*Buffer, std::move(buf)), queueCookie, nullptr, std::move(traceId)));
+        return;
     }
+
+    // FIXME: ensure that MsgQoS has the same field identifier in all structures
+    NKikimrBlobStorage::TEvVPut record;
+    processMsgQoS(record);
+
+    // serialize that extra buffer
+    TString buf;
+    const bool status = record.SerializeToString(&buf);
+    Y_ABORT_UNLESS(status);
+
+    TIntrusivePtr<TEventSerializedData> buffer;
+    if (Event) {
+        TAllocChunkSerializer serializer;
+        const bool success = Event->SerializeToArcadiaStream(&serializer);
+        Y_ABORT_UNLESS(success);
+        buffer = serializer.Release(Event->CreateSerializationInfo(false));
+        ++*serItems;
+        *serBytes += buffer->GetSize();
+        // keep section sizes consistent after appending MsgQoS.
+        if (const auto& info = buffer->GetSerializationInfo(); !info.Sections.empty()) {
+            TEventSerializationInfo updated(info);
+            updated.Sections.push_back(TEventSectionInfo{0, buf.size(), 0, 0, true});
+            buffer->SetSerializationInfo(std::move(updated));
+        }
+        buffer->Append(std::move(buf));
+    } else {
+        // keep the original buffer intact for retransmission.
+        buffer = MakeIntrusive<TEventSerializedData>(*Buffer, std::move(buf));
+    }
+
+    // send it to disk
+    ctx.Send(new IEventHandle(Type, flags, remoteVDisk, ctx.SelfID, std::move(buffer), queueCookie, nullptr,
+        std::move(traceId)));
 }
 
 void TEventHolder::Discard() {
     if (std::exchange(Type, 0)) {
         BSProxyCtx->Queue.Subtract(ByteSize);
         Buffer.Reset();
-        LocalEvent.reset();
+        Event.reset();
     }
 }
 

--- a/ydb/core/blobstorage/backpressure/event.h
+++ b/ydb/core/blobstorage/backpressure/event.h
@@ -36,10 +36,17 @@ class TEventHolder {
     TActorId Sender;
     ui64 Cookie;
     ui32 InterconnectChannel;
+    bool Local;
     mutable NLWTrace::TOrbit Orbit;
+
+    // exactly one of the two is set: either we keep the original event object
+    // and serialize it (if needed at all)
+    // when it is actually sent, or the event has arrived already serialized
+    // and we just keep the buffer
+    std::unique_ptr<IEventBase> Event;
     TIntrusivePtr<TEventSerializedData> Buffer;
+
     TBSProxyContextPtr BSProxyCtx;
-    std::unique_ptr<IEventBase> LocalEvent;
     std::optional<TMessageRelevance> Tracker;
 
 public:
@@ -48,16 +55,16 @@ public:
         , ByteSize(0)
         , Cookie(0)
         , InterconnectChannel(0)
+        , Local(false)
     {}
 
     template<typename TPtr>
-    TEventHolder(TPtr& ev, const ::NMonitoring::TDynamicCounters::TCounterPtr& serItems,
-            const ::NMonitoring::TDynamicCounters::TCounterPtr& serBytes, const TBSProxyContextPtr& bspctx,
-            ui32 interconnectChannel, bool local)
+    TEventHolder(TPtr& ev, const TBSProxyContextPtr& bspctx, ui32 interconnectChannel, bool local)
         : Type(ev->GetTypeRewrite())
         , Sender(ev->Sender)
         , Cookie(ev->Cookie)
         , InterconnectChannel(interconnectChannel)
+        , Local(local)
         , Orbit(MoveOrbit(ev))
         , BSProxyCtx(bspctx)
         , Tracker(std::move(ev->Get()->MessageRelevanceTracker))
@@ -71,17 +78,15 @@ public:
                     blob.BlobSize());
         }
 
-        if (local && ev->HasEvent()) {
+        if (ev->HasEvent()) {
+            // keep the event object itself; it is serialized in SendToVDisk,
+            // when the MsgQoS fields are known and the item is known to be actually going out --
+            // items that expire in the queue or get pruned while waiting never pay for serialization at all
             ByteSize = ev->Get()->GetCachedByteSize();
-            LocalEvent.reset(ev->ReleaseBase().Release());
+            Event.reset(ev->ReleaseBase().Release());
         } else {
-            const bool hasEvent = ev->HasEvent();
             Buffer = ev->ReleaseChainBuffer();
             ByteSize = Buffer->GetSize();
-            if (hasEvent) {
-                ++*serItems;
-                *serBytes += ByteSize;
-            }
         }
 
         BSProxyCtx->Queue.Add(ByteSize);
@@ -106,7 +111,7 @@ public:
     template<typename TCallable>
     auto Apply(TCallable&& callable) {
         switch (Type) {
-#define CASE(T) case TEvBlobStorage::T::EventType: return callable(static_cast<TEvBlobStorage::T*>(LocalEvent.get()))
+#define CASE(T) case TEvBlobStorage::T::EventType: return callable(static_cast<TEvBlobStorage::T*>(Event.get()))
             CASE(TEvVMovedPatch);
             CASE(TEvVPatchStart);
             CASE(TEvVPatchDiff);
@@ -145,7 +150,8 @@ public:
 
     void SendToVDisk(const TActorContext& ctx, const TActorId& remoteVDisk, ui64 queueCookie, ui64 msgId, ui64 sequenceId,
             bool sendMeCostSettings, NWilson::TTraceId traceId, const NBackpressure::TQueueClientId& clientId,
-            const TBSQueueTimer& processingTimer);
+            const TBSQueueTimer& processingTimer, const ::NMonitoring::TDynamicCounters::TCounterPtr& serItems,
+            const ::NMonitoring::TDynamicCounters::TCounterPtr& serBytes);
 
     void Discard();
 };

--- a/ydb/core/blobstorage/backpressure/queue.cpp
+++ b/ydb/core/blobstorage/backpressure/queue.cpp
@@ -239,7 +239,7 @@ void TBlobStorageQueue::SendToVDisk(const TActorContext& ctx, const TActorId& re
             });
         }
         item.Event.SendToVDisk(ctx, remoteVDisk, item.QueueCookie, item.MsgId, item.SequenceId, sendMeCostSettings,
-            item.Span.GetTraceId(), ClientId, item.ProcessingTimer);
+            item.Span.GetTraceId(), ClientId, item.ProcessingTimer, QueueSerializedItems, QueueSerializedBytes);
 
         // update counters as far as item got sent
         ++NextMsgId;

--- a/ydb/core/blobstorage/backpressure/queue.h
+++ b/ydb/core/blobstorage/backpressure/queue.h
@@ -50,14 +50,12 @@ class TBlobStorageQueue {
 
         template<typename TEvent>
         TItem(TAutoPtr<TEventHandle<TEvent>>& event, TInstant deadline,
-                const ::NMonitoring::TDynamicCounters::TCounterPtr& serItems,
-                const ::NMonitoring::TDynamicCounters::TCounterPtr& serBytes,
                 const TBSProxyContextPtr& bspctx, ui32 interconnectChannel,
                 bool local, bool useActorSystemTime)
             : Queue(EItemQueue::NotSet)
             , CostEssence(*event->Get())
             , Span(TWilson::VDiskTopLevel, std::move(event->TraceId), "Backpressure.InFlight")
-            , Event(event, serItems, serBytes, bspctx, interconnectChannel, local)
+            , Event(event, bspctx, interconnectChannel, local)
             , MsgId(Max<ui64>())
             , SequenceId(0)
             , Deadline(deadline)
@@ -207,9 +205,8 @@ public:
 
         TItemList::iterator newIt;
         if (Queues.Unused.empty()) {
-            newIt = Queues.Waiting.emplace(Queues.Waiting.end(), event, deadline,
-                QueueSerializedItems, QueueSerializedBytes, BSProxyCtx, InterconnectChannel, local,
-                UseActorSystemTime);
+            newIt = Queues.Waiting.emplace(Queues.Waiting.end(), event, deadline, BSProxyCtx, InterconnectChannel,
+                local, UseActorSystemTime);
             ++*QueueSize;
         } else {
             newIt = Queues.Unused.begin();
@@ -217,8 +214,7 @@ public:
             // reuse list item
             TItem& item = *newIt;
             item.~TItem();
-            new(&item) TItem(event, deadline, QueueSerializedItems, QueueSerializedBytes, BSProxyCtx,
-                InterconnectChannel, local, UseActorSystemTime);
+            new(&item) TItem(event, deadline, BSProxyCtx, InterconnectChannel, local, UseActorSystemTime);
         }
 
         newIt->Iterator = newIt;

--- a/ydb/core/blobstorage/backpressure/ut/event_ut.cpp
+++ b/ydb/core/blobstorage/backpressure/ut/event_ut.cpp
@@ -34,7 +34,13 @@ TEvBlobStorage::TEvVGet::TPtr MakeEvent(const TActorId& recipient, const TActorI
 }
 
 TTestActorRuntime::TEgg MakeRuntimeEgg() {
-    return {new TAppData(0, 0, 0, 0, {}, nullptr, nullptr, nullptr, nullptr), nullptr, nullptr, {}, {}};
+    return {
+        .App0 = new TAppData(0, 0, 0, 0, {}, nullptr, nullptr, nullptr, nullptr),
+        .Opaque = nullptr,
+        .KeyConfigGenerator = nullptr,
+        .Icb = {},
+        .Dcb = {},
+    };
 }
 
 struct TSendState {

--- a/ydb/core/blobstorage/backpressure/ut/event_ut.cpp
+++ b/ydb/core/blobstorage/backpressure/ut/event_ut.cpp
@@ -1,0 +1,146 @@
+#include "event.h"
+
+#include <ydb/core/testlib/actors/test_runtime.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+
+namespace NKikimr::NBsQueue {
+namespace {
+
+class TCountingVGet : public TEvBlobStorage::TEvVGet {
+    std::shared_ptr<ui32> SerializationCount;
+
+public:
+    TCountingVGet(std::unique_ptr<TEvBlobStorage::TEvVGet> event, std::shared_ptr<ui32> serializationCount)
+        : SerializationCount(std::move(serializationCount))
+    {
+        Record.Swap(&event->Record);
+    }
+
+    bool SerializeToArcadiaStream(TChunkSerializer* serializer) const override {
+        ++*SerializationCount;
+        return TEvBlobStorage::TEvVGet::SerializeToArcadiaStream(serializer);
+    }
+};
+
+TEvBlobStorage::TEvVGet::TPtr MakeEvent(const TActorId& recipient, const TActorId& sender,
+        const std::shared_ptr<ui32>& serializationCount) {
+    auto event = TEvBlobStorage::TEvVGet::CreateExtremeDataQuery(TVDiskID(1, 2, 3, 4, 5), TInstant::Max(),
+        NKikimrBlobStorage::EGetHandleClass::AsyncRead, TEvBlobStorage::TEvVGet::EFlags::None, 123,
+        {TLogoBlobID(1, 2, 3, 0, 10, 0)});
+    TAutoPtr<IEventHandle> handle = new IEventHandle(recipient, sender,
+        new TCountingVGet(std::move(event), serializationCount));
+    return IEventHandle::Downcast<TEvBlobStorage::TEvVGet>(std::move(handle));
+}
+
+TTestActorRuntime::TEgg MakeRuntimeEgg() {
+    return {new TAppData(0, 0, 0, 0, {}, nullptr, nullptr, nullptr, nullptr), nullptr, nullptr, {}, {}};
+}
+
+struct TSendState {
+    ui32 SerializationsBeforeSend = 0;
+    ui32 SerializationsAfterFirstSend = 0;
+    ui32 SerializationsAfterSecondSend = 0;
+    ui64 SerializedItemsAfterFirstSend = 0;
+    ui64 SerializedItemsAfterSecondSend = 0;
+    ui64 SerializedBytesAfterFirstSend = 0;
+    ui64 SerializedBytesAfterSecondSend = 0;
+};
+
+class TSendActor : public TActorBootstrapped<TSendActor> {
+    const TActorId Recipient;
+    const std::shared_ptr<ui32> SerializationCount;
+    const std::shared_ptr<TSendState> State;
+
+public:
+    TSendActor(TActorId recipient, std::shared_ptr<ui32> serializationCount, std::shared_ptr<TSendState> state)
+        : Recipient(recipient)
+        , SerializationCount(std::move(serializationCount))
+        , State(std::move(state))
+    {}
+
+    void Bootstrap(const TActorContext& ctx) {
+        auto counters = MakeIntrusive<::NMonitoring::TDynamicCounters>();
+        auto serItems = counters->GetCounter("SerializedItems", true);
+        auto serBytes = counters->GetCounter("SerializedBytes", true);
+        TBSProxyContextPtr bspctx = new TBSProxyContext(counters);
+        auto event = MakeEvent(ctx.SelfID, ctx.SelfID, SerializationCount);
+        TEventHolder holder(event, bspctx, 0, false);
+        TBSQueueTimer timer(false);
+
+        State->SerializationsBeforeSend = *SerializationCount;
+        holder.SendToVDisk(ctx, Recipient, 1, 10, 20, true, {}, NBackpressure::TQueueClientId(), timer,
+            serItems, serBytes);
+        State->SerializationsAfterFirstSend = *SerializationCount;
+        State->SerializedItemsAfterFirstSend = *serItems;
+        State->SerializedBytesAfterFirstSend = *serBytes;
+
+        holder.SendToVDisk(ctx, Recipient, 2, 11, 21, false, {}, NBackpressure::TQueueClientId(), timer,
+            serItems, serBytes);
+        State->SerializationsAfterSecondSend = *SerializationCount;
+        State->SerializedItemsAfterSecondSend = *serItems;
+        State->SerializedBytesAfterSecondSend = *serBytes;
+
+        PassAway();
+    }
+};
+
+void CheckMessage(const TEvBlobStorage::TEvVGet& event, ui64 msgId, ui64 sequenceId,
+        bool sendMeCostSettings) {
+    UNIT_ASSERT_VALUES_EQUAL(event.Record.GetCookie(), 123);
+    UNIT_ASSERT_VALUES_EQUAL(event.Record.ExtremeQueriesSize(), 1);
+    const auto& msgQoS = event.Record.GetMsgQoS();
+    UNIT_ASSERT_VALUES_EQUAL(msgQoS.GetMsgId().GetMsgId(), msgId);
+    UNIT_ASSERT_VALUES_EQUAL(msgQoS.GetMsgId().GetSequenceId(), sequenceId);
+    UNIT_ASSERT_VALUES_EQUAL(msgQoS.GetSendMeCostSettings(), sendMeCostSettings);
+}
+
+} // anonymous namespace
+
+Y_UNIT_TEST_SUITE(TEventHolderTest) {
+    Y_UNIT_TEST(DoesNotSerializeRejectedEvent) {
+        auto counters = MakeIntrusive<::NMonitoring::TDynamicCounters>();
+        auto serializationCount = std::make_shared<ui32>();
+        auto event = MakeEvent(TActorId(1, 1), TActorId(1, 2), serializationCount);
+        {
+            TEventHolder holder(event, new TBSProxyContext(counters), 0, false);
+
+            UNIT_ASSERT_VALUES_EQUAL(*serializationCount, 0);
+            std::unique_ptr<IEventBase> response(holder.MakeErrorReply(NKikimrProto::DEADLINE, "deadline exceeded",
+                counters->GetCounter("DeserializedItems", true), counters->GetCounter("DeserializedBytes", true)));
+            UNIT_ASSERT_VALUES_EQUAL(*serializationCount, 0);
+            UNIT_ASSERT_VALUES_EQUAL(static_cast<TEvBlobStorage::TEvVGetResult&>(*response).Record.GetStatus(),
+                NKikimrProto::DEADLINE);
+        }
+        UNIT_ASSERT_VALUES_EQUAL(*serializationCount, 0);
+    }
+
+    Y_UNIT_TEST(SerializesRemoteEventOnEverySend) {
+        TTestActorRuntime runtime;
+        runtime.Initialize(MakeRuntimeEgg());
+        runtime.SetDispatchTimeout(TDuration::Seconds(5));
+        const TActorId recipient = runtime.AllocateEdgeActor();
+        auto serializationCount = std::make_shared<ui32>();
+        auto state = std::make_shared<TSendState>();
+        runtime.Register(new TSendActor(recipient, serializationCount, state));
+
+        TAutoPtr<IEventHandle> firstHandle;
+        const auto* first = runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVGet>(firstHandle);
+        CheckMessage(*first, 10, 20, true);
+
+        TAutoPtr<IEventHandle> secondHandle;
+        const auto* second = runtime.GrabEdgeEventRethrow<TEvBlobStorage::TEvVGet>(secondHandle);
+        CheckMessage(*second, 11, 21, false);
+
+        UNIT_ASSERT_VALUES_EQUAL(state->SerializationsBeforeSend, 0);
+        UNIT_ASSERT_VALUES_EQUAL(state->SerializationsAfterFirstSend, 1);
+        UNIT_ASSERT_VALUES_EQUAL(state->SerializationsAfterSecondSend, 2);
+        UNIT_ASSERT_VALUES_EQUAL(state->SerializedItemsAfterFirstSend, 1);
+        UNIT_ASSERT_VALUES_EQUAL(state->SerializedItemsAfterSecondSend, 2);
+        UNIT_ASSERT_GT(state->SerializedBytesAfterFirstSend, 0);
+        UNIT_ASSERT_VALUES_EQUAL(state->SerializedBytesAfterSecondSend,
+            2 * state->SerializedBytesAfterFirstSend);
+    }
+}
+
+} // namespace NKikimr::NBsQueue

--- a/ydb/core/blobstorage/backpressure/ut/ya.make
+++ b/ydb/core/blobstorage/backpressure/ut/ya.make
@@ -9,9 +9,11 @@ PEERDIR(
     library/cpp/svnversion
     ydb/core/base
     ydb/core/blobstorage/dsproxy/mock
+    ydb/core/testlib/actors
 )
 
 SRCS(
+    event_ut.cpp
     queue_backpressure_client_ut.cpp
     queue_backpressure_server_ut.cpp
 )


### PR DESCRIPTION
### Description for reviewers

Keep original event objects while they are waiting in the backpressure queue and serialize remote events only when they are actually sent.

This avoids serialization work for requests that expire or are pruned while queued and moves serialization accounting to the send path.
