### PR TITLE
Soft-ignore stale DirectRead restore replies in PQ_READ_PROXY

### DIFF
--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -830,6 +830,19 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
     if (!PipeClient)
         return; // Pipe was already destroyed, direct read session is being restored. Will resend this request afterwards;
 
+    // Duplicate/stale Prepare is possible after pipe restart: ResendRecentRequests may
+    // re-send CurrentRequest while a previous CmdPrepareReadResult is still delivered.
+    // First response clears RequestInfly; ignore the rest (same as unwaited cookie).
+    if (!RequestInfly) {
+        YDB_LOG_DEBUG_CTX(ctx, "Unwaited prepare-response for direct read id",
+            {"PQLOGPREFIX", PQ_LOG_PREFIX},
+            {"partition", Partition},
+            {"directReadId", res.GetDirectReadId()},
+            {"readOffset", ReadOffset},
+            {"readGuid", ReadGuid});
+        return;
+    }
+
     EndOffset = res.GetEndOffset();
     SizeLag = res.GetSizeLag();
     WTime = res.GetWriteTimestampMS();
@@ -848,8 +861,6 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
         {"directReadId", DirectReadId});
 
     SendPublishDirectRead(DirectReadId, ctx);
-
-    PARTITION_ENSURE(RequestInfly);
 
     CurrentRequest.Clear();
     RequestInfly = false;

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -812,11 +812,16 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
         case EDirectReadRestoreStage::Forget:
             // RestoredDirectReadId may be 0: forget-first after nested pipe restart does not
             // assign it (see SendNextRestorePrepareOrForget), while DirectReadsToForget is kept.
-            PARTITION_ENSURE(result.HasCmdForgetReadResult())
-                ("result", result.ShortDebugString());
-            PARTITION_ENSURE(*DirectReadsToForget.begin() == result.GetCmdForgetReadResult().GetDirectReadId())
-                ("expected_direct_read_id", *DirectReadsToForget.begin())
-                ("got_direct_read_id", result.GetCmdForgetReadResult().GetDirectReadId());
+            // Late Prepare/Publish (or other non-Forget / wrong id) is possible after nested pipe
+            // restart — soft-ignore like Prepare/Publish stages.
+            if (!result.HasCmdForgetReadResult() || DirectReadsToForget.empty()
+                    || *DirectReadsToForget.begin() != result.GetCmdForgetReadResult().GetDirectReadId()) {
+                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()});
+                return;
+            }
             DirectReadsToForget.erase(DirectReadsToForget.begin());
             if (!SendNextRestorePrepareOrForget()) {
                 OnDirectReadsRestored();

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -806,10 +806,15 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Empty queue while expecting Publish is a bookkeeping anomaly (not a stale reply).
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToPublish.empty()) {
+                YDB_LOG_WARN_CTX(ctx, "Direct read restore Publish with empty DirectReadsToPublish",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()},
+                    {"result", result.ShortDebugString()});
                 ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
                     TStringBuilder() << "direct read restore Publish with empty DirectReadsToPublish"
-                        << ", cookie=" << result.GetCookie()
-                        << ", result=" << result.ShortDebugString(),
+                        << ", session=" << Session
+                        << ", cookie=" << Cookie,
                     PersQueue::ErrorCode::ERROR));
                 return;
             }
@@ -840,10 +845,15 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Empty queue while expecting Forget is a bookkeeping anomaly (not a stale reply).
             // Soft-ignore would hang restore forever; close the session so the client recovers.
             if (DirectReadsToForget.empty()) {
+                YDB_LOG_WARN_CTX(ctx, "Direct read restore Forget with empty DirectReadsToForget",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()},
+                    {"result", result.ShortDebugString()});
                 ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
                     TStringBuilder() << "direct read restore Forget with empty DirectReadsToForget"
-                        << ", cookie=" << result.GetCookie()
-                        << ", result=" << result.ShortDebugString(),
+                        << ", session=" << Session
+                        << ", cookie=" << Cookie,
                     PersQueue::ErrorCode::ERROR));
                 return;
             }

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -796,8 +796,24 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // Late/duplicate Prepare (or other non-Publish) is possible after nested pipe restart:
             // restore may re-send Prepare for the same id while a previous Prepare is still delivered
             // after we have already moved to Publish. Soft-ignore like Prepare stage.
-            if (!result.HasCmdPublishReadResult() || DirectReadsToPublish.empty()
-                    || *DirectReadsToPublish.begin() != result.GetCmdPublishReadResult().GetDirectReadId()) {
+            if (!result.HasCmdPublishReadResult()) {
+                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()});
+                return;
+            }
+            // Empty queue while expecting Publish is a bookkeeping anomaly (not a stale reply).
+            // Soft-ignore would hang restore forever; close the session so the client recovers.
+            if (DirectReadsToPublish.empty()) {
+                ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
+                    TStringBuilder() << "direct read restore Publish with empty DirectReadsToPublish"
+                        << ", cookie=" << result.GetCookie()
+                        << ", result=" << result.ShortDebugString(),
+                    PersQueue::ErrorCode::ERROR));
+                return;
+            }
+            if (*DirectReadsToPublish.begin() != result.GetCmdPublishReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
                     {"partition", Partition},
@@ -814,8 +830,24 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             // assign it (see SendNextRestorePrepareOrForget), while DirectReadsToForget is kept.
             // Late Prepare/Publish (or other non-Forget / wrong id) is possible after nested pipe
             // restart — soft-ignore like Prepare/Publish stages.
-            if (!result.HasCmdForgetReadResult() || DirectReadsToForget.empty()
-                    || *DirectReadsToForget.begin() != result.GetCmdForgetReadResult().GetDirectReadId()) {
+            if (!result.HasCmdForgetReadResult()) {
+                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()});
+                return;
+            }
+            // Empty queue while expecting Forget is a bookkeeping anomaly (not a stale reply).
+            // Soft-ignore would hang restore forever; close the session so the client recovers.
+            if (DirectReadsToForget.empty()) {
+                ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
+                    TStringBuilder() << "direct read restore Forget with empty DirectReadsToForget"
+                        << ", cookie=" << result.GetCookie()
+                        << ", result=" << result.ShortDebugString(),
+                    PersQueue::ErrorCode::ERROR));
+                return;
+            }
+            if (*DirectReadsToForget.begin() != result.GetCmdForgetReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect ForgetReadResult, got",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
                     {"partition", Partition},

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -804,8 +804,8 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             }
             return;
         case EDirectReadRestoreStage::Forget:
-            PARTITION_ENSURE(RestoredDirectReadId != 0)
-                ("restored_direct_read_id", RestoredDirectReadId);
+            // RestoredDirectReadId may be 0: forget-first after nested pipe restart does not
+            // assign it (see SendNextRestorePrepareOrForget), while DirectReadsToForget is kept.
             PARTITION_ENSURE(result.HasCmdForgetReadResult())
                 ("result", result.ShortDebugString());
             PARTITION_ENSURE(*DirectReadsToForget.begin() == result.GetCmdForgetReadResult().GetDirectReadId())

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -793,11 +793,17 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
             PARTITION_ENSURE(RestoredDirectReadId != 0)
                 ("restored_direct_read_id", RestoredDirectReadId);
 
-            PARTITION_ENSURE(result.HasCmdPublishReadResult())
-                ("result", result.ShortDebugString());
-            PARTITION_ENSURE(*DirectReadsToPublish.begin() == result.GetCmdPublishReadResult().GetDirectReadId())
-                ("expected_direct_read_id", *DirectReadsToPublish.begin())
-                ("got_direct_read_id", result.GetCmdPublishReadResult().GetDirectReadId());
+            // Late/duplicate Prepare (or other non-Publish) is possible after nested pipe restart:
+            // restore may re-send Prepare for the same id while a previous Prepare is still delivered
+            // after we have already moved to Publish. Soft-ignore like Prepare stage.
+            if (!result.HasCmdPublishReadResult() || DirectReadsToPublish.empty()
+                    || *DirectReadsToPublish.begin() != result.GetCmdPublishReadResult().GetDirectReadId()) {
+                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PublishReadResult, got",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()});
+                return;
+            }
             DirectReadsToPublish.erase(DirectReadsToPublish.begin());
             if (!SendNextRestorePrepareOrForget()) {
                 OnDirectReadsRestored();

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -835,15 +835,15 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
         ("direct_read_restore_stage", static_cast<int>(DirectReadRestoreStage));
 
     PARTITION_ENSURE(DirectRead);
-    PARTITION_ENSURE(res.GetDirectReadId() == DirectReadId)
-        ("got_direct_read_id", res.GetDirectReadId())
-        ("direct_read_id", DirectReadId);
     if (!PipeClient)
         return; // Pipe was already destroyed, direct read session is being restored. Will resend this request afterwards;
 
     // Duplicate/stale Prepare is possible after pipe restart: ResendRecentRequests may
     // re-send CurrentRequest while a previous CmdPrepareReadResult is still delivered.
-    // First response clears RequestInfly; ignore the rest (same as unwaited cookie).
+    // First response clears RequestInfly (and Publish may already advance DirectReadId).
+    // Check !RequestInfly before DirectReadId ENSURE: a post-Publish duplicate for the old
+    // id is normally dropped earlier by cookie!=ReadOffset, but if it still reaches here
+    // we must soft-ignore instead of PARTITION_ENSURE(DirectReadId).
     if (!RequestInfly) {
         YDB_LOG_DEBUG_CTX(ctx, "Unwaited prepare-response for direct read id",
             {"PQLOGPREFIX", PQ_LOG_PREFIX},
@@ -853,6 +853,10 @@ void TPartitionActor::Handle(const NKikimrClient::TPersQueuePartitionResponse::T
             {"readGuid", ReadGuid});
         return;
     }
+
+    PARTITION_ENSURE(res.GetDirectReadId() == DirectReadId)
+        ("got_direct_read_id", res.GetDirectReadId())
+        ("direct_read_id", DirectReadId);
 
     EndOffset = res.GetEndOffset();
     SizeLag = res.GetSizeLag();

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -785,11 +785,11 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
-                ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
+                CloseSessionAndDie(
                     TStringBuilder() << "direct read restore Prepare with empty DirectReadsToRestore"
                         << ", session=" << Session
                         << ", session_cookie=" << Cookie,
-                    PersQueue::ErrorCode::ERROR));
+                    PersQueue::ErrorCode::ERROR, ctx);
                 return;
             }
             if (DirectReadsToRestore.begin()->first != result.GetCmdPrepareReadResult().GetDirectReadId()) {
@@ -834,11 +834,11 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
-                ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
+                CloseSessionAndDie(
                     TStringBuilder() << "direct read restore Publish with empty DirectReadsToPublish"
                         << ", session=" << Session
                         << ", session_cookie=" << Cookie,
-                    PersQueue::ErrorCode::ERROR));
+                    PersQueue::ErrorCode::ERROR, ctx);
                 return;
             }
             if (*DirectReadsToPublish.begin() != result.GetCmdPublishReadResult().GetDirectReadId()) {
@@ -873,11 +873,11 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                     {"partition", Partition},
                     {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
-                ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
+                CloseSessionAndDie(
                     TStringBuilder() << "direct read restore Forget with empty DirectReadsToForget"
                         << ", session=" << Session
                         << ", session_cookie=" << Cookie,
-                    PersQueue::ErrorCode::ERROR));
+                    PersQueue::ErrorCode::ERROR, ctx);
                 return;
             }
             if (*DirectReadsToForget.begin() != result.GetCmdForgetReadResult().GetDirectReadId()) {
@@ -1943,13 +1943,19 @@ void TPartitionActor::Die(const TActorContext& ctx) {
     TActorBootstrapped<TPartitionActor>::Die(ctx);
 }
 
+void TPartitionActor::CloseSessionAndDie(const TString& reason, PersQueue::ErrorCode::ErrorCode code,
+                                         const TActorContext& ctx) {
+    ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(reason, code));
+    Die(ctx);
+}
+
 bool TPartitionActor::OnUnhandledException(const std::exception& exc) {
     NPQ::DoLogUnhandledException(NKikimrServices::PQ_READ_PROXY, TStringBuilder() << "[" << Session <<"][" << Partition << "] ", exc);
 
-    ActorContext().Send(ParentId, new TEvPQProxy::TEvCloseSession(
-        TStringBuilder() << "unexpected error: " << exc.what(), PersQueue::ErrorCode::ERROR));
-
-    this->Die(ActorContext());
+    CloseSessionAndDie(
+        TStringBuilder() << "unexpected error: " << exc.what(),
+        PersQueue::ErrorCode::ERROR,
+        ActorContext());
 
     return true;
 }

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -769,7 +769,30 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
         case EDirectReadRestoreStage::Prepare:
             PARTITION_ENSURE(RestoredDirectReadId != 0)
                 ("restored_direct_read_id", RestoredDirectReadId);
-            if (!result.HasCmdPrepareReadResult() || DirectReadsToRestore.empty() || DirectReadsToRestore.begin()->first != result.GetCmdPrepareReadResult().GetDirectReadId()) {
+            // Late/duplicate non-Prepare is possible after nested pipe restart — soft-ignore.
+            if (!result.HasCmdPrepareReadResult()) {
+                YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()});
+                return;
+            }
+            // Empty queue while expecting Prepare is a bookkeeping anomaly (not a stale reply).
+            // Soft-ignore would hang restore forever; close the session so the client recovers.
+            if (DirectReadsToRestore.empty()) {
+                YDB_LOG_WARN_CTX(ctx, "Direct read restore Prepare with empty DirectReadsToRestore",
+                    {"PQLOGPREFIX", PQ_LOG_PREFIX},
+                    {"partition", Partition},
+                    {"cookie", result.GetCookie()},
+                    {"result", result.ShortDebugString()});
+                ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
+                    TStringBuilder() << "direct read restore Prepare with empty DirectReadsToRestore"
+                        << ", session=" << Session
+                        << ", cookie=" << Cookie,
+                    PersQueue::ErrorCode::ERROR));
+                return;
+            }
+            if (DirectReadsToRestore.begin()->first != result.GetCmdPrepareReadResult().GetDirectReadId()) {
                 YDB_LOG_DEBUG_CTX(ctx, "Invalid response on direct read restore for expect PrepareReadResult, got",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
                     {"partition", Partition},

--- a/ydb/services/persqueue_v1/actors/partition_actor.cpp
+++ b/ydb/services/persqueue_v1/actors/partition_actor.cpp
@@ -783,12 +783,12 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 YDB_LOG_WARN_CTX(ctx, "Direct read restore Prepare with empty DirectReadsToRestore",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
                     {"partition", Partition},
-                    {"cookie", result.GetCookie()},
+                    {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
                 ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
                     TStringBuilder() << "direct read restore Prepare with empty DirectReadsToRestore"
                         << ", session=" << Session
-                        << ", cookie=" << Cookie,
+                        << ", session_cookie=" << Cookie,
                     PersQueue::ErrorCode::ERROR));
                 return;
             }
@@ -832,12 +832,12 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 YDB_LOG_WARN_CTX(ctx, "Direct read restore Publish with empty DirectReadsToPublish",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
                     {"partition", Partition},
-                    {"cookie", result.GetCookie()},
+                    {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
                 ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
                     TStringBuilder() << "direct read restore Publish with empty DirectReadsToPublish"
                         << ", session=" << Session
-                        << ", cookie=" << Cookie,
+                        << ", session_cookie=" << Cookie,
                     PersQueue::ErrorCode::ERROR));
                 return;
             }
@@ -871,12 +871,12 @@ void TPartitionActor::HandleDirectReadRestoreSession(const NKikimrClient::TPersQ
                 YDB_LOG_WARN_CTX(ctx, "Direct read restore Forget with empty DirectReadsToForget",
                     {"PQLOGPREFIX", PQ_LOG_PREFIX},
                     {"partition", Partition},
-                    {"cookie", result.GetCookie()},
+                    {"response_cookie", result.GetCookie()},
                     {"result", result.ShortDebugString()});
                 ctx.Send(ParentId, new TEvPQProxy::TEvCloseSession(
                     TStringBuilder() << "direct read restore Forget with empty DirectReadsToForget"
                         << ", session=" << Session
-                        << ", cookie=" << Cookie,
+                        << ", session_cookie=" << Cookie,
                     PersQueue::ErrorCode::ERROR));
                 return;
             }

