### PR TITLE
Break conveyor_composite usage->service header cycle

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -2820,7 +2820,7 @@ void TCompositeConveyorInitializer::InitializeServices(NActors::TActorSystemSetu
         TIntrusivePtr<::NMonitoring::TDynamicCounters> tabletGroup = GetServiceCounters(appData->Counters, "tablets");
         TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorGroup = tabletGroup->GetSubgroup("type", "TX_COMPOSITE_CONVEYOR");
 
-        auto service = NConveyorComposite::TServiceOperator::CreateService(*serviceConfig, conveyorGroup);
+        auto service = NConveyorComposite::CreateService(*serviceConfig, conveyorGroup);
 
         setup->LocalServices.push_back(std::make_pair(
             NConveyorComposite::TServiceOperator::MakeServiceId(NodeId), TActorSetupCmd(service, TMailboxType::HTSwap, appData->UserPoolId)));

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -113,6 +113,8 @@ PEERDIR(
     ydb/core/tx
     ydb/core/tx/columnshard
     ydb/core/tx/conveyor/service
+    ydb/core/tx/conveyor_composite/service
+    ydb/core/tx/conveyor_composite/usage
     ydb/core/tx/general_cache
     ydb/core/tx/columnshard/data_accessor/cache_policy
     ydb/core/tx/columnshard/column_fetching

--- a/ydb/core/testlib/test_client.cpp
+++ b/ydb/core/testlib/test_client.cpp
@@ -1284,7 +1284,7 @@ namespace Tests {
             Runtime->RegisterService(NConveyor::TScanServiceOperator::MakeServiceId(Runtime->GetNodeId(nodeIdx)), aid, nodeIdx);
         }
         {
-            auto* actor = NConveyorComposite::TServiceOperator::CreateService(NConveyorComposite::NConfig::TConfig::BuildDefault(), appData.Counters);
+            auto* actor = NConveyorComposite::CreateService(NConveyorComposite::NConfig::TConfig::BuildDefault(), appData.Counters);
             const auto aid = Runtime->Register(actor, nodeIdx, appData.UserPoolId, TMailboxType::Revolving, 0);
             Runtime->RegisterService(NConveyorComposite::TServiceOperator::MakeServiceId(Runtime->GetNodeId(nodeIdx)), aid, nodeIdx);
         }

--- a/ydb/core/testlib/ya.make
+++ b/ydb/core/testlib/ya.make
@@ -113,6 +113,8 @@ PEERDIR(
     ydb/services/discovery
     ydb/services/ymq
     ydb/core/tx/conveyor/service
+    ydb/core/tx/conveyor_composite/service
+    ydb/core/tx/conveyor_composite/usage
     ydb/core/tx/priorities/service
     ydb/core/tx/priorities/usage
     ydb/core/tx/limiter/grouped_memory/usage

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/ut/ut_manager.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/ut/ut_manager.cpp
@@ -24,6 +24,7 @@
 #include <ydb/core/tx/columnshard/engines/scheme/versions/versioned_index.h>
 #include <ydb/core/tx/columnshard/test_helper/helper.h>
 #include <ydb/core/tx/columnshard/test_helper/portion_test_helper.h>
+#include <ydb/core/tx/conveyor_composite/service/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/config.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 #include <ydb/core/tx/general_cache/usage/events.h>
@@ -240,8 +241,8 @@ public:
 };
 
 void EnableDeduplicationConveyorFlag() {
-    std::unique_ptr<NActors::IActor> unusedDistributor(NConveyorComposite::TServiceOperator::CreateService(
-        NConveyorComposite::NConfig::TConfig::BuildDefault(), MakeIntrusive<NMonitoring::TDynamicCounters>()));
+    std::unique_ptr<NActors::IActor> unusedDistributor(
+        NConveyorComposite::CreateService(NConveyorComposite::NConfig::TConfig::BuildDefault(), MakeIntrusive<NMonitoring::TDynamicCounters>()));
     Y_UNUSED(unusedDistributor);
 }
 

--- a/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/ut/ya.make
+++ b/ydb/core/tx/columnshard/engines/reader/trivial_reader/duplicates/ut/ya.make
@@ -28,6 +28,7 @@ PEERDIR(
     ydb/core/tx/columnshard/engines/storage/indexes
     ydb/core/tx/columnshard/splitter
     ydb/core/tx/columnshard/test_helper
+    ydb/core/tx/conveyor_composite/service
     ydb/core/tx/conveyor_composite/usage
     ydb/core/tx/general_cache/usage
     ydb/library/actors/core

--- a/ydb/core/tx/columnshard/ya.make
+++ b/ydb/core/tx/columnshard/ya.make
@@ -71,7 +71,7 @@ PEERDIR(
     ydb/core/tx/columnshard/transactions/operators
     ydb/core/tx/columnshard/tx_reader
     ydb/core/tx/conveyor/usage
-    ydb/core/tx/conveyor_composite/service
+    ydb/core/tx/conveyor_composite/usage
     ydb/core/tx/general_cache/usage
     ydb/core/tx/long_tx_service/public
     ydb/core/tx/priorities/usage

--- a/ydb/core/tx/conveyor_composite/service/service.h
+++ b/ydb/core/tx/conveyor_composite/service/service.h
@@ -4,6 +4,7 @@
 
 #include <ydb/core/tx/conveyor_composite/usage/config.h>
 #include <ydb/core/tx/conveyor_composite/usage/events.h>
+#include <ydb/core/tx/conveyor_composite/usage/service.h>
 
 #include <ydb/library/accessor/positive_integer.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -63,5 +64,10 @@ public:
 
     void Bootstrap();
 };
+
+inline NActors::IActor* CreateService(const NConfig::TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorSignals) {
+    TServiceOperator::Register(config);
+    return new TDistributor(config, conveyorSignals);
+}
 
 }   // namespace NKikimr::NConveyorComposite

--- a/ydb/core/tx/conveyor_composite/usage/service.h
+++ b/ydb/core/tx/conveyor_composite/usage/service.h
@@ -2,7 +2,6 @@
 #include "common.h"
 #include "config.h"
 
-#include <ydb/core/tx/conveyor_composite/service/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/events.h>
 
 #include <ydb/library/actors/core/actor.h>
@@ -14,11 +13,11 @@ class TServiceOperator {
 private:
     using TSelf = TServiceOperator;
     std::atomic<bool> IsEnabledFlag = false;
+
+public:
     static void Register(const NConfig::TConfig& serviceConfig) {
         Singleton<TSelf>()->IsEnabledFlag = serviceConfig.IsEnabled();
     }
-
-public:
     static bool SendTaskToExecute(const std::shared_ptr<ITask>& task, const ESpecialTaskCategory category, const ui64 internalProcessId) {
         if (TSelf::IsEnabled() && NActors::TlsActivationContext) {
             auto& context = NActors::TActorContext::AsActorContext();
@@ -35,10 +34,6 @@ public:
     }
     static NActors::TActorId MakeServiceId(const ui32 nodeId) {
         return NActors::TActorId(nodeId, "SrvcConvCmps");
-    }
-    static NActors::IActor* CreateService(const NConfig::TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorSignals) {
-        Register(config);
-        return new TDistributor(config, conveyorSignals);
     }
     static TProcessGuard StartProcess(
         const ESpecialTaskCategory category, const TString& scopeId, const ui64 externalProcessId, const TCPULimitsConfig& cpuLimits) {

--- a/ydb/core/tx/conveyor_composite/usage/ya.make
+++ b/ydb/core/tx/conveyor_composite/usage/ya.make
@@ -10,6 +10,8 @@ SRCS(
 PEERDIR(
     ydb/library/actors/core
     ydb/services/metadata/request
+    ydb/core/protos
+    ydb/core/tx/conveyor/usage
 )
 
 GENERATE_ENUM_SERIALIZATION(common.h)

--- a/ydb/core/tx/conveyor_composite/ut/ut_simple.cpp
+++ b/ydb/core/tx/conveyor_composite/ut/ut_simple.cpp
@@ -1,5 +1,6 @@
 #include <library/cpp/retry/retry.h>
 #include <ydb/core/tx/conveyor/usage/abstract.h>
+#include <ydb/core/tx/conveyor_composite/service/service.h>
 #include <ydb/core/tx/conveyor_composite/usage/config.h>
 #include <ydb/core/tx/conveyor_composite/usage/events.h>
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
@@ -151,7 +152,7 @@ public:
         AFL_VERIFY(google::protobuf::TextFormat::ParseFromString(textProto, &protoConfig));
 
         NConfig::TConfig config = NConfig::TConfig::BuildFromProto(protoConfig).DetachResult();
-        const auto actorId = actorSystem.Register(TServiceOperator::CreateService(config, counters));
+        const auto actorId = actorSystem.Register(CreateService(config, counters));
 
         std::vector<std::shared_ptr<IRequestProcessor>> requests = GetRequests();
         for (auto&& i : requests) {


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Breaks the `usage` → `service` header/peerdir cycle in `ydb/core/tx/conveyor_composite`.

- Moved the `CreateService` factory into `service/service.h`; dependency is now strictly `service → usage`.
- Declared the previously-transitive peerdirs (`conveyor/usage`, `core/protos`) in `usage/ya.make`, and added `conveyor_composite/{service,usage}` where they were undeclared in consumers.
- Columnshard now peers `conveyor_composite/usage` instead of `service` — it only uses the client API.
