### PR TITLE
Split TDataShard::AddUserTable into AddUserTable/ReplaceUserTable

### DIFF
--- a/ydb/core/tx/datashard/alter_cdc_stream_unit.cpp
+++ b/ydb/core/tx/datashard/alter_cdc_stream_unit.cpp
@@ -71,7 +71,7 @@ public:
 
         Y_ENSURE(tableInfo);
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/alter_table_unit.cpp
+++ b/ydb/core/tx/datashard/alter_table_unit.cpp
@@ -167,7 +167,7 @@ EExecutionStatus TAlterTableUnit::Execute(TOperation::TPtr op,
     auto oldInfo = DataShard.FindUserTable(tableId);
     auto newInfo = DataShard.AlterUserTable(ctx, txc, alterTableTx);
     TDataShardLocksDb locksDb(DataShard, txc);
-    DataShard.AddUserTable(tableId, newInfo, &locksDb);
+    DataShard.ReplaceUserTable(tableId, newInfo, locksDb);
 
     if (newInfo->NeedSchemaSnapshots()) {
         DataShard.AddSchemaSnapshot(tableId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/create_cdc_stream_unit.cpp
+++ b/ydb/core/tx/datashard/create_cdc_stream_unit.cpp
@@ -111,7 +111,7 @@ public:
         Y_ENSURE(tableInfo, "Table info must be initialized by Drop or Create action");
 
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, schemaVersion, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/datashard.cpp
+++ b/ydb/core/tx/datashard/datashard.cpp
@@ -2113,7 +2113,7 @@ TUserTable::TPtr TDataShard::MoveUserIndex(TOperation::TPtr op, const NKikimrTxD
 
     newTableInfo->SetSchema(schema);
     TDataShardLocksDb locksDb(*this, txc);
-    AddUserTable(pathId, newTableInfo, &locksDb);
+    ReplaceUserTable(pathId, newTableInfo, locksDb);
 
     if (newTableInfo->NeedSchemaSnapshots()) {
         AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/datashard_impl.h
+++ b/ydb/core/tx/datashard/datashard_impl.h
@@ -1772,13 +1772,19 @@ public:
         TableInfos.erase(tableId.LocalPathId);
     }
 
-    void AddUserTable(const TPathId& tableId, TUserTable::TPtr tableInfo, ILocksDb* locksDb = nullptr) {
-        if (locksDb) {
-            SysLocks.RemoveSchema(tableId, locksDb);
-        }
+    void SetUserTable(const TPathId& tableId, TUserTable::TPtr tableInfo) {
         TableInfos[tableId.LocalPathId] = tableInfo;
         SysLocks.UpdateSchema(tableId, tableInfo->KeyColumnTypes);
         Pipeline.GetDepTracker().UpdateSchema(tableId, *tableInfo);
+    }
+
+    void AddUserTable(const TPathId& tableId, TUserTable::TPtr tableInfo) {
+        SetUserTable(tableId, tableInfo);
+    }
+
+    void ReplaceUserTable(const TPathId& tableId, TUserTable::TPtr tableInfo, ILocksDb& locksDb) {
+        SysLocks.RemoveSchema(tableId, &locksDb);
+        SetUserTable(tableId, tableInfo);
     }
 
     bool IsUserTable(const TTableId& tableId) const {

--- a/ydb/core/tx/datashard/drop_cdc_stream_unit.cpp
+++ b/ydb/core/tx/datashard/drop_cdc_stream_unit.cpp
@@ -52,7 +52,7 @@ public:
 
         // Update table info once after processing all streams
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/drop_index_notice_unit.cpp
+++ b/ydb/core/tx/datashard/drop_index_notice_unit.cpp
@@ -54,7 +54,7 @@ public:
 
         Y_ENSURE(tableInfo);
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/finalize_build_index_unit.cpp
+++ b/ydb/core/tx/datashard/finalize_build_index_unit.cpp
@@ -58,7 +58,7 @@ public:
 
         Y_ENSURE(tableInfo);
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/initiate_build_index_unit.cpp
+++ b/ydb/core/tx/datashard/initiate_build_index_unit.cpp
@@ -55,7 +55,7 @@ public:
 
         Y_ENSURE(tableInfo);
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/prepare_index_validation_unit.cpp
+++ b/ydb/core/tx/datashard/prepare_index_validation_unit.cpp
@@ -48,7 +48,7 @@ public:
         description.MutablePartitionConfig()->MutableCompactionPolicy()->SetKeepEraseMarkers(false);
         auto newInfo = DataShard.AlterUserTable(ctx, txc, description);
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(tableId, newInfo, &locksDb);
+        DataShard.ReplaceUserTable(tableId, newInfo, locksDb);
 
         const TSnapshotKey key(tableId.OwnerId, tableId.LocalPathId, step, txId);
 

--- a/ydb/core/tx/datashard/rotate_cdc_stream_unit.cpp
+++ b/ydb/core/tx/datashard/rotate_cdc_stream_unit.cpp
@@ -44,7 +44,7 @@ public:
 
         Y_ENSURE(tableInfo);
         TDataShardLocksDb locksDb(DataShard, txc);
-        DataShard.AddUserTable(pathId, tableInfo, &locksDb);
+        DataShard.ReplaceUserTable(pathId, tableInfo, locksDb);
 
         if (tableInfo->NeedSchemaSnapshots()) {
             DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, ctx);

--- a/ydb/core/tx/datashard/truncate_unit.cpp
+++ b/ydb/core/tx/datashard/truncate_unit.cpp
@@ -93,7 +93,7 @@ EExecutionStatus TTruncateUnit::Execute(
     userTable->StatsNeedUpdate = true;
 
     // Passing locksDb invalidates every lock of this shard, like any other schema change does.
-    DataShard.AddUserTable(pathId, userTable, &locksDb);
+    DataShard.ReplaceUserTable(pathId, userTable, locksDb);
     if (userTable->NeedSchemaSnapshots()) {
         DataShard.AddSchemaSnapshot(pathId, version, op->GetStep(), op->GetTxId(), txc, actorCtx);
     }


### PR DESCRIPTION
AddUserTable had an optional locksDb parameter that changed its
semantics from "first install" to "replace existing schema" (tearing
down the old schema first). The name didn't reflect this, and the
optional parameter hid the replace contract behind a runtime null
check.

Split into three functions:
- SetUserTable: shared helper that stores table info and refreshes
  derived state (lock schema, dependency tracker)
- AddUserTable: first install (no prior schema to tear down)
- ReplaceUserTable: replace existing table (tears down old schema
  first via ILocksDb& by reference)