--- a/ydb/services/persqueue_v1/actors/partition_actor.h
+++ b/ydb/services/persqueue_v1/actors/partition_actor.h
@@ -85,6 +85,8 @@ public:
     void Bootstrap(const NActors::TActorContext& ctx);
     void Die(const NActors::TActorContext& ctx) override;
     bool OnUnhandledException(const std::exception& exc) override;
+    void CloseSessionAndDie(const TString& reason, PersQueue::ErrorCode::ErrorCode code,
+                            const NActors::TActorContext& ctx);
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() { return NKikimrServices::TActivity::FRONT_PQ_PARTITION; }
 private:

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -60,6 +60,13 @@ auto RunWithDispatch(NActors::TTestActorRuntime& runtime, TFunc&& func) {
     return static_cast<NKikimr::TTestActorRuntime&>(runtime).WaitFuture(std::move(future));
 }
 
+template <typename TCondition>
+void WaitUntil(NActors::TTestActorRuntime& runtime, TCondition&& condition, TDuration deadline = TDuration::Seconds(10)) {
+    TDispatchOptions opts;
+    opts.CustomFinalCondition = std::forward<TCondition>(condition);
+    UNIT_ASSERT_C(runtime.DispatchEvents(opts, deadline), "WaitUntil condition not met before deadline");
+}
+
 TDriverConfig MakeAsyncDriverConfig(const TString& endpoint) {
     TDriverConfig config;
     config.SetEndpoint(endpoint);
@@ -435,9 +442,9 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     env.HoldRestorePreparePublish.store(1);
     env.RebootPqTablet();
 
-    for (ui32 i = 0; i < 50 && env.HeldPrepareOrPublish.load() == 0; ++i) {
-        runtime.SimulateSleep(TDuration::MilliSeconds(50));
-    }
+    WaitUntil(runtime, [&] {
+        return env.HeldPrepareOrPublish.load() > 0;
+    });
     UNIT_ASSERT_C(env.HeldPrepareOrPublish.load() > 0,
         "expected dropped CmdPrepareReadResult/CmdPublishReadResult during restore");
 
@@ -486,18 +493,18 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
     client.InitDirectSession(runtime);
     client.StartDirectReadPartition(runtime);
 
-    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 1; ++i) {
-        runtime.SimulateSleep(TDuration::MilliSeconds(50));
-    }
+    WaitUntil(runtime, [&] {
+        return env.HeldPrepareResponses.load() >= 1;
+    });
     UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
         "expected at least one held CmdPrepareReadResult before reboot");
 
     env.RebootPqTablet();
 
     // Restore of empty DirectReadResults finishes quickly → ResendRecentRequests → second Prepare.
-    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 2; ++i) {
-        runtime.SimulateSleep(TDuration::MilliSeconds(50));
-    }
+    WaitUntil(runtime, [&] {
+        return env.HeldPrepareResponses.load() >= 2;
+    });
     UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 2,
         "expected held Prepare from original read and from ResendRecentRequests after restore"
             << "; held=" << env.HeldPrepareResponses.load());
@@ -546,17 +553,17 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
 
     env.RebootPqTablet();
 
-    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 1; ++i) {
-        runtime.SimulateSleep(TDuration::MilliSeconds(50));
-    }
+    WaitUntil(runtime, [&] {
+        return env.HeldPrepareResponses.load() >= 1;
+    });
     UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
         "expected held Prepare from first restore attempt");
 
     env.RebootPqTablet();
 
-    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 2; ++i) {
-        runtime.SimulateSleep(TDuration::MilliSeconds(50));
-    }
+    WaitUntil(runtime, [&] {
+        return env.HeldPrepareResponses.load() >= 2;
+    });
     UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 2,
         "expected two held Prepares from nested restore attempts"
             << "; held=" << env.HeldPrepareResponses.load());

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -524,10 +524,11 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     client.SendDirectReadAckNoWait(runtime, 1);
     runtime.SimulateSleep(TDuration::MilliSeconds(50));
 
+    // HoldRestorePreparePublish filters only Prepare/Publish, not Forget. Clear it before the
+    // nested reboot so Session→Forget is not mixed with the first-attempt prepare hold.
+    env.HoldRestorePreparePublish.store(0);
     const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
     env.RebootPqTablet();
-    // Allow Session→Forget path to run; do not hold Forget responses.
-    env.HoldRestorePreparePublish.store(0);
 
     WaitUntil(runtime, [&] {
         return env.UpdateSessionCount.load() > updateSessionsBefore

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -1,0 +1,434 @@
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/testlib/actors/test_runtime.h>
+#include <ydb/core/testlib/tablet_helpers.h>
+#include <ydb/core/tx/scheme_cache/scheme_cache.h>
+#include <ydb/core/tx/tx_proxy/proxy.h>
+#include <ydb/services/persqueue_v1/actors/events.h>
+
+#include <ydb/public/api/grpc/ydb_topic_v1.grpc.pb.h>
+#include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/topic/client.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/data_plane_helpers.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
+#include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
+
+#include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/async.h>
+
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+
+#include <util/generic/string.h>
+#include <util/generic/yexception.h>
+#include <util/thread/pool.h>
+
+#include <atomic>
+#include <memory>
+
+using namespace NYdb;
+using namespace NYdb::NTopic;
+using namespace NYdb::NTopic::NTests;
+using namespace Ydb::Topic;
+
+namespace NKikimr::NPersQueueTests {
+namespace {
+
+constexpr const char* kTopic = "dr-restore-topic";
+constexpr const char* kTopicPath = "/Root/dr-restore-topic";
+constexpr const char* kConsumer = "user";
+
+#define DR_ENSURE(cond) \
+    do { \
+        if (!(cond)) { \
+            ythrow yexception() << "check failed: " << #cond; \
+        } \
+    } while (false)
+
+IThreadPool& DispatchPool() {
+    struct THolder {
+        TThreadPool Pool;
+        THolder() {
+            Pool.Start(2);
+        }
+    };
+    static THolder holder;
+    return holder.Pool;
+}
+
+template <typename TFunc>
+auto RunWithDispatch(NActors::TTestActorRuntime& runtime, TFunc&& func) {
+    auto future = NThreading::Async(std::forward<TFunc>(func), DispatchPool());
+    return static_cast<NKikimr::TTestActorRuntime&>(runtime).WaitFuture(std::move(future));
+}
+
+TDriverConfig MakeAsyncDriverConfig(const TString& endpoint) {
+    TDriverConfig config;
+    config.SetEndpoint(endpoint);
+    config.SetDatabase("/Root");
+    config.SetAuthToken("root@builtin");
+    config.SetLog(std::make_unique<TStreamLogBackend>(&Cerr));
+    config.SetDiscoveryMode(EDiscoveryMode::Async);
+    return config;
+}
+
+ui64 ResolvePqTabletId(::NPersQueue::TTestServer& server, const TString& topicPath, ui32 partition = 0) {
+    auto& runtime = *server.CleverServer->GetRuntime();
+    const auto edge = runtime.AllocateEdgeActor();
+
+    auto navigate = std::make_unique<NSchemeCache::TSchemeCacheNavigate>();
+    navigate->DatabaseName = "/Root";
+    NSchemeCache::TSchemeCacheNavigate::TEntry entry;
+    entry.Path = SplitPath(topicPath);
+    entry.SyncVersion = true;
+    entry.ShowPrivatePath = true;
+    entry.Operation = NSchemeCache::TSchemeCacheNavigate::OpList;
+    navigate->ResultSet.push_back(std::move(entry));
+
+    runtime.Send(MakeSchemeCacheID(), edge,
+        new TEvTxProxySchemeCache::TEvNavigateKeySet(navigate.release()),
+        0, true);
+    auto response = runtime.GrabEdgeEvent<TEvTxProxySchemeCache::TEvNavigateKeySetResult>();
+    UNIT_ASSERT(response);
+    UNIT_ASSERT_VALUES_EQUAL(response->Request->ErrorCount, 0u);
+
+    auto& front = response->Request->ResultSet.front();
+    UNIT_ASSERT(front.PQGroupInfo);
+    for (const auto& p : front.PQGroupInfo->Description.GetPartitions()) {
+        if (p.GetPartitionId() == partition) {
+            return p.GetTabletId();
+        }
+    }
+    UNIT_FAIL("partition not found");
+    return 0;
+}
+
+struct TDirectReadRestoreEnv {
+    std::unique_ptr<::NPersQueue::TTestServer> Server;
+    TString Endpoint;
+    ui64 PqTabletId = 0;
+
+    std::atomic<ui64> HoldRestorePreparePublish{0};
+    std::atomic<ui64> HeldPrepareOrPublish{0};
+    std::atomic<ui64> RestoredDirectReadIdEnsure{0};
+    TString EnsureCloseReason;
+
+    NActors::TTestActorRuntime& Runtime() {
+        return *Server->CleverServer->GetRuntime();
+    }
+
+    void Start() {
+        auto settings = TTopicSdkTestSetup::MakeServerSettings();
+        settings.SetUseRealThreads(false);
+        settings.SetNodeCount(1);
+
+        Server = std::make_unique<::NPersQueue::TTestServer>(settings, /*start=*/false);
+        Server->StartServer(/*doClientInit=*/false, TString("/Root"));
+        Endpoint = Server->Endpoint;
+
+        auto& runtime = Runtime();
+        runtime.SetScheduledLimit(100'000);
+        runtime.UpdateCurrentTime(TInstant::Now());
+        Server->AnnoyingClient->SetNoConfigMode();
+
+        runtime.SetLogPriority(NKikimrServices::PQ_READ_PROXY, NActors::NLog::PRI_DEBUG);
+        runtime.SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_INFO);
+
+        InstallHooks();
+
+        RunWithDispatch(runtime, [&] {
+            Server->AnnoyingClient->FullInit();
+            return true;
+        });
+
+        RunWithDispatch(runtime, [&] {
+            TDriver driver(MakeAsyncDriverConfig(Endpoint));
+            TTopicClient client(driver);
+            auto status = client.CreateTopic(
+                kTopic,
+                TCreateTopicSettings()
+                    .BeginConfigurePartitioningSettings()
+                        .MinActivePartitions(1)
+                        .MaxActivePartitions(1)
+                        .BeginConfigureAutoPartitioningSettings()
+                            .Strategy(EAutoPartitioningStrategy::Disabled)
+                        .EndConfigureAutoPartitioningSettings()
+                    .EndConfigurePartitioningSettings()
+                    .BeginAddConsumer(kConsumer)
+                    .EndAddConsumer()).ExtractValueSync();
+            if (!status.IsSuccess()) {
+                ythrow yexception() << status.GetIssues().ToString();
+            }
+            driver.Stop(true);
+            return true;
+        });
+
+        PqTabletId = ResolvePqTabletId(*Server, kTopicPath);
+        Cerr << "PQ tablet id=" << PqTabletId << Endl;
+    }
+
+    void InstallHooks() {
+        auto& runtime = Runtime();
+
+        runtime.SetEventFilter([this](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
+            if (!HoldRestorePreparePublish.load()) {
+                return false;
+            }
+            auto* msg = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
+            if (!msg || !msg->Record.HasPartitionResponse()) {
+                return false;
+            }
+            const auto& part = msg->Record.GetPartitionResponse();
+            if (part.HasCmdPrepareReadResult() || part.HasCmdPublishReadResult()) {
+                const ui64 held = ++HeldPrepareOrPublish;
+                Cerr << "DROP restore Prepare/Publish response prepare="
+                     << part.HasCmdPrepareReadResult()
+                     << " publish=" << part.HasCmdPublishReadResult()
+                     << " held=" << held << Endl;
+                return true; // drop — keep restore stuck in Prepare
+            }
+            return false;
+        });
+
+        runtime.SetObserverFunc([this](TAutoPtr<IEventHandle>& ev) {
+            if (auto* msg = ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvCloseSession>()) {
+                if (msg->Reason.Contains("RestoredDirectReadId")) {
+                    EnsureCloseReason = msg->Reason;
+                    ++RestoredDirectReadIdEnsure;
+                    Cerr << "Observed CloseSession from RestoredDirectReadId ENSURE: "
+                         << msg->Reason << Endl;
+                }
+            }
+            return TTestActorRuntime::EEventAction::PROCESS;
+        });
+    }
+
+    void RebootPqTablet() {
+        auto& runtime = Runtime();
+        const auto edge = runtime.AllocateEdgeActor();
+        Cerr << "RebootTablet " << PqTabletId << Endl;
+        RebootTablet(runtime, PqTabletId, edge);
+        // Partition actor schedules pipe restart with RESTART_PIPE_DELAY_MS=100.
+        runtime.SimulateSleep(TDuration::MilliSeconds(250));
+    }
+};
+
+struct TGrpcDirectReadClient {
+    using TService = Ydb::Topic::V1::TopicService;
+
+    std::shared_ptr<grpc::Channel> Channel;
+    std::unique_ptr<TService::Stub> Stub;
+    THolder<grpc::ClientContext> ControlContext;
+    THolder<grpc::ClientContext> DirectContext;
+    std::unique_ptr<grpc::ClientReaderWriter<StreamReadMessage::FromClient, StreamReadMessage::FromServer>> ControlStream;
+    std::unique_ptr<grpc::ClientReaderWriter<StreamDirectReadMessage::FromClient, StreamDirectReadMessage::FromServer>> DirectStream;
+    TString SessionId;
+    ui64 AssignId = 0;
+    ui64 Generation = 0;
+
+    void Connect(const TString& endpoint) {
+        grpc::ChannelArguments args;
+        args.SetMaxReceiveMessageSize(64_MB);
+        args.SetMaxSendMessageSize(64_MB);
+        Channel = grpc::CreateCustomChannel(
+            endpoint,
+            grpc::InsecureChannelCredentials(),
+            args);
+        Stub = TService::NewStub(Channel);
+    }
+
+    void InitControlSession(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            ControlContext = MakeHolder<grpc::ClientContext>();
+            ControlStream = Stub->StreamRead(ControlContext.Get());
+            DR_ENSURE(ControlStream);
+
+            StreamReadMessage::FromClient req;
+            req.mutable_init_request()->add_topics_read_settings()->set_path(kTopicPath);
+            req.mutable_init_request()->set_consumer(kConsumer);
+            req.mutable_init_request()->set_direct_read(true);
+            DR_ENSURE(ControlStream->Write(req));
+
+            StreamReadMessage::FromServer resp;
+            DR_ENSURE(ControlStream->Read(&resp));
+            if (resp.server_message_case() != StreamReadMessage::FromServer::kInitResponse) {
+                ythrow yexception() << "expected InitResponse, got " << resp.ShortDebugString();
+            }
+            SessionId = resp.init_response().session_id();
+
+            StreamReadMessage::FromClient readReq;
+            readReq.mutable_read_request()->set_bytes_size(100_KB);
+            DR_ENSURE(ControlStream->Write(readReq));
+            return true;
+        });
+    }
+
+    void AcceptAssign(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            StreamReadMessage::FromServer resp;
+            DR_ENSURE(ControlStream->Read(&resp));
+            if (resp.server_message_case() != StreamReadMessage::FromServer::kStartPartitionSessionRequest) {
+                ythrow yexception() << "expected StartPartitionSessionRequest, got " << resp.ShortDebugString();
+            }
+            AssignId = resp.start_partition_session_request().partition_session().partition_session_id();
+            Generation = resp.start_partition_session_request().partition_location().generation();
+
+            StreamReadMessage::FromClient req;
+            req.mutable_start_partition_session_response()->set_partition_session_id(AssignId);
+            DR_ENSURE(ControlStream->Write(req));
+            return true;
+        });
+    }
+
+    void InitDirectSession(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            DirectContext = MakeHolder<grpc::ClientContext>();
+            DirectStream = Stub->StreamDirectRead(DirectContext.Get());
+            DR_ENSURE(DirectStream);
+
+            StreamDirectReadMessage::FromClient req;
+            req.mutable_init_request()->add_topics_read_settings()->set_path(kTopicPath);
+            req.mutable_init_request()->set_consumer(kConsumer);
+            req.mutable_init_request()->set_session_id(SessionId);
+            DR_ENSURE(DirectStream->Write(req));
+
+            StreamDirectReadMessage::FromServer resp;
+            DR_ENSURE(DirectStream->Read(&resp));
+            if (resp.status() != Ydb::StatusIds::SUCCESS) {
+                ythrow yexception() << "direct init failed: " << resp.ShortDebugString();
+            }
+            return true;
+        });
+    }
+
+    void StartDirectReadPartition(NActors::TTestActorRuntime& runtime) {
+        RunWithDispatch(runtime, [&] {
+            StreamDirectReadMessage::FromClient req;
+            auto& start = *req.mutable_start_direct_read_partition_session_request();
+            start.set_partition_session_id(AssignId);
+            start.set_generation(Generation);
+            DR_ENSURE(DirectStream->Write(req));
+
+            StreamDirectReadMessage::FromServer resp;
+            DR_ENSURE(DirectStream->Read(&resp));
+            if (resp.status() != Ydb::StatusIds::SUCCESS
+                    || resp.server_message_case() != StreamDirectReadMessage::FromServer::kStartDirectReadPartitionSessionResponse) {
+                ythrow yexception() << "start direct partition failed: " << resp.ShortDebugString();
+            }
+            return true;
+        });
+    }
+
+    void ReadDataNoAck(NActors::TTestActorRuntime& runtime, i64 expectedDirectReadId) {
+        RunWithDispatch(runtime, [&] {
+            StreamDirectReadMessage::FromServer resp;
+            DR_ENSURE(DirectStream->Read(&resp));
+            if (resp.status() != Ydb::StatusIds::SUCCESS
+                    || resp.server_message_case() != StreamDirectReadMessage::FromServer::kDirectReadResponse
+                    || resp.direct_read_response().direct_read_id() != expectedDirectReadId
+                    || resp.direct_read_response().partition_session_id() != static_cast<i64>(AssignId)) {
+                ythrow yexception() << "unexpected DirectReadResponse: " << resp.ShortDebugString();
+            }
+            Cerr << "Got DirectReadResponse id=" << expectedDirectReadId << Endl;
+            return true;
+        });
+    }
+
+    void SendDirectReadAckNoWait(NActors::TTestActorRuntime& runtime, ui64 directReadId) {
+        RunWithDispatch(runtime, [&] {
+            StreamReadMessage::FromClient req;
+            auto& ack = *req.mutable_direct_read_ack();
+            ack.set_partition_session_id(AssignId);
+            ack.set_direct_read_id(directReadId);
+            Cerr << "Send DirectReadAck id=" << directReadId << Endl;
+            DR_ENSURE(ControlStream->Write(req));
+            return true;
+        });
+    }
+};
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest) {
+
+// LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0.
+// Without the fix PARTITION_ENSURE(RestoredDirectReadId != 0) fires on Forget stage.
+Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
+    TDirectReadRestoreEnv env;
+    env.Start();
+    auto& runtime = env.Runtime();
+
+    RunWithDispatch(runtime, [&] {
+        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
+        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+        if (!writer->Write(TString(1_MB, 'x'))) {
+            ythrow yexception() << "write failed";
+        }
+        writer->Close();
+        driver.Stop(true);
+        return true;
+    });
+
+    TGrpcDirectReadClient client;
+    client.Connect(env.Endpoint);
+    client.InitControlSession(runtime);
+    client.AcceptAssign(runtime);
+    client.InitDirectSession(runtime);
+    client.StartDirectReadPartition(runtime);
+    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+
+    Cerr << "Arm hold of restore Prepare/Publish and reboot tablet\n";
+    env.HoldRestorePreparePublish.store(1);
+    env.RebootPqTablet();
+
+    for (ui32 i = 0; i < 50 && env.HeldPrepareOrPublish.load() == 0; ++i) {
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    }
+    UNIT_ASSERT_C(env.HeldPrepareOrPublish.load() > 0,
+        "expected dropped CmdPrepareReadResult/CmdPublishReadResult during restore");
+
+    Cerr << "Ack during held Prepare (queues DirectReadsToForget, clears DirectReadResults)\n";
+    client.SendDirectReadAckNoWait(runtime, 1);
+    runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+    Cerr << "Second reboot while Prepare is still held\n";
+    env.RebootPqTablet();
+    // Allow Session→Forget path to run; do not hold Forget responses.
+    env.HoldRestorePreparePublish.store(0);
+    runtime.SimulateSleep(TDuration::Seconds(1));
+
+    UNIT_ASSERT_C(env.RestoredDirectReadIdEnsure.load() > 0,
+        "expected PARTITION_ENSURE(RestoredDirectReadId != 0) on Forget after nested restart"
+            << "; held=" << env.HeldPrepareOrPublish.load()
+            << "; reason=" << env.EnsureCloseReason);
+
+    // Drop hooks before destroying actors / gRPC — they capture env by raw this.
+    runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
+    runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
+
+    // Tear down gRPC under dispatch pump: ShutdownGRpc blocks waiting for inflight
+    // while UseRealThreads=false needs the test thread to DispatchEvents.
+    if (client.ControlContext) {
+        client.ControlContext->TryCancel();
+    }
+    if (client.DirectContext) {
+        client.DirectContext->TryCancel();
+    }
+    client.ControlStream.reset();
+    client.DirectStream.reset();
+    client.Stub.reset();
+    client.Channel.reset();
+
+    auto shutdown = NThreading::Async([&] {
+        env.Server->ShutdownGRpc();
+        return true;
+    }, DispatchPool());
+    while (!shutdown.HasValue() && !shutdown.HasException()) {
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+    }
+    shutdown.GetValueSync();
+    env.Server->ShutdownServer();
+    env.Server.reset();
+}
+
+} // Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest)
+
+} // namespace NKikimr::NPersQueueTests

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -65,7 +65,6 @@ TDriverConfig MakeAsyncDriverConfig(const TString& endpoint) {
     config.SetEndpoint(endpoint);
     config.SetDatabase("/Root");
     config.SetAuthToken("root@builtin");
-    config.SetLog(std::make_unique<TStreamLogBackend>(&Cerr));
     config.SetDiscoveryMode(EDiscoveryMode::Async);
     return config;
 }
