### PR TITLE
schemeshard: keep committed Active partitions in Describe during topic split/merge alter

### DIFF
--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -795,6 +795,9 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
         for (const auto& [shardIdx, pqShard] : pqGroupInfo->Shards) {
             const auto& shardInfo = Self->ShardInfos.at(shardIdx);
             for (const auto& pq : pqShard->Partitions) {
+                if (pq->Status == NKikimrPQ::ETopicPartitionStatus::Deleted) {
+                    continue;
+                }
                 if (pq->CreateVersion <= pqGroupInfo->AlterVersion
                         || pq->AlterVersion <= pqGroupInfo->AlterVersion) {
                     auto partition = allocate->MutablePartitions()->Add();

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -19,6 +19,36 @@ void FillPartitionConfig(const NKikimrSchemeOp::TPartitionConfig& in, NKikimrSch
     out.MutableStorageRooms()->Clear();
 }
 
+// Parents deactivated in ReassignIds get AlterVersion bumped before topic AlterVersion,
+// so the usual AlterVersion filter would hide them together with new children and leave
+// Describe without an open-ended Active partition (breaks TBoundaryChooser / writers).
+// Keep the committed pre-alter view until FinishAlter: still show those parents as Active.
+THashSet<ui32> ParentsDeactivatedInFlight(const NKikimr::NSchemeShard::TTopicInfo& pqGroup) {
+    THashSet<ui32> parents;
+    if (!pqGroup.AlterData) {
+        return parents;
+    }
+    for (const auto& p : pqGroup.AlterData->PartitionsToAdd) {
+        parents.insert(p.ParentPartitionIds.begin(), p.ParentPartitionIds.end());
+    }
+    return parents;
+}
+
+bool IsPartitionVisibleInDescribe(
+        const NKikimr::NSchemeShard::TTopicTabletInfo::TTopicPartitionInfo& partition,
+        const NKikimr::NSchemeShard::TTopicInfo& pqGroup,
+        const THashSet<ui32>& parentsDeactivatedInFlight)
+{
+    if (partition.AlterVersion <= pqGroup.AlterVersion) {
+        return true;
+    }
+    // Only pre-alter parents (CreateVersion older than this alter), not intermediate
+    // partitions created and then further split within the same alter.
+    return pqGroup.AlterData
+        && parentsDeactivatedInFlight.contains(partition.PqId)
+        && partition.CreateVersion < pqGroup.AlterData->AlterVersion;
+}
+
 }
 
 namespace NKikimr {
@@ -705,7 +735,10 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
             struct TPartitionDesc {
             TTabletId TabletId;
             const TTopicTabletInfo::TTopicPartitionInfo* Info = nullptr;
+            bool ForceCommittedActive = false;
             };
+
+            const auto parentsDeactivatedInFlight = ParentsDeactivatedInFlight(*pqGroupInfo);
 
             // it is sorted list of partitions by partition id
             TVector<TPartitionDesc> descriptions; // index is pqId
@@ -716,11 +749,20 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                 Y_VERIFY_S(it != Self->ShardInfos.end(), "No shard with shardIdx: " << shardIdx);
 
                 for (const auto& partition : pqShard->Partitions) {
-                    if (partition->AlterVersion <= pqGroupInfo->AlterVersion) {
-                        Y_VERIFY_S(partition->PqId < pqGroupInfo->NextPartitionId,
-                                   "Wrong pqId: " << partition->PqId << ", nextPqId: " << pqGroupInfo->NextPartitionId);
-                        descriptions[partition->PqId] = {it->second.TabletID, partition.Get()};
+                    if (!IsPartitionVisibleInDescribe(*partition, *pqGroupInfo, parentsDeactivatedInFlight)) {
+                        continue;
                     }
+                    Y_VERIFY_S(partition->PqId < pqGroupInfo->NextPartitionId,
+                               "Wrong pqId: " << partition->PqId << ", nextPqId: " << pqGroupInfo->NextPartitionId);
+                    if (partition->PqId >= descriptions.size()) {
+                        descriptions.resize(partition->PqId + 1);
+                    }
+                    descriptions[partition->PqId] = {
+                        it->second.TabletID,
+                        partition.Get(),
+                        parentsDeactivatedInFlight.contains(partition->PqId)
+                            && partition->AlterVersion > pqGroupInfo->AlterVersion,
+                    };
                 }
             }
 
@@ -740,12 +782,18 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                     desc.Info->KeyRange->SerializeToProto(*partition.MutableKeyRange());
                 }
 
-                partition.SetStatus(desc.Info->Status);
+                partition.SetStatus(desc.ForceCommittedActive
+                    ? NKikimrPQ::ETopicPartitionStatus::Active
+                    : desc.Info->Status);
                 for (const auto parent : desc.Info->ParentPartitionIds) {
                     partition.AddParentPartitionIds(parent);
                 }
-                for (const auto child : desc.Info->ChildPartitionIds) {
-                    partition.AddChildPartitionIds(child);
+                // Do not expose child links created by the in-flight alter while we still
+                // present the parent as committed-Active.
+                if (!desc.ForceCommittedActive) {
+                    for (const auto child : desc.Info->ChildPartitionIds) {
+                        partition.AddChildPartitionIds(child);
+                    }
                 }
                 if (desc.Info->CreationTimestamp) {
                     partition.SetCreationTimestampSeconds(desc.Info->CreationTimestamp.Seconds());
@@ -771,26 +819,32 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
         allocate->SetBalancerOwnerId(pqGroupInfo->BalancerShardIdx.GetOwnerId());
         allocate->SetBalancerShardId(ui64(pqGroupInfo->BalancerShardIdx.GetLocalId()));
 
+        const auto parentsDeactivatedInFlight = ParentsDeactivatedInFlight(*pqGroupInfo);
         for (const auto& [shardIdx, pqShard] : pqGroupInfo->Shards) {
             const auto& shardInfo = Self->ShardInfos.at(shardIdx);
             for (const auto& pq : pqShard->Partitions) {
-                if (pq->AlterVersion <= pqGroupInfo->AlterVersion) {
-                    auto partition = allocate->MutablePartitions()->Add();
-                    partition->SetPartitionId(pq->PqId);
-                    partition->SetGroupId(pq->GroupId);
-                    partition->SetTabletId(ui64(shardInfo.TabletID));
-                    partition->SetOwnerId(shardIdx.GetOwnerId());
-                    partition->SetShardId(ui64(shardIdx.GetLocalId()));
-                    partition->SetStatus(pq->Status);
-                    for (const auto parent : pq->ParentPartitionIds) {
-                        partition->AddParentPartitionIds(parent);
-                    }
-                    if (pq->KeyRange) {
-                        pq->KeyRange->SerializeToProto(*partition->MutableKeyRange());
-                    }
-                    if (pq->CreationTimestamp) {
-                        partition->SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
-                    }
+                if (!IsPartitionVisibleInDescribe(*pq, *pqGroupInfo, parentsDeactivatedInFlight)) {
+                    continue;
+                }
+                auto partition = allocate->MutablePartitions()->Add();
+                partition->SetPartitionId(pq->PqId);
+                partition->SetGroupId(pq->GroupId);
+                partition->SetTabletId(ui64(shardInfo.TabletID));
+                partition->SetOwnerId(shardIdx.GetOwnerId());
+                partition->SetShardId(ui64(shardIdx.GetLocalId()));
+                const bool forceCommittedActive = parentsDeactivatedInFlight.contains(pq->PqId)
+                    && pq->AlterVersion > pqGroupInfo->AlterVersion;
+                partition->SetStatus(forceCommittedActive
+                    ? NKikimrPQ::ETopicPartitionStatus::Active
+                    : pq->Status);
+                for (const auto parent : pq->ParentPartitionIds) {
+                    partition->AddParentPartitionIds(parent);
+                }
+                if (pq->KeyRange) {
+                    pq->KeyRange->SerializeToProto(*partition->MutableKeyRange());
+                }
+                if (pq->CreationTimestamp) {
+                    partition->SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
                 }
             }
         }

--- a/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
+++ b/ydb/core/tx/schemeshard/schemeshard_path_describer.cpp
@@ -19,36 +19,6 @@ void FillPartitionConfig(const NKikimrSchemeOp::TPartitionConfig& in, NKikimrSch
     out.MutableStorageRooms()->Clear();
 }
 
-// Parents deactivated in ReassignIds get AlterVersion bumped before topic AlterVersion,
-// so the usual AlterVersion filter would hide them together with new children and leave
-// Describe without an open-ended Active partition (breaks TBoundaryChooser / writers).
-// Keep the committed pre-alter view until FinishAlter: still show those parents as Active.
-THashSet<ui32> ParentsDeactivatedInFlight(const NKikimr::NSchemeShard::TTopicInfo& pqGroup) {
-    THashSet<ui32> parents;
-    if (!pqGroup.AlterData) {
-        return parents;
-    }
-    for (const auto& p : pqGroup.AlterData->PartitionsToAdd) {
-        parents.insert(p.ParentPartitionIds.begin(), p.ParentPartitionIds.end());
-    }
-    return parents;
-}
-
-bool IsPartitionVisibleInDescribe(
-        const NKikimr::NSchemeShard::TTopicTabletInfo::TTopicPartitionInfo& partition,
-        const NKikimr::NSchemeShard::TTopicInfo& pqGroup,
-        const THashSet<ui32>& parentsDeactivatedInFlight)
-{
-    if (partition.AlterVersion <= pqGroup.AlterVersion) {
-        return true;
-    }
-    // Only pre-alter parents (CreateVersion older than this alter), not intermediate
-    // partitions created and then further split within the same alter.
-    return pqGroup.AlterData
-        && parentsDeactivatedInFlight.contains(partition.PqId)
-        && partition.CreateVersion < pqGroup.AlterData->AlterVersion;
-}
-
 }
 
 namespace NKikimr {
@@ -735,10 +705,7 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
             struct TPartitionDesc {
             TTabletId TabletId;
             const TTopicTabletInfo::TTopicPartitionInfo* Info = nullptr;
-            bool ForceCommittedActive = false;
             };
-
-            const auto parentsDeactivatedInFlight = ParentsDeactivatedInFlight(*pqGroupInfo);
 
             // it is sorted list of partitions by partition id
             TVector<TPartitionDesc> descriptions; // index is pqId
@@ -749,20 +716,25 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                 Y_VERIFY_S(it != Self->ShardInfos.end(), "No shard with shardIdx: " << shardIdx);
 
                 for (const auto& partition : pqShard->Partitions) {
-                    if (!IsPartitionVisibleInDescribe(*partition, *pqGroupInfo, parentsDeactivatedInFlight)) {
-                        continue;
+                    // Describe the partition set as of the committed topic AlterVersion.
+                    //
+                    // ReassignIds bumps parent AlterVersion (and sets Inactive) before FinishAlter
+                    // bumps topic AlterVersion. Filtering only by partition.AlterVersion would hide
+                    // those parents together with new children and leave no open-ended Active range
+                    // for TBoundaryChooser / writers.
+                    //
+                    // CreateVersion is the topic version when the partition was added:
+                    // - created in the in-flight alter: CreateVersion > committed → hidden
+                    // - existed before: CreateVersion <= committed → visible; if AlterVersion was
+                    //   bumped by the in-flight alter, still report Active until FinishAlter
+                    // - topic create quirk: CreateVersion may be 1 while AlterVersion is still 0 →
+                    //   visible via AlterVersion <= committed
+                    if (partition->CreateVersion <= pqGroupInfo->AlterVersion
+                            || partition->AlterVersion <= pqGroupInfo->AlterVersion) {
+                        Y_VERIFY_S(partition->PqId < pqGroupInfo->NextPartitionId,
+                                   "Wrong pqId: " << partition->PqId << ", nextPqId: " << pqGroupInfo->NextPartitionId);
+                        descriptions[partition->PqId] = {it->second.TabletID, partition.Get()};
                     }
-                    Y_VERIFY_S(partition->PqId < pqGroupInfo->NextPartitionId,
-                               "Wrong pqId: " << partition->PqId << ", nextPqId: " << pqGroupInfo->NextPartitionId);
-                    if (partition->PqId >= descriptions.size()) {
-                        descriptions.resize(partition->PqId + 1);
-                    }
-                    descriptions[partition->PqId] = {
-                        it->second.TabletID,
-                        partition.Get(),
-                        parentsDeactivatedInFlight.contains(partition->PqId)
-                            && partition->AlterVersion > pqGroupInfo->AlterVersion,
-                    };
                 }
             }
 
@@ -782,7 +754,8 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                     desc.Info->KeyRange->SerializeToProto(*partition.MutableKeyRange());
                 }
 
-                partition.SetStatus(desc.ForceCommittedActive
+                // Parents deactivated in the in-flight alter still look Active at committed version.
+                partition.SetStatus(desc.Info->AlterVersion > pqGroupInfo->AlterVersion
                     ? NKikimrPQ::ETopicPartitionStatus::Active
                     : desc.Info->Status);
                 for (const auto parent : desc.Info->ParentPartitionIds) {
@@ -790,7 +763,7 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
                 }
                 // Do not expose child links created by the in-flight alter while we still
                 // present the parent as committed-Active.
-                if (!desc.ForceCommittedActive) {
+                if (desc.Info->AlterVersion <= pqGroupInfo->AlterVersion) {
                     for (const auto child : desc.Info->ChildPartitionIds) {
                         partition.AddChildPartitionIds(child);
                     }
@@ -819,32 +792,29 @@ void TPathDescriber::DescribePersQueueGroup(TPathId pathId, TPathElement::TPtr p
         allocate->SetBalancerOwnerId(pqGroupInfo->BalancerShardIdx.GetOwnerId());
         allocate->SetBalancerShardId(ui64(pqGroupInfo->BalancerShardIdx.GetLocalId()));
 
-        const auto parentsDeactivatedInFlight = ParentsDeactivatedInFlight(*pqGroupInfo);
         for (const auto& [shardIdx, pqShard] : pqGroupInfo->Shards) {
             const auto& shardInfo = Self->ShardInfos.at(shardIdx);
             for (const auto& pq : pqShard->Partitions) {
-                if (!IsPartitionVisibleInDescribe(*pq, *pqGroupInfo, parentsDeactivatedInFlight)) {
-                    continue;
-                }
-                auto partition = allocate->MutablePartitions()->Add();
-                partition->SetPartitionId(pq->PqId);
-                partition->SetGroupId(pq->GroupId);
-                partition->SetTabletId(ui64(shardInfo.TabletID));
-                partition->SetOwnerId(shardIdx.GetOwnerId());
-                partition->SetShardId(ui64(shardIdx.GetLocalId()));
-                const bool forceCommittedActive = parentsDeactivatedInFlight.contains(pq->PqId)
-                    && pq->AlterVersion > pqGroupInfo->AlterVersion;
-                partition->SetStatus(forceCommittedActive
-                    ? NKikimrPQ::ETopicPartitionStatus::Active
-                    : pq->Status);
-                for (const auto parent : pq->ParentPartitionIds) {
-                    partition->AddParentPartitionIds(parent);
-                }
-                if (pq->KeyRange) {
-                    pq->KeyRange->SerializeToProto(*partition->MutableKeyRange());
-                }
-                if (pq->CreationTimestamp) {
-                    partition->SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
+                if (pq->CreateVersion <= pqGroupInfo->AlterVersion
+                        || pq->AlterVersion <= pqGroupInfo->AlterVersion) {
+                    auto partition = allocate->MutablePartitions()->Add();
+                    partition->SetPartitionId(pq->PqId);
+                    partition->SetGroupId(pq->GroupId);
+                    partition->SetTabletId(ui64(shardInfo.TabletID));
+                    partition->SetOwnerId(shardIdx.GetOwnerId());
+                    partition->SetShardId(ui64(shardIdx.GetLocalId()));
+                    partition->SetStatus(pq->AlterVersion > pqGroupInfo->AlterVersion
+                        ? NKikimrPQ::ETopicPartitionStatus::Active
+                        : pq->Status);
+                    for (const auto parent : pq->ParentPartitionIds) {
+                        partition->AddParentPartitionIds(parent);
+                    }
+                    if (pq->KeyRange) {
+                        pq->KeyRange->SerializeToProto(*partition->MutableKeyRange());
+                    }
+                    if (pq->CreationTimestamp) {
+                        partition->SetCreationTimestampSeconds(pq->CreationTimestamp.Seconds());
+                    }
                 }
             }
         }

--- a/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
+++ b/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
@@ -1,5 +1,6 @@
 #include <ydb/core/tx/schemeshard/ut_helpers/helpers.h>
 
+#include <ydb/core/persqueue/writer/partition_chooser_impl.h>
 #include <ydb/services/lib/sharding/sharding.h>
 
 #include <util/generic/size_literals.h>
@@ -173,6 +174,39 @@ auto DescribeTopic(TTestBasicRuntime& runtime, TString path = "/MyRoot/USER_1/To
     }
 
     return DescribePath(runtime, ss, path, true, true, true).GetPathDescription().GetPersQueueGroup();
+}
+
+// TBoundaryChooser requires at least one Active partition without ToBound (open-ended range).
+// Describe during in-flight split/merge alter can temporarily omit such partitions.
+void ValidateDescribeUsableByBoundaryChooser(const NKikimrSchemeOp::TPersQueueGroupDescription& topic) {
+    ui32 activeCount = 0;
+    bool hasOpenEndedActive = false;
+    TStringBuilder activeDump;
+    for (const auto& p : topic.GetPartitions()) {
+        if (p.GetStatus() != NKikimrPQ::ETopicPartitionStatus::Active) {
+            continue;
+        }
+        ++activeCount;
+        const bool openEnded = !p.HasKeyRange() || !p.GetKeyRange().HasToBound();
+        hasOpenEndedActive = hasOpenEndedActive || openEnded;
+        activeDump << " p" << p.GetPartitionId()
+                   << "{status=Active"
+                   << " from=" << (p.HasKeyRange() && p.GetKeyRange().HasFromBound() ? ToHex(p.GetKeyRange().GetFromBound()) : "-")
+                   << " to=" << (p.HasKeyRange() && p.GetKeyRange().HasToBound() ? ToHex(p.GetKeyRange().GetToBound()) : "-")
+                   << "}";
+    }
+
+    UNIT_ASSERT_C(activeCount > 0,
+                  "Describe returned no Active partitions; BoundaryChooser would fail. Partitions="
+                      << topic.PartitionsSize() << activeDump);
+    UNIT_ASSERT_C(hasOpenEndedActive,
+                  "Describe Active set has no open-ended ToBound; BoundaryChooser AFL_ENSURE. Active="
+                      << activeCount << activeDump);
+
+    NKikimr::NPQ::NPartitionChooser::TBoundaryChooser<NKikimr::NPQ::NPartitionChooser::TAsIsConverter> chooser(topic);
+    // Key past any finite ToBound must still land in the open-ended partition.
+    const unsigned char maxKey[] = {0xFF, 0xFF, 0xFF, 0xFF};
+    UNIT_ASSERT(chooser.GetPartition(TString(reinterpret_cast<const char*>(maxKey), sizeof(maxKey))));
 }
 
 void ValidatePartition(const NKikimrSchemeOp::TPersQueueGroupDescription::TPartition& partition,
@@ -1680,4 +1714,93 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
             alter.MutablePQTabletConfig()->MutablePartitionConfig()->SetLifetimeSeconds(7200);
         });
     } // Y_UNIT_TEST(AlterTopicConfigAfterMergeAlterInterruptedByReboot)
+
+    // Repro: after Propose/ReassignIds topic AlterVersion is still old, while split parents/children
+    // already have the new partition AlterVersion. Describe filters by
+    // partition->AlterVersion <= pqGroup->AlterVersion and can hide the open-ended Active partition.
+    // Writers then hit TBoundaryChooser AFL_ENSURE ("Partition not found. Maybe wrong partitions bounds").
+    Y_UNIT_TEST(DescribeDuringMinPartitionCountAlterKeepsOpenEndedActive) {
+        TTestBasicRuntime runtime;
+        TTestEnv env = CreateTestEnv(runtime);
+
+        ui64 txId = 100;
+
+        CreateSubDomain(runtime, env, ++txId);
+        CreateTopic(runtime, env, ++txId, 1);
+
+        ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
+
+        ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
+        scheme.SetName("Topic1");
+        scheme.MutablePQTabletConfig()->MutablePartitionConfig();
+        scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMaxPartitionCount(100);
+        scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetMinPartitionCount(5);
+        scheme.MutablePQTabletConfig()->MutablePartitionStrategy()->SetPartitionStrategyType(
+            ::NKikimrPQ::TPQTabletConfig_TPartitionStrategyType::TPQTabletConfig_TPartitionStrategyType_CAN_SPLIT_AND_MERGE);
+
+        TStringBuilder sb;
+        sb << scheme;
+        const TString schemeStr = sb.substr(1, sb.size() - 2);
+
+        AsyncAlterPQGroup(runtime, ++txId, "/MyRoot/USER_1", schemeStr);
+        TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
+
+        // In-flight window: publish after ReassignIds, before FinishAlter.
+        auto topicInFlight = DescribeTopic(runtime);
+        Cerr << "===== Describe during MinPartitionCount alter =====" << Endl
+             << topicInFlight.DebugString() << Endl << Flush;
+        ValidateDescribeUsableByBoundaryChooser(topicInFlight);
+
+        env.TestWaitNotification(runtime, txId);
+        ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
+    } // Y_UNIT_TEST(DescribeDuringMinPartitionCountAlterKeepsOpenEndedActive)
+
+    Y_UNIT_TEST(DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage) {
+        TTestBasicRuntime runtime;
+        TTestEnv env = CreateTestEnv(runtime);
+
+        ui64 txId = 100;
+
+        CreateSubDomain(runtime, env, ++txId);
+        CreateTopic(runtime, env, ++txId, 3);
+
+        auto topic = DescribeTopic(runtime);
+        UNIT_ASSERT_VALUES_EQUAL(topic.GetPartitions().size(), 3);
+        ValidateDescribeUsableByBoundaryChooser(topic);
+
+        ui32 openEndedId = Max<ui32>();
+        for (const auto& p : topic.GetPartitions()) {
+            if (p.GetStatus() == NKikimrPQ::ETopicPartitionStatus::Active
+                    && (!p.HasKeyRange() || !p.GetKeyRange().HasToBound())) {
+                openEndedId = p.GetPartitionId();
+                break;
+            }
+        }
+        UNIT_ASSERT_C(openEndedId != Max<ui32>(), "expected open-ended active partition before split");
+
+        const unsigned char b[] = {0xC0};
+        TString boundary((char*)b, sizeof(b));
+
+        ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
+        scheme.SetName("Topic1");
+        scheme.MutablePQTabletConfig()->MutablePartitionConfig();
+        auto* split = scheme.AddSplit();
+        split->SetPartition(openEndedId);
+        split->SetSplitBoundary(boundary);
+
+        TStringBuilder sb;
+        sb << scheme;
+        const TString schemeStr = sb.substr(1, sb.size() - 2);
+
+        AsyncAlterPQGroup(runtime, ++txId, "/MyRoot/USER_1", schemeStr);
+        TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
+
+        auto topicInFlight = DescribeTopic(runtime);
+        Cerr << "===== Describe during split of open-ended partition =====" << Endl
+             << topicInFlight.DebugString() << Endl << Flush;
+        ValidateDescribeUsableByBoundaryChooser(topicInFlight);
+
+        env.TestWaitNotification(runtime, txId);
+        ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
+    } // Y_UNIT_TEST(DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage)
 }

--- a/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
+++ b/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
@@ -209,6 +209,74 @@ void ValidateDescribeUsableByBoundaryChooser(const NKikimrSchemeOp::TPersQueueGr
     UNIT_ASSERT(chooser.GetPartition(TString(reinterpret_cast<const char*>(maxKey), sizeof(maxKey))));
 }
 
+// Prove Describe is still on the committed pre-alter snapshot (ReassignIds done, FinishAlter not).
+// Topic AlterVersion / NextPartitionId bump only in FinishAlter; new partition ids stay hidden.
+void ValidateInFlightCommittedDescribeSnapshot(
+        const NKikimrSchemeOp::TPersQueueGroupDescription& before,
+        const NKikimrSchemeOp::TPersQueueGroupDescription& inFlight)
+{
+    UNIT_ASSERT_VALUES_EQUAL_C(before.GetAlterVersion(), inFlight.GetAlterVersion(),
+        "mid-alter Describe must keep committed AlterVersion until FinishAlter");
+    UNIT_ASSERT_VALUES_EQUAL_C(before.GetNextPartitionId(), inFlight.GetNextPartitionId(),
+        "mid-alter Describe must keep committed NextPartitionId until FinishAlter");
+    UNIT_ASSERT_VALUES_EQUAL_C(before.PartitionsSize(), inFlight.PartitionsSize(),
+        "mid-alter Describe must not expose partitions created by the in-flight alter");
+
+    THashMap<ui32, NKikimrPQ::ETopicPartitionStatus> beforeStatus;
+    THashSet<ui32> beforeIds;
+    for (const auto& p : before.GetPartitions()) {
+        beforeIds.insert(p.GetPartitionId());
+        beforeStatus[p.GetPartitionId()] = p.GetStatus();
+        UNIT_ASSERT_C(p.GetPartitionId() < before.GetNextPartitionId(),
+            "pre-alter partition id out of committed NextPartitionId range");
+    }
+
+    THashSet<ui32> inFlightIds;
+    ui32 activeInFlight = 0;
+    for (const auto& p : inFlight.GetPartitions()) {
+        const ui32 id = p.GetPartitionId();
+        inFlightIds.insert(id);
+        UNIT_ASSERT_C(beforeIds.contains(id),
+            "mid-alter Describe exposed unexpected partition id " << id);
+        UNIT_ASSERT_C(id < inFlight.GetNextPartitionId(),
+            "visible partition id must belong to committed NextPartitionId range");
+
+        if (p.GetStatus() == NKikimrPQ::ETopicPartitionStatus::Active) {
+            ++activeInFlight;
+            // Parents deactivated by ReassignIds are still reported Active and must not
+            // advertise child links created by this alter.
+            UNIT_ASSERT_C(p.ChildPartitionIdsSize() == 0,
+                "mid-alter Active partition " << id << " must not expose in-flight child links");
+        }
+
+        // Partitions that were Active before the alter must remain Active in the snapshot.
+        const auto* statusBefore = beforeStatus.FindPtr(id);
+        UNIT_ASSERT_C(statusBefore, "mid-alter partition " << id << " missing from pre-alter map");
+        if (*statusBefore == NKikimrPQ::ETopicPartitionStatus::Active) {
+            UNIT_ASSERT_VALUES_EQUAL_C(
+                static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
+                static_cast<int>(p.GetStatus()),
+                "pre-alter Active partition " << id << " must stay Active mid-alter");
+        }
+    }
+
+    UNIT_ASSERT_C(beforeIds == inFlightIds,
+        "mid-alter visible partition set must equal the committed pre-alter set");
+    UNIT_ASSERT_C(activeInFlight > 0, "mid-alter snapshot must keep Active partitions");
+}
+
+void ValidateAlterFinishedDescribeProgress(
+        const NKikimrSchemeOp::TPersQueueGroupDescription& before,
+        const NKikimrSchemeOp::TPersQueueGroupDescription& done)
+{
+    UNIT_ASSERT_C(done.GetAlterVersion() > before.GetAlterVersion(),
+        "FinishAlter must bump AlterVersion");
+    UNIT_ASSERT_C(done.GetNextPartitionId() > before.GetNextPartitionId(),
+        "FinishAlter must bump NextPartitionId when partitions were added");
+    UNIT_ASSERT_C(done.PartitionsSize() > before.PartitionsSize(),
+        "finished alter must expose newly created partitions");
+}
+
 void ValidatePartition(const NKikimrSchemeOp::TPersQueueGroupDescription::TPartition& partition,
                        NKikimrPQ::ETopicPartitionStatus status, TMaybe<TString> fromBound, TMaybe<TString> toBound) {
     const auto id = partition.GetPartitionId();
@@ -1727,7 +1795,10 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         CreateSubDomain(runtime, env, ++txId);
         CreateTopic(runtime, env, ++txId, 1);
 
-        ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
+        auto topicBefore = DescribeTopic(runtime);
+        ValidateDescribeUsableByBoundaryChooser(topicBefore);
+        UNIT_ASSERT_VALUES_EQUAL(1, topicBefore.PartitionsSize());
+        UNIT_ASSERT_VALUES_EQUAL(1, topicBefore.GetNextPartitionId());
 
         ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
         scheme.SetName("Topic1");
@@ -1748,19 +1819,19 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         auto topicInFlight = DescribeTopic(runtime);
         Cerr << "===== Describe during MinPartitionCount alter =====" << Endl
              << topicInFlight.DebugString() << Endl << Flush;
+        ValidateInFlightCommittedDescribeSnapshot(topicBefore, topicInFlight);
         ValidateDescribeUsableByBoundaryChooser(topicInFlight);
 
-        // Children of the in-flight alter must not be visible yet.
-        for (const auto& p : topicInFlight.GetPartitions()) {
-            UNIT_ASSERT_VALUES_EQUAL_C(p.GetPartitionId(), 0,
-                "only the pre-alter partition must be visible mid-alter, got " << p.GetPartitionId());
-            UNIT_ASSERT_VALUES_EQUAL(
-                static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
-                static_cast<int>(p.GetStatus()));
-        }
+        UNIT_ASSERT_VALUES_EQUAL(1, topicInFlight.PartitionsSize());
+        UNIT_ASSERT_VALUES_EQUAL(0, topicInFlight.GetPartitions()[0].GetPartitionId());
+        UNIT_ASSERT_VALUES_EQUAL(
+            static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
+            static_cast<int>(topicInFlight.GetPartitions()[0].GetStatus()));
+        UNIT_ASSERT_VALUES_EQUAL(0, topicInFlight.GetPartitions()[0].ChildPartitionIdsSize());
 
         env.TestWaitNotification(runtime, txId);
         auto topicDone = DescribeTopic(runtime);
+        ValidateAlterFinishedDescribeProgress(topicBefore, topicDone);
         ValidateDescribeUsableByBoundaryChooser(topicDone);
         UNIT_ASSERT_VALUES_EQUAL(9, topicDone.GetPartitions().size());
     } // Y_UNIT_TEST(DescribeDuringMinPartitionCountAlterKeepsOpenEndedActive)
@@ -1774,13 +1845,13 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         CreateSubDomain(runtime, env, ++txId);
         CreateTopic(runtime, env, ++txId, 3);
 
-        auto topic = DescribeTopic(runtime);
-        UNIT_ASSERT_VALUES_EQUAL(topic.GetPartitions().size(), 3);
-        ValidateDescribeUsableByBoundaryChooser(topic);
+        auto topicBefore = DescribeTopic(runtime);
+        UNIT_ASSERT_VALUES_EQUAL(topicBefore.GetPartitions().size(), 3);
+        ValidateDescribeUsableByBoundaryChooser(topicBefore);
 
         ui32 openEndedId = Max<ui32>();
         ui32 activeBefore = 0;
-        for (const auto& p : topic.GetPartitions()) {
+        for (const auto& p : topicBefore.GetPartitions()) {
             if (p.GetStatus() == NKikimrPQ::ETopicPartitionStatus::Active) {
                 ++activeBefore;
                 if (!p.HasKeyRange() || !p.GetKeyRange().HasToBound()) {
@@ -1811,28 +1882,52 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         auto topicInFlight = DescribeTopic(runtime);
         Cerr << "===== Describe during split of open-ended partition =====" << Endl
              << topicInFlight.DebugString() << Endl << Flush;
+        ValidateInFlightCommittedDescribeSnapshot(topicBefore, topicInFlight);
         ValidateDescribeUsableByBoundaryChooser(topicInFlight);
 
-        ui32 activeInFlight = 0;
         bool openEndedStillActive = false;
         for (const auto& p : topicInFlight.GetPartitions()) {
-            if (p.GetStatus() != NKikimrPQ::ETopicPartitionStatus::Active) {
-                continue;
-            }
-            ++activeInFlight;
             if (p.GetPartitionId() == openEndedId) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
+                    static_cast<int>(p.GetStatus()));
+                UNIT_ASSERT_VALUES_EQUAL(0, p.ChildPartitionIdsSize());
                 openEndedStillActive = true;
-                UNIT_ASSERT_C(p.ChildPartitionIdsSize() == 0,
-                    "in-flight split parent must not expose new child links yet");
             }
+            // No partition created by this alter may appear yet.
+            UNIT_ASSERT_C(p.GetPartitionId() < topicBefore.GetNextPartitionId(),
+                "mid-alter must not expose new partition " << p.GetPartitionId());
         }
-        UNIT_ASSERT_VALUES_EQUAL(activeInFlight, activeBefore);
         UNIT_ASSERT(openEndedStillActive);
 
         env.TestWaitNotification(runtime, txId);
         auto topicDone = DescribeTopic(runtime);
+        ValidateAlterFinishedDescribeProgress(topicBefore, topicDone);
         ValidateDescribeUsableByBoundaryChooser(topicDone);
         UNIT_ASSERT_VALUES_EQUAL(5, topicDone.GetPartitions().size());
+
+        // Split parent is Inactive after FinishAlter; children are visible.
+        bool parentInactive = false;
+        ui32 openEndedChildren = 0;
+        for (const auto& p : topicDone.GetPartitions()) {
+            if (p.GetPartitionId() == openEndedId) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Inactive),
+                    static_cast<int>(p.GetStatus()));
+                UNIT_ASSERT_VALUES_EQUAL(2, p.ChildPartitionIdsSize());
+                parentInactive = true;
+            }
+            for (const auto parent : p.GetParentPartitionIds()) {
+                if (parent == openEndedId) {
+                    UNIT_ASSERT_VALUES_EQUAL(
+                        static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
+                        static_cast<int>(p.GetStatus()));
+                    ++openEndedChildren;
+                }
+            }
+        }
+        UNIT_ASSERT(parentInactive);
+        UNIT_ASSERT_VALUES_EQUAL(2, openEndedChildren);
     } // Y_UNIT_TEST(DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage)
 
     Y_UNIT_TEST(DescribeDuringMergeAlterKeepsOpenEndedActive) {
@@ -1844,8 +1939,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         CreateSubDomain(runtime, env, ++txId);
         CreateTopic(runtime, env, ++txId, 3);
 
-        auto topic = DescribeTopic(runtime);
-        ValidateDescribeUsableByBoundaryChooser(topic);
+        auto topicBefore = DescribeTopic(runtime);
+        ValidateDescribeUsableByBoundaryChooser(topicBefore);
+        UNIT_ASSERT_VALUES_EQUAL(3, topicBefore.GetNextPartitionId());
 
         // Merge two leftmost partitions (0 and 1).
         ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
@@ -1865,24 +1961,25 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         auto topicInFlight = DescribeTopic(runtime);
         Cerr << "===== Describe during merge alter =====" << Endl
              << topicInFlight.DebugString() << Endl << Flush;
+        ValidateInFlightCommittedDescribeSnapshot(topicBefore, topicInFlight);
         ValidateDescribeUsableByBoundaryChooser(topicInFlight);
 
-        // Pre-alter active parents must still be Active; merge child must be hidden.
-        THashSet<ui32> visibleIds;
+        // Pre-alter active parents must still be Active; merge child (id >= NextPartitionId) hidden.
         for (const auto& p : topicInFlight.GetPartitions()) {
-            visibleIds.insert(p.GetPartitionId());
+            UNIT_ASSERT_C(p.GetPartitionId() < topicBefore.GetNextPartitionId(),
+                "mid-alter must not expose merge child partition " << p.GetPartitionId());
             if (p.GetPartitionId() == 0 || p.GetPartitionId() == 1) {
                 UNIT_ASSERT_VALUES_EQUAL(
                     static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
                     static_cast<int>(p.GetStatus()));
+                UNIT_ASSERT_VALUES_EQUAL(0, p.ChildPartitionIdsSize());
             }
         }
-        UNIT_ASSERT(visibleIds.contains(0));
-        UNIT_ASSERT(visibleIds.contains(1));
-        UNIT_ASSERT(visibleIds.contains(2));
-        UNIT_ASSERT_VALUES_EQUAL(visibleIds.size(), 3);
 
         env.TestWaitNotification(runtime, txId);
-        ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
+        auto topicDone = DescribeTopic(runtime);
+        ValidateAlterFinishedDescribeProgress(topicBefore, topicDone);
+        ValidateDescribeUsableByBoundaryChooser(topicDone);
+        UNIT_ASSERT_VALUES_EQUAL(4, topicDone.PartitionsSize());
     } // Y_UNIT_TEST(DescribeDuringMergeAlterKeepsOpenEndedActive)
 }

--- a/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
+++ b/ydb/core/tx/schemeshard/ut_topic_splitmerge/ut_topic_splitmerge.cpp
@@ -177,7 +177,7 @@ auto DescribeTopic(TTestBasicRuntime& runtime, TString path = "/MyRoot/USER_1/To
 }
 
 // TBoundaryChooser requires at least one Active partition without ToBound (open-ended range).
-// Describe during in-flight split/merge alter can temporarily omit such partitions.
+// Describe during in-flight split/merge alter must keep such a partition visible.
 void ValidateDescribeUsableByBoundaryChooser(const NKikimrSchemeOp::TPersQueueGroupDescription& topic) {
     ui32 activeCount = 0;
     bool hasOpenEndedActive = false;
@@ -1715,10 +1715,9 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         });
     } // Y_UNIT_TEST(AlterTopicConfigAfterMergeAlterInterruptedByReboot)
 
