### PR TITLE
Fix VERIFY on double consumer Remove during topic partition config upgrade

### DIFF
--- a/ydb/core/persqueue/pqtablet/partition/partition.cpp
+++ b/ydb/core/persqueue/pqtablet/partition/partition.cpp
@@ -4065,12 +4065,14 @@ void TPartition::OnProcessTxsAndUserActsWriteComplete(const TActorContext& ctx) 
                 SendReadingFinished(user);
             }
         } else if (user != CLIENTID_WITHOUT_CONSUMER) {
-            auto ui = UsersInfoStorage->GetIfExists(user);
-            if (ui && ui->LabeledCounters) {
-                ScheduleDropPartitionLabeledCounters(ui->LabeledCounters->GetGroup());
+            // Consumer may already have been removed by an earlier write cycle
+            // (e.g. ChangePartitionConfig drop + FillReadFromTimestamps ESCI_DROP_READ_RULE).
+            if (auto* ui = UsersInfoStorage->GetIfExists(user)) {
+                if (ui->LabeledCounters) {
+                    ScheduleDropPartitionLabeledCounters(ui->LabeledCounters->GetGroup());
+                }
+                UsersInfoStorage->Remove(user, ctx);
             }
-
-            UsersInfoStorage->Remove(user, ctx);
 
             // Finish all ongoing reads
             std::unordered_set<ui64> readCookies;

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -55,6 +55,8 @@ struct TCreatePartitionParams {
     TMaybe<ui64> PlanStep;
     TMaybe<ui64> TxId;
     TConfigParams Config;
+    // Consumers present in KV user-info but not necessarily in Config (stale leftovers).
+    TVector<TCreateConsumerParams> ExtraDiskConsumers;
     TInstant EndWriteTimestamp;
     bool FillHead = false;
 };
@@ -504,7 +506,13 @@ TPartition* TPartitionFixture::CreatePartition(const TCreatePartitionParams& par
         SendMetaReadResponse(params.Begin, params.End, params.PlanStep, params.TxId, params.EndWriteTimestamp);
 
         WaitInfoRangeRequest();
-        SendInfoRangeResponse(params.Partition.InternalPartitionId, params.Config.Consumers);
+        {
+            auto infoConsumers = params.Config.Consumers;
+            infoConsumers.insert(infoConsumers.end(),
+                                 params.ExtraDiskConsumers.begin(),
+                                 params.ExtraDiskConsumers.end());
+            SendInfoRangeResponse(params.Partition.InternalPartitionId, infoConsumers);
+        }
 
         WaitDataRangeRequest();
         SendDataRangeResponse(params.Partition.InternalPartitionId, params.Begin, params.End, params.FillHead);
@@ -639,6 +647,9 @@ void TPartitionFixture::WaitCmdWrite(const TCmdWriteMatcher& matcher)
         case TKeyPrefix::TypeInfo: {
             UNIT_ASSERT(key.size() >= (1 + 10 + 1)); // type + partition + mark
             if (key[11] != TKeyPrefix::MarkUser) {
+                break;
+            }
+            if (matcher.UserInfos.empty()) {
                 break;
             }
 
@@ -2868,6 +2879,95 @@ Y_UNIT_TEST_F(TabletConfig_Is_Newer_That_PartitionConfig, TPartitionFixture)
                  {0, {.Partition=3, .Consumer="client-1"}}
                  }});
     SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+}