@@ -174,7 +173,6 @@ struct TDirectReadRestoreEnv {
         });
 
         PqTabletId = ResolvePqTabletId(*Server, kTopicPath);
-        Cerr << "PQ tablet id=" << PqTabletId << Endl;
     }
 
     void InstallHooks() {
@@ -188,21 +186,13 @@ struct TDirectReadRestoreEnv {
             const auto& part = msg->Record.GetPartitionResponse();
 
             if (HoldPrepareResponses.load() && part.HasCmdPrepareReadResult()) {
-                const ui64 held = ++HeldPrepareResponses;
-                Cerr << "HOLD CmdPrepareReadResult held=" << held
-                     << " cookie=" << part.GetCookie()
-                     << " directReadId=" << part.GetCmdPrepareReadResult().GetDirectReadId()
-                     << Endl;
+                ++HeldPrepareResponses;
                 HeldPrepareEvents.emplace_back(ev.Release());
                 return true;
             }
 
             if (HoldPublishResponses.load() && part.HasCmdPublishReadResult()) {
-                const ui64 held = ++HeldPublishResponses;
-                Cerr << "DROP CmdPublishReadResult held=" << held
-                     << " cookie=" << part.GetCookie()
-                     << " directReadId=" << part.GetCmdPublishReadResult().GetDirectReadId()
-                     << Endl;
+                ++HeldPublishResponses;
                 return true; // drop — keep restore stuck in Publish
             }
 
@@ -210,11 +200,7 @@ struct TDirectReadRestoreEnv {
                 return false;
             }
             if (part.HasCmdPrepareReadResult() || part.HasCmdPublishReadResult()) {
-                const ui64 held = ++HeldPrepareOrPublish;
-                Cerr << "DROP restore Prepare/Publish response prepare="
-                     << part.HasCmdPrepareReadResult()
-                     << " publish=" << part.HasCmdPublishReadResult()
-                     << " held=" << held << Endl;
+                ++HeldPrepareOrPublish;
                 return true; // drop — keep restore stuck in Prepare
             }
             return false;
@@ -226,8 +212,6 @@ struct TDirectReadRestoreEnv {
                 if (msg->Reason.Contains("unexpected error:")) {
                     UnexpectedErrorCloseReason = msg->Reason;
                     ++UnexpectedErrorCloseSession;
-                    Cerr << "Observed CloseSession from unhandled exception: "
-                         << msg->Reason << Endl;
                 }
             }
             return TTestActorRuntime::EEventAction::PROCESS;
@@ -237,7 +221,6 @@ struct TDirectReadRestoreEnv {
     void ReleaseHeldPrepares() {
         HoldPrepareResponses.store(0);
         auto& runtime = Runtime();
-        Cerr << "Release " << HeldPrepareEvents.size() << " held Prepare responses\n";
         for (auto& ev : HeldPrepareEvents) {
             runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
         }
@@ -254,7 +237,6 @@ struct TDirectReadRestoreEnv {
     void RebootPqTablet() {
         auto& runtime = Runtime();
         const auto edge = runtime.AllocateEdgeActor();
-        Cerr << "RebootTablet " << PqTabletId << Endl;
         RebootTablet(runtime, PqTabletId, edge);
         // Partition actor schedules pipe restart with RESTART_PIPE_DELAY_MS=100.
         runtime.SimulateSleep(TDuration::MilliSeconds(250));
@@ -377,7 +359,6 @@ struct TGrpcDirectReadClient {
                     || resp.direct_read_response().partition_session_id() != static_cast<i64>(AssignId)) {
                 ythrow yexception() << "unexpected DirectReadResponse: " << resp.ShortDebugString();
             }
-            Cerr << "Got DirectReadResponse id=" << expectedDirectReadId << Endl;
             return true;
         });
     }
@@ -388,7 +369,6 @@ struct TGrpcDirectReadClient {
             auto& ack = *req.mutable_direct_read_ack();
             ack.set_partition_session_id(AssignId);
             ack.set_direct_read_id(directReadId);
-            Cerr << "Send DirectReadAck id=" << directReadId << Endl;
             DR_ENSURE(ControlStream->Write(req));
             return true;
         });
@@ -452,7 +432,6 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     client.StartDirectReadPartition(runtime);
     client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
 
-    Cerr << "Arm hold of restore Prepare/Publish and reboot tablet\n";
     env.HoldRestorePreparePublish.store(1);
     env.RebootPqTablet();
 
@@ -462,11 +441,9 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     UNIT_ASSERT_C(env.HeldPrepareOrPublish.load() > 0,
         "expected dropped CmdPrepareReadResult/CmdPublishReadResult during restore");
 
-    Cerr << "Ack during held Prepare (queues DirectReadsToForget, clears DirectReadResults)\n";
     client.SendDirectReadAckNoWait(runtime, 1);
     runtime.SimulateSleep(TDuration::MilliSeconds(50));
 
-    Cerr << "Second reboot while Prepare is still held\n";
     env.RebootPqTablet();
     // Allow Session→Forget path to run; do not hold Forget responses.
     env.HoldRestorePreparePublish.store(0);
@@ -515,7 +492,6 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
     UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
         "expected at least one held CmdPrepareReadResult before reboot");
 
-    Cerr << "Reboot while Prepare is held (RequestInfly still true, DirectReadResults empty)\n";
     env.RebootPqTablet();
 
     // Restore of empty DirectReadResults finishes quickly → ResendRecentRequests → second Prepare.
@@ -526,7 +502,6 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
         "expected held Prepare from original read and from ResendRecentRequests after restore"
             << "; held=" << env.HeldPrepareResponses.load());
 
-    Cerr << "Release both Prepare responses onto the normal path\n";
     env.ReleaseHeldPrepares();
     runtime.SimulateSleep(TDuration::Seconds(1));
 
@@ -569,7 +544,6 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
     env.HoldPrepareResponses.store(1);
     env.HoldPublishResponses.store(1);
 
-    Cerr << "First reboot: restore sends Prepare for published DirectReadId=1\n";
     env.RebootPqTablet();
 
     for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 1; ++i) {
@@ -578,7 +552,6 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
     UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
         "expected held Prepare from first restore attempt");
 
-    Cerr << "Second reboot while Prepare is still held: restore re-sends Prepare for the same id\n";
     env.RebootPqTablet();
 
     for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 2; ++i) {
@@ -588,7 +561,6 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
         "expected two held Prepares from nested restore attempts"
             << "; held=" << env.HeldPrepareResponses.load());
 
-    Cerr << "Release both Prepares: first advances to Publish, second arrives on Publish stage\n";
     env.ReleaseHeldPrepares();
     runtime.SimulateSleep(TDuration::Seconds(1));
 

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -121,9 +121,14 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HeldPrepareResponses{0};
     TVector<THolder<IEventHandle>> HeldPrepareEvents;
 
-    // Hold CmdPublishReadResult to keep restore stuck in Publish stage.
+    // Hold CmdPublishReadResult (re-inject later) / keep restore stuck in Publish.
     std::atomic<ui64> HoldPublishResponses{0};
     std::atomic<ui64> HeldPublishResponses{0};
+    TVector<THolder<IEventHandle>> HeldPublishEvents;
+
+    // Drop CmdForgetReadResult to keep restore stuck in Forget stage.
+    std::atomic<ui64> HoldForgetResponses{0};
+    std::atomic<ui64> HeldForgetResponses{0};
 
     // PARTITION_ENSURE → OnUnhandledException → CloseSession("unexpected error: ...").
     std::atomic<ui64> UnexpectedErrorCloseSession{0};
