### PR TITLE
[issue-#49169] (-) Make prev-node tracing state lock-free in TExecutionContext

### DIFF
--- a/ydb/core/formats/arrow/program/abstract.h
+++ b/ydb/core/formats/arrow/program/abstract.h
@@ -330,7 +330,7 @@ public:
 
 class IResourceProcessor {
 public:
-    enum class EExecutionResult {
+    enum class EExecutionResult: ui8 {
         Success,
         Skipped,
         InBackground

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
@@ -90,8 +90,9 @@ void TProgramStep::ReportTracing(const std::shared_ptr<IDataSource>& source, con
         return;
     }
     const auto& step = source->GetExecutionContext().GetCursorStep();
-    const TString tracingName = source->GetExecutionContext().GetPrevCategoryName() + " - " + currentCategoryName;
-    const TString tracingExecutionResult = source->GetExecutionContext().GetPrevExecutionResult() + " - " + currentExecutionResult;
+    const auto prevTracing = source->GetExecutionContext().GetPrevNodeTracing();
+    const TString tracingName = prevTracing.CategoryName + " - " + currentCategoryName;
+    const TString tracingExecutionResult = prevTracing.ExecutionResult + " - " + currentExecutionResult;
     const TDuration finishDurationMs = source->GetAndResetWaitDuration();
     const auto processorType = processor->GetProcessorType();
     const TString details = processor->DebugJson().GetStringRobust();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
@@ -287,8 +287,7 @@ TConclusion<bool> TProgramStep::DoExecuteInplace(const std::shared_ptr<IDataSour
         const TString currentExecutionResult = conclusion.IsFail() ? "Fail" : ToString(*conclusion);
         ReportTracing(source, executionDurationMs, currentExecutionResult, tracingNodeId, tracingCategoryName, tracingProcessor,
             reservedMemoryBeforeExecute);
-        source->MutableExecutionContext().SetPrevNodeTracing(
-            tracingNodeId, conclusion.IsFail() ? TExecutionContext::EPrevNodeResult::Fail : TExecutionContext::ConvertResult(*conclusion));
+        source->MutableExecutionContext().SetPrevNodeTracing(tracingNodeId, conclusion);
         if (conclusion.IsFail()) {
             source->MutableExecutionContext().OnFailedProgramStepExecution();
             return conclusion;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/fetching.cpp
@@ -87,8 +87,6 @@ void TProgramStep::ReportTracing(const std::shared_ptr<IDataSource>& source, con
         !LWPROBE_ENABLED(ProgramFilter) && !LWPROBE_ENABLED(ProgramAggregation) && !LWPROBE_ENABLED(ProgramFetchOriginalData) &&
         !LWPROBE_ENABLED(ProgramAssembleOriginalData) && !LWPROBE_ENABLED(ProgramCheckIndexData) && !LWPROBE_ENABLED(ProgramCheckHeaderData) &&
         !LWPROBE_ENABLED(ProgramStreamLogic) && !LWPROBE_ENABLED(ProgramReserveMemory)) {
-        source->MutableExecutionContext().SetPrevCategoryName(currentCategoryName);
-        source->MutableExecutionContext().SetPrevExecutionResult(currentExecutionResult);
         return;
     }
     const auto& step = source->GetExecutionContext().GetCursorStep();
@@ -243,8 +241,6 @@ void TProgramStep::ReportTracing(const std::shared_ptr<IDataSource>& source, con
 #undef PROGRAM_PROBE_ARGS
 #undef PROGRAM_PROBE_RESERVED
 #undef PROGRAM_PROBE_TAIL
-    source->MutableExecutionContext().SetPrevCategoryName(currentCategoryName);
-    source->MutableExecutionContext().SetPrevExecutionResult(currentExecutionResult);
 }
 
 NO_SANITIZE_THREAD
@@ -291,6 +287,8 @@ TConclusion<bool> TProgramStep::DoExecuteInplace(const std::shared_ptr<IDataSour
         const TString currentExecutionResult = conclusion.IsFail() ? "Fail" : ToString(*conclusion);
         ReportTracing(source, executionDurationMs, currentExecutionResult, tracingNodeId, tracingCategoryName, tracingProcessor,
             reservedMemoryBeforeExecute);
+        source->MutableExecutionContext().SetPrevNodeTracing(
+            tracingNodeId, conclusion.IsFail() ? TExecutionContext::EPrevNodeResult::Fail : TExecutionContext::ConvertResult(*conclusion));
         if (conclusion.IsFail()) {
             source->MutableExecutionContext().OnFailedProgramStepExecution();
             return conclusion;

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.cpp
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.cpp
@@ -43,9 +43,11 @@ void TExecutionContext::Start(const std::shared_ptr<IDataSource>& source,
     NArrow::NSSA::TProcessorContext context(
         source, source->MutableStageData().ExtractTable(), readMeta->GetLimitRobustOptional(), readMeta->IsDescSorted());
     auto visitor = std::make_shared<NArrow::NSSA::NGraph::NExecution::TExecutionVisitor>(std::move(context));
+    AFL_VERIFY(!Program);
+    Program = program;
     SetProgramIterator(program->BuildIterator(visitor), visitor);
     SetCursorStep(step);
-    SetPrevCategoryName(step.GetPrevName());
+    SetStartCategoryName(step.GetPrevName());
 }
 
 const TFetchingStepSignals& TExecutionContext::GetCurrentStepSignalsVerified() const {

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -43,18 +43,11 @@ private:
 
     std::optional<TFetchingScriptCursor> CursorStep;
 
-public:
-    enum class EPrevNodeResult: ui8 {
-        Success,
-        Skipped,
-        InBackground,
-        Fail
-    };
-
 private:
     struct TPrevNodeState {
         ui32 NodeId = 0;
-        EPrevNodeResult Result = EPrevNodeResult::Success;
+        NArrow::NSSA::IResourceProcessor::EExecutionResult Result = NArrow::NSSA::IResourceProcessor::EExecutionResult::Success;
+        bool Failed = false;
         bool Defined = false;
     };
 
@@ -69,27 +62,19 @@ private:
     std::atomic<TPrevNodeState> PrevNode;
 
 public:
-    static EPrevNodeResult ConvertResult(const NArrow::NSSA::IResourceProcessor::EExecutionResult result) {
-        switch (result) {
-            case NArrow::NSSA::IResourceProcessor::EExecutionResult::Success:
-                return EPrevNodeResult::Success;
-            case NArrow::NSSA::IResourceProcessor::EExecutionResult::Skipped:
-                return EPrevNodeResult::Skipped;
-            case NArrow::NSSA::IResourceProcessor::EExecutionResult::InBackground:
-                return EPrevNodeResult::InBackground;
-        }
-    }
-
     void SetStartCategoryName(TString&& name) {
         StartCategoryName = std::move(name);
     }
 
-    void SetPrevNodeTracing(const ui32 nodeId, const EPrevNodeResult result) {
-        PrevNode.store(TPrevNodeState{ .NodeId = nodeId, .Result = result, .Defined = true }, std::memory_order_relaxed);
+    void SetPrevNodeTracing(const ui32 nodeId, const TConclusion<NArrow::NSSA::IResourceProcessor::EExecutionResult>& conclusion) {
+        PrevNode.store(TPrevNodeState{ .NodeId = nodeId,
+                           .Result = conclusion.IsFail() ? NArrow::NSSA::IResourceProcessor::EExecutionResult::Success : *conclusion,
+                           .Failed = conclusion.IsFail(),
+                           .Defined = true }, std::memory_order_release);
     }
 
     TString GetPrevCategoryName() const {
-        const TPrevNodeState state = PrevNode.load(std::memory_order_relaxed);
+        const TPrevNodeState state = PrevNode.load(std::memory_order_acquire);
         if (!state.Defined) {
             return StartCategoryName;
         }
@@ -100,20 +85,14 @@ public:
     }
 
     TString GetPrevExecutionResult() const {
-        const TPrevNodeState state = PrevNode.load(std::memory_order_relaxed);
+        const TPrevNodeState state = PrevNode.load(std::memory_order_acquire);
         if (!state.Defined) {
             return TString();
         }
-        switch (state.Result) {
-            case EPrevNodeResult::Success:
-                return "Success";
-            case EPrevNodeResult::Skipped:
-                return "Skipped";
-            case EPrevNodeResult::InBackground:
-                return "InBackground";
-            case EPrevNodeResult::Fail:
-                return "Fail";
+        if (state.Failed) {
+            return "Fail";
         }
+        return ::ToString(state.Result);
     }
 
     void OnStartProgramStepExecution(const ui32 nodeId, const std::shared_ptr<TFetchingStepSignals>& signals);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -22,6 +22,8 @@
 #include <library/cpp/lwtrace/shuttle.h>
 #include <util/string/join.h>
 
+#include <atomic>
+
 namespace NKikimr::NOlap {
 class IDataReader;
 }
@@ -40,10 +42,80 @@ private:
     std::optional<TMonotonic> CurrentNodeStart;
 
     std::optional<TFetchingScriptCursor> CursorStep;
-    YDB_ACCESSOR_DEF(TString, PrevCategoryName);
-    YDB_ACCESSOR_DEF(TString, PrevExecutionResult);
 
 public:
+    enum class EPrevNodeResult: ui8 {
+        Success,
+        Skipped,
+        InBackground,
+        Fail
+    };
+
+private:
+    struct TPrevNodeState {
+        ui32 NodeId = 0;
+        EPrevNodeResult Result = EPrevNodeResult::Success;
+        bool Defined = false;
+    };
+
+    static_assert(std::atomic<TPrevNodeState>::is_always_lock_free);
+
+    // Prev-node tracing state is written by every finished program-step frame; a continuation frame may
+    // still be unwinding concurrently (issue #49169), so mutable TStrings are not allowed here. The
+    // whole state fits into one lock-free atomic struct; the category name is resolved on read through
+    // the immutable compiled graph.
+    TString StartCategoryName;
+    std::shared_ptr<NArrow::NSSA::NGraph::NExecution::TCompiledGraph> Program;
+    std::atomic<TPrevNodeState> PrevNode;
+
+public:
+    static EPrevNodeResult ConvertResult(const NArrow::NSSA::IResourceProcessor::EExecutionResult result) {
+        switch (result) {
+            case NArrow::NSSA::IResourceProcessor::EExecutionResult::Success:
+                return EPrevNodeResult::Success;
+            case NArrow::NSSA::IResourceProcessor::EExecutionResult::Skipped:
+                return EPrevNodeResult::Skipped;
+            case NArrow::NSSA::IResourceProcessor::EExecutionResult::InBackground:
+                return EPrevNodeResult::InBackground;
+        }
+    }
+
+    void SetStartCategoryName(TString&& name) {
+        StartCategoryName = std::move(name);
+    }
+
+    void SetPrevNodeTracing(const ui32 nodeId, const EPrevNodeResult result) {
+        PrevNode.store(TPrevNodeState{ .NodeId = nodeId, .Result = result, .Defined = true }, std::memory_order_relaxed);
+    }
+
+    TString GetPrevCategoryName() const {
+        const TPrevNodeState state = PrevNode.load(std::memory_order_relaxed);
+        if (!state.Defined) {
+            return StartCategoryName;
+        }
+        AFL_VERIFY(Program);
+        auto it = Program->GetNodes().find(state.NodeId);
+        AFL_VERIFY(it != Program->GetNodes().end())("node_id", state.NodeId);
+        return it->second->GetProcessor()->GetSignalCategoryName();
+    }
+
+    TString GetPrevExecutionResult() const {
+        const TPrevNodeState state = PrevNode.load(std::memory_order_relaxed);
+        if (!state.Defined) {
+            return TString();
+        }
+        switch (state.Result) {
+            case EPrevNodeResult::Success:
+                return "Success";
+            case EPrevNodeResult::Skipped:
+                return "Skipped";
+            case EPrevNodeResult::InBackground:
+                return "InBackground";
+            case EPrevNodeResult::Fail:
+                return "Fail";
+        }
+    }
+
     void OnStartProgramStepExecution(const ui32 nodeId, const std::shared_ptr<TFetchingStepSignals>& signals);
 
     void OnFinishProgramStepExecution();

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -61,6 +61,16 @@ private:
     std::shared_ptr<NArrow::NSSA::NGraph::NExecution::TCompiledGraph> Program;
     std::atomic<TPrevNodeState> PrevNode = {};
 
+    TString RenderCategoryName(const TPrevNodeState& state) const {
+        if (!state.Defined) {
+            return StartCategoryName;
+        }
+        AFL_VERIFY(Program);
+        auto it = Program->GetNodes().find(state.NodeId);
+        AFL_VERIFY(it != Program->GetNodes().end())("node_id", state.NodeId);
+        return it->second->GetProcessor()->GetSignalCategoryName();
+    }
+
 public:
     void SetStartCategoryName(TString&& name) {
         StartCategoryName = std::move(name);
@@ -74,25 +84,23 @@ public:
     }
 
     TString GetPrevCategoryName() const {
-        const TPrevNodeState state = PrevNode.load(std::memory_order_acquire);
-        if (!state.Defined) {
-            return StartCategoryName;
-        }
-        AFL_VERIFY(Program);
-        auto it = Program->GetNodes().find(state.NodeId);
-        AFL_VERIFY(it != Program->GetNodes().end())("node_id", state.NodeId);
-        return it->second->GetProcessor()->GetSignalCategoryName();
+        return RenderCategoryName(PrevNode.load(std::memory_order_acquire));
     }
 
-    TString GetPrevExecutionResult() const {
+    struct TPrevNodeTracing {
+        TString CategoryName;
+        TString ExecutionResult;
+    };
+
+    // CategoryName/ExecutionResult are coupled only in the program-step transition tracing; a single
+    // load keeps the pair consistent.
+    TPrevNodeTracing GetPrevNodeTracing() const {
         const TPrevNodeState state = PrevNode.load(std::memory_order_acquire);
-        if (!state.Defined) {
-            return TString();
+        TString executionResult;
+        if (state.Defined) {
+            executionResult = state.Failed ? "Fail" : ::ToString(state.Result);
         }
-        if (state.Failed) {
-            return "Fail";
-        }
-        return ::ToString(state.Result);
+        return TPrevNodeTracing{ .CategoryName = RenderCategoryName(state), .ExecutionResult = std::move(executionResult) };
     }
 
     void OnStartProgramStepExecution(const ui32 nodeId, const std::shared_ptr<TFetchingStepSignals>& signals);

--- a/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
+++ b/ydb/core/tx/columnshard/engines/reader/common_reader/iterator/source.h
@@ -59,7 +59,7 @@ private:
     // the immutable compiled graph.
     TString StartCategoryName;
     std::shared_ptr<NArrow::NSSA::NGraph::NExecution::TCompiledGraph> Program;
-    std::atomic<TPrevNodeState> PrevNode;
+    std::atomic<TPrevNodeState> PrevNode = {};
 
 public:
     void SetStartCategoryName(TString&& name) {

--- a/ydb/tests/stability/tests/tsan.supp
+++ b/ydb/tests/stability/tests/tsan.supp
@@ -1,4 +1,3 @@
 # https://github.com/ydb-platform/ydb/issues/41296
 # Benign races on IDataSource / TExecutionContext metrics: source processing hops conveyor threads.
 race:AddExecutionDuration
-race:SetPrevCategoryName


### PR DESCRIPTION
### Changelog category

* Not for changelog (changelog entry is not required)

### Description for reviewers

Addresses #49169 (SIGSEGV in `TFetchedData::ExtractFetcherOptional` / `Fetchers.find` on Tpcds1 Query62).

A continuation `TStepAction` can start executing while the previous frame for the same source is still unwinding inside `TProgramStep::DoExecuteInplace` (the completion that schedules it — memory grant, cached blob read — may fire before the frame returns). PR #49129 made the unwinding frame's *reads* safe; the remaining unsynchronized *writes* are the prev-node tracing strings in `ReportTracing`: both frames assign `PrevCategoryName`/`PrevExecutionResult` concurrently. Concurrent `TString` assignment is UB (double/wild free of the buffer), which corrupts the heap and detonates at the next pointer-chasing reader — matching the crash inside `Fetchers.find` (the stack shows the victim, not the corruptor).

The fix makes that state lock-free instead of storing mutable `TString`s: `TExecutionContext` keeps an `std::atomic<const IResourceProcessor*>` (processors are stable objects owned by the compiled graph) plus an atomic execution-result code, and renders the strings on read. The initial category name (script step name) is written once in `Start()` before any concurrency and stays a plain string. `TThreadSafeOptional` was considered per review, but it is a write-once cell (`Set` verifies `!Has()`), while this value is rewritten after every executed graph node.

`PrevExecutionResult` is included because it is written in the same statement pair with the identical race.