+
+//
+// #49435: on init, persisted Config is older than TabletConfig → ChangePartitionConfig is
+// PushFront'ed. FillReadFromTimestamps still compares UsersInfo against the *old* Config and
+// queues ESCI_DROP_READ_RULE for stale KV consumers. ChangingConfig blocks those acts until
+// the config write completes; the second write cycle then Remove()'s an already-deleted user.
+// Covers hypotheses: (1) double DROP on init+config upgrade, (2) non-idempotent Remove,
+// (3) FillReadFromTimestamps unaware of pending ChangePartitionConfig.
+//
+Y_UNIT_TEST_F(Init_StaleDiskConsumer_DoubleDrop_OnConfigUpgrade, TPartitionFixture)
+{
+    const TPartitionId partition{3};
+
+    CreatePartition({
+        .Partition = partition,
+        .Begin = 0,
+        .End = 10,
+        .Config = {
+            .Version = 1,
+            .Consumers = {{.Consumer = "client-keep", .Offset = 3}},
+        },
+        // Stale consumer still on disk, already absent from persisted Config.
+        .ExtraDiskConsumers = {{.Consumer = "stale-client", .Offset = 5}},
+    },
+    {
+        .Version = 2,
+        .Consumers = {{.Consumer = "client-keep"}},
+    });
+
+    // Write cycle 1: ChangePartitionConfig drops stale-client.
+    WaitCmdWrite({
+        .UserInfos = {{0, {.Consumer = "client-keep", .Session = "", .Offset = 3}}},
+        .DeleteRanges = {{0, {.Partition = 3, .Consumer = "stale-client"}}},
+    });
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+
+    // Write cycle 2: FillReadFromTimestamps ESCI_DROP_READ_RULE for the same consumer.
+    // Must not VERIFY on the second Remove (#49435).
+    WaitCmdWrite({
+        .DeleteRanges = {{0, {.Partition = 3, .Consumer = "stale-client"}}},
+    });
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+    Ctx->Runtime->SimulateSleep(TDuration::Seconds(1));
+}
+
+//
+// #49435 hypothesis (2): Remove is not idempotent across write cycles.
+// ChangePartitionConfig drops the consumer; a later ESCI_DROP_READ_RULE tries again.
+//
+Y_UNIT_TEST_F(DropReadRule_AfterConfigAlreadyRemovedConsumer, TPartitionFixture)
+{
+    const TPartitionId partition{3};
+
+    CreatePartition({
+        .Partition = partition,
+        .Begin = 0,
+        .End = 10,
+        .Config = {
+            .Version = 1,
+            .Consumers = {
+                {.Consumer = "client-1", .Offset = 0, .Session = "session-1"},
+                {.Consumer = "client-2", .Offset = 0, .Session = "session-2"},
+            },
+        },
+    });
+
+    SendChangePartitionConfig({
+        .Version = 2,
+        .Consumers = {{.Consumer = "client-1", .Generation = 0}},
+    });
+
+    WaitCmdWrite({
+        .UserInfos = {{0, {.Consumer = "client-1", .Session = "session-1", .Offset = 0}}},
+        .DeleteRanges = {{0, {.Partition = 3, .Consumer = "client-2"}}},
+    });
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+    WaitPartitionConfigChanged({.Partition = partition});
+
+    SendEvent(new TEvPQ::TEvSetClientInfo(
+        0, "client-2", 0, "", 0, 0, 0, TActorId{},
+        TEvPQ::TEvSetClientInfo::ESCI_DROP_READ_RULE, 0));
+
+    WaitCmdWrite({
+        .DeleteRanges = {{0, {.Partition = 3, .Consumer = "client-2"}}},
+    });
+    SendCmdWriteResponse(NMsgBusProxy::MSTATUS_OK);
+    // Must not VERIFY on Remove of an already-deleted consumer (#49435).
+    Ctx->Runtime->SimulateSleep(TDuration::Seconds(1));
 }
 
 void TPartitionFixture::CmdChangeOwner(ui64 cookie, const TString& sourceId, TDuration duration, TString& ownerCookie)

--- a/ydb/core/persqueue/ut/partition_ut.cpp
+++ b/ydb/core/persqueue/ut/partition_ut.cpp
@@ -655,40 +655,46 @@ void TPartitionFixture::WaitCmdWrite(const TCmdWriteMatcher& matcher)
 
             NKikimrPQ::TUserInfo ud;
             UNIT_ASSERT(ud.ParseFromString(event->Record.GetCmdWrite(i).GetValue()));