@@ -228,7 +233,13 @@ struct TDirectReadRestoreEnv {
 
             if (HoldPublishResponses.load() && part.HasCmdPublishReadResult()) {
                 ++HeldPublishResponses;
-                return true; // drop — keep restore stuck in Publish
+                HeldPublishEvents.emplace_back(ev.Release());
+                return true;
+            }
+
+            if (HoldForgetResponses.load() && part.HasCmdForgetReadResult()) {
+                ++HeldForgetResponses;
+                return true; // drop — keep restore stuck in Forget
             }
 
             if (!HoldRestorePreparePublish.load()) {
@@ -262,11 +273,21 @@ struct TDirectReadRestoreEnv {
         HeldPrepareEvents.clear();
     }
 
+    void ReleaseHeldPublishes() {
+        HoldPublishResponses.store(0);
+        auto& runtime = Runtime();
+        for (auto& ev : HeldPublishEvents) {
+            runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+        }
+        HeldPublishEvents.clear();
+    }
+
     void DropHooks() {
         auto& runtime = Runtime();
         runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
         runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
         HeldPrepareEvents.clear();
+        HeldPublishEvents.clear();
     }
 
     void RebootPqTablet() {
@@ -603,6 +624,136 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
         "late Prepare during Publish restore must not kill partition actor via unhandled exception"
             << "; heldPrepare=" << env.HeldPrepareResponses.load()
             << "; heldPublish=" << env.HeldPublishResponses.load()
+            << "; reason=" << env.UnexpectedErrorCloseReason);
+
+    TearDownGrpcAndServer(env, client);
+}
+
+// LOGBROKER-10590: after ack during Prepare-restore + nested pipe restart, forget-first runs with
+// RestoredDirectReadId==0; a late Prepare from the previous restore attempt must be ignored.
+Y_UNIT_TEST(HasCmdForgetReadResultOnPrepareDuringForgetRestore) {
+    TDirectReadRestoreEnv env;
+    env.Start();
+    auto& runtime = env.Runtime();
+
+    RunWithDispatch(runtime, [&] {
+        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
+        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+        if (!writer->Write(TString(1_MB, 'x'))) {
+            ythrow yexception() << "write failed";
+        }
+        writer->Close();
+        driver.Stop(true);
+        return true;
+    });
+
+    TGrpcDirectReadClient client;
+    client.Connect(env.Endpoint);
+    client.InitControlSession(runtime);
+    client.AcceptAssign(runtime);
+    client.InitDirectSession(runtime);
+    client.StartDirectReadPartition(runtime);
+    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+
+    // Hold Prepare from the first restore so it can be re-injected later (late delivery).
+    env.HoldPrepareResponses.store(1);
+    env.RebootPqTablet();
+
+    WaitUntil(runtime, [&] {
+        return env.HeldPrepareResponses.load() >= 1;
+    });
+    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
+        "expected held Prepare from first restore attempt");
+
+    // Ack while RestoredDirectReadId==id → DirectReadsToForget; DirectReadResults cleared.
+    client.SendDirectReadAckNoWait(runtime, 1);
+    runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+    // Keep Forget stuck so released Prepare arrives on Forget stage (prod: Prepare in flight /
+    // mailbox vs new Forget after nested disconnect).
+    env.HoldForgetResponses.store(1);
+    env.RebootPqTablet();
+
+    WaitUntil(runtime, [&] {
+        return env.HeldForgetResponses.load() >= 1;
+    });
+    UNIT_ASSERT_C(env.HeldForgetResponses.load() >= 1,
+        "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
+
+    env.ReleaseHeldPrepares();
+    WaitUntil(runtime, [&] {
+        return env.UnexpectedErrorCloseSession.load() > 0;
+    });
+
+    // Repro: PARTITION_ENSURE(HasCmdForgetReadResult) on late Prepare during Forget.
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() > 0,
+        "expected PARTITION_ENSURE(HasCmdForgetReadResult) on late Prepare during Forget restore"
+            << "; heldPrepare=" << env.HeldPrepareResponses.load()
+            << "; heldForget=" << env.HeldForgetResponses.load()
+            << "; reason=" << env.UnexpectedErrorCloseReason);
+
+    TearDownGrpcAndServer(env, client);
+}
+
+// LOGBROKER-10590: Prepare+Publish restore in flight, client acks, nested pipe restart → forget-first;
+// late Publish from the previous restore attempt must be ignored (not ENSURE on Forget).
+Y_UNIT_TEST(HasCmdForgetReadResultOnPublishDuringForgetRestore) {
+    TDirectReadRestoreEnv env;
+    env.Start();
+    auto& runtime = env.Runtime();
+
+    RunWithDispatch(runtime, [&] {
+        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
+        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+        if (!writer->Write(TString(1_MB, 'x'))) {
+            ythrow yexception() << "write failed";
+        }
+        writer->Close();
+        driver.Stop(true);
+        return true;
+    });
+
+    TGrpcDirectReadClient client;
+    client.Connect(env.Endpoint);
+    client.InitControlSession(runtime);
+    client.AcceptAssign(runtime);
+    client.InitDirectSession(runtime);
+    client.StartDirectReadPartition(runtime);
+    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+
+    // Let Prepare complete; hold Publish (prod: Publish reply still on the wire / in mailbox).
+    env.HoldPublishResponses.store(1);
+    env.RebootPqTablet();
+
+    WaitUntil(runtime, [&] {
+        return env.HeldPublishResponses.load() >= 1;
+    });
+    UNIT_ASSERT_C(env.HeldPublishResponses.load() >= 1,
+        "expected held Publish from first restore attempt (stage=Publish, RestoredDirectReadId set)");
+
+    // Ack while RestoredDirectReadId==id → DirectReadsToForget; DirectReadResults cleared.
+    client.SendDirectReadAckNoWait(runtime, 1);
+    runtime.SimulateSleep(TDuration::MilliSeconds(50));
+
+    env.HoldForgetResponses.store(1);
+    env.RebootPqTablet();
+
+    WaitUntil(runtime, [&] {
+        return env.HeldForgetResponses.load() >= 1;
+    });
+    UNIT_ASSERT_C(env.HeldForgetResponses.load() >= 1,
+        "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
+
+    env.ReleaseHeldPublishes();
+    WaitUntil(runtime, [&] {
+        return env.UnexpectedErrorCloseSession.load() > 0;
+    });
+
+    // Repro: PARTITION_ENSURE(HasCmdForgetReadResult) on late Publish during Forget.
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() > 0,
+        "expected PARTITION_ENSURE(HasCmdForgetReadResult) on late Publish during Forget restore"
+            << "; heldPublish=" << env.HeldPublishResponses.load()
+            << "; heldForget=" << env.HeldForgetResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
 
     TearDownGrpcAndServer(env, client);

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -469,6 +469,10 @@ void TearDownGrpcAndServer(TDirectReadRestoreEnv& env, TGrpcDirectReadClient& cl
     client.Stub.reset();
     client.Channel.reset();
 
+    if (!env.Server) {
+        return;
+    }
+
     auto& runtime = env.Runtime();
     auto shutdown = NThreading::Async([&] {
         env.Server->ShutdownGRpc();
@@ -486,357 +490,305 @@ void TearDownGrpcAndServer(TDirectReadRestoreEnv& env, TGrpcDirectReadClient& cl
     env.Server.reset();
 }
 
+class TDirectReadRestoreFixture : public NUnitTest::TBaseFixture {
+protected:
+    TDirectReadRestoreEnv Env;
+    TGrpcDirectReadClient Client;
+
+    void SetUp(NUnitTest::TTestContext&) override {
+        Env.Start();
+    }
+
+    void TearDown(NUnitTest::TTestContext&) override {
+        TearDownGrpcAndServer(Env, Client);
+    }
+
+    NActors::TTestActorRuntime& Runtime() {
+        return Env.Runtime();
+    }
+
+    // 1. Produce one large message so DirectRead has data to restore.
+    void WriteOneMessage() {
+        RunWithDispatch(Runtime(), [&] {
+            TDriver driver(MakeAsyncDriverConfig(Env.Endpoint));
+            auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+            if (!writer->Write(TString(1_MB, 'x'))) {
+                ythrow yexception() << "write failed";
+            }
+            writer->Close();
+            driver.Stop(true);
+            return true;
+        });
+    }
+
+    // 2. Open control+direct sessions; optionally consume DirectReadId=1 without ack.
+    void ConnectControlSession() {
+        Client.Connect(Env.Endpoint);
+        Client.InitControlSession(Runtime());
+    }
+
+    void AcceptAssignAndStartDirectRead(bool readDataNoAck = true) {
+        auto& runtime = Runtime();
+        Client.AcceptAssign(runtime);
+        Client.InitDirectSession(runtime);
+        Client.StartDirectReadPartition(runtime);
+        if (readDataNoAck) {
+            Client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+        }
+    }
+
+    void OpenDirectReadSession(bool readDataNoAck = true) {
+        ConnectControlSession();
+        AcceptAssignAndStartDirectRead(readDataNoAck);
+    }
+
+    // 3. Reboot PQ tablet and wait until the matching hold counter reaches minHeld.
+    // Callers set Hold* flags before the first reboot when several holds are needed together.
+    void RebootAndWaitHeldPrepares(ui64 minHeld) {
+        if (Env.HoldPrepareResponses.load() == 0) {
+            Env.HoldPrepareResponses.store(1);
+        }
+        Env.RebootPqTablet();
+        WaitUntil(Runtime(), [&] {
+            return Env.HeldPrepareResponses.load() >= minHeld;
+        });
+        UNIT_ASSERT_C(Env.HeldPrepareResponses.load() >= minHeld,
+            "expected held CmdPrepareReadResult count >= " << minHeld
+                << "; held=" << Env.HeldPrepareResponses.load());
+    }
+
+    void RebootAndWaitHeldPublishes(ui64 minHeld) {
+        if (Env.HoldPublishResponses.load() == 0) {
+            Env.HoldPublishResponses.store(1);
+        }
+        Env.RebootPqTablet();
+        WaitUntil(Runtime(), [&] {
+            return Env.HeldPublishResponses.load() >= minHeld;
+        });
+        UNIT_ASSERT_C(Env.HeldPublishResponses.load() >= minHeld,
+            "expected held CmdPublishReadResult count >= " << minHeld
+                << "; held=" << Env.HeldPublishResponses.load());
+    }
+
+    void RebootAndWaitHeldForgets(ui64 minHeld) {
+        if (Env.HoldForgetResponses.load() == 0) {
+            Env.HoldForgetResponses.store(1);
+        }
+        Env.RebootPqTablet();
+        WaitUntil(Runtime(), [&] {
+            return Env.HeldForgetResponses.load() >= minHeld;
+        });
+        UNIT_ASSERT_C(Env.HeldForgetResponses.load() >= minHeld,
+            "expected held CmdForgetReadResult count >= " << minHeld
+                << "; held=" << Env.HeldForgetResponses.load());
+    }
+
+    void RebootAndWaitHeldRestorePrepareOrPublish() {
+        Env.HoldRestorePreparePublish.store(1);
+        Env.RebootPqTablet();
+        WaitUntil(Runtime(), [&] {
+            return Env.HeldPrepareOrPublish.load() > 0;
+        });
+        UNIT_ASSERT_C(Env.HeldPrepareOrPublish.load() > 0,
+            "expected dropped CmdPrepareReadResult/CmdPublishReadResult during restore");
+    }
+
+    // 4. Ack DirectRead and give the actor a short slice to process it.
+    void AckDirectRead(ui64 directReadId = 1) {
+        Client.SendDirectReadAckNoWait(Runtime(), directReadId);
+        Runtime().SimulateSleep(TDuration::MilliSeconds(50));
+    }
+
+    // 9–10. Shared asserts.
+    void AssertNoUnexpectedClose(const TString& what) {
+        UNIT_ASSERT_C(Env.UnexpectedErrorCloseSession.load() == 0,
+            what
+                << "; heldPrepare=" << Env.HeldPrepareResponses.load()
+                << "; heldPublish=" << Env.HeldPublishResponses.load()
+                << "; heldForget=" << Env.HeldForgetResponses.load()
+                << "; heldRestorePP=" << Env.HeldPrepareOrPublish.load()
+                << "; reason=" << Env.UnexpectedErrorCloseReason);
+    }
+
+    void AssertUpdateSessionAdvanced(ui64 before, const TString& what) {
+        UNIT_ASSERT_C(Env.UpdateSessionCount.load() > before, what);
+    }
+
+    void AssertDirectReadAdvanced(ui64 before, const TString& what) {
+        UNIT_ASSERT_C(Env.DirectReadResponseCount.load() > before, what);
+    }
+
+    // 5. Release held Prepares; wait until Publish is held (or crash).
+    void ReleasePreparesAndWaitPublishHeld() {
+        Env.ReleaseHeldPrepares();
+        WaitUntil(Runtime(), [&] {
+            return Env.HeldPublishResponses.load() >= 1
+                || Env.UnexpectedErrorCloseSession.load() > 0;
+        });
+        AssertNoUnexpectedClose(
+            "late Prepare during Publish restore must not kill partition actor via unhandled exception");
+        UNIT_ASSERT_C(Env.HeldPublishResponses.load() >= 1,
+            "expected Publish stage after releasing held Prepares");
+    }
+
+    // 6. Release held replies and wait for OnDirectReadsRestored → TEvUpdateSession.
+    template <typename TRelease>
+    void ReleaseAndWaitUpdateSession(TRelease&& release, const TString& what) {
+        const ui64 before = Env.UpdateSessionCount.load();
+        release();
+        WaitUntil(Runtime(), [&] {
+            return Env.UpdateSessionCount.load() > before
+                || Env.UnexpectedErrorCloseSession.load() > 0;
+        });
+        AssertNoUnexpectedClose(what);
+        AssertUpdateSessionAdvanced(before,
+            "restore must complete with TEvUpdateSession (not silent-hang)");
+    }
+
+    // 7. Release held Prepares and wait for normal-path DirectReadResponse.
+    template <typename TRelease>
+    void ReleaseAndWaitDirectReadResponse(TRelease&& release, const TString& what) {
+        const ui64 before = Env.DirectReadResponseCount.load();
+        release();
+        WaitUntil(Runtime(), [&] {
+            return Env.DirectReadResponseCount.load() > before
+                || Env.UnexpectedErrorCloseSession.load() > 0;
+        });
+        AssertNoUnexpectedClose(what);
+        AssertDirectReadAdvanced(before,
+            "Prepare/Publish must complete after releasing held Prepares (not silent-hang)");
+    }
+
+    // 8. Release a late reply onto the current restore stage; only assert survival.
+    template <typename TRelease>
+    void ReleaseLateReplyAndAssertSurvived(TRelease&& release, const TString& what) {
+        release();
+        Runtime().SimulateSleep(TDuration::MilliSeconds(200));
+        AssertNoUnexpectedClose(what);
+    }
+
+    // Wait for UpdateSession after an already-triggered action (e.g. nested reboot).
+    void WaitAndAssertUpdateSessionAdvanced(ui64 before, const TString& what) {
+        WaitUntil(Runtime(), [&] {
+            return Env.UpdateSessionCount.load() > before
+                || Env.UnexpectedErrorCloseSession.load() > 0;
+        });
+        AssertNoUnexpectedClose(what);
+        AssertUpdateSessionAdvanced(before,
+            "restore must complete with TEvUpdateSession (not silent-hang)");
+    }
+};
+
 } // namespace
 
-Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest) {
+Y_UNIT_TEST_SUITE_F(TDirectReadRestoreRaceTest, TDirectReadRestoreFixture) {
 
 // LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0
 // must not kill the partition actor (Forget stage must tolerate RestoredDirectReadId==0).
 Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
-    TDirectReadRestoreEnv env;
-    env.Start();
-    auto& runtime = env.Runtime();
+    WriteOneMessage();
+    OpenDirectReadSession();
 
-    RunWithDispatch(runtime, [&] {
-        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
-        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
-        if (!writer->Write(TString(1_MB, 'x'))) {
-            ythrow yexception() << "write failed";
-        }
-        writer->Close();
-        driver.Stop(true);
-        return true;
-    });
-
-    TGrpcDirectReadClient client;
-    client.Connect(env.Endpoint);
-    client.InitControlSession(runtime);
-    client.AcceptAssign(runtime);
-    client.InitDirectSession(runtime);
-    client.StartDirectReadPartition(runtime);
-    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
-
-    env.HoldRestorePreparePublish.store(1);
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.HeldPrepareOrPublish.load() > 0;
-    });
-    UNIT_ASSERT_C(env.HeldPrepareOrPublish.load() > 0,
-        "expected dropped CmdPrepareReadResult/CmdPublishReadResult during restore");
-
-    client.SendDirectReadAckNoWait(runtime, 1);
-    runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    RebootAndWaitHeldRestorePrepareOrPublish();
+    AckDirectRead();
 
     // HoldRestorePreparePublish filters only Prepare/Publish, not Forget. Clear it before the
     // nested reboot so Session→Forget is not mixed with the first-attempt prepare hold.
-    env.HoldRestorePreparePublish.store(0);
-    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.UpdateSessionCount.load() > updateSessionsBefore
-            || env.UnexpectedErrorCloseSession.load() > 0;
-    });
-
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "Forget after nested restart must not kill partition actor via unhandled exception"
-            << "; held=" << env.HeldPrepareOrPublish.load()
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
-        "restore must complete with TEvUpdateSession (not silent-hang in Forget)");
-
-    TearDownGrpcAndServer(env, client);
+    Env.HoldRestorePreparePublish.store(0);
+    const ui64 updateSessionsBefore = Env.UpdateSessionCount.load();
+    Env.RebootPqTablet();
+    WaitAndAssertUpdateSessionAdvanced(updateSessionsBefore,
+        "Forget after nested restart must not kill partition actor via unhandled exception");
 }
 
 // LOGBROKER-10590: after pipe restart with RequestInfly, ResendRecentRequests re-sends Prepare;
 // a late/duplicate CmdPrepareReadResult on the normal path must be ignored (not ENSURE).
 Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
