### PR TITLE
Break conveyor usage->service header cycle

### DIFF
--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1279,7 +1279,7 @@ namespace Tests {
             Runtime->RegisterService(NPrioritiesQueue::TCompServiceOperator::MakeServiceId(Runtime->GetNodeId(nodeIdx)), aid, nodeIdx);
         }
         {
-            auto* actor = NConveyor::TScanServiceOperator::CreateService(NConveyor::TConfig(), appData.Counters);
+            auto* actor = NConveyor::CreateService<NConveyor::TScanConveyorPolicy>(NConveyor::TConfig(), appData.Counters);
             const auto aid = Runtime->Register(actor, nodeIdx, appData.UserPoolId, TMailboxType::Revolving, 0);
             Runtime->RegisterService(NConveyor::TScanServiceOperator::MakeServiceId(Runtime->GetNodeId(nodeIdx)), aid, nodeIdx);
         }

--- a/ydb/core/testlib/ya.make
+++ b/ydb/core/testlib/ya.make
@@ -113,6 +113,7 @@ PEERDIR(
     ydb/services/discovery
     ydb/services/ymq
     ydb/core/tx/conveyor/service
+    ydb/core/tx/conveyor/usage
     ydb/core/tx/conveyor_composite/service
     ydb/core/tx/conveyor_composite/usage
     ydb/core/tx/priorities/service

--- a/ydb/core/tx/conveyor/service/service.h
+++ b/ydb/core/tx/conveyor/service/service.h
@@ -2,6 +2,7 @@
 #include "worker.h"
 #include <ydb/core/tx/conveyor/usage/config.h>
 #include <ydb/core/tx/conveyor/usage/events.h>
+#include <ydb/core/tx/conveyor/usage/service.h>
 #include <ydb/library/signals/owner.h>
 #include <ydb/library/accessor/positive_integer.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -292,5 +293,12 @@ public:
 
     void Bootstrap();
 };
+
+template <class TConveyorPolicy>
+NActors::IActor* CreateService(const TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorSignals) {
+    using TOperator = TServiceOperatorImpl<TConveyorPolicy>;
+    TOperator::Register(config);
+    return new TDistributor(config, TOperator::GetConveyorName(), TConveyorPolicy::EnableProcesses, conveyorSignals);
+}
 
 }

--- a/ydb/core/tx/conveyor/usage/service.h
+++ b/ydb/core/tx/conveyor/usage/service.h
@@ -1,10 +1,10 @@
 #pragma once
 #include "config.h"
 
-#include <ydb/core/tx/conveyor/service/service.h>
 #include <ydb/core/tx/conveyor/usage/events.h>
 
 #include <ydb/library/actors/core/actor.h>
+#include <ydb/library/actors/core/actor_bootstrapped.h>
 #include <ydb/library/actors/core/actorid.h>
 
 namespace NKikimr::NConveyor {
@@ -35,6 +35,8 @@ class TServiceOperatorImpl {
 private:
     using TSelf = TServiceOperatorImpl<TConveyorPolicy>;
     std::atomic<bool> IsEnabledFlag = false;
+
+public:
     static void Register(const TConfig& serviceConfig) {
         Singleton<TSelf>()->IsEnabledFlag = serviceConfig.IsEnabled();
     }
@@ -42,8 +44,6 @@ private:
         Y_ABORT_UNLESS(TConveyorPolicy::Name.size() == 4);
         return TConveyorPolicy::Name;
     }
-
-public:
     static void AsyncTaskToExecute(const std::shared_ptr<ITask>& task) {
         auto& context = NActors::TActorContext::AsActorContext();
         context.Register(new TAsyncTaskExecutor(task));
@@ -67,10 +67,6 @@ public:
     }
     static NActors::TActorId MakeServiceId(const ui32 nodeId) {
         return NActors::TActorId(nodeId, "SrvcConv" + GetConveyorName());
-    }
-    static NActors::IActor* CreateService(const TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorSignals) {
-        Register(config);
-        return new TDistributor(config, GetConveyorName(), TConveyorPolicy::EnableProcesses, conveyorSignals);
     }
     static TProcessGuard StartProcess(const ui64 externalProcessId, const TCPULimitsConfig& cpuLimits) {
         if (TSelf::IsEnabled() && NActors::TlsActivationContext) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Breaks the `usage` → `service` header/peerdir cycle in `ydb/core/tx/conveyor`.

- Moved the `CreateService` factory out of `usage/service.h` into `service/service.h`, so the client-side operator no longer needs to see `TDistributor`.
- Dependency direction is now strictly `service → usage`.
- Call sites use `NConveyor::CreateService<TScanConveyorPolicy>(...)`; added the `conveyor/usage` peerdir where it was previously only transitive.
