### PR TITLE
Break slide_limiter usage->service header cycle

### DIFF
--- a/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
+++ b/ydb/core/driver_lib/run/kikimr_services_initializers.cpp
@@ -2571,7 +2571,7 @@ void TCompDiskLimiterInitializer::InitializeServices(NActors::TActorSystemSetup*
         TIntrusivePtr<::NMonitoring::TDynamicCounters> tabletGroup = GetServiceCounters(appData->Counters, "tablets");
         TIntrusivePtr<::NMonitoring::TDynamicCounters> countersGroup = tabletGroup->GetSubgroup("type", "TX_COMP_DISK_LIMITER");
 
-        auto service = NLimiter::TCompDiskOperator::CreateService(serviceConfig, countersGroup);
+        auto service = NLimiter::CreateService<NLimiter::TCompDiskLimiterPolicy>(serviceConfig, countersGroup);
 
         setup->LocalServices.push_back(std::make_pair(
             NLimiter::TCompDiskOperator::MakeServiceId(NodeId),

--- a/ydb/core/driver_lib/run/ya.make
+++ b/ydb/core/driver_lib/run/ya.make
@@ -152,6 +152,7 @@ PEERDIR(
     ydb/library/security
     ydb/library/yql/providers/pq/cm_client
     ydb/library/slide_limiter/service
+    ydb/library/slide_limiter/usage
     ydb/library/yql/providers/s3/actors
     ydb/public/lib/base
     ydb/public/lib/deprecated/client

--- a/ydb/core/tx/columnshard/ya.make
+++ b/ydb/core/tx/columnshard/ya.make
@@ -82,6 +82,7 @@ PEERDIR(
     ydb/core/util
     ydb/library/actors/core
     ydb/library/chunks_limiter
+    ydb/library/slide_limiter/usage
     ydb/library/yql/dq/actors/compute
     ydb/public/api/protos
 )

--- a/ydb/library/slide_limiter/service/service.h
+++ b/ydb/library/slide_limiter/service/service.h
@@ -2,6 +2,7 @@
 #include <ydb/library/slide_limiter/usage/abstract.h>
 #include <ydb/library/slide_limiter/usage/config.h>
 #include <ydb/library/slide_limiter/usage/events.h>
+#include <ydb/library/slide_limiter/usage/service.h>
 
 #include <ydb/library/accessor/accessor.h>
 #include <ydb/library/actors/core/actor_bootstrapped.h>
@@ -95,5 +96,12 @@ public:
         Become(&TLimiterActor::StateMain);
     }
 };
+
+template <class TLimiterPolicy>
+NActors::IActor* CreateService(const TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> baseSignals) {
+    using TOperator = TServiceOperatorImpl<TLimiterPolicy>;
+    TOperator::Register(config);
+    return new TLimiterActor(config, TOperator::GetLimiterName(), baseSignals);
+}
 
 }   // namespace NKikimr::NLimiter

--- a/ydb/library/slide_limiter/usage/service.h
+++ b/ydb/library/slide_limiter/usage/service.h
@@ -3,7 +3,7 @@
 
 #include <ydb/library/actors/core/actor.h>
 #include <ydb/library/actors/core/actorid.h>
-#include <ydb/library/slide_limiter/service/service.h>
+#include <ydb/library/actors/core/log.h>
 #include <ydb/library/slide_limiter/usage/events.h>
 
 namespace NKikimr::NLimiter {
@@ -13,6 +13,8 @@ class TServiceOperatorImpl {
 private:
     using TSelf = TServiceOperatorImpl<TLimiterPolicy>;
     std::atomic<bool> IsEnabledFlag = false;
+
+public:
     static void Register(const TConfig& serviceConfig) {
         Singleton<TSelf>()->IsEnabledFlag = serviceConfig.IsEnabled() && serviceConfig.GetLimit();
     }
@@ -20,8 +22,6 @@ private:
         Y_ABORT_UNLESS(TLimiterPolicy::Name.size() == 4);
         return TLimiterPolicy::Name;
     }
-
-public:
     static bool AskResource(const std::shared_ptr<IResourceRequest>& request) {
         AFL_VERIFY(!!request);
         auto& context = NActors::TActorContext::AsActorContext();
@@ -39,10 +39,6 @@ public:
     }
     static NActors::TActorId MakeServiceId(const ui32 nodeId) {
         return NActors::TActorId(nodeId, "SrvcLimt" + GetLimiterName());
-    }
-    static NActors::IActor* CreateService(const TConfig& config, TIntrusivePtr<::NMonitoring::TDynamicCounters> baseSignals) {
-        Register(config);
-        return new TLimiterActor(config, GetLimiterName(), baseSignals);
     }
 };
 


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Breaks the `usage` → `service` header/peerdir cycle in `ydb/library/slide_limiter`.

- Moved the `CreateService` factory into `service/service.h`; dependency is now strictly `service → usage`.
- Call site updated; declared the previously-transitive peerdirs in the consumers.