-    TDirectReadRestoreEnv env;
-    env.Start();
-    auto& runtime = env.Runtime();
-
-    RunWithDispatch(runtime, [&] {
-        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
-        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
-        if (!writer->Write(TString(1_MB, 'x'))) {
-            ythrow yexception() << "write failed";
-        }
-        writer->Close();
-        driver.Stop(true);
-        return true;
-    });
-
-    TGrpcDirectReadClient client;
-    client.Connect(env.Endpoint);
-    client.InitControlSession(runtime);
+    WriteOneMessage();
+    ConnectControlSession();
 
     // Hold Prepare before partition starts reading, so RequestInfly stays true across reboot.
-    env.HoldPrepareResponses.store(1);
+    Env.HoldPrepareResponses.store(1);
+    AcceptAssignAndStartDirectRead(/*readDataNoAck=*/false);
 
-    client.AcceptAssign(runtime);
-    client.InitDirectSession(runtime);
-    client.StartDirectReadPartition(runtime);
-
-    WaitUntil(runtime, [&] {
-        return env.HeldPrepareResponses.load() >= 1;
+    WaitUntil(Runtime(), [&] {
+        return Env.HeldPrepareResponses.load() >= 1;
     });
-    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
+    UNIT_ASSERT_C(Env.HeldPrepareResponses.load() >= 1,
         "expected at least one held CmdPrepareReadResult before reboot");
 
-    env.RebootPqTablet();
-
     // Restore of empty DirectReadResults finishes quickly → ResendRecentRequests → second Prepare.
-    WaitUntil(runtime, [&] {
-        return env.HeldPrepareResponses.load() >= 2;
-    });
-    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 2,
-        "expected held Prepare from original read and from ResendRecentRequests after restore"
-            << "; held=" << env.HeldPrepareResponses.load());
+    RebootAndWaitHeldPrepares(/*minHeld=*/2);
 
-    const ui64 directReadsBefore = env.DirectReadResponseCount.load();
-    env.ReleaseHeldPrepares();
-
-    WaitUntil(runtime, [&] {
-        return env.DirectReadResponseCount.load() > directReadsBefore
-            || env.UnexpectedErrorCloseSession.load() > 0;
-    });
-
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "duplicate Prepare after pipe restart must not kill partition actor via unhandled exception"
-            << "; held=" << env.HeldPrepareResponses.load()
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-    UNIT_ASSERT_C(env.DirectReadResponseCount.load() > directReadsBefore,
-        "Prepare/Publish must complete after releasing held Prepares (not silent-hang)");
-
-    TearDownGrpcAndServer(env, client);
+    ReleaseAndWaitDirectReadResponse(
+        [&] { Env.ReleaseHeldPrepares(); },
+        "duplicate Prepare after pipe restart must not kill partition actor via unhandled exception");
 }
 
 // LOGBROKER-10590: nested pipe restart re-sends restore Prepare for the same DirectReadId;
 // a late Prepare after restore has moved to Publish must be ignored (not ENSURE).
 Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
-    TDirectReadRestoreEnv env;
-    env.Start();
-    auto& runtime = env.Runtime();
-
-    RunWithDispatch(runtime, [&] {
-        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
-        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
-        if (!writer->Write(TString(1_MB, 'x'))) {
-            ythrow yexception() << "write failed";
-        }
-        writer->Close();
-        driver.Stop(true);
-        return true;
-    });
-
-    TGrpcDirectReadClient client;
-    client.Connect(env.Endpoint);
-    client.InitControlSession(runtime);
-    client.AcceptAssign(runtime);
-    client.InitDirectSession(runtime);
-    client.StartDirectReadPartition(runtime);
-    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+    WriteOneMessage();
+    OpenDirectReadSession();
 
     // Hold Prepare (and Publish) so nested restart can queue a second real Prepare
     // before either response is delivered — same shape as late pipe replies in prod.
-    env.HoldPrepareResponses.store(1);
-    env.HoldPublishResponses.store(1);
+    Env.HoldPublishResponses.store(1);
+    RebootAndWaitHeldPrepares(/*minHeld=*/1);
+    RebootAndWaitHeldPrepares(/*minHeld=*/2);
 
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.HeldPrepareResponses.load() >= 1;
-    });
-    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
-        "expected held Prepare from first restore attempt");
-
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.HeldPrepareResponses.load() >= 2;
-    });
-    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 2,
-        "expected two held Prepares from nested restore attempts"
-            << "; held=" << env.HeldPrepareResponses.load());
-
-    env.ReleaseHeldPrepares();
     // First Prepare advances restore to Publish; second is soft-ignored on Publish stage.
-    WaitUntil(runtime, [&] {
-        return env.HeldPublishResponses.load() >= 1
-            || env.UnexpectedErrorCloseSession.load() > 0;
-    });
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "late Prepare during Publish restore must not kill partition actor via unhandled exception"
-            << "; heldPrepare=" << env.HeldPrepareResponses.load()
-            << "; heldPublish=" << env.HeldPublishResponses.load()
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-    UNIT_ASSERT_C(env.HeldPublishResponses.load() >= 1,
-        "expected Publish stage after releasing held Prepares");
-
-    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
-    env.ReleaseHeldPublishes();
-    WaitUntil(runtime, [&] {
-        return env.UpdateSessionCount.load() > updateSessionsBefore
-            || env.UnexpectedErrorCloseSession.load() > 0;
-    });
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "releasing Publish after late Prepare must not kill partition actor"
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
-        "Publish restore must complete with TEvUpdateSession after late Prepare soft-ignore");
-
-    TearDownGrpcAndServer(env, client);
+    ReleasePreparesAndWaitPublishHeld();
+    ReleaseAndWaitUpdateSession(
+        [&] { Env.ReleaseHeldPublishes(); },
+        "releasing Publish after late Prepare must not kill partition actor");
 }
 
 // LOGBROKER-10590: after ack during Prepare-restore + nested pipe restart, forget-first runs with
 // RestoredDirectReadId==0; a late Prepare from the previous restore attempt must be ignored.
 Y_UNIT_TEST(HasCmdForgetReadResultOnPrepareDuringForgetRestore) {
-    TDirectReadRestoreEnv env;
-    env.Start();
-    auto& runtime = env.Runtime();
-
-    RunWithDispatch(runtime, [&] {
-        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
-        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
-        if (!writer->Write(TString(1_MB, 'x'))) {
-            ythrow yexception() << "write failed";
-        }
-        writer->Close();
-        driver.Stop(true);
-        return true;
-    });
-
-    TGrpcDirectReadClient client;
-    client.Connect(env.Endpoint);
-    client.InitControlSession(runtime);
-    client.AcceptAssign(runtime);
-    client.InitDirectSession(runtime);
-    client.StartDirectReadPartition(runtime);
-    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+    WriteOneMessage();
+    OpenDirectReadSession();
 
     // Hold Prepare from the first restore so it can be re-injected later (late delivery).
-    env.HoldPrepareResponses.store(1);
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.HeldPrepareResponses.load() >= 1;
-    });
-    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
-        "expected held Prepare from first restore attempt");
+    RebootAndWaitHeldPrepares(/*minHeld=*/1);
 
     // Ack while RestoredDirectReadId==id → DirectReadsToForget; DirectReadResults cleared.
-    client.SendDirectReadAckNoWait(runtime, 1);
-    runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    AckDirectRead();
 
     // Keep Forget stuck so released Prepare arrives on Forget stage (prod: Prepare in flight /
     // mailbox vs new Forget after nested disconnect).
-    env.HoldForgetResponses.store(1);
-    env.RebootPqTablet();
+    RebootAndWaitHeldForgets(/*minHeld=*/1);
 
-    WaitUntil(runtime, [&] {
-        return env.HeldForgetResponses.load() >= 1;
-    });
-    UNIT_ASSERT_C(env.HeldForgetResponses.load() >= 1,
-        "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
-
-    env.ReleaseHeldPrepares();
-    runtime.SimulateSleep(TDuration::MilliSeconds(200));
-
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "late Prepare during Forget restore must not kill partition actor via unhandled exception"
-            << "; heldPrepare=" << env.HeldPrepareResponses.load()
-            << "; heldForget=" << env.HeldForgetResponses.load()
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-
-    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
-    env.ReleaseHeldForgets();
-    WaitUntil(runtime, [&] {
-        return env.UpdateSessionCount.load() > updateSessionsBefore
-            || env.UnexpectedErrorCloseSession.load() > 0;
-    });
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "releasing Forget after late Prepare must not kill partition actor"
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
-        "Forget restore must complete with TEvUpdateSession after late Prepare soft-ignore");
-
-    TearDownGrpcAndServer(env, client);
+    ReleaseLateReplyAndAssertSurvived(
+        [&] { Env.ReleaseHeldPrepares(); },
+        "late Prepare during Forget restore must not kill partition actor via unhandled exception");
+    ReleaseAndWaitUpdateSession(
+        [&] { Env.ReleaseHeldForgets(); },
+        "releasing Forget after late Prepare must not kill partition actor");
 }
 
 // LOGBROKER-10590: Prepare+Publish restore in flight, client acks, nested pipe restart → forget-first;
 // late Publish from the previous restore attempt must be ignored (not ENSURE on Forget).
 Y_UNIT_TEST(HasCmdForgetReadResultOnPublishDuringForgetRestore) {
-    TDirectReadRestoreEnv env;
-    env.Start();
-    auto& runtime = env.Runtime();
-
-    RunWithDispatch(runtime, [&] {
-        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
-        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
-        if (!writer->Write(TString(1_MB, 'x'))) {
-            ythrow yexception() << "write failed";
-        }
-        writer->Close();
-        driver.Stop(true);
-        return true;
-    });
-
-    TGrpcDirectReadClient client;
-    client.Connect(env.Endpoint);
-    client.InitControlSession(runtime);
-    client.AcceptAssign(runtime);
-    client.InitDirectSession(runtime);
-    client.StartDirectReadPartition(runtime);
-    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+    WriteOneMessage();
+    OpenDirectReadSession();
 
     // Let Prepare complete; hold Publish (prod: Publish reply still on the wire / in mailbox).
-    env.HoldPublishResponses.store(1);
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.HeldPublishResponses.load() >= 1;
-    });
-    UNIT_ASSERT_C(env.HeldPublishResponses.load() >= 1,
-        "expected held Publish from first restore attempt (stage=Publish, RestoredDirectReadId set)");
+    RebootAndWaitHeldPublishes(/*minHeld=*/1);
 
     // Ack while RestoredDirectReadId==id → DirectReadsToForget; DirectReadResults cleared.
-    client.SendDirectReadAckNoWait(runtime, 1);
-    runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    AckDirectRead();
+    RebootAndWaitHeldForgets(/*minHeld=*/1);
 
-    env.HoldForgetResponses.store(1);
-    env.RebootPqTablet();
-
-    WaitUntil(runtime, [&] {
-        return env.HeldForgetResponses.load() >= 1;
-    });
-    UNIT_ASSERT_C(env.HeldForgetResponses.load() >= 1,
-        "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
-
-    env.ReleaseHeldPublishes();
-    runtime.SimulateSleep(TDuration::MilliSeconds(200));
-
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "late Publish during Forget restore must not kill partition actor via unhandled exception"
-            << "; heldPublish=" << env.HeldPublishResponses.load()
-            << "; heldForget=" << env.HeldForgetResponses.load()
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-
-    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
-    env.ReleaseHeldForgets();
-    WaitUntil(runtime, [&] {
-        return env.UpdateSessionCount.load() > updateSessionsBefore
-            || env.UnexpectedErrorCloseSession.load() > 0;
-    });
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
-        "releasing Forget after late Publish must not kill partition actor"
-            << "; reason=" << env.UnexpectedErrorCloseReason);
-    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
-        "Forget restore must complete with TEvUpdateSession after late Publish soft-ignore");
-
-    TearDownGrpcAndServer(env, client);
+    ReleaseLateReplyAndAssertSurvived(
+        [&] { Env.ReleaseHeldPublishes(); },
+        "late Publish during Forget restore must not kill partition actor via unhandled exception");
+    ReleaseAndWaitUpdateSession(
+        [&] { Env.ReleaseHeldForgets(); },
+        "releasing Forget after late Publish must not kill partition actor");
 }
 
-} // Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest)
+} // Y_UNIT_TEST_SUITE_F(TDirectReadRestoreRaceTest)
 
 } // namespace NKikimr::NPersQueueTests

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -554,8 +554,7 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
 }
 
 // LOGBROKER-10590: nested pipe restart re-sends restore Prepare for the same DirectReadId;
-// if the first Prepare arrives only after the second has already moved restore to Publish,
-// PARTITION_ENSURE(result.HasCmdPublishReadResult()) fires (Prepare stage soft-ignores, Publish does not).
+// a late Prepare after restore has moved to Publish must be ignored (not ENSURE).
 Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
     TDirectReadRestoreEnv env;
     env.Start();
@@ -608,9 +607,8 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
     env.ReleaseHeldPrepares();
     runtime.SimulateSleep(TDuration::Seconds(1));
 
-    // Intentionally asserting the bug exists (repro). Flip after fix.
-    UNIT_ASSERT_C(env.HasCmdPublishReadResultEnsure.load() > 0,
-        "expected PARTITION_ENSURE(result.HasCmdPublishReadResult()) on late Prepare during Publish"
+    UNIT_ASSERT_C(env.HasCmdPublishReadResultEnsure.load() == 0,
+        "late Prepare during Publish restore must not hit PARTITION_ENSURE(result.HasCmdPublishReadResult())"
             << "; heldPrepare=" << env.HeldPrepareResponses.load()
             << "; heldPublish=" << env.HeldPublishResponses.load()
             << "; reason=" << env.EnsureCloseReason);

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -474,7 +474,11 @@ void TearDownGrpcAndServer(TDirectReadRestoreEnv& env, TGrpcDirectReadClient& cl
         env.Server->ShutdownGRpc();
         return true;
     }, DispatchPool());
