### PR TITLE
Fixed race in the topic workload

### DIFF
--- a/ydb/public/lib/ydb_cli/commands/topic_read_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_read_scenario.cpp
@@ -11,7 +11,7 @@ int TTopicReadScenario::DoRun(const TClientCommand::TConfig& config)
 {
     std::vector<std::future<void>> threads;
 
-    StatsCollector->Prepare();
+    StatsCollector->Init();
     StartConsumerThreads(threads, config.Database);
 
     StatsCollector->PrintWindowStatsLoop();

--- a/ydb/public/lib/ydb_cli/commands/topic_read_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_read_scenario.cpp
@@ -11,6 +11,7 @@ int TTopicReadScenario::DoRun(const TClientCommand::TConfig& config)
 {
     std::vector<std::future<void>> threads;
 
+    StatsCollector->Prepare();
     StartConsumerThreads(threads, config.Database);
 
     StatsCollector->PrintWindowStatsLoop();

--- a/ydb/public/lib/ydb_cli/commands/topic_readwrite_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_readwrite_scenario.cpp
@@ -20,7 +20,7 @@ int TTopicReadWriteScenario::DoRun(const TClientCommand::TConfig& config)
 
     std::vector<std::future<void>> threads;
 
-    StatsCollector->Prepare();
+    StatsCollector->Init();
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
     StartConfiguratorThread(threads, config.Database);

--- a/ydb/public/lib/ydb_cli/commands/topic_readwrite_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_readwrite_scenario.cpp
@@ -20,6 +20,7 @@ int TTopicReadWriteScenario::DoRun(const TClientCommand::TConfig& config)
 
     std::vector<std::future<void>> threads;
 
+    StatsCollector->Prepare();
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
     StartConfiguratorThread(threads, config.Database);

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
@@ -88,22 +88,22 @@ void TTopicWorkloadStatsCollector::PrintHeader(bool total) const {
     Cout << header << Flush;
 }
 
-void TTopicWorkloadStatsCollector::Prepare() {
-    StartTime = Now();
-    WarmupTime = StartTime + TDuration::Seconds(WarmupSec);
+void TTopicWorkloadStatsCollector::Init() {
+    WarmupTime = Now() + TDuration::Seconds(WarmupSec);
 }
 
 void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
-    Y_ABORT_UNLESS(StartTime != TInstant(), "Prepare() must be called before PrintWindowStatsLoop()");
+    Y_ABORT_UNLESS(WarmupTime != TInstant(), "Init() must be called before PrintWindowStatsLoop()");
 
     PrintHeader();
 
-    auto stopTime = StartTime + TDuration::Seconds(TotalSec + 1);
+    auto startTime = Now();
+    auto stopTime = startTime + TDuration::Seconds(TotalSec + 1);
 
     int windowIt = 1;
     auto windowDuration = TDuration::Seconds(WindowSec);
     while (Now() < stopTime && !*ErrorFlag) {
-        auto windowTime = [startTime = StartTime, windowDuration](int index) {
+        auto windowTime = [startTime, windowDuration](int index) {
             return startTime + index * windowDuration;
         };
         if (Now() > windowTime(windowIt) && !*ErrorFlag) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.cpp
@@ -88,17 +88,22 @@ void TTopicWorkloadStatsCollector::PrintHeader(bool total) const {
     Cout << header << Flush;
 }
 
+void TTopicWorkloadStatsCollector::Prepare() {
+    StartTime = Now();
+    WarmupTime = StartTime + TDuration::Seconds(WarmupSec);
+}
+
 void TTopicWorkloadStatsCollector::PrintWindowStatsLoop() {
+    Y_ABORT_UNLESS(StartTime != TInstant(), "Prepare() must be called before PrintWindowStatsLoop()");
+
     PrintHeader();
 
-    auto startTime = Now();
-    WarmupTime = startTime + TDuration::Seconds(WarmupSec);
-    auto stopTime = startTime + TDuration::Seconds(TotalSec + 1);
+    auto stopTime = StartTime + TDuration::Seconds(TotalSec + 1);
 
     int windowIt = 1;
     auto windowDuration = TDuration::Seconds(WindowSec);
     while (Now() < stopTime && !*ErrorFlag) {
-        auto windowTime = [startTime, windowDuration](int index) {
+        auto windowTime = [startTime = StartTime, windowDuration](int index) {
             return startTime + index * windowDuration;
         };
         if (Now() > windowTime(windowIt) && !*ErrorFlag) {

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
@@ -19,7 +19,7 @@ namespace NYdb {
                 bool transferMode);
 
             // Must be called before worker threads that call Add*Event start.
-            void Prepare();
+            void Init();
 
             void PrintWindowStatsLoop();
 
@@ -84,9 +84,8 @@ namespace NYdb {
             THolder<TTopicWorkloadStats> WindowStats;
             TTopicWorkloadStats TotalStats;
 
-            // Set in Prepare() before workers start; read-only afterwards.
+            // Set in Init() before workers start; read-only afterwards.
             TInstant WarmupTime;
-            TInstant StartTime;
         };
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/topic_workload_stats_collector.h
@@ -18,6 +18,9 @@ namespace NYdb {
                 std::shared_ptr<std::atomic_bool> errorFlag,
                 bool transferMode);
 
+            // Must be called before worker threads that call Add*Event start.
+            void Prepare();
+
             void PrintWindowStatsLoop();
 
             void PrintHeader(bool total = false) const;
@@ -81,7 +84,9 @@ namespace NYdb {
             THolder<TTopicWorkloadStats> WindowStats;
             TTopicWorkloadStats TotalStats;
 
+            // Set in Prepare() before workers start; read-only afterwards.
             TInstant WarmupTime;
+            TInstant StartTime;
         };
     }
 }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ut/topic_workload_writer_producer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ut/topic_workload_writer_producer_ut.cpp
@@ -53,9 +53,8 @@ namespace NTests {
                 GeneratedMessages(TTopicWorkloadWriterWorker::GenerateMessages(100'000))
             {}
             std::shared_ptr<TTopicWorkloadStatsCollector> StatsCollector = std::make_shared<TTopicWorkloadStatsCollector>(
-                // we need error flag = true, cause without it, stats collector will go into the infinite loop
-                // during the call to PrintWindowStatsLoop. And this call is the only way to deque write events to
-                // statisitcs.
+                // errorFlag=true so PrintWindowStatsLoop exits immediately instead of looping;
+                // it is still needed to drain write events into statistics.
                 1, 1, false, false, 5, 60, 0, 99, std::make_shared<std::atomic_bool>(true), false
             );
             std::shared_ptr<MockWriteSession> WriteSession;
@@ -172,15 +171,14 @@ namespace NTests {
             auto createTime = TInstant::MilliSeconds(1730111050000);
             producer->Send(createTime, {});
             UNIT_ASSERT_EQUAL(0, StatsCollector->GetTotalWriteMessages());
-            // We need this call, cause only this call initializes StatsCollector.WarmupTime.
-            // If it is not initialized, no events will be accepted.
-            // Both here and below it will not go into the loop, cause we provided errorFlag into the constructor above.
-            StatsCollector->PrintWindowStatsLoop();
+            // Prepare() initializes WarmupTime; without it no events are accepted.
+            StatsCollector->Prepare();
 
             auto ackEvent = CreateAckEvent(1);
             producer->HandleAckEvent(ackEvent);
 
-            // We need this call, cause only this way collector will deque wrtie events to statisitcs.
+            // PrintWindowStatsLoop drains write events into statistics.
+            // It will not go into the loop, cause we provided errorFlag into the constructor above.
             StatsCollector->PrintWindowStatsLoop();
             UNIT_ASSERT_VALUES_EQUAL(1, StatsCollector->GetTotalWriteMessages());
         }

--- a/ydb/public/lib/ydb_cli/commands/topic_workload/ut/topic_workload_writer_producer_ut.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_workload/ut/topic_workload_writer_producer_ut.cpp
@@ -171,8 +171,8 @@ namespace NTests {
             auto createTime = TInstant::MilliSeconds(1730111050000);
             producer->Send(createTime, {});
             UNIT_ASSERT_EQUAL(0, StatsCollector->GetTotalWriteMessages());
-            // Prepare() initializes WarmupTime; without it no events are accepted.
-            StatsCollector->Prepare();
+            // Init() sets WarmupTime; until then no events are accepted.
+            StatsCollector->Init();
 
             auto ackEvent = CreateAckEvent(1);
             producer->HandleAckEvent(ackEvent);

--- a/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
@@ -20,6 +20,7 @@ int TTopicWriteScenario::DoRun(const TClientCommand::TConfig& config)
 
     std::vector<std::future<void>> threads;
 
+    StatsCollector->Prepare();
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
     StartConfiguratorThread(threads, config.Database);

--- a/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
+++ b/ydb/public/lib/ydb_cli/commands/topic_write_scenario.cpp
@@ -20,7 +20,7 @@ int TTopicWriteScenario::DoRun(const TClientCommand::TConfig& config)
 
     std::vector<std::future<void>> threads;
 
-    StatsCollector->Prepare();
+    StatsCollector->Init();
     StartConsumerThreads(threads, config.Database);
     StartProducerThreads(threads, partitionCount, partitionSeed, generatedMessages, config.Database);
     StartConfiguratorThread(threads, config.Database);


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a data race in `ydb workload topic` stats collection

### Changelog category <!-- remove all except one -->

* Bugfix

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/40266 (CLI / workload part).

**Problem:** TSAN reported races in `TTopicWorkloadStatsCollector::AddReaderEvent` / `AddWriterEvent`. Writer and reader threads read `WarmupTime` in `AddEvent` while `PrintWindowStatsLoop` wrote it without synchronization.

**Fix:** Introduce `Init()`, which sets `WarmupTime` **before** worker threads start. Thread creation provides the happens-before, so `WarmupTime` stays read-only for workers. Scenarios (`read` / `write` / `readwrite`) call `Init()` before `Start*Threads`. `PrintWindowStatsLoop` keeps its own `startTime = Now()` for windows / `TotalSec`, so worker setup does not consume the measurement interval.

**Note:** The `TSingleClusterReadSessionImpl::SelfCheck` race from the same issue was already fixed in https://github.com/ydb-platform/ydb/pull/42213 and is not changed here.