### PR TITLE
Fix database path resolution for nested tables in analyze actor

### DIFF
--- a/ydb/core/statistics/aggregator/analyze_actor.cpp
+++ b/ydb/core/statistics/aggregator/analyze_actor.cpp
@@ -2,6 +2,7 @@
 
 #include <ydb/library/query_actor/query_actor.h>
 #include <ydb/core/statistics/events.h>
+#include <ydb/core/base/path.h>
 #include <util/generic/size_literals.h>
 #include <util/string/vector.h>
 #include <algorithm>
@@ -161,6 +162,13 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
     Y_ABORT_UNLESS(request.ResultSet.size() == 1);
     const NSchemeCache::TSchemeCacheNavigate::TEntry& entry = request.ResultSet.front();
 
+    // Second navigate round: resolve the domain key to an absolute database
+    // path for background traversals (where DatabaseName is empty).
+    if (ResolvingDatabase) {
+        HandleResolveDatabase(entry);
+        return;
+    }
+
     if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
         YDB_LOG_WARN("Navigate request failed",
             {"selfId", SelfId()},
@@ -192,17 +200,69 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
     TableName = "/" + JoinVectorIntoString(entry.Path, "/");
     IsColumnTable = !!entry.ColumnTableInfo;
 
-    // For background traversals, DatabaseName is empty (the SA does not know
-    // the tenant database). Derive it from the Navigate response: the database
-    // is the table path minus the last component (the table name).
-    if (DatabaseName.empty() && entry.Path.size() > 1) {
-        auto dbPath = entry.Path;
-        dbPath.pop_back();
-        DatabaseName = "/" + JoinVectorIntoString(dbPath, "/");
+    // For background traversals, DatabaseName is empty. Resolve it from
+    // the table's DomainKey via a second navigate round, which correctly
+    // handles tables nested in subdirectories. We use DomainKey (the tenant
+    // domain), not ResourcesDomainKey, because the scan query runs against
+    // the tenant database.
+    if (DatabaseName.empty()) {
+        const auto& domainKey = entry.DomainInfo->DomainKey;
+
+        auto resolveNavigate = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
+        resolveNavigate->DatabaseName = AppData()->DomainsInfo->GetDomain()->Name;
+        auto& resolveEntry = resolveNavigate->ResultSet.emplace_back();
+        resolveEntry.TableId = TTableId(domainKey.OwnerId, domainKey.LocalPathId);
+        resolveEntry.Operation = NSchemeCache::TSchemeCacheNavigate::EOp::OpPath;
+        resolveEntry.RequestType = NSchemeCache::TSchemeCacheNavigate::TEntry::ERequestType::ByTableId;
+        resolveEntry.RedirectRequired = false;
+
+        NavigateColumns = entry.Columns;
+        NavigateMultiColumnStatistics = entry.MultiColumnStatistics;
+        ResolvingDatabase = true;
+        Send(MakeSchemeCacheID(),
+            new TEvTxProxySchemeCache::TEvNavigateKeySet(resolveNavigate.release()));
+        return;
     }
 
+    NavigateColumns = entry.Columns;
+    NavigateMultiColumnStatistics = entry.MultiColumnStatistics;
+    HandleNavigateResult();
+}
+
+void TAnalyzeActor::HandleResolveDatabase(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry) {
+    ResolvingDatabase = false;
+
+    if (entry.Status != NSchemeCache::TSchemeCacheNavigate::EStatus::Ok) {
+        YDB_LOG_WARN("Resolve database navigate failed",
+            {"selfId", SelfId()},
+            {"status", entry.Status},
+            {"operationId", OperationId.Quote()},
+            {"pathId", PathId});
+
+        FinishWithFailure(
+            TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            NYql::TIssue(TStringBuilder() << "Resolve database navigate failed with " << entry.Status));
+        return;
+    }
+
+    DatabaseName = CanonizePath(entry.Path);
+    if (DatabaseName.empty()) {
+        FinishWithFailure(
+            TEvStatistics::TEvAnalyzeActorResult::EStatus::InternalError,
+            NYql::TIssue("Resolved database path is empty"));
+        return;
+    }
+    YDB_LOG_DEBUG("Resolved database path",
+        {"selfId", SelfId()},
+        {"operationId", OperationId.Quote()},
+        {"databaseName", DatabaseName});
+
+    HandleNavigateResult();
+}
+
+void TAnalyzeActor::HandleNavigateResult() {
     THashMap<ui32, TSysTables::TTableColumnInfo> tag2Column;
-    for (const auto& col : entry.Columns) {
+    for (const auto& col : NavigateColumns) {
         tag2Column[col.second.Id] = col.second;
 
         if (col.second.KeyOrder >= 0) {
@@ -211,7 +271,7 @@ void TAnalyzeActor::Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr&
         }
     }
 
-    for (const auto& def : entry.MultiColumnStatistics) {
+    for (const auto& def : NavigateMultiColumnStatistics) {
         TMultiColumnStatDesc desc;
         desc.Name = def.GetName();
 

--- a/ydb/core/statistics/aggregator/analyze_actor.h
+++ b/ydb/core/statistics/aggregator/analyze_actor.h
@@ -106,6 +106,12 @@ private:
     void Handle(TEvTxProxySchemeCache::TEvNavigateKeySetResult::TPtr& ev);
     void Handle(TEvTxProxySchemeCache::TEvResolveKeySetResult::TPtr& ev);
 
+    bool ResolvingDatabase = false;
+    THashMap<ui32, TSysTables::TTableColumnInfo> NavigateColumns;
+    TVector<NKikimrSchemeOp::TMultiColumnStatisticsDescription> NavigateMultiColumnStatistics;
+    void HandleNavigateResult();
+    void HandleResolveDatabase(const NSchemeCache::TSchemeCacheNavigate::TEntry& entry);
+
     // StateLocateTablets
 
     // In this stage tablet -> node correspondence is resolved. Currently this is only needed

--- a/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
+++ b/ydb/core/statistics/aggregator/ut/ut_traverse.cpp
@@ -9,6 +9,7 @@
 #include <ydb/core/statistics/events.h>
 #include <ydb/core/statistics/service/service.h>
 #include <ydb/core/base/counters.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
 
 namespace NKikimr {
 namespace NStat {
@@ -40,6 +41,17 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
         auto& runtime = *env.GetServer().GetRuntime();
         CreateDatabase(env, "Database");
         const auto tableInfo = PrepareTableWithIndexes(env, "Database", "Table", ColumnShard);
+
+        WaitForPrimaryCollection(runtime, tableInfo.PathId, ColumnTableRowsNumber, 1, ColumnShard);
+
+        ValidateStatistics(runtime, tableInfo.PathId);
+    }
+
+    Y_UNIT_TEST_TWIN(TraverseNestedTable, ColumnShard) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareTableWithIndexes(env, "Database", "subdir/Table", ColumnShard);
 
         WaitForPrimaryCollection(runtime, tableInfo.PathId, ColumnTableRowsNumber, 1, ColumnShard);
 
@@ -462,6 +474,33 @@ Y_UNIT_TEST_SUITE(TraverseStatistics) {
         });
 
         UNIT_ASSERT_VALUES_EQUAL(observer.GetSaveCount(), 1);
+    }
+
+    // Verifies the analyze actor resolves the correct database for a nested
+    // table by checking DatabaseName in the TEvResolveKeySet request.
+    Y_UNIT_TEST_TWIN(TraverseNestedTableResolvesCorrectDatabase, ColumnShard) {
+        TTestEnv env = CreateTestEnv();
+        auto& runtime = *env.GetServer().GetRuntime();
+        CreateDatabase(env, "Database");
+        const auto tableInfo = PrepareTableWithIndexes(env, "Database", "subdir/Table", ColumnShard);
+
+        TString resolveDatabaseName;
+        auto resolveObserver = runtime.AddObserver<TEvTxProxySchemeCache::TEvResolveKeySet>(
+            [&](TAutoPtr<TEventHandle<TEvTxProxySchemeCache::TEvResolveKeySet>>& ev) {
+                const auto& request = *ev->Get()->Request;
+                for (const auto& entry : request.ResultSet) {
+                    if (entry.KeyDescription
+                        && entry.KeyDescription->TableId.PathId == tableInfo.PathId) {
+                        resolveDatabaseName = request.DatabaseName;
+                    }
+                }
+            });
+
+        WaitForPrimaryCollection(runtime, tableInfo.PathId, ColumnTableRowsNumber, 1, ColumnShard);
+        resolveObserver.Remove();
+
+        UNIT_ASSERT_VALUES_EQUAL(resolveDatabaseName, "/Root/Database");
+        ValidateStatistics(runtime, tableInfo.PathId);
     }
 
 } // Y_UNIT_TEST_SUITE(TraverseStatistics)


### PR DESCRIPTION


Background traversal derived DatabaseName by stripping the last path component, which produced wrong results for tables in subdirectories (e.g. /Root/Database/subdir/Table -> /Root/Database/subdir instead of /Root/Database). Resolve the database path via a second navigate round using the table's DomainKey, which correctly handles nested tables.