+    const TInstant deadline = TInstant::Now() + TDuration::Seconds(5);
     while (!shutdown.HasValue() && !shutdown.HasException()) {
+        if (TInstant::Now() >= deadline) {
+            UNIT_FAIL("ShutdownGRpc did not complete within 5 seconds");
+        }
         runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
     }
     shutdown.GetValueSync();

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -137,23 +137,51 @@ struct TDirectReadRestoreEnv {
         auto settings = TTopicSdkTestSetup::MakeServerSettings();
         settings.SetUseRealThreads(false);
         settings.SetNodeCount(1);
+        // Skip SysViews roster WaitFor in TServer::Initialize (~10s under UseRealThreads=false).
+        settings.FeatureFlags.SetEnableRealSystemViewPaths(false);
 
+        // Inline TTestServer::StartServer so AnnoyingClient (Sync discovery) can run
+        // under RunWithDispatch; shared StartServer constructs it without a pump.
         Server = std::make_unique<::NPersQueue::TTestServer>(settings, /*start=*/false);
-        Server->StartServer(/*doClientInit=*/false, TString("/Root"));
         Endpoint = Server->Endpoint;
+
+        Server->PrepareNetDataFile();
+        Server->CleverServer = MakeHolder<NKikimr::Tests::TServer>(Server->ServerSettings);
+        Server->CleverServer->EnableGRpc(Server->GrpcServerOptions);
+
+        Server->Log.SetFormatter([](ELogPriority priority, TStringBuf message) {
+            return TStringBuilder() << TInstant::Now() << " " << priority << ": " << message << Endl;
+        });
+        Server->Log << TLOG_INFO << "TTestServer started on Port " << Server->Port
+                    << " GrpcPort " << Server->GrpcPort;
 
         auto& runtime = Runtime();
         runtime.SetScheduledLimit(100'000);
-        runtime.UpdateCurrentTime(TInstant::Now());
+
+        // TFlatMsgBusPQClient builds NYdb::TDriver with default Sync discovery, which blocks
+        // on ListEndpoints (GET_ENDPOINTS_TIMEOUT=10s). With UseRealThreads=false the request
+        // is only served while we DispatchEvents — so construct it under RunWithDispatch.
+        RunWithDispatch(runtime, [&] {
+            Server->AnnoyingClient = MakeHolder<NKikimr::NPersQueueTests::TFlatMsgBusPQClient>(
+                Server->ServerSettings, Server->GrpcPort, TString("/Root"));
+            return true;
+        });
+
         Server->AnnoyingClient->SetNoConfigMode();
 
-        runtime.SetLogPriority(NKikimrServices::PQ_READ_PROXY, NActors::NLog::PRI_DEBUG);
-        runtime.SetLogPriority(NKikimrServices::PERSQUEUE, NActors::NLog::PRI_INFO);
+        // Configure service log levels here if needed, e.g.:
+        // runtime.SetLogPriority(NKikimrServices::PQ_READ_PROXY, NActors::NLog::PRI_DEBUG);
 
         InstallHooks();
 
+        // No-config mode: FullInit() would still call InitSourceIds({}) with an empty
+        // path (CreateTable fails with "Path does not exist"). Only need Root + /PQ.
         RunWithDispatch(runtime, [&] {
-            Server->AnnoyingClient->FullInit();
+            Server->AnnoyingClient->InitRootScheme();
+            return true;
+        });
+        RunWithDispatch(runtime, [&] {
+            Server->AnnoyingClient->MkDir("/Root", "PQ");
             return true;
         });
 

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -349,8 +349,8 @@ struct TGrpcDirectReadClient {
 
 Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest) {
 
-// LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0.
-// Without the fix PARTITION_ENSURE(RestoredDirectReadId != 0) fires on Forget stage.
+// LOGBROKER-10590: forget-first after nested pipe restart with RestoredDirectReadId==0
+// must not kill the partition actor (Forget stage must tolerate RestoredDirectReadId==0).
 Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     TDirectReadRestoreEnv env;
     env.Start();
@@ -395,8 +395,8 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     env.HoldRestorePreparePublish.store(0);
     runtime.SimulateSleep(TDuration::Seconds(1));
 
-    UNIT_ASSERT_C(env.RestoredDirectReadIdEnsure.load() > 0,
-        "expected PARTITION_ENSURE(RestoredDirectReadId != 0) on Forget after nested restart"
+    UNIT_ASSERT_C(env.RestoredDirectReadIdEnsure.load() == 0,
+        "Forget after nested restart must not hit PARTITION_ENSURE(RestoredDirectReadId != 0)"
             << "; held=" << env.HeldPrepareOrPublish.load()
             << "; reason=" << env.EnsureCloseReason);
 

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -109,6 +109,13 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HoldRestorePreparePublish{0};
     std::atomic<ui64> HeldPrepareOrPublish{0};
     std::atomic<ui64> RestoredDirectReadIdEnsure{0};
+
+    // Hold CmdPrepareReadResult (re-inject later) to race with ResendRecentRequests after pipe restart.
+    std::atomic<ui64> HoldPrepareResponses{0};
+    std::atomic<ui64> HeldPrepareResponses{0};
+    std::atomic<ui64> RequestInflyEnsure{0};
+    TVector<THolder<IEventHandle>> HeldPrepareEvents;
+
     TString EnsureCloseReason;
 
     NActors::TTestActorRuntime& Runtime() {
@@ -169,14 +176,25 @@ struct TDirectReadRestoreEnv {
         auto& runtime = Runtime();
 
         runtime.SetEventFilter([this](TTestActorRuntimeBase&, TAutoPtr<IEventHandle>& ev) {
-            if (!HoldRestorePreparePublish.load()) {
-                return false;
-            }
             auto* msg = ev->CastAsLocal<TEvPersQueue::TEvResponse>();
             if (!msg || !msg->Record.HasPartitionResponse()) {
                 return false;
             }
             const auto& part = msg->Record.GetPartitionResponse();
+
+            if (HoldPrepareResponses.load() && part.HasCmdPrepareReadResult()) {
+                const ui64 held = ++HeldPrepareResponses;
+                Cerr << "HOLD CmdPrepareReadResult held=" << held
+                     << " cookie=" << part.GetCookie()
+                     << " directReadId=" << part.GetCmdPrepareReadResult().GetDirectReadId()
+                     << Endl;
+                HeldPrepareEvents.emplace_back(ev.Release());
+                return true;
+            }
+
+            if (!HoldRestorePreparePublish.load()) {
+                return false;
+            }
             if (part.HasCmdPrepareReadResult() || part.HasCmdPublishReadResult()) {
                 const ui64 held = ++HeldPrepareOrPublish;
                 Cerr << "DROP restore Prepare/Publish response prepare="
@@ -196,9 +214,33 @@ struct TDirectReadRestoreEnv {
                     Cerr << "Observed CloseSession from RestoredDirectReadId ENSURE: "
                          << msg->Reason << Endl;
                 }
+                // Match verification=RequestInfly, not verification=!RequestInfly.
+                if (msg->Reason.Contains("verification=RequestInfly")) {
+                    EnsureCloseReason = msg->Reason;
+                    ++RequestInflyEnsure;
+                    Cerr << "Observed CloseSession from RequestInfly ENSURE: "
+                         << msg->Reason << Endl;
+                }
             }
             return TTestActorRuntime::EEventAction::PROCESS;
         });
+    }
+
+    void ReleaseHeldPrepares() {
+        HoldPrepareResponses.store(0);
+        auto& runtime = Runtime();
+        Cerr << "Release " << HeldPrepareEvents.size() << " held Prepare responses\n";
+        for (auto& ev : HeldPrepareEvents) {
+            runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+        }
+        HeldPrepareEvents.clear();
+    }
+
+    void DropHooks() {
+        auto& runtime = Runtime();
+        runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
+        runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
+        HeldPrepareEvents.clear();
     }
 
     void RebootPqTablet() {
@@ -345,6 +387,33 @@ struct TGrpcDirectReadClient {
     }
 };
 
+void TearDownGrpcAndServer(TDirectReadRestoreEnv& env, TGrpcDirectReadClient& client) {
+    env.DropHooks();
+
+    if (client.ControlContext) {
+        client.ControlContext->TryCancel();
+    }
+    if (client.DirectContext) {
+        client.DirectContext->TryCancel();
+    }
+    client.ControlStream.reset();
+    client.DirectStream.reset();
+    client.Stub.reset();
+    client.Channel.reset();
+
+    auto& runtime = env.Runtime();
+    auto shutdown = NThreading::Async([&] {
+        env.Server->ShutdownGRpc();
+        return true;
+    }, DispatchPool());
+    while (!shutdown.HasValue() && !shutdown.HasException()) {
+        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+    }
+    shutdown.GetValueSync();
+    env.Server->ShutdownServer();
+    env.Server.reset();
+}
+
 } // namespace
 
 Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest) {
@@ -400,33 +469,66 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
             << "; held=" << env.HeldPrepareOrPublish.load()
             << "; reason=" << env.EnsureCloseReason);
 
-    // Drop hooks before destroying actors / gRPC — they capture env by raw this.
-    runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
-    runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
+    TearDownGrpcAndServer(env, client);
+}
 
-    // Tear down gRPC under dispatch pump: ShutdownGRpc blocks waiting for inflight
-    // while UseRealThreads=false needs the test thread to DispatchEvents.
-    if (client.ControlContext) {
-        client.ControlContext->TryCancel();
-    }
-    if (client.DirectContext) {
-        client.DirectContext->TryCancel();
-    }
-    client.ControlStream.reset();
-    client.DirectStream.reset();
-    client.Stub.reset();
-    client.Channel.reset();
+// LOGBROKER-10590: after pipe restart with RequestInfly, ResendRecentRequests re-sends Prepare;
+// a late/duplicate CmdPrepareReadResult on the normal path then hits PARTITION_ENSURE(RequestInfly).
+Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
+    TDirectReadRestoreEnv env;
+    env.Start();
+    auto& runtime = env.Runtime();
 
-    auto shutdown = NThreading::Async([&] {
-        env.Server->ShutdownGRpc();
+    RunWithDispatch(runtime, [&] {
+        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
+        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+        if (!writer->Write(TString(1_MB, 'x'))) {
+            ythrow yexception() << "write failed";
+        }
+        writer->Close();
+        driver.Stop(true);
         return true;
-    }, DispatchPool());
-    while (!shutdown.HasValue() && !shutdown.HasException()) {
-        runtime.DispatchEvents(TDispatchOptions(), TDuration::MilliSeconds(100));
+    });
+
+    TGrpcDirectReadClient client;
+    client.Connect(env.Endpoint);
+    client.InitControlSession(runtime);
+
+    // Hold Prepare before partition starts reading, so RequestInfly stays true across reboot.
+    env.HoldPrepareResponses.store(1);
+
+    client.AcceptAssign(runtime);
+    client.InitDirectSession(runtime);
+    client.StartDirectReadPartition(runtime);
+
+    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 1; ++i) {
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
     }
-    shutdown.GetValueSync();
-    env.Server->ShutdownServer();
-    env.Server.reset();
+    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
+        "expected at least one held CmdPrepareReadResult before reboot");
+
+    Cerr << "Reboot while Prepare is held (RequestInfly still true, DirectReadResults empty)\n";
+    env.RebootPqTablet();
+
+    // Restore of empty DirectReadResults finishes quickly → ResendRecentRequests → second Prepare.
+    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 2; ++i) {
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    }
+    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 2,
+        "expected held Prepare from original read and from ResendRecentRequests after restore"
+            << "; held=" << env.HeldPrepareResponses.load());
+
+    Cerr << "Release both Prepare responses onto the normal path\n";
+    env.ReleaseHeldPrepares();
+    runtime.SimulateSleep(TDuration::Seconds(1));
+
+    // Intentionally asserting the bug exists (repro). Flip after fix.
+    UNIT_ASSERT_C(env.RequestInflyEnsure.load() > 0,
+        "expected PARTITION_ENSURE(RequestInfly) on duplicate Prepare after pipe restart"
+            << "; held=" << env.HeldPrepareResponses.load()
+            << "; reason=" << env.EnsureCloseReason);
+
+    TearDownGrpcAndServer(env, client);
 }
 
 } // Y_UNIT_TEST_SUITE(TDirectReadRestoreRaceTest)

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -473,7 +473,7 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
 }
 
 // LOGBROKER-10590: after pipe restart with RequestInfly, ResendRecentRequests re-sends Prepare;
-// a late/duplicate CmdPrepareReadResult on the normal path then hits PARTITION_ENSURE(RequestInfly).
+// a late/duplicate CmdPrepareReadResult on the normal path must be ignored (not ENSURE).
 Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
     TDirectReadRestoreEnv env;
     env.Start();
@@ -522,9 +522,8 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
     env.ReleaseHeldPrepares();
     runtime.SimulateSleep(TDuration::Seconds(1));
 
-    // Intentionally asserting the bug exists (repro). Flip after fix.
-    UNIT_ASSERT_C(env.RequestInflyEnsure.load() > 0,
-        "expected PARTITION_ENSURE(RequestInfly) on duplicate Prepare after pipe restart"
+    UNIT_ASSERT_C(env.RequestInflyEnsure.load() == 0,
+        "duplicate Prepare after pipe restart must not hit PARTITION_ENSURE(RequestInfly)"
             << "; held=" << env.HeldPrepareResponses.load()
             << "; reason=" << env.EnsureCloseReason);
 

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -126,13 +126,19 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HeldPublishResponses{0};
     TVector<THolder<IEventHandle>> HeldPublishEvents;
 
-    // Drop CmdForgetReadResult to keep restore stuck in Forget stage.
+    // Hold CmdForgetReadResult (re-inject later) to keep restore stuck in Forget stage.
     std::atomic<ui64> HoldForgetResponses{0};
     std::atomic<ui64> HeldForgetResponses{0};
+    TVector<THolder<IEventHandle>> HeldForgetEvents;
 
     // PARTITION_ENSURE → OnUnhandledException → CloseSession("unexpected error: ...").
     std::atomic<ui64> UnexpectedErrorCloseSession{0};
     TString UnexpectedErrorCloseReason;
+
+    // OnDirectReadsRestored → TEvUpdateSession; proves restore finished (not silent-hang).
+    std::atomic<ui64> UpdateSessionCount{0};
+    // Normal-path Publish completed → TEvDirectReadResponse to read session.
+    std::atomic<ui64> DirectReadResponseCount{0};
 
     NActors::TTestActorRuntime& Runtime() {
         return *Server->CleverServer->GetRuntime();
@@ -239,7 +245,8 @@ struct TDirectReadRestoreEnv {
 
             if (HoldForgetResponses.load() && part.HasCmdForgetReadResult()) {
                 ++HeldForgetResponses;
-                return true; // drop — keep restore stuck in Forget
+                HeldForgetEvents.emplace_back(ev.Release());
+                return true;
             }
 
             if (!HoldRestorePreparePublish.load()) {
@@ -259,6 +266,12 @@ struct TDirectReadRestoreEnv {
                     UnexpectedErrorCloseReason = msg->Reason;
                     ++UnexpectedErrorCloseSession;
                 }
+            }
+            if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvUpdateSession>()) {
+                ++UpdateSessionCount;
+            }
+            if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvDirectReadResponse>()) {
+                ++DirectReadResponseCount;
             }
             return TTestActorRuntime::EEventAction::PROCESS;
         });
@@ -282,12 +295,22 @@ struct TDirectReadRestoreEnv {
         HeldPublishEvents.clear();
     }
 
+    void ReleaseHeldForgets() {
+        HoldForgetResponses.store(0);
+        auto& runtime = Runtime();
+        for (auto& ev : HeldForgetEvents) {
+            runtime.Send(ev.Release(), /*senderNodeIndex=*/0, /*viaActorSystem=*/true);
+        }
+        HeldForgetEvents.clear();
+    }
+
     void DropHooks() {
         auto& runtime = Runtime();
         runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
         runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
         HeldPrepareEvents.clear();
         HeldPublishEvents.clear();
+        HeldForgetEvents.clear();
     }
 
     void RebootPqTablet() {
@@ -429,6 +452,7 @@ struct TGrpcDirectReadClient {
             return true;
         });
     }
+
 };
 
 void TearDownGrpcAndServer(TDirectReadRestoreEnv& env, TGrpcDirectReadClient& client) {
@@ -500,15 +524,22 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     client.SendDirectReadAckNoWait(runtime, 1);
     runtime.SimulateSleep(TDuration::MilliSeconds(50));
 
+    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
     env.RebootPqTablet();
     // Allow Session→Forget path to run; do not hold Forget responses.
     env.HoldRestorePreparePublish.store(0);
-    runtime.SimulateSleep(TDuration::Seconds(1));
+
+    WaitUntil(runtime, [&] {
+        return env.UpdateSessionCount.load() > updateSessionsBefore
+            || env.UnexpectedErrorCloseSession.load() > 0;
+    });
 
     UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
         "Forget after nested restart must not kill partition actor via unhandled exception"
             << "; held=" << env.HeldPrepareOrPublish.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
+    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
+        "restore must complete with TEvUpdateSession (not silent-hang in Forget)");
 
     TearDownGrpcAndServer(env, client);
 }
@@ -558,13 +589,20 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
         "expected held Prepare from original read and from ResendRecentRequests after restore"
             << "; held=" << env.HeldPrepareResponses.load());
 
+    const ui64 directReadsBefore = env.DirectReadResponseCount.load();
     env.ReleaseHeldPrepares();
