### PR TITLE
Propagate SchemeShard error reason in Topic API schema operations

### DIFF
--- a/ydb/core/persqueue/public/schema/schema_operation.cpp
+++ b/ydb/core/persqueue/public/schema/schema_operation.cpp
@@ -95,7 +95,7 @@ private:
         switch (status) {
             case NTxProxy::TResultStatus::ExecComplete:
                 if (ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists) {
-                    return ReplyError(Ydb::StatusIds::ALREADY_EXISTS, ssStatus);
+                    return ReplyError(Ydb::StatusIds::ALREADY_EXISTS, ssStatus, record.GetSchemeShardReason());
                 } else {
                     return ReplyOkAndDie();
                 }
@@ -105,12 +105,12 @@ private:
                 return RetryPropose();
             case NTxProxy::TResultStatus::ExecAlready:
                 if (ssStatus == NKikimrScheme::EStatus::StatusAlreadyExists) {
-                    return ReplyError(Ydb::StatusIds::ALREADY_EXISTS, ssStatus);
+                    return ReplyError(Ydb::StatusIds::ALREADY_EXISTS, ssStatus, record.GetSchemeShardReason());
                 } else {
-                    return ReplyError(ydbStatus, ssStatus);
+                    return ReplyError(ydbStatus, ssStatus, record.GetSchemeShardReason());
                 }
             default:
-                return ReplyError(ydbStatus, ssStatus);
+                return ReplyError(ydbStatus, ssStatus, record.GetSchemeShardReason());
         }
     }
 
@@ -171,9 +171,13 @@ private:
     }
 
 private:
-    void ReplyError(Ydb::StatusIds::StatusCode errorCode, NKikimrScheme::EStatus ssStatus) {
-        ReplyErrorAndDie(errorCode,
-            TStringBuilder() << "Failed to execute operation: " << NKikimrScheme::EStatus_Name(ssStatus));
+    void ReplyError(Ydb::StatusIds::StatusCode errorCode, NKikimrScheme::EStatus ssStatus, const TString& reason) {
+        TStringBuilder message;
+        message << "Failed to execute operation: " << NKikimrScheme::EStatus_Name(ssStatus);
+        if (reason) {
+            message << ", reason: " << reason;
+        }
+        ReplyErrorAndDie(errorCode, std::move(message));
     }
 
     void ReplyErrorAndDie(Ydb::StatusIds::StatusCode errorCode, TString&& errorMessage) {


### PR DESCRIPTION
### Changelog entry

Include the SchemeShard error reason (e.g. which quota/limit was hit) in error messages returned by Topic API schema operations (CreateTopic/AlterTopic/DropTopic/AddConsumer/RemoveConsumer).

### Description for reviewers

`TSchemaOperationActor::ReplyError()` (`ydb/core/persqueue/public/schema/schema_operation.cpp`) only reported the bare SchemeShard status name, e.g.:

```
Failed to execute operation: StatusResourceExhausted
```

This discards the informative `SchemeShardReason` that TxProxy already receives from SchemeShard (`ydb/core/tx/tx_proxy/schemereq.cpp` fills `TEvProposeTransactionStatus.SchemeShardReason` from `TEvModifySchemeTransactionResult::GetReason()`). SchemeShard's own scheme-limit checks build specific, actionable messages, for example (`ydb/core/tx/schemeshard/schemeshard_path.cpp`):

- `"shards count limit exceeded (in subdomain), limit: X, shards: Y, delta: Z"`
- `"data stream shards limit exceeded, limit: X, data stream shards: Y, delta: Z"`
- `"data stream reserved storage size limit exceeded, limit: X bytes, ..."`
- `"database size limit exceeded, limit: X bytes, available: Y bytes, delta: Z bytes"`

but a user creating a topic via the Topic API only ever saw the generic status name, with no way to tell which resource/quota was actually exhausted (unlike, say, `CREATE TABLE`, whose errors go through a different path and keep the reason).

This PR passes `record.GetSchemeShardReason()` through to `ReplyError()` and appends it to the error message when present, so operators can act on the real cause without extra round-trips (e.g. `DescribeTable`/manual quota inspection) just to find out which limit was hit.

Found while investigating a support ticket where `CreateTopic` failed with an unhelpful `StatusResourceExhausted` and no indication of which limit (shards / data stream partitions / reserved storage / database size) was actually exceeded.