-    // Repro: after Propose/ReassignIds topic AlterVersion is still old, while split parents/children
-    // already have the new partition AlterVersion. Describe filters by
-    // partition->AlterVersion <= pqGroup->AlterVersion and can hide the open-ended Active partition.
-    // Writers then hit TBoundaryChooser AFL_ENSURE ("Partition not found. Maybe wrong partitions bounds").
+    // After Propose/ReassignIds topic AlterVersion is still old, while split parents/children
+    // already have the new partition AlterVersion. Filtering only by AlterVersion would hide
+    // the open-ended Active partition; writers then hit TBoundaryChooser AFL_ENSURE.
     Y_UNIT_TEST(DescribeDuringMinPartitionCountAlterKeepsOpenEndedActive) {
         TTestBasicRuntime runtime;
         TTestEnv env = CreateTestEnv(runtime);
@@ -1751,8 +1750,19 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
              << topicInFlight.DebugString() << Endl << Flush;
         ValidateDescribeUsableByBoundaryChooser(topicInFlight);
 
+        // Children of the in-flight alter must not be visible yet.
+        for (const auto& p : topicInFlight.GetPartitions()) {
+            UNIT_ASSERT_VALUES_EQUAL_C(p.GetPartitionId(), 0,
+                "only the pre-alter partition must be visible mid-alter, got " << p.GetPartitionId());
+            UNIT_ASSERT_VALUES_EQUAL(
+                static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
+                static_cast<int>(p.GetStatus()));
+        }
+
         env.TestWaitNotification(runtime, txId);
-        ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
+        auto topicDone = DescribeTopic(runtime);
+        ValidateDescribeUsableByBoundaryChooser(topicDone);
+        UNIT_ASSERT_VALUES_EQUAL(9, topicDone.GetPartitions().size());
     } // Y_UNIT_TEST(DescribeDuringMinPartitionCountAlterKeepsOpenEndedActive)
 
     Y_UNIT_TEST(DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage) {
@@ -1769,14 +1779,17 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
         ValidateDescribeUsableByBoundaryChooser(topic);
 
         ui32 openEndedId = Max<ui32>();
+        ui32 activeBefore = 0;
         for (const auto& p : topic.GetPartitions()) {
-            if (p.GetStatus() == NKikimrPQ::ETopicPartitionStatus::Active
-                    && (!p.HasKeyRange() || !p.GetKeyRange().HasToBound())) {
-                openEndedId = p.GetPartitionId();
-                break;
+            if (p.GetStatus() == NKikimrPQ::ETopicPartitionStatus::Active) {
+                ++activeBefore;
+                if (!p.HasKeyRange() || !p.GetKeyRange().HasToBound()) {
+                    openEndedId = p.GetPartitionId();
+                }
             }
         }
         UNIT_ASSERT_C(openEndedId != Max<ui32>(), "expected open-ended active partition before split");
+        UNIT_ASSERT_VALUES_EQUAL(activeBefore, 3);
 
         const unsigned char b[] = {0xC0};
         TString boundary((char*)b, sizeof(b));
@@ -1800,7 +1813,76 @@ Y_UNIT_TEST_SUITE(TSchemeShardTopicSplitMergePrescribedPartitionsTest) {
              << topicInFlight.DebugString() << Endl << Flush;
         ValidateDescribeUsableByBoundaryChooser(topicInFlight);
 
+        ui32 activeInFlight = 0;
+        bool openEndedStillActive = false;
+        for (const auto& p : topicInFlight.GetPartitions()) {
+            if (p.GetStatus() != NKikimrPQ::ETopicPartitionStatus::Active) {
+                continue;
+            }
+            ++activeInFlight;
+            if (p.GetPartitionId() == openEndedId) {
+                openEndedStillActive = true;
+                UNIT_ASSERT_C(p.ChildPartitionIdsSize() == 0,
+                    "in-flight split parent must not expose new child links yet");
+            }
+        }
+        UNIT_ASSERT_VALUES_EQUAL(activeInFlight, activeBefore);
+        UNIT_ASSERT(openEndedStillActive);
+
+        env.TestWaitNotification(runtime, txId);
+        auto topicDone = DescribeTopic(runtime);
+        ValidateDescribeUsableByBoundaryChooser(topicDone);
+        UNIT_ASSERT_VALUES_EQUAL(5, topicDone.GetPartitions().size());
+    } // Y_UNIT_TEST(DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage)
+
+    Y_UNIT_TEST(DescribeDuringMergeAlterKeepsOpenEndedActive) {
+        TTestBasicRuntime runtime;
+        TTestEnv env = CreateTestEnv(runtime);
+
+        ui64 txId = 100;
+
+        CreateSubDomain(runtime, env, ++txId);
+        CreateTopic(runtime, env, ++txId, 3);
+
+        auto topic = DescribeTopic(runtime);
+        ValidateDescribeUsableByBoundaryChooser(topic);
+
+        // Merge two leftmost partitions (0 and 1).
+        ::NKikimrSchemeOp::TPersQueueGroupDescription scheme;
+        scheme.SetName("Topic1");
+        scheme.MutablePQTabletConfig()->MutablePartitionConfig();
+        auto* merge = scheme.AddMerge();
+        merge->SetPartition(0);
+        merge->SetAdjacentPartition(1);
+
+        TStringBuilder sb;
+        sb << scheme;
+        const TString schemeStr = sb.substr(1, sb.size() - 2);
+
+        AsyncAlterPQGroup(runtime, ++txId, "/MyRoot/USER_1", schemeStr);
+        TestModificationResult(runtime, txId, NKikimrScheme::StatusAccepted);
+
+        auto topicInFlight = DescribeTopic(runtime);
+        Cerr << "===== Describe during merge alter =====" << Endl
+             << topicInFlight.DebugString() << Endl << Flush;
+        ValidateDescribeUsableByBoundaryChooser(topicInFlight);
+
+        // Pre-alter active parents must still be Active; merge child must be hidden.
+        THashSet<ui32> visibleIds;
+        for (const auto& p : topicInFlight.GetPartitions()) {
+            visibleIds.insert(p.GetPartitionId());
+            if (p.GetPartitionId() == 0 || p.GetPartitionId() == 1) {
+                UNIT_ASSERT_VALUES_EQUAL(
+                    static_cast<int>(NKikimrPQ::ETopicPartitionStatus::Active),
+                    static_cast<int>(p.GetStatus()));
+            }
+        }
+        UNIT_ASSERT(visibleIds.contains(0));
+        UNIT_ASSERT(visibleIds.contains(1));
+        UNIT_ASSERT(visibleIds.contains(2));
+        UNIT_ASSERT_VALUES_EQUAL(visibleIds.size(), 3);
+
         env.TestWaitNotification(runtime, txId);
         ValidateDescribeUsableByBoundaryChooser(DescribeTopic(runtime));
-    } // Y_UNIT_TEST(DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage)
+    } // Y_UNIT_TEST(DescribeDuringMergeAlterKeepsOpenEndedActive)
 }

