### PR TITLE
Fixed PartitionLocation timeout

### DIFF
--- a/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
@@ -46,6 +46,9 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
 
         static constexpr NKikimrServices::EServiceKikimr Service = NKikimrServices::EServiceKikimr::PQ_SCHEMA;
         static constexpr TDuration RequestTimeout = TDuration::Seconds(10);
+        static constexpr size_t StatsMaxRetries = 15;
+        static constexpr TDuration StatsRetryInitialDelay = TDuration::MilliSeconds(25);
+        static constexpr TDuration StatsRetryMaxDelay = TDuration::MilliSeconds(250);
         static constexpr ui64 LocationsRetryWakeupTag = 100;
         static constexpr ui64 RequestTimeoutWakeupTag = 101;
 
@@ -364,15 +367,14 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
 
         void RequestStats(ui64 tabletId) {
             LOG_D("Stats " << tabletId);
-            StatsBackoff.try_emplace(
-                tabletId, 5, TDuration::MilliSeconds(25), TDuration::MilliSeconds(250));
+            StatsBackoff.try_emplace(tabletId, StatsMaxRetries, StatsRetryInitialDelay, StatsRetryMaxDelay);
             SendToTablet(tabletId, CreateStatusRequest().release(), tabletId);
             TabletsInflight.insert(tabletId);
         }
 
         void ScheduleStatsRetry(ui64 tabletId) {
             auto [it, _] = StatsBackoff.try_emplace(
-                tabletId, 10, TDuration::MilliSeconds(25), TDuration::MilliSeconds(250));
+                tabletId, StatsMaxRetries, StatsRetryInitialDelay, StatsRetryMaxDelay);
             if (!it->second.HasMore()) {
                 LOG_W("Stats retries exceeded for tablet " << tabletId);
                 TabletsInflight.erase(tabletId);

--- a/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
@@ -341,6 +341,11 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
             if (LocationsReceived && ReadSessionsReceived) {
                 return;
             }
+            const auto remaining = RemainingRequestTimeout();
+            if (!remaining) {
+                HandleRequestTimeout();
+                return;
+            }
             if (!LocationsReceived) {
                 TVector<ui64> partitionIds;
                 for (const auto& partition : TopicInfo.Info->Description.GetPartitions()) {
@@ -351,7 +356,7 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
                 LOG_D("PartitionsLocation " << ReadBalancerTabletId << " partitions " << JoinSeq(", ", partitionIds));
                 SendToTablet(
                     ReadBalancerTabletId,
-                    new TEvPersQueue::TEvGetPartitionsLocation(partitionIds, RemainingRequestTimeout()));
+                    new TEvPersQueue::TEvGetPartitionsLocation(partitionIds, remaining));
             }
             if (!ReadSessionsReceived && this->GetProtoRequest()->include_stats()) {
                 auto ev = CreateReadSessionsInfoRequest();
@@ -373,6 +378,10 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
         }
 
         void ScheduleStatsRetry(ui64 tabletId) {
+            if (!RemainingRequestTimeout()) {
+                HandleRequestTimeout();
+                return;
+            }
             auto [it, _] = StatsBackoff.try_emplace(
                 tabletId, StatsMaxRetries, StatsRetryInitialDelay, StatsRetryMaxDelay);
             if (!it->second.HasMore()) {
@@ -400,6 +409,10 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
             if (!TabletsInflight.contains(tabletId)) {
                 return true;
             }
+            if (!RemainingRequestTimeout()) {
+                HandleRequestTimeout();
+                return true;
+            }
             RequestStats(tabletId);
             return true;
         }
@@ -413,6 +426,10 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
         }
 
         void ScheduleLocationsRetry() {
+            if (!RemainingRequestTimeout()) {
+                HandleRequestTimeout();
+                return;
+            }
             if (!LocationsBackoff.HasMore()) {
                 LOG_W("PartitionsLocation retries exceeded");
                 FailLocationsUnavailable();

--- a/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
@@ -287,7 +287,8 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
 
         void Handle(TEvPipeCache::TEvDeliveryProblem::TPtr& ev) {
             LOG_D("Handle TEvDeliveryProblem. TabletId=" << ev->Get()->TabletId);
-            if (OnUndelivered(ev)) {
+            // OnUndelivered returns true for the current pipe subscription; false means a stale notification.
+            if (!OnUndelivered(ev)) {
                 return;
             }
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
@@ -198,6 +198,9 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
                     HandleRequestTimeout();
                     return;
                 }
+                if (HandleStatsRetryWakeup(ev->Get<TEvents::TEvWakeup>()->Tag)) {
+                    return;
+                }
                 [[fallthrough]];
             default:
                 this->StateFuncBase(ev);
@@ -316,7 +319,7 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
             if (ev->Get()->TabletId == ReadBalancerTabletId) {
                 ScheduleLocationsRetry();
             } else {
-                RequestStats(ev->Get()->TabletId);
+                ScheduleStatsRetry(ev->Get()->TabletId);
             }
         }
 
@@ -361,8 +364,42 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
 
         void RequestStats(ui64 tabletId) {
             LOG_D("Stats " << tabletId);
+            StatsBackoff.try_emplace(
+                tabletId, 5, TDuration::MilliSeconds(25), TDuration::MilliSeconds(250));
             SendToTablet(tabletId, CreateStatusRequest().release(), tabletId);
             TabletsInflight.insert(tabletId);
+        }
+
+        void ScheduleStatsRetry(ui64 tabletId) {
+            auto [it, _] = StatsBackoff.try_emplace(
+                tabletId, 10, TDuration::MilliSeconds(25), TDuration::MilliSeconds(250));
+            if (!it->second.HasMore()) {
+                LOG_W("Stats retries exceeded for tablet " << tabletId);
+                TabletsInflight.erase(tabletId);
+                this->ReplyWithError(
+                    Ydb::StatusIds::UNAVAILABLE,
+                    TStringBuilder() << "Tablet " << tabletId << " unresponsive",
+                    Ydb::PersQueue::ErrorCode::ERROR);
+                return;
+            }
+            if (!StatsRetryPending.insert(tabletId).second) {
+                return;
+            }
+            const auto delay = it->second.Next();
+            LOG_D("Stats retry " << tabletId << " " << it->second.GetIteration() << " in " << delay);
+            // Wakeup tag is the tablet id (distinct from LocationsRetry/RequestTimeout tags).
+            this->Schedule(delay, new TEvents::TEvWakeup(tabletId));
+        }
+
+        bool HandleStatsRetryWakeup(ui64 tabletId) {
+            if (!StatsRetryPending.erase(tabletId)) {
+                return false;
+            }
+            if (!TabletsInflight.contains(tabletId)) {
+                return true;
+            }
+            RequestStats(tabletId);
+            return true;
         }
 
         void FailLocationsUnavailable() {
@@ -428,6 +465,8 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
         bool LocationsRetryPending = false;
         TBackoff LocationsBackoff = TBackoff(25, TDuration::MilliSeconds(10), TDuration::MilliSeconds(100));
         std::optional<TInstant> RequestStartTime;
+        absl::flat_hash_map<ui64, TBackoff> StatsBackoff;
+        absl::flat_hash_set<ui64> StatsRetryPending;
 
         Ydb::Scheme::Entry SelfEntry;
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
+++ b/ydb/services/persqueue_v1/actors/schema/topic/common_describe.h
@@ -13,6 +13,8 @@
 #include <ydb/library/yverify_stream/yverify_stream.h>
 #include <ydb/services/persqueue_v1/actors/schema/common/grpc_proxy_actor.h>
 
+#include <optional>
+
 namespace NKikimr::NGRpcProxy::V1::NTopic {
 
     template<class T>
@@ -43,7 +45,9 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
         using TBase = TGrpcProxyActor<TDerived, TRequest>;
 
         static constexpr NKikimrServices::EServiceKikimr Service = NKikimrServices::EServiceKikimr::PQ_SCHEMA;
+        static constexpr TDuration RequestTimeout = TDuration::Seconds(10);
         static constexpr ui64 LocationsRetryWakeupTag = 100;
+        static constexpr ui64 RequestTimeoutWakeupTag = 101;
 
     public:
         TDescribeBaseActor(NGRpcService::IRequestOpCtx* request, NPQ::NDescriber::TAccessRights accessRights)
@@ -69,6 +73,9 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
 
         void DoAction() {
             LOG_D("DoAction " << this->GetProtoRequest()->path());
+            RequestStartTime = TActivationContext::Now();
+            this->Schedule(RequestTimeout, new TEvents::TEvWakeup(RequestTimeoutWakeupTag));
+
             this->RegisterWithSameMailbox(NPQ::NDescriber::CreateDescriberActor(
                 this->SelfId(),
                 this->GetDatabase(),
@@ -94,6 +101,12 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
             switch (ev->GetTypeRewrite()) {
                 hFunc(NPQ::NDescriber::TEvDescribeTopicsResponse, Handle);
                 sFunc(TEvents::TEvPoison, PassAway);
+            case TEvents::TEvWakeup::EventType:
+                if (ev->Get<TEvents::TEvWakeup>()->Tag == RequestTimeoutWakeupTag) {
+                    HandleRequestTimeout();
+                    return;
+                }
+                [[fallthrough]];
             default:
                 this->StateFuncBase(ev);
             }
@@ -179,6 +192,10 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
             case TEvents::TEvWakeup::EventType:
                 if (ev->Get<TEvents::TEvWakeup>()->Tag == LocationsRetryWakeupTag) {
                     HandleLocationsRetryWakeup();
+                    return;
+                }
+                if (ev->Get<TEvents::TEvWakeup>()->Tag == RequestTimeoutWakeupTag) {
+                    HandleRequestTimeout();
                     return;
                 }
                 [[fallthrough]];
@@ -326,7 +343,9 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
                     }
                 }
                 LOG_D("PartitionsLocation " << ReadBalancerTabletId << " partitions " << JoinSeq(", ", partitionIds));
-                SendToTablet(ReadBalancerTabletId, new TEvPersQueue::TEvGetPartitionsLocation(partitionIds));
+                SendToTablet(
+                    ReadBalancerTabletId,
+                    new TEvPersQueue::TEvGetPartitionsLocation(partitionIds, RemainingRequestTimeout()));
             }
             if (!ReadSessionsReceived && this->GetProtoRequest()->include_stats()) {
                 auto ev = CreateReadSessionsInfoRequest();
@@ -377,6 +396,25 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
             RequestReadBalancer();
         }
 
+        TDuration RemainingRequestTimeout() const {
+            if (!RequestStartTime) {
+                return RequestTimeout;
+            }
+            const auto now = TActivationContext::Now();
+            if (now >= *RequestStartTime + RequestTimeout) {
+                return TDuration::Zero();
+            }
+            return *RequestStartTime + RequestTimeout - now;
+        }
+
+        void HandleRequestTimeout() {
+            LOG_W("Describe request timed out");
+            this->ReplyWithError(
+                Ydb::StatusIds::TIMEOUT,
+                "Describe request timed out",
+                Ydb::PersQueue::ErrorCode::ERROR);
+        }
+
     protected:
         const NPQ::NDescriber::TAccessRights AccessRights;
 
@@ -389,6 +427,7 @@ namespace NKikimr::NGRpcProxy::V1::NTopic {
         bool ReadSessionsReceived = false;
         bool LocationsRetryPending = false;
         TBackoff LocationsBackoff = TBackoff(25, TDuration::MilliSeconds(10), TDuration::MilliSeconds(100));
+        std::optional<TInstant> RequestStartTime;
 
         Ydb::Scheme::Entry SelfEntry;
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -283,7 +283,7 @@ Y_UNIT_TEST(DescribePartitionFailsAfterStatsRetriesExhausted) {
     auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
         runtime, request, CreateDescribePartitionActor, path);
 
-    // Initial attempt + 5 backoff retries, then fail on the next DeliveryProblem.
+    // Initial attempt + StatsMaxRetries backoff retries, then fail on the next DeliveryProblem.
     UNIT_ASSERT_VALUES_EQUAL(broken, 6u);
     AssertStatus(result, Ydb::StatusIds::UNAVAILABLE, "unresponsive");
 }

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -247,6 +247,47 @@ Y_UNIT_TEST(DescribePartitionTimesOutWhenLocationStuck) {
     AssertStatus(result, Ydb::StatusIds::TIMEOUT, "Describe request timed out");
 }
 
+Y_UNIT_TEST(DescribePartitionFailsAfterStatsRetriesExhausted) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_part_stats_retries";
+    CreateTopic(runtime, path);
+
+    size_t broken = 0;
+    auto* rt = &runtime;
+    auto breakObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+        [&broken, rt](TEvPipeCache::TEvForward::TPtr& ev) {
+            if (!ev || !ev->Get()->Ev) {
+                return;
+            }
+            if (ev->Get()->Ev->Type() != TEvPersQueue::TEvStatus::EventType) {
+                return;
+            }
+            ++broken;
+            const ui64 tabletId = ev->Get()->TabletId;
+            const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
+            rt->Send(new IEventHandle(
+                ev->Sender,
+                ev->Recipient,
+                new TEvPipeCache::TEvDeliveryProblem(tabletId, true /*notDelivered*/),
+                0,
+                subscribeCookie));
+            ev.Reset();
+        });
+
+    Ydb::Topic::DescribePartitionRequest request;
+    request.set_path(path);
+    request.set_partition_id(0);
+    request.set_include_stats(true);
+
+    auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
+        runtime, request, CreateDescribePartitionActor, path);
+
+    // Initial attempt + 5 backoff retries, then fail on the next DeliveryProblem.
+    UNIT_ASSERT_VALUES_EQUAL(broken, 6u);
+    AssertStatus(result, Ydb::StatusIds::UNAVAILABLE, "unresponsive");
+}
+
 Y_UNIT_TEST(DescribeUnknownConsumer) {
     auto setup = CreateSetup();
     auto& runtime = setup->GetRuntime();

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -74,13 +74,14 @@ std::shared_ptr<TResultHolder<TResponse>> DoActorRequest(
     const TRequest& request,
     NActors::IActor* (*factory)(NGRpcService::IRequestOpCtx*),
     const TString& path,
-    const TString& database = "/Root")
+    const TString& database = "/Root",
+    TDuration waitTimeout = TDuration::Seconds(10))
 {
     auto result = std::make_shared<TResultHolder<TResponse>>();
     auto edgeActor = runtime.AllocateEdgeActor();
     auto* ctx = new TRequestCtx<TRequest, TResponse>(request, path, database, result, edgeActor);
     runtime.Register(factory(ctx));
-    runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edgeActor, TDuration::Seconds(10));
+    runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edgeActor, waitTimeout);
     UNIT_ASSERT_C(result->ResultStatus, "The operation is still in progress");
     return result;
 }
