### PR TITLE
Add observe mode for checking database in HTTP requests

### DIFF
--- a/ydb/core/grpc_services/base/base.h
+++ b/ydb/core/grpc_services/base/base.h
@@ -23,6 +23,7 @@
 
 #include <ydb/core/jaeger_tracing/request_discriminator.h>
 #include <ydb/core/grpc_services/counters/proxy_counters.h>
+#include <ydb/core/grpc_services/base/http_database_access_verdict.h>
 #include <ydb/core/grpc_streaming/grpc_streaming.h>
 #include <ydb/core/base/events.h>
 #include <ydb/core/protos/config.pb.h>
@@ -1886,11 +1887,18 @@ public:
         Issues.AddIssue(error);
     }
 
-    TEvRequestAuthAndCheckResult(const TString& database, const TMaybe<TString>& ydbToken, const TIntrusiveConstPtr<NACLib::TUserToken>& userToken, const TAuditLogParts& auditLogParts)
+    TEvRequestAuthAndCheckResult(
+        const TString& database,
+        const TMaybe<TString>& ydbToken,
+        const TIntrusiveConstPtr<NACLib::TUserToken>& userToken,
+        const TAuditLogParts& auditLogParts,
+        const EHttpDatabaseAccessVerdict databaseAccessVerdict
+    )
         : Database(database)
         , YdbToken(ydbToken)
         , UserToken(userToken)
         , AuditLogParts(auditLogParts)
+        , DatabaseAccessVerdict(databaseAccessVerdict)
     {}
 
     Ydb::StatusIds::StatusCode Status = Ydb::StatusIds::SUCCESS;
@@ -1899,6 +1907,7 @@ public:
     TMaybe<TString> YdbToken;
     TIntrusiveConstPtr<NACLib::TUserToken> UserToken;
     TAuditLogParts AuditLogParts;
+    EHttpDatabaseAccessVerdict DatabaseAccessVerdict = EHttpDatabaseAccessVerdict::Ok;
 };
 
 class TEvRequestAuthAndCheck
@@ -1947,7 +1956,8 @@ public:
                     Database,
                     YdbToken,
                     UserToken,
-                    GetAuditLogParts()
+                    GetAuditLogParts(),
+                    DatabaseAccessVerdict
                 )
             );
         } else {
@@ -2118,6 +2128,7 @@ public:
     TInstant deadline = TInstant::Now() + TDuration::Seconds(10);
     TAuditMode AuditMode;
     TString PeerName;
+    EHttpDatabaseAccessVerdict DatabaseAccessVerdict = EHttpDatabaseAccessVerdict::Ok;
 
     inline static const TString EmptySerializedTokenMessage;
 };

--- a/ydb/core/grpc_services/base/http_database_access_verdict.h
+++ b/ydb/core/grpc_services/base/http_database_access_verdict.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace NKikimr::NGRpcService {
+
+enum class EHttpDatabaseAccessVerdict {
+    Ok /* "ok" */,
+    EmptyDatabase /* "empty_database" */,
+    NotADatabase /* "not_a_database" */,
+    NoConnectRight /* "no_connect_right" */,
+    NoSecurityObject /* "no_security_object" */,
+};
+
+} // namespace NKikimr::NGRpcService

--- a/ydb/core/grpc_services/base/ya.make
+++ b/ydb/core/grpc_services/base/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     base_service.h
     base.h
+    http_database_access_verdict.h
 )
 
 PEERDIR(
@@ -18,5 +19,7 @@ PEERDIR(
 )
 
 YQL_LAST_ABI_VERSION()
+
+GENERATE_ENUM_SERIALIZATION(http_database_access_verdict.h)
 
 END()

--- a/ydb/core/grpc_services/counters/proxy_counters.cpp
+++ b/ydb/core/grpc_services/counters/proxy_counters.cpp
@@ -15,6 +15,8 @@ protected:
     ::NMonitoring::TDynamicCounterPtr Root_;
 
     ::NMonitoring::TDynamicCounters::TCounterPtr DatabaseAccessDenyCounter_;
+    // HTTP monitoring observe-mode: would-deny for strict database tokens (request is not blocked).
+    ::NMonitoring::TDynamicCounters::TCounterPtr DatabaseHttpAccessDenyCounter_;
     ::NMonitoring::TDynamicCounters::TCounterPtr DatabaseSchemeErrorCounter_;
     ::NMonitoring::TDynamicCounters::TCounterPtr DatabaseUnavailableCounter_;
     ::NMonitoring::TDynamicCounters::TCounterPtr EmptyDatabaseNameCounter_;
@@ -36,6 +38,7 @@ public:
         }
 
         DatabaseAccessDenyCounter_ = group->GetCounter("databaseAccessDeny", true);
+        DatabaseHttpAccessDenyCounter_ = group->GetCounter("databaseHttpAccessDeny", true);
         DatabaseSchemeErrorCounter_ = group->GetCounter("databaseSchemeError", true);
         DatabaseUnavailableCounter_ = group->GetCounter("databaseUnavailable", true);
 