--- a/ydb/core/tx/schemeshard/ut_topic_splitmerge/ya.make
+++ b/ydb/core/tx/schemeshard/ut_topic_splitmerge/ya.make
@@ -9,6 +9,7 @@ PEERDIR(
     library/cpp/regex/pcre
     library/cpp/svnversion
     ydb/core/kqp/ut/common
+    ydb/core/persqueue/writer
     ydb/core/testlib/default
     ydb/core/tx
     ydb/core/tx/schemeshard/ut_helpers


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a crash when writing to a topic during an in-flight split/merge alter: SchemeShard Describe could temporarily omit the open-ended Active partition, and the partition chooser aborted the node.

### Description for reviewers <!-- (optional) description for those who read this PR -->

**Symptom:** `TBoundaryChooser::GetPartition` → `AFL_ENSURE` / terminate with `Partition not found. Maybe wrong partitions bounds` while a topic alter (split/merge or MinPartitionCount auto-split) is in progress.

**Cause:** In `ReassignIds`, parents get `Status=Inactive` and a new `partition->AlterVersion` before `FinishAlter` bumps `topic->AlterVersion`. Describe filters by `partition->AlterVersion <= topic->AlterVersion`, so both parents and new children disappear from the published description. Writers then build `TBoundaryChooser` without an open-ended Active range.

The race exists since split/merge support in schemeshard (`e067ade1b37`). It became much easier to hit in 26-3 after MinPartitionCount auto-split (#44306) and the ActivePartitionCount fix (#45018).

**Fix:** During an in-flight alter, Describe keeps the committed pre-alter view: still expose parents deactivated by this alter as Active (and hide children of the current alter). Balancer/ConfigureParts continue to see the real in-memory Inactive status.

**Tests:** `DescribeDuringMinPartitionCountAlterKeepsOpenEndedActive`, `DescribeDuringSplitOfOpenEndedPartitionKeepsCoverage` — describe mid-alter after Propose, assert Active set still usable by `TBoundaryChooser`.