-    runtime.SimulateSleep(TDuration::Seconds(1));
+
+    WaitUntil(runtime, [&] {
+        return env.DirectReadResponseCount.load() > directReadsBefore
+            || env.UnexpectedErrorCloseSession.load() > 0;
+    });
 
     UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
         "duplicate Prepare after pipe restart must not kill partition actor via unhandled exception"
             << "; held=" << env.HeldPrepareResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
+    UNIT_ASSERT_C(env.DirectReadResponseCount.load() > directReadsBefore,
+        "Prepare/Publish must complete after releasing held Prepares (not silent-hang)");
 
     TearDownGrpcAndServer(env, client);
 }
@@ -681,13 +719,25 @@ Y_UNIT_TEST(HasCmdForgetReadResultOnPrepareDuringForgetRestore) {
         "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
 
     env.ReleaseHeldPrepares();
-    runtime.SimulateSleep(TDuration::Seconds(1));
+    runtime.SimulateSleep(TDuration::MilliSeconds(200));
 
     UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
         "late Prepare during Forget restore must not kill partition actor via unhandled exception"
             << "; heldPrepare=" << env.HeldPrepareResponses.load()
             << "; heldForget=" << env.HeldForgetResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
+
+    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
+    env.ReleaseHeldForgets();
+    WaitUntil(runtime, [&] {
+        return env.UpdateSessionCount.load() > updateSessionsBefore
+            || env.UnexpectedErrorCloseSession.load() > 0;
+    });
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "releasing Forget after late Prepare must not kill partition actor"
+            << "; reason=" << env.UnexpectedErrorCloseReason);
+    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
+        "Forget restore must complete with TEvUpdateSession after late Prepare soft-ignore");
 
     TearDownGrpcAndServer(env, client);
 }
@@ -742,13 +792,25 @@ Y_UNIT_TEST(HasCmdForgetReadResultOnPublishDuringForgetRestore) {
         "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
 
     env.ReleaseHeldPublishes();
-    runtime.SimulateSleep(TDuration::Seconds(1));
+    runtime.SimulateSleep(TDuration::MilliSeconds(200));
 
     UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
         "late Publish during Forget restore must not kill partition actor via unhandled exception"
             << "; heldPublish=" << env.HeldPublishResponses.load()
             << "; heldForget=" << env.HeldForgetResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
+
+    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
+    env.ReleaseHeldForgets();
+    WaitUntil(runtime, [&] {
+        return env.UpdateSessionCount.load() > updateSessionsBefore
+            || env.UnexpectedErrorCloseSession.load() > 0;
+    });
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "releasing Forget after late Publish must not kill partition actor"
+            << "; reason=" << env.UnexpectedErrorCloseReason);
+    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
+        "Forget restore must complete with TEvUpdateSession after late Publish soft-ignore");
 
     TearDownGrpcAndServer(env, client);
 }

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -108,21 +108,20 @@ struct TDirectReadRestoreEnv {
 
     std::atomic<ui64> HoldRestorePreparePublish{0};
     std::atomic<ui64> HeldPrepareOrPublish{0};
-    std::atomic<ui64> RestoredDirectReadIdEnsure{0};
 
     // Hold CmdPrepareReadResult (re-inject later) to race with ResendRecentRequests after pipe restart.
     std::atomic<ui64> HoldPrepareResponses{0};
     std::atomic<ui64> HeldPrepareResponses{0};
-    std::atomic<ui64> RequestInflyEnsure{0};
     TVector<THolder<IEventHandle>> HeldPrepareEvents;
 
     // Hold CmdPublishReadResult to keep restore stuck in Publish stage.
     std::atomic<ui64> HoldPublishResponses{0};
     std::atomic<ui64> HeldPublishResponses{0};
-    std::atomic<ui64> HasCmdPublishReadResultEnsure{0};
     TVector<THolder<IEventHandle>> HeldPublishEvents;
 
-    TString EnsureCloseReason;
+    // PARTITION_ENSURE → OnUnhandledException → CloseSession("unexpected error: ...").
+    std::atomic<ui64> UnexpectedErrorCloseSession{0};
+    TString UnexpectedErrorCloseReason;
 
     NActors::TTestActorRuntime& Runtime() {
         return *Server->CleverServer->GetRuntime();
@@ -224,23 +223,11 @@ struct TDirectReadRestoreEnv {
 
         runtime.SetObserverFunc([this](TAutoPtr<IEventHandle>& ev) {
             if (auto* msg = ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvCloseSession>()) {
-                if (msg->Reason.Contains("RestoredDirectReadId")) {
-                    EnsureCloseReason = msg->Reason;
-                    ++RestoredDirectReadIdEnsure;
-                    Cerr << "Observed CloseSession from RestoredDirectReadId ENSURE: "
-                         << msg->Reason << Endl;
-                }
-                // Match verification=RequestInfly, not verification=!RequestInfly.
-                if (msg->Reason.Contains("verification=RequestInfly")) {
-                    EnsureCloseReason = msg->Reason;
-                    ++RequestInflyEnsure;
-                    Cerr << "Observed CloseSession from RequestInfly ENSURE: "
-                         << msg->Reason << Endl;
-                }
-                if (msg->Reason.Contains("HasCmdPublishReadResult")) {
-                    EnsureCloseReason = msg->Reason;
-                    ++HasCmdPublishReadResultEnsure;
-                    Cerr << "Observed CloseSession from HasCmdPublishReadResult ENSURE: "
+                // OnUnhandledException always prefixes with "unexpected error:".
+                if (msg->Reason.Contains("unexpected error:")) {
+                    UnexpectedErrorCloseReason = msg->Reason;
+                    ++UnexpectedErrorCloseSession;
+                    Cerr << "Observed CloseSession from unhandled exception: "
                          << msg->Reason << Endl;
                 }
             }
@@ -487,10 +474,10 @@ Y_UNIT_TEST(RestoredDirectReadIdZeroOnForgetAfterDoubleRestart) {
     env.HoldRestorePreparePublish.store(0);
     runtime.SimulateSleep(TDuration::Seconds(1));
 
-    UNIT_ASSERT_C(env.RestoredDirectReadIdEnsure.load() == 0,
-        "Forget after nested restart must not hit PARTITION_ENSURE(RestoredDirectReadId != 0)"
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "Forget after nested restart must not kill partition actor via unhandled exception"
             << "; held=" << env.HeldPrepareOrPublish.load()
-            << "; reason=" << env.EnsureCloseReason);
+            << "; reason=" << env.UnexpectedErrorCloseReason);
 
     TearDownGrpcAndServer(env, client);
 }
@@ -545,10 +532,10 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
     env.ReleaseHeldPrepares();
     runtime.SimulateSleep(TDuration::Seconds(1));
 
-    UNIT_ASSERT_C(env.RequestInflyEnsure.load() == 0,
-        "duplicate Prepare after pipe restart must not hit PARTITION_ENSURE(RequestInfly)"
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "duplicate Prepare after pipe restart must not kill partition actor via unhandled exception"
             << "; held=" << env.HeldPrepareResponses.load()
-            << "; reason=" << env.EnsureCloseReason);
+            << "; reason=" << env.UnexpectedErrorCloseReason);
 
     TearDownGrpcAndServer(env, client);
 }
@@ -607,11 +594,11 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
     env.ReleaseHeldPrepares();
     runtime.SimulateSleep(TDuration::Seconds(1));
 
-    UNIT_ASSERT_C(env.HasCmdPublishReadResultEnsure.load() == 0,
-        "late Prepare during Publish restore must not hit PARTITION_ENSURE(result.HasCmdPublishReadResult())"
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "late Prepare during Publish restore must not kill partition actor via unhandled exception"
             << "; heldPrepare=" << env.HeldPrepareResponses.load()
             << "; heldPublish=" << env.HeldPublishResponses.load()
-            << "; reason=" << env.EnsureCloseReason);
+            << "; reason=" << env.UnexpectedErrorCloseReason);
 
     TearDownGrpcAndServer(env, client);
 }

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -656,13 +656,30 @@ Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
             << "; held=" << env.HeldPrepareResponses.load());
 
     env.ReleaseHeldPrepares();
-    runtime.SimulateSleep(TDuration::Seconds(1));
-
+    // First Prepare advances restore to Publish; second is soft-ignored on Publish stage.
+    WaitUntil(runtime, [&] {
+        return env.HeldPublishResponses.load() >= 1
+            || env.UnexpectedErrorCloseSession.load() > 0;
+    });
     UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
         "late Prepare during Publish restore must not kill partition actor via unhandled exception"
             << "; heldPrepare=" << env.HeldPrepareResponses.load()
             << "; heldPublish=" << env.HeldPublishResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
+    UNIT_ASSERT_C(env.HeldPublishResponses.load() >= 1,
+        "expected Publish stage after releasing held Prepares");
+
+    const ui64 updateSessionsBefore = env.UpdateSessionCount.load();
+    env.ReleaseHeldPublishes();
+    WaitUntil(runtime, [&] {
+        return env.UpdateSessionCount.load() > updateSessionsBefore
+            || env.UnexpectedErrorCloseSession.load() > 0;
+    });
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "releasing Publish after late Prepare must not kill partition actor"
+            << "; reason=" << env.UnexpectedErrorCloseReason);
+    UNIT_ASSERT_C(env.UpdateSessionCount.load() > updateSessionsBefore,
+        "Publish restore must complete with TEvUpdateSession after late Prepare soft-ignore");
 
     TearDownGrpcAndServer(env, client);
 }

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -681,13 +681,10 @@ Y_UNIT_TEST(HasCmdForgetReadResultOnPrepareDuringForgetRestore) {
         "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
 
     env.ReleaseHeldPrepares();
-    WaitUntil(runtime, [&] {
-        return env.UnexpectedErrorCloseSession.load() > 0;
-    });
+    runtime.SimulateSleep(TDuration::Seconds(1));
 
-    // Repro: PARTITION_ENSURE(HasCmdForgetReadResult) on late Prepare during Forget.
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() > 0,
-        "expected PARTITION_ENSURE(HasCmdForgetReadResult) on late Prepare during Forget restore"
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "late Prepare during Forget restore must not kill partition actor via unhandled exception"
             << "; heldPrepare=" << env.HeldPrepareResponses.load()
             << "; heldForget=" << env.HeldForgetResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);
@@ -745,13 +742,10 @@ Y_UNIT_TEST(HasCmdForgetReadResultOnPublishDuringForgetRestore) {
         "expected Forget after nested restart (forget-first, RestoredDirectReadId==0)");
 
     env.ReleaseHeldPublishes();
-    WaitUntil(runtime, [&] {
-        return env.UnexpectedErrorCloseSession.load() > 0;
-    });
+    runtime.SimulateSleep(TDuration::Seconds(1));
 