@@ -64,6 +67,10 @@ public:
 
     void IncEmptyDatabaseNameCounter() override {
         EmptyDatabaseNameCounter_->Inc();
+    }
+
+    void IncDatabaseHttpAccessDenyCounter() override {
+        DatabaseHttpAccessDenyCounter_->Inc();
     }
 
     void IncDatabaseRateLimitedCounter() override {
@@ -283,6 +290,10 @@ public:
 
     void IncEmptyDatabaseNameCounter() override {
         Common->IncEmptyDatabaseNameCounter();
+    }
+
+    void IncDatabaseHttpAccessDenyCounter() override {
+        Common->IncDatabaseHttpAccessDenyCounter();
     }
 
     void IncDatabaseRateLimitedCounter() override {

--- a/ydb/core/grpc_services/counters/proxy_counters.h
+++ b/ydb/core/grpc_services/counters/proxy_counters.h
@@ -15,6 +15,7 @@ public:
     virtual void IncDatabaseSchemeErrorCounter() = 0;
     virtual void IncDatabaseUnavailableCounter() = 0;
     virtual void IncEmptyDatabaseNameCounter() = 0;
+    virtual void IncDatabaseHttpAccessDenyCounter() = 0;
     virtual void IncDatabaseRateLimitedCounter() = 0;
 
     virtual void AddConsumedRequestUnits(ui64 requestUnits) = 0;

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -11,16 +11,21 @@
 #include <ydb/library/actors/core/actor_bootstrapped.h>
 
 #include <ydb/core/audit/audit_config/audit_config.h>
+#include <ydb/core/base/auth.h>
 #include <ydb/core/base/path.h>
 #include <ydb/core/base/feature_flags.h>
 #include <ydb/core/base/subdomain.h>
+#include <ydb/core/grpc_services/base/http_database_access_verdict.h>
 #include <ydb/library/ydb_issue/issue_helpers.h>
 #include <ydb/core/grpc_services/counters/proxy_counters.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/core/security/secure_request.h>
 #include <ydb/core/tx/scheme_board/events.h>
 #include <ydb/core/tx/scheme_cache/scheme_cache.h>
 #include <ydb/library/wilson_ids/wilson.h>
 #include <ydb/library/cloud_permissions/cloud_permissions.h>
+
+#include <util/generic/serialized_enum.h>
 
 #include <util/string/split.h>
 
@@ -213,6 +218,7 @@ public:
         , SkipCheckConnectRights_(skipCheckConnectRights)
         , FacilityProvider_(facilityProvider)
         , CloudPermissionsSettings(cloudPermissionsSettings)
+        , RequestSchemeData_(schemeData)
     {
         TMaybe<TString> authToken = GrpcRequestBaseCtx_->GetYdbToken();
         if (authToken) {
@@ -244,6 +250,20 @@ public:
         }
 
         GrpcRequestBaseCtx_->SetCounters(Counters_);
+
+        if constexpr (IsHttpRequest) {
+            if (IsStrictDatabaseOnlyToken(AppData(), TBase::GetSerializedToken())) {
+                HttpDatabaseAccessVerdict_ = EvaluateHttpDatabaseAccessVerdict();
+                if (HttpDatabaseAccessVerdict_ != EHttpDatabaseAccessVerdict::Ok) {
+                    LOG_INFO_S(TlsActivationContext->AsActorContext(), NKikimrServices::GRPC_PROXY_NO_CONNECT_ACCESS,
+                        "HTTP monitoring database access would deny"
+                        << ", database: " << CheckedDatabaseName_
+                        << ", verdict: " << ToString(HttpDatabaseAccessVerdict_)
+                        << ", user: " << TBase::GetUserSID()
+                        << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
+                }
+            }
+        }
 
         if (!CheckedDatabaseName_.empty()) {
             GrpcRequestBaseCtx_->UseDatabase(CheckedDatabaseName_);
@@ -654,6 +674,8 @@ private:
         // way as for grpc API
         AuditRequest(GrpcRequestBaseCtx_, CheckedDatabaseName_);
 
+        ev->Get()->UseDatabase(CheckedDatabaseName_);
+        ev->Get()->DatabaseAccessVerdict = HttpDatabaseAccessVerdict_;
         ev->Get()->ReplyWithYdbStatus(Ydb::StatusIds::SUCCESS);
         PassAway();
     }
@@ -682,7 +704,6 @@ private:
                         << ", from ip: " << GrpcRequestBaseCtx_->GetPeerName());
             return {false, std::nullopt};
         }
-
 
         // An empty token at this point means that anonymous access is allowed by the system configuration,
         // as the EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement flags have already been
@@ -743,6 +764,51 @@ private:
         return {true, MakeIssue(NKikimrIssues::TIssuesIds::ACCESS_DENIED, error)};;
     }
 
+    EHttpDatabaseAccessVerdict EvaluateHttpDatabaseAccessVerdict() const {
+        const auto rawDatabaseName = GrpcRequestBaseCtx_->GetDatabaseName();
+        if (!rawDatabaseName || rawDatabaseName->empty()) {
+            return EHttpDatabaseAccessVerdict::EmptyDatabase;
+        }
+
+        const auto& domainDescription = RequestSchemeData_.GetPathDescription().GetDomainDescription();
+        const auto domainKey = TPathId::FromDomainKey(domainDescription.GetDomainKey());
+        const auto schemePathType = RequestSchemeData_.GetPathDescription().GetSelf().GetPathType();
+        const auto& self = RequestSchemeData_.GetPathDescription().GetSelf();
+        const auto selfPathId = TPathId(self.GetSchemeshardId(), self.GetPathId());
+        const bool isDatabaseRootPath = domainKey == selfPathId;
+        const bool isDatabasePathType =
+            schemePathType == NKikimrSchemeOp::EPathTypeSubDomain ||
+            schemePathType == NKikimrSchemeOp::EPathTypeExtSubDomain;
+        if (!isDatabasePathType || !isDatabaseRootPath) {
+            return EHttpDatabaseAccessVerdict::NotADatabase;
+        }
+
+        if (!SecurityObject_) {
+            return EHttpDatabaseAccessVerdict::NoSecurityObject;
+        }
+
+        const auto& parsedToken = TBase::GetParsedToken();
+        if (!parsedToken) {
+            // An empty token at this point means that anonymous access is allowed by the system configuration,
+            // as the EnforceUserTokenRequirement and EnforceUserTokenCheckRequirement flags have already been
+            // validated earlier in the request processing pipeline.
+            return EHttpDatabaseAccessVerdict::Ok;
+        }
+
+        const auto& databaseOwner = SecurityObject_->GetOwnerSID();
+        const bool isAdmin = TBase::IsUserAdmin() || IsDatabaseAdministrator(parsedToken.Get(), databaseOwner);
+        if (isAdmin) {
+            return EHttpDatabaseAccessVerdict::Ok;
+        }
+
+        const ui32 access = NACLib::ConnectDatabase;
+        if (SecurityObject_->CheckAccess(access, *parsedToken)) {
+            return EHttpDatabaseAccessVerdict::Ok;
+        }
+
+        return EHttpDatabaseAccessVerdict::NoConnectRight;
+    }
+
     const TActorId Owner_;
     TAutoPtr<TEventHandle<TEvent>> Request_;
     IGRpcProxyCounters::TPtr Counters_;
@@ -759,6 +825,8 @@ private:
     std::unordered_set<TString> DmlAuditExpectedSubjects_;
     NWilson::TSpan Span_;
     TCloudPermissionsSettings CloudPermissionsSettings;
+    EHttpDatabaseAccessVerdict HttpDatabaseAccessVerdict_ = EHttpDatabaseAccessVerdict::Ok;
+    TSchemeBoardEvents::TDescribeSchemeResult RequestSchemeData_;
 };
 
 // default behavior - attributes in schema

