### PR TITLE
Preserve undelivered recipient for session subscriptions

### DIFF
--- a/ydb/core/actorlib_impl/test_interconnect_ut.cpp
+++ b/ydb/core/actorlib_impl/test_interconnect_ut.cpp
@@ -507,27 +507,23 @@ Y_UNIT_TEST_SUITE(TInterconnectTest) {
 
     Y_UNIT_TEST(TestNotifyUndeliveredOnMissedActor) {
         TTestBasicRuntime runtime(2);
+        runtime.SetDispatchTimeout(TDuration::Seconds(10));
         runtime.Initialize(TAppPrepare().Unwrap());
         const auto edge = runtime.AllocateEdgeActor(0);
+        const TActorId missingActor(0xFFFFF, "null");
 
-        runtime.Send(new IEventHandle(runtime.GetInterconnectProxy(0, 1),
+        runtime.Send(new IEventHandle(missingActor,
                                       edge,
-                                      new TEvInterconnect::TEvConnectNode),
+                                      new TEvents::TEvPing,
+                                      IEventHandle::FlagSubscribeOnSession | IEventHandle::FlagTrackDelivery, 13),
                      0, true);
 
         TAutoPtr<IEventHandle> handle;
-        runtime.GrabEdgeEvent<TEvInterconnect::TEvNodeConnected>(handle);
-
-        runtime.Send(new IEventHandle(TActorId(runtime.GetNodeId(1), "null"),
-                                      edge,
-                                      new TEvents::TEvPing,
-                                      IEventHandle::FlagTrackDelivery, 13),
-                     0, true);
-
         const auto event = runtime.GrabEdgeEvent<TEvents::TEvUndelivered>(handle);
         UNIT_ASSERT_EQUAL(handle->Cookie, 13);
+        UNIT_ASSERT_EQUAL(handle->Sender, missingActor);
         UNIT_ASSERT_EQUAL(event->SourceType, TEvents::TEvPing::EventType);
-        UNIT_ASSERT_EQUAL(event->Reason, TEvents::TEvUndelivered::ReasonActorUnknown);
+        UNIT_ASSERT_EQUAL(event->Reason, TEvents::TEvUndelivered::Disconnected);
     }
 
     Y_UNIT_TEST(TestBlobEventUpToMebibytes) {

--- a/ydb/core/actorlib_impl/test_interconnect_ut.cpp
+++ b/ydb/core/actorlib_impl/test_interconnect_ut.cpp
@@ -507,23 +507,27 @@ Y_UNIT_TEST_SUITE(TInterconnectTest) {
 
     Y_UNIT_TEST(TestNotifyUndeliveredOnMissedActor) {
         TTestBasicRuntime runtime(2);
-        runtime.SetDispatchTimeout(TDuration::Seconds(10));
         runtime.Initialize(TAppPrepare().Unwrap());
         const auto edge = runtime.AllocateEdgeActor(0);
-        const TActorId missingActor(0xFFFFF, "null");
 
-        runtime.Send(new IEventHandle(missingActor,
+        runtime.Send(new IEventHandle(runtime.GetInterconnectProxy(0, 1),
                                       edge,
-                                      new TEvents::TEvPing,
-                                      IEventHandle::FlagSubscribeOnSession | IEventHandle::FlagTrackDelivery, 13),
+                                      new TEvInterconnect::TEvConnectNode),
                      0, true);
 
         TAutoPtr<IEventHandle> handle;
+        runtime.GrabEdgeEvent<TEvInterconnect::TEvNodeConnected>(handle);
+
+        runtime.Send(new IEventHandle(TActorId(runtime.GetNodeId(1), "null"),
+                                      edge,
+                                      new TEvents::TEvPing,
+                                      IEventHandle::FlagTrackDelivery, 13),
+                     0, true);
+
         const auto event = runtime.GrabEdgeEvent<TEvents::TEvUndelivered>(handle);
         UNIT_ASSERT_EQUAL(handle->Cookie, 13);
-        UNIT_ASSERT_EQUAL(handle->Sender, missingActor);
         UNIT_ASSERT_EQUAL(event->SourceType, TEvents::TEvPing::EventType);
-        UNIT_ASSERT_EQUAL(event->Reason, TEvents::TEvUndelivered::Disconnected);
+        UNIT_ASSERT_EQUAL(event->Reason, TEvents::TEvUndelivered::ReasonActorUnknown);
     }
 
     Y_UNIT_TEST(TestBlobEventUpToMebibytes) {

--- a/ydb/library/actors/core/actorsystem.cpp
+++ b/ydb/library/actors/core/actorsystem.cpp
@@ -339,6 +339,7 @@ namespace NActors {
                 "Event rewrite from " << ev->Recipient << " to " << recipient << " would be lost via interconnect");
             recipient = InterconnectProxy(recpNodeId);
             if (ev->Flags & IEventHandle::FlagSubscribeOnSession) {
+                const TActorId originalRecipient = ev->Recipient;
                 const TActorId sender = ev->Sender;
                 const ui64 cookie = ev->Cookie;
                 const ui32 flags = ev->Flags & ~IEventHandle::FlagSubscribeOnSession;
@@ -355,9 +356,10 @@ namespace NActors {
                 const TString stackTrace = collectTrace
                     ? ExtractCurrentStackTrace()
                     : TString();
-                auto wrapped = std::make_unique<IEventHandle>(recipient, sender,
+                auto wrapped = std::make_unique<IEventHandle>(originalRecipient, sender,
                     new TEvForwardSubscribeSession(ev.release(), activityIndex, eventTypeName, stackTrace),
                     flags, cookie, forwardOnNondelivery, std::move(traceId));
+                wrapped->Rewrite(TEvForwardSubscribeSession::EventType, recipient);
                 ev = std::move(wrapped);
             } else {
                 ev->Rewrite(TEvInterconnect::EvForward, recipient);

--- a/ydb/library/actors/core/ut/actorsystem_ut.cpp
+++ b/ydb/library/actors/core/ut/actorsystem_ut.cpp
@@ -1,7 +1,15 @@
 #include "actorsystem.h"
 
+#include "actor_bootstrapped.h"
+#include "events.h"
+#include "executor_pool_basic.h"
+#include "hfunc.h"
+#include "scheduler_basic.h"
+
 #include <ydb/library/actors/testlib/test_runtime.h>
 #include <library/cpp/testing/unittest/registar.h>
+
+#include <util/system/event.h>
 
 using namespace NActors;
 
@@ -41,5 +49,75 @@ Y_UNIT_TEST_SUITE(TActorSystemTest) {
         UNIT_ASSERT(prevActorId);
         UNIT_ASSERT_EQUAL(prevActorId, actorA);
         UNIT_ASSERT_EQUAL(runtime->GetLocalServiceId(myServiceId), actorB);
+    }
+
+    constexpr ui32 SelfNodeId = 1;
+    constexpr ui32 NodeWithoutProxy = 2;
+
+    class TUndeliveredProbe: public TActorBootstrapped<TUndeliveredProbe> {
+    public:
+        TUndeliveredProbe(const TActorId& target, ui32 flags, TActorId& undeliveredSender, TManualEvent& done)
+            : Target(target)
+            , Flags(flags)
+            , UndeliveredSender(undeliveredSender)
+            , Done(done)
+        {}
+
+        void Bootstrap() {
+            Become(&TThis::StateWork);
+            Send(Target, new TEvents::TEvPing, Flags);
+        }
+
+        STATEFN(StateWork) {
+            switch (ev->GetTypeRewrite()) {
+                hFunc(TEvents::TEvUndelivered, Handle);
+            }
+        }
+
+        void Handle(TEvents::TEvUndelivered::TPtr& ev) {
+            UndeliveredSender = ev->Sender;
+            Done.Signal();
+        }
+
+    private:
+        const TActorId Target;
+        const ui32 Flags;
+        TActorId& UndeliveredSender;
+        TManualEvent& Done;
+    };
+
+    TActorId GetUndeliveredSender(ui32 flags) {
+        auto setup = MakeHolder<TActorSystemSetup>();
+        setup->NodeId = SelfNodeId;
+        setup->ExecutorsCount = 1;
+        setup->Executors.Reset(new TAutoPtr<IExecutorPool>[setup->ExecutorsCount]);
+        setup->Executors[0] = new TBasicExecutorPool(0, 1, 10, "basic");
+        setup->Scheduler = CreateSchedulerThread(TSchedulerConfig());
+        setup->Interconnect.ProxyActors.resize(NodeWithoutProxy + 1);
+
+        TActorSystem actorSystem(setup);
+        actorSystem.Start();
+
+        TActorId undeliveredSender;
+        TManualEvent done;
+        actorSystem.Register(new TUndeliveredProbe(
+            TActorId(NodeWithoutProxy, 0, 12345, 0), flags, undeliveredSender, done));
+        UNIT_ASSERT_C(done.WaitT(TDuration::Seconds(30)), "TEvUndelivered was never received");
+
+        actorSystem.Stop();
+        return undeliveredSender;
+    }
+
+    Y_UNIT_TEST(UndeliveredKeepsRecipientNodeId) {
+        const auto sender = GetUndeliveredSender(IEventHandle::FlagTrackDelivery);
+        UNIT_ASSERT_VALUES_EQUAL_C(sender.NodeId(), NodeWithoutProxy,
+            "TEvUndelivered must be attributed to the node the event was addressed to, got sender " << sender);
+    }
+
+    Y_UNIT_TEST(UndeliveredKeepsRecipientNodeIdWhenSubscribedOnSession) {
+        const auto sender = GetUndeliveredSender(
+            IEventHandle::FlagTrackDelivery | IEventHandle::FlagSubscribeOnSession);
+        UNIT_ASSERT_VALUES_EQUAL_C(sender.NodeId(), NodeWithoutProxy,
+            "TEvUndelivered must be attributed to the node the event was addressed to, got sender " << sender);
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed TEvUndelivered sender for session-subscribed messages sent to nodes missing from NameserviceConfig.

### Description for reviewers <!-- (optional) description for those who read this PR -->

The subscription wrapper now preserves the original recipient and uses event rewrite only for routing to the interconnect proxy. This keeps the target node ID in TEvUndelivered::Sender, allowing bootstrapper to make progress after delivery failures.
