### PR TITLE
Fixed flaky tests

### DIFF
--- a/ydb/services/persqueue_v1/ut/persqueue_v1_gaps_ut.cpp
+++ b/ydb/services/persqueue_v1/ut/persqueue_v1_gaps_ut.cpp
@@ -469,11 +469,12 @@ Y_UNIT_TEST(StreamWriteRejectsEmptyAndMissingDatabase) {
     server.AnnoyingClient->GrantConnect("root@builtin");
     auto stub = MakeTopicStub(server);
 
-    Sleep(TDuration::Seconds(1));
-
     for (const auto& database : {TMaybe<TString>(TString()), TMaybe<TString>()}) {
+        // Rejection happens on stream accept (before any client message) via WriteAndFinish(BAD_REQUEST).
+        // Do not Write first: that races with server finish and can return false flakily.
         auto session = TStreamWriteSession::Open(*stub, database, /*withAuthTicket=*/true);
-        auto resp = InitStreamWrite(*session->Stream, TString(DefaultTopicShortName), "producer-empty-db");
+        Ydb::Topic::StreamWriteMessage::FromServer resp;
+        UNIT_ASSERT_C(session->Stream->Read(&resp), "expected BAD_REQUEST on accept");
         UNIT_ASSERT_VALUES_EQUAL_C(resp.status(), Ydb::StatusIds::BAD_REQUEST, resp);
     }
 }
@@ -484,13 +485,10 @@ Y_UNIT_TEST(StreamReadRejectsEmptyAndMissingDatabase) {
     auto stub = MakeTopicStub(server);
 
     for (const auto& database : {TMaybe<TString>(TString()), TMaybe<TString>()}) {
+        // Same as StreamWrite: empty/missing database is rejected on accept.
         auto session = TStreamReadSession::Open(*stub, database, /*withAuthTicket=*/true);
-        auto resp = InitStreamRead(
-            *session->Stream,
-            TString(DefaultTopicShortName),
-            TString(DefaultConsumer),
-            /*autoPartitioningSupport=*/false,
-            /*partitionIds=*/{0});
+        Ydb::Topic::StreamReadMessage::FromServer resp;
+        UNIT_ASSERT_C(session->Stream->Read(&resp), "expected BAD_REQUEST on accept");
         UNIT_ASSERT_VALUES_EQUAL_C(resp.status(), Ydb::StatusIds::BAD_REQUEST, resp);
     }
 }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

...

### Changelog category <!-- remove all except one -->

* Not for changelog (changelog entry is not required)

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes flaky `PersQueueV1Gaps_EmptyDatabase.StreamWriteRejectsEmptyAndMissingDatabase` (#48803) and `StreamReadRejectsEmptyAndMissingDatabase` (#48921).

Empty/missing database is rejected in `TGRpcRequestProxyImpl::PreHandle` right after stream accept via `WriteAndFinish(BAD_REQUEST)`, before any client message. The old tests called `Write(init)` first, which raced with server finish: `stream.Write()` could return `false` and trip `UNIT_ASSERT` instead of reading `BAD_REQUEST`. `Sleep(1s)` did not remove that race.

Both tests now only `Read` the reject status on the stream (no client Write, no sleep).