--- a/ydb/core/grpc_services/grpc_request_check_actor.h
+++ b/ydb/core/grpc_services/grpc_request_check_actor.h
@@ -218,8 +218,10 @@ public:
         , SkipCheckConnectRights_(skipCheckConnectRights)
         , FacilityProvider_(facilityProvider)
         , CloudPermissionsSettings(cloudPermissionsSettings)
-        , RequestSchemeData_(schemeData)
     {
+        if constexpr (IsHttpRequest) {
+            RequestSchemeData_ = schemeData;
+        }
         TMaybe<TString> authToken = GrpcRequestBaseCtx_->GetYdbToken();
         if (authToken) {
             TBase::SetSecurityToken(authToken.GetRef());
@@ -765,15 +767,16 @@ private:
     }
 
     EHttpDatabaseAccessVerdict EvaluateHttpDatabaseAccessVerdict() const {
+        Y_DEBUG_ABORT_UNLESS(RequestSchemeData_.Defined());
         const auto rawDatabaseName = GrpcRequestBaseCtx_->GetDatabaseName();
         if (!rawDatabaseName || rawDatabaseName->empty()) {
             return EHttpDatabaseAccessVerdict::EmptyDatabase;
         }
 
-        const auto& domainDescription = RequestSchemeData_.GetPathDescription().GetDomainDescription();
+        const auto& domainDescription = RequestSchemeData_->GetPathDescription().GetDomainDescription();
         const auto domainKey = TPathId::FromDomainKey(domainDescription.GetDomainKey());
-        const auto schemePathType = RequestSchemeData_.GetPathDescription().GetSelf().GetPathType();
-        const auto& self = RequestSchemeData_.GetPathDescription().GetSelf();
+        const auto schemePathType = RequestSchemeData_->GetPathDescription().GetSelf().GetPathType();
+        const auto& self = RequestSchemeData_->GetPathDescription().GetSelf();
         const auto selfPathId = TPathId(self.GetSchemeshardId(), self.GetPathId());
         const bool isDatabaseRootPath = domainKey == selfPathId;
         const bool isDatabasePathType =
@@ -826,7 +829,7 @@ private:
     NWilson::TSpan Span_;
     TCloudPermissionsSettings CloudPermissionsSettings;
     EHttpDatabaseAccessVerdict HttpDatabaseAccessVerdict_ = EHttpDatabaseAccessVerdict::Ok;
-    TSchemeBoardEvents::TDescribeSchemeResult RequestSchemeData_;
+    TMaybe<TSchemeBoardEvents::TDescribeSchemeResult> RequestSchemeData_;
 };
 
 // default behavior - attributes in schema

--- a/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
+++ b/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
@@ -413,7 +413,12 @@ TIntrusivePtr<TSecurityObject> MakeSecurityObjectWithoutConnect() {
     return MakeIntrusive<TSecurityObject>(object.GetOwnerSID(), object.GetACL().SerializeAsString(), false);
 }
 
-NGRpcService::TEvRequestAuthAndCheckResult* RunHttpAuthCheck(
+struct THttpAuthCheckResponse {
+    TAutoPtr<IEventHandle> Handle;
+    const NGRpcService::TEvRequestAuthAndCheckResult* Result = nullptr;
+};
+
+THttpAuthCheckResponse RunHttpAuthCheck(
     TTestSetup& setup,
     const TString& requestDatabase,
     TSchemeBoardEvents::TDescribeSchemeResult& describeSchemeResult,
@@ -455,10 +460,10 @@ NGRpcService::TEvRequestAuthAndCheckResult* RunHttpAuthCheck(
             .AccessServiceType = runtime->GetAppData().AuthConfig.GetAccessServiceType(),
         }));
 
-    TAutoPtr<IEventHandle> handle;
-    auto* result = runtime->GrabEdgeEvent<NGRpcService::TEvRequestAuthAndCheckResult>(handle);
-    UNIT_ASSERT_C(result, "Expected TEvRequestAuthAndCheckResult");
-    return result;
+    THttpAuthCheckResponse response;
+    response.Result = runtime->GrabEdgeEvent<NGRpcService::TEvRequestAuthAndCheckResult>(response.Handle);
+    UNIT_ASSERT_C(response.Result, "Expected TEvRequestAuthAndCheckResult");
+    return response;
 }
 
 } // namespace