@@ -207,6 +208,43 @@ Y_UNIT_TEST(DescribePartitionRetriesOnLocationDeliveryProblem) {
     UNIT_ASSERT(describeResult);
     UNIT_ASSERT(describeResult->partition().has_partition_location());
     UNIT_ASSERT_GT(describeResult->partition().partition_location().node_id(), 0);
+}
+
+Y_UNIT_TEST(DescribePartitionTimesOutWhenLocationStuck) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_part_timeout";
+    CreateTopic(runtime, path);
+
+    // Drop location forwards so the actor never gets a response and must hit RequestTimeout.
+    auto dropObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+        [](TEvPipeCache::TEvForward::TPtr& ev) {
+            if (ev && ev->Get()->Ev &&
+                ev->Get()->Ev->Type() == TEvPersQueue::TEvGetPartitionsLocation::EventType)
+            {
+                ev.Reset();
+            }
+        });
+
+    Ydb::Topic::DescribePartitionRequest request;
+    request.set_path(path);
+    request.set_partition_id(0);
+    request.set_include_location(true);
+
+    auto result = std::make_shared<TResultHolder<Ydb::Topic::DescribePartitionResponse>>();
+    auto edgeActor = runtime.AllocateEdgeActor();
+    auto* ctx = new TRequestCtx<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
+        request, path, "/Root", result, edgeActor);
+    auto actorId = runtime.Register(CreateDescribePartitionActor(ctx));
+    runtime.EnableScheduleForActor(actorId, true);
+
+    // Reach StateWork (location request stuck), then jump past RequestTimeout.
+    runtime.DispatchEvents(TDispatchOptions{}, TDuration::MilliSeconds(100));
+    runtime.AdvanceCurrentTime(TDuration::Seconds(11));
+
+    runtime.GrabEdgeEvent<NActors::TEvents::TEvWakeup>(edgeActor, TDuration::Seconds(5));
+    UNIT_ASSERT_C(result->ResultStatus, "The operation is still in progress");
+    AssertStatus(result, Ydb::StatusIds::TIMEOUT, "Describe request timed out");
 }
 
 Y_UNIT_TEST(DescribeUnknownConsumer) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -283,8 +283,8 @@ Y_UNIT_TEST(DescribePartitionFailsAfterStatsRetriesExhausted) {
     auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
         runtime, request, CreateDescribePartitionActor, path);
 