-    // Repro: PARTITION_ENSURE(HasCmdForgetReadResult) on late Publish during Forget.
-    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() > 0,
-        "expected PARTITION_ENSURE(HasCmdForgetReadResult) on late Publish during Forget restore"
+    UNIT_ASSERT_C(env.UnexpectedErrorCloseSession.load() == 0,
+        "late Publish during Forget restore must not kill partition actor via unhandled exception"
             << "; heldPublish=" << env.HeldPublishResponses.load()
             << "; heldForget=" << env.HeldForgetResponses.load()
             << "; reason=" << env.UnexpectedErrorCloseReason);

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -106,6 +106,7 @@ struct TDirectReadRestoreEnv {
     TString Endpoint;
     ui64 PqTabletId = 0;
 
+    // Drop restore Prepare/Publish responses to keep restore stuck in Prepare (Forget race).
     std::atomic<ui64> HoldRestorePreparePublish{0};
     std::atomic<ui64> HeldPrepareOrPublish{0};
 
@@ -117,7 +118,6 @@ struct TDirectReadRestoreEnv {
     // Hold CmdPublishReadResult to keep restore stuck in Publish stage.
     std::atomic<ui64> HoldPublishResponses{0};
     std::atomic<ui64> HeldPublishResponses{0};
-    TVector<THolder<IEventHandle>> HeldPublishEvents;
 
     // PARTITION_ENSURE → OnUnhandledException → CloseSession("unexpected error: ...").
     std::atomic<ui64> UnexpectedErrorCloseSession{0};
@@ -199,12 +199,11 @@ struct TDirectReadRestoreEnv {
 
             if (HoldPublishResponses.load() && part.HasCmdPublishReadResult()) {
                 const ui64 held = ++HeldPublishResponses;
-                Cerr << "HOLD CmdPublishReadResult held=" << held
+                Cerr << "DROP CmdPublishReadResult held=" << held
                      << " cookie=" << part.GetCookie()
                      << " directReadId=" << part.GetCmdPublishReadResult().GetDirectReadId()
                      << Endl;
-                HeldPublishEvents.emplace_back(ev.Release());
-                return true;
+                return true; // drop — keep restore stuck in Publish
             }
 
             if (!HoldRestorePreparePublish.load()) {
@@ -250,7 +249,6 @@ struct TDirectReadRestoreEnv {
         runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
         runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
         HeldPrepareEvents.clear();
-        HeldPublishEvents.clear();
     }
 
     void RebootPqTablet() {

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -116,6 +116,12 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> RequestInflyEnsure{0};
     TVector<THolder<IEventHandle>> HeldPrepareEvents;
 
+    // Hold CmdPublishReadResult to keep restore stuck in Publish stage.
+    std::atomic<ui64> HoldPublishResponses{0};
+    std::atomic<ui64> HeldPublishResponses{0};
+    std::atomic<ui64> HasCmdPublishReadResultEnsure{0};
+    TVector<THolder<IEventHandle>> HeldPublishEvents;
+
     TString EnsureCloseReason;
 
     NActors::TTestActorRuntime& Runtime() {
@@ -192,6 +198,16 @@ struct TDirectReadRestoreEnv {
                 return true;
             }
 
+            if (HoldPublishResponses.load() && part.HasCmdPublishReadResult()) {
+                const ui64 held = ++HeldPublishResponses;
+                Cerr << "HOLD CmdPublishReadResult held=" << held
+                     << " cookie=" << part.GetCookie()
+                     << " directReadId=" << part.GetCmdPublishReadResult().GetDirectReadId()
+                     << Endl;
+                HeldPublishEvents.emplace_back(ev.Release());
+                return true;
+            }
+
             if (!HoldRestorePreparePublish.load()) {
                 return false;
             }
@@ -221,6 +237,12 @@ struct TDirectReadRestoreEnv {
                     Cerr << "Observed CloseSession from RequestInfly ENSURE: "
                          << msg->Reason << Endl;
                 }
+                if (msg->Reason.Contains("HasCmdPublishReadResult")) {
+                    EnsureCloseReason = msg->Reason;
+                    ++HasCmdPublishReadResultEnsure;
+                    Cerr << "Observed CloseSession from HasCmdPublishReadResult ENSURE: "
+                         << msg->Reason << Endl;
+                }
             }
             return TTestActorRuntime::EEventAction::PROCESS;
         });
@@ -241,6 +263,7 @@ struct TDirectReadRestoreEnv {
         runtime.SetEventFilter(&TTestActorRuntimeBase::DefaultFilterFunc);
         runtime.SetObserverFunc(&TTestActorRuntimeBase::DefaultObserverFunc);
         HeldPrepareEvents.clear();
+        HeldPublishEvents.clear();
     }
 
     void RebootPqTablet() {
@@ -525,6 +548,71 @@ Y_UNIT_TEST(RequestInflyOnDuplicatePrepareAfterPipeRestart) {
     UNIT_ASSERT_C(env.RequestInflyEnsure.load() == 0,
         "duplicate Prepare after pipe restart must not hit PARTITION_ENSURE(RequestInfly)"
             << "; held=" << env.HeldPrepareResponses.load()
+            << "; reason=" << env.EnsureCloseReason);
+
+    TearDownGrpcAndServer(env, client);
+}
+
+// LOGBROKER-10590: nested pipe restart re-sends restore Prepare for the same DirectReadId;
+// if the first Prepare arrives only after the second has already moved restore to Publish,
+// PARTITION_ENSURE(result.HasCmdPublishReadResult()) fires (Prepare stage soft-ignores, Publish does not).
+Y_UNIT_TEST(HasCmdPublishReadResultOnPrepareDuringPublishRestore) {
+    TDirectReadRestoreEnv env;
+    env.Start();
+    auto& runtime = env.Runtime();
+
+    RunWithDispatch(runtime, [&] {
+        TDriver driver(MakeAsyncDriverConfig(env.Endpoint));
+        auto writer = CreateSimpleWriter(driver, kTopicPath, "src", /*partitionGroup=*/{}, TString("raw"));
+        if (!writer->Write(TString(1_MB, 'x'))) {
+            ythrow yexception() << "write failed";
+        }
+        writer->Close();
+        driver.Stop(true);
+        return true;
+    });
+
+    TGrpcDirectReadClient client;
+    client.Connect(env.Endpoint);
+    client.InitControlSession(runtime);
+    client.AcceptAssign(runtime);
+    client.InitDirectSession(runtime);
+    client.StartDirectReadPartition(runtime);
+    client.ReadDataNoAck(runtime, /*expectedDirectReadId=*/1);
+
+    // Hold Prepare (and Publish) so nested restart can queue a second real Prepare
+    // before either response is delivered — same shape as late pipe replies in prod.
+    env.HoldPrepareResponses.store(1);
+    env.HoldPublishResponses.store(1);
+
+    Cerr << "First reboot: restore sends Prepare for published DirectReadId=1\n";
+    env.RebootPqTablet();
+
+    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 1; ++i) {
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    }
+    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 1,
+        "expected held Prepare from first restore attempt");
+
+    Cerr << "Second reboot while Prepare is still held: restore re-sends Prepare for the same id\n";
+    env.RebootPqTablet();
+
+    for (ui32 i = 0; i < 100 && env.HeldPrepareResponses.load() < 2; ++i) {
+        runtime.SimulateSleep(TDuration::MilliSeconds(50));
+    }
+    UNIT_ASSERT_C(env.HeldPrepareResponses.load() >= 2,
+        "expected two held Prepares from nested restore attempts"
+            << "; held=" << env.HeldPrepareResponses.load());
+
+    Cerr << "Release both Prepares: first advances to Publish, second arrives on Publish stage\n";
+    env.ReleaseHeldPrepares();
+    runtime.SimulateSleep(TDuration::Seconds(1));
+
+    // Intentionally asserting the bug exists (repro). Flip after fix.
+    UNIT_ASSERT_C(env.HasCmdPublishReadResultEnsure.load() > 0,
+        "expected PARTITION_ENSURE(result.HasCmdPublishReadResult()) on late Prepare during Publish"
+            << "; heldPrepare=" << env.HeldPrepareResponses.load()
+            << "; heldPublish=" << env.HeldPublishResponses.load()
             << "; reason=" << env.EnsureCloseReason);
 
     TearDownGrpcAndServer(env, client);

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -140,6 +140,9 @@ struct TDirectReadRestoreEnv {
     // Normal-path Publish completed → TEvDirectReadResponse to read session.
     std::atomic<ui64> DirectReadResponseCount{0};
 
+    // Prepare/Publish delivered while Forget responses are held (late reply onto Forget stage).
+    std::atomic<ui64> LateNonForgetReplyDuringForget{0};
+
     NActors::TTestActorRuntime& Runtime() {
         return *Server->CleverServer->GetRuntime();
     }
@@ -249,12 +252,16 @@ struct TDirectReadRestoreEnv {
                 return true;
             }
 
-            if (!HoldRestorePreparePublish.load()) {
-                return false;
-            }
-            if (part.HasCmdPrepareReadResult() || part.HasCmdPublishReadResult()) {
+            if (HoldRestorePreparePublish.load()
+                    && (part.HasCmdPrepareReadResult() || part.HasCmdPublishReadResult())) {
                 ++HeldPrepareOrPublish;
                 return true; // drop — keep restore stuck in Prepare
+            }
+
+            // Late Prepare/Publish reaching the actor while Forget stage is held under test.
+            if (HoldForgetResponses.load()
+                    && (part.HasCmdPrepareReadResult() || part.HasCmdPublishReadResult())) {
+                ++LateNonForgetReplyDuringForget;
             }
             return false;
         });
@@ -659,11 +666,16 @@ protected:
             "Prepare/Publish must complete after releasing held Prepares (not silent-hang)");
     }
 
-    // 8. Release a late reply onto the current restore stage; only assert survival.
+    // 8. Release a late reply onto Forget stage; wait until it is delivered (or ENSURE fires).
     template <typename TRelease>
     void ReleaseLateReplyAndAssertSurvived(TRelease&& release, const TString& what) {
+        const ui64 lateBefore = Env.LateNonForgetReplyDuringForget.load();
+        const ui64 unexpectedBefore = Env.UnexpectedErrorCloseSession.load();
         release();
-        Runtime().SimulateSleep(TDuration::MilliSeconds(200));
+        WaitUntil(Runtime(), [&] {
+            return Env.LateNonForgetReplyDuringForget.load() > lateBefore
+                || Env.UnexpectedErrorCloseSession.load() > unexpectedBefore;
+        });
         AssertNoUnexpectedClose(what);
     }
 

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -139,6 +139,8 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> UpdateSessionCount{0};
     // Normal-path Publish completed → TEvDirectReadResponse to read session.
     std::atomic<ui64> DirectReadResponseCount{0};
+    // Control-path DirectReadAck delivered to partition actor.
+    std::atomic<ui64> DirectReadAckCount{0};
 
     // Prepare/Publish delivered while Forget responses are held (late reply onto Forget stage).
     std::atomic<ui64> LateNonForgetReplyDuringForget{0};
@@ -280,6 +282,9 @@ struct TDirectReadRestoreEnv {
             if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvDirectReadResponse>()) {
                 ++DirectReadResponseCount;
             }
+            if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvDirectReadAck>()) {
+                ++DirectReadAckCount;
+            }
             return TTestActorRuntime::EEventAction::PROCESS;
         });
     }
@@ -324,8 +329,7 @@ struct TDirectReadRestoreEnv {
         auto& runtime = Runtime();
         const auto edge = runtime.AllocateEdgeActor();
         RebootTablet(runtime, PqTabletId, edge);
-        // Partition actor schedules pipe restart with RESTART_PIPE_DELAY_MS=100.
-        runtime.SimulateSleep(TDuration::MilliSeconds(250));
+        // Callers WaitUntil for restore progress; DispatchEvents advances RESTART_PIPE_DELAY_MS.
     }
 };
 
@@ -600,10 +604,15 @@ protected:
             "expected dropped CmdPrepareReadResult/CmdPublishReadResult during restore");
     }
 
-    // 4. Ack DirectRead and give the actor a short slice to process it.
+    // 4. Ack DirectRead and wait until the ack reaches the partition actor.
     void AckDirectRead(ui64 directReadId = 1) {
+        const ui64 before = Env.DirectReadAckCount.load();
         Client.SendDirectReadAckNoWait(Runtime(), directReadId);
-        Runtime().SimulateSleep(TDuration::MilliSeconds(50));
+        WaitUntil(Runtime(), [&] {
+            return Env.DirectReadAckCount.load() > before
+                || Env.UnexpectedErrorCloseSession.load() > 0;
+        });
+        AssertNoUnexpectedClose("DirectReadAck must not kill partition actor");
     }
 
     // 9–10. Shared asserts.

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/direct_read_restore_ut.cpp
@@ -131,9 +131,10 @@ struct TDirectReadRestoreEnv {
     std::atomic<ui64> HeldForgetResponses{0};
     TVector<THolder<IEventHandle>> HeldForgetEvents;
 
-    // PARTITION_ENSURE → OnUnhandledException → CloseSession("unexpected error: ...").
-    std::atomic<ui64> UnexpectedErrorCloseSession{0};
-    TString UnexpectedErrorCloseReason;
+    // Any TEvCloseSession with ErrorCode != OK (ENSURE, empty-queue CloseSessionAndDie, bad ack, …).
+    // Teardown DropHooks() clears the observer before gRPC cancel, so shutdown noise is ignored.
+    std::atomic<ui64> ErrorCloseSession{0};
+    TString ErrorCloseReason;
 
     // OnDirectReadsRestored → TEvUpdateSession; proves restore finished (not silent-hang).
     std::atomic<ui64> UpdateSessionCount{0};
@@ -270,10 +271,9 @@ struct TDirectReadRestoreEnv {
 
         runtime.SetObserverFunc([this](TAutoPtr<IEventHandle>& ev) {
             if (auto* msg = ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvCloseSession>()) {
-                // OnUnhandledException always prefixes with "unexpected error:".
-                if (msg->Reason.Contains("unexpected error:")) {
-                    UnexpectedErrorCloseReason = msg->Reason;
-                    ++UnexpectedErrorCloseSession;
+                if (msg->ErrorCode != Ydb::PersQueue::ErrorCode::OK) {
+                    ErrorCloseReason = msg->Reason;
+                    ++ErrorCloseSession;
                 }
             }
             if (ev->CastAsLocal<NGRpcProxy::V1::TEvPQProxy::TEvUpdateSession>()) {
@@ -610,20 +610,20 @@ protected:
         Client.SendDirectReadAckNoWait(Runtime(), directReadId);
         WaitUntil(Runtime(), [&] {
             return Env.DirectReadAckCount.load() > before
-                || Env.UnexpectedErrorCloseSession.load() > 0;
+                || Env.ErrorCloseSession.load() > 0;
         });
-        AssertNoUnexpectedClose("DirectReadAck must not kill partition actor");
+        AssertNoErrorClose("DirectReadAck must not kill partition actor");
     }
 
     // 9–10. Shared asserts.
-    void AssertNoUnexpectedClose(const TString& what) {
-        UNIT_ASSERT_C(Env.UnexpectedErrorCloseSession.load() == 0,
+    void AssertNoErrorClose(const TString& what) {
+        UNIT_ASSERT_C(Env.ErrorCloseSession.load() == 0,
             what
                 << "; heldPrepare=" << Env.HeldPrepareResponses.load()
                 << "; heldPublish=" << Env.HeldPublishResponses.load()
                 << "; heldForget=" << Env.HeldForgetResponses.load()
                 << "; heldRestorePP=" << Env.HeldPrepareOrPublish.load()
-                << "; reason=" << Env.UnexpectedErrorCloseReason);
+                << "; reason=" << Env.ErrorCloseReason);
     }
 
     void AssertUpdateSessionAdvanced(ui64 before, const TString& what) {
@@ -639,9 +639,9 @@ protected:
         Env.ReleaseHeldPrepares();
         WaitUntil(Runtime(), [&] {
             return Env.HeldPublishResponses.load() >= 1
-                || Env.UnexpectedErrorCloseSession.load() > 0;
+                || Env.ErrorCloseSession.load() > 0;
         });
-        AssertNoUnexpectedClose(
+        AssertNoErrorClose(
             "late Prepare during Publish restore must not kill partition actor via unhandled exception");
         UNIT_ASSERT_C(Env.HeldPublishResponses.load() >= 1,
             "expected Publish stage after releasing held Prepares");
@@ -654,9 +654,9 @@ protected:
         release();
         WaitUntil(Runtime(), [&] {
             return Env.UpdateSessionCount.load() > before
-                || Env.UnexpectedErrorCloseSession.load() > 0;
+                || Env.ErrorCloseSession.load() > 0;
         });
-        AssertNoUnexpectedClose(what);
+        AssertNoErrorClose(what);
         AssertUpdateSessionAdvanced(before,
             "restore must complete with TEvUpdateSession (not silent-hang)");
     }
@@ -668,9 +668,9 @@ protected:
         release();
         WaitUntil(Runtime(), [&] {
             return Env.DirectReadResponseCount.load() > before
-                || Env.UnexpectedErrorCloseSession.load() > 0;
+                || Env.ErrorCloseSession.load() > 0;
         });
-        AssertNoUnexpectedClose(what);
+        AssertNoErrorClose(what);
         AssertDirectReadAdvanced(before,
             "Prepare/Publish must complete after releasing held Prepares (not silent-hang)");
     }
@@ -679,22 +679,22 @@ protected:
     template <typename TRelease>
     void ReleaseLateReplyAndAssertSurvived(TRelease&& release, const TString& what) {
         const ui64 lateBefore = Env.LateNonForgetReplyDuringForget.load();
-        const ui64 unexpectedBefore = Env.UnexpectedErrorCloseSession.load();
+        const ui64 errorCloseBefore = Env.ErrorCloseSession.load();
         release();
         WaitUntil(Runtime(), [&] {
             return Env.LateNonForgetReplyDuringForget.load() > lateBefore
-                || Env.UnexpectedErrorCloseSession.load() > unexpectedBefore;
+                || Env.ErrorCloseSession.load() > errorCloseBefore;
         });
-        AssertNoUnexpectedClose(what);
+        AssertNoErrorClose(what);
     }
 
     // Wait for UpdateSession after an already-triggered action (e.g. nested reboot).
     void WaitAndAssertUpdateSessionAdvanced(ui64 before, const TString& what) {
         WaitUntil(Runtime(), [&] {
             return Env.UpdateSessionCount.load() > before
-                || Env.UnexpectedErrorCloseSession.load() > 0;
+                || Env.ErrorCloseSession.load() > 0;
         });
-        AssertNoUnexpectedClose(what);
+        AssertNoErrorClose(what);
         AssertUpdateSessionAdvanced(before,
             "restore must complete with TEvUpdateSession (not silent-hang)");
     }

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/ya.make
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/ya.make
@@ -1,0 +1,34 @@
+UNITTEST_FOR(ydb/services/persqueue_v1)
+
+ADDINCL(
+    ydb/public/sdk/cpp
+)
+
+CFLAGS(
+    -DYDB_SDK_USE_STD_STRING
+)
+
+SIZE(MEDIUM)
+TIMEOUT(300)
+
+PEERDIR(
+    library/cpp/testing/unittest
+    library/cpp/threading/future
+    ydb/core/persqueue/events
+    ydb/core/testlib/default
+    ydb/core/testlib/actors
+    ydb/public/api/grpc
+    ydb/public/sdk/cpp/src/client/persqueue_public
+    ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
+    ydb/public/sdk/cpp/src/client/topic
+    ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
+    ydb/services/persqueue_v1
+)
+
+SRCS(
+    direct_read_restore_ut.cpp
+)
+
+YQL_LAST_ABI_VERSION()
+
+END()

--- a/ydb/services/persqueue_v1/ut/direct_read_restore_ut/ya.make
+++ b/ydb/services/persqueue_v1/ut/direct_read_restore_ut/ya.make
@@ -9,7 +9,7 @@ CFLAGS(
 )
 
 SIZE(MEDIUM)
-TIMEOUT(300)
+TIMEOUT(600)
 
 PEERDIR(
     library/cpp/testing/unittest

--- a/ydb/services/persqueue_v1/ya.make
+++ b/ydb/services/persqueue_v1/ya.make
@@ -52,4 +52,5 @@ RECURSE_FOR_TESTS(
     ut
     ut/new_schemecache_ut
     ut/describes_ut
+    ut/direct_read_restore_ut
 )


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

- After tablet pipe disconnects, late/out-of-order Prepare/Publish/Forget replies during DirectRead restore could hit `PARTITION_ENSURE` and crash `PQ_READ_PROXY`.
- Soft-ignore stale replies that do not match the current restore stage (including duplicate Prepare when `RequestInfly` is already cleared, and Forget with `RestoredDirectReadId == 0`).
- Close the read session if Publish/Forget restore queues are empty instead of hanging forever.
- Add `direct_read_restore_ut` covering RequestInfly, Publish-stage, and Forget-stage races.

### Description for reviewers <!-- (optional) description for those who read this PR -->

...