@@ -470,11 +475,11 @@ Y_UNIT_TEST(DedicatedOwnDbOk) {
     ConfigureSecurityConfig(setup.GetRuntime());
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
-    auto* result = RunHttpAuthCheck(
+    const auto response = RunHttpAuthCheck(
         setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
-    UNIT_ASSERT_EQUAL(result->Database, "/Root/db");
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+    UNIT_ASSERT_EQUAL(response.Result->Database, "/Root/db");
 }
 
 Y_UNIT_TEST(DedicatedNoConnectRightButSuccess) {
@@ -482,9 +487,9 @@ Y_UNIT_TEST(DedicatedNoConnectRightButSuccess) {
     ConfigureSecurityConfig(setup.GetRuntime());
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
-    auto* result = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithoutConnect());
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
+    const auto response = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithoutConnect());
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
 }
 
 Y_UNIT_TEST(ServerlessOwnDbOk) {
@@ -493,10 +498,10 @@ Y_UNIT_TEST(ServerlessOwnDbOk) {
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root/serverless", 2);
     describeSchemeResult.MutablePathDescription()->MutableSelf()->SetPathType(NKikimrSchemeOp::EPathTypeExtSubDomain);
-    auto* result = RunHttpAuthCheck(
+    const auto response = RunHttpAuthCheck(
         setup, "/Root/serverless", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
 }
 
 Y_UNIT_TEST(ServerlessForeignNoConnectRight) {
@@ -505,9 +510,9 @@ Y_UNIT_TEST(ServerlessForeignNoConnectRight) {
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root/foreign", 3);
     describeSchemeResult.MutablePathDescription()->MutableSelf()->SetPathType(NKikimrSchemeOp::EPathTypeExtSubDomain);
-    auto* result = RunHttpAuthCheck(setup, "/Root/foreign", describeSchemeResult, MakeSecurityObjectWithoutConnect());
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
+    const auto response = RunHttpAuthCheck(setup, "/Root/foreign", describeSchemeResult, MakeSecurityObjectWithoutConnect());
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
 }
 
 Y_UNIT_TEST(TopicPathNotADatabaseDespiteConnectRight) {
@@ -515,10 +520,10 @@ Y_UNIT_TEST(TopicPathNotADatabaseDespiteConnectRight) {
     ConfigureSecurityConfig(setup.GetRuntime());
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupTopicInDedicatedSubDomain(describeSchemeResult, "/Root/db", "mytopic");
-    auto* result = RunHttpAuthCheck(
+    const auto response = RunHttpAuthCheck(
         setup, "/Root/db/mytopic", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NotADatabase);
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NotADatabase);
 }
 
 Y_UNIT_TEST(EmptyDatabase) {
@@ -526,10 +531,10 @@ Y_UNIT_TEST(EmptyDatabase) {
     ConfigureSecurityConfig(setup.GetRuntime());
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
-    auto* result = RunHttpAuthCheck(
+    const auto response = RunHttpAuthCheck(
         setup, "", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::EmptyDatabase);
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::EmptyDatabase);
 }
 
 Y_UNIT_TEST(RootDatabase) {
@@ -537,10 +542,10 @@ Y_UNIT_TEST(RootDatabase) {
     ConfigureSecurityConfig(setup.GetRuntime());
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root", 1);
-    auto* result = RunHttpAuthCheck(
+    const auto response = RunHttpAuthCheck(
         setup, "/Root", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
 }
 
 Y_UNIT_TEST(ViewerTokenSkipsVerdict) {
@@ -548,9 +553,9 @@ Y_UNIT_TEST(ViewerTokenSkipsVerdict) {
     ConfigureSecurityConfig(setup.GetRuntime());
     TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
     SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
-    auto* result = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithoutConnect());
-    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
-    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+    const auto response = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithoutConnect());
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
 }
 
 } // HttpDatabaseAccessObserveMode

--- a/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
+++ b/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
@@ -492,6 +492,16 @@ Y_UNIT_TEST(DedicatedNoConnectRightButSuccess) {
     UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
 }
 
+Y_UNIT_TEST(NoSecurityObject) {
+    TTestSetup setup("database-only", "/Root/db", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
+    const auto response = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, nullptr);
+    UNIT_ASSERT_EQUAL(response.Result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(response.Result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoSecurityObject);
+}
+
 Y_UNIT_TEST(ServerlessOwnDbOk) {
     TTestSetup setup("database-only", "/Root/serverless", {});
     ConfigureSecurityConfig(setup.GetRuntime());

--- a/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
+++ b/ydb/core/grpc_services/grpc_request_check_actor_ut/grpc_request_check_actor_ut.cpp
@@ -1,9 +1,12 @@
 #include <ydb/core/testlib/test_client.h>
+#include <ydb/core/base/auth.h>
 #include <ydb/core/grpc_services/base/base.h>
 #include <ydb/core/grpc_services/grpc_request_check_actor.h>
+#include <ydb/core/grpc_services/base/http_database_access_verdict.h>
 #include <ydb/core/grpc_services/counters/proxy_counters.h>
 #include <ydb/core/tx/scheme_board/events.h>
 #include <ydb/core/scheme/scheme_tabledefs.h>
+#include <ydb/core/protos/flat_scheme_op.pb.h>
 #include <ydb/library/testlib/service_mocks/access_service_mock.h>
 #include <ydb/library/cloud_permissions/cloud_permissions.h>
 #include <library/cpp/testing/unittest/registar.h>
@@ -336,3 +339,219 @@ Y_UNIT_TEST(CanSetPermissionsForDbWithoutCloudUserAttributes) {
 }
 
 } // CheckCloudPermissions
+
+namespace {
+
+constexpr TStringBuf DatabaseOnlySid = "database-only@as";
+constexpr TStringBuf ViewerOnlySid = "viewer-only@as";
+constexpr TStringBuf MonitoringOnlySid = "monitoring-only@as";
+constexpr TStringBuf AdminOnlySid = "admin-only@as";
+
+void ConfigureSecurityConfig(TTestActorRuntime* runtime) {
+    auto& securityConfig = *runtime->GetAppData().DomainsConfig.MutableSecurityConfig();
+    securityConfig.AddDatabaseAllowedSIDs(TString{DatabaseOnlySid});
+    securityConfig.AddViewerAllowedSIDs(TString{ViewerOnlySid});
+    securityConfig.AddMonitoringAllowedSIDs(TString{MonitoringOnlySid});
+    securityConfig.AddAdministrationAllowedSIDs(TString{AdminOnlySid});
+    runtime->GetAppData().AdministrationAllowedSIDs = {TString{AdminOnlySid}};
+}
+
+void SetupDedicatedSubDomain(
+    TSchemeBoardEvents::TDescribeSchemeResult& describeSchemeResult,
+    const TString& path,
+    const ui64 pathId = 100,
+    const ui64 schemeShard = 1)
+{
+    describeSchemeResult.SetPath(CanonizePath(path));
+    auto* pathDescription = describeSchemeResult.MutablePathDescription();
+    auto* self = pathDescription->MutableSelf();
+    const TVector<TString> parts = SplitPath(path);
+    self->SetName(parts.back());
+    self->SetPathType(NKikimrSchemeOp::EPathTypeSubDomain);
+    self->SetPathId(pathId);
+    self->SetSchemeshardId(schemeShard);
+
+    auto* domainDescription = pathDescription->MutableDomainDescription();
+    domainDescription->MutableDomainKey()->SetSchemeShard(schemeShard);
+    domainDescription->MutableDomainKey()->SetPathId(pathId);
+    domainDescription->MutableResourcesDomainKey()->SetSchemeShard(schemeShard);
+    domainDescription->MutableResourcesDomainKey()->SetPathId(pathId);
+}
+
+void SetupTopicInDedicatedSubDomain(
+    TSchemeBoardEvents::TDescribeSchemeResult& describeSchemeResult,
+    const TString& databasePath,
+    const TString& topicName,
+    const ui64 databasePathId = 100,
+    const ui64 topicPathId = 101,
+    const ui64 schemeShard = 1)
+{
+    const TString path = databasePath + "/" + topicName;
+    describeSchemeResult.SetPath(CanonizePath(path));
+    auto* pathDescription = describeSchemeResult.MutablePathDescription();
+    auto* self = pathDescription->MutableSelf();
+    self->SetName(topicName);
+    self->SetPathType(NKikimrSchemeOp::EPathTypePersQueueGroup);
+    self->SetPathId(topicPathId);
+    self->SetSchemeshardId(schemeShard);
+
+    auto* domainDescription = pathDescription->MutableDomainDescription();
+    domainDescription->MutableDomainKey()->SetSchemeShard(schemeShard);
+    domainDescription->MutableDomainKey()->SetPathId(databasePathId);
+    domainDescription->MutableResourcesDomainKey()->SetSchemeShard(schemeShard);
+    domainDescription->MutableResourcesDomainKey()->SetPathId(databasePathId);
+}
+
+TIntrusivePtr<TSecurityObject> MakeSecurityObjectWithConnect(const TString& userSid) {
+    NACLib::TSecurityObject object("owner", false);
+    object.AddAccess(NACLib::EAccessType::Allow, NACLib::EAccessRights::ConnectDatabase, userSid);
+    return MakeIntrusive<TSecurityObject>(object.GetOwnerSID(), object.GetACL().SerializeAsString(), false);
+}
+
+TIntrusivePtr<TSecurityObject> MakeSecurityObjectWithoutConnect() {
+    NACLib::TSecurityObject object("owner", false);
+    return MakeIntrusive<TSecurityObject>(object.GetOwnerSID(), object.GetACL().SerializeAsString(), false);
+}
+
+NGRpcService::TEvRequestAuthAndCheckResult* RunHttpAuthCheck(
+    TTestSetup& setup,
+    const TString& requestDatabase,
+    TSchemeBoardEvents::TDescribeSchemeResult& describeSchemeResult,
+    TIntrusivePtr<TSecurityObject> securityObject)
+{
+    TTestActorRuntime* runtime = setup.GetRuntime();
+    runtime->GetAppData().FeatureFlags.SetCheckDatabaseAccessPermission(false);
+
+    const TString userToken = "Bearer " + setup.UserSid;
+    auto ev = std::make_unique<NGRpcService::TEvRequestAuthAndCheck>(
+        requestDatabase,
+        TMaybe<TString>(userToken),
+        setup.FakeMonActor,
+        NGRpcService::TAuditMode::Modifying(NGRpcService::TAuditMode::TLogClassConfig::ClusterAdmin),
+        "192.168.0.101");
+
+    std::unique_ptr<IEventHandle> ieh = std::make_unique<IEventHandle>(
+        NGRpcService::CreateGRpcRequestProxyId(),
+        setup.FakeMonActor,
+        ev.release(),
+        IEventHandle::FlagTrackDelivery);
+
+    TAutoPtr<TEventHandle<NGRpcService::TEvRequestAuthAndCheck>> request =
+        reinterpret_cast<TEventHandle<NGRpcService::TEvRequestAuthAndCheck>*>(ieh.release());
+
+    TActorId fakeGrpcRequestProxy = runtime->AllocateEdgeActor();
+    runtime->Register(CreateGrpcRequestCheckActor<NGRpcService::TEvRequestAuthAndCheck>(
+        fakeGrpcRequestProxy,
+        describeSchemeResult,
+        std::move(securityObject),
+        request,
+        NGRpcService::CreateGRpcProxyCounters(runtime->GetAppData().Counters),
+        false,
+        setup.RootAttributes,
+        nullptr,
+        {
+            .UseAccessService = true,
+            .NeedClusterAccessResourceCheck = true,
+            .AccessServiceType = runtime->GetAppData().AuthConfig.GetAccessServiceType(),
+        }));
+
+    TAutoPtr<IEventHandle> handle;
+    auto* result = runtime->GrabEdgeEvent<NGRpcService::TEvRequestAuthAndCheckResult>(handle);
+    UNIT_ASSERT_C(result, "Expected TEvRequestAuthAndCheckResult");
+    return result;
+}
+
+} // namespace
+
+Y_UNIT_TEST_SUITE(HttpDatabaseAccessObserveMode) {
+
+Y_UNIT_TEST(DedicatedOwnDbOk) {
+    TTestSetup setup("database-only", "/Root/db", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
+    auto* result = RunHttpAuthCheck(
+        setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+    UNIT_ASSERT_EQUAL(result->Database, "/Root/db");
+}
+
+Y_UNIT_TEST(DedicatedNoConnectRightButSuccess) {
+    TTestSetup setup("database-only", "/Root/db", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
+    auto* result = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithoutConnect());
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
+}
+
+Y_UNIT_TEST(ServerlessOwnDbOk) {
+    TTestSetup setup("database-only", "/Root/serverless", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/serverless", 2);
+    describeSchemeResult.MutablePathDescription()->MutableSelf()->SetPathType(NKikimrSchemeOp::EPathTypeExtSubDomain);
+    auto* result = RunHttpAuthCheck(
+        setup, "/Root/serverless", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+}
+
+Y_UNIT_TEST(ServerlessForeignNoConnectRight) {
+    TTestSetup setup("database-only", "/Root/foreign", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/foreign", 3);
+    describeSchemeResult.MutablePathDescription()->MutableSelf()->SetPathType(NKikimrSchemeOp::EPathTypeExtSubDomain);
+    auto* result = RunHttpAuthCheck(setup, "/Root/foreign", describeSchemeResult, MakeSecurityObjectWithoutConnect());
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NoConnectRight);
+}
+
+Y_UNIT_TEST(TopicPathNotADatabaseDespiteConnectRight) {
+    TTestSetup setup("database-only", "/Root/db", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupTopicInDedicatedSubDomain(describeSchemeResult, "/Root/db", "mytopic");
+    auto* result = RunHttpAuthCheck(
+        setup, "/Root/db/mytopic", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::NotADatabase);
+}
+
+Y_UNIT_TEST(EmptyDatabase) {
+    TTestSetup setup("database-only", "/Root/db", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
+    auto* result = RunHttpAuthCheck(
+        setup, "", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::EmptyDatabase);
+}
+
+Y_UNIT_TEST(RootDatabase) {
+    TTestSetup setup("database-only", "/Root", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root", 1);
+    auto* result = RunHttpAuthCheck(
+        setup, "/Root", describeSchemeResult, MakeSecurityObjectWithConnect(TString{DatabaseOnlySid}));
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+}
+
+Y_UNIT_TEST(ViewerTokenSkipsVerdict) {
+    TTestSetup setup("viewer-only", "/Root/db", {});
+    ConfigureSecurityConfig(setup.GetRuntime());
+    TSchemeBoardEvents::TDescribeSchemeResult describeSchemeResult;
+    SetupDedicatedSubDomain(describeSchemeResult, "/Root/db");
+    auto* result = RunHttpAuthCheck(setup, "/Root/db", describeSchemeResult, MakeSecurityObjectWithoutConnect());
+    UNIT_ASSERT_EQUAL(result->Status, Ydb::StatusIds::SUCCESS);
+    UNIT_ASSERT_EQUAL(result->DatabaseAccessVerdict, NGRpcService::EHttpDatabaseAccessVerdict::Ok);
+}
+
+} // HttpDatabaseAccessObserveMode
+

--- a/ydb/core/grpc_services/grpc_request_check_actor_ut/ya.make
+++ b/ydb/core/grpc_services/grpc_request_check_actor_ut/ya.make
@@ -5,6 +5,7 @@ FORK_SUBTESTS()
 SIZE(MEDIUM)
 
 PEERDIR(
+    ydb/core/base
     ydb/core/testlib/default
     ydb/library/testlib/service_mocks
 )

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -69,6 +69,7 @@ void InitMonHttpIncomingRequest(NHttp::TEvHttpProxy::TEvHttpIncomingRequest* eve
 
 void LogAuthorizedHttpRequest(
     const TAppData* appData,
+    const NKikimr::NGRpcService::IGRpcProxyCounters::TPtr& grpcProxyCounters,
     const NGRpcService::TEvRequestAuthAndCheckResult* result,
     const NHttp::THttpIncomingRequest& request,
     const TString& database)
@@ -82,10 +83,10 @@ void LogAuthorizedHttpRequest(
         : NGRpcService::EHttpDatabaseAccessVerdict::Ok;
     const bool wouldDeny = verdict != NGRpcService::EHttpDatabaseAccessVerdict::Ok;
     const TString verdictStr(ToString(verdict));
-    if (wouldDeny && userToken &&
+    if (wouldDeny && grpcProxyCounters && userToken &&
         IsStrictDatabaseOnlyToken(appData, userToken->GetSerializedToken()))
     {
-        NGRpcService::CreateGRpcProxyCounters(appData->Counters)->IncDatabaseHttpAccessDenyCounter();
+        grpcProxyCounters->IncDatabaseHttpAccessDenyCounter();
     }
     YDB_LOG_NOTICE(
         "Send request"
@@ -629,7 +630,7 @@ public:
     void SendRequest(const NKikimr::NGRpcService::TEvRequestAuthAndCheckResult* result = nullptr) {
         NHttp::THttpIncomingRequestPtr request = Event->Get()->Request;
         if (ActorMonPage->Authorizer) {
-            LogAuthorizedHttpRequest(AppData(), result, *request, Event->Get()->Database);
+            LogAuthorizedHttpRequest(AppData(), ActorMonPage->GrpcProxyCounters, result, *request, Event->Get()->Database);
         }
         TString serializedToken = result && result->UserToken ? result->UserToken->GetSerializedToken() : TString();
         Send(ActorMonPage->TargetActorId, new NMon::TEvHttpInfo(
@@ -1147,14 +1148,21 @@ public:
     TMon::TRegisterHandlerFields Fields;
     TMon::TRequestAuthorizer Authorizer;
     NMonitoring::NAudit::TAuditCtx AuditCtx;
+    NKikimr::NGRpcService::IGRpcProxyCounters::TPtr GrpcProxyCounters;
     NHttp::TEvHttpProxy::TEvSubscribeForCancel::TPtr CancelSubscriber;
     bool CsrfCookieSet = false;
 
-    THttpMonAuthorizedActorRequest(NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event, const TMon::TRegisterHandlerFields& fields, TMon::TRequestAuthorizer authorizer)
+    THttpMonAuthorizedActorRequest(
+        NHttp::TEvHttpProxy::TEvHttpIncomingRequest::TPtr event,
+        const TMon::TRegisterHandlerFields& fields,
+        TMon::TRequestAuthorizer authorizer,
+        NKikimr::NGRpcService::IGRpcProxyCounters::TPtr grpcProxyCounters
+    )
         : Event(std::move(event))
         , Request(Event->Get()->Request)
         , Fields(fields)
         , Authorizer(std::move(authorizer))
+        , GrpcProxyCounters(std::move(grpcProxyCounters))
     {}
 
     static constexpr NKikimrServices::TActivity::EType ActorActivityType() {
@@ -1279,7 +1287,7 @@ public:
 
     void SendRequest(const NKikimr::NGRpcService::TEvRequestAuthAndCheckResult* result = nullptr) {
         if (Authorizer) {
-            LogAuthorizedHttpRequest(AppData(), result, *Request, Event->Get()->Database);
+            LogAuthorizedHttpRequest(AppData(), GrpcProxyCounters, result, *Request, Event->Get()->Database);
         }
         Send(new IEventHandle(Fields.Handler, SelfId(), Event->ReleaseBase().Release(), IEventHandle::FlagTrackDelivery, Event->Cookie));
     }
@@ -1608,13 +1616,20 @@ THttpMonPageService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring:
 // receives everyhing not related to actor communcation, converts them to request-actors
 class THttpMonIndexService : public TActor<THttpMonIndexService> {
 public:
-    THttpMonIndexService(const TActorId& httpProxyActorId, TIntrusivePtr<NMonitoring::TIndexMonPage> indexMonPage,
-                         TVector<TString> allowedSIDs, TMon::TRequestAuthorizer authorizer, const TString& redirectRoot = {}, bool needMonLegacyAudit = true)
+    THttpMonIndexService(
+        const TActorId& httpProxyActorId,
+        TIntrusivePtr<NMonitoring::TIndexMonPage> indexMonPage,
+        TVector<TString> allowedSIDs,
+        TMon::TRequestAuthorizer authorizer,
+        NKikimr::NGRpcService::IGRpcProxyCounters::TPtr grpcProxyCounters,
+        const TString& redirectRoot = {},
+        bool needMonLegacyAudit = true)
         : TActor(&THttpMonIndexService::StateWork)
         , HttpProxyActorId(httpProxyActorId)
         , IndexMonPage(std::move(indexMonPage))
         , AllowedSIDs(std::move(allowedSIDs))
         , Authorizer(std::move(authorizer))
+        , GrpcProxyCounters(std::move(grpcProxyCounters))
         , RedirectRoot(redirectRoot)
         , NeedMonLegacyAudit(needMonLegacyAudit)
     {
@@ -1698,7 +1713,7 @@ public:
         while (!url.empty()) {
             auto it = Handlers.find(TString(url));
             if (it != Handlers.end()) {
-                Register(new THttpMonAuthorizedActorRequest(std::move(ev), it->second, Authorizer));
+                Register(new THttpMonAuthorizedActorRequest(std::move(ev), it->second, Authorizer, GrpcProxyCounters));
                 return;
             } else {
                 if (url.EndsWith('/')) {
@@ -1736,6 +1751,7 @@ public:
     std::unordered_map<TString, TMon::TRegisterHandlerFields> Handlers;
     TVector<TString> AllowedSIDs;
     TMon::TRequestAuthorizer Authorizer;
+    NKikimr::NGRpcService::IGRpcProxyCounters::TPtr GrpcProxyCounters;
     TString RedirectRoot;
     bool NeedMonLegacyAudit;
 };
@@ -1803,6 +1819,9 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
     Y_ABORT_UNLESS(actorSystem);
     TGuard<TMutex> g(Mutex);
     ActorSystem = actorSystem;
+    if (auto* appData = ActorSystem->AppData<NKikimr::TAppData>()) {
+        GrpcProxyCounters = NKikimr::NGRpcService::CreateGRpcProxyCounters(appData->Counters);
+    }
     Register(new TIndexRedirectMonPage(IndexMonPage));
     Register(new NMonitoring::TVersionMonPage);
     Register(new NMonitoring::TBootstrapCssMonPage);
@@ -1826,11 +1845,11 @@ std::future<void> TMon::Start(TActorSystem* actorSystem) {
         TMailboxType::ReadAsFilled,
         executorPool);
     HttpMonServiceActorId = ActorSystem->Register(
-        new THttpMonIndexService(HttpProxyActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, Config.RedirectMainPageTo),
+        new THttpMonIndexService(HttpProxyActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, GrpcProxyCounters, Config.RedirectMainPageTo),
         TMailboxType::ReadAsFilled,
         executorPool);
     HttpAuthMonServiceActorId = ActorSystem->Register(
-        new THttpMonIndexService(HttpMonServiceActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, Config.RedirectMainPageTo, false),
+        new THttpMonIndexService(HttpMonServiceActorId, IndexMonPage, Config.AllowedSIDs, Config.Authorizer, GrpcProxyCounters, Config.RedirectMainPageTo, false),
         TMailboxType::ReadAsFilled,
         executorPool);
     RegisterLwtrace();
@@ -1921,6 +1940,7 @@ NMonitoring::TIndexMonPage* TMon::RegisterIndexPage(const TString& path, const T
 void TMon::RegisterActorMonPage(const TActorMonPageInfo& pageInfo) {
     if (ActorSystem) {
         TActorMonPage* actorMonPage = static_cast<TActorMonPage*>(pageInfo.Page.Get());
+        actorMonPage->GrpcProxyCounters = GrpcProxyCounters;
         auto& actorId = ActorServices[pageInfo.Path];
         if (actorId) {
             ActorSystem->Send(new IEventHandle(TEvents::TSystem::Poison, 0, actorId, {}, nullptr, 0));

--- a/ydb/core/mon/mon.cpp
+++ b/ydb/core/mon/mon.cpp
@@ -11,6 +11,8 @@
 #include <ydb/core/base/monitoring_provider.h>
 #include <ydb/core/base/ticket_parser.h>
 #include <ydb/core/grpc_services/base/base.h>
+#include <ydb/core/grpc_services/counters/proxy_counters.h>
+#include <ydb/core/grpc_services/base/http_database_access_verdict.h>
 #include <ydb/core/mon/audit/audit.h>
 #include <ydb/core/protos/mon.pb.h>
 #include <ydb/core/util/wildcard.h>
@@ -75,6 +77,16 @@ void LogAuthorizedHttpRequest(
     const TString user = (result && result->UserToken) ? result->UserToken->GetUserSID() : "anonymous";
     const NACLib::TUserToken* userToken = (result && result->UserToken) ? result->UserToken.Get() : nullptr;
     const TString accessLevel = ToString(GetHighestAccessLevel(appData, userToken));
+    const NGRpcService::EHttpDatabaseAccessVerdict verdict = result
+        ? result->DatabaseAccessVerdict
+        : NGRpcService::EHttpDatabaseAccessVerdict::Ok;
+    const bool wouldDeny = verdict != NGRpcService::EHttpDatabaseAccessVerdict::Ok;
+    const TString verdictStr(ToString(verdict));
+    if (wouldDeny && userToken &&
+        IsStrictDatabaseOnlyToken(appData, userToken->GetSerializedToken()))
+    {
+        NGRpcService::CreateGRpcProxyCounters(appData->Counters)->IncDatabaseHttpAccessDenyCounter();
+    }
     YDB_LOG_NOTICE(
         "Send request"
             << " [" << address << "]"
@@ -82,13 +94,17 @@ void LogAuthorizedHttpRequest(
             << " " << request.Method
             << " " << request.URL
             << " highest_access_level=" << accessLevel
-            << " database=" << database,
+            << " database=" << database
+            << " database_access_verdict=" << verdictStr
+            << " would_deny=" << (wouldDeny ? 1 : 0),
         {"address", address},
         {"user", user},
         {"method", request.Method},
         {"url", request.URL},
         {"highest_access_level", accessLevel},
-        {"database", database});
+        {"database", database},
+        {"database_access_verdict", verdictStr},
+        {"would_deny", wouldDeny ? "1" : "0"});
 }
 
 const Ydb::Issue::IssueMessage* FindDeepestIssue(const google::protobuf::RepeatedPtrField<Ydb::Issue::IssueMessage>& issues) {

--- a/ydb/core/mon/mon.h
+++ b/ydb/core/mon/mon.h
@@ -17,6 +17,8 @@
 #include <yql/essentials/public/issue/yql_issue.h>
 #include <ydb/public/sdk/cpp/include/ydb-cpp-sdk/client/types/status/status.h>
 
+#include <ydb/core/grpc_services/counters/proxy_counters.h>
+
 namespace NKikimr {
     struct TAppData;
 }
@@ -132,6 +134,7 @@ protected:
     TActorId CountersServiceActorId;
     TActorId PingServiceActorId;
     TIntrusivePtr<NMonitoring::TDynamicCountersPage> CountersMonPage;
+    NKikimr::NGRpcService::IGRpcProxyCounters::TPtr GrpcProxyCounters;
 
     struct TActorMonPageInfo {
         NMonitoring::TMonPagePtr Page;

--- a/ydb/core/mon/mon_impl.h
+++ b/ydb/core/mon/mon_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mon.h"
+#include <ydb/core/grpc_services/counters/proxy_counters.h>
 #include <ydb/library/services/services.pb.h>
 #include <library/cpp/monlib/dynamic_counters/counters.h>
 #include <library/cpp/monlib/dynamic_counters/page.h>
@@ -168,6 +169,7 @@ public:
     TMon::TRequestAuthorizer Authorizer;
     TMon::EAuthMode AuthMode;
     TString MonServiceName;
+    NKikimr::NGRpcService::IGRpcProxyCounters::TPtr GrpcProxyCounters;
 };
 
 inline TString GetPageFullPath(const NMonitoring::IMonPage* page) {

--- a/ydb/core/mon/ya.make
+++ b/ydb/core/mon/ya.make
@@ -15,6 +15,7 @@ PEERDIR(
     library/cpp/string_utils/url
     ydb/core/base
     ydb/core/grpc_services/base
+    ydb/core/grpc_services/counters
     ydb/core/mon/audit
     ydb/core/protos
     ydb/library/aclib


### PR DESCRIPTION
### Description for reviewers
Ожидаем, что из UI в параметре `database` передают базу данных, к которой у пользователей есть права connect, но на всякий случай добавляем логирование и отправку сигналов в мониторинг. По ним будем принимать решение по переходу на следующий этап, описанный ниже.

Следующий этап изменений – добавление фичефлага, который будет принимать только такие HTTP-запросы, в которой указана именно баз данных в параметре, к которой есть право connect.
UPD1 Это будем включать пока только на облачных кластерах, анализируя логи.