-    // Initial attempt + StatsMaxRetries backoff retries, then fail on the next DeliveryProblem.
-    UNIT_ASSERT_VALUES_EQUAL(broken, 6u);
+    // Initial attempt + StatsMaxRetries(15) backoff retries, then fail on the next DeliveryProblem.
+    UNIT_ASSERT_VALUES_EQUAL(broken, 16u);
     AssertStatus(result, Ydb::StatusIds::UNAVAILABLE, "unresponsive");
 }
 

--- a/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
+++ b/ydb/services/persqueue_v1/actors/schema/topic/schema_ops_ut.cpp
@@ -1,10 +1,17 @@
 #include "actors.h"
 
+#include <ydb/core/base/tablet_pipecache.h>
+#include <ydb/core/persqueue/events/global.h>
+#include <ydb/core/testlib/actors/test_runtime.h>
 #include <ydb/core/testlib/grpc_request/grpc_request.h>
 #include <ydb/public/api/protos/ydb_topic.pb.h>
+#include <ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils/test_server.h>
 #include <ydb/public/sdk/cpp/src/client/topic/ut/ut_utils/topic_sdk_test_setup.h>
 
 #include <library/cpp/testing/unittest/registar.h>
+#include <library/cpp/threading/future/async.h>
+
+#include <util/thread/pool.h>
 
 namespace NKikimr::NGRpcProxy::V1::NTopic {
 
@@ -17,6 +24,48 @@ std::shared_ptr<TTopicSdkTestSetup> CreateSetup(const char* name = "TopicSchemaO
     auto setup = std::make_shared<TTopicSdkTestSetup>(name, TTopicSdkTestSetup::MakeServerSettings(), false);
     setup->GetServer().EnableLogs({NKikimrServices::PQ_SCHEMA}, NActors::NLog::PRI_DEBUG);
     return setup;
+}
+
+// Simulated threads are required for AddObserver on TEvPipeCache::TEvForward.
+// Avoid TTopicSdkTestSetup here: its StartServer(true)/FullInit deadlocks without a dispatcher.
+struct TSimulatedServer {
+    THolder<TThreadPool> Pool;
+    THolder<::NPersQueue::TTestServer> Server;
+
+    ~TSimulatedServer() {
+        Server.Reset();
+        if (Pool) {
+            Pool->Stop();
+        }
+    }
+
+    NActors::TTestActorRuntime& GetRuntime() {
+        return *Server->CleverServer->GetRuntime();
+    }
+};
+
+std::unique_ptr<TSimulatedServer> CreateSimulatedServer() {
+    auto settings = TTopicSdkTestSetup::MakeServerSettings();
+    settings.SetUseRealThreads(false);
+
+    auto out = std::make_unique<TSimulatedServer>();
+    out->Server = MakeHolder<::NPersQueue::TTestServer>(settings, /*start=*/false);
+    out->Server->StartServer(/*doClientInit=*/false, TString("/Root"));
+
+    auto& runtime = out->GetRuntime();
+    runtime.UpdateCurrentTime(TInstant::Now());
+    out->Server->EnableLogs({NKikimrServices::PQ_SCHEMA}, NActors::NLog::PRI_DEBUG);
+
+    out->Server->AnnoyingClient->SetNoConfigMode();
+    out->Pool = MakeHolder<TThreadPool>();
+    out->Pool->Start(2);
+    auto* server = out->Server.Get();
+    auto future = NThreading::Async([server] {
+        server->AnnoyingClient->FullInit();
+        return true;
+    }, *out->Pool);
+    static_cast<NKikimr::TTestActorRuntime&>(runtime).WaitFuture(std::move(future));
+    return out;
 }
 
 template <typename TRequest, typename TResponse>
@@ -108,6 +157,56 @@ Y_UNIT_TEST(DescribePartitionSmokeAndMissing) {
             runtime, request, CreateDescribePartitionActor, request.path());
         AssertStatus(result, Ydb::StatusIds::SCHEME_ERROR);
     }