+            UNIT_ASSERT(key.size() > (1 + 10 + 1)); // type + partition + mark + consumer
+            const TString consumerFromKey = key.substr(12);
 
             bool match = false;
             for (auto& [_, userInfo] : matcher.UserInfos) {
-                if (userInfo.Session && ud.HasSession()) {
-                    if (*userInfo.Session != ud.GetSession()) {
+                if (!userInfo.Consumer && !userInfo.Session) {
+                    continue;
+                }
+                if (userInfo.Consumer && *userInfo.Consumer != consumerFromKey) {
+                    continue;
+                }
+                if (userInfo.Session) {
+                    if (!ud.HasSession() || *userInfo.Session != ud.GetSession()) {
                         continue;
                     }
-
-                    match = true;
-
-                    if (userInfo.Generation) {
-                        UNIT_ASSERT(ud.HasGeneration());
-                        UNIT_ASSERT_VALUES_EQUAL(*userInfo.Generation, ud.GetGeneration());
-                    }
-                    if (userInfo.Step) {
-                        UNIT_ASSERT(ud.HasStep());
-                        UNIT_ASSERT_VALUES_EQUAL(*userInfo.Step, ud.GetStep());
-                    }
-                    if (userInfo.Offset) {
-                        UNIT_ASSERT(ud.HasOffset());
-                        UNIT_ASSERT_VALUES_EQUAL(*userInfo.Offset, ud.GetOffset());
-                    }
-                    if (userInfo.ReadRuleGeneration) {
-                        UNIT_ASSERT(ud.HasReadRuleGeneration());
-                        UNIT_ASSERT_VALUES_EQUAL(*userInfo.ReadRuleGeneration, ud.GetReadRuleGeneration());
-                    }
                 }
 
-                if (match) {
-                    break;
+                match = true;
+
+                if (userInfo.Generation) {
+                    UNIT_ASSERT(ud.HasGeneration());
+                    UNIT_ASSERT_VALUES_EQUAL(*userInfo.Generation, ud.GetGeneration());
                 }
+                if (userInfo.Step) {
+                    UNIT_ASSERT(ud.HasStep());
+                    UNIT_ASSERT_VALUES_EQUAL(*userInfo.Step, ud.GetStep());
+                }
+                if (userInfo.Offset) {
+                    UNIT_ASSERT(ud.HasOffset());
+                    UNIT_ASSERT_VALUES_EQUAL(*userInfo.Offset, ud.GetOffset());
+                }
+                if (userInfo.ReadRuleGeneration) {
+                    UNIT_ASSERT(ud.HasReadRuleGeneration());
+                    UNIT_ASSERT_VALUES_EQUAL(*userInfo.ReadRuleGeneration, ud.GetReadRuleGeneration());
+                }
+
+                break;
             }
 
-            UNIT_ASSERT(match);
+            UNIT_ASSERT_C(match, "No UserInfos matcher for consumer '" << consumerFromKey << "'");
 
             break;
         }


### PR DESCRIPTION
### Changelog entry <!-- a user-readable short description of the changes that goes to CHANGELOG.md and Release Notes -->

Fixed a crash of a topic partition tablet when applying a newer config on restart if a stale consumer was still present in KV storage.

### Description for reviewers <!-- (optional) description for those who read this PR -->

Fixes https://github.com/ydb-platform/ydb/issues/49435

On partition init, when persisted `Config` is older than `TabletConfig`, `ChangePartitionConfig` is queued at the front and drops consumers missing from the new config. Independently, `FillReadFromTimestamps` still compares `UsersInfo` against the old config and queues `ESCI_DROP_READ_RULE` for the same stale consumers. After the config write cycle removes the consumer, the second write cycle called `UsersInfoStorage->Remove` again and hit `AFL_ENSURE(it != UsersInfo.end())`.

**Fix:** in `OnProcessTxsAndUserActsWriteComplete`, call `Remove` only if the consumer still exists in `UsersInfo`. Other cleanup (finishing reads, notifying quota/batch actors) still runs.

**Tests:**
- `Init_StaleDiskConsumer_DoubleDrop_OnConfigUpgrade` — init + config upgrade with a stale disk consumer
- `DropReadRule_AfterConfigAlreadyRemovedConsumer` — `ESCI_DROP_READ_RULE` after config already removed the consumer