### PR TITLE
Fixed VERIFY failed: userInfo->ReadScheduled in partition_read.cpp

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -285,9 +285,12 @@ TActorId TPartition::ReplyTo(const ui64 destination, const TActorId& replyTo) co
 
 void TPartition::ReplyError(const TActorContext& ctx, const ui64 dst, NPersQueue::NErrorCode::EErrorCode errorCode, const TString& error, const TActorId& replyTo) {
     auto replyToActor = ReplyTo(dst, replyTo);
+    // IsInternal means "compaction / internal consumer reply", not merely "destined to Self".
+    // Timestamp reads use dst==0 and empty replyTo; they must stay non-internal so Handle(TEvError)
+    // can clear ReadingTimestamp. Compaction reads set replyTo to SelfId().
     ReplyPersQueueError(
         replyToActor, ctx, TabletId, TopicName(), Partition,
-        TabletCounters, NKikimrServices::PERSQUEUE, dst, errorCode, error, true, replyToActor == SelfId()
+        TabletCounters, NKikimrServices::PERSQUEUE, dst, errorCode, error, true, !!replyTo
     );
 }
 
@@ -2278,6 +2281,7 @@ void TPartition::Handle(TEvPQ::TEvError::TPtr& ev, const TActorContext& ctx) {
             // KeyCompactionReadCyclesTotal.Set(compacterCounters.ReadCyclesCount);
             // KeyCompactionWriteCyclesTotal.Set(compacterCounters.WriteCyclesCount);
         }
+        return;
     }
     ReadingTimestamp = false;
     auto userInfo = UsersInfoStorage->GetIfExists(ReadingForUser);
@@ -4713,7 +4717,8 @@ void TPartition::ScheduleReplyError(const ui64 dst, bool internal,
     Replies.emplace_back(internal ? SelfId() : TabletActorId,
                          MakeReplyError(dst,
                                         errorCode,
-                                        error).Release());
+                                        error,
+                                        internal).Release());
 }
 
 void TPartition::ScheduleReplyPropose(const NKikimrPQ::TEvProposeTransaction& event,

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -2246,6 +2246,43 @@ Y_UNIT_TEST_F(SetOffset, TPartitionFixture)
     WaitProxyResponse({.Cookie=5, .Status=NMsgBusProxy::MSTATUS_OK});
 }
 
+// Compactification replies with IsInternal=true. Those must not be treated as timestamp-read
+// completions: otherwise ReadingTimestamp/ReadScheduled get out of sync and the next
+// TEvProxyResponse hits PQ_ENSURE(userInfo->ReadScheduled) (issue #49357).
+Y_UNIT_TEST_F(InternalErrorDoesNotBreakTimestampRead, TPartitionFixture)
+{
+    const TPartitionId partition{0};
+    const TString client = "client";
+    const TString session = "session";
+
+    CreatePartition({
+        .Partition = partition,
+        .Begin = 0,
+        .End = 10,
+        .Config = {.Consumers = {{.Consumer = client, .Offset = 0, .Session = session}}},
+    });
+
+    auto blobRequest = Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvBlobRequest>(TDuration::Seconds(5));
+    UNIT_ASSERT_C(blobRequest != nullptr, "expected timestamp-read blob request");
+
+    SendEvent(new TEvPQ::TEvError(
+        NPersQueue::NErrorCode::ERROR,
+        "compaction internal error",
+        /*cookie=*/0,
+        /*isInternal=*/true));
+    Ctx->Runtime->SimulateSleep(TDuration::MilliSeconds(200));
+
+    auto restartedBlobRequest =
+        Ctx->Runtime->GrabEdgeEvent<TEvPQ::TEvBlobRequest>(TDuration::MilliSeconds(200));
+    UNIT_ASSERT_C(
+        restartedBlobRequest == nullptr,
+        "IsInternal TEvError must not restart an in-flight timestamp read");
+
+    // Partition stays responsive with the original timestamp read still in flight.
+    SendGetOffset(1, client);
+    WaitProxyResponse({.Cookie = 1, .Status = NMsgBusProxy::MSTATUS_OK, .Offset = 0});
+}
+
 Y_UNIT_TEST_F(TooManyImmediateTxs, TPartitionTxTestHelper)
 {
     const TPartitionId partition{0};


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a crash in topic partitions: `VERIFY failed: userInfo->ReadScheduled` while resolving consumer write timestamps under compaction.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/49357

**Root cause**

`Handle(TEvProxyResponse)` returns early for `IsInternal` (compaction) replies, but `Handle(TEvError)` did not. An internal compaction `TEvError` fell through into timestamp-read error handling, reset `ReadingTimestamp` / restarted the timestamp read while the original one was still in flight, and the next `TEvProxyResponse` hit `PQ_ENSURE(userInfo->ReadScheduled)`.

**Changes**

1. Return after handling `IsInternal` in `Handle(TEvError)` (same as `Handle(TEvProxyResponse)`).
2. Mark `ReplyError` as internal only when `replyTo` is set (compaction), not merely when the destination is `SelfId()` — timestamp reads use `dst == 0` and empty `replyTo` and must stay non-internal.
3. Pass the `internal` flag through `ScheduleReplyError` → `MakeReplyError`.
4. UT `InternalErrorDoesNotBreakTimestampRead`: in-flight timestamp blob read + internal `TEvError` must not start a second blob request.