+}
+
+Y_UNIT_TEST(DescribePartitionRetriesOnLocationDeliveryProblem) {
+    auto server = CreateSimulatedServer();
+    auto& runtime = server->GetRuntime();
+    const TString path = "/Root/topic_describe_part_delivery_problem";
+    CreateTopic(runtime, path);
+
+    // Break the first location forward and inject DeliveryProblem with the matching
+    // subscribe cookie — regresses silent ignore of OnUndelivered()==true.
+    size_t broken = 0;
+    auto* rt = &runtime;
+    auto breakObserver = runtime.AddObserver<TEvPipeCache::TEvForward>(
+        [&broken, rt](TEvPipeCache::TEvForward::TPtr& ev) {
+            if (!ev || !ev->Get()->Ev) {
+                return;
+            }
+            if (ev->Get()->Ev->Type() != TEvPersQueue::TEvGetPartitionsLocation::EventType) {
+                return;
+            }
+            if (broken >= 1) {
+                return;
+            }
+            ++broken;
+            const ui64 tabletId = ev->Get()->TabletId;
+            const ui64 subscribeCookie = ev->Get()->Options.SubscribeCookie;
+            rt->Send(new IEventHandle(
+                ev->Sender,
+                ev->Recipient,
+                new TEvPipeCache::TEvDeliveryProblem(tabletId, true /*notDelivered*/),
+                0,
+                subscribeCookie));
+            ev.Reset();
+        });
+
+    Ydb::Topic::DescribePartitionRequest request;
+    request.set_path(path);
+    request.set_partition_id(0);
+    request.set_include_location(true);
+
+    auto result = DoActorRequest<Ydb::Topic::DescribePartitionRequest, Ydb::Topic::DescribePartitionResponse>(
+        runtime, request, CreateDescribePartitionActor, path);
+
+    UNIT_ASSERT_VALUES_EQUAL(broken, 1u);
+    AssertStatus(result, Ydb::StatusIds::SUCCESS);
+
+    auto* describeResult = dynamic_cast<const Ydb::Topic::DescribePartitionResult*>(result->Response.get());
+    UNIT_ASSERT(describeResult);
+    UNIT_ASSERT(describeResult->partition().has_partition_location());
+    UNIT_ASSERT_GT(describeResult->partition().partition_location().node_id(), 0);
 }
 
 Y_UNIT_TEST(DescribeUnknownConsumer) {

--- a/ydb/services/persqueue_v1/actors/schema/topic/ut/ya.make
+++ b/ydb/services/persqueue_v1/actors/schema/topic/ut/ya.make
@@ -9,12 +9,15 @@ SRCS(
 )
 
 PEERDIR(
+    ydb/core/base
     ydb/core/persqueue/events
     ydb/core/persqueue/public
+    ydb/core/testlib/actors
     ydb/core/testlib/grpc_request
     ydb/public/sdk/cpp/src/client/persqueue_public/ut/ut_utils
     ydb/public/sdk/cpp/src/client/topic/ut/ut_utils
     library/cpp/testing/unittest
+    library/cpp/threading/future
 )
 
 ENV(INSIDE_YDB="1")


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed hang in Topic DescribePartition/DescribeConsumer when tablet pipe breaks or location/stats stall.

### Description for reviewers <!-- (optional) description for those who read this PR -->

`TDescribeBaseActor` (`common_describe.h`) could never answer within the client timeout when `include_location` / `include_stats` was set (e.g. SDK write session). Same base is used by DescribePartition and DescribeConsumer.

**Root causes**
1. **Bug:** `OnUndelivered()==true` (current pipe break) was treated as “ignore” → hang on real `DeliveryProblem`.
2. No overall request timeout (old describe had one).
3. Location request often sent with `TimeoutMs=0` when the remaining deadline was already zero.
4. Stats retries on partition-tablet `DeliveryProblem` were unbounded.

**Fixes**
1. Invert `OnUndelivered` check: retry on real DP, ignore stale notifications.
2. Overall `RequestTimeout = 10s` → reply `TIMEOUT` / `"Describe request timed out"`.
3. Pass `RemainingRequestTimeout()` into `TEvGetPartitionsLocation`; if remaining is zero, fail with timeout instead of sending without a deadline (also on location/stats retry paths).
4. Stats retries via per-tablet `TBackoff` (`StatsMaxRetries=15`, 25–250 ms) + `Schedule`; after exhaustion → `UNAVAILABLE` / `"Tablet … unresponsive"`; `StatsRetryPending` debounces duplicate schedules.

**Tests** (`schema_ops_ut.cpp`, simulated server with `UseRealThreads=false` for pipe-cache observers):
- `DescribePartitionRetriesOnLocationDeliveryProblem` — inject DP on first location forward, expect SUCCESS after retry.
- `DescribePartitionTimesOutWhenLocationStuck` — drop location forwards + advance 11s → `TIMEOUT`.
- `DescribePartitionFailsAfterStatsRetriesExhausted` — break all `TEvStatus` → `UNAVAILABLE` after retries exhausted.