### PR TITLE
Break general_cache usage->service and usage->source header cycles

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -217,6 +217,7 @@
 #include <ydb/core/tx/conveyor_composite/usage/service.h>
 #include <ydb/core/tx/columnshard/data_accessor/cache_policy/policy.h>
 #include <ydb/core/tx/columnshard/column_fetching/cache_policy.h>
+#include <ydb/core/tx/general_cache/service/service.h>
 #include <ydb/core/tx/general_cache/usage/service.h>
 #include <ydb/core/tx/priorities/usage/config.h>
 #include <ydb/core/tx/priorities/usage/service.h>
@@ -2617,7 +2618,7 @@ void TGeneralCachePortionsMetadataInitializer::InitializeServices(NActors::TActo
     TIntrusivePtr<::NMonitoring::TDynamicCounters> tabletGroup = GetServiceCounters(appData->Counters, "tablets");
     TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorGroup = tabletGroup->GetSubgroup("type", "TX_GENERAL_CACHE_PORTIONS_METADATA");
 
-    auto service = NGeneralCache::TServiceOperator<NOlap::NGeneralCache::TPortionsMetadataCachePolicy>::CreateService(*serviceConfig, conveyorGroup);
+    auto service = NGeneralCache::CreateService<NOlap::NGeneralCache::TPortionsMetadataCachePolicy>(*serviceConfig, conveyorGroup);
 
     setup->LocalServices.push_back(
         std::make_pair(NGeneralCache::TServiceOperator<NOlap::NGeneralCache::TPortionsMetadataCachePolicy>::MakeServiceId(NodeId),
@@ -2641,7 +2642,7 @@ void TGeneralCacheColumnDataInitializer::InitializeServices(NActors::TActorSyste
     TIntrusivePtr<::NMonitoring::TDynamicCounters> tabletGroup = GetServiceCounters(appData->Counters, "tablets");
     TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorGroup = tabletGroup->GetSubgroup("type", "TX_GENERAL_CACHE_COLUMN_DATA");
 
-    auto service = NGeneralCache::TServiceOperator<NOlap::NGeneralCache::TColumnDataCachePolicy>::CreateService(*serviceConfig, conveyorGroup);
+    auto service = NGeneralCache::CreateService<NOlap::NGeneralCache::TColumnDataCachePolicy>(*serviceConfig, conveyorGroup);
 
     setup->LocalServices.push_back(
         std::make_pair(NGeneralCache::TServiceOperator<NOlap::NGeneralCache::TColumnDataCachePolicy>::MakeServiceId(NodeId),

--- a/ydb/core/testlib/basics/services.cpp
+++ b/ydb/core/testlib/basics/services.cpp
@@ -21,6 +21,7 @@
 #include <ydb/core/tablet/tablet_list_renderer.h>
 #include <ydb/core/tablet_flat/shared_sausagecache.h>
 #include <ydb/core/tx/columnshard/data_accessor/cache_policy/policy.h>
+#include <ydb/core/tx/general_cache/service/service.h>
 #include <ydb/core/tx/columnshard/column_fetching/cache_policy.h>
 #include <ydb/core/tx/scheme_board/replica.h>
 #include <ydb/core/client/server/grpc_proxy_status.h>
@@ -169,14 +170,14 @@ namespace NKikimr {
     }
 
     void SetupCSMetadataCache(TTestActorRuntime& runtime, ui32 nodeIndex) {
-        auto* actor = NOlap::NDataAccessorControl::TGeneralCache::CreateService(
+        auto* actor = NGeneralCache::CreateService<NOlap::NGeneralCache::TPortionsMetadataCachePolicy>(
 			NGeneralCache::NPublic::TConfig::BuildDefault(), runtime.GetDynamicCounters(nodeIndex));
 		runtime.AddLocalService(NOlap::NDataAccessorControl::TGeneralCache::MakeServiceId(runtime.GetNodeId(nodeIndex)),
 			TActorSetupCmd(actor, TMailboxType::ReadAsFilled, 0), nodeIndex);
     }
 
     void SetupCSColumnDataCache(TTestActorRuntime& runtime, ui32 nodeIndex) {
-        auto* actor = NOlap::NColumnFetching::TGeneralCache::CreateService(
+        auto* actor = NGeneralCache::CreateService<NOlap::NGeneralCache::TColumnDataCachePolicy>(
             NGeneralCache::NPublic::TConfig::BuildDefault(), runtime.GetDynamicCounters(nodeIndex));
         runtime.AddLocalService(NOlap::NColumnFetching::TGeneralCache::MakeServiceId(runtime.GetNodeId(nodeIndex)),
             TActorSetupCmd(actor, TMailboxType::ReadAsFilled, 0), nodeIndex);

--- a/ydb/core/testlib/basics/ya.make
+++ b/ydb/core/testlib/basics/ya.make
@@ -25,6 +25,7 @@ PEERDIR(
     ydb/core/tablet_flat
     ydb/core/testlib/actors
     ydb/core/tx/columnshard
+    ydb/core/tx/general_cache
     ydb/core/tx/scheme_board
     ydb/core/tx/schemeshard
     ydb/core/util

--- a/ydb/core/tx/general_cache/service/service.h
+++ b/ydb/core/tx/general_cache/service/service.h
@@ -91,3 +91,12 @@ public:
 };
 
 }   // namespace NKikimr::NGeneralCache::NPrivate
+
+namespace NKikimr::NGeneralCache {
+
+template <class TPolicy>
+NActors::IActor* CreateService(const NPublic::TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> signals) {
+    return new NPrivate::TDistributor<TPolicy>(config, signals);
+}
+
+}   // namespace NKikimr::NGeneralCache

--- a/ydb/core/tx/general_cache/service/ya.make
+++ b/ydb/core/tx/general_cache/service/ya.make
@@ -8,6 +8,9 @@ SRCS(
 
 PEERDIR(
     ydb/core/protos
+    ydb/core/base
+    ydb/core/tx/general_cache/source
+    ydb/core/tx/general_cache/usage
 )
 
 END()

--- a/ydb/core/tx/general_cache/source/abstract.h
+++ b/ydb/core/tx/general_cache/source/abstract.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <ydb/core/tx/general_cache/usage/abstract.h>
-
 #include <util/generic/hash.h>
 
 #include <memory>

--- a/ydb/core/tx/general_cache/usage/service.h
+++ b/ydb/core/tx/general_cache/usage/service.h
@@ -1,8 +1,11 @@
 #pragma once
 #include "abstract.h"
 #include "config.h"
+#include "events.h"
 
-#include <ydb/core/tx/general_cache/service/service.h>
+#include <ydb/core/tx/general_cache/source/events.h>
+
+#include <ydb/library/actors/core/actor.h>
 
 namespace NKikimr::NGeneralCache {
 
@@ -49,9 +52,6 @@ public:
         return MakeServiceId(selfId.NodeId());
     }
 
-    static NActors::IActor* CreateService(const NPublic::TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> conveyorSignals) {
-        return new NPrivate::TDistributor<TPolicy>(config, conveyorSignals);
-    }
 };
 
 }   // namespace NKikimr::NGeneralCache

--- a/ydb/core/tx/general_cache/usage/ya.make
+++ b/ydb/core/tx/general_cache/usage/ya.make
@@ -9,7 +9,6 @@ SRCS(
 
 PEERDIR(
     ydb/core/protos
-    ydb/core/tx/general_cache/service
     ydb/core/tx/general_cache/source
 )
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Breaks two header/peerdir cycles in `ydb/core/tx/general_cache`.

- `usage → service`: moved the `CreateService` factory into `service/service.h`; dependency is now strictly `service → usage`.
- `usage → source`: dropped the unused `usage/abstract.h` include from `source/abstract.h`, making `source` a leaf below `usage`.
- Declared `service/ya.make`'s real deps (`usage`, `source`, `core/base`) that were previously transitive.
